### PR TITLE
fix(web): recover from stale lazy route chunks

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@indexnetwork/web",
-  "version": "0.25.5",
+  "version": "0.25.6",
   "license": "MIT",
   "scripts": {
     "dev": "vite --host 127.0.0.1",

--- a/apps/web/server.ts
+++ b/apps/web/server.ts
@@ -1,19 +1,29 @@
-import { readFileSync, existsSync, statSync } from "fs";
-import { join, extname } from "path";
+import { existsSync, readFileSync, statSync } from "fs";
+import { dirname, join } from "path";
+import { fileURLToPath } from "url";
+
 import { buildMetaMap, ORIGIN, type PageMeta } from "./meta.config";
 
-const DIST = join(import.meta.dir, "dist");
-const template = readFileSync(join(DIST, "index.html"), "utf-8");
-const metaMap = buildMetaMap(DIST);
+const DEFAULT_DIST = join(dirname(fileURLToPath(import.meta.url)), "dist");
+const HTML_CACHE_CONTROL = "no-store";
+const HASHED_ASSET_CACHE_CONTROL = "public, max-age=31536000, immutable";
+const STATIC_FILE_CACHE_CONTROL = "public, max-age=0, must-revalidate";
+const NOT_FOUND_CACHE_CONTROL = "no-store";
+
+interface WebHandlerOptions {
+  distDir?: string;
+  template?: string;
+  metaMap?: Record<string, PageMeta>;
+}
 
 function replaceMeta(html: string, attr: string, key: string, value: string): string {
   return html.replace(
-    new RegExp(`(<meta\\s+${attr}="${key}"\\s+content=")[^"]*(")`,"i"),
+    new RegExp(`(<meta\\s+${attr}="${key}"\\s+content=")[^"]*(")`, "i"),
     `$1${value}$2`,
   );
 }
 
-function injectMeta(meta: PageMeta, pathname: string): string {
+function injectMeta(template: string, meta: PageMeta, pathname: string): string {
   let html = template.replace(/<title>[^<]*<\/title>/, `<title>${meta.title}</title>`);
   html = replaceMeta(html, "name", "description", meta.description);
   html = replaceMeta(html, "property", "og:type", meta.type ?? "website");
@@ -27,8 +37,6 @@ function injectMeta(meta: PageMeta, pathname: string): string {
   return html;
 }
 
-const port = parseInt(process.env.PORT || "4173", 10);
-
 function stripPreviewSurface(html: string): string {
   return html
     .replace(
@@ -39,24 +47,84 @@ function stripPreviewSurface(html: string): string {
     .replace(/<title>[^<]*<\/title>\s*/i, "<title></title>");
 }
 
-Bun.serve({
-  port,
-  hostname: "0.0.0.0",
-  fetch(req) {
+function isDocumentNavigation(req: Request): boolean {
+  if (req.method !== "GET" && req.method !== "HEAD") return false;
+
+  return (
+    req.headers.get("sec-fetch-mode") === "navigate" ||
+    req.headers.get("accept")?.toLowerCase().includes("text/html") === true
+  );
+}
+
+function notFound(req: Request): Response {
+  return new Response(req.method === "HEAD" ? null : "Not Found", {
+    status: 404,
+    headers: {
+      "Cache-Control": NOT_FOUND_CACHE_CONTROL,
+      "Content-Type": "text/plain; charset=utf-8",
+    },
+  });
+}
+
+/**
+ * Creates the production web request handler.
+ *
+ * Document navigations receive the SPA entrypoint, while missing assets and
+ * non-document requests fail as real 404s instead of receiving HTML.
+ */
+export function createWebHandler(options: WebHandlerOptions = {}): (req: Request) => Response {
+  const distDir = options.distDir ?? DEFAULT_DIST;
+  const template = options.template ?? readFileSync(join(distDir, "index.html"), "utf-8");
+  const metaMap = options.metaMap ?? buildMetaMap(distDir);
+
+  return (req: Request): Response => {
     const reqUrl = new URL(req.url);
     const pathname = reqUrl.pathname;
     const suppressPreview = reqUrl.searchParams.get("link_preview") === "false";
+    const relativePath = pathname.replace(/^\/+/, "");
+    const filePath = join(distDir, relativePath);
 
-    const filePath = join(DIST, pathname);
     if (pathname !== "/" && existsSync(filePath) && statSync(filePath).isFile()) {
-      return new Response(Bun.file(filePath));
+      const file = Bun.file(filePath);
+      const cacheControl = pathname.startsWith("/assets/")
+        ? HASHED_ASSET_CACHE_CONTROL
+        : pathname.endsWith(".html")
+          ? HTML_CACHE_CONTROL
+          : STATIC_FILE_CACHE_CONTROL;
+
+      return new Response(req.method === "HEAD" ? null : file, {
+        headers: {
+          "Cache-Control": cacheControl,
+          "Content-Type": file.type,
+        },
+      });
+    }
+
+    if (pathname.startsWith("/assets/") || !isDocumentNavigation(req)) {
+      return notFound(req);
     }
 
     const meta = metaMap[pathname];
-    let html = meta ? injectMeta(meta, pathname) : template;
+    let html = meta ? injectMeta(template, meta, pathname) : template;
     if (suppressPreview) html = stripPreviewSurface(html);
-    return new Response(html, { headers: { "Content-Type": "text/html; charset=utf-8" } });
-  },
-});
 
-console.log(`Listening on :${port}`);
+    return new Response(req.method === "HEAD" ? null : html, {
+      headers: {
+        "Cache-Control": HTML_CACHE_CONTROL,
+        "Content-Type": "text/html; charset=utf-8",
+      },
+    });
+  };
+}
+
+if (import.meta.main) {
+  const port = parseInt(process.env.PORT || "4173", 10);
+
+  Bun.serve({
+    port,
+    hostname: "0.0.0.0",
+    fetch: createWebHandler(),
+  });
+
+  console.log(`Listening on :${port}`);
+}

--- a/apps/web/src/components/RouteErrorBoundary.tsx
+++ b/apps/web/src/components/RouteErrorBoundary.tsx
@@ -1,0 +1,45 @@
+import { useRouteError } from "react-router";
+
+import { classifyChunkLoadError } from "@/lib/lazy-route-recovery";
+
+/** Renders a recoverable application error instead of React Router's default screen. */
+export function RouteErrorBoundary() {
+  const error = useRouteError();
+  const isChunkFailure = classifyChunkLoadError(error) !== null;
+
+  return (
+    <main className="flex min-h-screen items-center justify-center bg-white px-6 py-16 text-neutral-950">
+      <section
+        className="w-full max-w-md rounded-2xl border border-neutral-200 bg-white p-8 text-center shadow-sm"
+        role="alert"
+      >
+        <p className="mb-3 text-sm font-medium uppercase tracking-[0.16em] text-neutral-500">
+          Index Network
+        </p>
+        <h1 className="text-2xl font-semibold tracking-tight">
+          {isChunkFailure ? "This page needs a refresh" : "Something went wrong"}
+        </h1>
+        <p className="mt-3 text-sm leading-6 text-neutral-600">
+          {isChunkFailure
+            ? "Index may have been updated while this page was open. Refresh to load the latest version without losing this URL."
+            : "We couldn't load this page. Refresh and try again, or return home if the problem continues."}
+        </p>
+        <div className="mt-7 flex flex-col gap-3 sm:flex-row sm:justify-center">
+          <button
+            className="rounded-full bg-neutral-950 px-5 py-2.5 text-sm font-medium text-white transition-colors hover:bg-neutral-800 focus:outline-none focus:ring-2 focus:ring-neutral-950 focus:ring-offset-2"
+            onClick={() => window.location.reload()}
+            type="button"
+          >
+            Refresh page
+          </button>
+          <a
+            className="rounded-full border border-neutral-300 px-5 py-2.5 text-sm font-medium text-neutral-800 transition-colors hover:bg-neutral-50 focus:outline-none focus:ring-2 focus:ring-neutral-950 focus:ring-offset-2"
+            href="/"
+          >
+            Go to home
+          </a>
+        </div>
+      </section>
+    </main>
+  );
+}

--- a/apps/web/src/lib/lazy-route-recovery.ts
+++ b/apps/web/src/lib/lazy-route-recovery.ts
@@ -1,0 +1,270 @@
+import { log } from "@/lib/logger";
+
+const logger = log.lib.from("lazy-route-recovery");
+const STORAGE_PREFIX = "index:lazy-route-recovery:v1";
+
+export type ChunkLoadCategory =
+  | "dynamic-import"
+  | "chunk-load"
+  | "module-script"
+  | "asset-preload";
+
+export interface ChunkLoadFailure {
+  category: ChunkLoadCategory;
+  failedChunkPath?: string;
+}
+
+export type ChunkRecoveryResult =
+  | "reload_started"
+  | "reload_already_attempted"
+  | "reload_blocked_pending"
+  | "storage_unavailable"
+  | "reload_failed";
+
+interface RecoveryStorage {
+  getItem(key: string): string | null;
+  setItem(key: string, value: string): void;
+  removeItem(key: string): void;
+}
+
+interface RecoveryLogMeta extends Record<string, unknown> {
+  buildIdentity: string;
+  route: string;
+  category: ChunkLoadCategory;
+  recoveryResult: ChunkRecoveryResult | "route_loaded";
+  failedChunkPath?: string;
+}
+
+export interface ChunkRecoveryRuntime {
+  href: string;
+  buildIdentity: string;
+  storage: RecoveryStorage | null;
+  reload: () => void;
+  report?: (level: "info" | "error", message: string, meta: RecoveryLogMeta) => void;
+}
+
+interface PendingRecovery {
+  buildIdentity: string;
+  category: ChunkLoadCategory;
+  failedChunkPath?: string;
+  route: string;
+}
+
+function getErrorName(error: unknown): string {
+  return error instanceof Error ? error.name : "";
+}
+
+function getErrorMessage(error: unknown): string {
+  if (error instanceof Error) return error.message;
+  return typeof error === "string" ? error : "";
+}
+
+function extractAssetPath(message: string): string | undefined {
+  const match = message.match(/(?:https?:\/\/[^\s"'<>]+)?\/assets\/[^\s"'<>)}\]]+/i);
+  if (!match) return undefined;
+
+  try {
+    const pathname = new URL(match[0], "https://index.network").pathname;
+    return pathname.startsWith("/assets/") ? pathname : undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+/** Classifies browser and bundler errors known to represent lazy asset failures. */
+export function classifyChunkLoadError(error: unknown): ChunkLoadFailure | null {
+  const name = getErrorName(error).toLowerCase();
+  const message = getErrorMessage(error);
+  const normalized = message.toLowerCase();
+  let category: ChunkLoadCategory | null = null;
+
+  if (name === "chunkloaderror" || /loading (?:css )?chunk [^\s]+ failed/.test(normalized)) {
+    category = "chunk-load";
+  } else if (normalized.includes("failed to fetch dynamically imported module")) {
+    category = "dynamic-import";
+  } else if (
+    normalized.includes("error loading dynamically imported module") ||
+    normalized.includes("importing a module script failed")
+  ) {
+    category = "module-script";
+  } else if (normalized.includes("unable to preload css for ")) {
+    category = "asset-preload";
+  }
+
+  return category
+    ? { category, failedChunkPath: extractAssetPath(message) }
+    : null;
+}
+
+/** Returns the hashed Vite entry filename used as this page's build identity. */
+export function getBuildIdentity(doc: Document = document): string {
+  const entry = Array.from(doc.querySelectorAll<HTMLScriptElement>('script[type="module"][src]'))
+    .map((script) => script.src)
+    .find((src) => {
+      try {
+        return new URL(src, doc.baseURI).pathname.startsWith("/assets/");
+      } catch {
+        return false;
+      }
+    });
+
+  if (!entry) return "unknown";
+
+  try {
+    return new URL(entry, doc.baseURI).pathname.split("/").pop() || "unknown";
+  } catch {
+    return "unknown";
+  }
+}
+
+function stableHash(value: string): string {
+  let hash = 0x811c9dc5;
+  for (let index = 0; index < value.length; index += 1) {
+    hash ^= value.charCodeAt(index);
+    hash = Math.imul(hash, 0x01000193);
+  }
+  return (hash >>> 0).toString(36);
+}
+
+function attemptKey(runtime: ChunkRecoveryRuntime): string {
+  return `${STORAGE_PREFIX}:attempt:${stableHash(`${runtime.buildIdentity}\u0000${runtime.href}`)}`;
+}
+
+function pendingKey(runtime: ChunkRecoveryRuntime): string {
+  return `${STORAGE_PREFIX}:pending:${stableHash(runtime.href)}`;
+}
+
+function report(
+  runtime: ChunkRecoveryRuntime,
+  level: "info" | "error",
+  message: string,
+  meta: RecoveryLogMeta,
+): void {
+  if (runtime.report) {
+    runtime.report(level, message, meta);
+    return;
+  }
+
+  logger[level](message, meta);
+}
+
+function createBrowserRuntime(): ChunkRecoveryRuntime {
+  const storage = (() => {
+    try {
+      return window.sessionStorage;
+    } catch {
+      return null;
+    }
+  })();
+
+  return {
+    href: `${window.location.pathname}${window.location.search}${window.location.hash}`,
+    buildIdentity: getBuildIdentity(),
+    storage,
+    reload: () => window.location.reload(),
+  };
+}
+
+/**
+ * Attempts one automatic reload for a chunk failure without changing the URL.
+ * A URL-level pending marker also prevents reload loops across build identities
+ * until a route module loads successfully.
+ */
+export function recoverChunkLoadError(
+  error: unknown,
+  route: string,
+  runtime: ChunkRecoveryRuntime = createBrowserRuntime(),
+): ChunkRecoveryResult | null {
+  const failure = classifyChunkLoadError(error);
+  if (!failure) return null;
+
+  let recoveryResult: ChunkRecoveryResult;
+  const marker: PendingRecovery = {
+    buildIdentity: runtime.buildIdentity,
+    category: failure.category,
+    failedChunkPath: failure.failedChunkPath,
+    route,
+  };
+
+  if (!runtime.storage) {
+    recoveryResult = "storage_unavailable";
+  } else {
+    try {
+      if (runtime.storage.getItem(pendingKey(runtime))) {
+        recoveryResult = "reload_blocked_pending";
+      } else if (runtime.storage.getItem(attemptKey(runtime))) {
+        recoveryResult = "reload_already_attempted";
+      } else {
+        runtime.storage.setItem(attemptKey(runtime), "1");
+        runtime.storage.setItem(pendingKey(runtime), JSON.stringify(marker));
+        recoveryResult = "reload_started";
+      }
+    } catch {
+      recoveryResult = "storage_unavailable";
+    }
+  }
+
+  const meta: RecoveryLogMeta = {
+    buildIdentity: runtime.buildIdentity,
+    route,
+    category: failure.category,
+    recoveryResult,
+    failedChunkPath: failure.failedChunkPath,
+  };
+  report(runtime, "error", "Lazy route asset failed to load", meta);
+
+  if (recoveryResult === "reload_started") {
+    try {
+      runtime.reload();
+    } catch {
+      recoveryResult = "reload_failed";
+      report(runtime, "error", "Lazy route reload failed", {
+        ...meta,
+        recoveryResult,
+      });
+    }
+  }
+
+  return recoveryResult;
+}
+
+function reportSuccessfulRecovery(route: string, runtime: ChunkRecoveryRuntime): void {
+  if (!runtime.storage) return;
+
+  try {
+    const key = pendingKey(runtime);
+    const value = runtime.storage.getItem(key);
+    if (!value) return;
+
+    const marker = JSON.parse(value) as PendingRecovery;
+    runtime.storage.removeItem(key);
+    report(runtime, "info", "Lazy route asset recovered after reload", {
+      buildIdentity: runtime.buildIdentity,
+      route,
+      category: marker.category,
+      recoveryResult: "route_loaded",
+      failedChunkPath: marker.failedChunkPath,
+    });
+  } catch {
+    // Storage and malformed-marker failures must not prevent route rendering.
+  }
+}
+
+/** Wraps a React Router lazy module import with bounded stale-chunk recovery. */
+export function lazyRoute<T>(
+  route: string,
+  loader: () => Promise<T>,
+  runtimeFactory: () => ChunkRecoveryRuntime = createBrowserRuntime,
+): () => Promise<T> {
+  return async () => {
+    const runtime = runtimeFactory();
+    try {
+      const routeModule = await loader();
+      reportSuccessfulRecovery(route, runtime);
+      return routeModule;
+    } catch (error) {
+      recoverChunkLoadError(error, route, runtime);
+      throw error;
+    }
+  };
+}

--- a/apps/web/src/routes.tsx
+++ b/apps/web/src/routes.tsx
@@ -9,6 +9,8 @@ import { AIChatProvider } from "@/contexts/AIChatContext";
 import { QuestionsProvider } from "@/contexts/QuestionsContext";
 
 import ClientWrapper from "@/components/ClientWrapper";
+import { RouteErrorBoundary } from "@/components/RouteErrorBoundary";
+import { lazyRoute } from "@/lib/lazy-route-recovery";
 
 /**
  * Root layout that wraps all routes with the provider tree and app shell.
@@ -40,151 +42,151 @@ function RootLayout() {
 export const router = createBrowserRouter([
   {
     element: <RootLayout />,
+    errorElement: <RouteErrorBoundary />,
     children: [
       {
         path: "/",
-        lazy: () => import("@/app/page"),
+        lazy: lazyRoute("/", () => import("@/app/page")),
       },
       {
         path: "/about",
-        lazy: () => import("@/app/about/page"),
+        lazy: lazyRoute("/about", () => import("@/app/about/page")),
       },
       {
         path: "/found-in-translation",
-        lazy: () => import("@/app/found-in-translation/page"),
+        lazy: lazyRoute("/found-in-translation", () => import("@/app/found-in-translation/page")),
       },
       {
         path: "/overview",
-        lazy: () => import("@/app/overview/page"),
+        lazy: lazyRoute("/overview", () => import("@/app/overview/page")),
       },
       {
         path: "/protocol",
-        lazy: () => import("@/app/protocol/page"),
+        lazy: lazyRoute("/protocol", () => import("@/app/protocol/page")),
       },
       {
         path: "/blog",
-        lazy: () => import("@/app/blog/page"),
+        lazy: lazyRoute("/blog", () => import("@/app/blog/page")),
       },
       {
         path: "/blog/:slug",
-        lazy: () => import("@/app/blog/[slug]/page"),
+        lazy: lazyRoute("/blog/:slug", () => import("@/app/blog/[slug]/page")),
       },
       {
         path: "/chat",
-        lazy: () => import("@/app/chat/page"),
+        lazy: lazyRoute("/chat", () => import("@/app/chat/page")),
       },
       {
         path: "/chat/:conversationId",
-        lazy: () => import("@/app/chat/[conversationId]/page"),
+        lazy: lazyRoute("/chat/:conversationId", () => import("@/app/chat/[conversationId]/page")),
       },
       {
         path: "/d/:id",
-        lazy: () => import("@/app/d/[id]/page"),
+        lazy: lazyRoute("/d/:id", () => import("@/app/d/[id]/page")),
       },
       {
         path: "/i/new",
-        lazy: () => import("@/app/i/new/page"),
+        lazy: lazyRoute("/i/new", () => import("@/app/i/new/page")),
       },
       {
         path: "/i/:intentId",
-        lazy: () => import("@/app/i/[intentId]/page"),
+        lazy: lazyRoute("/i/:intentId", () => import("@/app/i/[intentId]/page")),
       },
       {
         path: "/index/:indexId",
-        lazy: () => import("@/app/index/[indexId]/page"),
+        lazy: lazyRoute("/index/:indexId", () => import("@/app/index/[indexId]/page")),
       },
       {
         path: "/c/:code",
-        lazy: () => import("@/app/c/[code]/page"),
+        lazy: lazyRoute("/c/:code", () => import("@/app/c/[code]/page")),
       },
       {
         path: "/l/:code",
-        lazy: () => import("@/app/l/[code]/page"),
+        lazy: lazyRoute("/l/:code", () => import("@/app/l/[code]/page")),
       },
       {
         path: "/agents",
-        lazy: () => import("@/app/agents/page"),
+        lazy: lazyRoute("/agents", () => import("@/app/agents/page")),
       },
       {
         path: "/agents/:id",
-        lazy: () => import("@/app/agents/[id]/page"),
+        lazy: lazyRoute("/agents/:id", () => import("@/app/agents/[id]/page")),
       },
       {
         path: "/networks",
-        lazy: () => import("@/app/networks/page"),
+        lazy: lazyRoute("/networks", () => import("@/app/networks/page")),
       },
       {
         path: "/networks/:id/*",
-        lazy: () => import("@/app/networks/[id]/page"),
+        lazy: lazyRoute("/networks/:id/*", () => import("@/app/networks/[id]/page")),
       },
       {
         path: "/mynetwork/*",
-        lazy: () => import("@/app/mynetwork/page"),
+        lazy: lazyRoute("/mynetwork/*", () => import("@/app/mynetwork/page")),
       },
       {
         path: "/pages/privacy-policy",
-        lazy: () => import("@/app/pages/privacy-policy/page"),
+        lazy: lazyRoute("/pages/privacy-policy", () => import("@/app/pages/privacy-policy/page")),
       },
       {
         path: "/pages/terms-of-use",
-        lazy: () => import("@/app/pages/terms-of-use/page"),
+        lazy: lazyRoute("/pages/terms-of-use", () => import("@/app/pages/terms-of-use/page")),
       },
       {
         path: "/settings",
-        lazy: () => import("@/app/settings/page"),
+        lazy: lazyRoute("/settings", () => import("@/app/settings/page")),
       },
       {
         path: "/questions",
-        lazy: () => import("@/app/questions/page"),
+        lazy: lazyRoute("/questions", () => import("@/app/questions/page")),
       },
       {
         path: "/profile",
         element: <Navigate to="/settings" replace />,
       },
-      
       {
         path: "/s/:token",
-        lazy: () => import("@/app/s/[token]/page"),
+        lazy: lazyRoute("/s/:token", () => import("@/app/s/[token]/page")),
       },
       {
         path: "/u/:id",
-        lazy: () => import("@/app/u/[id]/page"),
+        lazy: lazyRoute("/u/:id", () => import("@/app/u/[id]/page")),
       },
       {
         path: "/u/:id/chat",
-        lazy: () => import("@/app/u/[id]/chat/page"),
+        lazy: lazyRoute("/u/:id/chat", () => import("@/app/u/[id]/chat/page")),
       },
       {
         path: "/opportunities/:id/skip",
-        lazy: () => import("@/app/opportunities/[id]/skip/page"),
+        lazy: lazyRoute("/opportunities/:id/skip", () => import("@/app/opportunities/[id]/skip/page")),
       },
       {
         path: "/onboarding",
-        lazy: () => import("@/app/onboarding/page"),
+        lazy: lazyRoute("/onboarding", () => import("@/app/onboarding/page")),
       },
       {
         path: "/oauth/callback",
-        lazy: () => import("@/app/oauth/callback/page"),
+        lazy: lazyRoute("/oauth/callback", () => import("@/app/oauth/callback/page")),
       },
       {
         path: "/cli-auth",
-        lazy: () => import("@/app/cli-auth/page"),
+        lazy: lazyRoute("/cli-auth", () => import("@/app/cli-auth/page")),
       },
       {
         path: "/login",
-        lazy: () => import("@/app/login/page"),
+        lazy: lazyRoute("/login", () => import("@/app/login/page")),
       },
       {
         path: "/dev/intent-proposal",
-        lazy: () => import("@/app/dev/intent-proposal/page"),
+        lazy: lazyRoute("/dev/intent-proposal", () => import("@/app/dev/intent-proposal/page")),
       },
       {
         path: "/agent/:tab?",
-        lazy: () => import("@/app/agent/page"),
+        lazy: lazyRoute("/agent/:tab?", () => import("@/app/agent/page")),
       },
       {
         path: "*",
-        lazy: () => import("@/app/not-found"),
+        lazy: lazyRoute("*", () => import("@/app/not-found")),
       },
     ],
   },

--- a/apps/web/tests/lazy-route-recovery.test.tsx
+++ b/apps/web/tests/lazy-route-recovery.test.tsx
@@ -1,0 +1,171 @@
+import { render, screen } from "@testing-library/react";
+import { createMemoryRouter, RouterProvider } from "react-router";
+import { describe, expect, test, vi } from "vitest";
+
+import { RouteErrorBoundary } from "@/components/RouteErrorBoundary";
+import { classifyChunkLoadError, lazyRoute, type ChunkRecoveryRuntime } from "@/lib/lazy-route-recovery";
+
+const CHUNK_ERROR = new TypeError(
+  "Failed to fetch dynamically imported module: https://index.network/assets/page-stale123.js",
+);
+
+class MemoryRecoveryStorage {
+  private readonly values = new Map<string, string>();
+
+  getItem(key: string): string | null {
+    return this.values.get(key) ?? null;
+  }
+
+  setItem(key: string, value: string): void {
+    this.values.set(key, value);
+  }
+
+  removeItem(key: string): void {
+    this.values.delete(key);
+  }
+}
+
+function createRuntime(overrides: Partial<ChunkRecoveryRuntime> = {}): ChunkRecoveryRuntime {
+  return {
+    href: "/i/intent-123?view=radar#latest",
+    buildIdentity: "index-oldbuild.js",
+    storage: new MemoryRecoveryStorage(),
+    reload: vi.fn(),
+    report: vi.fn(),
+    ...overrides,
+  };
+}
+
+describe("lazy route chunk recovery", () => {
+  test("classifies known chunk errors without treating ordinary fetch failures as chunks", () => {
+    expect(classifyChunkLoadError(CHUNK_ERROR)).toEqual({
+      category: "dynamic-import",
+      failedChunkPath: "/assets/page-stale123.js",
+    });
+    expect(classifyChunkLoadError(new Error("Failed to fetch intent"))).toBeNull();
+    expect(classifyChunkLoadError(new Error("Intent not found"))).toBeNull();
+  });
+
+  test("reloads at most once and preserves the requested URL", async () => {
+    const reloadedUrls: string[] = [];
+    const runtime = createRuntime({
+      reload: () => reloadedUrls.push(runtime.href),
+    });
+    const load = lazyRoute(
+      "/i/:intentId",
+      () => Promise.reject(CHUNK_ERROR),
+      () => runtime,
+    );
+
+    await expect(load()).rejects.toBe(CHUNK_ERROR);
+    await expect(load()).rejects.toBe(CHUNK_ERROR);
+
+    expect(reloadedUrls).toEqual(["/i/intent-123?view=radar#latest"]);
+    expect(runtime.report).toHaveBeenCalledWith(
+      "error",
+      "Lazy route asset failed to load",
+      expect.objectContaining({
+        buildIdentity: "index-oldbuild.js",
+        route: "/i/:intentId",
+        failedChunkPath: "/assets/page-stale123.js",
+        recoveryResult: "reload_started",
+      }),
+    );
+    expect(runtime.report).toHaveBeenLastCalledWith(
+      "error",
+      "Lazy route asset failed to load",
+      expect.objectContaining({ recoveryResult: "reload_blocked_pending" }),
+    );
+  });
+
+  test("reports a successful route load after the recovery reload", async () => {
+    const storage = new MemoryRecoveryStorage();
+    const staleRuntime = createRuntime({ storage });
+    const staleLoad = lazyRoute(
+      "/i/:intentId",
+      () => Promise.reject(CHUNK_ERROR),
+      () => staleRuntime,
+    );
+    await expect(staleLoad()).rejects.toBe(CHUNK_ERROR);
+
+    const currentRuntime = createRuntime({
+      buildIdentity: "index-currentbuild.js",
+      storage,
+    });
+    const recoveredLoad = lazyRoute(
+      "/i/:intentId",
+      () => Promise.resolve({ Component: () => null }),
+      () => currentRuntime,
+    );
+
+    await expect(recoveredLoad()).resolves.toBeDefined();
+    expect(currentRuntime.report).toHaveBeenCalledWith(
+      "info",
+      "Lazy route asset recovered after reload",
+      expect.objectContaining({
+        buildIdentity: "index-currentbuild.js",
+        route: "/i/:intentId",
+        recoveryResult: "route_loaded",
+      }),
+    );
+  });
+
+  test("does not reload or relabel ordinary route errors", async () => {
+    const ordinaryError = new Error("Intent loader failed");
+    const runtime = createRuntime();
+    const load = lazyRoute(
+      "/i/:intentId",
+      () => Promise.reject(ordinaryError),
+      () => runtime,
+    );
+
+    await expect(load()).rejects.toBe(ordinaryError);
+
+    expect(runtime.reload).not.toHaveBeenCalled();
+    expect(runtime.report).not.toHaveBeenCalled();
+  });
+
+  test("renders clear refresh UI when a chunk failure reaches the route boundary", async () => {
+    const router = createMemoryRouter(
+      [
+        {
+          path: "/i/:intentId",
+          lazy: () => Promise.reject(CHUNK_ERROR),
+          hydrateFallbackElement: <div>Loading</div>,
+          errorElement: <RouteErrorBoundary />,
+        },
+      ],
+      { initialEntries: ["/i/intent-123"] },
+    );
+
+    render(<RouterProvider router={router} />);
+
+    expect(await screen.findByRole("heading", { name: "This page needs a refresh" })).toBeVisible();
+    expect(screen.getByText(/updated while this page was open/i)).toBeVisible();
+    expect(screen.getByRole("button", { name: "Refresh page" })).toBeVisible();
+    expect(screen.queryByText(/Unexpected Application Error/i)).not.toBeInTheDocument();
+  });
+
+  test("renders an ordinary application error without chunk-update messaging", async () => {
+    const router = createMemoryRouter(
+      [
+        {
+          path: "/settings",
+          loader: () => {
+            throw new Error("Settings loader failed");
+          },
+          element: <div>Settings</div>,
+          hydrateFallbackElement: <div>Loading</div>,
+          errorElement: <RouteErrorBoundary />,
+        },
+      ],
+      { initialEntries: ["/settings"] },
+    );
+
+    render(<RouterProvider router={router} />);
+
+    expect(await screen.findByRole("heading", { name: "Something went wrong" })).toBeVisible();
+    expect(screen.queryByText(/updated while this page was open/i)).not.toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Refresh page" })).toBeVisible();
+  });
+});

--- a/apps/web/tests/server.test.ts
+++ b/apps/web/tests/server.test.ts
@@ -1,0 +1,97 @@
+// @vitest-environment node
+
+import { afterEach, beforeEach, describe, expect, test } from "vitest";
+import { mkdtempSync, mkdirSync, rmSync, writeFileSync } from "fs";
+import { join } from "path";
+import { tmpdir } from "os";
+
+import { createWebHandler } from "../server";
+
+describe("production web server", () => {
+  let distDir: string;
+
+  beforeEach(() => {
+    distDir = mkdtempSync(join(tmpdir(), "index-web-server-"));
+    mkdirSync(join(distDir, "assets"));
+    writeFileSync(
+      join(distDir, "index.html"),
+      "<!doctype html><html><head><title>Index</title></head><body>SPA entry</body></html>",
+    );
+    writeFileSync(join(distDir, "assets", "index-abc12345.js"), "export const ok = true;");
+    writeFileSync(join(distDir, "favicon.png"), "png");
+  });
+
+  afterEach(() => {
+    rmSync(distDir, { recursive: true, force: true });
+  });
+
+  test("serves the SPA entrypoint for document route navigation", async () => {
+    const fetch = createWebHandler({ distDir, metaMap: {} });
+
+    const response = fetch(
+      new Request("https://index.network/i/intent-123", {
+        headers: {
+          Accept: "text/html,application/xhtml+xml",
+          "Sec-Fetch-Mode": "navigate",
+        },
+      }),
+    );
+
+    expect(response.status).toBe(200);
+    expect(response.headers.get("Content-Type")).toContain("text/html");
+    expect(await response.text()).toContain("SPA entry");
+  });
+
+  test("returns a non-HTML 404 for a missing asset", async () => {
+    const fetch = createWebHandler({ distDir, metaMap: {} });
+
+    const response = fetch(
+      new Request("https://index.network/assets/page-stale123.js", {
+        headers: { Accept: "text/html,*/*" },
+      }),
+    );
+
+    expect(response.status).toBe(404);
+    expect(response.headers.get("Content-Type")).toBe("text/plain; charset=utf-8");
+    expect(response.headers.get("Cache-Control")).toBe("no-store");
+    expect(await response.text()).toBe("Not Found");
+  });
+
+  test("prevents HTML caching and caches valid hashed assets immutably", () => {
+    const fetch = createWebHandler({ distDir, metaMap: {} });
+
+    const htmlResponse = fetch(
+      new Request("https://index.network/settings", {
+        headers: { Accept: "text/html" },
+      }),
+    );
+    const assetResponse = fetch(
+      new Request("https://index.network/assets/index-abc12345.js"),
+    );
+    const publicFileResponse = fetch(
+      new Request("https://index.network/favicon.png"),
+    );
+
+    expect(htmlResponse.headers.get("Cache-Control")).toBe("no-store");
+    expect(assetResponse.headers.get("Cache-Control")).toBe(
+      "public, max-age=31536000, immutable",
+    );
+    expect(publicFileResponse.headers.get("Cache-Control")).toBe(
+      "public, max-age=0, must-revalidate",
+    );
+  });
+
+  test("does not use the SPA fallback for non-document requests", async () => {
+    const fetch = createWebHandler({ distDir, metaMap: {} });
+
+    const response = fetch(
+      new Request("https://index.network/i/intent-123", {
+        headers: { Accept: "application/json" },
+      }),
+    );
+
+    expect(response.status).toBe(404);
+    expect(response.headers.get("Content-Type")).toContain("text/plain");
+    expect(await response.text()).toBe("Not Found");
+  });
+});

--- a/docs/design/architecture-overview.md
+++ b/docs/design/architecture-overview.md
@@ -34,7 +34,7 @@ index/
 
 **API service** is a native Bun HTTP server (`Bun.serve`) running on port 3001. It hosts the API, LangGraph-based agent system, database layer, job queues, and event infrastructure.
 
-**Web app** is a single-page application built with Vite and React Router v7. In development, Vite proxies `/api/*` requests to the API service. In production, a reverse proxy handles routing.
+**Web app** is a single-page application built with Vite and React Router v7. In development, Vite proxies `/api/*` requests to the API service. In production, `apps/web/server.ts` serves the Vite output and falls back to `index.html` only for document navigations. HTML is `no-store`, generated `/assets/*` files are immutable, and missing assets return a non-HTML 404 so stale lazy imports can be detected and recovered safely. React Router lazy imports make one bounded, URL-preserving reload attempt per stale route load before the application error boundary presents an explicit refresh action.
 
 **Mac app** is a subtree-synced native Apple prototype under `apps/mac/`, with Swift WKWebView shells wrapping self-contained React/HTML bundles.
 


### PR DESCRIPTION
## Bug Fixes
- return a real non-HTML `404` for missing `/assets/*` requests while preserving SPA fallback for document navigations
- serve HTML with `Cache-Control: no-store` and valid Vite assets with immutable caching
- wrap all React Router lazy imports in a canonical chunk-load classifier with a URL-preserving, one-attempt recovery guard
- add an application route error boundary with explicit refresh and home actions
- emit privacy-safe chunk recovery logs with asset path, category, Vite entry build identity, route pattern, and recovery result

## Documentation
- document the production SPA fallback, cache policy, and lazy-route recovery contract

## Tests
- `cd apps/web && bun --bun vitest run tests/server.test.ts tests/lazy-route-recovery.test.tsx` — **10 passed**
- `cd apps/web && bun run lint` — **passed** (0 errors; 91 existing warnings)
- `cd apps/web && bun run build` — **passed** (existing Vite/CSS/chunk-size warnings only)
- `cd apps/web && bunx tsc --noEmit` — repository baseline remains red with 60 unrelated diagnostics; **0 diagnostics in changed files**
- Existing `tests/routes.test.tsx` remains red independently due its deleted `@/app/profile/page` import and stale provider mocks

## Feature Flags
- None

Fixes [IND-485](https://linear.app/indexnetwork/issue/IND-485/intent-navigation-can-fail-on-stale-or-missing-lazy-route-chunks)
