### PR TITLE
fix: hide chat session title bar on read-only reporter surface (IND-476)

### DIFF
--- a/apps/web/CHANGELOG.md
+++ b/apps/web/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
 
 ## [Unreleased]
 
+### Fixed
+
+- Hide the generic chat session title bar ("Untitled chat", back/rename/share controls) on read-only surfaces like the `/agent` reporter, which renders its own header (IND-476). Test config now resolves the reporter kickoff marker from protocol source so web tests no longer depend on a built `packages/protocol/dist`.
+
 ### Added
 
 - Add the flag-gated read-only Reporter Agent surface on `/agent` (IND-476): opening briefings use the shared reporter kickoff marker, status counts use fetched signals and pending questions, and suggested asks route through the reporter persona.

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@indexnetwork/web",
-  "version": "0.25.0",
+  "version": "0.25.1",
   "license": "MIT",
   "scripts": {
     "dev": "vite --host 127.0.0.1",

--- a/apps/web/src/components/ChatContent.tsx
+++ b/apps/web/src/components/ChatContent.tsx
@@ -1216,7 +1216,9 @@ export default function ChatContent({
   return (
     <>
       {!legacyOrchestratorReadOnly && !readOnlySurface && inviteModalElement}
-      {/* Sticky header - full width, min-h-17 matches ChatView header height */}
+      {/* Sticky header - full width, min-h-17 matches ChatView header height.
+          Hidden on read-only surfaces (e.g. /agent reporter), which render their own header. */}
+      {!readOnlySurface && (
       <div className="sticky top-0 bg-white z-10 px-4 py-3 flex items-center gap-3 min-h-17">
         <button
           type="button"
@@ -1314,6 +1316,7 @@ export default function ChatContent({
           </div>
         )}
       </div>
+      )}
 
       {/* Scrollable content */}
       <div className="px-6 lg:px-8 pb-32 flex-1">

--- a/apps/web/tests/negotiator-dm-inbox.test.tsx
+++ b/apps/web/tests/negotiator-dm-inbox.test.tsx
@@ -1019,3 +1019,44 @@ describe('Signal Agent web cutover', () => {
     await waitFor(() => expect(screen.getByTestId('location').textContent).toBe('/'));
   });
 });
+
+describe('Read-only surface header (IND-476)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.chat.messages = [];
+    mocks.chat.sessionId = null;
+    mocks.chat.sessionTitle = null;
+    mocks.chat.sessionLoadState = { status: 'idle', targetSessionId: null, error: null };
+    mocks.chat.sessionPersona = null;
+    mocks.chat.turnBlock = null;
+    mocks.chat.chatScope = null;
+    mocks.auth.features.signalAgent = false;
+    mocks.questionsService.getByConversation.mockResolvedValue([]);
+    mocks.questionsService.getPending.mockResolvedValue([]);
+    mocks.apiClient.post.mockResolvedValue({ intents: [] });
+  });
+
+  test('readOnlySurface hides the session title bar entirely', () => {
+    mocks.chat.messages = [{ id: 'm1', role: 'assistant', content: 'Overnight briefing', timestamp: new Date() }];
+    mocks.chat.sessionId = 'reporter-session-1';
+    mocks.chat.sessionPersona = 'reporter';
+
+    renderWithRouter(<ChatContent persona="reporter" readOnlySurface />, { route: '/agent' });
+
+    expect(screen.queryByText('Untitled chat')).toBeNull();
+    expect(screen.queryByRole('button', { name: 'Back to home' })).toBeNull();
+    expect(screen.queryByRole('button', { name: 'Rename conversation' })).toBeNull();
+    // The surface still has a composer for transparency asks.
+    expect(screen.getByTestId('chat-input')).not.toBeNull();
+  });
+
+  test('default surface keeps the title bar', () => {
+    mocks.chat.messages = [{ id: 'm1', role: 'assistant', content: 'Hello there', timestamp: new Date() }];
+    mocks.chat.sessionId = 'plain-session-1';
+
+    renderWithRouter(<ChatContent />, { route: '/' });
+
+    expect(screen.getByText('Untitled chat')).not.toBeNull();
+    expect(screen.getByRole('button', { name: 'Back to home' })).not.toBeNull();
+  });
+});

--- a/apps/web/vitest.config.ts
+++ b/apps/web/vitest.config.ts
@@ -7,6 +7,12 @@ export default defineConfig({
   resolve: {
     alias: {
       '@': path.resolve(__dirname, './src'),
+      // Mirrors vite.config.ts: resolve the reporter kickoff marker from source
+      // so tests never depend on a built packages/protocol/dist.
+      '@indexnetwork/protocol': path.resolve(
+        __dirname,
+        '../../packages/protocol/src/chat/reporter.prompt.ts',
+      ),
     },
   },
   test: {


### PR DESCRIPTION
## Problem
On the flag-on `/agent` reporter surface, once the hidden briefing kickoff created a session, ChatContent's generic sticky header leaked through under the reporter's own status header: an "Untitled chat" title, a back chevron that clears the chat and navigates to `/`, and share/debug controls. Screenshot from dev verification showed the stacked, meaningless chrome.

## Fix
- `ChatContent`: the sticky session title bar now renders only when `readOnlySurface` is false. Default chat and legacy orchestrator read-only surfaces are unchanged (verified by control test).
- `vitest.config.ts`: mirror the `@indexnetwork/protocol` → `reporter.prompt.ts` alias from `vite.config.ts`, so web tests resolve the reporter kickoff marker from source instead of silently depending on a built `packages/protocol/dist` (this is why the reporter surface test failed in a fresh worktree).

## Tests
- New: `readOnlySurface` hides title bar entirely (no "Untitled chat", no back/rename); control test asserts the default surface keeps it.
- `negotiator-dm-inbox` 26/26, reporter/agent/ai-chat-context suites 48/48 combined, `vite build` passes.

## Version
web 0.25.0 → 0.25.1 (patch).