### PR TITLE
chore: migrate workflow orchestration to Herdr

### DIFF
--- a/.pi/skills/address-code-review/SKILL.md
+++ b/.pi/skills/address-code-review/SKILL.md
@@ -25,7 +25,8 @@ Do not silently resolve Copilot conversations.
 
 - The repository uses GitHub pull requests.
 - The `gh` CLI is installed and authenticated.
-- Fetching threads, replying, and resolving are GitHub-side and work from any session. **Applying a code fix requires the PR's user-mediated worktree Pi session** — when this skill runs in the canonical-root session, e.g. via `finish-pr`, give that session one consolidated fix prompt (see `run-worktree-session`); only the reply/resolve happens in the canonical-root session.
+- Fetching threads, replying, and resolving are GitHub-side and work from any session. **Applying a code fix requires the PR's existing visible Herdr-managed Pi worktree session** — when this skill runs in the canonical-root coordinator, e.g. via `finish-pr`, give that session one consolidated fix prompt, poll it directly, and keep reply/resolve operations in the coordinator (see `run-worktree-session`).
+- Do not use hidden `Agent` subagents for code-review fixes, and do not create a watcher process or watcher pane. Reuse one visible Herdr workspace/Pi agent for every review round on the PR.
 - If the user does not provide a PR number, infer it from the current branch.
 
 ## Command safety rule
@@ -127,15 +128,48 @@ If you update `.github/instructions/pr-reviewer.instructions.md`:
 
 ### 4. Apply fixes when needed
 
