### PR TITLE
fix(discovery): resolve unscoped MCP discovery index scope and surface index-graph errors

### DIFF
--- a/packages/protocol/CHANGELOG.md
+++ b/packages/protocol/CHANGELOG.md
@@ -47,6 +47,11 @@ See [STABILITY.md](./STABILITY.md) for the public-contract and tier definitions.
 - Made trigger-intent discovery fail closed over current intent assignments, active owner memberships, and explicit caller scope; enforced active candidate membership across intent/premise/context retrieval plus pre-evaluation/pre-persistence rechecks and selected-intent Radar reads.
 - Removed network-derived co-attendance inference and added deterministic affiliation/presence claim rejection across evaluation, presenter/fallback/MCP/REST/delivery/chat/invite surfaces, with versioned presentation caches that do not retain degraded fallback copy.
 
+## [6.2.1] - 2026-07-18
+
+### Fixed
+- Restored unscoped asynchronous MCP discovery by wiring the background worker to real network and membership graphs, and surfaced network-read failures instead of misreporting them as zero memberships (IND-466).
+
 ## [4.3.0] - 2026-06-21
 
 ### Added

--- a/packages/protocol/package.json
+++ b/packages/protocol/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@indexnetwork/protocol",
-  "version": "6.2.0",
+  "version": "6.2.1",
   "type": "module",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",

