### PR TITLE
fix(pool): derive Lens C shadow network binding from task metadata (IND-465 slice 1)

### DIFF
--- a/services/api/CHANGELOG.md
+++ b/services/api/CHANGELOG.md
@@ -9,6 +9,26 @@ section before promoting to `main`).
 
 ## [Unreleased]
 
+### Fixed
+- Lens C shadow network binding is now derived from capture-time negotiation
+  task metadata instead of `opportunity.context.networkId` (IND-465 slice 1,
+  unblocking the IND-433 NO-GO where the context field was empty on all
+  evidence-bearing rows). All derivation rules fail closed: only structurally
+  valid tasks (capture-time intentSnapshots required) contribute; exactly one
+  distinct non-empty task networkId binds an opportunity; zero or disagreeing
+  values skip it; a present-but-different context networkId skips it
+  (contamination guard — context never overrides tasks). Segment building
+  still enforces pass-network equality per task, so sibling tasks recorded
+  under another network stay excluded. The Lens-C-local pool selection now
+  also includes terminal statuses (`stalled`/`accepted`/`rejected`/`expired`)
+  — evidence lives on decided negotiations — via a dedicated
+  `exactEvidencePoolWhere` predicate; the shared Lens A live-pool selection
+  is untouched. Shadow telemetry gains aggregate-only counters
+  (`skippedNoTaskNetwork`, `skippedNetworkDisagreement`,
+  `skippedContextMismatch`, `terminalStatusIncluded`) — counts only, never
+  IDs or text. No backfill, no creation-flow changes, no new flags;
+  `NEGOTIATION_EVIDENCE_QUESTIONS_MODE` semantics unchanged.
+
 ### Added
 - Aggregate question-funnel telemetry endpoint `GET /debug/questions/funnel` (IND-439 visibility-audit slice): whole-funnel counts grouped by (detection mode, status, expired-past-TTL) with per-group created/expiry date bounds, plus the caller's canonical pending splits. Aggregate-only by construction — the adapter projection carries counts and timestamps only, never question text, payloads, answers, evidence, or other users' IDs. Gated by the existing DebugGuard + AuthGuard wiring.
 - Default-off visit-triggered pool mining (`POOL_QUESTIONS_VISIT_TRIGGER`, IND-439 visibility-audit slice): when an intent owner's intent-scoped pending-questions fetch finds no live pending `pool_discovery` question, a debounced BullMQ job (one per caller+intent per 6h via deduplication ids — no new tables) re-mines the intent's pool through the exact shared discovery-completion hook with a new `intent_visit` trigger source. All existing gates apply unchanged (POOL_QUESTIONS_MODE, QUESTIONER_ENABLED, ≥5 pool floor, VoI threshold, ≤1 pool / ≤3 total pending per intent, fingerprint/Jaccard freshness, push budgets); expired rows are never resurrected and the 7-day TTL is untouched. Ships dark — unset/off is a strict no-op.

