### PR TITLE
feat: chat signal provenance and match-seeded openers (IND-475)

### DIFF
--- a/apps/web/CHANGELOG.md
+++ b/apps/web/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
 
 ### Added
 
+- Add viewer-scoped `via:` signal chips, client-rendered match-seeded openers, and optional inbox provenance subtitles for human match threads (IND-475).
 - Polished the signal-first Discover home (IND-473): header totals show listed signals and waiting opportunities, fresh signals display a WARMING state while discovery runs, and the list includes network scope, clamped titles, and the conversational new-signal CTA.
 
 

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@indexnetwork/web",
-  "version": "0.22.1",
+  "version": "0.23.0",
   "license": "MIT",
   "scripts": {
     "dev": "vite --host 127.0.0.1",

--- a/apps/web/src/components/ChatSidebar.tsx
+++ b/apps/web/src/components/ChatSidebar.tsx
@@ -14,6 +14,7 @@ interface RecentChat {
   name: string;
   lastMessage: string;
   lastMessageIsInternal: boolean;
+  viaTitle?: string;
   negotiationStatus: NegotiationStatus;
   sortTimestamp: number;
 }
@@ -117,6 +118,7 @@ export default function ChatSidebar() {
       name: conv.metadata?.title ?? peer?.name ?? 'Conversation',
       lastMessage: lastText,
       lastMessageIsInternal: false,
+      viaTitle: conv.via?.[0]?.title,
       negotiationStatus: null,
       sortTimestamp: new Date(conv.lastMessageAt ?? conv.createdAt).getTime(),
     };
@@ -191,6 +193,9 @@ export default function ChatSidebar() {
                       )}
                       <span className="truncate">{chat.name}</span>
                     </p>
