### PR TITLE
feat: Discover home warming state and header totals (IND-473)

### DIFF
--- a/apps/web/CHANGELOG.md
+++ b/apps/web/CHANGELOG.md
@@ -9,6 +9,9 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
 
 ### Added
 
+- Polished the signal-first Discover home (IND-473): header totals show listed signals and waiting opportunities, fresh signals display a WARMING state while discovery runs, and the list includes network scope, clamped titles, and the conversational new-signal CTA.
+
+
 - Persisted the signal workspace's answered question log across visits, with server-backed answers, optimistic deduplication, and clearer pending-question copy (IND-472).
 
 - Added the default-off Signal Agent main-web cutover (IND-449): every main-web continuation uses the dedicated Signal transport, legacy orchestrator history stays readable with all mutation controls disabled, and successful intent proposal confirmation navigates to the exact returned signal ID with truthful async undo behavior. Confirmations have per-proposal ownership and are bound to their originating route, in-memory session, and navigation generation, so concurrent cards in one chat complete independently while stale success or failure reports a safe non-actionable notification without mutating or navigating the newer chat. Request-local stream/load ownership prevents stale responses from overwriting newer chats, and typed policy refusals remain actionable in both home and loaded-chat states. CLI browser auth now uses an explicit state-bound v2 contract and a project-JWT-authenticated, fixed-shape CLI credential endpoint, while a temporary fail-closed v1 bridge mints separately tagged API keys for already-released clients without redirecting browser JWT compatibility back to the orchestrator.

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@indexnetwork/web",
-  "version": "0.21.0",
+  "version": "0.22.0",
   "license": "MIT",
   "scripts": {
     "dev": "vite --host 127.0.0.1",

--- a/apps/web/src/components/DiscoverHome.tsx
+++ b/apps/web/src/components/DiscoverHome.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState, useCallback } from "react";
+import { useEffect, useState, useCallback, useRef } from "react";
 import { useNavigate } from "react-router";
 import { Plus } from "lucide-react";
 
@@ -21,6 +21,7 @@ interface HomeIntent {
   waitingOpportunityCount?: number;
   pendingQuestionCount?: number;
   status?: string;
+  warming?: boolean;
 }
 
 /**
@@ -33,26 +34,34 @@ export default function DiscoverHome() {
   const { error: showError } = useNotifications();
   const [intents, setIntents] = useState<HomeIntent[]>([]);
   const [loading, setLoading] = useState(false);
+  const mountedRef = useRef(true);
+
+  const fetchIntents = useCallback(async () => {
+    try {
+      const res = await apiClient.post<{ intents?: HomeIntent[] }>("/intents/list", { page: 1, limit: 100 });
+      if (mountedRef.current) setIntents(res.intents ?? []);
+    } catch (err) {
+      logger.error("Failed to load signals", { error: err });
+      if (mountedRef.current) setIntents([]);
+    }
+  }, []);
 
   useEffect(() => {
-    let active = true;
+    mountedRef.current = true;
     setLoading(true);
-    apiClient
-      .post<{ intents?: HomeIntent[] }>("/intents/list", { page: 1, limit: 100 })
-      .then((res) => {
-        if (active) setIntents(res.intents ?? []);
-      })
-      .catch((err) => {
-        logger.error("Failed to load signals", { error: err });
-        if (active) setIntents([]);
-      })
-      .finally(() => {
-        if (active) setLoading(false);
-      });
+    fetchIntents().finally(() => {
+      if (mountedRef.current) setLoading(false);
+    });
     return () => {
-      active = false;
+      mountedRef.current = false;
     };
-  }, []);
+  }, [fetchIntents]);
+
+  useEffect(() => {
+    if (!intents.some((intent) => intent.warming)) return;
+    const interval = setInterval(fetchIntents, 30_000);
+    return () => clearInterval(interval);
+  }, [fetchIntents, intents]);
 
   const handleArchive = useCallback(
     async (intent: HomeIntent) => {
@@ -75,6 +84,9 @@ export default function DiscoverHome() {
           </h1>
           <DebugCopyButton fetchPath="/debug/home" title="Copy home debug JSON" iconSize="w-5 h-5" />
         </div>
+        <p className="mb-6 text-center text-xs text-gray-400 font-ibm-plex-mono">
+          {intents.length} signals · {intents.reduce((total, intent) => total + (intent.waitingOpportunityCount ?? 0), 0)} opportunities
+        </p>
 
         {/* New signal entry — styled to match IntentList rows */}
         <button
