### PR TITLE
fix: persist reporter briefing sessions

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -157,6 +157,9 @@ OPENROUTER_API_KEY=your-openrouter-api-key
 # WEB_AGENT_SURFACE_ENABLED=false          # Read-only Agent reporter persona (IND-476 PR1): when exactly "true", reporter
                                            # sessions may be started/continued on the main-web surface. Surfaced as
                                            # features.agentSurface on GET /auth/me. Default off; ship dark first.
+# REPORTER_BRIEFING_TTL_MS=86400000         # Lazy opening-briefing lifetime (IND-484), measured from session creation rather
+                                           # than follow-up activity. Positive whole milliseconds; defaults to 24 hours.
+                                           # Expired reporter sessions remain readable in ordinary web history.
 # WEB_AGENT_ACTIONS_ENABLED=false          # IND-490 PR1: owner-confirmed reporter cleanup-action proposals. Effective only
                                            # when WEB_AGENT_SURFACE_ENABLED is true; confirm endpoint is session-only.
                                            # Default off; ship dark first. Do not flip on Railway in this PR.

--- a/apps/web/CHANGELOG.md
+++ b/apps/web/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
 
 ### Fixed
 
+- Persist Reporter Agent opening briefings across reloads for 24 hours by default, hydrate the server-resolved session without replaying the hidden kickoff, and make **New conversation** atomically create and bind one fresh briefing while aborting and quarantining stale streams (IND-484).
 - Allow the reporter surface (`/agent`) to send messages after its briefing session is established; the route-mismatch guard now exempts the URL-less reporter session while preserving stale-session protection on `/d/:id` (IND-488).
 - Hide the generic chat session title bar ("Untitled chat", back/rename/share controls) on read-only surfaces like the `/agent` reporter, which renders its own header (IND-476). Test config now resolves the reporter kickoff marker from protocol source so web tests no longer depend on a built `packages/protocol/dist`.
 

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@indexnetwork/web",
-  "version": "0.27.0",
+  "version": "0.27.1",
   "license": "MIT",
   "scripts": {
     "dev": "vite --host 127.0.0.1",

--- a/apps/web/src/components/AgentReporterSurface.tsx
+++ b/apps/web/src/components/AgentReporterSurface.tsx
@@ -1,6 +1,5 @@
 import { useEffect, useMemo, useRef, useState } from "react";
 
-import { REPORTER_BRIEFING_KICKOFF } from "@indexnetwork/protocol";
 import { useAIChat } from "@/contexts/AIChatContext";
 import { useAuthContext } from "@/contexts/AuthContext";
 import { useQuestions } from "@/contexts/QuestionsContext";
@@ -18,7 +17,7 @@ const REPORTER_SUGGESTIONS: Suggestion[] = [
 /** Read-only, web-only reporter chat surface for /agent. */
 export default function AgentReporterSurface() {
   const { isAuthenticated, features } = useAuthContext();
-  const { messages, startReporterSession, sendWebMessage } = useAIChat();
+  const { messages, startReporterSession } = useAIChat();
   const intentsService = useIntents();
   const { globalPending, loading: questionsLoading } = useQuestions();
   const [activeSignalCount, setActiveSignalCount] = useState<number | null>(null);
@@ -30,15 +29,10 @@ export default function AgentReporterSurface() {
   useEffect(() => {
     if (!isAuthenticated || !agentSurfaceEnabled || startedRef.current) return;
     startedRef.current = true;
-    startReporterSession();
-    // The reporter prompt builder matches this marker to produce the opening briefing.
-    void sendWebMessage(
-      REPORTER_BRIEFING_KICKOFF,
-      undefined,
-      undefined,
-      { hidden: true, persona: "reporter" },
-    );
-  }, [agentSurfaceEnabled, isAuthenticated, sendWebMessage, startReporterSession]);
+    // The server returns the sole creation claim; the context sends the hidden
+    // kickoff only for that claimant and otherwise hydrates persisted messages.
+    void startReporterSession();
+  }, [agentSurfaceEnabled, isAuthenticated, startReporterSession]);
 
   useEffect(() => {
     let active = true;

--- a/apps/web/src/components/AgentSessionsPanel.tsx
+++ b/apps/web/src/components/AgentSessionsPanel.tsx
@@ -4,6 +4,7 @@ import { Plus, BotMessageSquare } from 'lucide-react';
 
 import { apiClient } from '@/lib/api';
 import { useAuthContext } from '@/contexts/AuthContext';
+import { useAIChat } from '@/contexts/AIChatContext';
 import { useAIChatSessions } from '@/contexts/AIChatSessionsContext';
 import { useNetworksState } from '@/contexts/IndexesContext';
 import { useNotifications } from '@/contexts/NotificationContext';
@@ -31,6 +32,7 @@ export default function AgentSessionsPanel() {
   const { pathname } = useLocation();
   const { user, features } = useAuthContext();
   const { sessionsVersion } = useAIChatSessions();
+  const { startReporterSession } = useAIChat();
   const { indexes } = useNetworksState();
   const { error } = useNotifications();
 
@@ -38,6 +40,8 @@ export default function AgentSessionsPanel() {
   const [loadingSessions, setLoadingSessions] = useState(false);
 
   const negotiatorEnabled = features?.negotiatorChat === true;
+  const reporterEnabled = features?.agentSurface === true;
+  const [openingReporter, setOpeningReporter] = useState(false);
   const [negotiatorSession, setNegotiatorSession] = useState<{ id: string; title: string | null } | null>(null);
   const [openingNegotiator, setOpeningNegotiator] = useState(false);
 
@@ -96,7 +100,9 @@ export default function AgentSessionsPanel() {
     const fetchSessions = async () => {
       try {
         if (isInitialLoad) setLoadingSessions(true);
-        const data = await apiClient.get<{ sessions: ChatSession[] }>('/chat/sessions');
+        // Session-authenticated web history keeps legacy, Signal, and Reporter
+        // conversations readable even when a persona flag is rolled back.
+        const data = await apiClient.get<{ sessions: ChatSession[] }>('/chat/web/sessions');
         setChatSessions(data.sessions.slice(0, 20));
       } catch (err) {
         logger.error('Failed to fetch chat sessions', { error: err });
@@ -107,12 +113,37 @@ export default function AgentSessionsPanel() {
     fetchSessions();
   }, [sessionsVersion, user?.id]);
 
+  const handleNewConversation = async () => {
+    if (!reporterEnabled) {
+      navigate('/agent');
+      return;
+    }
+    if (openingReporter) return;
+
+    setOpeningReporter(true);
+    const started = startReporterSession({ forceNew: true });
+    // Navigation is immediate; AgentReporterSurface coalesces its mount call
+    // with this in-flight reporter start instead of claiming a second session.
+    navigate('/agent');
+    try {
+      if (!(await started)) error('Failed to start a fresh Agent briefing');
+    } catch (err) {
+      logger.error('Failed to start reporter conversation', { error: err });
+      error('Failed to start a fresh Agent briefing');
+    } finally {
+      setOpeningReporter(false);
+    }
+  };
+
   return (
     <div className="flex flex-col h-full overflow-hidden">
       <div className="flex-shrink-0 px-4 py-4 border-b border-gray-100">
         <button
-          onClick={() => navigate('/agent')}
-          className="w-full flex items-center gap-2 px-3 py-2 rounded-md text-sm font-medium text-black hover:bg-gray-50 transition-colors border border-gray-200"
+          onClick={() => void handleNewConversation()}
+          disabled={openingReporter}
+          className={`w-full flex items-center gap-2 px-3 py-2 rounded-md text-sm font-medium text-black hover:bg-gray-50 transition-colors border border-gray-200 ${
+            openingReporter ? 'opacity-50 cursor-wait' : ''
+          }`}
         >
           <Plus className="w-4 h-4" />
           New conversation

--- a/apps/web/src/components/ChatContent.tsx
+++ b/apps/web/src/components/ChatContent.tsx
@@ -518,14 +518,15 @@ export default function ChatContent({
   }, [sessionIdFromUrl, routedSessionReady, sessionLoadState, loadSession]);
 
   useLayoutEffect(() => {
-    if (sessionIdFromUrl) return;
+    if (sessionIdFromUrl || persona === "reporter") return;
     navigatingToHomeRef.current = true;
     // Don't abort in-flight stream so the new session can finish and appear in the sidebar.
+    // The reporter surface owns a stronger abort-and-resolve boundary in AIChatContext.
     // Preserve a continuation's one-shot forced Signal persona across route cleanup.
     clearChat({ abortStream: false, preserveForcedPersona: true });
     setChatScope(null);
     setSelectedNetworkIds([]);
-  }, [sessionIdFromUrl, clearChat, setChatScope, setSelectedNetworkIds]);
+  }, [sessionIdFromUrl, persona, clearChat, setChatScope, setSelectedNetworkIds]);
 
 
   useEffect(() => {

--- a/apps/web/src/contexts/AIChatContext.tsx
+++ b/apps/web/src/contexts/AIChatContext.tsx
@@ -1,5 +1,7 @@
 import React, { createContext, useContext, useState, useCallback, useRef } from "react";
 import { useLocation } from "react-router";
+import { REPORTER_BRIEFING_KICKOFF } from "@indexnetwork/protocol";
+
 import { useAIChatSessions } from "@/contexts/AIChatSessionsContext";
 import { apiClient } from "@/lib/api";
 import { AuthSessionError, clearJwtToken } from "@/lib/auth-client";
@@ -228,8 +230,8 @@ interface AIChatContextType {
   clearChat: (options?: { abortStream?: boolean; preserveForcedPersona?: boolean }) => void;
   /** Clear the current chat and force the next new web session to request Signal. */
   startSignalSession: () => void;
-  /** Start a fresh main-web reporter session. */
-  startReporterSession: () => void;
+  /** Resolve the current reporter briefing, optionally forcing an explicit fresh conversation. */
+  startReporterSession: (options?: { forceNew?: boolean }) => Promise<boolean>;
   /** Load a session, returning false for failed or superseded requests. */
   loadSession: (sessionId: string) => Promise<boolean>;
   /** Observable target-specific load state for disabling route interactions until ready. */
@@ -423,6 +425,8 @@ export function AIChatProvider({ children }: { children: React.ReactNode }) {
   /** Independent latest-owner token for intent-session resolution requests. */
   const intentResolutionOwnerRef = useRef<symbol | null>(null);
   const activeSendRef = useRef<SendOperation | null>(null);
+  /** Coalesce route-mount resolution with an already-started reporter action. */
+  const reporterStartRef = useRef<Promise<boolean> | null>(null);
 
   const ownsOperation = useCallback((token: symbol) => operationOwnerRef.current === token, []);
 
@@ -597,13 +601,15 @@ export function AIChatProvider({ children }: { children: React.ReactNode }) {
       fileIds?: string[],
       attachmentNames?: string[],
       options?: ChatSendOptions,
+      targetSessionId?: string,
     ) => {
       const displayContent =
         message.trim() || (fileIds?.length ? "Attached file(s)." : "");
       if (!displayContent) return;
 
+      const operationSessionId = targetSessionId ?? sessionId;
       const requestedPersona = options?.persona
-        ?? (!sessionId ? forcePersonaNextSessionRef.current ?? undefined : undefined);
+        ?? (!operationSessionId ? forcePersonaNextSessionRef.current ?? undefined : undefined);
       const effectiveTransport: ChatTransport = transport === "onboarding"
         ? "onboarding"
         : transport === "web"
@@ -689,7 +695,7 @@ export function AIChatProvider({ children }: { children: React.ReactNode }) {
         const bodyPayload: Record<string, unknown> = {
           message:
             message.trim() || (fileIds?.length ? "Attached file(s)." : ""),
-          sessionId,
+          sessionId: operationSessionId,
           ...(fileIds?.length ? { fileIds } : {}),
           ...(chatScope ? { scopeType: chatScope.type, scopeId: chatScope.id } : {}),
           ...(options?.prefillMessages?.length ? { prefillMessages: options.prefillMessages } : {}),
@@ -739,7 +745,7 @@ export function AIChatProvider({ children }: { children: React.ReactNode }) {
         const newSessionId = responseSessionId;
         const responsePersona = response.headers.get("X-Chat-Persona");
         if (responsePersona) setSessionPersona(responsePersona);
-        if (newSessionId && !sessionId) {
+        if (newSessionId && !operationSessionId) {
           setSessionId(newSessionId);
           // The newly-created session is already the current in-memory target;
           // mark it route-ready so the ensuing /d/:id navigation never reloads
@@ -1387,6 +1393,7 @@ export function AIChatProvider({ children }: { children: React.ReactNode }) {
     const active = activeSendRef.current;
     operationOwnerRef.current = null;
     intentResolutionOwnerRef.current = null;
+    reporterStartRef.current = null;
     if (active && !abortStream) {
       active.refreshSidebarWhenStale = true;
     } else {
@@ -1419,11 +1426,6 @@ export function AIChatProvider({ children }: { children: React.ReactNode }) {
   const startSignalSession = useCallback(() => {
     clearChat();
     forcePersonaNextSessionRef.current = "signal";
-  }, [clearChat]);
-
-  const startReporterSession = useCallback(() => {
-    clearChat();
-    forcePersonaNextSessionRef.current = "reporter";
   }, [clearChat]);
 
   const loadSession = useCallback(async (id: string): Promise<boolean> => {
@@ -1537,6 +1539,58 @@ export function AIChatProvider({ children }: { children: React.ReactNode }) {
       return false;
     }
   }, [invalidateActiveSend, ownsOperation]);
+
+  const startReporterSession = useCallback((options?: {
+    forceNew?: boolean;
+  }): Promise<boolean> => {
+    const forceNew = options?.forceNew === true;
+    if (!forceNew && reporterStartRef.current) return reporterStartRef.current;
+
+    const start = (async (): Promise<boolean> => {
+      // Route cleanup deliberately detaches ordinary streams. Reporter entry and
+      // explicit New conversation are stronger ownership boundaries: abort and
+      // invalidate everything before claiming the server-authoritative briefing.
+      clearChat();
+      const resolutionToken = Symbol("resolve-reporter-session");
+      operationOwnerRef.current = resolutionToken;
+
+      try {
+        const resolved = await apiClient.post<{
+          session: { id: string };
+          created: boolean;
+        }>("/chat/reporter/session", { forceNew });
+        if (!ownsOperation(resolutionToken)) return false;
+
+        const loaded = await loadSession(resolved.session.id);
+        if (!loaded) return false;
+        if (!resolved.created) return true;
+
+        // Bind the hidden marker to the already-created claim explicitly. The
+        // load state update has not necessarily produced a new React closure yet.
+        await sendMessageWithTransport(
+          "web",
+          REPORTER_BRIEFING_KICKOFF,
+          undefined,
+          undefined,
+          { hidden: true, persona: "reporter" },
+          resolved.session.id,
+        );
+        return true;
+      } catch (error) {
+        if (ownsOperation(resolutionToken)) {
+          operationOwnerRef.current = null;
+          logger.error("Reporter session resolution failed", { error });
+        }
+        return false;
+      }
+    })();
+
+    const tracked = start.finally(() => {
+      if (reporterStartRef.current === tracked) reporterStartRef.current = null;
+    });
+    reporterStartRef.current = tracked;
+    return tracked;
+  }, [clearChat, loadSession, ownsOperation, sendMessageWithTransport]);
 
   const isSessionReady = useCallback((id: string) => (
     sessionLoadState.status === "ready"

--- a/apps/web/tests/agent-reporter-surface.test.tsx
+++ b/apps/web/tests/agent-reporter-surface.test.tsx
@@ -4,13 +4,8 @@ import { beforeEach, describe, expect, test, vi } from "vitest";
 import { render } from "@testing-library/react";
 
 const mocks = vi.hoisted(() => ({
-  startReporterSession: vi.fn(),
-  sendWebMessage: vi.fn().mockResolvedValue(undefined),
+  startReporterSession: vi.fn().mockResolvedValue(true),
   getIntents: vi.fn(),
-}));
-
-vi.mock("@indexnetwork/protocol", () => ({
-  REPORTER_BRIEFING_KICKOFF: "reporter-briefing-kickoff",
 }));
 
 vi.mock("@/contexts/AuthContext", () => ({
@@ -21,7 +16,6 @@ vi.mock("@/contexts/AIChatContext", () => ({
   useAIChat: () => ({
     messages: [],
     startReporterSession: mocks.startReporterSession,
-    sendWebMessage: mocks.sendWebMessage,
   }),
 }));
 
@@ -42,7 +36,6 @@ import AgentReporterSurface from "@/components/AgentReporterSurface";
 describe("AgentReporterSurface", () => {
   beforeEach(() => {
     mocks.startReporterSession.mockClear();
-    mocks.sendWebMessage.mockClear();
     mocks.getIntents.mockReset();
     mocks.getIntents.mockResolvedValue({
       intents: [
@@ -53,20 +46,14 @@ describe("AgentReporterSurface", () => {
     });
   });
 
-  test("starts one hidden reporter briefing and shows fetched counts", async () => {
+  test("resolves one server-authoritative reporter briefing and shows fetched counts", async () => {
     render(<AgentReporterSurface />);
 
     await waitFor(() => expect(screen.getByText(
       "online — watching 2 signals · 3 questions pending",
     )).toBeInTheDocument());
     expect(mocks.startReporterSession).toHaveBeenCalledTimes(1);
-    expect(mocks.sendWebMessage).toHaveBeenCalledTimes(1);
-    expect(mocks.sendWebMessage).toHaveBeenCalledWith(
-      "reporter-briefing-kickoff",
-      undefined,
-      undefined,
-      { hidden: true, persona: "reporter" },
-    );
+    expect(mocks.startReporterSession).toHaveBeenCalledWith();
     expect(screen.getByTestId("reporter-chat")).toBeInTheDocument();
   });
 });

--- a/apps/web/tests/agent-sessions-panel.test.tsx
+++ b/apps/web/tests/agent-sessions-panel.test.tsx
@@ -1,0 +1,93 @@
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { beforeEach, describe, expect, test, vi } from 'vitest';
+
+const mocks = vi.hoisted(() => ({
+  navigate: vi.fn(),
+  pathname: '/agent',
+  features: { agentSurface: true, negotiatorChat: false } as {
+    agentSurface?: boolean;
+    negotiatorChat?: boolean;
+  },
+  get: vi.fn(),
+  startReporterSession: vi.fn().mockResolvedValue(true),
+  error: vi.fn(),
+}));
+
+vi.mock('react-router', () => ({
+  useNavigate: () => mocks.navigate,
+  useLocation: () => ({ pathname: mocks.pathname }),
+}));
+
+vi.mock('@/lib/api', () => ({
+  apiClient: { get: mocks.get, post: vi.fn() },
+}));
+
+vi.mock('@/contexts/AuthContext', () => ({
+  useAuthContext: () => ({
+    user: { id: 'user-1', name: 'Reporter User' },
+    features: mocks.features,
+  }),
+}));
+
+vi.mock('@/contexts/AIChatContext', () => ({
+  useAIChat: () => ({ startReporterSession: mocks.startReporterSession }),
+}));
+
+vi.mock('@/contexts/AIChatSessionsContext', () => ({
+  useAIChatSessions: () => ({ sessionsVersion: 0 }),
+}));
+
+vi.mock('@/contexts/IndexesContext', () => ({
+  useNetworksState: () => ({ indexes: [] }),
+}));
+
+vi.mock('@/contexts/NotificationContext', () => ({
+  useNotifications: () => ({ error: mocks.error }),
+}));
+
+import AgentSessionsPanel from '@/components/AgentSessionsPanel';
+
+describe('AgentSessionsPanel reporter conversations', () => {
+  beforeEach(() => {
+    mocks.navigate.mockReset();
+    mocks.get.mockReset();
+    mocks.startReporterSession.mockReset();
+    mocks.startReporterSession.mockResolvedValue(true);
+    mocks.error.mockReset();
+    mocks.pathname = '/agent';
+    mocks.features = { agentSurface: true, negotiatorChat: false };
+    mocks.get.mockResolvedValue({
+      sessions: [{
+        id: 'stale-reporter',
+        title: 'Yesterday briefing',
+        networkId: null,
+        createdAt: '2026-07-21T00:00:00.000Z',
+        updatedAt: '2026-07-21T01:00:00.000Z',
+      }],
+    });
+  });
+
+  test('preserves stale reporter history and force-starts New conversation', async () => {
+    render(<AgentSessionsPanel />);
+
+    await waitFor(() => expect(mocks.get).toHaveBeenCalledWith('/chat/web/sessions'));
+    expect(screen.getByText('Yesterday briefing')).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole('button', { name: 'New conversation' }));
+
+    expect(mocks.startReporterSession).toHaveBeenCalledWith({ forceNew: true });
+    expect(mocks.navigate).toHaveBeenCalledWith('/agent');
+    await waitFor(() => expect(mocks.error).not.toHaveBeenCalled());
+  });
+
+  test('keeps navigation-only behavior when the reporter surface is disabled', async () => {
+    mocks.features = { agentSurface: false, negotiatorChat: false };
+    render(<AgentSessionsPanel />);
+
+    await waitFor(() => expect(mocks.get).toHaveBeenCalledWith('/chat/web/sessions'));
+    fireEvent.click(screen.getByRole('button', { name: 'New conversation' }));
+
+    expect(mocks.startReporterSession).not.toHaveBeenCalled();
+    expect(mocks.navigate).toHaveBeenCalledWith('/agent');
+  });
+});

--- a/apps/web/tests/ai-chat-context-signal.test.tsx
+++ b/apps/web/tests/ai-chat-context-signal.test.tsx
@@ -110,7 +110,8 @@ function Probe() {
       <button onClick={() => chat.clearChat()}>clear</button>
       <button onClick={() => chat.clearChat({ abortStream: false })}>clear detached</button>
       <button onClick={() => chat.startSignalSession()}>start signal</button>
-      <button onClick={() => chat.startReporterSession()}>start reporter</button>
+      <button onClick={() => void chat.startReporterSession()}>start reporter</button>
+      <button onClick={() => void chat.startReporterSession({ forceNew: true })}>new reporter</button>
       <button onClick={() => void chat.sendWebMessage('reporter message')}>reporter message</button>
       <button onClick={() => void chat.loadSession('session-a')}>load a</button>
       <button onClick={() => void chat.loadSession('session-b')}>load b</button>
@@ -188,22 +189,92 @@ describe('AIChatContext Signal persona transport and ownership', () => {
     expect(mocks.apiClient.stream.mock.calls[2]?.[0]).toBe('/chat/stream');
   });
 
-  test('reporter sessions resolve on the web route and forced sends use web transport', async () => {
-    mocks.apiClient.post.mockResolvedValueOnce({ session: { id: 'reporter-scope' } });
-    mocks.apiClient.stream.mockResolvedValueOnce(streamResponse({ sessionId: 'reporter-session', persona: 'reporter' }));
+  test('a newly claimed reporter session loads first and sends exactly one bound kickoff', async () => {
+    mocks.apiClient.post
+      .mockResolvedValueOnce({ session: { id: 'reporter-session' }, created: true })
+      .mockResolvedValueOnce(sessionResponse('reporter-session', 'persisted', 'reporter'));
+    mocks.apiClient.stream.mockResolvedValueOnce(streamResponse({
+      sessionId: 'reporter-session',
+      persona: 'reporter',
+      response: 'fresh briefing',
+    }));
 
     renderProvider();
-    fireEvent.click(screen.getByRole('button', { name: 'resolve reporter' }));
-    await waitFor(() => expect(mocks.apiClient.post).toHaveBeenCalledWith(
-      '/chat/web/session/resolve',
-      expect.objectContaining({ persona: 'reporter' }),
-    ));
-
     fireEvent.click(screen.getByRole('button', { name: 'start reporter' }));
-    fireEvent.click(screen.getByRole('button', { name: 'reporter message' }));
-    await waitFor(() => expect(text('session')).toBe('reporter-session'));
+
+    await waitFor(() => expect(mocks.apiClient.stream).toHaveBeenCalledTimes(1));
+    expect(mocks.apiClient.post.mock.calls[0]).toEqual([
+      '/chat/reporter/session',
+      { forceNew: false },
+    ]);
+    expect(mocks.apiClient.post.mock.calls[1]).toEqual([
+      '/chat/web/session',
+      { sessionId: 'reporter-session' },
+    ]);
     expect(mocks.apiClient.stream.mock.calls[0]?.[0]).toBe('/chat/web/stream');
-    expect(mocks.apiClient.stream.mock.calls[0]?.[1]).toMatchObject({ persona: 'reporter' });
+    expect(mocks.apiClient.stream.mock.calls[0]?.[1]).toMatchObject({
+      message: 'reporter-briefing-kickoff',
+      sessionId: 'reporter-session',
+      persona: 'reporter',
+    });
+    await waitFor(() => expect(text('session')).toBe('reporter-session'));
+  });
+
+  test('a within-TTL reporter session hydrates persisted messages without a kickoff', async () => {
+    mocks.apiClient.post
+      .mockResolvedValueOnce({ session: { id: 'reporter-existing' }, created: false })
+      .mockResolvedValueOnce(sessionResponse('reporter-existing', 'saved follow-up', 'reporter'));
+
+    renderProvider();
+    fireEvent.click(screen.getByRole('button', { name: 'start reporter' }));
+
+    await waitFor(() => expect(text('session')).toBe('reporter-existing'));
+    expect(text('messages')).toBe('saved follow-up');
+    expect(mocks.apiClient.stream).not.toHaveBeenCalled();
+  });
+
+  test('force-new aborts the old briefing and quarantines its late response', async () => {
+    const oldBriefing = deferred<Response>();
+    mocks.apiClient.post
+      .mockResolvedValueOnce({ session: { id: 'reporter-old' }, created: true })
+      .mockResolvedValueOnce(sessionResponse('reporter-old', 'old persisted', 'reporter'))
+      .mockResolvedValueOnce({ session: { id: 'reporter-fresh' }, created: true })
+      .mockResolvedValueOnce(sessionResponse('reporter-fresh', 'fresh persisted', 'reporter'));
+    mocks.apiClient.stream
+      .mockReturnValueOnce(oldBriefing.promise)
+      .mockResolvedValueOnce(streamResponse({
+        sessionId: 'reporter-fresh',
+        persona: 'reporter',
+        response: 'fresh briefing',
+      }));
+
+    renderProvider();
+    fireEvent.click(screen.getByRole('button', { name: 'start reporter' }));
+    await waitFor(() => expect(mocks.apiClient.stream).toHaveBeenCalledTimes(1));
+    const oldSignal = (mocks.apiClient.stream.mock.calls[0]?.[2] as { signal: AbortSignal }).signal;
+
+    fireEvent.click(screen.getByRole('button', { name: 'new reporter' }));
+    await waitFor(() => expect(mocks.apiClient.stream).toHaveBeenCalledTimes(2));
+    expect(oldSignal.aborted).toBe(true);
+    expect(mocks.apiClient.post.mock.calls[2]).toEqual([
+      '/chat/reporter/session',
+      { forceNew: true },
+    ]);
+    await waitFor(() => expect(text('session')).toBe('reporter-fresh'));
+
+    await act(async () => {
+      oldBriefing.resolve(streamResponse({
+        sessionId: 'reporter-old',
+        persona: 'reporter',
+        response: 'late old briefing',
+      }));
+      await oldBriefing.promise;
+    });
+
+    expect(text('session')).toBe('reporter-fresh');
+    expect(text('messages')).toContain('fresh briefing');
+    expect(text('messages')).not.toContain('late old briefing');
+    expect(text('loading')).toBe('no');
   });
 
   test('preserves a message submitted before the first web session id arrives', async () => {

--- a/apps/web/tests/negotiator-dm-inbox.test.tsx
+++ b/apps/web/tests/negotiator-dm-inbox.test.tsx
@@ -1112,6 +1112,7 @@ describe('Read-only surface header (IND-476)', () => {
     mocks.chat.sessionPersona = 'reporter';
 
     renderWithRouter(<ChatContent persona="reporter" readOnlySurface />, { route: '/agent' });
+    expect(mocks.chat.clearChat).not.toHaveBeenCalled();
     const input = screen.getByTestId('chat-input');
     fireEvent.change(input, { target: { value: "What's waiting on me?" } });
     fireEvent.submit(input.closest('form')!);

--- a/bun.lock
+++ b/bun.lock
@@ -19,7 +19,7 @@
     },
     "apps/web": {
       "name": "@indexnetwork/web",
-      "version": "0.27.0",
+      "version": "0.27.1",
       "dependencies": {
         "@radix-ui/react-alert-dialog": "^1.1.15",
         "@radix-ui/react-dialog": "^1.1.14",

--- a/docs/specs/api-reference.md
+++ b/docs/specs/api-reference.md
@@ -99,6 +99,12 @@ All error responses follow a consistent JSON format:
 
 ---
 
+## Agent reporter opening briefings
+
+`POST /api/chat/reporter/session` is session-authenticated and available only while `WEB_AGENT_SURFACE_ENABLED=true`. It accepts the strict body `{ "forceNew"?: boolean }` and returns `{ session, created }`. The server serializes each user's claim, reuses the newest reporter session whose creation time is within `REPORTER_BRIEFING_TTL_MS` (24 hours by default), and creates a successor otherwise. Only `created: true` authorizes the client to send the hidden opening-briefing marker. `forceNew: true` is used by the explicit Reporter **New conversation** action; callers cannot select another persona through this route.
+
+Expiry is lazy: stale reporter sessions and their user follow-ups remain readable in ordinary session-only web history, but follow-up activity does not extend freshness because the resolver uses `createdAt`, not `updatedAt`.
+
 ## Agent reporter cleanup actions
 
 The dark-shipped reporter action path is gated by `WEB_AGENT_ACTIONS_ENABLED=true` and the reporter surface flag. The proposal tool persists owner-scoped, full-UUID action plans; chat never mutates domain rows. The endpoint below is session-only and returns `404` while the action flag is off.

--- a/services/api/.test-isolated
+++ b/services/api/.test-isolated
@@ -51,6 +51,7 @@ src/services/tests/connect-link.service.isolated.ts
 src/controllers/tests/route-deprecation.controller.isolated.ts
 tests/contacts-disabled.e2e.isolated.ts
 src/controllers/tests/chat.negotiator.isolated.ts
+src/controllers/tests/chat.reporter.isolated.ts
 src/controllers/tests/negotiator-memory.controller.isolated.ts
 tests/negotiation.e2e.isolated.ts
 src/guards/tests/contacts.guard.isolated.ts
@@ -101,3 +102,4 @@ src/controllers/tests/question.visitmining.isolated.ts
 src/controllers/tests/agent-action.controller.isolated.ts
 src/services/tests/agent-action.service.isolated.ts
 src/adapters/tests/agent-action-proposal.database.adapter.isolated.ts
+src/adapters/tests/conversation.reporter.isolated.ts

--- a/services/api/package.json
+++ b/services/api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@indexnetwork/api",
-  "version": "0.52.5",
+  "version": "0.52.6",
   "license": "MIT",
   "private": true,
   "scripts": {

--- a/services/api/src/adapters/conversation.database.adapter.ts
+++ b/services/api/src/adapters/conversation.database.adapter.ts
@@ -1,4 +1,4 @@
-import { readUserContext, schema, Artifact, ChatConversationMeta, ChatMessage, ChatMessageMeta, ChatScopeType, ChatSession, Conversation, ConversationParticipant, ConversationSummary, CreateMessageInput, CreateSessionInput, Message, ResolvedParticipant, SYSTEM_AGENT_ID, Task, and, asc, count, db, desc, eq, gt, inArray, isNull, lt, ne, opportunities, or, sql } from './database.shared';
+import { readUserContext, schema, Artifact, ChatConversationMeta, ChatMessage, ChatMessageMeta, ChatScopeType, ChatSession, Conversation, ConversationParticipant, ConversationSummary, CreateMessageInput, CreateSessionInput, Message, ResolvedParticipant, SYSTEM_AGENT_ID, Task, and, asc, count, db, desc, eq, gt, gte, inArray, isNull, lt, ne, opportunities, or, sql } from './database.shared';
 import { emitOpportunityPendingBestEffort } from '../events/opportunity.event';
 import { acquireNegotiationAttemptLock, acquireNegotiationPairLock, qualifyingNegotiationAttemptTaskWhere, qualifyingPairNegotiationTaskWhere, type NegotiationAttemptTransaction } from './negotiation-attempt.atomic';
 
@@ -6,6 +6,7 @@ import { acquireNegotiationAttemptLock, acquireNegotiationPairLock, qualifyingNe
 const ORCHESTRATOR_PERSONA = 'orchestrator';
 const SIGNAL_PERSONA = 'signal';
 const NEGOTIATOR_PERSONA = 'negotiator';
+const REPORTER_PERSONA = 'reporter';
 
 /** Persona-specific registry key for Signal Agent's canonical intent scope. */
 const SIGNAL_INTENT_SCOPE_TYPE = 'signal-intent';
@@ -1957,6 +1958,72 @@ export class ConversationDatabaseAdapter {
         });
       }
     });
+  }
+
+  /**
+   * Atomically reuse the newest fresh reporter briefing or create its successor.
+   *
+   * A transaction-scoped per-user advisory lock serializes browser reloads and
+   * tabs before the freshness read. Expiry is lazy and creation-time based;
+   * old reporter rows are never deleted or hidden.
+   *
+   * @param data - Owner, candidate ID, stable freshness cutoff, and force-new flag
+   * @returns The authoritative reporter session and sole creation claim
+   */
+  async resolveReporterChatSession(data: {
+    id: string;
+    userId: string;
+    freshAfter: Date;
+    forceNew?: boolean;
+  }): Promise<{ session: ChatSession; created: boolean }> {
+    const resolved = await db.transaction(async (tx) => {
+      const lockName = `reporter-briefing:${data.userId}`;
+      await tx.execute(sql`SELECT pg_advisory_xact_lock(hashtextextended(${lockName}, 0))`);
+
+      if (!data.forceNew) {
+        const chatSessionIds = tx
+          .select({ conversationId: schema.conversationParticipants.conversationId })
+          .from(schema.conversationParticipants)
+          .where(and(
+            eq(schema.conversationParticipants.participantId, SYSTEM_AGENT_ID),
+            eq(schema.conversationParticipants.participantType, 'agent'),
+          ));
+        const [fresh] = await tx
+          .select({ id: schema.conversations.id })
+          .from(schema.conversationParticipants)
+          .innerJoin(
+            schema.conversations,
+            eq(schema.conversationParticipants.conversationId, schema.conversations.id),
+          )
+          .where(and(
+            eq(schema.conversationParticipants.participantId, data.userId),
+            eq(schema.conversationParticipants.participantType, 'user'),
+            inArray(schema.conversations.id, chatSessionIds),
+            eq(schema.conversations.persona, REPORTER_PERSONA),
+            gte(schema.conversations.createdAt, data.freshAfter),
+          ))
+          .orderBy(desc(schema.conversations.createdAt))
+          .limit(1);
+        if (fresh) return { id: fresh.id, created: false };
+      }
+
+      const now = new Date();
+      await tx.insert(schema.conversations).values({
+        id: data.id,
+        persona: REPORTER_PERSONA,
+        createdAt: now,
+        updatedAt: now,
+      });
+      await tx.insert(schema.conversationParticipants).values([
+        { conversationId: data.id, participantId: data.userId, participantType: 'user' as const },
+        { conversationId: data.id, participantId: SYSTEM_AGENT_ID, participantType: 'agent' as const },
+      ]);
+      return { id: data.id, created: true };
+    });
+
+    const session = await this.getChatSession(resolved.id);
+    if (!session) throw new Error('Reporter session claim could not be loaded');
+    return { session, created: resolved.created };
   }
 
   /**

--- a/services/api/src/adapters/tests/conversation.reporter.isolated.ts
+++ b/services/api/src/adapters/tests/conversation.reporter.isolated.ts
@@ -1,0 +1,77 @@
+/** Reporter briefing TTL, atomic claim, and history-preservation coverage. */
+import { config } from 'dotenv';
+config({ path: '.env.test', override: true });
+
+import { afterAll, describe, expect, test } from 'bun:test';
+
+import { ConversationDatabaseAdapter } from '../database.adapter';
+import { db, eq, schema } from '../database.shared';
+
+const adapter = new ConversationDatabaseAdapter();
+const createdSessionIds = new Set<string>();
+
+async function resolveReporter(
+  userId: string,
+  freshAfter: Date,
+  forceNew = false,
+) {
+  const result = await adapter.resolveReporterChatSession({
+    id: crypto.randomUUID(),
+    userId,
+    freshAfter,
+    forceNew,
+  });
+  createdSessionIds.add(result.session.id);
+  return result;
+}
+
+afterAll(async () => {
+  for (const id of createdSessionIds) {
+    await adapter.deleteChatSession(id).catch(() => {});
+  }
+});
+
+describe('ConversationDatabaseAdapter reporter briefing claims', () => {
+  test('reuses within TTL, expires by createdAt, and preserves stale history', async () => {
+    const userId = `reporter-ttl-${crypto.randomUUID()}`;
+    const first = await resolveReporter(userId, new Date(Date.now() - 60_000));
+    expect(first.created).toBe(true);
+    expect(first.session.persona).toBe('reporter');
+
+    const reused = await resolveReporter(userId, new Date(Date.now() - 60_000));
+    expect(reused.created).toBe(false);
+    expect(reused.session.id).toBe(first.session.id);
+
+    // Follow-up activity may move updatedAt, but cannot extend the opening
+    // briefing lifetime because freshness is anchored to createdAt.
+    await db.update(schema.conversations)
+      .set({
+        createdAt: new Date(Date.now() - (48 * 60 * 60 * 1000)),
+        updatedAt: new Date(Date.now() + 60_000),
+      })
+      .where(eq(schema.conversations.id, first.session.id));
+
+    const successor = await resolveReporter(
+      userId,
+      new Date(Date.now() - (24 * 60 * 60 * 1000)),
+    );
+    expect(successor.created).toBe(true);
+    expect(successor.session.id).not.toBe(first.session.id);
+
+    const history = await adapter.getUserChatSessions(userId, 20, 'reporter');
+    expect(history.map((session) => session.id)).toEqual(
+      expect.arrayContaining([first.session.id, successor.session.id]),
+    );
+  }, 15_000);
+
+  test('serializes concurrent tabs so only one caller claims creation', async () => {
+    const userId = `reporter-race-${crypto.randomUUID()}`;
+    const freshAfter = new Date(Date.now() - 60_000);
+    const results = await Promise.all(
+      Array.from({ length: 6 }, () => resolveReporter(userId, freshAfter)),
+    );
+
+    expect(results.filter((result) => result.created)).toHaveLength(1);
+    expect(new Set(results.map((result) => result.session.id)).size).toBe(1);
+  }, 15_000);
+});

--- a/services/api/src/controllers/chat.controller.ts
+++ b/services/api/src/controllers/chat.controller.ts
@@ -12,6 +12,7 @@ import { fileService } from "../services/file.service";
 import { agentService } from "../services/agent.service";
 import { userService } from "../services/user.service";
 import { isNegotiatorChatEnabled } from "../lib/negotiator-feature";
+import { isAgentSurfaceEnabled } from '../lib/agent-surface-feature';
 import { negotiationReflectQueue } from "../queues/negotiations/reflect.queue";
 import { SuggestionGenerator, ChatInterruptClassifier, NEGOTIATOR_PERSONA_ID, ORCHESTRATOR_PERSONA_ID, REPORTER_PERSONA_ID, SIGNAL_PERSONA_ID } from '@indexnetwork/protocol';
 import { createDoneEvent, createErrorEvent, createStatusEvent, createSteerOrQueueEvent, formatSSEEvent, type DebugMetaDiscoveryQuestions } from "../types/chat-streaming.types";
@@ -100,6 +101,10 @@ function getSuggestionGenerator(): SuggestionGenerator {
 const negotiatorSessionBodySchema = z.object({
   intentId: z.string().min(1).nullish(),
 });
+
+const reporterSessionBodySchema = z.object({
+  forceNew: z.boolean().optional(),
+}).strict();
 
 const resolveSessionBodySchema = z.object({
   scopeType: z.enum(['intent']),
@@ -872,6 +877,48 @@ export class ChatController {
       created: result.created,
       agent: { id: agent.id, name: agent.name, description: agent.description },
     });
+  }
+
+  /**
+   * Resolve the current Reporter opening briefing for the authenticated web session.
+   *
+   * The route never accepts a persona. It returns the adapter's atomic creation
+   * claim so only one tab sends the hidden opening marker. `forceNew` is reserved
+   * for the explicit New conversation action and bypasses normal TTL reuse.
+   *
+   * @param req - Body `{ forceNew?: boolean }`
+   * @param user - Session-authenticated user
+   * @returns The authoritative reporter session and creation claim
+   */
+  @Post("/reporter/session")
+  @UseGuards(RateLimit('write'), SessionOnlyGuard)
+  async reporterSession(req: Request, user: AuthenticatedUser) {
+    if (!isAgentSurfaceEnabled()) {
+      return Response.json({ error: "Not found" }, { status: 404 });
+    }
+
+    let body: z.infer<typeof reporterSessionBodySchema>;
+    try {
+      const parsed = reporterSessionBodySchema.safeParse(await req.json());
+      if (!parsed.success) {
+        return Response.json(
+          { error: "Invalid request body. Expected { forceNew?: boolean }" },
+          { status: 400 },
+        );
+      }
+      body = parsed.data;
+    } catch {
+      return Response.json(
+        { error: "Invalid JSON in request body" },
+        { status: 400 },
+      );
+    }
+
+    const result = await chatSessionService.resolveReporterSession(
+      user.id,
+      body.forceNew ?? false,
+    );
+    return Response.json(result);
   }
 
   /**

--- a/services/api/src/controllers/tests/chat.reporter.isolated.ts
+++ b/services/api/src/controllers/tests/chat.reporter.isolated.ts
@@ -1,0 +1,103 @@
+process.env.OPENROUTER_API_KEY = 'test-key';
+process.env.NODE_ENV = 'test';
+
+import { afterEach, describe, expect, mock, test } from 'bun:test';
+
+const AuthGuard = () => undefined;
+const SessionOnlyGuard = () => undefined;
+const resolveReporterSession = mock(() => Promise.resolve({
+  session: {
+    id: 'reporter-session-1',
+    userId: 'reporter-user-1',
+    title: null,
+    persona: 'reporter',
+    networkId: null,
+    scopeType: null,
+    scopeId: null,
+    shareToken: null,
+    createdAt: new Date('2026-07-22T00:00:00.000Z'),
+    updatedAt: new Date('2026-07-22T00:00:00.000Z'),
+  },
+  created: true,
+}));
+
+mock.module('../../lib/drizzle/drizzle', () => ({ default: {} }));
+mock.module('../../guards/auth.guard', () => ({ AuthGuard, SessionOnlyGuard }));
+mock.module('../../guards/limiter.guard', () => ({ RateLimit: () => () => undefined }));
+mock.module('../../services/chat.service', () => ({
+  chatSessionService: { resolveReporterSession },
+}));
+mock.module('../../services/file.service', () => ({ fileService: {} }));
+mock.module('../../services/agent.service', () => ({ agentService: {} }));
+mock.module('../../services/user.service', () => ({ userService: {} }));
+mock.module('../../queues/negotiations/reflect.queue', () => ({ negotiationReflectQueue: {} }));
+
+import { RouteRegistry } from '../../lib/router/router.decorators';
+import { ChatController } from '../chat.controller';
+
+type AuthenticatedUser = { id: string; email: string | null; name: string };
+
+const USER: AuthenticatedUser = {
+  id: 'reporter-user-1',
+  email: 'reporter@example.com',
+  name: 'Reporter User',
+};
+
+describe('Reporter briefing session resolver (IND-484)', () => {
+  const previousFlag = process.env.WEB_AGENT_SURFACE_ENABLED;
+
+  afterEach(() => {
+    resolveReporterSession.mockClear();
+    if (previousFlag === undefined) delete process.env.WEB_AGENT_SURFACE_ENABLED;
+    else process.env.WEB_AGENT_SURFACE_ENABLED = previousFlag;
+  });
+
+  test('returns the atomic creation claim and forwards only forceNew', async () => {
+    process.env.WEB_AGENT_SURFACE_ENABLED = 'true';
+    const controller = new ChatController();
+    const request = new Request('http://localhost/chat/reporter/session', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ forceNew: true }),
+    });
+
+    const response = await controller.reporterSession(request, USER);
+    const payload = await response.json() as { session: { id: string; persona: string }; created: boolean };
+
+    expect(response.status).toBe(200);
+    expect(payload).toMatchObject({
+      session: { id: 'reporter-session-1', persona: 'reporter' },
+      created: true,
+    });
+    expect(resolveReporterSession).toHaveBeenCalledWith(USER.id, true);
+  });
+
+  test('is session-only, flag-gated, and rejects caller-controlled persona fields', async () => {
+    const controller = new ChatController();
+    const request = (body: Record<string, unknown>) => new Request(
+      'http://localhost/chat/reporter/session',
+      {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(body),
+      },
+    );
+
+    delete process.env.WEB_AGENT_SURFACE_ENABLED;
+    const disabled = await controller.reporterSession(request({}), USER);
+    expect(disabled.status).toBe(404);
+    expect(resolveReporterSession).not.toHaveBeenCalled();
+
+    process.env.WEB_AGENT_SURFACE_ENABLED = 'true';
+    const spoofed = await controller.reporterSession(
+      request({ forceNew: false, persona: 'orchestrator' }),
+      USER,
+    );
+    expect(spoofed.status).toBe(400);
+    expect(resolveReporterSession).not.toHaveBeenCalled();
+
+    const guards = RouteRegistry.getGuards(ChatController, 'reporterSession');
+    expect(guards).toContain(SessionOnlyGuard);
+    expect(guards).not.toContain(AuthGuard);
+  });
+});

--- a/services/api/src/controllers/tests/chat.reporter.isolated.ts
+++ b/services/api/src/controllers/tests/chat.reporter.isolated.ts
@@ -96,8 +96,10 @@ describe('Reporter briefing session resolver (IND-484)', () => {
     expect(spoofed.status).toBe(400);
     expect(resolveReporterSession).not.toHaveBeenCalled();
 
-    const guards = RouteRegistry.getGuards(ChatController, 'reporterSession');
-    expect(guards).toContain(SessionOnlyGuard);
-    expect(guards).not.toContain(AuthGuard);
+    const guardNames = RouteRegistry
+      .getGuards(ChatController, 'reporterSession')
+      .map((guard) => guard.name);
+    expect(guardNames).toContain('SessionOnlyGuard');
+    expect(guardNames).not.toContain('AuthGuard');
   });
 });

--- a/services/api/src/lib/agent-surface-feature.ts
+++ b/services/api/src/lib/agent-surface-feature.ts
@@ -6,9 +6,28 @@
  * orchestrator behavior.
  */
 
+export const DEFAULT_REPORTER_BRIEFING_TTL_MS = 24 * 60 * 60 * 1000;
+
 /** @returns true when the reporter persona may be started or continued. */
 export function isAgentSurfaceEnabled(): boolean {
   return process.env.WEB_AGENT_SURFACE_ENABLED === 'true';
+}
+
+/**
+ * Resolve the lazy reporter briefing lifetime.
+ *
+ * Startup validation accepts only positive whole milliseconds; this runtime
+ * fallback keeps direct test imports and partially configured processes safe.
+ *
+ * @returns Briefing freshness lifetime in milliseconds
+ */
+export function getReporterBriefingTtlMs(): number {
+  const configured = process.env.REPORTER_BRIEFING_TTL_MS?.trim();
+  if (!configured) return DEFAULT_REPORTER_BRIEFING_TTL_MS;
+  const parsed = Number(configured);
+  return Number.isSafeInteger(parsed) && parsed > 0
+    ? parsed
+    : DEFAULT_REPORTER_BRIEFING_TTL_MS;
 }
 
 /** Cleanup-action proposals are effective only on the reporter surface. */

--- a/services/api/src/lib/tests/agent-surface-feature.spec.ts
+++ b/services/api/src/lib/tests/agent-surface-feature.spec.ts
@@ -1,12 +1,15 @@
 import { afterEach, describe, expect, test } from 'bun:test';
 
-import { isAgentSurfaceEnabled } from '../agent-surface-feature';
+import { DEFAULT_REPORTER_BRIEFING_TTL_MS, getReporterBriefingTtlMs, isAgentSurfaceEnabled } from '../agent-surface-feature';
 
 const previous = process.env.WEB_AGENT_SURFACE_ENABLED;
+const previousTtl = process.env.REPORTER_BRIEFING_TTL_MS;
 
 afterEach(() => {
   if (previous === undefined) delete process.env.WEB_AGENT_SURFACE_ENABLED;
   else process.env.WEB_AGENT_SURFACE_ENABLED = previous;
+  if (previousTtl === undefined) delete process.env.REPORTER_BRIEFING_TTL_MS;
+  else process.env.REPORTER_BRIEFING_TTL_MS = previousTtl;
 });
 
 describe('WEB_AGENT_SURFACE_ENABLED', () => {
@@ -22,5 +25,23 @@ describe('WEB_AGENT_SURFACE_ENABLED', () => {
 
     process.env.WEB_AGENT_SURFACE_ENABLED = 'true';
     expect(isAgentSurfaceEnabled()).toBe(true);
+  });
+});
+
+describe('REPORTER_BRIEFING_TTL_MS', () => {
+  test('defaults to 24 hours and accepts positive whole milliseconds', () => {
+    delete process.env.REPORTER_BRIEFING_TTL_MS;
+    expect(getReporterBriefingTtlMs()).toBe(DEFAULT_REPORTER_BRIEFING_TTL_MS);
+
+    process.env.REPORTER_BRIEFING_TTL_MS = '60000';
+    expect(getReporterBriefingTtlMs()).toBe(60_000);
+  });
+
+  test('falls back safely for direct imports with invalid values', () => {
+    process.env.REPORTER_BRIEFING_TTL_MS = '0';
+    expect(getReporterBriefingTtlMs()).toBe(DEFAULT_REPORTER_BRIEFING_TTL_MS);
+
+    process.env.REPORTER_BRIEFING_TTL_MS = 'not-a-number';
+    expect(getReporterBriefingTtlMs()).toBe(DEFAULT_REPORTER_BRIEFING_TTL_MS);
   });
 });

--- a/services/api/src/services/chat.service.ts
+++ b/services/api/src/services/chat.service.ts
@@ -7,7 +7,7 @@ import { getCheckpointer } from '../adapters/checkpointer.adapter';
 import { negotiatorMemoryRetrievalAdapter } from '../adapters/negotiator-memory.retrieval.adapter';
 import { isNegotiatorMemoryWriteEnabled } from '../lib/negotiator-feature';
 import { isWebSignalAgentEnabled } from '../lib/signal-feature';
-import { isAgentSurfaceEnabled } from '../lib/agent-surface-feature';
+import { getReporterBriefingTtlMs, isAgentSurfaceEnabled } from '../lib/agent-surface-feature';
 import { HumanMessage } from '@langchain/core/messages';
 import type { PostgresSaver } from '@langchain/langgraph-checkpoint-postgres';
 
@@ -68,12 +68,16 @@ function generateSnowflakeId(): string {
 interface ChatSessionServiceDeps {
   graphDatabase?: ChatGraphCompositeDatabase;
   createTitleGenerator?: () => Pick<ChatTitleGenerator, 'invoke'>;
+  now?: () => Date;
+  reporterBriefingTtlMs?: () => number;
 }
 
 export class ChatSessionService {
   private graphDb: ChatGraphCompositeDatabase;
   private _factory: ChatGraphFactory | null = null;
   private readonly createTitleGenerator: () => Pick<ChatTitleGenerator, 'invoke'>;
+  private readonly now: () => Date;
+  private readonly reporterBriefingTtlMs: () => number;
 
   constructor(
     private db: ConversationDatabaseAdapter = conversationDatabaseAdapter,
@@ -81,6 +85,8 @@ export class ChatSessionService {
   ) {
     this.graphDb = deps.graphDatabase ?? new ChatDatabaseAdapter();
     this.createTitleGenerator = deps.createTitleGenerator ?? (() => new ChatTitleGenerator());
+    this.now = deps.now ?? (() => new Date());
+    this.reporterBriefingTtlMs = deps.reporterBriefingTtlMs ?? getReporterBriefingTtlMs;
   }
 
   /**
@@ -312,6 +318,28 @@ export class ChatSessionService {
     });
 
     return id;
+  }
+
+  /**
+   * Resolve the current opening briefing for the main-web reporter surface.
+   *
+   * Freshness is anchored to immutable session creation time. The adapter owns
+   * the advisory-lock transaction so concurrent browser tabs receive one
+   * creation claim, while forceNew intentionally bypasses TTL reuse.
+   *
+   * @param userId - Authenticated session user
+   * @param forceNew - Whether an explicit New conversation action must create a successor
+   * @returns The authoritative reporter session and whether this caller claimed creation
+   */
+  async resolveReporterSession(userId: string, forceNew = false) {
+    const ttlMs = this.reporterBriefingTtlMs();
+    const freshAfter = new Date(this.now().getTime() - ttlMs);
+    return this.db.resolveReporterChatSession({
+      id: crypto.randomUUID(),
+      userId,
+      freshAfter,
+      forceNew,
+    });
   }
 
   /**

--- a/services/api/src/services/tests/chat.service.isolated.ts
+++ b/services/api/src/services/tests/chat.service.isolated.ts
@@ -141,6 +141,10 @@ function createMockDb(overrides: Partial<MockDb> = {}): MockDb {
     updateChatSessionScope: mock(() => Promise.resolve()),
     updateChatSessionTitle: mock(() => Promise.resolve()),
     getChatSessionByScope: mock(() => Promise.resolve(null)),
+    resolveReporterChatSession: mock(() => Promise.resolve({
+      session: makeSession({ persona: 'reporter' }),
+      created: false,
+    })),
     deleteChatSession: mock(() => Promise.resolve()),
     setChatShareToken: mock(() => Promise.resolve()),
     getChatSessionByShareToken: mock(() => Promise.resolve(null)),
@@ -155,6 +159,34 @@ function createMockDb(overrides: Partial<MockDb> = {}): MockDb {
 }
 
 // ─── createSession ────────────────────────────────────────────────────────────
+
+describe("ChatSessionService.resolveReporterSession", () => {
+  it("passes a creation-time cutoff and explicit force claim to the atomic adapter", async () => {
+    const now = new Date("2026-07-22T12:00:00.000Z");
+    const reporter = makeSession({ persona: "reporter", createdAt: now });
+    const resolveReporterChatSession = mock(() => Promise.resolve({
+      session: reporter,
+      created: true,
+    }));
+    const db = createMockDb({ resolveReporterChatSession });
+    const svc = new ChatSessionService(db as unknown as ConversationDatabaseAdapter, {
+      graphDatabase: graphDatabase as never,
+      now: () => now,
+      reporterBriefingTtlMs: () => 60_000,
+    });
+
+    const result = await svc.resolveReporterSession(USER_ID, true);
+
+    expect(result).toEqual({ session: reporter, created: true });
+    expect(resolveReporterChatSession).toHaveBeenCalledTimes(1);
+    expect(resolveReporterChatSession).toHaveBeenCalledWith({
+      id: expect.any(String),
+      userId: USER_ID,
+      freshAfter: new Date("2026-07-22T11:59:00.000Z"),
+      forceNew: true,
+    });
+  });
+});
 
 describe("ChatSessionService.resolveSessionForScope", () => {
   it("recovers the winning Signal session after a Drizzle-wrapped 23505", async () => {

--- a/services/api/src/startup.env.ts
+++ b/services/api/src/startup.env.ts
@@ -28,6 +28,7 @@ const requiredUnlessTest = isTest ? z.string().optional() : z.string().trim().mi
 const requiredInProduction = isTest || runtimeEnvironment !== 'production' ? z.string().optional() : z.string().trim().min(1);
 const optionalUrl = z.union([z.literal(''), z.string().url()]).optional();
 const optionalInt = z.union([z.literal(''), z.string().regex(/^\d+$/)]).optional();
+const optionalPositiveInt = z.union([z.literal(''), z.string().regex(/^[1-9]\d*$/)]).optional();
 const optionalBoolean = z.union([z.literal(''), z.enum(['true', 'false'])]).optional();
 const optionalOne = z.union([z.literal(''), z.literal('1')]).optional();
 
@@ -108,6 +109,7 @@ const envSchema = z.object({
   NEGOTIATOR_CHAT_ENABLED: optionalBoolean,
   WEB_SIGNAL_AGENT_ENABLED: optionalBoolean,
   WEB_AGENT_SURFACE_ENABLED: optionalBoolean,
+  REPORTER_BRIEFING_TTL_MS: optionalPositiveInt,
   WEB_AGENT_ACTIONS_ENABLED: optionalBoolean,
   NEGOTIATOR_TURN_TIMEOUT_MS: optionalInt,
   NEGOTIATION_SCREEN_MODE: z.union([z.literal(''), z.enum(['off', 'shadow', 'enforce'])]).optional(),


### PR DESCRIPTION
## Bug Fixes
- add a session-authenticated Reporter briefing resolver that reuses the newest creation-time-fresh session and atomically claims creation under a per-user advisory transaction lock
- default lazy expiry to 24 hours via validated `REPORTER_BRIEFING_TTL_MS`, preserving expired sessions and follow-ups in web history
- hydrate reused Reporter sessions without replaying the hidden kickoff; only the server creation claimant sends it
- make **New conversation** abort/invalidate the prior stream, clear queued work, force one fresh Reporter session, and quarantine stale SSE/finally writes
- preserve existing navigation-only behavior when the Reporter surface is disabled

## Refactors
- extend the existing AI chat operation-ownership path instead of introducing a parallel reporter state machine
- preserve the post-#1200 Signal terminology, guided-auth expiry recovery, per-operation placeholder cleanup, and lazy-route recovery while composing Reporter ownership and bound-kickoff behavior
- use session-only web history for the Agent sessions panel so stale Reporter sessions remain readable

## Documentation
- document the resolver contract and lazy TTL in the API reference and `.env.example`
- preserve the #1200 Signal terminology changelog entries and add the Reporter persistence entry
- bump `@indexnetwork/api` from current dev `0.52.5` to `0.52.6`
- bump `@indexnetwork/web` from current dev `0.27.0` to `0.27.1`
- narrowly align the `apps/web` workspace metadata in `bun.lock` to `0.27.1`; Bun 1.3.14's in-place install did not refresh that workspace version, while a fresh full regeneration produced 300+ lines of unrelated dependency churn that is intentionally excluded

## Rebase facts
- base: `origin/dev` at `e7eaf39abda905b448647fff494735f2b78c85fd` (PR #1200 Signal terminology cutover)
- head: `bc1a8222d23117db0dfd48fa6348ad96f9ade4a1`
- conflicts: `apps/web/package.json` and `bun.lock`; the package conflict was resolved to Web `0.27.1`. Bun 1.3.14's in-place install left the resolved base lock's Web workspace metadata at `0.27.0`, so the final follow-up changes exactly that one lock line to `0.27.1` rather than committing unrelated full-regeneration churn
- `apps/web/CHANGELOG.md` and `apps/web/src/components/ChatContent.tsx` auto-merged with both #1200 Signal behavior/copy and #1201 Reporter lifecycle behavior retained
- one post-rebase test-only commit makes the session-only guard assertion robust to Bun module identity while still requiring `SessionOnlyGuard` and excluding `AuthGuard`

## Verification
- `cd apps/web && bun --bun vitest run tests/agent-reporter-surface.test.tsx tests/agent-sessions-panel.test.tsx tests/ai-chat-context-signal.test.tsx tests/api-auth-expiry.test.ts tests/guided-signal-flow.test.tsx tests/lazy-route-recovery.test.tsx tests/negotiator-dm-inbox.test.tsx tests/agent-page-reporter.test.tsx` — 70 passed across 8 files
- `cd services/api && NODE_ENV=test bun test ./src/lib/tests/agent-surface-feature.spec.ts ./tests/env-example-drift.spec.ts` — 6 passed
- `cd services/api && TEST_DATABASE_SAFE=1 NODE_ENV=test bun test ./src/adapters/tests/conversation.reporter.isolated.ts ./src/controllers/tests/chat.reporter.isolated.ts ./src/services/tests/chat.service.isolated.ts` — 46 passed across exactly the 3 explicit paths; the aggregate isolated suite was not invoked
- `bun run --cwd services/api build` — passed
- `bun run --cwd apps/web build` — passed (existing VITE/CSS/chunk warnings only)
- `bun install --frozen-lockfile` — passed after the narrow lock correction
- targeted package/lock checks — Web manifest and lock are both `0.27.1`; API manifest is `0.52.6`; the pre-existing API lock metadata remains `0.51.0` and is unchanged/out of scope
- `git diff origin/dev -- bun.lock` — exactly one replacement (`apps/web` workspace version `0.27.0` → `0.27.1`)
- `git diff --check` and base-diff whitespace checks — passed
- exact conflict-marker scan across changed files — clean
- added Web diff lines contain no user-facing `intent` terminology
- `REPORTER_BRIEFING_TTL_MS` remains optional, positive-integer validated, and defaults to `24 * 60 * 60 * 1000` when unset

No Railway variables, local env files, feature flags, infrastructure, or production data were changed.

Fixes IND-484

