### PR TITLE
fix(web): recover guided intake from auth expiry

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@indexnetwork/web",
-  "version": "0.25.4",
+  "version": "0.25.5",
   "license": "MIT",
   "scripts": {
     "dev": "vite --host 127.0.0.1",

--- a/apps/web/src/app/i/new/page.tsx
+++ b/apps/web/src/app/i/new/page.tsx
@@ -9,6 +9,7 @@ import { useQuestionsService } from "@/contexts/APIContext";
 import { useNotifications } from "@/contexts/NotificationContext";
 import type { AnswerBody, PendingQuestion } from "@/services/questions";
 import { apiClient } from "@/lib/api";
+import { isAuthSessionError } from "@/lib/auth-client";
 import { parseAllBlocks, type MessageSegment } from "@/components/chat/AssistantMessageContent";
 
 interface AnsweredStep {
@@ -234,7 +235,7 @@ function Summary({ label, value }: { label: string; value: string }) {
 
 export default function NewSignalPage() {
   const navigate = useNavigate();
-  const { isAuthenticated, features } = useAuthContext();
+  const { isAuthenticated, features, openLoginModal, signOut } = useAuthContext();
   const { indexes } = useNetworksState();
   const questionsService = useQuestionsService();
   const { addNotification, error: showError } = useNotifications();
@@ -248,15 +249,17 @@ export default function NewSignalPage() {
   } = useAIChat();
   const [answered, setAnswered] = useState<AnsweredStep[]>([]);
   const [proposalError, setProposalError] = useState<string | null>(null);
+  const [kickoffError, setKickoffError] = useState<string | null>(null);
   const [confirming, setConfirming] = useState(false);
   const [skipped, setSkipped] = useState(false);
   const startedRef = useRef(false);
 
   const signalAgentEnabled = features?.signalAgent === true;
 
-  useEffect(() => {
+  const startKickoff = useCallback(() => {
     if (!isAuthenticated || !signalAgentEnabled || startedRef.current) return;
     startedRef.current = true;
+    setKickoffError(null);
     startSignalSession();
     // Keep this marker stable: the Signal prompt builder uses it to enter the
     // live, three-round intake rather than treating this as ordinary chat.
@@ -264,9 +267,34 @@ export default function NewSignalPage() {
       "new-signal-kickoff",
       undefined,
       undefined,
-      { hidden: true, persona: "signal" },
+      {
+        hidden: true,
+        persona: "signal",
+        onError: (error) => {
+          startedRef.current = false;
+          if (isAuthSessionError(error)) {
+            const callbackURL = typeof window === "undefined"
+              ? "/i/new"
+              : new URL("/i/new", window.location.origin).href;
+            setKickoffError("Your session expired. Please sign in again.");
+            showError("Session expired", "Please sign in again to start your signal.");
+            void signOut()
+              .catch(() => undefined)
+              .finally(() => {
+                navigate("/");
+                openLoginModal(callbackURL);
+              });
+            return;
+          }
+          setKickoffError("We couldn't start your signal. Please try again.");
+        },
+      },
     );
-  }, [isAuthenticated, sendWebMessage, signalAgentEnabled, startSignalSession]);
+  }, [isAuthenticated, navigate, openLoginModal, sendWebMessage, showError, signalAgentEnabled, signOut, startSignalSession]);
+
+  useEffect(() => {
+    startKickoff();
+  }, [startKickoff]);
 
   const answeredIds = useMemo(() => new Set(answered.map((step) => step.question.id)), [answered]);
   const currentQuestion = liveQuestions.find((question) => !answeredIds.has(question.id)) ?? null;
@@ -348,6 +376,7 @@ export default function NewSignalPage() {
     clearChat();
     setAnswered([]);
     setProposalError(null);
+    setKickoffError(null);
     setSkipped(false);
     startedRef.current = false;
   }, [clearChat]);
@@ -403,6 +432,17 @@ export default function NewSignalPage() {
           />
         ) : currentQuestion ? (
           <GuidedQuestion question={currentQuestion} onAnswer={handleAnswer} disabled={isLoading && !currentQuestion} />
+        ) : kickoffError ? (
+          <section role="alert" className="mt-14 rounded-2xl border border-red-100 bg-red-50 p-5 text-sm text-red-800">
+            <p>{kickoffError}</p>
+            <button
+              type="button"
+              onClick={startKickoff}
+              className="mt-4 rounded-full bg-[#041729] px-4 py-2 text-sm font-medium text-white"
+            >
+              Try again
+            </button>
+          </section>
         ) : isLoading ? (
           <div role="status" aria-label="Your agent is thinking" className="mt-14 flex items-center gap-3 text-sm text-gray-500">
             <Loader2 className="h-4 w-4 animate-spin" /> Your agent is thinking…

--- a/apps/web/src/contexts/AIChatContext.tsx
+++ b/apps/web/src/contexts/AIChatContext.tsx
@@ -2,6 +2,7 @@ import React, { createContext, useContext, useState, useCallback, useRef } from 
 import { useLocation } from "react-router";
 import { useAIChatSessions } from "@/contexts/AIChatSessionsContext";
 import { apiClient } from "@/lib/api";
+import { AuthSessionError, clearJwtToken } from "@/lib/auth-client";
 import type { Suggestion } from "@/hooks/useSuggestions";
 import type { Question } from "@/components/DecisionQuestions/types";
 import type { PendingQuestion } from "@/services/questions";
@@ -123,6 +124,8 @@ export interface ChatSendOptions {
   /** @deprecated Product surfaces should use their dedicated send helper. */
   surface?: "web" | "onboarding";
   existingMessageId?: string;
+  /** Surface-specific recovery hook. Errors remain handled by the shared chat state machine. */
+  onError?: (error: unknown) => void;
 }
 
 interface ChatMessage {
@@ -411,6 +414,7 @@ export function AIChatProvider({ children }: { children: React.ReactNode }) {
     token: symbol;
     controller: AbortController;
     transport: ChatTransport;
+    assistantMessageId?: string;
     abortReason?: SendAbortReason;
     refreshSidebarWhenStale: boolean;
   };
@@ -425,9 +429,21 @@ export function AIChatProvider({ children }: { children: React.ReactNode }) {
   const invalidateActiveSend = useCallback((reason: SendAbortReason, abort = true) => {
     const active = activeSendRef.current;
     if (!active) return;
+    const wasOwner = operationOwnerRef.current === active.token;
     active.abortReason = reason;
     if (abort && !active.controller.signal.aborted) active.controller.abort();
     if (activeSendRef.current === active) activeSendRef.current = null;
+    if (wasOwner) {
+      operationOwnerRef.current = null;
+      setIsLoading(false);
+    }
+    if (active.assistantMessageId) {
+      setMessages((current) => current.map((message) =>
+        message.id === active.assistantMessageId
+          ? { ...message, isStreaming: false }
+          : message,
+      ));
+    }
   }, []);
 
   React.useEffect(() => () => {
@@ -630,6 +646,7 @@ export function AIChatProvider({ children }: { children: React.ReactNode }) {
 
       // Add placeholder for assistant response
       const assistantMessageId = crypto.randomUUID();
+      operation.assistantMessageId = assistantMessageId;
       setMessages((prev) => [
         ...prev,
         {
@@ -642,6 +659,12 @@ export function AIChatProvider({ children }: { children: React.ReactNode }) {
       ]);
 
       setIsLoading(true);
+      let didNotifyError = false;
+      const notifySendError = (error: unknown) => {
+        if (didNotifyError) return;
+        didNotifyError = true;
+        options?.onError?.(error);
+      };
       /** Local trace buffer scoped to this sendMessage call — avoids cross-message corruption. */
       const streamTraceEvents: TraceEvent[] = [];
       /** Push a trace event to the local buffer and append it to the assistant message. */
@@ -692,6 +715,10 @@ export function AIChatProvider({ children }: { children: React.ReactNode }) {
         }
 
         if (!response.ok) {
+          if (response.status === 401) {
+            clearJwtToken();
+            throw new AuthSessionError();
+          }
           const failure = await response.json().catch(() => null);
           if (!ownsOperation(operation.token)) return;
           const parsedBlock = parseTurnBlock(failure);
@@ -1176,7 +1203,9 @@ export function AIChatProvider({ children }: { children: React.ReactNode }) {
                       }
                     }
                     break;
-                  case "error":
+                  case "error": {
+                    const streamError = new Error("Chat stream failed");
+                    notifySendError(streamError);
                     setMessages((prev) =>
                       prev.map((msg) =>
                         msg.id === assistantMessageId
@@ -1189,6 +1218,7 @@ export function AIChatProvider({ children }: { children: React.ReactNode }) {
                       ),
                     );
                     break;
+                  }
                 }
               } catch (e) {
                 logger.error("Failed to parse SSE event", { error: e });
@@ -1217,12 +1247,15 @@ export function AIChatProvider({ children }: { children: React.ReactNode }) {
           );
         } else {
           logger.error("Chat error", { error });
+          notifySendError(error);
           setMessages((prev) =>
             prev.map((msg) =>
               msg.id === assistantMessageId
                 ? {
                     ...msg,
-                    content: "Failed to get response. Please try again.",
+                    content: error instanceof AuthSessionError
+                      ? "Your session expired. Please sign in again."
+                      : "Failed to get response. Please try again.",
                     isStreaming: false,
                   }
                 : msg,
@@ -1230,21 +1263,25 @@ export function AIChatProvider({ children }: { children: React.ReactNode }) {
           );
         }
       } finally {
+        // Every operation owns its placeholder even after losing global state
+        // ownership. Finalize it without touching a successor's loading state.
+        setMessages((prev) =>
+          prev.map((msg) =>
+            msg.id === assistantMessageId
+              ? { ...msg, isStreaming: false }
+              : msg,
+          ),
+        );
         if (ownsOperation(operation.token)) {
           operationOwnerRef.current = null;
           if (activeSendRef.current === operation) activeSendRef.current = null;
           setIsLoading(false);
           // Queue drain is handled by the useEffect below (watches isLoading transition to false).
-          setMessages((prev) =>
-            prev.map((msg) =>
-              msg.id === assistantMessageId
-                ? { ...msg, isStreaming: false }
-                : msg,
-            ),
-          );
         } else if (activeSendRef.current === operation) {
-          // Local cleanup only; never clear a newer operation's controller or UI state.
+          // No successor owns the active-send slot, so local cleanup may also
+          // release loading. A newer operation always replaces this reference.
           activeSendRef.current = null;
+          setIsLoading(false);
         }
       }
     },

--- a/apps/web/src/lib/auth-client.ts
+++ b/apps/web/src/lib/auth-client.ts
@@ -11,17 +11,68 @@ export const authClient = createAuthClient({
 let cachedToken: string | null = null;
 let tokenExpiresAt = 0;
 
+const JWT_TOKEN_TIMEOUT_MS = 10_000;
+
+/** Authentication failed before an authenticated API request could begin. */
+export class AuthSessionError extends Error {
+  constructor(message = 'Your session has expired. Please sign in again.') {
+    super(message);
+    this.name = 'AuthSessionError';
+  }
+}
+
+/** Returns whether an unknown failure requires a fresh authenticated session. */
+export function isAuthSessionError(error: unknown): error is AuthSessionError {
+  return error instanceof AuthSessionError;
+}
+
+function readTokenExpiry(token: string): number {
+  const encodedPayload = token.split('.')[1];
+  if (!encodedPayload) throw new AuthSessionError();
+
+  try {
+    const normalized = encodedPayload.replace(/-/g, '+').replace(/_/g, '/');
+    const padded = normalized.padEnd(Math.ceil(normalized.length / 4) * 4, '=');
+    const payload = JSON.parse(atob(padded)) as { exp?: unknown };
+    if (typeof payload.exp !== 'number' || !Number.isFinite(payload.exp)) {
+      throw new AuthSessionError();
+    }
+    return payload.exp * 1000;
+  } catch (error) {
+    if (error instanceof AuthSessionError) throw error;
+    throw new AuthSessionError();
+  }
+}
+
 /** Returns a cached JWT, refreshing if within 60s of expiry. */
 export async function getJwtToken(): Promise<string> {
   if (cachedToken && Date.now() < tokenExpiresAt - 60_000) {
     return cachedToken;
   }
-  const { data, error } = await authClient.token();
-  if (error || !data?.token) throw new Error('Failed to obtain JWT');
-  cachedToken = data.token;
-  const payload = JSON.parse(atob(data.token.split('.')[1]));
-  tokenExpiresAt = payload.exp * 1000;
-  return cachedToken;
+
+  let timeoutId: ReturnType<typeof setTimeout> | undefined;
+  try {
+    const { data, error } = await Promise.race([
+      authClient.token(),
+      new Promise<never>((_, reject) => {
+        timeoutId = setTimeout(() => reject(new AuthSessionError()), JWT_TOKEN_TIMEOUT_MS);
+      }),
+    ]);
+    if (error || !data?.token) throw new AuthSessionError();
+
+    const expiresAt = readTokenExpiry(data.token);
+    if (expiresAt <= Date.now()) throw new AuthSessionError();
+
+    cachedToken = data.token;
+    tokenExpiresAt = expiresAt;
+    return cachedToken;
+  } catch (error) {
+    clearJwtToken();
+    if (error instanceof AuthSessionError) throw error;
+    throw new AuthSessionError();
+  } finally {
+    if (timeoutId !== undefined) clearTimeout(timeoutId);
+  }
 }
 
 export function clearJwtToken() {

--- a/apps/web/tests/ai-chat-context-signal.test.tsx
+++ b/apps/web/tests/ai-chat-context-signal.test.tsx
@@ -126,6 +126,7 @@ function Probe() {
       <span data-testid="persona">{chat.sessionPersona ?? 'none'}</span>
       <span data-testid="messages">{chat.messages.map((message) => message.content).join('|')}</span>
       <span data-testid="message-count">{chat.messages.length}</span>
+      <span data-testid="streaming-count">{chat.messages.filter((message) => message.isStreaming).length}</span>
       <span data-testid="block">{chat.turnBlock?.code ?? 'none'}</span>
       <span data-testid="block-message">{chat.turnBlock?.message ?? 'none'}</span>
       <span data-testid="block-action">{chat.turnBlock?.action?.type ?? 'none'}</span>
@@ -322,18 +323,22 @@ describe('AIChatContext Signal persona transport and ownership', () => {
     expect(oldSignal).not.toBe(currentSignal);
     expect(oldSignal.aborted).toBe(true);
     expect(currentSignal.aborted).toBe(false);
+    expect(text('loading')).toBe('yes');
+    expect(text('streaming-count')).toBe('1');
 
     await act(async () => {
       old.resolve(streamResponse({ response: 'old' }));
       await old.promise;
     });
     expect(text('loading')).toBe('yes');
+    expect(text('streaming-count')).toBe('1');
 
     await act(async () => {
       current.resolve(streamResponse({ response: 'new' }));
       await current.promise;
     });
     await waitFor(() => expect(text('loading')).toBe('no'));
+    expect(text('streaming-count')).toBe('0');
     expect(text('messages')).toContain('new');
     expect(text('messages')).not.toContain('old');
   });

--- a/apps/web/tests/api-auth-expiry.test.ts
+++ b/apps/web/tests/api-auth-expiry.test.ts
@@ -1,0 +1,67 @@
+import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+  token: vi.fn(),
+}));
+
+vi.mock("better-auth/react", () => ({
+  createAuthClient: () => ({ token: mocks.token }),
+}));
+vi.mock("better-auth/client/plugins", () => ({
+  magicLinkClient: () => ({}),
+  jwtClient: () => ({}),
+}));
+
+import { apiClient } from "@/lib/api";
+import { AuthSessionError, clearJwtToken } from "@/lib/auth-client";
+
+describe("authenticated stream token acquisition", () => {
+  beforeEach(() => {
+    clearJwtToken();
+    mocks.token.mockReset();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.restoreAllMocks();
+  });
+
+  test("rejects an invalid session without sending the chat request", async () => {
+    mocks.token.mockResolvedValue({
+      data: null,
+      error: { message: "invalid session" },
+    });
+    const fetchSpy = vi.spyOn(globalThis, "fetch");
+
+    await expect(apiClient.stream("/chat/web/stream", { message: "kickoff" }))
+      .rejects.toBeInstanceOf(AuthSessionError);
+    expect(fetchSpy).not.toHaveBeenCalled();
+  });
+
+  test("sends a valid-session stream with the acquired bearer token", async () => {
+    const token = `header.${btoa(JSON.stringify({ exp: Math.floor(Date.now() / 1000) + 3600 }))}.signature`;
+    mocks.token.mockResolvedValue({ data: { token }, error: null });
+    const fetchSpy = vi.spyOn(globalThis, "fetch").mockResolvedValue(new Response(null, { status: 200 }));
+
+    await expect(apiClient.stream("/chat/web/stream", { message: "kickoff" })).resolves.toBeInstanceOf(Response);
+    expect(fetchSpy).toHaveBeenCalledWith(
+      expect.stringContaining("/api/chat/web/stream"),
+      expect.objectContaining({
+        headers: expect.objectContaining({ Authorization: `Bearer ${token}` }),
+      }),
+    );
+  });
+
+  test("times out stalled token acquisition instead of leaving the send pending", async () => {
+    vi.useFakeTimers();
+    mocks.token.mockReturnValue(new Promise(() => undefined));
+    const fetchSpy = vi.spyOn(globalThis, "fetch");
+
+    const request = apiClient.stream("/chat/web/stream", { message: "kickoff" });
+    const rejection = expect(request).rejects.toBeInstanceOf(AuthSessionError);
+    await vi.advanceTimersByTimeAsync(10_000);
+
+    await rejection;
+    expect(fetchSpy).not.toHaveBeenCalled();
+  });
+});

--- a/apps/web/tests/guided-signal-flow.test.tsx
+++ b/apps/web/tests/guided-signal-flow.test.tsx
@@ -19,13 +19,20 @@ const mocks = vi.hoisted(() => ({
   apiPatch: vi.fn(),
   addNotification: vi.fn(),
   showError: vi.fn(),
+  signOut: vi.fn(),
+  openLoginModal: vi.fn(),
 }));
 
 vi.mock("@/contexts/AIChatContext", () => ({
   useAIChat: () => mocks.state,
 }));
 vi.mock("@/contexts/AuthContext", () => ({
-  useAuthContext: () => ({ isAuthenticated: true, features: { signalAgent: true } }),
+  useAuthContext: () => ({
+    isAuthenticated: true,
+    features: { signalAgent: true },
+    signOut: mocks.signOut,
+    openLoginModal: mocks.openLoginModal,
+  }),
 }));
 vi.mock("@/contexts/IndexesContext", () => ({
   useNetworksState: () => ({
@@ -85,13 +92,15 @@ beforeEach(() => {
   mocks.state.liveQuestions = [];
   mocks.state.isLoading = false;
   mocks.state.startSignalSession.mockReset();
-  mocks.state.sendWebMessage.mockReset();
+  mocks.state.sendWebMessage.mockReset().mockResolvedValue(undefined);
   mocks.state.clearChat.mockReset();
   mocks.answer.mockReset().mockResolvedValue({ success: true, resumed: true });
   mocks.apiPost.mockReset().mockResolvedValue({ intentId: "intent-1" });
   mocks.apiPatch.mockReset().mockResolvedValue({});
   mocks.addNotification.mockReset();
   mocks.showError.mockReset();
+  mocks.signOut.mockReset().mockResolvedValue(undefined);
+  mocks.openLoginModal.mockReset();
 });
 
 describe("guided Signal creation", () => {
@@ -103,7 +112,11 @@ describe("guided Signal creation", () => {
       "new-signal-kickoff",
       undefined,
       undefined,
-      { hidden: true, persona: "signal" },
+      expect.objectContaining({
+        hidden: true,
+        persona: "signal",
+        onError: expect.any(Function),
+      }),
     );
 
     const current = question("question-1");
@@ -126,6 +139,42 @@ describe("guided Signal creation", () => {
     fireEvent.click(screen.getByRole("button", { name: "Continue" }));
     await waitFor(() => expect(mocks.answer).toHaveBeenCalledWith("question-1", { selectedOptions: ["A collaborator"] }));
     expect(screen.getByText("A collaborator")).toBeInTheDocument();
+  });
+
+  test("offers an in-page retry when kickoff fails", async () => {
+    mocks.state.sendWebMessage.mockImplementationOnce((...args: unknown[]) => {
+      const options = args[3] as { onError?: (error: unknown) => void } | undefined;
+      options?.onError?.(new Error("network unavailable"));
+      return Promise.resolve();
+    });
+
+    renderPage();
+
+    expect(await screen.findByRole("alert")).toHaveTextContent("We couldn't start your signal. Please try again.");
+    fireEvent.click(screen.getByRole("button", { name: "Try again" }));
+
+    await waitFor(() => expect(mocks.state.sendWebMessage).toHaveBeenCalledTimes(2));
+    expect(mocks.state.startSignalSession).toHaveBeenCalledTimes(2);
+    expect(screen.getByTestId("location")).toHaveTextContent("/i/new");
+  });
+
+  test("redirects expired kickoff sessions to login with an auth error", async () => {
+    const { AuthSessionError } = await import("@/lib/auth-client");
+    mocks.state.sendWebMessage.mockImplementationOnce((...args: unknown[]) => {
+      const options = args[3] as { onError?: (error: unknown) => void } | undefined;
+      options?.onError?.(new AuthSessionError());
+      return Promise.resolve();
+    });
+
+    renderPage();
+
+    await waitFor(() => expect(mocks.showError).toHaveBeenCalledWith(
+      "Session expired",
+      "Please sign in again to start your signal.",
+    ));
+    await waitFor(() => expect(mocks.signOut).toHaveBeenCalledTimes(1));
+    expect(mocks.openLoginModal).toHaveBeenCalledWith(expect.stringContaining("/i/new"));
+    expect(screen.getByTestId("location")).toHaveTextContent("/");
   });
 
   test("shows the proposal confirmation card and confirms through the existing endpoint", async () => {

--- a/bun.lock
+++ b/bun.lock
@@ -19,7 +19,7 @@
     },
     "apps/web": {
       "name": "@indexnetwork/web",
-      "version": "0.25.1",
+      "version": "0.25.5",
       "dependencies": {
         "@radix-ui/react-alert-dialog": "^1.1.15",
         "@radix-ui/react-dialog": "^1.1.14",


### PR DESCRIPTION
## Bug Fixes
- Fixes IND-480 by bounding JWT acquisition and classifying invalid/expired sessions before the guided intake chat request.
- Finalizes superseded send placeholders without allowing stale operations to clear a successor's loading state.
- Surfaces guided-intake kickoff failures, redirects expired sessions to login, and supports safe in-page retries.
- Preserves the dedicated web transport and persisted Signal persona behavior for valid sessions.

## Tests
- `bun install --frozen-lockfile` — passed after rebasing onto current `origin/dev`.
- `cd apps/web && bun --bun vitest run tests/api-auth-expiry.test.ts tests/ai-chat-context-signal.test.tsx tests/guided-signal-flow.test.tsx` — 27 passed.
- `cd apps/web && bun run lint` — passed with 0 errors (91 existing warnings).
- `cd apps/web && bun run build` — passed.
- Required GitHub checks — check, eval-verify, lint, test, and typecheck all passed.

## Documentation
- No contract or architecture documentation changes required.

## Feature Flags
- None.