--- a/services/api/package.json
+++ b/services/api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@indexnetwork/api",
-  "version": "0.42.1",
+  "version": "0.43.0",
   "license": "MIT",
   "private": true,
   "scripts": {

--- a/services/api/src/adapters/chat.database.adapter.ts
+++ b/services/api/src/adapters/chat.database.adapter.ts
@@ -2460,6 +2460,13 @@ export class ChatDatabaseAdapter {
   ): Promise<OpportunityRow[]> {
     return this.opportunityAdapter.getLivePoolOpportunitiesForIntent(recipientUserId, intentId);
   }
+  /** Lens-C-only (IND-465): exact intent pool including terminal statuses. */
+  async getEvidencePoolOpportunitiesForIntent(
+    recipientUserId: string,
+    intentId: string,
+  ): Promise<OpportunityRow[]> {
+    return this.opportunityAdapter.getEvidencePoolOpportunitiesForIntent(recipientUserId, intentId);
+  }
   async getOpportunitiesForNetwork(
     networkId: string,
     options?: { status?: string; statuses?: string[]; limit?: number; offset?: number }

--- a/services/api/src/adapters/opportunity.database.adapter.ts
+++ b/services/api/src/adapters/opportunity.database.adapter.ts
@@ -2,7 +2,7 @@ import { schema, CreateOpportunityInput, OpportunityRow, UserIdentity, and, buil
 import { emitOpportunityPendingBestEffort } from '../events/opportunity.event';
 import { computeIntentFingerprint } from '../lib/intent/intent.fingerprint';
 import { computeOutcomeCounterpartDedupKey, computeOutcomeIdempotencyKey, computeOutcomeSnapshotHash } from '../lib/opportunity/outcome-feedback.identity';
-import { exactLivePoolWhere, POOL_LIVE_STATUSES } from './poolquery.shared';
+import { exactEvidencePoolWhere, exactLivePoolWhere, POOL_LIVE_STATUSES } from './poolquery.shared';
 
 interface OpportunityNetworkEligibilityInput {
   ownerUserId: string;
@@ -537,6 +537,24 @@ export class OpportunityDatabaseAdapter {
       .select()
       .from(opportunities)
       .where(exactLivePoolWhere(recipientUserId, intentId))
+      .orderBy(desc(opportunities.createdAt));
+    return rows.map(toOpportunityRow);
+  }
+
+  /**
+   * Lens-C-only (IND-465): the exact recipient+intent pool INCLUDING terminal
+   * statuses ('stalled','accepted','rejected','expired') — negotiation
+   * evidence lives on decided negotiations. Lens A discriminator mining must
+   * keep using {@link getLivePoolOpportunitiesForIntent}.
+   */
+  async getEvidencePoolOpportunitiesForIntent(
+    recipientUserId: string,
+    intentId: string,
+  ): Promise<OpportunityRow[]> {
+    const rows = await db
+      .select()
+      .from(opportunities)
+      .where(exactEvidencePoolWhere(recipientUserId, intentId))
       .orderBy(desc(opportunities.createdAt));
     return rows.map(toOpportunityRow);
   }

--- a/services/api/src/adapters/poolquery.shared.ts
+++ b/services/api/src/adapters/poolquery.shared.ts
@@ -6,12 +6,19 @@ import { opportunities } from '../schemas/database.schema';
 export const POOL_LIVE_STATUSES = ['draft', 'latent', 'pending', 'negotiating'] as const;
 
 /**
- * Canonical exact live-pool predicate shared by selectors and freshness gates.
- * Provenance is detection.triggeredBy; broad actors[].intent Radar fallback is
- * deliberately excluded.
+ * Terminal statuses added ONLY to the Lens C evidence pool (IND-465):
+ * negotiation evidence lives on decided negotiations, so the shadow pass must
+ * see them. Lens A discriminator mining stays on {@link POOL_LIVE_STATUSES}.
  */
-export function exactLivePoolWhere(recipientUserId: string, intentId: string) {
-  const visibilityGuard = sql`(
+export const POOL_TERMINAL_STATUSES = ['stalled', 'accepted', 'rejected', 'expired'] as const;
+
+/**
+ * Recipient visibility guard shared by the live-pool and evidence-pool
+ * predicates. Extracting it keeps the two predicates drift-free; the SQL
+ * emitted by {@link exactLivePoolWhere} is byte-identical to before.
+ */
+function recipientPoolVisibilityGuard(recipientUserId: string) {
+  return sql`(
     ${opportunities.actors} @> ${JSON.stringify([{ userId: recipientUserId, role: 'introducer' }])}::jsonb
     OR ${opportunities.actors} @> ${JSON.stringify([{ userId: recipientUserId, role: 'peer' }])}::jsonb
     OR (
@@ -30,7 +37,28 @@ export function exactLivePoolWhere(recipientUserId: string, intentId: string) {
       AND (${opportunities.status} NOT IN ('latent', 'draft') OR NOT (${opportunities.actors} @> '[{"role":"introducer"}]'::jsonb))
     )
   )`;
-  return sql`${visibilityGuard}
+}
+
+/**
+ * Canonical exact live-pool predicate shared by selectors and freshness gates.
+ * Provenance is detection.triggeredBy; broad actors[].intent Radar fallback is
+ * deliberately excluded.
+ */
+export function exactLivePoolWhere(recipientUserId: string, intentId: string) {
+  return sql`${recipientPoolVisibilityGuard(recipientUserId)}
     AND ${opportunities.detection}->>'triggeredBy' = ${intentId}
     AND ${inArray(opportunities.status, [...POOL_LIVE_STATUSES])}`;
+}
+
+/**
+ * Lens-C-only evidence-pool predicate (IND-465): same visibility guard and
+ * exact-trigger provenance as {@link exactLivePoolWhere}, but ALSO includes
+ * {@link POOL_TERMINAL_STATUSES} because negotiation evidence lives on decided
+ * negotiations. Lens A selection (selectPoolForMining and every freshness
+ * gate) must keep using {@link exactLivePoolWhere}.
+ */
+export function exactEvidencePoolWhere(recipientUserId: string, intentId: string) {
+  return sql`${recipientPoolVisibilityGuard(recipientUserId)}
+    AND ${opportunities.detection}->>'triggeredBy' = ${intentId}
+    AND ${inArray(opportunities.status, [...POOL_LIVE_STATUSES, ...POOL_TERMINAL_STATUSES])}`;
 }

--- a/services/api/src/adapters/tests/poolquery.shared.spec.ts
+++ b/services/api/src/adapters/tests/poolquery.shared.spec.ts
@@ -1,0 +1,36 @@
+import { describe, expect, it } from 'bun:test';
+
+import { PgDialect } from 'drizzle-orm/pg-core';
+
+import { exactEvidencePoolWhere, exactLivePoolWhere, POOL_LIVE_STATUSES, POOL_TERMINAL_STATUSES } from '../poolquery.shared';
+
+const dialect = new PgDialect();
+
+describe('poolquery predicates — Lens A vs Lens C (IND-465)', () => {
+  it('keeps the shared Lens A live-pool predicate on live statuses only', () => {
+    const { sql, params } = dialect.sqlToQuery(exactLivePoolWhere('user-1', 'intent-1'));
+    expect(sql).toContain("'triggeredBy'");
+    expect(params).toContain('intent-1');
+    for (const status of POOL_LIVE_STATUSES) expect(params).toContain(status);
+    for (const status of POOL_TERMINAL_STATUSES) expect(params).not.toContain(status);
+  });
+
+  it('widens ONLY the Lens C evidence-pool predicate to terminal statuses', () => {
+    const { sql, params } = dialect.sqlToQuery(exactEvidencePoolWhere('user-1', 'intent-1'));
+    expect(sql).toContain("'triggeredBy'");
+    expect(params).toContain('intent-1');
+    for (const status of [...POOL_LIVE_STATUSES, ...POOL_TERMINAL_STATUSES]) {
+      expect(params).toContain(status);
+    }
+  });
+
+  it('shares one visibility guard: the predicates differ only in the status list', () => {
+    const live = dialect.sqlToQuery(exactLivePoolWhere('user-1', 'intent-1'));
+    const evidence = dialect.sqlToQuery(exactEvidencePoolWhere('user-1', 'intent-1'));
+    const normalize = (query: { sql: string }) => query.sql.replace(/\$\d+/g, '$?');
+    expect(normalize(evidence).replace(', $?'.repeat(POOL_TERMINAL_STATUSES.length), ''))
+      .toBe(normalize(live));
+    expect(evidence.params.slice(0, live.params.length)).toEqual(live.params);
+    expect(evidence.params.slice(live.params.length)).toEqual([...POOL_TERMINAL_STATUSES]);
+  });
+});

--- a/services/api/src/queues/pool/negotiation-evidence.shadow.ts
+++ b/services/api/src/queues/pool/negotiation-evidence.shadow.ts
@@ -12,14 +12,23 @@
  * wired independently of the Lens A pool flags, so this lens can run even when
  * pool discriminator mining is disabled. Fully failure-isolated: it never
  * throws into the caller's discovery lifecycle.
+ *
+ * IND-465 slice 1: the single-network pass scope is derived from capture-time
+ * negotiation TASK metadata (which always records a validated networkId)
+ * instead of `opportunity.context.networkId` (only conditionally recorded at
+ * discovery creation, empty on most evidence-bearing rows). All derivation
+ * rules fail closed; context, when present, acts only as a contamination
+ * guard and never overrides tasks. The Lens-C-local pool selection also
+ * includes terminal statuses — evidence lives on decided negotiations —
+ * without touching the shared Lens A live-pool selection.
  */
 import { NEGOTIATION_EVIDENCE_MAX_OPPORTUNITIES, NegotiationEvidenceMiner, negotiationEvidenceQuestionsMode, runNegotiationEvidenceShadow } from '@indexnetwork/protocol';
 import type { RawEvidenceOutcome, RawEvidenceSegment, RawEvidenceTurn } from '@indexnetwork/protocol';
 
 import { chatDatabaseAdapter } from '../../adapters/database.adapter';
+import { POOL_TERMINAL_STATUSES } from '../../adapters/poolquery.shared';
 import { computeIntentFingerprint } from '../../lib/intent/intent.fingerprint';
 import { log } from '../../lib/log';
-import { selectPoolForMining } from './mining.shared';
 import type { PoolMiningTrigger } from './mining.shared';
 
 /** Greppable logger (IND-433): search deploy logs for "NegotiationEvidenceShadow". */
@@ -42,8 +51,9 @@ interface ShadowIntent {
 
 interface ShadowOpportunity {
   id: string;
+  status?: string | null;
   actors: Array<{ userId: string; role: string }>;
-  context?: { networkId?: string | null } | null;
+  context?: { networkId?: string | null; conversationId?: string | null } | null;
 }
 
 interface ShadowTask {
@@ -89,9 +99,27 @@ export interface NegotiationEvidenceShadowDeps {
   logger: ShadowLogger;
 }
 
+/**
+ * Lens-C-local pool selection (IND-465): the exact-trigger recipient+intent
+ * pool INCLUDING terminal statuses — negotiation evidence lives on decided
+ * negotiations. Deliberately separate from Lens A's selectPoolForMining,
+ * which stays live-status-only; session scoping and the size cap mirror it.
+ */
+async function selectEvidencePoolForShadow(
+  userId: string,
+  intentId: string,
+  sessionId: string | undefined,
+): Promise<ShadowOpportunity[]> {
+  const pool = await chatDatabaseAdapter.getEvidencePoolOpportunitiesForIntent(userId, intentId);
+  return pool
+    .filter((opportunity) => !sessionId
+      || opportunity.context?.conversationId === sessionId)
+    .slice(0, 50);
+}
+
 const DEFAULT_DEPS: NegotiationEvidenceShadowDeps = {
   database: chatDatabaseAdapter,
-  selectPool: (userId, intentId, sessionId) => selectPoolForMining(userId, intentId, sessionId),
+  selectPool: (userId, intentId, sessionId) => selectEvidencePoolForShadow(userId, intentId, sessionId),
   getMiner: () => {
     miner ??= new NegotiationEvidenceMiner();
     return miner;
@@ -171,22 +199,27 @@ function captureTimeIntentFingerprint(
   return computeIntentFingerprint(capturedIntent.description, capturedIntent.title);
 }
 
-function validateTask(
+interface TaskProvenanceInput {
+  opportunityId: string;
+  recipientUserId: string;
+  counterpartyUserId: string;
+  intentId: string;
+  currentIntentFingerprint: string;
+}
+
+/**
+ * Structural capture-time validation shared by network-binding derivation
+ * (IND-465) and segment building — every fail-closed check EXCEPT the
+ * pass-network equality, which only exists once a pass network is derived.
+ */
+function validateTaskProvenance(
   task: ShadowTask,
-  input: {
-    opportunityId: string;
-    networkId: string;
-    recipientUserId: string;
-    counterpartyUserId: string;
-    intentId: string;
-    currentIntentFingerprint: string;
-  },
+  input: TaskProvenanceInput,
 ): { sourceUserId: string; candidateUserId: string; intentFingerprint: string } | null {
   const metadata = task.metadata;
   if (!metadata
     || metadata.type !== 'negotiation'
-    || metadata.opportunityId !== input.opportunityId
-    || metadata.networkId !== input.networkId) {
+    || metadata.opportunityId !== input.opportunityId) {
     return null;
   }
 
@@ -212,6 +245,69 @@ function validateTask(
   if (intentFingerprint !== input.currentIntentFingerprint) return null;
 
   return { sourceUserId, candidateUserId, intentFingerprint };
+}
+
+/**
+ * Full segment-building validation: provenance PLUS pass-network equality.
+ * NOT relaxed by IND-465 — with a derived pass network this still guards
+ * sibling tasks of multi-task opportunities recorded under another network.
+ */
+function validateTask(
+  task: ShadowTask,
+  input: TaskProvenanceInput & { networkId: string },
+): { sourceUserId: string; candidateUserId: string; intentFingerprint: string } | null {
+  if (task.metadata?.networkId !== input.networkId) return null;
+  return validateTaskProvenance(task, input);
+}
+
+/** Aggregate-only derivation skip reasons (IND-465) — counted, never logged with IDs/text. */
+type NetworkBindingSkip = 'no_task_network' | 'network_disagreement' | 'context_mismatch';
+
+const SKIP_COUNTER_BY_OUTCOME = {
+  no_task_network: 'skippedNoTaskNetwork',
+  network_disagreement: 'skippedNetworkDisagreement',
+  context_mismatch: 'skippedContextMismatch',
+} as const satisfies Record<NetworkBindingSkip, string>;
+
+/**
+ * Derive one opportunity's network binding from capture-time negotiation task
+ * metadata (IND-465). ALL rules fail closed:
+ *  - only structurally valid tasks contribute (tasks without capture-time
+ *    intentSnapshots stay excluded, exactly as segment building excludes them);
+ *  - exactly one distinct non-empty task networkId binds the opportunity;
+ *  - zero or more than one distinct value skips it;
+ *  - a present-but-different `opportunity.context.networkId` skips it
+ *    (contamination guard — context never overrides tasks).
+ */
+export function deriveTaskNetworkBinding(
+  opportunity: ShadowOpportunity,
+  tasks: ShadowTask[],
+  input: { recipientUserId: string; intentId: string; currentIntentFingerprint: string },
+): { outcome: 'bound'; networkId: string } | { outcome: NetworkBindingSkip } {
+  const counterpartyUserId = getValidatedCounterpartyUserId(opportunity, input.recipientUserId);
+  if (!counterpartyUserId) return { outcome: 'no_task_network' };
+
+  const networkIds = new Set<string>();
+  for (const task of tasks) {
+    const provenance = validateTaskProvenance(task, {
+      opportunityId: opportunity.id,
+      recipientUserId: input.recipientUserId,
+      counterpartyUserId,
+      intentId: input.intentId,
+      currentIntentFingerprint: input.currentIntentFingerprint,
+    });
+    if (!provenance) continue;
+    const networkId = task.metadata?.networkId;
+    if (typeof networkId === 'string' && networkId.length > 0) networkIds.add(networkId);
+  }
+  if (networkIds.size === 0) return { outcome: 'no_task_network' };
+  if (networkIds.size > 1) return { outcome: 'network_disagreement' };
+  const [derivedNetworkId] = networkIds;
+  const contextNetworkId = opportunity.context?.networkId;
+  if (contextNetworkId && contextNetworkId !== derivedNetworkId) {
+    return { outcome: 'context_mismatch' };
+  }
+  return { outcome: 'bound', networkId: derivedNetworkId };
 }
 
 function readDataPart(parts: unknown): Record<string, unknown> | null {
@@ -293,6 +389,8 @@ export async function collectNegotiationEvidenceSegments(
     intentId: string;
     currentIntentFingerprint: string;
     networkId: string;
+    /** Tasks already fetched during network-binding derivation (IND-465). */
+    tasksByOpportunityId?: ReadonlyMap<string, ShadowTask[]>;
   },
   database: NegotiationEvidenceShadowDeps['database'],
 ): Promise<RawEvidenceSegment[]> {
@@ -305,7 +403,8 @@ export async function collectNegotiationEvidenceSegments(
     );
     if (!counterpartyUserId) continue;
 
-    const tasks = await database.getNegotiationTasksForOpportunity(opportunity.id);
+    const tasks = input.tasksByOpportunityId?.get(opportunity.id)
+      ?? await database.getNegotiationTasksForOpportunity(opportunity.id);
     const validatedTasks = tasks.flatMap((task) => {
       const validation = validateTask(task, {
         opportunityId: opportunity.id,
@@ -384,17 +483,33 @@ export async function maybeRunNegotiationEvidenceShadow(
 
     const pool = await deps.selectPool(userId, intentId, trigger.sessionId);
 
-    // Keep the pass single-network: mine only the largest network group.
-    const byNetwork = new Map<string, ShadowOpportunity[]>();
+    // IND-465: bind each opportunity's network from capture-time task
+    // metadata (fail closed), then keep the pass single-network by mining
+    // only the largest derived-network group. Tasks are fetched here, before
+    // grouping, and reused for segment building.
+    const skipCounts = {
+      skippedNoTaskNetwork: 0,
+      skippedNetworkDisagreement: 0,
+      skippedContextMismatch: 0,
+    };
+    const byNetwork = new Map<string, Array<{ opportunity: ShadowOpportunity; tasks: ShadowTask[] }>>();
     for (const opportunity of pool) {
-      const networkId = opportunity.context?.networkId;
-      if (!networkId) continue;
-      const group = byNetwork.get(networkId) ?? [];
-      group.push(opportunity);
-      byNetwork.set(networkId, group);
+      const tasks = await deps.database.getNegotiationTasksForOpportunity(opportunity.id);
+      const binding = deriveTaskNetworkBinding(opportunity, tasks, {
+        recipientUserId: userId,
+        intentId,
+        currentIntentFingerprint: intentFingerprint,
+      });
+      if (binding.outcome !== 'bound') {
+        skipCounts[SKIP_COUNTER_BY_OUTCOME[binding.outcome]] += 1;
+        continue;
+      }
+      const group = byNetwork.get(binding.networkId) ?? [];
+      group.push({ opportunity, tasks });
+      byNetwork.set(binding.networkId, group);
     }
     let passNetworkId: string | undefined;
-    let passPool: ShadowOpportunity[] = [];
+    let passPool: Array<{ opportunity: ShadowOpportunity; tasks: ShadowTask[] }> = [];
     for (const [networkId, group] of byNetwork) {
       if (group.length > passPool.length) {
         passNetworkId = networkId;
@@ -406,22 +521,30 @@ export async function maybeRunNegotiationEvidenceShadow(
         source: trigger.source,
         runId: trigger.runId ?? null,
         intentId,
+        ...skipCounts,
       });
       return;
     }
 
+    const passEntries = passPool.slice(0, NEGOTIATION_EVIDENCE_MAX_OPPORTUNITIES);
+    const terminalStatusIncluded = passEntries.filter(({ opportunity }) => opportunity.status != null
+      && (POOL_TERMINAL_STATUSES as readonly string[]).includes(opportunity.status)).length;
+
     const segments = await collectNegotiationEvidenceSegments({
-      opportunities: passPool.slice(0, NEGOTIATION_EVIDENCE_MAX_OPPORTUNITIES),
+      opportunities: passEntries.map(({ opportunity }) => opportunity),
       recipientUserId: userId,
       intentId,
       currentIntentFingerprint: intentFingerprint,
       networkId: passNetworkId,
+      tasksByOpportunityId: new Map(passEntries.map(({ opportunity, tasks }) => [opportunity.id, tasks])),
     }, deps.database);
     if (segments.length === 0) {
       deps.logger.debug('negotiation-evidence shadow skipped: no minable segments', {
         source: trigger.source,
         runId: trigger.runId ?? null,
         intentId,
+        ...skipCounts,
+        terminalStatusIncluded,
       });
       return;
     }
@@ -440,6 +563,8 @@ export async function maybeRunNegotiationEvidenceShadow(
     deps.logger.info('negotiation-evidence shadow result', {
       source: trigger.source,
       runId: trigger.runId ?? null,
+      ...skipCounts,
+      terminalStatusIncluded,
       ...result.telemetry,
     });
   } catch (error) {

--- a/services/api/src/queues/pool/tests/negotiation-evidence.shadow.spec.ts
+++ b/services/api/src/queues/pool/tests/negotiation-evidence.shadow.spec.ts
@@ -1,9 +1,10 @@
 import { afterEach, describe, expect, it, mock } from 'bun:test';
 
+import { runNegotiationEvidenceShadow } from '@indexnetwork/protocol';
 import type { NegotiationEvidenceMiner, RawEvidenceSegment } from '@indexnetwork/protocol';
 
 import { computeIntentFingerprint } from '../../../lib/intent/intent.fingerprint';
-import { canonicalizeNegotiationSender, collectNegotiationEvidenceSegments, getValidatedCounterpartyUserId, maybeRunNegotiationEvidenceShadow, toBoundedErrorTelemetry } from '../negotiation-evidence.shadow';
+import { canonicalizeNegotiationSender, collectNegotiationEvidenceSegments, deriveTaskNetworkBinding, getValidatedCounterpartyUserId, maybeRunNegotiationEvidenceShadow, toBoundedErrorTelemetry } from '../negotiation-evidence.shadow';
 import type { NegotiationEvidenceShadowDeps } from '../negotiation-evidence.shadow';
 import type { PoolMiningTrigger } from '../mining.shared';
 
@@ -56,13 +57,21 @@ function task(id: string, metadataOverrides: Record<string, unknown> = {}): Shad
   };
 }
 
+type ShadowScope = Parameters<NegotiationEvidenceShadowDeps['runShadow']>[0]['scope'];
+
 function makeDeps(overrides: Partial<NegotiationEvidenceShadowDeps> = {}): {
   deps: NegotiationEvidenceShadowDeps;
   capturedSegments: RawEvidenceSegment[][];
+  capturedScopes: ShadowScope[];
   warnings: Array<Record<string, unknown> | undefined>;
+  infos: Array<Record<string, unknown> | undefined>;
+  debugs: Array<Record<string, unknown> | undefined>;
 } {
   const capturedSegments: RawEvidenceSegment[][] = [];
+  const capturedScopes: ShadowScope[] = [];
   const warnings: Array<Record<string, unknown> | undefined> = [];
+  const infos: Array<Record<string, unknown> | undefined> = [];
+  const debugs: Array<Record<string, unknown> | undefined> = [];
   const database: ShadowDatabase = {
     getIntent: mock(async () => INTENT),
     getNegotiationTasksForOpportunity: mock(async () => [task('task-1')]),
@@ -73,6 +82,7 @@ function makeDeps(overrides: Partial<NegotiationEvidenceShadowDeps> = {}): {
   };
   const runShadow: NegotiationEvidenceShadowDeps['runShadow'] = async (input) => {
     capturedSegments.push(input.segments);
+    capturedScopes.push(input.scope);
     return {
       hypotheses: [],
       telemetry: {
@@ -100,13 +110,13 @@ function makeDeps(overrides: Partial<NegotiationEvidenceShadowDeps> = {}): {
     getMiner: () => ({}) as NegotiationEvidenceMiner,
     runShadow,
     logger: {
-      debug: mock(() => {}),
-      info: mock(() => {}),
+      debug: mock((_message, metadata) => { debugs.push(metadata); }),
+      info: mock((_message, metadata) => { infos.push(metadata); }),
       warn: mock((_message, metadata) => { warnings.push(metadata); }),
     },
     ...overrides,
   };
-  return { deps, capturedSegments, warnings };
+  return { deps, capturedSegments, capturedScopes, warnings, infos, debugs };
 }
 
 afterEach(() => {
@@ -384,5 +394,188 @@ describe('negotiation evidence final revalidation and telemetry', () => {
       ...telemetry,
     });
     expect(JSON.stringify(warnings)).not.toContain('SECRET_PROVIDER_RESPONSE_BODY');
+  });
+});
+
+describe('IND-465 — network binding derived from capture-time task metadata', () => {
+  const DERIVATION_INPUT = {
+    recipientUserId: 'owner-1',
+    intentId: 'intent-1',
+    currentIntentFingerprint: FINGERPRINT,
+  };
+
+  it('binds exactly one distinct non-empty task networkId and fails closed otherwise', () => {
+    // Single network across several tasks (empty/missing values ignored) → bound.
+    expect(deriveTaskNetworkBinding({ ...OPPORTUNITY, context: {} }, [
+      task('a'),
+      task('b', { networkId: '' }),
+      task('c', { networkId: undefined }),
+    ], DERIVATION_INPUT)).toEqual({ outcome: 'bound', networkId: 'net-1' });
+
+    // Task disagreement → skip.
+    expect(deriveTaskNetworkBinding({ ...OPPORTUNITY, context: {} }, [
+      task('a'),
+      task('b', { networkId: 'net-2' }),
+    ], DERIVATION_INPUT)).toEqual({ outcome: 'network_disagreement' });
+
+    // Zero task networkIds (or no structurally valid tasks at all) → skip.
+    expect(deriveTaskNetworkBinding({ ...OPPORTUNITY, context: {} }, [
+      task('a', { networkId: undefined }),
+    ], DERIVATION_INPUT)).toEqual({ outcome: 'no_task_network' });
+    expect(deriveTaskNetworkBinding({ ...OPPORTUNITY, context: {} }, [], DERIVATION_INPUT))
+      .toEqual({ outcome: 'no_task_network' });
+
+    // Structurally invalid tasks never contribute a (dis)agreeing networkId.
+    expect(deriveTaskNetworkBinding({ ...OPPORTUNITY, context: {} }, [
+      task('a'),
+      task('drifted', { networkId: 'net-2', intentSnapshots: [{ userId: 'owner-1', intentId: 'intent-1', description: 'Changed intent', title: INTENT.summary }] }),
+    ], DERIVATION_INPUT)).toEqual({ outcome: 'bound', networkId: 'net-1' });
+
+    // Present-but-different context → contamination guard; context never overrides tasks.
+    expect(deriveTaskNetworkBinding({ ...OPPORTUNITY, context: { networkId: 'net-2' } }, [
+      task('a'),
+    ], DERIVATION_INPUT)).toEqual({ outcome: 'context_mismatch' });
+
+    // Agreeing context stays bound.
+    expect(deriveTaskNetworkBinding(OPPORTUNITY, [task('a')], DERIVATION_INPUT))
+      .toEqual({ outcome: 'bound', networkId: 'net-1' });
+  });
+
+  it('mines an opportunity whose context.networkId is absent (the IND-433 NO-GO scenario)', async () => {
+    process.env.NEGOTIATION_EVIDENCE_QUESTIONS_MODE = 'shadow';
+    const { deps, capturedScopes, capturedSegments, infos } = makeDeps({
+      selectPool: mock(async () => [{ ...OPPORTUNITY, context: {} }]),
+    });
+
+    await maybeRunNegotiationEvidenceShadow(TRIGGER, deps);
+
+    expect(capturedScopes).toEqual([{
+      recipientUserId: 'owner-1',
+      intentId: 'intent-1',
+      intentFingerprint: FINGERPRINT,
+      networkId: 'net-1',
+    }]);
+    expect(capturedSegments[0].map((segment) => segment.networkId)).toEqual(['net-1']);
+    expect(infos[0]).toMatchObject({
+      skippedNoTaskNetwork: 0,
+      skippedNetworkDisagreement: 0,
+      skippedContextMismatch: 0,
+      terminalStatusIncluded: 0,
+    });
+  });
+
+  it('skips fail-closed opportunities and logs only aggregate skip counts', async () => {
+    process.env.NEGOTIATION_EVIDENCE_QUESTIONS_MODE = 'shadow';
+    const tasksByOpportunityId: Record<string, ReturnType<typeof task>[]> = {
+      'opp-disagree': [
+        task('d1', { opportunityId: 'opp-disagree' }),
+        task('d2', { opportunityId: 'opp-disagree', networkId: 'net-2' }),
+      ],
+      'opp-no-network': [task('n1', { opportunityId: 'opp-no-network', networkId: undefined })],
+      'opp-context-mismatch': [task('c1', { opportunityId: 'opp-context-mismatch' })],
+    };
+    const { deps, capturedSegments, debugs } = makeDeps({
+      selectPool: mock(async () => [
+        { ...OPPORTUNITY, id: 'opp-disagree', context: {} },
+        { ...OPPORTUNITY, id: 'opp-no-network', context: {} },
+        { ...OPPORTUNITY, id: 'opp-context-mismatch', context: { networkId: 'net-9' } },
+      ]),
+    });
+    deps.database.getNegotiationTasksForOpportunity = mock(
+      async (opportunityId: string) => tasksByOpportunityId[opportunityId] ?? [],
+    );
+
+    await maybeRunNegotiationEvidenceShadow(TRIGGER, deps);
+
+    expect(capturedSegments).toHaveLength(0);
+    expect(debugs).toHaveLength(1);
+    expect(debugs[0]).toMatchObject({
+      skippedNoTaskNetwork: 1,
+      skippedNetworkDisagreement: 1,
+      skippedContextMismatch: 1,
+    });
+    expect(JSON.stringify(debugs)).not.toContain('opp-disagree');
+    expect(JSON.stringify(debugs)).not.toContain('net-2');
+  });
+
+  it('mines only the largest derived-network group and still excludes sibling tasks from other networks', async () => {
+    process.env.NEGOTIATION_EVIDENCE_QUESTIONS_MODE = 'shadow';
+    const tasksByOpportunityId: Record<string, ReturnType<typeof task>[]> = {
+      // Bound to net-1; the empty-network sibling stays excluded from segments
+      // by the unrelaxed validateTask pass-network equality.
+      'opp-1': [task('t1', { opportunityId: 'opp-1' }), task('t1-sibling', { opportunityId: 'opp-1', networkId: '' })],
+      'opp-2': [task('t2', { opportunityId: 'opp-2' })],
+      'opp-3': [task('t3', { opportunityId: 'opp-3', networkId: 'net-2' })],
+    };
+    const { deps, capturedScopes, capturedSegments } = makeDeps({
+      selectPool: mock(async () => [
+        { ...OPPORTUNITY, id: 'opp-1', context: {} },
+        { ...OPPORTUNITY, id: 'opp-2', context: {} },
+        { ...OPPORTUNITY, id: 'opp-3', context: {} },
+      ]),
+    });
+    deps.database.getNegotiationTasksForOpportunity = mock(
+      async (opportunityId: string) => tasksByOpportunityId[opportunityId] ?? [],
+    );
+    deps.database.getMessagesByTaskIds = mock(async (taskIds: string[]) => new Map(
+      taskIds.map((taskId) => [taskId, [{ senderId: 'agent:owner-1', parts: [{ kind: 'data', data: { action: 'propose', message: null } }] }]]),
+    ));
+
+    await maybeRunNegotiationEvidenceShadow(TRIGGER, deps);
+
+    expect(capturedScopes.map((scope) => scope.networkId)).toEqual(['net-1']);
+    expect(capturedSegments[0].map((segment) => [segment.opportunityId, segment.taskId])).toEqual([
+      ['opp-1', 't1'],
+      ['opp-2', 't2'],
+    ]);
+    // Derivation-time tasks are reused; no second fetch per pass opportunity.
+    expect(deps.database.getNegotiationTasksForOpportunity).toHaveBeenCalledTimes(3);
+  });
+
+  it('counts terminal-status opportunities in the pass with aggregate telemetry only', async () => {
+    process.env.NEGOTIATION_EVIDENCE_QUESTIONS_MODE = 'shadow';
+    const { deps, capturedSegments, infos } = makeDeps({
+      selectPool: mock(async () => [
+        { ...OPPORTUNITY, id: 'opp-1', status: 'rejected', context: {} },
+      ]),
+    });
+
+    await maybeRunNegotiationEvidenceShadow(TRIGGER, deps);
+
+    expect(capturedSegments).toHaveLength(1);
+    expect(infos[0]).toMatchObject({ terminalStatusIncluded: 1 });
+  });
+
+  it('keeps the k>=5 distinct-opportunity floor and scope matching untouched', async () => {
+    process.env.NEGOTIATION_EVIDENCE_QUESTIONS_MODE = 'shadow';
+    const run = async (poolSize: number) => {
+      const mine = mock(async () => []);
+      const opportunities = Array.from({ length: poolSize }, (_, i) => ({
+        ...OPPORTUNITY,
+        id: `opp-${i + 1}`,
+        context: {},
+      }));
+      const { deps, infos } = makeDeps({
+        selectPool: mock(async () => opportunities),
+        runShadow: runNegotiationEvidenceShadow,
+        getMiner: () => ({ mine } as unknown as NegotiationEvidenceMiner),
+      });
+      deps.database.getNegotiationTasksForOpportunity = mock(
+        async (opportunityId: string) => [task(`task-${opportunityId}`, { opportunityId })],
+      );
+      deps.database.getMessagesByTaskIds = mock(async (taskIds: string[]) => new Map(
+        taskIds.map((taskId) => [taskId, [{ senderId: 'agent:owner-1', parts: [{ kind: 'data', data: { action: 'propose', message: null } }] }]]),
+      ));
+      await maybeRunNegotiationEvidenceShadow(TRIGGER, deps);
+      return { mine, infos };
+    };
+
+    const below = await run(4);
+    expect(below.mine).not.toHaveBeenCalled();
+    expect(below.infos[0]).toMatchObject({ distinctOpportunities: 4, hypothesesMined: 0 });
+
+    const atFloor = await run(5);
+    expect(atFloor.mine).toHaveBeenCalledTimes(1);
+    expect(atFloor.infos[0]).toMatchObject({ distinctOpportunities: 5 });
   });
 });


### PR DESCRIPTION
## Why

The IND-433 Lens C shadow acceptance review was a **NO-GO**: the shadow pass bound its single-network scope from `opportunity.context.networkId`, which is empty on 0/8 evidence-bearing dev opportunities (discovery creation only sets it conditionally). Negotiation task metadata ALWAYS records a validated `networkId` at capture time — so the binding is now derived from tasks. **No backfill, no creation-flow changes, no new flags.**

## Fail-closed derivation rules (per opportunity)

- Only **structurally valid** negotiation tasks contribute (capture-time `intentSnapshots` required, participants must match the validated bilateral counterparty, capture-time intent fingerprint must equal the current one — tasks without snapshots stay excluded exactly as before).
- **Exactly one** distinct non-empty task `metadata.networkId` → bind the opportunity to it.
- **Zero** or **more than one** distinct value → skip the opportunity.
- `opportunity.context.networkId` present **and different** from the derived value → skip (new contamination guard; context never overrides tasks).
- Opportunities are then grouped by derived networkId and only the single largest group is mined, as before.
- `validateTask` is **not relaxed**: segment building still enforces `metadata.networkId === passNetworkId` per task, so sibling tasks of multi-task opportunities recorded under another network remain excluded (test-covered).
- Tasks are fetched once (before grouping) and reused for segment building.

## Lens-C-local terminal-status selection

- Evidence lives on decided negotiations (2 of the 8 dev evidence-bearing opportunities are `rejected`), so the Lens C pool selection now also includes `stalled` / `accepted` / `rejected` / `expired` via a **dedicated** `exactEvidencePoolWhere` predicate + `getEvidencePoolOpportunitiesForIntent` adapter method.
- The shared Lens A discriminator selection is untouched: `selectPoolForMining` and `exactLivePoolWhere` behavior are unchanged. The recipient visibility guard was extracted into a shared private helper so the two predicates cannot drift — the SQL emitted by `exactLivePoolWhere` is byte-identical, asserted by a new `PgDialect`-rendering spec.

## Telemetry

The existing `"negotiation-evidence shadow result"` log gains aggregate-only counters: `skippedNoTaskNetwork`, `skippedNetworkDisagreement`, `skippedContextMismatch`, `terminalStatusIncluded`. Counts only — never IDs, question text, user IDs, or evidence payloads (test-asserted).

## Explicitly OUT of scope (follow-up PRs)

- `owner_answer` / `shared_message` segment projection (sharedTagged, answerer-authority)
- Any `opportunity.context` backfill
- Any change to `NEGOTIATION_EVIDENCE_QUESTIONS_MODE` semantics (dev stays `shadow`; `on` remains reserved for IND-437)

## Verification

- `packages/protocol` (untouched) + `services/api` build clean
- `bun test` (individual files): `negotiation-evidence.shadow.spec.ts` 16 pass (6 new IND-465 tests incl. the exact bug scenario, disagreement/zero/context-mismatch skips, largest-group + sibling-task guard, terminal-status counter, real-runShadow k>=5 floor), `poolquery.shared.spec.ts` 3 pass, `mining.shared.spec.ts` 10 pass, `adapter-interface-alignment.spec.ts` 33 pass — 62 pass / 0 fail
- eslint clean; `services/api` bumped to 0.43.0 + CHANGELOG entry

Refs IND-465, IND-433
