### PR TITLE
fix(web): show answered question log in negotiator chat branch (IND-481)

### DIFF
--- a/apps/web/CHANGELOG.md
+++ b/apps/web/CHANGELOG.md
@@ -23,6 +23,7 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
 
 ### Fixed
 
+- Keep the answered Q&A log visible in the Personal Agent negotiator chat branch after questions are answered (IND-481).
 - Clear stale browser auth sessions automatically when user lookup fails.
 - Show experiment networks such as Edge City in shared profile networks and link them to their network pages.
 - Limit automatic onboarding redirects to the home page so signed-in users can open app routes like `/networks` before finishing setup.

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@indexnetwork/web",
-  "version": "0.22.0",
+  "version": "0.22.1",
   "license": "MIT",
   "scripts": {
     "dev": "vite --host 127.0.0.1",

--- a/apps/web/src/app/i/[intentId]/page.tsx
+++ b/apps/web/src/app/i/[intentId]/page.tsx
@@ -6,6 +6,8 @@ import { Link } from "react-router";
 import ClientLayout from "@/components/ClientLayout";
 import { ContentContainer } from "@/components/layout";
 import OpportunityCard, { OpportunitySkeleton } from "@/components/chat/OpportunityCardInChat";
+import { AnsweredQuestionLog } from "@/components/InjectedQuestions/AnsweredQuestionLog";
+import type { AnsweredThreadEntry } from "@/components/InjectedQuestions/AnsweredQuestionLog";
 import { InjectedQuestions } from "@/components/InjectedQuestions/InjectedQuestions";
 import IntentMemoryStrip from "@/components/IntentMemoryStrip";
 import IntentNegotiatorChat from "@/components/IntentNegotiatorChat";
@@ -55,13 +57,6 @@ function normalizeIntentLifecycleStatus(status: unknown): IntentLifecycleStatus 
   return "ACTIVE";
 }
 
-interface AnsweredThreadEntry {
-  id: string;
-  prompt: string;
-  response: string;
-  answeredAt?: string;
-}
-
 function formatAnswer(selectedOptions: string[], freeText?: string): string {
   return [...selectedOptions, freeText?.trim() ?? ""].filter(Boolean).join(", ");
 }
@@ -75,20 +70,6 @@ function toAnsweredThreadEntry(question: PendingQuestion): AnsweredThreadEntry |
     response: formatAnswer(answer.selectedOptions, answer.freeText),
     answeredAt: answer.answeredAt,
   };
