### PR TITLE
feat: agent surface reporter chat UI (IND-476)

### DIFF
--- a/apps/web/CHANGELOG.md
+++ b/apps/web/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
 
 ### Added
 
+- Add the flag-gated read-only Reporter Agent surface on `/agent` (IND-476): opening briefings use the shared reporter kickoff marker, status counts use fetched signals and pending questions, and suggested asks route through the reporter persona.
 - Add unread indicators to conversation rows and a thread-count badge to the Chats navigation entry, with mark-read wiring for open threads (IND-475).
 - Add viewer-scoped `via:` signal chips, client-rendered match-seeded openers, and optional inbox provenance subtitles for human match threads (IND-475).
 - Polished the signal-first Discover home (IND-473): header totals show listed signals and waiting opportunities, fresh signals display a WARMING state while discovery runs, and the list includes network scope, clamped titles, and the conversational new-signal CTA.

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@indexnetwork/web",
-  "version": "0.24.0",
+  "version": "0.25.0",
   "license": "MIT",
   "scripts": {
     "dev": "vite --host 127.0.0.1",

--- a/apps/web/src/app/agent/page.tsx
+++ b/apps/web/src/app/agent/page.tsx
@@ -5,6 +5,7 @@ import { Loader2 } from "lucide-react";
 import { useAuthContext } from "@/contexts/AuthContext";
 import ClientLayout from "@/components/ClientLayout";
 import ChatContent from "@/components/ChatContent";
+import AgentReporterSurface from "@/components/AgentReporterSurface";
 import NegotiatorMemoryPanel from "@/components/NegotiatorMemoryPanel";
 import { ContentContainer } from "@/components/layout";
 
@@ -19,7 +20,7 @@ import { ContentContainer } from "@/components/layout";
 export default function AgentPage() {
   const navigate = useNavigate();
   const { tab } = useParams<{ tab?: string }>();
-  const { user, isAuthenticated, isLoading: authLoading } = useAuthContext();
+  const { user, isAuthenticated, isLoading: authLoading, features } = useAuthContext();
 
   useEffect(() => {
     if (!authLoading && !isAuthenticated) {
@@ -54,7 +55,7 @@ export default function AgentPage() {
 
   return (
     <ClientLayout>
-      <ChatContent />
+      {features?.agentSurface === true ? <AgentReporterSurface /> : <ChatContent />}
     </ClientLayout>
   );
 }

--- a/apps/web/src/components/AgentReporterSurface.tsx
+++ b/apps/web/src/components/AgentReporterSurface.tsx
@@ -1,0 +1,90 @@
+import { useEffect, useMemo, useRef, useState } from "react";
+
+import { REPORTER_BRIEFING_KICKOFF } from "@indexnetwork/protocol";
+import { useAIChat } from "@/contexts/AIChatContext";
+import { useAuthContext } from "@/contexts/AuthContext";
+import { useQuestions } from "@/contexts/QuestionsContext";
+import { useIntents } from "@/contexts/APIContext";
+import type { Suggestion } from "@/hooks/useSuggestions";
+import ChatContent from "@/components/ChatContent";
+
+const REPORTER_SUGGESTIONS: Suggestion[] = [
+  { label: "What did you do in the last 24 hours?", type: "direct", followupText: "What did you do in the last 24 hours?" },
+  { label: "Which signals got new opportunities?", type: "direct", followupText: "Which signals got new opportunities?" },
+  { label: "What's waiting on me?", type: "direct", followupText: "What's waiting on me?" },
+  { label: "Give me the short version", type: "direct", followupText: "Give me the short version of what's happening." },
+];
+
+/** Read-only, web-only reporter chat surface for /agent. */
+export default function AgentReporterSurface() {
+  const { isAuthenticated, features } = useAuthContext();
+  const { messages, startReporterSession, sendWebMessage } = useAIChat();
+  const intentsService = useIntents();
+  const { globalPending, loading: questionsLoading } = useQuestions();
+  const [activeSignalCount, setActiveSignalCount] = useState<number | null>(null);
+  const [signalsLoading, setSignalsLoading] = useState(true);
+  const startedRef = useRef(false);
+
+  const agentSurfaceEnabled = features?.agentSurface === true;
+
+  useEffect(() => {
+    if (!isAuthenticated || !agentSurfaceEnabled || startedRef.current) return;
+    startedRef.current = true;
+    startReporterSession();
+    // The reporter prompt builder matches this marker to produce the opening briefing.
+    void sendWebMessage(
+      REPORTER_BRIEFING_KICKOFF,
+      undefined,
+      undefined,
+      { hidden: true, persona: "reporter" },
+    );
+  }, [agentSurfaceEnabled, isAuthenticated, sendWebMessage, startReporterSession]);
+
+  useEffect(() => {
+    let active = true;
+    void intentsService.getIntents(1, 100, false)
+      .then((response) => {
+        if (!active) return;
+        const count = response.intents.filter((intent: { status?: string | null }) => (
+          !intent.status || intent.status === "ACTIVE"
+        )).length;
+        setActiveSignalCount(count);
+      })
+      .catch(() => {
+        if (active) setActiveSignalCount(null);
+      })
+      .finally(() => {
+        if (active) setSignalsLoading(false);
+      });
+    return () => {
+      active = false;
+    };
+  }, [intentsService]);
+
+  const hasUserMessage = useMemo(
+    () => messages.some((message) => message.role === "user"),
+    [messages],
+  );
+  const suggestions = hasUserMessage ? [] : REPORTER_SUGGESTIONS;
+  const isStatusLoading = signalsLoading || questionsLoading || activeSignalCount === null;
+
+  return (
+    <div className="flex min-h-full flex-col">
+      <div className="border-b border-gray-100 bg-white px-6 py-5 lg:px-8">
+        <div className="mx-auto max-w-3xl">
+          <h1 className="font-ibm-plex-mono text-xl font-bold text-[#041729]">Agent reporter</h1>
+          <p className="mt-1 text-xs font-ibm-plex-mono text-gray-500" aria-live="polite">
+            {isStatusLoading
+              ? "online"
+              : `online — watching ${activeSignalCount} signals · ${globalPending} questions pending`}
+          </p>
+        </div>
+      </div>
+      <ChatContent
+        persona="reporter"
+        readOnlySurface
+        suggestionOverride={suggestions}
+      />
+    </div>
+  );
+}

--- a/apps/web/src/components/ChatContent.tsx
+++ b/apps/web/src/components/ChatContent.tsx
@@ -27,7 +27,7 @@ import remarkGfm from "remark-gfm";
 import { useNetworkFilter } from "@/contexts/IndexFilterContext";
 import { useNetworksState } from "@/contexts/IndexesContext";
 import { apiClient } from "@/lib/api";
-import { useSuggestions } from "@/hooks/useSuggestions";
+import { useSuggestions, type Suggestion } from "@/hooks/useSuggestions";
 import { useOpportunityActions } from "@/hooks/useOpportunityActions";
 
 import { mentionsToMarkdownLinks } from "@/lib/mentions";
@@ -54,8 +54,16 @@ interface HomeIntent {
 
 interface ChatContentProps {
   sessionIdParam?: string | null;
+  persona?: "signal" | "reporter";
+  readOnlySurface?: boolean;
+  suggestionOverride?: Suggestion[];
 }
-export default function ChatContent({ sessionIdParam }: ChatContentProps) {
+export default function ChatContent({
+  sessionIdParam,
+  persona,
+  readOnlySurface = false,
+  suggestionOverride,
+}: ChatContentProps) {
   const navigate = useNavigate();
   const location = useLocation();
   const sessionIdFromUrl = sessionIdParam ?? null;
@@ -85,6 +93,7 @@ export default function ChatContent({ sessionIdParam }: ChatContentProps) {
   } = useAIChat();
   const { features } = useAuthContext();
   const signalAgentEnabled = features?.signalAgent === true;
+  const reporterSurface = persona === "reporter";
   const routedSessionReady = !sessionIdFromUrl
     || isSessionReady(sessionIdFromUrl)
     || (sessionId === sessionIdFromUrl && sessionLoadState.status === "idle");
@@ -516,10 +525,11 @@ export default function ChatContent({ sessionIdParam }: ChatContentProps) {
       navigatingToHomeRef.current = false;
       return;
     }
+    if (reporterSurface) return;
     if (sessionId && !sessionIdFromUrl) {
       navigate(`/d/${sessionId}`);
     }
-  }, [sessionId, sessionIdFromUrl, navigate]);
+  }, [reporterSurface, sessionId, sessionIdFromUrl, navigate]);
 
   const archiveProposalIntent = useCallback(
     async (proposalId: string, intentId: string) => {
@@ -723,7 +733,11 @@ export default function ChatContent({ sessionIdParam }: ChatContentProps) {
         msgContent,
         fileArg,
         nameArg,
-        !sessionId && signalAgentEnabled ? { persona: "signal" as const } : undefined,
+        !sessionId && persona
+          ? { persona }
+          : !sessionId && signalAgentEnabled
+            ? { persona: "signal" as const }
+            : undefined,
       );
     }
     inputRef.current?.focus();
@@ -1078,6 +1092,13 @@ export default function ChatContent({ sessionIdParam }: ChatContentProps) {
             <DebugCopyButton fetchPath="/debug/home" title="Copy home debug JSON" iconSize="w-5 h-5" />
           </div>
           <div className="bg-[linear-gradient(to_bottom,transparent_50%,#ffffff_50%)]">
+            {reporterSurface && (
+              <SuggestionChips
+                suggestions={suggestionOverride ?? []}
+                disabled={isUploadingFiles}
+                onSuggestionClick={handleSuggestionClick}
+              />
+            )}
             {turnBlock ? renderContinuationPanel() : (
             <form
               onSubmit={handleSubmit}
@@ -1133,7 +1154,7 @@ export default function ChatContent({ sessionIdParam }: ChatContentProps) {
                   autoFocus
                   inputRef={inputRef}
                 />
-                {renderScopeDropdown()}
+                {!reporterSurface && renderScopeDropdown()}
                 {isLoading ? (
                   <Button
                     type="button"
@@ -1159,7 +1180,7 @@ export default function ChatContent({ sessionIdParam }: ChatContentProps) {
             </form>
             )}
           </div>
-          {signalAgentEnabled && (
+          {signalAgentEnabled && !reporterSurface && (
             <button
               type="button"
               onClick={() => navigate("/i/new")}
@@ -1172,15 +1193,17 @@ export default function ChatContent({ sessionIdParam }: ChatContentProps) {
               </span>
             </button>
           )}
-          <div className="mt-8">
-            <IntentList
-              intents={homeIntents}
-              isLoading={homeIntentsLoading}
-              emptyMessage="No signals yet"
-              onIntentClick={(intent) => navigate(`/i/${intent.id}`)}
-              onArchiveIntent={turnBlock ? undefined : handleArchiveHomeIntent}
-            />
-          </div>
+          {!reporterSurface && (
+            <div className="mt-8">
+              <IntentList
+                intents={homeIntents}
+                isLoading={homeIntentsLoading}
+                emptyMessage="No signals yet"
+                onIntentClick={(intent) => navigate(`/i/${intent.id}`)}
+                onArchiveIntent={turnBlock ? undefined : handleArchiveHomeIntent}
+              />
+            </div>
+          )}
         </ContentContainer>
       </div>
     );
@@ -1192,7 +1215,7 @@ export default function ChatContent({ sessionIdParam }: ChatContentProps) {
 
   return (
     <>
-      {!legacyOrchestratorReadOnly && inviteModalElement}
+      {!legacyOrchestratorReadOnly && !readOnlySurface && inviteModalElement}
       {/* Sticky header - full width, min-h-17 matches ChatView header height */}
       <div className="sticky top-0 bg-white z-10 px-4 py-3 flex items-center gap-3 min-h-17">
         <button
@@ -1208,7 +1231,7 @@ export default function ChatContent({ sessionIdParam }: ChatContentProps) {
         >
           <ChevronLeft className="h-5 w-5" />
         </button>
-        {isEditingTitle && !legacyOrchestratorReadOnly ? (
+        {isEditingTitle && !legacyOrchestratorReadOnly && !readOnlySurface ? (
           <input
             ref={titleInputRef}
             type="text"
@@ -1232,14 +1255,14 @@ export default function ChatContent({ sessionIdParam }: ChatContentProps) {
             <button
               type="button"
               onClick={startEditingTitle}
-              disabled={!sessionId || legacyOrchestratorReadOnly}
+              disabled={!sessionId || legacyOrchestratorReadOnly || readOnlySurface}
               className="text-left font-bold font-ibm-plex-mono text-lg text-black truncate hover:text-gray-700 disabled:pointer-events-none focus:outline-none rounded"
             >
               {displayTitle}
             </button>
             {sessionId && (
               <>
-                {!legacyOrchestratorReadOnly && (
+                {!legacyOrchestratorReadOnly && !readOnlySurface && (
                   <>
                     <button
                       type="button"
@@ -1356,7 +1379,7 @@ export default function ChatContent({ sessionIdParam }: ChatContentProps) {
                           <AssistantMessageContent
                             content={msg.content}
                             isStreaming={msg.isStreaming ?? false}
-                            onOpportunityPrimaryAction={legacyOrchestratorReadOnly ? undefined : (
+                            onOpportunityPrimaryAction={legacyOrchestratorReadOnly || readOnlySurface ? undefined : (
                               oppId,
                               userId,
                               viewerRole,
@@ -1373,7 +1396,7 @@ export default function ChatContent({ sessionIdParam }: ChatContentProps) {
                                 isGhost,
                               );
                             }}
-                            onOpportunitySecondaryAction={legacyOrchestratorReadOnly ? undefined : (
+                            onOpportunitySecondaryAction={legacyOrchestratorReadOnly || readOnlySurface ? undefined : (
                               oppId,
                               userId,
                               viewerRole,
@@ -1392,12 +1415,12 @@ export default function ChatContent({ sessionIdParam }: ChatContentProps) {
                             }}
                             opportunityLoadingMap={opportunityActionLoading}
                             currentStatusMap={opportunityStatusMap}
-                            onIntentProposalApprove={legacyOrchestratorReadOnly ? undefined : handleIntentProposalApprove}
-                            onIntentProposalReject={legacyOrchestratorReadOnly ? undefined : handleIntentProposalReject}
-                            onIntentProposalUndo={legacyOrchestratorReadOnly ? undefined : handleIntentProposalUndo}
+                            onIntentProposalApprove={legacyOrchestratorReadOnly || readOnlySurface ? undefined : handleIntentProposalApprove}
+                            onIntentProposalReject={legacyOrchestratorReadOnly || readOnlySurface ? undefined : handleIntentProposalReject}
+                            onIntentProposalUndo={legacyOrchestratorReadOnly || readOnlySurface ? undefined : handleIntentProposalUndo}
                             intentProposalStatusMap={intentProposalStatusMap}
-                            OAuthLink={legacyOrchestratorReadOnly ? undefined : OAuthLink}
-                            onNetworkJoin={legacyOrchestratorReadOnly ? undefined : handleNetworkJoin}
+                            OAuthLink={legacyOrchestratorReadOnly || readOnlySurface ? undefined : OAuthLink}
+                            onNetworkJoin={legacyOrchestratorReadOnly || readOnlySurface ? undefined : handleNetworkJoin}
                             networkPanelPendingJoinIds={networkPanelPendingJoinIds}
                           />
                         </article>
@@ -1467,7 +1490,7 @@ export default function ChatContent({ sessionIdParam }: ChatContentProps) {
                             key={draft.opportunityId}
                             card={cardData}
                             currentStatus={cardStatus}
-                            onPrimaryAction={legacyOrchestratorReadOnly ? undefined : (oppId, userId) => {
+                            onPrimaryAction={legacyOrchestratorReadOnly || readOnlySurface ? undefined : (oppId, userId) => {
                               if (mutationsBlockedRef.current) return;
                               return handleStreamingDraftStartChat(oppId, userId);
                             }}
@@ -1479,6 +1502,7 @@ export default function ChatContent({ sessionIdParam }: ChatContentProps) {
                   )}
                 {msg.role === "assistant" &&
                   !legacyOrchestratorReadOnly &&
+                  !readOnlySurface &&
                   msg.decisionQuestions &&
                   msg.decisionQuestions.length > 0 && (
                     <DecisionQuestions
@@ -1500,6 +1524,7 @@ export default function ChatContent({ sessionIdParam }: ChatContentProps) {
                   )}
                 {msg.role === "assistant" &&
                   !legacyOrchestratorReadOnly &&
+                  !readOnlySurface &&
                   injectedByMessageId.has(msg.id) && (
                     <InjectedQuestions
                       questions={injectedByMessageId.get(msg.id)!}
@@ -1509,7 +1534,7 @@ export default function ChatContent({ sessionIdParam }: ChatContentProps) {
                   )}
               </div>
             ))}
-            {!legacyOrchestratorReadOnly && injectedByMessageId.has(null) && (
+            {!legacyOrchestratorReadOnly && !readOnlySurface && injectedByMessageId.has(null) && (
               <div data-testid={isNegotiatorDm ? "negotiator-question-inbox" : undefined}>
                 {isNegotiatorDm && (
                   <p className="text-xs font-medium uppercase tracking-wide text-gray-500 mt-4 mb-2">
@@ -1537,7 +1562,7 @@ export default function ChatContent({ sessionIdParam }: ChatContentProps) {
             ) : (
               <>
                 <SuggestionChips
-                  suggestions={suggestions}
+                  suggestions={suggestionOverride ?? suggestions}
                   disabled={isUploadingFiles}
                   onSuggestionClick={handleSuggestionClick}
                 />

--- a/apps/web/src/contexts/AIChatContext.tsx
+++ b/apps/web/src/contexts/AIChatContext.tsx
@@ -119,7 +119,7 @@ export interface QueuedMessage {
 export interface ChatSendOptions {
   hidden?: boolean;
   prefillMessages?: Array<{ role: "assistant" | "user"; content: string }>;
-  persona?: "signal";
+  persona?: "signal" | "reporter";
   /** @deprecated Product surfaces should use their dedicated send helper. */
   surface?: "web" | "onboarding";
   existingMessageId?: string;
@@ -192,7 +192,7 @@ interface AIChatContextType {
   /** Resolve or create the stable persona session for an intent scope. */
   resolveIntentSession: (
     intent: { id: string; label?: string },
-    persona?: "signal",
+    persona?: "signal" | "reporter",
   ) => Promise<string | null>;
   /** Context-aware suggestions from the last done event; empty when no messages or after clear/load. */
   suggestions: Suggestion[];
@@ -225,6 +225,8 @@ interface AIChatContextType {
   clearChat: (options?: { abortStream?: boolean; preserveForcedPersona?: boolean }) => void;
   /** Clear the current chat and force the next new web session to request Signal. */
   startSignalSession: () => void;
+  /** Start a fresh main-web reporter session. */
+  startReporterSession: () => void;
   /** Load a session, returning false for failed or superseded requests. */
   loadSession: (sessionId: string) => Promise<boolean>;
   /** Observable target-specific load state for disabling route interactions until ready. */
@@ -380,7 +382,7 @@ export function AIChatProvider({ children }: { children: React.ReactNode }) {
   const [sessionTitle, setSessionTitle] = useState<string | null>(null);
   const [sessionPersona, setSessionPersona] = useState<string | null>(null);
   const [turnBlock, setTurnBlock] = useState<ChatTurnBlock | null>(null);
-  const forceSignalNextSessionRef = useRef(false);
+  const forcePersonaNextSessionRef = useRef<"signal" | "reporter" | null>(null);
   const [suggestions, setSuggestions] = useState<Suggestion[]>([]);
   const [isLoading, setIsLoading] = useState(false);
   const [sessionLoadState, setSessionLoadState] = useState<ChatSessionLoadState>({
@@ -444,7 +446,7 @@ export function AIChatProvider({ children }: { children: React.ReactNode }) {
 
   const resolveIntentSession = useCallback(async (
     intent: { id: string; label?: string },
-    persona?: "signal",
+    persona?: "signal" | "reporter",
   ): Promise<string | null> => {
     const resolutionToken = Symbol(`resolve-intent-session:${intent.id}`);
     intentResolutionOwnerRef.current = resolutionToken;
@@ -574,10 +576,14 @@ export function AIChatProvider({ children }: { children: React.ReactNode }) {
       if (!displayContent) return;
 
       const requestedPersona = options?.persona
-        ?? (!sessionId && forceSignalNextSessionRef.current ? "signal" : undefined);
+        ?? (!sessionId ? forcePersonaNextSessionRef.current ?? undefined : undefined);
       const effectiveTransport: ChatTransport = transport === "onboarding"
         ? "onboarding"
-        : transport === "web" || requestedPersona === "signal" || sessionPersona === "signal"
+        : transport === "web"
+          || requestedPersona === "signal"
+          || requestedPersona === "reporter"
+          || sessionPersona === "signal"
+          || sessionPersona === "reporter"
           ? "web"
           : "compatibility";
 
@@ -701,7 +707,7 @@ export function AIChatProvider({ children }: { children: React.ReactNode }) {
           // mark it route-ready so the ensuing /d/:id navigation never reloads
           // or briefly replaces it with a loading shell.
           setSessionLoadState({ status: "ready", targetSessionId: newSessionId, error: null });
-          forceSignalNextSessionRef.current = false;
+          forcePersonaNextSessionRef.current = null;
           // The scope selected at session creation becomes the session's bound scope.
           if (chatScope) {
             setSessionScope(chatScope);
@@ -1242,7 +1248,11 @@ export function AIChatProvider({ children }: { children: React.ReactNode }) {
   ) => {
     const transport: ChatTransport = options?.surface === "onboarding"
       ? "onboarding"
-      : options?.surface === "web" || options?.persona === "signal" || sessionPersona === "signal"
+      : options?.surface === "web"
+        || options?.persona === "signal"
+        || options?.persona === "reporter"
+        || sessionPersona === "signal"
+        || sessionPersona === "reporter"
         ? "web"
         : "compatibility";
     return sendMessageWithTransport(transport, message, fileIds, attachmentNames, options);
@@ -1337,7 +1347,7 @@ export function AIChatProvider({ children }: { children: React.ReactNode }) {
     setSessionTitle(null);
     setSessionPersona(null);
     if (!options?.preserveForcedPersona) {
-      forceSignalNextSessionRef.current = false;
+      forcePersonaNextSessionRef.current = null;
     }
     setTurnBlock(null);
     setSessionScope(null); // Clear session-bound scope so new chat can use UI selection
@@ -1346,7 +1356,12 @@ export function AIChatProvider({ children }: { children: React.ReactNode }) {
 
   const startSignalSession = useCallback(() => {
     clearChat();
-    forceSignalNextSessionRef.current = true;
+    forcePersonaNextSessionRef.current = "signal";
+  }, [clearChat]);
+
+  const startReporterSession = useCallback(() => {
+    clearChat();
+    forcePersonaNextSessionRef.current = "reporter";
   }, [clearChat]);
 
   const loadSession = useCallback(async (id: string): Promise<boolean> => {
@@ -1366,7 +1381,7 @@ export function AIChatProvider({ children }: { children: React.ReactNode }) {
     setSessionNetworkId(null);
     setMessages([]);
     setSuggestions([]);
-    forceSignalNextSessionRef.current = false;
+    forcePersonaNextSessionRef.current = null;
 
     interruptTimeoutsRef.current.forEach((t) => clearTimeout(t));
     interruptTimeoutsRef.current.clear();
@@ -1511,6 +1526,7 @@ export function AIChatProvider({ children }: { children: React.ReactNode }) {
         sendOnboardingMessage,
         clearChat,
         startSignalSession,
+        startReporterSession,
         loadSession,
         sessionLoadState,
         isSessionReady,

--- a/apps/web/src/contexts/AuthContext.tsx
+++ b/apps/web/src/contexts/AuthContext.tsx
@@ -13,11 +13,13 @@ const logger = log.context.from('AuthContext');
 /**
  * Server-driven feature flags returned alongside the user on GET /auth/me
  * (sibling of `user`, not part of it). `negotiatorChat` gates the pinned
- * Personal Agent entry; `signalAgent` gates the main-web Signal cutover.
+ * Personal Agent entry; `signalAgent` gates the main-web Signal cutover;
+ * `agentSurface` gates the read-only Reporter Agent surface.
  */
 export type UserFeatures = {
   negotiatorChat?: boolean;
   signalAgent?: boolean;
+  agentSurface?: boolean;
 };
 
 type AuthContextType = {

--- a/apps/web/tests/agent-page-reporter.test.tsx
+++ b/apps/web/tests/agent-page-reporter.test.tsx
@@ -1,0 +1,66 @@
+import { render, screen } from "@testing-library/react";
+import type { ReactNode } from "react";
+import { beforeEach, describe, expect, test, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+  features: null as { agentSurface?: boolean } | null,
+  reporterSurface: vi.fn(() => <div data-testid="reporter-surface" />),
+  chatContent: vi.fn(() => <div data-testid="chat-content" />),
+}));
+
+vi.mock("react-router", () => ({
+  useNavigate: () => vi.fn(),
+  useParams: () => ({}),
+}));
+
+vi.mock("@/contexts/AuthContext", () => ({
+  useAuthContext: () => ({
+    user: null,
+    isAuthenticated: true,
+    isLoading: false,
+    features: mocks.features,
+  }),
+}));
+
+vi.mock("@/components/ClientLayout", () => ({
+  default: ({ children }: { children: ReactNode }) => <>{children}</>,
+}));
+
+vi.mock("@/components/ChatContent", () => ({
+  default: mocks.chatContent,
+}));
+
+vi.mock("@/components/AgentReporterSurface", () => ({
+  default: mocks.reporterSurface,
+}));
+
+vi.mock("@/components/NegotiatorMemoryPanel", () => ({
+  default: () => <div data-testid="memory-panel" />,
+}));
+
+import AgentPage from "@/app/agent/page";
+
+describe("/agent reporter surface gating", () => {
+  beforeEach(() => {
+    mocks.features = null;
+    mocks.reporterSurface.mockClear();
+    mocks.chatContent.mockClear();
+  });
+
+  test("flag off keeps the existing ChatContent surface", () => {
+    render(<AgentPage />);
+
+    expect(screen.getByTestId("chat-content")).toBeInTheDocument();
+    expect(screen.queryByTestId("reporter-surface")).not.toBeInTheDocument();
+    expect(mocks.reporterSurface).not.toHaveBeenCalled();
+  });
+
+  test("flag on renders the reporter surface", () => {
+    mocks.features = { agentSurface: true };
+
+    render(<AgentPage />);
+
+    expect(screen.getByTestId("reporter-surface")).toBeInTheDocument();
+    expect(screen.queryByTestId("chat-content")).not.toBeInTheDocument();
+  });
+});

--- a/apps/web/tests/agent-reporter-surface.test.tsx
+++ b/apps/web/tests/agent-reporter-surface.test.tsx
@@ -1,0 +1,72 @@
+import { screen, waitFor } from "@testing-library/react";
+import { beforeEach, describe, expect, test, vi } from "vitest";
+
+import { render } from "@testing-library/react";
+
+const mocks = vi.hoisted(() => ({
+  startReporterSession: vi.fn(),
+  sendWebMessage: vi.fn().mockResolvedValue(undefined),
+  getIntents: vi.fn(),
+}));
+
+vi.mock("@indexnetwork/protocol", () => ({
+  REPORTER_BRIEFING_KICKOFF: "reporter-briefing-kickoff",
+}));
+
+vi.mock("@/contexts/AuthContext", () => ({
+  useAuthContext: () => ({ isAuthenticated: true, features: { agentSurface: true } }),
+}));
+
+vi.mock("@/contexts/AIChatContext", () => ({
+  useAIChat: () => ({
+    messages: [],
+    startReporterSession: mocks.startReporterSession,
+    sendWebMessage: mocks.sendWebMessage,
+  }),
+}));
+
+vi.mock("@/contexts/QuestionsContext", () => ({
+  useQuestions: () => ({ globalPending: 3, loading: false }),
+}));
+
+vi.mock("@/contexts/APIContext", () => ({
+  useIntents: () => ({ getIntents: mocks.getIntents }),
+}));
+
+vi.mock("@/components/ChatContent", () => ({
+  default: () => <div data-testid="reporter-chat" />,
+}));
+
+import AgentReporterSurface from "@/components/AgentReporterSurface";
+
+describe("AgentReporterSurface", () => {
+  beforeEach(() => {
+    mocks.startReporterSession.mockClear();
+    mocks.sendWebMessage.mockClear();
+    mocks.getIntents.mockReset();
+    mocks.getIntents.mockResolvedValue({
+      intents: [
+        { id: "active-1", status: "ACTIVE" },
+        { id: "paused-1", status: "PAUSED" },
+        { id: "legacy-active", status: null },
+      ],
+    });
+  });
+
+  test("starts one hidden reporter briefing and shows fetched counts", async () => {
+    render(<AgentReporterSurface />);
+
+    await waitFor(() => expect(screen.getByText(
+      "online — watching 2 signals · 3 questions pending",
+    )).toBeInTheDocument());
+    expect(mocks.startReporterSession).toHaveBeenCalledTimes(1);
+    expect(mocks.sendWebMessage).toHaveBeenCalledTimes(1);
+    expect(mocks.sendWebMessage).toHaveBeenCalledWith(
+      "reporter-briefing-kickoff",
+      undefined,
+      undefined,
+      { hidden: true, persona: "reporter" },
+    );
+    expect(screen.getByTestId("reporter-chat")).toBeInTheDocument();
+  });
+});

--- a/apps/web/tests/ai-chat-context-signal.test.tsx
+++ b/apps/web/tests/ai-chat-context-signal.test.tsx
@@ -96,6 +96,9 @@ function Probe() {
       if (resolvedSessionId) setResolutionTarget(resolvedSessionId);
     });
   };
+  const resolveReporter = () => {
+    void chat.resolveIntentSession({ id: 'reporter-scope', label: 'Reporter scope' }, 'reporter');
+  };
   return (
     <div>
       <button onClick={() => void chat.sendWebMessage('first', undefined, undefined, { persona: 'signal' })}>
@@ -107,6 +110,8 @@ function Probe() {
       <button onClick={() => chat.clearChat()}>clear</button>
       <button onClick={() => chat.clearChat({ abortStream: false })}>clear detached</button>
       <button onClick={() => chat.startSignalSession()}>start signal</button>
+      <button onClick={() => chat.startReporterSession()}>start reporter</button>
+      <button onClick={() => void chat.sendWebMessage('reporter message')}>reporter message</button>
       <button onClick={() => void chat.loadSession('session-a')}>load a</button>
       <button onClick={() => void chat.loadSession('session-b')}>load b</button>
       <button onClick={() => void chat.loadSession('old-session')}>load old</button>
@@ -115,6 +120,7 @@ function Probe() {
       </button>
       <button onClick={() => resolveIntent('intent-a')}>resolve intent a</button>
       <button onClick={() => resolveIntent('intent-b')}>resolve intent b</button>
+      <button onClick={resolveReporter}>resolve reporter</button>
       <button onClick={() => chat.submitMidStreamMessage('queued follow-up', [])}>queue follow-up</button>
       <span data-testid="session">{chat.sessionId ?? 'none'}</span>
       <span data-testid="persona">{chat.sessionPersona ?? 'none'}</span>
@@ -179,6 +185,24 @@ describe('AIChatContext Signal persona transport and ownership', () => {
     fireEvent.click(screen.getByRole('button', { name: 'compatibility' }));
     await waitFor(() => expect(mocks.apiClient.stream).toHaveBeenCalledTimes(3));
     expect(mocks.apiClient.stream.mock.calls[2]?.[0]).toBe('/chat/stream');
+  });
+
+  test('reporter sessions resolve on the web route and forced sends use web transport', async () => {
+    mocks.apiClient.post.mockResolvedValueOnce({ session: { id: 'reporter-scope' } });
+    mocks.apiClient.stream.mockResolvedValueOnce(streamResponse({ sessionId: 'reporter-session', persona: 'reporter' }));
+
+    renderProvider();
+    fireEvent.click(screen.getByRole('button', { name: 'resolve reporter' }));
+    await waitFor(() => expect(mocks.apiClient.post).toHaveBeenCalledWith(
+      '/chat/web/session/resolve',
+      expect.objectContaining({ persona: 'reporter' }),
+    ));
+
+    fireEvent.click(screen.getByRole('button', { name: 'start reporter' }));
+    fireEvent.click(screen.getByRole('button', { name: 'reporter message' }));
+    await waitFor(() => expect(text('session')).toBe('reporter-session'));
+    expect(mocks.apiClient.stream.mock.calls[0]?.[0]).toBe('/chat/web/stream');
+    expect(mocks.apiClient.stream.mock.calls[0]?.[1]).toMatchObject({ persona: 'reporter' });
   });
 
   test('onboarding sends use the dedicated server-clamped route', async () => {

--- a/apps/web/vite.config.ts
+++ b/apps/web/vite.config.ts
@@ -31,6 +31,12 @@ export default defineConfig(({ mode, command }) => {
     resolve: {
       alias: {
         "@": path.resolve(__dirname, "./src"),
+        // Keep the reporter kickoff marker browser-safe without bundling the
+        // protocol runtime barrel (which includes Node-only graph modules).
+        "@indexnetwork/protocol": path.resolve(
+          __dirname,
+          "../../packages/protocol/src/chat/reporter.prompt.ts",
+        ),
       },
     },
     preview: {


### PR DESCRIPTION
## Summary

- Adds the flag-gated read-only Reporter Agent chat surface on `/agent`.
- Preserves the existing `/agent` ChatContent surface when `features.agentSurface` is falsy and leaves `/agent/memory` unchanged.
- Starts the reporter briefing with hidden `REPORTER_BRIEFING_KICKOFF` and routes reporter turns through the web transport.
- Shows fetched active-signal and pending-question counts plus reporter suggested-ask chips.

## Behavior

- `features.agentSurface` is default-off and ships dark; no Railway flag change is included.
- The surface is read-only: no intent creation, question-answering, archive, pause, or other mutation controls.
- Reporter kickoff messages never appear in the transcript (`hidden: true`).
- Flag-off behavior is unchanged.

## Verification

- Targeted reporter/AI chat tests: 22 passed.
- Web production build passes (with the existing unset `VITE_PROTOCOL_URL` warning).
- Web lint passes with existing warnings.
- Full web test suite still has 16 pre-existing DecisionQuestions failures across 4 files.