### PR TITLE
feat(signal): guided agent-driven New Signal intake (IND-474)

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@indexnetwork/web",
-  "version": "0.18.0",
+  "version": "0.19.0",
   "license": "MIT",
   "scripts": {
     "dev": "vite --host 127.0.0.1",

--- a/apps/web/src/app/i/new/page.tsx
+++ b/apps/web/src/app/i/new/page.tsx
@@ -1,0 +1,402 @@
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { Check, ChevronLeft, Loader2, Send } from "lucide-react";
+import { Navigate, useNavigate } from "react-router";
+
+import { useAIChat } from "@/contexts/AIChatContext";
+import { useAuthContext } from "@/contexts/AuthContext";
+import { useNetworksState } from "@/contexts/IndexesContext";
+import { useQuestionsService } from "@/contexts/APIContext";
+import { useNotifications } from "@/contexts/NotificationContext";
+import type { AnswerBody, PendingQuestion } from "@/services/questions";
+import { apiClient } from "@/lib/api";
+import { parseAllBlocks, type MessageSegment } from "@/components/chat/AssistantMessageContent";
+
+interface AnsweredStep {
+  question: PendingQuestion;
+  answer: AnswerBody;
+}
+
+type GuidedProposal = {
+  proposalId: string;
+  description: string;
+  networkId?: string;
+  lookingFor?: string;
+  youBring?: string;
+  offering?: string;
+  networks?: Array<{ id?: string; title?: string }>;
+};
+
+function asGuidedProposal(segment: MessageSegment): GuidedProposal | null {
+  if (segment.type !== "intent_proposal") return null;
+  const value = segment.data as IntentProposalDataWithExtras;
+  return {
+    proposalId: value.proposalId,
+    description: value.description,
+    ...(value.networkId ? { networkId: value.networkId } : {}),
+    ...(typeof value.lookingFor === "string" ? { lookingFor: value.lookingFor } : {}),
+    ...(typeof value.youBring === "string" ? { youBring: value.youBring } : {}),
+    ...(typeof value.offering === "string" ? { offering: value.offering } : {}),
+    ...(Array.isArray(value.networks) ? { networks: value.networks } : {}),
+  };
+}
+
+type IntentProposalDataWithExtras = {
+  proposalId: string;
+  description: string;
+  networkId?: string;
+  lookingFor?: string;
+  youBring?: string;
+  offering?: string;
+  networks?: Array<{ id?: string; title?: string }>;
+};
+
+function latestProposal(messages: Array<{ content: string }>): GuidedProposal | null {
+  for (let index = messages.length - 1; index >= 0; index -= 1) {
+    const segments = parseAllBlocks(messages[index].content);
+    for (let segmentIndex = segments.length - 1; segmentIndex >= 0; segmentIndex -= 1) {
+      const proposal = asGuidedProposal(segments[segmentIndex]);
+      if (proposal) return proposal;
+    }
+  }
+  return null;
+}
+
+function answerLabel(answer: AnswerBody): string {
+  return [...answer.selectedOptions, answer.freeText?.trim() ?? ""].filter(Boolean).join(", ");
+}
+
+function GuidedQuestion({
+  question,
+  onAnswer,
+  disabled,
+}: {
+  question: PendingQuestion;
+  onAnswer: (body: AnswerBody) => Promise<void>;
+  disabled: boolean;
+}) {
+  const [selected, setSelected] = useState<string[]>([]);
+  const [freeText, setFreeText] = useState("");
+  const [submitting, setSubmitting] = useState(false);
+  const canSubmit = selected.length > 0 || freeText.trim().length > 0;
+
+  const toggleOption = (label: string) => {
+    setSelected((current) => {
+      if (question.payload.multiSelect) {
+        return current.includes(label) ? current.filter((item) => item !== label) : [...current, label];
+      }
+      return [label];
+    });
+    setFreeText("");
+  };
+
+  const submit = async () => {
+    if (!canSubmit || submitting || disabled) return;
+    setSubmitting(true);
+    try {
+      await onAnswer({
+        selectedOptions: selected,
+        ...(freeText.trim() ? { freeText: freeText.trim() } : {}),
+      });
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  return (
+    <section aria-label="Current question" className="mt-8">
+      <p className="text-xs font-semibold uppercase tracking-[0.18em] text-gray-400">Next</p>
+      <h1 className="mt-3 text-2xl font-semibold leading-tight text-[#041729] sm:text-3xl">
+        {question.payload.prompt}
+      </h1>
+      {question.payload.multiSelect && (
+        <p className="mt-2 text-sm text-gray-500">Choose all that apply.</p>
+      )}
+      <div className="mt-6 grid gap-3">
+        {question.payload.options.map((option) => {
+          const checked = selected.includes(option.label);
+          return (
+            <button
+              key={option.label}
+              type="button"
+              disabled={disabled || submitting}
+              aria-pressed={checked}
+              onClick={() => toggleOption(option.label)}
+              className={`rounded-2xl border px-4 py-3 text-left transition ${
+                checked
+                  ? "border-[#041729] bg-[#041729] text-white"
+                  : "border-gray-200 bg-white text-gray-800 hover:border-gray-400"
+              } disabled:cursor-not-allowed disabled:opacity-60`}
+            >
+              <span className="block text-sm font-medium">{option.label}</span>
+              {option.description && (
+                <span className={`mt-1 block text-xs ${checked ? "text-gray-200" : "text-gray-500"}`}>
+                  {option.description}
+                </span>
+              )}
+            </button>
+          );
+        })}
+      </div>
+      <textarea
+        value={freeText}
+        onChange={(event) => {
+          setFreeText(event.target.value);
+          if (event.target.value.trim()) setSelected([]);
+        }}
+        disabled={disabled || submitting}
+        placeholder="Or tell me in your own words"
+        rows={2}
+        className="mt-4 w-full resize-none rounded-2xl border border-gray-200 bg-white px-4 py-3 text-sm text-gray-800 outline-none transition placeholder:text-gray-400 focus:border-[#041729] focus:ring-2 focus:ring-[#041729]/10 disabled:opacity-60"
+      />
+      <button
+        type="button"
+        onClick={() => void submit()}
+        disabled={!canSubmit || disabled || submitting}
+        className="mt-4 inline-flex items-center gap-2 rounded-full bg-[#041729] px-5 py-2.5 text-sm font-medium text-white transition hover:bg-[#0a2d4a] disabled:cursor-not-allowed disabled:opacity-40"
+      >
+        {submitting ? <Loader2 className="h-4 w-4 animate-spin" /> : <Send className="h-4 w-4" />}
+        Continue
+      </button>
+    </section>
+  );
+}
+
+function ProposalCard({
+  proposal,
+  networkTitle,
+  onConfirm,
+  onSkip,
+  busy,
+  error,
+}: {
+  proposal: GuidedProposal;
+  networkTitle: string;
+  onConfirm: () => Promise<void>;
+  onSkip: () => Promise<void>;
+  busy: boolean;
+  error: string | null;
+}) {
+  const [skipping, setSkipping] = useState(false);
+  const youBring = proposal.youBring ?? proposal.offering;
+  return (
+    <section aria-label="Confirm signal" className="mt-10 rounded-3xl border border-gray-200 bg-white p-6 shadow-sm sm:p-8">
+      <p className="text-xs font-semibold uppercase tracking-[0.18em] text-gray-400">One last look</p>
+      <h1 className="mt-3 text-2xl font-semibold text-[#041729]">Does this feel right?</h1>
+      <div className="mt-7 space-y-5">
+        <Summary label="LOOKING FOR" value={proposal.lookingFor ?? proposal.description} />
+        <Summary label="YOU BRING" value={youBring ?? "Not specified"} />
+        <Summary label="NETWORKS" value={networkTitle} />
+      </div>
+      {error && <p role="alert" className="mt-5 rounded-xl bg-red-50 px-3 py-2 text-sm text-red-700">{error}</p>}
+      <div className="mt-7 flex flex-wrap items-center gap-3">
+        <button
+          type="button"
+          disabled={busy || skipping}
+          onClick={() => void onConfirm()}
+          className="inline-flex items-center gap-2 rounded-full bg-[#041729] px-5 py-2.5 text-sm font-medium text-white hover:bg-[#0a2d4a] disabled:opacity-50"
+        >
+          {busy ? <Loader2 className="h-4 w-4 animate-spin" /> : <Check className="h-4 w-4" />}
+          Confirm signal
+        </button>
+        <button
+          type="button"
+          disabled={busy || skipping}
+          onClick={async () => {
+            setSkipping(true);
+            try {
+              await onSkip();
+            } finally {
+              setSkipping(false);
+            }
+          }}
+          className="rounded-full px-4 py-2.5 text-sm text-gray-500 hover:bg-gray-100 disabled:opacity-50"
+        >
+          {skipping ? "Skipping…" : "Not yet"}
+        </button>
+      </div>
+    </section>
+  );
+}
+
+function Summary({ label, value }: { label: string; value: string }) {
+  return (
+    <div>
+      <p className="text-[10px] font-semibold tracking-[0.18em] text-gray-400">{label}</p>
+      <p className="mt-1 text-base leading-relaxed text-gray-800">{value}</p>
+    </div>
+  );
+}
+
+export default function NewSignalPage() {
+  const navigate = useNavigate();
+  const { isAuthenticated, features } = useAuthContext();
+  const { indexes } = useNetworksState();
+  const questionsService = useQuestionsService();
+  const { addNotification, error: showError } = useNotifications();
+  const {
+    messages,
+    liveQuestions,
+    isLoading,
+    startSignalSession,
+    sendWebMessage,
+    clearChat,
+  } = useAIChat();
+  const [answered, setAnswered] = useState<AnsweredStep[]>([]);
+  const [proposalError, setProposalError] = useState<string | null>(null);
+  const [confirming, setConfirming] = useState(false);
+  const [skipped, setSkipped] = useState(false);
+  const startedRef = useRef(false);
+
+  const signalAgentEnabled = features?.signalAgent === true;
+
+  useEffect(() => {
+    if (!isAuthenticated || !signalAgentEnabled || startedRef.current) return;
+    startedRef.current = true;
+    startSignalSession();
+    void sendWebMessage(
+      "I want to create a new signal. Guide me through a few focused questions, then propose the signal for my confirmation.",
+      undefined,
+      undefined,
+      { hidden: true, persona: "signal" },
+    );
+  }, [isAuthenticated, sendWebMessage, signalAgentEnabled, startSignalSession]);
+
+  const answeredIds = useMemo(() => new Set(answered.map((step) => step.question.id)), [answered]);
+  const currentQuestion = liveQuestions.find((question) => !answeredIds.has(question.id)) ?? null;
+  const proposal = useMemo(() => latestProposal(messages), [messages]);
+  const networkTitle = useMemo(() => {
+    if (proposal?.networks?.length) {
+      const titles = proposal.networks
+        .map((network) => network.id ? indexes.find((item) => item.id === network.id)?.title : undefined)
+        .filter((title): title is string => Boolean(title));
+      if (titles.length) return titles.join(", ");
+    }
+    if (proposal?.networkId) return indexes.find((network) => network.id === proposal.networkId)?.title ?? "Everywhere";
+    return "Everywhere";
+  }, [indexes, proposal]);
+
+  const handleAnswer = useCallback(async (body: AnswerBody) => {
+    if (!currentQuestion) return;
+    const question = currentQuestion;
+    const response = await questionsService.answer(question.id, body);
+    setAnswered((current) => [...current.filter((step) => step.question.id !== question.id), { question, answer: body }]);
+    if (!response.resumed && !isLoading) {
+      const parts = [...body.selectedOptions, body.freeText?.trim() ?? ""].filter(Boolean);
+      if (parts.length) void sendWebMessage(`Re: "${question.payload.prompt}" — ${parts.join("; ")}`);
+    }
+  }, [currentQuestion, isLoading, questionsService, sendWebMessage]);
+
+  const handleConfirm = useCallback(async () => {
+    if (!proposal || confirming) return;
+    setConfirming(true);
+    setProposalError(null);
+    const networkId = proposal.networkId && indexes.some((network) => network.id === proposal.networkId)
+      ? proposal.networkId
+      : undefined;
+    try {
+      const response = await apiClient.post<{ intentId: string }>("/intents/confirm", {
+        proposalId: proposal.proposalId,
+        description: proposal.description,
+        ...(networkId ? { networkId } : {}),
+      });
+      addNotification({
+        type: "intent_broadcast",
+        title: networkId ? `Broadcasting to ${networkTitle}` : "Evaluating networks…",
+        message: proposal.description,
+        duration: 10000,
+        onAction: async () => {
+          await apiClient.patch(`/intents/${response.intentId}/archive`);
+          clearChat();
+          navigate("/i/new");
+        },
+      });
+      navigate(`/i/${response.intentId}`);
+    } catch (error) {
+      setProposalError("Couldn't create your signal. Please try again.");
+      showError("Signal creation failed", error instanceof Error ? error.message : "Please try again.");
+    } finally {
+      setConfirming(false);
+    }
+  }, [addNotification, clearChat, confirming, indexes, navigate, networkTitle, proposal, showError]);
+
+  const handleSkip = useCallback(async () => {
+    if (!proposal) return;
+    try {
+      await apiClient.post("/intents/reject", { proposalId: proposal.proposalId });
+      setSkipped(true);
+    } catch (error) {
+      setProposalError("Couldn't dismiss this signal. Please try again.");
+      showError("Signal dismissal failed", error instanceof Error ? error.message : "Please try again.");
+    }
+  }, [proposal, showError]);
+
+  const startOver = useCallback(() => {
+    clearChat();
+    setAnswered([]);
+    setProposalError(null);
+    setSkipped(false);
+    startedRef.current = false;
+  }, [clearChat]);
+
+  if (!isAuthenticated || !signalAgentEnabled) return <Navigate to="/" replace />;
+
+  return (
+    <div className="min-h-screen bg-[#FDFDFD] px-5 py-6 sm:px-8 sm:py-10">
+      <main className="mx-auto w-full max-w-2xl">
+        <button
+          type="button"
+          onClick={() => navigate("/")}
+          className="inline-flex items-center gap-1 text-sm text-gray-500 transition hover:text-[#041729]"
+        >
+          <ChevronLeft className="h-4 w-4" /> Back
+        </button>
+        <p className="mt-10 text-xs font-semibold uppercase tracking-[0.2em] text-gray-400">Start a new signal</p>
+        <h1 className="mt-3 text-3xl font-semibold tracking-tight text-[#041729] sm:text-4xl">Make what you’re looking for legible.</h1>
+
+        <div className="mt-8 flex gap-1.5" aria-label="Signal progress">
+          {Array.from({ length: Math.max(4, answered.length + (currentQuestion ? 1 : 0)) }).map((_, index) => (
+            <span
+              key={index}
+              className={`h-1.5 flex-1 rounded-full ${index < answered.length ? "bg-[#041729]" : index === answered.length && currentQuestion ? "bg-[#8BA8B8]" : "bg-gray-200"}`}
+            />
+          ))}
+        </div>
+
+        <div className="mt-10 space-y-5">
+          {answered.map((step) => (
+            <div key={step.question.id} className="border-b border-gray-100 pb-5">
+              <p className="text-xs uppercase tracking-[0.16em] text-gray-400">{step.question.payload.prompt}</p>
+              <p className="mt-1 text-base text-gray-700">{answerLabel(step.answer)}</p>
+            </div>
+          ))}
+        </div>
+
+        {skipped ? (
+          <section className="mt-12 rounded-3xl border border-gray-200 bg-white p-8 text-center">
+            <h2 className="text-xl font-semibold text-[#041729]">Nothing saved.</h2>
+            <button type="button" onClick={startOver} className="mt-5 rounded-full bg-[#041729] px-5 py-2.5 text-sm text-white">Start over</button>
+          </section>
+        ) : proposal ? (
+          <ProposalCard
+            proposal={proposal}
+            networkTitle={networkTitle}
+            onConfirm={handleConfirm}
+            onSkip={handleSkip}
+            busy={confirming}
+            error={proposalError}
+          />
+        ) : currentQuestion ? (
+          <GuidedQuestion question={currentQuestion} onAnswer={handleAnswer} disabled={isLoading && !currentQuestion} />
+        ) : isLoading ? (
+          <div role="status" aria-label="Your agent is thinking" className="mt-14 flex items-center gap-3 text-sm text-gray-500">
+            <Loader2 className="h-4 w-4 animate-spin" /> Your agent is thinking…
+          </div>
+        ) : (
+          <div role="status" className="mt-14 text-sm text-gray-500">Your agent is preparing the next step…</div>
+        )}
+      </main>
+    </div>
+  );
+}
+
+export const Component = NewSignalPage;

--- a/apps/web/src/app/i/new/page.tsx
+++ b/apps/web/src/app/i/new/page.tsx
@@ -164,6 +164,8 @@ function GuidedQuestion({
 function ProposalCard({
   proposal,
   networkTitle,
+  lookingFor,
+  youBring,
   onConfirm,
   onSkip,
   busy,
@@ -171,20 +173,23 @@ function ProposalCard({
 }: {
   proposal: GuidedProposal;
   networkTitle: string;
+  lookingFor?: string;
+  youBring?: string;
   onConfirm: () => Promise<void>;
   onSkip: () => Promise<void>;
   busy: boolean;
   error: string | null;
 }) {
   const [skipping, setSkipping] = useState(false);
-  const youBring = proposal.youBring ?? proposal.offering;
+  const resolvedLookingFor = lookingFor ?? proposal.lookingFor ?? proposal.description;
+  const resolvedYouBring = youBring ?? proposal.youBring ?? proposal.offering;
   return (
     <section aria-label="Confirm signal" className="mt-10 rounded-3xl border border-gray-200 bg-white p-6 shadow-sm sm:p-8">
       <p className="text-xs font-semibold uppercase tracking-[0.18em] text-gray-400">One last look</p>
       <h1 className="mt-3 text-2xl font-semibold text-[#041729]">Does this feel right?</h1>
       <div className="mt-7 space-y-5">
-        <Summary label="LOOKING FOR" value={proposal.lookingFor ?? proposal.description} />
-        <Summary label="YOU BRING" value={youBring ?? "Not specified"} />
+        <Summary label="LOOKING FOR" value={resolvedLookingFor} />
+        <Summary label="YOU BRING" value={resolvedYouBring ?? "Not specified"} />
         <Summary label="NETWORKS" value={networkTitle} />
       </div>
       {error && <p role="alert" className="mt-5 rounded-xl bg-red-50 px-3 py-2 text-sm text-red-700">{error}</p>}
@@ -253,8 +258,10 @@ export default function NewSignalPage() {
     if (!isAuthenticated || !signalAgentEnabled || startedRef.current) return;
     startedRef.current = true;
     startSignalSession();
+    // Keep this marker stable: the Signal prompt builder uses it to enter the
+    // live, three-round intake rather than treating this as ordinary chat.
     void sendWebMessage(
-      "I want to create a new signal. Guide me through a few focused questions, then propose the signal for my confirmation.",
+      "new-signal-kickoff",
       undefined,
       undefined,
       { hidden: true, persona: "signal" },
@@ -264,16 +271,25 @@ export default function NewSignalPage() {
   const answeredIds = useMemo(() => new Set(answered.map((step) => step.question.id)), [answered]);
   const currentQuestion = liveQuestions.find((question) => !answeredIds.has(question.id)) ?? null;
   const proposal = useMemo(() => latestProposal(messages), [messages]);
-  const networkTitle = useMemo(() => {
-    if (proposal?.networks?.length) {
-      const titles = proposal.networks
-        .map((network) => network.id ? indexes.find((item) => item.id === network.id)?.title : undefined)
-        .filter((title): title is string => Boolean(title));
-      if (titles.length) return titles.join(", ");
-    }
-    if (proposal?.networkId) return indexes.find((network) => network.id === proposal.networkId)?.title ?? "Everywhere";
-    return "Everywhere";
-  }, [indexes, proposal]);
+  const selectedNetwork = useMemo(() => {
+    const proposalNetwork = proposal?.networkId
+      ? indexes.find((network) => network.id === proposal.networkId)
+      : undefined;
+    if (proposalNetwork) return proposalNetwork;
+
+    const locationAnswer = answered[2]?.answer;
+    const labels = [
+      ...(locationAnswer?.selectedOptions ?? []),
+      locationAnswer?.freeText?.trim() ?? "",
+    ].filter(Boolean);
+    return indexes.find((network) => labels.some((label) =>
+      label.localeCompare(network.title, undefined, { sensitivity: "accent" }) === 0,
+    ));
+  }, [answered, indexes, proposal]);
+
+  const networkTitle = selectedNetwork?.title ?? "Everywhere";
+  const lookingFor = answered[0] ? answerLabel(answered[0].answer) : undefined;
+  const answeredContribution = answered[1] ? answerLabel(answered[1].answer) : undefined;
 
   const handleAnswer = useCallback(async (body: AnswerBody) => {
     if (!currentQuestion) return;
@@ -290,9 +306,7 @@ export default function NewSignalPage() {
     if (!proposal || confirming) return;
     setConfirming(true);
     setProposalError(null);
-    const networkId = proposal.networkId && indexes.some((network) => network.id === proposal.networkId)
-      ? proposal.networkId
-      : undefined;
+    const networkId = selectedNetwork?.id;
     try {
       const response = await apiClient.post<{ intentId: string }>("/intents/confirm", {
         proposalId: proposal.proposalId,
@@ -317,7 +331,7 @@ export default function NewSignalPage() {
     } finally {
       setConfirming(false);
     }
-  }, [addNotification, clearChat, confirming, indexes, navigate, networkTitle, proposal, showError]);
+  }, [addNotification, clearChat, confirming, navigate, networkTitle, proposal, selectedNetwork, showError]);
 
   const handleSkip = useCallback(async () => {
     if (!proposal) return;
@@ -380,6 +394,8 @@ export default function NewSignalPage() {
           <ProposalCard
             proposal={proposal}
             networkTitle={networkTitle}
+            lookingFor={lookingFor}
+            youBring={answeredContribution}
             onConfirm={handleConfirm}
             onSkip={handleSkip}
             busy={confirming}

--- a/apps/web/src/components/ChatContent.tsx
+++ b/apps/web/src/components/ChatContent.tsx
@@ -1169,8 +1169,8 @@ export default function ChatContent({ sessionIdParam }: ChatContentProps) {
             >
               <span className="flex h-7 w-7 items-center justify-center rounded-lg bg-[#041729] text-lg leading-none text-white">+</span>
               <span>
-                <span className="block text-sm font-medium text-[#041729]">Start a new signal</span>
-                <span className="block text-xs text-gray-500">Let your agent guide you through it.</span>
+                <span className="block text-sm font-medium text-[#041729]">Who are you trying to meet?</span>
+                <span className="block text-xs text-gray-500">Let your Signal Agent guide you through a new signal.</span>
               </span>
             </button>
           )}

--- a/apps/web/src/components/ChatContent.tsx
+++ b/apps/web/src/components/ChatContent.tsx
@@ -1161,6 +1161,19 @@ export default function ChatContent({ sessionIdParam }: ChatContentProps) {
             </form>
             )}
           </div>
+          {signalAgentEnabled && (
+            <button
+              type="button"
+              onClick={() => navigate("/i/new")}
+              className="mt-4 flex w-full items-center gap-3 rounded-2xl border border-gray-200 bg-white px-4 py-3 text-left transition hover:border-gray-400 hover:shadow-sm"
+            >
+              <span className="flex h-7 w-7 items-center justify-center rounded-lg bg-[#041729] text-lg leading-none text-white">+</span>
+              <span>
+                <span className="block text-sm font-medium text-[#041729]">Start a new signal</span>
+                <span className="block text-xs text-gray-500">Let your agent guide you through it.</span>
+              </span>
+            </button>
+          )}
           <div className="mt-8">
             <IntentList
               intents={homeIntents}

--- a/apps/web/src/components/ClientWrapper.tsx
+++ b/apps/web/src/components/ClientWrapper.tsx
@@ -31,7 +31,7 @@ export default function ClientWrapper({ children }: PropsWithChildren) {
 
   const appRoutes = ['/', '/d', '/i', '/u', '/networks', '/mynetwork', '/chat', '/settings', '/agents', '/agent', '/questions'];
   const publicRoutes = ['/c', '/l', '/index'];
-  const bareRoutes = ['/', '/onboarding', '/oauth/callback', '/found-in-translation', '/overview', '/protocol', '/blog', '/about', '/pages'];
+  const bareRoutes = ['/', '/i/new', '/onboarding', '/oauth/callback', '/found-in-translation', '/overview', '/protocol', '/blog', '/about', '/pages'];
 
   const isBareRoute = useMemo(() => {
     // Root is bare (landing) only for guests; authenticated users get the app shell.

--- a/apps/web/src/contexts/AIChatContext.tsx
+++ b/apps/web/src/contexts/AIChatContext.tsx
@@ -235,10 +235,10 @@ interface AIChatContextType {
   cancelQueuedMessage: (id: string) => void;
   submitMidStreamMessage: (message: string, traceEvents: TraceEvent[], fileIds?: string[], attachmentNames?: string[]) => void;
   /**
-   * Questions streamed live by the orchestrator's ask_user_question tool
+   * Questions streamed live by a chat persona's ask_user_question tool
    * (`user_question` SSE event). The turn is blocked server-side until they
-   * are answered/dismissed or the wait times out. ChatContent merges these
-   * into its inline injected-questions list.
+   * are answered/dismissed or the wait times out. ChatContent and guided
+   * Signal intake surfaces consume these from the same stream state.
    */
   liveQuestions: PendingQuestion[];
 }
@@ -400,7 +400,7 @@ export function AIChatProvider({ children }: { children: React.ReactNode }) {
   /** Per-message timeout IDs so cancelling or resolving one pending message doesn't affect others. */
   const interruptTimeoutsRef = useRef<Map<string, ReturnType<typeof setTimeout>>>(new Map());
   const [pendingQueue, setPendingQueue] = useState<QueuedMessage[]>([]);
-  /** Live inline questions from the ask_user_question tool (user_question SSE event). */
+  /** Live questions from any chat persona's ask_user_question tool (user_question SSE event). */
   const [liveQuestions, setLiveQuestions] = useState<PendingQuestion[]>([]);
   type SendAbortReason = "clear" | "load" | "steer" | "stopped" | "superseded" | "unmount";
   type SendOperation = {

--- a/apps/web/src/routes.tsx
+++ b/apps/web/src/routes.tsx
@@ -82,6 +82,10 @@ export const router = createBrowserRouter([
         lazy: () => import("@/app/d/[id]/page"),
       },
       {
+        path: "/i/new",
+        lazy: () => import("@/app/i/new/page"),
+      },
+      {
         path: "/i/:intentId",
         lazy: () => import("@/app/i/[intentId]/page"),
       },

--- a/apps/web/tests/ai-chat-context-signal.test.tsx
+++ b/apps/web/tests/ai-chat-context-signal.test.tsx
@@ -132,6 +132,8 @@ function Probe() {
       <span data-testid="chat-scope">{chat.chatScope ? `${chat.chatScope.type}:${chat.chatScope.id}` : 'none'}</span>
       <span data-testid="ready-b">{chat.isSessionReady('session-b') ? 'yes' : 'no'}</span>
       <span data-testid="queue-id">{chat.pendingQueue[0]?.id ?? 'none'}</span>
+      <span data-testid="live-question-count">{chat.liveQuestions.length}</span>
+      <span data-testid="live-question-prompt">{chat.liveQuestions[0]?.payload.prompt ?? 'none'}</span>
     </div>
   );
 }
@@ -437,6 +439,36 @@ describe('AIChatContext Signal persona transport and ownership', () => {
     fireEvent.click(screen.getByRole('button', { name: 'web first' }));
     await waitFor(() => expect(text('block')).toBe('WEB_SIGNAL_SESSION_REQUIRED'));
     expect(text('block-action')).toBe('none');
+  });
+
+  test('forwards blocking user_question events into live questions for guided surfaces', async () => {
+    const stream = controlledStream({ sessionId: 'signal-session', persona: 'signal' });
+    mocks.apiClient.stream.mockResolvedValueOnce(stream.response);
+
+    renderProvider();
+    fireEvent.click(screen.getByRole('button', { name: 'web first' }));
+    await waitFor(() => expect(text('session')).toBe('signal-session'));
+
+    await act(async () => {
+      stream.event({
+        type: 'user_question',
+        sessionId: 'signal-session',
+        questions: [{
+          id: 'question-1',
+          title: 'Signal focus',
+          prompt: 'What are you looking for?',
+          options: [{ label: 'A collaborator', description: 'Someone to build with' }],
+          multiSelect: false,
+        }],
+      });
+    });
+
+    await waitFor(() => expect(text('live-question-count')).toBe('1'));
+    expect(text('live-question-prompt')).toBe('What are you looking for?');
+    await act(async () => {
+      stream.event({ type: 'done', response: 'waiting' });
+      stream.close();
+    });
   });
 
   test('queued web sends retain the dedicated transport when drained', async () => {

--- a/apps/web/tests/guided-signal-flow.test.tsx
+++ b/apps/web/tests/guided-signal-flow.test.tsx
@@ -100,7 +100,7 @@ describe("guided Signal creation", () => {
 
     await waitFor(() => expect(mocks.state.startSignalSession).toHaveBeenCalledTimes(1));
     expect(mocks.state.sendWebMessage).toHaveBeenCalledWith(
-      expect.stringContaining("create a new signal"),
+      "new-signal-kickoff",
       undefined,
       undefined,
       { hidden: true, persona: "signal" },

--- a/apps/web/tests/guided-signal-flow.test.tsx
+++ b/apps/web/tests/guided-signal-flow.test.tsx
@@ -1,0 +1,171 @@
+import { act, fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { MemoryRouter, Route, Routes, useLocation } from "react-router";
+import { beforeEach, describe, expect, test, vi } from "vitest";
+
+import NewSignalPage from "@/app/i/new/page";
+import type { PendingQuestion } from "@/services/questions";
+
+const mocks = vi.hoisted(() => ({
+  state: {
+    messages: [] as Array<{ content: string }>,
+    liveQuestions: [] as PendingQuestion[],
+    isLoading: false,
+    startSignalSession: vi.fn(),
+    sendWebMessage: vi.fn(),
+    clearChat: vi.fn(),
+  },
+  answer: vi.fn(),
+  apiPost: vi.fn(),
+  apiPatch: vi.fn(),
+  addNotification: vi.fn(),
+  showError: vi.fn(),
+}));
+
+vi.mock("@/contexts/AIChatContext", () => ({
+  useAIChat: () => mocks.state,
+}));
+vi.mock("@/contexts/AuthContext", () => ({
+  useAuthContext: () => ({ isAuthenticated: true, features: { signalAgent: true } }),
+}));
+vi.mock("@/contexts/IndexesContext", () => ({
+  useNetworksState: () => ({
+    indexes: [{ id: "network-1", title: "Builders", isPersonal: false }],
+  }),
+}));
+vi.mock("@/contexts/APIContext", () => ({
+  useQuestionsService: () => ({ answer: mocks.answer }),
+}));
+vi.mock("@/contexts/NotificationContext", () => ({
+  useNotifications: () => ({ addNotification: mocks.addNotification, error: mocks.showError }),
+}));
+vi.mock("@/lib/api", () => ({
+  apiClient: { post: mocks.apiPost, patch: mocks.apiPatch },
+}));
+
+function LocationProbe() {
+  return <span data-testid="location">{useLocation().pathname}</span>;
+}
+
+function renderPage() {
+  return render(
+    <MemoryRouter initialEntries={["/i/new"]}>
+      <Routes>
+        <Route path="*" element={<><NewSignalPage /><LocationProbe /></>} />
+      </Routes>
+    </MemoryRouter>,
+  );
+}
+
+function question(id: string): PendingQuestion {
+  return {
+    id,
+    detection: {
+      mode: "chat",
+      sourceType: "conversation",
+      sourceId: "session-1",
+      timestamp: new Date().toISOString(),
+    },
+    actors: [],
+    payload: {
+      title: "Signal focus",
+      prompt: "What are you looking for?",
+      options: [{ label: "A collaborator", description: "Someone to build with" }],
+      multiSelect: false,
+    },
+    status: "pending",
+    answer: null,
+    expiresAt: null,
+    createdAt: new Date().toISOString(),
+    conversationId: "session-1",
+  };
+}
+
+beforeEach(() => {
+  mocks.state.messages = [];
+  mocks.state.liveQuestions = [];
+  mocks.state.isLoading = false;
+  mocks.state.startSignalSession.mockReset();
+  mocks.state.sendWebMessage.mockReset();
+  mocks.state.clearChat.mockReset();
+  mocks.answer.mockReset().mockResolvedValue({ success: true, resumed: true });
+  mocks.apiPost.mockReset().mockResolvedValue({ intentId: "intent-1" });
+  mocks.apiPatch.mockReset().mockResolvedValue({});
+  mocks.addNotification.mockReset();
+  mocks.showError.mockReset();
+});
+
+describe("guided Signal creation", () => {
+  test("starts a Signal session, renders blocking questions, and summarizes answers", async () => {
+    const view = renderPage();
+
+    await waitFor(() => expect(mocks.state.startSignalSession).toHaveBeenCalledTimes(1));
+    expect(mocks.state.sendWebMessage).toHaveBeenCalledWith(
+      expect.stringContaining("create a new signal"),
+      undefined,
+      undefined,
+      { hidden: true, persona: "signal" },
+    );
+
+    const current = question("question-1");
+    mocks.state.liveQuestions = [current];
+    mocks.state.isLoading = true;
+    await act(async () => {
+      // Re-rendering the route models the context update emitted by SSE.
+      view.rerender(
+        <MemoryRouter initialEntries={["/i/new"]}>
+          <Routes><Route path="*" element={<><NewSignalPage /><LocationProbe /></>} /></Routes>
+        </MemoryRouter>,
+      );
+    });
+
+    expect(screen.getByRole("heading", { name: "What are you looking for?" })).toBeInTheDocument();
+    expect(screen.getByText("A collaborator")).toBeInTheDocument();
+    expect(screen.getByLabelText("Signal progress")).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole("button", { name: /A collaborator/ }));
+    fireEvent.click(screen.getByRole("button", { name: "Continue" }));
+    await waitFor(() => expect(mocks.answer).toHaveBeenCalledWith("question-1", { selectedOptions: ["A collaborator"] }));
+    expect(screen.getByText("A collaborator")).toBeInTheDocument();
+  });
+
+  test("shows the proposal confirmation card and confirms through the existing endpoint", async () => {
+    const view = renderPage();
+    mocks.state.messages = [{ 
+      content: [
+        "Here is the signal.",
+        "```intent_proposal",
+        JSON.stringify({
+          proposalId: "proposal-1",
+          description: "Find a thoughtful technical collaborator",
+          youBring: "Product experience",
+          networkId: "network-1",
+        }),
+        "```",
+      ].join("\n"),
+    }];
+
+    await act(async () => {
+      view.rerender(
+        <MemoryRouter initialEntries={["/i/new"]}>
+          <Routes><Route path="*" element={<><NewSignalPage /><LocationProbe /></>} /></Routes>
+        </MemoryRouter>,
+      );
+    });
+
+    expect(screen.getByText("LOOKING FOR")).toBeInTheDocument();
+    expect(screen.getByText("Find a thoughtful technical collaborator")).toBeInTheDocument();
+    expect(screen.getByText("YOU BRING")).toBeInTheDocument();
+    expect(screen.getByText("Product experience")).toBeInTheDocument();
+    expect(screen.getByText("Builders")).toBeInTheDocument();
+    expect(screen.queryByText("Everywhere")).not.toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole("button", { name: "Confirm signal" }));
+    await waitFor(() => expect(mocks.apiPost).toHaveBeenCalledWith("/intents/confirm", {
+      proposalId: "proposal-1",
+      description: "Find a thoughtful technical collaborator",
+      networkId: "network-1",
+    }));
+    await waitFor(() => expect(screen.getByTestId("location")).toHaveTextContent("/i/intent-1"));
+    expect(mocks.addNotification).toHaveBeenCalledWith(expect.objectContaining({ type: "intent_broadcast" }));
+  });
+});

--- a/packages/protocol/package.json
+++ b/packages/protocol/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@indexnetwork/protocol",
-  "version": "6.3.0",
+  "version": "6.4.0",
   "type": "module",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",

--- a/packages/protocol/src/chat/signal.persona.ts
+++ b/packages/protocol/src/chat/signal.persona.ts
@@ -8,6 +8,9 @@ import { deriveAllowedNetworkIds, focusedIntentId, focusedNetworkId, scopeFromNe
 import type { ChatPersonaConfig } from "./chat.persona.js";
 import { buildSignalSystemContent } from "./signal.prompt.js";
 
+/** Public kickoff marker used by New Signal surfaces to enter guided intake. */
+export { SIGNAL_NEW_SIGNAL_KICKOFF } from "./signal.prompt.js";
+
 /** Stable persona id persisted for restricted Signal Agent conversations. */
 export const SIGNAL_PERSONA_ID = "signal";
 

--- a/packages/protocol/src/chat/signal.prompt.ts
+++ b/packages/protocol/src/chat/signal.prompt.ts
@@ -1,6 +1,99 @@
 import type { ResolvedToolContext } from "../shared/agent/tool.factory.js";
 import type { IterationContext } from "./chat.prompt.modules.js";
 
+/** Stable user-message marker for opening the guided New Signal intake. */
+export const SIGNAL_NEW_SIGNAL_KICKOFF = "new-signal-kickoff";
+
+/**
+ * Recognizes the one-shot kickoff sent by a New Signal surface. The aliases are
+ * intentionally limited to exact short commands so an ordinary Signal chat is
+ * never put into interview mode merely because it mentions a new signal.
+ *
+ * @param message - Latest user message from the current chat turn
+ * @returns Whether the message requests the guided New Signal intake
+ */
+export function isSignalNewSignalKickoff(message?: string): boolean {
+  const normalized = message?.trim().toLocaleLowerCase()
+    .replace(/[–—]/g, "-")
+    .replace(/^_+|_+$/g, "");
+  if (!normalized) return false;
+
+  return new Set([
+    SIGNAL_NEW_SIGNAL_KICKOFF,
+    "new-signal",
+    "new_signal",
+    "new signal",
+    "start a new signal",
+    "create a new signal",
+    "let's create a new signal",
+  ]).has(normalized);
+}
+
+type SignalIntakeStage = "who" | "contribution" | "where" | "proposal" | "complete";
+
+/**
+ * Determines the next guided-intake stage from the live agent-loop context.
+ * Counting tool calls is sufficient here: the blocking question tool does not
+ * return control to the loop until its current round has resolved.
+ *
+ * @param iterCtx - Current Signal Agent iteration context
+ * @returns The next intake stage, or null for ordinary Signal chats
+ */
+export function getSignalIntakeStage(iterCtx?: IterationContext): SignalIntakeStage | null {
+  if (!isSignalNewSignalKickoff(iterCtx?.currentMessage)) return null;
+
+  if (iterCtx?.recentTools.some((toolCall) => toolCall.name === "create_intent")) {
+    return "complete";
+  }
+
+  const questionRounds = iterCtx?.recentTools.filter(
+    (toolCall) => toolCall.name === "ask_user_question",
+  ).length ?? 0;
+  if (questionRounds === 0) return "who";
+  if (questionRounds === 1) return "contribution";
+  if (questionRounds === 2) return "where";
+  return "proposal";
+}
+
+function buildSignalIntakeGuidance(stage: SignalIntakeStage | null): string {
+  if (!stage) return "";
+
+  const common = `
+## NEW SIGNAL INTAKE (ACTIVE)
+This is a guided New Signal kickoff. Use the live Signal Agent tools now; do not answer with a questionnaire in prose and do not use read tools just to begin. The user's preloaded identity/profile context is available above. Use it to make the question wording and options feel specific to this person, but do not expose raw JSON, IDs, or internal vocabulary.
+
+Run one blocking \`ask_user_question\` round at a time. Draft exactly one concise question with 3–4 useful options plus a free-text option when appropriate. Ground each option in what the user has already shared and personalize it with relevant profile/identity context rather than generic networking choices. Wait for the tool result before continuing to the next round. The tool result contains the user's answer; use it as grounding for every later round.
+`;
+
+  if (stage === "who") {
+    return `${common}
+### Round 1 of 3: who they want to meet
+Call \`ask_user_question\` immediately. Ask who the user wants to meet or what kind of person they want to find right now. Offer distinct, concrete recipient profiles tailored to the preloaded context (for example, a peer, collaborator, customer, mentor, or a specific expertise gap), not generic "anyone" choices.`;
+  }
+
+  if (stage === "contribution") {
+    return `${common}
+### Round 2 of 3: what they bring and where the gap is
+Call \`ask_user_question\` immediately. Ask what the user would bring to this connection and what gap the other person should help fill. Use the Round 1 answer plus the preloaded identity/profile context to make the options concrete; include a useful option for mutual exchange when both sides matter.`;
+  }
+
+  if (stage === "where") {
+    return `${common}
+### Round 3 of 3: where to look
+Call \`ask_user_question\` immediately. Ask where this connection should be sought, such as a current community, location, online space, event, or no geographic constraint. Only suggest communities already present in the user's preloaded membership context, and never imply that this question changes membership.`;
+  }
+
+  if (stage === "proposal") {
+    return `
+## NEW SIGNAL INTAKE (SYNTHESIS)
+The guided intake has completed its blocking question rounds. Do not ask another question. Combine the user's answers with the preloaded identity/profile context into one clear, specific signal describing who they want to meet, what they bring or need, and where to look. Call \`create_intent\` now with that description (and only an existing-membership networkId if the user explicitly selected one). The tool is proposal-only: never persist or auto-approve. Pass the tool-produced \`\`\`intent_proposal\`\`\` block through verbatim and do not invent one.`;
+  }
+
+  return `
+## NEW SIGNAL INTAKE (COMPLETE)
+The proposal tool has already been called. Do not call it again or create a second signal. Pass the tool-produced \`\`\`intent_proposal\`\`\` block through verbatim, then briefly confirm that the user can approve or skip it.`;
+}
+
 /**
  * Builds the restricted Signal Agent system prompt.
  *
@@ -9,12 +102,12 @@ import type { IterationContext } from "./chat.prompt.modules.js";
  * are deliberately outside this persona and are not advertised here.
  *
  * @param ctx - Resolved user and scope context
- * @param _iterCtx - Agent-loop iteration context (reserved for future nudges)
+ * @param iterCtx - Agent-loop iteration context used for the New Signal kickoff
  * @returns The complete Signal Agent system prompt
  */
 export function buildSignalSystemContent(
   ctx: ResolvedToolContext,
-  _iterCtx?: IterationContext,
+  iterCtx?: IterationContext,
 ): string {
   const userContext = JSON.stringify(ctx.user, null, 2);
   const profileContext = ctx.userProfile
@@ -56,5 +149,5 @@ ${userContext}
 ${profileContext}
 \`\`\`
 
-Only the identity and profile context above are preloaded. Ground every claim about signals, placements, memberships, or premises in a tool result from this conversation. When calling a tool, briefly tell the user what you are checking or changing, then perform the call.`;
+Only the identity and profile context above are preloaded. Ground every claim about signals, placements, memberships, or premises in a tool result from this conversation. When calling a tool, briefly tell the user what you are checking or changing, then perform the call.${buildSignalIntakeGuidance(getSignalIntakeStage(iterCtx))}`;
 }

--- a/packages/protocol/src/chat/signal.prompt.ts
+++ b/packages/protocol/src/chat/signal.prompt.ts
@@ -80,7 +80,7 @@ Call \`ask_user_question\` immediately. Ask what the user would bring to this co
   if (stage === "where") {
     return `${common}
 ### Round 3 of 3: where to look
-Call \`ask_user_question\` immediately. Ask where this connection should be sought, such as a current community, location, online space, event, or no geographic constraint. Only suggest communities already present in the user's preloaded membership context, and never imply that this question changes membership.`;
+Call \`ask_user_question\` immediately. Ask where this connection should be sought, such as a current community, location, online space, event, or no geographic constraint. Only suggest communities already present in the preloaded membership list, using their exact titles plus \"Everywhere\"; never invent a community, expose an ID, or imply that this question changes membership.`;
   }
 
   if (stage === "proposal") {
@@ -113,6 +113,15 @@ export function buildSignalSystemContent(
   const profileContext = ctx.userProfile
     ? JSON.stringify(ctx.userProfile, null, 2)
     : "null";
+  const membershipContext = JSON.stringify(
+    ctx.userNetworks.map((network) => ({
+      id: network.networkId,
+      title: network.networkTitle,
+      isPersonal: network.isPersonal,
+    })),
+    null,
+    2,
+  );
 
   return `You are Signal Agent, the private signals and profile assistant for ${ctx.userName}.
 
@@ -149,5 +158,10 @@ ${userContext}
 ${profileContext}
 \`\`\`
 
-Only the identity and profile context above are preloaded. Ground every claim about signals, placements, memberships, or premises in a tool result from this conversation. When calling a tool, briefly tell the user what you are checking or changing, then perform the call.${buildSignalIntakeGuidance(getSignalIntakeStage(iterCtx))}`;
+### Current network memberships (preloaded, read-only)
+\`\`\`json
+${membershipContext}
+\`\`\`
+
+Only the identity, profile, and current membership context above are preloaded. Ground every claim about signals, placements, memberships, or premises in a tool result from this conversation. When calling a tool, briefly tell the user what you are checking or changing, then perform the call.${buildSignalIntakeGuidance(getSignalIntakeStage(iterCtx))}`;
 }

--- a/packages/protocol/src/chat/tests/signal.persona.spec.ts
+++ b/packages/protocol/src/chat/tests/signal.persona.spec.ts
@@ -5,7 +5,7 @@ import { describe, expect, it, mock } from "bun:test";
 
 import { ORCHESTRATOR_PERSONA, ORCHESTRATOR_PERSONA_ID } from "../chat.persona.js";
 import { SIGNAL_PERSONA, SIGNAL_PERSONA_ID, SIGNAL_TOOL_NAMES, filterSignalTools, narrowSignalTools } from "../signal.persona.js";
-import { buildSignalSystemContent } from "../signal.prompt.js";
+import { buildSignalSystemContent, getSignalIntakeStage, isSignalNewSignalKickoff, SIGNAL_NEW_SIGNAL_KICKOFF } from "../signal.prompt.js";
 import type { ChatTools, ResolvedToolContext } from "../../shared/agent/tool.factory.js";
 import type { SystemDatabase, UserDatabase } from "../../shared/interfaces/database.interface.js";
 
@@ -222,6 +222,71 @@ describe("SIGNAL_PERSONA", () => {
     expect(SIGNAL_PERSONA.buildSystemContent(ctx, { iteration: 1 } as never)).toBe(
       buildSignalSystemContent(ctx),
     );
+  });
+});
+
+describe("guided New Signal intake", () => {
+  const context = makeContext();
+  const iteration = (recentTools: Array<{ name: string; args?: Record<string, unknown> }> = []) => ({
+    currentMessage: SIGNAL_NEW_SIGNAL_KICKOFF,
+    recentTools: recentTools.map((toolCall) => ({ name: toolCall.name, args: toolCall.args ?? {} })),
+    ctx: context,
+  });
+
+  it("recognizes only the New Signal kickoff aliases", () => {
+    expect(isSignalNewSignalKickoff(SIGNAL_NEW_SIGNAL_KICKOFF)).toBe(true);
+    expect(isSignalNewSignalKickoff("START A NEW SIGNAL")).toBe(true);
+    expect(isSignalNewSignalKickoff("please tell me about my new signal")).toBe(false);
+  });
+
+  it("advances through three blocking rounds and then proposal synthesis", () => {
+    expect(getSignalIntakeStage(iteration())).toBe("who");
+    expect(getSignalIntakeStage(iteration([{ name: "ask_user_question" }]))).toBe("contribution");
+    expect(getSignalIntakeStage(iteration([
+      { name: "ask_user_question" },
+      { name: "ask_user_question" },
+    ]))).toBe("where");
+    expect(getSignalIntakeStage(iteration([
+      { name: "ask_user_question" },
+      { name: "ask_user_question" },
+      { name: "ask_user_question" },
+    ]))).toBe("proposal");
+    expect(getSignalIntakeStage(iteration([
+      { name: "ask_user_question" },
+      { name: "ask_user_question" },
+      { name: "ask_user_question" },
+      { name: "create_intent" },
+    ]))).toBe("complete");
+  });
+
+  it("instructs the live Signal Agent to ask personalized blocking questions", () => {
+    const prompt = buildSignalSystemContent(context, iteration());
+    expect(prompt).toContain("NEW SIGNAL INTAKE (ACTIVE)");
+    expect(prompt).toContain("Round 1 of 3: who they want to meet");
+    expect(prompt).toContain("ask_user_question");
+    expect(prompt).toContain("preloaded identity/profile context");
+    expect(prompt).toContain("Product builder in Berlin");
+  });
+
+  it("moves from contribution to location and then emits the existing proposal", () => {
+    const contribution = buildSignalSystemContent(context, iteration([{ name: "ask_user_question" }]));
+    expect(contribution).toContain("what they bring and where the gap is");
+
+    const where = buildSignalSystemContent(context, iteration([
+      { name: "ask_user_question" },
+      { name: "ask_user_question" },
+    ]));
+    expect(where).toContain("Round 3 of 3: where to look");
+    expect(where).toContain("Only suggest communities already present");
+
+    const proposal = buildSignalSystemContent(context, iteration([
+      { name: "ask_user_question" },
+      { name: "ask_user_question" },
+      { name: "ask_user_question" },
+    ]));
+    expect(proposal).toContain("Call `create_intent` now");
+    expect(proposal).toContain("```intent_proposal");
+    expect(proposal).toContain("proposal-only");
   });
 });
 

--- a/packages/protocol/src/index.ts
+++ b/packages/protocol/src/index.ts
@@ -95,6 +95,7 @@ export { NEGOTIATOR_PERSONA_ID, createNegotiatorPersona } from "./chat/negotiato
 export {
   SIGNAL_PERSONA_ID,
   SIGNAL_PERSONA,
+  SIGNAL_NEW_SIGNAL_KICKOFF,
   SIGNAL_TOOL_NAMES,
   createSignalTools,
   filterSignalTools,


### PR DESCRIPTION
Closes IND-474

## Summary
- Adds a live Signal Agent New Signal kickoff with three blocking, profile- and membership-aware question rounds before proposal-only intent creation.
- Adds `/i/new` full-screen guided Signal intake with progress, answered-step summary, typing state, live `user_question` handling, safe membership-only network confirmation, and existing intent confirmation/undo behavior.
- Adds the home “Who are you trying to meet?” entry CTA while preserving the `WEB_SIGNAL_AGENT_ENABLED` flag boundary and existing Signal allowlist.

## Verification
- `cd packages/protocol && bun test src/chat/tests/signal.persona.spec.ts`
- `cd packages/protocol && bun run build`
- `cd services/api && bun test src/controllers/tests/chat.signal.spec.ts src/lib/tests/signal-feature.spec.ts`
- `cd apps/web && bun run test tests/ai-chat-context-signal.test.tsx tests/guided-signal-flow.test.tsx` (20 passed)
- `cd apps/web && bun run build`
- `cd apps/web && bun run lint` (0 errors; existing warnings remain)

## Manual acceptance
With `WEB_SIGNAL_AGENT_ENABLED` on, click “Who are you trying to meet?” on home, answer the live Signal Agent’s three question cards, confirm the proposal, and verify navigation to `/i/:intentId`. With the flag off, `/i/new` redirects home and the existing composer behavior remains unchanged.
