### PR TITLE
fix(web): limit unread badges to visible chats

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@indexnetwork/web",
-  "version": "0.25.6",
+  "version": "0.25.7",
   "license": "MIT",
   "scripts": {
     "dev": "vite --host 127.0.0.1",

--- a/apps/web/src/components/ChatSidebar.tsx
+++ b/apps/web/src/components/ChatSidebar.tsx
@@ -4,6 +4,7 @@ import { MoreHorizontal, Trash2 } from 'lucide-react';
 import UserAvatar from '@/components/UserAvatar';
 import { useAuthContext } from '@/contexts/AuthContext';
 import { useConversation } from '@/contexts/ConversationContext';
+import { isVisibleH2HConversation } from '@/lib/conversation-visibility';
 
 type NegotiationStatus = 'accepted' | 'rejected' | 'in_progress' | null;
 
@@ -16,6 +17,7 @@ interface RecentChat {
   lastMessageIsInternal: boolean;
   viaTitle?: string;
   unreadCount: number;
+  showUnreadCount: boolean;
   negotiationStatus: NegotiationStatus;
   sortTimestamp: number;
 }
@@ -72,10 +74,7 @@ export default function ChatSidebar() {
   }, [user?.id, refreshConversations, refreshNegotiations]);
 
   const filteredConversations = mode === 'h2h'
-    ? conversations.filter((conv) => {
-        const participants = conv.participants ?? [];
-        return participants.length === 2 && participants.every((p) => p.participantType === 'user');
-      })
+    ? conversations.filter(isVisibleH2HConversation)
     // Negotiations with zero messages are orphaned conversation rows (no turns
     // ever landed, or the task parked and never completed) — hide them.
     // Still show ones whose only content is an internal assessment.reasoning.
@@ -107,6 +106,7 @@ export default function ChatSidebar() {
         lastMessage: preview,
         lastMessageIsInternal: !messageText && !!reasoningText,
         unreadCount: conv.unreadCount,
+        showUnreadCount: false,
         negotiationStatus,
         sortTimestamp: new Date(conv.lastMessageAt ?? conv.createdAt).getTime(),
       };
@@ -122,6 +122,7 @@ export default function ChatSidebar() {
       lastMessageIsInternal: false,
       viaTitle: conv.via?.[0]?.title,
       unreadCount: conv.unreadCount,
+      showUnreadCount: conv.unreadCount > 0,
       negotiationStatus: null,
       sortTimestamp: new Date(conv.lastMessageAt ?? conv.createdAt).getTime(),
     };
