### PR TITLE
fix(web): preserve early Agent chat submissions

### DIFF
--- a/apps/web/CHANGELOG.md
+++ b/apps/web/CHANGELOG.md
@@ -30,6 +30,7 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
 
 ### Fixed
 
+- Preserve messages submitted while the Reporter Agent's opening briefing is creating its first web session, so Enter and Send submissions are queued rather than dropped; add an accessible label to the send control.
 - Keep the answered Q&A log visible in the Personal Agent negotiator chat branch after questions are answered (IND-481).
 - Clear stale browser auth sessions automatically when user lookup fails.
 - Show experiment networks such as Edge City in shared profile networks and link them to their network pages.

--- a/apps/web/src/components/ChatContent.tsx
+++ b/apps/web/src/components/ChatContent.tsx
@@ -928,6 +928,8 @@ export default function ChatContent({
                 type="submit"
                 size="icon"
                 disabled={!canSend || isUploadingFiles}
+                title="Send message"
+                aria-label="Send message"
                 className="shrink-0 h-8 w-8 rounded-full bg-[#041729] text-white hover:bg-[#0a2d4a] disabled:opacity-50 disabled:cursor-not-allowed p-0"
               >
                 <ArrowUp className="h-4 w-4" />
@@ -1171,6 +1173,8 @@ export default function ChatContent({
                     type="submit"
                     size="icon"
                     disabled={!canSend || isUploadingFiles}
+                    title="Send message"
+                    aria-label="Send message"
                     className="shrink-0 h-8 w-8 rounded-full bg-[#041729] text-white hover:bg-[#0a2d4a] disabled:opacity-50 disabled:cursor-not-allowed p-0"
                   >
                     <ArrowUp className="h-4 w-4" />

--- a/apps/web/src/contexts/AIChatContext.tsx
+++ b/apps/web/src/contexts/AIChatContext.tsx
@@ -401,6 +401,8 @@ export function AIChatProvider({ children }: { children: React.ReactNode }) {
   }>>([]);
   /** Per-message timeout IDs so cancelling or resolving one pending message doesn't affect others. */
   const interruptTimeoutsRef = useRef<Map<string, ReturnType<typeof setTimeout>>>(new Map());
+  /** Messages submitted while the first web stream is creating its session. */
+  const preSessionQueueRef = useRef<QueuedMessage[]>([]);
   const [pendingQueue, setPendingQueue] = useState<QueuedMessage[]>([]);
   /** Live questions from any chat persona's ask_user_question tool (user_question SSE event). */
   const [liveQuestions, setLiveQuestions] = useState<PendingQuestion[]>([]);
@@ -473,24 +475,19 @@ export function AIChatProvider({ children }: { children: React.ReactNode }) {
     const t = interruptTimeoutsRef.current.get(id);
     if (t !== undefined) { clearTimeout(t); interruptTimeoutsRef.current.delete(id); }
     pendingQueueRef.current = pendingQueueRef.current.filter((q) => q.id !== id);
+    preSessionQueueRef.current = preSessionQueueRef.current.filter((q) => q.id !== id);
     setPendingQueue([...pendingQueueRef.current]);
     setMessages((prev) => prev.filter((msg) => msg.id !== id));
   }, []);
 
   const submitMidStreamMessage = useCallback(
     (message: string, traceEvents: TraceEvent[], fileIds?: string[], attachmentNames?: string[]) => {
-      if (!sessionId) return;
       const pendingMsgId = crypto.randomUUID();
       const displayContent = message.trim() || (fileIds?.length ? "Attached file(s)." : "");
       if (!displayContent) return;
 
       const originatingOperation = activeSendRef.current;
       const transport = originatingOperation?.transport ?? "compatibility";
-      setMessages((prev) => [...prev, {
-        id: pendingMsgId, role: "user" as const, content: displayContent,
-        timestamp: new Date(), isPending: true,
-        ...(attachmentNames?.length ? { attachmentNames } : {}),
-      }]);
       const entry: QueuedMessage = {
         id: pendingMsgId,
         message,
@@ -499,6 +496,20 @@ export function AIChatProvider({ children }: { children: React.ReactNode }) {
         status: "pending",
         transport,
       };
+      setMessages((prev) => [...prev, {
+        id: pendingMsgId, role: "user" as const, content: displayContent,
+        timestamp: new Date(), isPending: true,
+        ...(attachmentNames?.length ? { attachmentNames } : {}),
+      }]);
+
+      // A new session has no id until the first stream receives its response
+      // headers. Keep submissions made during that window instead of dropping
+      // them (the reporter briefing hits this path).
+      if (!sessionId) {
+        preSessionQueueRef.current = [...preSessionQueueRef.current, entry];
+        return;
+      }
+
       pendingQueueRef.current = [...pendingQueueRef.current, entry];
       setPendingQueue([...pendingQueueRef.current]);
 
@@ -1279,12 +1290,25 @@ export function AIChatProvider({ children }: { children: React.ReactNode }) {
     active.controller.abort();
   }, []);
 
-  // Drain the pending queue whenever loading ends.
-  // Steer messages take priority; queued messages drain FIFO.
-  // Uses useEffect (not inline in sendMessage) to avoid React Compiler circular-reference issues.
+  // Drain pending messages whenever loading ends.
+  // Pre-session messages are first so a new reporter chat cannot lose a user
+  // submission while its hidden briefing creates the session.
   React.useEffect(() => {
     if (isLoading || turnBlock) return;
-    if (steerPendingRef.current.length > 0) {
+    if (preSessionQueueRef.current.length > 0 && sessionId) {
+      const [nextMsg, ...rest] = preSessionQueueRef.current;
+      preSessionQueueRef.current = rest;
+      setMessages((prev) => prev.map((msg) =>
+        msg.id === nextMsg.id ? { ...msg, isPending: false, isQueued: false } : msg,
+      ));
+      void sendMessageWithTransport(
+        nextMsg.transport,
+        nextMsg.message,
+        nextMsg.fileIds,
+        nextMsg.attachmentNames,
+        { hidden: true, existingMessageId: nextMsg.id },
+      );
+    } else if (steerPendingRef.current.length > 0) {
       const [steerMsg, ...rest] = steerPendingRef.current;
       steerPendingRef.current = rest;
       // Preserve the originating transport so a web continuation cannot fall back.
@@ -1316,7 +1340,7 @@ export function AIChatProvider({ children }: { children: React.ReactNode }) {
         { hidden: true, existingMessageId: nextMsg.id },
       );
     }
-  }, [isLoading, sendMessageWithTransport, turnBlock]);
+  }, [isLoading, sendMessageWithTransport, sessionId, turnBlock]);
 
   const clearChat = useCallback((options?: {
     abortStream?: boolean;
@@ -1336,6 +1360,7 @@ export function AIChatProvider({ children }: { children: React.ReactNode }) {
     interruptTimeoutsRef.current.forEach((t) => clearTimeout(t));
     interruptTimeoutsRef.current.clear();
     pendingQueueRef.current = [];
+    preSessionQueueRef.current = [];
     steerPendingRef.current = [];
     setPendingQueue([]);
     setIsLoading(false);
@@ -1386,6 +1411,7 @@ export function AIChatProvider({ children }: { children: React.ReactNode }) {
     interruptTimeoutsRef.current.forEach((t) => clearTimeout(t));
     interruptTimeoutsRef.current.clear();
     pendingQueueRef.current = [];
+    preSessionQueueRef.current = [];
     steerPendingRef.current = [];
     setPendingQueue([]);
     setLiveQuestions([]);

--- a/apps/web/tests/ai-chat-context-signal.test.tsx
+++ b/apps/web/tests/ai-chat-context-signal.test.tsx
@@ -205,6 +205,33 @@ describe('AIChatContext Signal persona transport and ownership', () => {
     expect(mocks.apiClient.stream.mock.calls[0]?.[1]).toMatchObject({ persona: 'reporter' });
   });
 
+  test('preserves a message submitted before the first web session id arrives', async () => {
+    const first = deferred<Response>();
+    mocks.apiClient.stream
+      .mockReturnValueOnce(first.promise)
+      .mockResolvedValueOnce(streamResponse({ response: 'follow-up response' }));
+
+    renderProvider();
+    fireEvent.click(screen.getByRole('button', { name: 'web first' }));
+    await waitFor(() => expect(text('loading')).toBe('yes'));
+
+    fireEvent.click(screen.getByRole('button', { name: 'queue follow-up' }));
+    expect(text('messages')).toContain('queued follow-up');
+    expect(mocks.apiClient.stream).toHaveBeenCalledTimes(1);
+
+    await act(async () => {
+      first.resolve(streamResponse({ sessionId: 'web-session', persona: 'reporter' }));
+      await first.promise;
+    });
+
+    await waitFor(() => expect(mocks.apiClient.stream).toHaveBeenCalledTimes(2));
+    expect(mocks.apiClient.stream.mock.calls[1]?.[0]).toBe('/chat/web/stream');
+    expect(mocks.apiClient.stream.mock.calls[1]?.[1]).toMatchObject({
+      message: 'queued follow-up',
+      sessionId: 'web-session',
+    });
+  });
+
   test('onboarding sends use the dedicated server-clamped route', async () => {
     mocks.apiClient.stream.mockResolvedValueOnce(streamResponse({
       sessionId: 'onboarding-session',


### PR DESCRIPTION
## Summary

- queue Agent Reporter messages submitted while the hidden opening briefing is still creating the first web session
- preserve Enter and Send submissions instead of dropping them when no session ID exists yet
- add an accessible label and tooltip to the send control

## Verification

- `cd apps/web && bun run test -- tests/ai-chat-context-signal.test.tsx` (20 passed)
- `cd apps/web && bun run build` (passed)
- `cd apps/web && bunx eslint src/components/ChatContent.tsx src/contexts/AIChatContext.tsx` (0 errors; existing warnings)

## Manual acceptance

On `/agent`, submit a message with Enter and the send icon while the opening briefing is still loading; the message should remain visible and send after the reporter session is established.

Related: IND-476; separate auth-expiry symptom tracked by IND-480.