@@ -86,7 +98,7 @@ export default function DiscoverHome() {
             <Plus className="w-4 h-4" strokeWidth={2.5} />
           </span>
           <span className="text-sm font-medium text-gray-900 group-hover:text-black">
-            Start a new signal
+            who are you trying to meet?
           </span>
         </button>
 

--- a/apps/web/src/components/IntentList.tsx
+++ b/apps/web/src/components/IntentList.tsx
@@ -13,6 +13,10 @@ interface BaseIntent {
   sourceName?: string;
   sourceValue?: string | null;
   sourceMeta?: string | null;
+  /** Whether this fresh intent is still awaiting its first discovery run. */
+  warming?: boolean;
+  /** Networks this intent is currently registered to. */
+  networks?: { id: string; title: string }[];
   /**
    * Count of `pending` opportunities anchored on this intent, awaiting the user.
    * Shown next to the date. Undefined/0 renders nothing.
@@ -144,9 +148,14 @@ export default function IntentList<T extends BaseIntent>({
           >
             <div className="flex items-start justify-between gap-4">
               <div className="flex-1 min-w-0">
-                <p className="text-sm text-gray-900 leading-relaxed font-medium">
+                <p className="line-clamp-2 text-sm text-gray-900 leading-relaxed font-medium">
                   {summary}
                 </p>
+                {intent.networks && intent.networks.length > 0 && (
+                  <p className="mt-1 text-[11px] text-gray-400 font-ibm-plex-mono truncate">
+                    {intent.networks.map((network) => network.title).join(' · ')}
+                  </p>
+                )}
                 
                 <div className="flex flex-wrap items-center gap-x-2.5 gap-y-1.5 mt-2.5">
                   {/* Date */}
@@ -157,8 +166,13 @@ export default function IntentList<T extends BaseIntent>({
                     </div>
                   )}
 
-                  {/* Running — active signals are worked in the background */}
-                  {isActive && (
+                  {/* Fresh signals are waiting for their first discovery run. */}
+                  {intent.warming ? (
+                    <span className="text-[10px] tracking-wide font-ibm-plex-mono font-medium uppercase text-amber-700 bg-amber-50 border border-amber-200 px-1.5 py-0.5 rounded">
+                      WARMING
+                    </span>
+                  ) : isActive && (
+                    /* Running — active signals are worked in the background */
                     <div className="flex items-center gap-1.5 text-xs font-medium text-emerald-600 font-ibm-plex-mono">
                       <span className="relative flex h-1.5 w-1.5">
                         <span className="absolute inline-flex h-full w-full animate-ping rounded-full bg-emerald-400 opacity-75" />
@@ -168,8 +182,11 @@ export default function IntentList<T extends BaseIntent>({
                     </div>
                   )}
 
-                  {/* Opportunities — actionable, quiet blue accent. Only when any. */}
-                  {(intent.waitingOpportunityCount ?? 0) > 0 && (
+                  {/* Opportunities — actionable, quiet blue accent. Warming
+                      signals show an explicit unknown value instead. */}
+                  {intent.warming ? (
+                    <span className="text-xs text-gray-400 font-ibm-plex-mono" aria-label="opportunities unknown">—</span>
+                  ) : (intent.waitingOpportunityCount ?? 0) > 0 && (
                     <div
                       className="flex items-center gap-1 text-xs font-medium text-[#4091BB] font-ibm-plex-mono px-2 py-0.5 rounded-full bg-[#4091BB]/10 border border-[#4091BB]/25"
                       title={`${intent.waitingOpportunityCount} ${intent.waitingOpportunityCount === 1 ? 'opportunity' : 'opportunities'} for you`}

--- a/apps/web/tests/discover-home.test.tsx
+++ b/apps/web/tests/discover-home.test.tsx
@@ -1,0 +1,95 @@
+import { render, screen } from '@testing-library/react';
+import { MemoryRouter } from 'react-router';
+import { beforeEach, afterEach, describe, expect, test, vi } from 'vitest';
+
+import DiscoverHome from '@/components/DiscoverHome';
+
+const mocks = vi.hoisted(() => ({
+  apiClient: {
+    post: vi.fn(),
+    patch: vi.fn(),
+    get: vi.fn(),
+  },
+  showError: vi.fn(),
+}));
+
+vi.mock('@/lib/api', () => ({ apiClient: mocks.apiClient }));
+vi.mock('@/contexts/NotificationContext', () => ({
+  useNotifications: () => ({ error: mocks.showError }),
+}));
+
+function renderHome() {
+  return render(
+    <MemoryRouter>
+      <DiscoverHome />
+    </MemoryRouter>,
+  );
+}
+
+const intent = (overrides: Record<string, unknown> = {}) => ({
+  id: 'intent-1',
+  payload: 'Looking for collaborators',
+  summary: 'Looking for collaborators',
+  createdAt: '2026-07-01T00:00:00.000Z',
+  status: 'ACTIVE',
+  warming: false,
+  waitingOpportunityCount: 0,
+  ...overrides,
+});
+
+describe('DiscoverHome', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.apiClient.post.mockResolvedValue({ intents: [] });
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  test('renders header totals from listed signals and their opportunities', async () => {
+    mocks.apiClient.post.mockResolvedValueOnce({
+      intents: [
+        intent({ id: 'intent-1', waitingOpportunityCount: 2 }),
+        intent({ id: 'intent-2', waitingOpportunityCount: 1 }),
+      ],
+    });
+
+    renderHome();
+
+    expect(await screen.findByText('2 signals · 3 opportunities')).toBeInTheDocument();
+  });
+
+  test('renders WARMING and an unknown opportunity count without a live dot', async () => {
+    mocks.apiClient.post.mockResolvedValueOnce({
+      intents: [intent({ warming: true, waitingOpportunityCount: 4 })],
+    });
+
+    renderHome();
+
+    expect(await screen.findByText('WARMING')).toBeInTheDocument();
+    expect(screen.getByLabelText('opportunities unknown')).toHaveTextContent('—');
+    expect(screen.queryByText('live')).not.toBeInTheDocument();
+  });
+
+  test('polling clears WARMING without remounting when discovery completes', async () => {
+    vi.useFakeTimers();
+    mocks.apiClient.post
+      .mockResolvedValueOnce({ intents: [intent({ warming: true })] })
+      .mockResolvedValueOnce({ intents: [intent({ warming: false })] });
+
+    renderHome();
+    await vi.waitFor(() => expect(screen.getByText('WARMING')).toBeInTheDocument());
+
+    await vi.advanceTimersByTimeAsync(30_000);
+    await vi.waitFor(() => expect(mocks.apiClient.post).toHaveBeenCalledTimes(2));
+    await vi.waitFor(() => expect(screen.queryByText('WARMING')).not.toBeInTheDocument());
+    expect(screen.getByText('live')).toBeInTheDocument();
+  });
+
+  test('uses the conversational new-signal CTA copy', async () => {
+    renderHome();
+
+    expect(await screen.findByText('who are you trying to meet?')).toBeInTheDocument();
+  });
+});

--- a/services/api/CHANGELOG.md
+++ b/services/api/CHANGELOG.md
@@ -9,6 +9,9 @@ section before promoting to `main`).
 
 ## [Unreleased]
 
+### Added
+- Expose a read-side `warming` state for fresh owned intents until a succeeded discovery run is recorded (IND-473). The state uses the 24-hour creation window and discovery-run JSON intent linkage without schema or pipeline changes.
+
 ### Fixed
 - Hardened frame-drift scheduler observability (IND-468): startup now reconciles the stable BullMQ job scheduler non-destructively — reading it first, comparing pattern/timezone/name/template-data/attempts/backoff/removal-retention, reusing materially matching schedulers (including overdue `next` values, which previously risked losing the pending iteration to an `upsertJobScheduler` override), upserting only on missing or materially changed definitions, and logging `schedulerAction: created|reused|updated` with the authoritative next timestamp. Every BullMQ attempt is durably tracked in the new privacy-minimized `frame_drift_execution_attempts` table (migration `0097`, unique on `(job_id, attempt)`, no observation-run FK, no vectors/prompts/user-network IDs/raw errors — only an allowlisted failure category), with idempotent start/terminal recording, started-before-flag-before-measurement ordering, redelivery short-circuiting on existing terminal rows, and tracking failures failing the job so measurement never succeeds untracked. Absent attempt rows are unobserved/unknown, not proof BullMQ never enqueued.
 

--- a/services/api/package.json
+++ b/services/api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@indexnetwork/api",
-  "version": "0.47.0",
+  "version": "0.48.0",
   "license": "MIT",
   "private": true,
   "scripts": {

--- a/services/api/src/adapters/database.shared.ts
+++ b/services/api/src/adapters/database.shared.ts
@@ -173,6 +173,8 @@ export interface IntentListRow {
   pendingQuestionCount: number;
   /** Count of `pending` opportunities anchored on this intent, awaiting the user. */
   waitingOpportunityCount: number;
+  /** True while a fresh intent has not completed its first discovery run. */
+  warming: boolean;
 }
 // UserIdentity shape (aligned with `@indexnetwork/protocol`'s UserIdentity; defined
 // locally to honor the adapter layering rule of not importing protocol interfaces).

--- a/services/api/src/adapters/intent.database.adapter.ts
+++ b/services/api/src/adapters/intent.database.adapter.ts
@@ -548,10 +548,11 @@ export class IntentDatabaseAdapter {
   }
 
   /**
-   * Enrich a page of intent list rows with their registered networks plus the
+   * Enrich a page of intent list rows with their registered networks, the
    * per-intent counts the UI surfaces (pending questions, waiting
-   * opportunities). Runs three grouped queries in parallel and joins in memory,
-   * so it stays O(1) round-trips regardless of page size.
+   * opportunities), and the fresh-intent discovery state. Runs three grouped
+   * queries in parallel and joins in memory, so it stays O(1) round-trips
+   * regardless of page size.
    *
    * @param rows - The paginated base intent rows to enrich.
    * @param userId - Owner, used to scope the waiting-opportunity actor match.
@@ -559,21 +560,44 @@ export class IntentDatabaseAdapter {
    *   `waitingOpportunityCount` populated (empty/zero when none).
    */
   private async attachIntentExtras(
-    rows: Omit<IntentListRow, 'networks' | 'pendingQuestionCount' | 'waitingOpportunityCount'>[],
+    rows: Omit<IntentListRow, 'networks' | 'pendingQuestionCount' | 'waitingOpportunityCount' | 'warming'>[],
     userId: string,
   ): Promise<IntentListRow[]> {
     if (rows.length === 0) return [];
     const intentIds = rows.map(r => r.id);
-    const [networks, counts] = await Promise.all([
+    const warmingCutoff = new Date(Date.now() - 24 * 60 * 60 * 1000);
+    const freshIntentIds = rows
+      .filter(r => r.createdAt > warmingCutoff)
+      .map(r => r.id);
+    const [networks, counts, succeededDiscoveryIntentIds] = await Promise.all([
       this.networksByIntent(intentIds),
       this.countsByIntent(intentIds, userId),
+      this.succeededDiscoveryIntentIds(freshIntentIds),
     ]);
+    const succeededIds = new Set(succeededDiscoveryIntentIds);
     return rows.map(r => ({
       ...r,
       networks: networks.get(r.id) ?? [],
       pendingQuestionCount: counts.get(r.id)?.questions ?? 0,
       waitingOpportunityCount: counts.get(r.id)?.opportunities ?? 0,
+      warming: r.createdAt > warmingCutoff && !succeededIds.has(r.id),
     }));
+  }
+
+  /**
+   * Return intent IDs with a completed discovery run. The caller only passes
+   * fresh intents because rows older than the warming window are never warm.
+   */
+  private async succeededDiscoveryIntentIds(intentIds: string[]): Promise<string[]> {
+    if (intentIds.length === 0) return [];
+    const idList = sql.join(intentIds.map(id => sql`${id}`), sql`, `);
+    const rows = await db.execute(sql`
+      SELECT ${schema.opportunityDiscoveryRuns.input}->>'intentId' AS intent_id
+      FROM ${schema.opportunityDiscoveryRuns}
+      WHERE ${schema.opportunityDiscoveryRuns.status} = 'succeeded'
+        AND (${schema.opportunityDiscoveryRuns.input}->>'intentId') = ANY(ARRAY[${idList}]::text[])
+    `) as unknown as Array<{ intent_id: string | null }>;
+    return rows.flatMap(row => row.intent_id ? [row.intent_id] : []);
   }
 
   /**

--- a/services/api/src/controllers/tests/intent.controller.spec.ts
+++ b/services/api/src/controllers/tests/intent.controller.spec.ts
@@ -12,7 +12,7 @@ import { ScopeViolationError } from '../../guards/agent-scope.guard';
 import type { AuthenticatedUser } from "../../guards/auth.guard";
 import db from '../../lib/drizzle/drizzle';
 import { IntentEvents } from '../../events/intent.event';
-import { intentNetworks as intentNetworksTable, intents as intentsTable, networkMembers as networkMembersTable } from '../../schemas/database.schema';
+import { intentNetworks as intentNetworksTable, intents as intentsTable, networkMembers as networkMembersTable, opportunityDiscoveryRuns as opportunityDiscoveryRunsTable } from '../../schemas/database.schema';
 import { IntentNetworkMembershipError } from '../../services/intent.service';
 
 // ═══════════════════════════════════════════════════════════════════════════════
@@ -192,6 +192,47 @@ describe("IntentDatabaseAdapter Integration", () => {
     expect(row).toBeDefined();
     expect(row!.networks).toEqual([]);
   });
+
+  test("listIntents derives warming from fresh intents without a succeeded discovery run", async () => {
+    const freshWarming = await adapter.createIntent({
+      userId: testUserId,
+      payload: 'Fresh intent waiting for discovery',
+      summary: 'Fresh warming intent',
+    });
+    const freshComplete = await adapter.createIntent({
+      userId: testUserId,
+      payload: 'Fresh intent with completed discovery',
+      summary: 'Fresh completed intent',
+    });
+    const oldIntent = await adapter.createIntent({
+      userId: testUserId,
+      payload: 'Old intent without discovery',
+      summary: 'Old intent',
+    });
+    await db.update(intentsTable).set({
+      createdAt: new Date(Date.now() - 25 * 60 * 60 * 1000),
+    }).where(eq(intentsTable.id, oldIntent.id));
+    const [run] = await db.insert(opportunityDiscoveryRunsTable).values({
+      userId: testUserId,
+      status: 'succeeded',
+      input: { intentId: freshComplete.id },
+      context: { userId: testUserId, userName: 'Test User', userEmail: testEmail },
+      completedAt: new Date(),
+      expiresAt: new Date(Date.now() + 60 * 60 * 1000),
+    }).returning({ id: opportunityDiscoveryRunsTable.id });
+
+    try {
+      const { rows } = await adapter.listIntents(testUserId, { page: 1, limit: 100, archived: false });
+      expect(rows.find((row) => row.id === freshWarming.id)?.warming).toBe(true);
+      expect(rows.find((row) => row.id === freshComplete.id)?.warming).toBe(false);
+      expect(rows.find((row) => row.id === oldIntent.id)?.warming).toBe(false);
+    } finally {
+      await db.delete(opportunityDiscoveryRunsTable).where(eq(opportunityDiscoveryRunsTable.id, run.id));
+      for (const intent of [freshWarming, freshComplete, oldIntent]) {
+        await db.delete(intentsTable).where(eq(intentsTable.id, intent.id));
+      }
+    }
+  }, 30_000);
 
   test("listIntents attaches assigned networks and excludes soft-deleted ones", async () => {
     const chatAdapter = new ChatDatabaseAdapter();
@@ -491,12 +532,13 @@ describe("IntentController Integration", () => {
       body: JSON.stringify({ page: 1, limit: 10 }),
     });
     const res = await controller.list(req, mockUser());
-    const data = (await res.json()) as { intents?: unknown[]; pagination?: unknown };
+    const data = (await res.json()) as { intents?: Array<{ id: string; warming?: unknown }>; pagination?: unknown };
 
     expect(res.status).toBe(200);
     expect(Array.isArray(data.intents)).toBe(true);
     expect(data.pagination).toBeDefined();
     expect(data.intents!.length).toBeGreaterThanOrEqual(1);
+    expect(typeof data.intents!.find((intent) => intent.id === testIntentId)?.warming).toBe('boolean');
   });
 
   test("getById should return 404 when intent not found", async () => {


### PR DESCRIPTION
## What / why
- Add viewer-scoped Discover home header totals for listed signals and waiting opportunities.
- Derive and display a `WARMING` state for fresh signals awaiting their first succeeded discovery run.
- Poll warming rows until discovery completes, and polish signal rows with network scope, title clamping, and the conversational CTA.

## Warming derivation
`warming = intent.createdAt > now - 24h && intent has no succeeded discovery run`.
This is read-side only: discovery-run rows outlive the 24-hour window, so old intents are never warming without a schema migration or pipeline change.

## Test evidence
- `cd apps/web && bun run test tests/discover-home.test.tsx` — 4 passed
- `cd services/api && bun test src/controllers/tests/intent.controller.spec.ts --test-name-pattern 'derives warming'` — passed
- `cd services/api && bun run build` — passed
- `cd apps/web && bun run build` — passed
- Full intent controller spec has one existing unrelated context-to-intent candidate-search failure; the new warming test passes independently.

Closes IND-473