@@ -186,7 +187,7 @@ export default function ChatSidebar() {
                 >
                   <UserAvatar avatar={chat.peerAvatar} id={chat.peerUserId ?? chat.groupId} name={chat.name} size={28} className="flex-shrink-0" />
                   <div className="min-w-0 flex-1">
-                    <p className={`truncate text-sm flex items-center gap-1.5 ${chat.unreadCount > 0 ? 'font-bold' : 'font-medium'} text-black`}>
+                    <p className={`truncate text-sm flex items-center gap-1.5 ${chat.showUnreadCount ? 'font-bold' : 'font-medium'} text-black`}>
                       {chat.negotiationStatus && (
                         <span
                           className={`inline-block w-2 h-2 rounded-full flex-shrink-0 ${STATUS_DOT[chat.negotiationStatus].cls}`}
@@ -195,7 +196,7 @@ export default function ChatSidebar() {
                         />
                       )}
                       <span className="truncate">{chat.name}</span>
-                      {chat.unreadCount > 0 && (
+                      {chat.showUnreadCount && (
                         <span
                           data-testid={`chat-unread-${chat.groupId}`}
                           aria-label={`${chat.unreadCount} unread message${chat.unreadCount === 1 ? '' : 's'}`}

--- a/apps/web/src/components/TopBar.tsx
+++ b/apps/web/src/components/TopBar.tsx
@@ -9,6 +9,7 @@ import { useNetworkFilter } from '@/contexts/IndexFilterContext';
 import { useQuestions } from '@/contexts/QuestionsContext';
 import { useConversation } from '@/contexts/ConversationContext';
 import UserAvatar from '@/components/UserAvatar';
+import { isVisibleH2HConversation } from '@/lib/conversation-visibility';
 import { log } from '@/lib/logger';
 
 const logger = log.ui.from('TopBar');
@@ -28,7 +29,9 @@ export default function TopBar() {
   const { setSelectedNetworkIds } = useNetworkFilter();
   const { personalAgentPending } = useQuestions();
   const { conversations } = useConversation();
-  const unreadConversationCount = conversations.filter((conversation) => conversation.unreadCount > 0).length;
+  const unreadConversationCount = conversations.filter(
+    (conversation) => isVisibleH2HConversation(conversation) && conversation.unreadCount > 0,
+  ).length;
 
   const [userDropdownOpen, setUserDropdownOpen] = useState(false);
   const [mobileMenuOpen, setMobileMenuOpen] = useState(false);

--- a/apps/web/src/lib/conversation-visibility.ts
+++ b/apps/web/src/lib/conversation-visibility.ts
@@ -1,0 +1,15 @@
+import type { ConversationSummary } from '@/services/conversation';
+
+/**
+ * Returns whether a conversation belongs in the human-to-human Messages list.
+ *
+ * Participant topology is canonical: persona cannot distinguish these rows
+ * because ordinary H2H conversations also inherit the `orchestrator` default.
+ */
+export function isVisibleH2HConversation(
+  conversation: Pick<ConversationSummary, 'participants'>,
+): boolean {
+  const participants = conversation.participants ?? [];
+  return participants.length === 2
+    && participants.every((participant) => participant.participantType === 'user');
+}

--- a/apps/web/tests/chat-sidebar-unread.test.tsx
+++ b/apps/web/tests/chat-sidebar-unread.test.tsx
@@ -1,12 +1,12 @@
-import { screen } from '@testing-library/react';
-import { beforeEach, describe, expect, test, vi } from 'vitest';
+import { fireEvent, render, screen } from '@testing-library/react';
 import { MemoryRouter } from 'react-router';
+import { beforeEach, describe, expect, test, vi } from 'vitest';
 
 import ChatSidebar from '@/components/ChatSidebar';
-import { render } from '@testing-library/react';
 
 const mocks = vi.hoisted(() => ({
   conversations: [] as Array<Record<string, unknown>>,
+  negotiations: [] as Array<Record<string, unknown>>,
 }));
 
 vi.mock('@/contexts/AuthContext', () => ({
@@ -16,7 +16,7 @@ vi.mock('@/contexts/AuthContext', () => ({
 vi.mock('@/contexts/ConversationContext', () => ({
   useConversation: () => ({
     conversations: mocks.conversations,
-    negotiations: [],
+    negotiations: mocks.negotiations,
     refreshConversations: vi.fn().mockResolvedValue(undefined),
     refreshNegotiations: vi.fn().mockResolvedValue(undefined),
     hideConversation: vi.fn(),
@@ -27,7 +27,7 @@ vi.mock('@/components/UserAvatar', () => ({
   default: ({ name }: { name: string }) => <span>{name}</span>,
 }));
 
-function summary(unreadCount: number) {
+function h2hSummary(unreadCount: number) {
   return {
     id: 'conv-1',
     participants: [
@@ -43,21 +43,57 @@ function summary(unreadCount: number) {
   };
 }
 
+function negotiationSummary(unreadCount: number) {
+  return {
+    id: 'neg-1',
+    participants: [
+      { participantId: 'agent:viewer', participantType: 'agent', name: 'Viewer Agent', avatar: null },
+      { participantId: 'agent:peer', participantType: 'agent', name: 'Peer Agent', avatar: null },
+    ],
+    lastMessage: {
+      parts: [{ kind: 'data', data: { action: 'accept', message: 'Ready to connect' } }],
+      senderId: 'agent:peer',
+      createdAt: new Date().toISOString(),
+    },
+    metadata: { title: 'Agent negotiation' },
+    via: [],
+    unreadCount,
+    lastMessageAt: new Date().toISOString(),
+    createdAt: new Date().toISOString(),
+  };
+}
+
 beforeEach(() => {
-  mocks.conversations = [summary(0)];
+  mocks.conversations = [h2hSummary(0)];
+  mocks.negotiations = [];
 });
 
 describe('ChatSidebar unread indicators', () => {
   test('renders the unread count on a conversation row', () => {
-    mocks.conversations = [summary(2)];
+    mocks.conversations = [h2hSummary(2)];
     render(<MemoryRouter><ChatSidebar /></MemoryRouter>);
 
-    expect(screen.getByTestId('chat-unread-conv-1')).toHaveTextContent('2');
+    const unreadBadge = screen.getByTestId('chat-unread-conv-1');
+    expect(unreadBadge).toHaveTextContent('2');
+    expect(unreadBadge).toHaveAccessibleName('2 unread messages');
   });
 
   test('hides the unread indicator when the count is zero', () => {
     render(<MemoryRouter><ChatSidebar /></MemoryRouter>);
 
     expect(screen.queryByTestId('chat-unread-conv-1')).toBeNull();
+  });
+
+  test('suppresses unread counts on negotiation rows while preserving status and preview', () => {
+    mocks.negotiations = [negotiationSummary(4)];
+    render(<MemoryRouter><ChatSidebar /></MemoryRouter>);
+
+    fireEvent.click(screen.getByRole('button', { name: 'Negotiations' }));
+
+    expect(screen.getAllByText('Agent negotiation').length).toBeGreaterThan(0);
+    expect(screen.getByText('Ready to connect')).toBeInTheDocument();
+    expect(screen.getByLabelText('Accepted')).toBeInTheDocument();
+    expect(screen.queryByTestId('chat-unread-neg-1')).toBeNull();
+    expect(screen.queryByLabelText('4 unread messages')).toBeNull();
   });
 });

--- a/apps/web/tests/topbar.test.tsx
+++ b/apps/web/tests/topbar.test.tsx
@@ -13,7 +13,7 @@ import TopBar from '@/components/TopBar';
 
 const mocks = vi.hoisted(() => ({
   questionsState: { personalAgentPending: 0 },
-  conversations: [] as Array<{ unreadCount: number }>,
+  conversations: [] as Array<Record<string, unknown>>,
   navigate: vi.fn(),
 }));
 
@@ -56,6 +56,30 @@ vi.mock('@/components/UserAvatar', () => ({
   default: () => <div data-testid="avatar" />,
 }));
 
+function conversationSummary(
+  id: string,
+  unreadCount: number,
+  participantTypes: Array<'user' | 'agent'> = ['user', 'user'],
+  persona = 'orchestrator',
+) {
+  return {
+    id,
+    persona,
+    participants: participantTypes.map((participantType, index) => ({
+      participantId: `${participantType}-${index}`,
+      participantType,
+      name: null,
+      avatar: null,
+    })),
+    lastMessage: null,
+    metadata: null,
+    via: [],
+    unreadCount,
+    lastMessageAt: null,
+    createdAt: new Date().toISOString(),
+  };
+}
+
 function renderTopBar(initialPath = '/') {
   return render(
     <MemoryRouter initialEntries={[initialPath]}>
@@ -77,14 +101,36 @@ describe('TopBar Personal Agent badge', () => {
     expect(screen.getByRole('button', { name: /^Agent$/ })).toBeInTheDocument();
   });
 
-  test('chat badge counts unread threads', () => {
-    mocks.conversations = [{ unreadCount: 2 }, { unreadCount: 1 }, { unreadCount: 0 }];
+  test('chat badge counts visible unread H2H threads rather than unread messages', () => {
+    mocks.conversations = [
+      conversationSummary('visible-1', 12),
+      conversationSummary('visible-2', 1),
+      conversationSummary('read', 0),
+    ];
     renderTopBar();
     expect(screen.getByTestId('chat-unread-badge')).toHaveTextContent('2');
   });
 
-  test('chat badge disappears when all threads are read', () => {
-    mocks.conversations = [{ unreadCount: 0 }];
+  test('chat badge excludes sidebar-hidden persona sessions', () => {
+    mocks.conversations = [
+      // H2H rows also inherit the orchestrator default, so participant topology
+      // rather than persona determines whether a conversation is visible.
+      conversationSummary('visible-h2h', 1, ['user', 'user'], 'orchestrator'),
+      conversationSummary('signal', 1, ['user', 'agent'], 'signal'),
+      conversationSummary('reporter', 1, ['user', 'agent'], 'reporter'),
+      conversationSummary('negotiator', 1, ['user', 'agent'], 'negotiator'),
+      conversationSummary('legacy-orchestrator', 1, ['user', 'agent'], 'orchestrator'),
+      conversationSummary('hidden-group', 1, ['user', 'user', 'user'], 'orchestrator'),
+    ];
+    renderTopBar();
+    expect(screen.getByTestId('chat-unread-badge')).toHaveTextContent('1');
+  });
+
+  test('chat badge disappears when all visible threads are read', () => {
+    mocks.conversations = [
+      conversationSummary('read-h2h', 0),
+      conversationSummary('unread-signal', 3, ['user', 'agent'], 'signal'),
+    ];
     renderTopBar();
     expect(screen.queryByTestId('chat-unread-badge')).toBeNull();
   });


### PR DESCRIPTION
## Bug Fixes
- resolve IND-487 by keeping unread pills on visible H2H message rows while suppressing them on A2A negotiation rows
- share the participant-topology visibility predicate between ChatSidebar and TopBar so hidden Signal, Reporter, Negotiator, legacy Orchestrator, and other non-H2H sessions do not inflate the global Chat badge
- preserve negotiation rows, previews, status indicators, filters, navigation, and viewer-scoped read tracking

## Tests
- `cd apps/web && bun --bun vitest run tests/chat-sidebar-unread.test.tsx tests/topbar.test.tsx` (11 passed)
- `cd apps/web && bun run lint` (0 errors; 91 pre-existing warnings)
- `cd apps/web && bun run build`
- `bun install --frozen-lockfile --ignore-scripts`

## Notes
- Feature flags: none
- No public contract or documentation changes
- Ad-hoc `cd apps/web && bunx tsc --noEmit -p tsconfig.json` remains blocked by pre-existing repository-wide type errors; none referenced the changed files