### PR TITLE
fix(opportunities): normalize actor intent sentinels

### DIFF
--- a/packages/protocol/CHANGELOG.md
+++ b/packages/protocol/CHANGELOG.md
@@ -41,6 +41,7 @@ See [STABILITY.md](./STABILITY.md) for the public-contract and tier definitions.
 - Included protocol documentation files in the published package tarball so README links remain available to package consumers.
 
 ### Fixed
+- Normalized opportunity actor intent IDs at evaluator, graph, and shared persistence boundaries so blank or null-like model sentinels are omitted, valid branded string IDs remain supported, enrichment cannot use or reintroduce malformed provenance, and legacy negotiation reads fail closed (IND-469).
 - Forwarded per-attempt `AbortSignal`s through eval provider paths and hardened failure provenance against secret leakage, hostile rejection objects, classifier failures, and concurrent artifact writers (IND-444).
 - Aligned HyDE evidence scoring with the live background `0.30` cutoff, retained per-lens cosines for score/ranking revalidation, required report-stage parent recomputation, and prevented forced outputs from overwriting input evidence artifacts (IND-426).
 - Scoped pool-question adjustments to the exact answering recipient and selected intent, ignored legacy unscoped factors, and restricted Tier-0/newborn writes to exact trigger-intent provenance so shared opportunities cannot re-rank another viewer or intent.

--- a/packages/protocol/package.json
+++ b/packages/protocol/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@indexnetwork/protocol",
-  "version": "6.2.1",
+  "version": "6.2.2",
   "type": "module",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",

--- a/packages/protocol/src/opportunity/opportunity.actor.ts
+++ b/packages/protocol/src/opportunity/opportunity.actor.ts
@@ -1,0 +1,56 @@
+import type { CreateOpportunityData, OpportunityActor } from '../shared/interfaces/database.interface.js';
+
+/**
+ * Normalize an actor intent value while preserving protocol string IDs.
+ * Null-like model sentinels are represented by absence in persisted actors.
+ */
+export function normalizeOpportunityActorIntent(value: unknown): string | undefined {
+  if (typeof value !== 'string') return undefined;
+
+  const normalized = value.trim();
+  if (
+    normalized.length === 0
+    || normalized.toLowerCase() === 'null'
+    || normalized.toLowerCase() === 'undefined'
+  ) {
+    return undefined;
+  }
+
+  return normalized;
+}
+
+/** Resolve the normalized intent from either evaluator or persisted actor fields. */
+export function resolveOpportunityActorIntent(actor: {
+  intentId?: unknown;
+  intent?: unknown;
+}): string | undefined {
+  return normalizeOpportunityActorIntent(actor.intentId)
+    ?? normalizeOpportunityActorIntent(actor.intent);
+}
+
+/** Return a non-mutating actor copy with a canonical optional intent. */
+export function normalizeOpportunityActors(
+  actors: readonly OpportunityActor[],
+): OpportunityActor[] {
+  return actors.map((actor) => {
+    const normalizedActor = { ...actor };
+    const normalizedIntent = normalizeOpportunityActorIntent(actor.intent);
+
+    delete normalizedActor.intent;
+    if (normalizedIntent !== undefined) {
+      normalizedActor.intent = normalizedIntent as NonNullable<OpportunityActor['intent']>;
+    }
+
+    return normalizedActor;
+  });
+}
+
+/** Return non-mutating create data whose actor intents are canonical. */
+export function normalizeCreateOpportunityActorIntents(
+  data: CreateOpportunityData,
+): CreateOpportunityData {
+  return {
+    ...data,
+    actors: normalizeOpportunityActors(data.actors),
+  };
+}

--- a/packages/protocol/src/opportunity/opportunity.evaluator.ts
+++ b/packages/protocol/src/opportunity/opportunity.evaluator.ts
@@ -12,6 +12,7 @@ import { invokeWithAbortSignal } from "../shared/agent/model-signal.js";
 import type { OpportunityEvidence } from '../shared/schemas/network-assignment.schema.js';
 import { renderOpportunityEvidenceForPrompt } from './opportunity.evidence.js';
 import { hasUnsupportedOpportunityClaim } from './opportunity.claim-safety.js';
+import { normalizeOpportunityActorIntent } from './opportunity.actor.js';
 
 const logger = protocolLogger("OpportunityEvaluator");
 const invokeLog = protocolLogger("OpportunityEvaluator:invoke");