+                    {chat.viaTitle && (
+                      <p className="truncate text-[11px] font-ibm-plex-mono text-gray-400">via {chat.viaTitle}</p>
+                    )}
                     <p className="truncate text-sm font-normal text-gray-500">
                       {chat.lastMessageIsInternal && (
                         <span className="mr-1 italic text-gray-400">Internal:</span>

--- a/apps/web/src/components/chat/ChatView.tsx
+++ b/apps/web/src/components/chat/ChatView.tsx
@@ -38,6 +38,7 @@ export default function ChatView({ userId, userName, userAvatar, isGhost = false
   const opportunitiesService = useOpportunities();
   const {
     messages: allMessages,
+    conversations,
     sendMessage: conversationSend,
     loadMessages,
     getOrCreateDM,
@@ -45,6 +46,7 @@ export default function ChatView({ userId, userName, userAvatar, isGhost = false
   } = useConversation();
 
   const [conversationId, setConversationId] = useState<string | null>(initialGroupId ?? null);
+  const [conversationSummary, setConversationSummary] = useState<ReturnType<typeof useConversation>['conversations'][number] | null>(null);
   const [messageText, setMessageText] = useState(autoSend ? '' : (initialMessage ?? ''));
   const hasAutoSentRef = useRef(false);
   const hasFiredFirstMessageRef = useRef(false);
@@ -63,6 +65,7 @@ export default function ChatView({ userId, userName, userAvatar, isGhost = false
     if (prevUserIdRef.current !== userId) {
       prevUserIdRef.current = userId;
       setConversationId(null);
+      setConversationSummary(null);
       setMessagesLoading(true);
       setContextLoading(true);
       setAcceptedOpportunities([]);
@@ -75,6 +78,14 @@ export default function ChatView({ userId, userName, userAvatar, isGhost = false
     () => (conversationId ? allMessages.get(conversationId) ?? [] : []),
     [conversationId, allMessages],
   );
+  const via = conversationSummary?.via ?? [];
+  const latestVia = via[0] ?? null;
+
+  useEffect(() => {
+    if (!conversationId) return;
+    const summary = conversations.find((conversation) => conversation.id === conversationId);
+    if (summary) setConversationSummary(summary);
+  }, [conversationId, conversations]);
 
   useEffect(() => {
     if (!userId) return;
@@ -117,6 +128,7 @@ export default function ChatView({ userId, userName, userAvatar, isGhost = false
         const conv = await getOrCreateDM(userId);
         if (!mounted) return;
         const cid = initialGroupId ?? conv.id;
+        setConversationSummary(conv);
         if (cid && !conversationId) setConversationId(cid);
       } catch (err) {
         logger.error('DM init error', { error: err });
@@ -239,16 +251,26 @@ export default function ChatView({ userId, userName, userAvatar, isGhost = false
       <div className="sticky top-0 bg-white z-10 px-4 py-3 flex items-center justify-between min-h-[68px]">
         <div className="flex items-center gap-3">
           <button onClick={handleBack} className="text-[#3D3D3D] hover:text-black transition-colors text-xl mr-2">&larr;</button>
-          <Link to={`/u/${userId}`} className="flex items-center gap-3 hover:opacity-80 transition-opacity">
+          <div className="flex items-center gap-3">
             <UserAvatar avatar={userAvatar} id={userId} name={userName} size={44} blur={isGhost} />
             <div>
               <h2 className="font-ibm-plex-mono font-bold text-lg text-black flex items-center gap-1.5">
-                {userName}
+                <Link to={`/u/${userId}`} className="hover:opacity-80 transition-opacity">{userName}</Link>
                 {isGhost && <GhostBadge />}
               </h2>
               {isGhost && <p className="text-xs text-gray-400 -mt-0.5">Not yet on Index</p>}
+              {latestVia && (
+                <Link
+                  to={`/i/${latestVia.intentId}`}
+                  title={via.map((entry) => entry.title).join(' · ')}
+                  className="font-ibm-plex-mono text-[11px] text-gray-400 hover:text-gray-700 transition-colors"
+                  onClick={(event) => event.stopPropagation()}
+                >
+                  via: {latestVia.title}
+                </Link>
+              )}
             </div>
-          </Link>
+          </div>
         </div>
         <div className="relative" ref={menuRef}>
           <button onClick={() => setShowMenu(!showMenu)} className="p-2 hover:bg-gray-100 rounded-full transition-colors">
@@ -277,6 +299,10 @@ export default function ChatView({ userId, userName, userAvatar, isGhost = false
           <div className="space-y-4">
             {messagesLoading ? (
               <div className="flex items-center justify-center py-20"><Loader2 className="w-6 h-6 animate-spin text-gray-400" /></div>
+            ) : messages.length === 0 && via.length > 0 ? (
+              <div className="text-center py-5 text-[13px] text-gray-400 font-ibm-plex-mono">
+                agents matched you on this signal — say hi.
+              </div>
             ) : messages.length === 0 && !contextLoading && acceptedOpportunities.length === 0 ? (
               <div className="flex flex-col items-center justify-center py-20 text-[#3D3D3D]">
                 {isGhost ? (

--- a/apps/web/src/contexts/ConversationContext.tsx
+++ b/apps/web/src/contexts/ConversationContext.tsx
@@ -186,8 +186,9 @@ export function ConversationProvider({ children }: { children: React.ReactNode }
     );
     // Add to list if not already present
     setConversations((prev) => {
-      if (prev.some((c) => c.id === data.conversation.id)) return prev;
-      return [data.conversation, ...prev];
+      const existingIndex = prev.findIndex((c) => c.id === data.conversation.id);
+      if (existingIndex < 0) return [data.conversation, ...prev];
+      return prev.map((conversation, index) => index === existingIndex ? data.conversation : conversation);
     });
     return data.conversation;
   }, []);

--- a/apps/web/src/services/conversation.ts
+++ b/apps/web/src/services/conversation.ts
@@ -7,6 +7,8 @@ export interface ConversationSummary {
   participants: { participantId: string; participantType: 'user' | 'agent'; name: string | null; avatar: string | null; ownerName?: string | null }[];
   lastMessage: { parts: unknown[]; senderId: string; createdAt: string } | null;
   metadata: { title?: string; shareToken?: string } | null;
+  /** Viewer-scoped opportunity signal provenance, latest first. */
+  via: Array<{ intentId: string; opportunityId: string; title: string }>;
   lastMessageAt: string | null;
   createdAt: string;
 }

--- a/apps/web/tests/chat-signal-provenance.test.tsx
+++ b/apps/web/tests/chat-signal-provenance.test.tsx
@@ -1,0 +1,104 @@
+import { screen } from '@testing-library/react';
+import { beforeEach, describe, expect, test, vi } from 'vitest';
+
+import ChatView from '@/components/chat/ChatView';
+import { renderWithRouter } from '@/test/test-utils';
+
+const mocks = vi.hoisted(() => ({
+  auth: { user: { id: 'viewer', name: 'Viewer', avatar: null } },
+  conversations: [] as Array<Record<string, unknown>>,
+  messages: new Map<string, Array<Record<string, unknown>>>(),
+  getOrCreateDM: vi.fn(),
+  loadMessages: vi.fn().mockResolvedValue(undefined),
+  getChatContext: vi.fn().mockResolvedValue([]),
+}));
+
+vi.mock('@/contexts/AuthContext', () => ({
+  useAuthContext: () => mocks.auth,
+}));
+
+vi.mock('@/contexts/APIContext', () => ({
+  useOpportunities: () => ({ getChatContext: mocks.getChatContext }),
+}));
+
+vi.mock('@/contexts/ConversationContext', () => ({
+  useConversation: () => ({
+    conversations: mocks.conversations,
+    messages: mocks.messages,
+    sendMessage: vi.fn(),
+    loadMessages: mocks.loadMessages,
+    getOrCreateDM: mocks.getOrCreateDM,
+    hideConversation: vi.fn(),
+  }),
+}));
+
+vi.mock('@/components/UserAvatar', () => ({
+  default: ({ name }: { name: string }) => <span>{name}</span>,
+}));
+
+vi.mock('@/components/GhostBadge', () => ({ default: () => null }));
+
+const props = {
+  userId: 'peer',
+  userName: 'Peer',
+  onClose: vi.fn(),
+};
+
+function summary(via: Array<{ intentId: string; opportunityId: string; title: string }>) {
+  return {
+    id: 'conv-1',
+    participants: [],
+    lastMessage: null,
+    metadata: null,
+    via,
+    lastMessageAt: null,
+    createdAt: new Date().toISOString(),
+  };
+}
+
+beforeEach(() => {
+  mocks.conversations = [summary([])];
+  mocks.messages = new Map();
+  mocks.getOrCreateDM.mockResolvedValue(summary([]));
+  mocks.getChatContext.mockResolvedValue([]);
+});
+
+describe('ChatView match provenance', () => {
+  test('renders the latest via chip linking to the viewer intent and the seeded opener', async () => {
+    const via = [
+      { intentId: 'intent-latest', opportunityId: 'opp-latest', title: 'Latest signal' },
+      { intentId: 'intent-earlier', opportunityId: 'opp-earlier', title: 'Earlier signal' },
+    ];
+    mocks.conversations = [summary(via)];
+    mocks.getOrCreateDM.mockResolvedValue(summary(via));
+
+    renderWithRouter(<ChatView {...props} initialGroupId="conv-1" />);
+
+    const chip = await screen.findByRole('link', { name: 'via: Latest signal' });
+    expect(chip).toHaveAttribute('href', '/i/intent-latest');
+    expect(chip).toHaveAttribute('title', 'Latest signal · Earlier signal');
+    expect(screen.getByText('agents matched you on this signal — say hi.')).toBeInTheDocument();
+  });
+
+  test('removes the seeded opener once a real message exists', async () => {
+    const via = [{ intentId: 'intent-1', opportunityId: 'opp-1', title: 'A signal' }];
+    mocks.conversations = [summary(via)];
+    mocks.getOrCreateDM.mockResolvedValue(summary(via));
+    mocks.messages = new Map([['conv-1', [{
+      id: 'message-1', conversationId: 'conv-1', senderId: 'viewer', role: 'user',
+      parts: [{ text: 'hello' }], createdAt: new Date().toISOString(),
+    }]]]);
+
+    renderWithRouter(<ChatView {...props} initialGroupId="conv-1" />);
+
+    expect(screen.queryByText('agents matched you on this signal — say hi.')).not.toBeInTheDocument();
+  });
+
+  test('does not render provenance UI for a plain DM', async () => {
+    renderWithRouter(<ChatView {...props} initialGroupId="conv-1" />);
+
+    await screen.findByText('Start a conversation with Peer');
+    expect(screen.queryByText(/^via:/)).not.toBeInTheDocument();
+    expect(screen.queryByText('agents matched you on this signal — say hi.')).not.toBeInTheDocument();
+  });
+});

--- a/services/api/CHANGELOG.md
+++ b/services/api/CHANGELOG.md
@@ -10,6 +10,7 @@ section before promoting to `main`).
 ## [Unreleased]
 
 ### Added
+- Record viewer-safe match provenance on start-chat DMs and expose intent-scoped `via` summaries for chat signal provenance (IND-475).
 - Expose a read-side `warming` state for fresh owned intents until a succeeded discovery run is recorded (IND-473). The state uses the 24-hour creation window and discovery-run JSON intent linkage without schema or pipeline changes.
 
 ### Fixed

--- a/services/api/package.json
+++ b/services/api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@indexnetwork/api",
-  "version": "0.48.0",
+  "version": "0.49.0",
   "license": "MIT",
   "private": true,
   "scripts": {

--- a/services/api/src/adapters/chat.database.adapter.ts
+++ b/services/api/src/adapters/chat.database.adapter.ts
@@ -3376,6 +3376,15 @@ export class ChatDatabaseAdapter {
     return conversationAdapter.unhideConversation(userId, conversationId);
   }
 
+  /** Append a deduplicated match provenance entry to a DM metadata sidecar. */
+  async appendMatchProvenance(
+    conversationId: string,
+    provenance: Parameters<ConversationDatabaseAdapter['appendMatchProvenance']>[1],
+  ): Promise<void> {
+    const conversationAdapter = new ConversationDatabaseAdapter();
+    return conversationAdapter.appendMatchProvenance(conversationId, provenance);
+  }
+
   // ─────────────────────────────────────────────────────────────────────────
   // Premises Methods (premise CRUD and network assignment)
   // ─────────────────────────────────────────────────────────────────────────

--- a/services/api/src/adapters/conversation.database.adapter.ts
+++ b/services/api/src/adapters/conversation.database.adapter.ts
@@ -35,6 +35,25 @@ const NEGOTIATOR_SCOPE = { scopeType: 'persona', scopeId: NEGOTIATOR_PERSONA } a
  */
 const NEGOTIATOR_INTENT_SCOPE_TYPE = 'negotiator-intent';
 
+interface MatchProvenanceEntry {
+  opportunityId: string;
+  intents: Array<{ userId: string; intentId: string }>;
+  recordedAt: string;
+}
+
+function isMatchProvenanceEntry(value: unknown): value is MatchProvenanceEntry {
+  if (typeof value !== 'object' || value === null || Array.isArray(value)) return false;
+  const entry = value as Record<string, unknown>;
+  return typeof entry.opportunityId === 'string'
+    && typeof entry.recordedAt === 'string'
+    && Array.isArray(entry.intents)
+    && entry.intents.every((intent) => {
+      if (typeof intent !== 'object' || intent === null || Array.isArray(intent)) return false;
+      const record = intent as Record<string, unknown>;
+      return typeof record.userId === 'string' && typeof record.intentId === 'string';
+    });
+}
+
 export interface CreateNegotiationTaskForAttemptInput {
   conversationId: string;
   opportunityId: string;
@@ -360,8 +379,59 @@ export class ConversationDatabaseAdapter {
     }
 
     const metaByConv = new Map<string, Record<string, unknown>>();
+    const provenanceIntentIds = new Set<string>();
     for (const m of allMeta) {
-      metaByConv.set(m.conversationId, m.metadata as Record<string, unknown>);
+      const metadata = m.metadata as Record<string, unknown>;
+      const publicMetadata = { ...metadata };
+      delete publicMetadata.matchProvenance;
+      metaByConv.set(m.conversationId, publicMetadata);
+      if (Array.isArray(metadata.matchProvenance)) {
+        for (const rawEntry of metadata.matchProvenance) {
+          if (!isMatchProvenanceEntry(rawEntry)) continue;
+          for (const intent of rawEntry.intents) {
+            if (intent.userId === userId) provenanceIntentIds.add(intent.intentId);
+          }
+        }
+      }
+    }
+
+    // Resolve only the viewer's own intent titles. Filtering by owner in the
+    // query is a second privacy boundary: counterpart intent IDs in metadata
+    // can never become visible through a conversation summary.
+    const viewerIntentRows = provenanceIntentIds.size > 0
+      ? await db
+        .select({ id: schema.intents.id, payload: schema.intents.payload, summary: schema.intents.summary })
+        .from(schema.intents)
+        .where(and(
+          inArray(schema.intents.id, [...provenanceIntentIds]),
+          eq(schema.intents.userId, userId),
+        ))
+      : [];
+    const viewerIntentTitles = new Map(
+      viewerIntentRows.map((intent) => [intent.id, intent.summary?.trim() || intent.payload]),
+    );
+
+    const viaByConv = new Map<string, Array<{ intentId: string; opportunityId: string; title: string }>>();
+    for (const metadataRow of allMeta) {
+      const metadata = metadataRow.metadata as Record<string, unknown>;
+      if (!Array.isArray(metadata.matchProvenance)) continue;
+      const entries = metadata.matchProvenance
+        .filter(isMatchProvenanceEntry)
+        .map((entry, index) => ({ entry, index }))
+        .sort((a, b) => {
+          const recordedAtDelta = new Date(b.entry.recordedAt).getTime() - new Date(a.entry.recordedAt).getTime();
+          return Number.isNaN(recordedAtDelta) || recordedAtDelta === 0
+            ? b.index - a.index
+            : recordedAtDelta;
+        });
+      const via: Array<{ intentId: string; opportunityId: string; title: string }> = [];
+      for (const { entry } of entries) {
+        for (const intent of entry.intents) {
+          const title = intent.userId === userId ? viewerIntentTitles.get(intent.intentId) : undefined;
+          if (title) via.push({ intentId: intent.intentId, opportunityId: entry.opportunityId, title });
+        }
+      }
+      viaByConv.set(metadataRow.conversationId, via);
     }
 
     return convs.map((c) => ({
@@ -369,6 +439,7 @@ export class ConversationDatabaseAdapter {
       participants: participantsByConv.get(c.id) ?? [],
       lastMessage: lastMessageByConv.get(c.id) ?? null,
       metadata: metaByConv.get(c.id) ?? null,
+      via: viaByConv.get(c.id) ?? [],
     }));
   }
 
@@ -861,6 +932,25 @@ export class ConversationDatabaseAdapter {
       .limit(1);
 
     return (row?.metadata as Record<string, unknown>) ?? null;
+  }
+
+  /**
+   * Appends match provenance without duplicating an opportunity on DM re-entry.
+   * The metadata sidecar remains the source of truth; no message is written.
+   */
+  async appendMatchProvenance(conversationId: string, provenance: MatchProvenanceEntry): Promise<void> {
+    const existing = await this.getMetadata(conversationId);
+    const existingEntries = Array.isArray(existing?.matchProvenance)
+      ? existing.matchProvenance.filter(isMatchProvenanceEntry)
+      : [];
+    const nextEntries = [
+      ...existingEntries.filter((entry) => entry.opportunityId !== provenance.opportunityId),
+      provenance,
+    ];
+    await this.upsertMetadata(conversationId, {
+      ...(existing ?? {}),
+      matchProvenance: nextEntries,
+    });
   }
 
   // ─────────────────────────────────────────────────────────────────────────

--- a/services/api/src/adapters/database.shared.ts
+++ b/services/api/src/adapters/database.shared.ts
@@ -663,6 +663,7 @@ export interface ConversationSummary {
   participants: ResolvedParticipant[];
   lastMessage: { parts: unknown[]; senderId: string; createdAt: Date } | null;
   metadata: Record<string, unknown> | null;
+  via: Array<{ intentId: string; opportunityId: string; title: string }>;
 }
 
 /**

--- a/services/api/src/adapters/tests/conversation.database.adapter.spec.ts
+++ b/services/api/src/adapters/tests/conversation.database.adapter.spec.ts
@@ -2,15 +2,26 @@ import { config } from 'dotenv';
 config({ path: '.env.test', override: true });
 
 import { describe, it, expect, afterAll } from 'bun:test';
+import { inArray } from 'drizzle-orm';
+import db from '../../lib/drizzle/drizzle';
+import * as schema from '../../schemas/database.schema';
 import { ConversationDatabaseAdapter } from '../database.adapter';
 
 describe('ConversationDatabaseAdapter', () => {
   const adapter = new ConversationDatabaseAdapter();
   const createdIds: string[] = [];
+  const createdIntentIds: string[] = [];
+  const createdUserIds: string[] = [];
 
   afterAll(async () => {
     for (const id of createdIds) {
       try { await adapter.deleteConversation(id); } catch {}
+    }
+    if (createdIntentIds.length > 0) {
+      await db.delete(schema.intents).where(inArray(schema.intents.id, createdIntentIds));
+    }
+    if (createdUserIds.length > 0) {
+      await db.delete(schema.users).where(inArray(schema.users.id, createdUserIds));
     }
   });
 
@@ -199,5 +210,49 @@ describe('ConversationDatabaseAdapter', () => {
       const meta = await adapter.getMetadata(createdIds[0]);
       expect(meta).toEqual({ title: 'Test Chat', shareToken: 'abc' });
     }, 10000);
+
+    it('appends match provenance in latest-first order and deduplicates re-entry', async () => {
+      const first = { opportunityId: 'opp-first', intents: [{ userId: 'viewer', intentId: 'intent-first' }], recordedAt: '2026-01-01T00:00:00.000Z' };
+      const second = { opportunityId: 'opp-second', intents: [{ userId: 'viewer', intentId: 'intent-second' }], recordedAt: '2026-01-02T00:00:00.000Z' };
+      await adapter.appendMatchProvenance(createdIds[0], first);
+      await adapter.appendMatchProvenance(createdIds[0], second);
+      await adapter.appendMatchProvenance(createdIds[0], { ...first, recordedAt: '2026-01-03T00:00:00.000Z' });
+
+      const meta = await adapter.getMetadata(createdIds[0]);
+      expect(meta?.matchProvenance).toEqual([second, { ...first, recordedAt: '2026-01-03T00:00:00.000Z' }]);
+    }, 10000);
+
+    it('exposes only the viewer intent title as via on conversation summaries', async () => {
+      const run = crypto.randomUUID();
+      const viewerId = `provenance-viewer-${run}`;
+      const counterpartId = `provenance-counterpart-${run}`;
+      const viewerIntentId = `provenance-viewer-intent-${run}`;
+      const counterpartIntentId = `provenance-counterpart-intent-${run}`;
+      createdUserIds.push(viewerId, counterpartId);
+      createdIntentIds.push(viewerIntentId, counterpartIntentId);
+
+      await db.insert(schema.users).values([
+        { id: viewerId, email: `${viewerId}@test.com`, name: 'Provenance Viewer' },
+        { id: counterpartId, email: `${counterpartId}@test.com`, name: 'Provenance Counterpart' },
+      ]);
+      await db.insert(schema.intents).values([
+        { id: viewerIntentId, userId: viewerId, payload: 'Viewer private framing', summary: 'Viewer signal' },
+        { id: counterpartIntentId, userId: counterpartId, payload: 'Counterpart private framing', summary: 'Counterpart signal' },
+      ]);
+      const dm = await adapter.getOrCreateDM(viewerId, counterpartId);
+      createdIds.push(dm.id);
+      await adapter.appendMatchProvenance(dm.id, {
+        opportunityId: 'opp-private-signal',
+        intents: [
+          { userId: viewerId, intentId: viewerIntentId },
+          { userId: counterpartId, intentId: counterpartIntentId },
+        ],
+        recordedAt: new Date().toISOString(),
+      });
+
+      const summary = (await adapter.getConversationsForUser(viewerId)).find((conversation) => conversation.id === dm.id);
+      expect(summary?.via).toEqual([{ intentId: viewerIntentId, opportunityId: 'opp-private-signal', title: 'Viewer signal' }]);
+      expect(summary?.metadata).not.toHaveProperty('matchProvenance');
+    }, 20000);
   });
 });

--- a/services/api/src/controllers/conversation.controller.ts
+++ b/services/api/src/controllers/conversation.controller.ts
@@ -210,7 +210,11 @@ export class ConversationController {
 
     try {
       const conversation = await this.conversationService.getOrCreateDM(user.id, body.peerUserId);
-      return Response.json({ conversation });
+      // Return the same viewer-scoped summary shape as GET /conversations so
+      // a thread opened directly can render match provenance immediately.
+      const summary = (await this.conversationService.getConversations(user.id))
+        .find((candidate) => candidate.id === conversation.id);
+      return Response.json({ conversation: summary ?? conversation });
     } catch (err: unknown) {
       const message = err instanceof Error ? err.message : String(err);
       logger.error('getOrCreateDM failed', { userId: user.id, error: message });

--- a/services/api/src/services/opportunity.service.ts
+++ b/services/api/src/services/opportunity.service.ts
@@ -125,6 +125,34 @@ function matchesSelectedIntentScope(
   return opportunity.actors.some((actor) => actor.userId === userId && actor.intent === scope.scopeId);
 }
 
+interface MatchProvenanceInput {
+  opportunityId: string;
+  intents: Array<{ userId: string; intentId: string }>;
+  recordedAt: string;
+}
+
+type MatchProvenanceDatabase = OpportunityControllerDatabase & {
+  appendMatchProvenance(conversationId: string, provenance: MatchProvenanceInput): Promise<void>;
+};
+
+function buildMatchProvenance(opportunity: Pick<Opportunity, 'id' | 'actors'>): MatchProvenanceInput {
+  return {
+    opportunityId: opportunity.id,
+    intents: opportunity.actors
+      .filter((actor): actor is typeof actor & { intent: string } => typeof actor.intent === 'string' && actor.intent.length > 0)
+      .map((actor) => ({ userId: actor.userId, intentId: actor.intent })),
+    recordedAt: new Date().toISOString(),
+  };
+}
+
+async function appendMatchProvenance(
+  database: OpportunityControllerDatabase,
+  conversationId: string,
+  provenance: MatchProvenanceInput,
+): Promise<void> {
+  await (database as MatchProvenanceDatabase).appendMatchProvenance(conversationId, provenance);
+}
+
 function matchesAgentNetworkScope(
   opportunity: Pick<Opportunity, 'actors'>,
   userId: string,
@@ -862,6 +890,11 @@ export class OpportunityService {
         });
         return { error: 'Failed to resolve conversation for this opportunity', status: 500 };
       }
+      await appendMatchProvenance(this.db, conversation.id, buildMatchProvenance(opp)).catch((err: unknown) => {
+        startChatLogger.error('appendMatchProvenance failed (non-blocking)', {
+          conversationId: conversation.id, opportunityId, userId, error: err,
+        });
+      });
       await this.db.unhideConversation(userId, conversation.id).catch((err) => {
         startChatLogger.error('unhideConversation failed (non-blocking)', {
           conversationId: conversation.id, userId, error: err,
@@ -923,6 +956,15 @@ export class OpportunityService {
       });
       return { error: 'Failed to resolve conversation for this opportunity', status: 500 };
     }
+
+    await appendMatchProvenance(this.db, conversation.id, buildMatchProvenance(opp)).catch((err: unknown) => {
+      startChatLogger.error('appendMatchProvenance failed (non-blocking)', {
+        conversationId: conversation.id,
+        opportunityId,
+        userId,
+        error: err,
+      });
+    });
 
     // Clear hiddenAt so the conversation appears in the sidebar even if the
     // user previously hid it. This must happen before returning — the frontend

--- a/services/api/src/services/tests/opportunity.service.startChat.spec.ts
+++ b/services/api/src/services/tests/opportunity.service.startChat.spec.ts
@@ -27,8 +27,8 @@ function makeOpportunity(overrides: Partial<Opportunity> = {}): Opportunity {
     id: OPP_ID,
     detection: { source: 'opportunity_graph', timestamp: new Date().toISOString() },
     actors: [
-      { networkId: 'idx-1', userId: VIEWER_ID, role: 'patient' },
-      { networkId: 'idx-1', userId: PEER_ID, role: 'agent' },
+      { networkId: 'idx-1', userId: VIEWER_ID, role: 'patient', intent: SELECTED_INTENT_ID },
+      { networkId: 'idx-1', userId: PEER_ID, role: 'agent', intent: 'peer-intent' },
     ],
     interpretation: {
       category: 'collaboration',
@@ -62,6 +62,7 @@ function makeServiceWithDb(
     acceptSiblingOpportunities: mock(async () => [] as string[]),
     upsertContactMembership: mock(async () => {}),
     getOrCreateDM: mock(async () => ({ id: CONV_ID })),
+    appendMatchProvenance: mock(async () => {}),
     unhideConversation: mock(async () => {}),
     ...overrides,
   } as unknown as OpportunityControllerDatabase;
@@ -202,6 +203,13 @@ describe('OpportunityService.startChat', () => {
     expect(result.counterpartUserId).toBe(PEER_ID);
     expect(db.stampOpportunityActorAction).toHaveBeenCalledWith(OPP_ID, VIEWER_ID, 'accepted', VIEWER_ID);
     expect(db.getOrCreateDM).toHaveBeenCalledWith(VIEWER_ID, PEER_ID);
+    expect(db.appendMatchProvenance).toHaveBeenCalledWith(CONV_ID, expect.objectContaining({
+      opportunityId: OPP_ID,
+      intents: [
+        { userId: VIEWER_ID, intentId: SELECTED_INTENT_ID },
+        { userId: PEER_ID, intentId: 'peer-intent' },
+      ],
+    }));
 
     // Both-way contact membership: accepter (restore:true) + counterpart (restore:false)
     expect(db.upsertContactMembership).toHaveBeenCalledTimes(2);
@@ -233,6 +241,7 @@ describe('OpportunityService.startChat', () => {
     expect(result.conversationId).toBe(CONV_ID);
     expect(result.counterpartUserId).toBe(PEER_ID);
     expect(db.getOrCreateDM).toHaveBeenCalledWith(VIEWER_ID, PEER_ID);
+    expect(db.appendMatchProvenance).toHaveBeenCalledWith(CONV_ID, expect.objectContaining({ opportunityId: OPP_ID }));
     expect(db.unhideConversation).toHaveBeenCalledWith(VIEWER_ID, CONV_ID);
     // No status change or side effects — those ran on the original accept
     expect(db.updateOpportunityStatus).not.toHaveBeenCalled();


### PR DESCRIPTION
## Design summary
- Keep DM-per-pair.
- Record append-only match provenance as a deduplicated list in the `conversation_metadata` JSONB sidecar.
- Render the seeded opener client-side from viewer-scoped provenance; never insert a stored message.

## What changed
- `start-chat` records the opportunity and actor intent provenance on both accepted re-entry and pending/draft/latent acceptance paths.
- Conversation summaries expose only the requesting viewer's own intent titles as latest-first `via` entries; raw provenance is not returned.
- Match threads render a linked `via:` chip and an empty-history seeded opener; inbox rows show an optional `via` subtitle.
- Added API and web coverage for provenance recording, deduplication, append behavior, viewer privacy, chip links, seeded opener gating, and plain DMs.

## Test evidence
- API touched suites: 33 pass, 0 fail.
- Web provenance suite: 3 pass, 0 fail.
- `services/api` build: passed.
- `apps/web` build: passed.
- `apps/web` lint: passed.
- Full web suite currently has 4 pre-existing failing files / 16 failures in unrelated DecisionQuestions and existing UI tests; the new provenance suite passes.
- Opportunity controller suite: 23 pass, 1 pre-existing failure (`getProfile should return a users-sourced profile document for existing user`), as noted in the handoff.

Part 1 of IND-475 (unread badge follows in PR2).
