### PR TITLE
refactor(eval): versioned artifact contracts with collision-safe persistence (IND-442)

### DIFF
--- a/packages/protocol/eval/README.md
+++ b/packages/protocol/eval/README.md
@@ -50,9 +50,10 @@ only a secondary evaluator-regression check, not retrieval evidence.
 actually reads* once a match exists — complementary surfaces of the same feature.
 
 Common flags (most baseline-backed harnesses): `--runs N`, `--rule R`, `--case ID`, `--tier N`,
-`--list-cases`, `--no-judge`, `--update-baseline`, `--report [path]`, `--html [path]`,
+`--list-cases`, `--no-judge`, `--update-baseline`, `--force`, `--report [path]`, `--html [path]`,
 `--rolling-baseline [days]`, `--alpha P`, `--no-save`. The `premise` harness additionally
-takes `--component decompose|analyze`.
+takes `--component decompose|analyze`. Baseline/report writes refuse to replace existing
+files unless `--force` is passed (see the artifact envelope section below).
 
 ## Architecture: shared lib + thin harnesses
 
@@ -67,7 +68,10 @@ eval/
 │   ├── stats.ts            # Wilson CI, binomial + beta-binomial p-values
 │   ├── types.ts            # CaseResultLike / ScorecardLike / RuleResult / Regression
 │   ├── scorecard.ts        # buildScorecard (generic over the case type)
-│   ├── baseline.ts         # read/write/diff baselines, writeRunReport
+│   ├── artifact.ts         # versioned artifact envelope: Zod schemas, fingerprints, git provenance
+│   ├── artifact.io.ts      # atomic writes, overwrite refusal, write-plan collision checks
+│   ├── migrate-legacy-baselines.ts  # explicit legacy → v1 baseline conversion CLI
+│   ├── baseline.ts         # read/write/diff baselines, writeRunReport (envelope-backed)
 │   ├── rolling.ts          # computeRollingBaseline from recent run reports
 │   ├── console.ts          # formatConsole (parameterized title)
 │   ├── runner.ts           # repeatRuns: repeat-with-retry execution loop
@@ -90,6 +94,36 @@ harness defines its own richer `CaseResult` (with per-run assertions + agent-out
 that extends `CaseResultLike`, and specializes `Scorecard = ScorecardLike<CaseResult>`. The
 shared layer never reads harness-specific run internals, so harness types stay fully owned
 by the harness while reusing all aggregation, baseline, rolling, console, and HTML code.
+
+## Versioned artifact envelope (schema v1)
+
+Every baseline-backed JSON artifact (committed `baselines/*.baseline.json` and gitignored
+`runs/*.json` run reports) is wrapped in a small versioned envelope
+(`index-eval/baseline` / `index-eval/run-report`, `eval/shared/artifact.ts`) and validated
+with Zod on **every read and write**. The envelope records provenance — harness +
+version, source (`run` or `legacy-migration`), created/start/completion times, configured
+model IDs, selection filters, run count, SHA-256 corpus/config fingerprints over
+canonicalized inputs, Git revision + dirty state, and a completeness summary — while the
+scorecard stays a harness-owned payload (per-case detail passes through untouched).
+Validation rejects malformed numbers, duplicate case/rule ids, inconsistent
+aggregates/completeness, non-monotonic timestamps, unknown schema versions, and
+incompatible artifact types with actionable errors. Fingerprint inputs must never contain
+embeddings, API keys, secret-bearing prompts, or raw environment values (secret-like
+config keys are rejected).
+
+Persistence is collision-safe (`eval/shared/artifact.io.ts`): writes validate first, go
+through a same-directory temp file + atomic rename (an interrupted write can never replace
+a valid artifact with a partial one), and refuse to overwrite existing files unless
+`--force` is passed. Each harness asserts its full write plan up front, so an output can
+never clobber an input (e.g. `--report <baseline path>` is rejected) and multi-output runs
+fail before anything is written rather than leaving partial combinations behind.
+
+Legacy (pre-envelope) baselines are converted only through the explicit, reviewable
+`bun eval/shared/migrate-legacy-baselines.ts --write` CLI — payload score values are
+preserved verbatim, unavailable provenance carries explicit `unavailable-legacy-migration`
+sentinels, and readers never cast a legacy scorecard silently. Pre-envelope files in
+`runs/` are simply skipped by the rolling baseline. A provider-free spec
+(`eval/shared/tests/migration.spec.ts`) keeps every committed baseline valid.
 
 ## Anatomy of a harness
 
@@ -138,7 +172,11 @@ eval/<name>/
 7. **Write the CLI** in `<name>.eval.ts`, importing `buildScorecard`, `diffBaseline`,
    `readBaseline`, `writeBaseline`, `writeRunReport`, `computeRollingBaseline`,
    `formatConsole`, and `arg`/`has`/`flagValue` from `../shared/index.js`. Pass a
-   `leanCase` to `writeBaseline` that strips your per-run `detail`.
+   `leanCase` to `writeBaseline` that strips your per-run `detail`. Build an
+   `EvalRunMeta` (harness id/version, model IDs, `fingerprintEvalCorpus(selected)`,
+   `fingerprintEvalConfig({…})`, `readEvalGitProvenance(import.meta.dir)`,
+   started/completed timestamps) for the write calls, support `--force`, and assert an
+   `assertEvalWritePlan({ inputs, outputs, force })` before running any cases.
 
 8. **Add a package.json script**:
    ```json

--- a/packages/protocol/eval/matching/README.md
+++ b/packages/protocol/eval/matching/README.md
@@ -19,7 +19,7 @@ bun run eval:matching -- --case location/known-mismatch-penalized # one case/pre
 bun run eval:matching -- --tier 4             # one tier
 bun run eval:matching -- --list-cases         # print selected cases and exit
 bun run eval:matching -- --no-judge           # skip LLM reasoning checks (free)
-bun run eval:matching -- --update-baseline    # overwrite the committed baseline
+bun run eval:matching -- --update-baseline --force # replace the committed baseline
 bun run eval:matching -- --report             # write a full run report incl. evaluator reasoning
 bun run eval:matching -- --report out.json    # ...to a specific path
 bun run eval:matching -- --html              # write a standalone HTML scorecard
@@ -95,7 +95,7 @@ report can show whether failures cluster by domain rather than only by evaluator
 check can't express the expectation. Only assert `role` when the case is explicitly about
 valency; query-primary and score-calibration cases should usually avoid role assertions so
 component metrics stay isolated. Negative cases are best authored as minimal-pair
-perturbations of a positive. Re-run with `--update-baseline` after an intentional change.
+perturbations of a positive. Re-run with `--update-baseline --force` after an intentional change.
 
 The eval runner uses `returnAll: true` to capture diagnostic low scores, but the scorer only
 counts a candidate as surfaced when `score >= MATCHING_MIN_SCORE` (currently 30). A returned

--- a/packages/protocol/eval/matching/baselines/matching.baseline.json
+++ b/packages/protocol/eval/matching/baselines/matching.baseline.json
@@ -1,7401 +1,7432 @@
 {
-  "generatedAt": "2026-05-29T18:05:23.210Z",
-  "model": "google/gemini-2.5-flash",
-  "runs": 7,
-  "aggregatePassRate": 0.9890109890109889,
-  "rules": [
-    {
-      "rule": "is_a_identity",
-      "caseCount": 7,
-      "passRate": 1
-    },
-    {
-      "rule": "query_primary",
-      "caseCount": 7,
-      "passRate": 0.979591836734694
-    },
-    {
-      "rule": "complementary_role",
-      "caseCount": 4,
-      "passRate": 0.9642857142857143
-    },
-    {
-      "rule": "same_side",
-      "caseCount": 3,
-      "passRate": 1
-    },
-    {
-      "rule": "already_known",
-      "caseCount": 1,
-      "passRate": 1
-    },
-    {
-      "rule": "location",
-      "caseCount": 4,
-      "passRate": 1
-    },
-    {
-      "rule": "valency_role",
-      "caseCount": 3,
-      "passRate": 1
-    },
-    {
-      "rule": "score_calibration",
-      "caseCount": 4,
-      "passRate": 1
-    },
-    {
-      "rule": "event_network",
-      "caseCount": 1,
-      "passRate": 1
-    },
-    {
-      "rule": "historical",
-      "caseCount": 5,
-      "passRate": 0.9714285714285715
-    }
+  "artifactType": "index-eval/baseline",
+  "schemaVersion": 1,
+  "harness": "matching",
+  "harnessVersion": "1",
+  "source": "legacy-migration",
+  "createdAt": "2026-05-29T18:05:23.210Z",
+  "startedAt": "2026-05-29T18:05:23.210Z",
+  "completedAt": "2026-05-29T18:05:23.210Z",
+  "models": [
+    "google/gemini-2.5-flash"
   ],
-  "cases": [
-    {
-      "caseId": "is_a_identity/samurai-vs-character-designer",
-      "rule": "is_a_identity",
-      "runs": 7,
-      "passes": 7,
-      "passRate": 1,
-      "flaky": false,
-      "runResults": [
-        {
-          "passed": true,
-          "assertions": [
-            {
-              "kind": "match",
-              "candidateId": "c-yuki",
-              "passed": true,
-              "detail": "expected match=false, got surfaced=false (score 0, threshold 30)"
-            },
-            {
-              "kind": "band",
-              "candidateId": "c-yuki",
-              "passed": true,
-              "detail": "expected score in [0,29], got 0"
-            }
-          ]
-        },
-        {
-          "passed": true,
-          "assertions": [
-            {
-              "kind": "match",
-              "candidateId": "c-yuki",
-              "passed": true,
-              "detail": "expected match=false, got surfaced=false (score 0, threshold 30)"
-            },
-            {
-              "kind": "band",
-              "candidateId": "c-yuki",
-              "passed": true,
-              "detail": "expected score in [0,29], got 0"
-            }
-          ]
-        },
-        {
-          "passed": true,
-          "assertions": [
-            {
-              "kind": "match",
-              "candidateId": "c-yuki",
-              "passed": true,
-              "detail": "expected match=false, got surfaced=false (score 0, threshold 30)"
-            },
-            {
-              "kind": "band",
-              "candidateId": "c-yuki",
-              "passed": true,
-              "detail": "expected score in [0,29], got 0"
-            }
-          ]
-        },
-        {
-          "passed": true,
-          "assertions": [
-            {
-              "kind": "match",
-              "candidateId": "c-yuki",
-              "passed": true,
-              "detail": "expected match=false, got surfaced=false (score 0, threshold 30)"
-            },
-            {
-              "kind": "band",
-              "candidateId": "c-yuki",
-              "passed": true,
-              "detail": "expected score in [0,29], got 0"
-            }
-          ]
-        },
-        {
-          "passed": true,
-          "assertions": [
-            {
-              "kind": "match",
-              "candidateId": "c-yuki",
-              "passed": true,
-              "detail": "expected match=false, got surfaced=false (score 0, threshold 30)"
-            },
-            {
-              "kind": "band",
-              "candidateId": "c-yuki",
-              "passed": true,
-              "detail": "expected score in [0,29], got 0"
-            }
-          ]
-        },
-        {
-          "passed": true,
-          "assertions": [
-            {
-              "kind": "match",
-              "candidateId": "c-yuki",
-              "passed": true,
-              "detail": "expected match=false, got surfaced=false (score 0, threshold 30)"
-            },
-            {
-              "kind": "band",
-              "candidateId": "c-yuki",
-              "passed": true,
-              "detail": "expected score in [0,29], got 0"
-            }
-          ]
-        },
-        {
-          "passed": true,
-          "assertions": [
-            {
-              "kind": "match",
-              "candidateId": "c-yuki",
-              "passed": true,
-              "detail": "expected match=false, got surfaced=false (score 0, threshold 30)"
-            },
-            {
-              "kind": "band",
-              "candidateId": "c-yuki",
-              "passed": true,
-              "detail": "expected score in [0,29], got 0"
-            }
-          ]
-        }
-      ]
-    },
-    {
-      "caseId": "is_a_identity/investor-vs-funded-engineer",
-      "rule": "is_a_identity",
-      "runs": 7,
-      "passes": 7,
-      "passRate": 1,
-      "flaky": false,
-      "runResults": [
-        {
-          "passed": true,
-          "assertions": [
-            {
-              "kind": "match",
-              "candidateId": "c-sam",
-              "passed": true,
-              "detail": "expected match=false, got surfaced=false (score 0, threshold 30)"
-            },
-            {
-              "kind": "band",
-              "candidateId": "c-sam",
-              "passed": true,
-              "detail": "expected score in [0,29], got 0"
-            }
-          ]
-        },
-        {
-          "passed": true,
-          "assertions": [
-            {
-              "kind": "match",
-              "candidateId": "c-sam",
-              "passed": true,
-              "detail": "expected match=false, got surfaced=false (score 0, threshold 30)"
-            },
-            {
-              "kind": "band",
-              "candidateId": "c-sam",
-              "passed": true,
-              "detail": "expected score in [0,29], got 0"
-            }
-          ]
-        },
-        {
-          "passed": true,
-          "assertions": [
-            {
-              "kind": "match",
-              "candidateId": "c-sam",
-              "passed": true,
-              "detail": "expected match=false, got surfaced=false (score 0, threshold 30)"
-            },
-            {
-              "kind": "band",
-              "candidateId": "c-sam",
-              "passed": true,
-              "detail": "expected score in [0,29], got 0"
-            }
-          ]
-        },
-        {
-          "passed": true,
-          "assertions": [
-            {
-              "kind": "match",
-              "candidateId": "c-sam",
-              "passed": true,
-              "detail": "expected match=false, got surfaced=false (score 0, threshold 30)"
-            },
-            {
-              "kind": "band",
-              "candidateId": "c-sam",
-              "passed": true,
-              "detail": "expected score in [0,29], got 0"
-            }
-          ]
-        },
-        {
-          "passed": true,
-          "assertions": [
-            {
-              "kind": "match",
-              "candidateId": "c-sam",
-              "passed": true,
-              "detail": "expected match=false, got surfaced=false (score 0, threshold 30)"
-            },
-            {
-              "kind": "band",
-              "candidateId": "c-sam",
-              "passed": true,
-              "detail": "expected score in [0,29], got 0"
-            }
-          ]
-        },
-        {
-          "passed": true,
-          "assertions": [
-            {
-              "kind": "match",
-              "candidateId": "c-sam",
-              "passed": true,
-              "detail": "expected match=false, got surfaced=false (score 0, threshold 30)"
-            },
-            {
-              "kind": "band",
-              "candidateId": "c-sam",
-              "passed": true,
-              "detail": "expected score in [0,29], got 0"
-            }
-          ]
-        },
-        {
-          "passed": true,
-          "assertions": [
-            {
-              "kind": "match",
-              "candidateId": "c-sam",
-              "passed": true,
-              "detail": "expected match=false, got surfaced=false (score 0, threshold 30)"
-            },
-            {
-              "kind": "band",
-              "candidateId": "c-sam",
-              "passed": true,
-              "detail": "expected score in [0,29], got 0"
-            }
-          ]
-        }
-      ]
-    },
-    {
-      "caseId": "is_a_identity/investor-vs-real-investor",
-      "rule": "is_a_identity",
-      "runs": 7,
-      "passes": 7,
-      "passRate": 1,
-      "flaky": false,
-      "runResults": [
-        {
-          "passed": true,
-          "assertions": [
-            {
-              "kind": "match",
-              "candidateId": "c-sarah",
-              "passed": true,
-              "detail": "expected match=true, got surfaced=true (score 95, threshold 30)"
-            },
-            {
-              "kind": "band",
-              "candidateId": "c-sarah",
-              "passed": true,
-              "detail": "expected score in [70,100], got 95"
-            }
-          ]
-        },
-        {
-          "passed": true,
-          "assertions": [
-            {
-              "kind": "match",
-              "candidateId": "c-sarah",
-              "passed": true,
-              "detail": "expected match=true, got surfaced=true (score 95, threshold 30)"
-            },
-            {
-              "kind": "band",
-              "candidateId": "c-sarah",
-              "passed": true,
-              "detail": "expected score in [70,100], got 95"
-            }
-          ]
-        },
-        {
-          "passed": true,
-          "assertions": [
-            {
-              "kind": "match",
-              "candidateId": "c-sarah",
-              "passed": true,
-              "detail": "expected match=true, got surfaced=true (score 95, threshold 30)"
-            },
-            {
-              "kind": "band",
-              "candidateId": "c-sarah",
-              "passed": true,
-              "detail": "expected score in [70,100], got 95"
-            }
-          ]
-        },
-        {
-          "passed": true,
-          "assertions": [
-            {
-              "kind": "match",
-              "candidateId": "c-sarah",
-              "passed": true,
-              "detail": "expected match=true, got surfaced=true (score 95, threshold 30)"
-            },
-            {
-              "kind": "band",
-              "candidateId": "c-sarah",
-              "passed": true,
-              "detail": "expected score in [70,100], got 95"
-            }
-          ]
-        },
-        {
-          "passed": true,
-          "assertions": [
-            {
-              "kind": "match",
-              "candidateId": "c-sarah",
-              "passed": true,
-              "detail": "expected match=true, got surfaced=true (score 95, threshold 30)"
-            },
-            {
-              "kind": "band",
-              "candidateId": "c-sarah",
-              "passed": true,
-              "detail": "expected score in [70,100], got 95"
-            }
-          ]
-        },
-        {
-          "passed": true,
-          "assertions": [
-            {
-              "kind": "match",
-              "candidateId": "c-sarah",
-              "passed": true,
-              "detail": "expected match=true, got surfaced=true (score 95, threshold 30)"
-            },
-            {
-              "kind": "band",
-              "candidateId": "c-sarah",
-              "passed": true,
-              "detail": "expected score in [70,100], got 95"
-            }
-          ]
-        },
-        {
-          "passed": true,
-          "assertions": [
-            {
-              "kind": "match",
-              "candidateId": "c-sarah",
-              "passed": true,
-              "detail": "expected match=true, got surfaced=true (score 95, threshold 30)"
-            },
-            {
-              "kind": "band",
-              "candidateId": "c-sarah",
-              "passed": true,
-              "detail": "expected score in [70,100], got 95"
-            }
-          ]
-        }
-      ]
-    },
-    {
-      "caseId": "query_primary/background-intent-does-not-rescue",
-      "rule": "query_primary",
-      "runs": 7,
-      "passes": 7,
-      "passRate": 1,
-      "flaky": false,
-      "runResults": [
-        {
-          "passed": true,
-          "assertions": [
-            {
-              "kind": "match",
-              "candidateId": "c-yuki",
-              "passed": true,
-              "detail": "expected match=false, got surfaced=false (score 0, threshold 30)"
-            },
-            {
-              "kind": "band",
-              "candidateId": "c-yuki",
-              "passed": true,
-              "detail": "expected score in [0,29], got 0"
-            },
-            {
-              "kind": "reasoning",
-              "candidateId": "c-yuki",
-              "passed": true,
-              "detail": "judge passed"
-            }
-          ]
-        },
-        {
-          "passed": true,
-          "assertions": [
-            {
-              "kind": "match",
-              "candidateId": "c-yuki",
-              "passed": true,
-              "detail": "expected match=false, got surfaced=false (score 0, threshold 30)"
-            },
-            {
-              "kind": "band",
-              "candidateId": "c-yuki",
-              "passed": true,
-              "detail": "expected score in [0,29], got 0"
-            },
-            {
-              "kind": "reasoning",
-              "candidateId": "c-yuki",
-              "passed": true,
-              "detail": "judge passed"
-            }
-          ]
-        },
-        {
-          "passed": true,
-          "assertions": [
-            {
-              "kind": "match",
-              "candidateId": "c-yuki",
-              "passed": true,
-              "detail": "expected match=false, got surfaced=false (score 0, threshold 30)"
-            },
-            {
-              "kind": "band",
-              "candidateId": "c-yuki",
-              "passed": true,
-              "detail": "expected score in [0,29], got 0"
-            },
-            {
-              "kind": "reasoning",
-              "candidateId": "c-yuki",
-              "passed": true,
-              "detail": "judge passed"
-            }
-          ]
-        },
-        {
-          "passed": true,
-          "assertions": [
-            {
-              "kind": "match",
-              "candidateId": "c-yuki",
-              "passed": true,
-              "detail": "expected match=false, got surfaced=false (score 0, threshold 30)"
-            },
-            {
-              "kind": "band",
-              "candidateId": "c-yuki",
-              "passed": true,
-              "detail": "expected score in [0,29], got 0"
-            },
-            {
-              "kind": "reasoning",
-              "candidateId": "c-yuki",
-              "passed": true,
-              "detail": "judge passed"
-            }
-          ]
-        },
-        {
-          "passed": true,
-          "assertions": [
-            {
-              "kind": "match",
-              "candidateId": "c-yuki",
-              "passed": true,
-              "detail": "expected match=false, got surfaced=false (score 0, threshold 30)"
-            },
-            {
-              "kind": "band",
-              "candidateId": "c-yuki",
-              "passed": true,
-              "detail": "expected score in [0,29], got 0"
-            },
-            {
-              "kind": "reasoning",
-              "candidateId": "c-yuki",
-              "passed": true,
-              "detail": "judge passed"
-            }
-          ]
-        },
-        {
-          "passed": true,
-          "assertions": [
-            {
-              "kind": "match",
-              "candidateId": "c-yuki",
-              "passed": true,
-              "detail": "expected match=false, got surfaced=false (score 0, threshold 30)"
-            },
-            {
-              "kind": "band",
-              "candidateId": "c-yuki",
-              "passed": true,
-              "detail": "expected score in [0,29], got 0"
-            },
-            {
-              "kind": "reasoning",
-              "candidateId": "c-yuki",
-              "passed": true,
-              "detail": "judge passed"
-            }
-          ]
-        },
-        {
-          "passed": true,
-          "assertions": [
-            {
-              "kind": "match",
-              "candidateId": "c-yuki",
-              "passed": true,
-              "detail": "expected match=false, got surfaced=false (score 0, threshold 30)"
-            },
-            {
-              "kind": "band",
-              "candidateId": "c-yuki",
-              "passed": true,
-              "detail": "expected score in [0,29], got 0"
-            },
-            {
-              "kind": "reasoning",
-              "candidateId": "c-yuki",
-              "passed": true,
-              "detail": "judge passed"
-            }
-          ]
-        }
-      ]
-    },
-    {
-      "caseId": "query_primary/specific-art-query-accepts-illustrator",
-      "rule": "query_primary",
-      "runs": 7,
-      "passes": 6,
-      "passRate": 0.8571428571428571,
-      "flaky": true,
-      "runResults": [
-        {
-          "passed": true,
-          "assertions": [
-            {
-              "kind": "match",
-              "candidateId": "c-yuki",
-              "passed": true,
-              "detail": "expected match=true, got surfaced=true (score 95, threshold 30)"
-            },
-            {
-              "kind": "band",
-              "candidateId": "c-yuki",
-              "passed": true,
-              "detail": "expected score in [70,100], got 95"
-            },
-            {
-              "kind": "role",
-              "candidateId": "c-yuki",
-              "passed": true,
-              "detail": "expected role=agent, got agent"
-            }
-          ]
-        },
-        {
-          "passed": true,
-          "assertions": [
-            {
-              "kind": "match",
-              "candidateId": "c-yuki",
-              "passed": true,
-              "detail": "expected match=true, got surfaced=true (score 98, threshold 30)"
-            },
-            {
-              "kind": "band",
-              "candidateId": "c-yuki",
-              "passed": true,
-              "detail": "expected score in [70,100], got 98"
-            },
-            {
-              "kind": "role",
-              "candidateId": "c-yuki",
-              "passed": true,
-              "detail": "expected role=agent, got agent"
-            }
-          ]
-        },
-        {
-          "passed": true,
-          "assertions": [
-            {
-              "kind": "match",
-              "candidateId": "c-yuki",
-              "passed": true,
-              "detail": "expected match=true, got surfaced=true (score 95, threshold 30)"
-            },
-            {
-              "kind": "band",
-              "candidateId": "c-yuki",
-              "passed": true,
-              "detail": "expected score in [70,100], got 95"
-            },
-            {
-              "kind": "role",
-              "candidateId": "c-yuki",
-              "passed": true,
-              "detail": "expected role=agent, got agent"
-            }
-          ]
-        },
-        {
-          "passed": true,
-          "assertions": [
-            {
-              "kind": "match",
-              "candidateId": "c-yuki",
-              "passed": true,
-              "detail": "expected match=true, got surfaced=true (score 95, threshold 30)"
-            },
-            {
-              "kind": "band",
-              "candidateId": "c-yuki",
-              "passed": true,
-              "detail": "expected score in [70,100], got 95"
-            },
-            {
-              "kind": "role",
-              "candidateId": "c-yuki",
-              "passed": true,
-              "detail": "expected role=agent, got agent"
-            }
-          ]
-        },
-        {
-          "passed": true,
-          "assertions": [
-            {
-              "kind": "match",
-              "candidateId": "c-yuki",
-              "passed": true,
-              "detail": "expected match=true, got surfaced=true (score 95, threshold 30)"
-            },
-            {
-              "kind": "band",
-              "candidateId": "c-yuki",
-              "passed": true,
-              "detail": "expected score in [70,100], got 95"
-            },
-            {
-              "kind": "role",
-              "candidateId": "c-yuki",
-              "passed": true,
-              "detail": "expected role=agent, got agent"
-            }
-          ]
-        },
-        {
-          "passed": true,
-          "assertions": [
-            {
-              "kind": "match",
-              "candidateId": "c-yuki",
-              "passed": true,
-              "detail": "expected match=true, got surfaced=true (score 95, threshold 30)"
-            },
-            {
-              "kind": "band",
-              "candidateId": "c-yuki",
-              "passed": true,
-              "detail": "expected score in [70,100], got 95"
-            },
-            {
-              "kind": "role",
-              "candidateId": "c-yuki",
-              "passed": true,
-              "detail": "expected role=agent, got agent"
-            }
-          ]
-        },
-        {
-          "passed": false,
-          "assertions": [
-            {
-              "kind": "match",
-              "candidateId": "c-yuki",
-              "passed": true,
-              "detail": "expected match=true, got surfaced=true (score 95, threshold 30)"
-            },
-            {
-              "kind": "band",
-              "candidateId": "c-yuki",
-              "passed": true,
-              "detail": "expected score in [70,100], got 95"
-            },
-            {
-              "kind": "role",
-              "candidateId": "c-yuki",
-              "passed": false,
-              "detail": "expected role=agent, got peer"
-            }
-          ]
-        }
-      ]
-    },
-    {
-      "caseId": "query_primary/investors-query-rejects-funded-founder",
-      "rule": "query_primary",
-      "runs": 7,
-      "passes": 7,
-      "passRate": 1,
-      "flaky": false,
-      "runResults": [
-        {
-          "passed": true,
-          "assertions": [
-            {
-              "kind": "match",
-              "candidateId": "c-sam",
-              "passed": true,
-              "detail": "expected match=false, got surfaced=false (score 0, threshold 30)"
-            },
-            {
-              "kind": "band",
-              "candidateId": "c-sam",
-              "passed": true,
-              "detail": "expected score in [0,29], got 0"
-            }
-          ]
-        },
-        {
-          "passed": true,
-          "assertions": [
-            {
-              "kind": "match",
-              "candidateId": "c-sam",
-              "passed": true,
-              "detail": "expected match=false, got surfaced=false (score 0, threshold 30)"
-            },
-            {
-              "kind": "band",
-              "candidateId": "c-sam",
-              "passed": true,
-              "detail": "expected score in [0,29], got 0"
-            }
-          ]
-        },
-        {
-          "passed": true,
-          "assertions": [
-            {
-              "kind": "match",
-              "candidateId": "c-sam",
-              "passed": true,
-              "detail": "expected match=false, got surfaced=false (score 0, threshold 30)"
-            },
-            {
-              "kind": "band",
-              "candidateId": "c-sam",
-              "passed": true,
-              "detail": "expected score in [0,29], got 0"
-            }
-          ]
-        },
-        {
-          "passed": true,
-          "assertions": [
-            {
-              "kind": "match",
-              "candidateId": "c-sam",
-              "passed": true,
-              "detail": "expected match=false, got surfaced=false (score 0, threshold 30)"
-            },
-            {
-              "kind": "band",
-              "candidateId": "c-sam",
-              "passed": true,
-              "detail": "expected score in [0,29], got 0"
-            }
-          ]
-        },
-        {
-          "passed": true,
-          "assertions": [
-            {
-              "kind": "match",
-              "candidateId": "c-sam",
-              "passed": true,
-              "detail": "expected match=false, got surfaced=false (score 0, threshold 30)"
-            },
-            {
-              "kind": "band",
-              "candidateId": "c-sam",
-              "passed": true,
-              "detail": "expected score in [0,29], got 0"
-            }
-          ]
-        },
-        {
-          "passed": true,
-          "assertions": [
-            {
-              "kind": "match",
-              "candidateId": "c-sam",
-              "passed": true,
-              "detail": "expected match=false, got surfaced=false (score 0, threshold 30)"
-            },
-            {
-              "kind": "band",
-              "candidateId": "c-sam",
-              "passed": true,
-              "detail": "expected score in [0,29], got 0"
-            }
-          ]
-        },
-        {
-          "passed": true,
-          "assertions": [
-            {
-              "kind": "match",
-              "candidateId": "c-sam",
-              "passed": true,
-              "detail": "expected match=false, got surfaced=false (score 0, threshold 30)"
-            },
-            {
-              "kind": "band",
-              "candidateId": "c-sam",
-              "passed": true,
-              "detail": "expected score in [0,29], got 0"
-            }
-          ]
-        }
-      ]
-    },
-    {
-      "caseId": "query_primary/founders-raising-seed-accepts-founder",
-      "rule": "query_primary",
-      "runs": 7,
-      "passes": 7,
-      "passRate": 1,
-      "flaky": false,
-      "runResults": [
-        {
-          "passed": true,
-          "assertions": [
-            {
-              "kind": "match",
-              "candidateId": "c-sam",
-              "passed": true,
-              "detail": "expected match=true, got surfaced=true (score 95, threshold 30)"
-            },
-            {
-              "kind": "band",
-              "candidateId": "c-sam",
-              "passed": true,
-              "detail": "expected score in [70,100], got 95"
-            }
-          ]
-        },
-        {
-          "passed": true,
-          "assertions": [
-            {
-              "kind": "match",
-              "candidateId": "c-sam",
-              "passed": true,
-              "detail": "expected match=true, got surfaced=true (score 95, threshold 30)"
-            },
-            {
-              "kind": "band",
-              "candidateId": "c-sam",
-              "passed": true,
-              "detail": "expected score in [70,100], got 95"
-            }
-          ]
-        },
-        {
-          "passed": true,
-          "assertions": [
-            {
-              "kind": "match",
-              "candidateId": "c-sam",
-              "passed": true,
-              "detail": "expected match=true, got surfaced=true (score 95, threshold 30)"
-            },
-            {
-              "kind": "band",
-              "candidateId": "c-sam",
-              "passed": true,
-              "detail": "expected score in [70,100], got 95"
-            }
-          ]
-        },
-        {
-          "passed": true,
-          "assertions": [
-            {
-              "kind": "match",
-              "candidateId": "c-sam",
-              "passed": true,
-              "detail": "expected match=true, got surfaced=true (score 95, threshold 30)"
-            },
-            {
-              "kind": "band",
-              "candidateId": "c-sam",
-              "passed": true,
-              "detail": "expected score in [70,100], got 95"
-            }
-          ]
-        },
-        {
-          "passed": true,
-          "assertions": [
-            {
-              "kind": "match",
-              "candidateId": "c-sam",
-              "passed": true,
-              "detail": "expected match=true, got surfaced=true (score 95, threshold 30)"
-            },
-            {
-              "kind": "band",
-              "candidateId": "c-sam",
-              "passed": true,
-              "detail": "expected score in [70,100], got 95"
-            }
-          ]
-        },
-        {
-          "passed": true,
-          "assertions": [
-            {
-              "kind": "match",
-              "candidateId": "c-sam",
-              "passed": true,
-              "detail": "expected match=true, got surfaced=true (score 95, threshold 30)"
-            },
-            {
-              "kind": "band",
-              "candidateId": "c-sam",
-              "passed": true,
-              "detail": "expected score in [70,100], got 95"
-            }
-          ]
-        },
-        {
-          "passed": true,
-          "assertions": [
-            {
-              "kind": "match",
-              "candidateId": "c-sam",
-              "passed": true,
-              "detail": "expected match=true, got surfaced=true (score 95, threshold 30)"
-            },
-            {
-              "kind": "band",
-              "candidateId": "c-sam",
-              "passed": true,
-              "detail": "expected score in [70,100], got 95"
-            }
-          ]
-        }
-      ]
-    },
-    {
-      "caseId": "query_primary/location-query-rejects-wrong-city",
-      "rule": "query_primary",
-      "runs": 7,
-      "passes": 7,
-      "passRate": 1,
-      "flaky": false,
-      "runResults": [
-        {
-          "passed": true,
-          "assertions": [
-            {
-              "kind": "match",
-              "candidateId": "c-berlin-unreal",
-              "passed": true,
-              "detail": "expected match=false, got surfaced=false (score 0, threshold 30)"
-            },
-            {
-              "kind": "band",
-              "candidateId": "c-berlin-unreal",
-              "passed": true,
-              "detail": "expected score in [0,29], got 0"
-            }
-          ]
-        },
-        {
-          "passed": true,
-          "assertions": [
-            {
-              "kind": "match",
-              "candidateId": "c-berlin-unreal",
-              "passed": true,
-              "detail": "expected match=false, got surfaced=false (score 0, threshold 30)"
-            },
-            {
-              "kind": "band",
-              "candidateId": "c-berlin-unreal",
-              "passed": true,
-              "detail": "expected score in [0,29], got 0"
-            }
-          ]
-        },
-        {
-          "passed": true,
-          "assertions": [
-            {
-              "kind": "match",
-              "candidateId": "c-berlin-unreal",
-              "passed": true,
-              "detail": "expected match=false, got surfaced=false (score 0, threshold 30)"
-            },
-            {
-              "kind": "band",
-              "candidateId": "c-berlin-unreal",
-              "passed": true,
-              "detail": "expected score in [0,29], got 0"
-            }
-          ]
-        },
-        {
-          "passed": true,
-          "assertions": [
-            {
-              "kind": "match",
-              "candidateId": "c-berlin-unreal",
-              "passed": true,
-              "detail": "expected match=false, got surfaced=false (score 0, threshold 30)"
-            },
-            {
-              "kind": "band",
-              "candidateId": "c-berlin-unreal",
-              "passed": true,
-              "detail": "expected score in [0,29], got 0"
-            }
-          ]
-        },
-        {
-          "passed": true,
-          "assertions": [
-            {
-              "kind": "match",
-              "candidateId": "c-berlin-unreal",
-              "passed": true,
-              "detail": "expected match=false, got surfaced=false (score 0, threshold 30)"
-            },
-            {
-              "kind": "band",
-              "candidateId": "c-berlin-unreal",
-              "passed": true,
-              "detail": "expected score in [0,29], got 0"
-            }
-          ]
-        },
-        {
-          "passed": true,
-          "assertions": [
-            {
-              "kind": "match",
-              "candidateId": "c-berlin-unreal",
-              "passed": true,
-              "detail": "expected match=false, got surfaced=false (score 0, threshold 30)"
-            },
-            {
-              "kind": "band",
-              "candidateId": "c-berlin-unreal",
-              "passed": true,
-              "detail": "expected score in [0,29], got 0"
-            }
-          ]
-        },
-        {
-          "passed": true,
-          "assertions": [
-            {
-              "kind": "match",
-              "candidateId": "c-berlin-unreal",
-              "passed": true,
-              "detail": "expected match=false, got surfaced=false (score 0, threshold 30)"
-            },
-            {
-              "kind": "band",
-              "candidateId": "c-berlin-unreal",
-              "passed": true,
-              "detail": "expected score in [0,29], got 0"
-            }
-          ]
-        }
-      ]
-    },
-    {
-      "caseId": "query_primary/vague-query-can-use-background-intent",
-      "rule": "query_primary",
-      "runs": 7,
-      "passes": 7,
-      "passRate": 1,
-      "flaky": false,
-      "runResults": [
-        {
-          "passed": true,
-          "assertions": [
-            {
-              "kind": "match",
-              "candidateId": "c-yuki",
-              "passed": true,
-              "detail": "expected match=true, got surfaced=true (score 95, threshold 30)"
-            },
-            {
-              "kind": "band",
-              "candidateId": "c-yuki",
-              "passed": true,
-              "detail": "expected score in [70,100], got 95"
-            }
-          ]
-        },
-        {
-          "passed": true,
-          "assertions": [
-            {
-              "kind": "match",
-              "candidateId": "c-yuki",
-              "passed": true,
-              "detail": "expected match=true, got surfaced=true (score 95, threshold 30)"
-            },
-            {
-              "kind": "band",
-              "candidateId": "c-yuki",
-              "passed": true,
-              "detail": "expected score in [70,100], got 95"
-            }
-          ]
-        },
-        {
-          "passed": true,
-          "assertions": [
-            {
-              "kind": "match",
-              "candidateId": "c-yuki",
-              "passed": true,
-              "detail": "expected match=true, got surfaced=true (score 85, threshold 30)"
-            },
-            {
-              "kind": "band",
-              "candidateId": "c-yuki",
-              "passed": true,
-              "detail": "expected score in [70,100], got 85"
-            }
-          ]
-        },
-        {
-          "passed": true,
-          "assertions": [
-            {
-              "kind": "match",
-              "candidateId": "c-yuki",
-              "passed": true,
-              "detail": "expected match=true, got surfaced=true (score 95, threshold 30)"
-            },
-            {
-              "kind": "band",
-              "candidateId": "c-yuki",
-              "passed": true,
-              "detail": "expected score in [70,100], got 95"
-            }
-          ]
-        },
-        {
-          "passed": true,
-          "assertions": [
-            {
-              "kind": "match",
-              "candidateId": "c-yuki",
-              "passed": true,
-              "detail": "expected match=true, got surfaced=true (score 90, threshold 30)"
-            },
-            {
-              "kind": "band",
-              "candidateId": "c-yuki",
-              "passed": true,
-              "detail": "expected score in [70,100], got 90"
-            }
-          ]
-        },
-        {
-          "passed": true,
-          "assertions": [
-            {
-              "kind": "match",
-              "candidateId": "c-yuki",
-              "passed": true,
-              "detail": "expected match=true, got surfaced=true (score 95, threshold 30)"
-            },
-            {
-              "kind": "band",
-              "candidateId": "c-yuki",
-              "passed": true,
-              "detail": "expected score in [70,100], got 95"
-            }
-          ]
-        },
-        {
-          "passed": true,
-          "assertions": [
-            {
-              "kind": "match",
-              "candidateId": "c-yuki",
-              "passed": true,
-              "detail": "expected match=true, got surfaced=true (score 90, threshold 30)"
-            },
-            {
-              "kind": "band",
-              "candidateId": "c-yuki",
-              "passed": true,
-              "detail": "expected score in [70,100], got 90"
-            }
-          ]
-        }
-      ]
-    },
-    {
-      "caseId": "query_primary/scouts-query-rejects-scouted-athlete",
-      "rule": "query_primary",
-      "runs": 7,
-      "passes": 7,
-      "passRate": 1,
-      "flaky": false,
-      "runResults": [
-        {
-          "passed": true,
-          "assertions": [
-            {
-              "kind": "match",
-              "candidateId": "c-athlete",
-              "passed": true,
-              "detail": "expected match=false, got surfaced=false (score 0, threshold 30)"
-            },
-            {
-              "kind": "band",
-              "candidateId": "c-athlete",
-              "passed": true,
-              "detail": "expected score in [0,29], got 0"
-            }
-          ]
-        },
-        {
-          "passed": true,
-          "assertions": [
-            {
-              "kind": "match",
-              "candidateId": "c-athlete",
-              "passed": true,
-              "detail": "expected match=false, got surfaced=false (score 0, threshold 30)"
-            },
-            {
-              "kind": "band",
-              "candidateId": "c-athlete",
-              "passed": true,
-              "detail": "expected score in [0,29], got 0"
-            }
-          ]
-        },
-        {
-          "passed": true,
-          "assertions": [
-            {
-              "kind": "match",
-              "candidateId": "c-athlete",
-              "passed": true,
-              "detail": "expected match=false, got surfaced=false (score 0, threshold 30)"
-            },
-            {
-              "kind": "band",
-              "candidateId": "c-athlete",
-              "passed": true,
-              "detail": "expected score in [0,29], got 0"
-            }
-          ]
-        },
-        {
-          "passed": true,
-          "assertions": [
-            {
-              "kind": "match",
-              "candidateId": "c-athlete",
-              "passed": true,
-              "detail": "expected match=false, got surfaced=false (score 0, threshold 30)"
-            },
-            {
-              "kind": "band",
-              "candidateId": "c-athlete",
-              "passed": true,
-              "detail": "expected score in [0,29], got 0"
-            }
-          ]
-        },
-        {
-          "passed": true,
-          "assertions": [
-            {
-              "kind": "match",
-              "candidateId": "c-athlete",
-              "passed": true,
-              "detail": "expected match=false, got surfaced=false (score 0, threshold 30)"
-            },
-            {
-              "kind": "band",
-              "candidateId": "c-athlete",
-              "passed": true,
-              "detail": "expected score in [0,29], got 0"
-            }
-          ]
-        },
-        {
-          "passed": true,
-          "assertions": [
-            {
-              "kind": "match",
-              "candidateId": "c-athlete",
-              "passed": true,
-              "detail": "expected match=false, got surfaced=false (score 0, threshold 30)"
-            },
-            {
-              "kind": "band",
-              "candidateId": "c-athlete",
-              "passed": true,
-              "detail": "expected score in [0,29], got 0"
-            }
-          ]
-        },
-        {
-          "passed": true,
-          "assertions": [
-            {
-              "kind": "match",
-              "candidateId": "c-athlete",
-              "passed": true,
-              "detail": "expected match=false, got surfaced=false (score 0, threshold 30)"
-            },
-            {
-              "kind": "band",
-              "candidateId": "c-athlete",
-              "passed": true,
-              "detail": "expected score in [0,29], got 0"
-            }
-          ]
-        }
-      ]
-    },
-    {
-      "caseId": "complementary_role/vc-for-cofounder-intent",
-      "rule": "complementary_role",
-      "runs": 7,
-      "passes": 7,
-      "passRate": 1,
-      "flaky": false,
-      "runResults": [
-        {
-          "passed": true,
-          "assertions": [
-            {
-              "kind": "match",
-              "candidateId": "p-vc",
-              "passed": true,
-              "detail": "expected match=false, got surfaced=false (score 0, threshold 30)"
-            },
-            {
-              "kind": "band",
-              "candidateId": "p-vc",
-              "passed": true,
-              "detail": "expected score in [0,29], got 0"
-            }
-          ]
-        },
-        {
-          "passed": true,
-          "assertions": [
-            {
-              "kind": "match",
-              "candidateId": "p-vc",
-              "passed": true,
-              "detail": "expected match=false, got surfaced=false (score 0, threshold 30)"
-            },
-            {
-              "kind": "band",
-              "candidateId": "p-vc",
-              "passed": true,
-              "detail": "expected score in [0,29], got 0"
-            }
-          ]
-        },
-        {
-          "passed": true,
-          "assertions": [
-            {
-              "kind": "match",
-              "candidateId": "p-vc",
-              "passed": true,
-              "detail": "expected match=false, got surfaced=false (score 0, threshold 30)"
-            },
-            {
-              "kind": "band",
-              "candidateId": "p-vc",
-              "passed": true,
-              "detail": "expected score in [0,29], got 0"
-            }
-          ]
-        },
-        {
-          "passed": true,
-          "assertions": [
-            {
-              "kind": "match",
-              "candidateId": "p-vc",
-              "passed": true,
-              "detail": "expected match=false, got surfaced=false (score 0, threshold 30)"
-            },
-            {
-              "kind": "band",
-              "candidateId": "p-vc",
-              "passed": true,
-              "detail": "expected score in [0,29], got 0"
-            }
-          ]
-        },
-        {
-          "passed": true,
-          "assertions": [
-            {
-              "kind": "match",
-              "candidateId": "p-vc",
-              "passed": true,
-              "detail": "expected match=false, got surfaced=false (score 0, threshold 30)"
-            },
-            {
-              "kind": "band",
-              "candidateId": "p-vc",
-              "passed": true,
-              "detail": "expected score in [0,29], got 0"
-            }
-          ]
-        },
-        {
-          "passed": true,
-          "assertions": [
-            {
-              "kind": "match",
-              "candidateId": "p-vc",
-              "passed": true,
-              "detail": "expected match=false, got surfaced=false (score 0, threshold 30)"
-            },
-            {
-              "kind": "band",
-              "candidateId": "p-vc",
-              "passed": true,
-              "detail": "expected score in [0,29], got 0"
-            }
-          ]
-        },
-        {
-          "passed": true,
-          "assertions": [
-            {
-              "kind": "match",
-              "candidateId": "p-vc",
-              "passed": true,
-              "detail": "expected match=false, got surfaced=false (score 0, threshold 30)"
-            },
-            {
-              "kind": "band",
-              "candidateId": "p-vc",
-              "passed": true,
-              "detail": "expected score in [0,29], got 0"
-            }
-          ]
-        }
-      ]
-    },
-    {
-      "caseId": "complementary_role/engineer-for-cofounder-intent",
-      "rule": "complementary_role",
-      "runs": 7,
-      "passes": 7,
-      "passRate": 1,
-      "flaky": false,
-      "runResults": [
-        {
-          "passed": true,
-          "assertions": [
-            {
-              "kind": "match",
-              "candidateId": "p-tech-cofounder",
-              "passed": true,
-              "detail": "expected match=true, got surfaced=true (score 98, threshold 30)"
-            },
-            {
-              "kind": "band",
-              "candidateId": "p-tech-cofounder",
-              "passed": true,
-              "detail": "expected score in [70,100], got 98"
-            },
-            {
-              "kind": "role",
-              "candidateId": "p-tech-cofounder",
-              "passed": true,
-              "detail": "expected role=agent, got agent"
-            }
-          ]
-        },
-        {
-          "passed": true,
-          "assertions": [
-            {
-              "kind": "match",
-              "candidateId": "p-tech-cofounder",
-              "passed": true,
-              "detail": "expected match=true, got surfaced=true (score 98, threshold 30)"
-            },
-            {
-              "kind": "band",
-              "candidateId": "p-tech-cofounder",
-              "passed": true,
-              "detail": "expected score in [70,100], got 98"
-            },
-            {
-              "kind": "role",
-              "candidateId": "p-tech-cofounder",
-              "passed": true,
-              "detail": "expected role=agent, got agent"
-            }
-          ]
-        },
-        {
-          "passed": true,
-          "assertions": [
-            {
-              "kind": "match",
-              "candidateId": "p-tech-cofounder",
-              "passed": true,
-              "detail": "expected match=true, got surfaced=true (score 98, threshold 30)"
-            },
-            {
-              "kind": "band",
-              "candidateId": "p-tech-cofounder",
-              "passed": true,
-              "detail": "expected score in [70,100], got 98"
-            },
-            {
-              "kind": "role",
-              "candidateId": "p-tech-cofounder",
-              "passed": true,
-              "detail": "expected role=agent, got agent"
-            }
-          ]
-        },
-        {
-          "passed": true,
-          "assertions": [
-            {
-              "kind": "match",
-              "candidateId": "p-tech-cofounder",
-              "passed": true,
-              "detail": "expected match=true, got surfaced=true (score 98, threshold 30)"
-            },
-            {
-              "kind": "band",
-              "candidateId": "p-tech-cofounder",
-              "passed": true,
-              "detail": "expected score in [70,100], got 98"
-            },
-            {
-              "kind": "role",
-              "candidateId": "p-tech-cofounder",
-              "passed": true,
-              "detail": "expected role=agent, got agent"
-            }
-          ]
-        },
-        {
-          "passed": true,
-          "assertions": [
-            {
-              "kind": "match",
-              "candidateId": "p-tech-cofounder",
-              "passed": true,
-              "detail": "expected match=true, got surfaced=true (score 98, threshold 30)"
-            },
-            {
-              "kind": "band",
-              "candidateId": "p-tech-cofounder",
-              "passed": true,
-              "detail": "expected score in [70,100], got 98"
-            },
-            {
-              "kind": "role",
-              "candidateId": "p-tech-cofounder",
-              "passed": true,
-              "detail": "expected role=agent, got agent"
-            }
-          ]
-        },
-        {
-          "passed": true,
-          "assertions": [
-            {
-              "kind": "match",
-              "candidateId": "p-tech-cofounder",
-              "passed": true,
-              "detail": "expected match=true, got surfaced=true (score 98, threshold 30)"
-            },
-            {
-              "kind": "band",
-              "candidateId": "p-tech-cofounder",
-              "passed": true,
-              "detail": "expected score in [70,100], got 98"
-            },
-            {
-              "kind": "role",
-              "candidateId": "p-tech-cofounder",
-              "passed": true,
-              "detail": "expected role=agent, got agent"
-            }
-          ]
-        },
-        {
-          "passed": true,
-          "assertions": [
-            {
-              "kind": "match",
-              "candidateId": "p-tech-cofounder",
-              "passed": true,
-              "detail": "expected match=true, got surfaced=true (score 98, threshold 30)"
-            },
-            {
-              "kind": "band",
-              "candidateId": "p-tech-cofounder",
-              "passed": true,
-              "detail": "expected score in [70,100], got 98"
-            },
-            {
-              "kind": "role",
-              "candidateId": "p-tech-cofounder",
-              "passed": true,
-              "detail": "expected role=agent, got agent"
-            }
-          ]
-        }
-      ]
-    },
-    {
-      "caseId": "same_side/both-seeking-investors",
-      "rule": "same_side",
-      "runs": 7,
-      "passes": 7,
-      "passRate": 1,
-      "flaky": false,
-      "runResults": [
-        {
-          "passed": true,
-          "assertions": [
-            {
-              "kind": "match",
-              "candidateId": "c-raising",
-              "passed": true,
-              "detail": "expected match=false, got surfaced=false (score 0, threshold 30)"
-            },
-            {
-              "kind": "band",
-              "candidateId": "c-raising",
-              "passed": true,
-              "detail": "expected score in [0,29], got 0"
-            }
-          ]
-        },
-        {
-          "passed": true,
-          "assertions": [
-            {
-              "kind": "match",
-              "candidateId": "c-raising",
-              "passed": true,
-              "detail": "expected match=false, got surfaced=false (score 0, threshold 30)"
-            },
-            {
-              "kind": "band",
-              "candidateId": "c-raising",
-              "passed": true,
-              "detail": "expected score in [0,29], got 0"
-            }
-          ]
-        },
-        {
-          "passed": true,
-          "assertions": [
-            {
-              "kind": "match",
-              "candidateId": "c-raising",
-              "passed": true,
-              "detail": "expected match=false, got surfaced=false (score 0, threshold 30)"
-            },
-            {
-              "kind": "band",
-              "candidateId": "c-raising",
-              "passed": true,
-              "detail": "expected score in [0,29], got 0"
-            }
-          ]
-        },
-        {
-          "passed": true,
-          "assertions": [
-            {
-              "kind": "match",
-              "candidateId": "c-raising",
-              "passed": true,
-              "detail": "expected match=false, got surfaced=false (score 0, threshold 30)"
-            },
-            {
-              "kind": "band",
-              "candidateId": "c-raising",
-              "passed": true,
-              "detail": "expected score in [0,29], got 0"
-            }
-          ]
-        },
-        {
-          "passed": true,
-          "assertions": [
-            {
-              "kind": "match",
-              "candidateId": "c-raising",
-              "passed": true,
-              "detail": "expected match=false, got surfaced=false (score 0, threshold 30)"
-            },
-            {
-              "kind": "band",
-              "candidateId": "c-raising",
-              "passed": true,
-              "detail": "expected score in [0,29], got 0"
-            }
-          ]
-        },
-        {
-          "passed": true,
-          "assertions": [
-            {
-              "kind": "match",
-              "candidateId": "c-raising",
-              "passed": true,
-              "detail": "expected match=false, got surfaced=false (score 0, threshold 30)"
-            },
-            {
-              "kind": "band",
-              "candidateId": "c-raising",
-              "passed": true,
-              "detail": "expected score in [0,29], got 0"
-            }
-          ]
-        },
-        {
-          "passed": true,
-          "assertions": [
-            {
-              "kind": "match",
-              "candidateId": "c-raising",
-              "passed": true,
-              "detail": "expected match=false, got surfaced=false (score 0, threshold 30)"
-            },
-            {
-              "kind": "band",
-              "candidateId": "c-raising",
-              "passed": true,
-              "detail": "expected score in [0,29], got 0"
-            }
-          ]
-        }
-      ]
-    },
-    {
-      "caseId": "already_known/same-company-cofounders",
-      "rule": "already_known",
-      "runs": 7,
-      "passes": 7,
-      "passRate": 1,
-      "flaky": false,
-      "runResults": [
-        {
-          "passed": true,
-          "assertions": [
-            {
-              "kind": "match",
-              "candidateId": "c-acme",
-              "passed": true,
-              "detail": "expected match=false, got surfaced=false (score 0, threshold 30)"
-            },
-            {
-              "kind": "band",
-              "candidateId": "c-acme",
-              "passed": true,
-              "detail": "expected score in [0,29], got 0"
-            }
-          ]
-        },
-        {
-          "passed": true,
-          "assertions": [
-            {
-              "kind": "match",
-              "candidateId": "c-acme",
-              "passed": true,
-              "detail": "expected match=false, got surfaced=false (score 0, threshold 30)"
-            },
-            {
-              "kind": "band",
-              "candidateId": "c-acme",
-              "passed": true,
-              "detail": "expected score in [0,29], got 0"
-            }
-          ]
-        },
-        {
-          "passed": true,
-          "assertions": [
-            {
-              "kind": "match",
-              "candidateId": "c-acme",
-              "passed": true,
-              "detail": "expected match=false, got surfaced=false (score 0, threshold 30)"
-            },
-            {
-              "kind": "band",
-              "candidateId": "c-acme",
-              "passed": true,
-              "detail": "expected score in [0,29], got 0"
-            }
-          ]
-        },
-        {
-          "passed": true,
-          "assertions": [
-            {
-              "kind": "match",
-              "candidateId": "c-acme",
-              "passed": true,
-              "detail": "expected match=false, got surfaced=false (score 0, threshold 30)"
-            },
-            {
-              "kind": "band",
-              "candidateId": "c-acme",
-              "passed": true,
-              "detail": "expected score in [0,29], got 0"
-            }
-          ]
-        },
-        {
-          "passed": true,
-          "assertions": [
-            {
-              "kind": "match",
-              "candidateId": "c-acme",
-              "passed": true,
-              "detail": "expected match=false, got surfaced=false (score 0, threshold 30)"
-            },
-            {
-              "kind": "band",
-              "candidateId": "c-acme",
-              "passed": true,
-              "detail": "expected score in [0,29], got 0"
-            }
-          ]
-        },
-        {
-          "passed": true,
-          "assertions": [
-            {
-              "kind": "match",
-              "candidateId": "c-acme",
-              "passed": true,
-              "detail": "expected match=false, got surfaced=false (score 0, threshold 30)"
-            },
-            {
-              "kind": "band",
-              "candidateId": "c-acme",
-              "passed": true,
-              "detail": "expected score in [0,29], got 0"
-            }
-          ]
-        },
-        {
-          "passed": true,
-          "assertions": [
-            {
-              "kind": "match",
-              "candidateId": "c-acme",
-              "passed": true,
-              "detail": "expected match=false, got surfaced=false (score 0, threshold 30)"
-            },
-            {
-              "kind": "band",
-              "candidateId": "c-acme",
-              "passed": true,
-              "detail": "expected score in [0,29], got 0"
-            }
-          ]
-        }
-      ]
-    },
-    {
-      "caseId": "location/known-mismatch-penalized",
-      "rule": "location",
-      "runs": 7,
-      "passes": 7,
-      "passRate": 1,
-      "flaky": false,
-      "runResults": [
-        {
-          "passed": true,
-          "assertions": [
-            {
-              "kind": "match",
-              "candidateId": "c-ny",
-              "passed": true,
-              "detail": "expected match=false, got surfaced=false (score 0, threshold 30)"
-            },
-            {
-              "kind": "band",
-              "candidateId": "c-ny",
-              "passed": true,
-              "detail": "expected score in [0,29], got 0"
-            }
-          ]
-        },
-        {
-          "passed": true,
-          "assertions": [
-            {
-              "kind": "match",
-              "candidateId": "c-ny",
-              "passed": true,
-              "detail": "expected match=false, got surfaced=false (score 0, threshold 30)"
-            },
-            {
-              "kind": "band",
-              "candidateId": "c-ny",
-              "passed": true,
-              "detail": "expected score in [0,29], got 0"
-            }
-          ]
-        },
-        {
-          "passed": true,
-          "assertions": [
-            {
-              "kind": "match",
-              "candidateId": "c-ny",
-              "passed": true,
-              "detail": "expected match=false, got surfaced=false (score 0, threshold 30)"
-            },
-            {
-              "kind": "band",
-              "candidateId": "c-ny",
-              "passed": true,
-              "detail": "expected score in [0,29], got 0"
-            }
-          ]
-        },
-        {
-          "passed": true,
-          "assertions": [
-            {
-              "kind": "match",
-              "candidateId": "c-ny",
-              "passed": true,
-              "detail": "expected match=false, got surfaced=false (score 0, threshold 30)"
-            },
-            {
-              "kind": "band",
-              "candidateId": "c-ny",
-              "passed": true,
-              "detail": "expected score in [0,29], got 0"
-            }
-          ]
-        },
-        {
-          "passed": true,
-          "assertions": [
-            {
-              "kind": "match",
-              "candidateId": "c-ny",
-              "passed": true,
-              "detail": "expected match=false, got surfaced=false (score 0, threshold 30)"
-            },
-            {
-              "kind": "band",
-              "candidateId": "c-ny",
-              "passed": true,
-              "detail": "expected score in [0,29], got 0"
-            }
-          ]
-        },
-        {
-          "passed": true,
-          "assertions": [
-            {
-              "kind": "match",
-              "candidateId": "c-ny",
-              "passed": true,
-              "detail": "expected match=false, got surfaced=false (score 0, threshold 30)"
-            },
-            {
-              "kind": "band",
-              "candidateId": "c-ny",
-              "passed": true,
-              "detail": "expected score in [0,29], got 0"
-            }
-          ]
-        },
-        {
-          "passed": true,
-          "assertions": [
-            {
-              "kind": "match",
-              "candidateId": "c-ny",
-              "passed": true,
-              "detail": "expected match=false, got surfaced=false (score 0, threshold 30)"
-            },
-            {
-              "kind": "band",
-              "candidateId": "c-ny",
-              "passed": true,
-              "detail": "expected score in [0,29], got 0"
-            }
-          ]
-        }
-      ]
-    },
-    {
-      "caseId": "location/unknown-not-penalized",
-      "rule": "location",
-      "runs": 7,
-      "passes": 7,
-      "passRate": 1,
-      "flaky": false,
-      "runResults": [
-        {
-          "passed": true,
-          "assertions": [
-            {
-              "kind": "match",
-              "candidateId": "c-unknown",
-              "passed": true,
-              "detail": "expected match=true, got surfaced=true (score 80, threshold 30)"
-            },
-            {
-              "kind": "band",
-              "candidateId": "c-unknown",
-              "passed": true,
-              "detail": "expected score in [60,100], got 80"
-            }
-          ]
-        },
-        {
-          "passed": true,
-          "assertions": [
-            {
-              "kind": "match",
-              "candidateId": "c-unknown",
-              "passed": true,
-              "detail": "expected match=true, got surfaced=true (score 85, threshold 30)"
-            },
-            {
-              "kind": "band",
-              "candidateId": "c-unknown",
-              "passed": true,
-              "detail": "expected score in [60,100], got 85"
-            }
-          ]
-        },
-        {
-          "passed": true,
-          "assertions": [
-            {
-              "kind": "match",
-              "candidateId": "c-unknown",
-              "passed": true,
-              "detail": "expected match=true, got surfaced=true (score 80, threshold 30)"
-            },
-            {
-              "kind": "band",
-              "candidateId": "c-unknown",
-              "passed": true,
-              "detail": "expected score in [60,100], got 80"
-            }
-          ]
-        },
-        {
-          "passed": true,
-          "assertions": [
-            {
-              "kind": "match",
-              "candidateId": "c-unknown",
-              "passed": true,
-              "detail": "expected match=true, got surfaced=true (score 85, threshold 30)"
-            },
-            {
-              "kind": "band",
-              "candidateId": "c-unknown",
-              "passed": true,
-              "detail": "expected score in [60,100], got 85"
-            }
-          ]
-        },
-        {
-          "passed": true,
-          "assertions": [
-            {
-              "kind": "match",
-              "candidateId": "c-unknown",
-              "passed": true,
-              "detail": "expected match=true, got surfaced=true (score 85, threshold 30)"
-            },
-            {
-              "kind": "band",
-              "candidateId": "c-unknown",
-              "passed": true,
-              "detail": "expected score in [60,100], got 85"
-            }
-          ]
-        },
-        {
-          "passed": true,
-          "assertions": [
-            {
-              "kind": "match",
-              "candidateId": "c-unknown",
-              "passed": true,
-              "detail": "expected match=true, got surfaced=true (score 80, threshold 30)"
-            },
-            {
-              "kind": "band",
-              "candidateId": "c-unknown",
-              "passed": true,
-              "detail": "expected score in [60,100], got 80"
-            }
-          ]
-        },
-        {
-          "passed": true,
-          "assertions": [
-            {
-              "kind": "match",
-              "candidateId": "c-unknown",
-              "passed": true,
-              "detail": "expected match=true, got surfaced=true (score 80, threshold 30)"
-            },
-            {
-              "kind": "band",
-              "candidateId": "c-unknown",
-              "passed": true,
-              "detail": "expected score in [60,100], got 80"
-            }
-          ]
-        }
-      ]
-    },
-    {
-      "caseId": "valency_role/seeker-gets-patient-provider-gets-agent",
-      "rule": "valency_role",
-      "runs": 7,
-      "passes": 7,
-      "passRate": 1,
-      "flaky": false,
-      "runResults": [
-        {
-          "passed": true,
-          "assertions": [
-            {
-              "kind": "match",
-              "candidateId": "c-ml",
-              "passed": true,
-              "detail": "expected match=true, got surfaced=true (score 98, threshold 30)"
-            },
-            {
-              "kind": "band",
-              "candidateId": "c-ml",
-              "passed": true,
-              "detail": "expected score in [70,100], got 98"
-            },
-            {
-              "kind": "role",
-              "candidateId": "c-ml",
-              "passed": true,
-              "detail": "expected role=agent, got agent"
-            }
-          ]
-        },
-        {
-          "passed": true,
-          "assertions": [
-            {
-              "kind": "match",
-              "candidateId": "c-ml",
-              "passed": true,
-              "detail": "expected match=true, got surfaced=true (score 98, threshold 30)"
-            },
-            {
-              "kind": "band",
-              "candidateId": "c-ml",
-              "passed": true,
-              "detail": "expected score in [70,100], got 98"
-            },
-            {
-              "kind": "role",
-              "candidateId": "c-ml",
-              "passed": true,
-              "detail": "expected role=agent, got agent"
-            }
-          ]
-        },
-        {
-          "passed": true,
-          "assertions": [
-            {
-              "kind": "match",
-              "candidateId": "c-ml",
-              "passed": true,
-              "detail": "expected match=true, got surfaced=true (score 98, threshold 30)"
-            },
-            {
-              "kind": "band",
-              "candidateId": "c-ml",
-              "passed": true,
-              "detail": "expected score in [70,100], got 98"
-            },
-            {
-              "kind": "role",
-              "candidateId": "c-ml",
-              "passed": true,
-              "detail": "expected role=agent, got agent"
-            }
-          ]
-        },
-        {
-          "passed": true,
-          "assertions": [
-            {
-              "kind": "match",
-              "candidateId": "c-ml",
-              "passed": true,
-              "detail": "expected match=true, got surfaced=true (score 98, threshold 30)"
-            },
-            {
-              "kind": "band",
-              "candidateId": "c-ml",
-              "passed": true,
-              "detail": "expected score in [70,100], got 98"
-            },
-            {
-              "kind": "role",
-              "candidateId": "c-ml",
-              "passed": true,
-              "detail": "expected role=agent, got agent"
-            }
-          ]
-        },
-        {
-          "passed": true,
-          "assertions": [
-            {
-              "kind": "match",
-              "candidateId": "c-ml",
-              "passed": true,
-              "detail": "expected match=true, got surfaced=true (score 98, threshold 30)"
-            },
-            {
-              "kind": "band",
-              "candidateId": "c-ml",
-              "passed": true,
-              "detail": "expected score in [70,100], got 98"
-            },
-            {
-              "kind": "role",
-              "candidateId": "c-ml",
-              "passed": true,
-              "detail": "expected role=agent, got agent"
-            }
-          ]
-        },
-        {
-          "passed": true,
-          "assertions": [
-            {
-              "kind": "match",
-              "candidateId": "c-ml",
-              "passed": true,
-              "detail": "expected match=true, got surfaced=true (score 98, threshold 30)"
-            },
-            {
-              "kind": "band",
-              "candidateId": "c-ml",
-              "passed": true,
-              "detail": "expected score in [70,100], got 98"
-            },
-            {
-              "kind": "role",
-              "candidateId": "c-ml",
-              "passed": true,
-              "detail": "expected role=agent, got agent"
-            }
-          ]
-        },
-        {
-          "passed": true,
-          "assertions": [
-            {
-              "kind": "match",
-              "candidateId": "c-ml",
-              "passed": true,
-              "detail": "expected match=true, got surfaced=true (score 98, threshold 30)"
-            },
-            {
-              "kind": "band",
-              "candidateId": "c-ml",
-              "passed": true,
-              "detail": "expected score in [70,100], got 98"
-            },
-            {
-              "kind": "role",
-              "candidateId": "c-ml",
-              "passed": true,
-              "detail": "expected role=agent, got agent"
-            }
-          ]
-        }
-      ]
-    },
-    {
-      "caseId": "score_calibration/must-meet-primary-role",
-      "rule": "score_calibration",
-      "runs": 7,
-      "passes": 7,
-      "passRate": 1,
-      "flaky": false,
-      "runResults": [
-        {
-          "passed": true,
-          "assertions": [
-            {
-              "kind": "match",
-              "candidateId": "c-aiml",
-              "passed": true,
-              "detail": "expected match=true, got surfaced=true (score 98, threshold 30)"
-            },
-            {
-              "kind": "band",
-              "candidateId": "c-aiml",
-              "passed": true,
-              "detail": "expected score in [85,100], got 98"
-            }
-          ]
-        },
-        {
-          "passed": true,
-          "assertions": [
-            {
-              "kind": "match",
-              "candidateId": "c-aiml",
-              "passed": true,
-              "detail": "expected match=true, got surfaced=true (score 98, threshold 30)"
-            },
-            {
-              "kind": "band",
-              "candidateId": "c-aiml",
-              "passed": true,
-              "detail": "expected score in [85,100], got 98"
-            }
-          ]
-        },
-        {
-          "passed": true,
-          "assertions": [
-            {
-              "kind": "match",
-              "candidateId": "c-aiml",
-              "passed": true,
-              "detail": "expected match=true, got surfaced=true (score 98, threshold 30)"
-            },
-            {
-              "kind": "band",
-              "candidateId": "c-aiml",
-              "passed": true,
-              "detail": "expected score in [85,100], got 98"
-            }
-          ]
-        },
-        {
-          "passed": true,
-          "assertions": [
-            {
-              "kind": "match",
-              "candidateId": "c-aiml",
-              "passed": true,
-              "detail": "expected match=true, got surfaced=true (score 98, threshold 30)"
-            },
-            {
-              "kind": "band",
-              "candidateId": "c-aiml",
-              "passed": true,
-              "detail": "expected score in [85,100], got 98"
-            }
-          ]
-        },
-        {
-          "passed": true,
-          "assertions": [
-            {
-              "kind": "match",
-              "candidateId": "c-aiml",
-              "passed": true,
-              "detail": "expected match=true, got surfaced=true (score 95, threshold 30)"
-            },
-            {
-              "kind": "band",
-              "candidateId": "c-aiml",
-              "passed": true,
-              "detail": "expected score in [85,100], got 95"
-            }
-          ]
-        },
-        {
-          "passed": true,
-          "assertions": [
-            {
-              "kind": "match",
-              "candidateId": "c-aiml",
-              "passed": true,
-              "detail": "expected match=true, got surfaced=true (score 98, threshold 30)"
-            },
-            {
-              "kind": "band",
-              "candidateId": "c-aiml",
-              "passed": true,
-              "detail": "expected score in [85,100], got 98"
-            }
-          ]
-        },
-        {
-          "passed": true,
-          "assertions": [
-            {
-              "kind": "match",
-              "candidateId": "c-aiml",
-              "passed": true,
-              "detail": "expected match=true, got surfaced=true (score 98, threshold 30)"
-            },
-            {
-              "kind": "band",
-              "candidateId": "c-aiml",
-              "passed": true,
-              "detail": "expected score in [85,100], got 98"
-            }
-          ]
-        }
-      ]
-    },
-    {
-      "caseId": "event_network/co-attendance-theme-lift",
-      "rule": "event_network",
-      "runs": 7,
-      "passes": 7,
-      "passRate": 1,
-      "flaky": false,
-      "runResults": [
-        {
-          "passed": true,
-          "assertions": [
-            {
-              "kind": "match",
-              "candidateId": "c-attendee",
-              "passed": true,
-              "detail": "expected match=true, got surfaced=true (score 95, threshold 30)"
-            },
-            {
-              "kind": "band",
-              "candidateId": "c-attendee",
-              "passed": true,
-              "detail": "expected score in [70,100], got 95"
-            },
-            {
-              "kind": "role",
-              "candidateId": "c-attendee",
-              "passed": true,
-              "detail": "expected role=peer, got peer"
-            }
-          ]
-        },
-        {
-          "passed": true,
-          "assertions": [
-            {
-              "kind": "match",
-              "candidateId": "c-attendee",
-              "passed": true,
-              "detail": "expected match=true, got surfaced=true (score 95, threshold 30)"
-            },
-            {
-              "kind": "band",
-              "candidateId": "c-attendee",
-              "passed": true,
-              "detail": "expected score in [70,100], got 95"
-            },
-            {
-              "kind": "role",
-              "candidateId": "c-attendee",
-              "passed": true,
-              "detail": "expected role=peer, got peer"
-            }
-          ]
-        },
-        {
-          "passed": true,
-          "assertions": [
-            {
-              "kind": "match",
-              "candidateId": "c-attendee",
-              "passed": true,
-              "detail": "expected match=true, got surfaced=true (score 98, threshold 30)"
-            },
-            {
-              "kind": "band",
-              "candidateId": "c-attendee",
-              "passed": true,
-              "detail": "expected score in [70,100], got 98"
-            },
-            {
-              "kind": "role",
-              "candidateId": "c-attendee",
-              "passed": true,
-              "detail": "expected role=peer, got peer"
-            }
-          ]
-        },
-        {
-          "passed": true,
-          "assertions": [
-            {
-              "kind": "match",
-              "candidateId": "c-attendee",
-              "passed": true,
-              "detail": "expected match=true, got surfaced=true (score 98, threshold 30)"
-            },
-            {
-              "kind": "band",
-              "candidateId": "c-attendee",
-              "passed": true,
-              "detail": "expected score in [70,100], got 98"
-            },
-            {
-              "kind": "role",
-              "candidateId": "c-attendee",
-              "passed": true,
-              "detail": "expected role=peer, got peer"
-            }
-          ]
-        },
-        {
-          "passed": true,
-          "assertions": [
-            {
-              "kind": "match",
-              "candidateId": "c-attendee",
-              "passed": true,
-              "detail": "expected match=true, got surfaced=true (score 95, threshold 30)"
-            },
-            {
-              "kind": "band",
-              "candidateId": "c-attendee",
-              "passed": true,
-              "detail": "expected score in [70,100], got 95"
-            },
-            {
-              "kind": "role",
-              "candidateId": "c-attendee",
-              "passed": true,
-              "detail": "expected role=peer, got peer"
-            }
-          ]
-        },
-        {
-          "passed": true,
-          "assertions": [
-            {
-              "kind": "match",
-              "candidateId": "c-attendee",
-              "passed": true,
-              "detail": "expected match=true, got surfaced=true (score 98, threshold 30)"
-            },
-            {
-              "kind": "band",
-              "candidateId": "c-attendee",
-              "passed": true,
-              "detail": "expected score in [70,100], got 98"
-            },
-            {
-              "kind": "role",
-              "candidateId": "c-attendee",
-              "passed": true,
-              "detail": "expected role=peer, got peer"
-            }
-          ]
-        },
-        {
-          "passed": true,
-          "assertions": [
-            {
-              "kind": "match",
-              "candidateId": "c-attendee",
-              "passed": true,
-              "detail": "expected match=true, got surfaced=true (score 95, threshold 30)"
-            },
-            {
-              "kind": "band",
-              "candidateId": "c-attendee",
-              "passed": true,
-              "detail": "expected score in [70,100], got 95"
-            },
-            {
-              "kind": "role",
-              "candidateId": "c-attendee",
-              "passed": true,
-              "detail": "expected role=peer, got peer"
-            }
-          ]
-        }
-      ]
-    },
-    {
-      "caseId": "score_calibration/tier2-cofounder-pool",
-      "rule": "score_calibration",
-      "runs": 7,
-      "passes": 7,
-      "passRate": 1,
-      "flaky": false,
-      "runResults": [
-        {
-          "passed": true,
-          "assertions": [
-            {
-              "kind": "match",
-              "candidateId": "p-tech-cofounder",
-              "passed": true,
-              "detail": "expected match=true, got surfaced=true (score 98, threshold 30)"
-            },
-            {
-              "kind": "band",
-              "candidateId": "p-tech-cofounder",
-              "passed": true,
-              "detail": "expected score in [70,100], got 98"
-            },
-            {
-              "kind": "match",
-              "candidateId": "p-vc",
-              "passed": true,
-              "detail": "expected match=false, got surfaced=false (score 0, threshold 30)"
-            },
-            {
-              "kind": "band",
-              "candidateId": "p-vc",
-              "passed": true,
-              "detail": "expected score in [0,29], got 0"
-            },
-            {
-              "kind": "match",
-              "candidateId": "p-designer",
-              "passed": true,
-              "detail": "expected match=false, got surfaced=false (score 0, threshold 30)"
-            },
-            {
-              "kind": "band",
-              "candidateId": "p-designer",
-              "passed": true,
-              "detail": "expected score in [0,29], got 0"
-            }
-          ]
-        },
-        {
-          "passed": true,
-          "assertions": [
-            {
-              "kind": "match",
-              "candidateId": "p-tech-cofounder",
-              "passed": true,
-              "detail": "expected match=true, got surfaced=true (score 98, threshold 30)"
-            },
-            {
-              "kind": "band",
-              "candidateId": "p-tech-cofounder",
-              "passed": true,
-              "detail": "expected score in [70,100], got 98"
-            },
-            {
-              "kind": "match",
-              "candidateId": "p-vc",
-              "passed": true,
-              "detail": "expected match=false, got surfaced=false (score 0, threshold 30)"
-            },
-            {
-              "kind": "band",
-              "candidateId": "p-vc",
-              "passed": true,
-              "detail": "expected score in [0,29], got 0"
-            },
-            {
-              "kind": "match",
-              "candidateId": "p-designer",
-              "passed": true,
-              "detail": "expected match=false, got surfaced=false (score 0, threshold 30)"
-            },
-            {
-              "kind": "band",
-              "candidateId": "p-designer",
-              "passed": true,
-              "detail": "expected score in [0,29], got 0"
-            }
-          ]
-        },
-        {
-          "passed": true,
-          "assertions": [
-            {
-              "kind": "match",
-              "candidateId": "p-tech-cofounder",
-              "passed": true,
-              "detail": "expected match=true, got surfaced=true (score 98, threshold 30)"
-            },
-            {
-              "kind": "band",
-              "candidateId": "p-tech-cofounder",
-              "passed": true,
-              "detail": "expected score in [70,100], got 98"
-            },
-            {
-              "kind": "match",
-              "candidateId": "p-vc",
-              "passed": true,
-              "detail": "expected match=false, got surfaced=false (score 0, threshold 30)"
-            },
-            {
-              "kind": "band",
-              "candidateId": "p-vc",
-              "passed": true,
-              "detail": "expected score in [0,29], got 0"
-            },
-            {
-              "kind": "match",
-              "candidateId": "p-designer",
-              "passed": true,
-              "detail": "expected match=false, got surfaced=false (score 0, threshold 30)"
-            },
-            {
-              "kind": "band",
-              "candidateId": "p-designer",
-              "passed": true,
-              "detail": "expected score in [0,29], got 0"
-            }
-          ]
-        },
-        {
-          "passed": true,
-          "assertions": [
-            {
-              "kind": "match",
-              "candidateId": "p-tech-cofounder",
-              "passed": true,
-              "detail": "expected match=true, got surfaced=true (score 98, threshold 30)"
-            },
-            {
-              "kind": "band",
-              "candidateId": "p-tech-cofounder",
-              "passed": true,
-              "detail": "expected score in [70,100], got 98"
-            },
-            {
-              "kind": "match",
-              "candidateId": "p-vc",
-              "passed": true,
-              "detail": "expected match=false, got surfaced=false (score 0, threshold 30)"
-            },
-            {
-              "kind": "band",
-              "candidateId": "p-vc",
-              "passed": true,
-              "detail": "expected score in [0,29], got 0"
-            },
-            {
-              "kind": "match",
-              "candidateId": "p-designer",
-              "passed": true,
-              "detail": "expected match=false, got surfaced=false (score 0, threshold 30)"
-            },
-            {
-              "kind": "band",
-              "candidateId": "p-designer",
-              "passed": true,
-              "detail": "expected score in [0,29], got 0"
-            }
-          ]
-        },
-        {
-          "passed": true,
-          "assertions": [
-            {
-              "kind": "match",
-              "candidateId": "p-tech-cofounder",
-              "passed": true,
-              "detail": "expected match=true, got surfaced=true (score 98, threshold 30)"
-            },
-            {
-              "kind": "band",
-              "candidateId": "p-tech-cofounder",
-              "passed": true,
-              "detail": "expected score in [70,100], got 98"
-            },
-            {
-              "kind": "match",
-              "candidateId": "p-vc",
-              "passed": true,
-              "detail": "expected match=false, got surfaced=false (score 0, threshold 30)"
-            },
-            {
-              "kind": "band",
-              "candidateId": "p-vc",
-              "passed": true,
-              "detail": "expected score in [0,29], got 0"
-            },
-            {
-              "kind": "match",
-              "candidateId": "p-designer",
-              "passed": true,
-              "detail": "expected match=false, got surfaced=false (score 0, threshold 30)"
-            },
-            {
-              "kind": "band",
-              "candidateId": "p-designer",
-              "passed": true,
-              "detail": "expected score in [0,29], got 0"
-            }
-          ]
-        },
-        {
-          "passed": true,
-          "assertions": [
-            {
-              "kind": "match",
-              "candidateId": "p-tech-cofounder",
-              "passed": true,
-              "detail": "expected match=true, got surfaced=true (score 98, threshold 30)"
-            },
-            {
-              "kind": "band",
-              "candidateId": "p-tech-cofounder",
-              "passed": true,
-              "detail": "expected score in [70,100], got 98"
-            },
-            {
-              "kind": "match",
-              "candidateId": "p-vc",
-              "passed": true,
-              "detail": "expected match=false, got surfaced=false (score 0, threshold 30)"
-            },
-            {
-              "kind": "band",
-              "candidateId": "p-vc",
-              "passed": true,
-              "detail": "expected score in [0,29], got 0"
-            },
-            {
-              "kind": "match",
-              "candidateId": "p-designer",
-              "passed": true,
-              "detail": "expected match=false, got surfaced=false (score 0, threshold 30)"
-            },
-            {
-              "kind": "band",
-              "candidateId": "p-designer",
-              "passed": true,
-              "detail": "expected score in [0,29], got 0"
-            }
-          ]
-        },
-        {
-          "passed": true,
-          "assertions": [
-            {
-              "kind": "match",
-              "candidateId": "p-tech-cofounder",
-              "passed": true,
-              "detail": "expected match=true, got surfaced=true (score 98, threshold 30)"
-            },
-            {
-              "kind": "band",
-              "candidateId": "p-tech-cofounder",
-              "passed": true,
-              "detail": "expected score in [70,100], got 98"
-            },
-            {
-              "kind": "match",
-              "candidateId": "p-vc",
-              "passed": true,
-              "detail": "expected match=false, got surfaced=false (score 0, threshold 30)"
-            },
-            {
-              "kind": "band",
-              "candidateId": "p-vc",
-              "passed": true,
-              "detail": "expected score in [0,29], got 0"
-            },
-            {
-              "kind": "match",
-              "candidateId": "p-designer",
-              "passed": true,
-              "detail": "expected match=false, got surfaced=false (score 0, threshold 30)"
-            },
-            {
-              "kind": "band",
-              "candidateId": "p-designer",
-              "passed": true,
-              "detail": "expected score in [0,29], got 0"
-            }
-          ]
-        }
-      ]
-    },
-    {
-      "caseId": "historical/builder-and-operator",
-      "rule": "historical",
-      "runs": 7,
-      "passes": 7,
-      "passRate": 1,
-      "flaky": false,
-      "runResults": [
-        {
-          "passed": true,
-          "assertions": [
-            {
-              "kind": "match",
-              "candidateId": "h1-b",
-              "passed": true,
-              "detail": "expected match=true, got surfaced=true (score 95, threshold 30)"
-            },
-            {
-              "kind": "band",
-              "candidateId": "h1-b",
-              "passed": true,
-              "detail": "expected score in [60,100], got 95"
-            },
-            {
-              "kind": "role",
-              "candidateId": "h1-b",
-              "passed": true,
-              "detail": "expected role=agent, got agent"
-            },
-            {
-              "kind": "match",
-              "candidateId": "h1-c",
-              "passed": true,
-              "detail": "expected match=false, got surfaced=false (score 0, threshold 30)"
-            },
-            {
-              "kind": "band",
-              "candidateId": "h1-c",
-              "passed": true,
-              "detail": "expected score in [0,29], got 0"
-            },
-            {
-              "kind": "match",
-              "candidateId": "h1-d",
-              "passed": true,
-              "detail": "expected match=false, got surfaced=false (score 0, threshold 30)"
-            },
-            {
-              "kind": "band",
-              "candidateId": "h1-d",
-              "passed": true,
-              "detail": "expected score in [0,29], got 0"
-            },
-            {
-              "kind": "match",
-              "candidateId": "h1-e",
-              "passed": true,
-              "detail": "expected match=false, got surfaced=false (score 0, threshold 30)"
-            },
-            {
-              "kind": "band",
-              "candidateId": "h1-e",
-              "passed": true,
-              "detail": "expected score in [0,29], got 0"
-            }
-          ]
-        },
-        {
-          "passed": true,
-          "assertions": [
-            {
-              "kind": "match",
-              "candidateId": "h1-b",
-              "passed": true,
-              "detail": "expected match=true, got surfaced=true (score 95, threshold 30)"
-            },
-            {
-              "kind": "band",
-              "candidateId": "h1-b",
-              "passed": true,
-              "detail": "expected score in [60,100], got 95"
-            },
-            {
-              "kind": "role",
-              "candidateId": "h1-b",
-              "passed": true,
-              "detail": "expected role=agent, got agent"
-            },
-            {
-              "kind": "match",
-              "candidateId": "h1-c",
-              "passed": true,
-              "detail": "expected match=false, got surfaced=false (score 0, threshold 30)"
-            },
-            {
-              "kind": "band",
-              "candidateId": "h1-c",
-              "passed": true,
-              "detail": "expected score in [0,29], got 0"
-            },
-            {
-              "kind": "match",
-              "candidateId": "h1-d",
-              "passed": true,
-              "detail": "expected match=false, got surfaced=false (score 0, threshold 30)"
-            },
-            {
-              "kind": "band",
-              "candidateId": "h1-d",
-              "passed": true,
-              "detail": "expected score in [0,29], got 0"
-            },
-            {
-              "kind": "match",
-              "candidateId": "h1-e",
-              "passed": true,
-              "detail": "expected match=false, got surfaced=false (score 0, threshold 30)"
-            },
-            {
-              "kind": "band",
-              "candidateId": "h1-e",
-              "passed": true,
-              "detail": "expected score in [0,29], got 0"
-            }
-          ]
-        },
-        {
-          "passed": true,
-          "assertions": [
-            {
-              "kind": "match",
-              "candidateId": "h1-b",
-              "passed": true,
-              "detail": "expected match=true, got surfaced=true (score 95, threshold 30)"
-            },
-            {
-              "kind": "band",
-              "candidateId": "h1-b",
-              "passed": true,
-              "detail": "expected score in [60,100], got 95"
-            },
-            {
-              "kind": "role",
-              "candidateId": "h1-b",
-              "passed": true,
-              "detail": "expected role=agent, got agent"
-            },
-            {
-              "kind": "match",
-              "candidateId": "h1-c",
-              "passed": true,
-              "detail": "expected match=false, got surfaced=false (score 0, threshold 30)"
-            },
-            {
-              "kind": "band",
-              "candidateId": "h1-c",
-              "passed": true,
-              "detail": "expected score in [0,29], got 0"
-            },
-            {
-              "kind": "match",
-              "candidateId": "h1-d",
-              "passed": true,
-              "detail": "expected match=false, got surfaced=false (score 0, threshold 30)"
-            },
-            {
-              "kind": "band",
-              "candidateId": "h1-d",
-              "passed": true,
-              "detail": "expected score in [0,29], got 0"
-            },
-            {
-              "kind": "match",
-              "candidateId": "h1-e",
-              "passed": true,
-              "detail": "expected match=false, got surfaced=false (score 0, threshold 30)"
-            },
-            {
-              "kind": "band",
-              "candidateId": "h1-e",
-              "passed": true,
-              "detail": "expected score in [0,29], got 0"
-            }
-          ]
-        },
-        {
-          "passed": true,
-          "assertions": [
-            {
-              "kind": "match",
-              "candidateId": "h1-b",
-              "passed": true,
-              "detail": "expected match=true, got surfaced=true (score 98, threshold 30)"
-            },
-            {
-              "kind": "band",
-              "candidateId": "h1-b",
-              "passed": true,
-              "detail": "expected score in [60,100], got 98"
-            },
-            {
-              "kind": "role",
-              "candidateId": "h1-b",
-              "passed": true,
-              "detail": "expected role=agent, got agent"
-            },
-            {
-              "kind": "match",
-              "candidateId": "h1-c",
-              "passed": true,
-              "detail": "expected match=false, got surfaced=false (score 0, threshold 30)"
-            },
-            {
-              "kind": "band",
-              "candidateId": "h1-c",
-              "passed": true,
-              "detail": "expected score in [0,29], got 0"
-            },
-            {
-              "kind": "match",
-              "candidateId": "h1-d",
-              "passed": true,
-              "detail": "expected match=false, got surfaced=false (score 0, threshold 30)"
-            },
-            {
-              "kind": "band",
-              "candidateId": "h1-d",
-              "passed": true,
-              "detail": "expected score in [0,29], got 0"
-            },
-            {
-              "kind": "match",
-              "candidateId": "h1-e",
-              "passed": true,
-              "detail": "expected match=false, got surfaced=false (score 0, threshold 30)"
-            },
-            {
-              "kind": "band",
-              "candidateId": "h1-e",
-              "passed": true,
-              "detail": "expected score in [0,29], got 0"
-            }
-          ]
-        },
-        {
-          "passed": true,
-          "assertions": [
-            {
-              "kind": "match",
-              "candidateId": "h1-b",
-              "passed": true,
-              "detail": "expected match=true, got surfaced=true (score 95, threshold 30)"
-            },
-            {
-              "kind": "band",
-              "candidateId": "h1-b",
-              "passed": true,
-              "detail": "expected score in [60,100], got 95"
-            },
-            {
-              "kind": "role",
-              "candidateId": "h1-b",
-              "passed": true,
-              "detail": "expected role=agent, got agent"
-            },
-            {
-              "kind": "match",
-              "candidateId": "h1-c",
-              "passed": true,
-              "detail": "expected match=false, got surfaced=false (score 0, threshold 30)"
-            },
-            {
-              "kind": "band",
-              "candidateId": "h1-c",
-              "passed": true,
-              "detail": "expected score in [0,29], got 0"
-            },
-            {
-              "kind": "match",
-              "candidateId": "h1-d",
-              "passed": true,
-              "detail": "expected match=false, got surfaced=false (score 0, threshold 30)"
-            },
-            {
-              "kind": "band",
-              "candidateId": "h1-d",
-              "passed": true,
-              "detail": "expected score in [0,29], got 0"
-            },
-            {
-              "kind": "match",
-              "candidateId": "h1-e",
-              "passed": true,
-              "detail": "expected match=false, got surfaced=false (score 0, threshold 30)"
-            },
-            {
-              "kind": "band",
-              "candidateId": "h1-e",
-              "passed": true,
-              "detail": "expected score in [0,29], got 0"
-            }
-          ]
-        },
-        {
-          "passed": true,
-          "assertions": [
-            {
-              "kind": "match",
-              "candidateId": "h1-b",
-              "passed": true,
-              "detail": "expected match=true, got surfaced=true (score 95, threshold 30)"
-            },
-            {
-              "kind": "band",
-              "candidateId": "h1-b",
-              "passed": true,
-              "detail": "expected score in [60,100], got 95"
-            },
-            {
-              "kind": "role",
-              "candidateId": "h1-b",
-              "passed": true,
-              "detail": "expected role=agent, got agent"
-            },
-            {
-              "kind": "match",
-              "candidateId": "h1-c",
-              "passed": true,
-              "detail": "expected match=false, got surfaced=false (score 0, threshold 30)"
-            },
-            {
-              "kind": "band",
-              "candidateId": "h1-c",
-              "passed": true,
-              "detail": "expected score in [0,29], got 0"
-            },
-            {
-              "kind": "match",
-              "candidateId": "h1-d",
-              "passed": true,
-              "detail": "expected match=false, got surfaced=false (score 0, threshold 30)"
-            },
-            {
-              "kind": "band",
-              "candidateId": "h1-d",
-              "passed": true,
-              "detail": "expected score in [0,29], got 0"
-            },
-            {
-              "kind": "match",
-              "candidateId": "h1-e",
-              "passed": true,
-              "detail": "expected match=false, got surfaced=false (score 0, threshold 30)"
-            },
-            {
-              "kind": "band",
-              "candidateId": "h1-e",
-              "passed": true,
-              "detail": "expected score in [0,29], got 0"
-            }
-          ]
-        },
-        {
-          "passed": true,
-          "assertions": [
-            {
-              "kind": "match",
-              "candidateId": "h1-b",
-              "passed": true,
-              "detail": "expected match=true, got surfaced=true (score 95, threshold 30)"
-            },
-            {
-              "kind": "band",
-              "candidateId": "h1-b",
-              "passed": true,
-              "detail": "expected score in [60,100], got 95"
-            },
-            {
-              "kind": "role",
-              "candidateId": "h1-b",
-              "passed": true,
-              "detail": "expected role=agent, got agent"
-            },
-            {
-              "kind": "match",
-              "candidateId": "h1-c",
-              "passed": true,
-              "detail": "expected match=false, got surfaced=false (score 0, threshold 30)"
-            },
-            {
-              "kind": "band",
-              "candidateId": "h1-c",
-              "passed": true,
-              "detail": "expected score in [0,29], got 0"
-            },
-            {
-              "kind": "match",
-              "candidateId": "h1-d",
-              "passed": true,
-              "detail": "expected match=false, got surfaced=false (score 0, threshold 30)"
-            },
-            {
-              "kind": "band",
-              "candidateId": "h1-d",
-              "passed": true,
-              "detail": "expected score in [0,29], got 0"
-            },
-            {
-              "kind": "match",
-              "candidateId": "h1-e",
-              "passed": true,
-              "detail": "expected match=false, got surfaced=false (score 0, threshold 30)"
-            },
-            {
-              "kind": "band",
-              "candidateId": "h1-e",
-              "passed": true,
-              "detail": "expected score in [0,29], got 0"
-            }
-          ]
-        }
-      ]
-    },
-    {
-      "caseId": "historical/co-researchers-structure",
-      "rule": "historical",
-      "runs": 7,
-      "passes": 6,
-      "passRate": 0.8571428571428571,
-      "flaky": true,
-      "runResults": [
-        {
-          "passed": true,
-          "assertions": [
-            {
-              "kind": "match",
-              "candidateId": "h2-b",
-              "passed": true,
-              "detail": "expected match=true, got surfaced=true (score 98, threshold 30)"
-            },
-            {
-              "kind": "band",
-              "candidateId": "h2-b",
-              "passed": true,
-              "detail": "expected score in [60,100], got 98"
-            },
-            {
-              "kind": "match",
-              "candidateId": "h2-c",
-              "passed": true,
-              "detail": "expected match=false, got surfaced=false (score 0, threshold 30)"
-            },
-            {
-              "kind": "band",
-              "candidateId": "h2-c",
-              "passed": true,
-              "detail": "expected score in [0,29], got 0"
-            },
-            {
-              "kind": "match",
-              "candidateId": "h2-d",
-              "passed": true,
-              "detail": "expected match=false, got surfaced=false (score 0, threshold 30)"
-            },
-            {
-              "kind": "band",
-              "candidateId": "h2-d",
-              "passed": true,
-              "detail": "expected score in [0,29], got 0"
-            },
-            {
-              "kind": "match",
-              "candidateId": "h2-e",
-              "passed": true,
-              "detail": "expected match=false, got surfaced=false (score 0, threshold 30)"
-            },
-            {
-              "kind": "band",
-              "candidateId": "h2-e",
-              "passed": true,
-              "detail": "expected score in [0,29], got 0"
-            }
-          ]
-        },
-        {
-          "passed": true,
-          "assertions": [
-            {
-              "kind": "match",
-              "candidateId": "h2-b",
-              "passed": true,
-              "detail": "expected match=true, got surfaced=true (score 98, threshold 30)"
-            },
-            {
-              "kind": "band",
-              "candidateId": "h2-b",
-              "passed": true,
-              "detail": "expected score in [60,100], got 98"
-            },
-            {
-              "kind": "match",
-              "candidateId": "h2-c",
-              "passed": true,
-              "detail": "expected match=false, got surfaced=false (score 0, threshold 30)"
-            },
-            {
-              "kind": "band",
-              "candidateId": "h2-c",
-              "passed": true,
-              "detail": "expected score in [0,29], got 0"
-            },
-            {
-              "kind": "match",
-              "candidateId": "h2-d",
-              "passed": true,
-              "detail": "expected match=false, got surfaced=false (score 0, threshold 30)"
-            },
-            {
-              "kind": "band",
-              "candidateId": "h2-d",
-              "passed": true,
-              "detail": "expected score in [0,29], got 0"
-            },
-            {
-              "kind": "match",
-              "candidateId": "h2-e",
-              "passed": true,
-              "detail": "expected match=false, got surfaced=false (score 0, threshold 30)"
-            },
-            {
-              "kind": "band",
-              "candidateId": "h2-e",
-              "passed": true,
-              "detail": "expected score in [0,29], got 0"
-            }
-          ]
-        },
-        {
-          "passed": true,
-          "assertions": [
-            {
-              "kind": "match",
-              "candidateId": "h2-b",
-              "passed": true,
-              "detail": "expected match=true, got surfaced=true (score 98, threshold 30)"
-            },
-            {
-              "kind": "band",
-              "candidateId": "h2-b",
-              "passed": true,
-              "detail": "expected score in [60,100], got 98"
-            },
-            {
-              "kind": "match",
-              "candidateId": "h2-c",
-              "passed": true,
-              "detail": "expected match=false, got surfaced=false (score 0, threshold 30)"
-            },
-            {
-              "kind": "band",
-              "candidateId": "h2-c",
-              "passed": true,
-              "detail": "expected score in [0,29], got 0"
-            },
-            {
-              "kind": "match",
-              "candidateId": "h2-d",
-              "passed": true,
-              "detail": "expected match=false, got surfaced=false (score 0, threshold 30)"
-            },
-            {
-              "kind": "band",
-              "candidateId": "h2-d",
-              "passed": true,
-              "detail": "expected score in [0,29], got 0"
-            },
-            {
-              "kind": "match",
-              "candidateId": "h2-e",
-              "passed": true,
-              "detail": "expected match=false, got surfaced=false (score 0, threshold 30)"
-            },
-            {
-              "kind": "band",
-              "candidateId": "h2-e",
-              "passed": true,
-              "detail": "expected score in [0,29], got 0"
-            }
-          ]
-        },
-        {
-          "passed": false,
-          "assertions": [
-            {
-              "kind": "match",
-              "candidateId": "h2-b",
-              "passed": true,
-              "detail": "expected match=true, got surfaced=true (score 98, threshold 30)"
-            },
-            {
-              "kind": "band",
-              "candidateId": "h2-b",
-              "passed": true,
-              "detail": "expected score in [60,100], got 98"
-            },
-            {
-              "kind": "match",
-              "candidateId": "h2-c",
-              "passed": false,
-              "detail": "expected match=false, got surfaced=true (score 65, threshold 30)"
-            },
-            {
-              "kind": "band",
-              "candidateId": "h2-c",
-              "passed": false,
-              "detail": "expected score in [0,29], got 65"
-            },
-            {
-              "kind": "match",
-              "candidateId": "h2-d",
-              "passed": true,
-              "detail": "expected match=false, got surfaced=false (score 0, threshold 30)"
-            },
-            {
-              "kind": "band",
-              "candidateId": "h2-d",
-              "passed": true,
-              "detail": "expected score in [0,29], got 0"
-            },
-            {
-              "kind": "match",
-              "candidateId": "h2-e",
-              "passed": true,
-              "detail": "expected match=false, got surfaced=false (score 0, threshold 30)"
-            },
-            {
-              "kind": "band",
-              "candidateId": "h2-e",
-              "passed": true,
-              "detail": "expected score in [0,29], got 0"
-            }
-          ]
-        },
-        {
-          "passed": true,
-          "assertions": [
-            {
-              "kind": "match",
-              "candidateId": "h2-b",
-              "passed": true,
-              "detail": "expected match=true, got surfaced=true (score 98, threshold 30)"
-            },
-            {
-              "kind": "band",
-              "candidateId": "h2-b",
-              "passed": true,
-              "detail": "expected score in [60,100], got 98"
-            },
-            {
-              "kind": "match",
-              "candidateId": "h2-c",
-              "passed": true,
-              "detail": "expected match=false, got surfaced=false (score 0, threshold 30)"
-            },
-            {
-              "kind": "band",
-              "candidateId": "h2-c",
-              "passed": true,
-              "detail": "expected score in [0,29], got 0"
-            },
-            {
-              "kind": "match",
-              "candidateId": "h2-d",
-              "passed": true,
-              "detail": "expected match=false, got surfaced=false (score 0, threshold 30)"
-            },
-            {
-              "kind": "band",
-              "candidateId": "h2-d",
-              "passed": true,
-              "detail": "expected score in [0,29], got 0"
-            },
-            {
-              "kind": "match",
-              "candidateId": "h2-e",
-              "passed": true,
-              "detail": "expected match=false, got surfaced=false (score 0, threshold 30)"
-            },
-            {
-              "kind": "band",
-              "candidateId": "h2-e",
-              "passed": true,
-              "detail": "expected score in [0,29], got 0"
-            }
-          ]
-        },
-        {
-          "passed": true,
-          "assertions": [
-            {
-              "kind": "match",
-              "candidateId": "h2-b",
-              "passed": true,
-              "detail": "expected match=true, got surfaced=true (score 98, threshold 30)"
-            },
-            {
-              "kind": "band",
-              "candidateId": "h2-b",
-              "passed": true,
-              "detail": "expected score in [60,100], got 98"
-            },
-            {
-              "kind": "match",
-              "candidateId": "h2-c",
-              "passed": true,
-              "detail": "expected match=false, got surfaced=false (score 0, threshold 30)"
-            },
-            {
-              "kind": "band",
-              "candidateId": "h2-c",
-              "passed": true,
-              "detail": "expected score in [0,29], got 0"
-            },
-            {
-              "kind": "match",
-              "candidateId": "h2-d",
-              "passed": true,
-              "detail": "expected match=false, got surfaced=false (score 0, threshold 30)"
-            },
-            {
-              "kind": "band",
-              "candidateId": "h2-d",
-              "passed": true,
-              "detail": "expected score in [0,29], got 0"
-            },
-            {
-              "kind": "match",
-              "candidateId": "h2-e",
-              "passed": true,
-              "detail": "expected match=false, got surfaced=false (score 0, threshold 30)"
-            },
-            {
-              "kind": "band",
-              "candidateId": "h2-e",
-              "passed": true,
-              "detail": "expected score in [0,29], got 0"
-            }
-          ]
-        },
-        {
-          "passed": true,
-          "assertions": [
-            {
-              "kind": "match",
-              "candidateId": "h2-b",
-              "passed": true,
-              "detail": "expected match=true, got surfaced=true (score 98, threshold 30)"
-            },
-            {
-              "kind": "band",
-              "candidateId": "h2-b",
-              "passed": true,
-              "detail": "expected score in [60,100], got 98"
-            },
-            {
-              "kind": "match",
-              "candidateId": "h2-c",
-              "passed": true,
-              "detail": "expected match=false, got surfaced=false (score 0, threshold 30)"
-            },
-            {
-              "kind": "band",
-              "candidateId": "h2-c",
-              "passed": true,
-              "detail": "expected score in [0,29], got 0"
-            },
-            {
-              "kind": "match",
-              "candidateId": "h2-d",
-              "passed": true,
-              "detail": "expected match=false, got surfaced=false (score 0, threshold 30)"
-            },
-            {
-              "kind": "band",
-              "candidateId": "h2-d",
-              "passed": true,
-              "detail": "expected score in [0,29], got 0"
-            },
-            {
-              "kind": "match",
-              "candidateId": "h2-e",
-              "passed": true,
-              "detail": "expected match=false, got surfaced=false (score 0, threshold 30)"
-            },
-            {
-              "kind": "band",
-              "candidateId": "h2-e",
-              "passed": true,
-              "detail": "expected score in [0,29], got 0"
-            }
-          ]
-        }
-      ]
-    },
-    {
-      "caseId": "historical/songwriting-duo",
-      "rule": "historical",
-      "runs": 7,
-      "passes": 7,
-      "passRate": 1,
-      "flaky": false,
-      "runResults": [
-        {
-          "passed": true,
-          "assertions": [
-            {
-              "kind": "match",
-              "candidateId": "h3-b",
-              "passed": true,
-              "detail": "expected match=true, got surfaced=true (score 98, threshold 30)"
-            },
-            {
-              "kind": "band",
-              "candidateId": "h3-b",
-              "passed": true,
-              "detail": "expected score in [60,100], got 98"
-            },
-            {
-              "kind": "match",
-              "candidateId": "h3-c",
-              "passed": true,
-              "detail": "expected match=false, got surfaced=false (score 0, threshold 30)"
-            },
-            {
-              "kind": "band",
-              "candidateId": "h3-c",
-              "passed": true,
-              "detail": "expected score in [0,29], got 0"
-            },
-            {
-              "kind": "match",
-              "candidateId": "h3-d",
-              "passed": true,
-              "detail": "expected match=false, got surfaced=false (score 0, threshold 30)"
-            },
-            {
-              "kind": "band",
-              "candidateId": "h3-d",
-              "passed": true,
-              "detail": "expected score in [0,29], got 0"
-            },
-            {
-              "kind": "match",
-              "candidateId": "h3-e",
-              "passed": true,
-              "detail": "expected match=false, got surfaced=false (score 0, threshold 30)"
-            },
-            {
-              "kind": "band",
-              "candidateId": "h3-e",
-              "passed": true,
-              "detail": "expected score in [0,29], got 0"
-            }
-          ]
-        },
-        {
-          "passed": true,
-          "assertions": [
-            {
-              "kind": "match",
-              "candidateId": "h3-b",
-              "passed": true,
-              "detail": "expected match=true, got surfaced=true (score 95, threshold 30)"
-            },
-            {
-              "kind": "band",
-              "candidateId": "h3-b",
-              "passed": true,
-              "detail": "expected score in [60,100], got 95"
-            },
-            {
-              "kind": "match",
-              "candidateId": "h3-c",
-              "passed": true,
-              "detail": "expected match=false, got surfaced=false (score 0, threshold 30)"
-            },
-            {
-              "kind": "band",
-              "candidateId": "h3-c",
-              "passed": true,
-              "detail": "expected score in [0,29], got 0"
-            },
-            {
-              "kind": "match",
-              "candidateId": "h3-d",
-              "passed": true,
-              "detail": "expected match=false, got surfaced=false (score 0, threshold 30)"
-            },
-            {
-              "kind": "band",
-              "candidateId": "h3-d",
-              "passed": true,
-              "detail": "expected score in [0,29], got 0"
-            },
-            {
-              "kind": "match",
-              "candidateId": "h3-e",
-              "passed": true,
-              "detail": "expected match=false, got surfaced=false (score 0, threshold 30)"
-            },
-            {
-              "kind": "band",
-              "candidateId": "h3-e",
-              "passed": true,
-              "detail": "expected score in [0,29], got 0"
-            }
-          ]
-        },
-        {
-          "passed": true,
-          "assertions": [
-            {
-              "kind": "match",
-              "candidateId": "h3-b",
-              "passed": true,
-              "detail": "expected match=true, got surfaced=true (score 98, threshold 30)"
-            },
-            {
-              "kind": "band",
-              "candidateId": "h3-b",
-              "passed": true,
-              "detail": "expected score in [60,100], got 98"
-            },
-            {
-              "kind": "match",
-              "candidateId": "h3-c",
-              "passed": true,
-              "detail": "expected match=false, got surfaced=false (score 0, threshold 30)"
-            },
-            {
-              "kind": "band",
-              "candidateId": "h3-c",
-              "passed": true,
-              "detail": "expected score in [0,29], got 0"
-            },
-            {
-              "kind": "match",
-              "candidateId": "h3-d",
-              "passed": true,
-              "detail": "expected match=false, got surfaced=false (score 0, threshold 30)"
-            },
-            {
-              "kind": "band",
-              "candidateId": "h3-d",
-              "passed": true,
-              "detail": "expected score in [0,29], got 0"
-            },
-            {
-              "kind": "match",
-              "candidateId": "h3-e",
-              "passed": true,
-              "detail": "expected match=false, got surfaced=false (score 0, threshold 30)"
-            },
-            {
-              "kind": "band",
-              "candidateId": "h3-e",
-              "passed": true,
-              "detail": "expected score in [0,29], got 0"
-            }
-          ]
-        },
-        {
-          "passed": true,
-          "assertions": [
-            {
-              "kind": "match",
-              "candidateId": "h3-b",
-              "passed": true,
-              "detail": "expected match=true, got surfaced=true (score 98, threshold 30)"
-            },
-            {
-              "kind": "band",
-              "candidateId": "h3-b",
-              "passed": true,
-              "detail": "expected score in [60,100], got 98"
-            },
-            {
-              "kind": "match",
-              "candidateId": "h3-c",
-              "passed": true,
-              "detail": "expected match=false, got surfaced=false (score 0, threshold 30)"
-            },
-            {
-              "kind": "band",
-              "candidateId": "h3-c",
-              "passed": true,
-              "detail": "expected score in [0,29], got 0"
-            },
-            {
-              "kind": "match",
-              "candidateId": "h3-d",
-              "passed": true,
-              "detail": "expected match=false, got surfaced=false (score 0, threshold 30)"
-            },
-            {
-              "kind": "band",
-              "candidateId": "h3-d",
-              "passed": true,
-              "detail": "expected score in [0,29], got 0"
-            },
-            {
-              "kind": "match",
-              "candidateId": "h3-e",
-              "passed": true,
-              "detail": "expected match=false, got surfaced=false (score 0, threshold 30)"
-            },
-            {
-              "kind": "band",
-              "candidateId": "h3-e",
-              "passed": true,
-              "detail": "expected score in [0,29], got 0"
-            }
-          ]
-        },
-        {
-          "passed": true,
-          "assertions": [
-            {
-              "kind": "match",
-              "candidateId": "h3-b",
-              "passed": true,
-              "detail": "expected match=true, got surfaced=true (score 98, threshold 30)"
-            },
-            {
-              "kind": "band",
-              "candidateId": "h3-b",
-              "passed": true,
-              "detail": "expected score in [60,100], got 98"
-            },
-            {
-              "kind": "match",
-              "candidateId": "h3-c",
-              "passed": true,
-              "detail": "expected match=false, got surfaced=false (score 0, threshold 30)"
-            },
-            {
-              "kind": "band",
-              "candidateId": "h3-c",
-              "passed": true,
-              "detail": "expected score in [0,29], got 0"
-            },
-            {
-              "kind": "match",
-              "candidateId": "h3-d",
-              "passed": true,
-              "detail": "expected match=false, got surfaced=false (score 0, threshold 30)"
-            },
-            {
-              "kind": "band",
-              "candidateId": "h3-d",
-              "passed": true,
-              "detail": "expected score in [0,29], got 0"
-            },
-            {
-              "kind": "match",
-              "candidateId": "h3-e",
-              "passed": true,
-              "detail": "expected match=false, got surfaced=false (score 0, threshold 30)"
-            },
-            {
-              "kind": "band",
-              "candidateId": "h3-e",
-              "passed": true,
-              "detail": "expected score in [0,29], got 0"
-            }
-          ]
-        },
-        {
-          "passed": true,
-          "assertions": [
-            {
-              "kind": "match",
-              "candidateId": "h3-b",
-              "passed": true,
-              "detail": "expected match=true, got surfaced=true (score 95, threshold 30)"
-            },
-            {
-              "kind": "band",
-              "candidateId": "h3-b",
-              "passed": true,
-              "detail": "expected score in [60,100], got 95"
-            },
-            {
-              "kind": "match",
-              "candidateId": "h3-c",
-              "passed": true,
-              "detail": "expected match=false, got surfaced=false (score 0, threshold 30)"
-            },
-            {
-              "kind": "band",
-              "candidateId": "h3-c",
-              "passed": true,
-              "detail": "expected score in [0,29], got 0"
-            },
-            {
-              "kind": "match",
-              "candidateId": "h3-d",
-              "passed": true,
-              "detail": "expected match=false, got surfaced=false (score 0, threshold 30)"
-            },
-            {
-              "kind": "band",
-              "candidateId": "h3-d",
-              "passed": true,
-              "detail": "expected score in [0,29], got 0"
-            },
-            {
-              "kind": "match",
-              "candidateId": "h3-e",
-              "passed": true,
-              "detail": "expected match=false, got surfaced=false (score 0, threshold 30)"
-            },
-            {
-              "kind": "band",
-              "candidateId": "h3-e",
-              "passed": true,
-              "detail": "expected score in [0,29], got 0"
-            }
-          ]
-        },
-        {
-          "passed": true,
-          "assertions": [
-            {
-              "kind": "match",
-              "candidateId": "h3-b",
-              "passed": true,
-              "detail": "expected match=true, got surfaced=true (score 98, threshold 30)"
-            },
-            {
-              "kind": "band",
-              "candidateId": "h3-b",
-              "passed": true,
-              "detail": "expected score in [60,100], got 98"
-            },
-            {
-              "kind": "match",
-              "candidateId": "h3-c",
-              "passed": true,
-              "detail": "expected match=false, got surfaced=false (score 0, threshold 30)"
-            },
-            {
-              "kind": "band",
-              "candidateId": "h3-c",
-              "passed": true,
-              "detail": "expected score in [0,29], got 0"
-            },
-            {
-              "kind": "match",
-              "candidateId": "h3-d",
-              "passed": true,
-              "detail": "expected match=false, got surfaced=false (score 0, threshold 30)"
-            },
-            {
-              "kind": "band",
-              "candidateId": "h3-d",
-              "passed": true,
-              "detail": "expected score in [0,29], got 0"
-            },
-            {
-              "kind": "match",
-              "candidateId": "h3-e",
-              "passed": true,
-              "detail": "expected match=false, got surfaced=false (score 0, threshold 30)"
-            },
-            {
-              "kind": "band",
-              "candidateId": "h3-e",
-              "passed": true,
-              "detail": "expected score in [0,29], got 0"
-            }
-          ]
-        }
-      ]
-    },
-    {
-      "caseId": "historical/first-check-investor",
-      "rule": "historical",
-      "runs": 7,
-      "passes": 7,
-      "passRate": 1,
-      "flaky": false,
-      "runResults": [
-        {
-          "passed": true,
-          "assertions": [
-            {
-              "kind": "match",
-              "candidateId": "h4-b",
-              "passed": true,
-              "detail": "expected match=true, got surfaced=true (score 98, threshold 30)"
-            },
-            {
-              "kind": "band",
-              "candidateId": "h4-b",
-              "passed": true,
-              "detail": "expected score in [60,100], got 98"
-            },
-            {
-              "kind": "role",
-              "candidateId": "h4-b",
-              "passed": true,
-              "detail": "expected role=agent, got agent"
-            },
-            {
-              "kind": "match",
-              "candidateId": "h4-c",
-              "passed": true,
-              "detail": "expected match=false, got surfaced=false (score 0, threshold 30)"
-            },
-            {
-              "kind": "band",
-              "candidateId": "h4-c",
-              "passed": true,
-              "detail": "expected score in [0,29], got 0"
-            },
-            {
-              "kind": "match",
-              "candidateId": "h4-d",
-              "passed": true,
-              "detail": "expected match=false, got surfaced=false (score 0, threshold 30)"
-            },
-            {
-              "kind": "band",
-              "candidateId": "h4-d",
-              "passed": true,
-              "detail": "expected score in [0,29], got 0"
-            },
-            {
-              "kind": "match",
-              "candidateId": "h4-e",
-              "passed": true,
-              "detail": "expected match=false, got surfaced=false (score 0, threshold 30)"
-            },
-            {
-              "kind": "band",
-              "candidateId": "h4-e",
-              "passed": true,
-              "detail": "expected score in [0,29], got 0"
-            }
-          ]
-        },
-        {
-          "passed": true,
-          "assertions": [
-            {
-              "kind": "match",
-              "candidateId": "h4-b",
-              "passed": true,
-              "detail": "expected match=true, got surfaced=true (score 98, threshold 30)"
-            },
-            {
-              "kind": "band",
-              "candidateId": "h4-b",
-              "passed": true,
-              "detail": "expected score in [60,100], got 98"
-            },
-            {
-              "kind": "role",
-              "candidateId": "h4-b",
-              "passed": true,
-              "detail": "expected role=agent, got agent"
-            },
-            {
-              "kind": "match",
-              "candidateId": "h4-c",
-              "passed": true,
-              "detail": "expected match=false, got surfaced=false (score 0, threshold 30)"
-            },
-            {
-              "kind": "band",
-              "candidateId": "h4-c",
-              "passed": true,
-              "detail": "expected score in [0,29], got 0"
-            },
-            {
-              "kind": "match",
-              "candidateId": "h4-d",
-              "passed": true,
-              "detail": "expected match=false, got surfaced=false (score 0, threshold 30)"
-            },
-            {
-              "kind": "band",
-              "candidateId": "h4-d",
-              "passed": true,
-              "detail": "expected score in [0,29], got 0"
-            },
-            {
-              "kind": "match",
-              "candidateId": "h4-e",
-              "passed": true,
-              "detail": "expected match=false, got surfaced=false (score 0, threshold 30)"
-            },
-            {
-              "kind": "band",
-              "candidateId": "h4-e",
-              "passed": true,
-              "detail": "expected score in [0,29], got 0"
-            }
-          ]
-        },
-        {
-          "passed": true,
-          "assertions": [
-            {
-              "kind": "match",
-              "candidateId": "h4-b",
-              "passed": true,
-              "detail": "expected match=true, got surfaced=true (score 98, threshold 30)"
-            },
-            {
-              "kind": "band",
-              "candidateId": "h4-b",
-              "passed": true,
-              "detail": "expected score in [60,100], got 98"
-            },
-            {
-              "kind": "role",
-              "candidateId": "h4-b",
-              "passed": true,
-              "detail": "expected role=agent, got agent"
-            },
-            {
-              "kind": "match",
-              "candidateId": "h4-c",
-              "passed": true,
-              "detail": "expected match=false, got surfaced=false (score 0, threshold 30)"
-            },
-            {
-              "kind": "band",
-              "candidateId": "h4-c",
-              "passed": true,
-              "detail": "expected score in [0,29], got 0"
-            },
-            {
-              "kind": "match",
-              "candidateId": "h4-d",
-              "passed": true,
-              "detail": "expected match=false, got surfaced=false (score 0, threshold 30)"
-            },
-            {
-              "kind": "band",
-              "candidateId": "h4-d",
-              "passed": true,
-              "detail": "expected score in [0,29], got 0"
-            },
-            {
-              "kind": "match",
-              "candidateId": "h4-e",
-              "passed": true,
-              "detail": "expected match=false, got surfaced=false (score 0, threshold 30)"
-            },
-            {
-              "kind": "band",
-              "candidateId": "h4-e",
-              "passed": true,
-              "detail": "expected score in [0,29], got 0"
-            }
-          ]
-        },
-        {
-          "passed": true,
-          "assertions": [
-            {
-              "kind": "match",
-              "candidateId": "h4-b",
-              "passed": true,
-              "detail": "expected match=true, got surfaced=true (score 98, threshold 30)"
-            },
-            {
-              "kind": "band",
-              "candidateId": "h4-b",
-              "passed": true,
-              "detail": "expected score in [60,100], got 98"
-            },
-            {
-              "kind": "role",
-              "candidateId": "h4-b",
-              "passed": true,
-              "detail": "expected role=agent, got agent"
-            },
-            {
-              "kind": "match",
-              "candidateId": "h4-c",
-              "passed": true,
-              "detail": "expected match=false, got surfaced=false (score 0, threshold 30)"
-            },
-            {
-              "kind": "band",
-              "candidateId": "h4-c",
-              "passed": true,
-              "detail": "expected score in [0,29], got 0"
-            },
-            {
-              "kind": "match",
-              "candidateId": "h4-d",
-              "passed": true,
-              "detail": "expected match=false, got surfaced=false (score 0, threshold 30)"
-            },
-            {
-              "kind": "band",
-              "candidateId": "h4-d",
-              "passed": true,
-              "detail": "expected score in [0,29], got 0"
-            },
-            {
-              "kind": "match",
-              "candidateId": "h4-e",
-              "passed": true,
-              "detail": "expected match=false, got surfaced=false (score 0, threshold 30)"
-            },
-            {
-              "kind": "band",
-              "candidateId": "h4-e",
-              "passed": true,
-              "detail": "expected score in [0,29], got 0"
-            }
-          ]
-        },
-        {
-          "passed": true,
-          "assertions": [
-            {
-              "kind": "match",
-              "candidateId": "h4-b",
-              "passed": true,
-              "detail": "expected match=true, got surfaced=true (score 98, threshold 30)"
-            },
-            {
-              "kind": "band",
-              "candidateId": "h4-b",
-              "passed": true,
-              "detail": "expected score in [60,100], got 98"
-            },
-            {
-              "kind": "role",
-              "candidateId": "h4-b",
-              "passed": true,
-              "detail": "expected role=agent, got agent"
-            },
-            {
-              "kind": "match",
-              "candidateId": "h4-c",
-              "passed": true,
-              "detail": "expected match=false, got surfaced=false (score 0, threshold 30)"
-            },
-            {
-              "kind": "band",
-              "candidateId": "h4-c",
-              "passed": true,
-              "detail": "expected score in [0,29], got 0"
-            },
-            {
-              "kind": "match",
-              "candidateId": "h4-d",
-              "passed": true,
-              "detail": "expected match=false, got surfaced=false (score 0, threshold 30)"
-            },
-            {
-              "kind": "band",
-              "candidateId": "h4-d",
-              "passed": true,
-              "detail": "expected score in [0,29], got 0"
-            },
-            {
-              "kind": "match",
-              "candidateId": "h4-e",
-              "passed": true,
-              "detail": "expected match=false, got surfaced=false (score 0, threshold 30)"
-            },
-            {
-              "kind": "band",
-              "candidateId": "h4-e",
-              "passed": true,
-              "detail": "expected score in [0,29], got 0"
-            }
-          ]
-        },
-        {
-          "passed": true,
-          "assertions": [
-            {
-              "kind": "match",
-              "candidateId": "h4-b",
-              "passed": true,
-              "detail": "expected match=true, got surfaced=true (score 98, threshold 30)"
-            },
-            {
-              "kind": "band",
-              "candidateId": "h4-b",
-              "passed": true,
-              "detail": "expected score in [60,100], got 98"
-            },
-            {
-              "kind": "role",
-              "candidateId": "h4-b",
-              "passed": true,
-              "detail": "expected role=agent, got agent"
-            },
-            {
-              "kind": "match",
-              "candidateId": "h4-c",
-              "passed": true,
-              "detail": "expected match=false, got surfaced=false (score 0, threshold 30)"
-            },
-            {
-              "kind": "band",
-              "candidateId": "h4-c",
-              "passed": true,
-              "detail": "expected score in [0,29], got 0"
-            },
-            {
-              "kind": "match",
-              "candidateId": "h4-d",
-              "passed": true,
-              "detail": "expected match=false, got surfaced=false (score 0, threshold 30)"
-            },
-            {
-              "kind": "band",
-              "candidateId": "h4-d",
-              "passed": true,
-              "detail": "expected score in [0,29], got 0"
-            },
-            {
-              "kind": "match",
-              "candidateId": "h4-e",
-              "passed": true,
-              "detail": "expected match=false, got surfaced=false (score 0, threshold 30)"
-            },
-            {
-              "kind": "band",
-              "candidateId": "h4-e",
-              "passed": true,
-              "detail": "expected score in [0,29], got 0"
-            }
-          ]
-        },
-        {
-          "passed": true,
-          "assertions": [
-            {
-              "kind": "match",
-              "candidateId": "h4-b",
-              "passed": true,
-              "detail": "expected match=true, got surfaced=true (score 98, threshold 30)"
-            },
-            {
-              "kind": "band",
-              "candidateId": "h4-b",
-              "passed": true,
-              "detail": "expected score in [60,100], got 98"
-            },
-            {
-              "kind": "role",
-              "candidateId": "h4-b",
-              "passed": true,
-              "detail": "expected role=agent, got agent"
-            },
-            {
-              "kind": "match",
-              "candidateId": "h4-c",
-              "passed": true,
-              "detail": "expected match=false, got surfaced=false (score 0, threshold 30)"
-            },
-            {
-              "kind": "band",
-              "candidateId": "h4-c",
-              "passed": true,
-              "detail": "expected score in [0,29], got 0"
-            },
-            {
-              "kind": "match",
-              "candidateId": "h4-d",
-              "passed": true,
-              "detail": "expected match=false, got surfaced=false (score 0, threshold 30)"
-            },
-            {
-              "kind": "band",
-              "candidateId": "h4-d",
-              "passed": true,
-              "detail": "expected score in [0,29], got 0"
-            },
-            {
-              "kind": "match",
-              "candidateId": "h4-e",
-              "passed": true,
-              "detail": "expected match=false, got surfaced=false (score 0, threshold 30)"
-            },
-            {
-              "kind": "band",
-              "candidateId": "h4-e",
-              "passed": true,
-              "detail": "expected score in [0,29], got 0"
-            }
-          ]
-        }
-      ]
-    },
-    {
-      "caseId": "historical/domain-expert-and-ml",
-      "rule": "historical",
-      "runs": 7,
-      "passes": 7,
-      "passRate": 1,
-      "flaky": false,
-      "runResults": [
-        {
-          "passed": true,
-          "assertions": [
-            {
-              "kind": "match",
-              "candidateId": "h5-b",
-              "passed": true,
-              "detail": "expected match=true, got surfaced=true (score 98, threshold 30)"
-            },
-            {
-              "kind": "band",
-              "candidateId": "h5-b",
-              "passed": true,
-              "detail": "expected score in [60,100], got 98"
-            },
-            {
-              "kind": "match",
-              "candidateId": "h5-c",
-              "passed": true,
-              "detail": "expected match=false, got surfaced=false (score 0, threshold 30)"
-            },
-            {
-              "kind": "band",
-              "candidateId": "h5-c",
-              "passed": true,
-              "detail": "expected score in [0,29], got 0"
-            },
-            {
-              "kind": "match",
-              "candidateId": "h5-d",
-              "passed": true,
-              "detail": "expected match=false, got surfaced=false (score 0, threshold 30)"
-            },
-            {
-              "kind": "band",
-              "candidateId": "h5-d",
-              "passed": true,
-              "detail": "expected score in [0,29], got 0"
-            },
-            {
-              "kind": "match",
-              "candidateId": "h5-e",
-              "passed": true,
-              "detail": "expected match=false, got surfaced=false (score 0, threshold 30)"
-            },
-            {
-              "kind": "band",
-              "candidateId": "h5-e",
-              "passed": true,
-              "detail": "expected score in [0,29], got 0"
-            }
-          ]
-        },
-        {
-          "passed": true,
-          "assertions": [
-            {
-              "kind": "match",
-              "candidateId": "h5-b",
-              "passed": true,
-              "detail": "expected match=true, got surfaced=true (score 98, threshold 30)"
-            },
-            {
-              "kind": "band",
-              "candidateId": "h5-b",
-              "passed": true,
-              "detail": "expected score in [60,100], got 98"
-            },
-            {
-              "kind": "match",
-              "candidateId": "h5-c",
-              "passed": true,
-              "detail": "expected match=false, got surfaced=false (score 0, threshold 30)"
-            },
-            {
-              "kind": "band",
-              "candidateId": "h5-c",
-              "passed": true,
-              "detail": "expected score in [0,29], got 0"
-            },
-            {
-              "kind": "match",
-              "candidateId": "h5-d",
-              "passed": true,
-              "detail": "expected match=false, got surfaced=false (score 0, threshold 30)"
-            },
-            {
-              "kind": "band",
-              "candidateId": "h5-d",
-              "passed": true,
-              "detail": "expected score in [0,29], got 0"
-            },
-            {
-              "kind": "match",
-              "candidateId": "h5-e",
-              "passed": true,
-              "detail": "expected match=false, got surfaced=false (score 0, threshold 30)"
-            },
-            {
-              "kind": "band",
-              "candidateId": "h5-e",
-              "passed": true,
-              "detail": "expected score in [0,29], got 0"
-            }
-          ]
-        },
-        {
-          "passed": true,
-          "assertions": [
-            {
-              "kind": "match",
-              "candidateId": "h5-b",
-              "passed": true,
-              "detail": "expected match=true, got surfaced=true (score 98, threshold 30)"
-            },
-            {
-              "kind": "band",
-              "candidateId": "h5-b",
-              "passed": true,
-              "detail": "expected score in [60,100], got 98"
-            },
-            {
-              "kind": "match",
-              "candidateId": "h5-c",
-              "passed": true,
-              "detail": "expected match=false, got surfaced=false (score 0, threshold 30)"
-            },
-            {
-              "kind": "band",
-              "candidateId": "h5-c",
-              "passed": true,
-              "detail": "expected score in [0,29], got 0"
-            },
-            {
-              "kind": "match",
-              "candidateId": "h5-d",
-              "passed": true,
-              "detail": "expected match=false, got surfaced=false (score 0, threshold 30)"
-            },
-            {
-              "kind": "band",
-              "candidateId": "h5-d",
-              "passed": true,
-              "detail": "expected score in [0,29], got 0"
-            },
-            {
-              "kind": "match",
-              "candidateId": "h5-e",
-              "passed": true,
-              "detail": "expected match=false, got surfaced=false (score 0, threshold 30)"
-            },
-            {
-              "kind": "band",
-              "candidateId": "h5-e",
-              "passed": true,
-              "detail": "expected score in [0,29], got 0"
-            }
-          ]
-        },
-        {
-          "passed": true,
-          "assertions": [
-            {
-              "kind": "match",
-              "candidateId": "h5-b",
-              "passed": true,
-              "detail": "expected match=true, got surfaced=true (score 95, threshold 30)"
-            },
-            {
-              "kind": "band",
-              "candidateId": "h5-b",
-              "passed": true,
-              "detail": "expected score in [60,100], got 95"
-            },
-            {
-              "kind": "match",
-              "candidateId": "h5-c",
-              "passed": true,
-              "detail": "expected match=false, got surfaced=false (score 0, threshold 30)"
-            },
-            {
-              "kind": "band",
-              "candidateId": "h5-c",
-              "passed": true,
-              "detail": "expected score in [0,29], got 0"
-            },
-            {
-              "kind": "match",
-              "candidateId": "h5-d",
-              "passed": true,
-              "detail": "expected match=false, got surfaced=false (score 0, threshold 30)"
-            },
-            {
-              "kind": "band",
-              "candidateId": "h5-d",
-              "passed": true,
-              "detail": "expected score in [0,29], got 0"
-            },
-            {
-              "kind": "match",
-              "candidateId": "h5-e",
-              "passed": true,
-              "detail": "expected match=false, got surfaced=false (score 0, threshold 30)"
-            },
-            {
-              "kind": "band",
-              "candidateId": "h5-e",
-              "passed": true,
-              "detail": "expected score in [0,29], got 0"
-            }
-          ]
-        },
-        {
-          "passed": true,
-          "assertions": [
-            {
-              "kind": "match",
-              "candidateId": "h5-b",
-              "passed": true,
-              "detail": "expected match=true, got surfaced=true (score 98, threshold 30)"
-            },
-            {
-              "kind": "band",
-              "candidateId": "h5-b",
-              "passed": true,
-              "detail": "expected score in [60,100], got 98"
-            },
-            {
-              "kind": "match",
-              "candidateId": "h5-c",
-              "passed": true,
-              "detail": "expected match=false, got surfaced=false (score 0, threshold 30)"
-            },
-            {
-              "kind": "band",
-              "candidateId": "h5-c",
-              "passed": true,
-              "detail": "expected score in [0,29], got 0"
-            },
-            {
-              "kind": "match",
-              "candidateId": "h5-d",
-              "passed": true,
-              "detail": "expected match=false, got surfaced=false (score 0, threshold 30)"
-            },
-            {
-              "kind": "band",
-              "candidateId": "h5-d",
-              "passed": true,
-              "detail": "expected score in [0,29], got 0"
-            },
-            {
-              "kind": "match",
-              "candidateId": "h5-e",
-              "passed": true,
-              "detail": "expected match=false, got surfaced=false (score 0, threshold 30)"
-            },
-            {
-              "kind": "band",
-              "candidateId": "h5-e",
-              "passed": true,
-              "detail": "expected score in [0,29], got 0"
-            }
-          ]
-        },
-        {
-          "passed": true,
-          "assertions": [
-            {
-              "kind": "match",
-              "candidateId": "h5-b",
-              "passed": true,
-              "detail": "expected match=true, got surfaced=true (score 98, threshold 30)"
-            },
-            {
-              "kind": "band",
-              "candidateId": "h5-b",
-              "passed": true,
-              "detail": "expected score in [60,100], got 98"
-            },
-            {
-              "kind": "match",
-              "candidateId": "h5-c",
-              "passed": true,
-              "detail": "expected match=false, got surfaced=false (score 0, threshold 30)"
-            },
-            {
-              "kind": "band",
-              "candidateId": "h5-c",
-              "passed": true,
-              "detail": "expected score in [0,29], got 0"
-            },
-            {
-              "kind": "match",
-              "candidateId": "h5-d",
-              "passed": true,
-              "detail": "expected match=false, got surfaced=false (score 0, threshold 30)"
-            },
-            {
-              "kind": "band",
-              "candidateId": "h5-d",
-              "passed": true,
-              "detail": "expected score in [0,29], got 0"
-            },
-            {
-              "kind": "match",
-              "candidateId": "h5-e",
-              "passed": true,
-              "detail": "expected match=false, got surfaced=false (score 0, threshold 30)"
-            },
-            {
-              "kind": "band",
-              "candidateId": "h5-e",
-              "passed": true,
-              "detail": "expected score in [0,29], got 0"
-            }
-          ]
-        },
-        {
-          "passed": true,
-          "assertions": [
-            {
-              "kind": "match",
-              "candidateId": "h5-b",
-              "passed": true,
-              "detail": "expected match=true, got surfaced=true (score 95, threshold 30)"
-            },
-            {
-              "kind": "band",
-              "candidateId": "h5-b",
-              "passed": true,
-              "detail": "expected score in [60,100], got 95"
-            },
-            {
-              "kind": "match",
-              "candidateId": "h5-c",
-              "passed": true,
-              "detail": "expected match=false, got surfaced=false (score 0, threshold 30)"
-            },
-            {
-              "kind": "band",
-              "candidateId": "h5-c",
-              "passed": true,
-              "detail": "expected score in [0,29], got 0"
-            },
-            {
-              "kind": "match",
-              "candidateId": "h5-d",
-              "passed": true,
-              "detail": "expected match=false, got surfaced=false (score 0, threshold 30)"
-            },
-            {
-              "kind": "band",
-              "candidateId": "h5-d",
-              "passed": true,
-              "detail": "expected score in [0,29], got 0"
-            },
-            {
-              "kind": "match",
-              "candidateId": "h5-e",
-              "passed": true,
-              "detail": "expected match=false, got surfaced=false (score 0, threshold 30)"
-            },
-            {
-              "kind": "band",
-              "candidateId": "h5-e",
-              "passed": true,
-              "detail": "expected score in [0,29], got 0"
-            }
-          ]
-        }
-      ]
-    },
-    {
-      "caseId": "is_a_identity/startup-funder-vs-funded-bootstrapper",
-      "rule": "is_a_identity",
-      "runs": 7,
-      "passes": 7,
-      "passRate": 1,
-      "flaky": false,
-      "runResults": [
-        {
-          "passed": true,
-          "assertions": [
-            {
-              "kind": "match",
-              "candidateId": "c-bootstrap",
-              "passed": true,
-              "detail": "expected match=false, got surfaced=false (score 0, threshold 30)"
-            },
-            {
-              "kind": "band",
-              "candidateId": "c-bootstrap",
-              "passed": true,
-              "detail": "expected score in [0,29], got 0"
-            }
-          ]
-        },
-        {
-          "passed": true,
-          "assertions": [
-            {
-              "kind": "match",
-              "candidateId": "c-bootstrap",
-              "passed": true,
-              "detail": "expected match=false, got surfaced=false (score 0, threshold 30)"
-            },
-            {
-              "kind": "band",
-              "candidateId": "c-bootstrap",
-              "passed": true,
-              "detail": "expected score in [0,29], got 0"
-            }
-          ]
-        },
-        {
-          "passed": true,
-          "assertions": [
-            {
-              "kind": "match",
-              "candidateId": "c-bootstrap",
-              "passed": true,
-              "detail": "expected match=false, got surfaced=false (score 0, threshold 30)"
-            },
-            {
-              "kind": "band",
-              "candidateId": "c-bootstrap",
-              "passed": true,
-              "detail": "expected score in [0,29], got 0"
-            }
-          ]
-        },
-        {
-          "passed": true,
-          "assertions": [
-            {
-              "kind": "match",
-              "candidateId": "c-bootstrap",
-              "passed": true,
-              "detail": "expected match=false, got surfaced=false (score 0, threshold 30)"
-            },
-            {
-              "kind": "band",
-              "candidateId": "c-bootstrap",
-              "passed": true,
-              "detail": "expected score in [0,29], got 0"
-            }
-          ]
-        },
-        {
-          "passed": true,
-          "assertions": [
-            {
-              "kind": "match",
-              "candidateId": "c-bootstrap",
-              "passed": true,
-              "detail": "expected match=false, got surfaced=false (score 0, threshold 30)"
-            },
-            {
-              "kind": "band",
-              "candidateId": "c-bootstrap",
-              "passed": true,
-              "detail": "expected score in [0,29], got 0"
-            }
-          ]
-        },
-        {
-          "passed": true,
-          "assertions": [
-            {
-              "kind": "match",
-              "candidateId": "c-bootstrap",
-              "passed": true,
-              "detail": "expected match=false, got surfaced=false (score 0, threshold 30)"
-            },
-            {
-              "kind": "band",
-              "candidateId": "c-bootstrap",
-              "passed": true,
-              "detail": "expected score in [0,29], got 0"
-            }
-          ]
-        },
-        {
-          "passed": true,
-          "assertions": [
-            {
-              "kind": "match",
-              "candidateId": "c-bootstrap",
-              "passed": true,
-              "detail": "expected match=false, got surfaced=false (score 0, threshold 30)"
-            },
-            {
-              "kind": "band",
-              "candidateId": "c-bootstrap",
-              "passed": true,
-              "detail": "expected score in [0,29], got 0"
-            }
-          ]
-        }
-      ]
-    },
-    {
-      "caseId": "is_a_identity/art-director-vs-illustrator",
-      "rule": "is_a_identity",
-      "runs": 7,
-      "passes": 7,
-      "passRate": 1,
-      "flaky": false,
-      "runResults": [
-        {
-          "passed": true,
-          "assertions": [
-            {
-              "kind": "match",
-              "candidateId": "c-lucia",
-              "passed": true,
-              "detail": "expected match=false, got surfaced=false (score 0, threshold 30)"
-            },
-            {
-              "kind": "band",
-              "candidateId": "c-lucia",
-              "passed": true,
-              "detail": "expected score in [0,29], got 0"
-            }
-          ]
-        },
-        {
-          "passed": true,
-          "assertions": [
-            {
-              "kind": "match",
-              "candidateId": "c-lucia",
-              "passed": true,
-              "detail": "expected match=false, got surfaced=false (score 0, threshold 30)"
-            },
-            {
-              "kind": "band",
-              "candidateId": "c-lucia",
-              "passed": true,
-              "detail": "expected score in [0,29], got 0"
-            }
-          ]
-        },
-        {
-          "passed": true,
-          "assertions": [
-            {
-              "kind": "match",
-              "candidateId": "c-lucia",
-              "passed": true,
-              "detail": "expected match=false, got surfaced=false (score 0, threshold 30)"
-            },
-            {
-              "kind": "band",
-              "candidateId": "c-lucia",
-              "passed": true,
-              "detail": "expected score in [0,29], got 0"
-            }
-          ]
-        },
-        {
-          "passed": true,
-          "assertions": [
-            {
-              "kind": "match",
-              "candidateId": "c-lucia",
-              "passed": true,
-              "detail": "expected match=false, got surfaced=false (score 0, threshold 30)"
-            },
-            {
-              "kind": "band",
-              "candidateId": "c-lucia",
-              "passed": true,
-              "detail": "expected score in [0,29], got 0"
-            }
-          ]
-        },
-        {
-          "passed": true,
-          "assertions": [
-            {
-              "kind": "match",
-              "candidateId": "c-lucia",
-              "passed": true,
-              "detail": "expected match=false, got surfaced=false (score 0, threshold 30)"
-            },
-            {
-              "kind": "band",
-              "candidateId": "c-lucia",
-              "passed": true,
-              "detail": "expected score in [0,29], got 0"
-            }
-          ]
-        },
-        {
-          "passed": true,
-          "assertions": [
-            {
-              "kind": "match",
-              "candidateId": "c-lucia",
-              "passed": true,
-              "detail": "expected match=false, got surfaced=false (score 0, threshold 30)"
-            },
-            {
-              "kind": "band",
-              "candidateId": "c-lucia",
-              "passed": true,
-              "detail": "expected score in [0,29], got 0"
-            }
-          ]
-        },
-        {
-          "passed": true,
-          "assertions": [
-            {
-              "kind": "match",
-              "candidateId": "c-lucia",
-              "passed": true,
-              "detail": "expected match=false, got surfaced=false (score 0, threshold 30)"
-            },
-            {
-              "kind": "band",
-              "candidateId": "c-lucia",
-              "passed": true,
-              "detail": "expected score in [0,29], got 0"
-            }
-          ]
-        }
-      ]
-    },
-    {
-      "caseId": "is_a_identity/scout-vs-scouted-athlete",
-      "rule": "is_a_identity",
-      "runs": 7,
-      "passes": 7,
-      "passRate": 1,
-      "flaky": false,
-      "runResults": [
-        {
-          "passed": true,
-          "assertions": [
-            {
-              "kind": "match",
-              "candidateId": "c-scout",
-              "passed": true,
-              "detail": "expected match=true, got surfaced=true (score 92, threshold 30)"
-            },
-            {
-              "kind": "band",
-              "candidateId": "c-scout",
-              "passed": true,
-              "detail": "expected score in [70,100], got 92"
-            },
-            {
-              "kind": "match",
-              "candidateId": "c-athlete",
-              "passed": true,
-              "detail": "expected match=false, got surfaced=false (score 0, threshold 30)"
-            },
-            {
-              "kind": "band",
-              "candidateId": "c-athlete",
-              "passed": true,
-              "detail": "expected score in [0,29], got 0"
-            }
-          ]
-        },
-        {
-          "passed": true,
-          "assertions": [
-            {
-              "kind": "match",
-              "candidateId": "c-scout",
-              "passed": true,
-              "detail": "expected match=true, got surfaced=true (score 85, threshold 30)"
-            },
-            {
-              "kind": "band",
-              "candidateId": "c-scout",
-              "passed": true,
-              "detail": "expected score in [70,100], got 85"
-            },
-            {
-              "kind": "match",
-              "candidateId": "c-athlete",
-              "passed": true,
-              "detail": "expected match=false, got surfaced=false (score 0, threshold 30)"
-            },
-            {
-              "kind": "band",
-              "candidateId": "c-athlete",
-              "passed": true,
-              "detail": "expected score in [0,29], got 0"
-            }
-          ]
-        },
-        {
-          "passed": true,
-          "assertions": [
-            {
-              "kind": "match",
-              "candidateId": "c-scout",
-              "passed": true,
-              "detail": "expected match=true, got surfaced=true (score 95, threshold 30)"
-            },
-            {
-              "kind": "band",
-              "candidateId": "c-scout",
-              "passed": true,
-              "detail": "expected score in [70,100], got 95"
-            },
-            {
-              "kind": "match",
-              "candidateId": "c-athlete",
-              "passed": true,
-              "detail": "expected match=false, got surfaced=false (score 0, threshold 30)"
-            },
-            {
-              "kind": "band",
-              "candidateId": "c-athlete",
-              "passed": true,
-              "detail": "expected score in [0,29], got 0"
-            }
-          ]
-        },
-        {
-          "passed": true,
-          "assertions": [
-            {
-              "kind": "match",
-              "candidateId": "c-scout",
-              "passed": true,
-              "detail": "expected match=true, got surfaced=true (score 95, threshold 30)"
-            },
-            {
-              "kind": "band",
-              "candidateId": "c-scout",
-              "passed": true,
-              "detail": "expected score in [70,100], got 95"
-            },
-            {
-              "kind": "match",
-              "candidateId": "c-athlete",
-              "passed": true,
-              "detail": "expected match=false, got surfaced=false (score 0, threshold 30)"
-            },
-            {
-              "kind": "band",
-              "candidateId": "c-athlete",
-              "passed": true,
-              "detail": "expected score in [0,29], got 0"
-            }
-          ]
-        },
-        {
-          "passed": true,
-          "assertions": [
-            {
-              "kind": "match",
-              "candidateId": "c-scout",
-              "passed": true,
-              "detail": "expected match=true, got surfaced=true (score 95, threshold 30)"
-            },
-            {
-              "kind": "band",
-              "candidateId": "c-scout",
-              "passed": true,
-              "detail": "expected score in [70,100], got 95"
-            },
-            {
-              "kind": "match",
-              "candidateId": "c-athlete",
-              "passed": true,
-              "detail": "expected match=false, got surfaced=false (score 0, threshold 30)"
-            },
-            {
-              "kind": "band",
-              "candidateId": "c-athlete",
-              "passed": true,
-              "detail": "expected score in [0,29], got 0"
-            }
-          ]
-        },
-        {
-          "passed": true,
-          "assertions": [
-            {
-              "kind": "match",
-              "candidateId": "c-scout",
-              "passed": true,
-              "detail": "expected match=true, got surfaced=true (score 95, threshold 30)"
-            },
-            {
-              "kind": "band",
-              "candidateId": "c-scout",
-              "passed": true,
-              "detail": "expected score in [70,100], got 95"
-            },
-            {
-              "kind": "match",
-              "candidateId": "c-athlete",
-              "passed": true,
-              "detail": "expected match=false, got surfaced=false (score 0, threshold 30)"
-            },
-            {
-              "kind": "band",
-              "candidateId": "c-athlete",
-              "passed": true,
-              "detail": "expected score in [0,29], got 0"
-            }
-          ]
-        },
-        {
-          "passed": true,
-          "assertions": [
-            {
-              "kind": "match",
-              "candidateId": "c-scout",
-              "passed": true,
-              "detail": "expected match=true, got surfaced=true (score 95, threshold 30)"
-            },
-            {
-              "kind": "band",
-              "candidateId": "c-scout",
-              "passed": true,
-              "detail": "expected score in [70,100], got 95"
-            },
-            {
-              "kind": "match",
-              "candidateId": "c-athlete",
-              "passed": true,
-              "detail": "expected match=false, got surfaced=false (score 0, threshold 30)"
-            },
-            {
-              "kind": "band",
-              "candidateId": "c-athlete",
-              "passed": true,
-              "detail": "expected score in [0,29], got 0"
-            }
-          ]
-        }
-      ]
-    },
-    {
-      "caseId": "is_a_identity/investor-vs-grant-recipient",
-      "rule": "is_a_identity",
-      "runs": 7,
-      "passes": 7,
-      "passRate": 1,
-      "flaky": false,
-      "runResults": [
-        {
-          "passed": true,
-          "assertions": [
-            {
-              "kind": "match",
-              "candidateId": "c-grant",
-              "passed": true,
-              "detail": "expected match=false, got surfaced=false (score 0, threshold 30)"
-            },
-            {
-              "kind": "band",
-              "candidateId": "c-grant",
-              "passed": true,
-              "detail": "expected score in [0,29], got 0"
-            }
-          ]
-        },
-        {
-          "passed": true,
-          "assertions": [
-            {
-              "kind": "match",
-              "candidateId": "c-grant",
-              "passed": true,
-              "detail": "expected match=false, got surfaced=false (score 0, threshold 30)"
-            },
-            {
-              "kind": "band",
-              "candidateId": "c-grant",
-              "passed": true,
-              "detail": "expected score in [0,29], got 0"
-            }
-          ]
-        },
-        {
-          "passed": true,
-          "assertions": [
-            {
-              "kind": "match",
-              "candidateId": "c-grant",
-              "passed": true,
-              "detail": "expected match=false, got surfaced=false (score 0, threshold 30)"
-            },
-            {
-              "kind": "band",
-              "candidateId": "c-grant",
-              "passed": true,
-              "detail": "expected score in [0,29], got 0"
-            }
-          ]
-        },
-        {
-          "passed": true,
-          "assertions": [
-            {
-              "kind": "match",
-              "candidateId": "c-grant",
-              "passed": true,
-              "detail": "expected match=false, got surfaced=false (score 0, threshold 30)"
-            },
-            {
-              "kind": "band",
-              "candidateId": "c-grant",
-              "passed": true,
-              "detail": "expected score in [0,29], got 0"
-            }
-          ]
-        },
-        {
-          "passed": true,
-          "assertions": [
-            {
-              "kind": "match",
-              "candidateId": "c-grant",
-              "passed": true,
-              "detail": "expected match=false, got surfaced=false (score 0, threshold 30)"
-            },
-            {
-              "kind": "band",
-              "candidateId": "c-grant",
-              "passed": true,
-              "detail": "expected score in [0,29], got 0"
-            }
-          ]
-        },
-        {
-          "passed": true,
-          "assertions": [
-            {
-              "kind": "match",
-              "candidateId": "c-grant",
-              "passed": true,
-              "detail": "expected match=false, got surfaced=false (score 0, threshold 30)"
-            },
-            {
-              "kind": "band",
-              "candidateId": "c-grant",
-              "passed": true,
-              "detail": "expected score in [0,29], got 0"
-            }
-          ]
-        },
-        {
-          "passed": true,
-          "assertions": [
-            {
-              "kind": "match",
-              "candidateId": "c-grant",
-              "passed": true,
-              "detail": "expected match=false, got surfaced=false (score 0, threshold 30)"
-            },
-            {
-              "kind": "band",
-              "candidateId": "c-grant",
-              "passed": true,
-              "detail": "expected score in [0,29], got 0"
-            }
-          ]
-        }
-      ]
-    },
-    {
-      "caseId": "complementary_role/design-cofounder-for-tech-founder",
-      "rule": "complementary_role",
-      "runs": 7,
-      "passes": 6,
-      "passRate": 0.8571428571428571,
-      "flaky": true,
-      "runResults": [
-        {
-          "passed": true,
-          "assertions": [
-            {
-              "kind": "match",
-              "candidateId": "p-vc",
-              "passed": true,
-              "detail": "expected match=false, got surfaced=false (score 0, threshold 30)"
-            },
-            {
-              "kind": "band",
-              "candidateId": "p-vc",
-              "passed": true,
-              "detail": "expected score in [0,29], got 0"
-            },
-            {
-              "kind": "match",
-              "candidateId": "p-designer-alt",
-              "passed": true,
-              "detail": "expected match=true, got surfaced=true (score 95, threshold 30)"
-            },
-            {
-              "kind": "band",
-              "candidateId": "p-designer-alt",
-              "passed": true,
-              "detail": "expected score in [70,100], got 95"
-            },
-            {
-              "kind": "role",
-              "candidateId": "p-designer-alt",
-              "passed": true,
-              "detail": "expected role=agent, got agent"
-            }
-          ]
-        },
-        {
-          "passed": true,
-          "assertions": [
-            {
-              "kind": "match",
-              "candidateId": "p-vc",
-              "passed": true,
-              "detail": "expected match=false, got surfaced=false (score 0, threshold 30)"
-            },
-            {
-              "kind": "band",
-              "candidateId": "p-vc",
-              "passed": true,
-              "detail": "expected score in [0,29], got 0"
-            },
-            {
-              "kind": "match",
-              "candidateId": "p-designer-alt",
-              "passed": true,
-              "detail": "expected match=true, got surfaced=true (score 92, threshold 30)"
-            },
-            {
-              "kind": "band",
-              "candidateId": "p-designer-alt",
-              "passed": true,
-              "detail": "expected score in [70,100], got 92"
-            },
-            {
-              "kind": "role",
-              "candidateId": "p-designer-alt",
-              "passed": true,
-              "detail": "expected role=agent, got agent"
-            }
-          ]
-        },
-        {
-          "passed": true,
-          "assertions": [
-            {
-              "kind": "match",
-              "candidateId": "p-vc",
-              "passed": true,
-              "detail": "expected match=false, got surfaced=false (score 0, threshold 30)"
-            },
-            {
-              "kind": "band",
-              "candidateId": "p-vc",
-              "passed": true,
-              "detail": "expected score in [0,29], got 0"
-            },
-            {
-              "kind": "match",
-              "candidateId": "p-designer-alt",
-              "passed": true,
-              "detail": "expected match=true, got surfaced=true (score 95, threshold 30)"
-            },
-            {
-              "kind": "band",
-              "candidateId": "p-designer-alt",
-              "passed": true,
-              "detail": "expected score in [70,100], got 95"
-            },
-            {
-              "kind": "role",
-              "candidateId": "p-designer-alt",
-              "passed": true,
-              "detail": "expected role=agent, got agent"
-            }
-          ]
-        },
-        {
-          "passed": true,
-          "assertions": [
-            {
-              "kind": "match",
-              "candidateId": "p-vc",
-              "passed": true,
-              "detail": "expected match=false, got surfaced=false (score 0, threshold 30)"
-            },
-            {
-              "kind": "band",
-              "candidateId": "p-vc",
-              "passed": true,
-              "detail": "expected score in [0,29], got 0"
-            },
-            {
-              "kind": "match",
-              "candidateId": "p-designer-alt",
-              "passed": true,
-              "detail": "expected match=true, got surfaced=true (score 95, threshold 30)"
-            },
-            {
-              "kind": "band",
-              "candidateId": "p-designer-alt",
-              "passed": true,
-              "detail": "expected score in [70,100], got 95"
-            },
-            {
-              "kind": "role",
-              "candidateId": "p-designer-alt",
-              "passed": true,
-              "detail": "expected role=agent, got agent"
-            }
-          ]
-        },
-        {
-          "passed": true,
-          "assertions": [
-            {
-              "kind": "match",
-              "candidateId": "p-vc",
-              "passed": true,
-              "detail": "expected match=false, got surfaced=false (score 0, threshold 30)"
-            },
-            {
-              "kind": "band",
-              "candidateId": "p-vc",
-              "passed": true,
-              "detail": "expected score in [0,29], got 0"
-            },
-            {
-              "kind": "match",
-              "candidateId": "p-designer-alt",
-              "passed": true,
-              "detail": "expected match=true, got surfaced=true (score 95, threshold 30)"
-            },
-            {
-              "kind": "band",
-              "candidateId": "p-designer-alt",
-              "passed": true,
-              "detail": "expected score in [70,100], got 95"
-            },
-            {
-              "kind": "role",
-              "candidateId": "p-designer-alt",
-              "passed": true,
-              "detail": "expected role=agent, got agent"
-            }
-          ]
-        },
-        {
-          "passed": false,
-          "assertions": [
-            {
-              "kind": "match",
-              "candidateId": "p-vc",
-              "passed": true,
-              "detail": "expected match=false, got surfaced=false (score 0, threshold 30)"
-            },
-            {
-              "kind": "band",
-              "candidateId": "p-vc",
-              "passed": true,
-              "detail": "expected score in [0,29], got 0"
-            },
-            {
-              "kind": "match",
-              "candidateId": "p-designer-alt",
-              "passed": true,
-              "detail": "expected match=true, got surfaced=true (score 95, threshold 30)"
-            },
-            {
-              "kind": "band",
-              "candidateId": "p-designer-alt",
-              "passed": true,
-              "detail": "expected score in [70,100], got 95"
-            },
-            {
-              "kind": "role",
-              "candidateId": "p-designer-alt",
-              "passed": false,
-              "detail": "expected role=agent, got peer"
-            }
-          ]
-        },
-        {
-          "passed": true,
-          "assertions": [
-            {
-              "kind": "match",
-              "candidateId": "p-vc",
-              "passed": true,
-              "detail": "expected match=false, got surfaced=false (score 0, threshold 30)"
-            },
-            {
-              "kind": "band",
-              "candidateId": "p-vc",
-              "passed": true,
-              "detail": "expected score in [0,29], got 0"
-            },
-            {
-              "kind": "match",
-              "candidateId": "p-designer-alt",
-              "passed": true,
-              "detail": "expected match=true, got surfaced=true (score 95, threshold 30)"
-            },
-            {
-              "kind": "band",
-              "candidateId": "p-designer-alt",
-              "passed": true,
-              "detail": "expected score in [70,100], got 95"
-            },
-            {
-              "kind": "role",
-              "candidateId": "p-designer-alt",
-              "passed": true,
-              "detail": "expected role=agent, got agent"
-            }
-          ]
-        }
-      ]
-    },
-    {
-      "caseId": "complementary_role/marketing-cofounder-for-ai-engineer",
-      "rule": "complementary_role",
-      "runs": 7,
-      "passes": 7,
-      "passRate": 1,
-      "flaky": false,
-      "runResults": [
-        {
-          "passed": true,
-          "assertions": [
-            {
-              "kind": "match",
-              "candidateId": "p-operator",
-              "passed": true,
-              "detail": "expected match=true, got surfaced=true (score 95, threshold 30)"
-            },
-            {
-              "kind": "band",
-              "candidateId": "p-operator",
-              "passed": true,
-              "detail": "expected score in [70,100], got 95"
-            },
-            {
-              "kind": "role",
-              "candidateId": "p-operator",
-              "passed": true,
-              "detail": "expected role=agent, got agent"
-            },
-            {
-              "kind": "match",
-              "candidateId": "p-tech-alt",
-              "passed": true,
-              "detail": "expected match=false, got surfaced=false (score 0, threshold 30)"
-            },
-            {
-              "kind": "band",
-              "candidateId": "p-tech-alt",
-              "passed": true,
-              "detail": "expected score in [0,29], got 0"
-            }
-          ]
-        },
-        {
-          "passed": true,
-          "assertions": [
-            {
-              "kind": "match",
-              "candidateId": "p-operator",
-              "passed": true,
-              "detail": "expected match=true, got surfaced=true (score 88, threshold 30)"
-            },
-            {
-              "kind": "band",
-              "candidateId": "p-operator",
-              "passed": true,
-              "detail": "expected score in [70,100], got 88"
-            },
-            {
-              "kind": "role",
-              "candidateId": "p-operator",
-              "passed": true,
-              "detail": "expected role=agent, got agent"
-            },
-            {
-              "kind": "match",
-              "candidateId": "p-tech-alt",
-              "passed": true,
-              "detail": "expected match=false, got surfaced=false (score 0, threshold 30)"
-            },
-            {
-              "kind": "band",
-              "candidateId": "p-tech-alt",
-              "passed": true,
-              "detail": "expected score in [0,29], got 0"
-            }
-          ]
-        },
-        {
-          "passed": true,
-          "assertions": [
-            {
-              "kind": "match",
-              "candidateId": "p-operator",
-              "passed": true,
-              "detail": "expected match=true, got surfaced=true (score 85, threshold 30)"
-            },
-            {
-              "kind": "band",
-              "candidateId": "p-operator",
-              "passed": true,
-              "detail": "expected score in [70,100], got 85"
-            },
-            {
-              "kind": "role",
-              "candidateId": "p-operator",
-              "passed": true,
-              "detail": "expected role=agent, got agent"
-            },
-            {
-              "kind": "match",
-              "candidateId": "p-tech-alt",
-              "passed": true,
-              "detail": "expected match=false, got surfaced=false (score 0, threshold 30)"
-            },
-            {
-              "kind": "band",
-              "candidateId": "p-tech-alt",
-              "passed": true,
-              "detail": "expected score in [0,29], got 0"
-            }
-          ]
-        },
-        {
-          "passed": true,
-          "assertions": [
-            {
-              "kind": "match",
-              "candidateId": "p-operator",
-              "passed": true,
-              "detail": "expected match=true, got surfaced=true (score 90, threshold 30)"
-            },
-            {
-              "kind": "band",
-              "candidateId": "p-operator",
-              "passed": true,
-              "detail": "expected score in [70,100], got 90"
-            },
-            {
-              "kind": "role",
-              "candidateId": "p-operator",
-              "passed": true,
-              "detail": "expected role=agent, got agent"
-            },
-            {
-              "kind": "match",
-              "candidateId": "p-tech-alt",
-              "passed": true,
-              "detail": "expected match=false, got surfaced=false (score 0, threshold 30)"
-            },
-            {
-              "kind": "band",
-              "candidateId": "p-tech-alt",
-              "passed": true,
-              "detail": "expected score in [0,29], got 0"
-            }
-          ]
-        },
-        {
-          "passed": true,
-          "assertions": [
-            {
-              "kind": "match",
-              "candidateId": "p-operator",
-              "passed": true,
-              "detail": "expected match=true, got surfaced=true (score 95, threshold 30)"
-            },
-            {
-              "kind": "band",
-              "candidateId": "p-operator",
-              "passed": true,
-              "detail": "expected score in [70,100], got 95"
-            },
-            {
-              "kind": "role",
-              "candidateId": "p-operator",
-              "passed": true,
-              "detail": "expected role=agent, got agent"
-            },
-            {
-              "kind": "match",
-              "candidateId": "p-tech-alt",
-              "passed": true,
-              "detail": "expected match=false, got surfaced=false (score 0, threshold 30)"
-            },
-            {
-              "kind": "band",
-              "candidateId": "p-tech-alt",
-              "passed": true,
-              "detail": "expected score in [0,29], got 0"
-            }
-          ]
-        },
-        {
-          "passed": true,
-          "assertions": [
-            {
-              "kind": "match",
-              "candidateId": "p-operator",
-              "passed": true,
-              "detail": "expected match=true, got surfaced=true (score 95, threshold 30)"
-            },
-            {
-              "kind": "band",
-              "candidateId": "p-operator",
-              "passed": true,
-              "detail": "expected score in [70,100], got 95"
-            },
-            {
-              "kind": "role",
-              "candidateId": "p-operator",
-              "passed": true,
-              "detail": "expected role=agent, got agent"
-            },
-            {
-              "kind": "match",
-              "candidateId": "p-tech-alt",
-              "passed": true,
-              "detail": "expected match=false, got surfaced=false (score 0, threshold 30)"
-            },
-            {
-              "kind": "band",
-              "candidateId": "p-tech-alt",
-              "passed": true,
-              "detail": "expected score in [0,29], got 0"
-            }
-          ]
-        },
-        {
-          "passed": true,
-          "assertions": [
-            {
-              "kind": "match",
-              "candidateId": "p-operator",
-              "passed": true,
-              "detail": "expected match=true, got surfaced=true (score 95, threshold 30)"
-            },
-            {
-              "kind": "band",
-              "candidateId": "p-operator",
-              "passed": true,
-              "detail": "expected score in [70,100], got 95"
-            },
-            {
-              "kind": "role",
-              "candidateId": "p-operator",
-              "passed": true,
-              "detail": "expected role=agent, got agent"
-            },
-            {
-              "kind": "match",
-              "candidateId": "p-tech-alt",
-              "passed": true,
-              "detail": "expected match=false, got surfaced=false (score 0, threshold 30)"
-            },
-            {
-              "kind": "band",
-              "candidateId": "p-tech-alt",
-              "passed": true,
-              "detail": "expected score in [0,29], got 0"
-            }
-          ]
-        }
-      ]
-    },
-    {
-      "caseId": "same_side/both-seeking-cofounders",
-      "rule": "same_side",
-      "runs": 7,
-      "passes": 7,
-      "passRate": 1,
-      "flaky": false,
-      "runResults": [
-        {
-          "passed": true,
-          "assertions": [
-            {
-              "kind": "match",
-              "candidateId": "c-seek-cof",
-              "passed": true,
-              "detail": "expected match=false, got surfaced=false (score 0, threshold 30)"
-            },
-            {
-              "kind": "band",
-              "candidateId": "c-seek-cof",
-              "passed": true,
-              "detail": "expected score in [0,29], got 0"
-            }
-          ]
-        },
-        {
-          "passed": true,
-          "assertions": [
-            {
-              "kind": "match",
-              "candidateId": "c-seek-cof",
-              "passed": true,
-              "detail": "expected match=false, got surfaced=false (score 0, threshold 30)"
-            },
-            {
-              "kind": "band",
-              "candidateId": "c-seek-cof",
-              "passed": true,
-              "detail": "expected score in [0,29], got 0"
-            }
-          ]
-        },
-        {
-          "passed": true,
-          "assertions": [
-            {
-              "kind": "match",
-              "candidateId": "c-seek-cof",
-              "passed": true,
-              "detail": "expected match=false, got surfaced=false (score 0, threshold 30)"
-            },
-            {
-              "kind": "band",
-              "candidateId": "c-seek-cof",
-              "passed": true,
-              "detail": "expected score in [0,29], got 0"
-            }
-          ]
-        },
-        {
-          "passed": true,
-          "assertions": [
-            {
-              "kind": "match",
-              "candidateId": "c-seek-cof",
-              "passed": true,
-              "detail": "expected match=false, got surfaced=false (score 0, threshold 30)"
-            },
-            {
-              "kind": "band",
-              "candidateId": "c-seek-cof",
-              "passed": true,
-              "detail": "expected score in [0,29], got 0"
-            }
-          ]
-        },
-        {
-          "passed": true,
-          "assertions": [
-            {
-              "kind": "match",
-              "candidateId": "c-seek-cof",
-              "passed": true,
-              "detail": "expected match=false, got surfaced=false (score 0, threshold 30)"
-            },
-            {
-              "kind": "band",
-              "candidateId": "c-seek-cof",
-              "passed": true,
-              "detail": "expected score in [0,29], got 0"
-            }
-          ]
-        },
-        {
-          "passed": true,
-          "assertions": [
-            {
-              "kind": "match",
-              "candidateId": "c-seek-cof",
-              "passed": true,
-              "detail": "expected match=false, got surfaced=false (score 0, threshold 30)"
-            },
-            {
-              "kind": "band",
-              "candidateId": "c-seek-cof",
-              "passed": true,
-              "detail": "expected score in [0,29], got 0"
-            }
-          ]
-        },
-        {
-          "passed": true,
-          "assertions": [
-            {
-              "kind": "match",
-              "candidateId": "c-seek-cof",
-              "passed": true,
-              "detail": "expected match=false, got surfaced=false (score 0, threshold 30)"
-            },
-            {
-              "kind": "band",
-              "candidateId": "c-seek-cof",
-              "passed": true,
-              "detail": "expected score in [0,29], got 0"
-            }
-          ]
-        }
-      ]
-    },
-    {
-      "caseId": "same_side/both-hiring-engineers",
-      "rule": "same_side",
-      "runs": 7,
-      "passes": 7,
-      "passRate": 1,
-      "flaky": false,
-      "runResults": [
-        {
-          "passed": true,
-          "assertions": [
-            {
-              "kind": "match",
-              "candidateId": "c-recruiting",
-              "passed": true,
-              "detail": "expected match=false, got surfaced=false (score 0, threshold 30)"
-            },
-            {
-              "kind": "band",
-              "candidateId": "c-recruiting",
-              "passed": true,
-              "detail": "expected score in [0,29], got 0"
-            }
-          ]
-        },
-        {
-          "passed": true,
-          "assertions": [
-            {
-              "kind": "match",
-              "candidateId": "c-recruiting",
-              "passed": true,
-              "detail": "expected match=false, got surfaced=false (score 0, threshold 30)"
-            },
-            {
-              "kind": "band",
-              "candidateId": "c-recruiting",
-              "passed": true,
-              "detail": "expected score in [0,29], got 0"
-            }
-          ]
-        },
-        {
-          "passed": true,
-          "assertions": [
-            {
-              "kind": "match",
-              "candidateId": "c-recruiting",
-              "passed": true,
-              "detail": "expected match=false, got surfaced=false (score 0, threshold 30)"
-            },
-            {
-              "kind": "band",
-              "candidateId": "c-recruiting",
-              "passed": true,
-              "detail": "expected score in [0,29], got 0"
-            }
-          ]
-        },
-        {
-          "passed": true,
-          "assertions": [
-            {
-              "kind": "match",
-              "candidateId": "c-recruiting",
-              "passed": true,
-              "detail": "expected match=false, got surfaced=false (score 0, threshold 30)"
-            },
-            {
-              "kind": "band",
-              "candidateId": "c-recruiting",
-              "passed": true,
-              "detail": "expected score in [0,29], got 0"
-            }
-          ]
-        },
-        {
-          "passed": true,
-          "assertions": [
-            {
-              "kind": "match",
-              "candidateId": "c-recruiting",
-              "passed": true,
-              "detail": "expected match=false, got surfaced=false (score 0, threshold 30)"
-            },
-            {
-              "kind": "band",
-              "candidateId": "c-recruiting",
-              "passed": true,
-              "detail": "expected score in [0,29], got 0"
-            }
-          ]
-        },
-        {
-          "passed": true,
-          "assertions": [
-            {
-              "kind": "match",
-              "candidateId": "c-recruiting",
-              "passed": true,
-              "detail": "expected match=false, got surfaced=false (score 0, threshold 30)"
-            },
-            {
-              "kind": "band",
-              "candidateId": "c-recruiting",
-              "passed": true,
-              "detail": "expected score in [0,29], got 0"
-            }
-          ]
-        },
-        {
-          "passed": true,
-          "assertions": [
-            {
-              "kind": "match",
-              "candidateId": "c-recruiting",
-              "passed": true,
-              "detail": "expected match=false, got surfaced=false (score 0, threshold 30)"
-            },
-            {
-              "kind": "band",
-              "candidateId": "c-recruiting",
-              "passed": true,
-              "detail": "expected score in [0,29], got 0"
-            }
-          ]
-        }
-      ]
-    },
-    {
-      "caseId": "location/berlin-mismatch-vs-london-query",
-      "rule": "location",
-      "runs": 7,
-      "passes": 7,
-      "passRate": 1,
-      "flaky": false,
-      "runResults": [
-        {
-          "passed": true,
-          "assertions": [
-            {
-              "kind": "match",
-              "candidateId": "c-berlin",
-              "passed": true,
-              "detail": "expected match=false, got surfaced=false (score 0, threshold 30)"
-            },
-            {
-              "kind": "band",
-              "candidateId": "c-berlin",
-              "passed": true,
-              "detail": "expected score in [0,29], got 0"
-            }
-          ]
-        },
-        {
-          "passed": true,
-          "assertions": [
-            {
-              "kind": "match",
-              "candidateId": "c-berlin",
-              "passed": true,
-              "detail": "expected match=false, got surfaced=false (score 0, threshold 30)"
-            },
-            {
-              "kind": "band",
-              "candidateId": "c-berlin",
-              "passed": true,
-              "detail": "expected score in [0,29], got 0"
-            }
-          ]
-        },
-        {
-          "passed": true,
-          "assertions": [
-            {
-              "kind": "match",
-              "candidateId": "c-berlin",
-              "passed": true,
-              "detail": "expected match=false, got surfaced=false (score 0, threshold 30)"
-            },
-            {
-              "kind": "band",
-              "candidateId": "c-berlin",
-              "passed": true,
-              "detail": "expected score in [0,29], got 0"
-            }
-          ]
-        },
-        {
-          "passed": true,
-          "assertions": [
-            {
-              "kind": "match",
-              "candidateId": "c-berlin",
-              "passed": true,
-              "detail": "expected match=false, got surfaced=false (score 0, threshold 30)"
-            },
-            {
-              "kind": "band",
-              "candidateId": "c-berlin",
-              "passed": true,
-              "detail": "expected score in [0,29], got 0"
-            }
-          ]
-        },
-        {
-          "passed": true,
-          "assertions": [
-            {
-              "kind": "match",
-              "candidateId": "c-berlin",
-              "passed": true,
-              "detail": "expected match=false, got surfaced=false (score 0, threshold 30)"
-            },
-            {
-              "kind": "band",
-              "candidateId": "c-berlin",
-              "passed": true,
-              "detail": "expected score in [0,29], got 0"
-            }
-          ]
-        },
-        {
-          "passed": true,
-          "assertions": [
-            {
-              "kind": "match",
-              "candidateId": "c-berlin",
-              "passed": true,
-              "detail": "expected match=false, got surfaced=false (score 0, threshold 30)"
-            },
-            {
-              "kind": "band",
-              "candidateId": "c-berlin",
-              "passed": true,
-              "detail": "expected score in [0,29], got 0"
-            }
-          ]
-        },
-        {
-          "passed": true,
-          "assertions": [
-            {
-              "kind": "match",
-              "candidateId": "c-berlin",
-              "passed": true,
-              "detail": "expected match=false, got surfaced=false (score 0, threshold 30)"
-            },
-            {
-              "kind": "band",
-              "candidateId": "c-berlin",
-              "passed": true,
-              "detail": "expected score in [0,29], got 0"
-            }
-          ]
-        }
-      ]
-    },
-    {
-      "caseId": "location/unknown-city-not-penalized-variant",
-      "rule": "location",
-      "runs": 7,
-      "passes": 7,
-      "passRate": 1,
-      "flaky": false,
-      "runResults": [
-        {
-          "passed": true,
-          "assertions": [
-            {
-              "kind": "match",
-              "candidateId": "c-empty-loc",
-              "passed": true,
-              "detail": "expected match=true, got surfaced=true (score 85, threshold 30)"
-            },
-            {
-              "kind": "band",
-              "candidateId": "c-empty-loc",
-              "passed": true,
-              "detail": "expected score in [60,100], got 85"
-            }
-          ]
-        },
-        {
-          "passed": true,
-          "assertions": [
-            {
-              "kind": "match",
-              "candidateId": "c-empty-loc",
-              "passed": true,
-              "detail": "expected match=true, got surfaced=true (score 85, threshold 30)"
-            },
-            {
-              "kind": "band",
-              "candidateId": "c-empty-loc",
-              "passed": true,
-              "detail": "expected score in [60,100], got 85"
-            }
-          ]
-        },
-        {
-          "passed": true,
-          "assertions": [
-            {
-              "kind": "match",
-              "candidateId": "c-empty-loc",
-              "passed": true,
-              "detail": "expected match=true, got surfaced=true (score 85, threshold 30)"
-            },
-            {
-              "kind": "band",
-              "candidateId": "c-empty-loc",
-              "passed": true,
-              "detail": "expected score in [60,100], got 85"
-            }
-          ]
-        },
-        {
-          "passed": true,
-          "assertions": [
-            {
-              "kind": "match",
-              "candidateId": "c-empty-loc",
-              "passed": true,
-              "detail": "expected match=true, got surfaced=true (score 85, threshold 30)"
-            },
-            {
-              "kind": "band",
-              "candidateId": "c-empty-loc",
-              "passed": true,
-              "detail": "expected score in [60,100], got 85"
-            }
-          ]
-        },
-        {
-          "passed": true,
-          "assertions": [
-            {
-              "kind": "match",
-              "candidateId": "c-empty-loc",
-              "passed": true,
-              "detail": "expected match=true, got surfaced=true (score 85, threshold 30)"
-            },
-            {
-              "kind": "band",
-              "candidateId": "c-empty-loc",
-              "passed": true,
-              "detail": "expected score in [60,100], got 85"
-            }
-          ]
-        },
-        {
-          "passed": true,
-          "assertions": [
-            {
-              "kind": "match",
-              "candidateId": "c-empty-loc",
-              "passed": true,
-              "detail": "expected match=true, got surfaced=true (score 85, threshold 30)"
-            },
-            {
-              "kind": "band",
-              "candidateId": "c-empty-loc",
-              "passed": true,
-              "detail": "expected score in [60,100], got 85"
-            }
-          ]
-        },
-        {
-          "passed": true,
-          "assertions": [
-            {
-              "kind": "match",
-              "candidateId": "c-empty-loc",
-              "passed": true,
-              "detail": "expected match=true, got surfaced=true (score 85, threshold 30)"
-            },
-            {
-              "kind": "band",
-              "candidateId": "c-empty-loc",
-              "passed": true,
-              "detail": "expected score in [60,100], got 85"
-            }
-          ]
-        }
-      ]
-    },
-    {
-      "caseId": "valency_role/seeker-needs-design-provider-offers-design",
-      "rule": "valency_role",
-      "runs": 7,
-      "passes": 7,
-      "passRate": 1,
-      "flaky": false,
-      "runResults": [
-        {
-          "passed": true,
-          "assertions": [
-            {
-              "kind": "match",
-              "candidateId": "c-designer-alt",
-              "passed": true,
-              "detail": "expected match=true, got surfaced=true (score 98, threshold 30)"
-            },
-            {
-              "kind": "band",
-              "candidateId": "c-designer-alt",
-              "passed": true,
-              "detail": "expected score in [70,100], got 98"
-            },
-            {
-              "kind": "role",
-              "candidateId": "c-designer-alt",
-              "passed": true,
-              "detail": "expected role=agent, got agent"
-            }
-          ]
-        },
-        {
-          "passed": true,
-          "assertions": [
-            {
-              "kind": "match",
-              "candidateId": "c-designer-alt",
-              "passed": true,
-              "detail": "expected match=true, got surfaced=true (score 98, threshold 30)"
-            },
-            {
-              "kind": "band",
-              "candidateId": "c-designer-alt",
-              "passed": true,
-              "detail": "expected score in [70,100], got 98"
-            },
-            {
-              "kind": "role",
-              "candidateId": "c-designer-alt",
-              "passed": true,
-              "detail": "expected role=agent, got agent"
-            }
-          ]
-        },
-        {
-          "passed": true,
-          "assertions": [
-            {
-              "kind": "match",
-              "candidateId": "c-designer-alt",
-              "passed": true,
-              "detail": "expected match=true, got surfaced=true (score 98, threshold 30)"
-            },
-            {
-              "kind": "band",
-              "candidateId": "c-designer-alt",
-              "passed": true,
-              "detail": "expected score in [70,100], got 98"
-            },
-            {
-              "kind": "role",
-              "candidateId": "c-designer-alt",
-              "passed": true,
-              "detail": "expected role=agent, got agent"
-            }
-          ]
-        },
-        {
-          "passed": true,
-          "assertions": [
-            {
-              "kind": "match",
-              "candidateId": "c-designer-alt",
-              "passed": true,
-              "detail": "expected match=true, got surfaced=true (score 98, threshold 30)"
-            },
-            {
-              "kind": "band",
-              "candidateId": "c-designer-alt",
-              "passed": true,
-              "detail": "expected score in [70,100], got 98"
-            },
-            {
-              "kind": "role",
-              "candidateId": "c-designer-alt",
-              "passed": true,
-              "detail": "expected role=agent, got agent"
-            }
-          ]
-        },
-        {
-          "passed": true,
-          "assertions": [
-            {
-              "kind": "match",
-              "candidateId": "c-designer-alt",
-              "passed": true,
-              "detail": "expected match=true, got surfaced=true (score 98, threshold 30)"
-            },
-            {
-              "kind": "band",
-              "candidateId": "c-designer-alt",
-              "passed": true,
-              "detail": "expected score in [70,100], got 98"
-            },
-            {
-              "kind": "role",
-              "candidateId": "c-designer-alt",
-              "passed": true,
-              "detail": "expected role=agent, got agent"
-            }
-          ]
-        },
-        {
-          "passed": true,
-          "assertions": [
-            {
-              "kind": "match",
-              "candidateId": "c-designer-alt",
-              "passed": true,
-              "detail": "expected match=true, got surfaced=true (score 98, threshold 30)"
-            },
-            {
-              "kind": "band",
-              "candidateId": "c-designer-alt",
-              "passed": true,
-              "detail": "expected score in [70,100], got 98"
-            },
-            {
-              "kind": "role",
-              "candidateId": "c-designer-alt",
-              "passed": true,
-              "detail": "expected role=agent, got agent"
-            }
-          ]
-        },
-        {
-          "passed": true,
-          "assertions": [
-            {
-              "kind": "match",
-              "candidateId": "c-designer-alt",
-              "passed": true,
-              "detail": "expected match=true, got surfaced=true (score 98, threshold 30)"
-            },
-            {
-              "kind": "band",
-              "candidateId": "c-designer-alt",
-              "passed": true,
-              "detail": "expected score in [70,100], got 98"
-            },
-            {
-              "kind": "role",
-              "candidateId": "c-designer-alt",
-              "passed": true,
-              "detail": "expected role=agent, got agent"
-            }
-          ]
-        }
-      ]
-    },
-    {
-      "caseId": "valency_role/seeker-offers-capacity-provider-needs-capacity",
-      "rule": "valency_role",
-      "runs": 7,
-      "passes": 7,
-      "passRate": 1,
-      "flaky": false,
-      "runResults": [
-        {
-          "passed": true,
-          "assertions": [
-            {
-              "kind": "match",
-              "candidateId": "c-needs-gpu",
-              "passed": true,
-              "detail": "expected match=true, got surfaced=true (score 98, threshold 30)"
-            },
-            {
-              "kind": "band",
-              "candidateId": "c-needs-gpu",
-              "passed": true,
-              "detail": "expected score in [70,100], got 98"
-            },
-            {
-              "kind": "role",
-              "candidateId": "c-needs-gpu",
-              "passed": true,
-              "detail": "expected role=patient, got patient"
-            }
-          ]
-        },
-        {
-          "passed": true,
-          "assertions": [
-            {
-              "kind": "match",
-              "candidateId": "c-needs-gpu",
-              "passed": true,
-              "detail": "expected match=true, got surfaced=true (score 98, threshold 30)"
-            },
-            {
-              "kind": "band",
-              "candidateId": "c-needs-gpu",
-              "passed": true,
-              "detail": "expected score in [70,100], got 98"
-            },
-            {
-              "kind": "role",
-              "candidateId": "c-needs-gpu",
-              "passed": true,
-              "detail": "expected role=patient, got patient"
-            }
-          ]
-        },
-        {
-          "passed": true,
-          "assertions": [
-            {
-              "kind": "match",
-              "candidateId": "c-needs-gpu",
-              "passed": true,
-              "detail": "expected match=true, got surfaced=true (score 98, threshold 30)"
-            },
-            {
-              "kind": "band",
-              "candidateId": "c-needs-gpu",
-              "passed": true,
-              "detail": "expected score in [70,100], got 98"
-            },
-            {
-              "kind": "role",
-              "candidateId": "c-needs-gpu",
-              "passed": true,
-              "detail": "expected role=patient, got patient"
-            }
-          ]
-        },
-        {
-          "passed": true,
-          "assertions": [
-            {
-              "kind": "match",
-              "candidateId": "c-needs-gpu",
-              "passed": true,
-              "detail": "expected match=true, got surfaced=true (score 98, threshold 30)"
-            },
-            {
-              "kind": "band",
-              "candidateId": "c-needs-gpu",
-              "passed": true,
-              "detail": "expected score in [70,100], got 98"
-            },
-            {
-              "kind": "role",
-              "candidateId": "c-needs-gpu",
-              "passed": true,
-              "detail": "expected role=patient, got patient"
-            }
-          ]
-        },
-        {
-          "passed": true,
-          "assertions": [
-            {
-              "kind": "match",
-              "candidateId": "c-needs-gpu",
-              "passed": true,
-              "detail": "expected match=true, got surfaced=true (score 98, threshold 30)"
-            },
-            {
-              "kind": "band",
-              "candidateId": "c-needs-gpu",
-              "passed": true,
-              "detail": "expected score in [70,100], got 98"
-            },
-            {
-              "kind": "role",
-              "candidateId": "c-needs-gpu",
-              "passed": true,
-              "detail": "expected role=patient, got patient"
-            }
-          ]
-        },
-        {
-          "passed": true,
-          "assertions": [
-            {
-              "kind": "match",
-              "candidateId": "c-needs-gpu",
-              "passed": true,
-              "detail": "expected match=true, got surfaced=true (score 98, threshold 30)"
-            },
-            {
-              "kind": "band",
-              "candidateId": "c-needs-gpu",
-              "passed": true,
-              "detail": "expected score in [70,100], got 98"
-            },
-            {
-              "kind": "role",
-              "candidateId": "c-needs-gpu",
-              "passed": true,
-              "detail": "expected role=patient, got patient"
-            }
-          ]
-        },
-        {
-          "passed": true,
-          "assertions": [
-            {
-              "kind": "match",
-              "candidateId": "c-needs-gpu",
-              "passed": true,
-              "detail": "expected match=true, got surfaced=true (score 98, threshold 30)"
-            },
-            {
-              "kind": "band",
-              "candidateId": "c-needs-gpu",
-              "passed": true,
-              "detail": "expected score in [70,100], got 98"
-            },
-            {
-              "kind": "role",
-              "candidateId": "c-needs-gpu",
-              "passed": true,
-              "detail": "expected role=patient, got patient"
-            }
-          ]
-        }
-      ]
-    },
-    {
-      "caseId": "score_calibration/must-meet-sales-cofounder",
-      "rule": "score_calibration",
-      "runs": 7,
-      "passes": 7,
-      "passRate": 1,
-      "flaky": false,
-      "runResults": [
-        {
-          "passed": true,
-          "assertions": [
-            {
-              "kind": "match",
-              "candidateId": "c-sales-cof",
-              "passed": true,
-              "detail": "expected match=true, got surfaced=true (score 98, threshold 30)"
-            },
-            {
-              "kind": "band",
-              "candidateId": "c-sales-cof",
-              "passed": true,
-              "detail": "expected score in [85,100], got 98"
-            }
-          ]
-        },
-        {
-          "passed": true,
-          "assertions": [
-            {
-              "kind": "match",
-              "candidateId": "c-sales-cof",
-              "passed": true,
-              "detail": "expected match=true, got surfaced=true (score 98, threshold 30)"
-            },
-            {
-              "kind": "band",
-              "candidateId": "c-sales-cof",
-              "passed": true,
-              "detail": "expected score in [85,100], got 98"
-            }
-          ]
-        },
-        {
-          "passed": true,
-          "assertions": [
-            {
-              "kind": "match",
-              "candidateId": "c-sales-cof",
-              "passed": true,
-              "detail": "expected match=true, got surfaced=true (score 98, threshold 30)"
-            },
-            {
-              "kind": "band",
-              "candidateId": "c-sales-cof",
-              "passed": true,
-              "detail": "expected score in [85,100], got 98"
-            }
-          ]
-        },
-        {
-          "passed": true,
-          "assertions": [
-            {
-              "kind": "match",
-              "candidateId": "c-sales-cof",
-              "passed": true,
-              "detail": "expected match=true, got surfaced=true (score 95, threshold 30)"
-            },
-            {
-              "kind": "band",
-              "candidateId": "c-sales-cof",
-              "passed": true,
-              "detail": "expected score in [85,100], got 95"
-            }
-          ]
-        },
-        {
-          "passed": true,
-          "assertions": [
-            {
-              "kind": "match",
-              "candidateId": "c-sales-cof",
-              "passed": true,
-              "detail": "expected match=true, got surfaced=true (score 98, threshold 30)"
-            },
-            {
-              "kind": "band",
-              "candidateId": "c-sales-cof",
-              "passed": true,
-              "detail": "expected score in [85,100], got 98"
-            }
-          ]
-        },
-        {
-          "passed": true,
-          "assertions": [
-            {
-              "kind": "match",
-              "candidateId": "c-sales-cof",
-              "passed": true,
-              "detail": "expected match=true, got surfaced=true (score 98, threshold 30)"
-            },
-            {
-              "kind": "band",
-              "candidateId": "c-sales-cof",
-              "passed": true,
-              "detail": "expected score in [85,100], got 98"
-            }
-          ]
-        },
-        {
-          "passed": true,
-          "assertions": [
-            {
-              "kind": "match",
-              "candidateId": "c-sales-cof",
-              "passed": true,
-              "detail": "expected match=true, got surfaced=true (score 93, threshold 30)"
-            },
-            {
-              "kind": "band",
-              "candidateId": "c-sales-cof",
-              "passed": true,
-              "detail": "expected score in [85,100], got 93"
-            }
-          ]
-        }
-      ]
-    },
-    {
-      "caseId": "score_calibration/tier2-researcher-pool-variant",
-      "rule": "score_calibration",
-      "runs": 7,
-      "passes": 7,
-      "passRate": 1,
-      "flaky": false,
-      "runResults": [
-        {
-          "passed": true,
-          "assertions": [
-            {
-              "kind": "match",
-              "candidateId": "p-tech-cofounder",
-              "passed": true,
-              "detail": "expected match=true, got surfaced=true (score 85, threshold 30)"
-            },
-            {
-              "kind": "band",
-              "candidateId": "p-tech-cofounder",
-              "passed": true,
-              "detail": "expected score in [70,100], got 85"
-            },
-            {
-              "kind": "match",
-              "candidateId": "p-researcher",
-              "passed": true,
-              "detail": "expected match=false, got surfaced=false (score 0, threshold 30)"
-            },
-            {
-              "kind": "band",
-              "candidateId": "p-researcher",
-              "passed": true,
-              "detail": "expected score in [0,29], got 0"
-            },
-            {
-              "kind": "match",
-              "candidateId": "p-operator",
-              "passed": true,
-              "detail": "expected match=false, got surfaced=false (score 0, threshold 30)"
-            },
-            {
-              "kind": "band",
-              "candidateId": "p-operator",
-              "passed": true,
-              "detail": "expected score in [0,29], got 0"
-            }
-          ]
-        },
-        {
-          "passed": true,
-          "assertions": [
-            {
-              "kind": "match",
-              "candidateId": "p-tech-cofounder",
-              "passed": true,
-              "detail": "expected match=true, got surfaced=true (score 98, threshold 30)"
-            },
-            {
-              "kind": "band",
-              "candidateId": "p-tech-cofounder",
-              "passed": true,
-              "detail": "expected score in [70,100], got 98"
-            },
-            {
-              "kind": "match",
-              "candidateId": "p-researcher",
-              "passed": true,
-              "detail": "expected match=false, got surfaced=false (score 0, threshold 30)"
-            },
-            {
-              "kind": "band",
-              "candidateId": "p-researcher",
-              "passed": true,
-              "detail": "expected score in [0,29], got 0"
-            },
-            {
-              "kind": "match",
-              "candidateId": "p-operator",
-              "passed": true,
-              "detail": "expected match=false, got surfaced=false (score 0, threshold 30)"
-            },
-            {
-              "kind": "band",
-              "candidateId": "p-operator",
-              "passed": true,
-              "detail": "expected score in [0,29], got 0"
-            }
-          ]
-        },
-        {
-          "passed": true,
-          "assertions": [
-            {
-              "kind": "match",
-              "candidateId": "p-tech-cofounder",
-              "passed": true,
-              "detail": "expected match=true, got surfaced=true (score 98, threshold 30)"
-            },
-            {
-              "kind": "band",
-              "candidateId": "p-tech-cofounder",
-              "passed": true,
-              "detail": "expected score in [70,100], got 98"
-            },
-            {
-              "kind": "match",
-              "candidateId": "p-researcher",
-              "passed": true,
-              "detail": "expected match=false, got surfaced=false (score 0, threshold 30)"
-            },
-            {
-              "kind": "band",
-              "candidateId": "p-researcher",
-              "passed": true,
-              "detail": "expected score in [0,29], got 0"
-            },
-            {
-              "kind": "match",
-              "candidateId": "p-operator",
-              "passed": true,
-              "detail": "expected match=false, got surfaced=false (score 0, threshold 30)"
-            },
-            {
-              "kind": "band",
-              "candidateId": "p-operator",
-              "passed": true,
-              "detail": "expected score in [0,29], got 0"
-            }
-          ]
-        },
-        {
-          "passed": true,
-          "assertions": [
-            {
-              "kind": "match",
-              "candidateId": "p-tech-cofounder",
-              "passed": true,
-              "detail": "expected match=true, got surfaced=true (score 98, threshold 30)"
-            },
-            {
-              "kind": "band",
-              "candidateId": "p-tech-cofounder",
-              "passed": true,
-              "detail": "expected score in [70,100], got 98"
-            },
-            {
-              "kind": "match",
-              "candidateId": "p-researcher",
-              "passed": true,
-              "detail": "expected match=false, got surfaced=false (score 0, threshold 30)"
-            },
-            {
-              "kind": "band",
-              "candidateId": "p-researcher",
-              "passed": true,
-              "detail": "expected score in [0,29], got 0"
-            },
-            {
-              "kind": "match",
-              "candidateId": "p-operator",
-              "passed": true,
-              "detail": "expected match=false, got surfaced=false (score 0, threshold 30)"
-            },
-            {
-              "kind": "band",
-              "candidateId": "p-operator",
-              "passed": true,
-              "detail": "expected score in [0,29], got 0"
-            }
-          ]
-        },
-        {
-          "passed": true,
-          "assertions": [
-            {
-              "kind": "match",
-              "candidateId": "p-tech-cofounder",
-              "passed": true,
-              "detail": "expected match=true, got surfaced=true (score 95, threshold 30)"
-            },
-            {
-              "kind": "band",
-              "candidateId": "p-tech-cofounder",
-              "passed": true,
-              "detail": "expected score in [70,100], got 95"
-            },
-            {
-              "kind": "match",
-              "candidateId": "p-researcher",
-              "passed": true,
-              "detail": "expected match=false, got surfaced=false (score 0, threshold 30)"
-            },
-            {
-              "kind": "band",
-              "candidateId": "p-researcher",
-              "passed": true,
-              "detail": "expected score in [0,29], got 0"
-            },
-            {
-              "kind": "match",
-              "candidateId": "p-operator",
-              "passed": true,
-              "detail": "expected match=false, got surfaced=false (score 0, threshold 30)"
-            },
-            {
-              "kind": "band",
-              "candidateId": "p-operator",
-              "passed": true,
-              "detail": "expected score in [0,29], got 0"
-            }
-          ]
-        },
-        {
-          "passed": true,
-          "assertions": [
-            {
-              "kind": "match",
-              "candidateId": "p-tech-cofounder",
-              "passed": true,
-              "detail": "expected match=true, got surfaced=true (score 95, threshold 30)"
-            },
-            {
-              "kind": "band",
-              "candidateId": "p-tech-cofounder",
-              "passed": true,
-              "detail": "expected score in [70,100], got 95"
-            },
-            {
-              "kind": "match",
-              "candidateId": "p-researcher",
-              "passed": true,
-              "detail": "expected match=false, got surfaced=false (score 0, threshold 30)"
-            },
-            {
-              "kind": "band",
-              "candidateId": "p-researcher",
-              "passed": true,
-              "detail": "expected score in [0,29], got 0"
-            },
-            {
-              "kind": "match",
-              "candidateId": "p-operator",
-              "passed": true,
-              "detail": "expected match=false, got surfaced=false (score 0, threshold 30)"
-            },
-            {
-              "kind": "band",
-              "candidateId": "p-operator",
-              "passed": true,
-              "detail": "expected score in [0,29], got 0"
-            }
-          ]
-        },
-        {
-          "passed": true,
-          "assertions": [
-            {
-              "kind": "match",
-              "candidateId": "p-tech-cofounder",
-              "passed": true,
-              "detail": "expected match=true, got surfaced=true (score 95, threshold 30)"
-            },
-            {
-              "kind": "band",
-              "candidateId": "p-tech-cofounder",
-              "passed": true,
-              "detail": "expected score in [70,100], got 95"
-            },
-            {
-              "kind": "match",
-              "candidateId": "p-researcher",
-              "passed": true,
-              "detail": "expected match=false, got surfaced=false (score 0, threshold 30)"
-            },
-            {
-              "kind": "band",
-              "candidateId": "p-researcher",
-              "passed": true,
-              "detail": "expected score in [0,29], got 0"
-            },
-            {
-              "kind": "match",
-              "candidateId": "p-operator",
-              "passed": true,
-              "detail": "expected match=false, got surfaced=false (score 0, threshold 30)"
-            },
-            {
-              "kind": "band",
-              "candidateId": "p-operator",
-              "passed": true,
-              "detail": "expected score in [0,29], got 0"
-            }
-          ]
-        }
-      ]
-    }
-  ]
+  "runs": 7,
+  "selection": {
+    "fullCorpus": true,
+    "filters": {}
+  },
+  "corpusFingerprint": "unavailable-legacy-migration",
+  "configFingerprint": "unavailable-legacy-migration",
+  "git": {
+    "revision": "unknown",
+    "dirty": null
+  },
+  "completeness": {
+    "caseCount": 39,
+    "ruleCount": 10,
+    "totalRuns": 273,
+    "totalPasses": 270,
+    "flakyCaseCount": 3
+  },
+  "payload": {
+    "generatedAt": "2026-05-29T18:05:23.210Z",
+    "model": "google/gemini-2.5-flash",
+    "runs": 7,
+    "aggregatePassRate": 0.9890109890109889,
+    "rules": [
+      {
+        "rule": "is_a_identity",
+        "caseCount": 7,
+        "passRate": 1
+      },
+      {
+        "rule": "query_primary",
+        "caseCount": 7,
+        "passRate": 0.979591836734694
+      },
+      {
+        "rule": "complementary_role",
+        "caseCount": 4,
+        "passRate": 0.9642857142857143
+      },
+      {
+        "rule": "same_side",
+        "caseCount": 3,
+        "passRate": 1
+      },
+      {
+        "rule": "already_known",
+        "caseCount": 1,
+        "passRate": 1
+      },
+      {
+        "rule": "location",
+        "caseCount": 4,
+        "passRate": 1
+      },
+      {
+        "rule": "valency_role",
+        "caseCount": 3,
+        "passRate": 1
+      },
+      {
+        "rule": "score_calibration",
+        "caseCount": 4,
+        "passRate": 1
+      },
+      {
+        "rule": "event_network",
+        "caseCount": 1,
+        "passRate": 1
+      },
+      {
+        "rule": "historical",
+        "caseCount": 5,
+        "passRate": 0.9714285714285715
+      }
+    ],
+    "cases": [
+      {
+        "caseId": "is_a_identity/samurai-vs-character-designer",
+        "rule": "is_a_identity",
+        "runs": 7,
+        "passes": 7,
+        "passRate": 1,
+        "flaky": false,
+        "runResults": [
+          {
+            "passed": true,
+            "assertions": [
+              {
+                "kind": "match",
+                "candidateId": "c-yuki",
+                "passed": true,
+                "detail": "expected match=false, got surfaced=false (score 0, threshold 30)"
+              },
+              {
+                "kind": "band",
+                "candidateId": "c-yuki",
+                "passed": true,
+                "detail": "expected score in [0,29], got 0"
+              }
+            ]
+          },
+          {
+            "passed": true,
+            "assertions": [
+              {
+                "kind": "match",
+                "candidateId": "c-yuki",
+                "passed": true,
+                "detail": "expected match=false, got surfaced=false (score 0, threshold 30)"
+              },
+              {
+                "kind": "band",
+                "candidateId": "c-yuki",
+                "passed": true,
+                "detail": "expected score in [0,29], got 0"
+              }
+            ]
+          },
+          {
+            "passed": true,
+            "assertions": [
+              {
+                "kind": "match",
+                "candidateId": "c-yuki",
+                "passed": true,
+                "detail": "expected match=false, got surfaced=false (score 0, threshold 30)"
+              },
+              {
+                "kind": "band",
+                "candidateId": "c-yuki",
+                "passed": true,
+                "detail": "expected score in [0,29], got 0"
+              }
+            ]
+          },
+          {
+            "passed": true,
+            "assertions": [
+              {
+                "kind": "match",
+                "candidateId": "c-yuki",
+                "passed": true,
+                "detail": "expected match=false, got surfaced=false (score 0, threshold 30)"
+              },
+              {
+                "kind": "band",
+                "candidateId": "c-yuki",
+                "passed": true,
+                "detail": "expected score in [0,29], got 0"
+              }
+            ]
+          },
+          {
+            "passed": true,
+            "assertions": [
+              {
+                "kind": "match",
+                "candidateId": "c-yuki",
+                "passed": true,
+                "detail": "expected match=false, got surfaced=false (score 0, threshold 30)"
+              },
+              {
+                "kind": "band",
+                "candidateId": "c-yuki",
+                "passed": true,
+                "detail": "expected score in [0,29], got 0"
+              }
+            ]
+          },
+          {
+            "passed": true,
+            "assertions": [
+              {
+                "kind": "match",
+                "candidateId": "c-yuki",
+                "passed": true,
+                "detail": "expected match=false, got surfaced=false (score 0, threshold 30)"
+              },
+              {
+                "kind": "band",
+                "candidateId": "c-yuki",
+                "passed": true,
+                "detail": "expected score in [0,29], got 0"
+              }
+            ]
+          },
+          {
+            "passed": true,
+            "assertions": [
+              {
+                "kind": "match",
+                "candidateId": "c-yuki",
+                "passed": true,
+                "detail": "expected match=false, got surfaced=false (score 0, threshold 30)"
+              },
+              {
+                "kind": "band",
+                "candidateId": "c-yuki",
+                "passed": true,
+                "detail": "expected score in [0,29], got 0"
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "caseId": "is_a_identity/investor-vs-funded-engineer",
+        "rule": "is_a_identity",
+        "runs": 7,
+        "passes": 7,
+        "passRate": 1,
+        "flaky": false,
+        "runResults": [
+          {
+            "passed": true,
+            "assertions": [
+              {
+                "kind": "match",
+                "candidateId": "c-sam",
+                "passed": true,
+                "detail": "expected match=false, got surfaced=false (score 0, threshold 30)"
+              },
+              {
+                "kind": "band",
+                "candidateId": "c-sam",
+                "passed": true,
+                "detail": "expected score in [0,29], got 0"
+              }
+            ]
+          },
+          {
+            "passed": true,
+            "assertions": [
+              {
+                "kind": "match",
+                "candidateId": "c-sam",
+                "passed": true,
+                "detail": "expected match=false, got surfaced=false (score 0, threshold 30)"
+              },
+              {
+                "kind": "band",
+                "candidateId": "c-sam",
+                "passed": true,
+                "detail": "expected score in [0,29], got 0"
+              }
+            ]
+          },
+          {
+            "passed": true,
+            "assertions": [
+              {
+                "kind": "match",
+                "candidateId": "c-sam",
+                "passed": true,
+                "detail": "expected match=false, got surfaced=false (score 0, threshold 30)"
+              },
+              {
+                "kind": "band",
+                "candidateId": "c-sam",
+                "passed": true,
+                "detail": "expected score in [0,29], got 0"
+              }
+            ]
+          },
+          {
+            "passed": true,
+            "assertions": [
+              {
+                "kind": "match",
+                "candidateId": "c-sam",
+                "passed": true,
+                "detail": "expected match=false, got surfaced=false (score 0, threshold 30)"
+              },
+              {
+                "kind": "band",
+                "candidateId": "c-sam",
+                "passed": true,
+                "detail": "expected score in [0,29], got 0"
+              }
+            ]
+          },
+          {
+            "passed": true,
+            "assertions": [
+              {
+                "kind": "match",
+                "candidateId": "c-sam",
+                "passed": true,
+                "detail": "expected match=false, got surfaced=false (score 0, threshold 30)"
+              },
+              {
+                "kind": "band",
+                "candidateId": "c-sam",
+                "passed": true,
+                "detail": "expected score in [0,29], got 0"
+              }
+            ]
+          },
+          {
+            "passed": true,
+            "assertions": [
+              {
+                "kind": "match",
+                "candidateId": "c-sam",
+                "passed": true,
+                "detail": "expected match=false, got surfaced=false (score 0, threshold 30)"
+              },
+              {
+                "kind": "band",
+                "candidateId": "c-sam",
+                "passed": true,
+                "detail": "expected score in [0,29], got 0"
+              }
+            ]
+          },
+          {
+            "passed": true,
+            "assertions": [
+              {
+                "kind": "match",
+                "candidateId": "c-sam",
+                "passed": true,
+                "detail": "expected match=false, got surfaced=false (score 0, threshold 30)"
+              },
+              {
+                "kind": "band",
+                "candidateId": "c-sam",
+                "passed": true,
+                "detail": "expected score in [0,29], got 0"
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "caseId": "is_a_identity/investor-vs-real-investor",
+        "rule": "is_a_identity",
+        "runs": 7,
+        "passes": 7,
+        "passRate": 1,
+        "flaky": false,
+        "runResults": [
+          {
+            "passed": true,
+            "assertions": [
+              {
+                "kind": "match",
+                "candidateId": "c-sarah",
+                "passed": true,
+                "detail": "expected match=true, got surfaced=true (score 95, threshold 30)"
+              },
+              {
+                "kind": "band",
+                "candidateId": "c-sarah",
+                "passed": true,
+                "detail": "expected score in [70,100], got 95"
+              }
+            ]
+          },
+          {
+            "passed": true,
+            "assertions": [
+              {
+                "kind": "match",
+                "candidateId": "c-sarah",
+                "passed": true,
+                "detail": "expected match=true, got surfaced=true (score 95, threshold 30)"
+              },
+              {
+                "kind": "band",
+                "candidateId": "c-sarah",
+                "passed": true,
+                "detail": "expected score in [70,100], got 95"
+              }
+            ]
+          },
+          {
+            "passed": true,
+            "assertions": [
+              {
+                "kind": "match",
+                "candidateId": "c-sarah",
+                "passed": true,
+                "detail": "expected match=true, got surfaced=true (score 95, threshold 30)"
+              },
+              {
+                "kind": "band",
+                "candidateId": "c-sarah",
+                "passed": true,
+                "detail": "expected score in [70,100], got 95"
+              }
+            ]
+          },
+          {
+            "passed": true,
+            "assertions": [
+              {
+                "kind": "match",
+                "candidateId": "c-sarah",
+                "passed": true,
+                "detail": "expected match=true, got surfaced=true (score 95, threshold 30)"
+              },
+              {
+                "kind": "band",
+                "candidateId": "c-sarah",
+                "passed": true,
+                "detail": "expected score in [70,100], got 95"
+              }
+            ]
+          },
+          {
+            "passed": true,
+            "assertions": [
+              {
+                "kind": "match",
+                "candidateId": "c-sarah",
+                "passed": true,
+                "detail": "expected match=true, got surfaced=true (score 95, threshold 30)"
+              },
+              {
+                "kind": "band",
+                "candidateId": "c-sarah",
+                "passed": true,
+                "detail": "expected score in [70,100], got 95"
+              }
+            ]
+          },
+          {
+            "passed": true,
+            "assertions": [
+              {
+                "kind": "match",
+                "candidateId": "c-sarah",
+                "passed": true,
+                "detail": "expected match=true, got surfaced=true (score 95, threshold 30)"
+              },
+              {
+                "kind": "band",
+                "candidateId": "c-sarah",
+                "passed": true,
+                "detail": "expected score in [70,100], got 95"
+              }
+            ]
+          },
+          {
+            "passed": true,
+            "assertions": [
+              {
+                "kind": "match",
+                "candidateId": "c-sarah",
+                "passed": true,
+                "detail": "expected match=true, got surfaced=true (score 95, threshold 30)"
+              },
+              {
+                "kind": "band",
+                "candidateId": "c-sarah",
+                "passed": true,
+                "detail": "expected score in [70,100], got 95"
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "caseId": "query_primary/background-intent-does-not-rescue",
+        "rule": "query_primary",
+        "runs": 7,
+        "passes": 7,
+        "passRate": 1,
+        "flaky": false,
+        "runResults": [
+          {
+            "passed": true,
+            "assertions": [
+              {
+                "kind": "match",
+                "candidateId": "c-yuki",
+                "passed": true,
+                "detail": "expected match=false, got surfaced=false (score 0, threshold 30)"
+              },
+              {
+                "kind": "band",
+                "candidateId": "c-yuki",
+                "passed": true,
+                "detail": "expected score in [0,29], got 0"
+              },
+              {
+                "kind": "reasoning",
+                "candidateId": "c-yuki",
+                "passed": true,
+                "detail": "judge passed"
+              }
+            ]
+          },
+          {
+            "passed": true,
+            "assertions": [
+              {
+                "kind": "match",
+                "candidateId": "c-yuki",
+                "passed": true,
+                "detail": "expected match=false, got surfaced=false (score 0, threshold 30)"
+              },
+              {
+                "kind": "band",
+                "candidateId": "c-yuki",
+                "passed": true,
+                "detail": "expected score in [0,29], got 0"
+              },
+              {
+                "kind": "reasoning",
+                "candidateId": "c-yuki",
+                "passed": true,
+                "detail": "judge passed"
+              }
+            ]
+          },
+          {
+            "passed": true,
+            "assertions": [
+              {
+                "kind": "match",
+                "candidateId": "c-yuki",
+                "passed": true,
+                "detail": "expected match=false, got surfaced=false (score 0, threshold 30)"
+              },
+              {
+                "kind": "band",
+                "candidateId": "c-yuki",
+                "passed": true,
+                "detail": "expected score in [0,29], got 0"
+              },
+              {
+                "kind": "reasoning",
+                "candidateId": "c-yuki",
+                "passed": true,
+                "detail": "judge passed"
+              }
+            ]
+          },
+          {
+            "passed": true,
+            "assertions": [
+              {
+                "kind": "match",
+                "candidateId": "c-yuki",
+                "passed": true,
+                "detail": "expected match=false, got surfaced=false (score 0, threshold 30)"
+              },
+              {
+                "kind": "band",
+                "candidateId": "c-yuki",
+                "passed": true,
+                "detail": "expected score in [0,29], got 0"
+              },
+              {
+                "kind": "reasoning",
+                "candidateId": "c-yuki",
+                "passed": true,
+                "detail": "judge passed"
+              }
+            ]
+          },
+          {
+            "passed": true,
+            "assertions": [
+              {
+                "kind": "match",
+                "candidateId": "c-yuki",
+                "passed": true,
+                "detail": "expected match=false, got surfaced=false (score 0, threshold 30)"
+              },
+              {
+                "kind": "band",
+                "candidateId": "c-yuki",
+                "passed": true,
+                "detail": "expected score in [0,29], got 0"
+              },
+              {
+                "kind": "reasoning",
+                "candidateId": "c-yuki",
+                "passed": true,
+                "detail": "judge passed"
+              }
+            ]
+          },
+          {
+            "passed": true,
+            "assertions": [
+              {
+                "kind": "match",
+                "candidateId": "c-yuki",
+                "passed": true,
+                "detail": "expected match=false, got surfaced=false (score 0, threshold 30)"
+              },
+              {
+                "kind": "band",
+                "candidateId": "c-yuki",
+                "passed": true,
+                "detail": "expected score in [0,29], got 0"
+              },
+              {
+                "kind": "reasoning",
+                "candidateId": "c-yuki",
+                "passed": true,
+                "detail": "judge passed"
+              }
+            ]
+          },
+          {
+            "passed": true,
+            "assertions": [
+              {
+                "kind": "match",
+                "candidateId": "c-yuki",
+                "passed": true,
+                "detail": "expected match=false, got surfaced=false (score 0, threshold 30)"
+              },
+              {
+                "kind": "band",
+                "candidateId": "c-yuki",
+                "passed": true,
+                "detail": "expected score in [0,29], got 0"
+              },
+              {
+                "kind": "reasoning",
+                "candidateId": "c-yuki",
+                "passed": true,
+                "detail": "judge passed"
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "caseId": "query_primary/specific-art-query-accepts-illustrator",
+        "rule": "query_primary",
+        "runs": 7,
+        "passes": 6,
+        "passRate": 0.8571428571428571,
+        "flaky": true,
+        "runResults": [
+          {
+            "passed": true,
+            "assertions": [
+              {
+                "kind": "match",
+                "candidateId": "c-yuki",
+                "passed": true,
+                "detail": "expected match=true, got surfaced=true (score 95, threshold 30)"
+              },
+              {
+                "kind": "band",
+                "candidateId": "c-yuki",
+                "passed": true,
+                "detail": "expected score in [70,100], got 95"
+              },
+              {
+                "kind": "role",
+                "candidateId": "c-yuki",
+                "passed": true,
+                "detail": "expected role=agent, got agent"
+              }
+            ]
+          },
+          {
+            "passed": true,
+            "assertions": [
+              {
+                "kind": "match",
+                "candidateId": "c-yuki",
+                "passed": true,
+                "detail": "expected match=true, got surfaced=true (score 98, threshold 30)"
+              },
+              {
+                "kind": "band",
+                "candidateId": "c-yuki",
+                "passed": true,
+                "detail": "expected score in [70,100], got 98"
+              },
+              {
+                "kind": "role",
+                "candidateId": "c-yuki",
+                "passed": true,
+                "detail": "expected role=agent, got agent"
+              }
+            ]
+          },
+          {
+            "passed": true,
+            "assertions": [
+              {
+                "kind": "match",
+                "candidateId": "c-yuki",
+                "passed": true,
+                "detail": "expected match=true, got surfaced=true (score 95, threshold 30)"
+              },
+              {
+                "kind": "band",
+                "candidateId": "c-yuki",
+                "passed": true,
+                "detail": "expected score in [70,100], got 95"
+              },
+              {
+                "kind": "role",
+                "candidateId": "c-yuki",
+                "passed": true,
+                "detail": "expected role=agent, got agent"
+              }
+            ]
+          },
+          {
+            "passed": true,
+            "assertions": [
+              {
+                "kind": "match",
+                "candidateId": "c-yuki",
+                "passed": true,
+                "detail": "expected match=true, got surfaced=true (score 95, threshold 30)"
+              },
+              {
+                "kind": "band",
+                "candidateId": "c-yuki",
+                "passed": true,
+                "detail": "expected score in [70,100], got 95"
+              },
+              {
+                "kind": "role",
+                "candidateId": "c-yuki",
+                "passed": true,
+                "detail": "expected role=agent, got agent"
+              }
+            ]
+          },
+          {
+            "passed": true,
+            "assertions": [
+              {
+                "kind": "match",
+                "candidateId": "c-yuki",
+                "passed": true,
+                "detail": "expected match=true, got surfaced=true (score 95, threshold 30)"
+              },
+              {
+                "kind": "band",
+                "candidateId": "c-yuki",
+                "passed": true,
+                "detail": "expected score in [70,100], got 95"
+              },
+              {
+                "kind": "role",
+                "candidateId": "c-yuki",
+                "passed": true,
+                "detail": "expected role=agent, got agent"
+              }
+            ]
+          },
+          {
+            "passed": true,
+            "assertions": [
+              {
+                "kind": "match",
+                "candidateId": "c-yuki",
+                "passed": true,
+                "detail": "expected match=true, got surfaced=true (score 95, threshold 30)"
+              },
+              {
+                "kind": "band",
+                "candidateId": "c-yuki",
+                "passed": true,
+                "detail": "expected score in [70,100], got 95"
+              },
+              {
+                "kind": "role",
+                "candidateId": "c-yuki",
+                "passed": true,
+                "detail": "expected role=agent, got agent"
+              }
+            ]
+          },
+          {
+            "passed": false,
+            "assertions": [
+              {
+                "kind": "match",
+                "candidateId": "c-yuki",
+                "passed": true,
+                "detail": "expected match=true, got surfaced=true (score 95, threshold 30)"
+              },
+              {
+                "kind": "band",
+                "candidateId": "c-yuki",
+                "passed": true,
+                "detail": "expected score in [70,100], got 95"
+              },
+              {
+                "kind": "role",
+                "candidateId": "c-yuki",
+                "passed": false,
+                "detail": "expected role=agent, got peer"
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "caseId": "query_primary/investors-query-rejects-funded-founder",
+        "rule": "query_primary",
+        "runs": 7,
+        "passes": 7,
+        "passRate": 1,
+        "flaky": false,
+        "runResults": [
+          {
+            "passed": true,
+            "assertions": [
+              {
+                "kind": "match",
+                "candidateId": "c-sam",
+                "passed": true,
+                "detail": "expected match=false, got surfaced=false (score 0, threshold 30)"
+              },
+              {
+                "kind": "band",
+                "candidateId": "c-sam",
+                "passed": true,
+                "detail": "expected score in [0,29], got 0"
+              }
+            ]
+          },
+          {
+            "passed": true,
+            "assertions": [
+              {
+                "kind": "match",
+                "candidateId": "c-sam",
+                "passed": true,
+                "detail": "expected match=false, got surfaced=false (score 0, threshold 30)"
+              },
+              {
+                "kind": "band",
+                "candidateId": "c-sam",
+                "passed": true,
+                "detail": "expected score in [0,29], got 0"
+              }
+            ]
+          },
+          {
+            "passed": true,
+            "assertions": [
+              {
+                "kind": "match",
+                "candidateId": "c-sam",
+                "passed": true,
+                "detail": "expected match=false, got surfaced=false (score 0, threshold 30)"
+              },
+              {
+                "kind": "band",
+                "candidateId": "c-sam",
+                "passed": true,
+                "detail": "expected score in [0,29], got 0"
+              }
+            ]
+          },
+          {
+            "passed": true,
+            "assertions": [
+              {
+                "kind": "match",
+                "candidateId": "c-sam",
+                "passed": true,
+                "detail": "expected match=false, got surfaced=false (score 0, threshold 30)"
+              },
+              {
+                "kind": "band",
+                "candidateId": "c-sam",
+                "passed": true,
+                "detail": "expected score in [0,29], got 0"
+              }
+            ]
+          },
+          {
+            "passed": true,
+            "assertions": [
+              {
+                "kind": "match",
+                "candidateId": "c-sam",
+                "passed": true,
+                "detail": "expected match=false, got surfaced=false (score 0, threshold 30)"
+              },
+              {
+                "kind": "band",
+                "candidateId": "c-sam",
+                "passed": true,
+                "detail": "expected score in [0,29], got 0"
+              }
+            ]
+          },
+          {
+            "passed": true,
+            "assertions": [
+              {
+                "kind": "match",
+                "candidateId": "c-sam",
+                "passed": true,
+                "detail": "expected match=false, got surfaced=false (score 0, threshold 30)"
+              },
+              {
+                "kind": "band",
+                "candidateId": "c-sam",
+                "passed": true,
+                "detail": "expected score in [0,29], got 0"
+              }
+            ]
+          },
+          {
+            "passed": true,
+            "assertions": [
+              {
+                "kind": "match",
+                "candidateId": "c-sam",
+                "passed": true,
+                "detail": "expected match=false, got surfaced=false (score 0, threshold 30)"
+              },
+              {
+                "kind": "band",
+                "candidateId": "c-sam",
+                "passed": true,
+                "detail": "expected score in [0,29], got 0"
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "caseId": "query_primary/founders-raising-seed-accepts-founder",
+        "rule": "query_primary",
+        "runs": 7,
+        "passes": 7,
+        "passRate": 1,
+        "flaky": false,
+        "runResults": [
+          {
+            "passed": true,
+            "assertions": [
+              {
+                "kind": "match",
+                "candidateId": "c-sam",
+                "passed": true,
+                "detail": "expected match=true, got surfaced=true (score 95, threshold 30)"
+              },
+              {
+                "kind": "band",
+                "candidateId": "c-sam",
+                "passed": true,
+                "detail": "expected score in [70,100], got 95"
+              }
+            ]
+          },
+          {
+            "passed": true,
+            "assertions": [
+              {
+                "kind": "match",
+                "candidateId": "c-sam",
+                "passed": true,
+                "detail": "expected match=true, got surfaced=true (score 95, threshold 30)"
+              },
+              {
+                "kind": "band",
+                "candidateId": "c-sam",
+                "passed": true,
+                "detail": "expected score in [70,100], got 95"
+              }
+            ]
+          },
+          {
+            "passed": true,
+            "assertions": [
+              {
+                "kind": "match",
+                "candidateId": "c-sam",
+                "passed": true,
+                "detail": "expected match=true, got surfaced=true (score 95, threshold 30)"
+              },
+              {
+                "kind": "band",
+                "candidateId": "c-sam",
+                "passed": true,
+                "detail": "expected score in [70,100], got 95"
+              }
+            ]
+          },
+          {
+            "passed": true,
+            "assertions": [
+              {
+                "kind": "match",
+                "candidateId": "c-sam",
+                "passed": true,
+                "detail": "expected match=true, got surfaced=true (score 95, threshold 30)"
+              },
+              {
+                "kind": "band",
+                "candidateId": "c-sam",
+                "passed": true,
+                "detail": "expected score in [70,100], got 95"
+              }
+            ]
+          },
+          {
+            "passed": true,
+            "assertions": [
+              {
+                "kind": "match",
+                "candidateId": "c-sam",
+                "passed": true,
+                "detail": "expected match=true, got surfaced=true (score 95, threshold 30)"
+              },
+              {
+                "kind": "band",
+                "candidateId": "c-sam",
+                "passed": true,
+                "detail": "expected score in [70,100], got 95"
+              }
+            ]
+          },
+          {
+            "passed": true,
+            "assertions": [
+              {
+                "kind": "match",
+                "candidateId": "c-sam",
+                "passed": true,
+                "detail": "expected match=true, got surfaced=true (score 95, threshold 30)"
+              },
+              {
+                "kind": "band",
+                "candidateId": "c-sam",
+                "passed": true,
+                "detail": "expected score in [70,100], got 95"
+              }
+            ]
+          },
+          {
+            "passed": true,
+            "assertions": [
+              {
+                "kind": "match",
+                "candidateId": "c-sam",
+                "passed": true,
+                "detail": "expected match=true, got surfaced=true (score 95, threshold 30)"
+              },
+              {
+                "kind": "band",
+                "candidateId": "c-sam",
+                "passed": true,
+                "detail": "expected score in [70,100], got 95"
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "caseId": "query_primary/location-query-rejects-wrong-city",
+        "rule": "query_primary",
+        "runs": 7,
+        "passes": 7,
+        "passRate": 1,
+        "flaky": false,
+        "runResults": [
+          {
+            "passed": true,
+            "assertions": [
+              {
+                "kind": "match",
+                "candidateId": "c-berlin-unreal",
+                "passed": true,
+                "detail": "expected match=false, got surfaced=false (score 0, threshold 30)"
+              },
+              {
+                "kind": "band",
+                "candidateId": "c-berlin-unreal",
+                "passed": true,
+                "detail": "expected score in [0,29], got 0"
+              }
+            ]
+          },
+          {
+            "passed": true,
+            "assertions": [
+              {
+                "kind": "match",
+                "candidateId": "c-berlin-unreal",
+                "passed": true,
+                "detail": "expected match=false, got surfaced=false (score 0, threshold 30)"
+              },
+              {
+                "kind": "band",
+                "candidateId": "c-berlin-unreal",
+                "passed": true,
+                "detail": "expected score in [0,29], got 0"
+              }
+            ]
+          },
+          {
+            "passed": true,
+            "assertions": [
+              {
+                "kind": "match",
+                "candidateId": "c-berlin-unreal",
+                "passed": true,
+                "detail": "expected match=false, got surfaced=false (score 0, threshold 30)"
+              },
+              {
+                "kind": "band",
+                "candidateId": "c-berlin-unreal",
+                "passed": true,
+                "detail": "expected score in [0,29], got 0"
+              }
+            ]
+          },
+          {
+            "passed": true,
+            "assertions": [
+              {
+                "kind": "match",
+                "candidateId": "c-berlin-unreal",
+                "passed": true,
+                "detail": "expected match=false, got surfaced=false (score 0, threshold 30)"
+              },
+              {
+                "kind": "band",
+                "candidateId": "c-berlin-unreal",
+                "passed": true,
+                "detail": "expected score in [0,29], got 0"
+              }
+            ]
+          },
+          {
+            "passed": true,
+            "assertions": [
+              {
+                "kind": "match",
+                "candidateId": "c-berlin-unreal",
+                "passed": true,
+                "detail": "expected match=false, got surfaced=false (score 0, threshold 30)"
+              },
+              {
+                "kind": "band",
+                "candidateId": "c-berlin-unreal",
+                "passed": true,
+                "detail": "expected score in [0,29], got 0"
+              }
+            ]
+          },
+          {
+            "passed": true,
+            "assertions": [
+              {
+                "kind": "match",
+                "candidateId": "c-berlin-unreal",
+                "passed": true,
+                "detail": "expected match=false, got surfaced=false (score 0, threshold 30)"
+              },
+              {
+                "kind": "band",
+                "candidateId": "c-berlin-unreal",
+                "passed": true,
+                "detail": "expected score in [0,29], got 0"
+              }
+            ]
+          },
+          {
+            "passed": true,
+            "assertions": [
+              {
+                "kind": "match",
+                "candidateId": "c-berlin-unreal",
+                "passed": true,
+                "detail": "expected match=false, got surfaced=false (score 0, threshold 30)"
+              },
+              {
+                "kind": "band",
+                "candidateId": "c-berlin-unreal",
+                "passed": true,
+                "detail": "expected score in [0,29], got 0"
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "caseId": "query_primary/vague-query-can-use-background-intent",
+        "rule": "query_primary",
+        "runs": 7,
+        "passes": 7,
+        "passRate": 1,
+        "flaky": false,
+        "runResults": [
+          {
+            "passed": true,
+            "assertions": [
+              {
+                "kind": "match",
+                "candidateId": "c-yuki",
+                "passed": true,
+                "detail": "expected match=true, got surfaced=true (score 95, threshold 30)"
+              },
+              {
+                "kind": "band",
+                "candidateId": "c-yuki",
+                "passed": true,
+                "detail": "expected score in [70,100], got 95"
+              }
+            ]
+          },
+          {
+            "passed": true,
+            "assertions": [
+              {
+                "kind": "match",
+                "candidateId": "c-yuki",
+                "passed": true,
+                "detail": "expected match=true, got surfaced=true (score 95, threshold 30)"
+              },
+              {
+                "kind": "band",
+                "candidateId": "c-yuki",
+                "passed": true,
+                "detail": "expected score in [70,100], got 95"
+              }
+            ]
+          },
+          {
+            "passed": true,
+            "assertions": [
+              {
+                "kind": "match",
+                "candidateId": "c-yuki",
+                "passed": true,
+                "detail": "expected match=true, got surfaced=true (score 85, threshold 30)"
+              },
+              {
+                "kind": "band",
+                "candidateId": "c-yuki",
+                "passed": true,
+                "detail": "expected score in [70,100], got 85"
+              }
+            ]
+          },
+          {
+            "passed": true,
+            "assertions": [
+              {
+                "kind": "match",
+                "candidateId": "c-yuki",
+                "passed": true,
+                "detail": "expected match=true, got surfaced=true (score 95, threshold 30)"
+              },
+              {
+                "kind": "band",
+                "candidateId": "c-yuki",
+                "passed": true,
+                "detail": "expected score in [70,100], got 95"
+              }
+            ]
+          },
+          {
+            "passed": true,
+            "assertions": [
+              {
+                "kind": "match",
+                "candidateId": "c-yuki",
+                "passed": true,
+                "detail": "expected match=true, got surfaced=true (score 90, threshold 30)"
+              },
+              {
+                "kind": "band",
+                "candidateId": "c-yuki",
+                "passed": true,
+                "detail": "expected score in [70,100], got 90"
+              }
+            ]
+          },
+          {
+            "passed": true,
+            "assertions": [
+              {
+                "kind": "match",
+                "candidateId": "c-yuki",
+                "passed": true,
+                "detail": "expected match=true, got surfaced=true (score 95, threshold 30)"
+              },
+              {
+                "kind": "band",
+                "candidateId": "c-yuki",
+                "passed": true,
+                "detail": "expected score in [70,100], got 95"
+              }
+            ]
+          },
+          {
+            "passed": true,
+            "assertions": [
+              {
+                "kind": "match",
+                "candidateId": "c-yuki",
+                "passed": true,
+                "detail": "expected match=true, got surfaced=true (score 90, threshold 30)"
+              },
+              {
+                "kind": "band",
+                "candidateId": "c-yuki",
+                "passed": true,
+                "detail": "expected score in [70,100], got 90"
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "caseId": "query_primary/scouts-query-rejects-scouted-athlete",
+        "rule": "query_primary",
+        "runs": 7,
+        "passes": 7,
+        "passRate": 1,
+        "flaky": false,
+        "runResults": [
+          {
+            "passed": true,
+            "assertions": [
+              {
+                "kind": "match",
+                "candidateId": "c-athlete",
+                "passed": true,
+                "detail": "expected match=false, got surfaced=false (score 0, threshold 30)"
+              },
+              {
+                "kind": "band",
+                "candidateId": "c-athlete",
+                "passed": true,
+                "detail": "expected score in [0,29], got 0"
+              }
+            ]
+          },
+          {
+            "passed": true,
+            "assertions": [
+              {
+                "kind": "match",
+                "candidateId": "c-athlete",
+                "passed": true,
+                "detail": "expected match=false, got surfaced=false (score 0, threshold 30)"
+              },
+              {
+                "kind": "band",
+                "candidateId": "c-athlete",
+                "passed": true,
+                "detail": "expected score in [0,29], got 0"
+              }
+            ]
+          },
+          {
+            "passed": true,
+            "assertions": [
+              {
+                "kind": "match",
+                "candidateId": "c-athlete",
+                "passed": true,
+                "detail": "expected match=false, got surfaced=false (score 0, threshold 30)"
+              },
+              {
+                "kind": "band",
+                "candidateId": "c-athlete",
+                "passed": true,
+                "detail": "expected score in [0,29], got 0"
+              }
+            ]
+          },
+          {
+            "passed": true,
+            "assertions": [
+              {
+                "kind": "match",
+                "candidateId": "c-athlete",
+                "passed": true,
+                "detail": "expected match=false, got surfaced=false (score 0, threshold 30)"
+              },
+              {
+                "kind": "band",
+                "candidateId": "c-athlete",
+                "passed": true,
+                "detail": "expected score in [0,29], got 0"
+              }
+            ]
+          },
+          {
+            "passed": true,
+            "assertions": [
+              {
+                "kind": "match",
+                "candidateId": "c-athlete",
+                "passed": true,
+                "detail": "expected match=false, got surfaced=false (score 0, threshold 30)"
+              },
+              {
+                "kind": "band",
+                "candidateId": "c-athlete",
+                "passed": true,
+                "detail": "expected score in [0,29], got 0"
+              }
+            ]
+          },
+          {
+            "passed": true,
+            "assertions": [
+              {
+                "kind": "match",
+                "candidateId": "c-athlete",
+                "passed": true,
+                "detail": "expected match=false, got surfaced=false (score 0, threshold 30)"
+              },
+              {
+                "kind": "band",
+                "candidateId": "c-athlete",
+                "passed": true,
+                "detail": "expected score in [0,29], got 0"
+              }
+            ]
+          },
+          {
+            "passed": true,
+            "assertions": [
+              {
+                "kind": "match",
+                "candidateId": "c-athlete",
+                "passed": true,
+                "detail": "expected match=false, got surfaced=false (score 0, threshold 30)"
+              },
+              {
+                "kind": "band",
+                "candidateId": "c-athlete",
+                "passed": true,
+                "detail": "expected score in [0,29], got 0"
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "caseId": "complementary_role/vc-for-cofounder-intent",
+        "rule": "complementary_role",
+        "runs": 7,
+        "passes": 7,
+        "passRate": 1,
+        "flaky": false,
+        "runResults": [
+          {
+            "passed": true,
+            "assertions": [
+              {
+                "kind": "match",
+                "candidateId": "p-vc",
+                "passed": true,
+                "detail": "expected match=false, got surfaced=false (score 0, threshold 30)"
+              },
+              {
+                "kind": "band",
+                "candidateId": "p-vc",
+                "passed": true,
+                "detail": "expected score in [0,29], got 0"
+              }
+            ]
+          },
+          {
+            "passed": true,
+            "assertions": [
+              {
+                "kind": "match",
+                "candidateId": "p-vc",
+                "passed": true,
+                "detail": "expected match=false, got surfaced=false (score 0, threshold 30)"
+              },
+              {
+                "kind": "band",
+                "candidateId": "p-vc",
+                "passed": true,
+                "detail": "expected score in [0,29], got 0"
+              }
+            ]
+          },
+          {
+            "passed": true,
+            "assertions": [
+              {
+                "kind": "match",
+                "candidateId": "p-vc",
+                "passed": true,
+                "detail": "expected match=false, got surfaced=false (score 0, threshold 30)"
+              },
+              {
+                "kind": "band",
+                "candidateId": "p-vc",
+                "passed": true,
+                "detail": "expected score in [0,29], got 0"
+              }
+            ]
+          },
+          {
+            "passed": true,
+            "assertions": [
+              {
+                "kind": "match",
+                "candidateId": "p-vc",
+                "passed": true,
+                "detail": "expected match=false, got surfaced=false (score 0, threshold 30)"
+              },
+              {
+                "kind": "band",
+                "candidateId": "p-vc",
+                "passed": true,
+                "detail": "expected score in [0,29], got 0"
+              }
+            ]
+          },
+          {
+            "passed": true,
+            "assertions": [
+              {
+                "kind": "match",
+                "candidateId": "p-vc",
+                "passed": true,
+                "detail": "expected match=false, got surfaced=false (score 0, threshold 30)"
+              },
+              {
+                "kind": "band",
+                "candidateId": "p-vc",
+                "passed": true,
+                "detail": "expected score in [0,29], got 0"
+              }
+            ]
+          },
+          {
+            "passed": true,
+            "assertions": [
+              {
+                "kind": "match",
+                "candidateId": "p-vc",
+                "passed": true,
+                "detail": "expected match=false, got surfaced=false (score 0, threshold 30)"
+              },
+              {
+                "kind": "band",
+                "candidateId": "p-vc",
+                "passed": true,
+                "detail": "expected score in [0,29], got 0"
+              }
+            ]
+          },
+          {
+            "passed": true,
+            "assertions": [
+              {
+                "kind": "match",
+                "candidateId": "p-vc",
+                "passed": true,
+                "detail": "expected match=false, got surfaced=false (score 0, threshold 30)"
+              },
+              {
+                "kind": "band",
+                "candidateId": "p-vc",
+                "passed": true,
+                "detail": "expected score in [0,29], got 0"
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "caseId": "complementary_role/engineer-for-cofounder-intent",
+        "rule": "complementary_role",
+        "runs": 7,
+        "passes": 7,
+        "passRate": 1,
+        "flaky": false,
+        "runResults": [
+          {
+            "passed": true,
+            "assertions": [
+              {
+                "kind": "match",
+                "candidateId": "p-tech-cofounder",
+                "passed": true,
+                "detail": "expected match=true, got surfaced=true (score 98, threshold 30)"
+              },
+              {
+                "kind": "band",
+                "candidateId": "p-tech-cofounder",
+                "passed": true,
+                "detail": "expected score in [70,100], got 98"
+              },
+              {
+                "kind": "role",
+                "candidateId": "p-tech-cofounder",
+                "passed": true,
+                "detail": "expected role=agent, got agent"
+              }
+            ]
+          },
+          {
+            "passed": true,
+            "assertions": [
+              {
+                "kind": "match",
+                "candidateId": "p-tech-cofounder",
+                "passed": true,
+                "detail": "expected match=true, got surfaced=true (score 98, threshold 30)"
+              },
+              {
+                "kind": "band",
+                "candidateId": "p-tech-cofounder",
+                "passed": true,
+                "detail": "expected score in [70,100], got 98"
+              },
+              {
+                "kind": "role",
+                "candidateId": "p-tech-cofounder",
+                "passed": true,
+                "detail": "expected role=agent, got agent"
+              }
+            ]
+          },
+          {
+            "passed": true,
+            "assertions": [
+              {
+                "kind": "match",
+                "candidateId": "p-tech-cofounder",
+                "passed": true,
+                "detail": "expected match=true, got surfaced=true (score 98, threshold 30)"
+              },
+              {
+                "kind": "band",
+                "candidateId": "p-tech-cofounder",
+                "passed": true,
+                "detail": "expected score in [70,100], got 98"
+              },
+              {
+                "kind": "role",
+                "candidateId": "p-tech-cofounder",
+                "passed": true,
+                "detail": "expected role=agent, got agent"
+              }
+            ]
+          },
+          {
+            "passed": true,
+            "assertions": [
+              {
+                "kind": "match",
+                "candidateId": "p-tech-cofounder",
+                "passed": true,
+                "detail": "expected match=true, got surfaced=true (score 98, threshold 30)"
+              },
+              {
+                "kind": "band",
+                "candidateId": "p-tech-cofounder",
+                "passed": true,
+                "detail": "expected score in [70,100], got 98"
+              },
+              {
+                "kind": "role",
+                "candidateId": "p-tech-cofounder",
+                "passed": true,
+                "detail": "expected role=agent, got agent"
+              }
+            ]
+          },
+          {
+            "passed": true,
+            "assertions": [
+              {
+                "kind": "match",
+                "candidateId": "p-tech-cofounder",
+                "passed": true,
+                "detail": "expected match=true, got surfaced=true (score 98, threshold 30)"
+              },
+              {
+                "kind": "band",
+                "candidateId": "p-tech-cofounder",
+                "passed": true,
+                "detail": "expected score in [70,100], got 98"
+              },
+              {
+                "kind": "role",
+                "candidateId": "p-tech-cofounder",
+                "passed": true,
+                "detail": "expected role=agent, got agent"
+              }
+            ]
+          },
+          {
+            "passed": true,
+            "assertions": [
+              {
+                "kind": "match",
+                "candidateId": "p-tech-cofounder",
+                "passed": true,
+                "detail": "expected match=true, got surfaced=true (score 98, threshold 30)"
+              },
+              {
+                "kind": "band",
+                "candidateId": "p-tech-cofounder",
+                "passed": true,
+                "detail": "expected score in [70,100], got 98"
+              },
+              {
+                "kind": "role",
+                "candidateId": "p-tech-cofounder",
+                "passed": true,
+                "detail": "expected role=agent, got agent"
+              }
+            ]
+          },
+          {
+            "passed": true,
+            "assertions": [
+              {
+                "kind": "match",
+                "candidateId": "p-tech-cofounder",
+                "passed": true,
+                "detail": "expected match=true, got surfaced=true (score 98, threshold 30)"
+              },
+              {
+                "kind": "band",
+                "candidateId": "p-tech-cofounder",
+                "passed": true,
+                "detail": "expected score in [70,100], got 98"
+              },
+              {
+                "kind": "role",
+                "candidateId": "p-tech-cofounder",
+                "passed": true,
+                "detail": "expected role=agent, got agent"
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "caseId": "same_side/both-seeking-investors",
+        "rule": "same_side",
+        "runs": 7,
+        "passes": 7,
+        "passRate": 1,
+        "flaky": false,
+        "runResults": [
+          {
+            "passed": true,
+            "assertions": [
+              {
+                "kind": "match",
+                "candidateId": "c-raising",
+                "passed": true,
+                "detail": "expected match=false, got surfaced=false (score 0, threshold 30)"
+              },
+              {
+                "kind": "band",
+                "candidateId": "c-raising",
+                "passed": true,
+                "detail": "expected score in [0,29], got 0"
+              }
+            ]
+          },
+          {
+            "passed": true,
+            "assertions": [
+              {
+                "kind": "match",
+                "candidateId": "c-raising",
+                "passed": true,
+                "detail": "expected match=false, got surfaced=false (score 0, threshold 30)"
+              },
+              {
+                "kind": "band",
+                "candidateId": "c-raising",
+                "passed": true,
+                "detail": "expected score in [0,29], got 0"
+              }
+            ]
+          },
+          {
+            "passed": true,
+            "assertions": [
+              {
+                "kind": "match",
+                "candidateId": "c-raising",
+                "passed": true,
+                "detail": "expected match=false, got surfaced=false (score 0, threshold 30)"
+              },
+              {
+                "kind": "band",
+                "candidateId": "c-raising",
+                "passed": true,
+                "detail": "expected score in [0,29], got 0"
+              }
+            ]
+          },
+          {
+            "passed": true,
+            "assertions": [
+              {
+                "kind": "match",
+                "candidateId": "c-raising",
+                "passed": true,
+                "detail": "expected match=false, got surfaced=false (score 0, threshold 30)"
+              },
+              {
+                "kind": "band",
+                "candidateId": "c-raising",
+                "passed": true,
+                "detail": "expected score in [0,29], got 0"
+              }
+            ]
+          },
+          {
+            "passed": true,
+            "assertions": [
+              {
+                "kind": "match",
+                "candidateId": "c-raising",
+                "passed": true,
+                "detail": "expected match=false, got surfaced=false (score 0, threshold 30)"
+              },
+              {
+                "kind": "band",
+                "candidateId": "c-raising",
+                "passed": true,
+                "detail": "expected score in [0,29], got 0"
+              }
+            ]
+          },
+          {
+            "passed": true,
+            "assertions": [
+              {
+                "kind": "match",
+                "candidateId": "c-raising",
+                "passed": true,
+                "detail": "expected match=false, got surfaced=false (score 0, threshold 30)"
+              },
+              {
+                "kind": "band",
+                "candidateId": "c-raising",
+                "passed": true,
+                "detail": "expected score in [0,29], got 0"
+              }
+            ]
+          },
+          {
+            "passed": true,
+            "assertions": [
+              {
+                "kind": "match",
+                "candidateId": "c-raising",
+                "passed": true,
+                "detail": "expected match=false, got surfaced=false (score 0, threshold 30)"
+              },
+              {
+                "kind": "band",
+                "candidateId": "c-raising",
+                "passed": true,
+                "detail": "expected score in [0,29], got 0"
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "caseId": "already_known/same-company-cofounders",
+        "rule": "already_known",
+        "runs": 7,
+        "passes": 7,
+        "passRate": 1,
+        "flaky": false,
+        "runResults": [
+          {
+            "passed": true,
+            "assertions": [
+              {
+                "kind": "match",
+                "candidateId": "c-acme",
+                "passed": true,
+                "detail": "expected match=false, got surfaced=false (score 0, threshold 30)"
+              },
+              {
+                "kind": "band",
+                "candidateId": "c-acme",
+                "passed": true,
+                "detail": "expected score in [0,29], got 0"
+              }
+            ]
+          },
+          {
+            "passed": true,
+            "assertions": [
+              {
+                "kind": "match",
+                "candidateId": "c-acme",
+                "passed": true,
+                "detail": "expected match=false, got surfaced=false (score 0, threshold 30)"
+              },
+              {
+                "kind": "band",
+                "candidateId": "c-acme",
+                "passed": true,
+                "detail": "expected score in [0,29], got 0"
+              }
+            ]
+          },
+          {
+            "passed": true,
+            "assertions": [
+              {
+                "kind": "match",
+                "candidateId": "c-acme",
+                "passed": true,
+                "detail": "expected match=false, got surfaced=false (score 0, threshold 30)"
+              },
+              {
+                "kind": "band",
+                "candidateId": "c-acme",
+                "passed": true,
+                "detail": "expected score in [0,29], got 0"
+              }
+            ]
+          },
+          {
+            "passed": true,
+            "assertions": [
+              {
+                "kind": "match",
+                "candidateId": "c-acme",
+                "passed": true,
+                "detail": "expected match=false, got surfaced=false (score 0, threshold 30)"
+              },
+              {
+                "kind": "band",
+                "candidateId": "c-acme",
+                "passed": true,
+                "detail": "expected score in [0,29], got 0"
+              }
+            ]
+          },
+          {
+            "passed": true,
+            "assertions": [
+              {
+                "kind": "match",
+                "candidateId": "c-acme",
+                "passed": true,
+                "detail": "expected match=false, got surfaced=false (score 0, threshold 30)"
+              },
+              {
+                "kind": "band",
+                "candidateId": "c-acme",
+                "passed": true,
+                "detail": "expected score in [0,29], got 0"
+              }
+            ]
+          },
+          {
+            "passed": true,
+            "assertions": [
+              {
+                "kind": "match",
+                "candidateId": "c-acme",
+                "passed": true,
+                "detail": "expected match=false, got surfaced=false (score 0, threshold 30)"
+              },
+              {
+                "kind": "band",
+                "candidateId": "c-acme",
+                "passed": true,
+                "detail": "expected score in [0,29], got 0"
+              }
+            ]
+          },
+          {
+            "passed": true,
+            "assertions": [
+              {
+                "kind": "match",
+                "candidateId": "c-acme",
+                "passed": true,
+                "detail": "expected match=false, got surfaced=false (score 0, threshold 30)"
+              },
+              {
+                "kind": "band",
+                "candidateId": "c-acme",
+                "passed": true,
+                "detail": "expected score in [0,29], got 0"
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "caseId": "location/known-mismatch-penalized",
+        "rule": "location",
+        "runs": 7,
+        "passes": 7,
+        "passRate": 1,
+        "flaky": false,
+        "runResults": [
+          {
+            "passed": true,
+            "assertions": [
+              {
+                "kind": "match",
+                "candidateId": "c-ny",
+                "passed": true,
+                "detail": "expected match=false, got surfaced=false (score 0, threshold 30)"
+              },
+              {
+                "kind": "band",
+                "candidateId": "c-ny",
+                "passed": true,
+                "detail": "expected score in [0,29], got 0"
+              }
+            ]
+          },
+          {
+            "passed": true,
+            "assertions": [
+              {
+                "kind": "match",
+                "candidateId": "c-ny",
+                "passed": true,
+                "detail": "expected match=false, got surfaced=false (score 0, threshold 30)"
+              },
+              {
+                "kind": "band",
+                "candidateId": "c-ny",
+                "passed": true,
+                "detail": "expected score in [0,29], got 0"
+              }
+            ]
+          },
+          {
+            "passed": true,
+            "assertions": [
+              {
+                "kind": "match",
+                "candidateId": "c-ny",
+                "passed": true,
+                "detail": "expected match=false, got surfaced=false (score 0, threshold 30)"
+              },
+              {
+                "kind": "band",
+                "candidateId": "c-ny",
+                "passed": true,
+                "detail": "expected score in [0,29], got 0"
+              }
+            ]
+          },
+          {
+            "passed": true,
+            "assertions": [
+              {
+                "kind": "match",
+                "candidateId": "c-ny",
+                "passed": true,
+                "detail": "expected match=false, got surfaced=false (score 0, threshold 30)"
+              },
+              {
+                "kind": "band",
+                "candidateId": "c-ny",
+                "passed": true,
+                "detail": "expected score in [0,29], got 0"
+              }
+            ]
+          },
+          {
+            "passed": true,
+            "assertions": [
+              {
+                "kind": "match",
+                "candidateId": "c-ny",
+                "passed": true,
+                "detail": "expected match=false, got surfaced=false (score 0, threshold 30)"
+              },
+              {
+                "kind": "band",
+                "candidateId": "c-ny",
+                "passed": true,
+                "detail": "expected score in [0,29], got 0"
+              }
+            ]
+          },
+          {
+            "passed": true,
+            "assertions": [
+              {
+                "kind": "match",
+                "candidateId": "c-ny",
+                "passed": true,
+                "detail": "expected match=false, got surfaced=false (score 0, threshold 30)"
+              },
+              {
+                "kind": "band",
+                "candidateId": "c-ny",
+                "passed": true,
+                "detail": "expected score in [0,29], got 0"
+              }
+            ]
+          },
+          {
+            "passed": true,
+            "assertions": [
+              {
+                "kind": "match",
+                "candidateId": "c-ny",
+                "passed": true,
+                "detail": "expected match=false, got surfaced=false (score 0, threshold 30)"
+              },
+              {
+                "kind": "band",
+                "candidateId": "c-ny",
+                "passed": true,
+                "detail": "expected score in [0,29], got 0"
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "caseId": "location/unknown-not-penalized",
+        "rule": "location",
+        "runs": 7,
+        "passes": 7,
+        "passRate": 1,
+        "flaky": false,
+        "runResults": [
+          {
+            "passed": true,
+            "assertions": [
+              {
+                "kind": "match",
+                "candidateId": "c-unknown",
+                "passed": true,
+                "detail": "expected match=true, got surfaced=true (score 80, threshold 30)"
+              },
+              {
+                "kind": "band",
+                "candidateId": "c-unknown",
+                "passed": true,
+                "detail": "expected score in [60,100], got 80"
+              }
+            ]
+          },
+          {
+            "passed": true,
+            "assertions": [
+              {
+                "kind": "match",
+                "candidateId": "c-unknown",
+                "passed": true,
+                "detail": "expected match=true, got surfaced=true (score 85, threshold 30)"
+              },
+              {
+                "kind": "band",
+                "candidateId": "c-unknown",
+                "passed": true,
+                "detail": "expected score in [60,100], got 85"
+              }
+            ]
+          },
+          {
+            "passed": true,
+            "assertions": [
+              {
+                "kind": "match",
+                "candidateId": "c-unknown",
+                "passed": true,
+                "detail": "expected match=true, got surfaced=true (score 80, threshold 30)"
+              },
+              {
+                "kind": "band",
+                "candidateId": "c-unknown",
+                "passed": true,
+                "detail": "expected score in [60,100], got 80"
+              }
+            ]
+          },
+          {
+            "passed": true,
+            "assertions": [
+              {
+                "kind": "match",
+                "candidateId": "c-unknown",
+                "passed": true,
+                "detail": "expected match=true, got surfaced=true (score 85, threshold 30)"
+              },
+              {
+                "kind": "band",
+                "candidateId": "c-unknown",
+                "passed": true,
+                "detail": "expected score in [60,100], got 85"
+              }
+            ]
+          },
+          {
+            "passed": true,
+            "assertions": [
+              {
+                "kind": "match",
+                "candidateId": "c-unknown",
+                "passed": true,
+                "detail": "expected match=true, got surfaced=true (score 85, threshold 30)"
+              },
+              {
+                "kind": "band",
+                "candidateId": "c-unknown",
+                "passed": true,
+                "detail": "expected score in [60,100], got 85"
+              }
+            ]
+          },
+          {
+            "passed": true,
+            "assertions": [
+              {
+                "kind": "match",
+                "candidateId": "c-unknown",
+                "passed": true,
+                "detail": "expected match=true, got surfaced=true (score 80, threshold 30)"
+              },
+              {
+                "kind": "band",
+                "candidateId": "c-unknown",
+                "passed": true,
+                "detail": "expected score in [60,100], got 80"
+              }
+            ]
+          },
+          {
+            "passed": true,
+            "assertions": [
+              {
+                "kind": "match",
+                "candidateId": "c-unknown",
+                "passed": true,
+                "detail": "expected match=true, got surfaced=true (score 80, threshold 30)"
+              },
+              {
+                "kind": "band",
+                "candidateId": "c-unknown",
+                "passed": true,
+                "detail": "expected score in [60,100], got 80"
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "caseId": "valency_role/seeker-gets-patient-provider-gets-agent",
+        "rule": "valency_role",
+        "runs": 7,
+        "passes": 7,
+        "passRate": 1,
+        "flaky": false,
+        "runResults": [
+          {
+            "passed": true,
+            "assertions": [
+              {
+                "kind": "match",
+                "candidateId": "c-ml",
+                "passed": true,
+                "detail": "expected match=true, got surfaced=true (score 98, threshold 30)"
+              },
+              {
+                "kind": "band",
+                "candidateId": "c-ml",
+                "passed": true,
+                "detail": "expected score in [70,100], got 98"
+              },
+              {
+                "kind": "role",
+                "candidateId": "c-ml",
+                "passed": true,
+                "detail": "expected role=agent, got agent"
+              }
+            ]
+          },
+          {
+            "passed": true,
+            "assertions": [
+              {
+                "kind": "match",
+                "candidateId": "c-ml",
+                "passed": true,
+                "detail": "expected match=true, got surfaced=true (score 98, threshold 30)"
+              },
+              {
+                "kind": "band",
+                "candidateId": "c-ml",
+                "passed": true,
+                "detail": "expected score in [70,100], got 98"
+              },
+              {
+                "kind": "role",
+                "candidateId": "c-ml",
+                "passed": true,
+                "detail": "expected role=agent, got agent"
+              }
+            ]
+          },
+          {
+            "passed": true,
+            "assertions": [
+              {
+                "kind": "match",
+                "candidateId": "c-ml",
+                "passed": true,
+                "detail": "expected match=true, got surfaced=true (score 98, threshold 30)"
+              },
+              {
+                "kind": "band",
+                "candidateId": "c-ml",
+                "passed": true,
+                "detail": "expected score in [70,100], got 98"
+              },
+              {
+                "kind": "role",
+                "candidateId": "c-ml",
+                "passed": true,
+                "detail": "expected role=agent, got agent"
+              }
+            ]
+          },
+          {
+            "passed": true,
+            "assertions": [
+              {
+                "kind": "match",
+                "candidateId": "c-ml",
+                "passed": true,
+                "detail": "expected match=true, got surfaced=true (score 98, threshold 30)"
+              },
+              {
+                "kind": "band",
+                "candidateId": "c-ml",
+                "passed": true,
+                "detail": "expected score in [70,100], got 98"
+              },
+              {
+                "kind": "role",
+                "candidateId": "c-ml",
+                "passed": true,
+                "detail": "expected role=agent, got agent"
+              }
+            ]
+          },
+          {
+            "passed": true,
+            "assertions": [
+              {
+                "kind": "match",
+                "candidateId": "c-ml",
+                "passed": true,
+                "detail": "expected match=true, got surfaced=true (score 98, threshold 30)"
+              },
+              {
+                "kind": "band",
+                "candidateId": "c-ml",
+                "passed": true,
+                "detail": "expected score in [70,100], got 98"
+              },
+              {
+                "kind": "role",
+                "candidateId": "c-ml",
+                "passed": true,
+                "detail": "expected role=agent, got agent"
+              }
+            ]
+          },
+          {
+            "passed": true,
+            "assertions": [
+              {
+                "kind": "match",
+                "candidateId": "c-ml",
+                "passed": true,
+                "detail": "expected match=true, got surfaced=true (score 98, threshold 30)"
+              },
+              {
+                "kind": "band",
+                "candidateId": "c-ml",
+                "passed": true,
+                "detail": "expected score in [70,100], got 98"
+              },
+              {
+                "kind": "role",
+                "candidateId": "c-ml",
+                "passed": true,
+                "detail": "expected role=agent, got agent"
+              }
+            ]
+          },
+          {
+            "passed": true,
+            "assertions": [
+              {
+                "kind": "match",
+                "candidateId": "c-ml",
+                "passed": true,
+                "detail": "expected match=true, got surfaced=true (score 98, threshold 30)"
+              },
+              {
+                "kind": "band",
+                "candidateId": "c-ml",
+                "passed": true,
+                "detail": "expected score in [70,100], got 98"
+              },
+              {
+                "kind": "role",
+                "candidateId": "c-ml",
+                "passed": true,
+                "detail": "expected role=agent, got agent"
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "caseId": "score_calibration/must-meet-primary-role",
+        "rule": "score_calibration",
+        "runs": 7,
+        "passes": 7,
+        "passRate": 1,
+        "flaky": false,
+        "runResults": [
+          {
+            "passed": true,
+            "assertions": [
+              {
+                "kind": "match",
+                "candidateId": "c-aiml",
+                "passed": true,
+                "detail": "expected match=true, got surfaced=true (score 98, threshold 30)"
+              },
+              {
+                "kind": "band",
+                "candidateId": "c-aiml",
+                "passed": true,
+                "detail": "expected score in [85,100], got 98"
+              }
+            ]
+          },
+          {
+            "passed": true,
+            "assertions": [
+              {
+                "kind": "match",
+                "candidateId": "c-aiml",
+                "passed": true,
+                "detail": "expected match=true, got surfaced=true (score 98, threshold 30)"
+              },
+              {
+                "kind": "band",
+                "candidateId": "c-aiml",
+                "passed": true,
+                "detail": "expected score in [85,100], got 98"
+              }
+            ]
+          },
+          {
+            "passed": true,
+            "assertions": [
+              {
+                "kind": "match",
+                "candidateId": "c-aiml",
+                "passed": true,
+                "detail": "expected match=true, got surfaced=true (score 98, threshold 30)"
+              },
+              {
+                "kind": "band",
+                "candidateId": "c-aiml",
+                "passed": true,
+                "detail": "expected score in [85,100], got 98"
+              }
+            ]
+          },
+          {
+            "passed": true,
+            "assertions": [
+              {
+                "kind": "match",
+                "candidateId": "c-aiml",
+                "passed": true,
+                "detail": "expected match=true, got surfaced=true (score 98, threshold 30)"
+              },
+              {
+                "kind": "band",
+                "candidateId": "c-aiml",
+                "passed": true,
+                "detail": "expected score in [85,100], got 98"
+              }
+            ]
+          },
+          {
+            "passed": true,
+            "assertions": [
+              {
+                "kind": "match",
+                "candidateId": "c-aiml",
+                "passed": true,
+                "detail": "expected match=true, got surfaced=true (score 95, threshold 30)"
+              },
+              {
+                "kind": "band",
+                "candidateId": "c-aiml",
+                "passed": true,
+                "detail": "expected score in [85,100], got 95"
+              }
+            ]
+          },
+          {
+            "passed": true,
+            "assertions": [
+              {
+                "kind": "match",
+                "candidateId": "c-aiml",
+                "passed": true,
+                "detail": "expected match=true, got surfaced=true (score 98, threshold 30)"
+              },
+              {
+                "kind": "band",
+                "candidateId": "c-aiml",
+                "passed": true,
+                "detail": "expected score in [85,100], got 98"
+              }
+            ]
+          },
+          {
+            "passed": true,
+            "assertions": [
+              {
+                "kind": "match",
+                "candidateId": "c-aiml",
+                "passed": true,
+                "detail": "expected match=true, got surfaced=true (score 98, threshold 30)"
+              },
+              {
+                "kind": "band",
+                "candidateId": "c-aiml",
+                "passed": true,
+                "detail": "expected score in [85,100], got 98"
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "caseId": "event_network/co-attendance-theme-lift",
+        "rule": "event_network",
+        "runs": 7,
+        "passes": 7,
+        "passRate": 1,
+        "flaky": false,
+        "runResults": [
+          {
+            "passed": true,
+            "assertions": [
+              {
+                "kind": "match",
+                "candidateId": "c-attendee",
+                "passed": true,
+                "detail": "expected match=true, got surfaced=true (score 95, threshold 30)"
+              },
+              {
+                "kind": "band",
+                "candidateId": "c-attendee",
+                "passed": true,
+                "detail": "expected score in [70,100], got 95"
+              },
+              {
+                "kind": "role",
+                "candidateId": "c-attendee",
+                "passed": true,
+                "detail": "expected role=peer, got peer"
+              }
+            ]
+          },
+          {
+            "passed": true,
+            "assertions": [
+              {
+                "kind": "match",
+                "candidateId": "c-attendee",
+                "passed": true,
+                "detail": "expected match=true, got surfaced=true (score 95, threshold 30)"
+              },
+              {
+                "kind": "band",
+                "candidateId": "c-attendee",
+                "passed": true,
+                "detail": "expected score in [70,100], got 95"
+              },
+              {
+                "kind": "role",
+                "candidateId": "c-attendee",
+                "passed": true,
+                "detail": "expected role=peer, got peer"
+              }
+            ]
+          },
+          {
+            "passed": true,
+            "assertions": [
+              {
+                "kind": "match",
+                "candidateId": "c-attendee",
+                "passed": true,
+                "detail": "expected match=true, got surfaced=true (score 98, threshold 30)"
+              },
+              {
+                "kind": "band",
+                "candidateId": "c-attendee",
+                "passed": true,
+                "detail": "expected score in [70,100], got 98"
+              },
+              {
+                "kind": "role",
+                "candidateId": "c-attendee",
+                "passed": true,
+                "detail": "expected role=peer, got peer"
+              }
+            ]
+          },
+          {
+            "passed": true,
+            "assertions": [
+              {
+                "kind": "match",
+                "candidateId": "c-attendee",
+                "passed": true,
+                "detail": "expected match=true, got surfaced=true (score 98, threshold 30)"
+              },
+              {
+                "kind": "band",
+                "candidateId": "c-attendee",
+                "passed": true,
+                "detail": "expected score in [70,100], got 98"
+              },
+              {
+                "kind": "role",
+                "candidateId": "c-attendee",
+                "passed": true,
+                "detail": "expected role=peer, got peer"
+              }
+            ]
+          },
+          {
+            "passed": true,
+            "assertions": [
+              {
+                "kind": "match",
+                "candidateId": "c-attendee",
+                "passed": true,
+                "detail": "expected match=true, got surfaced=true (score 95, threshold 30)"
+              },
+              {
+                "kind": "band",
+                "candidateId": "c-attendee",
+                "passed": true,
+                "detail": "expected score in [70,100], got 95"
+              },
+              {
+                "kind": "role",
+                "candidateId": "c-attendee",
+                "passed": true,
+                "detail": "expected role=peer, got peer"
+              }
+            ]
+          },
+          {
+            "passed": true,
+            "assertions": [
+              {
+                "kind": "match",
+                "candidateId": "c-attendee",
+                "passed": true,
+                "detail": "expected match=true, got surfaced=true (score 98, threshold 30)"
+              },
+              {
+                "kind": "band",
+                "candidateId": "c-attendee",
+                "passed": true,
+                "detail": "expected score in [70,100], got 98"
+              },
+              {
+                "kind": "role",
+                "candidateId": "c-attendee",
+                "passed": true,
+                "detail": "expected role=peer, got peer"
+              }
+            ]
+          },
+          {
+            "passed": true,
+            "assertions": [
+              {
+                "kind": "match",
+                "candidateId": "c-attendee",
+                "passed": true,
+                "detail": "expected match=true, got surfaced=true (score 95, threshold 30)"
+              },
+              {
+                "kind": "band",
+                "candidateId": "c-attendee",
+                "passed": true,
+                "detail": "expected score in [70,100], got 95"
+              },
+              {
+                "kind": "role",
+                "candidateId": "c-attendee",
+                "passed": true,
+                "detail": "expected role=peer, got peer"
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "caseId": "score_calibration/tier2-cofounder-pool",
+        "rule": "score_calibration",
+        "runs": 7,
+        "passes": 7,
+        "passRate": 1,
+        "flaky": false,
+        "runResults": [
+          {
+            "passed": true,
+            "assertions": [
+              {
+                "kind": "match",
+                "candidateId": "p-tech-cofounder",
+                "passed": true,
+                "detail": "expected match=true, got surfaced=true (score 98, threshold 30)"
+              },
+              {
+                "kind": "band",
+                "candidateId": "p-tech-cofounder",
+                "passed": true,
+                "detail": "expected score in [70,100], got 98"
+              },
+              {
+                "kind": "match",
+                "candidateId": "p-vc",
+                "passed": true,
+                "detail": "expected match=false, got surfaced=false (score 0, threshold 30)"
+              },
+              {
+                "kind": "band",
+                "candidateId": "p-vc",
+                "passed": true,
+                "detail": "expected score in [0,29], got 0"
+              },
+              {
+                "kind": "match",
+                "candidateId": "p-designer",
+                "passed": true,
+                "detail": "expected match=false, got surfaced=false (score 0, threshold 30)"
+              },
+              {
+                "kind": "band",
+                "candidateId": "p-designer",
+                "passed": true,
+                "detail": "expected score in [0,29], got 0"
+              }
+            ]
+          },
+          {
+            "passed": true,
+            "assertions": [
+              {
+                "kind": "match",
+                "candidateId": "p-tech-cofounder",
+                "passed": true,
+                "detail": "expected match=true, got surfaced=true (score 98, threshold 30)"
+              },
+              {
+                "kind": "band",
+                "candidateId": "p-tech-cofounder",
+                "passed": true,
+                "detail": "expected score in [70,100], got 98"
+              },
+              {
+                "kind": "match",
+                "candidateId": "p-vc",
+                "passed": true,
+                "detail": "expected match=false, got surfaced=false (score 0, threshold 30)"
+              },
+              {
+                "kind": "band",
+                "candidateId": "p-vc",
+                "passed": true,
+                "detail": "expected score in [0,29], got 0"
+              },
+              {
+                "kind": "match",
+                "candidateId": "p-designer",
+                "passed": true,
+                "detail": "expected match=false, got surfaced=false (score 0, threshold 30)"
+              },
+              {
+                "kind": "band",
+                "candidateId": "p-designer",
+                "passed": true,
+                "detail": "expected score in [0,29], got 0"
+              }
+            ]
+          },
+          {
+            "passed": true,
+            "assertions": [
+              {
+                "kind": "match",
+                "candidateId": "p-tech-cofounder",
+                "passed": true,
+                "detail": "expected match=true, got surfaced=true (score 98, threshold 30)"
+              },
+              {
+                "kind": "band",
+                "candidateId": "p-tech-cofounder",
+                "passed": true,
+                "detail": "expected score in [70,100], got 98"
+              },
+              {
+                "kind": "match",
+                "candidateId": "p-vc",
+                "passed": true,
+                "detail": "expected match=false, got surfaced=false (score 0, threshold 30)"
+              },
+              {
+                "kind": "band",
+                "candidateId": "p-vc",
+                "passed": true,
+                "detail": "expected score in [0,29], got 0"
+              },
+              {
+                "kind": "match",
+                "candidateId": "p-designer",
+                "passed": true,
+                "detail": "expected match=false, got surfaced=false (score 0, threshold 30)"
+              },
+              {
+                "kind": "band",
+                "candidateId": "p-designer",
+                "passed": true,
+                "detail": "expected score in [0,29], got 0"
+              }
+            ]
+          },
+          {
+            "passed": true,
+            "assertions": [
+              {
+                "kind": "match",
+                "candidateId": "p-tech-cofounder",
+                "passed": true,
+                "detail": "expected match=true, got surfaced=true (score 98, threshold 30)"
+              },
+              {
+                "kind": "band",
+                "candidateId": "p-tech-cofounder",
+                "passed": true,
+                "detail": "expected score in [70,100], got 98"
+              },
+              {
+                "kind": "match",
+                "candidateId": "p-vc",
+                "passed": true,
+                "detail": "expected match=false, got surfaced=false (score 0, threshold 30)"
+              },
+              {
+                "kind": "band",
+                "candidateId": "p-vc",
+                "passed": true,
+                "detail": "expected score in [0,29], got 0"
+              },
+              {
+                "kind": "match",
+                "candidateId": "p-designer",
+                "passed": true,
+                "detail": "expected match=false, got surfaced=false (score 0, threshold 30)"
+              },
+              {
+                "kind": "band",
+                "candidateId": "p-designer",
+                "passed": true,
+                "detail": "expected score in [0,29], got 0"
+              }
+            ]
+          },
+          {
+            "passed": true,
+            "assertions": [
+              {
+                "kind": "match",
+                "candidateId": "p-tech-cofounder",
+                "passed": true,
+                "detail": "expected match=true, got surfaced=true (score 98, threshold 30)"
+              },
+              {
+                "kind": "band",
+                "candidateId": "p-tech-cofounder",
+                "passed": true,
+                "detail": "expected score in [70,100], got 98"
+              },
+              {
+                "kind": "match",
+                "candidateId": "p-vc",
+                "passed": true,
+                "detail": "expected match=false, got surfaced=false (score 0, threshold 30)"
+              },
+              {
+                "kind": "band",
+                "candidateId": "p-vc",
+                "passed": true,
+                "detail": "expected score in [0,29], got 0"
+              },
+              {
+                "kind": "match",
+                "candidateId": "p-designer",
+                "passed": true,
+                "detail": "expected match=false, got surfaced=false (score 0, threshold 30)"
+              },
+              {
+                "kind": "band",
+                "candidateId": "p-designer",
+                "passed": true,
+                "detail": "expected score in [0,29], got 0"
+              }
+            ]
+          },
+          {
+            "passed": true,
+            "assertions": [
+              {
+                "kind": "match",
+                "candidateId": "p-tech-cofounder",
+                "passed": true,
+                "detail": "expected match=true, got surfaced=true (score 98, threshold 30)"
+              },
+              {
+                "kind": "band",
+                "candidateId": "p-tech-cofounder",
+                "passed": true,
+                "detail": "expected score in [70,100], got 98"
+              },
+              {
+                "kind": "match",
+                "candidateId": "p-vc",
+                "passed": true,
+                "detail": "expected match=false, got surfaced=false (score 0, threshold 30)"
+              },
+              {
+                "kind": "band",
+                "candidateId": "p-vc",
+                "passed": true,
+                "detail": "expected score in [0,29], got 0"
+              },
+              {
+                "kind": "match",
+                "candidateId": "p-designer",
+                "passed": true,
+                "detail": "expected match=false, got surfaced=false (score 0, threshold 30)"
+              },
+              {
+                "kind": "band",
+                "candidateId": "p-designer",
+                "passed": true,
+                "detail": "expected score in [0,29], got 0"
+              }
+            ]
+          },
+          {
+            "passed": true,
+            "assertions": [
+              {
+                "kind": "match",
+                "candidateId": "p-tech-cofounder",
+                "passed": true,
+                "detail": "expected match=true, got surfaced=true (score 98, threshold 30)"
+              },
+              {
+                "kind": "band",
+                "candidateId": "p-tech-cofounder",
+                "passed": true,
+                "detail": "expected score in [70,100], got 98"
+              },
+              {
+                "kind": "match",
+                "candidateId": "p-vc",
+                "passed": true,
+                "detail": "expected match=false, got surfaced=false (score 0, threshold 30)"
+              },
+              {
+                "kind": "band",
+                "candidateId": "p-vc",
+                "passed": true,
+                "detail": "expected score in [0,29], got 0"
+              },
+              {
+                "kind": "match",
+                "candidateId": "p-designer",
+                "passed": true,
+                "detail": "expected match=false, got surfaced=false (score 0, threshold 30)"
+              },
+              {
+                "kind": "band",
+                "candidateId": "p-designer",
+                "passed": true,
+                "detail": "expected score in [0,29], got 0"
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "caseId": "historical/builder-and-operator",
+        "rule": "historical",
+        "runs": 7,
+        "passes": 7,
+        "passRate": 1,
+        "flaky": false,
+        "runResults": [
+          {
+            "passed": true,
+            "assertions": [
+              {
+                "kind": "match",
+                "candidateId": "h1-b",
+                "passed": true,
+                "detail": "expected match=true, got surfaced=true (score 95, threshold 30)"
+              },
+              {
+                "kind": "band",
+                "candidateId": "h1-b",
+                "passed": true,
+                "detail": "expected score in [60,100], got 95"
+              },
+              {
+                "kind": "role",
+                "candidateId": "h1-b",
+                "passed": true,
+                "detail": "expected role=agent, got agent"
+              },
+              {
+                "kind": "match",
+                "candidateId": "h1-c",
+                "passed": true,
+                "detail": "expected match=false, got surfaced=false (score 0, threshold 30)"
+              },
+              {
+                "kind": "band",
+                "candidateId": "h1-c",
+                "passed": true,
+                "detail": "expected score in [0,29], got 0"
+              },
+              {
+                "kind": "match",
+                "candidateId": "h1-d",
+                "passed": true,
+                "detail": "expected match=false, got surfaced=false (score 0, threshold 30)"
+              },
+              {
+                "kind": "band",
+                "candidateId": "h1-d",
+                "passed": true,
+                "detail": "expected score in [0,29], got 0"
+              },
+              {
+                "kind": "match",
+                "candidateId": "h1-e",
+                "passed": true,
+                "detail": "expected match=false, got surfaced=false (score 0, threshold 30)"
+              },
+              {
+                "kind": "band",
+                "candidateId": "h1-e",
+                "passed": true,
+                "detail": "expected score in [0,29], got 0"
+              }
+            ]
+          },
+          {
+            "passed": true,
+            "assertions": [
+              {
+                "kind": "match",
+                "candidateId": "h1-b",
+                "passed": true,
+                "detail": "expected match=true, got surfaced=true (score 95, threshold 30)"
+              },
+              {
+                "kind": "band",
+                "candidateId": "h1-b",
+                "passed": true,
+                "detail": "expected score in [60,100], got 95"
+              },
+              {
+                "kind": "role",
+                "candidateId": "h1-b",
+                "passed": true,
+                "detail": "expected role=agent, got agent"
+              },
+              {
+                "kind": "match",
+                "candidateId": "h1-c",
+                "passed": true,
+                "detail": "expected match=false, got surfaced=false (score 0, threshold 30)"
+              },
+              {
+                "kind": "band",
+                "candidateId": "h1-c",
+                "passed": true,
+                "detail": "expected score in [0,29], got 0"
+              },
+              {
+                "kind": "match",
+                "candidateId": "h1-d",
+                "passed": true,
+                "detail": "expected match=false, got surfaced=false (score 0, threshold 30)"
+              },
+              {
+                "kind": "band",
+                "candidateId": "h1-d",
+                "passed": true,
+                "detail": "expected score in [0,29], got 0"
+              },
+              {
+                "kind": "match",
+                "candidateId": "h1-e",
+                "passed": true,
+                "detail": "expected match=false, got surfaced=false (score 0, threshold 30)"
+              },
+              {
+                "kind": "band",
+                "candidateId": "h1-e",
+                "passed": true,
+                "detail": "expected score in [0,29], got 0"
+              }
+            ]
+          },
+          {
+            "passed": true,
+            "assertions": [
+              {
+                "kind": "match",
+                "candidateId": "h1-b",
+                "passed": true,
+                "detail": "expected match=true, got surfaced=true (score 95, threshold 30)"
+              },
+              {
+                "kind": "band",
+                "candidateId": "h1-b",
+                "passed": true,
+                "detail": "expected score in [60,100], got 95"
+              },
+              {
+                "kind": "role",
+                "candidateId": "h1-b",
+                "passed": true,
+                "detail": "expected role=agent, got agent"
+              },
+              {
+                "kind": "match",
+                "candidateId": "h1-c",
+                "passed": true,
+                "detail": "expected match=false, got surfaced=false (score 0, threshold 30)"
+              },
+              {
+                "kind": "band",
+                "candidateId": "h1-c",
+                "passed": true,
+                "detail": "expected score in [0,29], got 0"
+              },
+              {
+                "kind": "match",
+                "candidateId": "h1-d",
+                "passed": true,
+                "detail": "expected match=false, got surfaced=false (score 0, threshold 30)"
+              },
+              {
+                "kind": "band",
+                "candidateId": "h1-d",
+                "passed": true,
+                "detail": "expected score in [0,29], got 0"
+              },
+              {
+                "kind": "match",
+                "candidateId": "h1-e",
+                "passed": true,
+                "detail": "expected match=false, got surfaced=false (score 0, threshold 30)"
+              },
+              {
+                "kind": "band",
+                "candidateId": "h1-e",
+                "passed": true,
+                "detail": "expected score in [0,29], got 0"
+              }
+            ]
+          },
+          {
+            "passed": true,
+            "assertions": [
+              {
+                "kind": "match",
+                "candidateId": "h1-b",
+                "passed": true,
+                "detail": "expected match=true, got surfaced=true (score 98, threshold 30)"
+              },
+              {
+                "kind": "band",
+                "candidateId": "h1-b",
+                "passed": true,
+                "detail": "expected score in [60,100], got 98"
+              },
+              {
+                "kind": "role",
+                "candidateId": "h1-b",
+                "passed": true,
+                "detail": "expected role=agent, got agent"
+              },
+              {
+                "kind": "match",
+                "candidateId": "h1-c",
+                "passed": true,
+                "detail": "expected match=false, got surfaced=false (score 0, threshold 30)"
+              },
+              {
+                "kind": "band",
+                "candidateId": "h1-c",
+                "passed": true,
+                "detail": "expected score in [0,29], got 0"
+              },
+              {
+                "kind": "match",
+                "candidateId": "h1-d",
+                "passed": true,
+                "detail": "expected match=false, got surfaced=false (score 0, threshold 30)"
+              },
+              {
+                "kind": "band",
+                "candidateId": "h1-d",
+                "passed": true,
+                "detail": "expected score in [0,29], got 0"
+              },
+              {
+                "kind": "match",
+                "candidateId": "h1-e",
+                "passed": true,
+                "detail": "expected match=false, got surfaced=false (score 0, threshold 30)"
+              },
+              {
+                "kind": "band",
+                "candidateId": "h1-e",
+                "passed": true,
+                "detail": "expected score in [0,29], got 0"
+              }
+            ]
+          },
+          {
+            "passed": true,
+            "assertions": [
+              {
+                "kind": "match",
+                "candidateId": "h1-b",
+                "passed": true,
+                "detail": "expected match=true, got surfaced=true (score 95, threshold 30)"
+              },
+              {
+                "kind": "band",
+                "candidateId": "h1-b",
+                "passed": true,
+                "detail": "expected score in [60,100], got 95"
+              },
+              {
+                "kind": "role",
+                "candidateId": "h1-b",
+                "passed": true,
+                "detail": "expected role=agent, got agent"
+              },
+              {
+                "kind": "match",
+                "candidateId": "h1-c",
+                "passed": true,
+                "detail": "expected match=false, got surfaced=false (score 0, threshold 30)"
+              },
+              {
+                "kind": "band",
+                "candidateId": "h1-c",
+                "passed": true,
+                "detail": "expected score in [0,29], got 0"
+              },
+              {
+                "kind": "match",
+                "candidateId": "h1-d",
+                "passed": true,
+                "detail": "expected match=false, got surfaced=false (score 0, threshold 30)"
+              },
+              {
+                "kind": "band",
+                "candidateId": "h1-d",
+                "passed": true,
+                "detail": "expected score in [0,29], got 0"
+              },
+              {
+                "kind": "match",
+                "candidateId": "h1-e",
+                "passed": true,
+                "detail": "expected match=false, got surfaced=false (score 0, threshold 30)"
+              },
+              {
+                "kind": "band",
+                "candidateId": "h1-e",
+                "passed": true,
+                "detail": "expected score in [0,29], got 0"
+              }
+            ]
+          },
+          {
+            "passed": true,
+            "assertions": [
+              {
+                "kind": "match",
+                "candidateId": "h1-b",
+                "passed": true,
+                "detail": "expected match=true, got surfaced=true (score 95, threshold 30)"
+              },
+              {
+                "kind": "band",
+                "candidateId": "h1-b",
+                "passed": true,
+                "detail": "expected score in [60,100], got 95"
+              },
+              {
+                "kind": "role",
+                "candidateId": "h1-b",
+                "passed": true,
+                "detail": "expected role=agent, got agent"
+              },
+              {
+                "kind": "match",
+                "candidateId": "h1-c",
+                "passed": true,
+                "detail": "expected match=false, got surfaced=false (score 0, threshold 30)"
+              },
+              {
+                "kind": "band",
+                "candidateId": "h1-c",
+                "passed": true,
+                "detail": "expected score in [0,29], got 0"
+              },
+              {
+                "kind": "match",
+                "candidateId": "h1-d",
+                "passed": true,
+                "detail": "expected match=false, got surfaced=false (score 0, threshold 30)"
+              },
+              {
+                "kind": "band",
+                "candidateId": "h1-d",
+                "passed": true,
+                "detail": "expected score in [0,29], got 0"
+              },
+              {
+                "kind": "match",
+                "candidateId": "h1-e",
+                "passed": true,
+                "detail": "expected match=false, got surfaced=false (score 0, threshold 30)"
+              },
+              {
+                "kind": "band",
+                "candidateId": "h1-e",
+                "passed": true,
+                "detail": "expected score in [0,29], got 0"
+              }
+            ]
+          },
+          {
+            "passed": true,
+            "assertions": [
+              {
+                "kind": "match",
+                "candidateId": "h1-b",
+                "passed": true,
+                "detail": "expected match=true, got surfaced=true (score 95, threshold 30)"
+              },
+              {
+                "kind": "band",
+                "candidateId": "h1-b",
+                "passed": true,
+                "detail": "expected score in [60,100], got 95"
+              },
+              {
+                "kind": "role",
+                "candidateId": "h1-b",
+                "passed": true,
+                "detail": "expected role=agent, got agent"
+              },
+              {
+                "kind": "match",
+                "candidateId": "h1-c",
+                "passed": true,
+                "detail": "expected match=false, got surfaced=false (score 0, threshold 30)"
+              },
+              {
+                "kind": "band",
+                "candidateId": "h1-c",
+                "passed": true,
+                "detail": "expected score in [0,29], got 0"
+              },
+              {
+                "kind": "match",
+                "candidateId": "h1-d",
+                "passed": true,
+                "detail": "expected match=false, got surfaced=false (score 0, threshold 30)"
+              },
+              {
+                "kind": "band",
+                "candidateId": "h1-d",
+                "passed": true,
+                "detail": "expected score in [0,29], got 0"
+              },
+              {
+                "kind": "match",
+                "candidateId": "h1-e",
+                "passed": true,
+                "detail": "expected match=false, got surfaced=false (score 0, threshold 30)"
+              },
+              {
+                "kind": "band",
+                "candidateId": "h1-e",
+                "passed": true,
+                "detail": "expected score in [0,29], got 0"
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "caseId": "historical/co-researchers-structure",
+        "rule": "historical",
+        "runs": 7,
+        "passes": 6,
+        "passRate": 0.8571428571428571,
+        "flaky": true,
+        "runResults": [
+          {
+            "passed": true,
+            "assertions": [
+              {
+                "kind": "match",
+                "candidateId": "h2-b",
+                "passed": true,
+                "detail": "expected match=true, got surfaced=true (score 98, threshold 30)"
+              },
+              {
+                "kind": "band",
+                "candidateId": "h2-b",
+                "passed": true,
+                "detail": "expected score in [60,100], got 98"
+              },
+              {
+                "kind": "match",
+                "candidateId": "h2-c",
+                "passed": true,
+                "detail": "expected match=false, got surfaced=false (score 0, threshold 30)"
+              },
+              {
+                "kind": "band",
+                "candidateId": "h2-c",
+                "passed": true,
+                "detail": "expected score in [0,29], got 0"
+              },
+              {
+                "kind": "match",
+                "candidateId": "h2-d",
+                "passed": true,
+                "detail": "expected match=false, got surfaced=false (score 0, threshold 30)"
+              },
+              {
+                "kind": "band",
+                "candidateId": "h2-d",
+                "passed": true,
+                "detail": "expected score in [0,29], got 0"
+              },
+              {
+                "kind": "match",
+                "candidateId": "h2-e",
+                "passed": true,
+                "detail": "expected match=false, got surfaced=false (score 0, threshold 30)"
+              },
+              {
+                "kind": "band",
+                "candidateId": "h2-e",
+                "passed": true,
+                "detail": "expected score in [0,29], got 0"
+              }
+            ]
+          },
+          {
+            "passed": true,
+            "assertions": [
+              {
+                "kind": "match",
+                "candidateId": "h2-b",
+                "passed": true,
+                "detail": "expected match=true, got surfaced=true (score 98, threshold 30)"
+              },
+              {
+                "kind": "band",
+                "candidateId": "h2-b",
+                "passed": true,
+                "detail": "expected score in [60,100], got 98"
+              },
+              {
+                "kind": "match",
+                "candidateId": "h2-c",
+                "passed": true,
+                "detail": "expected match=false, got surfaced=false (score 0, threshold 30)"
+              },
+              {
+                "kind": "band",
+                "candidateId": "h2-c",
+                "passed": true,
+                "detail": "expected score in [0,29], got 0"
+              },
+              {
+                "kind": "match",
+                "candidateId": "h2-d",
+                "passed": true,
+                "detail": "expected match=false, got surfaced=false (score 0, threshold 30)"
+              },
+              {
+                "kind": "band",
+                "candidateId": "h2-d",
+                "passed": true,
+                "detail": "expected score in [0,29], got 0"
+              },
+              {
+                "kind": "match",
+                "candidateId": "h2-e",
+                "passed": true,
+                "detail": "expected match=false, got surfaced=false (score 0, threshold 30)"
+              },
+              {
+                "kind": "band",
+                "candidateId": "h2-e",
+                "passed": true,
+                "detail": "expected score in [0,29], got 0"
+              }
+            ]
+          },
+          {
+            "passed": true,
+            "assertions": [
+              {
+                "kind": "match",
+                "candidateId": "h2-b",
+                "passed": true,
+                "detail": "expected match=true, got surfaced=true (score 98, threshold 30)"
+              },
+              {
+                "kind": "band",
+                "candidateId": "h2-b",
+                "passed": true,
+                "detail": "expected score in [60,100], got 98"
+              },
+              {
+                "kind": "match",
+                "candidateId": "h2-c",
+                "passed": true,
+                "detail": "expected match=false, got surfaced=false (score 0, threshold 30)"
+              },
+              {
+                "kind": "band",
+                "candidateId": "h2-c",
+                "passed": true,
+                "detail": "expected score in [0,29], got 0"
+              },
+              {
+                "kind": "match",
+                "candidateId": "h2-d",
+                "passed": true,
+                "detail": "expected match=false, got surfaced=false (score 0, threshold 30)"
+              },
+              {
+                "kind": "band",
+                "candidateId": "h2-d",
+                "passed": true,
+                "detail": "expected score in [0,29], got 0"
+              },
+              {
+                "kind": "match",
+                "candidateId": "h2-e",
+                "passed": true,
+                "detail": "expected match=false, got surfaced=false (score 0, threshold 30)"
+              },
+              {
+                "kind": "band",
+                "candidateId": "h2-e",
+                "passed": true,
+                "detail": "expected score in [0,29], got 0"
+              }
+            ]
+          },
+          {
+            "passed": false,
+            "assertions": [
+              {
+                "kind": "match",
+                "candidateId": "h2-b",
+                "passed": true,
+                "detail": "expected match=true, got surfaced=true (score 98, threshold 30)"
+              },
+              {
+                "kind": "band",
+                "candidateId": "h2-b",
+                "passed": true,
+                "detail": "expected score in [60,100], got 98"
+              },
+              {
+                "kind": "match",
+                "candidateId": "h2-c",
+                "passed": false,
+                "detail": "expected match=false, got surfaced=true (score 65, threshold 30)"
+              },
+              {
+                "kind": "band",
+                "candidateId": "h2-c",
+                "passed": false,
+                "detail": "expected score in [0,29], got 65"
+              },
+              {
+                "kind": "match",
+                "candidateId": "h2-d",
+                "passed": true,
+                "detail": "expected match=false, got surfaced=false (score 0, threshold 30)"
+              },
+              {
+                "kind": "band",
+                "candidateId": "h2-d",
+                "passed": true,
+                "detail": "expected score in [0,29], got 0"
+              },
+              {
+                "kind": "match",
+                "candidateId": "h2-e",
+                "passed": true,
+                "detail": "expected match=false, got surfaced=false (score 0, threshold 30)"
+              },
+              {
+                "kind": "band",
+                "candidateId": "h2-e",
+                "passed": true,
+                "detail": "expected score in [0,29], got 0"
+              }
+            ]
+          },
+          {
+            "passed": true,
+            "assertions": [
+              {
+                "kind": "match",
+                "candidateId": "h2-b",
+                "passed": true,
+                "detail": "expected match=true, got surfaced=true (score 98, threshold 30)"
+              },
+              {
+                "kind": "band",
+                "candidateId": "h2-b",
+                "passed": true,
+                "detail": "expected score in [60,100], got 98"
+              },
+              {
+                "kind": "match",
+                "candidateId": "h2-c",
+                "passed": true,
+                "detail": "expected match=false, got surfaced=false (score 0, threshold 30)"
+              },
+              {
+                "kind": "band",
+                "candidateId": "h2-c",
+                "passed": true,
+                "detail": "expected score in [0,29], got 0"
+              },
+              {
+                "kind": "match",
+                "candidateId": "h2-d",
+                "passed": true,
+                "detail": "expected match=false, got surfaced=false (score 0, threshold 30)"
+              },
+              {
+                "kind": "band",
+                "candidateId": "h2-d",
+                "passed": true,
+                "detail": "expected score in [0,29], got 0"
+              },
+              {
+                "kind": "match",
+                "candidateId": "h2-e",
+                "passed": true,
+                "detail": "expected match=false, got surfaced=false (score 0, threshold 30)"
+              },
+              {
+                "kind": "band",
+                "candidateId": "h2-e",
+                "passed": true,
+                "detail": "expected score in [0,29], got 0"
+              }
+            ]
+          },
+          {
+            "passed": true,
+            "assertions": [
+              {
+                "kind": "match",
+                "candidateId": "h2-b",
+                "passed": true,
+                "detail": "expected match=true, got surfaced=true (score 98, threshold 30)"
+              },
+              {
+                "kind": "band",
+                "candidateId": "h2-b",
+                "passed": true,
+                "detail": "expected score in [60,100], got 98"
+              },
+              {
+                "kind": "match",
+                "candidateId": "h2-c",
+                "passed": true,
+                "detail": "expected match=false, got surfaced=false (score 0, threshold 30)"
+              },
+              {
+                "kind": "band",
+                "candidateId": "h2-c",
+                "passed": true,
+                "detail": "expected score in [0,29], got 0"
+              },
+              {
+                "kind": "match",
+                "candidateId": "h2-d",
+                "passed": true,
+                "detail": "expected match=false, got surfaced=false (score 0, threshold 30)"
+              },
+              {
+                "kind": "band",
+                "candidateId": "h2-d",
+                "passed": true,
+                "detail": "expected score in [0,29], got 0"
+              },
+              {
+                "kind": "match",
+                "candidateId": "h2-e",
+                "passed": true,
+                "detail": "expected match=false, got surfaced=false (score 0, threshold 30)"
+              },
+              {
+                "kind": "band",
+                "candidateId": "h2-e",
+                "passed": true,
+                "detail": "expected score in [0,29], got 0"
+              }
+            ]
+          },
+          {
+            "passed": true,
+            "assertions": [
+              {
+                "kind": "match",
+                "candidateId": "h2-b",
+                "passed": true,
+                "detail": "expected match=true, got surfaced=true (score 98, threshold 30)"
+              },
+              {
+                "kind": "band",
+                "candidateId": "h2-b",
+                "passed": true,
+                "detail": "expected score in [60,100], got 98"
+              },
+              {
+                "kind": "match",
+                "candidateId": "h2-c",
+                "passed": true,
+                "detail": "expected match=false, got surfaced=false (score 0, threshold 30)"
+              },
+              {
+                "kind": "band",
+                "candidateId": "h2-c",
+                "passed": true,
+                "detail": "expected score in [0,29], got 0"
+              },
+              {
+                "kind": "match",
+                "candidateId": "h2-d",
+                "passed": true,
+                "detail": "expected match=false, got surfaced=false (score 0, threshold 30)"
+              },
+              {
+                "kind": "band",
+                "candidateId": "h2-d",
+                "passed": true,
+                "detail": "expected score in [0,29], got 0"
+              },
+              {
+                "kind": "match",
+                "candidateId": "h2-e",
+                "passed": true,
+                "detail": "expected match=false, got surfaced=false (score 0, threshold 30)"
+              },
+              {
+                "kind": "band",
+                "candidateId": "h2-e",
+                "passed": true,
+                "detail": "expected score in [0,29], got 0"
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "caseId": "historical/songwriting-duo",
+        "rule": "historical",
+        "runs": 7,
+        "passes": 7,
+        "passRate": 1,
+        "flaky": false,
+        "runResults": [
+          {
+            "passed": true,
+            "assertions": [
+              {
+                "kind": "match",
+                "candidateId": "h3-b",
+                "passed": true,
+                "detail": "expected match=true, got surfaced=true (score 98, threshold 30)"
+              },
+              {
+                "kind": "band",
+                "candidateId": "h3-b",
+                "passed": true,
+                "detail": "expected score in [60,100], got 98"
+              },
+              {
+                "kind": "match",
+                "candidateId": "h3-c",
+                "passed": true,
+                "detail": "expected match=false, got surfaced=false (score 0, threshold 30)"
+              },
+              {
+                "kind": "band",
+                "candidateId": "h3-c",
+                "passed": true,
+                "detail": "expected score in [0,29], got 0"
+              },
+              {
+                "kind": "match",
+                "candidateId": "h3-d",
+                "passed": true,
+                "detail": "expected match=false, got surfaced=false (score 0, threshold 30)"
+              },
+              {
+                "kind": "band",
+                "candidateId": "h3-d",
+                "passed": true,
+                "detail": "expected score in [0,29], got 0"
+              },
+              {
+                "kind": "match",
+                "candidateId": "h3-e",
+                "passed": true,
+                "detail": "expected match=false, got surfaced=false (score 0, threshold 30)"
+              },
+              {
+                "kind": "band",
+                "candidateId": "h3-e",
+                "passed": true,
+                "detail": "expected score in [0,29], got 0"
+              }
+            ]
+          },
+          {
+            "passed": true,
+            "assertions": [
+              {
+                "kind": "match",
+                "candidateId": "h3-b",
+                "passed": true,
+                "detail": "expected match=true, got surfaced=true (score 95, threshold 30)"
+              },
+              {
+                "kind": "band",
+                "candidateId": "h3-b",
+                "passed": true,
+                "detail": "expected score in [60,100], got 95"
+              },
+              {
+                "kind": "match",
+                "candidateId": "h3-c",
+                "passed": true,
+                "detail": "expected match=false, got surfaced=false (score 0, threshold 30)"
+              },
+              {
+                "kind": "band",
+                "candidateId": "h3-c",
+                "passed": true,
+                "detail": "expected score in [0,29], got 0"
+              },
+              {
+                "kind": "match",
+                "candidateId": "h3-d",
+                "passed": true,
+                "detail": "expected match=false, got surfaced=false (score 0, threshold 30)"
+              },
+              {
+                "kind": "band",
+                "candidateId": "h3-d",
+                "passed": true,
+                "detail": "expected score in [0,29], got 0"
+              },
+              {
+                "kind": "match",
+                "candidateId": "h3-e",
+                "passed": true,
+                "detail": "expected match=false, got surfaced=false (score 0, threshold 30)"
+              },
+              {
+                "kind": "band",
+                "candidateId": "h3-e",
+                "passed": true,
+                "detail": "expected score in [0,29], got 0"
+              }
+            ]
+          },
+          {
+            "passed": true,
+            "assertions": [
+              {
+                "kind": "match",
+                "candidateId": "h3-b",
+                "passed": true,
+                "detail": "expected match=true, got surfaced=true (score 98, threshold 30)"
+              },
+              {
+                "kind": "band",
+                "candidateId": "h3-b",
+                "passed": true,
+                "detail": "expected score in [60,100], got 98"
+              },
+              {
+                "kind": "match",
+                "candidateId": "h3-c",
+                "passed": true,
+                "detail": "expected match=false, got surfaced=false (score 0, threshold 30)"
+              },
+              {
+                "kind": "band",
+                "candidateId": "h3-c",
+                "passed": true,
+                "detail": "expected score in [0,29], got 0"
+              },
+              {
+                "kind": "match",
+                "candidateId": "h3-d",
+                "passed": true,
+                "detail": "expected match=false, got surfaced=false (score 0, threshold 30)"
+              },
+              {
+                "kind": "band",
+                "candidateId": "h3-d",
+                "passed": true,
+                "detail": "expected score in [0,29], got 0"
+              },
+              {
+                "kind": "match",
+                "candidateId": "h3-e",
+                "passed": true,
+                "detail": "expected match=false, got surfaced=false (score 0, threshold 30)"
+              },
+              {
+                "kind": "band",
+                "candidateId": "h3-e",
+                "passed": true,
+                "detail": "expected score in [0,29], got 0"
+              }
+            ]
+          },
+          {
+            "passed": true,
+            "assertions": [
+              {
+                "kind": "match",
+                "candidateId": "h3-b",
+                "passed": true,
+                "detail": "expected match=true, got surfaced=true (score 98, threshold 30)"
+              },
+              {
+                "kind": "band",
+                "candidateId": "h3-b",
+                "passed": true,
+                "detail": "expected score in [60,100], got 98"
+              },
+              {
+                "kind": "match",
+                "candidateId": "h3-c",
+                "passed": true,
+                "detail": "expected match=false, got surfaced=false (score 0, threshold 30)"
+              },
+              {
+                "kind": "band",
+                "candidateId": "h3-c",
+                "passed": true,
+                "detail": "expected score in [0,29], got 0"
+              },
+              {
+                "kind": "match",
+                "candidateId": "h3-d",
+                "passed": true,
+                "detail": "expected match=false, got surfaced=false (score 0, threshold 30)"
+              },
+              {
+                "kind": "band",
+                "candidateId": "h3-d",
+                "passed": true,
+                "detail": "expected score in [0,29], got 0"
+              },
+              {
+                "kind": "match",
+                "candidateId": "h3-e",
+                "passed": true,
+                "detail": "expected match=false, got surfaced=false (score 0, threshold 30)"
+              },
+              {
+                "kind": "band",
+                "candidateId": "h3-e",
+                "passed": true,
+                "detail": "expected score in [0,29], got 0"
+              }
+            ]
+          },
+          {
+            "passed": true,
+            "assertions": [
+              {
+                "kind": "match",
+                "candidateId": "h3-b",
+                "passed": true,
+                "detail": "expected match=true, got surfaced=true (score 98, threshold 30)"
+              },
+              {
+                "kind": "band",
+                "candidateId": "h3-b",
+                "passed": true,
+                "detail": "expected score in [60,100], got 98"
+              },
+              {
+                "kind": "match",
+                "candidateId": "h3-c",
+                "passed": true,
+                "detail": "expected match=false, got surfaced=false (score 0, threshold 30)"
+              },
+              {
+                "kind": "band",
+                "candidateId": "h3-c",
+                "passed": true,
+                "detail": "expected score in [0,29], got 0"
+              },
+              {
+                "kind": "match",
+                "candidateId": "h3-d",
+                "passed": true,
+                "detail": "expected match=false, got surfaced=false (score 0, threshold 30)"
+              },
+              {
+                "kind": "band",
+                "candidateId": "h3-d",
+                "passed": true,
+                "detail": "expected score in [0,29], got 0"
+              },
+              {
+                "kind": "match",
+                "candidateId": "h3-e",
+                "passed": true,
+                "detail": "expected match=false, got surfaced=false (score 0, threshold 30)"
+              },
+              {
+                "kind": "band",
+                "candidateId": "h3-e",
+                "passed": true,
+                "detail": "expected score in [0,29], got 0"
+              }
+            ]
+          },
+          {
+            "passed": true,
+            "assertions": [
+              {
+                "kind": "match",
+                "candidateId": "h3-b",
+                "passed": true,
+                "detail": "expected match=true, got surfaced=true (score 95, threshold 30)"
+              },
+              {
+                "kind": "band",
+                "candidateId": "h3-b",
+                "passed": true,
+                "detail": "expected score in [60,100], got 95"
+              },
+              {
+                "kind": "match",
+                "candidateId": "h3-c",
+                "passed": true,
+                "detail": "expected match=false, got surfaced=false (score 0, threshold 30)"
+              },
+              {
+                "kind": "band",
+                "candidateId": "h3-c",
+                "passed": true,
+                "detail": "expected score in [0,29], got 0"
+              },
+              {
+                "kind": "match",
+                "candidateId": "h3-d",
+                "passed": true,
+                "detail": "expected match=false, got surfaced=false (score 0, threshold 30)"
+              },
+              {
+                "kind": "band",
+                "candidateId": "h3-d",
+                "passed": true,
+                "detail": "expected score in [0,29], got 0"
+              },
+              {
+                "kind": "match",
+                "candidateId": "h3-e",
+                "passed": true,
+                "detail": "expected match=false, got surfaced=false (score 0, threshold 30)"
+              },
+              {
+                "kind": "band",
+                "candidateId": "h3-e",
+                "passed": true,
+                "detail": "expected score in [0,29], got 0"
+              }
+            ]
+          },
+          {
+            "passed": true,
+            "assertions": [
+              {
+                "kind": "match",
+                "candidateId": "h3-b",
+                "passed": true,
+                "detail": "expected match=true, got surfaced=true (score 98, threshold 30)"
+              },
+              {
+                "kind": "band",
+                "candidateId": "h3-b",
+                "passed": true,
+                "detail": "expected score in [60,100], got 98"
+              },
+              {
+                "kind": "match",
+                "candidateId": "h3-c",
+                "passed": true,
+                "detail": "expected match=false, got surfaced=false (score 0, threshold 30)"
+              },
+              {
+                "kind": "band",
+                "candidateId": "h3-c",
+                "passed": true,
+                "detail": "expected score in [0,29], got 0"
+              },
+              {
+                "kind": "match",
+                "candidateId": "h3-d",
+                "passed": true,
+                "detail": "expected match=false, got surfaced=false (score 0, threshold 30)"
+              },
+              {
+                "kind": "band",
+                "candidateId": "h3-d",
+                "passed": true,
+                "detail": "expected score in [0,29], got 0"
+              },
+              {
+                "kind": "match",
+                "candidateId": "h3-e",
+                "passed": true,
+                "detail": "expected match=false, got surfaced=false (score 0, threshold 30)"
+              },
+              {
+                "kind": "band",
+                "candidateId": "h3-e",
+                "passed": true,
+                "detail": "expected score in [0,29], got 0"
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "caseId": "historical/first-check-investor",
+        "rule": "historical",
+        "runs": 7,
+        "passes": 7,
+        "passRate": 1,
+        "flaky": false,
+        "runResults": [
+          {
+            "passed": true,
+            "assertions": [
+              {
+                "kind": "match",
+                "candidateId": "h4-b",
+                "passed": true,
+                "detail": "expected match=true, got surfaced=true (score 98, threshold 30)"
+              },
+              {
+                "kind": "band",
+                "candidateId": "h4-b",
+                "passed": true,
+                "detail": "expected score in [60,100], got 98"
+              },
+              {
+                "kind": "role",
+                "candidateId": "h4-b",
+                "passed": true,
+                "detail": "expected role=agent, got agent"
+              },
+              {
+                "kind": "match",
+                "candidateId": "h4-c",
+                "passed": true,
+                "detail": "expected match=false, got surfaced=false (score 0, threshold 30)"
+              },
+              {
+                "kind": "band",
+                "candidateId": "h4-c",
+                "passed": true,
+                "detail": "expected score in [0,29], got 0"
+              },
+              {
+                "kind": "match",
+                "candidateId": "h4-d",
+                "passed": true,
+                "detail": "expected match=false, got surfaced=false (score 0, threshold 30)"
+              },
+              {
+                "kind": "band",
+                "candidateId": "h4-d",
+                "passed": true,
+                "detail": "expected score in [0,29], got 0"
+              },
+              {
+                "kind": "match",
+                "candidateId": "h4-e",
+                "passed": true,
+                "detail": "expected match=false, got surfaced=false (score 0, threshold 30)"
+              },
+              {
+                "kind": "band",
+                "candidateId": "h4-e",
+                "passed": true,
+                "detail": "expected score in [0,29], got 0"
+              }
+            ]
+          },
+          {
+            "passed": true,
+            "assertions": [
+              {
+                "kind": "match",
+                "candidateId": "h4-b",
+                "passed": true,
+                "detail": "expected match=true, got surfaced=true (score 98, threshold 30)"
+              },
+              {
+                "kind": "band",
+                "candidateId": "h4-b",
+                "passed": true,
+                "detail": "expected score in [60,100], got 98"
+              },
+              {
+                "kind": "role",
+                "candidateId": "h4-b",
+                "passed": true,
+                "detail": "expected role=agent, got agent"
+              },
+              {
+                "kind": "match",
+                "candidateId": "h4-c",
+                "passed": true,
+                "detail": "expected match=false, got surfaced=false (score 0, threshold 30)"
+              },
+              {
+                "kind": "band",
+                "candidateId": "h4-c",
+                "passed": true,
+                "detail": "expected score in [0,29], got 0"
+              },
+              {
+                "kind": "match",
+                "candidateId": "h4-d",
+                "passed": true,
+                "detail": "expected match=false, got surfaced=false (score 0, threshold 30)"
+              },
+              {
+                "kind": "band",
+                "candidateId": "h4-d",
+                "passed": true,
+                "detail": "expected score in [0,29], got 0"
+              },
+              {
+                "kind": "match",
+                "candidateId": "h4-e",
+                "passed": true,
+                "detail": "expected match=false, got surfaced=false (score 0, threshold 30)"
+              },
+              {
+                "kind": "band",
+                "candidateId": "h4-e",
+                "passed": true,
+                "detail": "expected score in [0,29], got 0"
+              }
+            ]
+          },
+          {
+            "passed": true,
+            "assertions": [
+              {
+                "kind": "match",
+                "candidateId": "h4-b",
+                "passed": true,
+                "detail": "expected match=true, got surfaced=true (score 98, threshold 30)"
+              },
+              {
+                "kind": "band",
+                "candidateId": "h4-b",
+                "passed": true,
+                "detail": "expected score in [60,100], got 98"
+              },
+              {
+                "kind": "role",
+                "candidateId": "h4-b",
+                "passed": true,
+                "detail": "expected role=agent, got agent"
+              },
+              {
+                "kind": "match",
+                "candidateId": "h4-c",
+                "passed": true,
+                "detail": "expected match=false, got surfaced=false (score 0, threshold 30)"
+              },
+              {
+                "kind": "band",
+                "candidateId": "h4-c",
+                "passed": true,
+                "detail": "expected score in [0,29], got 0"
+              },
+              {
+                "kind": "match",
+                "candidateId": "h4-d",
+                "passed": true,
+                "detail": "expected match=false, got surfaced=false (score 0, threshold 30)"
+              },
+              {
+                "kind": "band",
+                "candidateId": "h4-d",
+                "passed": true,
+                "detail": "expected score in [0,29], got 0"
+              },
+              {
+                "kind": "match",
+                "candidateId": "h4-e",
+                "passed": true,
+                "detail": "expected match=false, got surfaced=false (score 0, threshold 30)"
+              },
+              {
+                "kind": "band",
+                "candidateId": "h4-e",
+                "passed": true,
+                "detail": "expected score in [0,29], got 0"
+              }
+            ]
+          },
+          {
+            "passed": true,
+            "assertions": [
+              {
+                "kind": "match",
+                "candidateId": "h4-b",
+                "passed": true,
+                "detail": "expected match=true, got surfaced=true (score 98, threshold 30)"
+              },
+              {
+                "kind": "band",
+                "candidateId": "h4-b",
+                "passed": true,
+                "detail": "expected score in [60,100], got 98"
+              },
+              {
+                "kind": "role",
+                "candidateId": "h4-b",
+                "passed": true,
+                "detail": "expected role=agent, got agent"
+              },
+              {
+                "kind": "match",
+                "candidateId": "h4-c",
+                "passed": true,
+                "detail": "expected match=false, got surfaced=false (score 0, threshold 30)"
+              },
+              {
+                "kind": "band",
+                "candidateId": "h4-c",
+                "passed": true,
+                "detail": "expected score in [0,29], got 0"
+              },
+              {
+                "kind": "match",
+                "candidateId": "h4-d",
+                "passed": true,
+                "detail": "expected match=false, got surfaced=false (score 0, threshold 30)"
+              },
+              {
+                "kind": "band",
+                "candidateId": "h4-d",
+                "passed": true,
+                "detail": "expected score in [0,29], got 0"
+              },
+              {
+                "kind": "match",
+                "candidateId": "h4-e",
+                "passed": true,
+                "detail": "expected match=false, got surfaced=false (score 0, threshold 30)"
+              },
+              {
+                "kind": "band",
+                "candidateId": "h4-e",
+                "passed": true,
+                "detail": "expected score in [0,29], got 0"
+              }
+            ]
+          },
+          {
+            "passed": true,
+            "assertions": [
+              {
+                "kind": "match",
+                "candidateId": "h4-b",
+                "passed": true,
+                "detail": "expected match=true, got surfaced=true (score 98, threshold 30)"
+              },
+              {
+                "kind": "band",
+                "candidateId": "h4-b",
+                "passed": true,
+                "detail": "expected score in [60,100], got 98"
+              },
+              {
+                "kind": "role",
+                "candidateId": "h4-b",
+                "passed": true,
+                "detail": "expected role=agent, got agent"
+              },
+              {
+                "kind": "match",
+                "candidateId": "h4-c",
+                "passed": true,
+                "detail": "expected match=false, got surfaced=false (score 0, threshold 30)"
+              },
+              {
+                "kind": "band",
+                "candidateId": "h4-c",
+                "passed": true,
+                "detail": "expected score in [0,29], got 0"
+              },
+              {
+                "kind": "match",
+                "candidateId": "h4-d",
+                "passed": true,
+                "detail": "expected match=false, got surfaced=false (score 0, threshold 30)"
+              },
+              {
+                "kind": "band",
+                "candidateId": "h4-d",
+                "passed": true,
+                "detail": "expected score in [0,29], got 0"
+              },
+              {
+                "kind": "match",
+                "candidateId": "h4-e",
+                "passed": true,
+                "detail": "expected match=false, got surfaced=false (score 0, threshold 30)"
+              },
+              {
+                "kind": "band",
+                "candidateId": "h4-e",
+                "passed": true,
+                "detail": "expected score in [0,29], got 0"
+              }
+            ]
+          },
+          {
+            "passed": true,
+            "assertions": [
+              {
+                "kind": "match",
+                "candidateId": "h4-b",
+                "passed": true,
+                "detail": "expected match=true, got surfaced=true (score 98, threshold 30)"
+              },
+              {
+                "kind": "band",
+                "candidateId": "h4-b",
+                "passed": true,
+                "detail": "expected score in [60,100], got 98"
+              },
+              {
+                "kind": "role",
+                "candidateId": "h4-b",
+                "passed": true,
+                "detail": "expected role=agent, got agent"
+              },
+              {
+                "kind": "match",
+                "candidateId": "h4-c",
+                "passed": true,
+                "detail": "expected match=false, got surfaced=false (score 0, threshold 30)"
+              },
+              {
+                "kind": "band",
+                "candidateId": "h4-c",
+                "passed": true,
+                "detail": "expected score in [0,29], got 0"
+              },
+              {
+                "kind": "match",
+                "candidateId": "h4-d",
+                "passed": true,
+                "detail": "expected match=false, got surfaced=false (score 0, threshold 30)"
+              },
+              {
+                "kind": "band",
+                "candidateId": "h4-d",
+                "passed": true,
+                "detail": "expected score in [0,29], got 0"
+              },
+              {
+                "kind": "match",
+                "candidateId": "h4-e",
+                "passed": true,
+                "detail": "expected match=false, got surfaced=false (score 0, threshold 30)"
+              },
+              {
+                "kind": "band",
+                "candidateId": "h4-e",
+                "passed": true,
+                "detail": "expected score in [0,29], got 0"
+              }
+            ]
+          },
+          {
+            "passed": true,
+            "assertions": [
+              {
+                "kind": "match",
+                "candidateId": "h4-b",
+                "passed": true,
+                "detail": "expected match=true, got surfaced=true (score 98, threshold 30)"
+              },
+              {
+                "kind": "band",
+                "candidateId": "h4-b",
+                "passed": true,
+                "detail": "expected score in [60,100], got 98"
+              },
+              {
+                "kind": "role",
+                "candidateId": "h4-b",
+                "passed": true,
+                "detail": "expected role=agent, got agent"
+              },
+              {
+                "kind": "match",
+                "candidateId": "h4-c",
+                "passed": true,
+                "detail": "expected match=false, got surfaced=false (score 0, threshold 30)"
+              },
+              {
+                "kind": "band",
+                "candidateId": "h4-c",
+                "passed": true,
+                "detail": "expected score in [0,29], got 0"
+              },
+              {
+                "kind": "match",
+                "candidateId": "h4-d",
+                "passed": true,
+                "detail": "expected match=false, got surfaced=false (score 0, threshold 30)"
+              },
+              {
+                "kind": "band",
+                "candidateId": "h4-d",
+                "passed": true,
+                "detail": "expected score in [0,29], got 0"
+              },
+              {
+                "kind": "match",
+                "candidateId": "h4-e",
+                "passed": true,
+                "detail": "expected match=false, got surfaced=false (score 0, threshold 30)"
+              },
+              {
+                "kind": "band",
+                "candidateId": "h4-e",
+                "passed": true,
+                "detail": "expected score in [0,29], got 0"
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "caseId": "historical/domain-expert-and-ml",
+        "rule": "historical",
+        "runs": 7,
+        "passes": 7,
+        "passRate": 1,
+        "flaky": false,
+        "runResults": [
+          {
+            "passed": true,
+            "assertions": [
+              {
+                "kind": "match",
+                "candidateId": "h5-b",
+                "passed": true,
+                "detail": "expected match=true, got surfaced=true (score 98, threshold 30)"
+              },
+              {
+                "kind": "band",
+                "candidateId": "h5-b",
+                "passed": true,
+                "detail": "expected score in [60,100], got 98"
+              },
+              {
+                "kind": "match",
+                "candidateId": "h5-c",
+                "passed": true,
+                "detail": "expected match=false, got surfaced=false (score 0, threshold 30)"
+              },
+              {
+                "kind": "band",
+                "candidateId": "h5-c",
+                "passed": true,
+                "detail": "expected score in [0,29], got 0"
+              },
+              {
+                "kind": "match",
+                "candidateId": "h5-d",
+                "passed": true,
+                "detail": "expected match=false, got surfaced=false (score 0, threshold 30)"
+              },
+              {
+                "kind": "band",
+                "candidateId": "h5-d",
+                "passed": true,
+                "detail": "expected score in [0,29], got 0"
+              },
+              {
+                "kind": "match",
+                "candidateId": "h5-e",
+                "passed": true,
+                "detail": "expected match=false, got surfaced=false (score 0, threshold 30)"
+              },
+              {
+                "kind": "band",
+                "candidateId": "h5-e",
+                "passed": true,
+                "detail": "expected score in [0,29], got 0"
+              }
+            ]
+          },
+          {
+            "passed": true,
+            "assertions": [
+              {
+                "kind": "match",
+                "candidateId": "h5-b",
+                "passed": true,
+                "detail": "expected match=true, got surfaced=true (score 98, threshold 30)"
+              },
+              {
+                "kind": "band",
+                "candidateId": "h5-b",
+                "passed": true,
+                "detail": "expected score in [60,100], got 98"
+              },
+              {
+                "kind": "match",
+                "candidateId": "h5-c",
+                "passed": true,
+                "detail": "expected match=false, got surfaced=false (score 0, threshold 30)"
+              },
+              {
+                "kind": "band",
+                "candidateId": "h5-c",
+                "passed": true,
+                "detail": "expected score in [0,29], got 0"
+              },
+              {
+                "kind": "match",
+                "candidateId": "h5-d",
+                "passed": true,
+                "detail": "expected match=false, got surfaced=false (score 0, threshold 30)"
+              },
+              {
+                "kind": "band",
+                "candidateId": "h5-d",
+                "passed": true,
+                "detail": "expected score in [0,29], got 0"
+              },
+              {
+                "kind": "match",
+                "candidateId": "h5-e",
+                "passed": true,
+                "detail": "expected match=false, got surfaced=false (score 0, threshold 30)"
+              },
+              {
+                "kind": "band",
+                "candidateId": "h5-e",
+                "passed": true,
+                "detail": "expected score in [0,29], got 0"
+              }
+            ]
+          },
+          {
+            "passed": true,
+            "assertions": [
+              {
+                "kind": "match",
+                "candidateId": "h5-b",
+                "passed": true,
+                "detail": "expected match=true, got surfaced=true (score 98, threshold 30)"
+              },
+              {
+                "kind": "band",
+                "candidateId": "h5-b",
+                "passed": true,
+                "detail": "expected score in [60,100], got 98"
+              },
+              {
+                "kind": "match",
+                "candidateId": "h5-c",
+                "passed": true,
+                "detail": "expected match=false, got surfaced=false (score 0, threshold 30)"
+              },
+              {
+                "kind": "band",
+                "candidateId": "h5-c",
+                "passed": true,
+                "detail": "expected score in [0,29], got 0"
+              },
+              {
+                "kind": "match",
+                "candidateId": "h5-d",
+                "passed": true,
+                "detail": "expected match=false, got surfaced=false (score 0, threshold 30)"
+              },
+              {
+                "kind": "band",
+                "candidateId": "h5-d",
+                "passed": true,
+                "detail": "expected score in [0,29], got 0"
+              },
+              {
+                "kind": "match",
+                "candidateId": "h5-e",
+                "passed": true,
+                "detail": "expected match=false, got surfaced=false (score 0, threshold 30)"
+              },
+              {
+                "kind": "band",
+                "candidateId": "h5-e",
+                "passed": true,
+                "detail": "expected score in [0,29], got 0"
+              }
+            ]
+          },
+          {
+            "passed": true,
+            "assertions": [
+              {
+                "kind": "match",
+                "candidateId": "h5-b",
+                "passed": true,
+                "detail": "expected match=true, got surfaced=true (score 95, threshold 30)"
+              },
+              {
+                "kind": "band",
+                "candidateId": "h5-b",
+                "passed": true,
+                "detail": "expected score in [60,100], got 95"
+              },
+              {
+                "kind": "match",
+                "candidateId": "h5-c",
+                "passed": true,
+                "detail": "expected match=false, got surfaced=false (score 0, threshold 30)"
+              },
+              {
+                "kind": "band",
+                "candidateId": "h5-c",
+                "passed": true,
+                "detail": "expected score in [0,29], got 0"
+              },
+              {
+                "kind": "match",
+                "candidateId": "h5-d",
+                "passed": true,
+                "detail": "expected match=false, got surfaced=false (score 0, threshold 30)"
+              },
+              {
+                "kind": "band",
+                "candidateId": "h5-d",
+                "passed": true,
+                "detail": "expected score in [0,29], got 0"
+              },
+              {
+                "kind": "match",
+                "candidateId": "h5-e",
+                "passed": true,
+                "detail": "expected match=false, got surfaced=false (score 0, threshold 30)"
+              },
+              {
+                "kind": "band",
+                "candidateId": "h5-e",
+                "passed": true,
+                "detail": "expected score in [0,29], got 0"
+              }
+            ]
+          },
+          {
+            "passed": true,
+            "assertions": [
+              {
+                "kind": "match",
+                "candidateId": "h5-b",
+                "passed": true,
+                "detail": "expected match=true, got surfaced=true (score 98, threshold 30)"
+              },
+              {
+                "kind": "band",
+                "candidateId": "h5-b",
+                "passed": true,
+                "detail": "expected score in [60,100], got 98"
+              },
+              {
+                "kind": "match",
+                "candidateId": "h5-c",
+                "passed": true,
+                "detail": "expected match=false, got surfaced=false (score 0, threshold 30)"
+              },
+              {
+                "kind": "band",
+                "candidateId": "h5-c",
+                "passed": true,
+                "detail": "expected score in [0,29], got 0"
+              },
+              {
+                "kind": "match",
+                "candidateId": "h5-d",
+                "passed": true,
+                "detail": "expected match=false, got surfaced=false (score 0, threshold 30)"
+              },
+              {
+                "kind": "band",
+                "candidateId": "h5-d",
+                "passed": true,
+                "detail": "expected score in [0,29], got 0"
+              },
+              {
+                "kind": "match",
+                "candidateId": "h5-e",
+                "passed": true,
+                "detail": "expected match=false, got surfaced=false (score 0, threshold 30)"
+              },
+              {
+                "kind": "band",
+                "candidateId": "h5-e",
+                "passed": true,
+                "detail": "expected score in [0,29], got 0"
+              }
+            ]
+          },
+          {
+            "passed": true,
+            "assertions": [
+              {
+                "kind": "match",
+                "candidateId": "h5-b",
+                "passed": true,
+                "detail": "expected match=true, got surfaced=true (score 98, threshold 30)"
+              },
+              {
+                "kind": "band",
+                "candidateId": "h5-b",
+                "passed": true,
+                "detail": "expected score in [60,100], got 98"
+              },
+              {
+                "kind": "match",
+                "candidateId": "h5-c",
+                "passed": true,
+                "detail": "expected match=false, got surfaced=false (score 0, threshold 30)"
+              },
+              {
+                "kind": "band",
+                "candidateId": "h5-c",
+                "passed": true,
+                "detail": "expected score in [0,29], got 0"
+              },
+              {
+                "kind": "match",
+                "candidateId": "h5-d",
+                "passed": true,
+                "detail": "expected match=false, got surfaced=false (score 0, threshold 30)"
+              },
+              {
+                "kind": "band",
+                "candidateId": "h5-d",
+                "passed": true,
+                "detail": "expected score in [0,29], got 0"
+              },
+              {
+                "kind": "match",
+                "candidateId": "h5-e",
+                "passed": true,
+                "detail": "expected match=false, got surfaced=false (score 0, threshold 30)"
+              },
+              {
+                "kind": "band",
+                "candidateId": "h5-e",
+                "passed": true,
+                "detail": "expected score in [0,29], got 0"
+              }
+            ]
+          },
+          {
+            "passed": true,
+            "assertions": [
+              {
+                "kind": "match",
+                "candidateId": "h5-b",
+                "passed": true,
+                "detail": "expected match=true, got surfaced=true (score 95, threshold 30)"
+              },
+              {
+                "kind": "band",
+                "candidateId": "h5-b",
+                "passed": true,
+                "detail": "expected score in [60,100], got 95"
+              },
+              {
+                "kind": "match",
+                "candidateId": "h5-c",
+                "passed": true,
+                "detail": "expected match=false, got surfaced=false (score 0, threshold 30)"
+              },
+              {
+                "kind": "band",
+                "candidateId": "h5-c",
+                "passed": true,
+                "detail": "expected score in [0,29], got 0"
+              },
+              {
+                "kind": "match",
+                "candidateId": "h5-d",
+                "passed": true,
+                "detail": "expected match=false, got surfaced=false (score 0, threshold 30)"
+              },
+              {
+                "kind": "band",
+                "candidateId": "h5-d",
+                "passed": true,
+                "detail": "expected score in [0,29], got 0"
+              },
+              {
+                "kind": "match",
+                "candidateId": "h5-e",
+                "passed": true,
+                "detail": "expected match=false, got surfaced=false (score 0, threshold 30)"
+              },
+              {
+                "kind": "band",
+                "candidateId": "h5-e",
+                "passed": true,
+                "detail": "expected score in [0,29], got 0"
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "caseId": "is_a_identity/startup-funder-vs-funded-bootstrapper",
+        "rule": "is_a_identity",
+        "runs": 7,
+        "passes": 7,
+        "passRate": 1,
+        "flaky": false,
+        "runResults": [
+          {
+            "passed": true,
+            "assertions": [
+              {
+                "kind": "match",
+                "candidateId": "c-bootstrap",
+                "passed": true,
+                "detail": "expected match=false, got surfaced=false (score 0, threshold 30)"
+              },
+              {
+                "kind": "band",
+                "candidateId": "c-bootstrap",
+                "passed": true,
+                "detail": "expected score in [0,29], got 0"
+              }
+            ]
+          },
+          {
+            "passed": true,
+            "assertions": [
+              {
+                "kind": "match",
+                "candidateId": "c-bootstrap",
+                "passed": true,
+                "detail": "expected match=false, got surfaced=false (score 0, threshold 30)"
+              },
+              {
+                "kind": "band",
+                "candidateId": "c-bootstrap",
+                "passed": true,
+                "detail": "expected score in [0,29], got 0"
+              }
+            ]
+          },
+          {
+            "passed": true,
+            "assertions": [
+              {
+                "kind": "match",
+                "candidateId": "c-bootstrap",
+                "passed": true,
+                "detail": "expected match=false, got surfaced=false (score 0, threshold 30)"
+              },
+              {
+                "kind": "band",
+                "candidateId": "c-bootstrap",
+                "passed": true,
+                "detail": "expected score in [0,29], got 0"
+              }
+            ]
+          },
+          {
+            "passed": true,
+            "assertions": [
+              {
+                "kind": "match",
+                "candidateId": "c-bootstrap",
+                "passed": true,
+                "detail": "expected match=false, got surfaced=false (score 0, threshold 30)"
+              },
+              {
+                "kind": "band",
+                "candidateId": "c-bootstrap",
+                "passed": true,
+                "detail": "expected score in [0,29], got 0"
+              }
+            ]
+          },
+          {
+            "passed": true,
+            "assertions": [
+              {
+                "kind": "match",
+                "candidateId": "c-bootstrap",
+                "passed": true,
+                "detail": "expected match=false, got surfaced=false (score 0, threshold 30)"
+              },
+              {
+                "kind": "band",
+                "candidateId": "c-bootstrap",
+                "passed": true,
+                "detail": "expected score in [0,29], got 0"
+              }
+            ]
+          },
+          {
+            "passed": true,
+            "assertions": [
+              {
+                "kind": "match",
+                "candidateId": "c-bootstrap",
+                "passed": true,
+                "detail": "expected match=false, got surfaced=false (score 0, threshold 30)"
+              },
+              {
+                "kind": "band",
+                "candidateId": "c-bootstrap",
+                "passed": true,
+                "detail": "expected score in [0,29], got 0"
+              }
+            ]
+          },
+          {
+            "passed": true,
+            "assertions": [
+              {
+                "kind": "match",
+                "candidateId": "c-bootstrap",
+                "passed": true,
+                "detail": "expected match=false, got surfaced=false (score 0, threshold 30)"
+              },
+              {
+                "kind": "band",
+                "candidateId": "c-bootstrap",
+                "passed": true,
+                "detail": "expected score in [0,29], got 0"
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "caseId": "is_a_identity/art-director-vs-illustrator",
+        "rule": "is_a_identity",
+        "runs": 7,
+        "passes": 7,
+        "passRate": 1,
+        "flaky": false,
+        "runResults": [
+          {
+            "passed": true,
+            "assertions": [
+              {
+                "kind": "match",
+                "candidateId": "c-lucia",
+                "passed": true,
+                "detail": "expected match=false, got surfaced=false (score 0, threshold 30)"
+              },
+              {
+                "kind": "band",
+                "candidateId": "c-lucia",
+                "passed": true,
+                "detail": "expected score in [0,29], got 0"
+              }
+            ]
+          },
+          {
+            "passed": true,
+            "assertions": [
+              {
+                "kind": "match",
+                "candidateId": "c-lucia",
+                "passed": true,
+                "detail": "expected match=false, got surfaced=false (score 0, threshold 30)"
+              },
+              {
+                "kind": "band",
+                "candidateId": "c-lucia",
+                "passed": true,
+                "detail": "expected score in [0,29], got 0"
+              }
+            ]
+          },
+          {
+            "passed": true,
+            "assertions": [
+              {
+                "kind": "match",
+                "candidateId": "c-lucia",
+                "passed": true,
+                "detail": "expected match=false, got surfaced=false (score 0, threshold 30)"
+              },
+              {
+                "kind": "band",
+                "candidateId": "c-lucia",
+                "passed": true,
+                "detail": "expected score in [0,29], got 0"
+              }
+            ]
+          },
+          {
+            "passed": true,
+            "assertions": [
+              {
+                "kind": "match",
+                "candidateId": "c-lucia",
+                "passed": true,
+                "detail": "expected match=false, got surfaced=false (score 0, threshold 30)"
+              },
+              {
+                "kind": "band",
+                "candidateId": "c-lucia",
+                "passed": true,
+                "detail": "expected score in [0,29], got 0"
+              }
+            ]
+          },
+          {
+            "passed": true,
+            "assertions": [
+              {
+                "kind": "match",
+                "candidateId": "c-lucia",
+                "passed": true,
+                "detail": "expected match=false, got surfaced=false (score 0, threshold 30)"
+              },
+              {
+                "kind": "band",
+                "candidateId": "c-lucia",
+                "passed": true,
+                "detail": "expected score in [0,29], got 0"
+              }
+            ]
+          },
+          {
+            "passed": true,
+            "assertions": [
+              {
+                "kind": "match",
+                "candidateId": "c-lucia",
+                "passed": true,
+                "detail": "expected match=false, got surfaced=false (score 0, threshold 30)"
+              },
+              {
+                "kind": "band",
+                "candidateId": "c-lucia",
+                "passed": true,
+                "detail": "expected score in [0,29], got 0"
+              }
+            ]
+          },
+          {
+            "passed": true,
+            "assertions": [
+              {
+                "kind": "match",
+                "candidateId": "c-lucia",
+                "passed": true,
+                "detail": "expected match=false, got surfaced=false (score 0, threshold 30)"
+              },
+              {
+                "kind": "band",
+                "candidateId": "c-lucia",
+                "passed": true,
+                "detail": "expected score in [0,29], got 0"
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "caseId": "is_a_identity/scout-vs-scouted-athlete",
+        "rule": "is_a_identity",
+        "runs": 7,
+        "passes": 7,
+        "passRate": 1,
+        "flaky": false,
+        "runResults": [
+          {
+            "passed": true,
+            "assertions": [
+              {
+                "kind": "match",
+                "candidateId": "c-scout",
+                "passed": true,
+                "detail": "expected match=true, got surfaced=true (score 92, threshold 30)"
+              },
+              {
+                "kind": "band",
+                "candidateId": "c-scout",
+                "passed": true,
+                "detail": "expected score in [70,100], got 92"
+              },
+              {
+                "kind": "match",
+                "candidateId": "c-athlete",
+                "passed": true,
+                "detail": "expected match=false, got surfaced=false (score 0, threshold 30)"
+              },
+              {
+                "kind": "band",
+                "candidateId": "c-athlete",
+                "passed": true,
+                "detail": "expected score in [0,29], got 0"
+              }
+            ]
+          },
+          {
+            "passed": true,
+            "assertions": [
+              {
+                "kind": "match",
+                "candidateId": "c-scout",
+                "passed": true,
+                "detail": "expected match=true, got surfaced=true (score 85, threshold 30)"
+              },
+              {
+                "kind": "band",
+                "candidateId": "c-scout",
+                "passed": true,
+                "detail": "expected score in [70,100], got 85"
+              },
+              {
+                "kind": "match",
+                "candidateId": "c-athlete",
+                "passed": true,
+                "detail": "expected match=false, got surfaced=false (score 0, threshold 30)"
+              },
+              {
+                "kind": "band",
+                "candidateId": "c-athlete",
+                "passed": true,
+                "detail": "expected score in [0,29], got 0"
+              }
+            ]
+          },
+          {
+            "passed": true,
+            "assertions": [
+              {
+                "kind": "match",
+                "candidateId": "c-scout",
+                "passed": true,
+                "detail": "expected match=true, got surfaced=true (score 95, threshold 30)"
+              },
+              {
+                "kind": "band",
+                "candidateId": "c-scout",
+                "passed": true,
+                "detail": "expected score in [70,100], got 95"
+              },
+              {
+                "kind": "match",
+                "candidateId": "c-athlete",
+                "passed": true,
+                "detail": "expected match=false, got surfaced=false (score 0, threshold 30)"
+              },
+              {
+                "kind": "band",
+                "candidateId": "c-athlete",
+                "passed": true,
+                "detail": "expected score in [0,29], got 0"
+              }
+            ]
+          },
+          {
+            "passed": true,
+            "assertions": [
+              {
+                "kind": "match",
+                "candidateId": "c-scout",
+                "passed": true,
+                "detail": "expected match=true, got surfaced=true (score 95, threshold 30)"
+              },
+              {
+                "kind": "band",
+                "candidateId": "c-scout",
+                "passed": true,
+                "detail": "expected score in [70,100], got 95"
+              },
+              {
+                "kind": "match",
+                "candidateId": "c-athlete",
+                "passed": true,
+                "detail": "expected match=false, got surfaced=false (score 0, threshold 30)"
+              },
+              {
+                "kind": "band",
+                "candidateId": "c-athlete",
+                "passed": true,
+                "detail": "expected score in [0,29], got 0"
+              }
+            ]
+          },
+          {
+            "passed": true,
+            "assertions": [
+              {
+                "kind": "match",
+                "candidateId": "c-scout",
+                "passed": true,
+                "detail": "expected match=true, got surfaced=true (score 95, threshold 30)"
+              },
+              {
+                "kind": "band",
+                "candidateId": "c-scout",
+                "passed": true,
+                "detail": "expected score in [70,100], got 95"
+              },
+              {
+                "kind": "match",
+                "candidateId": "c-athlete",
+                "passed": true,
+                "detail": "expected match=false, got surfaced=false (score 0, threshold 30)"
+              },
+              {
+                "kind": "band",
+                "candidateId": "c-athlete",
+                "passed": true,
+                "detail": "expected score in [0,29], got 0"
+              }
+            ]
+          },
+          {
+            "passed": true,
+            "assertions": [
+              {
+                "kind": "match",
+                "candidateId": "c-scout",
+                "passed": true,
+                "detail": "expected match=true, got surfaced=true (score 95, threshold 30)"
+              },
+              {
+                "kind": "band",
+                "candidateId": "c-scout",
+                "passed": true,
+                "detail": "expected score in [70,100], got 95"
+              },
+              {
+                "kind": "match",
+                "candidateId": "c-athlete",
+                "passed": true,
+                "detail": "expected match=false, got surfaced=false (score 0, threshold 30)"
+              },
+              {
+                "kind": "band",
+                "candidateId": "c-athlete",
+                "passed": true,
+                "detail": "expected score in [0,29], got 0"
+              }
+            ]
+          },
+          {
+            "passed": true,
+            "assertions": [
+              {
+                "kind": "match",
+                "candidateId": "c-scout",
+                "passed": true,
+                "detail": "expected match=true, got surfaced=true (score 95, threshold 30)"
+              },
+              {
+                "kind": "band",
+                "candidateId": "c-scout",
+                "passed": true,
+                "detail": "expected score in [70,100], got 95"
+              },
+              {
+                "kind": "match",
+                "candidateId": "c-athlete",
+                "passed": true,
+                "detail": "expected match=false, got surfaced=false (score 0, threshold 30)"
+              },
+              {
+                "kind": "band",
+                "candidateId": "c-athlete",
+                "passed": true,
+                "detail": "expected score in [0,29], got 0"
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "caseId": "is_a_identity/investor-vs-grant-recipient",
+        "rule": "is_a_identity",
+        "runs": 7,
+        "passes": 7,
+        "passRate": 1,
+        "flaky": false,
+        "runResults": [
+          {
+            "passed": true,
+            "assertions": [
+              {
+                "kind": "match",
+                "candidateId": "c-grant",
+                "passed": true,
+                "detail": "expected match=false, got surfaced=false (score 0, threshold 30)"
+              },
+              {
+                "kind": "band",
+                "candidateId": "c-grant",
+                "passed": true,
+                "detail": "expected score in [0,29], got 0"
+              }
+            ]
+          },
+          {
+            "passed": true,
+            "assertions": [
+              {
+                "kind": "match",
+                "candidateId": "c-grant",
+                "passed": true,
+                "detail": "expected match=false, got surfaced=false (score 0, threshold 30)"
+              },
+              {
+                "kind": "band",
+                "candidateId": "c-grant",
+                "passed": true,
+                "detail": "expected score in [0,29], got 0"
+              }
+            ]
+          },
+          {
+            "passed": true,
+            "assertions": [
+              {
+                "kind": "match",
+                "candidateId": "c-grant",
+                "passed": true,
+                "detail": "expected match=false, got surfaced=false (score 0, threshold 30)"
+              },
+              {
+                "kind": "band",
+                "candidateId": "c-grant",
+                "passed": true,
+                "detail": "expected score in [0,29], got 0"
+              }
+            ]
+          },
+          {
+            "passed": true,
+            "assertions": [
+              {
+                "kind": "match",
+                "candidateId": "c-grant",
+                "passed": true,
+                "detail": "expected match=false, got surfaced=false (score 0, threshold 30)"
+              },
+              {
+                "kind": "band",
+                "candidateId": "c-grant",
+                "passed": true,
+                "detail": "expected score in [0,29], got 0"
+              }
+            ]
+          },
+          {
+            "passed": true,
+            "assertions": [
+              {
+                "kind": "match",
+                "candidateId": "c-grant",
+                "passed": true,
+                "detail": "expected match=false, got surfaced=false (score 0, threshold 30)"
+              },
+              {
+                "kind": "band",
+                "candidateId": "c-grant",
+                "passed": true,
+                "detail": "expected score in [0,29], got 0"
+              }
+            ]
+          },
+          {
+            "passed": true,
+            "assertions": [
+              {
+                "kind": "match",
+                "candidateId": "c-grant",
+                "passed": true,
+                "detail": "expected match=false, got surfaced=false (score 0, threshold 30)"
+              },
+              {
+                "kind": "band",
+                "candidateId": "c-grant",
+                "passed": true,
+                "detail": "expected score in [0,29], got 0"
+              }
+            ]
+          },
+          {
+            "passed": true,
+            "assertions": [
+              {
+                "kind": "match",
+                "candidateId": "c-grant",
+                "passed": true,
+                "detail": "expected match=false, got surfaced=false (score 0, threshold 30)"
+              },
+              {
+                "kind": "band",
+                "candidateId": "c-grant",
+                "passed": true,
+                "detail": "expected score in [0,29], got 0"
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "caseId": "complementary_role/design-cofounder-for-tech-founder",
+        "rule": "complementary_role",
+        "runs": 7,
+        "passes": 6,
+        "passRate": 0.8571428571428571,
+        "flaky": true,
+        "runResults": [
+          {
+            "passed": true,
+            "assertions": [
+              {
+                "kind": "match",
+                "candidateId": "p-vc",
+                "passed": true,
+                "detail": "expected match=false, got surfaced=false (score 0, threshold 30)"
+              },
+              {
+                "kind": "band",
+                "candidateId": "p-vc",
+                "passed": true,
+                "detail": "expected score in [0,29], got 0"
+              },
+              {
+                "kind": "match",
+                "candidateId": "p-designer-alt",
+                "passed": true,
+                "detail": "expected match=true, got surfaced=true (score 95, threshold 30)"
+              },
+              {
+                "kind": "band",
+                "candidateId": "p-designer-alt",
+                "passed": true,
+                "detail": "expected score in [70,100], got 95"
+              },
+              {
+                "kind": "role",
+                "candidateId": "p-designer-alt",
+                "passed": true,
+                "detail": "expected role=agent, got agent"
+              }
+            ]
+          },
+          {
+            "passed": true,
+            "assertions": [
+              {
+                "kind": "match",
+                "candidateId": "p-vc",
+                "passed": true,
+                "detail": "expected match=false, got surfaced=false (score 0, threshold 30)"
+              },
+              {
+                "kind": "band",
+                "candidateId": "p-vc",
+                "passed": true,
+                "detail": "expected score in [0,29], got 0"
+              },
+              {
+                "kind": "match",
+                "candidateId": "p-designer-alt",
+                "passed": true,
+                "detail": "expected match=true, got surfaced=true (score 92, threshold 30)"
+              },
+              {
+                "kind": "band",
+                "candidateId": "p-designer-alt",
+                "passed": true,
+                "detail": "expected score in [70,100], got 92"
+              },
+              {
+                "kind": "role",
+                "candidateId": "p-designer-alt",
+                "passed": true,
+                "detail": "expected role=agent, got agent"
+              }
+            ]
+          },
+          {
+            "passed": true,
+            "assertions": [
+              {
+                "kind": "match",
+                "candidateId": "p-vc",
+                "passed": true,
+                "detail": "expected match=false, got surfaced=false (score 0, threshold 30)"
+              },
+              {
+                "kind": "band",
+                "candidateId": "p-vc",
+                "passed": true,
+                "detail": "expected score in [0,29], got 0"
+              },
+              {
+                "kind": "match",
+                "candidateId": "p-designer-alt",
+                "passed": true,
+                "detail": "expected match=true, got surfaced=true (score 95, threshold 30)"
+              },
+              {
+                "kind": "band",
+                "candidateId": "p-designer-alt",
+                "passed": true,
+                "detail": "expected score in [70,100], got 95"
+              },
+              {
+                "kind": "role",
+                "candidateId": "p-designer-alt",
+                "passed": true,
+                "detail": "expected role=agent, got agent"
+              }
+            ]
+          },
+          {
+            "passed": true,
+            "assertions": [
+              {
+                "kind": "match",
+                "candidateId": "p-vc",
+                "passed": true,
+                "detail": "expected match=false, got surfaced=false (score 0, threshold 30)"
+              },
+              {
+                "kind": "band",
+                "candidateId": "p-vc",
+                "passed": true,
+                "detail": "expected score in [0,29], got 0"
+              },
+              {
+                "kind": "match",
+                "candidateId": "p-designer-alt",
+                "passed": true,
+                "detail": "expected match=true, got surfaced=true (score 95, threshold 30)"
+              },
+              {
+                "kind": "band",
+                "candidateId": "p-designer-alt",
+                "passed": true,
+                "detail": "expected score in [70,100], got 95"
+              },
+              {
+                "kind": "role",
+                "candidateId": "p-designer-alt",
+                "passed": true,
+                "detail": "expected role=agent, got agent"
+              }
+            ]
+          },
+          {
+            "passed": true,
+            "assertions": [
+              {
+                "kind": "match",
+                "candidateId": "p-vc",
+                "passed": true,
+                "detail": "expected match=false, got surfaced=false (score 0, threshold 30)"
+              },
+              {
+                "kind": "band",
+                "candidateId": "p-vc",
+                "passed": true,
+                "detail": "expected score in [0,29], got 0"
+              },
+              {
+                "kind": "match",
+                "candidateId": "p-designer-alt",
+                "passed": true,
+                "detail": "expected match=true, got surfaced=true (score 95, threshold 30)"
+              },
+              {
+                "kind": "band",
+                "candidateId": "p-designer-alt",
+                "passed": true,
+                "detail": "expected score in [70,100], got 95"
+              },
+              {
+                "kind": "role",
+                "candidateId": "p-designer-alt",
+                "passed": true,
+                "detail": "expected role=agent, got agent"
+              }
+            ]
+          },
+          {
+            "passed": false,
+            "assertions": [
+              {
+                "kind": "match",
+                "candidateId": "p-vc",
+                "passed": true,
+                "detail": "expected match=false, got surfaced=false (score 0, threshold 30)"
+              },
+              {
+                "kind": "band",
+                "candidateId": "p-vc",
+                "passed": true,
+                "detail": "expected score in [0,29], got 0"
+              },
+              {
+                "kind": "match",
+                "candidateId": "p-designer-alt",
+                "passed": true,
+                "detail": "expected match=true, got surfaced=true (score 95, threshold 30)"
+              },
+              {
+                "kind": "band",
+                "candidateId": "p-designer-alt",
+                "passed": true,
+                "detail": "expected score in [70,100], got 95"
+              },
+              {
+                "kind": "role",
+                "candidateId": "p-designer-alt",
+                "passed": false,
+                "detail": "expected role=agent, got peer"
+              }
+            ]
+          },
+          {
+            "passed": true,
+            "assertions": [
+              {
+                "kind": "match",
+                "candidateId": "p-vc",
+                "passed": true,
+                "detail": "expected match=false, got surfaced=false (score 0, threshold 30)"
+              },
+              {
+                "kind": "band",
+                "candidateId": "p-vc",
+                "passed": true,
+                "detail": "expected score in [0,29], got 0"
+              },
+              {
+                "kind": "match",
+                "candidateId": "p-designer-alt",
+                "passed": true,
+                "detail": "expected match=true, got surfaced=true (score 95, threshold 30)"
+              },
+              {
+                "kind": "band",
+                "candidateId": "p-designer-alt",
+                "passed": true,
+                "detail": "expected score in [70,100], got 95"
+              },
+              {
+                "kind": "role",
+                "candidateId": "p-designer-alt",
+                "passed": true,
+                "detail": "expected role=agent, got agent"
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "caseId": "complementary_role/marketing-cofounder-for-ai-engineer",
+        "rule": "complementary_role",
+        "runs": 7,
+        "passes": 7,
+        "passRate": 1,
+        "flaky": false,
+        "runResults": [
+          {
+            "passed": true,
+            "assertions": [
+              {
+                "kind": "match",
+                "candidateId": "p-operator",
+                "passed": true,
+                "detail": "expected match=true, got surfaced=true (score 95, threshold 30)"
+              },
+              {
+                "kind": "band",
+                "candidateId": "p-operator",
+                "passed": true,
+                "detail": "expected score in [70,100], got 95"
+              },
+              {
+                "kind": "role",
+                "candidateId": "p-operator",
+                "passed": true,
+                "detail": "expected role=agent, got agent"
+              },
+              {
+                "kind": "match",
+                "candidateId": "p-tech-alt",
+                "passed": true,
+                "detail": "expected match=false, got surfaced=false (score 0, threshold 30)"
+              },
+              {
+                "kind": "band",
+                "candidateId": "p-tech-alt",
+                "passed": true,
+                "detail": "expected score in [0,29], got 0"
+              }
+            ]
+          },
+          {
+            "passed": true,
+            "assertions": [
+              {
+                "kind": "match",
+                "candidateId": "p-operator",
+                "passed": true,
+                "detail": "expected match=true, got surfaced=true (score 88, threshold 30)"
+              },
+              {
+                "kind": "band",
+                "candidateId": "p-operator",
+                "passed": true,
+                "detail": "expected score in [70,100], got 88"
+              },
+              {
+                "kind": "role",
+                "candidateId": "p-operator",
+                "passed": true,
+                "detail": "expected role=agent, got agent"
+              },
+              {
+                "kind": "match",
+                "candidateId": "p-tech-alt",
+                "passed": true,
+                "detail": "expected match=false, got surfaced=false (score 0, threshold 30)"
+              },
+              {
+                "kind": "band",
+                "candidateId": "p-tech-alt",
+                "passed": true,
+                "detail": "expected score in [0,29], got 0"
+              }
+            ]
+          },
+          {
+            "passed": true,
+            "assertions": [
+              {
+                "kind": "match",
+                "candidateId": "p-operator",
+                "passed": true,
+                "detail": "expected match=true, got surfaced=true (score 85, threshold 30)"
+              },
+              {
+                "kind": "band",
+                "candidateId": "p-operator",
+                "passed": true,
+                "detail": "expected score in [70,100], got 85"
+              },
+              {
+                "kind": "role",
+                "candidateId": "p-operator",
+                "passed": true,
+                "detail": "expected role=agent, got agent"
+              },
+              {
+                "kind": "match",
+                "candidateId": "p-tech-alt",
+                "passed": true,
+                "detail": "expected match=false, got surfaced=false (score 0, threshold 30)"
+              },
+              {
+                "kind": "band",
+                "candidateId": "p-tech-alt",
+                "passed": true,
+                "detail": "expected score in [0,29], got 0"
+              }
+            ]
+          },
+          {
+            "passed": true,
+            "assertions": [
+              {
+                "kind": "match",
+                "candidateId": "p-operator",
+                "passed": true,
+                "detail": "expected match=true, got surfaced=true (score 90, threshold 30)"
+              },
+              {
+                "kind": "band",
+                "candidateId": "p-operator",
+                "passed": true,
+                "detail": "expected score in [70,100], got 90"
+              },
+              {
+                "kind": "role",
+                "candidateId": "p-operator",
+                "passed": true,
+                "detail": "expected role=agent, got agent"
+              },
+              {
+                "kind": "match",
+                "candidateId": "p-tech-alt",
+                "passed": true,
+                "detail": "expected match=false, got surfaced=false (score 0, threshold 30)"
+              },
+              {
+                "kind": "band",
+                "candidateId": "p-tech-alt",
+                "passed": true,
+                "detail": "expected score in [0,29], got 0"
+              }
+            ]
+          },
+          {
+            "passed": true,
+            "assertions": [
+              {
+                "kind": "match",
+                "candidateId": "p-operator",
+                "passed": true,
+                "detail": "expected match=true, got surfaced=true (score 95, threshold 30)"
+              },
+              {
+                "kind": "band",
+                "candidateId": "p-operator",
+                "passed": true,
+                "detail": "expected score in [70,100], got 95"
+              },
+              {
+                "kind": "role",
+                "candidateId": "p-operator",
+                "passed": true,
+                "detail": "expected role=agent, got agent"
+              },
+              {
+                "kind": "match",
+                "candidateId": "p-tech-alt",
+                "passed": true,
+                "detail": "expected match=false, got surfaced=false (score 0, threshold 30)"
+              },
+              {
+                "kind": "band",
+                "candidateId": "p-tech-alt",
+                "passed": true,
+                "detail": "expected score in [0,29], got 0"
+              }
+            ]
+          },
+          {
+            "passed": true,
+            "assertions": [
+              {
+                "kind": "match",
+                "candidateId": "p-operator",
+                "passed": true,
+                "detail": "expected match=true, got surfaced=true (score 95, threshold 30)"
+              },
+              {
+                "kind": "band",
+                "candidateId": "p-operator",
+                "passed": true,
+                "detail": "expected score in [70,100], got 95"
+              },
+              {
+                "kind": "role",
+                "candidateId": "p-operator",
+                "passed": true,
+                "detail": "expected role=agent, got agent"
+              },
+              {
+                "kind": "match",
+                "candidateId": "p-tech-alt",
+                "passed": true,
+                "detail": "expected match=false, got surfaced=false (score 0, threshold 30)"
+              },
+              {
+                "kind": "band",
+                "candidateId": "p-tech-alt",
+                "passed": true,
+                "detail": "expected score in [0,29], got 0"
+              }
+            ]
+          },
+          {
+            "passed": true,
+            "assertions": [
+              {
+                "kind": "match",
+                "candidateId": "p-operator",
+                "passed": true,
+                "detail": "expected match=true, got surfaced=true (score 95, threshold 30)"
+              },
+              {
+                "kind": "band",
+                "candidateId": "p-operator",
+                "passed": true,
+                "detail": "expected score in [70,100], got 95"
+              },
+              {
+                "kind": "role",
+                "candidateId": "p-operator",
+                "passed": true,
+                "detail": "expected role=agent, got agent"
+              },
+              {
+                "kind": "match",
+                "candidateId": "p-tech-alt",
+                "passed": true,
+                "detail": "expected match=false, got surfaced=false (score 0, threshold 30)"
+              },
+              {
+                "kind": "band",
+                "candidateId": "p-tech-alt",
+                "passed": true,
+                "detail": "expected score in [0,29], got 0"
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "caseId": "same_side/both-seeking-cofounders",
+        "rule": "same_side",
+        "runs": 7,
+        "passes": 7,
+        "passRate": 1,
+        "flaky": false,
+        "runResults": [
+          {
+            "passed": true,
+            "assertions": [
+              {
+                "kind": "match",
+                "candidateId": "c-seek-cof",
+                "passed": true,
+                "detail": "expected match=false, got surfaced=false (score 0, threshold 30)"
+              },
+              {
+                "kind": "band",
+                "candidateId": "c-seek-cof",
+                "passed": true,
+                "detail": "expected score in [0,29], got 0"
+              }
+            ]
+          },
+          {
+            "passed": true,
+            "assertions": [
+              {
+                "kind": "match",
+                "candidateId": "c-seek-cof",
+                "passed": true,
+                "detail": "expected match=false, got surfaced=false (score 0, threshold 30)"
+              },
+              {
+                "kind": "band",
+                "candidateId": "c-seek-cof",
+                "passed": true,
+                "detail": "expected score in [0,29], got 0"
+              }
+            ]
+          },
+          {
+            "passed": true,
+            "assertions": [
+              {
+                "kind": "match",
+                "candidateId": "c-seek-cof",
+                "passed": true,
+                "detail": "expected match=false, got surfaced=false (score 0, threshold 30)"
+              },
+              {
+                "kind": "band",
+                "candidateId": "c-seek-cof",
+                "passed": true,
+                "detail": "expected score in [0,29], got 0"
+              }
+            ]
+          },
+          {
+            "passed": true,
+            "assertions": [
+              {
+                "kind": "match",
+                "candidateId": "c-seek-cof",
+                "passed": true,
+                "detail": "expected match=false, got surfaced=false (score 0, threshold 30)"
+              },
+              {
+                "kind": "band",
+                "candidateId": "c-seek-cof",
+                "passed": true,
+                "detail": "expected score in [0,29], got 0"
+              }
+            ]
+          },
+          {
+            "passed": true,
+            "assertions": [
+              {
+                "kind": "match",
+                "candidateId": "c-seek-cof",
+                "passed": true,
+                "detail": "expected match=false, got surfaced=false (score 0, threshold 30)"
+              },
+              {
+                "kind": "band",
+                "candidateId": "c-seek-cof",
+                "passed": true,
+                "detail": "expected score in [0,29], got 0"
+              }
+            ]
+          },
+          {
+            "passed": true,
+            "assertions": [
+              {
+                "kind": "match",
+                "candidateId": "c-seek-cof",
+                "passed": true,
+                "detail": "expected match=false, got surfaced=false (score 0, threshold 30)"
+              },
+              {
+                "kind": "band",
+                "candidateId": "c-seek-cof",
+                "passed": true,
+                "detail": "expected score in [0,29], got 0"
+              }
+            ]
+          },
+          {
+            "passed": true,
+            "assertions": [
+              {
+                "kind": "match",
+                "candidateId": "c-seek-cof",
+                "passed": true,
+                "detail": "expected match=false, got surfaced=false (score 0, threshold 30)"
+              },
+              {
+                "kind": "band",
+                "candidateId": "c-seek-cof",
+                "passed": true,
+                "detail": "expected score in [0,29], got 0"
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "caseId": "same_side/both-hiring-engineers",
+        "rule": "same_side",
+        "runs": 7,
+        "passes": 7,
+        "passRate": 1,
+        "flaky": false,
+        "runResults": [
+          {
+            "passed": true,
+            "assertions": [
+              {
+                "kind": "match",
+                "candidateId": "c-recruiting",
+                "passed": true,
+                "detail": "expected match=false, got surfaced=false (score 0, threshold 30)"
+              },
+              {
+                "kind": "band",
+                "candidateId": "c-recruiting",
+                "passed": true,
+                "detail": "expected score in [0,29], got 0"
+              }
+            ]
+          },
+          {
+            "passed": true,
+            "assertions": [
+              {
+                "kind": "match",
+                "candidateId": "c-recruiting",
+                "passed": true,
+                "detail": "expected match=false, got surfaced=false (score 0, threshold 30)"
+              },
+              {
+                "kind": "band",
+                "candidateId": "c-recruiting",
+                "passed": true,
+                "detail": "expected score in [0,29], got 0"
+              }
+            ]
+          },
+          {
+            "passed": true,
+            "assertions": [
+              {
+                "kind": "match",
+                "candidateId": "c-recruiting",
+                "passed": true,
+                "detail": "expected match=false, got surfaced=false (score 0, threshold 30)"
+              },
+              {
+                "kind": "band",
+                "candidateId": "c-recruiting",
+                "passed": true,
+                "detail": "expected score in [0,29], got 0"
+              }
+            ]
+          },
+          {
+            "passed": true,
+            "assertions": [
+              {
+                "kind": "match",
+                "candidateId": "c-recruiting",
+                "passed": true,
+                "detail": "expected match=false, got surfaced=false (score 0, threshold 30)"
+              },
+              {
+                "kind": "band",
+                "candidateId": "c-recruiting",
+                "passed": true,
+                "detail": "expected score in [0,29], got 0"
+              }
+            ]
+          },
+          {
+            "passed": true,
+            "assertions": [
+              {
+                "kind": "match",
+                "candidateId": "c-recruiting",
+                "passed": true,
+                "detail": "expected match=false, got surfaced=false (score 0, threshold 30)"
+              },
+              {
+                "kind": "band",
+                "candidateId": "c-recruiting",
+                "passed": true,
+                "detail": "expected score in [0,29], got 0"
+              }
+            ]
+          },
+          {
+            "passed": true,
+            "assertions": [
+              {
+                "kind": "match",
+                "candidateId": "c-recruiting",
+                "passed": true,
+                "detail": "expected match=false, got surfaced=false (score 0, threshold 30)"
+              },
+              {
+                "kind": "band",
+                "candidateId": "c-recruiting",
+                "passed": true,
+                "detail": "expected score in [0,29], got 0"
+              }
+            ]
+          },
+          {
+            "passed": true,
+            "assertions": [
+              {
+                "kind": "match",
+                "candidateId": "c-recruiting",
+                "passed": true,
+                "detail": "expected match=false, got surfaced=false (score 0, threshold 30)"
+              },
+              {
+                "kind": "band",
+                "candidateId": "c-recruiting",
+                "passed": true,
+                "detail": "expected score in [0,29], got 0"
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "caseId": "location/berlin-mismatch-vs-london-query",
+        "rule": "location",
+        "runs": 7,
+        "passes": 7,
+        "passRate": 1,
+        "flaky": false,
+        "runResults": [
+          {
+            "passed": true,
+            "assertions": [
+              {
+                "kind": "match",
+                "candidateId": "c-berlin",
+                "passed": true,
+                "detail": "expected match=false, got surfaced=false (score 0, threshold 30)"
+              },
+              {
+                "kind": "band",
+                "candidateId": "c-berlin",
+                "passed": true,
+                "detail": "expected score in [0,29], got 0"
+              }
+            ]
+          },
+          {
+            "passed": true,
+            "assertions": [
+              {
+                "kind": "match",
+                "candidateId": "c-berlin",
+                "passed": true,
+                "detail": "expected match=false, got surfaced=false (score 0, threshold 30)"
+              },
+              {
+                "kind": "band",
+                "candidateId": "c-berlin",
+                "passed": true,
+                "detail": "expected score in [0,29], got 0"
+              }
+            ]
+          },
+          {
+            "passed": true,
+            "assertions": [
+              {
+                "kind": "match",
+                "candidateId": "c-berlin",
+                "passed": true,
+                "detail": "expected match=false, got surfaced=false (score 0, threshold 30)"
+              },
+              {
+                "kind": "band",
+                "candidateId": "c-berlin",
+                "passed": true,
+                "detail": "expected score in [0,29], got 0"
+              }
+            ]
+          },
+          {
+            "passed": true,
+            "assertions": [
+              {
+                "kind": "match",
+                "candidateId": "c-berlin",
+                "passed": true,
+                "detail": "expected match=false, got surfaced=false (score 0, threshold 30)"
+              },
+              {
+                "kind": "band",
+                "candidateId": "c-berlin",
+                "passed": true,
+                "detail": "expected score in [0,29], got 0"
+              }
+            ]
+          },
+          {
+            "passed": true,
+            "assertions": [
+              {
+                "kind": "match",
+                "candidateId": "c-berlin",
+                "passed": true,
+                "detail": "expected match=false, got surfaced=false (score 0, threshold 30)"
+              },
+              {
+                "kind": "band",
+                "candidateId": "c-berlin",
+                "passed": true,
+                "detail": "expected score in [0,29], got 0"
+              }
+            ]
+          },
+          {
+            "passed": true,
+            "assertions": [
+              {
+                "kind": "match",
+                "candidateId": "c-berlin",
+                "passed": true,
+                "detail": "expected match=false, got surfaced=false (score 0, threshold 30)"
+              },
+              {
+                "kind": "band",
+                "candidateId": "c-berlin",
+                "passed": true,
+                "detail": "expected score in [0,29], got 0"
+              }
+            ]
+          },
+          {
+            "passed": true,
+            "assertions": [
+              {
+                "kind": "match",
+                "candidateId": "c-berlin",
+                "passed": true,
+                "detail": "expected match=false, got surfaced=false (score 0, threshold 30)"
+              },
+              {
+                "kind": "band",
+                "candidateId": "c-berlin",
+                "passed": true,
+                "detail": "expected score in [0,29], got 0"
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "caseId": "location/unknown-city-not-penalized-variant",
+        "rule": "location",
+        "runs": 7,
+        "passes": 7,
+        "passRate": 1,
+        "flaky": false,
+        "runResults": [
+          {
+            "passed": true,
+            "assertions": [
+              {
+                "kind": "match",
+                "candidateId": "c-empty-loc",
+                "passed": true,
+                "detail": "expected match=true, got surfaced=true (score 85, threshold 30)"
+              },
+              {
+                "kind": "band",
+                "candidateId": "c-empty-loc",
+                "passed": true,
+                "detail": "expected score in [60,100], got 85"
+              }
+            ]
+          },
+          {
+            "passed": true,
+            "assertions": [
+              {
+                "kind": "match",
+                "candidateId": "c-empty-loc",
+                "passed": true,
+                "detail": "expected match=true, got surfaced=true (score 85, threshold 30)"
+              },
+              {
+                "kind": "band",
+                "candidateId": "c-empty-loc",
+                "passed": true,
+                "detail": "expected score in [60,100], got 85"
+              }
+            ]
+          },
+          {
+            "passed": true,
+            "assertions": [
+              {
+                "kind": "match",
+                "candidateId": "c-empty-loc",
+                "passed": true,
+                "detail": "expected match=true, got surfaced=true (score 85, threshold 30)"
+              },
+              {
+                "kind": "band",
+                "candidateId": "c-empty-loc",
+                "passed": true,
+                "detail": "expected score in [60,100], got 85"
+              }
+            ]
+          },
+          {
+            "passed": true,
+            "assertions": [
+              {
+                "kind": "match",
+                "candidateId": "c-empty-loc",
+                "passed": true,
+                "detail": "expected match=true, got surfaced=true (score 85, threshold 30)"
+              },
+              {
+                "kind": "band",
+                "candidateId": "c-empty-loc",
+                "passed": true,
+                "detail": "expected score in [60,100], got 85"
+              }
+            ]
+          },
+          {
+            "passed": true,
+            "assertions": [
+              {
+                "kind": "match",
+                "candidateId": "c-empty-loc",
+                "passed": true,
+                "detail": "expected match=true, got surfaced=true (score 85, threshold 30)"
+              },
+              {
+                "kind": "band",
+                "candidateId": "c-empty-loc",
+                "passed": true,
+                "detail": "expected score in [60,100], got 85"
+              }
+            ]
+          },
+          {
+            "passed": true,
+            "assertions": [
+              {
+                "kind": "match",
+                "candidateId": "c-empty-loc",
+                "passed": true,
+                "detail": "expected match=true, got surfaced=true (score 85, threshold 30)"
+              },
+              {
+                "kind": "band",
+                "candidateId": "c-empty-loc",
+                "passed": true,
+                "detail": "expected score in [60,100], got 85"
+              }
+            ]
+          },
+          {
+            "passed": true,
+            "assertions": [
+              {
+                "kind": "match",
+                "candidateId": "c-empty-loc",
+                "passed": true,
+                "detail": "expected match=true, got surfaced=true (score 85, threshold 30)"
+              },
+              {
+                "kind": "band",
+                "candidateId": "c-empty-loc",
+                "passed": true,
+                "detail": "expected score in [60,100], got 85"
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "caseId": "valency_role/seeker-needs-design-provider-offers-design",
+        "rule": "valency_role",
+        "runs": 7,
+        "passes": 7,
+        "passRate": 1,
+        "flaky": false,
+        "runResults": [
+          {
+            "passed": true,
+            "assertions": [
+              {
+                "kind": "match",
+                "candidateId": "c-designer-alt",
+                "passed": true,
+                "detail": "expected match=true, got surfaced=true (score 98, threshold 30)"
+              },
+              {
+                "kind": "band",
+                "candidateId": "c-designer-alt",
+                "passed": true,
+                "detail": "expected score in [70,100], got 98"
+              },
+              {
+                "kind": "role",
+                "candidateId": "c-designer-alt",
+                "passed": true,
+                "detail": "expected role=agent, got agent"
+              }
+            ]
+          },
+          {
+            "passed": true,
+            "assertions": [
+              {
+                "kind": "match",
+                "candidateId": "c-designer-alt",
+                "passed": true,
+                "detail": "expected match=true, got surfaced=true (score 98, threshold 30)"
+              },
+              {
+                "kind": "band",
+                "candidateId": "c-designer-alt",
+                "passed": true,
+                "detail": "expected score in [70,100], got 98"
+              },
+              {
+                "kind": "role",
+                "candidateId": "c-designer-alt",
+                "passed": true,
+                "detail": "expected role=agent, got agent"
+              }
+            ]
+          },
+          {
+            "passed": true,
+            "assertions": [
+              {
+                "kind": "match",
+                "candidateId": "c-designer-alt",
+                "passed": true,
+                "detail": "expected match=true, got surfaced=true (score 98, threshold 30)"
+              },
+              {
+                "kind": "band",
+                "candidateId": "c-designer-alt",
+                "passed": true,
+                "detail": "expected score in [70,100], got 98"
+              },
+              {
+                "kind": "role",
+                "candidateId": "c-designer-alt",
+                "passed": true,
+                "detail": "expected role=agent, got agent"
+              }
+            ]
+          },
+          {
+            "passed": true,
+            "assertions": [
+              {
+                "kind": "match",
+                "candidateId": "c-designer-alt",
+                "passed": true,
+                "detail": "expected match=true, got surfaced=true (score 98, threshold 30)"
+              },
+              {
+                "kind": "band",
+                "candidateId": "c-designer-alt",
+                "passed": true,
+                "detail": "expected score in [70,100], got 98"
+              },
+              {
+                "kind": "role",
+                "candidateId": "c-designer-alt",
+                "passed": true,
+                "detail": "expected role=agent, got agent"
+              }
+            ]
+          },
+          {
+            "passed": true,
+            "assertions": [
+              {
+                "kind": "match",
+                "candidateId": "c-designer-alt",
+                "passed": true,
+                "detail": "expected match=true, got surfaced=true (score 98, threshold 30)"
+              },
+              {
+                "kind": "band",
+                "candidateId": "c-designer-alt",
+                "passed": true,
+                "detail": "expected score in [70,100], got 98"
+              },
+              {
+                "kind": "role",
+                "candidateId": "c-designer-alt",
+                "passed": true,
+                "detail": "expected role=agent, got agent"
+              }
+            ]
+          },
+          {
+            "passed": true,
+            "assertions": [
+              {
+                "kind": "match",
+                "candidateId": "c-designer-alt",
+                "passed": true,
+                "detail": "expected match=true, got surfaced=true (score 98, threshold 30)"
+              },
+              {
+                "kind": "band",
+                "candidateId": "c-designer-alt",
+                "passed": true,
+                "detail": "expected score in [70,100], got 98"
+              },
+              {
+                "kind": "role",
+                "candidateId": "c-designer-alt",
+                "passed": true,
+                "detail": "expected role=agent, got agent"
+              }
+            ]
+          },
+          {
+            "passed": true,
+            "assertions": [
+              {
+                "kind": "match",
+                "candidateId": "c-designer-alt",
+                "passed": true,
+                "detail": "expected match=true, got surfaced=true (score 98, threshold 30)"
+              },
+              {
+                "kind": "band",
+                "candidateId": "c-designer-alt",
+                "passed": true,
+                "detail": "expected score in [70,100], got 98"
+              },
+              {
+                "kind": "role",
+                "candidateId": "c-designer-alt",
+                "passed": true,
+                "detail": "expected role=agent, got agent"
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "caseId": "valency_role/seeker-offers-capacity-provider-needs-capacity",
+        "rule": "valency_role",
+        "runs": 7,
+        "passes": 7,
+        "passRate": 1,
+        "flaky": false,
+        "runResults": [
+          {
+            "passed": true,
+            "assertions": [
+              {
+                "kind": "match",
+                "candidateId": "c-needs-gpu",
+                "passed": true,
+                "detail": "expected match=true, got surfaced=true (score 98, threshold 30)"
+              },
+              {
+                "kind": "band",
+                "candidateId": "c-needs-gpu",
+                "passed": true,
+                "detail": "expected score in [70,100], got 98"
+              },
+              {
+                "kind": "role",
+                "candidateId": "c-needs-gpu",
+                "passed": true,
+                "detail": "expected role=patient, got patient"
+              }
+            ]
+          },
+          {
+            "passed": true,
+            "assertions": [
+              {
+                "kind": "match",
+                "candidateId": "c-needs-gpu",
+                "passed": true,
+                "detail": "expected match=true, got surfaced=true (score 98, threshold 30)"
+              },
+              {
+                "kind": "band",
+                "candidateId": "c-needs-gpu",
+                "passed": true,
+                "detail": "expected score in [70,100], got 98"
+              },
+              {
+                "kind": "role",
+                "candidateId": "c-needs-gpu",
+                "passed": true,
+                "detail": "expected role=patient, got patient"
+              }
+            ]
+          },
+          {
+            "passed": true,
+            "assertions": [
+              {
+                "kind": "match",
+                "candidateId": "c-needs-gpu",
+                "passed": true,
+                "detail": "expected match=true, got surfaced=true (score 98, threshold 30)"
+              },
+              {
+                "kind": "band",
+                "candidateId": "c-needs-gpu",
+                "passed": true,
+                "detail": "expected score in [70,100], got 98"
+              },
+              {
+                "kind": "role",
+                "candidateId": "c-needs-gpu",
+                "passed": true,
+                "detail": "expected role=patient, got patient"
+              }
+            ]
+          },
+          {
+            "passed": true,
+            "assertions": [
+              {
+                "kind": "match",
+                "candidateId": "c-needs-gpu",
+                "passed": true,
+                "detail": "expected match=true, got surfaced=true (score 98, threshold 30)"
+              },
+              {
+                "kind": "band",
+                "candidateId": "c-needs-gpu",
+                "passed": true,
+                "detail": "expected score in [70,100], got 98"
+              },
+              {
+                "kind": "role",
+                "candidateId": "c-needs-gpu",
+                "passed": true,
+                "detail": "expected role=patient, got patient"
+              }
+            ]
+          },
+          {
+            "passed": true,
+            "assertions": [
+              {
+                "kind": "match",
+                "candidateId": "c-needs-gpu",
+                "passed": true,
+                "detail": "expected match=true, got surfaced=true (score 98, threshold 30)"
+              },
+              {
+                "kind": "band",
+                "candidateId": "c-needs-gpu",
+                "passed": true,
+                "detail": "expected score in [70,100], got 98"
+              },
+              {
+                "kind": "role",
+                "candidateId": "c-needs-gpu",
+                "passed": true,
+                "detail": "expected role=patient, got patient"
+              }
+            ]
+          },
+          {
+            "passed": true,
+            "assertions": [
+              {
+                "kind": "match",
+                "candidateId": "c-needs-gpu",
+                "passed": true,
+                "detail": "expected match=true, got surfaced=true (score 98, threshold 30)"
+              },
+              {
+                "kind": "band",
+                "candidateId": "c-needs-gpu",
+                "passed": true,
+                "detail": "expected score in [70,100], got 98"
+              },
+              {
+                "kind": "role",
+                "candidateId": "c-needs-gpu",
+                "passed": true,
+                "detail": "expected role=patient, got patient"
+              }
+            ]
+          },
+          {
+            "passed": true,
+            "assertions": [
+              {
+                "kind": "match",
+                "candidateId": "c-needs-gpu",
+                "passed": true,
+                "detail": "expected match=true, got surfaced=true (score 98, threshold 30)"
+              },
+              {
+                "kind": "band",
+                "candidateId": "c-needs-gpu",
+                "passed": true,
+                "detail": "expected score in [70,100], got 98"
+              },
+              {
+                "kind": "role",
+                "candidateId": "c-needs-gpu",
+                "passed": true,
+                "detail": "expected role=patient, got patient"
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "caseId": "score_calibration/must-meet-sales-cofounder",
+        "rule": "score_calibration",
+        "runs": 7,
+        "passes": 7,
+        "passRate": 1,
+        "flaky": false,
+        "runResults": [
+          {
+            "passed": true,
+            "assertions": [
+              {
+                "kind": "match",
+                "candidateId": "c-sales-cof",
+                "passed": true,
+                "detail": "expected match=true, got surfaced=true (score 98, threshold 30)"
+              },
+              {
+                "kind": "band",
+                "candidateId": "c-sales-cof",
+                "passed": true,
+                "detail": "expected score in [85,100], got 98"
+              }
+            ]
+          },
+          {
+            "passed": true,
+            "assertions": [
+              {
+                "kind": "match",
+                "candidateId": "c-sales-cof",
+                "passed": true,
+                "detail": "expected match=true, got surfaced=true (score 98, threshold 30)"
+              },
+              {
+                "kind": "band",
+                "candidateId": "c-sales-cof",
+                "passed": true,
+                "detail": "expected score in [85,100], got 98"
+              }
+            ]
+          },
+          {
+            "passed": true,
+            "assertions": [
+              {
+                "kind": "match",
+                "candidateId": "c-sales-cof",
+                "passed": true,
+                "detail": "expected match=true, got surfaced=true (score 98, threshold 30)"
+              },
+              {
+                "kind": "band",
+                "candidateId": "c-sales-cof",
+                "passed": true,
+                "detail": "expected score in [85,100], got 98"
+              }
+            ]
+          },
+          {
+            "passed": true,
+            "assertions": [
+              {
+                "kind": "match",
+                "candidateId": "c-sales-cof",
+                "passed": true,
+                "detail": "expected match=true, got surfaced=true (score 95, threshold 30)"
+              },
+              {
+                "kind": "band",
+                "candidateId": "c-sales-cof",
+                "passed": true,
+                "detail": "expected score in [85,100], got 95"
+              }
+            ]
+          },
+          {
+            "passed": true,
+            "assertions": [
+              {
+                "kind": "match",
+                "candidateId": "c-sales-cof",
+                "passed": true,
+                "detail": "expected match=true, got surfaced=true (score 98, threshold 30)"
+              },
+              {
+                "kind": "band",
+                "candidateId": "c-sales-cof",
+                "passed": true,
+                "detail": "expected score in [85,100], got 98"
+              }
+            ]
+          },
+          {
+            "passed": true,
+            "assertions": [
+              {
+                "kind": "match",
+                "candidateId": "c-sales-cof",
+                "passed": true,
+                "detail": "expected match=true, got surfaced=true (score 98, threshold 30)"
+              },
+              {
+                "kind": "band",
+                "candidateId": "c-sales-cof",
+                "passed": true,
+                "detail": "expected score in [85,100], got 98"
+              }
+            ]
+          },
+          {
+            "passed": true,
+            "assertions": [
+              {
+                "kind": "match",
+                "candidateId": "c-sales-cof",
+                "passed": true,
+                "detail": "expected match=true, got surfaced=true (score 93, threshold 30)"
+              },
+              {
+                "kind": "band",
+                "candidateId": "c-sales-cof",
+                "passed": true,
+                "detail": "expected score in [85,100], got 93"
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "caseId": "score_calibration/tier2-researcher-pool-variant",
+        "rule": "score_calibration",
+        "runs": 7,
+        "passes": 7,
+        "passRate": 1,
+        "flaky": false,
+        "runResults": [
+          {
+            "passed": true,
+            "assertions": [
+              {
+                "kind": "match",
+                "candidateId": "p-tech-cofounder",
+                "passed": true,
+                "detail": "expected match=true, got surfaced=true (score 85, threshold 30)"
+              },
+              {
+                "kind": "band",
+                "candidateId": "p-tech-cofounder",
+                "passed": true,
+                "detail": "expected score in [70,100], got 85"
+              },
+              {
+                "kind": "match",
+                "candidateId": "p-researcher",
+                "passed": true,
+                "detail": "expected match=false, got surfaced=false (score 0, threshold 30)"
+              },
+              {
+                "kind": "band",
+                "candidateId": "p-researcher",
+                "passed": true,
+                "detail": "expected score in [0,29], got 0"
+              },
+              {
+                "kind": "match",
+                "candidateId": "p-operator",
+                "passed": true,
+                "detail": "expected match=false, got surfaced=false (score 0, threshold 30)"
+              },
+              {
+                "kind": "band",
+                "candidateId": "p-operator",
+                "passed": true,
+                "detail": "expected score in [0,29], got 0"
+              }
+            ]
+          },
+          {
+            "passed": true,
+            "assertions": [
+              {
+                "kind": "match",
+                "candidateId": "p-tech-cofounder",
+                "passed": true,
+                "detail": "expected match=true, got surfaced=true (score 98, threshold 30)"
+              },
+              {
+                "kind": "band",
+                "candidateId": "p-tech-cofounder",
+                "passed": true,
+                "detail": "expected score in [70,100], got 98"
+              },
+              {
+                "kind": "match",
+                "candidateId": "p-researcher",
+                "passed": true,
+                "detail": "expected match=false, got surfaced=false (score 0, threshold 30)"
+              },
+              {
+                "kind": "band",
+                "candidateId": "p-researcher",
+                "passed": true,
+                "detail": "expected score in [0,29], got 0"
+              },
+              {
+                "kind": "match",
+                "candidateId": "p-operator",
+                "passed": true,
+                "detail": "expected match=false, got surfaced=false (score 0, threshold 30)"
+              },
+              {
+                "kind": "band",
+                "candidateId": "p-operator",
+                "passed": true,
+                "detail": "expected score in [0,29], got 0"
+              }
+            ]
+          },
+          {
+            "passed": true,
+            "assertions": [
+              {
+                "kind": "match",
+                "candidateId": "p-tech-cofounder",
+                "passed": true,
+                "detail": "expected match=true, got surfaced=true (score 98, threshold 30)"
+              },
+              {
+                "kind": "band",
+                "candidateId": "p-tech-cofounder",
+                "passed": true,
+                "detail": "expected score in [70,100], got 98"
+              },
+              {
+                "kind": "match",
+                "candidateId": "p-researcher",
+                "passed": true,
+                "detail": "expected match=false, got surfaced=false (score 0, threshold 30)"
+              },
+              {
+                "kind": "band",
+                "candidateId": "p-researcher",
+                "passed": true,
+                "detail": "expected score in [0,29], got 0"
+              },
+              {
+                "kind": "match",
+                "candidateId": "p-operator",
+                "passed": true,
+                "detail": "expected match=false, got surfaced=false (score 0, threshold 30)"
+              },
+              {
+                "kind": "band",
+                "candidateId": "p-operator",
+                "passed": true,
+                "detail": "expected score in [0,29], got 0"
+              }
+            ]
+          },
+          {
+            "passed": true,
+            "assertions": [
+              {
+                "kind": "match",
+                "candidateId": "p-tech-cofounder",
+                "passed": true,
+                "detail": "expected match=true, got surfaced=true (score 98, threshold 30)"
+              },
+              {
+                "kind": "band",
+                "candidateId": "p-tech-cofounder",
+                "passed": true,
+                "detail": "expected score in [70,100], got 98"
+              },
+              {
+                "kind": "match",
+                "candidateId": "p-researcher",
+                "passed": true,
+                "detail": "expected match=false, got surfaced=false (score 0, threshold 30)"
+              },
+              {
+                "kind": "band",
+                "candidateId": "p-researcher",
+                "passed": true,
+                "detail": "expected score in [0,29], got 0"
+              },
+              {
+                "kind": "match",
+                "candidateId": "p-operator",
+                "passed": true,
+                "detail": "expected match=false, got surfaced=false (score 0, threshold 30)"
+              },
+              {
+                "kind": "band",
+                "candidateId": "p-operator",
+                "passed": true,
+                "detail": "expected score in [0,29], got 0"
+              }
+            ]
+          },
+          {
+            "passed": true,
+            "assertions": [
+              {
+                "kind": "match",
+                "candidateId": "p-tech-cofounder",
+                "passed": true,
+                "detail": "expected match=true, got surfaced=true (score 95, threshold 30)"
+              },
+              {
+                "kind": "band",
+                "candidateId": "p-tech-cofounder",
+                "passed": true,
+                "detail": "expected score in [70,100], got 95"
+              },
+              {
+                "kind": "match",
+                "candidateId": "p-researcher",
+                "passed": true,
+                "detail": "expected match=false, got surfaced=false (score 0, threshold 30)"
+              },
+              {
+                "kind": "band",
+                "candidateId": "p-researcher",
+                "passed": true,
+                "detail": "expected score in [0,29], got 0"
+              },
+              {
+                "kind": "match",
+                "candidateId": "p-operator",
+                "passed": true,
+                "detail": "expected match=false, got surfaced=false (score 0, threshold 30)"
+              },
+              {
+                "kind": "band",
+                "candidateId": "p-operator",
+                "passed": true,
+                "detail": "expected score in [0,29], got 0"
+              }
+            ]
+          },
+          {
+            "passed": true,
+            "assertions": [
+              {
+                "kind": "match",
+                "candidateId": "p-tech-cofounder",
+                "passed": true,
+                "detail": "expected match=true, got surfaced=true (score 95, threshold 30)"
+              },
+              {
+                "kind": "band",
+                "candidateId": "p-tech-cofounder",
+                "passed": true,
+                "detail": "expected score in [70,100], got 95"
+              },
+              {
+                "kind": "match",
+                "candidateId": "p-researcher",
+                "passed": true,
+                "detail": "expected match=false, got surfaced=false (score 0, threshold 30)"
+              },
+              {
+                "kind": "band",
+                "candidateId": "p-researcher",
+                "passed": true,
+                "detail": "expected score in [0,29], got 0"
+              },
+              {
+                "kind": "match",
+                "candidateId": "p-operator",
+                "passed": true,
+                "detail": "expected match=false, got surfaced=false (score 0, threshold 30)"
+              },
+              {
+                "kind": "band",
+                "candidateId": "p-operator",
+                "passed": true,
+                "detail": "expected score in [0,29], got 0"
+              }
+            ]
+          },
+          {
+            "passed": true,
+            "assertions": [
+              {
+                "kind": "match",
+                "candidateId": "p-tech-cofounder",
+                "passed": true,
+                "detail": "expected match=true, got surfaced=true (score 95, threshold 30)"
+              },
+              {
+                "kind": "band",
+                "candidateId": "p-tech-cofounder",
+                "passed": true,
+                "detail": "expected score in [70,100], got 95"
+              },
+              {
+                "kind": "match",
+                "candidateId": "p-researcher",
+                "passed": true,
+                "detail": "expected match=false, got surfaced=false (score 0, threshold 30)"
+              },
+              {
+                "kind": "band",
+                "candidateId": "p-researcher",
+                "passed": true,
+                "detail": "expected score in [0,29], got 0"
+              },
+              {
+                "kind": "match",
+                "candidateId": "p-operator",
+                "passed": true,
+                "detail": "expected match=false, got surfaced=false (score 0, threshold 30)"
+              },
+              {
+                "kind": "band",
+                "candidateId": "p-operator",
+                "passed": true,
+                "detail": "expected score in [0,29], got 0"
+              }
+            ]
+          }
+        ]
+      }
+    ]
+  }
 }

--- a/packages/protocol/eval/matching/matching.eval.ts
+++ b/packages/protocol/eval/matching/matching.eval.ts
@@ -10,7 +10,7 @@
  *   bun run eval:matching -- --tier 4
  *   bun run eval:matching -- --list-cases       # list selected cases and exit
  *   bun run eval:matching -- --no-judge         # skip assertLLM checks (free)
- *   bun run eval:matching -- --update-baseline  # overwrite the committed baseline
+ *   bun run eval:matching -- --update-baseline --force  # replace the committed baseline
  *   bun run eval:matching -- --report           # write a full run report (incl. evaluator reasoning)
  *   bun run eval:matching -- --report path.json # ...to a specific path
  *   bun run eval:matching -- --html             # write a standalone HTML scorecard
@@ -30,9 +30,12 @@ import { CASES } from "./matching.cases.js";
 import { runCase } from "./matching.runner.js";
 import { scoreCase, type Judge } from "./matching.scorer.js";
 import { formatCaseList, hasRule, parseTier, selectCases } from "./matching.selection.js";
+import { assertEvalWritePlan, fingerprintEvalConfig, fingerprintEvalCorpus, readEvalGitProvenance, type EvalRunMeta } from "../shared/index.js";
 import { buildScorecard, computeRollingBaseline, diffBaseline, formatConsole, readBaseline, writeBaseline, writeHtmlReport, writeRunReport } from "./matching.reporter.js";
 import type { CaseResult } from "./matching.types.js";
 
+const HARNESS = "matching";
+const HARNESS_VERSION = "1";
 const DEFAULT_ALPHA = 0.05;
 const BASELINE_PATH = path.resolve(import.meta.dir, "baselines/matching.baseline.json");
 const RUNS_DIR = path.resolve(import.meta.dir, "runs");
@@ -56,7 +59,8 @@ Execution:
   --no-save                 Do not auto-save full-corpus run JSON for rolling baseline fuel
 
 Baselines/reports:
-  --update-baseline         Overwrite committed baseline (full corpus only)
+  --update-baseline         Overwrite committed baseline (full corpus only; needs --force if one exists)
+  --force                   Consent to overwrite existing baseline/report/HTML outputs
   --rolling-baseline [days] Compare against recent run reports (default: 7)
   --report [path]           Write JSON scorecard
   --html [path]             Write standalone HTML scorecard
@@ -109,6 +113,7 @@ async function main(): Promise<void> {
   const report = has("--report");
   const html = has("--html");
   const noSave = has("--no-save");
+  const force = has("--force");
   const alpha = Number(arg("--alpha") ?? DEFAULT_ALPHA);
   if (!Number.isFinite(alpha) || alpha <= 0 || alpha >= 1) {
     console.error(`--alpha must be a number between 0 and 1 (got "${arg("--alpha")}")`);
@@ -147,10 +152,30 @@ async function main(): Promise<void> {
     process.exit(2);
   }
 
+  // Assert every declared output before running anything: no output may
+  // clobber an input, and existing destinations need explicit --force.
+  const explicitReportPath = report ? flagValue("--report") : undefined;
+  const explicitHtmlPath = html ? flagValue("--html") : undefined;
+  try {
+    await assertEvalWritePlan({
+      inputs: [BASELINE_PATH],
+      outputs: [
+        ...(updateBaseline ? [{ path: BASELINE_PATH, updatesInput: true }] : []),
+        ...(explicitReportPath ? [explicitReportPath] : []),
+        ...(explicitHtmlPath ? [explicitHtmlPath] : []),
+      ],
+      force,
+    });
+  } catch (err) {
+    console.error(err instanceof Error ? err.message : String(err));
+    process.exit(2);
+  }
+
   const evaluator = new OpportunityEvaluator();
   const model = getModelName("opportunityEvaluator");
   console.log(`Running ${selected.length} case(s) × ${runs} run(s) against ${model}${noJudge ? " (judge off)" : ""}…`);
 
+  const startedAt = new Date().toISOString();
   const results: CaseResult[] = [];
   for (const c of selected) {
     process.stdout.write(`  ${c.id} … `);
@@ -161,6 +186,24 @@ async function main(): Promise<void> {
   }
 
   const scorecard = buildScorecard(results, { model, runs });
+  const completedAt = new Date().toISOString();
+  const filters: Record<string, string> = {};
+  if (ruleFilter) filters.rule = ruleFilter;
+  if (caseFilter) filters.case = caseFilter;
+  if (tierFilter !== undefined) filters.tier = String(tierFilter);
+  const models = [...new Set([model])];
+  const meta: EvalRunMeta = {
+    harness: HARNESS,
+    harnessVersion: HARNESS_VERSION,
+    models,
+    runs,
+    selection: { fullCorpus, filters },
+    corpusFingerprint: fingerprintEvalCorpus(selected),
+    configFingerprint: fingerprintEvalConfig({ runs, alpha, judge: !noJudge, filters, models }),
+    git: readEvalGitProvenance(import.meta.dir),
+    startedAt,
+    completedAt,
+  };
   const baseline = rollingBaselineDays !== null
     ? await computeRollingBaseline(RUNS_DIR, rollingBaselineDays)
     : await readBaseline(BASELINE_PATH);
@@ -177,19 +220,20 @@ async function main(): Promise<void> {
   console.log(formatConsole(scorecard, regressions, skippedCaseIds));
 
   if (updateBaseline) {
-    await writeBaseline(BASELINE_PATH, scorecard);
+    await writeBaseline(BASELINE_PATH, scorecard, { meta, force });
     console.log(`\nBaseline updated at ${BASELINE_PATH}`);
   }
 
   const stamp = new Date().toISOString().replace(/[:.]/g, "-");
   const autoRunPath = path.resolve(RUNS_DIR, `${stamp}.json`);
-  if (fullCorpus && !noSave) {
-    await writeRunReport(autoRunPath, scorecard);
+  const autoSaved = fullCorpus && !noSave;
+  if (autoSaved) {
+    await writeRunReport(autoRunPath, scorecard, { meta });
   }
 
   if (report) {
     const reportPath = flagValue("--report") ?? autoRunPath;
-    if (reportPath !== autoRunPath) await writeRunReport(reportPath, scorecard);
+    if (!(autoSaved && reportPath === autoRunPath)) await writeRunReport(reportPath, scorecard, { meta, force });
     console.log(`\nRun report written to ${reportPath}`);
   }
 

--- a/packages/protocol/eval/matching/matching.reporter.ts
+++ b/packages/protocol/eval/matching/matching.reporter.ts
@@ -1,4 +1,4 @@
-import { binomialCI, buildScorecard, computeRollingBaseline, diffBaseline, formatConsole as sharedFormatConsole, readBaseline as sharedReadBaseline, writeBaseline as sharedWriteBaseline, writeRunReport, binomialPValue, binomialSignificance, predictivePValue, renderHumanReport, HUMAN_CSS, type HumanReport, type Regression } from "../shared/index.js";
+import { binomialCI, buildScorecard, computeRollingBaseline, diffBaseline, formatConsole as sharedFormatConsole, readBaseline as sharedReadBaseline, writeBaseline as sharedWriteBaseline, writeRunReport, binomialPValue, binomialSignificance, predictivePValue, renderHumanReport, HUMAN_CSS, type EvalRunMeta, type HumanReport, type Regression } from "../shared/index.js";
 import type { CaseResult, Scorecard, MatchingCase, CandidateExpectation, CandidateOutcome, AssertionKind, Rule } from "./matching.types.js";
 
 // ── Shared machinery re-exported for matching consumers and tests ────────────
@@ -19,7 +19,7 @@ export {
 
 /** Read a committed matching baseline, typed as a matching {@link Scorecard}. */
 export function readBaseline(path: string): Promise<Scorecard | null> {
-  return sharedReadBaseline<Scorecard>(path);
+  return sharedReadBaseline<Scorecard>(path, { harness: "matching" });
 }
 
 /** Console scorecard with the matching-specific title. */
@@ -34,9 +34,13 @@ export function formatConsole(sc: Scorecard, regressions: Regression[], skippedC
  *
  * @param path - Absolute or relative path to write to.
  * @param sc - The scorecard to persist (candidate detail stripped before writing).
+ * @param opts.meta - Run provenance recorded in the versioned envelope.
+ * @param opts.force - Explicit consent to overwrite an existing baseline.
  */
-export async function writeBaseline(path: string, sc: Scorecard): Promise<void> {
+export async function writeBaseline(path: string, sc: Scorecard, opts: { meta: EvalRunMeta; force?: boolean }): Promise<void> {
   await sharedWriteBaseline(path, sc, {
+    meta: opts.meta,
+    force: opts.force,
     leanCase: (c) => ({
       ...c,
       runResults: c.runResults.map(({ candidates: _candidates, ...rest }) => rest),

--- a/packages/protocol/eval/matching/tests/matching.cases.spec.ts
+++ b/packages/protocol/eval/matching/tests/matching.cases.spec.ts
@@ -64,8 +64,8 @@ describe("matching corpus", () => {
       "event_network/co-membership-is-not-attendance", // added in #1144 without a baseline run
     ]);
 
-    const baseline = (await Bun.file(new URL("../baselines/matching.baseline.json", import.meta.url)).json()) as Scorecard;
-    const baselineIds = new Set(baseline.cases.map((c) => c.caseId));
+    const envelope = (await Bun.file(new URL("../baselines/matching.baseline.json", import.meta.url)).json()) as { payload: Scorecard };
+    const baselineIds = new Set(envelope.payload.cases.map((c) => c.caseId));
     const corpusIds = new Set(CASES.map((c) => c.id));
 
     const missing = CASES.map((c) => c.id).filter((id) => !baselineIds.has(id) && !BASELINE_PENDING_CASE_IDS.has(id));

--- a/packages/protocol/eval/matching/tests/matching.reporter.spec.ts
+++ b/packages/protocol/eval/matching/tests/matching.reporter.spec.ts
@@ -4,6 +4,9 @@ import { join } from "node:path";
 import { mkdir, rm, unlink } from "node:fs/promises";
 import { binomialCI, binomialPValue, binomialSignificance, predictivePValue, buildScorecard, computeRollingBaseline, diffBaseline, formatConsole, renderHtml, writeBaseline, writeRunReport, readBaseline } from "../matching.reporter.js";
 import type { CaseResult, MatchingCase, Scorecard } from "../matching.types.js";
+import { makeTestMeta } from "../../shared/tests/artifact.fixtures.js";
+
+const matchingMeta = (runs: number) => makeTestMeta({ harness: "matching", runs });
 
 const caseResult = (caseId: string, rule: CaseResult["rule"], passRate: number): CaseResult => ({
   caseId,
@@ -327,7 +330,7 @@ describe("computeRollingBaseline", () => {
       generatedAt: "2026-05-27T00:00:00.000Z",
     };
     const recentPartial: Scorecard = {
-      ...buildScorecard([caseResult("a", "same_side", 0.33)], { model: "m", runs: 3 }),
+      ...buildScorecard([caseResult("a", "same_side", 1 / 3)], { model: "m", runs: 3 }),
       generatedAt: "2026-05-26T00:00:00.000Z",
     };
     const oldRun: Scorecard = {
@@ -335,9 +338,10 @@ describe("computeRollingBaseline", () => {
       generatedAt: "2026-05-01T00:00:00.000Z",
     };
 
-    await writeRunReport(join(dir, "recent-perfect.json"), recentPerfect);
-    await writeRunReport(join(dir, "recent-partial.json"), recentPartial);
-    await writeRunReport(join(dir, "old.json"), oldRun);
+    const meta = makeTestMeta({ harness: "matching", runs: 3, startedAt: "2026-04-30T00:00:00.000Z", completedAt: "2026-04-30T00:01:00.000Z" });
+    await writeRunReport(join(dir, "recent-perfect.json"), recentPerfect, { meta });
+    await writeRunReport(join(dir, "recent-partial.json"), recentPartial, { meta });
+    await writeRunReport(join(dir, "old.json"), oldRun, { meta });
 
     const rolling = await computeRollingBaseline(dir, 7, now);
     expect(rolling).not.toBeNull();
@@ -375,7 +379,7 @@ describe("baseline vs run-report reasoning handling", () => {
 
   it("strips candidate reasoning from the committed baseline", async () => {
     const p = join(tmpdir(), `matching-baseline-${Date.now()}.json`);
-    await writeBaseline(p, scWithReasoning());
+    await writeBaseline(p, scWithReasoning(), { meta: matchingMeta(1) });
     const back = await readBaseline(p);
     expect(back!.cases[0].runResults[0].candidates).toBeUndefined();
     await unlink(p);
@@ -383,8 +387,8 @@ describe("baseline vs run-report reasoning handling", () => {
 
   it("keeps candidate reasoning verbatim in the run report", async () => {
     const p = join(tmpdir(), `matching-report-${Date.now()}.json`);
-    await writeRunReport(p, scWithReasoning());
-    const back = JSON.parse(await Bun.file(p).text()) as Scorecard;
+    await writeRunReport(p, scWithReasoning(), { meta: matchingMeta(1) });
+    const back = (JSON.parse(await Bun.file(p).text()) as { payload: Scorecard }).payload;
     expect(back.cases[0].runResults[0].candidates![0].reasoning).toBe("because X");
     await unlink(p);
   });

--- a/packages/protocol/eval/opportunity/README.md
+++ b/packages/protocol/eval/opportunity/README.md
@@ -17,7 +17,7 @@ bun run eval:opportunity -- --case greeting/        # one case or id prefix
 bun run eval:opportunity -- --tier 1               # one tier
 bun run eval:opportunity -- --list-cases           # print selected cases and exit
 bun run eval:opportunity -- --no-judge             # skip LLM grounding/framing/tone checks (free)
-bun run eval:opportunity -- --update-baseline      # overwrite the committed baseline
+bun run eval:opportunity -- --update-baseline --force # replace the committed baseline
 bun run eval:opportunity -- --report [path]        # write a full run report incl. generated cards
 bun run eval:opportunity -- --html [path]          # write a standalone HTML scorecard
 bun run eval:opportunity -- --rolling-baseline [d] # compare against trailing run average (default 7d)
@@ -50,7 +50,7 @@ Append an `OpportunityCase` to `CASES`. Set `rule`, `tier` (1 surgical, 2 realis
 `expect`. The deterministic guarantees are on by default; add judged `mustReference` /
 `framingCriteria` / `toneCriteria` for grounding, framing, and tone. To stress leakage, embed
 a UUID or an internal label in the `input` and rely on the default `no_leakage` assertion.
-Re-run with `--update-baseline` after an intentional change.
+Re-run with `--update-baseline --force` after an intentional change.
 
 ## Layout
 

--- a/packages/protocol/eval/opportunity/baselines/opportunity.baseline.json
+++ b/packages/protocol/eval/opportunity/baselines/opportunity.baseline.json
@@ -1,855 +1,886 @@
 {
-  "generatedAt": "2026-06-16T17:14:34.977Z",
-  "model": "google/gemini-2.5-flash",
-  "runs": 3,
-  "aggregatePassRate": 0.7916666666666666,
-  "rules": [
-    {
-      "rule": "viewer_voice",
-      "caseCount": 2,
-      "passRate": 1
-    },
-    {
-      "rule": "no_leakage",
-      "caseCount": 1,
-      "passRate": 1
-    },
-    {
-      "rule": "greeting",
-      "caseCount": 1,
-      "passRate": 0
-    },
-    {
-      "rule": "grounding",
-      "caseCount": 1,
-      "passRate": 1
-    },
-    {
-      "rule": "introducer_role",
-      "caseCount": 2,
-      "passRate": 0.8333333333333333
-    },
-    {
-      "rule": "tone",
-      "caseCount": 1,
-      "passRate": 0.6666666666666666
-    }
+  "artifactType": "index-eval/baseline",
+  "schemaVersion": 1,
+  "harness": "opportunity",
+  "harnessVersion": "1",
+  "source": "legacy-migration",
+  "createdAt": "2026-06-16T17:14:34.977Z",
+  "startedAt": "2026-06-16T17:14:34.977Z",
+  "completedAt": "2026-06-16T17:14:34.977Z",
+  "models": [
+    "google/gemini-2.5-flash"
   ],
-  "cases": [
-    {
-      "caseId": "viewer_voice/founder-investor",
-      "rule": "viewer_voice",
-      "runs": 3,
-      "passes": 3,
-      "passRate": 1,
-      "flaky": false,
-      "runResults": [
-        {
-          "passed": true,
-          "assertions": [
-            {
-              "kind": "non_empty",
-              "passed": true,
-              "detail": "headline, summary, and suggested action must be non-empty"
-            },
-            {
-              "kind": "voice",
-              "passed": true,
-              "detail": "summary speaks to the viewer"
-            },
-            {
-              "kind": "uuid",
-              "passed": true,
-              "detail": "no UUIDs in user-facing copy"
-            },
-            {
-              "kind": "label",
-              "passed": true,
-              "detail": "no internal labels in user-facing copy"
-            },
-            {
-              "kind": "grounding",
-              "passed": true,
-              "detail": "judge: grounded in context"
-            }
-          ]
-        },
-        {
-          "passed": true,
-          "assertions": [
-            {
-              "kind": "non_empty",
-              "passed": true,
-              "detail": "headline, summary, and suggested action must be non-empty"
-            },
-            {
-              "kind": "voice",
-              "passed": true,
-              "detail": "summary speaks to the viewer"
-            },
-            {
-              "kind": "uuid",
-              "passed": true,
-              "detail": "no UUIDs in user-facing copy"
-            },
-            {
-              "kind": "label",
-              "passed": true,
-              "detail": "no internal labels in user-facing copy"
-            },
-            {
-              "kind": "grounding",
-              "passed": true,
-              "detail": "judge: grounded in context"
-            }
-          ]
-        },
-        {
-          "passed": true,
-          "assertions": [
-            {
-              "kind": "non_empty",
-              "passed": true,
-              "detail": "headline, summary, and suggested action must be non-empty"
-            },
-            {
-              "kind": "voice",
-              "passed": true,
-              "detail": "summary speaks to the viewer"
-            },
-            {
-              "kind": "uuid",
-              "passed": true,
-              "detail": "no UUIDs in user-facing copy"
-            },
-            {
-              "kind": "label",
-              "passed": true,
-              "detail": "no internal labels in user-facing copy"
-            },
-            {
-              "kind": "grounding",
-              "passed": true,
-              "detail": "judge: grounded in context"
-            }
-          ]
-        }
-      ]
-    },
-    {
-      "caseId": "no_leakage/identifiers-in-context",
-      "rule": "no_leakage",
-      "runs": 3,
-      "passes": 3,
-      "passRate": 1,
-      "flaky": false,
-      "runResults": [
-        {
-          "passed": true,
-          "assertions": [
-            {
-              "kind": "non_empty",
-              "passed": true,
-              "detail": "headline, summary, and suggested action must be non-empty"
-            },
-            {
-              "kind": "voice",
-              "passed": true,
-              "detail": "summary speaks to the viewer"
-            },
-            {
-              "kind": "uuid",
-              "passed": true,
-              "detail": "no UUIDs in user-facing copy"
-            },
-            {
-              "kind": "label",
-              "passed": true,
-              "detail": "no internal labels in user-facing copy"
-            }
-          ]
-        },
-        {
-          "passed": true,
-          "assertions": [
-            {
-              "kind": "non_empty",
-              "passed": true,
-              "detail": "headline, summary, and suggested action must be non-empty"
-            },
-            {
-              "kind": "voice",
-              "passed": true,
-              "detail": "summary speaks to the viewer"
-            },
-            {
-              "kind": "uuid",
-              "passed": true,
-              "detail": "no UUIDs in user-facing copy"
-            },
-            {
-              "kind": "label",
-              "passed": true,
-              "detail": "no internal labels in user-facing copy"
-            }
-          ]
-        },
-        {
-          "passed": true,
-          "assertions": [
-            {
-              "kind": "non_empty",
-              "passed": true,
-              "detail": "headline, summary, and suggested action must be non-empty"
-            },
-            {
-              "kind": "voice",
-              "passed": true,
-              "detail": "summary speaks to the viewer"
-            },
-            {
-              "kind": "uuid",
-              "passed": true,
-              "detail": "no UUIDs in user-facing copy"
-            },
-            {
-              "kind": "label",
-              "passed": true,
-              "detail": "no internal labels in user-facing copy"
-            }
-          ]
-        }
-      ]
-    },
-    {
-      "caseId": "greeting/plain-prose",
-      "rule": "greeting",
-      "runs": 3,
-      "passes": 0,
-      "passRate": 0,
-      "flaky": false,
-      "runResults": [
-        {
-          "passed": false,
-          "assertions": [
-            {
-              "kind": "non_empty",
-              "passed": true,
-              "detail": "headline, summary, and suggested action must be non-empty"
-            },
-            {
-              "kind": "voice",
-              "passed": true,
-              "detail": "summary speaks to the viewer"
-            },
-            {
-              "kind": "uuid",
-              "passed": true,
-              "detail": "no UUIDs in user-facing copy"
-            },
-            {
-              "kind": "label",
-              "passed": true,
-              "detail": "no internal labels in user-facing copy"
-            },
-            {
-              "kind": "greeting_format",
-              "passed": false,
-              "detail": "greeting has markdown or a 'Hey Name,' prefix"
-            },
-            {
-              "kind": "greeting_length",
-              "passed": true,
-              "detail": "greeting is 209 chars (max 500)"
-            }
-          ]
-        },
-        {
-          "passed": false,
-          "assertions": [
-            {
-              "kind": "non_empty",
-              "passed": true,
-              "detail": "headline, summary, and suggested action must be non-empty"
-            },
-            {
-              "kind": "voice",
-              "passed": true,
-              "detail": "summary speaks to the viewer"
-            },
-            {
-              "kind": "uuid",
-              "passed": true,
-              "detail": "no UUIDs in user-facing copy"
-            },
-            {
-              "kind": "label",
-              "passed": true,
-              "detail": "no internal labels in user-facing copy"
-            },
-            {
-              "kind": "greeting_format",
-              "passed": false,
-              "detail": "greeting has markdown or a 'Hey Name,' prefix"
-            },
-            {
-              "kind": "greeting_length",
-              "passed": true,
-              "detail": "greeting is 223 chars (max 500)"
-            }
-          ]
-        },
-        {
-          "passed": false,
-          "assertions": [
-            {
-              "kind": "non_empty",
-              "passed": true,
-              "detail": "headline, summary, and suggested action must be non-empty"
-            },
-            {
-              "kind": "voice",
-              "passed": true,
-              "detail": "summary speaks to the viewer"
-            },
-            {
-              "kind": "uuid",
-              "passed": true,
-              "detail": "no UUIDs in user-facing copy"
-            },
-            {
-              "kind": "label",
-              "passed": true,
-              "detail": "no internal labels in user-facing copy"
-            },
-            {
-              "kind": "greeting_format",
-              "passed": false,
-              "detail": "greeting has markdown or a 'Hey Name,' prefix"
-            },
-            {
-              "kind": "greeting_length",
-              "passed": true,
-              "detail": "greeting is 223 chars (max 500)"
-            }
-          ]
-        }
-      ]
-    },
-    {
-      "caseId": "grounding/specific-intents",
-      "rule": "grounding",
-      "runs": 3,
-      "passes": 3,
-      "passRate": 1,
-      "flaky": false,
-      "runResults": [
-        {
-          "passed": true,
-          "assertions": [
-            {
-              "kind": "non_empty",
-              "passed": true,
-              "detail": "headline, summary, and suggested action must be non-empty"
-            },
-            {
-              "kind": "voice",
-              "passed": true,
-              "detail": "summary speaks to the viewer"
-            },
-            {
-              "kind": "uuid",
-              "passed": true,
-              "detail": "no UUIDs in user-facing copy"
-            },
-            {
-              "kind": "label",
-              "passed": true,
-              "detail": "no internal labels in user-facing copy"
-            },
-            {
-              "kind": "grounding",
-              "passed": true,
-              "detail": "judge: grounded in context"
-            },
-            {
-              "kind": "tone",
-              "passed": true,
-              "detail": "judge: tone good"
-            }
-          ]
-        },
-        {
-          "passed": true,
-          "assertions": [
-            {
-              "kind": "non_empty",
-              "passed": true,
-              "detail": "headline, summary, and suggested action must be non-empty"
-            },
-            {
-              "kind": "voice",
-              "passed": true,
-              "detail": "summary speaks to the viewer"
-            },
-            {
-              "kind": "uuid",
-              "passed": true,
-              "detail": "no UUIDs in user-facing copy"
-            },
-            {
-              "kind": "label",
-              "passed": true,
-              "detail": "no internal labels in user-facing copy"
-            },
-            {
-              "kind": "grounding",
-              "passed": true,
-              "detail": "judge: grounded in context"
-            },
-            {
-              "kind": "tone",
-              "passed": true,
-              "detail": "judge: tone good"
-            }
-          ]
-        },
-        {
-          "passed": true,
-          "assertions": [
-            {
-              "kind": "non_empty",
-              "passed": true,
-              "detail": "headline, summary, and suggested action must be non-empty"
-            },
-            {
-              "kind": "voice",
-              "passed": true,
-              "detail": "summary speaks to the viewer"
-            },
-            {
-              "kind": "uuid",
-              "passed": true,
-              "detail": "no UUIDs in user-facing copy"
-            },
-            {
-              "kind": "label",
-              "passed": true,
-              "detail": "no internal labels in user-facing copy"
-            },
-            {
-              "kind": "grounding",
-              "passed": true,
-              "detail": "judge: grounded in context"
-            },
-            {
-              "kind": "tone",
-              "passed": true,
-              "detail": "judge: tone good"
-            }
-          ]
-        }
-      ]
-    },
-    {
-      "caseId": "introducer_role/connecting-two-others",
-      "rule": "introducer_role",
-      "runs": 3,
-      "passes": 2,
-      "passRate": 0.6666666666666666,
-      "flaky": true,
-      "runResults": [
-        {
-          "passed": true,
-          "assertions": [
-            {
-              "kind": "non_empty",
-              "passed": true,
-              "detail": "headline, summary, and suggested action must be non-empty"
-            },
-            {
-              "kind": "voice",
-              "passed": true,
-              "detail": "summary speaks to the viewer"
-            },
-            {
-              "kind": "uuid",
-              "passed": true,
-              "detail": "no UUIDs in user-facing copy"
-            },
-            {
-              "kind": "label",
-              "passed": true,
-              "detail": "no internal labels in user-facing copy"
-            },
-            {
-              "kind": "framing",
-              "passed": true,
-              "detail": "judge: framing correct"
-            }
-          ]
-        },
-        {
-          "passed": false,
-          "assertions": [
-            {
-              "kind": "non_empty",
-              "passed": true,
-              "detail": "headline, summary, and suggested action must be non-empty"
-            },
-            {
-              "kind": "voice",
-              "passed": true,
-              "detail": "summary speaks to the viewer"
-            },
-            {
-              "kind": "uuid",
-              "passed": true,
-              "detail": "no UUIDs in user-facing copy"
-            },
-            {
-              "kind": "label",
-              "passed": true,
-              "detail": "no internal labels in user-facing copy"
-            },
-            {
-              "kind": "framing",
-              "passed": false,
-              "detail": "judge: framing wrong"
-            }
-          ]
-        },
-        {
-          "passed": true,
-          "assertions": [
-            {
-              "kind": "non_empty",
-              "passed": true,
-              "detail": "headline, summary, and suggested action must be non-empty"
-            },
-            {
-              "kind": "voice",
-              "passed": true,
-              "detail": "summary speaks to the viewer"
-            },
-            {
-              "kind": "uuid",
-              "passed": true,
-              "detail": "no UUIDs in user-facing copy"
-            },
-            {
-              "kind": "label",
-              "passed": true,
-              "detail": "no internal labels in user-facing copy"
-            },
-            {
-              "kind": "framing",
-              "passed": true,
-              "detail": "judge: framing correct"
-            }
-          ]
-        }
-      ]
-    },
-    {
-      "caseId": "introducer_role/explicit-introduction",
-      "rule": "introducer_role",
-      "runs": 3,
-      "passes": 3,
-      "passRate": 1,
-      "flaky": false,
-      "runResults": [
-        {
-          "passed": true,
-          "assertions": [
-            {
-              "kind": "non_empty",
-              "passed": true,
-              "detail": "headline, summary, and suggested action must be non-empty"
-            },
-            {
-              "kind": "voice",
-              "passed": true,
-              "detail": "summary speaks to the viewer"
-            },
-            {
-              "kind": "uuid",
-              "passed": true,
-              "detail": "no UUIDs in user-facing copy"
-            },
-            {
-              "kind": "label",
-              "passed": true,
-              "detail": "no internal labels in user-facing copy"
-            },
-            {
-              "kind": "framing",
-              "passed": true,
-              "detail": "judge: framing correct"
-            }
-          ]
-        },
-        {
-          "passed": true,
-          "assertions": [
-            {
-              "kind": "non_empty",
-              "passed": true,
-              "detail": "headline, summary, and suggested action must be non-empty"
-            },
-            {
-              "kind": "voice",
-              "passed": true,
-              "detail": "summary speaks to the viewer"
-            },
-            {
-              "kind": "uuid",
-              "passed": true,
-              "detail": "no UUIDs in user-facing copy"
-            },
-            {
-              "kind": "label",
-              "passed": true,
-              "detail": "no internal labels in user-facing copy"
-            },
-            {
-              "kind": "framing",
-              "passed": true,
-              "detail": "judge: framing correct"
-            }
-          ]
-        },
-        {
-          "passed": true,
-          "assertions": [
-            {
-              "kind": "non_empty",
-              "passed": true,
-              "detail": "headline, summary, and suggested action must be non-empty"
-            },
-            {
-              "kind": "voice",
-              "passed": true,
-              "detail": "summary speaks to the viewer"
-            },
-            {
-              "kind": "uuid",
-              "passed": true,
-              "detail": "no UUIDs in user-facing copy"
-            },
-            {
-              "kind": "label",
-              "passed": true,
-              "detail": "no internal labels in user-facing copy"
-            },
-            {
-              "kind": "framing",
-              "passed": true,
-              "detail": "judge: framing correct"
-            }
-          ]
-        }
-      ]
-    },
-    {
-      "caseId": "tone/compelling-not-analytical",
-      "rule": "tone",
-      "runs": 3,
-      "passes": 2,
-      "passRate": 0.6666666666666666,
-      "flaky": true,
-      "runResults": [
-        {
-          "passed": false,
-          "assertions": [
-            {
-              "kind": "non_empty",
-              "passed": true,
-              "detail": "headline, summary, and suggested action must be non-empty"
-            },
-            {
-              "kind": "voice",
-              "passed": true,
-              "detail": "summary speaks to the viewer"
-            },
-            {
-              "kind": "uuid",
-              "passed": true,
-              "detail": "no UUIDs in user-facing copy"
-            },
-            {
-              "kind": "label",
-              "passed": true,
-              "detail": "no internal labels in user-facing copy"
-            },
-            {
-              "kind": "tone",
-              "passed": false,
-              "detail": "judge: tone off"
-            }
-          ]
-        },
-        {
-          "passed": true,
-          "assertions": [
-            {
-              "kind": "non_empty",
-              "passed": true,
-              "detail": "headline, summary, and suggested action must be non-empty"
-            },
-            {
-              "kind": "voice",
-              "passed": true,
-              "detail": "summary speaks to the viewer"
-            },
-            {
-              "kind": "uuid",
-              "passed": true,
-              "detail": "no UUIDs in user-facing copy"
-            },
-            {
-              "kind": "label",
-              "passed": true,
-              "detail": "no internal labels in user-facing copy"
-            },
-            {
-              "kind": "tone",
-              "passed": true,
-              "detail": "judge: tone good"
-            }
-          ]
-        },
-        {
-          "passed": true,
-          "assertions": [
-            {
-              "kind": "non_empty",
-              "passed": true,
-              "detail": "headline, summary, and suggested action must be non-empty"
-            },
-            {
-              "kind": "voice",
-              "passed": true,
-              "detail": "summary speaks to the viewer"
-            },
-            {
-              "kind": "uuid",
-              "passed": true,
-              "detail": "no UUIDs in user-facing copy"
-            },
-            {
-              "kind": "label",
-              "passed": true,
-              "detail": "no internal labels in user-facing copy"
-            },
-            {
-              "kind": "tone",
-              "passed": true,
-              "detail": "judge: tone good"
-            }
-          ]
-        }
-      ]
-    },
-    {
-      "caseId": "viewer_voice/patient-role",
-      "rule": "viewer_voice",
-      "runs": 3,
-      "passes": 3,
-      "passRate": 1,
-      "flaky": false,
-      "runResults": [
-        {
-          "passed": true,
-          "assertions": [
-            {
-              "kind": "non_empty",
-              "passed": true,
-              "detail": "headline, summary, and suggested action must be non-empty"
-            },
-            {
-              "kind": "voice",
-              "passed": true,
-              "detail": "summary speaks to the viewer"
-            },
-            {
-              "kind": "uuid",
-              "passed": true,
-              "detail": "no UUIDs in user-facing copy"
-            },
-            {
-              "kind": "label",
-              "passed": true,
-              "detail": "no internal labels in user-facing copy"
-            },
-            {
-              "kind": "grounding",
-              "passed": true,
-              "detail": "judge: grounded in context"
-            }
-          ]
-        },
-        {
-          "passed": true,
-          "assertions": [
-            {
-              "kind": "non_empty",
-              "passed": true,
-              "detail": "headline, summary, and suggested action must be non-empty"
-            },
-            {
-              "kind": "voice",
-              "passed": true,
-              "detail": "summary speaks to the viewer"
-            },
-            {
-              "kind": "uuid",
-              "passed": true,
-              "detail": "no UUIDs in user-facing copy"
-            },
-            {
-              "kind": "label",
-              "passed": true,
-              "detail": "no internal labels in user-facing copy"
-            },
-            {
-              "kind": "grounding",
-              "passed": true,
-              "detail": "judge: grounded in context"
-            }
-          ]
-        },
-        {
-          "passed": true,
-          "assertions": [
-            {
-              "kind": "non_empty",
-              "passed": true,
-              "detail": "headline, summary, and suggested action must be non-empty"
-            },
-            {
-              "kind": "voice",
-              "passed": true,
-              "detail": "summary speaks to the viewer"
-            },
-            {
-              "kind": "uuid",
-              "passed": true,
-              "detail": "no UUIDs in user-facing copy"
-            },
-            {
-              "kind": "label",
-              "passed": true,
-              "detail": "no internal labels in user-facing copy"
-            },
-            {
-              "kind": "grounding",
-              "passed": true,
-              "detail": "judge: grounded in context"
-            }
-          ]
-        }
-      ]
-    }
-  ]
+  "runs": 3,
+  "selection": {
+    "fullCorpus": true,
+    "filters": {}
+  },
+  "corpusFingerprint": "unavailable-legacy-migration",
+  "configFingerprint": "unavailable-legacy-migration",
+  "git": {
+    "revision": "unknown",
+    "dirty": null
+  },
+  "completeness": {
+    "caseCount": 8,
+    "ruleCount": 6,
+    "totalRuns": 24,
+    "totalPasses": 19,
+    "flakyCaseCount": 2
+  },
+  "payload": {
+    "generatedAt": "2026-06-16T17:14:34.977Z",
+    "model": "google/gemini-2.5-flash",
+    "runs": 3,
+    "aggregatePassRate": 0.7916666666666666,
+    "rules": [
+      {
+        "rule": "viewer_voice",
+        "caseCount": 2,
+        "passRate": 1
+      },
+      {
+        "rule": "no_leakage",
+        "caseCount": 1,
+        "passRate": 1
+      },
+      {
+        "rule": "greeting",
+        "caseCount": 1,
+        "passRate": 0
+      },
+      {
+        "rule": "grounding",
+        "caseCount": 1,
+        "passRate": 1
+      },
+      {
+        "rule": "introducer_role",
+        "caseCount": 2,
+        "passRate": 0.8333333333333333
+      },
+      {
+        "rule": "tone",
+        "caseCount": 1,
+        "passRate": 0.6666666666666666
+      }
+    ],
+    "cases": [
+      {
+        "caseId": "viewer_voice/founder-investor",
+        "rule": "viewer_voice",
+        "runs": 3,
+        "passes": 3,
+        "passRate": 1,
+        "flaky": false,
+        "runResults": [
+          {
+            "passed": true,
+            "assertions": [
+              {
+                "kind": "non_empty",
+                "passed": true,
+                "detail": "headline, summary, and suggested action must be non-empty"
+              },
+              {
+                "kind": "voice",
+                "passed": true,
+                "detail": "summary speaks to the viewer"
+              },
+              {
+                "kind": "uuid",
+                "passed": true,
+                "detail": "no UUIDs in user-facing copy"
+              },
+              {
+                "kind": "label",
+                "passed": true,
+                "detail": "no internal labels in user-facing copy"
+              },
+              {
+                "kind": "grounding",
+                "passed": true,
+                "detail": "judge: grounded in context"
+              }
+            ]
+          },
+          {
+            "passed": true,
+            "assertions": [
+              {
+                "kind": "non_empty",
+                "passed": true,
+                "detail": "headline, summary, and suggested action must be non-empty"
+              },
+              {
+                "kind": "voice",
+                "passed": true,
+                "detail": "summary speaks to the viewer"
+              },
+              {
+                "kind": "uuid",
+                "passed": true,
+                "detail": "no UUIDs in user-facing copy"
+              },
+              {
+                "kind": "label",
+                "passed": true,
+                "detail": "no internal labels in user-facing copy"
+              },
+              {
+                "kind": "grounding",
+                "passed": true,
+                "detail": "judge: grounded in context"
+              }
+            ]
+          },
+          {
+            "passed": true,
+            "assertions": [
+              {
+                "kind": "non_empty",
+                "passed": true,
+                "detail": "headline, summary, and suggested action must be non-empty"
+              },
+              {
+                "kind": "voice",
+                "passed": true,
+                "detail": "summary speaks to the viewer"
+              },
+              {
+                "kind": "uuid",
+                "passed": true,
+                "detail": "no UUIDs in user-facing copy"
+              },
+              {
+                "kind": "label",
+                "passed": true,
+                "detail": "no internal labels in user-facing copy"
+              },
+              {
+                "kind": "grounding",
+                "passed": true,
+                "detail": "judge: grounded in context"
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "caseId": "no_leakage/identifiers-in-context",
+        "rule": "no_leakage",
+        "runs": 3,
+        "passes": 3,
+        "passRate": 1,
+        "flaky": false,
+        "runResults": [
+          {
+            "passed": true,
+            "assertions": [
+              {
+                "kind": "non_empty",
+                "passed": true,
+                "detail": "headline, summary, and suggested action must be non-empty"
+              },
+              {
+                "kind": "voice",
+                "passed": true,
+                "detail": "summary speaks to the viewer"
+              },
+              {
+                "kind": "uuid",
+                "passed": true,
+                "detail": "no UUIDs in user-facing copy"
+              },
+              {
+                "kind": "label",
+                "passed": true,
+                "detail": "no internal labels in user-facing copy"
+              }
+            ]
+          },
+          {
+            "passed": true,
+            "assertions": [
+              {
+                "kind": "non_empty",
+                "passed": true,
+                "detail": "headline, summary, and suggested action must be non-empty"
+              },
+              {
+                "kind": "voice",
+                "passed": true,
+                "detail": "summary speaks to the viewer"
+              },
+              {
+                "kind": "uuid",
+                "passed": true,
+                "detail": "no UUIDs in user-facing copy"
+              },
+              {
+                "kind": "label",
+                "passed": true,
+                "detail": "no internal labels in user-facing copy"
+              }
+            ]
+          },
+          {
+            "passed": true,
+            "assertions": [
+              {
+                "kind": "non_empty",
+                "passed": true,
+                "detail": "headline, summary, and suggested action must be non-empty"
+              },
+              {
+                "kind": "voice",
+                "passed": true,
+                "detail": "summary speaks to the viewer"
+              },
+              {
+                "kind": "uuid",
+                "passed": true,
+                "detail": "no UUIDs in user-facing copy"
+              },
+              {
+                "kind": "label",
+                "passed": true,
+                "detail": "no internal labels in user-facing copy"
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "caseId": "greeting/plain-prose",
+        "rule": "greeting",
+        "runs": 3,
+        "passes": 0,
+        "passRate": 0,
+        "flaky": false,
+        "runResults": [
+          {
+            "passed": false,
+            "assertions": [
+              {
+                "kind": "non_empty",
+                "passed": true,
+                "detail": "headline, summary, and suggested action must be non-empty"
+              },
+              {
+                "kind": "voice",
+                "passed": true,
+                "detail": "summary speaks to the viewer"
+              },
+              {
+                "kind": "uuid",
+                "passed": true,
+                "detail": "no UUIDs in user-facing copy"
+              },
+              {
+                "kind": "label",
+                "passed": true,
+                "detail": "no internal labels in user-facing copy"
+              },
+              {
+                "kind": "greeting_format",
+                "passed": false,
+                "detail": "greeting has markdown or a 'Hey Name,' prefix"
+              },
+              {
+                "kind": "greeting_length",
+                "passed": true,
+                "detail": "greeting is 209 chars (max 500)"
+              }
+            ]
+          },
+          {
+            "passed": false,
+            "assertions": [
+              {
+                "kind": "non_empty",
+                "passed": true,
+                "detail": "headline, summary, and suggested action must be non-empty"
+              },
+              {
+                "kind": "voice",
+                "passed": true,
+                "detail": "summary speaks to the viewer"
+              },
+              {
+                "kind": "uuid",
+                "passed": true,
+                "detail": "no UUIDs in user-facing copy"
+              },
+              {
+                "kind": "label",
+                "passed": true,
+                "detail": "no internal labels in user-facing copy"
+              },
+              {
+                "kind": "greeting_format",
+                "passed": false,
+                "detail": "greeting has markdown or a 'Hey Name,' prefix"
+              },
+              {
+                "kind": "greeting_length",
+                "passed": true,
+                "detail": "greeting is 223 chars (max 500)"
+              }
+            ]
+          },
+          {
+            "passed": false,
+            "assertions": [
+              {
+                "kind": "non_empty",
+                "passed": true,
+                "detail": "headline, summary, and suggested action must be non-empty"
+              },
+              {
+                "kind": "voice",
+                "passed": true,
+                "detail": "summary speaks to the viewer"
+              },
+              {
+                "kind": "uuid",
+                "passed": true,
+                "detail": "no UUIDs in user-facing copy"
+              },
+              {
+                "kind": "label",
+                "passed": true,
+                "detail": "no internal labels in user-facing copy"
+              },
+              {
+                "kind": "greeting_format",
+                "passed": false,
+                "detail": "greeting has markdown or a 'Hey Name,' prefix"
+              },
+              {
+                "kind": "greeting_length",
+                "passed": true,
+                "detail": "greeting is 223 chars (max 500)"
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "caseId": "grounding/specific-intents",
+        "rule": "grounding",
+        "runs": 3,
+        "passes": 3,
+        "passRate": 1,
+        "flaky": false,
+        "runResults": [
+          {
+            "passed": true,
+            "assertions": [
+              {
+                "kind": "non_empty",
+                "passed": true,
+                "detail": "headline, summary, and suggested action must be non-empty"
+              },
+              {
+                "kind": "voice",
+                "passed": true,
+                "detail": "summary speaks to the viewer"
+              },
+              {
+                "kind": "uuid",
+                "passed": true,
+                "detail": "no UUIDs in user-facing copy"
+              },
+              {
+                "kind": "label",
+                "passed": true,
+                "detail": "no internal labels in user-facing copy"
+              },
+              {
+                "kind": "grounding",
+                "passed": true,
+                "detail": "judge: grounded in context"
+              },
+              {
+                "kind": "tone",
+                "passed": true,
+                "detail": "judge: tone good"
+              }
+            ]
+          },
+          {
+            "passed": true,
+            "assertions": [
+              {
+                "kind": "non_empty",
+                "passed": true,
+                "detail": "headline, summary, and suggested action must be non-empty"
+              },
+              {
+                "kind": "voice",
+                "passed": true,
+                "detail": "summary speaks to the viewer"
+              },
+              {
+                "kind": "uuid",
+                "passed": true,
+                "detail": "no UUIDs in user-facing copy"
+              },
+              {
+                "kind": "label",
+                "passed": true,
+                "detail": "no internal labels in user-facing copy"
+              },
+              {
+                "kind": "grounding",
+                "passed": true,
+                "detail": "judge: grounded in context"
+              },
+              {
+                "kind": "tone",
+                "passed": true,
+                "detail": "judge: tone good"
+              }
+            ]
+          },
+          {
+            "passed": true,
+            "assertions": [
+              {
+                "kind": "non_empty",
+                "passed": true,
+                "detail": "headline, summary, and suggested action must be non-empty"
+              },
+              {
+                "kind": "voice",
+                "passed": true,
+                "detail": "summary speaks to the viewer"
+              },
+              {
+                "kind": "uuid",
+                "passed": true,
+                "detail": "no UUIDs in user-facing copy"
+              },
+              {
+                "kind": "label",
+                "passed": true,
+                "detail": "no internal labels in user-facing copy"
+              },
+              {
+                "kind": "grounding",
+                "passed": true,
+                "detail": "judge: grounded in context"
+              },
+              {
+                "kind": "tone",
+                "passed": true,
+                "detail": "judge: tone good"
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "caseId": "introducer_role/connecting-two-others",
+        "rule": "introducer_role",
+        "runs": 3,
+        "passes": 2,
+        "passRate": 0.6666666666666666,
+        "flaky": true,
+        "runResults": [
+          {
+            "passed": true,
+            "assertions": [
+              {
+                "kind": "non_empty",
+                "passed": true,
+                "detail": "headline, summary, and suggested action must be non-empty"
+              },
+              {
+                "kind": "voice",
+                "passed": true,
+                "detail": "summary speaks to the viewer"
+              },
+              {
+                "kind": "uuid",
+                "passed": true,
+                "detail": "no UUIDs in user-facing copy"
+              },
+              {
+                "kind": "label",
+                "passed": true,
+                "detail": "no internal labels in user-facing copy"
+              },
+              {
+                "kind": "framing",
+                "passed": true,
+                "detail": "judge: framing correct"
+              }
+            ]
+          },
+          {
+            "passed": false,
+            "assertions": [
+              {
+                "kind": "non_empty",
+                "passed": true,
+                "detail": "headline, summary, and suggested action must be non-empty"
+              },
+              {
+                "kind": "voice",
+                "passed": true,
+                "detail": "summary speaks to the viewer"
+              },
+              {
+                "kind": "uuid",
+                "passed": true,
+                "detail": "no UUIDs in user-facing copy"
+              },
+              {
+                "kind": "label",
+                "passed": true,
+                "detail": "no internal labels in user-facing copy"
+              },
+              {
+                "kind": "framing",
+                "passed": false,
+                "detail": "judge: framing wrong"
+              }
+            ]
+          },
+          {
+            "passed": true,
+            "assertions": [
+              {
+                "kind": "non_empty",
+                "passed": true,
+                "detail": "headline, summary, and suggested action must be non-empty"
+              },
+              {
+                "kind": "voice",
+                "passed": true,
+                "detail": "summary speaks to the viewer"
+              },
+              {
+                "kind": "uuid",
+                "passed": true,
+                "detail": "no UUIDs in user-facing copy"
+              },
+              {
+                "kind": "label",
+                "passed": true,
+                "detail": "no internal labels in user-facing copy"
+              },
+              {
+                "kind": "framing",
+                "passed": true,
+                "detail": "judge: framing correct"
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "caseId": "introducer_role/explicit-introduction",
+        "rule": "introducer_role",
+        "runs": 3,
+        "passes": 3,
+        "passRate": 1,
+        "flaky": false,
+        "runResults": [
+          {
+            "passed": true,
+            "assertions": [
+              {
+                "kind": "non_empty",
+                "passed": true,
+                "detail": "headline, summary, and suggested action must be non-empty"
+              },
+              {
+                "kind": "voice",
+                "passed": true,
+                "detail": "summary speaks to the viewer"
+              },
+              {
+                "kind": "uuid",
+                "passed": true,
+                "detail": "no UUIDs in user-facing copy"
+              },
+              {
+                "kind": "label",
+                "passed": true,
+                "detail": "no internal labels in user-facing copy"
+              },
+              {
+                "kind": "framing",
+                "passed": true,
+                "detail": "judge: framing correct"
+              }
+            ]
+          },
+          {
+            "passed": true,
+            "assertions": [
+              {
+                "kind": "non_empty",
+                "passed": true,
+                "detail": "headline, summary, and suggested action must be non-empty"
+              },
+              {
+                "kind": "voice",
+                "passed": true,
+                "detail": "summary speaks to the viewer"
+              },
+              {
+                "kind": "uuid",
+                "passed": true,
+                "detail": "no UUIDs in user-facing copy"
+              },
+              {
+                "kind": "label",
+                "passed": true,
+                "detail": "no internal labels in user-facing copy"
+              },
+              {
+                "kind": "framing",
+                "passed": true,
+                "detail": "judge: framing correct"
+              }
+            ]
+          },
+          {
+            "passed": true,
+            "assertions": [
+              {
+                "kind": "non_empty",
+                "passed": true,
+                "detail": "headline, summary, and suggested action must be non-empty"
+              },
+              {
+                "kind": "voice",
+                "passed": true,
+                "detail": "summary speaks to the viewer"
+              },
+              {
+                "kind": "uuid",
+                "passed": true,
+                "detail": "no UUIDs in user-facing copy"
+              },
+              {
+                "kind": "label",
+                "passed": true,
+                "detail": "no internal labels in user-facing copy"
+              },
+              {
+                "kind": "framing",
+                "passed": true,
+                "detail": "judge: framing correct"
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "caseId": "tone/compelling-not-analytical",
+        "rule": "tone",
+        "runs": 3,
+        "passes": 2,
+        "passRate": 0.6666666666666666,
+        "flaky": true,
+        "runResults": [
+          {
+            "passed": false,
+            "assertions": [
+              {
+                "kind": "non_empty",
+                "passed": true,
+                "detail": "headline, summary, and suggested action must be non-empty"
+              },
+              {
+                "kind": "voice",
+                "passed": true,
+                "detail": "summary speaks to the viewer"
+              },
+              {
+                "kind": "uuid",
+                "passed": true,
+                "detail": "no UUIDs in user-facing copy"
+              },
+              {
+                "kind": "label",
+                "passed": true,
+                "detail": "no internal labels in user-facing copy"
+              },
+              {
+                "kind": "tone",
+                "passed": false,
+                "detail": "judge: tone off"
+              }
+            ]
+          },
+          {
+            "passed": true,
+            "assertions": [
+              {
+                "kind": "non_empty",
+                "passed": true,
+                "detail": "headline, summary, and suggested action must be non-empty"
+              },
+              {
+                "kind": "voice",
+                "passed": true,
+                "detail": "summary speaks to the viewer"
+              },
+              {
+                "kind": "uuid",
+                "passed": true,
+                "detail": "no UUIDs in user-facing copy"
+              },
+              {
+                "kind": "label",
+                "passed": true,
+                "detail": "no internal labels in user-facing copy"
+              },
+              {
+                "kind": "tone",
+                "passed": true,
+                "detail": "judge: tone good"
+              }
+            ]
+          },
+          {
+            "passed": true,
+            "assertions": [
+              {
+                "kind": "non_empty",
+                "passed": true,
+                "detail": "headline, summary, and suggested action must be non-empty"
+              },
+              {
+                "kind": "voice",
+                "passed": true,
+                "detail": "summary speaks to the viewer"
+              },
+              {
+                "kind": "uuid",
+                "passed": true,
+                "detail": "no UUIDs in user-facing copy"
+              },
+              {
+                "kind": "label",
+                "passed": true,
+                "detail": "no internal labels in user-facing copy"
+              },
+              {
+                "kind": "tone",
+                "passed": true,
+                "detail": "judge: tone good"
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "caseId": "viewer_voice/patient-role",
+        "rule": "viewer_voice",
+        "runs": 3,
+        "passes": 3,
+        "passRate": 1,
+        "flaky": false,
+        "runResults": [
+          {
+            "passed": true,
+            "assertions": [
+              {
+                "kind": "non_empty",
+                "passed": true,
+                "detail": "headline, summary, and suggested action must be non-empty"
+              },
+              {
+                "kind": "voice",
+                "passed": true,
+                "detail": "summary speaks to the viewer"
+              },
+              {
+                "kind": "uuid",
+                "passed": true,
+                "detail": "no UUIDs in user-facing copy"
+              },
+              {
+                "kind": "label",
+                "passed": true,
+                "detail": "no internal labels in user-facing copy"
+              },
+              {
+                "kind": "grounding",
+                "passed": true,
+                "detail": "judge: grounded in context"
+              }
+            ]
+          },
+          {
+            "passed": true,
+            "assertions": [
+              {
+                "kind": "non_empty",
+                "passed": true,
+                "detail": "headline, summary, and suggested action must be non-empty"
+              },
+              {
+                "kind": "voice",
+                "passed": true,
+                "detail": "summary speaks to the viewer"
+              },
+              {
+                "kind": "uuid",
+                "passed": true,
+                "detail": "no UUIDs in user-facing copy"
+              },
+              {
+                "kind": "label",
+                "passed": true,
+                "detail": "no internal labels in user-facing copy"
+              },
+              {
+                "kind": "grounding",
+                "passed": true,
+                "detail": "judge: grounded in context"
+              }
+            ]
+          },
+          {
+            "passed": true,
+            "assertions": [
+              {
+                "kind": "non_empty",
+                "passed": true,
+                "detail": "headline, summary, and suggested action must be non-empty"
+              },
+              {
+                "kind": "voice",
+                "passed": true,
+                "detail": "summary speaks to the viewer"
+              },
+              {
+                "kind": "uuid",
+                "passed": true,
+                "detail": "no UUIDs in user-facing copy"
+              },
+              {
+                "kind": "label",
+                "passed": true,
+                "detail": "no internal labels in user-facing copy"
+              },
+              {
+                "kind": "grounding",
+                "passed": true,
+                "detail": "judge: grounded in context"
+              }
+            ]
+          }
+        ]
+      }
+    ]
+  }
 }

--- a/packages/protocol/eval/opportunity/opportunity.eval.ts
+++ b/packages/protocol/eval/opportunity/opportunity.eval.ts
@@ -10,7 +10,7 @@
  *   bun run eval:opportunity -- --tier 1               # one tier
  *   bun run eval:opportunity -- --list-cases           # print selected cases and exit
  *   bun run eval:opportunity -- --no-judge             # skip LLM grounding/framing/tone checks
- *   bun run eval:opportunity -- --update-baseline      # overwrite the committed baseline
+ *   bun run eval:opportunity -- --update-baseline --force # replace the committed baseline
  *   bun run eval:opportunity -- --report [path]        # write a full run report (incl. generated cards)
  *   bun run eval:opportunity -- --html [path]          # write a standalone HTML scorecard
  *   bun run eval:opportunity -- --rolling-baseline [d] # compare against recent runs (default 7d)
@@ -25,7 +25,7 @@ import path from "path";
 import { OpportunityPresenter } from "../../src/opportunity/opportunity.presenter.js";
 import { getModelName } from "../../src/shared/agent/model.config.js";
 import { assertLLM } from "../../src/shared/agent/tests/llm-assert.js";
-import { arg, buildScorecard, computeRollingBaseline, diffBaseline, flagValue, formatConsole, has, readBaseline, writeBaseline, writeRunReport } from "../shared/index.js";
+import { arg, assertEvalWritePlan, buildScorecard, computeRollingBaseline, diffBaseline, fingerprintEvalConfig, fingerprintEvalCorpus, flagValue, formatConsole, has, readBaseline, readEvalGitProvenance, writeBaseline, writeRunReport, type EvalRunMeta } from "../shared/index.js";
 import { CASES } from "./opportunity.cases.js";
 import { runCase } from "./opportunity.runner.js";
 import { scoreCase, type Judge } from "./opportunity.scorer.js";
@@ -33,6 +33,8 @@ import { writeHtmlReport } from "./opportunity.reporter.js";
 import { formatCaseList, hasRule, parseTier, selectCases } from "./opportunity.selection.js";
 import type { CaseResult, Scorecard } from "./opportunity.types.js";
 
+const HARNESS = "opportunity";
+const HARNESS_VERSION = "1";
 const DEFAULT_ALPHA = 0.05;
 const BASELINE_PATH = path.resolve(import.meta.dir, "baselines/opportunity.baseline.json");
 const RUNS_DIR = path.resolve(import.meta.dir, "runs");
@@ -56,7 +58,8 @@ Execution:
   --no-save                 Do not auto-save full-corpus run JSON for rolling-baseline fuel
 
 Baselines/reports:
-  --update-baseline         Overwrite committed baseline (full corpus only)
+  --update-baseline         Overwrite committed baseline (full corpus only; needs --force if one exists)
+  --force                   Consent to overwrite existing baseline/report/HTML outputs
   --rolling-baseline [days] Compare against recent run reports (default: 7)
   --report [path]           Write JSON scorecard
   --html [path]             Write standalone HTML scorecard
@@ -96,6 +99,7 @@ async function main(): Promise<void> {
   const report = has("--report");
   const html = has("--html");
   const noSave = has("--no-save");
+  const force = has("--force");
   const alpha = Number(arg("--alpha") ?? DEFAULT_ALPHA);
   if (!Number.isFinite(alpha) || alpha <= 0 || alpha >= 1) {
     console.error(`--alpha must be a number between 0 and 1 (got "${arg("--alpha")}")`);
@@ -134,10 +138,30 @@ async function main(): Promise<void> {
     process.exit(2);
   }
 
+  // Assert every declared output before running anything: no output may
+  // clobber an input, and existing destinations need explicit --force.
+  const explicitReportPath = report ? flagValue("--report") : undefined;
+  const explicitHtmlPath = html ? flagValue("--html") : undefined;
+  try {
+    await assertEvalWritePlan({
+      inputs: [BASELINE_PATH],
+      outputs: [
+        ...(updateBaseline ? [{ path: BASELINE_PATH, updatesInput: true }] : []),
+        ...(explicitReportPath ? [explicitReportPath] : []),
+        ...(explicitHtmlPath ? [explicitHtmlPath] : []),
+      ],
+      force,
+    });
+  } catch (err) {
+    console.error(err instanceof Error ? err.message : String(err));
+    process.exit(2);
+  }
+
   const presenter = new OpportunityPresenter();
   const model = getModelName("opportunityPresenter");
   console.log(`Running ${selected.length} case(s) × ${runs} run(s) against ${model}${noJudge ? " (judge off)" : ""}…`);
 
+  const startedAt = new Date().toISOString();
   const results: CaseResult[] = [];
   for (const c of selected) {
     process.stdout.write(`  ${c.id} … `);
@@ -148,10 +172,28 @@ async function main(): Promise<void> {
   }
 
   const scorecard = buildScorecard(results, { model, runs }) as Scorecard;
+  const completedAt = new Date().toISOString();
+  const filters: Record<string, string> = {};
+  if (ruleFilter) filters.rule = ruleFilter;
+  if (caseFilter) filters.case = caseFilter;
+  if (tierFilter !== undefined) filters.tier = String(tierFilter);
+  const models = [...new Set([model])];
+  const meta: EvalRunMeta = {
+    harness: HARNESS,
+    harnessVersion: HARNESS_VERSION,
+    models,
+    runs,
+    selection: { fullCorpus, filters },
+    corpusFingerprint: fingerprintEvalCorpus(selected),
+    configFingerprint: fingerprintEvalConfig({ runs, alpha, judge: !noJudge, filters, models }),
+    git: readEvalGitProvenance(import.meta.dir),
+    startedAt,
+    completedAt,
+  };
   const baseline =
     rollingBaselineDays !== null
       ? await computeRollingBaseline(RUNS_DIR, rollingBaselineDays)
-      : await readBaseline<Scorecard>(BASELINE_PATH);
+      : await readBaseline<Scorecard>(BASELINE_PATH, { harness: HARNESS });
   const { regressions, skippedCaseIds } = diffBaseline(scorecard, baseline, alpha);
 
   if (rollingBaselineDays !== null) {
@@ -166,6 +208,8 @@ async function main(): Promise<void> {
 
   if (updateBaseline) {
     await writeBaseline(BASELINE_PATH, scorecard, {
+      meta,
+      force,
       leanCase: (c) => ({ ...c, runResults: c.runResults.map(({ detail: _detail, ...rest }) => rest) }),
     });
     console.log(`\nBaseline updated at ${BASELINE_PATH}`);
@@ -173,13 +217,14 @@ async function main(): Promise<void> {
 
   const stamp = new Date().toISOString().replace(/[:.]/g, "-");
   const autoRunPath = path.resolve(RUNS_DIR, `${stamp}.json`);
-  if (fullCorpus && !noSave) {
-    await writeRunReport(autoRunPath, scorecard);
+  const autoSaved = fullCorpus && !noSave;
+  if (autoSaved) {
+    await writeRunReport(autoRunPath, scorecard, { meta });
   }
 
   if (report) {
     const reportPath = flagValue("--report") ?? autoRunPath;
-    if (reportPath !== autoRunPath) await writeRunReport(reportPath, scorecard);
+    if (!(autoSaved && reportPath === autoRunPath)) await writeRunReport(reportPath, scorecard, { meta, force });
     console.log(`\nRun report written to ${reportPath}`);
   }
 

--- a/packages/protocol/eval/premise/README.md
+++ b/packages/protocol/eval/premise/README.md
@@ -21,7 +21,7 @@ bun run eval:premise -- --case atomicity/      # one case or id prefix
 bun run eval:premise -- --tier 1               # one tier
 bun run eval:premise -- --list-cases           # print selected cases and exit
 bun run eval:premise -- --no-judge             # skip LLM coverage/exclusion/reasoning checks (free)
-bun run eval:premise -- --update-baseline      # overwrite the committed baseline
+bun run eval:premise -- --update-baseline --force # replace the committed baseline
 bun run eval:premise -- --report [path]        # write a full run report incl. agent output
 bun run eval:premise -- --html [path]          # write a standalone HTML scorecard
 bun run eval:premise -- --rolling-baseline [d] # compare against trailing run average (default 7d)
@@ -54,7 +54,7 @@ Append a `PremiseCase` to `CASES` in `premise.cases.ts`. Set `component`
 (`decompose` | `analyze`), `rule`, `tier` (1 surgical, 2 realistic), `input`, and the
 component-specific `expect`. Prefer deterministic expectations; reach for judged
 `mustCover` / `mustNotContain` / `reasoningCriteria` only when a code check can't express
-the expectation. Re-run with `--update-baseline` after an intentional change.
+the expectation. Re-run with `--update-baseline --force` after an intentional change.
 
 ## Layout
 

--- a/packages/protocol/eval/premise/baselines/premise.baseline.json
+++ b/packages/protocol/eval/premise/baselines/premise.baseline.json
@@ -1,640 +1,671 @@
 {
-  "generatedAt": "2026-06-16T15:27:23.785Z",
-  "model": "google/gemini-2.5-flash / google/gemini-2.5-flash",
-  "runs": 3,
-  "aggregatePassRate": 1,
-  "rules": [
-    {
-      "rule": "atomicity",
-      "caseCount": 2,
-      "passRate": 1
-    },
-    {
-      "rule": "tier_classification",
-      "caseCount": 1,
-      "passRate": 1
-    },
-    {
-      "rule": "intent_exclusion",
-      "caseCount": 1,
-      "passRate": 1
-    },
-    {
-      "rule": "empty_input",
-      "caseCount": 1,
-      "passRate": 1
-    },
-    {
-      "rule": "speech_act",
-      "caseCount": 2,
-      "passRate": 1
-    },
-    {
-      "rule": "felicity_calibration",
-      "caseCount": 2,
-      "passRate": 1
-    },
-    {
-      "rule": "entropy",
-      "caseCount": 1,
-      "passRate": 1
-    }
+  "artifactType": "index-eval/baseline",
+  "schemaVersion": 1,
+  "harness": "premise",
+  "harnessVersion": "1",
+  "source": "legacy-migration",
+  "createdAt": "2026-06-16T15:27:23.785Z",
+  "startedAt": "2026-06-16T15:27:23.785Z",
+  "completedAt": "2026-06-16T15:27:23.785Z",
+  "models": [
+    "google/gemini-2.5-flash"
   ],
-  "cases": [
-    {
-      "caseId": "atomicity/compound-split",
-      "rule": "atomicity",
-      "runs": 3,
-      "passes": 3,
-      "passRate": 1,
-      "flaky": false,
-      "runResults": [
-        {
-          "passed": true,
-          "assertions": [
-            {
-              "kind": "count",
-              "passed": true,
-              "detail": "expected 4–7 premises, got 5"
-            },
-            {
-              "kind": "first_person",
-              "passed": true,
-              "detail": "all premises first-person"
-            },
-            {
-              "kind": "coverage",
-              "passed": true,
-              "detail": "judge: all facts covered"
-            }
-          ]
-        },
-        {
-          "passed": true,
-          "assertions": [
-            {
-              "kind": "count",
-              "passed": true,
-              "detail": "expected 4–7 premises, got 5"
-            },
-            {
-              "kind": "first_person",
-              "passed": true,
-              "detail": "all premises first-person"
-            },
-            {
-              "kind": "coverage",
-              "passed": true,
-              "detail": "judge: all facts covered"
-            }
-          ]
-        },
-        {
-          "passed": true,
-          "assertions": [
-            {
-              "kind": "count",
-              "passed": true,
-              "detail": "expected 4–7 premises, got 5"
-            },
-            {
-              "kind": "first_person",
-              "passed": true,
-              "detail": "all premises first-person"
-            },
-            {
-              "kind": "coverage",
-              "passed": true,
-              "detail": "judge: all facts covered"
-            }
-          ]
-        }
-      ]
-    },
-    {
-      "caseId": "atomicity/third-person-to-first",
-      "rule": "atomicity",
-      "runs": 3,
-      "passes": 3,
-      "passRate": 1,
-      "flaky": false,
-      "runResults": [
-        {
-          "passed": true,
-          "assertions": [
-            {
-              "kind": "count",
-              "passed": true,
-              "detail": "expected 3–6 premises, got 4"
-            },
-            {
-              "kind": "first_person",
-              "passed": true,
-              "detail": "all premises first-person"
-            },
-            {
-              "kind": "coverage",
-              "passed": true,
-              "detail": "judge: all facts covered"
-            }
-          ]
-        },
-        {
-          "passed": true,
-          "assertions": [
-            {
-              "kind": "count",
-              "passed": true,
-              "detail": "expected 3–6 premises, got 4"
-            },
-            {
-              "kind": "first_person",
-              "passed": true,
-              "detail": "all premises first-person"
-            },
-            {
-              "kind": "coverage",
-              "passed": true,
-              "detail": "judge: all facts covered"
-            }
-          ]
-        },
-        {
-          "passed": true,
-          "assertions": [
-            {
-              "kind": "count",
-              "passed": true,
-              "detail": "expected 3–6 premises, got 4"
-            },
-            {
-              "kind": "first_person",
-              "passed": true,
-              "detail": "all premises first-person"
-            },
-            {
-              "kind": "coverage",
-              "passed": true,
-              "detail": "judge: all facts covered"
-            }
-          ]
-        }
-      ]
-    },
-    {
-      "caseId": "tier_classification/founder-raising",
-      "rule": "tier_classification",
-      "runs": 3,
-      "passes": 3,
-      "passRate": 1,
-      "flaky": false,
-      "runResults": [
-        {
-          "passed": true,
-          "assertions": [
-            {
-              "kind": "count",
-              "passed": true,
-              "detail": "expected 3–∞ premises, got 4"
-            },
-            {
-              "kind": "tier",
-              "passed": true,
-              "detail": "expected ≥2 assertive, got 3"
-            },
-            {
-              "kind": "tier",
-              "passed": true,
-              "detail": "expected ≥1 contextual, got 1"
-            },
-            {
-              "kind": "first_person",
-              "passed": true,
-              "detail": "all premises first-person"
-            },
-            {
-              "kind": "coverage",
-              "passed": true,
-              "detail": "judge: all facts covered"
-            }
-          ]
-        },
-        {
-          "passed": true,
-          "assertions": [
-            {
-              "kind": "count",
-              "passed": true,
-              "detail": "expected 3–∞ premises, got 4"
-            },
-            {
-              "kind": "tier",
-              "passed": true,
-              "detail": "expected ≥2 assertive, got 3"
-            },
-            {
-              "kind": "tier",
-              "passed": true,
-              "detail": "expected ≥1 contextual, got 1"
-            },
-            {
-              "kind": "first_person",
-              "passed": true,
-              "detail": "all premises first-person"
-            },
-            {
-              "kind": "coverage",
-              "passed": true,
-              "detail": "judge: all facts covered"
-            }
-          ]
-        },
-        {
-          "passed": true,
-          "assertions": [
-            {
-              "kind": "count",
-              "passed": true,
-              "detail": "expected 3–∞ premises, got 4"
-            },
-            {
-              "kind": "tier",
-              "passed": true,
-              "detail": "expected ≥2 assertive, got 3"
-            },
-            {
-              "kind": "tier",
-              "passed": true,
-              "detail": "expected ≥1 contextual, got 1"
-            },
-            {
-              "kind": "first_person",
-              "passed": true,
-              "detail": "all premises first-person"
-            },
-            {
-              "kind": "coverage",
-              "passed": true,
-              "detail": "judge: all facts covered"
-            }
-          ]
-        }
-      ]
-    },
-    {
-      "caseId": "intent_exclusion/skip-desires",
-      "rule": "intent_exclusion",
-      "runs": 3,
-      "passes": 3,
-      "passRate": 1,
-      "flaky": false,
-      "runResults": [
-        {
-          "passed": true,
-          "assertions": [
-            {
-              "kind": "count",
-              "passed": true,
-              "detail": "expected 2–4 premises, got 2"
-            },
-            {
-              "kind": "first_person",
-              "passed": true,
-              "detail": "all premises first-person"
-            },
-            {
-              "kind": "coverage",
-              "passed": true,
-              "detail": "judge: all facts covered"
-            },
-            {
-              "kind": "exclusion",
-              "passed": true,
-              "detail": "judge: excluded content absent"
-            }
-          ]
-        },
-        {
-          "passed": true,
-          "assertions": [
-            {
-              "kind": "count",
-              "passed": true,
-              "detail": "expected 2–4 premises, got 2"
-            },
-            {
-              "kind": "first_person",
-              "passed": true,
-              "detail": "all premises first-person"
-            },
-            {
-              "kind": "coverage",
-              "passed": true,
-              "detail": "judge: all facts covered"
-            },
-            {
-              "kind": "exclusion",
-              "passed": true,
-              "detail": "judge: excluded content absent"
-            }
-          ]
-        },
-        {
-          "passed": true,
-          "assertions": [
-            {
-              "kind": "count",
-              "passed": true,
-              "detail": "expected 2–4 premises, got 2"
-            },
-            {
-              "kind": "first_person",
-              "passed": true,
-              "detail": "all premises first-person"
-            },
-            {
-              "kind": "coverage",
-              "passed": true,
-              "detail": "judge: all facts covered"
-            },
-            {
-              "kind": "exclusion",
-              "passed": true,
-              "detail": "judge: excluded content absent"
-            }
-          ]
-        }
-      ]
-    },
-    {
-      "caseId": "empty_input/greeting",
-      "rule": "empty_input",
-      "runs": 3,
-      "passes": 3,
-      "passRate": 1,
-      "flaky": false,
-      "runResults": [
-        {
-          "passed": true,
-          "assertions": [
-            {
-              "kind": "empty",
-              "passed": true,
-              "detail": "expected no premises, got 0"
-            }
-          ]
-        },
-        {
-          "passed": true,
-          "assertions": [
-            {
-              "kind": "empty",
-              "passed": true,
-              "detail": "expected no premises, got 0"
-            }
-          ]
-        },
-        {
-          "passed": true,
-          "assertions": [
-            {
-              "kind": "empty",
-              "passed": true,
-              "detail": "expected no premises, got 0"
-            }
-          ]
-        }
-      ]
-    },
-    {
-      "caseId": "speech_act/declarative-identity",
-      "rule": "speech_act",
-      "runs": 3,
-      "passes": 3,
-      "passRate": 1,
-      "flaky": false,
-      "runResults": [
-        {
-          "passed": true,
-          "assertions": [
-            {
-              "kind": "speech_act",
-              "passed": true,
-              "detail": "expected DECLARATIVE, got DECLARATIVE"
-            }
-          ]
-        },
-        {
-          "passed": true,
-          "assertions": [
-            {
-              "kind": "speech_act",
-              "passed": true,
-              "detail": "expected DECLARATIVE, got DECLARATIVE"
-            }
-          ]
-        },
-        {
-          "passed": true,
-          "assertions": [
-            {
-              "kind": "speech_act",
-              "passed": true,
-              "detail": "expected DECLARATIVE, got DECLARATIVE"
-            }
-          ]
-        }
-      ]
-    },
-    {
-      "caseId": "speech_act/assertive-capability",
-      "rule": "speech_act",
-      "runs": 3,
-      "passes": 3,
-      "passRate": 1,
-      "flaky": false,
-      "runResults": [
-        {
-          "passed": true,
-          "assertions": [
-            {
-              "kind": "speech_act",
-              "passed": true,
-              "detail": "expected ASSERTIVE, got ASSERTIVE"
-            }
-          ]
-        },
-        {
-          "passed": true,
-          "assertions": [
-            {
-              "kind": "speech_act",
-              "passed": true,
-              "detail": "expected ASSERTIVE, got ASSERTIVE"
-            }
-          ]
-        },
-        {
-          "passed": true,
-          "assertions": [
-            {
-              "kind": "speech_act",
-              "passed": true,
-              "detail": "expected ASSERTIVE, got ASSERTIVE"
-            }
-          ]
-        }
-      ]
-    },
-    {
-      "caseId": "felicity_calibration/specific-high-clarity",
-      "rule": "felicity_calibration",
-      "runs": 3,
-      "passes": 3,
-      "passRate": 1,
-      "flaky": false,
-      "runResults": [
-        {
-          "passed": true,
-          "assertions": [
-            {
-              "kind": "clarity",
-              "passed": true,
-              "detail": "expected clarity in [65,100], got 100"
-            },
-            {
-              "kind": "entropy",
-              "passed": true,
-              "detail": "expected entropy in [0,0.45], got 0.05"
-            }
-          ]
-        },
-        {
-          "passed": true,
-          "assertions": [
-            {
-              "kind": "clarity",
-              "passed": true,
-              "detail": "expected clarity in [65,100], got 100"
-            },
-            {
-              "kind": "entropy",
-              "passed": true,
-              "detail": "expected entropy in [0,0.45], got 0"
-            }
-          ]
-        },
-        {
-          "passed": true,
-          "assertions": [
-            {
-              "kind": "clarity",
-              "passed": true,
-              "detail": "expected clarity in [65,100], got 100"
-            },
-            {
-              "kind": "entropy",
-              "passed": true,
-              "detail": "expected entropy in [0,0.45], got 0.05"
-            }
-          ]
-        }
-      ]
-    },
-    {
-      "caseId": "felicity_calibration/grandiose-low-authority",
-      "rule": "felicity_calibration",
-      "runs": 3,
-      "passes": 3,
-      "passRate": 1,
-      "flaky": false,
-      "runResults": [
-        {
-          "passed": true,
-          "assertions": [
-            {
-              "kind": "authority",
-              "passed": true,
-              "detail": "expected authority in [0,45], got 0"
-            }
-          ]
-        },
-        {
-          "passed": true,
-          "assertions": [
-            {
-              "kind": "authority",
-              "passed": true,
-              "detail": "expected authority in [0,45], got 0"
-            }
-          ]
-        },
-        {
-          "passed": true,
-          "assertions": [
-            {
-              "kind": "authority",
-              "passed": true,
-              "detail": "expected authority in [0,45], got 0"
-            }
-          ]
-        }
-      ]
-    },
-    {
-      "caseId": "entropy/vague-high-entropy",
-      "rule": "entropy",
-      "runs": 3,
-      "passes": 3,
-      "passRate": 1,
-      "flaky": false,
-      "runResults": [
-        {
-          "passed": true,
-          "assertions": [
-            {
-              "kind": "clarity",
-              "passed": true,
-              "detail": "expected clarity in [0,45], got 20"
-            },
-            {
-              "kind": "entropy",
-              "passed": true,
-              "detail": "expected entropy in [0.6,1], got 1"
-            }
-          ]
-        },
-        {
-          "passed": true,
-          "assertions": [
-            {
-              "kind": "clarity",
-              "passed": true,
-              "detail": "expected clarity in [0,45], got 5"
-            },
-            {
-              "kind": "entropy",
-              "passed": true,
-              "detail": "expected entropy in [0.6,1], got 0.99"
-            }
-          ]
-        },
-        {
-          "passed": true,
-          "assertions": [
-            {
-              "kind": "clarity",
-              "passed": true,
-              "detail": "expected clarity in [0,45], got 20"
-            },
-            {
-              "kind": "entropy",
-              "passed": true,
-              "detail": "expected entropy in [0.6,1], got 1"
-            }
-          ]
-        }
-      ]
-    }
-  ]
+  "runs": 3,
+  "selection": {
+    "fullCorpus": true,
+    "filters": {}
+  },
+  "corpusFingerprint": "unavailable-legacy-migration",
+  "configFingerprint": "unavailable-legacy-migration",
+  "git": {
+    "revision": "unknown",
+    "dirty": null
+  },
+  "completeness": {
+    "caseCount": 10,
+    "ruleCount": 7,
+    "totalRuns": 30,
+    "totalPasses": 30,
+    "flakyCaseCount": 0
+  },
+  "payload": {
+    "generatedAt": "2026-06-16T15:27:23.785Z",
+    "model": "google/gemini-2.5-flash / google/gemini-2.5-flash",
+    "runs": 3,
+    "aggregatePassRate": 1,
+    "rules": [
+      {
+        "rule": "atomicity",
+        "caseCount": 2,
+        "passRate": 1
+      },
+      {
+        "rule": "tier_classification",
+        "caseCount": 1,
+        "passRate": 1
+      },
+      {
+        "rule": "intent_exclusion",
+        "caseCount": 1,
+        "passRate": 1
+      },
+      {
+        "rule": "empty_input",
+        "caseCount": 1,
+        "passRate": 1
+      },
+      {
+        "rule": "speech_act",
+        "caseCount": 2,
+        "passRate": 1
+      },
+      {
+        "rule": "felicity_calibration",
+        "caseCount": 2,
+        "passRate": 1
+      },
+      {
+        "rule": "entropy",
+        "caseCount": 1,
+        "passRate": 1
+      }
+    ],
+    "cases": [
+      {
+        "caseId": "atomicity/compound-split",
+        "rule": "atomicity",
+        "runs": 3,
+        "passes": 3,
+        "passRate": 1,
+        "flaky": false,
+        "runResults": [
+          {
+            "passed": true,
+            "assertions": [
+              {
+                "kind": "count",
+                "passed": true,
+                "detail": "expected 4–7 premises, got 5"
+              },
+              {
+                "kind": "first_person",
+                "passed": true,
+                "detail": "all premises first-person"
+              },
+              {
+                "kind": "coverage",
+                "passed": true,
+                "detail": "judge: all facts covered"
+              }
+            ]
+          },
+          {
+            "passed": true,
+            "assertions": [
+              {
+                "kind": "count",
+                "passed": true,
+                "detail": "expected 4–7 premises, got 5"
+              },
+              {
+                "kind": "first_person",
+                "passed": true,
+                "detail": "all premises first-person"
+              },
+              {
+                "kind": "coverage",
+                "passed": true,
+                "detail": "judge: all facts covered"
+              }
+            ]
+          },
+          {
+            "passed": true,
+            "assertions": [
+              {
+                "kind": "count",
+                "passed": true,
+                "detail": "expected 4–7 premises, got 5"
+              },
+              {
+                "kind": "first_person",
+                "passed": true,
+                "detail": "all premises first-person"
+              },
+              {
+                "kind": "coverage",
+                "passed": true,
+                "detail": "judge: all facts covered"
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "caseId": "atomicity/third-person-to-first",
+        "rule": "atomicity",
+        "runs": 3,
+        "passes": 3,
+        "passRate": 1,
+        "flaky": false,
+        "runResults": [
+          {
+            "passed": true,
+            "assertions": [
+              {
+                "kind": "count",
+                "passed": true,
+                "detail": "expected 3–6 premises, got 4"
+              },
+              {
+                "kind": "first_person",
+                "passed": true,
+                "detail": "all premises first-person"
+              },
+              {
+                "kind": "coverage",
+                "passed": true,
+                "detail": "judge: all facts covered"
+              }
+            ]
+          },
+          {
+            "passed": true,
+            "assertions": [
+              {
+                "kind": "count",
+                "passed": true,
+                "detail": "expected 3–6 premises, got 4"
+              },
+              {
+                "kind": "first_person",
+                "passed": true,
+                "detail": "all premises first-person"
+              },
+              {
+                "kind": "coverage",
+                "passed": true,
+                "detail": "judge: all facts covered"
+              }
+            ]
+          },
+          {
+            "passed": true,
+            "assertions": [
+              {
+                "kind": "count",
+                "passed": true,
+                "detail": "expected 3–6 premises, got 4"
+              },
+              {
+                "kind": "first_person",
+                "passed": true,
+                "detail": "all premises first-person"
+              },
+              {
+                "kind": "coverage",
+                "passed": true,
+                "detail": "judge: all facts covered"
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "caseId": "tier_classification/founder-raising",
+        "rule": "tier_classification",
+        "runs": 3,
+        "passes": 3,
+        "passRate": 1,
+        "flaky": false,
+        "runResults": [
+          {
+            "passed": true,
+            "assertions": [
+              {
+                "kind": "count",
+                "passed": true,
+                "detail": "expected 3–∞ premises, got 4"
+              },
+              {
+                "kind": "tier",
+                "passed": true,
+                "detail": "expected ≥2 assertive, got 3"
+              },
+              {
+                "kind": "tier",
+                "passed": true,
+                "detail": "expected ≥1 contextual, got 1"
+              },
+              {
+                "kind": "first_person",
+                "passed": true,
+                "detail": "all premises first-person"
+              },
+              {
+                "kind": "coverage",
+                "passed": true,
+                "detail": "judge: all facts covered"
+              }
+            ]
+          },
+          {
+            "passed": true,
+            "assertions": [
+              {
+                "kind": "count",
+                "passed": true,
+                "detail": "expected 3–∞ premises, got 4"
+              },
+              {
+                "kind": "tier",
+                "passed": true,
+                "detail": "expected ≥2 assertive, got 3"
+              },
+              {
+                "kind": "tier",
+                "passed": true,
+                "detail": "expected ≥1 contextual, got 1"
+              },
+              {
+                "kind": "first_person",
+                "passed": true,
+                "detail": "all premises first-person"
+              },
+              {
+                "kind": "coverage",
+                "passed": true,
+                "detail": "judge: all facts covered"
+              }
+            ]
+          },
+          {
+            "passed": true,
+            "assertions": [
+              {
+                "kind": "count",
+                "passed": true,
+                "detail": "expected 3–∞ premises, got 4"
+              },
+              {
+                "kind": "tier",
+                "passed": true,
+                "detail": "expected ≥2 assertive, got 3"
+              },
+              {
+                "kind": "tier",
+                "passed": true,
+                "detail": "expected ≥1 contextual, got 1"
+              },
+              {
+                "kind": "first_person",
+                "passed": true,
+                "detail": "all premises first-person"
+              },
+              {
+                "kind": "coverage",
+                "passed": true,
+                "detail": "judge: all facts covered"
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "caseId": "intent_exclusion/skip-desires",
+        "rule": "intent_exclusion",
+        "runs": 3,
+        "passes": 3,
+        "passRate": 1,
+        "flaky": false,
+        "runResults": [
+          {
+            "passed": true,
+            "assertions": [
+              {
+                "kind": "count",
+                "passed": true,
+                "detail": "expected 2–4 premises, got 2"
+              },
+              {
+                "kind": "first_person",
+                "passed": true,
+                "detail": "all premises first-person"
+              },
+              {
+                "kind": "coverage",
+                "passed": true,
+                "detail": "judge: all facts covered"
+              },
+              {
+                "kind": "exclusion",
+                "passed": true,
+                "detail": "judge: excluded content absent"
+              }
+            ]
+          },
+          {
+            "passed": true,
+            "assertions": [
+              {
+                "kind": "count",
+                "passed": true,
+                "detail": "expected 2–4 premises, got 2"
+              },
+              {
+                "kind": "first_person",
+                "passed": true,
+                "detail": "all premises first-person"
+              },
+              {
+                "kind": "coverage",
+                "passed": true,
+                "detail": "judge: all facts covered"
+              },
+              {
+                "kind": "exclusion",
+                "passed": true,
+                "detail": "judge: excluded content absent"
+              }
+            ]
+          },
+          {
+            "passed": true,
+            "assertions": [
+              {
+                "kind": "count",
+                "passed": true,
+                "detail": "expected 2–4 premises, got 2"
+              },
+              {
+                "kind": "first_person",
+                "passed": true,
+                "detail": "all premises first-person"
+              },
+              {
+                "kind": "coverage",
+                "passed": true,
+                "detail": "judge: all facts covered"
+              },
+              {
+                "kind": "exclusion",
+                "passed": true,
+                "detail": "judge: excluded content absent"
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "caseId": "empty_input/greeting",
+        "rule": "empty_input",
+        "runs": 3,
+        "passes": 3,
+        "passRate": 1,
+        "flaky": false,
+        "runResults": [
+          {
+            "passed": true,
+            "assertions": [
+              {
+                "kind": "empty",
+                "passed": true,
+                "detail": "expected no premises, got 0"
+              }
+            ]
+          },
+          {
+            "passed": true,
+            "assertions": [
+              {
+                "kind": "empty",
+                "passed": true,
+                "detail": "expected no premises, got 0"
+              }
+            ]
+          },
+          {
+            "passed": true,
+            "assertions": [
+              {
+                "kind": "empty",
+                "passed": true,
+                "detail": "expected no premises, got 0"
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "caseId": "speech_act/declarative-identity",
+        "rule": "speech_act",
+        "runs": 3,
+        "passes": 3,
+        "passRate": 1,
+        "flaky": false,
+        "runResults": [
+          {
+            "passed": true,
+            "assertions": [
+              {
+                "kind": "speech_act",
+                "passed": true,
+                "detail": "expected DECLARATIVE, got DECLARATIVE"
+              }
+            ]
+          },
+          {
+            "passed": true,
+            "assertions": [
+              {
+                "kind": "speech_act",
+                "passed": true,
+                "detail": "expected DECLARATIVE, got DECLARATIVE"
+              }
+            ]
+          },
+          {
+            "passed": true,
+            "assertions": [
+              {
+                "kind": "speech_act",
+                "passed": true,
+                "detail": "expected DECLARATIVE, got DECLARATIVE"
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "caseId": "speech_act/assertive-capability",
+        "rule": "speech_act",
+        "runs": 3,
+        "passes": 3,
+        "passRate": 1,
+        "flaky": false,
+        "runResults": [
+          {
+            "passed": true,
+            "assertions": [
+              {
+                "kind": "speech_act",
+                "passed": true,
+                "detail": "expected ASSERTIVE, got ASSERTIVE"
+              }
+            ]
+          },
+          {
+            "passed": true,
+            "assertions": [
+              {
+                "kind": "speech_act",
+                "passed": true,
+                "detail": "expected ASSERTIVE, got ASSERTIVE"
+              }
+            ]
+          },
+          {
+            "passed": true,
+            "assertions": [
+              {
+                "kind": "speech_act",
+                "passed": true,
+                "detail": "expected ASSERTIVE, got ASSERTIVE"
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "caseId": "felicity_calibration/specific-high-clarity",
+        "rule": "felicity_calibration",
+        "runs": 3,
+        "passes": 3,
+        "passRate": 1,
+        "flaky": false,
+        "runResults": [
+          {
+            "passed": true,
+            "assertions": [
+              {
+                "kind": "clarity",
+                "passed": true,
+                "detail": "expected clarity in [65,100], got 100"
+              },
+              {
+                "kind": "entropy",
+                "passed": true,
+                "detail": "expected entropy in [0,0.45], got 0.05"
+              }
+            ]
+          },
+          {
+            "passed": true,
+            "assertions": [
+              {
+                "kind": "clarity",
+                "passed": true,
+                "detail": "expected clarity in [65,100], got 100"
+              },
+              {
+                "kind": "entropy",
+                "passed": true,
+                "detail": "expected entropy in [0,0.45], got 0"
+              }
+            ]
+          },
+          {
+            "passed": true,
+            "assertions": [
+              {
+                "kind": "clarity",
+                "passed": true,
+                "detail": "expected clarity in [65,100], got 100"
+              },
+              {
+                "kind": "entropy",
+                "passed": true,
+                "detail": "expected entropy in [0,0.45], got 0.05"
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "caseId": "felicity_calibration/grandiose-low-authority",
+        "rule": "felicity_calibration",
+        "runs": 3,
+        "passes": 3,
+        "passRate": 1,
+        "flaky": false,
+        "runResults": [
+          {
+            "passed": true,
+            "assertions": [
+              {
+                "kind": "authority",
+                "passed": true,
+                "detail": "expected authority in [0,45], got 0"
+              }
+            ]
+          },
+          {
+            "passed": true,
+            "assertions": [
+              {
+                "kind": "authority",
+                "passed": true,
+                "detail": "expected authority in [0,45], got 0"
+              }
+            ]
+          },
+          {
+            "passed": true,
+            "assertions": [
+              {
+                "kind": "authority",
+                "passed": true,
+                "detail": "expected authority in [0,45], got 0"
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "caseId": "entropy/vague-high-entropy",
+        "rule": "entropy",
+        "runs": 3,
+        "passes": 3,
+        "passRate": 1,
+        "flaky": false,
+        "runResults": [
+          {
+            "passed": true,
+            "assertions": [
+              {
+                "kind": "clarity",
+                "passed": true,
+                "detail": "expected clarity in [0,45], got 20"
+              },
+              {
+                "kind": "entropy",
+                "passed": true,
+                "detail": "expected entropy in [0.6,1], got 1"
+              }
+            ]
+          },
+          {
+            "passed": true,
+            "assertions": [
+              {
+                "kind": "clarity",
+                "passed": true,
+                "detail": "expected clarity in [0,45], got 5"
+              },
+              {
+                "kind": "entropy",
+                "passed": true,
+                "detail": "expected entropy in [0.6,1], got 0.99"
+              }
+            ]
+          },
+          {
+            "passed": true,
+            "assertions": [
+              {
+                "kind": "clarity",
+                "passed": true,
+                "detail": "expected clarity in [0,45], got 20"
+              },
+              {
+                "kind": "entropy",
+                "passed": true,
+                "detail": "expected entropy in [0.6,1], got 1"
+              }
+            ]
+          }
+        ]
+      }
+    ]
+  }
 }

--- a/packages/protocol/eval/premise/premise.eval.ts
+++ b/packages/protocol/eval/premise/premise.eval.ts
@@ -11,7 +11,7 @@
  *   bun run eval:premise -- --tier 1               # one tier
  *   bun run eval:premise -- --list-cases           # print selected cases and exit
  *   bun run eval:premise -- --no-judge             # skip LLM coverage/exclusion/reasoning checks
- *   bun run eval:premise -- --update-baseline      # overwrite the committed baseline
+ *   bun run eval:premise -- --update-baseline --force # replace the committed baseline
  *   bun run eval:premise -- --report [path]        # write a full run report (incl. agent output)
  *   bun run eval:premise -- --html [path]          # write a standalone HTML scorecard
  *   bun run eval:premise -- --rolling-baseline [d] # compare against recent runs (default 7d)
@@ -27,7 +27,7 @@ import { PremiseAnalyzer } from "../../src/premise/premise.analyzer.js";
 import { PremiseDecomposer } from "../../src/premise/premise.decomposer.js";
 import { getModelName } from "../../src/shared/agent/model.config.js";
 import { assertLLM } from "../../src/shared/agent/tests/llm-assert.js";
-import { arg, buildScorecard, computeRollingBaseline, diffBaseline, flagValue, formatConsole, has, readBaseline, writeBaseline, writeRunReport } from "../shared/index.js";
+import { arg, assertEvalWritePlan, buildScorecard, computeRollingBaseline, diffBaseline, fingerprintEvalConfig, fingerprintEvalCorpus, flagValue, formatConsole, has, readBaseline, readEvalGitProvenance, writeBaseline, writeRunReport, type EvalRunMeta } from "../shared/index.js";
 import { CASES } from "./premise.cases.js";
 import { runCase } from "./premise.runner.js";
 import { scoreCase, type Judge } from "./premise.scorer.js";
@@ -35,6 +35,8 @@ import { writeHtmlReport } from "./premise.reporter.js";
 import { formatCaseList, hasRule, parseComponent, parseTier, selectCases } from "./premise.selection.js";
 import type { CaseResult, Scorecard } from "./premise.types.js";
 
+const HARNESS = "premise";
+const HARNESS_VERSION = "1";
 const DEFAULT_ALPHA = 0.05;
 const BASELINE_PATH = path.resolve(import.meta.dir, "baselines/premise.baseline.json");
 const RUNS_DIR = path.resolve(import.meta.dir, "runs");
@@ -59,7 +61,8 @@ Execution:
   --no-save                 Do not auto-save full-corpus run JSON for rolling-baseline fuel
 
 Baselines/reports:
-  --update-baseline         Overwrite committed baseline (full corpus only)
+  --update-baseline         Overwrite committed baseline (full corpus only; needs --force if one exists)
+  --force                   Consent to overwrite existing baseline/report/HTML outputs
   --rolling-baseline [days] Compare against recent run reports (default: 7)
   --report [path]           Write JSON scorecard
   --html [path]             Write standalone HTML scorecard
@@ -101,6 +104,7 @@ async function main(): Promise<void> {
   const report = has("--report");
   const html = has("--html");
   const noSave = has("--no-save");
+  const force = has("--force");
   const alpha = Number(arg("--alpha") ?? DEFAULT_ALPHA);
   if (!Number.isFinite(alpha) || alpha <= 0 || alpha >= 1) {
     console.error(`--alpha must be a number between 0 and 1 (got "${arg("--alpha")}")`);
@@ -139,10 +143,30 @@ async function main(): Promise<void> {
     process.exit(2);
   }
 
+  // Assert every declared output before running anything: no output may
+  // clobber an input, and existing destinations need explicit --force.
+  const explicitReportPath = report ? flagValue("--report") : undefined;
+  const explicitHtmlPath = html ? flagValue("--html") : undefined;
+  try {
+    await assertEvalWritePlan({
+      inputs: [BASELINE_PATH],
+      outputs: [
+        ...(updateBaseline ? [{ path: BASELINE_PATH, updatesInput: true }] : []),
+        ...(explicitReportPath ? [explicitReportPath] : []),
+        ...(explicitHtmlPath ? [explicitHtmlPath] : []),
+      ],
+      force,
+    });
+  } catch (err) {
+    console.error(err instanceof Error ? err.message : String(err));
+    process.exit(2);
+  }
+
   const deps = { decomposer: new PremiseDecomposer(), analyzer: new PremiseAnalyzer() };
   const model = `${getModelName("premiseDecomposer")} / ${getModelName("premiseAnalyzer")}`;
   console.log(`Running ${selected.length} case(s) × ${runs} run(s) against ${model}${noJudge ? " (judge off)" : ""}…`);
 
+  const startedAt = new Date().toISOString();
   const results: CaseResult[] = [];
   for (const c of selected) {
     process.stdout.write(`  ${c.id} … `);
@@ -153,10 +177,29 @@ async function main(): Promise<void> {
   }
 
   const scorecard = buildScorecard(results, { model, runs }) as Scorecard;
+  const completedAt = new Date().toISOString();
+  const filters: Record<string, string> = {};
+  if (ruleFilter) filters.rule = ruleFilter;
+  if (caseFilter) filters.case = caseFilter;
+  if (componentFilter) filters.component = componentFilter;
+  if (tierFilter !== undefined) filters.tier = String(tierFilter);
+  const models = [...new Set([getModelName("premiseDecomposer"), getModelName("premiseAnalyzer")])];
+  const meta: EvalRunMeta = {
+    harness: HARNESS,
+    harnessVersion: HARNESS_VERSION,
+    models,
+    runs,
+    selection: { fullCorpus, filters },
+    corpusFingerprint: fingerprintEvalCorpus(selected),
+    configFingerprint: fingerprintEvalConfig({ runs, alpha, judge: !noJudge, filters, models }),
+    git: readEvalGitProvenance(import.meta.dir),
+    startedAt,
+    completedAt,
+  };
   const baseline =
     rollingBaselineDays !== null
       ? await computeRollingBaseline(RUNS_DIR, rollingBaselineDays)
-      : await readBaseline<Scorecard>(BASELINE_PATH);
+      : await readBaseline<Scorecard>(BASELINE_PATH, { harness: HARNESS });
   const { regressions, skippedCaseIds } = diffBaseline(scorecard, baseline, alpha);
 
   if (rollingBaselineDays !== null) {
@@ -171,6 +214,8 @@ async function main(): Promise<void> {
 
   if (updateBaseline) {
     await writeBaseline(BASELINE_PATH, scorecard, {
+      meta,
+      force,
       leanCase: (c) => ({ ...c, runResults: c.runResults.map(({ detail: _detail, ...rest }) => rest) }),
     });
     console.log(`\nBaseline updated at ${BASELINE_PATH}`);
@@ -178,13 +223,14 @@ async function main(): Promise<void> {
 
   const stamp = new Date().toISOString().replace(/[:.]/g, "-");
   const autoRunPath = path.resolve(RUNS_DIR, `${stamp}.json`);
-  if (fullCorpus && !noSave) {
-    await writeRunReport(autoRunPath, scorecard);
+  const autoSaved = fullCorpus && !noSave;
+  if (autoSaved) {
+    await writeRunReport(autoRunPath, scorecard, { meta });
   }
 
   if (report) {
     const reportPath = flagValue("--report") ?? autoRunPath;
-    if (reportPath !== autoRunPath) await writeRunReport(reportPath, scorecard);
+    if (!(autoSaved && reportPath === autoRunPath)) await writeRunReport(reportPath, scorecard, { meta, force });
     console.log(`\nRun report written to ${reportPath}`);
   }
 

--- a/packages/protocol/eval/profile/README.md
+++ b/packages/protocol/eval/profile/README.md
@@ -15,7 +15,7 @@ bun run eval:profile -- --case extraction/     # one case or id prefix
 bun run eval:profile -- --tier 1               # one tier
 bun run eval:profile -- --list-cases           # print selected cases and exit
 bun run eval:profile -- --no-judge             # skip LLM coverage/apply/preserve checks (free)
-bun run eval:profile -- --update-baseline      # overwrite the committed baseline
+bun run eval:profile -- --update-baseline --force # replace the committed baseline
 bun run eval:profile -- --report [path]        # write a full run report incl. generated profiles
 bun run eval:profile -- --html [path]          # write a standalone HTML scorecard
 bun run eval:profile -- --rolling-baseline [d] # compare against trailing run average (default 7d)
@@ -46,7 +46,7 @@ realistic), the raw `input`, and `expect`. Prefer deterministic expectations; re
 judged `mustHaveSkills` / `mustApply` / `mustPreserve` / `reasoningCriteria` only when a
 code check can't express it. Privacy cases should feed contact identifiers in the input and
 rely on the default `privacy` assertion to prove they were redacted. Re-run with
-`--update-baseline` after an intentional change.
+`--update-baseline --force` after an intentional change.
 
 ## Layout
 

--- a/packages/protocol/eval/profile/baselines/profile.baseline.json
+++ b/packages/protocol/eval/profile/baselines/profile.baseline.json
@@ -1,790 +1,821 @@
 {
-  "generatedAt": "2026-06-16T15:32:16.555Z",
-  "model": "google/gemini-2.5-flash",
-  "runs": 3,
-  "aggregatePassRate": 1,
-  "rules": [
-    {
-      "rule": "extraction",
-      "caseCount": 2,
-      "passRate": 1
-    },
-    {
-      "rule": "location",
-      "caseCount": 1,
-      "passRate": 1
-    },
-    {
-      "rule": "privacy",
-      "caseCount": 3,
-      "passRate": 1
-    },
-    {
-      "rule": "skills_interests",
-      "caseCount": 1,
-      "passRate": 1
-    },
-    {
-      "rule": "update",
-      "caseCount": 1,
-      "passRate": 1
-    }
+  "artifactType": "index-eval/baseline",
+  "schemaVersion": 1,
+  "harness": "profile",
+  "harnessVersion": "1",
+  "source": "legacy-migration",
+  "createdAt": "2026-06-16T15:32:16.555Z",
+  "startedAt": "2026-06-16T15:32:16.555Z",
+  "completedAt": "2026-06-16T15:32:16.555Z",
+  "models": [
+    "google/gemini-2.5-flash"
   ],
-  "cases": [
-    {
-      "caseId": "extraction/clean-bio",
-      "rule": "extraction",
-      "runs": 3,
-      "passes": 3,
-      "passRate": 1,
-      "flaky": false,
-      "runResults": [
-        {
-          "passed": true,
-          "assertions": [
-            {
-              "kind": "name",
-              "passed": true,
-              "detail": "expected name to contain \"Ada\", got \"Ada Lovelace\""
-            },
-            {
-              "kind": "location",
-              "passed": true,
-              "detail": "expected location to contain \"London\", got \"London, UK\""
-            },
-            {
-              "kind": "privacy",
-              "passed": true,
-              "detail": "no PII in public fields"
-            },
-            {
-              "kind": "skills",
-              "passed": true,
-              "detail": "expected ≥2 skills, got 3"
-            },
-            {
-              "kind": "interests",
-              "passed": true,
-              "detail": "expected ≥1 interests, got 2"
-            },
-            {
-              "kind": "coverage_skills",
-              "passed": true,
-              "detail": "judge: skills covered"
-            }
-          ]
-        },
-        {
-          "passed": true,
-          "assertions": [
-            {
-              "kind": "name",
-              "passed": true,
-              "detail": "expected name to contain \"Ada\", got \"Ada Lovelace\""
-            },
-            {
-              "kind": "location",
-              "passed": true,
-              "detail": "expected location to contain \"London\", got \"London, UK\""
-            },
-            {
-              "kind": "privacy",
-              "passed": true,
-              "detail": "no PII in public fields"
-            },
-            {
-              "kind": "skills",
-              "passed": true,
-              "detail": "expected ≥2 skills, got 3"
-            },
-            {
-              "kind": "interests",
-              "passed": true,
-              "detail": "expected ≥1 interests, got 2"
-            },
-            {
-              "kind": "coverage_skills",
-              "passed": true,
-              "detail": "judge: skills covered"
-            }
-          ]
-        },
-        {
-          "passed": true,
-          "assertions": [
-            {
-              "kind": "name",
-              "passed": true,
-              "detail": "expected name to contain \"Ada\", got \"Ada Lovelace\""
-            },
-            {
-              "kind": "location",
-              "passed": true,
-              "detail": "expected location to contain \"London\", got \"London, UK\""
-            },
-            {
-              "kind": "privacy",
-              "passed": true,
-              "detail": "no PII in public fields"
-            },
-            {
-              "kind": "skills",
-              "passed": true,
-              "detail": "expected ≥2 skills, got 3"
-            },
-            {
-              "kind": "interests",
-              "passed": true,
-              "detail": "expected ≥1 interests, got 2"
-            },
-            {
-              "kind": "coverage_skills",
-              "passed": true,
-              "detail": "judge: skills covered"
-            }
-          ]
-        }
-      ]
-    },
-    {
-      "caseId": "extraction/scraped-blob",
-      "rule": "extraction",
-      "runs": 3,
-      "passes": 3,
-      "passRate": 1,
-      "flaky": false,
-      "runResults": [
-        {
-          "passed": true,
-          "assertions": [
-            {
-              "kind": "name",
-              "passed": true,
-              "detail": "expected name to contain \"Priya\", got \"Priya Nair\""
-            },
-            {
-              "kind": "location",
-              "passed": true,
-              "detail": "expected location to contain \"San Francisco\", got \"San Francisco Bay Area\""
-            },
-            {
-              "kind": "privacy",
-              "passed": true,
-              "detail": "no PII in public fields"
-            },
-            {
-              "kind": "skills",
-              "passed": true,
-              "detail": "expected ≥3 skills, got 4"
-            },
-            {
-              "kind": "coverage_skills",
-              "passed": true,
-              "detail": "judge: skills covered"
-            }
-          ]
-        },
-        {
-          "passed": true,
-          "assertions": [
-            {
-              "kind": "name",
-              "passed": true,
-              "detail": "expected name to contain \"Priya\", got \"Priya Nair\""
-            },
-            {
-              "kind": "location",
-              "passed": true,
-              "detail": "expected location to contain \"San Francisco\", got \"San Francisco Bay Area\""
-            },
-            {
-              "kind": "privacy",
-              "passed": true,
-              "detail": "no PII in public fields"
-            },
-            {
-              "kind": "skills",
-              "passed": true,
-              "detail": "expected ≥3 skills, got 5"
-            },
-            {
-              "kind": "coverage_skills",
-              "passed": true,
-              "detail": "judge: skills covered"
-            }
-          ]
-        },
-        {
-          "passed": true,
-          "assertions": [
-            {
-              "kind": "name",
-              "passed": true,
-              "detail": "expected name to contain \"Priya\", got \"Priya Nair\""
-            },
-            {
-              "kind": "location",
-              "passed": true,
-              "detail": "expected location to contain \"San Francisco\", got \"San Francisco Bay Area\""
-            },
-            {
-              "kind": "privacy",
-              "passed": true,
-              "detail": "no PII in public fields"
-            },
-            {
-              "kind": "skills",
-              "passed": true,
-              "detail": "expected ≥3 skills, got 6"
-            },
-            {
-              "kind": "coverage_skills",
-              "passed": true,
-              "detail": "judge: skills covered"
-            }
-          ]
-        }
-      ]
-    },
-    {
-      "caseId": "location/explicit-city",
-      "rule": "location",
-      "runs": 3,
-      "passes": 3,
-      "passRate": 1,
-      "flaky": false,
-      "runResults": [
-        {
-          "passed": true,
-          "assertions": [
-            {
-              "kind": "name",
-              "passed": true,
-              "detail": "expected name to contain \"Lars\", got \"Lars Berg\""
-            },
-            {
-              "kind": "location",
-              "passed": true,
-              "detail": "expected location to contain \"Berlin\", got \"Berlin, Germany\""
-            },
-            {
-              "kind": "privacy",
-              "passed": true,
-              "detail": "no PII in public fields"
-            }
-          ]
-        },
-        {
-          "passed": true,
-          "assertions": [
-            {
-              "kind": "name",
-              "passed": true,
-              "detail": "expected name to contain \"Lars\", got \"Lars Berg\""
-            },
-            {
-              "kind": "location",
-              "passed": true,
-              "detail": "expected location to contain \"Berlin\", got \"Berlin, Germany\""
-            },
-            {
-              "kind": "privacy",
-              "passed": true,
-              "detail": "no PII in public fields"
-            }
-          ]
-        },
-        {
-          "passed": true,
-          "assertions": [
-            {
-              "kind": "name",
-              "passed": true,
-              "detail": "expected name to contain \"Lars\", got \"Lars Berg\""
-            },
-            {
-              "kind": "location",
-              "passed": true,
-              "detail": "expected location to contain \"Berlin\", got \"Berlin, Germany\""
-            },
-            {
-              "kind": "privacy",
-              "passed": true,
-              "detail": "no PII in public fields"
-            }
-          ]
-        }
-      ]
-    },
-    {
-      "caseId": "privacy/email-and-phone",
-      "rule": "privacy",
-      "runs": 3,
-      "passes": 3,
-      "passRate": 1,
-      "flaky": false,
-      "runResults": [
-        {
-          "passed": true,
-          "assertions": [
-            {
-              "kind": "name",
-              "passed": true,
-              "detail": "expected name to contain \"John\", got \"John Park\""
-            },
-            {
-              "kind": "location",
-              "passed": true,
-              "detail": "expected location to contain \"Austin\", got \"Austin, TX\""
-            },
-            {
-              "kind": "privacy",
-              "passed": true,
-              "detail": "no PII in public fields"
-            },
-            {
-              "kind": "coverage_skills",
-              "passed": true,
-              "detail": "judge: skills covered"
-            }
-          ]
-        },
-        {
-          "passed": true,
-          "assertions": [
-            {
-              "kind": "name",
-              "passed": true,
-              "detail": "expected name to contain \"John\", got \"John Park\""
-            },
-            {
-              "kind": "location",
-              "passed": true,
-              "detail": "expected location to contain \"Austin\", got \"Austin, TX\""
-            },
-            {
-              "kind": "privacy",
-              "passed": true,
-              "detail": "no PII in public fields"
-            },
-            {
-              "kind": "coverage_skills",
-              "passed": true,
-              "detail": "judge: skills covered"
-            }
-          ]
-        },
-        {
-          "passed": true,
-          "assertions": [
-            {
-              "kind": "name",
-              "passed": true,
-              "detail": "expected name to contain \"John\", got \"John Park\""
-            },
-            {
-              "kind": "location",
-              "passed": true,
-              "detail": "expected location to contain \"Austin\", got \"Austin, TX\""
-            },
-            {
-              "kind": "privacy",
-              "passed": true,
-              "detail": "no PII in public fields"
-            },
-            {
-              "kind": "coverage_skills",
-              "passed": true,
-              "detail": "judge: skills covered"
-            }
-          ]
-        }
-      ]
-    },
-    {
-      "caseId": "privacy/contact-heavy",
-      "rule": "privacy",
-      "runs": 3,
-      "passes": 3,
-      "passRate": 1,
-      "flaky": false,
-      "runResults": [
-        {
-          "passed": true,
-          "assertions": [
-            {
-              "kind": "name",
-              "passed": true,
-              "detail": "expected name to contain \"Maria\", got \"Maria Gomez\""
-            },
-            {
-              "kind": "location",
-              "passed": true,
-              "detail": "expected location to contain \"New York\", got \"New York\""
-            },
-            {
-              "kind": "privacy",
-              "passed": true,
-              "detail": "no PII in public fields"
-            },
-            {
-              "kind": "skills",
-              "passed": true,
-              "detail": "expected ≥2 skills, got 3"
-            }
-          ]
-        },
-        {
-          "passed": true,
-          "assertions": [
-            {
-              "kind": "name",
-              "passed": true,
-              "detail": "expected name to contain \"Maria\", got \"Maria Gomez\""
-            },
-            {
-              "kind": "location",
-              "passed": true,
-              "detail": "expected location to contain \"New York\", got \"New York\""
-            },
-            {
-              "kind": "privacy",
-              "passed": true,
-              "detail": "no PII in public fields"
-            },
-            {
-              "kind": "skills",
-              "passed": true,
-              "detail": "expected ≥2 skills, got 3"
-            }
-          ]
-        },
-        {
-          "passed": true,
-          "assertions": [
-            {
-              "kind": "name",
-              "passed": true,
-              "detail": "expected name to contain \"Maria\", got \"Maria Gomez\""
-            },
-            {
-              "kind": "location",
-              "passed": true,
-              "detail": "expected location to contain \"New York\", got \"New York\""
-            },
-            {
-              "kind": "privacy",
-              "passed": true,
-              "detail": "no PII in public fields"
-            },
-            {
-              "kind": "skills",
-              "passed": true,
-              "detail": "expected ≥2 skills, got 3"
-            }
-          ]
-        }
-      ]
-    },
-    {
-      "caseId": "skills_interests/multi-skill",
-      "rule": "skills_interests",
-      "runs": 3,
-      "passes": 3,
-      "passRate": 1,
-      "flaky": false,
-      "runResults": [
-        {
-          "passed": true,
-          "assertions": [
-            {
-              "kind": "name",
-              "passed": true,
-              "detail": "expected name to contain \"Sam\", got \"Sam Okafor\""
-            },
-            {
-              "kind": "privacy",
-              "passed": true,
-              "detail": "no PII in public fields"
-            },
-            {
-              "kind": "skills",
-              "passed": true,
-              "detail": "expected ≥4 skills, got 6"
-            },
-            {
-              "kind": "interests",
-              "passed": true,
-              "detail": "expected ≥2 interests, got 3"
-            },
-            {
-              "kind": "coverage_skills",
-              "passed": true,
-              "detail": "judge: skills covered"
-            },
-            {
-              "kind": "coverage_interests",
-              "passed": true,
-              "detail": "judge: interests covered"
-            }
-          ]
-        },
-        {
-          "passed": true,
-          "assertions": [
-            {
-              "kind": "name",
-              "passed": true,
-              "detail": "expected name to contain \"Sam\", got \"Sam Okafor\""
-            },
-            {
-              "kind": "privacy",
-              "passed": true,
-              "detail": "no PII in public fields"
-            },
-            {
-              "kind": "skills",
-              "passed": true,
-              "detail": "expected ≥4 skills, got 5"
-            },
-            {
-              "kind": "interests",
-              "passed": true,
-              "detail": "expected ≥2 interests, got 3"
-            },
-            {
-              "kind": "coverage_skills",
-              "passed": true,
-              "detail": "judge: skills covered"
-            },
-            {
-              "kind": "coverage_interests",
-              "passed": true,
-              "detail": "judge: interests covered"
-            }
-          ]
-        },
-        {
-          "passed": true,
-          "assertions": [
-            {
-              "kind": "name",
-              "passed": true,
-              "detail": "expected name to contain \"Sam\", got \"Sam Okafor\""
-            },
-            {
-              "kind": "privacy",
-              "passed": true,
-              "detail": "no PII in public fields"
-            },
-            {
-              "kind": "skills",
-              "passed": true,
-              "detail": "expected ≥4 skills, got 5"
-            },
-            {
-              "kind": "interests",
-              "passed": true,
-              "detail": "expected ≥2 interests, got 3"
-            },
-            {
-              "kind": "coverage_skills",
-              "passed": true,
-              "detail": "judge: skills covered"
-            },
-            {
-              "kind": "coverage_interests",
-              "passed": true,
-              "detail": "judge: interests covered"
-            }
-          ]
-        }
-      ]
-    },
-    {
-      "caseId": "update/add-and-remove",
-      "rule": "update",
-      "runs": 3,
-      "passes": 3,
-      "passRate": 1,
-      "flaky": false,
-      "runResults": [
-        {
-          "passed": true,
-          "assertions": [
-            {
-              "kind": "name",
-              "passed": true,
-              "detail": "expected name to contain \"Dana\", got \"Dana Lee\""
-            },
-            {
-              "kind": "location",
-              "passed": true,
-              "detail": "expected location to contain \"Toronto\", got \"Toronto, Canada\""
-            },
-            {
-              "kind": "privacy",
-              "passed": true,
-              "detail": "no PII in public fields"
-            },
-            {
-              "kind": "apply",
-              "passed": true,
-              "detail": "judge: change applied"
-            },
-            {
-              "kind": "preserve",
-              "passed": true,
-              "detail": "judge: preserved"
-            }
-          ]
-        },
-        {
-          "passed": true,
-          "assertions": [
-            {
-              "kind": "name",
-              "passed": true,
-              "detail": "expected name to contain \"Dana\", got \"Dana Lee\""
-            },
-            {
-              "kind": "location",
-              "passed": true,
-              "detail": "expected location to contain \"Toronto\", got \"Toronto, Canada\""
-            },
-            {
-              "kind": "privacy",
-              "passed": true,
-              "detail": "no PII in public fields"
-            },
-            {
-              "kind": "apply",
-              "passed": true,
-              "detail": "judge: change applied"
-            },
-            {
-              "kind": "preserve",
-              "passed": true,
-              "detail": "judge: preserved"
-            }
-          ]
-        },
-        {
-          "passed": true,
-          "assertions": [
-            {
-              "kind": "name",
-              "passed": true,
-              "detail": "expected name to contain \"Dana\", got \"Dana Lee\""
-            },
-            {
-              "kind": "location",
-              "passed": true,
-              "detail": "expected location to contain \"Toronto\", got \"Toronto, Canada\""
-            },
-            {
-              "kind": "privacy",
-              "passed": true,
-              "detail": "no PII in public fields"
-            },
-            {
-              "kind": "apply",
-              "passed": true,
-              "detail": "judge: change applied"
-            },
-            {
-              "kind": "preserve",
-              "passed": true,
-              "detail": "judge: preserved"
-            }
-          ]
-        }
-      ]
-    },
-    {
-      "caseId": "privacy/no-contact-clean",
-      "rule": "privacy",
-      "runs": 3,
-      "passes": 3,
-      "passRate": 1,
-      "flaky": false,
-      "runResults": [
-        {
-          "passed": true,
-          "assertions": [
-            {
-              "kind": "name",
-              "passed": true,
-              "detail": "expected name to contain \"Wei\", got \"Wei Chen\""
-            },
-            {
-              "kind": "location",
-              "passed": true,
-              "detail": "expected location to contain \"Boston\", got \"Boston\""
-            },
-            {
-              "kind": "privacy",
-              "passed": true,
-              "detail": "no PII in public fields"
-            },
-            {
-              "kind": "skills",
-              "passed": true,
-              "detail": "expected ≥2 skills, got 3"
-            }
-          ]
-        },
-        {
-          "passed": true,
-          "assertions": [
-            {
-              "kind": "name",
-              "passed": true,
-              "detail": "expected name to contain \"Wei\", got \"Wei Chen\""
-            },
-            {
-              "kind": "location",
-              "passed": true,
-              "detail": "expected location to contain \"Boston\", got \"Boston\""
-            },
-            {
-              "kind": "privacy",
-              "passed": true,
-              "detail": "no PII in public fields"
-            },
-            {
-              "kind": "skills",
-              "passed": true,
-              "detail": "expected ≥2 skills, got 3"
-            }
-          ]
-        },
-        {
-          "passed": true,
-          "assertions": [
-            {
-              "kind": "name",
-              "passed": true,
-              "detail": "expected name to contain \"Wei\", got \"Wei Chen\""
-            },
-            {
-              "kind": "location",
-              "passed": true,
-              "detail": "expected location to contain \"Boston\", got \"Boston\""
-            },
-            {
-              "kind": "privacy",
-              "passed": true,
-              "detail": "no PII in public fields"
-            },
-            {
-              "kind": "skills",
-              "passed": true,
-              "detail": "expected ≥2 skills, got 3"
-            }
-          ]
-        }
-      ]
-    }
-  ]
+  "runs": 3,
+  "selection": {
+    "fullCorpus": true,
+    "filters": {}
+  },
+  "corpusFingerprint": "unavailable-legacy-migration",
+  "configFingerprint": "unavailable-legacy-migration",
+  "git": {
+    "revision": "unknown",
+    "dirty": null
+  },
+  "completeness": {
+    "caseCount": 8,
+    "ruleCount": 5,
+    "totalRuns": 24,
+    "totalPasses": 24,
+    "flakyCaseCount": 0
+  },
+  "payload": {
+    "generatedAt": "2026-06-16T15:32:16.555Z",
+    "model": "google/gemini-2.5-flash",
+    "runs": 3,
+    "aggregatePassRate": 1,
+    "rules": [
+      {
+        "rule": "extraction",
+        "caseCount": 2,
+        "passRate": 1
+      },
+      {
+        "rule": "location",
+        "caseCount": 1,
+        "passRate": 1
+      },
+      {
+        "rule": "privacy",
+        "caseCount": 3,
+        "passRate": 1
+      },
+      {
+        "rule": "skills_interests",
+        "caseCount": 1,
+        "passRate": 1
+      },
+      {
+        "rule": "update",
+        "caseCount": 1,
+        "passRate": 1
+      }
+    ],
+    "cases": [
+      {
+        "caseId": "extraction/clean-bio",
+        "rule": "extraction",
+        "runs": 3,
+        "passes": 3,
+        "passRate": 1,
+        "flaky": false,
+        "runResults": [
+          {
+            "passed": true,
+            "assertions": [
+              {
+                "kind": "name",
+                "passed": true,
+                "detail": "expected name to contain \"Ada\", got \"Ada Lovelace\""
+              },
+              {
+                "kind": "location",
+                "passed": true,
+                "detail": "expected location to contain \"London\", got \"London, UK\""
+              },
+              {
+                "kind": "privacy",
+                "passed": true,
+                "detail": "no PII in public fields"
+              },
+              {
+                "kind": "skills",
+                "passed": true,
+                "detail": "expected ≥2 skills, got 3"
+              },
+              {
+                "kind": "interests",
+                "passed": true,
+                "detail": "expected ≥1 interests, got 2"
+              },
+              {
+                "kind": "coverage_skills",
+                "passed": true,
+                "detail": "judge: skills covered"
+              }
+            ]
+          },
+          {
+            "passed": true,
+            "assertions": [
+              {
+                "kind": "name",
+                "passed": true,
+                "detail": "expected name to contain \"Ada\", got \"Ada Lovelace\""
+              },
+              {
+                "kind": "location",
+                "passed": true,
+                "detail": "expected location to contain \"London\", got \"London, UK\""
+              },
+              {
+                "kind": "privacy",
+                "passed": true,
+                "detail": "no PII in public fields"
+              },
+              {
+                "kind": "skills",
+                "passed": true,
+                "detail": "expected ≥2 skills, got 3"
+              },
+              {
+                "kind": "interests",
+                "passed": true,
+                "detail": "expected ≥1 interests, got 2"
+              },
+              {
+                "kind": "coverage_skills",
+                "passed": true,
+                "detail": "judge: skills covered"
+              }
+            ]
+          },
+          {
+            "passed": true,
+            "assertions": [
+              {
+                "kind": "name",
+                "passed": true,
+                "detail": "expected name to contain \"Ada\", got \"Ada Lovelace\""
+              },
+              {
+                "kind": "location",
+                "passed": true,
+                "detail": "expected location to contain \"London\", got \"London, UK\""
+              },
+              {
+                "kind": "privacy",
+                "passed": true,
+                "detail": "no PII in public fields"
+              },
+              {
+                "kind": "skills",
+                "passed": true,
+                "detail": "expected ≥2 skills, got 3"
+              },
+              {
+                "kind": "interests",
+                "passed": true,
+                "detail": "expected ≥1 interests, got 2"
+              },
+              {
+                "kind": "coverage_skills",
+                "passed": true,
+                "detail": "judge: skills covered"
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "caseId": "extraction/scraped-blob",
+        "rule": "extraction",
+        "runs": 3,
+        "passes": 3,
+        "passRate": 1,
+        "flaky": false,
+        "runResults": [
+          {
+            "passed": true,
+            "assertions": [
+              {
+                "kind": "name",
+                "passed": true,
+                "detail": "expected name to contain \"Priya\", got \"Priya Nair\""
+              },
+              {
+                "kind": "location",
+                "passed": true,
+                "detail": "expected location to contain \"San Francisco\", got \"San Francisco Bay Area\""
+              },
+              {
+                "kind": "privacy",
+                "passed": true,
+                "detail": "no PII in public fields"
+              },
+              {
+                "kind": "skills",
+                "passed": true,
+                "detail": "expected ≥3 skills, got 4"
+              },
+              {
+                "kind": "coverage_skills",
+                "passed": true,
+                "detail": "judge: skills covered"
+              }
+            ]
+          },
+          {
+            "passed": true,
+            "assertions": [
+              {
+                "kind": "name",
+                "passed": true,
+                "detail": "expected name to contain \"Priya\", got \"Priya Nair\""
+              },
+              {
+                "kind": "location",
+                "passed": true,
+                "detail": "expected location to contain \"San Francisco\", got \"San Francisco Bay Area\""
+              },
+              {
+                "kind": "privacy",
+                "passed": true,
+                "detail": "no PII in public fields"
+              },
+              {
+                "kind": "skills",
+                "passed": true,
+                "detail": "expected ≥3 skills, got 5"
+              },
+              {
+                "kind": "coverage_skills",
+                "passed": true,
+                "detail": "judge: skills covered"
+              }
+            ]
+          },
+          {
+            "passed": true,
+            "assertions": [
+              {
+                "kind": "name",
+                "passed": true,
+                "detail": "expected name to contain \"Priya\", got \"Priya Nair\""
+              },
+              {
+                "kind": "location",
+                "passed": true,
+                "detail": "expected location to contain \"San Francisco\", got \"San Francisco Bay Area\""
+              },
+              {
+                "kind": "privacy",
+                "passed": true,
+                "detail": "no PII in public fields"
+              },
+              {
+                "kind": "skills",
+                "passed": true,
+                "detail": "expected ≥3 skills, got 6"
+              },
+              {
+                "kind": "coverage_skills",
+                "passed": true,
+                "detail": "judge: skills covered"
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "caseId": "location/explicit-city",
+        "rule": "location",
+        "runs": 3,
+        "passes": 3,
+        "passRate": 1,
+        "flaky": false,
+        "runResults": [
+          {
+            "passed": true,
+            "assertions": [
+              {
+                "kind": "name",
+                "passed": true,
+                "detail": "expected name to contain \"Lars\", got \"Lars Berg\""
+              },
+              {
+                "kind": "location",
+                "passed": true,
+                "detail": "expected location to contain \"Berlin\", got \"Berlin, Germany\""
+              },
+              {
+                "kind": "privacy",
+                "passed": true,
+                "detail": "no PII in public fields"
+              }
+            ]
+          },
+          {
+            "passed": true,
+            "assertions": [
+              {
+                "kind": "name",
+                "passed": true,
+                "detail": "expected name to contain \"Lars\", got \"Lars Berg\""
+              },
+              {
+                "kind": "location",
+                "passed": true,
+                "detail": "expected location to contain \"Berlin\", got \"Berlin, Germany\""
+              },
+              {
+                "kind": "privacy",
+                "passed": true,
+                "detail": "no PII in public fields"
+              }
+            ]
+          },
+          {
+            "passed": true,
+            "assertions": [
+              {
+                "kind": "name",
+                "passed": true,
+                "detail": "expected name to contain \"Lars\", got \"Lars Berg\""
+              },
+              {
+                "kind": "location",
+                "passed": true,
+                "detail": "expected location to contain \"Berlin\", got \"Berlin, Germany\""
+              },
+              {
+                "kind": "privacy",
+                "passed": true,
+                "detail": "no PII in public fields"
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "caseId": "privacy/email-and-phone",
+        "rule": "privacy",
+        "runs": 3,
+        "passes": 3,
+        "passRate": 1,
+        "flaky": false,
+        "runResults": [
+          {
+            "passed": true,
+            "assertions": [
+              {
+                "kind": "name",
+                "passed": true,
+                "detail": "expected name to contain \"John\", got \"John Park\""
+              },
+              {
+                "kind": "location",
+                "passed": true,
+                "detail": "expected location to contain \"Austin\", got \"Austin, TX\""
+              },
+              {
+                "kind": "privacy",
+                "passed": true,
+                "detail": "no PII in public fields"
+              },
+              {
+                "kind": "coverage_skills",
+                "passed": true,
+                "detail": "judge: skills covered"
+              }
+            ]
+          },
+          {
+            "passed": true,
+            "assertions": [
+              {
+                "kind": "name",
+                "passed": true,
+                "detail": "expected name to contain \"John\", got \"John Park\""
+              },
+              {
+                "kind": "location",
+                "passed": true,
+                "detail": "expected location to contain \"Austin\", got \"Austin, TX\""
+              },
+              {
+                "kind": "privacy",
+                "passed": true,
+                "detail": "no PII in public fields"
+              },
+              {
+                "kind": "coverage_skills",
+                "passed": true,
+                "detail": "judge: skills covered"
+              }
+            ]
+          },
+          {
+            "passed": true,
+            "assertions": [
+              {
+                "kind": "name",
+                "passed": true,
+                "detail": "expected name to contain \"John\", got \"John Park\""
+              },
+              {
+                "kind": "location",
+                "passed": true,
+                "detail": "expected location to contain \"Austin\", got \"Austin, TX\""
+              },
+              {
+                "kind": "privacy",
+                "passed": true,
+                "detail": "no PII in public fields"
+              },
+              {
+                "kind": "coverage_skills",
+                "passed": true,
+                "detail": "judge: skills covered"
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "caseId": "privacy/contact-heavy",
+        "rule": "privacy",
+        "runs": 3,
+        "passes": 3,
+        "passRate": 1,
+        "flaky": false,
+        "runResults": [
+          {
+            "passed": true,
+            "assertions": [
+              {
+                "kind": "name",
+                "passed": true,
+                "detail": "expected name to contain \"Maria\", got \"Maria Gomez\""
+              },
+              {
+                "kind": "location",
+                "passed": true,
+                "detail": "expected location to contain \"New York\", got \"New York\""
+              },
+              {
+                "kind": "privacy",
+                "passed": true,
+                "detail": "no PII in public fields"
+              },
+              {
+                "kind": "skills",
+                "passed": true,
+                "detail": "expected ≥2 skills, got 3"
+              }
+            ]
+          },
+          {
+            "passed": true,
+            "assertions": [
+              {
+                "kind": "name",
+                "passed": true,
+                "detail": "expected name to contain \"Maria\", got \"Maria Gomez\""
+              },
+              {
+                "kind": "location",
+                "passed": true,
+                "detail": "expected location to contain \"New York\", got \"New York\""
+              },
+              {
+                "kind": "privacy",
+                "passed": true,
+                "detail": "no PII in public fields"
+              },
+              {
+                "kind": "skills",
+                "passed": true,
+                "detail": "expected ≥2 skills, got 3"
+              }
+            ]
+          },
+          {
+            "passed": true,
+            "assertions": [
+              {
+                "kind": "name",
+                "passed": true,
+                "detail": "expected name to contain \"Maria\", got \"Maria Gomez\""
+              },
+              {
+                "kind": "location",
+                "passed": true,
+                "detail": "expected location to contain \"New York\", got \"New York\""
+              },
+              {
+                "kind": "privacy",
+                "passed": true,
+                "detail": "no PII in public fields"
+              },
+              {
+                "kind": "skills",
+                "passed": true,
+                "detail": "expected ≥2 skills, got 3"
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "caseId": "skills_interests/multi-skill",
+        "rule": "skills_interests",
+        "runs": 3,
+        "passes": 3,
+        "passRate": 1,
+        "flaky": false,
+        "runResults": [
+          {
+            "passed": true,
+            "assertions": [
+              {
+                "kind": "name",
+                "passed": true,
+                "detail": "expected name to contain \"Sam\", got \"Sam Okafor\""
+              },
+              {
+                "kind": "privacy",
+                "passed": true,
+                "detail": "no PII in public fields"
+              },
+              {
+                "kind": "skills",
+                "passed": true,
+                "detail": "expected ≥4 skills, got 6"
+              },
+              {
+                "kind": "interests",
+                "passed": true,
+                "detail": "expected ≥2 interests, got 3"
+              },
+              {
+                "kind": "coverage_skills",
+                "passed": true,
+                "detail": "judge: skills covered"
+              },
+              {
+                "kind": "coverage_interests",
+                "passed": true,
+                "detail": "judge: interests covered"
+              }
+            ]
+          },
+          {
+            "passed": true,
+            "assertions": [
+              {
+                "kind": "name",
+                "passed": true,
+                "detail": "expected name to contain \"Sam\", got \"Sam Okafor\""
+              },
+              {
+                "kind": "privacy",
+                "passed": true,
+                "detail": "no PII in public fields"
+              },
+              {
+                "kind": "skills",
+                "passed": true,
+                "detail": "expected ≥4 skills, got 5"
+              },
+              {
+                "kind": "interests",
+                "passed": true,
+                "detail": "expected ≥2 interests, got 3"
+              },
+              {
+                "kind": "coverage_skills",
+                "passed": true,
+                "detail": "judge: skills covered"
+              },
+              {
+                "kind": "coverage_interests",
+                "passed": true,
+                "detail": "judge: interests covered"
+              }
+            ]
+          },
+          {
+            "passed": true,
+            "assertions": [
+              {
+                "kind": "name",
+                "passed": true,
+                "detail": "expected name to contain \"Sam\", got \"Sam Okafor\""
+              },
+              {
+                "kind": "privacy",
+                "passed": true,
+                "detail": "no PII in public fields"
+              },
+              {
+                "kind": "skills",
+                "passed": true,
+                "detail": "expected ≥4 skills, got 5"
+              },
+              {
+                "kind": "interests",
+                "passed": true,
+                "detail": "expected ≥2 interests, got 3"
+              },
+              {
+                "kind": "coverage_skills",
+                "passed": true,
+                "detail": "judge: skills covered"
+              },
+              {
+                "kind": "coverage_interests",
+                "passed": true,
+                "detail": "judge: interests covered"
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "caseId": "update/add-and-remove",
+        "rule": "update",
+        "runs": 3,
+        "passes": 3,
+        "passRate": 1,
+        "flaky": false,
+        "runResults": [
+          {
+            "passed": true,
+            "assertions": [
+              {
+                "kind": "name",
+                "passed": true,
+                "detail": "expected name to contain \"Dana\", got \"Dana Lee\""
+              },
+              {
+                "kind": "location",
+                "passed": true,
+                "detail": "expected location to contain \"Toronto\", got \"Toronto, Canada\""
+              },
+              {
+                "kind": "privacy",
+                "passed": true,
+                "detail": "no PII in public fields"
+              },
+              {
+                "kind": "apply",
+                "passed": true,
+                "detail": "judge: change applied"
+              },
+              {
+                "kind": "preserve",
+                "passed": true,
+                "detail": "judge: preserved"
+              }
+            ]
+          },
+          {
+            "passed": true,
+            "assertions": [
+              {
+                "kind": "name",
+                "passed": true,
+                "detail": "expected name to contain \"Dana\", got \"Dana Lee\""
+              },
+              {
+                "kind": "location",
+                "passed": true,
+                "detail": "expected location to contain \"Toronto\", got \"Toronto, Canada\""
+              },
+              {
+                "kind": "privacy",
+                "passed": true,
+                "detail": "no PII in public fields"
+              },
+              {
+                "kind": "apply",
+                "passed": true,
+                "detail": "judge: change applied"
+              },
+              {
+                "kind": "preserve",
+                "passed": true,
+                "detail": "judge: preserved"
+              }
+            ]
+          },
+          {
+            "passed": true,
+            "assertions": [
+              {
+                "kind": "name",
+                "passed": true,
+                "detail": "expected name to contain \"Dana\", got \"Dana Lee\""
+              },
+              {
+                "kind": "location",
+                "passed": true,
+                "detail": "expected location to contain \"Toronto\", got \"Toronto, Canada\""
+              },
+              {
+                "kind": "privacy",
+                "passed": true,
+                "detail": "no PII in public fields"
+              },
+              {
+                "kind": "apply",
+                "passed": true,
+                "detail": "judge: change applied"
+              },
+              {
+                "kind": "preserve",
+                "passed": true,
+                "detail": "judge: preserved"
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "caseId": "privacy/no-contact-clean",
+        "rule": "privacy",
+        "runs": 3,
+        "passes": 3,
+        "passRate": 1,
+        "flaky": false,
+        "runResults": [
+          {
+            "passed": true,
+            "assertions": [
+              {
+                "kind": "name",
+                "passed": true,
+                "detail": "expected name to contain \"Wei\", got \"Wei Chen\""
+              },
+              {
+                "kind": "location",
+                "passed": true,
+                "detail": "expected location to contain \"Boston\", got \"Boston\""
+              },
+              {
+                "kind": "privacy",
+                "passed": true,
+                "detail": "no PII in public fields"
+              },
+              {
+                "kind": "skills",
+                "passed": true,
+                "detail": "expected ≥2 skills, got 3"
+              }
+            ]
+          },
+          {
+            "passed": true,
+            "assertions": [
+              {
+                "kind": "name",
+                "passed": true,
+                "detail": "expected name to contain \"Wei\", got \"Wei Chen\""
+              },
+              {
+                "kind": "location",
+                "passed": true,
+                "detail": "expected location to contain \"Boston\", got \"Boston\""
+              },
+              {
+                "kind": "privacy",
+                "passed": true,
+                "detail": "no PII in public fields"
+              },
+              {
+                "kind": "skills",
+                "passed": true,
+                "detail": "expected ≥2 skills, got 3"
+              }
+            ]
+          },
+          {
+            "passed": true,
+            "assertions": [
+              {
+                "kind": "name",
+                "passed": true,
+                "detail": "expected name to contain \"Wei\", got \"Wei Chen\""
+              },
+              {
+                "kind": "location",
+                "passed": true,
+                "detail": "expected location to contain \"Boston\", got \"Boston\""
+              },
+              {
+                "kind": "privacy",
+                "passed": true,
+                "detail": "no PII in public fields"
+              },
+              {
+                "kind": "skills",
+                "passed": true,
+                "detail": "expected ≥2 skills, got 3"
+              }
+            ]
+          }
+        ]
+      }
+    ]
+  }
 }

--- a/packages/protocol/eval/profile/profile.eval.ts
+++ b/packages/protocol/eval/profile/profile.eval.ts
@@ -10,7 +10,7 @@
  *   bun run eval:profile -- --tier 1               # one tier
  *   bun run eval:profile -- --list-cases           # print selected cases and exit
  *   bun run eval:profile -- --no-judge             # skip LLM coverage/apply/preserve checks
- *   bun run eval:profile -- --update-baseline      # overwrite the committed baseline
+ *   bun run eval:profile -- --update-baseline --force # replace the committed baseline
  *   bun run eval:profile -- --report [path]        # write a full run report (incl. generated profiles)
  *   bun run eval:profile -- --html [path]          # write a standalone HTML scorecard
  *   bun run eval:profile -- --rolling-baseline [d] # compare against recent runs (default 7d)
@@ -25,7 +25,7 @@ import path from "path";
 import { EnrichmentGenerator } from "../../src/enrichment/enrichment.generator.js";
 import { getModelName } from "../../src/shared/agent/model.config.js";
 import { assertLLM } from "../../src/shared/agent/tests/llm-assert.js";
-import { arg, buildScorecard, computeRollingBaseline, diffBaseline, flagValue, formatConsole, has, readBaseline, writeBaseline, writeRunReport } from "../shared/index.js";
+import { arg, assertEvalWritePlan, buildScorecard, computeRollingBaseline, diffBaseline, fingerprintEvalConfig, fingerprintEvalCorpus, flagValue, formatConsole, has, readBaseline, readEvalGitProvenance, writeBaseline, writeRunReport, type EvalRunMeta } from "../shared/index.js";
 import { CASES } from "./profile.cases.js";
 import { runCase } from "./profile.runner.js";
 import { scoreCase, type Judge } from "./profile.scorer.js";
@@ -33,6 +33,8 @@ import { writeHtmlReport } from "./profile.reporter.js";
 import { formatCaseList, hasRule, parseTier, selectCases } from "./profile.selection.js";
 import type { CaseResult, Scorecard } from "./profile.types.js";
 
+const HARNESS = "profile";
+const HARNESS_VERSION = "1";
 const DEFAULT_ALPHA = 0.05;
 const BASELINE_PATH = path.resolve(import.meta.dir, "baselines/profile.baseline.json");
 const RUNS_DIR = path.resolve(import.meta.dir, "runs");
@@ -56,7 +58,8 @@ Execution:
   --no-save                 Do not auto-save full-corpus run JSON for rolling-baseline fuel
 
 Baselines/reports:
-  --update-baseline         Overwrite committed baseline (full corpus only)
+  --update-baseline         Overwrite committed baseline (full corpus only; needs --force if one exists)
+  --force                   Consent to overwrite existing baseline/report/HTML outputs
   --rolling-baseline [days] Compare against recent run reports (default: 7)
   --report [path]           Write JSON scorecard
   --html [path]             Write standalone HTML scorecard
@@ -96,6 +99,7 @@ async function main(): Promise<void> {
   const report = has("--report");
   const html = has("--html");
   const noSave = has("--no-save");
+  const force = has("--force");
   const alpha = Number(arg("--alpha") ?? DEFAULT_ALPHA);
   if (!Number.isFinite(alpha) || alpha <= 0 || alpha >= 1) {
     console.error(`--alpha must be a number between 0 and 1 (got "${arg("--alpha")}")`);
@@ -134,10 +138,30 @@ async function main(): Promise<void> {
     process.exit(2);
   }
 
+  // Assert every declared output before running anything: no output may
+  // clobber an input, and existing destinations need explicit --force.
+  const explicitReportPath = report ? flagValue("--report") : undefined;
+  const explicitHtmlPath = html ? flagValue("--html") : undefined;
+  try {
+    await assertEvalWritePlan({
+      inputs: [BASELINE_PATH],
+      outputs: [
+        ...(updateBaseline ? [{ path: BASELINE_PATH, updatesInput: true }] : []),
+        ...(explicitReportPath ? [explicitReportPath] : []),
+        ...(explicitHtmlPath ? [explicitHtmlPath] : []),
+      ],
+      force,
+    });
+  } catch (err) {
+    console.error(err instanceof Error ? err.message : String(err));
+    process.exit(2);
+  }
+
   const generator = new EnrichmentGenerator();
   const model = getModelName("profileGenerator");
   console.log(`Running ${selected.length} case(s) × ${runs} run(s) against ${model}${noJudge ? " (judge off)" : ""}…`);
 
+  const startedAt = new Date().toISOString();
   const results: CaseResult[] = [];
   for (const c of selected) {
     process.stdout.write(`  ${c.id} … `);
@@ -148,10 +172,28 @@ async function main(): Promise<void> {
   }
 
   const scorecard = buildScorecard(results, { model, runs }) as Scorecard;
+  const completedAt = new Date().toISOString();
+  const filters: Record<string, string> = {};
+  if (ruleFilter) filters.rule = ruleFilter;
+  if (caseFilter) filters.case = caseFilter;
+  if (tierFilter !== undefined) filters.tier = String(tierFilter);
+  const models = [...new Set([model])];
+  const meta: EvalRunMeta = {
+    harness: HARNESS,
+    harnessVersion: HARNESS_VERSION,
+    models,
+    runs,
+    selection: { fullCorpus, filters },
+    corpusFingerprint: fingerprintEvalCorpus(selected),
+    configFingerprint: fingerprintEvalConfig({ runs, alpha, judge: !noJudge, filters, models }),
+    git: readEvalGitProvenance(import.meta.dir),
+    startedAt,
+    completedAt,
+  };
   const baseline =
     rollingBaselineDays !== null
       ? await computeRollingBaseline(RUNS_DIR, rollingBaselineDays)
-      : await readBaseline<Scorecard>(BASELINE_PATH);
+      : await readBaseline<Scorecard>(BASELINE_PATH, { harness: HARNESS });
   const { regressions, skippedCaseIds } = diffBaseline(scorecard, baseline, alpha);
 
   if (rollingBaselineDays !== null) {
@@ -166,6 +208,8 @@ async function main(): Promise<void> {
 
   if (updateBaseline) {
     await writeBaseline(BASELINE_PATH, scorecard, {
+      meta,
+      force,
       leanCase: (c) => ({ ...c, runResults: c.runResults.map(({ detail: _detail, ...rest }) => rest) }),
     });
     console.log(`\nBaseline updated at ${BASELINE_PATH}`);
@@ -173,13 +217,14 @@ async function main(): Promise<void> {
 
   const stamp = new Date().toISOString().replace(/[:.]/g, "-");
   const autoRunPath = path.resolve(RUNS_DIR, `${stamp}.json`);
-  if (fullCorpus && !noSave) {
-    await writeRunReport(autoRunPath, scorecard);
+  const autoSaved = fullCorpus && !noSave;
+  if (autoSaved) {
+    await writeRunReport(autoRunPath, scorecard, { meta });
   }
 
   if (report) {
     const reportPath = flagValue("--report") ?? autoRunPath;
-    if (reportPath !== autoRunPath) await writeRunReport(reportPath, scorecard);
+    if (!(autoSaved && reportPath === autoRunPath)) await writeRunReport(reportPath, scorecard, { meta, force });
     console.log(`\nRun report written to ${reportPath}`);
   }
 

--- a/packages/protocol/eval/shared/artifact.io.ts
+++ b/packages/protocol/eval/shared/artifact.io.ts
@@ -1,0 +1,139 @@
+/**
+ * Collision-safe persistence for versioned eval artifacts.
+ *
+ * - Reads parse + validate through the shared envelope schema and surface
+ *   actionable errors for corrupt/truncated JSON.
+ * - Writes validate first, then go through a same-directory temp file and an
+ *   atomic rename, so an interrupted write can never replace a previous valid
+ *   artifact with a partial one.
+ * - Overwrites are refused by default (`force` opts in), and a write plan can
+ *   be asserted up front so multi-output runs fail before *any* output is
+ *   written and inputs can never double as outputs.
+ */
+import { randomBytes } from "node:crypto";
+import { mkdir, rename, unlink, writeFile } from "node:fs/promises";
+import path from "node:path";
+
+import { parseEvalArtifact, type EvalArtifactEnvelope, type ParseEvalArtifactOptions } from "./artifact.js";
+import type { ScorecardLike } from "./types.js";
+
+/**
+ * Reads and validates an eval artifact envelope from disk.
+ *
+ * @returns The validated envelope, or `null` when the file does not exist.
+ * @throws Actionable errors for unreadable/corrupt JSON and any envelope violation.
+ */
+export async function readEvalArtifact<P extends ScorecardLike = ScorecardLike>(
+  filePath: string,
+  options: ParseEvalArtifactOptions,
+): Promise<EvalArtifactEnvelope<P> | null> {
+  const file = Bun.file(filePath);
+  if (!(await file.exists())) return null;
+  let value: unknown;
+  try {
+    value = await file.json();
+  } catch (err) {
+    throw new Error(`Eval artifact at ${filePath} is not valid JSON (corrupt or truncated write?)`, { cause: err });
+  }
+  try {
+    return parseEvalArtifact<P>(value, options);
+  } catch (err) {
+    throw new Error(`${filePath}: ${err instanceof Error ? err.message : String(err)}`, { cause: err });
+  }
+}
+
+export interface WriteEvalArtifactOptions {
+  /** Allow replacing an existing file. Defaults to false (refuse overwrite). */
+  force?: boolean;
+}
+
+/**
+ * Validates and atomically writes an eval artifact envelope.
+ *
+ * The envelope is re-parsed before serialization (invalid artifacts can never
+ * reach disk), written to a same-directory temp file, and renamed into place.
+ * Existing destinations are refused unless `force` is set.
+ */
+export async function writeEvalArtifact(
+  filePath: string,
+  envelope: EvalArtifactEnvelope,
+  options: WriteEvalArtifactOptions = {},
+): Promise<void> {
+  const validated = parseEvalArtifact(envelope, { expectedType: envelope.artifactType });
+  if (!options.force && (await Bun.file(filePath).exists())) {
+    throw new Error(
+      `Refusing to overwrite existing eval artifact at ${filePath}; pass --force to replace it`,
+    );
+  }
+  const dir = path.dirname(filePath);
+  await mkdir(dir, { recursive: true });
+  const tempPath = path.join(
+    dir,
+    `.${path.basename(filePath)}.${process.pid}.${randomBytes(6).toString("hex")}.tmp`,
+  );
+  try {
+    await writeFile(tempPath, JSON.stringify(validated, null, 2) + "\n");
+    await rename(tempPath, filePath);
+  } catch (err) {
+    await unlink(tempPath).catch(() => {});
+    throw err;
+  }
+}
+
+export interface EvalWriteOutput {
+  path: string;
+  /**
+   * Marks the sanctioned in-place update flow (e.g. `--update-baseline`
+   * rewriting the baseline it just diffed against). Exempts the output from
+   * the input-collision rule but NOT from overwrite consent.
+   */
+  updatesInput?: boolean;
+}
+
+export interface EvalWritePlan {
+  /** Paths this run reads (committed baselines, rolling run dirs, …). */
+  inputs?: string[];
+  /** Every output the run may write, declared up front. */
+  outputs: (string | EvalWriteOutput)[];
+  /** Explicit overwrite consent (the CLI's `--force`). */
+  force?: boolean;
+}
+
+/**
+ * Asserts an entire write plan before any output is produced.
+ *
+ * Rejects: an output path listed twice, an output that would clobber an input
+ * (unless it is the declared in-place update flow), and — without `force` —
+ * any already-existing destination. Because every violation is reported before
+ * the first write, a run can never leave a partial multi-output combination
+ * behind.
+ */
+export async function assertEvalWritePlan(plan: EvalWritePlan): Promise<void> {
+  const inputs = new Set((plan.inputs ?? []).map((p) => path.resolve(p)));
+  const outputs = plan.outputs.map((entry) =>
+    typeof entry === "string" ? { path: path.resolve(entry) } : { ...entry, path: path.resolve(entry.path) },
+  );
+
+  const seen = new Set<string>();
+  for (const output of outputs) {
+    if (seen.has(output.path)) {
+      throw new Error(`Output path declared twice: ${output.path}; refusing to run`);
+    }
+    seen.add(output.path);
+    if (!output.updatesInput && inputs.has(output.path)) {
+      throw new Error(`Output path would overwrite an input artifact: ${output.path}; refusing to run`);
+    }
+  }
+
+  if (!plan.force) {
+    const existing: string[] = [];
+    for (const output of outputs) {
+      if (await Bun.file(output.path).exists()) existing.push(output.path);
+    }
+    if (existing.length > 0) {
+      throw new Error(
+        `Refusing to overwrite existing output(s) without --force:\n  ${existing.join("\n  ")}`,
+      );
+    }
+  }
+}

--- a/packages/protocol/eval/shared/artifact.ts
+++ b/packages/protocol/eval/shared/artifact.ts
@@ -1,0 +1,559 @@
+/**
+ * Versioned envelope for shared eval artifacts (committed baselines and run
+ * reports), plus the runtime validation and deterministic provenance helpers
+ * every baseline-backed harness reuses.
+ *
+ * Design constraints (IND-442):
+ * - The envelope is generic: harness-specific per-case detail stays a
+ *   harness-owned payload (case objects are passthrough beyond the shared
+ *   aggregate fields). No HyDE adjudication / private-key / bootstrap concepts
+ *   live here.
+ * - Every read and write validates: malformed numbers, duplicate case/rule
+ *   ids, inconsistent aggregates, non-monotonic timestamps, unknown schema
+ *   versions, and incompatible artifact types are all rejected with
+ *   actionable errors.
+ * - Provenance is deterministic: SHA-256 over canonicalized (key-sorted,
+ *   undefined-stripped) JSON for corpus/config inputs, and injectable Git
+ *   revision/dirty readers. Fingerprint inputs must never contain embeddings,
+ *   API keys, secret-bearing prompts, or raw environment values.
+ */
+import { execFileSync } from "node:child_process";
+import { createHash } from "node:crypto";
+
+import { z } from "zod";
+
+import type { CaseResultLike, ScorecardLike } from "./types.js";
+
+// ─── Constants ───────────────────────────────────────────────────────────────
+
+/** Current shared eval artifact schema version. Bump on envelope shape changes. */
+export const EVAL_ARTIFACT_SCHEMA_VERSION = 1;
+
+export const EVAL_BASELINE_ARTIFACT_TYPE = "index-eval/baseline";
+export const EVAL_RUN_REPORT_ARTIFACT_TYPE = "index-eval/run-report";
+
+export type EvalArtifactType = typeof EVAL_BASELINE_ARTIFACT_TYPE | typeof EVAL_RUN_REPORT_ARTIFACT_TYPE;
+
+/**
+ * Sentinel for provenance that cannot be reconstructed when converting a
+ * legacy (pre-envelope) artifact. Only valid when `source` is
+ * `"legacy-migration"`; artifacts written by a live run must carry real
+ * fingerprints.
+ */
+export const EVAL_LEGACY_UNAVAILABLE = "unavailable-legacy-migration";
+
+/** Numeric tolerance for validating stored rates against recomputed rates. */
+const RATE_TOLERANCE = 1e-6;
+
+// ─── Schemas ─────────────────────────────────────────────────────────────────
+
+const sha256Schema = z.string().regex(/^[a-f0-9]{64}$/, "expected a lowercase hex SHA-256");
+const dateTimeSchema = z.string().datetime({ offset: true });
+const rateSchema = z.number().finite().min(0).max(1);
+const countSchema = z.number().int().min(0);
+
+export const EvalGitProvenanceSchema = z
+  .object({
+    /** Commit hash, or "unknown" when Git metadata could not be read. */
+    revision: z.union([z.string().regex(/^[a-f0-9]{40,64}$/i), z.literal("unknown")]),
+    /** True when the worktree had uncommitted changes; null when unknown. */
+    dirty: z.boolean().nullable(),
+  })
+  .strict();
+
+export type EvalGitProvenance = z.infer<typeof EvalGitProvenanceSchema>;
+
+export const EvalSelectionSchema = z
+  .object({
+    /** True when no case/rule/tier/component filters narrowed the corpus. */
+    fullCorpus: z.boolean(),
+    /** The raw CLI filters that produced the selection (empty when full corpus). */
+    filters: z.record(z.string().min(1)),
+  })
+  .strict()
+  .superRefine((selection, context) => {
+    if (selection.fullCorpus && Object.keys(selection.filters).length > 0) {
+      context.addIssue({
+        code: z.ZodIssueCode.custom,
+        path: ["filters"],
+        message: "fullCorpus artifacts must not carry selection filters",
+      });
+    }
+  });
+
+export type EvalSelection = z.infer<typeof EvalSelectionSchema>;
+
+export const EvalCompletenessSchema = z
+  .object({
+    caseCount: countSchema,
+    ruleCount: countSchema,
+    totalRuns: countSchema,
+    totalPasses: countSchema,
+    flakyCaseCount: countSchema,
+  })
+  .strict();
+
+export type EvalCompleteness = z.infer<typeof EvalCompletenessSchema>;
+
+/** Shared per-case aggregate fields; harness-specific detail passes through. */
+const caseResultSchema = z
+  .object({
+    caseId: z.string().min(1),
+    rule: z.string().min(1),
+    runs: z.number().int().min(1),
+    passes: countSchema,
+    passRate: rateSchema,
+    flaky: z.boolean(),
+  })
+  .passthrough();
+
+const ruleResultSchema = z
+  .object({
+    rule: z.string().min(1),
+    caseCount: z.number().int().min(1),
+    passRate: rateSchema,
+  })
+  .strict();
+
+/** Shared scorecard payload: aggregate fields validated, cases passthrough. */
+export const EvalScorecardPayloadSchema = z
+  .object({
+    generatedAt: dateTimeSchema,
+    model: z.string().min(1),
+    runs: z.number().int().min(1),
+    aggregatePassRate: rateSchema,
+    rules: z.array(ruleResultSchema).min(1),
+    cases: z.array(caseResultSchema).min(1),
+  })
+  .strict()
+  .superRefine((payload, context) => {
+    const mean = (values: number[]): number => values.reduce((sum, v) => sum + v, 0) / values.length;
+
+    const caseIds = payload.cases.map((c) => c.caseId);
+    if (new Set(caseIds).size !== caseIds.length) {
+      context.addIssue({ code: z.ZodIssueCode.custom, path: ["cases"], message: "duplicate caseId values" });
+    }
+    const ruleLabels = payload.rules.map((r) => r.rule);
+    if (new Set(ruleLabels).size !== ruleLabels.length) {
+      context.addIssue({ code: z.ZodIssueCode.custom, path: ["rules"], message: "duplicate rule labels" });
+    }
+
+    for (const [index, c] of payload.cases.entries()) {
+      if (c.passes > c.runs) {
+        context.addIssue({
+          code: z.ZodIssueCode.custom,
+          path: ["cases", index],
+          message: `case ${c.caseId}: passes (${c.passes}) exceeds runs (${c.runs})`,
+        });
+        continue;
+      }
+      if (Math.abs(c.passRate - c.passes / c.runs) > RATE_TOLERANCE) {
+        context.addIssue({
+          code: z.ZodIssueCode.custom,
+          path: ["cases", index, "passRate"],
+          message: `case ${c.caseId}: passRate ${c.passRate} is inconsistent with ${c.passes}/${c.runs}`,
+        });
+      }
+      if (c.flaky !== (c.passes > 0 && c.passes < c.runs)) {
+        context.addIssue({
+          code: z.ZodIssueCode.custom,
+          path: ["cases", index, "flaky"],
+          message: `case ${c.caseId}: flaky flag is inconsistent with passes/runs`,
+        });
+      }
+    }
+
+    if (payload.cases.length > 0
+      && Math.abs(payload.aggregatePassRate - mean(payload.cases.map((c) => c.passRate))) > RATE_TOLERANCE) {
+      context.addIssue({
+        code: z.ZodIssueCode.custom,
+        path: ["aggregatePassRate"],
+        message: "aggregatePassRate is inconsistent with the mean of case pass rates",
+      });
+    }
+
+    const casesByRule = new Map<string, typeof payload.cases>();
+    for (const c of payload.cases) {
+      const list = casesByRule.get(c.rule) ?? [];
+      list.push(c);
+      casesByRule.set(c.rule, list);
+    }
+    if (casesByRule.size !== payload.rules.length) {
+      context.addIssue({
+        code: z.ZodIssueCode.custom,
+        path: ["rules"],
+        message: "rules rollup does not cover exactly the rules present in cases",
+      });
+    }
+    for (const [index, rule] of payload.rules.entries()) {
+      const members = casesByRule.get(rule.rule);
+      if (!members) continue; // covered by the rollup mismatch issue above
+      if (members.length !== rule.caseCount) {
+        context.addIssue({
+          code: z.ZodIssueCode.custom,
+          path: ["rules", index, "caseCount"],
+          message: `rule ${rule.rule}: caseCount ${rule.caseCount} != ${members.length} cases`,
+        });
+      } else if (Math.abs(rule.passRate - mean(members.map((c) => c.passRate))) > RATE_TOLERANCE) {
+        context.addIssue({
+          code: z.ZodIssueCode.custom,
+          path: ["rules", index, "passRate"],
+          message: `rule ${rule.rule}: passRate is inconsistent with its member cases`,
+        });
+      }
+    }
+  });
+
+const fingerprintSchema = z.union([sha256Schema, z.literal(EVAL_LEGACY_UNAVAILABLE)]);
+
+export const EvalArtifactEnvelopeSchema = z
+  .object({
+    artifactType: z.enum([EVAL_BASELINE_ARTIFACT_TYPE, EVAL_RUN_REPORT_ARTIFACT_TYPE]),
+    schemaVersion: z.literal(EVAL_ARTIFACT_SCHEMA_VERSION),
+    harness: z.string().min(1),
+    harnessVersion: z.string().min(1),
+    /** "run" for artifacts written by a live harness run; "legacy-migration" for explicit conversions. */
+    source: z.enum(["run", "legacy-migration"]),
+    createdAt: dateTimeSchema,
+    startedAt: dateTimeSchema,
+    completedAt: dateTimeSchema,
+    /** Configured model IDs (no keys, no prompts). */
+    models: z.array(z.string().min(1)).min(1),
+    /** Configured runs per case. */
+    runs: z.number().int().min(1),
+    selection: EvalSelectionSchema,
+    corpusFingerprint: fingerprintSchema,
+    configFingerprint: fingerprintSchema,
+    git: EvalGitProvenanceSchema,
+    completeness: EvalCompletenessSchema,
+    payload: EvalScorecardPayloadSchema,
+  })
+  .strict()
+  .superRefine((artifact, context) => {
+    const started = Date.parse(artifact.startedAt);
+    const completed = Date.parse(artifact.completedAt);
+    const created = Date.parse(artifact.createdAt);
+    if (!(started <= completed && completed <= created)) {
+      context.addIssue({
+        code: z.ZodIssueCode.custom,
+        path: ["completedAt"],
+        message: "timestamps must satisfy startedAt <= completedAt <= createdAt",
+      });
+    }
+    if (artifact.source === "run") {
+      for (const key of ["corpusFingerprint", "configFingerprint"] as const) {
+        if (artifact[key] === EVAL_LEGACY_UNAVAILABLE) {
+          context.addIssue({
+            code: z.ZodIssueCode.custom,
+            path: [key],
+            message: `${key} "${EVAL_LEGACY_UNAVAILABLE}" is only valid for source "legacy-migration"`,
+          });
+        }
+      }
+    }
+    if (new Set(artifact.models).size !== artifact.models.length) {
+      context.addIssue({ code: z.ZodIssueCode.custom, path: ["models"], message: "duplicate model IDs" });
+    }
+    if (artifact.payload.runs !== artifact.runs) {
+      context.addIssue({
+        code: z.ZodIssueCode.custom,
+        path: ["runs"],
+        message: `envelope runs (${artifact.runs}) != payload runs (${artifact.payload.runs})`,
+      });
+    }
+    const expected = summarizeCompleteness(artifact.payload.cases, artifact.payload.rules.length);
+    const stored = artifact.completeness;
+    for (const key of Object.keys(expected) as (keyof EvalCompleteness)[]) {
+      if (stored[key] !== expected[key]) {
+        context.addIssue({
+          code: z.ZodIssueCode.custom,
+          path: ["completeness", key],
+          message: `completeness.${key} ${stored[key]} is inconsistent with the payload (expected ${expected[key]})`,
+        });
+      }
+    }
+  });
+
+export type EvalArtifactEnvelope<P extends ScorecardLike = ScorecardLike> =
+  Omit<z.infer<typeof EvalArtifactEnvelopeSchema>, "payload"> & { payload: P };
+
+// ─── Parsing ─────────────────────────────────────────────────────────────────
+
+export interface ParseEvalArtifactOptions {
+  /** Reject the artifact unless its type matches. */
+  expectedType: EvalArtifactType;
+  /** Reject the artifact unless it belongs to this harness. */
+  expectedHarness?: string;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+/** True when a value looks like a pre-envelope (legacy) bare scorecard. */
+export function looksLikeLegacyScorecard(value: unknown): boolean {
+  return isRecord(value)
+    && !("artifactType" in value)
+    && typeof value.generatedAt === "string"
+    && Array.isArray(value.cases);
+}
+
+/**
+ * Parses and strictly validates a shared eval artifact envelope.
+ *
+ * Throws actionable errors for: legacy unversioned scorecards (pointing at the
+ * migration script), incompatible artifact types, unknown schema versions, and
+ * any structural/consistency violation found by the envelope schema.
+ */
+export function parseEvalArtifact<P extends ScorecardLike = ScorecardLike>(
+  value: unknown,
+  options: ParseEvalArtifactOptions,
+): EvalArtifactEnvelope<P> {
+  if (!isRecord(value)) {
+    throw new Error("Eval artifact is not a JSON object; the file is corrupt or truncated");
+  }
+  if (looksLikeLegacyScorecard(value)) {
+    throw new Error(
+      "Legacy unversioned eval artifact detected. Convert it explicitly with "
+        + "`bun eval/shared/migrate-legacy-baselines.ts --write` (run from packages/protocol); "
+        + "legacy scorecards are never cast silently.",
+    );
+  }
+  if (value.artifactType !== options.expectedType) {
+    throw new Error(
+      `Incompatible artifact type: expected "${options.expectedType}", got "${String(value.artifactType)}"`,
+    );
+  }
+  if (value.schemaVersion !== EVAL_ARTIFACT_SCHEMA_VERSION) {
+    throw new Error(
+      `Unsupported eval artifact schema version ${String(value.schemaVersion)}; `
+        + `this build supports version ${EVAL_ARTIFACT_SCHEMA_VERSION}. `
+        + "Re-generate the artifact or upgrade the eval tooling.",
+    );
+  }
+  const parsed = EvalArtifactEnvelopeSchema.safeParse(value);
+  if (!parsed.success) {
+    const detail = parsed.error.issues
+      .slice(0, 5)
+      .map((issue) => `${issue.path.join(".") || "(root)"}: ${issue.message}`)
+      .join("; ");
+    throw new Error(`Invalid eval artifact: ${detail}`);
+  }
+  if (options.expectedHarness !== undefined && parsed.data.harness !== options.expectedHarness) {
+    throw new Error(
+      `Eval artifact belongs to harness "${parsed.data.harness}", expected "${options.expectedHarness}"`,
+    );
+  }
+  return parsed.data as unknown as EvalArtifactEnvelope<P>;
+}
+
+// ─── Building ────────────────────────────────────────────────────────────────
+
+function summarizeCompleteness(
+  cases: readonly Pick<CaseResultLike, "runs" | "passes" | "flaky">[],
+  ruleCount: number,
+): EvalCompleteness {
+  return {
+    caseCount: cases.length,
+    ruleCount,
+    totalRuns: cases.reduce((sum, c) => sum + c.runs, 0),
+    totalPasses: cases.reduce((sum, c) => sum + c.passes, 0),
+    flakyCaseCount: cases.filter((c) => c.flaky).length,
+  };
+}
+
+/** Run-scoped provenance every harness collects once per invocation. */
+export interface EvalRunMeta {
+  harness: string;
+  harnessVersion: string;
+  models: string[];
+  runs: number;
+  selection: EvalSelection;
+  corpusFingerprint: string;
+  configFingerprint: string;
+  git: EvalGitProvenance;
+  startedAt: string;
+  completedAt: string;
+}
+
+/**
+ * Wraps a scorecard payload in a validated envelope. Completeness is derived
+ * from the payload (never trusted from the caller) and the result is parsed
+ * before being returned, so an inconsistent envelope can never be produced.
+ */
+export function buildEvalArtifact<P extends ScorecardLike>(
+  artifactType: EvalArtifactType,
+  payload: P,
+  meta: EvalRunMeta,
+  options: { source?: "run" | "legacy-migration"; createdAt?: string } = {},
+): EvalArtifactEnvelope<P> {
+  const envelope = {
+    artifactType,
+    schemaVersion: EVAL_ARTIFACT_SCHEMA_VERSION,
+    harness: meta.harness,
+    harnessVersion: meta.harnessVersion,
+    source: options.source ?? "run",
+    createdAt: options.createdAt ?? new Date().toISOString(),
+    startedAt: meta.startedAt,
+    completedAt: meta.completedAt,
+    models: meta.models,
+    runs: meta.runs,
+    selection: meta.selection,
+    corpusFingerprint: meta.corpusFingerprint,
+    configFingerprint: meta.configFingerprint,
+    git: meta.git,
+    completeness: summarizeCompleteness(payload.cases, payload.rules.length),
+    payload,
+  };
+  return parseEvalArtifact<P>(envelope, { expectedType: artifactType });
+}
+
+// ─── Fingerprints ────────────────────────────────────────────────────────────
+
+function compareAscii(left: string, right: string): number {
+  return left < right ? -1 : left > right ? 1 : 0;
+}
+
+/** Key-sorted, undefined-stripped deep copy so JSON serialization is canonical. */
+export function canonicalizeForFingerprint(value: unknown): unknown {
+  if (Array.isArray(value)) return value.map(canonicalizeForFingerprint);
+  if (value && typeof value === "object") {
+    return Object.fromEntries(
+      Object.entries(value)
+        .filter(([, entry]) => entry !== undefined && typeof entry !== "function")
+        .sort(([left], [right]) => compareAscii(left, right))
+        .map(([key, entry]) => [key, canonicalizeForFingerprint(entry)]),
+    );
+  }
+  if (typeof value === "number" && !Number.isFinite(value)) {
+    throw new Error("Fingerprint input contains a non-finite number");
+  }
+  return value;
+}
+
+const SECRETLIKE_KEY = /(api[-_]?key|secret|token|password|credential|authorization)/i;
+
+function assertNoSecretlikeKeys(value: unknown, path: string): void {
+  if (Array.isArray(value)) {
+    value.forEach((entry, index) => assertNoSecretlikeKeys(entry, `${path}[${index}]`));
+    return;
+  }
+  if (value && typeof value === "object") {
+    for (const [key, entry] of Object.entries(value)) {
+      if (SECRETLIKE_KEY.test(key)) {
+        throw new Error(
+          `Fingerprint input contains a secret-like key "${path}.${key}"; `
+            + "corpus/config fingerprints must never include API keys, tokens, or raw environment values",
+        );
+      }
+      assertNoSecretlikeKeys(entry, `${path}.${key}`);
+    }
+  }
+}
+
+/** SHA-256 hex over canonicalized JSON. Deterministic across key order. */
+export function fingerprintCanonicalJson(value: unknown): string {
+  return createHash("sha256").update(JSON.stringify(canonicalizeForFingerprint(value))).digest("hex");
+}
+
+/** Deterministic fingerprint of the selected corpus (case definitions). */
+export function fingerprintEvalCorpus(cases: readonly unknown[]): string {
+  return fingerprintCanonicalJson(cases);
+}
+
+/**
+ * Deterministic fingerprint of the run configuration. Rejects secret-like keys
+ * so credentials/environment values can never leak into provenance inputs.
+ */
+export function fingerprintEvalConfig(config: Record<string, unknown>): string {
+  assertNoSecretlikeKeys(config, "config");
+  return fingerprintCanonicalJson(config);
+}
+
+// ─── Git provenance ──────────────────────────────────────────────────────────
+
+export type GitCommandRunner = (args: string[], cwd: string) => string;
+
+function runGitCommand(args: string[], cwd: string): string {
+  return execFileSync("git", args, {
+    cwd,
+    encoding: "utf8",
+    stdio: ["ignore", "pipe", "ignore"],
+    timeout: 5_000,
+    maxBuffer: 1024 * 1024,
+  }).trim();
+}
+
+/**
+ * Reads revision/dirty state without invoking a shell. Falls back to
+ * `{ revision: "unknown", dirty: null }` when Git metadata is unavailable.
+ * The runner is injectable so provenance stays unit-testable.
+ */
+export function readEvalGitProvenance(cwd: string, runGit: GitCommandRunner = runGitCommand): EvalGitProvenance {
+  try {
+    const revision = runGit(["rev-parse", "HEAD"], cwd).trim();
+    if (!/^[a-f0-9]{40,64}$/i.test(revision)) throw new Error("git returned a non-revision");
+    const dirty = runGit(["status", "--porcelain=v1", "--untracked-files=normal"], cwd).trim().length > 0;
+    return { revision: revision.toLowerCase(), dirty };
+  } catch {
+    return { revision: "unknown", dirty: null };
+  }
+}
+
+// ─── Legacy migration ────────────────────────────────────────────────────────
+
+const legacyScorecardSchema = z
+  .object({
+    generatedAt: dateTimeSchema,
+    model: z.string().min(1),
+    runs: z.number().int().min(1),
+    aggregatePassRate: rateSchema,
+    rules: z.array(ruleResultSchema).min(1),
+    cases: z.array(caseResultSchema).min(1),
+  })
+  .strict();
+
+/**
+ * Explicitly converts a legacy bare scorecard into a v1 baseline envelope.
+ *
+ * The payload is carried over untouched (identical case/rule/run/pass values);
+ * provenance that cannot be reconstructed is marked with explicit
+ * legacy-migration sentinels rather than fabricated. The result is fully
+ * validated, so a legacy scorecard that is internally inconsistent fails the
+ * conversion instead of becoming authoritative.
+ */
+export function migrateLegacyBaseline<P extends ScorecardLike>(
+  legacyValue: unknown,
+  options: { harness: string; harnessVersion: string; migratedAt?: string },
+): EvalArtifactEnvelope<P> {
+  if (!looksLikeLegacyScorecard(legacyValue)) {
+    throw new Error("Refusing to migrate: input is not a legacy unversioned scorecard");
+  }
+  const legacyParsed = legacyScorecardSchema.safeParse(legacyValue);
+  if (!legacyParsed.success) {
+    const detail = legacyParsed.error.issues
+      .slice(0, 5)
+      .map((issue) => `${issue.path.join(".") || "(root)"}: ${issue.message}`)
+      .join("; ");
+    throw new Error(`Legacy scorecard failed validation; fix or regenerate it instead of migrating: ${detail}`);
+  }
+  const legacy = legacyValue as P;
+  const models = legacy.model.split(" / ").map((m) => m.trim()).filter((m) => m.length > 0);
+  return buildEvalArtifact<P>(
+    EVAL_BASELINE_ARTIFACT_TYPE,
+    legacy,
+    {
+      harness: options.harness,
+      harnessVersion: options.harnessVersion,
+      models: [...new Set(models)],
+      runs: legacy.runs,
+      selection: { fullCorpus: true, filters: {} },
+      corpusFingerprint: EVAL_LEGACY_UNAVAILABLE,
+      configFingerprint: EVAL_LEGACY_UNAVAILABLE,
+      git: { revision: "unknown", dirty: null },
+      startedAt: legacy.generatedAt,
+      completedAt: legacy.generatedAt,
+    },
+    { source: "legacy-migration", createdAt: options.migratedAt ?? legacy.generatedAt },
+  );
+}

--- a/packages/protocol/eval/shared/baseline.ts
+++ b/packages/protocol/eval/shared/baseline.ts
@@ -1,3 +1,5 @@
+import { buildEvalArtifact, EVAL_BASELINE_ARTIFACT_TYPE, EVAL_RUN_REPORT_ARTIFACT_TYPE, type EvalRunMeta } from "./artifact.js";
+import { readEvalArtifact, writeEvalArtifact } from "./artifact.io.js";
 import { predictivePValue } from "./stats.js";
 import type { CaseResultLike, Regression, ScorecardLike } from "./types.js";
 
@@ -66,19 +68,30 @@ export function diffBaseline(
 }
 
 /**
- * Reads a baseline scorecard from a JSON file on disk.
+ * Reads a committed baseline through the versioned artifact envelope.
+ *
+ * The file must be a valid `index-eval/baseline` envelope for the given
+ * harness; corrupt files, legacy unversioned scorecards, unknown schema
+ * versions, and incompatible artifact types all fail with actionable errors
+ * instead of being trusted through a cast.
  *
  * @param path - Absolute or relative path to the baseline JSON file.
- * @returns The parsed scorecard, or `null` if the file does not exist.
+ * @param options.harness - The harness that owns this baseline.
+ * @returns The validated baseline scorecard payload, or `null` if the file does not exist.
  */
-export async function readBaseline<T extends ScorecardLike>(path: string): Promise<T | null> {
-  const file = Bun.file(path);
-  if (!(await file.exists())) return null;
-  return (await file.json()) as T;
+export async function readBaseline<T extends ScorecardLike>(
+  path: string,
+  options: { harness: string },
+): Promise<T | null> {
+  const envelope = await readEvalArtifact<T>(path, {
+    expectedType: EVAL_BASELINE_ARTIFACT_TYPE,
+    expectedHarness: options.harness,
+  });
+  return envelope?.payload ?? null;
 }
 
 /**
- * Writes a scorecard to disk as a formatted JSON baseline file.
+ * Writes a scorecard to disk as a versioned, validated baseline artifact.
  *
  * The committed baseline is a diff target, so verbose per-run detail (model
  * reasoning, candidate outcomes) is best stripped to keep `--update-baseline`
@@ -86,29 +99,44 @@ export async function readBaseline<T extends ScorecardLike>(path: string): Promi
  * per-run candidate payloads); the full detail lives in the run report instead
  * (see {@link writeRunReport}).
  *
- * @param path - Absolute or relative path to write to (created or overwritten).
+ * Writes are atomic (same-directory temp file + rename) and refuse to replace
+ * an existing baseline unless `force` is set (the CLI's `--force`).
+ *
+ * @param path - Absolute or relative path to write to.
  * @param sc - The scorecard to persist.
+ * @param opts.meta - Run provenance recorded in the envelope.
  * @param opts.leanCase - Optional per-case transform applied before serialization.
+ * @param opts.force - Explicit consent to overwrite an existing baseline.
  */
 export async function writeBaseline<C extends CaseResultLike>(
   path: string,
   sc: ScorecardLike<C>,
-  opts: { leanCase?: (c: C) => C } = {},
+  opts: { meta: EvalRunMeta; leanCase?: (c: C) => C; force?: boolean },
 ): Promise<void> {
   const leanCase = opts.leanCase ?? ((c: C) => c);
   const lean: ScorecardLike<C> = { ...sc, cases: sc.cases.map(leanCase) };
-  await Bun.write(path, JSON.stringify(lean, null, 2) + "\n");
+  const envelope = buildEvalArtifact(EVAL_BASELINE_ARTIFACT_TYPE, lean, opts.meta);
+  await writeEvalArtifact(path, envelope, { force: opts.force });
 }
 
 /**
  * Writes a full run report to disk: the scorecard *including* every per-run
- * detail. This is the explanatory artifact a reviewer or a report skill reads to
- * see the agent's own justification for each score. Written on demand via the
- * `--report` flag and auto-saved for full-corpus runs; never committed.
+ * detail, wrapped in the same versioned envelope as baselines (with
+ * `artifactType: "index-eval/run-report"`). This is the explanatory artifact a
+ * reviewer or a report skill reads to see the agent's own justification for
+ * each score. Written on demand via the `--report` flag and auto-saved for
+ * full-corpus runs; never committed.
  *
- * @param path - Absolute or relative path to write to. Parent dirs are created by Bun.
+ * @param path - Absolute or relative path to write to (parent dirs are created).
  * @param sc - The scorecard to persist, with detail intact.
+ * @param opts.meta - Run provenance recorded in the envelope.
+ * @param opts.force - Explicit consent to overwrite an existing report.
  */
-export async function writeRunReport(path: string, sc: ScorecardLike): Promise<void> {
-  await Bun.write(path, JSON.stringify(sc, null, 2) + "\n");
+export async function writeRunReport(
+  path: string,
+  sc: ScorecardLike,
+  opts: { meta: EvalRunMeta; force?: boolean },
+): Promise<void> {
+  const envelope = buildEvalArtifact(EVAL_RUN_REPORT_ARTIFACT_TYPE, sc, opts.meta);
+  await writeEvalArtifact(path, envelope, { force: opts.force });
 }

--- a/packages/protocol/eval/shared/index.ts
+++ b/packages/protocol/eval/shared/index.ts
@@ -21,6 +21,40 @@ export { buildScorecard, meanRate } from "./scorecard.js";
 export { diffBaseline, readBaseline, writeBaseline, writeRunReport } from "./baseline.js";
 export { computeRollingBaseline } from "./rolling.js";
 
+// ─── Versioned artifact envelope ───────────────────────────────────────────
+export {
+  EVAL_ARTIFACT_SCHEMA_VERSION,
+  EVAL_BASELINE_ARTIFACT_TYPE,
+  EVAL_RUN_REPORT_ARTIFACT_TYPE,
+  EVAL_LEGACY_UNAVAILABLE,
+  EvalArtifactEnvelopeSchema,
+  EvalScorecardPayloadSchema,
+  buildEvalArtifact,
+  parseEvalArtifact,
+  looksLikeLegacyScorecard,
+  migrateLegacyBaseline,
+  canonicalizeForFingerprint,
+  fingerprintCanonicalJson,
+  fingerprintEvalCorpus,
+  fingerprintEvalConfig,
+  readEvalGitProvenance,
+  type EvalArtifactType,
+  type EvalArtifactEnvelope,
+  type EvalRunMeta,
+  type EvalSelection,
+  type EvalGitProvenance,
+  type EvalCompleteness,
+  type GitCommandRunner,
+} from "./artifact.js";
+export {
+  readEvalArtifact,
+  writeEvalArtifact,
+  assertEvalWritePlan,
+  type EvalWritePlan,
+  type EvalWriteOutput,
+  type WriteEvalArtifactOptions,
+} from "./artifact.io.js";
+
 // ─── Reporting ─────────────────────────────────────────────────────────────
 export { formatConsole, type ConsoleOptions } from "./console.js";
 export {

--- a/packages/protocol/eval/shared/migrate-legacy-baselines.ts
+++ b/packages/protocol/eval/shared/migrate-legacy-baselines.ts
@@ -1,0 +1,79 @@
+#!/usr/bin/env bun
+/**
+ * Explicit, reviewable conversion of legacy (pre-envelope) committed baselines
+ * into versioned `index-eval/baseline` artifacts.
+ *
+ * Usage (from packages/protocol):
+ *   bun eval/shared/migrate-legacy-baselines.ts            # dry-run: report what would change
+ *   bun eval/shared/migrate-legacy-baselines.ts --write    # convert in place (review the git diff)
+ *
+ * The scorecard payload is carried over byte-for-byte in value terms —
+ * identical case/rule/run/pass numbers — and the conversion is validated
+ * before anything is written. Provenance that cannot be reconstructed
+ * (corpus/config fingerprints, git revision) is marked with explicit
+ * legacy-migration sentinels; nothing is fabricated and nothing is cast
+ * silently. Already-converted baselines are reported and skipped.
+ */
+import path from "node:path";
+
+import { looksLikeLegacyScorecard, migrateLegacyBaseline } from "./artifact.js";
+import { writeEvalArtifact } from "./artifact.io.js";
+import { has } from "./cli.js";
+
+/** Every baseline-backed harness with a committed baseline. */
+const COMMITTED_BASELINES = [
+  { harness: "matching", harnessVersion: "1" },
+  { harness: "premise", harnessVersion: "1" },
+  { harness: "profile", harnessVersion: "1" },
+  { harness: "opportunity", harnessVersion: "1" },
+] as const;
+
+async function main(): Promise<void> {
+  const write = has("--write");
+  let failures = 0;
+
+  for (const { harness, harnessVersion } of COMMITTED_BASELINES) {
+    const baselinePath = path.resolve(import.meta.dir, `../${harness}/baselines/${harness}.baseline.json`);
+    const file = Bun.file(baselinePath);
+    if (!(await file.exists())) {
+      console.log(`- ${harness}: no committed baseline at ${baselinePath}; skipping`);
+      continue;
+    }
+    let value: unknown;
+    try {
+      value = await file.json();
+    } catch {
+      console.error(`✗ ${harness}: ${baselinePath} is not valid JSON; refusing to migrate`);
+      failures += 1;
+      continue;
+    }
+    if (!looksLikeLegacyScorecard(value)) {
+      console.log(`- ${harness}: already a versioned artifact; skipping`);
+      continue;
+    }
+    try {
+      const envelope = migrateLegacyBaseline(value, { harness, harnessVersion });
+      if (write) {
+        // In-place conversion is the sanctioned input==output flow of this
+        // script; the git diff is the review surface.
+        await writeEvalArtifact(baselinePath, envelope, { force: true });
+        console.log(`✓ ${harness}: converted ${baselinePath} (schema v${envelope.schemaVersion}, `
+          + `${envelope.completeness.caseCount} cases, ${envelope.completeness.totalPasses}/${envelope.completeness.totalRuns} passes)`);
+      } else {
+        console.log(`~ ${harness}: would convert ${baselinePath} (schema v${envelope.schemaVersion}, `
+          + `${envelope.completeness.caseCount} cases, ${envelope.completeness.totalPasses}/${envelope.completeness.totalRuns} passes)`);
+      }
+    } catch (err) {
+      console.error(`✗ ${harness}: ${err instanceof Error ? err.message : String(err)}`);
+      failures += 1;
+    }
+  }
+
+  if (!write) console.log("\nDry run only. Re-run with --write to convert, then review the git diff.");
+  process.exit(failures > 0 ? 1 : 0);
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exit(2);
+});

--- a/packages/protocol/eval/shared/rolling.ts
+++ b/packages/protocol/eval/shared/rolling.ts
@@ -1,5 +1,6 @@
 import { readdir } from "node:fs/promises";
 
+import { EVAL_RUN_REPORT_ARTIFACT_TYPE, parseEvalArtifact } from "./artifact.js";
 import { buildScorecard } from "./scorecard.js";
 import type { CaseResultLike, ScorecardLike } from "./types.js";
 
@@ -10,7 +11,12 @@ interface RollingCaseAcc {
   runs: number;
 }
 
-/** Reads all JSON scorecards in a run directory, ignoring missing dirs and malformed files. */
+/**
+ * Reads all versioned run-report envelopes in a run directory, ignoring
+ * missing dirs plus malformed, legacy-unversioned, or non-report files. Only
+ * payloads that pass full envelope validation contribute to the rolling
+ * baseline, so a corrupt or stale-format report can never skew it.
+ */
 async function readRunScorecards(runsDir: string): Promise<ScorecardLike[]> {
   let entries: string[];
   try {
@@ -24,11 +30,11 @@ async function readRunScorecards(runsDir: string): Promise<ScorecardLike[]> {
     if (!entry.endsWith(".json")) continue;
     try {
       const file = Bun.file(`${runsDir}/${entry}`);
-      const sc = (await file.json()) as ScorecardLike;
-      if (sc.generatedAt && Array.isArray(sc.cases)) out.push(sc);
+      const envelope = parseEvalArtifact(await file.json(), { expectedType: EVAL_RUN_REPORT_ARTIFACT_TYPE });
+      out.push(envelope.payload);
     } catch {
-      // Run reports are diagnostic artifacts; one malformed file should not
-      // disable rolling-baseline computation for every other run.
+      // Run reports are diagnostic artifacts; one malformed or legacy file
+      // should not disable rolling-baseline computation for every other run.
     }
   }
   return out;

--- a/packages/protocol/eval/shared/tests/artifact.fixtures.ts
+++ b/packages/protocol/eval/shared/tests/artifact.fixtures.ts
@@ -1,0 +1,29 @@
+/**
+ * Shared test fixtures for the versioned eval artifact envelope. Used by the
+ * shared specs and by harness specs that exercise the envelope-backed
+ * baseline/run-report writers.
+ */
+import type { EvalRunMeta } from "../artifact.js";
+
+/** A syntactically valid SHA-256 fingerprint for fixtures. */
+export const TEST_FINGERPRINT = "a".repeat(64);
+
+/** A syntactically valid Git revision for fixtures. */
+export const TEST_REVISION = "b".repeat(40);
+
+/** A fully populated run meta; override per test. */
+export function makeTestMeta(overrides: Partial<EvalRunMeta> = {}): EvalRunMeta {
+  return {
+    harness: "test-harness",
+    harnessVersion: "1",
+    models: ["test/model"],
+    runs: 1,
+    selection: { fullCorpus: true, filters: {} },
+    corpusFingerprint: TEST_FINGERPRINT,
+    configFingerprint: TEST_FINGERPRINT,
+    git: { revision: TEST_REVISION, dirty: false },
+    startedAt: "2026-01-01T00:00:00.000Z",
+    completedAt: "2026-01-01T00:01:00.000Z",
+    ...overrides,
+  };
+}

--- a/packages/protocol/eval/shared/tests/artifact.io.spec.ts
+++ b/packages/protocol/eval/shared/tests/artifact.io.spec.ts
@@ -1,0 +1,150 @@
+import { describe, expect, it } from "bun:test";
+import { mkdir, readdir, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { EVAL_BASELINE_ARTIFACT_TYPE, buildEvalArtifact } from "../artifact.js";
+import { assertEvalWritePlan, readEvalArtifact, writeEvalArtifact } from "../artifact.io.js";
+import { buildScorecard } from "../scorecard.js";
+import type { CaseResultLike } from "../types.js";
+import { makeTestMeta } from "./artifact.fixtures.js";
+
+const caseResult = (caseId: string, passes: number, runs = 3): CaseResultLike => ({
+  caseId,
+  rule: "g",
+  runs,
+  passes,
+  passRate: passes / runs,
+  flaky: passes > 0 && passes < runs,
+});
+
+const envelope = (passes = 3) =>
+  buildEvalArtifact(
+    EVAL_BASELINE_ARTIFACT_TYPE,
+    buildScorecard([caseResult("a", passes)], { model: "test/model", runs: 3 }),
+    makeTestMeta({ runs: 3 }),
+  );
+
+const freshDir = async (): Promise<string> => {
+  const dir = join(tmpdir(), `eval-artifact-io-${Date.now()}-${Math.random().toString(36).slice(2)}`);
+  await mkdir(dir, { recursive: true });
+  return dir;
+};
+
+describe("writeEvalArtifact + readEvalArtifact", () => {
+  it("round-trips through an atomic write with no temp residue", async () => {
+    const dir = await freshDir();
+    const p = join(dir, "baseline.json");
+    await writeEvalArtifact(p, envelope());
+    const back = await readEvalArtifact(p, { expectedType: EVAL_BASELINE_ARTIFACT_TYPE, expectedHarness: "test-harness" });
+    expect(back!.payload.cases[0].caseId).toBe("a");
+    expect(await readdir(dir)).toEqual(["baseline.json"]);
+    await rm(dir, { recursive: true, force: true });
+  });
+
+  it("returns null for a missing file", async () => {
+    expect(await readEvalArtifact(join(tmpdir(), `missing-${Date.now()}.json`), { expectedType: EVAL_BASELINE_ARTIFACT_TYPE })).toBeNull();
+  });
+
+  it("fails actionably on corrupt/truncated JSON", async () => {
+    const dir = await freshDir();
+    const p = join(dir, "baseline.json");
+    await Bun.write(p, JSON.stringify(envelope()).slice(0, 40));
+    await expect(readEvalArtifact(p, { expectedType: EVAL_BASELINE_ARTIFACT_TYPE })).rejects.toThrow(/not valid JSON.*corrupt or truncated/);
+    await rm(dir, { recursive: true, force: true });
+  });
+
+  it("fails actionably on a stale (unknown) schema version, naming the file", async () => {
+    const dir = await freshDir();
+    const p = join(dir, "baseline.json");
+    await Bun.write(p, JSON.stringify({ ...envelope(), schemaVersion: 0 }));
+    await expect(readEvalArtifact(p, { expectedType: EVAL_BASELINE_ARTIFACT_TYPE })).rejects.toThrow(/baseline\.json.*schema version 0/);
+    await rm(dir, { recursive: true, force: true });
+  });
+
+  it("refuses to overwrite an existing artifact without force", async () => {
+    const dir = await freshDir();
+    const p = join(dir, "baseline.json");
+    await writeEvalArtifact(p, envelope(3));
+    await expect(writeEvalArtifact(p, envelope(2))).rejects.toThrow(/Refusing to overwrite.*--force/);
+    const back = await readEvalArtifact(p, { expectedType: EVAL_BASELINE_ARTIFACT_TYPE });
+    expect(back!.payload.cases[0].passes).toBe(3); // original intact
+    await writeEvalArtifact(p, envelope(2), { force: true });
+    const replaced = await readEvalArtifact(p, { expectedType: EVAL_BASELINE_ARTIFACT_TYPE });
+    expect(replaced!.payload.cases[0].passes).toBe(2);
+    await rm(dir, { recursive: true, force: true });
+  });
+
+  it("never lets an invalid artifact replace a previous valid one", async () => {
+    const dir = await freshDir();
+    const p = join(dir, "baseline.json");
+    await writeEvalArtifact(p, envelope(3));
+    const corrupted = { ...envelope(2), completeness: { ...envelope(2).completeness, totalPasses: 999 } };
+    await expect(writeEvalArtifact(p, corrupted, { force: true })).rejects.toThrow(/completeness\.totalPasses/);
+    const back = await readEvalArtifact(p, { expectedType: EVAL_BASELINE_ARTIFACT_TYPE });
+    expect(back!.payload.cases[0].passes).toBe(3); // previous valid artifact untouched
+    expect(await readdir(dir)).toEqual(["baseline.json"]); // no temp residue
+    await rm(dir, { recursive: true, force: true });
+  });
+
+  it("cleans up its temp file when the rename target is unusable", async () => {
+    const dir = await freshDir();
+    const asDir = join(dir, "collision.json");
+    await mkdir(asDir); // rename onto an existing directory fails
+    await expect(writeEvalArtifact(asDir, envelope(), { force: true })).rejects.toThrow();
+    expect((await readdir(dir)).filter((f) => f.includes(".tmp"))).toEqual([]);
+    await rm(dir, { recursive: true, force: true });
+  });
+
+  it("creates missing parent directories", async () => {
+    const dir = await freshDir();
+    const p = join(dir, "nested/deeper/baseline.json");
+    await writeEvalArtifact(p, envelope());
+    expect(await readEvalArtifact(p, { expectedType: EVAL_BASELINE_ARTIFACT_TYPE })).not.toBeNull();
+    await rm(dir, { recursive: true, force: true });
+  });
+});
+
+describe("assertEvalWritePlan", () => {
+  it("rejects an output that would overwrite an input", async () => {
+    const dir = await freshDir();
+    const baseline = join(dir, "baseline.json");
+    await expect(assertEvalWritePlan({ inputs: [baseline], outputs: [baseline] }))
+      .rejects.toThrow(/would overwrite an input artifact/);
+    await rm(dir, { recursive: true, force: true });
+  });
+
+  it("allows the sanctioned in-place baseline update while still requiring consent", async () => {
+    const dir = await freshDir();
+    const baseline = join(dir, "baseline.json");
+    // Non-existent baseline: fine without force.
+    await assertEvalWritePlan({ inputs: [baseline], outputs: [{ path: baseline, updatesInput: true }] });
+    // Existing baseline: refused without force, allowed with force.
+    await writeEvalArtifact(baseline, envelope());
+    await expect(assertEvalWritePlan({ inputs: [baseline], outputs: [{ path: baseline, updatesInput: true }] }))
+      .rejects.toThrow(/--force/);
+    await assertEvalWritePlan({ inputs: [baseline], outputs: [{ path: baseline, updatesInput: true }], force: true });
+    await rm(dir, { recursive: true, force: true });
+  });
+
+  it("rejects the same output declared twice (partial multi-output protection)", async () => {
+    const p = join(tmpdir(), `dup-${Date.now()}.json`);
+    await expect(assertEvalWritePlan({ outputs: [p, p] })).rejects.toThrow(/declared twice/);
+  });
+
+  it("reports every existing destination before anything is written", async () => {
+    const dir = await freshDir();
+    const a = join(dir, "a.json");
+    const b = join(dir, "b.json");
+    const c = join(dir, "c.json");
+    await Bun.write(a, "{}");
+    await Bun.write(b, "{}");
+    const err = await assertEvalWritePlan({ outputs: [a, b, c] }).catch((e: unknown) => e as Error);
+    expect(err).toBeInstanceOf(Error);
+    expect((err as Error).message).toContain(a);
+    expect((err as Error).message).toContain(b);
+    expect((err as Error).message).not.toContain(c);
+    await assertEvalWritePlan({ outputs: [a, b, c], force: true });
+    await rm(dir, { recursive: true, force: true });
+  });
+});

--- a/packages/protocol/eval/shared/tests/artifact.spec.ts
+++ b/packages/protocol/eval/shared/tests/artifact.spec.ts
@@ -1,0 +1,277 @@
+import { describe, expect, it } from "bun:test";
+
+import { EVAL_ARTIFACT_SCHEMA_VERSION, EVAL_BASELINE_ARTIFACT_TYPE, EVAL_LEGACY_UNAVAILABLE, EVAL_RUN_REPORT_ARTIFACT_TYPE, buildEvalArtifact, canonicalizeForFingerprint, fingerprintCanonicalJson, fingerprintEvalConfig, fingerprintEvalCorpus, looksLikeLegacyScorecard, migrateLegacyBaseline, parseEvalArtifact, readEvalGitProvenance } from "../artifact.js";
+import { buildScorecard } from "../scorecard.js";
+import type { CaseResultLike, ScorecardLike } from "../types.js";
+import { TEST_REVISION, makeTestMeta } from "./artifact.fixtures.js";
+
+const caseResult = (caseId: string, rule: string, passes: number, runs = 3): CaseResultLike => ({
+  caseId,
+  rule,
+  runs,
+  passes,
+  passRate: passes / runs,
+  flaky: passes > 0 && passes < runs,
+});
+
+const scorecard = (): ScorecardLike =>
+  buildScorecard([caseResult("a", "g", 3), caseResult("b", "g", 1), caseResult("c", "h", 0)], {
+    model: "test/model",
+    runs: 3,
+  });
+
+const validEnvelope = () => buildEvalArtifact(EVAL_BASELINE_ARTIFACT_TYPE, scorecard(), makeTestMeta({ runs: 3 }));
+
+describe("buildEvalArtifact + parseEvalArtifact", () => {
+  it("round-trips a valid baseline envelope", () => {
+    const envelope = validEnvelope();
+    const parsed = parseEvalArtifact(envelope, {
+      expectedType: EVAL_BASELINE_ARTIFACT_TYPE,
+      expectedHarness: "test-harness",
+    });
+    expect(parsed.schemaVersion).toBe(EVAL_ARTIFACT_SCHEMA_VERSION);
+    expect(parsed.payload.cases).toHaveLength(3);
+    expect(parsed.completeness).toEqual({
+      caseCount: 3,
+      ruleCount: 2,
+      totalRuns: 9,
+      totalPasses: 4,
+      flakyCaseCount: 1,
+    });
+  });
+
+  it("rejects non-object values as corrupt", () => {
+    expect(() => parseEvalArtifact("truncated…", { expectedType: EVAL_BASELINE_ARTIFACT_TYPE })).toThrow(/corrupt or truncated/);
+    expect(() => parseEvalArtifact(null, { expectedType: EVAL_BASELINE_ARTIFACT_TYPE })).toThrow(/corrupt or truncated/);
+  });
+
+  it("rejects legacy unversioned scorecards with a migration pointer", () => {
+    expect(() => parseEvalArtifact(scorecard(), { expectedType: EVAL_BASELINE_ARTIFACT_TYPE }))
+      .toThrow(/migrate-legacy-baselines.*never cast silently/s);
+  });
+
+  it("rejects incompatible artifact types", () => {
+    const envelope = validEnvelope();
+    expect(() => parseEvalArtifact(envelope, { expectedType: EVAL_RUN_REPORT_ARTIFACT_TYPE }))
+      .toThrow(/Incompatible artifact type.*index-eval\/run-report.*index-eval\/baseline/);
+  });
+
+  it("rejects unknown schema versions with the supported version named", () => {
+    const envelope = { ...validEnvelope(), schemaVersion: 999 };
+    expect(() => parseEvalArtifact(envelope, { expectedType: EVAL_BASELINE_ARTIFACT_TYPE }))
+      .toThrow(/schema version 999.*supports version 1/);
+  });
+
+  it("rejects a harness mismatch", () => {
+    const envelope = validEnvelope();
+    expect(() => parseEvalArtifact(envelope, { expectedType: EVAL_BASELINE_ARTIFACT_TYPE, expectedHarness: "other" }))
+      .toThrow(/belongs to harness "test-harness", expected "other"/);
+  });
+
+  it("rejects unknown envelope keys", () => {
+    const envelope = { ...validEnvelope(), extraneous: true };
+    expect(() => parseEvalArtifact(envelope, { expectedType: EVAL_BASELINE_ARTIFACT_TYPE })).toThrow(/Invalid eval artifact/);
+  });
+
+  it("rejects malformed numbers (NaN, out-of-range rates, non-integers)", () => {
+    const base = validEnvelope();
+    const withCase = (patch: Partial<CaseResultLike>) => ({
+      ...base,
+      payload: {
+        ...base.payload,
+        cases: base.payload.cases.map((c, i) => (i === 0 ? { ...c, ...patch } : c)),
+      },
+    });
+    expect(() => parseEvalArtifact(withCase({ passRate: Number.NaN }), { expectedType: EVAL_BASELINE_ARTIFACT_TYPE })).toThrow(/Invalid eval artifact/);
+    expect(() => parseEvalArtifact(withCase({ passRate: 1.5 }), { expectedType: EVAL_BASELINE_ARTIFACT_TYPE })).toThrow(/Invalid eval artifact/);
+    expect(() => parseEvalArtifact(withCase({ runs: 2.5 }), { expectedType: EVAL_BASELINE_ARTIFACT_TYPE })).toThrow(/Invalid eval artifact/);
+    expect(() => parseEvalArtifact(withCase({ passes: -1 }), { expectedType: EVAL_BASELINE_ARTIFACT_TYPE })).toThrow(/Invalid eval artifact/);
+  });
+
+  it("rejects passes greater than runs", () => {
+    const base = validEnvelope();
+    const bad = {
+      ...base,
+      payload: { ...base.payload, cases: base.payload.cases.map((c, i) => (i === 0 ? { ...c, passes: 99 } : c)) },
+    };
+    expect(() => parseEvalArtifact(bad, { expectedType: EVAL_BASELINE_ARTIFACT_TYPE })).toThrow(/exceeds runs/);
+  });
+
+  it("rejects duplicate case ids and duplicate rule labels", () => {
+    const base = validEnvelope();
+    const dupCase = {
+      ...base,
+      payload: { ...base.payload, cases: [...base.payload.cases, base.payload.cases[0]] },
+    };
+    expect(() => parseEvalArtifact(dupCase, { expectedType: EVAL_BASELINE_ARTIFACT_TYPE })).toThrow(/duplicate caseId/);
+    const dupRule = {
+      ...base,
+      payload: { ...base.payload, rules: [...base.payload.rules, base.payload.rules[0]] },
+    };
+    expect(() => parseEvalArtifact(dupRule, { expectedType: EVAL_BASELINE_ARTIFACT_TYPE })).toThrow(/duplicate rule|rules rollup/);
+  });
+
+  it("rejects inconsistent aggregate counts and rates", () => {
+    const base = validEnvelope();
+    const badAggregate = { ...base, payload: { ...base.payload, aggregatePassRate: 0.123 } };
+    expect(() => parseEvalArtifact(badAggregate, { expectedType: EVAL_BASELINE_ARTIFACT_TYPE }))
+      .toThrow(/aggregatePassRate is inconsistent/);
+    const badRule = {
+      ...base,
+      payload: {
+        ...base.payload,
+        rules: base.payload.rules.map((r, i) => (i === 0 ? { ...r, passRate: 0.001 } : r)),
+      },
+    };
+    expect(() => parseEvalArtifact(badRule, { expectedType: EVAL_BASELINE_ARTIFACT_TYPE }))
+      .toThrow(/passRate is inconsistent with its member cases/);
+    const badCompleteness = { ...base, completeness: { ...base.completeness, totalPasses: 123 } };
+    expect(() => parseEvalArtifact(badCompleteness, { expectedType: EVAL_BASELINE_ARTIFACT_TYPE }))
+      .toThrow(/completeness\.totalPasses/);
+  });
+
+  it("rejects inconsistent flaky flags", () => {
+    const base = validEnvelope();
+    const bad = {
+      ...base,
+      payload: { ...base.payload, cases: base.payload.cases.map((c, i) => (i === 0 ? { ...c, flaky: true } : c)) },
+    };
+    expect(() => parseEvalArtifact(bad, { expectedType: EVAL_BASELINE_ARTIFACT_TYPE })).toThrow(/flaky flag is inconsistent/);
+  });
+
+  it("rejects non-monotonic timestamps", () => {
+    const base = validEnvelope();
+    const bad = { ...base, startedAt: "2026-02-01T00:00:00.000Z" }; // after completedAt
+    expect(() => parseEvalArtifact(bad, { expectedType: EVAL_BASELINE_ARTIFACT_TYPE }))
+      .toThrow(/startedAt <= completedAt <= createdAt/);
+  });
+
+  it("rejects legacy fingerprint sentinels on run-sourced artifacts", () => {
+    const base = validEnvelope();
+    const bad = { ...base, corpusFingerprint: EVAL_LEGACY_UNAVAILABLE };
+    expect(() => parseEvalArtifact(bad, { expectedType: EVAL_BASELINE_ARTIFACT_TYPE }))
+      .toThrow(/only valid for source "legacy-migration"/);
+  });
+
+  it("rejects an envelope/payload run-count mismatch and duplicate models", () => {
+    const base = validEnvelope();
+    expect(() => parseEvalArtifact({ ...base, runs: 7 }, { expectedType: EVAL_BASELINE_ARTIFACT_TYPE }))
+      .toThrow(/envelope runs \(7\) != payload runs \(3\)/);
+    expect(() => parseEvalArtifact({ ...base, models: ["m", "m"] }, { expectedType: EVAL_BASELINE_ARTIFACT_TYPE }))
+      .toThrow(/duplicate model IDs/);
+  });
+
+  it("rejects selection filters on full-corpus artifacts", () => {
+    expect(() =>
+      buildEvalArtifact(EVAL_BASELINE_ARTIFACT_TYPE, scorecard(), makeTestMeta({
+        runs: 3,
+        selection: { fullCorpus: true, filters: { rule: "g" } },
+      })),
+    ).toThrow(/must not carry selection filters/);
+  });
+
+  it("derives completeness from the payload rather than trusting the caller", () => {
+    const envelope = validEnvelope();
+    expect(envelope.completeness.totalRuns).toBe(9);
+    expect(envelope.completeness.flakyCaseCount).toBe(1);
+  });
+});
+
+describe("fingerprints", () => {
+  it("is independent of key order", () => {
+    expect(fingerprintCanonicalJson({ a: 1, b: [{ x: 1, y: 2 }] }))
+      .toBe(fingerprintCanonicalJson({ b: [{ y: 2, x: 1 }], a: 1 }));
+  });
+
+  it("is sensitive to array order and values", () => {
+    expect(fingerprintCanonicalJson([1, 2])).not.toBe(fingerprintCanonicalJson([2, 1]));
+    expect(fingerprintCanonicalJson({ a: 1 })).not.toBe(fingerprintCanonicalJson({ a: 2 }));
+  });
+
+  it("treats undefined values and functions as absent", () => {
+    expect(fingerprintCanonicalJson({ a: 1, b: undefined, f: () => 1 })).toBe(fingerprintCanonicalJson({ a: 1 }));
+  });
+
+  it("rejects non-finite numbers", () => {
+    expect(() => canonicalizeForFingerprint({ a: Number.POSITIVE_INFINITY })).toThrow(/non-finite/);
+  });
+
+  it("fingerprints a corpus deterministically", () => {
+    const corpus = [{ id: "case-1", input: "x" }, { id: "case-2", input: "y" }];
+    expect(fingerprintEvalCorpus(corpus)).toBe(fingerprintEvalCorpus([...corpus]));
+    expect(fingerprintEvalCorpus(corpus)).toMatch(/^[a-f0-9]{64}$/);
+  });
+
+  it("refuses secret-like keys in config fingerprints", () => {
+    expect(() => fingerprintEvalConfig({ runs: 3, apiKey: "sk-nope" })).toThrow(/secret-like key/);
+    expect(() => fingerprintEvalConfig({ nested: { OPENROUTER_API_KEY: "x" } })).toThrow(/secret-like key/);
+    expect(fingerprintEvalConfig({ runs: 3, alpha: 0.05 })).toMatch(/^[a-f0-9]{64}$/);
+  });
+});
+
+describe("readEvalGitProvenance", () => {
+  it("reads a clean revision deterministically via the injected runner", () => {
+    const git = readEvalGitProvenance("/repo", (args) => (args[0] === "rev-parse" ? TEST_REVISION : ""));
+    expect(git).toEqual({ revision: TEST_REVISION, dirty: false });
+  });
+
+  it("marks dirty worktrees", () => {
+    const git = readEvalGitProvenance("/repo", (args) => (args[0] === "rev-parse" ? TEST_REVISION : " M file.ts"));
+    expect(git).toEqual({ revision: TEST_REVISION, dirty: true });
+  });
+
+  it("falls back to unknown when git is unavailable", () => {
+    const git = readEvalGitProvenance("/repo", () => {
+      throw new Error("no git");
+    });
+    expect(git).toEqual({ revision: "unknown", dirty: null });
+  });
+
+  it("rejects non-revision output", () => {
+    const git = readEvalGitProvenance("/repo", () => "not-a-hash");
+    expect(git).toEqual({ revision: "unknown", dirty: null });
+  });
+});
+
+describe("migrateLegacyBaseline", () => {
+  it("preserves the legacy payload value-for-value with explicit sentinels", () => {
+    const legacy = scorecard();
+    const envelope = migrateLegacyBaseline(JSON.parse(JSON.stringify(legacy)), {
+      harness: "test-harness",
+      harnessVersion: "1",
+    });
+    expect(envelope.source).toBe("legacy-migration");
+    expect(envelope.corpusFingerprint).toBe(EVAL_LEGACY_UNAVAILABLE);
+    expect(envelope.configFingerprint).toBe(EVAL_LEGACY_UNAVAILABLE);
+    expect(envelope.git).toEqual({ revision: "unknown", dirty: null });
+    expect(envelope.createdAt).toBe(legacy.generatedAt);
+    expect(JSON.parse(JSON.stringify(envelope.payload))).toEqual(JSON.parse(JSON.stringify(legacy)));
+  });
+
+  it("splits legacy multi-model strings into unique model ids", () => {
+    const legacy = { ...scorecard(), model: "provider/a / provider/a" };
+    const envelope = migrateLegacyBaseline(JSON.parse(JSON.stringify(legacy)), {
+      harness: "test-harness",
+      harnessVersion: "1",
+    });
+    expect(envelope.models).toEqual(["provider/a"]);
+  });
+
+  it("refuses non-legacy input", () => {
+    expect(() => migrateLegacyBaseline(validEnvelope(), { harness: "h", harnessVersion: "1" }))
+      .toThrow(/not a legacy unversioned scorecard/);
+  });
+
+  it("refuses an internally inconsistent legacy scorecard", () => {
+    const legacy = scorecard();
+    const bad = { ...legacy, cases: legacy.cases.map((c, i) => (i === 0 ? { ...c, passRate: 0.5 } : c)) };
+    expect(() => migrateLegacyBaseline(JSON.parse(JSON.stringify(bad)), { harness: "h", harnessVersion: "1" }))
+      .toThrow(/inconsistent|Invalid eval artifact/);
+  });
+
+  it("detects legacy scorecards structurally", () => {
+    expect(looksLikeLegacyScorecard(scorecard())).toBe(true);
+    expect(looksLikeLegacyScorecard(validEnvelope())).toBe(false);
+    expect(looksLikeLegacyScorecard("nope")).toBe(false);
+  });
+});

--- a/packages/protocol/eval/shared/tests/baseline.spec.ts
+++ b/packages/protocol/eval/shared/tests/baseline.spec.ts
@@ -7,6 +7,7 @@ import { buildScorecard } from "../scorecard.js";
 import { diffBaseline, readBaseline, writeBaseline, writeRunReport } from "../baseline.js";
 import { computeRollingBaseline } from "../rolling.js";
 import type { CaseResultLike, ScorecardLike } from "../types.js";
+import { makeTestMeta } from "./artifact.fixtures.js";
 
 const R = 7;
 const BS = 0.8;
@@ -78,23 +79,24 @@ describe("writeBaseline leanCase transform", () => {
   it("applies the per-case transform before serializing", async () => {
     const p = join(tmpdir(), `shared-baseline-${Date.now()}.json`);
     await writeBaseline(p, rich(), {
+      meta: makeTestMeta(),
       leanCase: (c) => ({ ...c, runResults: c.runResults.map(({ detail: _d, ...rest }) => rest) }),
     });
-    const back = await readBaseline<ScorecardLike<RichCase>>(p);
+    const back = await readBaseline<ScorecardLike<RichCase>>(p, { harness: "test-harness" });
     expect(back!.cases[0].runResults[0].detail).toBeUndefined();
     await unlink(p);
   });
 
   it("keeps detail verbatim with the default (identity) transform", async () => {
     const p = join(tmpdir(), `shared-report-${Date.now()}.json`);
-    await writeRunReport(p, rich());
-    const back = JSON.parse(await Bun.file(p).text()) as ScorecardLike<RichCase>;
+    await writeRunReport(p, rich(), { meta: makeTestMeta() });
+    const back = (JSON.parse(await Bun.file(p).text()) as { payload: ScorecardLike<RichCase> }).payload;
     expect(back.cases[0].runResults[0].detail).toBe("verbose");
     await unlink(p);
   });
 
   it("readBaseline returns null when the file is missing", async () => {
-    const back = await readBaseline(join(tmpdir(), `missing-${Date.now()}.json`));
+    const back = await readBaseline(join(tmpdir(), `missing-${Date.now()}.json`), { harness: "test-harness" });
     expect(back).toBeNull();
   });
 });
@@ -113,9 +115,10 @@ describe("computeRollingBaseline", () => {
       ...buildScorecard([s("a", "g", passRate, 3)], { model: "m", runs: 3 }),
       generatedAt: at,
     });
-    await writeRunReport(join(dir, "recent-perfect.json"), mk(1, "2026-05-27T00:00:00.000Z"));
-    await writeRunReport(join(dir, "recent-partial.json"), mk(0.33, "2026-05-26T00:00:00.000Z"));
-    await writeRunReport(join(dir, "old.json"), mk(0, "2026-05-01T00:00:00.000Z"));
+    const meta = makeTestMeta({ runs: 3, startedAt: "2026-04-30T00:00:00.000Z", completedAt: "2026-04-30T00:01:00.000Z" });
+    await writeRunReport(join(dir, "recent-perfect.json"), mk(1, "2026-05-27T00:00:00.000Z"), { meta });
+    await writeRunReport(join(dir, "recent-partial.json"), mk(1 / 3, "2026-05-26T00:00:00.000Z"), { meta });
+    await writeRunReport(join(dir, "old.json"), mk(0, "2026-05-01T00:00:00.000Z"), { meta });
 
     const rolling = await computeRollingBaseline(dir, 7, now);
     expect(rolling).not.toBeNull();

--- a/packages/protocol/eval/shared/tests/migration.spec.ts
+++ b/packages/protocol/eval/shared/tests/migration.spec.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it } from "bun:test";
+import path from "node:path";
+
+import { EVAL_BASELINE_ARTIFACT_TYPE, EVAL_LEGACY_UNAVAILABLE } from "../artifact.js";
+import { readEvalArtifact } from "../artifact.io.js";
+
+/**
+ * Every committed baseline must be a valid versioned envelope. This is the
+ * provider-free guard that keeps the explicit legacy migration honest: the
+ * payloads validate under the full consistency rules (identical
+ * case/rule/run/pass values were asserted at conversion time via the git
+ * diff), and provenance that could not be reconstructed carries explicit
+ * sentinels instead of fabricated values.
+ */
+const COMMITTED_BASELINES = ["matching", "premise", "profile", "opportunity"] as const;
+
+describe("committed baselines are versioned artifacts", () => {
+  for (const harness of COMMITTED_BASELINES) {
+    it(`${harness} baseline validates as a v1 baseline envelope`, async () => {
+      const baselinePath = path.resolve(import.meta.dir, `../../${harness}/baselines/${harness}.baseline.json`);
+      const envelope = await readEvalArtifact(baselinePath, {
+        expectedType: EVAL_BASELINE_ARTIFACT_TYPE,
+        expectedHarness: harness,
+      });
+      expect(envelope).not.toBeNull();
+      expect(envelope!.schemaVersion).toBe(1);
+      expect(envelope!.source).toBe("legacy-migration");
+      expect(envelope!.corpusFingerprint).toBe(EVAL_LEGACY_UNAVAILABLE);
+      expect(envelope!.selection).toEqual({ fullCorpus: true, filters: {} });
+      expect(envelope!.completeness.caseCount).toBe(envelope!.payload.cases.length);
+      expect(envelope!.completeness.totalPasses).toBeLessThanOrEqual(envelope!.completeness.totalRuns);
+    });
+  }
+});


### PR DESCRIPTION
Implements [IND-442](https://linear.app/indexnetwork/issue/IND-442): every baseline-backed eval artifact (committed baselines + run reports) is now a versioned, runtime-validated, collision-safe envelope. Follows #1148 (IND-441) — the new specs run under `eval:verify`.

## What changed

### New shared contract (`eval/shared/artifact.ts`)
- **v1 envelope schema** (`index-eval/baseline` / `index-eval/run-report`): artifact type + schema version, harness id/version, source, started/completed/created timestamps, model IDs, case selection, completeness summary, wrapped around the harness-owned scorecard `payload`.
- **Runtime Zod validation** on every read and write: rejects malformed numbers, duplicate case/rule ids, inconsistent aggregates/completeness, non-monotonic timestamps, unknown schema versions, and wrong artifact types with actionable errors naming the file and violation. Legacy unversioned scorecards are pointed at the migration CLI instead of being cast silently.
- **Deterministic provenance**: SHA-256 fingerprints over canonicalized corpus/config JSON (secret-like config keys are refused), plus git revision/dirty state.

### Collision-safe IO (`eval/shared/artifact.io.ts`)
- Validate-first **atomic writes** (same-directory temp file + rename) — an interrupted or invalid write can never replace a valid artifact.
- **Overwrite refusal** without `--force`, asserted **before any LLM call is spent**.
- `assertEvalWritePlan`: rejects duplicate outputs, outputs that clobber inputs (except the sanctioned `--update-baseline` flow), and checks all destinations up front so multi-output runs fail before anything is written.

### Harness wiring
- `matching` / `premise` / `profile` / `opportunity` mains: `--force` flag, up-front write-plan assertion, `EvalRunMeta` provenance on writes, harness-checked baseline reads. Also fixes a silent no-write when pathless `--report` ran on a filtered run.
- Rolling baselines only consume valid run-report envelopes; legacy files are skipped.

### Baseline migration
- The 4 committed baselines were converted with the explicit, reviewable `eval/shared/migrate-legacy-baselines.ts` CLI (dry-run by default).
- **Review with `git diff -w`** — the payload is byte-identical (score values verified programmatically against HEAD); the diff is a pure envelope prepend plus indentation. Unreconstructable provenance carries explicit `unavailable-legacy-migration` / `unknown` sentinels.

### Tests & docs
- New provider-free specs: `artifact.spec.ts` (~30 envelope/consistency/fingerprint rejection cases), `artifact.io.spec.ts` (atomicity, no temp residue, overwrite/collision refusal), `migration.spec.ts` (committed baselines validate as v1 envelopes).
- Root eval README + 4 harness READMEs updated (envelope section, `--force`, new-harness recipe).

## Verification
- `bun run eval:verify` — ✅ all 7 suites, provider-free
- `bun test eval` — 300 pass / 1 skip / 0 fail
- Protocol `bun run build` (tsc), eslint on `eval/` — clean
- CLI safety smoke-tested provider-free: overwrite refusal without `--force`, `--report <baseline path>` rejected as input/output collision

## Notes
- No production (`src/`) behavior change; HyDE adjudication/private-key concepts intentionally stay out of shared.
- Rebased onto #1148: kept its `EnrichmentGenerator` rename and `BASELINE_PENDING_CASE_IDS` allowlist through the merge.
- Known limitation: overwrite refusal has an inherent check-then-rename TOCTOU window (documented); HTML reports get plan-level protection but are not enveloped (not JSON artifacts).