-}
-
-/** Compact relative time for the answered thread, e.g. "just now", "2d ago". */
-function timeAgo(iso?: string): string {
-  if (!iso) return "";
-  const then = new Date(iso).getTime();
-  if (Number.isNaN(then)) return "";
-  const secs = Math.max(0, Math.floor((Date.now() - then) / 1000));
-  if (secs < 60) return "just now";
-  const mins = Math.floor(secs / 60);
-  if (mins < 60) return `${mins}m ago`;
-  const hrs = Math.floor(mins / 60);
-  if (hrs < 24) return `${hrs}h ago`;
-  return `${Math.floor(hrs / 24)}d ago`;
 }
 
 /**
@@ -891,6 +872,7 @@ export default function IntentDetailPage() {
                       key={intentId}
                       intentId={intentId}
                       questions={questions}
+                      answered={answered}
                       onAnswerQuestion={handleAnswer}
                       onDismissQuestion={handleDismiss}
                       questionChainPending={questionChainPending}
@@ -941,32 +923,7 @@ export default function IntentDetailPage() {
                               </p>
                             </div>
                           )}
-                          {answered.length > 0 && (
-                            <div className="flex flex-col gap-3">
-                              {answered.map((a) => (
-                                <div key={a.id} className="px-1">
-                                  {a.prompt && (
-                                    <p className="text-[13px] text-gray-400">
-                                      {a.prompt}
-                                      {a.answeredAt && (
-                                        <span className="text-gray-300">
-                                          {" · "}
-                                          {timeAgo(a.answeredAt)}
-                                        </span>
-                                      )}
-                                    </p>
-                                  )}
-                                  <p className="mt-0.5 flex gap-1.5 text-[13px] text-gray-900 font-ibm-plex-mono">
-                                    <span className="text-gray-400">›</span>
-                                    <span>{a.response}</span>
-                                  </p>
-                                  <p className="mt-1 text-[12px] text-gray-400">
-                                    noted — updating the search.
-                                  </p>
-                                </div>
-                              ))}
-                            </div>
-                          )}
+                          {answered.length > 0 && <AnsweredQuestionLog entries={answered} />}
                           {(questions.length > 0 || questionChainPending) && (
                             <InjectedQuestions
                               questions={questions}

--- a/apps/web/src/components/InjectedQuestions/AnsweredQuestionLog.tsx
+++ b/apps/web/src/components/InjectedQuestions/AnsweredQuestionLog.tsx
@@ -1,0 +1,50 @@
+export interface AnsweredThreadEntry {
+  id: string;
+  prompt: string;
+  response: string;
+  answeredAt?: string;
+}
+
+/** Compact relative time for the answered thread, e.g. "just now", "2d ago". */
+function timeAgo(iso?: string): string {
+  if (!iso) return "";
+  const then = new Date(iso).getTime();
+  if (Number.isNaN(then)) return "";
+  const secs = Math.max(0, Math.floor((Date.now() - then) / 1000));
+  if (secs < 60) return "just now";
+  const mins = Math.floor(secs / 60);
+  if (mins < 60) return `${mins}m ago`;
+  const hrs = Math.floor(mins / 60);
+  if (hrs < 24) return `${hrs}h ago`;
+  return `${Math.floor(hrs / 24)}d ago`;
+}
+
+/** Renders the user's answered question exchanges in the intent conversation. */
+export function AnsweredQuestionLog({ entries }: { entries: AnsweredThreadEntry[] }) {
+  return (
+    <div className="flex flex-col gap-3">
+      {entries.map((entry) => (
+        <div key={entry.id} className="px-1">
+          {entry.prompt && (
+            <p className="text-[13px] text-gray-400">
+              {entry.prompt}
+              {entry.answeredAt && (
+                <span className="text-gray-300">
+                  {" · "}
+                  {timeAgo(entry.answeredAt)}
+                </span>
+              )}
+            </p>
+          )}
+          <p className="mt-0.5 flex gap-1.5 text-[13px] text-gray-900 font-ibm-plex-mono">
+            <span className="text-gray-400">›</span>
+            <span>{entry.response}</span>
+          </p>
+          <p className="mt-1 text-[12px] text-gray-400">
+            noted — updating the search.
+          </p>
+        </div>
+      ))}
+    </div>
+  );
+}

--- a/apps/web/src/components/IntentNegotiatorChat.tsx
+++ b/apps/web/src/components/IntentNegotiatorChat.tsx
@@ -2,6 +2,8 @@ import { useCallback, useEffect, useRef, useState } from "react";
 import { ArrowUp, BotMessageSquare, Square } from "lucide-react";
 
 import { useAIChat } from "@/contexts/AIChatContext";
+import { AnsweredQuestionLog } from "@/components/InjectedQuestions/AnsweredQuestionLog";
+import type { AnsweredThreadEntry } from "@/components/InjectedQuestions/AnsweredQuestionLog";
 import { InjectedQuestions } from "@/components/InjectedQuestions/InjectedQuestions";
 import { QuestionsEmptyState } from "@/components/InjectedQuestions/QuestionsEmptyState";
 import AssistantMessageContent from "@/components/chat/AssistantMessageContent";