-When a fix is needed (in the PR's user-mediated worktree Pi session — see Preconditions):
+When a fix is needed, add every actionable thread to one complete prompt for the PR's
+existing visible Herdr-managed Pi session. Include the absolute worktree path, PR head
+branch, exact findings, requested changes, and targeted checks. Before delivery, verify
+the existing agent and read its recent output:
 
-1. Edit the code.
-2. Run targeted tests, lint, typecheck, or a focused verification command when practical.
-3. Commit and push the fix if the user expects the PR to be updated remotely.
-4. Reply to the Copilot review comment with a concise summary of the fix.
-5. Resolve the thread.
+```bash
+herdr agent get "$AGENT_NAME"
+herdr agent read "$AGENT_NAME" --source recent-unwrapped --lines 200
+herdr agent prompt "$AGENT_NAME" "$(< /absolute/path/to/review-fixes.md)"
+```
 
-When running in the canonical-root session, add all code-review findings to one prompt for the existing worktree session. Once the user returns with the pushed commit, reply (referencing it) and resolve; do not create a separate worktree session for each thread.
+Use `herdr agent prompt` only when no structured question/editor draft is active. The
+coordinator remains active and polls the agent directly:
+
+```bash
+herdr agent wait "$AGENT_NAME" --until blocked --until idle --until done --timeout 30000
+herdr agent read "$AGENT_NAME" --source recent-unwrapped --lines 200
+```
+
+A timeout is a polling checkpoint. Continue until the visible Pi has:
+
+1. verified its cwd and PR head branch;
+2. edited the code;
+3. run targeted tests, lint, typecheck, or another focused check;
+4. committed and pushed the fixes.
+
+For routine implementation questions, inspect the output and answer the recommended or
+safest project-compliant option automatically. Escalate only genuine
+product/architecture ambiguity, destructive operations, external infrastructure
+mutation, credentials/secrets, or merge approval. If a structured prompt is active,
+answer it through targeted pane input instead of appending a new agent prompt:
+
+```bash
+herdr pane read "$PANE_ID" --source visible --lines 120
+herdr pane send-text "$PANE_ID" "<safe answer>"
+herdr pane send-keys "$PANE_ID" enter
+```
+
+After the pushed commit is verified, reply to each affected Copilot comment with a
+concise summary referencing the commit, then resolve the thread. Reuse the same
+workspace, pane, and agent for all review rounds; do not create a worktree/session per
+thread.
 
 Reply to a PR review comment using this exact REST endpoint shape:
 

--- a/.pi/skills/create-worktree/SKILL.md
+++ b/.pi/skills/create-worktree/SKILL.md
@@ -13,6 +13,23 @@ Git worktree there, run the mandatory setup, then open the exact checkout in Her
 Herdr is the default visible execution plane; do not launch a hidden implementation
 subagent.
 
+## Herdr preflight
+
+Before worktree orchestration, verify the installed CLI, running server, and Pi
+integration:
+
+```bash
+command -v herdr
+herdr status server
+herdr integration status
+```
+
+If the server/client is not running, have the user launch `herdr` from the repository
+so the workspace remains visible. If the Pi integration is missing or outdated, follow
+`docs/guides/getting-started.md` and install it before starting the agent. Do not silently
+fall back to hidden execution; use the legacy helper only when the user explicitly
+chooses that fallback because Herdr is unavailable.
+
 ## Branch and folder policy
 
 Branches must match:

--- a/.pi/skills/create-worktree/SKILL.md
+++ b/.pi/skills/create-worktree/SKILL.md
@@ -1,28 +1,19 @@
 ---
 name: create-worktree
 description: >-
-  Create or reuse an isolated Index worktree and observable tmux-hosted Pi session with
-  the deterministic worktree:session helper. Use before implementation from the
-  canonical root, when resuming a branch session, or when validating branch/worktree
-  naming and setup without mutation.
+  Create or reuse an isolated Index worktree and open its visible Herdr-managed Pi
+  session. Use before implementation from the canonical root, when resuming a branch
+  session, or when validating branch/worktree/workspace identity before mutation.
 ---
 
 # create-worktree
 
-Use the repository launcher instead of manually composing `git worktree`, setup, tmux,
-and Pi commands:
+Keep the canonical root on `dev` and read-only for source changes. Create or reuse the
+Git worktree there, run the mandatory setup, then open the exact checkout in Herdr.
+Herdr is the default visible execution plane; do not launch a hidden implementation
+subagent.
 
-```bash
-bun run worktree:session -- <type>/<description>
-```
-
-It derives the only valid folder name (`<type>-<description>`), resolves the canonical
-worktree from `git worktree list --porcelain`, safely creates or reuses the matching
-worktree, runs `bun run worktree:setup <folder>`, and starts or reuses tmux session
-`pi-<folder>` at the exact real worktree path. New Pi processes receive the same stable
-name through the installed and documented `pi --name <name>` option.
-
-## Branch policy
+## Branch and folder policy
 
 Branches must match:
 
@@ -31,49 +22,88 @@ Branches must match:
 ```
 
 The description must explain the change. Opaque issue-only names such as
-`chore/ind-422` are rejected. Never accept or invent a separate folder argument.
+`chore/ind-422` are rejected. The only valid folder is the branch with `/` replaced by
+`-`; never accept or invent a separate folder argument.
 
-Examples:
-
-```bash
-bun run worktree:session -- feat/negotiation-evidence-shadow
-bun run worktree:session -- fix/opportunity-scope-hardening --base origin/dev
-```
-
-## Observe, deliver, and attach
-
-Detached tmux is the default so the caller remains observable and can attach when
-ready:
+From the canonical root, derive the identities once:
 
 ```bash
-tmux attach-session -t pi-feat-negotiation-evidence-shadow
+ROOT=$(git rev-parse --show-toplevel)
+BRANCH=feat/negotiation-evidence-shadow
+FOLDER=${BRANCH/\//-}
+WORKTREE="$ROOT/.worktrees/$FOLDER"
 ```
 
-Use `--attach` to attach after setup. To deliver a handoff without shell-quoting its
-contents, write it to an absolute file and pass:
+Before creating anything, verify the root and inspect all registered worktrees:
 
 ```bash
-bun run worktree:session -- feat/negotiation-evidence-shadow \
-  --prompt-file /absolute/path/to/handoff.md --attach
+pwd
+git branch --show-current
+git status --short --branch
+git worktree list --porcelain
 ```
 
-The helper uses tmux buffers for both new and existing sessions and verifies an existing
-pane's cwd before reuse. It does not modify tmux configuration.
+The canonical root must be `ROOT` on `dev`. If `WORKTREE` already exists, reuse it only
+when its registered path and branch exactly match. Reject a path collision, a branch
+mounted at another path, or a mismatched checkout instead of mutating it.
 
-## Inspect before mutation
-
-Use the deterministic dry-run contract when reviewing the plan or integrating tooling:
+When no matching worktree exists, create it from `origin/dev`. Use the existing local
+branch when present; otherwise create the semantic branch:
 
 ```bash
-bun run worktree:session -- chore/session-automation --dry-run --json
+git fetch origin dev
+if git show-ref --verify --quiet "refs/heads/$BRANCH"; then
+  git worktree add "$WORKTREE" "$BRANCH"
+else
+  git worktree add -b "$BRANCH" "$WORKTREE" origin/dev
+fi
 ```
 
-Dry-run performs no mutation. JSON includes schema version 1 facts and ordered command
-argv. `--attach` and `--json` are intentionally incompatible.
+Run setup for both new and reused worktrees:
 
-## Work inside the session
+```bash
+bun run worktree:setup "$FOLDER"
+```
 
-Once inside the worktree, verify:
+Setup is mandatory: it installs dependencies and links the root environment files.
+
+## Open or focus the Herdr workspace
+
+Open the exact existing Git worktree and use the dashed folder as the stable workspace
+label:
+
+```bash
+herdr worktree open \
+  --path "$WORKTREE" \
+  --label "$FOLDER" \
+  --focus \
+  --json
+```
+
+Record the returned `.result.workspace.workspace_id` and
+`.result.root_pane.pane_id`. The response may report `already_open: true`; that means
+reuse, not permission to skip identity checks. Confirm the returned worktree path and
+branch, and inspect the IDs directly when needed:
+
+```bash
+herdr workspace get "$WORKSPACE_ID"
+herdr pane get "$PANE_ID"
+herdr agent get "$PANE_ID"
+```
+
+If the root pane is an interactive shell with no Pi agent, start one. The stable agent
+name is the same dashed folder:
+
+```bash
+herdr agent start "$FOLDER" --kind pi --pane "$PANE_ID"
+```
+
+If Pi already exists in that pane, reuse it only when its cwd is `WORKTREE` and its
+identity belongs to this workspace. Never start a second writer in the same worktree.
+
+## Verify before mutation
+
+The first handoff must require the visible Pi to run:
 
 ```bash
 pwd
@@ -81,10 +111,17 @@ git branch --show-current
 git status --short --branch
 ```
 
-Do not create another worktree when the requested implementation session is already in
-one. Make ordinary edits, run tests, commit, push, and open a PR without asking for a
-routine approval gate. Ask only for genuine architecture or scope ambiguity,
-destructive actions, external infrastructure mutations, or merge approval.
+The path and branch must match `WORKTREE` and `BRANCH`. Stop on any collision or
+mismatch. Ordinary edits, tests, commits, pushes, and PR creation need no approval;
+escalate only genuine product/architecture ambiguity, destructive actions, external
+infrastructure mutation, credentials/secrets, or merge approval.
+
+Parallel implementation is allowed only when it is genuinely useful: give each writer
+a separate semantic branch, Git worktree, Herdr workspace, and Pi session. One writer
+per worktree remains mandatory.
+
+The repository's `bun run worktree:session` launcher remains a legacy fallback when
+Herdr is unavailable; it is not the default orchestration path.
 
 If GPG signing fails in a non-interactive shell, preserve repository-wide settings. A
 worktree-local fallback is allowed when needed:
@@ -97,5 +134,5 @@ Never use plain `git config commit.gpgsign false`, which affects every worktree.
 
 ## See also
 
-- `run-worktree-session` — implementation and fix-loop ownership inside the launched session.
+- `run-worktree-session` — visible handoff, polling, question handling, and fix loops.
 - `finish-pr` — explicit merge approval and post-merge verification.

--- a/.pi/skills/finish-pr/SKILL.md
+++ b/.pi/skills/finish-pr/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: finish-pr
-description: "Finish a pull request end-to-end from the canonical/root session: investigate PR health (base freshness, checks, review threads, version bumps, local builds), hand needed worktree changes to the user-mediated worktree session in one consolidated prompt, merge after explicit confirmation, verify post-merge GitHub/Railway deployment health, and close or update related GitHub and Linear issues. Use when the user says a PR is ready to finish, ship, merge, or close out."
+description: "Finish a pull request end-to-end from the canonical/root session: investigate PR health, coordinate fixes in the existing visible Herdr-managed Pi worktree session, merge only after explicit confirmation, verify post-merge GitHub/Railway health, and close or update related issues. Use when the user says a PR is ready to finish, ship, merge, or close out."
 ---
 
 # Finish PR
@@ -19,22 +19,34 @@ Safely finish a PR end-to-end from the canonical/root session: identify the PR/i
 - Never claim deployment success from a queued/in-progress status. Wait for a terminal success state or report that it is still pending.
 - If Railway MCP tools are unavailable, report deployment as unverified; do not claim success or close related issues until it can be verified. GitHub merge safety does not depend on MCP availability.
 - If checks fail, keep issues open and report the blocker.
-- Never edit files or run mutating git commands (commit, rebase, push, force-push) from the canonical root. When a worktree change is needed, hand it to the user-mediated PR worktree session in one consolidated prompt; that session verifies the worktree's absolute path and feature branch before mutation. GitHub-side actions (review-thread replies/resolutions, the merge itself, issue updates) and read-only verification (builds, tests, diffs against remote refs) are fine.
+- Never edit files or run mutating git commands (commit, rebase, push, force-push) from the canonical root. When a worktree change is needed, send one consolidated prompt to the existing visible Herdr-managed Pi session for the PR worktree, then poll it directly from the coordinator. That session verifies the worktree's absolute path and feature branch before mutation. GitHub-side actions (review-thread replies/resolutions, the merge itself, issue updates) and read-only verification (builds, tests, diffs against remote refs) are fine.
+- Do not use hidden `Agent` subagents for implementation/fix rounds, and do not create a watcher process or watcher pane. Reuse the same Herdr workspace, pane, and Pi agent.
 - A PR-branch rebase is executed only from the verified PR worktree, and only ever on the PR's own feature branch — never a shared/long-lived head branch (`dev`, `main` — e.g. a release PR's head): that rewrites shared history and breaks other worktrees. Use `--force-with-lease`, never plain `--force`.
 - Do not remove a git worktree without confirming the PR is merged, the working tree is clean (no uncommitted/unpushed work), and the user has not asked to keep it. When in doubt, ask before removing.
 
 ## Supporting rpiv skills
 
-Use other rpiv skills when they fit: `run-worktree-session` for the user-mediated worktree handoff and fix loop, `manage-feature-flags` for env-flag flips across Railway/local surfaces, `address-code-review` for unresolved review threads, `validate` for rpiv-plan success criteria, `code-review` for risky/multi-round diffs, `changelog` for release notes, `commit` for finishing commits, and `verify-production-release` for dev→main releases. Do not invoke heavyweight skills for trivial PRs with already-green checks and no open review threads.
+Use other rpiv skills when they fit: `run-worktree-session` for the coordinator-managed visible Herdr handoff and fix loop, `manage-feature-flags` for env-flag flips across Railway/local surfaces, `address-code-review` for unresolved review threads, `validate` for rpiv-plan success criteria, `code-review` for risky/multi-round diffs, `changelog` for release notes, `commit` for finishing commits, and `verify-production-release` for dev→main releases. Do not invoke heavyweight skills for trivial PRs with already-green checks and no open review threads.
 
-## Handing fixes to the worktree session
+## Coordinating fixes in the visible Herdr session
 
 When a workflow step finds code, rebase, version, or push work, do not mutate from the
-canonical root. Produce one consolidated prompt for the existing user-mediated PR
-worktree session. Include the stable handoff name, absolute worktree path, branch,
-concrete findings/log excerpts, requested actions, and targeted checks.
+canonical root. Locate the PR's existing Herdr workspace by its exact Git worktree path
+and capture the workspace, pane, and agent identities. Reject path/branch collisions;
+never open a second writer for the same checkout.
 
-That worktree session confirms before mutation:
+Produce one consolidated prompt containing the stable handoff name, absolute worktree
+path, PR head branch, concrete findings/log excerpts, requested actions, and targeted
+checks. Inspect the agent and recent output before delivery:
+
+```bash
+herdr agent get "$AGENT_NAME"
+herdr agent read "$AGENT_NAME" --source recent-unwrapped --lines 200
+herdr agent prompt "$AGENT_NAME" "$(< /absolute/path/to/fix-handoff.md)"
+```
+
+Use `herdr agent prompt` only when no structured question/editor draft is active. The
+visible session confirms before mutation:
 
 ```bash
 cd /absolute/path/to/pr-worktree
@@ -43,12 +55,31 @@ git branch --show-current
 git status --short --branch
 ```
 
-The path must be the PR worktree and the branch must be the PR head. Reuse the same
-session for every fix loop; do not create a fresh worktree/session for each finding.
+The coordinator remains active and polls directly; no watcher process or pane:
 
-After a narrow fix, rerun its affected local checks plus PR-head, required-check, and
-unresolved-thread status. Re-run the full readiness pass only after a rebase, broad
-change, or uncertain impact. Never merge from a feature worktree.
+```bash
+herdr agent get "$AGENT_NAME"
+herdr agent read "$AGENT_NAME" --source recent-unwrapped --lines 200
+herdr agent wait "$AGENT_NAME" --until blocked --until idle --until done --timeout 30000
+```
+
+On a routine question, inspect the visible output and automatically choose the safe,
+recommended project-compliant option. Escalate only product/architecture ambiguity,
+destructive operations, external infrastructure mutation, credentials/secrets, or
+merge approval. If a structured prompt is active, read it and answer through targeted
+pane input rather than appending a new prompt:
+
+```bash
+herdr pane read "$PANE_ID" --source visible --lines 120
+herdr pane send-text "$PANE_ID" "<safe answer>"
+herdr pane send-keys "$PANE_ID" enter
+```
+
+Reuse the same workspace/session for every fix loop; do not create a fresh worktree or
+Pi agent for each finding. After a narrow fix, rerun its affected local checks plus
+PR-head, required-check, and unresolved-thread status. Re-run the full readiness pass
+only after a rebase, broad change, or uncertain impact. Never merge from a feature
+worktree and never infer merge approval from delegated output.
 
 ## Workflow
 
@@ -229,7 +260,7 @@ Before merging, summarize:
 - env variable decisions (what was set in Railway / `.env.development` / `.env.test`, what was deliberately left unset),
 - related GitHub/Linear issues that will be updated after merge.
 
-Do not ask for merge confirmation while any finding is outstanding — hand it to the existing worktree session, then re-verify proportionally when the user returns. Ask the user for explicit confirmation to merge.
+Do not ask for merge confirmation while any finding is outstanding — hand it to the existing visible Herdr session, poll through its fix/verification/push result, then re-verify proportionally. Ask the user for explicit confirmation to merge in the coordinator session.
 
 After confirmation, merge using the repository's preferred strategy. If unknown, inspect repo conventions or ask. In multi-worktree repos where the base branch is checked out in the canonical root, run the merge from that canonical root (not from the feature worktree): `gh pr merge --delete-branch` may complete the server-side merge but fail local branch cleanup if it tries to check out a base branch already used by another worktree.
 

--- a/.pi/skills/run-worktree-session/SKILL.md
+++ b/.pi/skills/run-worktree-session/SKILL.md
@@ -1,67 +1,116 @@
 ---
 name: run-worktree-session
 description: >-
-  Run feature and fix implementation in an observable tmux-hosted Pi worktree session,
-  using deterministic handoff delivery and a focused verify-commit-push-PR loop. Use
-  when Index work moves from root investigation into implementation or returns for PR
-  review and finish-pr fixes.
+  Run feature and fix implementation in a visible Herdr-managed Pi worktree session,
+  with direct coordinator polling and a focused verify-commit-push-PR loop. Use when
+  Index work moves from root investigation into implementation or returns for review
+  and finish-pr fixes.
 ---
 
 # run-worktree-session
 
-The canonical root coordinates; the worktree Pi session owns code mutations. tmux is
-the first observable-session layer. Pi RPC and dashboards are deliberately out of scope.
+The canonical/root Pi coordinates and remains active. The visible Pi in the exact Herdr
+worktree workspace owns code mutations. Do not use hidden `Agent` subagents for
+implementation or fix rounds, and do not create a watcher process or watcher pane.
 
-## 1. Launch or reuse the session
+## 1. Create or reuse the visible session
 
-Choose a semantic branch and invoke the repository helper from the canonical root:
+Follow `create-worktree` from the canonical root:
 
-```bash
-bun run worktree:session -- <type>/<description>
-```
+1. derive the semantic branch, dashed folder, and absolute worktree path;
+2. create or reuse the exact Git worktree after collision checks;
+3. run `bun run worktree:setup <folder>`;
+4. open or focus it with Herdr;
+5. start Pi only if the returned root pane has no existing agent.
 
-The helper derives the folder, safely creates or reuses the worktree, runs full setup,
-verifies any existing tmux pane cwd, and launches a named Pi session. Never manually
-accept a separate worktree folder and never create another worktree when the requested
-session is already inside one.
-
-For a deterministic preflight:
+The installed CLI contract is:
 
 ```bash
-bun run worktree:session -- <type>/<description> --dry-run --json
+herdr worktree open --path "$WORKTREE" --label "$FOLDER" --focus --json
+herdr agent start "$FOLDER" --kind pi --pane "$PANE_ID"
 ```
+
+Capture the returned workspace and pane IDs. Reuse the existing workspace/Pi when
+Herdr reports the worktree is already open. Reject a cwd, branch, workspace, pane, or
+agent-name collision rather than sending work to the wrong checkout.
 
 ## 2. Deliver one complete handoff
 
-When a root coordinator needs to hand work over, prepare one prompt file outside the
-repository with:
+Prepare one prompt file outside the repository containing:
 
-- a stable handoff name, branch, and expected absolute worktree path;
+- a stable handoff name, branch, dashed folder, and expected absolute worktree path;
 - verified findings and agreed scope;
-- key files and constraints;
+- key files, constraints, and exclusions;
 - targeted verification commands;
-- an instruction to verify cwd/branch and not create another worktree.
+- instructions to verify cwd/branch, commit, push, and open/update the PR;
+- an instruction not to create another worktree or hidden implementation subagent.
 
-Deliver the file through tmux rather than interpolating its contents into a shell
-command:
-
-```bash
-bun run worktree:session -- <type>/<description> \
-  --prompt-file /absolute/path/to/handoff.md
-```
-
-The same command works for a new or existing tmux session. Attach explicitly when
-interactive observation is wanted:
+Before delivery, inspect the visible agent and recent pane output:
 
 ```bash
-tmux attach-session -t pi-<type>-<description>
+herdr agent get "$AGENT_NAME"
+herdr agent read "$AGENT_NAME" --source recent-unwrapped --lines 200
 ```
 
-Do not create task-specific committed `.pi` handoff files.
+Send the full handoff as one prompt only when the agent is ready and no structured
+question or editor draft is active:
 
-## 3. Verify session identity
+```bash
+herdr agent prompt "$AGENT_NAME" "$(< /absolute/path/to/handoff.md)"
+```
 
-Before edits:
+Do not commit task-specific handoff files under `.pi`.
+
+## 3. Poll directly from the coordinator
+
+The coordinator stays active while implementation runs. Poll the same visible agent;
+do not delegate observation to a background watcher:
+
+```bash
+herdr agent get "$AGENT_NAME"
+herdr agent read "$AGENT_NAME" --source recent-unwrapped --lines 200
+herdr agent wait "$AGENT_NAME" \
+  --until blocked --until idle --until done \
+  --timeout 30000
+```
+
+A wait timeout is a polling checkpoint, not a failure. Read new output, handle any
+question, and continue polling until the agent reports completion or a real blocker.
+Ground decisions in the visible output rather than assuming that `working`, `idle`, or
+`done` alone proves success.
+
+## 4. Answer questions safely
+
+For routine implementation questions, inspect the pane and choose the recommended or
+safest project-compliant option automatically. Examples include ordinary file edits,
+targeted tests, commits, pushes, and PR creation.
+
+Escalate to the user only for:
+
+- genuine product or architecture ambiguity;
+- destructive operations;
+- external infrastructure mutation;
+- credentials or secrets;
+- merge approval.
+
+Never infer merge approval.
+
+If a structured question, selector, or editor draft is active, do **not** use
+`herdr agent prompt`: it can append text to stale input. Read the pane, then answer the
+active UI through its pane ID with targeted text/keys:
+
+```bash
+herdr pane read "$PANE_ID" --source visible --lines 120
+herdr pane send-text "$PANE_ID" "<safe answer>"
+herdr pane send-keys "$PANE_ID" enter
+```
+
+For a selector, send only the navigation/confirmation keys required by the visible UI.
+Re-read the pane afterward to verify that the answer landed in the intended control.
+
+## 5. Verify session identity and implementation
+
+The visible Pi must run before mutation:
 
 ```bash
 pwd
@@ -69,38 +118,34 @@ git branch --show-current
 git status --short --branch
 ```
 
-The path and branch must match the handoff. Stop on a collision or mismatch rather than
-mutating another checkout.
+The path and branch must match the handoff. Keep changes within scope. Run targeted
+tests, lint, typechecks, and manual checks appropriate to the diff. Update required
+docs, package versions, and generated artifacts before committing. Report failures
+honestly.
 
-## 4. Implement and verify
+After verification succeeds, the visible Pi:
 
-Keep changes within the agreed foundation or fix scope. Run targeted tests, lint,
-typechecks, and manual acceptance checks appropriate to the diff. Update required docs,
-package versions, and generated artifacts before committing. Report failures honestly.
+1. commits with a conventional commit message;
+2. pushes the semantic branch;
+3. opens or updates a PR into `dev` with exact verification results and caveats.
 
-Ask only when there is genuine architecture or scope ambiguity, a destructive action,
-an external infrastructure mutation, or merge approval. Do not ask before ordinary
-edits, tests, commits, pushes, or PR creation.
-
-## 5. Commit, push, and open the PR
-
-After verification succeeds:
-
-1. commit with a conventional commit message;
-2. push the semantic feature branch;
-3. open or update a PR into `dev` with exact verification results and caveats.
-
-Opening a PR is not merge approval. The canonical `finish-pr` workflow owns readiness,
-explicit merge confirmation, deployment verification, issue updates, and cleanup.
+Opening a PR is not merge approval. The coordinator's `finish-pr` workflow owns
+readiness, explicit merge confirmation, deployment verification, issue updates, and
+cleanup.
 
 ## 6. Reuse for fix rounds
 
-For review or finish-pr findings, return to the same tmux/worktree session and deliver
-one consolidated prompt file. Apply the focused fixes, rerun affected checks, commit,
-and push. Do not create a fresh worktree or Pi session for each comment.
+For review or finish-pr findings, return to the same Herdr workspace, pane, and Pi
+agent. Send one consolidated fix prompt, poll directly, answer routine questions, and
+wait for the focused checks/commit/push result. Do not create a fresh worktree, agent,
+or prompt per comment.
+
+Parallel work uses separate visible Herdr workspaces and separate Git worktrees, with
+one writer per worktree. Merge or reconcile those branches deliberately; never let two
+agents mutate one checkout.
 
 ## See also
 
-- `create-worktree` — launcher contract, branch policy, and GPG fallback.
-- `address-code-review` — factual thread inspection and resolution workflow.
+- `create-worktree` — branch, setup, Herdr-open, and collision contracts.
+- `address-code-review` — factual thread inspection and visible fix-loop workflow.
 - `finish-pr` — merge approval and post-merge operations.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -189,8 +189,8 @@ git add packages/edge-city/agentvillage
 bun install                                # Install dependencies for all workspaces
 bun run dev                                # Interactive: select root or a worktree to run dev
 bun run worktree:list                       # List worktrees and their setup status
-bun run worktree:session -- <type>/<desc>    # Create/reuse worktree + setup + named Pi tmux session
 bun run worktree:setup <name>               # Install node_modules & symlink .env files into a worktree
+herdr worktree open --path <path> --label <name> --focus --json # Open/focus the visible worktree workspace
 bun run worktree:dev <name>                 # Run all dev servers from a worktree (auto-setups if needed)
 bun run worktree:build [name]               # Build at root, or in worktree <name> if given
 bun run skills:validate                      # Validate every project-local Pi skill
@@ -477,21 +477,39 @@ TSDoc on all classes (summary) and public methods (`@param`, `@returns`, `@throw
 
 ### Worktrees
 
-**Always use worktrees** for features and fixes. Keep `dev` stable. Worktrees live in `.worktrees/` (gitignored). Branches use semantic `<type>/<description>` names; the launcher derives the dashed folder and does not accept a separate folder argument.
+**Always use worktrees** for features and fixes. Keep the canonical root on `dev` and
+read-only for source mutations. Worktrees live in `.worktrees/` (gitignored). Branches
+use semantic `<type>/<description>` names and the only valid folder is the dashed form
+`<type>-<description>`; never accept a separate folder name.
+
+From the canonical root, create or reuse the exact Git worktree after checking
+`git worktree list --porcelain`, then always run setup:
 
 ```bash
-bun run worktree:session -- feat/user-authentication             # detached tmux by default
-bun run worktree:session -- fix/login-redirect-loop --attach     # attach after setup
-bun run worktree:session -- chore/session-automation --dry-run --json
+bun run worktree:setup feat-user-authentication
+herdr worktree open \
+  --path "$PWD/.worktrees/feat-user-authentication" \
+  --label feat-user-authentication \
+  --focus \
+  --json
+herdr agent start feat-user-authentication --kind pi --pane <returned-pane-id>
 ```
 
-The launcher creates or reuses the matching worktree, runs `worktree:setup`, verifies
-the tmux pane cwd, and starts a deterministic Pi session with `pi --name`. tmux is the
-first observable-session layer; Pi RPC/dashboard automation is deferred.
+Herdr is the default visible execution plane. Record the workspace and pane IDs returned
+by `herdr worktree open`; reuse an existing workspace/Pi only when its worktree path,
+branch, and cwd match. The canonical/root Pi remains the coordinator, sends one complete
+handoff, and polls with `herdr agent get/read/wait` directly—never through a hidden
+implementation subagent, background watcher process, or watcher pane. It answers routine
+implementation questions with the safe/recommended option and escalates only genuine
+product/architecture ambiguity, destructive actions, external infrastructure mutation,
+credentials/secrets, or merge approval. A structured question/editor draft must be
+answered through targeted `herdr pane read/send-text/send-keys`, not a new agent prompt.
+Never infer merge approval.
 
-Agents ask only for genuine architecture/scope ambiguity, destructive actions, external
-infrastructure mutations, or merge approval. They do not ask before ordinary edits,
-tests, commits, pushes, or PR creation.
+Parallel implementation uses separate semantic branches, Git worktrees, visible Herdr
+workspaces, and Pi sessions, with one writer per worktree. Reuse the same visible session
+for review and finish-pr fix loops. The legacy `bun run worktree:session` helper remains
+a fallback when Herdr is unavailable, not the default workflow.
 
 ### Conventional Commits
 
@@ -524,9 +542,13 @@ Use `gh` CLI to create PRs into `origin/dev`. Description as changelog: New Feat
 
 ## Superpowers Workflow
 
-### Implementation via Subagents in Worktrees
+### Implementation in Visible Herdr Worktrees
 
-When executing implementation plans, **always use subagent-driven development with worktree isolation** (`isolation: "worktree"`). This keeps `dev` stable and allows parallel independent tasks. Combine the `superpowers:subagent-driven-development` and `superpowers:using-git-worktrees` skills.
+Execute implementation and fix plans in visible Herdr-managed Pi sessions for isolated
+Git worktrees. The canonical/root Pi coordinates, remains active, polls Herdr directly,
+and keeps `dev` stable; it does not delegate implementation to hidden subagents. When
+parallel work is genuinely useful, use separate worktrees/workspaces with one writer per
+checkout. Follow the `create-worktree` and `run-worktree-session` skills.
 
 ### Receiving Code Review (`/address-code-review`)
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -482,7 +482,9 @@ read-only for source mutations. Worktrees live in `.worktrees/` (gitignored). Br
 use semantic `<type>/<description>` names and the only valid folder is the dashed form
 `<type>-<description>`; never accept a separate folder name.
 
-From the canonical root, create or reuse the exact Git worktree after checking
+Before socket orchestration, follow the Herdr setup in
+`docs/guides/getting-started.md`; its server and Pi integration must be available. From
+the canonical root, create or reuse the exact Git worktree after checking
 `git worktree list --porcelain`, then always run setup:
 
 ```bash

--- a/docs/guides/getting-started.md
+++ b/docs/guides/getting-started.md
@@ -23,6 +23,7 @@ Install the following before cloning the repository.
 | **pgvector** extension | 0.5+ | 2000-dimensional vector similarity search |
 | **Redis** | 6+ | Job queues (BullMQ) and caching |
 | **Git** | 2.30+ | Version control, worktrees |
+| **Herdr** | current CLI | Visible worktree workspaces and Pi sessions |
 
 Install Bun (if not already installed):
 
@@ -361,30 +362,73 @@ This shows all BullMQ job queues, their status, and lets you retry failed jobs o
 
 ## Git workflow
 
-### Worktrees
+### Worktrees and visible Pi sessions
 
-All feature and fix work happens in git worktrees, keeping the main working tree (`dev` branch) stable.
+All feature and fix work happens in Git worktrees, keeping the canonical working tree
+on `dev` and read-only for source changes. Worktrees live in `.worktrees/` (gitignored).
+Use a semantic slash branch such as `feat/my-feature`; its only valid folder is the
+dashed form `feat-my-feature`.
 
-Worktrees live in `.worktrees/` (gitignored). Use a semantic slash branch; the
-session launcher derives the dashed folder and does not accept a separate folder.
+From the canonical root, inspect existing registrations before creating anything:
 
 ```bash
-# Create/reuse the worktree, run setup, and start a named Pi tmux session
-bun run worktree:session -- feat/my-feature
+git worktree list --porcelain
+```
 
-# Inspect the exact no-mutation plan as deterministic JSON
-bun run worktree:session -- feat/my-feature --dry-run --json
+Reuse an existing checkout only when its absolute path and branch match. Otherwise,
+create the semantic branch/worktree, then run the mandatory setup:
 
+```bash
+git fetch origin dev
+git worktree add -b feat/my-feature .worktrees/feat-my-feature origin/dev
+bun run worktree:setup feat-my-feature
+```
+
+For an existing local branch that is not mounted elsewhere, omit `-b`:
+
+```bash
+git worktree add .worktrees/feat-my-feature feat/my-feature
+bun run worktree:setup feat-my-feature
+```
+
+Setup symlinks root `.env*` files into the worktree and installs workspace
+dependencies. Then open or focus the exact checkout in Herdr:
+
+```bash
+herdr worktree open \
+  --path "$PWD/.worktrees/feat-my-feature" \
+  --label feat-my-feature \
+  --focus \
+  --json
+```
+
+Record `.result.workspace.workspace_id` and `.result.root_pane.pane_id` from the JSON.
+If the returned root pane is an interactive shell with no agent, start the stable Pi
+agent named from the dashed folder:
+
+```bash
+herdr agent start feat-my-feature --kind pi --pane <returned-pane-id>
+```
+
+Before mutation, the visible Pi verifies `pwd`, `git branch --show-current`, and
+`git status --short --branch`. The canonical/root Pi sends one complete handoff and
+polls the same agent directly with `herdr agent get`, `herdr agent read`, and
+`herdr agent wait`; it does not create a background watcher. Routine questions are
+answered with the safe/recommended option. Structured prompts are read and answered
+through targeted `herdr pane` text/keys rather than a new agent prompt.
+
+Use one writer per worktree. Parallel work requires separate branches, worktrees,
+Herdr workspaces, and Pi sessions. Reuse the same visible session for review and PR-fix
+rounds. The legacy `bun run worktree:session` helper remains only a fallback when Herdr
+is unavailable.
+
+```bash
 # Start dev servers from the worktree
 bun run worktree:dev feat-my-feature
 
 # List all worktrees and their setup status
 bun run worktree:list
 ```
-
-The launcher invokes `worktree:setup`, which symlinks root `.env*` files into the
-worktree root and installs workspace dependencies. tmux is detached by default; attach
-with `tmux attach-session -t pi-feat-my-feature` or pass `--attach`.
 
 ### Conventional commits
 

--- a/docs/guides/getting-started.md
+++ b/docs/guides/getting-started.md
@@ -31,6 +31,19 @@ Install Bun (if not already installed):
 curl -fsSL https://bun.sh/install | bash
 ```
 
+Install Herdr on macOS or Linux, then install and verify its official Pi integration:
+
+```bash
+curl -fsSL https://herdr.dev/install.sh | sh
+herdr integration install pi
+herdr integration status
+```
+
+Before coordinator socket commands such as `herdr worktree open` are used, launch
+`herdr` once from the repository so its visible client/server session is running (or
+ensure an existing Herdr server/client is active). Verify the server when needed with
+`herdr status server`.
+
 Install the pgvector extension for PostgreSQL. The method varies by platform:
 
 ```bash


### PR DESCRIPTION
## Refactors

- Make visible Herdr-managed Pi worktree sessions the default implementation and fix execution plane.
- Keep the canonical/root Pi active as coordinator with direct `herdr agent get/read/wait` polling and safe automatic handling of routine questions.
- Reuse one stable workspace/Pi session per worktree across implementation, review, and finish loops; preserve one writer per worktree and explicit merge approval.

## Documentation

- Update `create-worktree`, `run-worktree-session`, `finish-pr`, and `address-code-review` with the installed Herdr CLI contract and structured-prompt pane handling.
- Replace tmux/subagent-default guidance in `CLAUDE.md` and the getting-started guide while retaining the legacy launcher only as a fallback.

## Tests

- `bun .pi/skills/learn-skill/scripts/skillctl.ts validate .pi/skills/create-worktree` — passed (`OK`)
- `bun .pi/skills/learn-skill/scripts/skillctl.ts validate .pi/skills/run-worktree-session` — passed (`OK`)
- `bun .pi/skills/learn-skill/scripts/skillctl.ts validate .pi/skills/finish-pr` — passed (`OK`)
- `bun .pi/skills/learn-skill/scripts/skillctl.ts validate .pi/skills/address-code-review` — passed (`OK`)
- `bun run skills:validate` — passed (all 22 project-local skills `OK`)
- stale-reference `rg` from the handoff — no matches (expected exit 1)
- `git diff --check` — passed with no output

No package version bump is required because this PR changes only skills and documentation.
