### PR TITLE
feat(web): persist answered-question log in signal workspace (IND-472)

### DIFF
--- a/apps/web/CHANGELOG.md
+++ b/apps/web/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
 
 ### Added
 
+- Persisted the signal workspace's answered question log across visits, with server-backed answers, optimistic deduplication, and clearer pending-question copy (IND-472).
+
 - Added the default-off Signal Agent main-web cutover (IND-449): every main-web continuation uses the dedicated Signal transport, legacy orchestrator history stays readable with all mutation controls disabled, and successful intent proposal confirmation navigates to the exact returned signal ID with truthful async undo behavior. Confirmations have per-proposal ownership and are bound to their originating route, in-memory session, and navigation generation, so concurrent cards in one chat complete independently while stale success or failure reports a safe non-actionable notification without mutating or navigating the newer chat. Request-local stream/load ownership prevents stale responses from overwriting newer chats, and typed policy refusals remain actionable in both home and loaded-chat states. CLI browser auth now uses an explicit state-bound v2 contract and a project-JWT-authenticated, fixed-shape CLI credential endpoint, while a temporary fail-closed v1 bridge mints separately tagged API keys for already-released clients without redirecting browser JWT compatibility back to the orchestrator.
 
 - Added a neutral, informational empty state to the intent-page Questions surfaces (IND-439 visibility-audit slice): both the fallback Questions panel and the Personal Agent chat zero-state now explain "No open questions right now — your agent asks when new matches need a decision" instead of leaving an unexplained gap. No warning colors or deprioritization cues.

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@indexnetwork/web",
-  "version": "0.20.0",
+  "version": "0.21.0",
   "license": "MIT",
   "scripts": {
     "dev": "vite --host 127.0.0.1",

--- a/apps/web/src/app/i/[intentId]/page.tsx
+++ b/apps/web/src/app/i/[intentId]/page.tsx
@@ -17,7 +17,7 @@ import { useOpportunityActions } from "@/hooks/useOpportunityActions";
 import { useIntentVisitPing } from "@/hooks/useIntentVisitPing";
 import type { HomeViewCardItem, OpportunityLifecycleStatus } from "@/services/opportunities";
 import type { IntentLifecycleStatus, MutableIntentLifecycleStatus } from "@/services/intents";
-import type { AnswerBody, PendingQuestion } from "@/services/questions";
+import type { AnswerBody, PendingQuestion, QuestionAnswer } from "@/services/questions";
 import { cn } from "@/lib/utils";
 
 /** Raw opportunity status -> radar display bucket (mirrors the Hermes dashboard). */
@@ -53,6 +53,28 @@ function normalizeIntentLifecycleStatus(status: unknown): IntentLifecycleStatus 
     return status;
   }
   return "ACTIVE";
+}
+
+interface AnsweredThreadEntry {
+  id: string;
+  prompt: string;
+  response: string;
+  answeredAt?: string;
+}
+
+function formatAnswer(selectedOptions: string[], freeText?: string): string {
+  return [...selectedOptions, freeText?.trim() ?? ""].filter(Boolean).join(", ");
+}
+
+function toAnsweredThreadEntry(question: PendingQuestion): AnsweredThreadEntry | null {
+  const answer: QuestionAnswer | null = question.answer;
+  if (!answer) return null;
+  return {
+    id: question.id,
+    prompt: question.payload.prompt,
+    response: formatAnswer(answer.selectedOptions, answer.freeText),
+    answeredAt: answer.answeredAt,
+  };
 }
 
 /** Compact relative time for the answered thread, e.g. "just now", "2d ago". */
@@ -306,14 +328,7 @@ export default function IntentDetailPage() {
     [clearReactionTimers],
   );
   // Conversation thread: answered questions kept in view (oldest first).
-  const [answered, setAnswered] = useState<
-    Array<{
-      id: string;
-      prompt?: string;
-      response: string;
-      answeredAt?: string;
-    }>
-  >([]);
+  const [answered, setAnswered] = useState<AnsweredThreadEntry[]>([]);
   // Chat-style conversation column: scrolls internally, pinned to the bottom so
   // the newest question is always in view above the composer.
   const conversationRef = useRef<HTMLDivElement>(null);
