### PR TITLE
fix(discovery): prevent taskless negotiating opportunities (IND-470)

### DIFF
--- a/packages/protocol/CHANGELOG.md
+++ b/packages/protocol/CHANGELOG.md
@@ -41,6 +41,7 @@ See [STABILITY.md](./STABILITY.md) for the public-contract and tier definitions.
 - Included protocol documentation files in the published package tarball so README links remain available to package consumers.
 
 ### Fixed
+- Routed continuation-created and recovered opportunities through the normal negotiation boundary, protected active/input-required tasks from duplicate negotiation, compensated pre-task failures and timeouts to truthful draft/latent states, and refreshed continuation cards from current lifecycle state (IND-470).
 - Normalized opportunity actor intent IDs at evaluator, graph, and shared persistence boundaries so blank or null-like model sentinels are omitted, valid branded string IDs remain supported, enrichment cannot use or reintroduce malformed provenance, and legacy negotiation reads fail closed (IND-469).
 - Forwarded per-attempt `AbortSignal`s through eval provider paths and hardened failure provenance against secret leakage, hostile rejection objects, classifier failures, and concurrent artifact writers (IND-444).
 - Aligned HyDE evidence scoring with the live background `0.30` cutoff, retained per-lens cosines for score/ranking revalidation, required report-stage parent recomputation, and prevented forced outputs from overwriting input evidence artifacts (IND-426).

--- a/packages/protocol/CHANGELOG.md
+++ b/packages/protocol/CHANGELOG.md
@@ -41,7 +41,7 @@ See [STABILITY.md](./STABILITY.md) for the public-contract and tier definitions.
 - Included protocol documentation files in the published package tarball so README links remain available to package consumers.
 
 ### Fixed
-- Routed continuation-created and recovered opportunities through the normal negotiation boundary, protected active/input-required tasks from duplicate negotiation, compensated pre-task failures and timeouts to truthful draft/latent states, and refreshed continuation cards from current lifecycle state (IND-470).
+- Routed continuation-created and recovered opportunities through the normal negotiation boundary, threaded each persisted attempt version into atomic negotiation-task claiming, protected active/input-required tasks from duplicate negotiation, compensated pre-task failures and timeouts to truthful draft/latent states, and refreshed continuation cards from current lifecycle state (IND-470).
 - Normalized opportunity actor intent IDs at evaluator, graph, and shared persistence boundaries so blank or null-like model sentinels are omitted, valid branded string IDs remain supported, enrichment cannot use or reintroduce malformed provenance, and legacy negotiation reads fail closed (IND-469).
 - Forwarded per-attempt `AbortSignal`s through eval provider paths and hardened failure provenance against secret leakage, hostile rejection objects, classifier failures, and concurrent artifact writers (IND-444).
 - Aligned HyDE evidence scoring with the live background `0.30` cutoff, retained per-lens cosines for score/ranking revalidation, required report-stage parent recomputation, and prevented forced outputs from overwriting input evidence artifacts (IND-426).

--- a/packages/protocol/package.json
+++ b/packages/protocol/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@indexnetwork/protocol",
-  "version": "6.2.2",
+  "version": "6.2.3",
   "type": "module",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",

--- a/packages/protocol/src/negotiation/negotiation.graph.ts
+++ b/packages/protocol/src/negotiation/negotiation.graph.ts
@@ -262,7 +262,7 @@ export class NegotiationGraphFactory {
           protocolVersion = configuredProtocolVersion();
         }
 
