### PR TITLE
fix(web): allow sends on reporter surface after briefing session exists (IND-488)

### DIFF
--- a/apps/web/CHANGELOG.md
+++ b/apps/web/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
 
 ### Fixed
 
+- Allow the reporter surface (`/agent`) to send messages after its briefing session is established; the route-mismatch guard now exempts the URL-less reporter session while preserving stale-session protection on `/d/:id` (IND-488).
 - Hide the generic chat session title bar ("Untitled chat", back/rename/share controls) on read-only surfaces like the `/agent` reporter, which renders its own header (IND-476). Test config now resolves the reporter kickoff marker from protocol source so web tests no longer depend on a built `packages/protocol/dist`.
 
 ### Added

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@indexnetwork/web",
-  "version": "0.25.1",
+  "version": "0.25.2",
   "license": "MIT",
   "scripts": {
     "dev": "vite --host 127.0.0.1",

--- a/apps/web/src/components/ChatContent.tsx
+++ b/apps/web/src/components/ChatContent.tsx
@@ -107,7 +107,8 @@ export default function ChatContent({
     && sessionId === sessionIdFromUrl
     && routedSessionReady;
   const routeSessionMismatch = sessionId !== sessionIdFromUrl
-    && Boolean(sessionId || sessionIdFromUrl);
+    && Boolean(sessionId || sessionIdFromUrl)
+    && !(reporterSurface && !sessionIdFromUrl);
   const mutationsBlocked = legacyOrchestratorReadOnly
     || routeSessionMismatch
     || (Boolean(sessionIdFromUrl) && !routedSessionReady);

--- a/apps/web/tests/negotiator-dm-inbox.test.tsx
+++ b/apps/web/tests/negotiator-dm-inbox.test.tsx
@@ -1030,6 +1030,9 @@ describe('Read-only surface header (IND-476)', () => {
     mocks.chat.sessionPersona = null;
     mocks.chat.turnBlock = null;
     mocks.chat.chatScope = null;
+    mocks.chat.isLoading = false;
+    mocks.chat.isSessionReady.mockReset();
+    mocks.chat.isSessionReady.mockReturnValue(false);
     mocks.auth.features.signalAgent = false;
     mocks.questionsService.getByConversation.mockResolvedValue([]);
     mocks.questionsService.getPending.mockResolvedValue([]);
@@ -1058,5 +1061,58 @@ describe('Read-only surface header (IND-476)', () => {
 
     expect(screen.getByText('Untitled chat')).not.toBeNull();
     expect(screen.getByRole('button', { name: 'Back to home' })).not.toBeNull();
+  });
+
+  test('reporter surface sends with an established URL-less session', async () => {
+    mocks.chat.messages = [{ id: 'm1', role: 'assistant', content: 'Overnight briefing', timestamp: new Date() }];
+    mocks.chat.sessionId = 'reporter-session-1';
+    mocks.chat.sessionPersona = 'reporter';
+
+    renderWithRouter(<ChatContent persona="reporter" readOnlySurface />, { route: '/agent' });
+    const input = screen.getByTestId('chat-input');
+    fireEvent.change(input, { target: { value: "What's waiting on me?" } });
+    fireEvent.submit(input.closest('form')!);
+
+    await waitFor(() => expect(mocks.chat.sendWebMessage).toHaveBeenCalledWith(
+      "What's waiting on me?",
+      undefined,
+      undefined,
+      undefined,
+    ));
+  });
+
+  test('default surface still blocks a mismatched routed session', () => {
+    mocks.chat.messages = [{ id: 'm1', role: 'assistant', content: 'Current chat', timestamp: new Date() }];
+    mocks.chat.sessionId = 'current-session';
+    mocks.chat.isSessionReady.mockReturnValue(true);
+
+    renderWithRouter(<ChatContent sessionIdParam="different-session" />, { route: '/d/different-session' });
+    const input = screen.getByTestId('chat-input');
+    fireEvent.change(input, { target: { value: 'This must be blocked' } });
+    fireEvent.submit(input.closest('form')!);
+
+    expect(mocks.chat.sendWebMessage).not.toHaveBeenCalled();
+  });
+
+  test('reporter surface remains sendable after a failed briefing without a session', async () => {
+    mocks.chat.messages = [{
+      id: 'm1',
+      role: 'assistant',
+      content: 'Failed to get response. Please try again.',
+      timestamp: new Date(),
+      isStreaming: false,
+    }];
+
+    renderWithRouter(<ChatContent persona="reporter" readOnlySurface />, { route: '/agent' });
+    const input = screen.getByTestId('chat-input');
+    fireEvent.change(input, { target: { value: 'Try the briefing again' } });
+    fireEvent.submit(input.closest('form')!);
+
+    await waitFor(() => expect(mocks.chat.sendWebMessage).toHaveBeenCalledWith(
+      'Try the briefing again',
+      undefined,
+      undefined,
+      { persona: 'reporter' },
+    ));
   });
 });


### PR DESCRIPTION
## Problem
On the `/agent` reporter surface, follow-up sends and suggestion-chip sends silently no-op after the opening briefing creates its hidden session.

## Root cause
`ChatContent` treated the established in-memory session as mismatched with the absent URL session parameter. The reporter surface intentionally stays at `/agent` and does not navigate to `/d/:id`, so `mutationsBlocked` remained true permanently.

## Fix
Exempt only the URL-less reporter surface from `routeSessionMismatch`. Reporter `/agent` sends now work after the briefing session exists, including the existing Gmail continuation path and suggestion-chip sends. Reporter remains read-only server-side; no API/protocol behavior changed.

## Guard preservation
The other mutation guards are unchanged. A reporter persona mounted with a mismatched `/d/:id` parameter remains blocked, and the default surface still blocks stale routed-session sends. The failed-briefing/no-session state is also covered so the composer remains usable.

## Tests
- `bun --bun vitest run tests/negotiator-dm-inbox.test.tsx` — 29 passed
- `bun --bun vitest run` — 189 passed; 16 pre-existing DecisionQuestions failures and the known `tests/routes.test.tsx` missing `@/app/profile/page` import remain
- `bun run build` — passed (existing Vite warnings only)
- Pre-commit ESLint passed

## Manual acceptance
Open `/agent`, wait for the briefing to finish, type `What's waiting on me?` and send; the reporter reply should stream into the same conversation. Suggestion chips should also send. Opening an old `/d/:id` chat and navigating around should continue to show the read-only/stale protections.