@@ -377,6 +392,41 @@ export default function IntentDetailPage() {
       });
     } catch {
       // Best-effort refresh; keep already-rendered questions on failure.
+    }
+  }, [intentId, questionsService]);
+
+  const loadAnswered = useCallback(async () => {
+    if (!intentId) return;
+    try {
+      const res = await questionsService.getAnswered({
+        scopeType: "intent",
+        scopeId: intentId,
+      });
+      if (activeIntentIdRef.current !== intentId) return;
+      const serverEntries = res
+        .map(toAnsweredThreadEntry)
+        .filter((entry): entry is AnsweredThreadEntry => entry !== null);
+      const serverIds = new Set(serverEntries.map((entry) => entry.id));
+      setAnswered((current) => {
+        const merged = [
+          ...serverEntries,
+          ...current.filter((entry) => !serverIds.has(entry.id)),
+        ];
+        const unchanged =
+          merged.length === current.length &&
+          merged.every((entry, index) => {
+            const previous = current[index];
+            return (
+              previous?.id === entry.id &&
+              previous.prompt === entry.prompt &&
+              previous.response === entry.response &&
+              previous.answeredAt === entry.answeredAt
+            );
+          });
+        return unchanged ? current : merged;
+      });
+    } catch {
+      // Best-effort hydration; keep optimistic entries on failure.
     }
   }, [intentId, questionsService]);
 
@@ -446,11 +496,12 @@ export default function IntentDetailPage() {
         if (active) setIntentLoading(false);
       });
     void loadQuestions();
+    void loadAnswered();
     void loadOpportunities();
     return () => {
       active = false;
     };
-  }, [intentId, intentsService, loadQuestions, loadOpportunities]);
+  }, [intentId, intentsService, loadQuestions, loadAnswered, loadOpportunities]);
 
   const refreshWorkspaceAfterReaction = useCallback((includeQuestions: boolean) => {
     setNegotiatorRefreshVersion((version) => version + 1);
@@ -570,18 +621,18 @@ export default function IntentDetailPage() {
       await questionsService.answer(questionId, body);
       // Keep the answered exchange visible in the conversation thread.
       if (answered) {
-        const response = body.freeText?.trim() || body.selectedOptions.join(", ");
         setAnswered((prev) => [
-          ...prev,
+          ...prev.filter((entry) => entry.id !== questionId),
           {
             id: questionId,
             prompt: answered.payload.prompt,
-            response,
+            response: formatAnswer(body.selectedOptions, body.freeText),
             answeredAt: new Date().toISOString(),
           },
         ]);
       }
       setQuestions((prev) => prev.filter((q) => q.id !== questionId));
+      void loadAnswered();
       void refreshQuestionCounts();
       // Chain once per answer: a pool_discovery answer may have synchronously
       // produced a follow-up question — refetch shortly and append it.
@@ -618,7 +669,7 @@ export default function IntentDetailPage() {
         }, 1200);
       }
     },
-    [questions, questionsService, intentId, refreshQuestionCounts, scheduleBoundedWorkspaceRefresh],
+    [questions, questionsService, intentId, loadAnswered, refreshQuestionCounts, scheduleBoundedWorkspaceRefresh],
   );
 
   const handleDismiss = useCallback(
@@ -886,7 +937,7 @@ export default function IntentDetailPage() {
                                 />
                               </video>
                               <p className="max-w-[19rem] text-[13px] leading-relaxed text-gray-400">
-                                Your agent is negotiating. Nothing needs you yet.
+                                no pending questions right now.
                               </p>
                             </div>
                           )}
@@ -909,6 +960,9 @@ export default function IntentDetailPage() {
                                     <span className="text-gray-400">›</span>
                                     <span>{a.response}</span>
                                   </p>
+                                  <p className="mt-1 text-[12px] text-gray-400">
+                                    noted — updating the search.
+                                  </p>
                                 </div>
                               ))}
                             </div>