--- a/packages/protocol/src/opportunity/opportunity.tools.ts
+++ b/packages/protocol/src/opportunity/opportunity.tools.ts
@@ -1213,6 +1213,9 @@ export function createOpportunityTools(defineTool: DefineTool, deps: ToolDeps) {
         const _scopeIndexMs = Date.now() - _scopeGraphStart;
         _scopeIndexTraceEmitter?.({ type: "graph_end", name: "index", durationMs: _scopeIndexMs });
         _scopeGraphTimings.push({ name: 'index', durationMs: _scopeIndexMs, agents: [] });
+        if (indexResult.error) {
+          return error(indexResult.error);
+        }
         indexScope = (indexResult.readResult?.memberOf || []).map(
           (m: { networkId: string }) => m.networkId,
         );

--- a/packages/protocol/src/opportunity/tests/opportunity.tools.spec.ts
+++ b/packages/protocol/src/opportunity/tests/opportunity.tools.spec.ts
@@ -11,7 +11,12 @@ type CapturedDiscoverInput = {
   indexScope: string[];
 };
 
-function captureDiscoverToolForScopeTest(runDiscoverFromQuery: (input: CapturedDiscoverInput) => Promise<unknown>) {
+function captureDiscoverToolForScopeTest(
+  runDiscoverFromQuery?: (input: CapturedDiscoverInput) => Promise<unknown>,
+  indexGraph: { invoke: (input: unknown) => Promise<unknown> } = {
+    invoke: async () => ({ readResult: { memberOf: [] } }),
+  },
+) {
   let captured: { handler: (input: { context: ResolvedToolContext; query: Record<string, unknown> }) => Promise<string> } | undefined;
   const defineTool = (def: { name: string }) => {
     if (def.name === "discover_opportunities") captured = def as never;
@@ -24,12 +29,12 @@ function captureDiscoverToolForScopeTest(runDiscoverFromQuery: (input: CapturedD
     cache: {} as never,
     graphs: {
       opportunity: { invoke: async () => ({}) },
-      index: { invoke: async () => ({ readResult: { memberOf: [] } }) },
+      index: indexGraph,
       networkMembership: { invoke: async () => ({}) },
     } as never,
-    opportunityDiscovery: {
-      runDiscoverFromQuery: runDiscoverFromQuery as never,
-    },
+    ...(runDiscoverFromQuery
+      ? { opportunityDiscovery: { runDiscoverFromQuery: runDiscoverFromQuery as never } }
+      : {}),
   } as unknown as ToolDeps;
   createOpportunityTools(defineTool as never, deps);
   if (!captured) throw new Error("discover_opportunities tool not registered");
@@ -93,6 +98,82 @@ describe("discover_opportunities — scoped discovery reach", () => {
 
     expect(result.success).toBe(true);
     expect(capturedInput?.indexScope).toEqual([]);
+  });
+});
+
+describe("discover_opportunities — unscoped discovery reach", () => {
+  const unscopedContext = () => makeScopeTestContext({
+    networkId: undefined,
+    scopeType: undefined,
+    scopeId: undefined,
+  });
+
+  it("resolves every membership returned by the index graph", async () => {
+    let capturedInput: CapturedDiscoverInput | undefined;
+    const tool = captureDiscoverToolForScopeTest(
+      async (input) => {
+        capturedInput = input;
+        return { found: false, message: "No matching opportunities found." };
+      },
+      {
+        invoke: async () => ({
+          readResult: {
+            memberOf: [
+              { networkId: "network-1" },
+              { networkId: "network-2" },
+              { networkId: "network-3" },
+            ],
+          },
+        }),
+      },
+    );
+
+    const raw = await tool.handler({
+      context: unscopedContext(),
+      query: { searchQuery: "AI collaborators" },
+    });
+    const result = JSON.parse(raw) as { success: boolean };
+
+    expect(result.success).toBe(true);
+    expect(capturedInput?.indexScope).toEqual(["network-1", "network-2", "network-3"]);
+  });
+
+  it("surfaces index-graph errors instead of treating them as no memberships", async () => {
+    let discoveryCalled = false;
+    const tool = captureDiscoverToolForScopeTest(
+      async () => {
+        discoveryCalled = true;
+        return { found: false };
+      },
+      { invoke: async () => ({ error: "Failed to fetch network information." }) },
+    );
+
+    const raw = await tool.handler({
+      context: unscopedContext(),
+      query: { searchQuery: "AI collaborators" },
+    });
+    const result = JSON.parse(raw) as { success: boolean; error?: string };
+
+    expect(result).toEqual({
+      success: false,
+      error: "Failed to fetch network information.",
+    });
+    expect(discoveryCalled).toBe(false);
+  });
+
+  it("keeps the join-a-network response for genuine zero-membership users", async () => {
+    const tool = captureDiscoverToolForScopeTest();
+
+    const raw = await tool.handler({
+      context: unscopedContext(),
+      query: { searchQuery: "AI collaborators" },
+    });
+    const result = JSON.parse(raw) as { success: boolean; data?: { message?: string } };
+
+    expect(result.success).toBe(true);
+    expect(result.data?.message).toBe(
+      "You need to join at least one network (community) to discover opportunities. Use read_networks to see available networks, or create one.",
+    );
   });
 });
 

--- a/services/api/CHANGELOG.md
+++ b/services/api/CHANGELOG.md
@@ -31,6 +31,7 @@ section before promoting to `main`).
   consent primitive; deferred to IND-467).
 
 ### Fixed
+- Restored unscoped asynchronous MCP discovery by wiring discovery-run workers to real network and membership graphs instead of no-op placeholders (IND-466).
 - Lens C shadow network binding is now derived from capture-time negotiation
   task metadata instead of `opportunity.context.networkId` (IND-465 slice 1,
   unblocking the IND-433 NO-GO where the context field was empty on all

--- a/services/api/package.json
+++ b/services/api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@indexnetwork/api",
-  "version": "0.44.0",
+  "version": "0.44.1",
   "license": "MIT",
   "private": true,
   "scripts": {

--- a/services/api/src/queues/opportunity/discovery-run.queue.ts
+++ b/services/api/src/queues/opportunity/discovery-run.queue.ts
@@ -1,6 +1,6 @@
 import { Job } from 'bullmq';
 
-import { deriveAllowedNetworkIds, HydeGenerator, HydeGraphFactory, LensInferrer, OpportunityGraphFactory, createOpportunityTools, getToolTimeoutPolicy, requestContext, resolveChatContext } from '@indexnetwork/protocol';
+import { deriveAllowedNetworkIds, HydeGenerator, HydeGraphFactory, LensInferrer, NetworkGraphFactory, NetworkMembershipGraphFactory, OpportunityGraphFactory, createOpportunityTools, getToolTimeoutPolicy, requestContext, resolveChatContext } from '@indexnetwork/protocol';
 import type { AgentDispatcher, CompiledGraph, DiscoveryRunInput, DiscoveryRunRecord, HydeGraphDatabase, NegotiationGraphLike, OpportunityGraphDatabase, RawToolDefinition, ResolvedToolContext, StampNewbornOpportunitiesFn, ToolDeps } from '@indexnetwork/protocol';
 
 import { log } from '../../lib/log';
@@ -51,6 +51,14 @@ function assertDiscoveryRunOutputFits(raw: string): void {
       `Discovery run result exceeded MCP output cap: ${outputBytes} bytes > ${policy.maxOutputBytes} bytes`,
     );
   }
+}
+
+/** Build the real network graphs required when replaying discovery outside the MCP request. */
+export function createDiscoveryRunScopeGraphs(database: ToolDeps['database']): Pick<ToolDeps['graphs'], 'index' | 'networkMembership'> {
+  return {
+    index: new NetworkGraphFactory(database).createGraph(),
+    networkMembership: new NetworkMembershipGraphFactory(database).createGraph(),
+  };
 }
 
 export class DiscoveryRunQueue {
@@ -218,6 +226,7 @@ export class DiscoveryRunQueue {
       },
       this.deps?.stampNewbornOpportunities,
     ).createGraph();
+    const scopeGraphs = createDiscoveryRunScopeGraphs(chatDatabaseAdapter);
 
     // Env-gated questioner enqueue: queued/async discovery runs generate
     // discovery-mode questions exactly like synchronous MCP discover calls
@@ -258,8 +267,8 @@ export class DiscoveryRunQueue {
       graphs: {
         profile: { invoke: async () => ({}) } as CompiledGraph,
         intent: { invoke: async () => ({}) } as CompiledGraph,
-        index: { invoke: async () => ({}) } as CompiledGraph,
-        networkMembership: { invoke: async () => ({}) } as CompiledGraph,
+        index: scopeGraphs.index,
+        networkMembership: scopeGraphs.networkMembership,
         intentIndex: { invoke: async () => ({}) } as CompiledGraph,
         opportunity: opportunityGraph,
         premise: { invoke: async () => ({}) } as CompiledGraph,

--- a/services/api/src/queues/tests/discovery-run.queue.deps.spec.ts
+++ b/services/api/src/queues/tests/discovery-run.queue.deps.spec.ts
@@ -1,4 +1,4 @@
-/** Runtime dependency propagation for asynchronous MCP discovery runs. */
+/** Runtime dependency and graph wiring for asynchronous MCP discovery runs. */
 import { config } from 'dotenv';
 config({ path: '.env.test', override: true });
 
@@ -17,7 +17,7 @@ mock.module('../../lib/bullmq/bullmq', () => ({
   },
 }));
 
-import { DiscoveryRunQueue } from '../opportunity/discovery-run.queue';
+const { createDiscoveryRunScopeGraphs, DiscoveryRunQueue } = await import('../opportunity/discovery-run.queue');
 
 afterAll(() => {
   mock.restore();
@@ -33,5 +33,38 @@ describe('DiscoveryRunQueue runtime deps', () => {
       deps?: { stampNewbornOpportunities?: StampNewbornOpportunitiesFn };
     }).deps;
     expect(deps?.stampNewbornOpportunities).toBe(stampNewbornOpportunities);
+  });
+
+  it('builds real scope graphs for background discovery membership resolution', async () => {
+    const joinedAt = new Date('2026-07-18T00:00:00.000Z');
+    const database = {
+      getNetworkMemberships: async () => [
+        { networkId: 'network-1', networkTitle: 'One', indexPrompt: null, autoAssign: true, isPersonal: false, joinedAt },
+        { networkId: 'network-2', networkTitle: 'Two', indexPrompt: null, autoAssign: true, isPersonal: false, joinedAt },
+        { networkId: 'network-3', networkTitle: 'Three', indexPrompt: null, autoAssign: true, isPersonal: true, joinedAt },
+      ],
+      getOwnedIndexes: async () => [],
+      getPublicIndexesNotJoined: async () => ({ networks: [] }),
+      isNetworkMember: async () => false,
+    } as never;
+    const graphs = createDiscoveryRunScopeGraphs(database);
+
+    const indexResult = await graphs.index.invoke({
+      userId: 'user-1',
+      operationMode: 'read',
+      showAll: true,
+    });
+    const membershipResult = await graphs.networkMembership.invoke({
+      userId: 'user-1',
+      networkId: 'network-denied',
+      operationMode: 'read',
+    });
+
+    expect(indexResult.readResult?.memberOf.map((membership: { networkId: string }) => membership.networkId)).toEqual([
+      'network-1',
+      'network-2',
+      'network-3',
+    ]);
+    expect(membershipResult.error).toBe('Network not found or you are not a member.');
   });
 });


