### PR TITLE
feat(api): add route deprecation telemetry

### DIFF
--- a/services/api/package.json
+++ b/services/api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@indexnetwork/api",
-  "version": "0.40.1",
+  "version": "0.41.0",
   "license": "MIT",
   "private": true,
   "scripts": {

--- a/services/api/src/controllers/chat.controller.ts
+++ b/services/api/src/controllers/chat.controller.ts
@@ -4,6 +4,7 @@ import { AuthGuard, type AuthenticatedUser } from "../guards/auth.guard";
 import { RateLimit } from "../guards/limiter.guard";
 import { requestContext } from "../lib/request-context";
 import { log } from "../lib/log";
+import { deprecatedRoute } from "../lib/router/deprecated-route";
 import { Controller, Get, Post, UseGuards } from "../lib/router/router.decorators";
 import { chatSessionService } from "../services/chat.service";
 import { fileService } from "../services/file.service";
@@ -138,6 +139,7 @@ export class ChatController {
    * @returns JSON response with graph execution result including responseText
    */
   @Post("/message")
+  @deprecatedRoute('chat.message')
   @UseGuards(RateLimit('write'), AuthGuard)
   async message(req: Request, user: AuthenticatedUser) {
     // 1. Parse request body for message

--- a/services/api/src/controllers/network-experiment.controller.ts
+++ b/services/api/src/controllers/network-experiment.controller.ts
@@ -3,6 +3,7 @@ import { AuthGuard, type AuthenticatedUser } from '../guards/auth.guard';
 import { ExperimentMasterKeyGuard, type ExperimentNetwork } from '../guards/experiment.guard';
 import { RateLimit } from '../guards/limiter.guard';
 import { log } from '../lib/log';
+import { deprecatedRoute } from '../lib/router/deprecated-route';
 import { Controller, Post, Put, UseGuards } from '../lib/router/router.decorators';
 import { experimentService, SignupNotCompleteError, type ImportRow } from '../services/experiment.service';
 import { networkInvitationService } from '../services/network-invitation.service';
@@ -355,6 +356,7 @@ export class NetworkExperimentController {
    * @returns Updated network or validation error
    */
   @Put('/:id/key')
+  @deprecatedRoute('network.update-key')
   @UseGuards(RateLimit('write'), AuthGuard)
   async updateKey(req: Request, user: AuthenticatedUser, params: Record<string, string>) {
     let body: { key?: string };

--- a/services/api/src/controllers/network.controller.ts
+++ b/services/api/src/controllers/network.controller.ts
@@ -4,6 +4,7 @@ import { assertAgentNetworkScope, withAgentScope } from '../guards/agent-scope.g
 import { AuthGuard, type AuthenticatedUser } from '../guards/auth.guard';
 import { RateLimit } from '../guards/limiter.guard';
 import { log } from '../lib/log';
+import { deprecatedRoute } from '../lib/router/deprecated-route';
 import { Controller, Delete, Get, Patch, Post, Put, UseGuards } from '../lib/router/router.decorators';
 import { networkService } from '../services/network.service';
 
@@ -442,6 +443,7 @@ export class NetworkController {
    * IMPORTANT: This must come before GET /:id to avoid route collision.
    */
   @Get('/:id/my-intents')
+  @deprecatedRoute('network.my-intents')
   @UseGuards(RateLimit('read'), AuthGuard)
   async getMyIntents(req: Request, user: AuthenticatedUser, params: Record<string, string>) {
     try {

--- a/services/api/src/controllers/opportunity.controller.ts
+++ b/services/api/src/controllers/opportunity.controller.ts
@@ -1,6 +1,7 @@
 import { z } from 'zod';
 
 import { opportunityService } from '../services/opportunity.service';
+import { deprecatedRoute } from '../lib/router/deprecated-route';
 import { Controller, Get, Post, Patch, UseGuards } from '../lib/router/router.decorators';
 import { assertAgentNetworkScope, withAgentScope } from '../guards/agent-scope.guard';
 import { AuthGuard } from '../guards/auth.guard';
@@ -407,6 +408,7 @@ export class OpportunityController {
    * Requires x-api-key (agent polling) or session auth.
    */
   @Post('/:id/connect-token')
+  @deprecatedRoute('opportunity.connect-token')
   @UseGuards(RateLimit('write'), AuthGuard)
   async createConnectToken(_req: Request, user: AuthenticatedUser, params?: RouteParams) {
     const id = params?.id;
@@ -483,6 +485,7 @@ export class OpportunityController {
    * is required.
    */
   @Get('/:id/connect')
+  @deprecatedRoute('opportunity.connect')
   @UseGuards(RateLimit('read'))
   async connect(req: Request, _user: unknown, params?: RouteParams) {
     const id = params?.id;
@@ -563,6 +566,7 @@ export class OpportunityController {
    * mechanism as the `/connect` endpoint).
    */
   @Get('/:id/approve-introduction')
+  @deprecatedRoute('opportunity.approve-introduction')
   @UseGuards(RateLimit('read'))
   async approveIntroduction(req: Request, _user: unknown, params?: RouteParams) {
     const id = params?.id;

--- a/services/api/src/controllers/tests/route-deprecation.controller.spec.ts
+++ b/services/api/src/controllers/tests/route-deprecation.controller.spec.ts
@@ -1,0 +1,62 @@
+/** Config */
+import { config } from 'dotenv';
+config({ path: '.env.test', override: true });
+
+import { afterAll, beforeAll, describe, expect, mock, spyOn, test } from 'bun:test';
+
+import type { AuthenticatedUser } from '../../guards/auth.guard';
+import { recordRequestAuthContext } from '../../lib/request-auth-context';
+
+mock.module('../../queues/notification.queue', () => ({
+  queueOpportunityNotification: async () => ({ id: 'mock-job' }),
+}));
+
+let OpportunityControllerClass: typeof import('../opportunity.controller').OpportunityController;
+
+beforeAll(async () => {
+  const mod = await import('../opportunity.controller');
+  OpportunityControllerClass = mod.OpportunityController;
+});
+
+afterAll(() => {
+  mock.restore();
+});
+
+describe('deprecated controller routes', () => {
+  test('adds the deprecation header and emits one structured warning', async () => {
+    const warnSpy = spyOn(console, 'warn').mockImplementation(() => {});
+    const req = new Request(
+      'http://localhost/api/opportunities/example/connect-token?noise=secret-query',
+      { method: 'POST', headers: { 'x-api-key': 'secret-api-key' } },
+    );
+    const agentId = crypto.randomUUID();
+    recordRequestAuthContext(req, { kind: 'api_key', agentId });
+    const user: AuthenticatedUser = {
+      id: crypto.randomUUID(),
+      email: 'deprecated-route@example.com',
+      name: 'Deprecated Route Test',
+    };
+
+    try {
+      const response = await new OpportunityControllerClass().createConnectToken(req, user);
+      const body = (await response.json()) as { error: string };
+
+      expect(response.status).toBe(400);
+      expect(body).toEqual({ error: 'Missing opportunity id' });
+      expect(response.headers.get('Deprecation')).toBe('true');
+      expect(warnSpy).toHaveBeenCalledTimes(1);
+
+      const warning = warnSpy.mock.calls[0]?.map(String).join(' ') ?? '';
+      expect(warning).toContain('Deprecated API route used');
+      expect(warning).toContain('"routeId":"opportunity.connect-token"');
+      expect(warning).toContain('"method":"POST"');
+      expect(warning).toContain('"path":"/api/opportunities/example/connect-token"');
+      expect(warning).toContain('"authKind":"api_key"');
+      expect(warning).toContain(`"agentId":"${agentId}"`);
+      expect(warning).not.toContain('secret-query');
+      expect(warning).not.toContain('secret-api-key');
+    } finally {
+      warnSpy.mockRestore();
+    }
+  });
+});

--- a/services/api/src/controllers/user.controller.ts
+++ b/services/api/src/controllers/user.controller.ts
@@ -5,6 +5,7 @@ import { AuthGuard } from '../guards/auth.guard';
 import type { AuthenticatedUser } from '../guards/auth.guard';
 import { RateLimit } from '../guards/limiter.guard';
 import { ContactsEnabledGuard } from '../guards/contacts.guard';
+import { deprecatedRoute } from '../lib/router/deprecated-route';
 import { userService } from '../services/user.service';
 import { contactService } from '../services/contact.service';
 import { TaskService } from '../services/task.service';
@@ -564,6 +565,7 @@ export class UserController {
    * @returns Updated user or validation error
    */
   @Put('/me/key')
+  @deprecatedRoute('user.update-key')
   @UseGuards(RateLimit('write'), AuthGuard)
   async updateKey(req: Request, user: AuthenticatedUser) {
     let body: { key?: string };

--- a/services/api/src/guards/auth.guard.ts
+++ b/services/api/src/guards/auth.guard.ts
@@ -6,6 +6,7 @@ import { resolveApiKeyUserId } from '../lib/apikey/principal';
 import { apikeys, users } from '../schemas/database.schema';
 import { API_URL, JWT_AUDIENCE } from '../lib/betterauth/betterauth';
 import { log } from '../lib/log';
+import { recordRequestAuthContext } from '../lib/request-auth-context';
 
 const logger = log.server.from('auth.guard');
 
@@ -41,11 +42,13 @@ const resolveJwtUser = async (req: Request): Promise<AuthenticatedUser> => {
   }
   try {
     const { payload } = await jwtVerify(token, JWKS, { issuer: API_URL, audience: JWT_AUDIENCE });
-    return {
+    const user = {
       id: payload.id as string,
       email: (payload.email as string) ?? null,
       name: payload.name as string,
     };
+    recordRequestAuthContext(req, { kind: 'session' });
+    return user;
   } catch {
     throw new Error('Invalid or expired access token');
   }
@@ -92,6 +95,16 @@ export const SessionOnlyGuard = async (req: Request): Promise<AuthenticatedUser>
   throw new Error('Access token required');
 };
 
+function parseApiKeyAgentId(metadata: string | null): string | null {
+  if (!metadata) return null;
+  try {
+    const parsed = JSON.parse(metadata) as Record<string, unknown>;
+    return typeof parsed.agentId === 'string' ? parsed.agentId : null;
+  } catch {
+    return null;
+  }
+}
+
 /**
  * Resolve the `metadata.agentId` of the API key on the request, or null if
  * the request is JWT-authenticated, has no key, or the key has no agent
@@ -115,14 +128,7 @@ export const resolveApiKeyAgentId = async (req: Request): Promise<string | null>
     .where(eq(apikeys.key, hashed))
     .limit(1);
 
-  if (!row?.metadata) return null;
-
-  try {
-    const parsed = JSON.parse(row.metadata) as Record<string, unknown>;
-    return typeof parsed.agentId === 'string' ? parsed.agentId : null;
-  } catch {
-    return null;
-  }
+  return parseApiKeyAgentId(row?.metadata ?? null);
 };
 
 /**
@@ -152,6 +158,7 @@ export const AuthGuard = async (req: Request): Promise<AuthenticatedUser> => {
       userId: apikeys.userId,
       enabled: apikeys.enabled,
       expiresAt: apikeys.expiresAt,
+      metadata: apikeys.metadata,
     })
     .from(apikeys)
     .where(eq(apikeys.key, hashed))
@@ -192,6 +199,11 @@ export const AuthGuard = async (req: Request): Promise<AuthenticatedUser> => {
     logger.warn('API key rejected', { reason: 'user_not_found', keyHashPrefix, ua });
     throw new Error('Invalid API key');
   }
+
+  recordRequestAuthContext(req, {
+    kind: 'api_key',
+    agentId: parseApiKeyAgentId(row.metadata),
+  });
 
   return {
     id: user.id,

--- a/services/api/src/lib/request-auth-context.ts
+++ b/services/api/src/lib/request-auth-context.ts
@@ -1,0 +1,25 @@
+export type RequestAuthContext =
+  | { kind: 'session' }
+  | { kind: 'api_key'; agentId: string | null };
+
+const requestAuthContexts = new WeakMap<Request, RequestAuthContext>();
+
+/**
+ * Record the credential context established by a successful authentication guard.
+ *
+ * @param req - Authenticated request
+ * @param context - Credential kind and optional API-key agent binding
+ */
+export function recordRequestAuthContext(req: Request, context: RequestAuthContext): void {
+  requestAuthContexts.set(req, context);
+}
+
+/**
+ * Read the credential context established for a request.
+ *
+ * @param req - Request whose authentication context should be read
+ * @returns Recorded context, or undefined when the route was not authenticated by a supported guard
+ */
+export function getRequestAuthContext(req: Request): RequestAuthContext | undefined {
+  return requestAuthContexts.get(req);
+}

--- a/services/api/src/lib/router/deprecated-route.ts
+++ b/services/api/src/lib/router/deprecated-route.ts
@@ -1,0 +1,50 @@
+import { getRequestAuthContext } from '../request-auth-context';
+import { log } from '../log';
+
+const logger = log.route.from('deprecation');
+
+function addDeprecationHeader(response: Response): Response {
+  const headers = new Headers(response.headers);
+  headers.set('Deprecation', 'true');
+  return new Response(response.body, {
+    status: response.status,
+    statusText: response.statusText,
+    headers,
+  });
+}
+
+/**
+ * Mark a controller handler as deprecated without changing its response body or status.
+ * Each invocation emits one structured warning and adds `Deprecation: true` to the response.
+ *
+ * @param routeId - Stable identifier used to aggregate route hits across parameterized paths
+ * @returns Method decorator for a controller route handler
+ */
+export function deprecatedRoute(routeId: string): MethodDecorator {
+  return (_target: object, _propertyKey: string | symbol, descriptor: PropertyDescriptor) => {
+    const original = descriptor.value as ((...args: unknown[]) => unknown) | undefined;
+    if (!original) throw new Error(`@deprecatedRoute(${routeId}) requires a method`);
+
+    descriptor.value = async function (this: object, ...args: unknown[]): Promise<unknown> {
+      const req = args[0];
+      if (!(req instanceof Request)) {
+        return Reflect.apply(original, this, args);
+      }
+
+      const authContext = getRequestAuthContext(req);
+      logger.warn('Deprecated API route used', {
+        event: 'deprecated_route_used',
+        routeId,
+        method: req.method,
+        path: new URL(req.url, 'http://localhost').pathname,
+        authKind: authContext?.kind ?? 'anonymous',
+        ...(authContext?.kind === 'api_key' && authContext.agentId
+          ? { agentId: authContext.agentId }
+          : {}),
+      });
+
+      const response = await Reflect.apply(original, this, args);
+      return response instanceof Response ? addDeprecationHeader(response) : response;
+    };
+  };
+}


### PR DESCRIPTION
## New Features
- emit one structured warn-level event for each hit to seven suspected-dead API routes
- record route ID, method, path, auth kind, and agent ID for agent-bound API keys
- add `Deprecation: true` while preserving existing response status, body, and headers

## Refactors
- retain request-scoped authentication provenance after `AuthGuard` resolves session or API-key credentials
- bump `@indexnetwork/api` to `0.41.0`

## IND-461 Verification
- confirmed `buildCandidateEvidence` is active through `withCandidateEvidence` across discovery candidate paths
- confirmed it is exported from the published protocol barrel, so no removal or protocol version bump is included

## Tests
- `cd packages/protocol && bun run build`
- `cd packages/protocol && bun test src/opportunity/tests/opportunity.evidence.spec.ts src/opportunity/tests/opportunity.graph.spec.ts` — 82 passed
- `cd services/api && bun run build`
- `cd services/api && bun test src/controllers/tests/route-deprecation.controller.spec.ts` — 1 passed
- targeted ESLint on all touched TypeScript files

Refs IND-460
Refs IND-461