@@ -18,6 +20,8 @@ export interface IntentNegotiatorChatProps {
   intentId: string;
   /** Pending questions for the intent — rendered as the chat's opening turns. */
   questions: PendingQuestion[];
+  /** Answered questions retained above the pending opening turns. */
+  answered: AnsweredThreadEntry[];
   onAnswerQuestion: (questionId: string, body: AnswerBody) => Promise<void>;
   onDismissQuestion: (questionId: string) => Promise<void>;
   /**
@@ -57,6 +61,7 @@ export interface IntentNegotiatorChatProps {
 export default function IntentNegotiatorChat({
   intentId,
   questions,
+  answered,
   onAnswerQuestion,
   onDismissQuestion,
   questionChainPending,
@@ -196,7 +201,7 @@ export default function IntentNegotiatorChat({
           </div>
         ) : (
           <>
-            {messages.length === 0 && questions.length === 0 && (
+            {messages.length === 0 && (answered.length > 0 || questions.length === 0) && (
               <div className="flex flex-col gap-3">
                 <div className="flex items-start gap-2 text-sm text-gray-600 font-ibm-plex-mono">
                   <BotMessageSquare className="mt-0.5 h-4 w-4 shrink-0 text-gray-400" />
@@ -206,7 +211,13 @@ export default function IntentNegotiatorChat({
                     behalf.
                   </p>
                 </div>
-                {!questionChainPending && <QuestionsEmptyState />}
+                {answered.length === 0 && !questionChainPending && <QuestionsEmptyState />}
+              </div>
+            )}
+
+            {answered.length > 0 && (
+              <div data-testid="negotiator-answered-log">
+                <AnsweredQuestionLog entries={answered} />
               </div>
             )}
 

--- a/apps/web/tests/intent-negotiator-chat.test.tsx
+++ b/apps/web/tests/intent-negotiator-chat.test.tsx
@@ -80,6 +80,7 @@ function renderChat(overrides: Partial<Parameters<typeof IntentNegotiatorChat>[0
   const props = {
     intentId: 'intent-1',
     questions: [] as PendingQuestion[],
+    answered: [],
     onAnswerQuestion: vi.fn(),
     onDismissQuestion: vi.fn(),
     opportunityStatusMap: {},
@@ -120,6 +121,23 @@ describe('IntentNegotiatorChat', () => {
 
     await screen.findByTestId('negotiator-opening-questions');
     expect(screen.getByTestId('injected-questions').textContent).toContain('Which city should we prioritize?');
+  });
+
+  test('keeps answered history visible without the empty state', async () => {
+    renderChat({
+      answered: [{
+        id: 'answered-1',
+        prompt: 'What should we prioritize?',
+        response: 'Berlin',
+        answeredAt: new Date().toISOString(),
+      }],
+    });
+
+    expect(await screen.findByTestId('negotiator-answered-log')).toBeInTheDocument();
+    expect(screen.getByText('What should we prioritize?')).toBeInTheDocument();
+    expect(screen.getByText('Berlin')).toBeInTheDocument();
+    expect(screen.getByText('noted — updating the search.')).toBeInTheDocument();
+    expect(screen.queryByTestId('questions-empty-state')).toBeNull();
   });
 
   test('falls back via onUnavailable when the bootstrap fails', async () => {

--- a/apps/web/tests/intent-page-negotiator.test.tsx
+++ b/apps/web/tests/intent-page-negotiator.test.tsx
@@ -6,16 +6,33 @@
  * fallback (flag off or runtime bootstrap failure) is the unchanged
  * questions block.
  */
-import { render, screen, waitFor } from '@testing-library/react';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
 import { Route, Routes } from 'react-router';
 import { MemoryRouter } from 'react-router';
 import { beforeEach, describe, expect, test, vi } from 'vitest';
 
 import IntentDetailPage from '@/app/i/[intentId]/page';
+import { AnsweredQuestionLog } from '@/components/InjectedQuestions/AnsweredQuestionLog';
+import type { AnsweredThreadEntry } from '@/components/InjectedQuestions/AnsweredQuestionLog';
 
 const mocks = vi.hoisted(() => ({
   authState: {
     features: null as Record<string, unknown> | null,
+  },
+  questionsService: {
+    getPending: vi.fn(),
+    getAnswered: vi.fn(),
+    answer: vi.fn(),
+    dismiss: vi.fn(),
+  },
+  intentsService: {
+    getIntent: vi.fn(),
+    archiveIntent: vi.fn(),
+    refineIntent: vi.fn(),
+    visitIntent: vi.fn(),
+  },
+  opportunitiesService: {
+    getHomeView: vi.fn(),
   },
   chatStubBehavior: { failBootstrap: false },
 }));
@@ -34,13 +51,40 @@ vi.mock('@/components/InjectedQuestions/InjectedQuestions', () => ({
 }));
 
 vi.mock('@/components/IntentNegotiatorChat', () => ({
-  default: ({ onUnavailable }: { onUnavailable: () => void }) => {
+  default: ({
+    answered = [],
+    onAnswerQuestion,
+    onUnavailable,
+    questions = [],
+  }: {
+    answered?: AnsweredThreadEntry[];
+    onAnswerQuestion: (questionId: string, body: { selectedOptions: string[]; freeText?: string }) => Promise<void>;
+    onUnavailable: () => void;
+    questions?: Array<{ id: string; payload: { prompt: string } }>;
+  }) => {
     if (mocks.chatStubBehavior.failBootstrap) {
       // Simulate a runtime bootstrap failure (e.g. backend flag flipped off).
       setTimeout(onUnavailable, 0);
       return null;
     }
-    return <div data-testid="intent-negotiator-chat-stub" />;
+    return (
+      <div data-testid="intent-negotiator-chat-stub">
+        {answered.length > 0 && (
+          <div data-testid="negotiator-answered-log">
+            <AnsweredQuestionLog entries={answered} />
+          </div>
+        )}
+        {questions.map((question) => (
+          <button
+            key={question.id}
+            type="button"
+            onClick={() => void onAnswerQuestion(question.id, { selectedOptions: ['Berlin'] })}
+          >
+            answer-{question.id}
+          </button>
+        ))}
+      </div>
+    );
   },
 }));
 
@@ -61,38 +105,9 @@ vi.mock('@/contexts/AuthContext', () => ({
 }));
 
 vi.mock('@/contexts/APIContext', () => ({
-  useIntents: () => ({
-    getIntent: vi.fn().mockResolvedValue({
-      id: 'intent-1',
-      payload: 'Looking for a technical co-founder',
-      summary: 'Looking for a technical co-founder',
-      createdAt: new Date().toISOString(),
-    }),
-    archiveIntent: vi.fn(),
-    refineIntent: vi.fn(),
-    visitIntent: vi.fn(async () => {}),
-  }),
-  useOpportunities: () => ({
-    getHomeView: vi.fn().mockResolvedValue({ sections: [] }),
-  }),
-  useQuestionsService: () => ({
-    getPending: vi.fn().mockResolvedValue([
-      {
-        id: 'q-1',
-        title: 'Which city?',
-        prompt: 'Which city?',
-        options: [],
-        multiSelect: false,
-        mode: 'intent',
-        sourceType: 'intent',
-        sourceId: 'intent-1',
-        createdAt: new Date().toISOString(),
-      },
-    ]),
-    getAnswered: vi.fn().mockResolvedValue([]),
-    answer: vi.fn(),
-    dismiss: vi.fn(),
-  }),
+  useIntents: () => mocks.intentsService,
+  useOpportunities: () => mocks.opportunitiesService,
+  useQuestionsService: () => mocks.questionsService,
 }));
 
 
@@ -133,6 +148,35 @@ describe('Intent page — negotiator chat gating', () => {
   beforeEach(() => {
     vi.clearAllMocks();
     mocks.authState.features = null;
+    mocks.intentsService.getIntent.mockResolvedValue({
+      id: 'intent-1',
+      payload: 'Looking for a technical co-founder',
+      summary: 'Looking for a technical co-founder',
+      createdAt: new Date().toISOString(),
+    });
+    mocks.intentsService.visitIntent.mockResolvedValue(undefined);
+    mocks.opportunitiesService.getHomeView.mockResolvedValue({ sections: [] });
+    mocks.questionsService.getPending.mockResolvedValue([
+      {
+        id: 'q-1',
+        title: 'Which city?',
+        prompt: 'Which city?',
+        payload: {
+          prompt: 'Which city?',
+          title: 'Which city?',
+          options: [],
+          multiSelect: false,
+        },
+        options: [],
+        multiSelect: false,
+        mode: 'intent',
+        sourceType: 'intent',
+        sourceId: 'intent-1',
+        createdAt: new Date().toISOString(),
+      },
+    ]);
+    mocks.questionsService.getAnswered.mockResolvedValue([]);
+    mocks.questionsService.answer.mockReset();
     mocks.chatStubBehavior.failBootstrap = false;
   });
 
@@ -154,6 +198,59 @@ describe('Intent page — negotiator chat gating', () => {
     expect(screen.queryByTestId('injected-questions')).toBeNull();
     expect(screen.getByText(/^Personal Agent$/)).toBeInTheDocument();
     expect(screen.queryByText(/^Questions \(/)).toBeNull();
+  });
+
+  test('hydrated answered entries render inside the negotiator branch', async () => {
+    mocks.authState.features = { negotiatorChat: true };
+    mocks.questionsService.getAnswered.mockResolvedValue([{
+      id: 'answered-1',
+      payload: {
+        title: 'What kind of collaborator?',
+        prompt: 'What kind of collaborator?',
+        options: [],
+        multiSelect: false,
+      },
+      answer: {
+        selectedOptions: ['Technical founder'],
+        freeText: 'in Europe',
+        answeredBy: 'user-1',
+        answeredAt: new Date().toISOString(),
+      },
+      status: 'answered',
+    }]);
+    renderIntentPage();
+
+    await waitFor(() => expect(mocks.questionsService.getAnswered).toHaveBeenCalled());
+    expect(await screen.findByTestId('negotiator-answered-log')).toBeInTheDocument();
+    expect(screen.getByText('What kind of collaborator?')).toBeInTheDocument();
+    expect(screen.getByText('Technical founder, in Europe')).toBeInTheDocument();
+  });
+
+  test('answering a pending question keeps prior entries and appends the new answer', async () => {
+    mocks.authState.features = { negotiatorChat: true };
+    mocks.questionsService.getAnswered.mockResolvedValue([{
+      id: 'answered-1',
+      payload: {
+        title: 'What kind of collaborator?',
+        prompt: 'What kind of collaborator?',
+        options: [],
+        multiSelect: false,
+      },
+      answer: {
+        selectedOptions: ['Technical founder'],
+        answeredBy: 'user-1',
+        answeredAt: new Date().toISOString(),
+      },
+      status: 'answered',
+    }]);
+    renderIntentPage();
+
+    expect(await screen.findByText('Technical founder')).toBeInTheDocument();
+    fireEvent.click(screen.getByRole('button', { name: 'answer-q-1' }));
+
+    await waitFor(() => expect(screen.getByText('Berlin')).toBeInTheDocument());
+    expect(screen.getByText('Technical founder')).toBeInTheDocument();
+    expect(mocks.questionsService.answer).toHaveBeenCalledWith('q-1', { selectedOptions: ['Berlin'] });
   });
 
   test('runtime bootstrap failure → falls back to the questions block', async () => {


### PR DESCRIPTION
## Problem
With `features.negotiatorChat === true`, the Personal Agent branch replaced the intent-page questions column and dropped the persistent IND-472 answered Q&A log. Answers therefore disappeared after submission.

## Root cause
The answered state, hydration, and optimistic append already ran for both branches, but the answered-log markup only existed in the fallback questions-column render.

## What changed
- Extracted the shared `AnsweredQuestionLog` presentation component and moved the entry type/time helper alongside it.
- Rendered the shared log in both fallback and negotiator branches, above pending opening questions; answered history also suppresses the negotiator empty state.
- Added hydration and append-retention coverage for the negotiator branch, plus component coverage.
- Bumped `@indexnetwork/web` from 0.22.0 to 0.22.1 and added a changelog entry.

## Test evidence
- `bun run test tests/intent-page-negotiator.test.tsx tests/intent-page-lifecycle.test.tsx tests/pool-discovery-questions.test.tsx tests/intent-negotiator-chat.test.tsx` — 34 tests passed
- `bun run build` — passed (existing Vite warnings only)
- `bun run lint` — passed with existing warnings

Closes IND-481