### PR DESCRIPTION
## Bug Fixes
- wire asynchronous MCP discovery runs to real network and network-membership graphs instead of no-op placeholders
- surface index-graph failures rather than silently treating them as zero memberships
- preserve scoped discovery behavior and the genuine zero-membership join-network response

## Root Cause
The discovery-run queue rebuilt the opportunity and HyDE graphs for background execution but injected stubbed `graphs.index` and `graphs.networkMembership` implementations that returned `{}`. Unscoped `discover_opportunities` therefore resolved an empty membership list and exited before invoking the opportunity graph. Explicit-network discovery bypassed the empty scope because its branch only checked for a graph error.

## Acceptance Mapping
- **Unscoped user with memberships:** the background queue now composes `NetworkGraphFactory` and resolves all active memberships.
- **Index graph failure:** `discover_opportunities` returns the graph error instead of the misleading join-network message.
- **True zero memberships:** the existing join-at-least-one-network response is unchanged.
- **Scope safety:** scoped-chat and scoped-context derivation, retrieval cutoff, lens scoring, and evaluation behavior are unchanged; explicit-network execution now uses the real membership graph.

## Tests
- `cd packages/protocol && bun test src/opportunity/tests/opportunity.tools.spec.ts` (55 passed)
- `cd services/api && bun test src/queues/tests/discovery-run.queue.deps.spec.ts` (2 passed)
- `cd packages/protocol && bun run build`
- `cd packages/protocol && bun run eval:verify` (all 9 suites)
- `cd services/api && bun run build`
- `git diff --check origin/dev..HEAD`

## Versions
- `@indexnetwork/protocol`: 6.2.1
- `@indexnetwork/api`: 0.44.1

Linear: IND-466