-        const task = await database.createTask(conversation.id, {
+        const taskMetadata = {
           type: 'negotiation',
           sourceUserId: state.sourceUser.id,
           initiatorUserId,
@@ -274,9 +274,24 @@ export class NegotiationGraphFactory {
           maxTurns,
           isContinuation,
           priorTurnCount: priorTurns.length,
-        });
+        };
+        const task = state.opportunityId && state.opportunityUpdatedAt
+          ? await database.createNegotiationTaskForAttempt({
+              conversationId: conversation.id,
+              opportunityId: state.opportunityId,
+              expectedUpdatedAt: state.opportunityUpdatedAt,
+              metadata: taskMetadata,
+            })
+          : await database.createTask(conversation.id, taskMetadata);
 
-        if (state.opportunityId) {
+        if (!task) {
+          throw new Error('Negotiation attempt is stale or already claimed');
+        }
+
+        // Attempt-bound discovery already persisted `negotiating` and the atomic
+        // task claim verified that exact version. Legacy/direct invocations with
+        // only an opportunity ID retain the prior best-effort status update.
+        if (state.opportunityId && !state.opportunityUpdatedAt) {
           await database.updateOpportunityStatus(state.opportunityId, 'negotiating').catch((err) => {
             initLog.error('Failed to set opportunity status to negotiating', { opportunityId: state.opportunityId, error: err });
           });
@@ -1055,6 +1070,8 @@ export interface NegotiationCandidate {
    * (`accept` → 'pending', `reject` → 'rejected', otherwise → 'stalled').
    */
   opportunityId?: string;
+  /** Exact persisted lifecycle version claimed by this negotiation attempt. */
+  opportunityUpdatedAt?: Date;
 }
 
 export interface NegotiationResult {
@@ -1150,6 +1167,7 @@ export async function negotiateCandidates(
           },
           ...(candidate.discoveryQuery && { discoveryQuery: candidate.discoveryQuery }),
           ...(candidate.opportunityId && { opportunityId: candidate.opportunityId }),
+          ...(candidate.opportunityUpdatedAt && { opportunityUpdatedAt: candidate.opportunityUpdatedAt }),
           ...(initiatorUserId && { initiatorUserId }),
           ...(maxTurns !== undefined && { maxTurns }),
           ...(timeoutMs !== undefined && { timeoutMs }),

--- a/packages/protocol/src/negotiation/negotiation.state.ts
+++ b/packages/protocol/src/negotiation/negotiation.state.ts
@@ -90,6 +90,8 @@ export interface NegotiationGraphLike {
     seedAssessment: Omit<SeedAssessment, "actors">;
     discoveryQuery?: string;
     opportunityId?: string;
+    /** Exact persisted lifecycle version claimed by this negotiation attempt. */
+    opportunityUpdatedAt?: Date;
     maxTurns?: number;
     timeoutMs?: number;
     /**
@@ -204,6 +206,11 @@ export const NegotiationGraphState = Annotation.Root({
   opportunityId: Annotation<string>({
     reducer: (curr, next) => next ?? curr,
     default: () => "",
+  }),
+  /** Exact persisted lifecycle version claimed by this negotiation attempt. */
+  opportunityUpdatedAt: Annotation<Date | undefined>({
+    reducer: (curr, next) => next ?? curr,
+    default: () => undefined,
   }),
   conversationId: Annotation<string>({
     reducer: (curr, next) => next ?? curr,

--- a/packages/protocol/src/negotiation/tests/negotiation.graph.spec.ts
+++ b/packages/protocol/src/negotiation/tests/negotiation.graph.spec.ts
@@ -97,6 +97,74 @@ describe("negotiation graph — task intent snapshots", () => {
       },
     ]);
   });
+
+  it("fails init closed when the exact opportunity attempt cannot claim a task", async () => {
+    const { database, dispatcher } = mkStubs();
+    const persistedBoundary = new Date("2026-07-18T12:00:00.000Z");
+    const claims: Array<{
+      conversationId: string;
+      opportunityId: string;
+      expectedUpdatedAt: Date;
+      metadata: Record<string, unknown>;
+    }> = [];
+    let genericTaskCreates = 0;
+    let statusUpdates = 0;
+
+    database.createNegotiationTaskForAttempt = async (input) => {
+      claims.push(input);
+      return null;
+    };
+    database.createTask = async () => {
+      genericTaskCreates += 1;
+      return { id: "unexpected-task", conversationId: "conv-1", state: "submitted" };
+    };
+    database.updateTaskState = async () => {
+      throw new Error("task not found");
+    };
+    database.updateOpportunityStatus = async () => {
+      statusUpdates += 1;
+      return null;
+    };
+
+    const result = await new NegotiationGraphFactory(database, dispatcher).createGraph().invoke({
+      sourceUser: {
+        id: "u-src",
+        intents: [{ id: "intent-src", title: "Source", description: "Source intent", confidence: 1 }],
+        profile: {},
+      },
+      candidateUser: {
+        id: "u-cand",
+        intents: [{ id: "intent-cand", title: "Candidate", description: "Candidate intent", confidence: 1 }],
+        profile: {},
+      },
+      indexContext: { networkId: "net-1", prompt: "" },
+      seedAssessment: { reasoning: "x", valencyRole: "peer" },
+      opportunityId: "opp-stale",
+      opportunityUpdatedAt: persistedBoundary,
+      maxTurns: 1,
+    } as Partial<typeof NegotiationGraphState.State>);
+
+    expect(result.error).toContain("Negotiation attempt is stale or already claimed");
+    expect(genericTaskCreates).toBe(0);
+    expect(statusUpdates).toBe(0);
+    expect(claims).toHaveLength(1);
+    expect(claims[0]).toMatchObject({
+      conversationId: "conv-1",
+      opportunityId: "opp-stale",
+      expectedUpdatedAt: persistedBoundary,
+      metadata: {
+        type: "negotiation",
+        opportunityId: "opp-stale",
+        sourceUserId: "u-src",
+        candidateUserId: "u-cand",
+        networkId: "net-1",
+        intentSnapshots: [
+          { userId: "u-src", intentId: "intent-src", title: "Source", description: "Source intent" },
+          { userId: "u-cand", intentId: "intent-cand", title: "Candidate", description: "Candidate intent" },
+        ],
+      },
+    });
+  });
 });
 
 describe("negotiation graph — negotiation_turn emission", () => {

--- a/packages/protocol/src/opportunity/opportunity.discover.ts
+++ b/packages/protocol/src/opportunity/opportunity.discover.ts
@@ -278,6 +278,8 @@ interface EnrichOpportunitiesInput {
   debugSteps: DiscoverDebugStep[];
   /** IDs of pre-existing opportunities merged into the list; these preserve their real status. */
   existingOpportunityIds?: Set<string>;
+  /** Preserve refreshed lifecycle status instead of applying the chat-session draft projection. */
+  preserveLifecycleStatus?: boolean;
   /** When set, bypass the embedding filter for this specific user (direct connection mode). */
   targetUserId?: string;
 }
@@ -303,6 +305,7 @@ async function enrichOpportunities(
     useHomeCardFormat,
     debugSteps,
     existingOpportunityIds,
+    preserveLifecycleStatus,
     targetUserId,
   } = input;
 
@@ -602,7 +605,9 @@ async function enrichOpportunities(
           },
         ),
         score: item.confidence,
-        status: chatSessionId && !existingOpportunityIds?.has(item.opportunity.id) ? "draft" : item.opportunity.status,
+        status: !preserveLifecycleStatus && chatSessionId && !existingOpportunityIds?.has(item.opportunity.id)
+          ? "draft"
+          : item.opportunity.status,
         viewerRole: item.viewerRole,
         viewerApproved: item.viewerApproved,
         viewerActedAt: item.viewerActedAt,
@@ -1322,10 +1327,18 @@ export async function continueDiscovery(input: {
     });
   }
 
-  // Check for opportunities in result
+  // Check for opportunities in result. Negotiation mutates lifecycle state after
+  // persistence, so continuation must refresh before enrichment/presentation rather
+  // than returning the graph state's persist-time `negotiating` snapshots.
   const opportunities: Opportunity[] = Array.isArray(result.opportunities) ? result.opportunities : [];
+  const refreshed = opportunities.length > 0
+    ? await database.getOpportunitiesByIds(opportunities.map((opportunity) => opportunity.id))
+    : [];
+  const refreshedById = new Map(refreshed.map((opportunity) => [opportunity.id, opportunity] as const));
+  const currentOpportunities = opportunities.map((opportunity) =>
+    refreshedById.get(opportunity.id) ?? opportunity);
 
-  if (opportunities.length === 0) {
+  if (currentOpportunities.length === 0) {
     return {
       found: false,
       count: 0,
@@ -1336,7 +1349,7 @@ export async function continueDiscovery(input: {
   }
 
   const enriched = await enrichOpportunities({
-    opportunities,
+    opportunities: currentOpportunities,
     database,
     userId,
     chatSessionId,
@@ -1344,6 +1357,7 @@ export async function continueDiscovery(input: {
     presenter: input.presenter,
     useHomeCardFormat: input.useHomeCardFormat,
     debugSteps,
+    preserveLifecycleStatus: true,
   });
 
   return {

--- a/packages/protocol/src/opportunity/opportunity.graph.ts
+++ b/packages/protocol/src/opportunity/opportunity.graph.ts
@@ -2194,6 +2194,7 @@ export class OpportunityGraphFactory {
             return {
               userId,
               opportunityId: opp.id as string,
+              opportunityUpdatedAt: opp.updatedAt,
               reasoning: (opp.interpretation as { reasoning?: string } | null)?.reasoning ?? '',
               valencyRole: candidateActor.role ?? 'peer',
               networkId: candidateActor.networkId as string,

--- a/packages/protocol/src/opportunity/opportunity.graph.ts
+++ b/packages/protocol/src/opportunity/opportunity.graph.ts
@@ -51,6 +51,7 @@ import type { CreateOpportunityData, Opportunity, OpportunityActor, OpportunityN
 import { persistOpportunities } from './opportunity.persist.js';
 import { INTRODUCER_DISCOVERY_SOURCE } from './opportunity.introducer.js';
 import { negotiateCandidates, type NegotiationCandidate, type OnNegotiationResolved } from "../negotiation/negotiation.graph.js";
+import { ASK_USER_LOCK_SLACK_MS, askUserAnswerWindowMs } from "../negotiation/negotiation.protocol.js";
 import { AMBIENT_PARK_WINDOW_MS } from "../negotiation/negotiation.tools.js";
 import { buildDiscoverySummary, toDiscoveryNegotiation, type NegotiationResolution } from "./negotiation-summary.builder.js";
 import type { NegotiationGraphLike, UserNegotiationContext } from "../negotiation/negotiation.state.js";
@@ -86,6 +87,21 @@ const routingLog = protocolLogger('OpportunityGraph:Routing');
 /** Time window for persist-node dedup. Suppresses a second opportunity with the same person while a recent one (within 30 days) is still in flight, so a person is not re-surfaced multiple times within a month (EDG-23). */
 const DEDUP_WINDOW_MS = 30 * 24 * 60 * 60 * 1000;
 const NEGOTIATION_INTENT_LIMIT = 5;
+const ACTIVE_NEGOTIATION_TASK_STATES = new Set([
+  'submitted',
+  'working',
+  'input_required',
+  'waiting_for_agent',
+  'claimed',
+]);
+
+function isActiveNegotiationTaskFresh(task: { state: string; updatedAt: Date }): boolean {
+  if (!ACTIVE_NEGOTIATION_TASK_STATES.has(task.state)) return false;
+  const freshnessMs = task.state === 'input_required'
+    ? askUserAnswerWindowMs() + ASK_USER_LOCK_SLACK_MS
+    : 5 * 60 * 1000;
+  return Date.now() - new Date(task.updatedAt).getTime() < freshnessMs;
+}
 
 interface NegotiationIntentSource {
   id?: string | null;
@@ -2047,6 +2063,30 @@ export class OpportunityGraphFactory {
 
       const traceEmitter = requestContext.getStore()?.traceEmitter;
       const graphStart = Date.now();
+      const persistedById = new Map(
+        state.opportunities.map((opportunity) => [opportunity.id, opportunity] as const),
+      );
+      const attemptBoundaryById = new Map(
+        state.opportunities.map((opportunity) => [opportunity.id, opportunity.updatedAt] as const),
+      );
+      const compensateTasklessNegotiatingOpportunity = async (opportunityId: string): Promise<void> => {
+        const opportunity = persistedById.get(opportunityId);
+        const expectedUpdatedAt = attemptBoundaryById.get(opportunityId);
+        if (opportunity?.status !== 'negotiating' || !expectedUpdatedAt) return;
+        const fallbackStatus = opportunity.actors.some((actor) => actor.role === 'introducer')
+          ? 'latent'
+          : 'draft';
+        await this.database
+          .compensateTasklessNegotiatingOpportunity(opportunityId, expectedUpdatedAt, fallbackStatus)
+          .catch((error: unknown) => {
+            negotiateLog.warn('Failed to compensate taskless negotiating opportunity', {
+              opportunityId,
+              expectedUpdatedAt,
+              fallbackStatus,
+              error,
+            });
+          });
+      };
       traceEmitter?.({ type: "graph_start", name: "Negotiation graph" });
 
       try {
@@ -2088,6 +2128,7 @@ export class OpportunityGraphFactory {
           discoveryUserId,
         });
 
+        const filteredBeforeInvocation: string[] = [];
         const candidateEntries = state.opportunities
           .map(opp => {
             // Skip opportunities where any introducer exists but has not yet approved.
@@ -2099,6 +2140,7 @@ export class OpportunityGraphFactory {
                 introducerCount: introducerActors.length,
                 approvedCount: introducerActors.filter(a => a.approved === true).length,
               });
+              filteredBeforeInvocation.push(opp.id);
               return null;
             }
 
@@ -2115,11 +2157,14 @@ export class OpportunityGraphFactory {
                 discoveryUserId,
                 actors: (opp.actors as OpportunityActor[])?.map(a => ({ userId: a.userId, role: a.role })) ?? [],
               });
+              filteredBeforeInvocation.push(opp.id);
               return null;
             }
             return { opp, candidateActor };
           })
           .filter((e): e is NonNullable<typeof e> => e !== null);
+
+        await Promise.all(filteredBeforeInvocation.map(compensateTasklessNegotiatingOpportunity));
 
         negotiateLog.verbose('Candidate filtering complete', {
           inputOpportunities: state.opportunities.length,
@@ -2251,8 +2296,10 @@ export class OpportunityGraphFactory {
         candidates.forEach((c, i) => candidateOrderById.set(c.userId, i));
 
         const resolutions: Array<NegotiationResolution & { __order: number }> = [];
+        const resolvedOpportunityIds = new Set<string>();
 
         const onCandidateResolved: OnNegotiationResolved = async ({ candidate, accepted, turns, outcome }) => {
+          if (candidate.opportunityId) resolvedOpportunityIds.add(candidate.opportunityId);
           resolutions.push({
             __order: candidateOrderById.get(candidate.userId) ?? Number.MAX_SAFE_INTEGER,
             candidateUserId: candidate.userId,
@@ -2267,6 +2314,10 @@ export class OpportunityGraphFactory {
             turns,
             outcome,
           });
+
+          if (candidate.opportunityId) {
+            await compensateTasklessNegotiatingOpportunity(candidate.opportunityId);
+          }
 
           if (state.trigger !== 'orchestrator') return;
           // ─── orchestrator streaming body ───
@@ -2361,6 +2412,14 @@ export class OpportunityGraphFactory {
             if (timerId !== undefined) clearTimeout(timerId);
           }
           if (raced === NEGOTIATE_TIMER_SENTINEL) {
+            // Restore any attempt that is still before its task boundary. A running or
+            // parked negotiation already has a task and makes the CAS a no-op; a hung
+            // pre-task init becomes owner-actionable while its floating work may retry.
+            await Promise.all(
+              candidates
+                .filter((candidate) => candidate.opportunityId && !resolvedOpportunityIds.has(candidate.opportunityId))
+                .map((candidate) => compensateTasklessNegotiatingOpportunity(candidate.opportunityId!)),
+            );
             // Floating promise is intentional — see comment above.
             void negotiationWork.catch((err) => {
               negotiateLog.warn('background negotiation failed after timer fired', { error: err });
@@ -2447,6 +2506,8 @@ export class OpportunityGraphFactory {
           discoverySummary,
         };
       } catch (err) {
+        await Promise.all(state.opportunities.map((opportunity) =>
+          compensateTasklessNegotiatingOpportunity(opportunity.id)));
         negotiateLog.error("Negotiation stage failed", { error: err });
         traceEmitter?.({ type: "graph_end", name: "Negotiation graph", durationMs: Date.now() - graphStart });
         return {
@@ -2820,6 +2881,7 @@ export class OpportunityGraphFactory {
             opportunityId: string,
             status: Opportunity['status'],
             existingActors: OpportunityActor[],
+            expectedStatus: Opportunity['status'],
           ): Promise<Opportunity | null> => {
             // Reactivation preserves the existing opportunity row, so lock the
             // existing participant anchors rather than the evaluator's current
@@ -2839,6 +2901,7 @@ export class OpportunityGraphFactory {
               status,
               anchors,
               networkEligibility,
+              expectedStatus,
             );
           };
 
@@ -3011,7 +3074,9 @@ export class OpportunityGraphFactory {
                   if (existing.status === 'stalled' || sameIntroducer) {
                     // Introduction path always targets 'draft' (chat-only surface) rather than using
                     // initialStatus, because introductions are always chat-initiated, not background-discovered.
-                    const reactivated = await updateStatusIfStillEligible(existing.id, 'draft', existing.actors);
+                    const reactivated = await updateStatusIfStillEligible(
+                      existing.id, 'draft', existing.actors, existing.status,
+                    );
                     if (reactivated) {
                       persistLog.verbose('Reactivated opportunity (introduction path)', {
                         opportunityId: existing.id,
@@ -3025,25 +3090,23 @@ export class OpportunityGraphFactory {
                 } else if (existing.status === 'negotiating') {
                   // Orphan heal (introduction path): same logic as discovery path
                   const priorTask = await this.database.getNegotiationTaskForOpportunity(existing.id);
-                  if (priorTask) {
-                    const activeStates = ['submitted', 'working', 'input_required', 'waiting_for_agent', 'claimed'];
-                    const isFresh = (Date.now() - new Date(priorTask.updatedAt).getTime()) < 5 * 60 * 1000;
-                    if (activeStates.includes(priorTask.state) && isFresh) {
-                      existingBetweenActors.push({
-                        candidateUserId: candidateUserId as Id<'users'>,
-                        networkId: (state.networkId ?? indexIdForActors ?? '') as Id<'networks'>,
-                        existingOpportunityId: existing.id as Id<'opportunities'>,
-                        existingStatus: existing.status,
-                      });
-                      persistLog.verbose('Skipping negotiating opportunity with active task (introduction path)', {
-                        opportunityId: existing.id,
-                        candidateUserId,
-                        taskState: priorTask.state,
-                      });
-                      continue;
-                    }
+                  if (priorTask && isActiveNegotiationTaskFresh(priorTask)) {
+                    existingBetweenActors.push({
+                      candidateUserId: candidateUserId as Id<'users'>,
+                      networkId: (state.networkId ?? indexIdForActors ?? '') as Id<'networks'>,
+                      existingOpportunityId: existing.id as Id<'opportunities'>,
+                      existingStatus: existing.status,
+                    });
+                    persistLog.verbose('Skipping negotiating opportunity with active task (introduction path)', {
+                      opportunityId: existing.id,
+                      candidateUserId,
+                      taskState: priorTask.state,
+                    });
+                    continue;
                   }
-                  const reactivated = await updateStatusIfStillEligible(existing.id, 'draft', existing.actors);
+                  const reactivated = await updateStatusIfStillEligible(
+                    existing.id, 'draft', existing.actors, existing.status,
+                  );
                   if (reactivated) {
                     persistLog.info('Resuming orphaned negotiating opportunity (introduction path)', {
                       opportunityId: existing.id,
@@ -3055,7 +3118,9 @@ export class OpportunityGraphFactory {
                   continue;
                 } else if (existing.status === 'latent') {
                   // Upgrade latent to draft for introduction path
-                  const upgraded = await updateStatusIfStillEligible(existing.id, 'draft', existing.actors);
+                  const upgraded = await updateStatusIfStillEligible(
+                    existing.id, 'draft', existing.actors, existing.status,
+                  );
                   if (upgraded) {
                     persistLog.verbose('Upgraded latent opportunity to draft (introduction path)', {
                       opportunityId: existing.id,
@@ -3184,7 +3249,9 @@ export class OpportunityGraphFactory {
                   // Reactivate expired or stalled opportunities.
                   // Stalled opportunities are reactivated regardless of age: a stalled negotiation
                   // is still in-flight for this pair, so we resume it rather than create a parallel one.
-                  const reactivated = await updateStatusIfStillEligible(existing.id, initialStatus, existing.actors);
+                  const reactivated = await updateStatusIfStillEligible(
+                    existing.id, initialStatus, existing.actors, existing.status,
+                  );
                   if (reactivated) {
                     persistLog.verbose('Reactivated opportunity', {
                       opportunityId: existing.id,
@@ -3199,27 +3266,25 @@ export class OpportunityGraphFactory {
                   // Orphan heal: if a prior opportunity is stuck in 'negotiating' with a stale task,
                   // reactivate it so the new discovery run can reuse it instead of creating a duplicate.
                   const priorTask = await this.database.getNegotiationTaskForOpportunity(existing.id);
-                  if (priorTask) {
-                    const activeStates = ['submitted', 'working', 'input_required', 'waiting_for_agent', 'claimed'];
-                    const isFresh = (Date.now() - new Date(priorTask.updatedAt).getTime()) < 5 * 60 * 1000;
-                    if (activeStates.includes(priorTask.state) && isFresh) {
-                      // Still active — skip (lock gate in init node will handle)
-                      existingBetweenActors.push({
-                        candidateUserId: candidateUserId as Id<'users'>,
-                        networkId: existingIndexId,
-                        existingOpportunityId: existing.id as Id<'opportunities'>,
-                        existingStatus: existing.status,
-                      });
-                      persistLog.verbose('Skipping negotiating opportunity with active task', {
-                        opportunityId: existing.id,
-                        candidateUserId,
-                        taskState: priorTask.state,
-                      });
-                      continue;
-                    }
+                  if (priorTask && isActiveNegotiationTaskFresh(priorTask)) {
+                    // Still active — skip (lock gate in init node will handle)
+                    existingBetweenActors.push({
+                      candidateUserId: candidateUserId as Id<'users'>,
+                      networkId: existingIndexId,
+                      existingOpportunityId: existing.id as Id<'opportunities'>,
+                      existingStatus: existing.status,
+                    });
+                    persistLog.verbose('Skipping negotiating opportunity with active task', {
+                      opportunityId: existing.id,
+                      candidateUserId,
+                      taskState: priorTask.state,
+                    });
+                    continue;
                   }
                   // Task is stale or missing — reactivate the orphaned negotiating opportunity
-                  const reactivated = await updateStatusIfStillEligible(existing.id, initialStatus, existing.actors);
+                  const reactivated = await updateStatusIfStillEligible(
+                    existing.id, initialStatus, existing.actors, existing.status,
+                  );
                   if (reactivated) {
                     persistLog.info('Resuming orphaned negotiating opportunity', {
                       opportunityId: existing.id,
@@ -3231,7 +3296,9 @@ export class OpportunityGraphFactory {
                   continue;
                 } else if (existing.status === 'latent' && initialStatus !== 'latent') {
                   // Upgrade latent (background-discovered) to the higher-priority status (e.g. pending)
-                  const upgraded = await updateStatusIfStillEligible(existing.id, initialStatus, existing.actors);
+                  const upgraded = await updateStatusIfStillEligible(
+                    existing.id, initialStatus, existing.actors, existing.status,
+                  );
                   if (upgraded) {
                     persistLog.verbose('Upgraded latent opportunity to higher-priority status', {
                       opportunityId: existing.id,
@@ -4110,15 +4177,13 @@ export class OpportunityGraphFactory {
       })
 
       // Discovery → Ranking → Persist → Negotiate (post-persist).
-      // Negotiation runs against persisted opportunities so each negotiation receives the
-      // opportunity's id and its outcome flips status (pending|stalled|rejected) via the
-      // negotiation graph's finalize node. Skipped for continue_discovery and when no
-      // negotiation graph or no opportunities were persisted (negotiateNode returns early).
+      // Fresh and continuation discovery both negotiate newly created/reactivated
+      // opportunities. The stage is skipped only when no negotiation graph is wired or
+      // persistence produced no negotiation targets (negotiateNode also guards both cases).
       .addNode('negotiate', negotiateNode)
       .addEdge('evaluation', 'ranking')
       .addEdge('ranking', 'persist')
       .addConditionalEdges('persist', (state) => {
-        if (state.operationMode === 'continue_discovery') return END;
         if (!this.negotiationGraph) return END;
         if (!state.opportunities || state.opportunities.length === 0) return END;
         return 'negotiate';

--- a/packages/protocol/src/opportunity/opportunity.tools.ts
+++ b/packages/protocol/src/opportunity/opportunity.tools.ts
@@ -904,8 +904,31 @@ export function createOpportunityTools(defineTool: DefineTool, deps: ToolDeps) {
           });
         }
 
+        // Continuation now negotiates just like fresh discovery. For MCP callers,
+        // surface only post-negotiation drafts; keep in-flight attempts count-only
+        // and never render rejected/stalled or fallback latent rows as cards.
+        let negotiatingCount = 0;
+        const continuationCards = context.isMcp
+          ? (result.opportunities ?? []).filter((opportunity) => {
+              if (opportunity.status === 'draft') return true;
+              if (opportunity.status === 'negotiating') {
+                negotiatingCount += 1;
+                return false;
+              }
+              if (opportunity.status === 'rejected' || opportunity.status === 'stalled' || opportunity.status === 'latent') {
+                return false;
+              }
+              discoverOpportunitiesLog.warn('unexpected continuation status — counting as negotiating', {
+                opportunityId: opportunity.opportunityId,
+                status: opportunity.status,
+              });
+              negotiatingCount += 1;
+              return false;
+            })
+          : (result.opportunities ?? []);
+
         // Build card data; cap at CHAT_DISPLAY_LIMIT (remaining feeds into pagination)
-        const allCardData = (result.opportunities ?? []).map((opp) => ({
+        const allCardData = continuationCards.map((opp) => ({
           opportunityId: opp.opportunityId,
           userId: opp.userId,
           name: opp.name,
@@ -930,14 +953,21 @@ export function createOpportunityTools(defineTool: DefineTool, deps: ToolDeps) {
           isMcp: context.isMcp ?? false,
           leadIn: `Found ${displayedCards.length} more potential connection(s).`,
         });
+        if (context.isMcp && negotiatingCount > 0) {
+          message = displayedCards.length > 0
+            ? `${message}\n\n${negotiatingCount} more opportunit${negotiatingCount === 1 ? 'y is' : 'ies are'} still being evaluated — check back via \`list_opportunities\` shortly.`
+            : `Found candidates, but they're still being evaluated. Try \`list_opportunities\` in a minute — ${negotiatingCount} pending.`;
+        } else if (context.isMcp && displayedCards.length === 0) {
+          message = 'No additional actionable matches were found in this continuation.';
+        }
 
         const isIntroducerContinuation = !!query.introTargetUserId?.trim();
         const totalRemaining = (result.pagination?.remaining ?? 0) + extraFromCap;
         if (totalRemaining > 0 && result.pagination?.discoveryId) {
           message += `\n\nThere are ${totalRemaining} more candidates. Ask if the user wants to see more — they can say "show me more" and you should call discover_opportunities with continueFrom="${result.pagination.discoveryId}".`;
-        } else if (isIntroducerContinuation) {
+        } else if (displayedCards.length > 0 && isIntroducerContinuation) {
           message += `\n\nThese are all the introduction candidates I found for this person.`;
-        } else {
+        } else if (displayedCards.length > 0) {
           message += `\n\nThese are all the connections I found. If the user wants to attract more connections, suggest they create a signal — e.g. "Would you like to create a signal so others looking for someone like you can find you?" If they agree, call create_intent with a description based on what they were searching for.`;
         }
 

--- a/packages/protocol/src/opportunity/tests/opportunity.discover.continuation-lifecycle.spec.ts
+++ b/packages/protocol/src/opportunity/tests/opportunity.discover.continuation-lifecycle.spec.ts
@@ -1,0 +1,90 @@
+import { config } from 'dotenv';
+config({ path: '.env.test', override: true });
+process.env.OPENROUTER_API_KEY ??= 'test';
+
+import { describe, expect, test } from 'bun:test';
+
+import { continueDiscovery } from '../opportunity.discover.js';
+import type { Opportunity } from '../../shared/interfaces/database.interface.js';
+
+const viewerId = 'continuation-viewer';
+const candidateId = 'continuation-candidate';
+const persistedAt = new Date('2026-06-01T12:00:00.000Z');
+
+function opportunity(status: Opportunity['status']): Opportunity {
+  return {
+    id: 'continuation-opportunity',
+    detection: { source: 'opportunity_graph', timestamp: persistedAt.toISOString() },
+    actors: [
+      { userId: viewerId, networkId: 'network-1', role: 'patient' },
+      { userId: candidateId, networkId: 'network-1', role: 'agent' },
+    ],
+    interpretation: {
+      category: 'collaboration',
+      reasoning: 'A relevant collaboration.',
+      confidence: 0.9,
+      signals: [],
+    },
+    context: { networkId: 'network-1' },
+    confidence: '0.9',
+    status,
+    createdAt: persistedAt,
+    updatedAt: persistedAt,
+    expiresAt: null,
+  };
+}
+
+describe('continueDiscovery lifecycle refresh', () => {
+  test('preserves the current database status instead of the persist-time or chat-session projection', async () => {
+    const graphOpportunity = opportunity('negotiating');
+    const currentOpportunity = { ...graphOpportunity, status: 'rejected' as const, updatedAt: new Date(persistedAt.getTime() + 1_000) };
+    let refreshedIds: string[] = [];
+
+    const result = await continueDiscovery({
+      opportunityGraph: {
+        invoke: async () => ({
+          opportunities: [graphOpportunity],
+          remainingCandidates: [],
+          trace: [],
+        }),
+      } as never,
+      database: {
+        getOpportunitiesByIds: async (ids: string[]) => {
+          refreshedIds = ids;
+          return [currentOpportunity];
+        },
+        getProfile: async () => ({
+          identity: { name: 'Candidate' },
+          context: '',
+        }),
+        getUser: async (id: string) => ({
+          id,
+          name: id === viewerId ? 'Viewer' : 'Candidate',
+          email: `${id}@test.local`,
+          socials: [],
+        }),
+      } as never,
+      cache: {
+        get: async () => ({
+          candidates: [],
+          userId: viewerId,
+          query: 'find a collaborator',
+          indexScope: ['network-1'],
+          options: {},
+          trigger: 'orchestrator',
+        }),
+        set: async () => undefined,
+        delete: async () => undefined,
+      } as never,
+      userId: viewerId,
+      discoveryId: 'continuation-id',
+      chatSessionId: 'chat-session-1',
+      minimalForChat: true,
+    });
+
+    expect(refreshedIds).toEqual([graphOpportunity.id]);
+    expect(result.opportunities).toHaveLength(1);
+    expect(result.opportunities?.[0].status).toBe('rejected');
+    expect(result.opportunities?.[0].homeCardPresentation?.personalizedSummary).toBeTruthy();
+  });
+});

--- a/packages/protocol/src/opportunity/tests/opportunity.graph.dedup.spec.ts
+++ b/packages/protocol/src/opportunity/tests/opportunity.graph.dedup.spec.ts
@@ -19,6 +19,7 @@ import type { OpportunityEvaluatorLike, StampNewbornOpportunitiesFn } from '../o
 import type { Id } from '../../types/common.types.js';
 import type { OpportunityGraphDatabase, Opportunity } from '../../shared/interfaces/database.interface.js';
 import type { Embedder } from '../../shared/interfaces/embedder.interface.js';
+import type { NegotiationGraphLike } from '../../negotiation/negotiation.state.js';
 
 // ---------------------------------------------------------------------------
 // Shared constants
@@ -154,6 +155,7 @@ function buildDb(overrides: Partial<OpportunityGraphDatabase>): OpportunityGraph
     getOrCreateDM: async () => ({ id: 'conv-1' }),
     getIntent: async () => null,
     getNegotiationTaskForOpportunity: async () => null,
+    compensateTasklessNegotiatingOpportunity: async () => null,
     stampOpportunityActorAction: async () => null,
     getPremisesForUser: async () => [],
     searchPremisesBySimilarity: async () => [],
@@ -164,7 +166,11 @@ function buildDb(overrides: Partial<OpportunityGraphDatabase>): OpportunityGraph
 function buildGraph(
   db: OpportunityGraphDatabase,
   stamper?: StampNewbornOpportunitiesFn,
-  overrides?: { embedder?: Embedder; evaluator?: OpportunityEvaluatorLike },
+  overrides?: {
+    embedder?: Embedder;
+    evaluator?: OpportunityEvaluatorLike;
+    negotiationGraph?: NegotiationGraphLike;
+  },
 ) {
   return new OpportunityGraphFactory(
     db,
@@ -172,11 +178,30 @@ function buildGraph(
     dummyHyde,
     overrides?.evaluator ?? mockEvaluator,
     async () => undefined,
-    undefined,
+    overrides?.negotiationGraph,
     undefined,
     undefined,
     stamper,
   ).createGraph();
+}
+
+function resolvedNegotiationGraph(
+  onInvoke?: (input: Parameters<NegotiationGraphLike['invoke']>[0]) => void,
+): NegotiationGraphLike {
+  return {
+    invoke: async (input) => {
+      onInvoke?.(input);
+      return {
+        outcome: {
+          hasOpportunity: false,
+          agreedRoles: [],
+          reasoning: 'No agreement',
+          turnCount: 0,
+        },
+        messages: [],
+      };
+    },
+  };
 }
 
 const discoveryInput = {
@@ -184,6 +209,23 @@ const discoveryInput = {
   operationMode: 'discover' as const,
   searchQuery: 'co-founder',
   options: { initialStatus: 'latent' as const },
+};
+
+const continuationInput = {
+  userId: USER_A,
+  operationMode: 'continue_discovery' as const,
+  trigger: 'orchestrator' as const,
+  searchQuery: 'co-founder',
+  candidates: [{
+    candidateUserId: USER_B,
+    candidateIntentId: 'intent-bob' as Id<'intents'>,
+    networkId: NET_ID,
+    similarity: 0.9,
+    lens: 'mirror',
+    candidatePayload: 'Looking to join a startup',
+    candidateSummary: 'Potential co-founder',
+  }],
+  options: {},
 };
 
 // ---------------------------------------------------------------------------
@@ -318,6 +360,139 @@ describe('opportunity graph — newborn stamping seam', () => {
   });
 });
 
+describe('opportunity graph — continuation negotiation lifecycle', () => {
+  test('continuation negotiates a newly persisted orchestrator candidate and observes its task boundary', async () => {
+    const persistedBoundary = new Date('2026-06-01T12:00:00.000Z');
+    const negotiationInputs: Array<Parameters<NegotiationGraphLike['invoke']>[0]> = [];
+    const observedTaskBoundaries: string[] = [];
+    const compensationCalls: Array<[string, Date, 'latent' | 'draft']> = [];
+    const db = buildDb({
+      createOpportunity: async (data) => ({
+        ...data,
+        id: 'opp-continuation-new',
+        status: 'negotiating',
+        createdAt: new Date(),
+        updatedAt: persistedBoundary,
+        expiresAt: null,
+      }),
+      compensateTasklessNegotiatingOpportunity: async (id, expectedUpdatedAt, fallbackStatus) => {
+        compensationCalls.push([id, expectedUpdatedAt, fallbackStatus]);
+        return null;
+      },
+    });
+
+    await buildGraph(db, undefined, {
+      negotiationGraph: resolvedNegotiationGraph((input) => {
+        negotiationInputs.push(input);
+        if (input.opportunityId) observedTaskBoundaries.push(input.opportunityId);
+      }),
+    }).invoke(continuationInput);
+
+    expect(negotiationInputs).toHaveLength(1);
+    expect(negotiationInputs[0].opportunityId).toBe('opp-continuation-new');
+    expect(observedTaskBoundaries).toEqual(['opp-continuation-new']);
+    expect(compensationCalls).toEqual([
+      ['opp-continuation-new', persistedBoundary, 'draft'],
+    ]);
+  });
+
+  test('continuation leaves an active input-required task out of negotiation and compensation beyond five minutes', async () => {
+    const existing = makeOpportunity({
+      status: 'negotiating',
+      createdAt: new Date(Date.now() - 60_000),
+    });
+    let negotiationInvocations = 0;
+    let compensationInvocations = 0;
+    const now = new Date();
+    const db = buildDb({
+      findOpportunitiesByActors: async () => [existing],
+      getNegotiationTaskForOpportunity: async () => ({
+        id: 'task-active',
+        conversationId: 'conversation-active',
+        state: 'input_required',
+        metadata: { type: 'negotiation', opportunityId: existing.id },
+        createdAt: new Date(now.getTime() - 10 * 60 * 1000),
+        updatedAt: new Date(now.getTime() - 10 * 60 * 1000),
+      }),
+      compensateTasklessNegotiatingOpportunity: async () => {
+        compensationInvocations += 1;
+        return null;
+      },
+    });
+
+    const result = await buildGraph(db, undefined, {
+      negotiationGraph: resolvedNegotiationGraph(() => { negotiationInvocations += 1; }),
+    }).invoke(continuationInput);
+
+    expect(negotiationInvocations).toBe(0);
+    expect(compensationInvocations).toBe(0);
+    expect(result.opportunities).toHaveLength(0);
+    expect(result.existingBetweenActors).toHaveLength(1);
+  });
+
+  test('pre-task negotiation init failure compensates the exact persisted version to draft', async () => {
+    const persistedBoundary = new Date('2026-06-01T13:00:00.000Z');
+    const compensationCalls: Array<[string, Date, 'latent' | 'draft']> = [];
+    const db = buildDb({
+      createOpportunity: async (data) => ({
+        ...data,
+        id: 'opp-init-failure',
+        status: 'negotiating',
+        createdAt: new Date(),
+        updatedAt: persistedBoundary,
+        expiresAt: null,
+      }),
+      compensateTasklessNegotiatingOpportunity: async (id, expectedUpdatedAt, fallbackStatus) => {
+        compensationCalls.push([id, expectedUpdatedAt, fallbackStatus]);
+        return null;
+      },
+    });
+    const failingNegotiationGraph: NegotiationGraphLike = {
+      invoke: async () => { throw new Error('init failed before task creation'); },
+    };
+
+    await buildGraph(db, undefined, { negotiationGraph: failingNegotiationGraph })
+      .invoke(continuationInput);
+
+    expect(compensationCalls).toEqual([
+      ['opp-init-failure', persistedBoundary, 'draft'],
+    ]);
+  });
+
+  test('unapproved introducer filtering compensates taskless negotiating state to latent', async () => {
+    const persistedBoundary = new Date('2026-06-01T14:00:00.000Z');
+    const compensationCalls: Array<[string, Date, 'latent' | 'draft']> = [];
+    let negotiationInvocations = 0;
+    const db = buildDb({
+      createOpportunity: async (data) => ({
+        ...data,
+        id: 'opp-unapproved-introducer',
+        actors: [
+          ...data.actors,
+          { userId: USER_C, role: 'introducer', networkId: NET_ID, approved: false },
+        ],
+        status: 'negotiating',
+        createdAt: new Date(),
+        updatedAt: persistedBoundary,
+        expiresAt: null,
+      }),
+      compensateTasklessNegotiatingOpportunity: async (id, expectedUpdatedAt, fallbackStatus) => {
+        compensationCalls.push([id, expectedUpdatedAt, fallbackStatus]);
+        return null;
+      },
+    });
+
+    await buildGraph(db, undefined, {
+      negotiationGraph: resolvedNegotiationGraph(() => { negotiationInvocations += 1; }),
+    }).invoke(continuationInput);
+
+    expect(negotiationInvocations).toBe(0);
+    expect(compensationCalls).toEqual([
+      ['opp-unapproved-introducer', persistedBoundary, 'latent'],
+    ]);
+  });
+});
+
 describe('opportunity graph — time-based dedup (Persist node)', () => {
   test('parallel job dedup: recent existing opp skips creation (IND-166 regression)', async () => {
     // Existing opportunity created 2 minutes ago — within the 30-day window.
@@ -420,36 +595,47 @@ describe('opportunity graph — time-based dedup (Persist node)', () => {
     expect(updateCalledWith![1]).toBe('pending');
   });
 
-  test('stuck negotiating fix: orphaned negotiating opp is reactivated instead of creating new', async () => {
-    // Existing negotiating opportunity created 15 minutes ago — within the 30-day window,
-    // but the orphan-heal path reactivates regardless of age when no active task exists.
-    // getNegotiationTaskForOpportunity returns null (no active task), so persist node
-    // reactivates the orphaned opp via updateOpportunityStatus instead of creating a new one.
+  test('taskless negotiating dedup reactivates and invokes negotiation on a fresh orchestrator run', async () => {
     const oldNegotiatingOpp = makeOpportunity({
       status: 'negotiating',
       createdAt: new Date(Date.now() - 15 * 60 * 1000),
     });
+    const reactivatedBoundary = new Date('2026-06-01T15:00:00.000Z');
 
     let createCalled = false;
     let updateCalledWith: [string, string] | null = null;
+    const negotiationInputs: Array<Parameters<NegotiationGraphLike['invoke']>[0]> = [];
     const db = buildDb({
       findOpportunitiesByActors: async () => [oldNegotiatingOpp],
       updateOpportunityStatus: async (id, status) => {
         updateCalledWith = [id, status];
-        return { ...oldNegotiatingOpp, status: 'latent' } as unknown as Opportunity;
+        return {
+          ...oldNegotiatingOpp,
+          status: 'negotiating',
+          updatedAt: reactivatedBoundary,
+        } as Opportunity;
       },
       createOpportunity: async (data) => {
         createCalled = true;
-        return { ...data, id: 'opp-new', status: 'latent' as const, createdAt: new Date(), updatedAt: new Date(), expiresAt: null };
+        return { ...data, id: 'opp-new', status: 'negotiating' as const, createdAt: new Date(), updatedAt: new Date(), expiresAt: null };
       },
     });
 
-    const graph = buildGraph(db);
-    const result = await graph.invoke(discoveryInput);
+    const graph = buildGraph(db, undefined, {
+      negotiationGraph: resolvedNegotiationGraph((input) => negotiationInputs.push(input)),
+    });
+    const result = await graph.invoke({
+      userId: USER_A,
+      operationMode: 'create' as const,
+      trigger: 'orchestrator' as const,
+      searchQuery: 'co-founder',
+      options: {},
+    });
 
     expect(createCalled).toBe(false);
-    expect(updateCalledWith).not.toBeNull();
-    expect(updateCalledWith![0]).toBe(OPP_ID);
+    expect(updateCalledWith).toEqual([OPP_ID, 'negotiating']);
+    expect(negotiationInputs).toHaveLength(1);
+    expect(negotiationInputs[0].opportunityId).toBe(OPP_ID);
     expect(result.opportunities?.length).toBeGreaterThanOrEqual(1);
   });
 

--- a/packages/protocol/src/opportunity/tests/opportunity.graph.dedup.spec.ts
+++ b/packages/protocol/src/opportunity/tests/opportunity.graph.dedup.spec.ts
@@ -390,6 +390,7 @@ describe('opportunity graph — continuation negotiation lifecycle', () => {
 
     expect(negotiationInputs).toHaveLength(1);
     expect(negotiationInputs[0].opportunityId).toBe('opp-continuation-new');
+    expect(negotiationInputs[0].opportunityUpdatedAt).toEqual(persistedBoundary);
     expect(observedTaskBoundaries).toEqual(['opp-continuation-new']);
     expect(compensationCalls).toEqual([
       ['opp-continuation-new', persistedBoundary, 'draft'],

--- a/packages/protocol/src/opportunity/tests/opportunity.graph.negotiate-timeout.spec.ts
+++ b/packages/protocol/src/opportunity/tests/opportunity.graph.negotiate-timeout.spec.ts
@@ -14,7 +14,10 @@ import type { EvaluatedOpportunityWithActors } from '../opportunity.evaluator.js
 
 const dummyEmbedding = new Array(2000).fill(0.1);
 
-function makeFactory(opts: { hangNegotiationForever: boolean }) {
+function makeFactory(opts: {
+  hangNegotiationForever: boolean;
+  onCompensate?: (opportunityId: string) => void;
+}) {
   const persistedOpp = {
     id: 'opp-hang-1',
     detection: { source: 'auto' },
@@ -71,6 +74,10 @@ function makeFactory(opts: { hangNegotiationForever: boolean }) {
     getNetworkMemberContext: async () => null,
     getOrCreateDM: async () => ({ id: 'conv-1' }),
     getNegotiationTaskForOpportunity: async () => null,
+    compensateTasklessNegotiatingOpportunity: async (opportunityId: string) => {
+      opts.onCompensate?.(opportunityId);
+      return null;
+    },
     stampOpportunityActorAction: async () => null,
     getPremisesForUser: async () => [],
     searchPremisesBySimilarity: async () => [],
@@ -156,8 +163,12 @@ function makeFactory(opts: { hangNegotiationForever: boolean }) {
 }
 
 describe('opportunity graph: negotiateTimeoutMs', () => {
-  test('returns within the budget with a timed_out trace when negotiateCandidates hangs', async () => {
-    const factory = makeFactory({ hangNegotiationForever: true });
+  test('returns within the budget with a timed_out trace and compensates a pre-task hang', async () => {
+    const compensatedOpportunityIds: string[] = [];
+    const factory = makeFactory({
+      hangNegotiationForever: true,
+      onCompensate: (opportunityId) => compensatedOpportunityIds.push(opportunityId),
+    });
     const graph = factory.createGraph();
 
     const start = Date.now();
@@ -173,6 +184,7 @@ describe('opportunity graph: negotiateTimeoutMs', () => {
     expect(negotiateTrace).toBeDefined();
     expect(negotiateTrace?.detail).toBe('timed_out');
     expect(negotiateTrace?.data).toMatchObject({ negotiateTimeoutMs: 50 });
+    expect(compensatedOpportunityIds).toEqual(['opp-hang-1']);
   });
 
   test('returns the normal trace shape when negotiate finishes before the budget', async () => {

--- a/packages/protocol/src/opportunity/tests/opportunity.graph.spec.ts
+++ b/packages/protocol/src/opportunity/tests/opportunity.graph.spec.ts
@@ -1474,6 +1474,7 @@ describe('Opportunity Graph', () => {
           ownerUserId: 'a0000000-0000-4000-8000-000000000001',
           allowedNetworkIds: ['idx-1'],
         },
+        'expired',
       );
       expect(result.opportunities.length).toBe(1);
       expect(result.opportunities[0].id).toBe('opp-expired');

--- a/packages/protocol/src/opportunity/tests/opportunity.tools.continueFrom-routing.spec.ts
+++ b/packages/protocol/src/opportunity/tests/opportunity.tools.continueFrom-routing.spec.ts
@@ -103,6 +103,63 @@ describe('IND-305: discover_opportunities continueFrom routing', () => {
     expect(discoverCalls).toHaveLength(0);
   });
 
+  test('continuation renders only safe draft cards and counts negotiating rows', async () => {
+    const deps = makeDeps();
+    if (!deps.opportunityDiscovery) throw new Error('opportunity discovery deps missing');
+    deps.opportunityDiscovery.continueDiscovery = async () => ({
+      found: true,
+      count: 3,
+      opportunities: [
+        {
+          opportunityId: 'opp-draft',
+          userId: 'draft-user',
+          name: 'Draft Candidate',
+          status: 'draft',
+          viewerRole: 'patient',
+          score: 0.9,
+          homeCardPresentation: {
+            headline: 'Presenter headline',
+            personalizedSummary: 'Presenter-approved draft summary.',
+            digestSummary: 'Presenter digest.',
+            suggestedAction: 'Connect.',
+            narratorRemark: 'Worth a look.',
+            primaryActionLabel: 'Connect',
+            secondaryActionLabel: 'Not now',
+            mutualIntentsLabel: 'Shared goals',
+            greeting: '',
+          },
+        },
+        {
+          opportunityId: 'opp-negotiating',
+          userId: 'negotiating-user',
+          name: 'Negotiating Candidate',
+          status: 'negotiating',
+          viewerRole: 'patient',
+          score: 0.8,
+        },
+        {
+          opportunityId: 'opp-rejected',
+          userId: 'rejected-user',
+          name: 'Rejected Candidate',
+          status: 'rejected',
+          viewerRole: 'patient',
+          score: 0.7,
+        },
+      ],
+    } as never);
+    const tool = captureDiscoverTool(deps);
+
+    const output = await tool.handler({
+      context: makeContext({ isMcp: true }),
+      query: { continueFrom: 'some-discovery-id' },
+    });
+
+    expect(output).toContain('Presenter-approved draft summary.');
+    expect(output).toContain('1 more opportunity is still being evaluated');
+    expect(output).not.toContain('Negotiating Candidate');
+    expect(output).not.toContain('Rejected Candidate');
+  });
+
   // IND-305 regression guard. Before the fix, a caller (typically an MCP
   // client's LLM) passing a fresh `searchQuery` alongside a stale
   // `continueFrom` was silently routed to `continueDiscovery`, which resumed

--- a/packages/protocol/src/shared/interfaces/database.interface.ts
+++ b/packages/protocol/src/shared/interfaces/database.interface.ts
@@ -1381,8 +1381,8 @@ export interface Database {
 
   /**
    * Atomically restores a taskless negotiation attempt to its pre-negotiation status.
-   * Transitions only the exact still-current `negotiating` version and only when no
-   * active negotiation task exists and no task was created at or after `expectedUpdatedAt`.
+   * Serializes with exact-attempt task creation, then transitions only the exact
+   * still-current `negotiating` version when no qualifying negotiation task exists.
    *
    * @param id - Opportunity ID
    * @param expectedUpdatedAt - Persistence boundary for this negotiation attempt
@@ -2431,7 +2431,19 @@ export type NegotiationGraphDatabase = Pick<
     metadata?: Record<string, unknown> | null;
   }): Promise<{ id: string; senderId: string; role: 'user' | 'agent'; parts: unknown; createdAt: Date }>;
 
-  /** Creates a task to track the negotiation lifecycle within a conversation. */
+  /**
+   * Atomically claims an exact persisted opportunity attempt and creates its
+   * negotiation task. Returns null when the status/version is stale or another
+   * qualifying task already owns the attempt.
+   */
+  createNegotiationTaskForAttempt(input: {
+    conversationId: string;
+    opportunityId: string;
+    expectedUpdatedAt: Date;
+    metadata: Record<string, unknown>;
+  }): Promise<{ id: string; conversationId: string; state: string } | null>;
+
+  /** Creates a generic task to track a non-attempt-bound lifecycle. */
   createTask(conversationId: string, metadata?: Record<string, unknown>): Promise<{ id: string; conversationId: string; state: string }>;
 
   /** Transitions a task to a new state (e.g. working, completed, failed). */

--- a/packages/protocol/src/shared/interfaces/database.interface.ts
+++ b/packages/protocol/src/shared/interfaces/database.interface.ts
@@ -1274,13 +1274,22 @@ export interface Database {
 
   /**
    * Atomically update status only while the supplied participant anchors remain
-   * active. Used for discovery dedup reactivation races.
+   * active and, when supplied, the opportunity still has `expectedStatus`.
+   * Used for discovery dedup reactivation races.
+   *
+   * @param id - Opportunity ID
+   * @param status - Target lifecycle status
+   * @param actors - Participant anchors that must remain network-eligible
+   * @param eligibility - Authoritative owner/network/intent scope
+   * @param expectedStatus - Optional compare-and-set source status
+   * @returns The updated opportunity, or null after eligibility/status drift
    */
   updateOpportunityStatusIfNetworkEligible?(
     id: string,
     status: OpportunityStatus,
     actors: OpportunityActor[],
     eligibility: OpportunityNetworkEligibility,
+    expectedStatus?: OpportunityStatus,
   ): Promise<Opportunity | null>;
 
   /**
@@ -1368,6 +1377,22 @@ export interface Database {
     status: OpportunityStatus,
     acceptedBy?: string,
     outbox?: OutcomeOutbox,
+  ): Promise<Opportunity | null>;
+
+  /**
+   * Atomically restores a taskless negotiation attempt to its pre-negotiation status.
+   * Transitions only the exact still-current `negotiating` version and only when no
+   * active negotiation task exists and no task was created at or after `expectedUpdatedAt`.
+   *
+   * @param id - Opportunity ID
+   * @param expectedUpdatedAt - Persistence boundary for this negotiation attempt
+   * @param fallbackStatus - Status restored when the guarded transition succeeds
+   * @returns The compensated opportunity, or null on a status, version, or task race
+   */
+  compensateTasklessNegotiatingOpportunity(
+    id: string,
+    expectedUpdatedAt: Date,
+    fallbackStatus: 'latent' | 'draft',
   ): Promise<Opportunity | null>;
 
   /**
@@ -2163,6 +2188,7 @@ export type ChatGraphCompositeDatabase = Pick<
   | 'findOpportunitiesByActors'
   | 'getOpportunitiesForUser'
   | 'updateOpportunityStatus'
+  | 'compensateTasklessNegotiatingOpportunity'
   | 'updateOpportunityActorApproval'
   | 'stampOpportunityActorAction'
   | 'getOrCreateDM'
@@ -2263,6 +2289,7 @@ export type OpportunityGraphDatabase = Pick<
   | 'getOpportunity'
   | 'getOpportunitiesForUser'
   | 'updateOpportunityStatus'
+  | 'compensateTasklessNegotiatingOpportunity'
   | 'stampOpportunityActorAction'
   | 'updateOpportunityActorApproval'
   | 'isNetworkMember'

--- a/services/api/CHANGELOG.md
+++ b/services/api/CHANGELOG.md
@@ -31,7 +31,7 @@ section before promoting to `main`).
   consent primitive; deferred to IND-467).
 
 ### Fixed
-- Added exact-version, task-aware compensation for taskless negotiating opportunities and expected-status compare-and-set reactivation so continuation recovery cannot overwrite concurrent lifecycle or negotiation-task changes (IND-470).
+- Serialized exact-version negotiation-task creation and taskless compensation on shared opportunity advisory/row locks, and added expected-status compare-and-set reactivation, so continuation recovery cannot race a late task insert or overwrite concurrent lifecycle changes (IND-470).
 - Normalized blank and null-like opportunity actor intents before uptake lookups and added the idempotent, order-preserving `0096_normalize_opportunity_actor_intents` data migration, which removes malformed `intent` keys while leaving unaffected rows and all other actor data unchanged. The Railway-dev audit scope was 7,690 affected opportunities, requiring explicit release review before rollout (IND-469).
 - Restored unscoped asynchronous MCP discovery by wiring discovery-run workers to real network and membership graphs instead of no-op placeholders (IND-466).
 - Lens C shadow network binding is now derived from capture-time negotiation

--- a/services/api/CHANGELOG.md
+++ b/services/api/CHANGELOG.md
@@ -31,6 +31,7 @@ section before promoting to `main`).
   consent primitive; deferred to IND-467).
 
 ### Fixed
+- Added exact-version, task-aware compensation for taskless negotiating opportunities and expected-status compare-and-set reactivation so continuation recovery cannot overwrite concurrent lifecycle or negotiation-task changes (IND-470).
 - Normalized blank and null-like opportunity actor intents before uptake lookups and added the idempotent, order-preserving `0096_normalize_opportunity_actor_intents` data migration, which removes malformed `intent` keys while leaving unaffected rows and all other actor data unchanged. The Railway-dev audit scope was 7,690 affected opportunities, requiring explicit release review before rollout (IND-469).
 - Restored unscoped asynchronous MCP discovery by wiring discovery-run workers to real network and membership graphs instead of no-op placeholders (IND-466).
 - Lens C shadow network binding is now derived from capture-time negotiation

--- a/services/api/package.json
+++ b/services/api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@indexnetwork/api",
-  "version": "0.44.2",
+  "version": "0.44.3",
   "license": "MIT",
   "private": true,
   "scripts": {

--- a/services/api/src/adapters/chat.database.adapter.ts
+++ b/services/api/src/adapters/chat.database.adapter.ts
@@ -2495,13 +2495,52 @@ export class ChatDatabaseAdapter {
   ): Promise<OpportunityRow | null> {
     return this.opportunityAdapter.updateOpportunityStatus(id, status, acceptedBy, outbox);
   }
+
+  /**
+   * Delegates exact-version, active-task-aware compensation for a taskless
+   * `negotiating` opportunity to OpportunityDatabaseAdapter.
+   *
+   * @param id - Opportunity ID
+   * @param expectedUpdatedAt - Persistence boundary for the negotiation attempt
+   * @param fallbackStatus - Status restored when the guarded update succeeds
+   * @returns The compensated opportunity, or null on a status, version, or task race
+   */
+  async compensateTasklessNegotiatingOpportunity(
+    id: string,
+    expectedUpdatedAt: Date,
+    fallbackStatus: 'latent' | 'draft',
+  ): Promise<OpportunityRow | null> {
+    return this.opportunityAdapter.compensateTasklessNegotiatingOpportunity(
+      id,
+      expectedUpdatedAt,
+      fallbackStatus,
+    );
+  }
+
+  /**
+   * Delegates network-eligible status compare-and-set reactivation.
+   *
+   * @param id - Opportunity ID
+   * @param status - Target lifecycle status
+   * @param actors - Participant network anchors
+   * @param eligibility - Authoritative owner/network/intent scope
+   * @param expectedStatus - Optional compare-and-set source status
+   * @returns The updated opportunity, or null after scope/status drift
+   */
   async updateOpportunityStatusIfNetworkEligible(
     id: string,
     status: 'latent' | 'draft' | 'negotiating' | 'pending' | 'stalled' | 'accepted' | 'rejected' | 'expired',
     actors: Array<{ userId: string; networkId: string }>,
     eligibility: Parameters<OpportunityDatabaseAdapter['updateOpportunityStatusIfNetworkEligible']>[3],
+    expectedStatus?: Parameters<OpportunityDatabaseAdapter['updateOpportunityStatusIfNetworkEligible']>[4],
   ): Promise<OpportunityRow | null> {
-    return this.opportunityAdapter.updateOpportunityStatusIfNetworkEligible(id, status, actors, eligibility);
+    return this.opportunityAdapter.updateOpportunityStatusIfNetworkEligible(
+      id,
+      status,
+      actors,
+      eligibility,
+      expectedStatus,
+    );
   }
   async updateOpportunityActorApproval(
     id: string,

--- a/services/api/src/adapters/conversation.database.adapter.ts
+++ b/services/api/src/adapters/conversation.database.adapter.ts
@@ -1,5 +1,6 @@
 import { readUserContext, schema, Artifact, ChatConversationMeta, ChatMessage, ChatMessageMeta, ChatScopeType, ChatSession, Conversation, ConversationParticipant, ConversationSummary, CreateMessageInput, CreateSessionInput, Message, ResolvedParticipant, SYSTEM_AGENT_ID, Task, and, asc, count, db, desc, eq, gt, inArray, isNull, lt, ne, opportunities, or, sql } from './database.shared';
 import { emitOpportunityPendingBestEffort } from '../events/opportunity.event';
+import { acquireNegotiationAttemptLock, qualifyingNegotiationAttemptTaskWhere, type NegotiationAttemptTransaction } from './negotiation-attempt.atomic';
 
 /**
  * Persona value for the user's negotiator DM session (P4.1 / IND-402).
@@ -28,6 +29,56 @@ const NEGOTIATOR_SCOPE = { scopeType: 'persona', scopeId: NEGOTIATOR_PERSONA } a
  * is identical to any intent-scoped session.
  */
 const NEGOTIATOR_INTENT_SCOPE_TYPE = 'negotiator-intent';
+
+export interface CreateNegotiationTaskForAttemptInput {
+  conversationId: string;
+  opportunityId: string;
+  expectedUpdatedAt: Date;
+  metadata: Record<string, unknown>;
+}
+
+/**
+ * Claim an exact negotiating opportunity version and insert its task while the
+ * shared attempt lock and opportunity row lock are held.
+ */
+export async function createNegotiationTaskForAttemptInTransaction(
+  tx: NegotiationAttemptTransaction,
+  input: CreateNegotiationTaskForAttemptInput,
+): Promise<Task | null> {
+  if (input.metadata.type !== 'negotiation' || input.metadata.opportunityId !== input.opportunityId) {
+    throw new Error('Negotiation task metadata does not match the claimed opportunity');
+  }
+
+  await acquireNegotiationAttemptLock(tx, input.opportunityId);
+
+  const [opportunity] = await tx
+    .select({ status: opportunities.status, updatedAt: opportunities.updatedAt })
+    .from(opportunities)
+    .where(eq(opportunities.id, input.opportunityId))
+    .for('update');
+  if (
+    opportunity?.status !== 'negotiating'
+    || opportunity.updatedAt.getTime() !== input.expectedUpdatedAt.getTime()
+  ) {
+    return null;
+  }
+
+  const [qualifyingTask] = await tx
+    .select({ id: schema.tasks.id })
+    .from(schema.tasks)
+    .where(qualifyingNegotiationAttemptTaskWhere(input.opportunityId, input.expectedUpdatedAt))
+    .limit(1);
+  if (qualifyingTask) return null;
+
+  const [task] = await tx
+    .insert(schema.tasks)
+    .values({
+      conversationId: input.conversationId,
+      metadata: input.metadata,
+    })
+    .returning();
+  return task ?? null;
+}
 
 function isExactPoolPushParts(parts: unknown, expectedText: string): boolean {
   if (!Array.isArray(parts) || parts.length !== 1) return false;
@@ -860,6 +911,20 @@ export class ConversationDatabaseAdapter {
   // ─────────────────────────────────────────────────────────────────────────
   // Tasks
   // ─────────────────────────────────────────────────────────────────────────
+
+  /**
+   * Atomically creates a negotiation task for an exact persisted opportunity attempt.
+   * Task creation and fallback compensation serialize on the same advisory lock;
+   * the opportunity row is then locked and revalidated before insertion.
+   *
+   * @param input - Conversation, opportunity version, and unchanged task metadata
+   * @returns The created task, or null when the attempt is stale or already claimed
+   */
+  async createNegotiationTaskForAttempt(
+    input: CreateNegotiationTaskForAttemptInput,
+  ): Promise<Task | null> {
+    return db.transaction((tx) => createNegotiationTaskForAttemptInTransaction(tx, input));
+  }
 
   /**
    * Creates a task in the submitted state.

--- a/services/api/src/adapters/negotiation-attempt.atomic.ts
+++ b/services/api/src/adapters/negotiation-attempt.atomic.ts
@@ -1,0 +1,46 @@
+import { db, schema, sql } from './database.shared';
+
+/** Drizzle transaction handle shared by negotiation-attempt atomic operations. */
+export type NegotiationAttemptTransaction = Parameters<Parameters<typeof db.transaction>[0]>[0];
+
+/** Stable advisory-lock namespace for one opportunity's negotiation attempts. */
+export function negotiationAttemptLockName(opportunityId: string): string {
+  return `negotiation-attempt:${opportunityId}`;
+}
+
+/**
+ * Serialize task creation and fallback compensation for one opportunity.
+ * The transaction-scoped lock is released automatically on commit/rollback.
+ */
+export async function acquireNegotiationAttemptLock(
+  tx: NegotiationAttemptTransaction,
+  opportunityId: string,
+): Promise<void> {
+  await tx.execute(sql`
+    SELECT pg_advisory_xact_lock(
+      hashtextextended(${negotiationAttemptLockName(opportunityId)}, 0)
+    )
+  `);
+}
+
+/**
+ * Qualifying tasks that prove an attempt is already owned or still active.
+ * Historical stale non-input-required tasks deliberately do not qualify.
+ */
+export function qualifyingNegotiationAttemptTaskWhere(
+  opportunityId: string,
+  expectedUpdatedAt: Date,
+) {
+  return sql`
+    ${schema.tasks.metadata}->>'type' = 'negotiation'
+    AND ${schema.tasks.metadata}->>'opportunityId' = ${opportunityId}
+    AND (
+      ${schema.tasks.createdAt} >= ${expectedUpdatedAt.toISOString()}::timestamptz
+      OR ${schema.tasks.state} = 'input_required'
+      OR (
+        ${schema.tasks.state} IN ('submitted', 'working', 'waiting_for_agent', 'claimed')
+        AND ${schema.tasks.updatedAt} >= NOW() - INTERVAL '5 minutes'
+      )
+    )
+  `;
+}

--- a/services/api/src/adapters/opportunity.database.adapter.ts
+++ b/services/api/src/adapters/opportunity.database.adapter.ts
@@ -3,6 +3,7 @@ import { emitOpportunityPendingBestEffort } from '../events/opportunity.event';
 import { computeIntentFingerprint } from '../lib/intent/intent.fingerprint';
 import { computeOutcomeCounterpartDedupKey, computeOutcomeIdempotencyKey, computeOutcomeSnapshotHash } from '../lib/opportunity/outcome-feedback.identity';
 import { exactEvidencePoolWhere, exactLivePoolWhere, POOL_LIVE_STATUSES } from './poolquery.shared';
+import { acquireNegotiationAttemptLock, qualifyingNegotiationAttemptTaskWhere } from './negotiation-attempt.atomic';
 
 interface OpportunityNetworkEligibilityInput {
   ownerUserId: string;
@@ -156,6 +157,50 @@ export async function runAtomicOutcomeTransition<T extends OutcomeTransitionResu
     }
     return updated;
   });
+}
+
+/**
+ * Restore an exact taskless attempt while holding the shared negotiation lock.
+ * The opportunity row and qualifying-task query run after lock acquisition, so
+ * they observe the committed winner rather than a pre-lock READ COMMITTED snapshot.
+ */
+export async function compensateTasklessNegotiatingOpportunityInTransaction(
+  tx: DrizzleTx,
+  id: string,
+  expectedUpdatedAt: Date,
+  fallbackStatus: 'latent' | 'draft',
+): Promise<OpportunityRow | null> {
+  await acquireNegotiationAttemptLock(tx, id);
+
+  const [opportunity] = await tx
+    .select({ status: opportunities.status, updatedAt: opportunities.updatedAt })
+    .from(opportunities)
+    .where(eq(opportunities.id, id))
+    .for('update');
+  if (
+    opportunity?.status !== 'negotiating'
+    || opportunity.updatedAt.getTime() !== expectedUpdatedAt.getTime()
+  ) {
+    return null;
+  }
+
+  const [qualifyingTask] = await tx
+    .select({ id: schema.tasks.id })
+    .from(schema.tasks)
+    .where(qualifyingNegotiationAttemptTaskWhere(id, expectedUpdatedAt))
+    .limit(1);
+  if (qualifyingTask) return null;
+
+  const [row] = await tx
+    .update(opportunities)
+    .set({ status: fallbackStatus, acceptedBy: null, updatedAt: new Date() })
+    .where(and(
+      eq(opportunities.id, id),
+      eq(opportunities.status, 'negotiating'),
+      eq(opportunities.updatedAt, expectedUpdatedAt),
+    ))
+    .returning();
+  return row ? toOpportunityRow(row) : null;
 }
 
 export class OpportunityDatabaseAdapter {
@@ -351,9 +396,8 @@ export class OpportunityDatabaseAdapter {
 
   /**
    * Atomically restores an exact taskless negotiation attempt to its fallback status.
-   * The update succeeds only while the opportunity remains at the expected
-   * `negotiating` version, no active task exists, and no task was created at or
-   * after that boundary.
+   * Compensation and attempt-bound task creation serialize on the same advisory
+   * lock before rechecking the opportunity row and qualifying task existence.
    *
    * @param id - Opportunity ID
    * @param expectedUpdatedAt - Persistence boundary for the negotiation attempt
@@ -365,30 +409,12 @@ export class OpportunityDatabaseAdapter {
     expectedUpdatedAt: Date,
     fallbackStatus: 'latent' | 'draft',
   ): Promise<OpportunityRow | null> {
-    const [row] = await db
-      .update(opportunities)
-      .set({ status: fallbackStatus, acceptedBy: null, updatedAt: new Date() })
-      .where(and(
-        eq(opportunities.id, id),
-        eq(opportunities.status, 'negotiating'),
-        eq(opportunities.updatedAt, expectedUpdatedAt),
-        sql`NOT EXISTS (
-          SELECT 1
-          FROM ${schema.tasks}
-          WHERE ${schema.tasks.metadata}->>'type' = 'negotiation'
-            AND ${schema.tasks.metadata}->>'opportunityId' = ${id}
-            AND (
-              ${schema.tasks.createdAt} >= ${expectedUpdatedAt.toISOString()}::timestamptz
-              OR ${schema.tasks.state} = 'input_required'
-              OR (
-                ${schema.tasks.state} IN ('submitted', 'working', 'waiting_for_agent', 'claimed')
-                AND ${schema.tasks.updatedAt} >= NOW() - INTERVAL '5 minutes'
-              )
-            )
-        )`,
-      ))
-      .returning();
-    return row ? toOpportunityRow(row) : null;
+    return db.transaction((tx) => compensateTasklessNegotiatingOpportunityInTransaction(
+      tx,
+      id,
+      expectedUpdatedAt,
+      fallbackStatus,
+    ));
   }
 
   async getOpportunity(id: string): Promise<OpportunityRow | null> {

--- a/services/api/src/adapters/opportunity.database.adapter.ts
+++ b/services/api/src/adapters/opportunity.database.adapter.ts
@@ -173,6 +173,7 @@ export class OpportunityDatabaseAdapter {
         context: data.context,
         confidence: data.confidence,
         status: data.status ?? 'pending',
+        updatedAt: new Date(),
         expiresAt: data.expiresAt ?? null,
         ...(data.metadata !== undefined ? { metadata: data.metadata } : {}),
       })
@@ -250,6 +251,7 @@ export class OpportunityDatabaseAdapter {
           context: data.context,
           confidence: data.confidence,
           status: data.status ?? 'pending',
+          updatedAt: new Date(),
           expiresAt: data.expiresAt ?? null,
           ...(data.metadata !== undefined ? { metadata: data.metadata } : {}),
         })
@@ -261,11 +263,23 @@ export class OpportunityDatabaseAdapter {
     return created;
   }
 
+  /**
+   * Reactivates an opportunity only while participant scope and optional source
+   * status remain current.
+   *
+   * @param id - Opportunity ID
+   * @param status - Target lifecycle status
+   * @param actors - Participant network anchors
+   * @param eligibility - Authoritative owner/network/intent scope
+   * @param expectedStatus - Optional compare-and-set source status
+   * @returns The updated opportunity, or null after scope/status drift
+   */
   async updateOpportunityStatusIfNetworkEligible(
     id: string,
     status: OpportunityRow['status'],
     actors: Array<{ userId: string; networkId: string }>,
     eligibility: OpportunityNetworkEligibilityInput,
+    expectedStatus?: OpportunityRow['status'],
   ): Promise<OpportunityRow | null> {
     const actorNetworkIds = [...new Set(actors.map((actor) => actor.networkId))];
     const allowedNetworkIds = new Set(eligibility.allowedNetworkIds);
@@ -324,12 +338,57 @@ export class OpportunityDatabaseAdapter {
       const [row] = await tx
         .update(opportunities)
         .set({ status, acceptedBy: null, updatedAt: new Date() })
-        .where(eq(opportunities.id, id))
+        .where(and(
+          eq(opportunities.id, id),
+          ...(expectedStatus ? [eq(opportunities.status, expectedStatus)] : []),
+        ))
         .returning();
       return row ? toOpportunityRow(row) : null;
     });
     if (updated) emitOpportunityPendingBestEffort(updated);
     return updated;
+  }
+
+  /**
+   * Atomically restores an exact taskless negotiation attempt to its fallback status.
+   * The update succeeds only while the opportunity remains at the expected
+   * `negotiating` version, no active task exists, and no task was created at or
+   * after that boundary.
+   *
+   * @param id - Opportunity ID
+   * @param expectedUpdatedAt - Persistence boundary for the negotiation attempt
+   * @param fallbackStatus - Status to restore when the guarded update succeeds
+   * @returns The compensated opportunity, or null on a status, version, or task race
+   */
+  async compensateTasklessNegotiatingOpportunity(
+    id: string,
+    expectedUpdatedAt: Date,
+    fallbackStatus: 'latent' | 'draft',
+  ): Promise<OpportunityRow | null> {
+    const [row] = await db
+      .update(opportunities)
+      .set({ status: fallbackStatus, acceptedBy: null, updatedAt: new Date() })
+      .where(and(
+        eq(opportunities.id, id),
+        eq(opportunities.status, 'negotiating'),
+        eq(opportunities.updatedAt, expectedUpdatedAt),
+        sql`NOT EXISTS (
+          SELECT 1
+          FROM ${schema.tasks}
+          WHERE ${schema.tasks.metadata}->>'type' = 'negotiation'
+            AND ${schema.tasks.metadata}->>'opportunityId' = ${id}
+            AND (
+              ${schema.tasks.createdAt} >= ${expectedUpdatedAt.toISOString()}::timestamptz
+              OR ${schema.tasks.state} = 'input_required'
+              OR (
+                ${schema.tasks.state} IN ('submitted', 'working', 'waiting_for_agent', 'claimed')
+                AND ${schema.tasks.updatedAt} >= NOW() - INTERVAL '5 minutes'
+              )
+            )
+        )`,
+      ))
+      .returning();
+    return row ? toOpportunityRow(row) : null;
   }
 
   async getOpportunity(id: string): Promise<OpportunityRow | null> {
@@ -888,6 +947,7 @@ export class OpportunityDatabaseAdapter {
           context: data.context,
           confidence: data.confidence,
           status: data.status ?? 'pending',
+          updatedAt: new Date(),
           expiresAt: data.expiresAt ?? null,
           ...(data.metadata !== undefined ? { metadata: data.metadata } : {}),
         })
@@ -979,6 +1039,7 @@ export class OpportunityDatabaseAdapter {
           context: data.context,
           confidence: data.confidence,
           status: data.status ?? 'pending',
+          updatedAt: new Date(),
           expiresAt: data.expiresAt ?? null,
           ...(data.metadata !== undefined ? { metadata: data.metadata } : {}),
         })

--- a/services/api/src/adapters/tests/opportunity-negotiation-compensation.database.spec.ts
+++ b/services/api/src/adapters/tests/opportunity-negotiation-compensation.database.spec.ts
@@ -1,0 +1,213 @@
+import { config } from 'dotenv';
+config({ path: '.env.test', override: true });
+
+import { afterAll, describe, expect, test } from 'bun:test';
+import { eq, inArray } from 'drizzle-orm';
+
+import db from '../../lib/drizzle/drizzle';
+import { OpportunityDatabaseAdapter } from '../opportunity.database.adapter';
+import { conversations, networkMembers, networks, opportunities, tasks, users } from '../../schemas/database.schema';
+
+const adapter = new OpportunityDatabaseAdapter();
+const createdOpportunityIds: string[] = [];
+const createdConversationIds: string[] = [];
+const createdNetworkIds: string[] = [];
+const createdUserIds: string[] = [];
+
+async function createNegotiatingOpportunity() {
+  const opportunity = await adapter.createOpportunity({
+    detection: {
+      source: 'opportunity_graph',
+      timestamp: new Date().toISOString(),
+    },
+    actors: [
+      { userId: crypto.randomUUID(), networkId: crypto.randomUUID(), role: 'patient' },
+      { userId: crypto.randomUUID(), networkId: crypto.randomUUID(), role: 'agent' },
+    ],
+    interpretation: {
+      category: 'collaboration',
+      reasoning: 'Compensation integration fixture',
+      confidence: 0.8,
+      signals: [],
+    },
+    context: {},
+    confidence: '0.8',
+    status: 'negotiating',
+  });
+  createdOpportunityIds.push(opportunity.id);
+  return opportunity;
+}
+
+async function createNetworkEligibleNegotiatingOpportunity() {
+  const ownerUserId = crypto.randomUUID();
+  const candidateUserId = crypto.randomUUID();
+  const networkId = crypto.randomUUID();
+  createdUserIds.push(ownerUserId, candidateUserId);
+  createdNetworkIds.push(networkId);
+  await db.insert(users).values([
+    { id: ownerUserId, email: `${ownerUserId}@test.local`, name: 'Compensation owner' },
+    { id: candidateUserId, email: `${candidateUserId}@test.local`, name: 'Compensation candidate' },
+  ]);
+  await db.insert(networks).values({ id: networkId, title: 'Compensation network' });
+  await db.insert(networkMembers).values([
+    { networkId, userId: ownerUserId, permissions: ['owner'] },
+    { networkId, userId: candidateUserId, permissions: ['member'] },
+  ]);
+  const opportunity = await adapter.createOpportunity({
+    detection: { source: 'opportunity_graph', timestamp: new Date().toISOString() },
+    actors: [
+      { userId: ownerUserId, networkId, role: 'patient' },
+      { userId: candidateUserId, networkId, role: 'agent' },
+    ],
+    interpretation: {
+      category: 'collaboration',
+      reasoning: 'Network-eligible compensation fixture',
+      confidence: 0.8,
+      signals: [],
+    },
+    context: { networkId },
+    confidence: '0.8',
+    status: 'negotiating',
+  });
+  createdOpportunityIds.push(opportunity.id);
+  return { opportunity, ownerUserId, networkId };
+}
+
+afterAll(async () => {
+  if (createdConversationIds.length > 0) {
+    await db.delete(conversations).where(inArray(conversations.id, createdConversationIds));
+  }
+  if (createdOpportunityIds.length > 0) {
+    await db.delete(opportunities).where(inArray(opportunities.id, createdOpportunityIds));
+  }
+  if (createdNetworkIds.length > 0) {
+    await db.delete(networkMembers).where(inArray(networkMembers.networkId, createdNetworkIds));
+    await db.delete(networks).where(inArray(networks.id, createdNetworkIds));
+  }
+  if (createdUserIds.length > 0) {
+    await db.delete(users).where(inArray(users.id, createdUserIds));
+  }
+});
+
+describe('OpportunityDatabaseAdapter.compensateTasklessNegotiatingOpportunity', () => {
+  test('restores the exact taskless negotiating version to draft', async () => {
+    const opportunity = await createNegotiatingOpportunity();
+
+    const compensated = await adapter.compensateTasklessNegotiatingOpportunity(
+      opportunity.id,
+      opportunity.updatedAt,
+      'draft',
+    );
+
+    const [raw] = await db
+      .select({ acceptedBy: opportunities.acceptedBy })
+      .from(opportunities)
+      .where(eq(opportunities.id, opportunity.id));
+
+    expect(compensated).not.toBeNull();
+    expect(compensated?.status).toBe('draft');
+    expect(raw.acceptedBy).toBeNull();
+  });
+
+  test('returns null and preserves a newer status/version', async () => {
+    const opportunity = await createNegotiatingOpportunity();
+    const newerUpdatedAt = new Date(opportunity.updatedAt.getTime() + 1_000);
+    await db
+      .update(opportunities)
+      .set({ status: 'pending', updatedAt: newerUpdatedAt })
+      .where(eq(opportunities.id, opportunity.id));
+
+    const compensated = await adapter.compensateTasklessNegotiatingOpportunity(
+      opportunity.id,
+      opportunity.updatedAt,
+      'draft',
+    );
+    const preserved = await adapter.getOpportunity(opportunity.id);
+
+    expect(compensated).toBeNull();
+    expect(preserved?.status).toBe('pending');
+    expect(preserved?.updatedAt.getTime()).toBe(newerUpdatedAt.getTime());
+  });
+
+  test('network-eligible reactivation does not overwrite concurrent status drift', async () => {
+    const { opportunity, ownerUserId, networkId } = await createNetworkEligibleNegotiatingOpportunity();
+    await adapter.updateOpportunityStatus(opportunity.id, 'rejected');
+
+    const reactivated = await adapter.updateOpportunityStatusIfNetworkEligible(
+      opportunity.id,
+      'negotiating',
+      opportunity.actors,
+      { ownerUserId, allowedNetworkIds: [networkId] },
+      'negotiating',
+    );
+    const preserved = await adapter.getOpportunity(opportunity.id);
+
+    expect(reactivated).toBeNull();
+    expect(preserved?.status).toBe('rejected');
+  });
+
+  test('returns null when an active negotiation task predates the attempt boundary', async () => {
+    const opportunity = await createNegotiatingOpportunity();
+    const [conversation] = await db.insert(conversations).values({}).returning();
+    createdConversationIds.push(conversation.id);
+    await db.insert(tasks).values({
+      conversationId: conversation.id,
+      state: 'input_required',
+      metadata: { type: 'negotiation', opportunityId: opportunity.id },
+      createdAt: new Date(opportunity.updatedAt.getTime() - 1_000),
+    });
+
+    const compensated = await adapter.compensateTasklessNegotiatingOpportunity(
+      opportunity.id,
+      opportunity.updatedAt,
+      'draft',
+    );
+    const preserved = await adapter.getOpportunity(opportunity.id);
+
+    expect(compensated).toBeNull();
+    expect(preserved?.status).toBe('negotiating');
+  });
+
+  test('allows compensation when the only working task is stale', async () => {
+    const opportunity = await createNegotiatingOpportunity();
+    const [conversation] = await db.insert(conversations).values({}).returning();
+    createdConversationIds.push(conversation.id);
+    const staleAt = new Date(opportunity.updatedAt.getTime() - 10 * 60 * 1000);
+    await db.insert(tasks).values({
+      conversationId: conversation.id,
+      state: 'working',
+      metadata: { type: 'negotiation', opportunityId: opportunity.id },
+      createdAt: staleAt,
+      updatedAt: staleAt,
+    });
+
+    const compensated = await adapter.compensateTasklessNegotiatingOpportunity(
+      opportunity.id,
+      opportunity.updatedAt,
+      'draft',
+    );
+
+    expect(compensated?.status).toBe('draft');
+  });
+
+  test('returns null when a negotiation task was created after the attempt boundary', async () => {
+    const opportunity = await createNegotiatingOpportunity();
+    const [conversation] = await db.insert(conversations).values({}).returning();
+    createdConversationIds.push(conversation.id);
+    await db.insert(tasks).values({
+      conversationId: conversation.id,
+      metadata: { type: 'negotiation', opportunityId: opportunity.id },
+      createdAt: new Date(opportunity.updatedAt.getTime() + 1_000),
+    });
+
+    const compensated = await adapter.compensateTasklessNegotiatingOpportunity(
+      opportunity.id,
+      opportunity.updatedAt,
+      'draft',
+    );
+    const preserved = await adapter.getOpportunity(opportunity.id);
+
+    expect(compensated).toBeNull();
+    expect(preserved?.status).toBe('negotiating');
+  });
+});

--- a/services/api/src/adapters/tests/opportunity-negotiation-compensation.database.spec.ts
+++ b/services/api/src/adapters/tests/opportunity-negotiation-compensation.database.spec.ts
@@ -1,14 +1,18 @@
 import { config } from 'dotenv';
 config({ path: '.env.test', override: true });
 
-import { afterAll, describe, expect, test } from 'bun:test';
-import { eq, inArray } from 'drizzle-orm';
+import { afterAll, describe, expect, setDefaultTimeout, test } from 'bun:test';
+import { eq, inArray, sql } from 'drizzle-orm';
 
 import db from '../../lib/drizzle/drizzle';
-import { OpportunityDatabaseAdapter } from '../opportunity.database.adapter';
+import { ConversationDatabaseAdapter, createNegotiationTaskForAttemptInTransaction, type CreateNegotiationTaskForAttemptInput } from '../conversation.database.adapter';
+import { OpportunityDatabaseAdapter, compensateTasklessNegotiatingOpportunityInTransaction } from '../opportunity.database.adapter';
 import { conversations, networkMembers, networks, opportunities, tasks, users } from '../../schemas/database.schema';
 
+setDefaultTimeout(30_000);
+
 const adapter = new OpportunityDatabaseAdapter();
+const conversationAdapter = new ConversationDatabaseAdapter();
 const createdOpportunityIds: string[] = [];
 const createdConversationIds: string[] = [];
 const createdNetworkIds: string[] = [];
@@ -36,6 +40,68 @@ async function createNegotiatingOpportunity() {
   });
   createdOpportunityIds.push(opportunity.id);
   return opportunity;
+}
+
+async function createAttemptInput(
+  opportunity: Awaited<ReturnType<typeof createNegotiatingOpportunity>>,
+): Promise<CreateNegotiationTaskForAttemptInput> {
+  const [conversation] = await db.insert(conversations).values({}).returning();
+  createdConversationIds.push(conversation.id);
+  return {
+    conversationId: conversation.id,
+    opportunityId: opportunity.id,
+    expectedUpdatedAt: opportunity.updatedAt,
+    metadata: {
+      type: 'negotiation',
+      opportunityId: opportunity.id,
+      sourceUserId: opportunity.actors[0]?.userId,
+      candidateUserId: opportunity.actors[1]?.userId,
+      networkId: opportunity.actors[0]?.networkId,
+      intentSnapshots: [],
+    },
+  };
+}
+
+function deferred<T>() {
+  let resolve!: (value: T | PromiseLike<T>) => void;
+  let reject!: (reason?: unknown) => void;
+  const promise = new Promise<T>((resolvePromise, rejectPromise) => {
+    resolve = resolvePromise;
+    reject = rejectPromise;
+  });
+  return { promise, resolve, reject };
+}
+
+async function currentBackendPid(
+  tx: Parameters<Parameters<typeof db.transaction>[0]>[0],
+): Promise<number> {
+  const rows = await tx.execute(sql`SELECT pg_backend_pid()::int AS pid`);
+  return Number((rows as unknown as Array<{ pid: number }>)[0]?.pid);
+}
+
+async function waitForAdvisoryWaiter(holderPid: number): Promise<void> {
+  const deadline = Date.now() + 5_000;
+  while (Date.now() < deadline) {
+    const rows = await db.execute(sql`
+      SELECT COUNT(*)::int AS count
+      FROM pg_locks holder
+      JOIN pg_locks waiter
+        ON waiter.locktype = holder.locktype
+       AND waiter.database IS NOT DISTINCT FROM holder.database
+       AND waiter.classid IS NOT DISTINCT FROM holder.classid
+       AND waiter.objid IS NOT DISTINCT FROM holder.objid
+       AND waiter.objsubid IS NOT DISTINCT FROM holder.objsubid
+      WHERE holder.pid = ${holderPid}
+        AND holder.locktype = 'advisory'
+        AND holder.granted = true
+        AND waiter.pid <> holder.pid
+        AND waiter.granted = false
+    `);
+    const count = Number((rows as unknown as Array<{ count: number }>)[0]?.count ?? 0);
+    if (count > 0) return;
+    await new Promise((resolve) => setTimeout(resolve, 10));
+  }
+  throw new Error(`Timed out waiting for an advisory-lock waiter behind backend ${holderPid}`);
 }
 
 async function createNetworkEligibleNegotiatingOpportunity() {
@@ -209,5 +275,103 @@ describe('OpportunityDatabaseAdapter.compensateTasklessNegotiatingOpportunity', 
 
     expect(compensated).toBeNull();
     expect(preserved?.status).toBe('negotiating');
+  });
+
+  test('waits behind task creation, then preserves negotiating with the committed task', async () => {
+    const opportunity = await createNegotiatingOpportunity();
+    const input = await createAttemptInput(opportunity);
+    const releaseWinner = deferred<void>();
+    const winnerReady = deferred<number>();
+
+    const taskWinner = db.transaction(async (tx) => {
+      const task = await createNegotiationTaskForAttemptInTransaction(tx, input);
+      winnerReady.resolve(await currentBackendPid(tx));
+      await releaseWinner.promise;
+      return task;
+    });
+
+    const holderPid = await winnerReady.promise;
+    const compensation = adapter.compensateTasklessNegotiatingOpportunity(
+      opportunity.id,
+      opportunity.updatedAt,
+      'draft',
+    );
+
+    try {
+      await waitForAdvisoryWaiter(holderPid);
+    } finally {
+      releaseWinner.resolve();
+    }
+
+    const [createdTask, compensated] = await Promise.all([taskWinner, compensation]);
+    const preserved = await adapter.getOpportunity(opportunity.id);
+    const persistedTasks = await db
+      .select()
+      .from(tasks)
+      .where(eq(tasks.id, createdTask?.id ?? ''));
+
+    expect(createdTask).not.toBeNull();
+    expect(compensated).toBeNull();
+    expect(preserved?.status).toBe('negotiating');
+    expect(persistedTasks).toHaveLength(1);
+  });
+
+  test('compensation wins the shared lock and late task creation fails closed', async () => {
+    const opportunity = await createNegotiatingOpportunity();
+    const input = await createAttemptInput(opportunity);
+    const releaseWinner = deferred<void>();
+    const winnerReady = deferred<number>();
+
+    const compensationWinner = db.transaction(async (tx) => {
+      const compensated = await compensateTasklessNegotiatingOpportunityInTransaction(
+        tx,
+        opportunity.id,
+        opportunity.updatedAt,
+        'draft',
+      );
+      winnerReady.resolve(await currentBackendPid(tx));
+      await releaseWinner.promise;
+      return compensated;
+    });
+
+    const holderPid = await winnerReady.promise;
+    const lateTask = conversationAdapter.createNegotiationTaskForAttempt(input);
+
+    try {
+      await waitForAdvisoryWaiter(holderPid);
+    } finally {
+      releaseWinner.resolve();
+    }
+
+    const [compensated, createdTask] = await Promise.all([compensationWinner, lateTask]);
+    const preserved = await adapter.getOpportunity(opportunity.id);
+    const persistedTasks = await db
+      .select({ id: tasks.id })
+      .from(tasks)
+      .where(sql`${tasks.metadata}->>'opportunityId' = ${opportunity.id}`);
+
+    expect(compensated?.status).toBe('draft');
+    expect(createdTask).toBeNull();
+    expect(preserved?.status).toBe('draft');
+    expect(persistedTasks).toHaveLength(0);
+  });
+
+  test('stale task creation fails closed after a newer opportunity version/status', async () => {
+    const opportunity = await createNegotiatingOpportunity();
+    const input = await createAttemptInput(opportunity);
+    const newerUpdatedAt = new Date(opportunity.updatedAt.getTime() + 1_000);
+    await db
+      .update(opportunities)
+      .set({ status: 'pending', updatedAt: newerUpdatedAt })
+      .where(eq(opportunities.id, opportunity.id));
+
+    const createdTask = await conversationAdapter.createNegotiationTaskForAttempt(input);
+    const persistedTasks = await db
+      .select({ id: tasks.id })
+      .from(tasks)
+      .where(sql`${tasks.metadata}->>'opportunityId' = ${opportunity.id}`);
+
+    expect(createdTask).toBeNull();
+    expect(persistedTasks).toHaveLength(0);
   });
 });


### PR DESCRIPTION
## Bug Fixes
- Route continuation-created and recovered opportunities through the same post-persist negotiation boundary as fresh discovery.
- Prevent duplicate negotiation when a current active or input-required task exists.
- Compensate pre-task failures, filtered candidates, and timeout-before-task paths from `negotiating` to truthful `draft`/`latent` status with exact-version, task-aware compare-and-set semantics.
- Serialize attempt-bound task creation and compensation on one advisory lock so task creation wins cleanly or stale late initialization fails closed.
- Refresh continuation results from current database lifecycle state before MCP card filtering.

## Refactors
- Add expected-status compare-and-set protection to network-eligible opportunity reactivation.
- Thread the exact persisted opportunity version into negotiation initialization and atomically revalidate it before task insertion.
- Delegate the narrow compensation primitive through `ChatDatabaseAdapter` without changing Lens C, question authority, task snapshots, network binding, flags, or live-question modes.

## Documentation
- Bump `@indexnetwork/protocol` to `6.2.3` and `@indexnetwork/api` to `0.44.3` after rebasing over the prior patch release.
- Update package changelogs for IND-470.

## Tests
- `packages/protocol`: 110 targeted negotiation/opportunity/continuation/introducer tests passed.
- `services/api`: 9 focused compensation/reactivation/atomic-lock adapter tests passed, including both deterministic lock-order races.
- Protocol build passed.
- API build passed.
- Changed-file lint passed with no errors.

## Acceptance
Owner manually accepted the implementation before versioning and publication.

Linear: IND-470