@@ -222,7 +223,9 @@ export interface EvaluatorInput {
 const ActorSchema = z.object({
   userId: z.string(),
   role: z.enum(['agent', 'patient', 'peer']),
-  intentId: z.string().nullable().describe('If the match is intent-driven, the specific intent ID; null otherwise'),
+  intentId: z.string().nullable()
+    .transform((value) => normalizeOpportunityActorIntent(value) ?? null)
+    .describe('If the match is intent-driven, the specific intent ID; null otherwise'),
   evidenceKey: z.string().nullable().optional().describe('Stable evidence key for the matched entity; null if unknown'),
 });
 

--- a/packages/protocol/src/opportunity/opportunity.graph.ts
+++ b/packages/protocol/src/opportunity/opportunity.graph.ts
@@ -61,6 +61,7 @@ import { renderNetworkContext } from '../shared/network/metadata.renderer.js';
 import { requestContext } from "../shared/observability/request-context.js";
 import type { OpportunityEvidence } from '../shared/schemas/network-assignment.schema.js';
 import { mergeOpportunityEvidence, withCandidateEvidence, withMatchedStrategies } from './opportunity.evidence.js';
+import { normalizeOpportunityActorIntent, resolveOpportunityActorIntent } from './opportunity.actor.js';
 
 const logger = protocolLogger('OpportunityGraph');
 const prepLog = protocolLogger('OpportunityGraph:Prep');
@@ -2128,7 +2129,7 @@ export class OpportunityGraphFactory {
         const candidates: NegotiationCandidate[] = await Promise.all(
           candidateEntries.map(async ({ opp, candidateActor }) => {
             const userId = candidateActor.userId as string;
-            const candidateIntentId = candidateActor.intentId ?? candidateActor.intent;
+            const candidateIntentId = resolveOpportunityActorIntent(candidateActor);
             const [profile, user, activeIntents, intent] = await Promise.all([
               this.database.getProfile(userId).catch(() => null),
               this.database.getUser(userId).catch(() => null),
@@ -2918,12 +2919,15 @@ export class OpportunityGraphFactory {
                 continue;
               }
               // Introduction path: manual detection, introducer actor, curator_judgment signal.
-              const evaluatorActors: OpportunityActor[] = evaluated.actors.map((a: EvaluatedOpportunityActor) => ({
-                networkId: a.networkId ?? indexIdForActors,
-                userId: a.userId,
-                role: a.role,
-                ...(a.intentId ? { intent: a.intentId } : {}),
-              }));
+              const evaluatorActors: OpportunityActor[] = evaluated.actors.map((a: EvaluatedOpportunityActor) => {
+                const intent = normalizeOpportunityActorIntent(a.intentId);
+                return {
+                  networkId: a.networkId ?? indexIdForActors,
+                  userId: a.userId,
+                  role: a.role,
+                  ...(intent ? { intent: intent as Id<'intents'> } : {}),
+                };
+              });
               const viewerAlreadyInActors = evaluatorActors.some(a => a.userId === state.userId);
               actors = viewerAlreadyInActors
                 ? evaluatorActors
@@ -2967,12 +2971,15 @@ export class OpportunityGraphFactory {
                 continue;
               }
               // Introducer discovery path: introducer is state.userId, target is onBehalfOfUserId.
-              const evaluatorActors: OpportunityActor[] = evaluated.actors.map((a: EvaluatedOpportunityActor) => ({
-                networkId: a.networkId ?? indexIdForActors,
-                userId: a.userId,
-                role: a.role,
-                ...(a.intentId ? { intent: a.intentId } : {}),
-              }));
+              const evaluatorActors: OpportunityActor[] = evaluated.actors.map((a: EvaluatedOpportunityActor) => {
+                const intent = normalizeOpportunityActorIntent(a.intentId);
+                return {
+                  networkId: a.networkId ?? indexIdForActors,
+                  userId: a.userId,
+                  role: a.role,
+                  ...(intent ? { intent: intent as Id<'intents'> } : {}),
+                };
+              });
               const viewerAlreadyInActors = evaluatorActors.some(a => a.userId === state.userId);
               actors = viewerAlreadyInActors
                 ? evaluatorActors
@@ -3120,13 +3127,16 @@ export class OpportunityGraphFactory {
                 }
               }
 
-              const evaluatorActors: OpportunityActor[] = evaluated.actors.map((a: EvaluatedOpportunityActor) => ({
-                networkId: a.networkId ?? indexIdForActors,
-                userId: a.userId,
-                role: a.role,
-                ...(a.intentId ? { intent: a.intentId } : {}),
-                ...(premiseLookup.has(a.userId) ? { premise: premiseLookup.get(a.userId)!.premiseId as Id<'premises'> } : {}),
-              }));
+              const evaluatorActors: OpportunityActor[] = evaluated.actors.map((a: EvaluatedOpportunityActor) => {
+                const intent = normalizeOpportunityActorIntent(a.intentId);
+                return {
+                  networkId: a.networkId ?? indexIdForActors,
+                  userId: a.userId,
+                  role: a.role,
+                  ...(intent ? { intent: intent as Id<'intents'> } : {}),
+                  ...(premiseLookup.has(a.userId) ? { premise: premiseLookup.get(a.userId)!.premiseId as Id<'premises'> } : {}),
+                };
+              });
               actors = evaluatorActors;
 
               const hasIntroducerActor = actors.some(a => a.role === 'introducer');
@@ -3805,8 +3815,8 @@ export class OpportunityGraphFactory {
           return {};
         }
 
-        const sourceIntentId = sourceActor.intentId ?? sourceActor.intent;
-        const candidateIntentId = candidateActor.intentId ?? candidateActor.intent;
+        const sourceIntentId = resolveOpportunityActorIntent(sourceActor);
+        const candidateIntentId = resolveOpportunityActorIntent(candidateActor);
 
         // Load user data for both actors in parallel
         const [sourceUserAccount, sourceProfile, sourceIntents, candidateAccount, candidateProfile, candidateIntents] =

--- a/packages/protocol/src/opportunity/opportunity.persist.ts
+++ b/packages/protocol/src/opportunity/opportunity.persist.ts
@@ -7,6 +7,7 @@ import type { CreateOpportunityData, Opportunity, OpportunityNetworkEligibility,
 import type { Embedder } from '../shared/interfaces/embedder.interface.js';
 import type { EnricherDatabase } from './opportunity.enricher.js';
 import { enrichOrCreate } from './opportunity.enricher.js';
+import { normalizeCreateOpportunityActorIntents } from './opportunity.actor.js';
 import { protocolLogger } from '../shared/observability/protocol.logger.js';
 
 const logger = protocolLogger('OpportunityPersist');
@@ -65,8 +66,9 @@ export async function persistOpportunities(params: PersistOpportunitiesParams): 
   for (let itemIndex = 0; itemIndex < items.length; itemIndex++) {
     const data = items[itemIndex];
     try {
-      const enrichment = await enrichOrCreate(database, embedder, data);
-      const toCreate = enrichment.data;
+      const normalizedData = normalizeCreateOpportunityActorIntents(data);
+      const enrichment = await enrichOrCreate(database, embedder, normalizedData);
+      const toCreate = normalizeCreateOpportunityActorIntents(enrichment.data);
       if (enrichment.enriched) {
         toCreate.status = enrichment.resolvedStatus;
       }

--- a/packages/protocol/src/opportunity/tests/opportunity.graph.spec.ts
+++ b/packages/protocol/src/opportunity/tests/opportunity.graph.spec.ts
@@ -1223,6 +1223,50 @@ describe('Opportunity Graph', () => {
       expect(createSpy).toHaveBeenCalledWith(expect.objectContaining({ status: 'pending' }));
     });
 
+    test('does not persist a literal null evaluator actor intent', async () => {
+      const { compiledGraph, mockDb, mockEmbedder } = createMockGraph({
+        evaluatorResult: [{
+          reasoning: 'A strong provider-free regression match.',
+          score: 90,
+          actors: [
+            {
+              userId: 'a0000000-0000-4000-8000-000000000001',
+              role: 'patient',
+              intentId: 'null',
+            },
+            {
+              userId: 'b0000000-0000-4000-8000-000000000002',
+              role: 'agent',
+              intentId: '  intent-1  ',
+            },
+          ],
+        }],
+      });
+      const createSpy = spyOn(mockDb, 'createOpportunity');
+      spyOn(mockEmbedder, 'searchWithHydeEmbeddings').mockResolvedValue([{
+        type: 'intent',
+        id: 'intent-bob',
+        userId: 'b0000000-0000-4000-8000-000000000002',
+        score: 0.9,
+        matchedVia: 'mirror',
+        networkId: 'idx-1',
+      }]);
+
+      await compiledGraph.invoke({
+        userId: 'a0000000-0000-4000-8000-000000000001' as Id<'users'>,
+        searchQuery: 'co-founder',
+        options: { minScore: 70 },
+      } as OpportunityGraphInvokeInput);
+
+      const persisted = createSpy.mock.calls[0]?.[0];
+      const sourceActor = persisted?.actors.find((actor) =>
+        actor.userId === 'a0000000-0000-4000-8000-000000000001');
+      const candidateActor = persisted?.actors.find((actor) =>
+        actor.userId === 'b0000000-0000-4000-8000-000000000002');
+      expect(Object.prototype.hasOwnProperty.call(sourceActor ?? {}, 'intent')).toBe(false);
+      expect(candidateActor?.intent).toBe('intent-1');
+    });
+
     test('when evaluator assigns discoverer as agent (no introducer), persist swaps discoverer to patient', async () => {
       // Evaluator thinks the discoverer (a0000000-0000-4000-8000-000000000001) is the agent (provider) and
       // the candidate (b0000000-0000-4000-8000-000000000002) is the patient (seeker). The lifecycle guard in the
@@ -2568,8 +2612,9 @@ describe('Opportunity Graph', () => {
       expect(negotiationInvocations).toHaveLength(0);
     });
 
-    test('invokes the negotiation graph when introducer actor has approved: true', async () => {
+    test('invokes negotiation and ignores a null-like exact actor intent from persisted data', async () => {
       const negotiationInvocations: unknown[] = [];
+      const exactIntentLookups: string[] = [];
 
       const mockNegotiationGraph = {
         invoke: async (input: unknown) => {
@@ -2586,7 +2631,9 @@ describe('Opportunity Graph', () => {
             id: 'opp-approved',
             detection: data.detection,
             actors: [
-              ...data.actors,
+              ...data.actors.map((actor) => actor.userId === 'b0000000-0000-4000-8000-000000000002'
+                ? { ...actor, intentId: ' NULL ' }
+                : actor),
               {
                 networkId: 'idx-1' as Id<'networks'>,
                 userId: 'introducer-user' as Id<'users'>,
@@ -2673,7 +2720,37 @@ describe('Opportunity Graph', () => {
           }),
       };
 
-      const evaluator = createMockEvaluator(defaultMockEvaluatorResult);
+      mockDb.getIntent = (intentId) => {
+        exactIntentLookups.push(intentId);
+        return Promise.resolve({
+          id: intentId as Id<'intents'>,
+          userId: 'b0000000-0000-4000-8000-000000000002',
+          payload: 'Candidate exact intent',
+          summary: 'Candidate exact',
+          isIncognito: false,
+          createdAt: new Date(),
+          updatedAt: new Date(),
+          archivedAt: null,
+          status: 'ACTIVE',
+        });
+      };
+
+      const evaluator = createMockEvaluator([{
+        reasoning: 'Candidate intent should be loaded exactly.',
+        score: 90,
+        actors: [
+          {
+            userId: 'a0000000-0000-4000-8000-000000000001',
+            role: 'patient',
+            intentId: null,
+          },
+          {
+            userId: 'b0000000-0000-4000-8000-000000000002',
+            role: 'agent',
+            intentId: 'intent-bob',
+          },
+        ],
+      }]);
       const factory = new OpportunityGraphFactory(
         mockDb,
         mockEmbedder,
@@ -2691,17 +2768,19 @@ describe('Opportunity Graph', () => {
         options: { initialStatus: 'latent' as const },
       });
 
-      // The gate should allow negotiation when introducer is approved.
       expect(negotiationInvocations.length).toBeGreaterThan(0);
+      expect(exactIntentLookups.length).toBeGreaterThan(0);
+      expect(new Set(exactIntentLookups)).toEqual(new Set(['intent-bob']));
     });
   });
 
   // ─── negotiate_existing mode tests ───────────────────────────────────────────
 
   describe('negotiate_existing mode', () => {
-    test('invokes negotiation with source and candidate actors, notifies non-introducer actors on acceptance', async () => {
+    test('normalizes both actor intent fields before exact negotiation reads', async () => {
       const negotiationInvocations: unknown[] = [];
       const notifiedUserIds: string[] = [];
+      const exactIntentLookups: string[] = [];
 
       // Mock negotiation graph that records invocations and returns acceptance
       const mockNegotiationGraph = {
@@ -2726,14 +2805,16 @@ describe('Opportunity Graph', () => {
             userId: 'patient-user' as Id<'users'>,
             role: 'patient' as const,
             networkId: 'idx-1' as Id<'networks'>,
-            intentId: 'intent-patient' as Id<'intents'>,
+            intentId: ' NULL ' as Id<'intents'>,
+            intent: 'intent-patient' as Id<'intents'>,
             approved: undefined,
           },
           {
             userId: 'agent-user' as Id<'users'>,
             role: 'agent' as const,
             networkId: 'idx-1' as Id<'networks'>,
-            intentId: 'intent-agent' as Id<'intents'>,
+            intentId: ' undefined ' as Id<'intents'>,
+            intent: 'intent-agent' as Id<'intents'>,
             approved: undefined,
           },
           {
@@ -2801,7 +2882,9 @@ describe('Opportunity Graph', () => {
         getOpportunitiesForUser: () => Promise.resolve([]),
         updateOpportunityStatus: () => Promise.resolve(null),
         updateOpportunityActorApproval: () => Promise.resolve(null),
-        getIntent: (intentId: string) => Promise.resolve({
+        getIntent: (intentId: string) => {
+          exactIntentLookups.push(intentId);
+          return Promise.resolve({
           id: intentId as Id<'intents'>,
           userId: intentId === 'intent-patient' ? 'patient-user' : 'agent-user',
           payload: `Exact payload for ${intentId}`,
@@ -2811,7 +2894,8 @@ describe('Opportunity Graph', () => {
           updatedAt: new Date(),
           archivedAt: null,
           status: 'ACTIVE' as const,
-        }),
+          });
+        },
         getIntentIndexScores: async () => [],
         getNetworkMemberContext: async () => null,
         getNegotiationTaskForOpportunity: async () => null,
@@ -2865,6 +2949,7 @@ describe('Opportunity Graph', () => {
       expect(invocation.candidateUser.intents).toHaveLength(5);
       expect(invocation.sourceUser.intents[0]?.id).toBe('intent-patient');
       expect(invocation.candidateUser.intents[0]?.id).toBe('intent-agent');
+      expect(exactIntentLookups).toEqual(['intent-patient', 'intent-agent']);
       expect(new Set(invocation.sourceUser.intents.map((intent) => intent.id)).size).toBe(5);
       expect(new Set(invocation.candidateUser.intents.map((intent) => intent.id)).size).toBe(5);
 

--- a/packages/protocol/src/opportunity/tests/opportunity.persist.spec.ts
+++ b/packages/protocol/src/opportunity/tests/opportunity.persist.spec.ts
@@ -5,7 +5,7 @@ config({ path: '.env.test', override: true });
 import { describe, it, expect } from "bun:test";
 import type { Opportunity, CreateOpportunityData, OpportunityStatus } from "../../shared/interfaces/database.interface.js";
 import type { Embedder } from "../../shared/interfaces/embedder.interface.js";
-import { persistOpportunities } from "../opportunity.persist.js";
+import { persistOpportunities, type PersistOpportunityDatabase } from "../opportunity.persist.js";
 
 // ─── Mock helpers ─────────────────────────────────────────────────────────────
 
@@ -25,13 +25,19 @@ function makeOpportunity(overrides: Partial<Opportunity> = {}): Opportunity {
 
 function makeCreateData(overrides: Partial<CreateOpportunityData> = {}): CreateOpportunityData {
   return {
-    payload: 'New opportunity',
-    actors: [{ userId: 'user-1', role: 'patient', intentId: null }],
-    score: 80,
-    reasoning: 'Good fit',
+    detection: { source: 'manual', timestamp: new Date().toISOString() },
+    actors: [{ networkId: 'net-1' as never, userId: 'user-1' as never, role: 'patient' }],
+    interpretation: {
+      category: 'collaboration',
+      reasoning: 'Good fit',
+      confidence: 0.8,
+      signals: [],
+    },
+    context: { networkId: 'net-1' as never },
+    confidence: '0.8',
     status: 'pending',
     ...overrides,
-  } as CreateOpportunityData;
+  };
 }
 
 const mockEmbedder: Embedder = {
@@ -184,5 +190,202 @@ describe('persistOpportunities', () => {
     expect(atomicCalled).toBe(true);
     expect(result.created).toHaveLength(1);
     expect(result.expired).toHaveLength(1);
+  });
+
+  it('normalizes null-like runtime actor intents without mutating inputs', async () => {
+    const nullLikeValues: unknown[] = [null, undefined, '', '   ', 'null', ' NULL ', 'undefined'];
+
+    for (const value of nullLikeValues) {
+      const inputActor = {
+        networkId: 'net-1',
+        userId: 'user-1',
+        role: 'patient',
+        intent: value,
+        preserved: { source: 'test' },
+      };
+      let persisted: CreateOpportunityData | undefined;
+      const database = {
+        findOpportunitiesByActors: async () => [],
+        createOpportunity: async (data: CreateOpportunityData) => {
+          persisted = data;
+          return makeOpportunity({ actors: data.actors });
+        },
+        updateOpportunityStatus: async () => {},
+      };
+
+      await persistOpportunities({
+        database,
+        embedder: mockEmbedder,
+        items: [makeCreateData({ actors: [inputActor] as never })],
+      });
+
+      const persistedActor = persisted?.actors[0] as unknown as Record<string, unknown>;
+      expect(Object.prototype.hasOwnProperty.call(persistedActor, 'intent')).toBe(false);
+      expect(persistedActor.preserved).toEqual({ source: 'test' });
+      expect(persistedActor).not.toBe(inputActor);
+      expect(inputActor.intent).toBe(value);
+      expect(inputActor.preserved).toEqual({ source: 'test' });
+    }
+  });
+
+  it('preserves and trims valid non-UUID actor intents', async () => {
+    const inputActor = {
+      networkId: 'net-1',
+      userId: 'user-1',
+      role: 'patient',
+      intent: '  intent-1  ',
+    };
+    let persisted: CreateOpportunityData | undefined;
+    const database = {
+      findOpportunitiesByActors: async () => [],
+      createOpportunity: async (data: CreateOpportunityData) => {
+        persisted = data;
+        return makeOpportunity({ actors: data.actors });
+      },
+      updateOpportunityStatus: async () => {},
+    };
+
+    await persistOpportunities({
+      database,
+      embedder: mockEmbedder,
+      items: [makeCreateData({ actors: [inputActor] as never })],
+    });
+
+    expect(persisted?.actors[0]?.intent).toBe('intent-1');
+    expect(inputActor.intent).toBe('  intent-1  ');
+  });
+
+  it('removes malformed intents before enrichment overlap checks', async () => {
+    const existing = makeOpportunity({
+      actors: [{
+        networkId: 'net-1',
+        userId: 'user-1',
+        role: 'patient',
+        intent: 'null',
+      }] as never,
+      interpretation: {
+        category: 'collaboration',
+        reasoning: 'short',
+        confidence: 0.5,
+        signals: [],
+      },
+    });
+    let atomicCalled = false;
+    let persisted: CreateOpportunityData | undefined;
+    const database = {
+      findOpportunitiesByActors: async () => [existing],
+      createOpportunity: async (data: CreateOpportunityData) => {
+        persisted = data;
+        return makeOpportunity({ actors: data.actors });
+      },
+      createOpportunityAndExpireIds: async () => {
+        atomicCalled = true;
+        return { created: makeOpportunity(), expired: [existing] };
+      },
+      updateOpportunityStatus: async () => {},
+    };
+    const input = makeCreateData({
+      actors: [{ networkId: 'net-1', userId: 'user-1', role: 'patient', intent: 'null' }] as never,
+      interpretation: {
+        category: 'collaboration',
+        reasoning: 'short',
+        confidence: 0.8,
+        signals: [],
+      },
+    });
+
+    await persistOpportunities({ database, embedder: mockEmbedder, items: [input] });
+
+    expect(atomicCalled).toBe(false);
+    expect(persisted).toBeDefined();
+    expect(Object.prototype.hasOwnProperty.call(persisted!.actors[0], 'intent')).toBe(false);
+    expect(input.actors[0]?.intent).toBe('null');
+  });
+
+  it('normalizes actors immediately before every create path', async () => {
+    const existing = makeOpportunity({
+      id: 'opp-existing',
+      actors: [
+        { networkId: 'net-1', userId: 'user-1', role: 'patient', intent: 'intent-shared' },
+        {
+          networkId: 'net-1',
+          userId: 'user-2',
+          role: 'agent',
+          intent: ' undefined ',
+          preserved: 'legacy-key',
+        },
+      ] as never,
+    });
+    const eligibility = { ownerUserId: 'user-1', allowedNetworkIds: ['net-1'] };
+
+    async function runPath(
+      path: 'plain' | 'atomic' | 'eligible' | 'eligible-atomic',
+    ): Promise<CreateOpportunityData> {
+      let persisted: CreateOpportunityData | undefined;
+      const enrichedPath = path !== 'eligible';
+      const database: PersistOpportunityDatabase = {
+        findOpportunitiesByActors: async () => enrichedPath ? [existing] : [],
+        createOpportunity: async (data) => {
+          persisted = data;
+          return makeOpportunity({ id: `opp-${path}`, actors: data.actors });
+        },
+        updateOpportunityStatus: async () => {},
+      };
+
+      if (path === 'atomic') {
+        database.createOpportunityAndExpireIds = async (data) => {
+          persisted = data;
+          return {
+            created: makeOpportunity({ id: 'opp-atomic', actors: data.actors }),
+            expired: [existing],
+          };
+        };
+      }
+      if (path === 'eligible') {
+        database.createOpportunityIfNetworkEligible = async (data) => {
+          persisted = data;
+          return makeOpportunity({ id: 'opp-eligible', actors: data.actors });
+        };
+      }
+      if (path === 'eligible-atomic') {
+        database.createOpportunityAndExpireIdsIfNetworkEligible = async (data) => {
+          persisted = data;
+          return {
+            created: makeOpportunity({ id: 'opp-eligible-atomic', actors: data.actors }),
+            expired: [existing],
+          };
+        };
+      }
+
+      const actors = enrichedPath
+        ? [{ networkId: 'net-1', userId: 'user-1', role: 'patient', intent: 'intent-shared' }]
+        : [{ networkId: 'net-1', userId: 'user-1', role: 'patient', intent: ' NULL ' }];
+      const result = await persistOpportunities({
+        database,
+        embedder: mockEmbedder,
+        items: [makeCreateData({ actors: actors as never })],
+        ...(path.startsWith('eligible') ? { networkEligibility: eligibility } : {}),
+      });
+
+      expect(result.errors).toBeUndefined();
+      expect(result.created).toHaveLength(1);
+      expect(persisted).toBeDefined();
+      return persisted!;
+    }
+
+    for (const path of ['plain', 'atomic', 'eligible', 'eligible-atomic'] as const) {
+      const persisted = await runPath(path);
+      for (const actor of persisted.actors) {
+        expect(actor.intent).not.toBe('null');
+        expect(actor.intent).not.toBe('undefined');
+        expect(actor.intent?.trim().toLowerCase()).not.toBe('null');
+        expect(actor.intent?.trim().toLowerCase()).not.toBe('undefined');
+      }
+      if (path !== 'eligible') {
+        const legacyActor = persisted.actors.find((actor) => actor.userId === 'user-2') as unknown as Record<string, unknown>;
+        expect(legacyActor.preserved).toBe('legacy-key');
+        expect(Object.prototype.hasOwnProperty.call(legacyActor, 'intent')).toBe(false);
+      }
+    }
   });
 });

--- a/services/api/CHANGELOG.md
+++ b/services/api/CHANGELOG.md
@@ -31,6 +31,7 @@ section before promoting to `main`).
   consent primitive; deferred to IND-467).
 
 ### Fixed
+- Normalized blank and null-like opportunity actor intents before uptake lookups and added the idempotent, order-preserving `0096_normalize_opportunity_actor_intents` data migration, which removes malformed `intent` keys while leaving unaffected rows and all other actor data unchanged. The Railway-dev audit scope was 7,690 affected opportunities, requiring explicit release review before rollout (IND-469).
 - Restored unscoped asynchronous MCP discovery by wiring discovery-run workers to real network and membership graphs instead of no-op placeholders (IND-466).
 - Lens C shadow network binding is now derived from capture-time negotiation
   task metadata instead of `opportunity.context.networkId` (IND-465 slice 1,

--- a/services/api/drizzle/0096_normalize_opportunity_actor_intents.sql
+++ b/services/api/drizzle/0096_normalize_opportunity_actor_intents.sql
@@ -1,0 +1,33 @@
+-- Normalize malformed model sentinels in persisted opportunity actors.
+-- OpportunityActor.intent is optional, so null-like strings are represented by
+-- removing the key rather than writing JSON null.
+UPDATE "opportunities"
+SET "actors" = (
+  SELECT jsonb_agg(
+    CASE
+      WHEN jsonb_typeof(actor.value -> 'intent') = 'string'
+        AND lower(btrim(actor.value ->> 'intent')) IN ('', 'null', 'undefined')
+      THEN actor.value - 'intent'
+      ELSE actor.value
+    END
+    ORDER BY actor.ordinality
+  )
+  FROM jsonb_array_elements(
+    CASE
+      WHEN jsonb_typeof("opportunities"."actors") = 'array' THEN "opportunities"."actors"
+      ELSE '[]'::jsonb
+    END
+  ) WITH ORDINALITY AS actor(value, ordinality)
+)
+WHERE jsonb_typeof("actors") = 'array'
+  AND EXISTS (
+    SELECT 1
+    FROM jsonb_array_elements(
+      CASE
+        WHEN jsonb_typeof("opportunities"."actors") = 'array' THEN "opportunities"."actors"
+        ELSE '[]'::jsonb
+      END
+    ) AS actor(value)
+    WHERE jsonb_typeof(actor.value -> 'intent') = 'string'
+      AND lower(btrim(actor.value ->> 'intent')) IN ('', 'null', 'undefined')
+  );--> statement-breakpoint

--- a/services/api/drizzle/meta/_journal.json
+++ b/services/api/drizzle/meta/_journal.json
@@ -673,6 +673,13 @@
       "when": 1784291736818,
       "tag": "0095_add_outcome_feedback_events",
       "breakpoints": true
+    },
+    {
+      "idx": 96,
+      "version": "7",
+      "when": 1784397197143,
+      "tag": "0096_normalize_opportunity_actor_intents",
+      "breakpoints": true
     }
   ]
 }

--- a/services/api/package.json
+++ b/services/api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@indexnetwork/api",
-  "version": "0.44.1",
+  "version": "0.44.2",
   "license": "MIT",
   "private": true,
   "scripts": {

--- a/services/api/src/lib/opportunity/tests/actor-intent-migration.spec.ts
+++ b/services/api/src/lib/opportunity/tests/actor-intent-migration.spec.ts
@@ -1,0 +1,75 @@
+import { config } from 'dotenv';
+import { resolve } from 'node:path';
+config({ path: resolve(import.meta.dir, '../../../../../../.env.test'), override: true });
+
+import { afterAll, beforeAll, describe, expect, it } from 'bun:test';
+import { readFileSync } from 'node:fs';
+import postgres from 'postgres';
+
+const migrationPath = resolve(
+  import.meta.dir,
+  '../../../../drizzle/0096_normalize_opportunity_actor_intents.sql',
+);
+const migrationSql = readFileSync(migrationPath, 'utf8');
+
+let client: ReturnType<typeof postgres>;
+
+beforeAll(() => {
+  if (!process.env.DATABASE_URL) throw new Error('DATABASE_URL is required for migration behavior tests');
+  client = postgres(process.env.DATABASE_URL, { max: 1, prepare: false });
+});
+
+afterAll(async () => {
+  await client.end({ timeout: 5 });
+});
+
+describe('0096 opportunity actor intent normalization', () => {
+  it('removes only malformed keys, preserves actor order and untouched rows, and is idempotent', async () => {
+    await client.begin(async (sql) => {
+      await sql.unsafe(`
+        CREATE TEMP TABLE "opportunities" (
+          "id" text PRIMARY KEY,
+          "actors" jsonb NOT NULL
+        ) ON COMMIT DROP
+      `);
+
+      const affectedActors = [
+        { slot: 'first', intent: ' NULL ', nested: { keep: true } },
+        { slot: 'second', untouched: 'value' },
+        { slot: 'third', intent: 'undefined', count: 3 },
+        { slot: 'fourth', intent: ' intent-1 ', valid: true },
+      ];
+      const untouchedActors = [
+        { slot: 'only', intent: 'intent-2', nested: ['preserve', 2] },
+      ];
+      await sql`
+        INSERT INTO "opportunities" ("id", "actors")
+        VALUES
+          ('affected', ${sql.json(affectedActors)}),
+          ('untouched', ${sql.json(untouchedActors)}),
+          ('not-an-array', ${sql.json({ intent: 'null' })})
+      `;
+
+      const firstRun = await sql.unsafe(migrationSql);
+      expect(firstRun.count).toBe(1);
+
+      const rows = await sql<{ id: string; actors: unknown }[]>`
+        SELECT "id", "actors"
+        FROM "opportunities"
+        ORDER BY "id"
+      `;
+      const byId = new Map(rows.map((row) => [row.id, row.actors]));
+      expect(byId.get('affected')).toEqual([
+        { slot: 'first', nested: { keep: true } },
+        { slot: 'second', untouched: 'value' },
+        { slot: 'third', count: 3 },
+        { slot: 'fourth', intent: ' intent-1 ', valid: true },
+      ]);
+      expect(byId.get('untouched')).toEqual(untouchedActors);
+      expect(byId.get('not-an-array')).toEqual({ intent: 'null' });
+
+      const secondRun = await sql.unsafe(migrationSql);
+      expect(secondRun.count).toBe(0);
+    });
+  });
+});

--- a/services/api/src/services/tests/uptake-question.service.spec.ts
+++ b/services/api/src/services/tests/uptake-question.service.spec.ts
@@ -102,6 +102,54 @@ describe('UptakeQuestionService', () => {
     expect(jobId).toBe(`uptake-${RECIPIENT}-${OPPORTUNITY}`);
   });
 
+  it('skips legacy blank and null-like actor intents without an intent lookup', async () => {
+    const nullLikeValues: unknown[] = [null, undefined, '', '   ', 'null', ' NULL ', 'undefined'];
+
+    for (const intent of nullLikeValues) {
+      const getIntent = mock(async () => null);
+      const { service, enqueue } = makeDeps({
+        getOpportunity: async () => opportunity({
+          actors: [
+            { userId: RECIPIENT, networkId: NETWORK, role: 'patient' },
+            { userId: COUNTERPARTY, networkId: NETWORK, role: 'peer', intent } as never,
+          ],
+        }),
+        getIntent,
+      });
+
+      await service.handlePending(OPPORTUNITY);
+
+      expect(getIntent).not.toHaveBeenCalled();
+      expect(enqueue).not.toHaveBeenCalled();
+    }
+  });
+
+  it('trims a valid non-UUID actor intent before the exact lookup', async () => {
+    const getIntent = mock(async (intentId: string) => ({
+      id: intentId,
+      userId: COUNTERPARTY,
+      payload: 'Host a hands-on TypeScript workshop',
+      summary: 'Host a TypeScript workshop',
+      status: 'ACTIVE' as const,
+      archivedAt: null,
+      felicityAuthority: 45,
+    }));
+    const { service, enqueue } = makeDeps({
+      getOpportunity: async () => opportunity({
+        actors: [
+          { userId: RECIPIENT, networkId: NETWORK, role: 'patient' },
+          { userId: COUNTERPARTY, networkId: NETWORK, role: 'peer', intent: `  ${INTENT}  ` },
+        ],
+      }),
+      getIntent,
+    });
+
+    await service.handlePending(OPPORTUNITY);
+
+    expect(getIntent).toHaveBeenCalledWith(INTENT, NETWORK);
+    expect(enqueue).toHaveBeenCalledTimes(1);
+  });
+
   it('skips high or unknown authority', async () => {
     for (const felicityAuthority of [70, null]) {
       const { service, enqueue } = makeDeps({

--- a/services/api/src/services/uptake-question.service.ts
+++ b/services/api/src/services/uptake-question.service.ts
@@ -32,7 +32,18 @@ function isRecipient(actor: OpportunityActor): boolean {
 }
 
 function exactActorIntent(actor: OpportunityActor): string | null {
-  return typeof actor.intent === 'string' && actor.intent.trim() ? actor.intent : null;
+  if (typeof actor.intent !== 'string') return null;
+
+  const normalized = actor.intent.trim();
+  if (
+    normalized.length === 0
+    || normalized.toLowerCase() === 'null'
+    || normalized.toLowerCase() === 'undefined'
+  ) {
+    return null;
+  }
+
+  return normalized;
 }
 
 function sharedActorNetworks(


### PR DESCRIPTION
## Bug Fixes

- Normalize opportunity actor intent values at evaluator, graph, and shared persistence boundaries, preserving trimmed branded string IDs while omitting blank, `null`, and `undefined` sentinels.
- Normalize before enrichment overlap checks and again after enrichment so legacy malformed actors cannot affect intent overlap or be copied into replacement rows.
- Harden uptake and both negotiation exact-intent lookup paths against malformed legacy actor data.
- Add migration `0096_normalize_opportunity_actor_intents`, which removes malformed `intent` keys, explicitly preserves actor order with ordinality, narrows updates to affected JSONB arrays, and is idempotent.

## Migration Safety

- Railway-dev read-only audit scope: **7,690 / 10,476 opportunities** and **11,110 literal `\"null\"` actor values**.
- The migration rewrites only rows containing string intents whose trimmed lowercase value is empty, `null`, or `undefined`; unaffected rows are not updated.
- No Neon data was mutated during implementation. This broad migration scope requires explicit release review before dev/main rollout.

## Versions

- `@indexnetwork/protocol`: `6.2.1` → `6.2.2`
- `@indexnetwork/api`: `0.44.1` → `0.44.2`
- `bun install` produced no root lockfile delta.

## Tests

- `cd packages/protocol && bun test src/opportunity/tests/opportunity.persist.spec.ts` — 10 passed
- `cd packages/protocol && bun test src/opportunity/tests/opportunity.graph.spec.ts` — 78 passed
- `cd services/api && bun test src/services/tests/uptake-question.service.spec.ts` — 8 passed
- `cd services/api && bun test src/lib/opportunity/tests/actor-intent-migration.spec.ts` — 1 passed
- `cd packages/protocol && bun run build`
- `cd packages/protocol && bun run eval:verify` — all 9 provider-free suites passed
- `cd services/api && bun run build`
- `cd services/api && bun run db:generate` — no schema changes
- `git diff --check`

References IND-469.