@@ -919,6 +973,7 @@ export default function IntentDetailPage() {
                               onAnswer={handleAnswer}
                               onDismiss={handleDismiss}
                               showTypingIndicator={questionChainPending}
+                              showAskedKicker
                             />
                           )}
                         </div>

--- a/apps/web/src/components/InjectedQuestions/InjectedQuestions.tsx
+++ b/apps/web/src/components/InjectedQuestions/InjectedQuestions.tsx
@@ -8,9 +8,15 @@ interface InjectedQuestionCardProps {
   question: PendingQuestion;
   onAnswer: (questionId: string, body: AnswerBody) => Promise<void>;
   onDismiss: (questionId: string) => Promise<void>;
+  showAskedKicker?: boolean;
 }
 
-function InjectedQuestionCard({ question, onAnswer, onDismiss }: InjectedQuestionCardProps) {
+function InjectedQuestionCard({
+  question,
+  onAnswer,
+  onDismiss,
+  showAskedKicker = false,
+}: InjectedQuestionCardProps) {
   const [selectedLabels, setSelectedLabels] = useState<string[]>([]);
   const [otherText, setOtherText] = useState('');
   const [otherSelected, setOtherSelected] = useState(false);
@@ -57,6 +63,11 @@ function InjectedQuestionCard({ question, onAnswer, onDismiss }: InjectedQuestio
 
   return (
     <div className="rounded-lg border border-gray-200 bg-white p-5">
+      {showAskedKicker && (
+        <p className="mb-2 text-xs uppercase tracking-wider text-gray-500 font-ibm-plex-mono">
+          ASKED JUST NOW
+        </p>
+      )}
       {payload.evidence && (
         <div className="mb-2">
           <span
@@ -161,6 +172,8 @@ interface InjectedQuestionsProps {
   onDismiss: (questionId: string) => Promise<void>;
   /** Show a typing indicator below the cards (follow-up may be incoming). */
   showTypingIndicator?: boolean;
+  /** Render the intent-workspace-only pending-question kicker. */
+  showAskedKicker?: boolean;
 }
 
 export function InjectedQuestions({
@@ -168,6 +181,7 @@ export function InjectedQuestions({
   onAnswer,
   onDismiss,
   showTypingIndicator,
+  showAskedKicker,
 }: InjectedQuestionsProps) {
   if (questions.length === 0 && !showTypingIndicator) return null;
 
@@ -179,6 +193,7 @@ export function InjectedQuestions({
           question={q}
           onAnswer={onAnswer}
           onDismiss={onDismiss}
+          showAskedKicker={showAskedKicker}
         />
       ))}
       {showTypingIndicator && <TypingDots />}

--- a/apps/web/src/services/questions.ts
+++ b/apps/web/src/services/questions.ts
@@ -61,8 +61,17 @@ export interface PendingQuestion {
   conversationId: string | null;
 }
 
+export type AnsweredQuestion = Omit<PendingQuestion, 'status' | 'answer'> & {
+  status: 'answered';
+  answer: QuestionAnswer;
+};
+
 export interface QuestionsListResponse {
   questions: PendingQuestion[];
+}
+
+export interface AnsweredQuestionsListResponse {
+  questions: AnsweredQuestion[];
 }
 
 export interface PendingQuestionCounts {
@@ -111,6 +120,18 @@ export const createQuestionsService = (
     if (filters?.noConversation) params.set('noConversation', 'true');
     if (filters?.excludeModes?.length) params.set('excludeModes', filters.excludeModes.join(','));
     const res = await api.get<QuestionsListResponse>(`/questions?${params}`);
+    return res.questions ?? [];
+  },
+
+  /** Fetch answered questions for an intent-scoped conversation log. */
+  getAnswered: async (filters?: {
+    scopeType?: 'intent';
+    scopeId?: string;
+  }): Promise<AnsweredQuestion[]> => {
+    const params = new URLSearchParams({ status: 'answered' });
+    if (filters?.scopeType) params.set('scopeType', filters.scopeType);
+    if (filters?.scopeId) params.set('scopeId', filters.scopeId);
+    const res = await api.get<AnsweredQuestionsListResponse>(`/questions?${params}`);
     return res.questions ?? [];
   },
 

--- a/apps/web/tests/intent-page-lifecycle.test.tsx
+++ b/apps/web/tests/intent-page-lifecycle.test.tsx
@@ -4,6 +4,7 @@ import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
 
 import IntentDetailPage from '@/app/i/[intentId]/page';
 import { createIntentsService } from '@/services/intents';
+import { createQuestionsService } from '@/services/questions';
 
 const mocks = vi.hoisted(() => {
   const intent: {
@@ -26,6 +27,7 @@ const mocks = vi.hoisted(() => {
   const refineIntent = vi.fn();
   const getHomeView = vi.fn();
   const getPending = vi.fn();
+  const getAnswered = vi.fn();
   const answerQuestion = vi.fn();
   const dismissQuestion = vi.fn();
 
@@ -37,6 +39,7 @@ const mocks = vi.hoisted(() => {
     refineIntent,
     getHomeView,
     getPending,
+    getAnswered,
     answerQuestion,
     dismissQuestion,
     notificationError: vi.fn(),
@@ -44,6 +47,7 @@ const mocks = vi.hoisted(() => {
     opportunitiesService: { getHomeView },
     questionsService: {
       getPending,
+      getAnswered,
       answer: answerQuestion,
       dismiss: dismissQuestion,
     },
@@ -150,6 +154,7 @@ describe('Intent detail lifecycle', () => {
         items: [{ opportunityId: 'opportunity-1', status: 'pending' }],
       }],
     });
+    mocks.getAnswered.mockResolvedValue([]);
     mocks.getPending.mockResolvedValue([{
       id: 'question-1',
       title: 'Which region?',
@@ -171,6 +176,39 @@ describe('Intent detail lifecycle', () => {
 
   afterEach(() => {
     vi.useRealTimers();
+  });
+
+  test('hydrates the answered Q&A log from the server', async () => {
+    mocks.getPending.mockResolvedValue([]);
+    mocks.getAnswered.mockResolvedValue([{
+      id: 'answered-1',
+      payload: {
+        title: 'What kind of collaborator?',
+        prompt: 'What kind of collaborator?',
+        options: [],
+        multiSelect: false,
+      },
+      answer: {
+        selectedOptions: ['Technical founder', 'Climate operator'],
+        freeText: 'in Europe',
+        answeredBy: 'user-1',
+        answeredAt: new Date().toISOString(),
+      },
+      status: 'answered',
+    }]);
+    renderIntentPage();
+
+    expect(await screen.findByText('What kind of collaborator?')).toBeInTheDocument();
+    expect(screen.getByText('Technical founder, Climate operator, in Europe')).toBeInTheDocument();
+    expect(screen.getByText('noted — updating the search.')).toBeInTheDocument();
+  });
+
+  test('renders the questions empty state when there are no pending questions', async () => {
+    mocks.getPending.mockResolvedValue([]);
+    mocks.getAnswered.mockResolvedValue([]);
+    renderIntentPage();
+
+    expect(await screen.findByText('no pending questions right now.')).toBeInTheDocument();
   });
 
   test('ACTIVE renders live discovery, Pause, and the existing workspace', async () => {
@@ -395,6 +433,14 @@ describe('Intent detail lifecycle', () => {
 });
 
 describe('intent lifecycle service', () => {
+  test('fetches answered questions scoped to the intent', async () => {
+    const get = vi.fn().mockResolvedValue({ questions: [] });
+    const service = createQuestionsService({ get } as never);
+
+    await expect(service.getAnswered({ scopeType: 'intent', scopeId: 'intent-1' })).resolves.toEqual([]);
+    expect(get).toHaveBeenCalledWith('/questions?status=answered&scopeType=intent&scopeId=intent-1');
+  });
+
   test('PATCHes the lifecycle endpoint and returns the authoritative response', async () => {
     const patch = vi.fn().mockResolvedValue({
       success: true,

--- a/apps/web/tests/intent-page-negotiator.test.tsx
+++ b/apps/web/tests/intent-page-negotiator.test.tsx
@@ -89,6 +89,7 @@ vi.mock('@/contexts/APIContext', () => ({
         createdAt: new Date().toISOString(),
       },
     ]),
+    getAnswered: vi.fn().mockResolvedValue([]),
     answer: vi.fn(),
     dismiss: vi.fn(),
   }),

--- a/apps/web/tests/pool-discovery-questions.test.tsx
+++ b/apps/web/tests/pool-discovery-questions.test.tsx
@@ -21,6 +21,7 @@ const mocks = vi.hoisted(() => ({
   },
   questionsService: {
     getPending: vi.fn(),
+    getAnswered: vi.fn(),
     answer: vi.fn(),
     dismiss: vi.fn(),
   },
@@ -192,6 +193,7 @@ describe('intent page — pending question count badge', () => {
   beforeEach(() => {
     vi.clearAllMocks();
     primePageServices();
+    mocks.questionsService.getAnswered.mockResolvedValue([]);
     mocks.authState.features = { negotiatorChat: true };
   });
 
@@ -219,9 +221,43 @@ describe('intent page — interview-mode chaining', () => {
   beforeEach(() => {
     vi.clearAllMocks();
     primePageServices();
+    mocks.questionsService.getAnswered.mockResolvedValue([]);
     // Flag off → the static Questions panel renders the real InjectedQuestions.
     mocks.authState.features = null;
     mocks.questionsService.answer.mockResolvedValue({ success: true });
+  });
+
+  test('after answering, the optimistic log is replaced by one server-backed entry', async () => {
+    const question = makePoolQuestion({ id: 'q-pool-1', prompt: 'What matters more in a co-founder?' });
+    mocks.questionsService.getPending.mockResolvedValue([question]);
+    mocks.questionsService.getAnswered
+      .mockResolvedValueOnce([])
+      .mockResolvedValue([{
+        ...question,
+        status: 'answered',
+        answer: {
+          selectedOptions: ['Server answer'],
+          answeredBy: 'user-1',
+          answeredAt: new Date().toISOString(),
+        },
+      }]);
+
+    const { container } = renderIntentPage();
+    await screen.findByText('What matters more in a co-founder?');
+
+    fireEvent.click(container.querySelector('input[value="Both matter"]') as HTMLInputElement);
+    fireEvent.click(screen.getByRole('button', { name: 'Submit' }));
+
+    await waitFor(() =>
+      expect(mocks.questionsService.answer).toHaveBeenCalledWith('q-pool-1', {
+        selectedOptions: ['Both matter'],
+      }),
+    );
+    expect(await screen.findByText('noted — updating the search.')).toBeInTheDocument();
+    expect(screen.getAllByText('What matters more in a co-founder?')).toHaveLength(1);
+    expect(screen.getByText('Server answer')).toBeInTheDocument();
+    expect(screen.queryByText('Both matter')).toBeNull();
+    expect(mocks.questionsService.getAnswered).toHaveBeenCalledTimes(2);
   });
 
   test('after answering a pool_discovery question, refetches once and appends the follow-up', async () => {


### PR DESCRIPTION
## What / why
- Fetch intent-scoped answered questions from the authoritative API and hydrate the signal workspace Q&A log on load.
- Keep optimistic answers visible while deduplicating server refreshes with server data winning.
- Polish the Questions column empty state and pending-card kicker without changing Radar or header presentation.
- Bump `@indexnetwork/web` to 0.21.0 and document the change.

## Test evidence
- `cd apps/web && bun run test tests/intent-page-lifecycle.test.tsx tests/intent-page-negotiator.test.tsx tests/pool-discovery-questions.test.tsx` — 3 files, 24 tests passed.
- `cd apps/web && bun run build` — passed (existing Vite warnings only).
- `cd apps/web && bun run lint` — passed with existing warnings, 0 errors.

Closes IND-472