### PR TITLE
feat(web): show network context and signals overview

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@indexnetwork/web",
-  "version": "0.25.7",
+  "version": "0.26.0",
   "license": "MIT",
   "scripts": {
     "dev": "vite --host 127.0.0.1",

--- a/apps/web/src/components/NetworkOverviewPanel.tsx
+++ b/apps/web/src/components/NetworkOverviewPanel.tsx
@@ -1,7 +1,6 @@
 import { useState, useEffect, useCallback } from 'react';
 import { useNavigate } from 'react-router';
 import * as AlertDialog from '@radix-ui/react-alert-dialog';
-import { LogOut } from 'lucide-react';
 import { Network } from '@/lib/types';
 import { Button } from '@/components/ui/button';
 import IntentList from '@/components/IntentList';
@@ -24,7 +23,7 @@ interface NetworkOverviewPanelProps {
   onLeaveRequestHandled?: () => void;
 }
 
-export default function NetworkOverviewPanel({ index, isOwner, onLeft, onLeaveRequest, onLeaveRequestHandled }: NetworkOverviewPanelProps) {
+export default function NetworkOverviewPanel({ index, onLeft, onLeaveRequest, onLeaveRequestHandled }: NetworkOverviewPanelProps) {
   const navigate = useNavigate();
   const { removeIndex } = useNetworksState();
   const { success, error } = useNotifications();
@@ -45,7 +44,6 @@ export default function NetworkOverviewPanel({ index, isOwner, onLeft, onLeaveRe
     }
   }, [onLeaveRequest, onLeaveRequestHandled]);
   
-  // Intents state
   const [intents, setIntents] = useState<{
     id: string;
     payload: string;
@@ -54,22 +52,19 @@ export default function NetworkOverviewPanel({ index, isOwner, onLeft, onLeaveRe
     userId: string;
     userName: string;
   }[]>([]);
-  const [intentsLoading, setIntentsLoading] = useState(true);
-  const [premises, setPremises] = useState<{ id: string; text: string; summary: string | null; createdAt: string }[]>([]);
+  const [overviewLoading, setOverviewLoading] = useState(true);
   const [userContext, setUserContext] = useState<{ text: string; generatedAt: string } | null>(null);
 
-  // Load the full network overview (intents, premises, user_context) when component mounts
   useEffect(() => {
     const loadOverview = async () => {
       try {
         const overview = await indexesService.getNetworkOverview(index.id);
         setIntents(overview.intents);
-        setPremises(overview.premises);
         setUserContext(overview.userContext);
       } catch (err) {
         logger.error('Error loading network overview', { error: err });
       } finally {
-        setIntentsLoading(false);
+        setOverviewLoading(false);
       }
     };
     loadOverview();
@@ -107,69 +102,47 @@ export default function NetworkOverviewPanel({ index, isOwner, onLeft, onLeaveRe
     }
   };
 
-  const isPublic = index.permissions?.joinPolicy === 'anyone';
-
   return (
     <>
       <div className="space-y-8">
-
-        {/* My Intents */}
         <div>
-          <div className="flex items-center justify-between mb-4">
-            <p className="text-xs font-semibold text-gray-400 uppercase tracking-wider font-ibm-plex-mono">
-              My Intents
-            </p>
-            {!intentsLoading && (
-              <span className="text-xs text-gray-400">{intents.length} intent{intents.length !== 1 ? 's' : ''}</span>
-            )}
-          </div>
-          <IntentList
-            intents={intents}
-            isLoading={intentsLoading}
-            emptyMessage="You haven't shared any intents in this network yet"
-            onIntentClick={handleOpenIntentChat}
-          />
-        </div>
-
-        {/* My Premises */}
-        <div>
-          <div className="flex items-center justify-between mb-4">
-            <p className="text-xs font-semibold text-gray-400 uppercase tracking-wider font-ibm-plex-mono">
-              My Premises
-            </p>
-            {!intentsLoading && (
-              <span className="text-xs text-gray-400">{premises.length} premise{premises.length !== 1 ? 's' : ''}</span>
-            )}
-          </div>
-          {intentsLoading ? null : premises.length === 0 ? (
-            <div className="text-sm text-gray-500 font-ibm-plex-mono py-12 text-center border border-dashed border-gray-200 rounded-lg">
-              <p>No premises assigned to this network yet</p>
+          <p className="text-xs font-semibold text-gray-400 uppercase tracking-wider font-ibm-plex-mono mb-4">
+            Your Context
+          </p>
+          {overviewLoading ? (
+            <div
+              role="status"
+              className="text-sm text-gray-500 font-ibm-plex-mono py-12 text-center border border-dashed border-gray-200 rounded-lg"
+            >
+              Loading your network context…
+            </div>
+          ) : userContext && userContext.text.trim().length > 0 ? (
+            <div className="p-4 rounded-lg border border-gray-200 bg-gray-50">
+              <p className="text-sm text-gray-700 leading-relaxed whitespace-pre-wrap">{userContext.text}</p>
             </div>
           ) : (
-            <div className="space-y-3">
-              {premises.map((p) => (
-                <div key={p.id} className="p-4 rounded-lg border border-gray-200 bg-white">
-                  <p className="text-sm text-gray-900 leading-relaxed">
-                    {(p.summary && p.summary.trim().length > 0 ? p.summary : p.text).trim()}
-                  </p>
-                </div>
-              ))}
+            <div className="text-sm text-gray-500 font-ibm-plex-mono py-12 text-center border border-dashed border-gray-200 rounded-lg">
+              <p>Your context for this network is still being generated</p>
             </div>
           )}
         </div>
 
-        {/* Your Context */}
-        {userContext && userContext.text.trim().length > 0 && (
-          <div>
-            <p className="text-xs font-semibold text-gray-400 uppercase tracking-wider font-ibm-plex-mono mb-4">
-              Your Context
+        <div>
+          <div className="flex items-center justify-between mb-4">
+            <p className="text-xs font-semibold text-gray-400 uppercase tracking-wider font-ibm-plex-mono">
+              Your Signals
             </p>
-            <div className="p-4 rounded-lg border border-gray-200 bg-gray-50">
-              <p className="text-sm text-gray-700 leading-relaxed whitespace-pre-wrap">{userContext.text}</p>
-            </div>
+            {!overviewLoading && (
+              <span className="text-xs text-gray-400">{intents.length} signal{intents.length !== 1 ? 's' : ''}</span>
+            )}
           </div>
-        )}
-
+          <IntentList
+            intents={intents}
+            isLoading={overviewLoading}
+            emptyMessage="You haven't shared any signals in this network yet"
+            onIntentClick={handleOpenIntentChat}
+          />
+        </div>
       </div>
 
       <AlertDialog.Root open={showLeaveConfirmation} onOpenChange={setShowLeaveConfirmation}>

--- a/apps/web/tests/network-overview-panel.test.tsx
+++ b/apps/web/tests/network-overview-panel.test.tsx
@@ -1,0 +1,184 @@
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { MemoryRouter } from 'react-router';
+import { beforeEach, describe, expect, test, vi } from 'vitest';
+
+import NetworkOverviewPanel from '@/components/NetworkOverviewPanel';
+
+interface OverviewResponse {
+  intents: Array<{
+    id: string;
+    payload: string;
+    summary?: string | null;
+    createdAt: string;
+    userId: string;
+    userName: string;
+  }>;
+  premises: Array<{ id: string; text: string; summary: string | null; createdAt: string }>;
+  userContext: { text: string; generatedAt: string } | null;
+}
+
+const mocks = vi.hoisted(() => ({
+  getNetworkOverview: vi.fn(),
+  navigate: vi.fn(),
+  clearChat: vi.fn(),
+  resolveIntentSession: vi.fn(),
+  setSelectedNetworkIds: vi.fn(),
+  removeIndex: vi.fn(),
+  success: vi.fn(),
+  error: vi.fn(),
+  apiPost: vi.fn(),
+}));
+
+vi.mock('react-router', async () => {
+  const actual = await vi.importActual<typeof import('react-router')>('react-router');
+  return {
+    ...actual,
+    useNavigate: () => mocks.navigate,
+  };
+});
+
+vi.mock('@/contexts/APIContext', () => ({
+  useNetworks: () => ({ getNetworkOverview: mocks.getNetworkOverview }),
+}));
+
+vi.mock('@/contexts/IndexesContext', () => ({
+  useNetworksState: () => ({ removeIndex: mocks.removeIndex }),
+}));
+
+vi.mock('@/contexts/NotificationContext', () => ({
+  useNotifications: () => ({ success: mocks.success, error: mocks.error }),
+}));
+
+vi.mock('@/contexts/AIChatContext', () => ({
+  useAIChat: () => ({
+    clearChat: mocks.clearChat,
+    resolveIntentSession: mocks.resolveIntentSession,
+  }),
+}));
+
+vi.mock('@/contexts/AuthContext', () => ({
+  useAuthContext: () => ({ features: { signalAgent: false } }),
+}));
+
+vi.mock('@/contexts/IndexFilterContext', () => ({
+  useNetworkFilter: () => ({ setSelectedNetworkIds: mocks.setSelectedNetworkIds }),
+}));
+
+vi.mock('@/lib/api', () => ({
+  useAuthenticatedAPI: () => ({ post: mocks.apiPost }),
+}));
+
+const network = {
+  id: 'network-1',
+  title: 'Design Network',
+  permissions: { joinPolicy: 'anyone' },
+} as Parameters<typeof NetworkOverviewPanel>[0]['index'];
+
+const renderPanel = () =>
+  render(
+    <MemoryRouter>
+      <NetworkOverviewPanel index={network} isOwner />
+    </MemoryRouter>,
+  );
+
+const emptyOverview = (): OverviewResponse => ({
+  intents: [],
+  premises: [],
+  userContext: null,
+});
+
+describe('NetworkOverviewPanel context and signals overview', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.resolveIntentSession.mockResolvedValue('session-1');
+  });
+
+  test('renders Your Context before Your Signals with a context loading state', async () => {
+    let resolveOverview!: (overview: OverviewResponse) => void;
+    mocks.getNetworkOverview.mockReturnValue(new Promise<OverviewResponse>((resolve) => {
+      resolveOverview = resolve;
+    }));
+
+    renderPanel();
+
+    expect(screen.getAllByText(/Your (Context|Signals)/).map((node) => node.textContent)).toEqual([
+      'Your Context',
+      'Your Signals',
+    ]);
+    expect(screen.getByRole('status')).toHaveTextContent('Loading your network context…');
+    expect(screen.queryByText('My Intents')).not.toBeInTheDocument();
+    expect(screen.queryByText('My Premises')).not.toBeInTheDocument();
+
+    resolveOverview(emptyOverview());
+    await waitFor(() => expect(screen.queryByRole('status')).not.toBeInTheDocument());
+  });
+
+  test('renders coherent empty states and never presents premises from the overview API', async () => {
+    mocks.getNetworkOverview.mockResolvedValue({
+      ...emptyOverview(),
+      premises: [{
+        id: 'premise-1',
+        text: 'Internal premise that must not appear',
+        summary: 'Hidden premise summary',
+        createdAt: '2026-07-01T00:00:00.000Z',
+      }],
+    });
+
+    renderPanel();
+
+    expect(await screen.findByText('Your context for this network is still being generated')).toBeInTheDocument();
+    expect(screen.getByText("You haven't shared any signals in this network yet")).toBeInTheDocument();
+    expect(screen.getByText('0 signals')).toBeInTheDocument();
+    expect(screen.queryByText('My Premises')).not.toBeInTheDocument();
+    expect(screen.queryByText('Hidden premise summary')).not.toBeInTheDocument();
+    expect(screen.queryByText('Internal premise that must not appear')).not.toBeInTheDocument();
+    expect(mocks.getNetworkOverview).toHaveBeenCalledWith('network-1');
+  });
+
+  test('preserves network-scoped context, signal count/list rendering, and click-through', async () => {
+    mocks.getNetworkOverview.mockResolvedValue({
+      intents: [
+        {
+          id: 'intent-1',
+          payload: 'Find a product designer',
+          summary: 'Seeking a product designer',
+          createdAt: '2026-07-02T00:00:00.000Z',
+          userId: 'user-1',
+          userName: 'Alice',
+        },
+        {
+          id: 'intent-2',
+          payload: 'Explore climate partnerships',
+          summary: null,
+          createdAt: '2026-07-01T00:00:00.000Z',
+          userId: 'user-1',
+          userName: 'Alice',
+        },
+      ],
+      premises: [],
+      userContext: {
+        text: 'In this network, you focus on collaborative product design.',
+        generatedAt: '2026-07-03T00:00:00.000Z',
+      },
+    });
+
+    renderPanel();
+
+    expect(await screen.findByText('In this network, you focus on collaborative product design.')).toBeInTheDocument();
+    expect(screen.getByText('2 signals')).toBeInTheDocument();
+    expect(screen.getByText('Seeking a product designer')).toBeInTheDocument();
+    expect(screen.getByText('Explore climate partnerships')).toBeInTheDocument();
+
+    fireEvent.click(screen.getByText('Seeking a product designer'));
+
+    await waitFor(() => {
+      expect(mocks.clearChat).toHaveBeenCalledWith({ abortStream: false });
+      expect(mocks.setSelectedNetworkIds).toHaveBeenCalledWith([]);
+      expect(mocks.resolveIntentSession).toHaveBeenCalledWith(
+        { id: 'intent-1', label: 'Seeking a product designer' },
+        undefined,
+      );
+      expect(mocks.navigate).toHaveBeenCalledWith('/d/session-1');
+    });
+  });
+});


### PR DESCRIPTION
## New Features
- present the network overview as **Your Context** followed by **Your Signals**
- add explicit network-context loading and empty states
- preserve signal counts, list rendering, and intent-chat click-through behavior

## Refactors
- remove premise headings/cards from the overview presentation only
- keep the network overview API and its premise response contract unchanged
- rebase onto current `dev` while preserving the merged auth-expiry recovery, lazy-route recovery, and visible-chat unread behavior
- bump `@indexnetwork/web` from the current `dev` floor `0.25.7` to `0.26.0`

## Documentation
- none; no public API or developer contract changed

## Tests
- `bun install --frozen-lockfile` — passed
- `cd apps/web && bun run test tests/network-overview-panel.test.tsx` — 3 passed
- `cd apps/web && bun run lint` — passed with 0 errors (88 existing warnings)
- `cd apps/web && bun run build` — passed (existing Vite CSS/chunk/import warnings)
- rebase checks — `origin/dev` is an ancestor, feature patch is preserved byte-for-byte, protected dev paths match, and `git diff --check` passes

## Feature Flags
- none

Closes IND-486
