### PR TITLE
fix(web): place intent questions in Personal Agent timeline

### DIFF
--- a/apps/web/CHANGELOG.md
+++ b/apps/web/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
 
 ### Fixed
 
+- Place intent-page Personal Agent questions in the conversation timeline: anchored questions follow their triggering assistant message, unanchored pending questions stay at the current end, and answered exchanges use authoritative anchors or timestamps instead of a permanent pre-chat block.
 - Persist Reporter Agent opening briefings across reloads for 24 hours by default, hydrate the server-resolved session without replaying the hidden kickoff, and make **New conversation** atomically create and bind one fresh briefing while aborting and quarantining stale streams (IND-484).
 - Separate guided-signal session reset from kickoff across a committed React render so `/i/new` and flag-on onboarding cannot send through a stale session or scope closure (IND-450).
 - Allow the reporter surface (`/agent`) to send messages after its briefing session is established; the route-mismatch guard now exempts the URL-less reporter session while preserving stale-session protection on `/d/:id` (IND-488).

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@indexnetwork/web",
-  "version": "0.28.0",
+  "version": "0.28.1",
   "license": "MIT",
   "scripts": {
     "dev": "vite --host 127.0.0.1",

--- a/apps/web/src/app/i/[intentId]/page.tsx
+++ b/apps/web/src/app/i/[intentId]/page.tsx
@@ -68,6 +68,9 @@ function toAnsweredThreadEntry(question: PendingQuestion): AnsweredThreadEntry |
     id: question.id,
     prompt: question.payload.prompt,
     response: formatAnswer(answer.selectedOptions, answer.freeText),
+    messageId: question.detection?.messageId,
+    createdAt: question.createdAt,
+    detectedAt: question.detection?.timestamp,
     answeredAt: answer.answeredAt,
   };
 }
@@ -308,7 +311,8 @@ export default function IntentDetailPage() {
     },
     [clearReactionTimers],
   );
-  // Conversation thread: answered questions kept in view (oldest first).
+  // Conversation thread: answered questions retain server anchors/timestamps so
+  // the Personal Agent can place them within chat history after reloads.
   const [answered, setAnswered] = useState<AnsweredThreadEntry[]>([]);
   // Chat-style conversation column: scrolls internally, pinned to the bottom so
   // the newest question is always in view above the composer.
@@ -401,6 +405,9 @@ export default function IntentDetailPage() {
               previous?.id === entry.id &&
               previous.prompt === entry.prompt &&
               previous.response === entry.response &&
+              previous.messageId === entry.messageId &&
+              previous.createdAt === entry.createdAt &&
+              previous.detectedAt === entry.detectedAt &&
               previous.answeredAt === entry.answeredAt
             );
           });
@@ -608,7 +615,9 @@ export default function IntentDetailPage() {
             id: questionId,
             prompt: answered.payload.prompt,
             response: formatAnswer(body.selectedOptions, body.freeText),
-            answeredAt: new Date().toISOString(),
+            messageId: answered.detection?.messageId,
+            createdAt: answered.createdAt,
+            detectedAt: answered.detection?.timestamp,
           },
         ]);
       }

--- a/apps/web/src/components/InjectedQuestions/AnsweredQuestionLog.tsx
+++ b/apps/web/src/components/InjectedQuestions/AnsweredQuestionLog.tsx
@@ -2,6 +2,13 @@ export interface AnsweredThreadEntry {
   id: string;
   prompt: string;
   response: string;
+  /** Authoritative assistant message anchor, when the question came from chat. */
+  messageId?: string;
+  /** Authoritative question creation timestamp used only when no message anchor is available. */
+  createdAt?: string;
+  /** Authoritative detection timestamp used only when no message anchor is available. */
+  detectedAt?: string;
+  /** Authoritative answer timestamp returned by the server after hydration. */
   answeredAt?: string;
 }
 

--- a/apps/web/src/components/IntentNegotiatorChat.tsx
+++ b/apps/web/src/components/IntentNegotiatorChat.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useRef, useState } from "react";
+import { Fragment, useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { ArrowUp, BotMessageSquare, Square } from "lucide-react";
 
 import { useAIChat } from "@/contexts/AIChatContext";
@@ -8,6 +8,7 @@ import { InjectedQuestions } from "@/components/InjectedQuestions/InjectedQuesti
 import { QuestionsEmptyState } from "@/components/InjectedQuestions/QuestionsEmptyState";
 import AssistantMessageContent from "@/components/chat/AssistantMessageContent";
 import { ToolCallsDisplay } from "@/components/chat/ToolCallsDisplay";
+import { buildIntentQuestionTimeline } from "@/components/intent-question.timeline";
 import type { PendingQuestion, AnswerBody } from "@/services/questions";
 import { apiClient } from "@/lib/api";
 import { cn } from "@/lib/utils";
@@ -29,9 +30,9 @@ function formatRelativeTimestamp(timestamp: Date | undefined): string | null {
 export interface IntentNegotiatorChatProps {
   /** The intent this chat is pinned to. */
   intentId: string;
-  /** Pending questions for the intent — rendered as the chat's opening turns. */
+  /** Pending questions for the intent, placed at their message anchor or the current end. */
   questions: PendingQuestion[];
-  /** Answered questions retained above the pending opening turns. */
+  /** Answered question exchanges interleaved with the conversation timeline. */
   answered: AnsweredThreadEntry[];
   onAnswerQuestion: (questionId: string, body: AnswerBody) => Promise<void>;
   onDismissQuestion: (questionId: string) => Promise<void>;
@@ -65,9 +66,10 @@ export interface IntentNegotiatorChatProps {
  *
  * Replaces the static questions block on the intent page with a chat window
  * to the user's personal negotiator, pinned to this intent. Pending intent
- * questions render as the opening turns (cards, answered through the
- * existing questions pipeline); everything conversational streams through
- * the shared AIChatContext against the per-intent negotiator session.
+ * questions render at their triggering assistant-message anchor, or at the
+ * current end when unanchored (cards still use the existing questions
+ * pipeline); everything conversational streams through the shared
+ * AIChatContext against the per-intent negotiator session.
  */
 export default function IntentNegotiatorChat({
   intentId,
@@ -154,7 +156,7 @@ export default function IntentNegotiatorChat({
   // Follow the stream.
   useEffect(() => {
     scrollRef.current?.scrollIntoView({ behavior: "smooth", block: "end" });
-  }, [messages, questions.length, questionChainPending, ready]);
+  }, [answered.length, messages, questions.length, questionChainPending, ready]);
 
   const handleSend = useCallback(async () => {
     const text = input.trim();
@@ -192,6 +194,34 @@ export default function IntentNegotiatorChat({
   const restoredHistoryLastActive = hasRestoredHistory
     ? formatRelativeTimestamp(messages[messages.length - 1]?.timestamp)
     : null;
+  const questionTimeline = useMemo(
+    () => buildIntentQuestionTimeline(messages, questions, answered),
+    [answered, messages, questions],
+  );
+
+  const renderAnswered = (entries: AnsweredThreadEntry[], key: string) => (
+    <div key={key} data-testid="negotiator-answered-exchange">
+      <AnsweredQuestionLog entries={entries} />
+    </div>
+  );
+
+  const renderPending = (
+    pendingQuestions: PendingQuestion[],
+    key: string,
+    showTypingIndicator = false,
+  ) => (
+    <div key={key} data-testid="negotiator-pending-questions">
+      <p className="mb-2 text-xs uppercase tracking-wider text-gray-500 font-ibm-plex-mono">
+        Your Personal Agent needs your input
+      </p>
+      <InjectedQuestions
+        questions={pendingQuestions}
+        onAnswer={onAnswerQuestion}
+        onDismiss={onDismissQuestion}
+        showTypingIndicator={showTypingIndicator}
+      />
+    </div>
+  );
 
   return (
     <div
@@ -234,26 +264,6 @@ export default function IntentNegotiatorChat({
               </div>
             )}
 
-            {answered.length > 0 && (
-              <div data-testid="negotiator-answered-log">
-                <AnsweredQuestionLog entries={answered} />
-              </div>
-            )}
-
-            {(questions.length > 0 || questionChainPending) && (
-              <div data-testid="negotiator-opening-questions">
-                <p className="mb-2 text-xs uppercase tracking-wider text-gray-500 font-ibm-plex-mono">
-                  Your Personal Agent needs your input
-                </p>
-                <InjectedQuestions
-                  questions={questions}
-                  onAnswer={onAnswerQuestion}
-                  onDismiss={onDismissQuestion}
-                  showTypingIndicator={questionChainPending}
-                />
-              </div>
-            )}
-
             {hasRestoredHistory && (
               <div
                 className="border-y border-gray-100 py-1 text-center text-[11px] text-gray-400 font-ibm-plex-mono"
@@ -265,42 +275,64 @@ export default function IntentNegotiatorChat({
               </div>
             )}
 
-            {messages.map((msg) =>
-              msg.role === "user" ? (
-                <div key={msg.id} className="flex justify-end">
-                  <div className="max-w-[85%] rounded-2xl rounded-br-md bg-[#041729] px-4 py-2 text-sm text-white whitespace-pre-wrap">
-                    {msg.content}
-                  </div>
-                </div>
-              ) : (
-                <div key={msg.id} className="text-sm text-gray-900">
-                  {msg.traceEvents && msg.traceEvents.length > 0 && (
-                    <ToolCallsDisplay
-                      traceEvents={msg.traceEvents}
-                      isStreaming={msg.isStreaming}
-                      wasStoppedByUser={msg.wasStoppedByUser}
-                      stoppedAt={msg.stoppedAt}
-                    />
+            {questionTimeline.items.map((item) => {
+              if (item.type === "answered") {
+                return renderAnswered([item.entry], `answered-${item.entry.id}`);
+              }
+
+              const msg = item.message;
+              const anchoredAnswered = questionTimeline.answeredByMessageId.get(msg.id) ?? [];
+              const anchoredPending = questionTimeline.pendingByMessageId.get(msg.id) ?? [];
+              return (
+                <Fragment key={`message-${msg.id}`}>
+                  {msg.role === "user" ? (
+                    <div className="flex justify-end">
+                      <div className="max-w-[85%] rounded-2xl rounded-br-md bg-[#041729] px-4 py-2 text-sm text-white whitespace-pre-wrap">
+                        {msg.content}
+                      </div>
+                    </div>
+                  ) : (
+                    <div className="text-sm text-gray-900">
+                      {msg.traceEvents && msg.traceEvents.length > 0 && (
+                        <ToolCallsDisplay
+                          traceEvents={msg.traceEvents}
+                          isStreaming={msg.isStreaming}
+                          wasStoppedByUser={msg.wasStoppedByUser}
+                          stoppedAt={msg.stoppedAt}
+                        />
+                      )}
+                      <AssistantMessageContent
+                        content={msg.content}
+                        isStreaming={msg.isStreaming ?? false}
+                        onOpportunityPrimaryAction={(id, userId, role, name) =>
+                          onOpportunityAction(id, "accepted", userId, role, name)
+                        }
+                        onOpportunitySecondaryAction={(id, userId, role, name) =>
+                          onOpportunityAction(id, "rejected", userId, role, name)
+                        }
+                        opportunityLoadingMap={opportunityActionLoading}
+                        currentStatusMap={opportunityStatusMap}
+                        onIntentProposalApprove={handleProposalApprove}
+                        onIntentProposalReject={handleProposalReject}
+                        onIntentProposalUndo={handleProposalUndo}
+                        intentProposalStatusMap={proposalStatusMap}
+                      />
+                    </div>
                   )}
-                  <AssistantMessageContent
-                    content={msg.content}
-                    isStreaming={msg.isStreaming ?? false}
-                    onOpportunityPrimaryAction={(id, userId, role, name) =>
-                      onOpportunityAction(id, "accepted", userId, role, name)
-                    }
-                    onOpportunitySecondaryAction={(id, userId, role, name) =>
-                      onOpportunityAction(id, "rejected", userId, role, name)
-                    }
-                    opportunityLoadingMap={opportunityActionLoading}
-                    currentStatusMap={opportunityStatusMap}
-                    onIntentProposalApprove={handleProposalApprove}
-                    onIntentProposalReject={handleProposalReject}
-                    onIntentProposalUndo={handleProposalUndo}
-                    intentProposalStatusMap={proposalStatusMap}
-                  />
-                </div>
-              ),
-            )}
+                  {anchoredAnswered.length > 0 &&
+                    renderAnswered(anchoredAnswered, `answered-for-${msg.id}`)}
+                  {anchoredPending.length > 0 &&
+                    renderPending(anchoredPending, `pending-for-${msg.id}`)}
+                </Fragment>
+              );
+            })}
+
+            {(questionTimeline.trailingPending.length > 0 || questionChainPending) &&
+              renderPending(
+                questionTimeline.trailingPending,
+                "trailing-pending",
+                questionChainPending,
+              )}
           </>
         )}
         <div ref={scrollRef} />

--- a/apps/web/src/components/intent-question.timeline.ts
+++ b/apps/web/src/components/intent-question.timeline.ts
@@ -1,0 +1,136 @@
+import type { AnsweredThreadEntry } from "@/components/InjectedQuestions/AnsweredQuestionLog";
+import type { PendingQuestion } from "@/services/questions";
+
+interface IntentTimelineMessage {
+  id: string;
+  role: "user" | "assistant";
+  timestamp: Date;
+}
+
+export type IntentQuestionTimelineItem<TMessage extends IntentTimelineMessage> =
+  | { type: "message"; message: TMessage }
+  | { type: "answered"; entry: AnsweredThreadEntry };
+
+export interface IntentQuestionTimeline<TMessage extends IntentTimelineMessage> {
+  items: Array<IntentQuestionTimelineItem<TMessage>>;
+  answeredByMessageId: Map<string, AnsweredThreadEntry[]>;
+  pendingByMessageId: Map<string, PendingQuestion[]>;
+  trailingPending: PendingQuestion[];
+}
+
+function timestampMs(value: Date | string | undefined): number | null {
+  if (!value) return null;
+  const timestamp = value instanceof Date ? value.getTime() : new Date(value).getTime();
+  return Number.isNaN(timestamp) ? null : timestamp;
+}
+
+function answeredTimestamp(entry: AnsweredThreadEntry): number | null {
+  return timestampMs(entry.answeredAt)
+    ?? timestampMs(entry.detectedAt)
+    ?? timestampMs(entry.createdAt);
+}
+
+function pendingTimestamp(question: PendingQuestion): number | null {
+  return timestampMs(question.detection?.timestamp) ?? timestampMs(question.createdAt);
+}
+
+function compareTimestamped<T>(
+  left: T,
+  right: T,
+  getTimestamp: (value: T) => number | null,
+  getId: (value: T) => string,
+): number {
+  const leftTimestamp = getTimestamp(left);
+  const rightTimestamp = getTimestamp(right);
+  if (leftTimestamp !== null && rightTimestamp !== null && leftTimestamp !== rightTimestamp) {
+    return leftTimestamp - rightTimestamp;
+  }
+  if (leftTimestamp === null && rightTimestamp !== null) return 1;
+  if (leftTimestamp !== null && rightTimestamp === null) return -1;
+  return getId(left).localeCompare(getId(right));
+}
+
+/**
+ * Builds the intent-page Personal Agent timeline without mutating question data.
+ * Exact assistant-message anchors win. Unanchored answered exchanges use their
+ * authoritative timestamps, while pending questions stay at the current end.
+ */
+export function buildIntentQuestionTimeline<TMessage extends IntentTimelineMessage>(
+  messages: TMessage[],
+  pending: PendingQuestion[],
+  answered: AnsweredThreadEntry[],
+): IntentQuestionTimeline<TMessage> {
+  const assistantMessageIds = new Set(
+    messages.filter((message) => message.role === "assistant").map((message) => message.id),
+  );
+  const answeredByMessageId = new Map<string, AnsweredThreadEntry[]>();
+  const pendingByMessageId = new Map<string, PendingQuestion[]>();
+  const unanchoredAnswered: AnsweredThreadEntry[] = [];
+  const trailingPending: PendingQuestion[] = [];
+
+  for (const entry of answered) {
+    if (entry.messageId && assistantMessageIds.has(entry.messageId)) {
+      answeredByMessageId.set(entry.messageId, [
+        ...(answeredByMessageId.get(entry.messageId) ?? []),
+        entry,
+      ]);
+    } else {
+      unanchoredAnswered.push(entry);
+    }
+  }
+
+  for (const question of pending) {
+    const messageId = question.detection?.messageId;
+    if (messageId && assistantMessageIds.has(messageId)) {
+      pendingByMessageId.set(messageId, [
+        ...(pendingByMessageId.get(messageId) ?? []),
+        question,
+      ]);
+    } else {
+      trailingPending.push(question);
+    }
+  }
+
+  for (const entries of answeredByMessageId.values()) {
+    entries.sort((left, right) => compareTimestamped(left, right, answeredTimestamp, (entry) => entry.id));
+  }
+  for (const questions of pendingByMessageId.values()) {
+    questions.sort((left, right) => compareTimestamped(left, right, pendingTimestamp, (question) => question.id));
+  }
+  trailingPending.sort((left, right) => compareTimestamped(left, right, pendingTimestamp, (question) => question.id));
+
+  const items: Array<IntentQuestionTimelineItem<TMessage> & { timestamp: number | null; sequence: number }> = [
+    ...messages.map((message, sequence) => ({
+      type: "message" as const,
+      message,
+      timestamp: timestampMs(message.timestamp),
+      sequence,
+    })),
+    ...unanchoredAnswered.map((entry, sequence) => ({
+      type: "answered" as const,
+      entry,
+      timestamp: answeredTimestamp(entry),
+      sequence: messages.length + sequence,
+    })),
+  ];
+
+  items.sort((left, right) => {
+    if (left.timestamp !== null && right.timestamp !== null && left.timestamp !== right.timestamp) {
+      return left.timestamp - right.timestamp;
+    }
+    if (left.timestamp === null && right.timestamp !== null) return 1;
+    if (left.timestamp !== null && right.timestamp === null) return -1;
+    if (left.type !== right.type) return left.type === "message" ? -1 : 1;
+    if (left.sequence !== right.sequence) return left.sequence - right.sequence;
+    const leftId = left.type === "message" ? left.message.id : left.entry.id;
+    const rightId = right.type === "message" ? right.message.id : right.entry.id;
+    return leftId.localeCompare(rightId);
+  });
+
+  return {
+    items: items.map(({ timestamp: _timestamp, sequence: _sequence, ...item }) => item),
+    answeredByMessageId,
+    pendingByMessageId,
+    trailingPending,
+  };
+}

--- a/apps/web/tests/intent-negotiator-chat.test.tsx
+++ b/apps/web/tests/intent-negotiator-chat.test.tsx
@@ -41,10 +41,26 @@ vi.mock('@/contexts/AIChatContext', () => ({
 }));
 
 vi.mock('@/components/InjectedQuestions/InjectedQuestions', () => ({
-  InjectedQuestions: ({ questions }: { questions: PendingQuestion[] }) => (
+  InjectedQuestions: ({
+    questions,
+    onAnswer,
+    onDismiss,
+  }: {
+    questions: PendingQuestion[];
+    onAnswer: (questionId: string, body: { selectedOptions: string[] }) => Promise<void>;
+    onDismiss: (questionId: string) => Promise<void>;
+  }) => (
     <div data-testid="injected-questions">
-      {questions.map((q) => (
-        <div key={q.id}>{q.title}</div>
+      {questions.map((question) => (
+        <div key={question.id}>
+          <span>{question.payload.title}</span>
+          <button type="button" onClick={() => void onAnswer(question.id, { selectedOptions: ['Berlin'] })}>
+            answer-{question.id}
+          </button>
+          <button type="button" onClick={() => void onDismiss(question.id)}>
+            dismiss-{question.id}
+          </button>
+        </div>
       ))}
     </div>
   ),
@@ -66,15 +82,25 @@ const SESSION_RESPONSE = {
 
 const QUESTION: PendingQuestion = {
   id: 'q-1',
-  title: 'Which city should we prioritize?',
-  prompt: 'Which city should we prioritize?',
-  options: [],
-  multiSelect: false,
-  mode: 'intent',
-  sourceType: 'intent',
-  sourceId: 'intent-1',
-  createdAt: new Date().toISOString(),
-} as unknown as PendingQuestion;
+  detection: {
+    mode: 'intent',
+    sourceType: 'intent',
+    sourceId: 'intent-1',
+    timestamp: '2026-07-20T10:02:00Z',
+  },
+  actors: [{ userId: 'user-1', role: 'subject' }],
+  payload: {
+    title: 'Which city should we prioritize?',
+    prompt: 'Which city should we prioritize?',
+    options: [],
+    multiSelect: false,
+  },
+  status: 'pending',
+  answer: null,
+  expiresAt: null,
+  createdAt: '2026-07-20T10:02:00Z',
+  conversationId: null,
+};
 
 function renderChat(overrides: Partial<Parameters<typeof IntentNegotiatorChat>[0]> = {}) {
   const props = {
@@ -130,11 +156,102 @@ describe('IntentNegotiatorChat', () => {
     expect(divider).toHaveTextContent('may not reflect current signal state');
   });
 
-  test('renders pending intent questions as the opening turns (existing pipeline)', async () => {
+  test('renders pending intent questions through the existing answer pipeline', async () => {
     renderChat({ questions: [QUESTION] });
 
-    await screen.findByTestId('negotiator-opening-questions');
+    await screen.findByTestId('negotiator-pending-questions');
     expect(screen.getByTestId('injected-questions').textContent).toContain('Which city should we prioritize?');
+  });
+
+  test('places an unanchored pending question after older chat history', async () => {
+    mocks.chat.messages = [
+      { id: 'old-user', role: 'user', content: 'Earlier request', timestamp: new Date('2026-07-20T10:00:00Z') },
+      { id: 'old-assistant', role: 'assistant', content: 'Earlier response', timestamp: new Date('2026-07-20T10:01:00Z') },
+    ];
+
+    renderChat({ questions: [QUESTION] });
+
+    const chat = await screen.findByTestId('intent-negotiator-chat');
+    await screen.findByText('Earlier response');
+    const content = chat.textContent ?? '';
+    expect(content.indexOf('Earlier response')).toBeLessThan(content.indexOf('Which city should we prioritize?'));
+  });
+
+  test('places anchored answered and pending questions after their assistant message', async () => {
+    mocks.chat.messages = [
+      { id: 'anchor-message', role: 'assistant', content: 'I need one detail.', timestamp: new Date('2026-07-20T10:00:00Z') },
+      { id: 'later-user', role: 'user', content: 'A later reply', timestamp: new Date('2026-07-20T10:05:00Z') },
+    ];
+    const anchoredQuestion = {
+      ...QUESTION,
+      id: 'q-anchored',
+      detection: { ...QUESTION.detection, messageId: 'anchor-message' },
+    };
+    const { props } = renderChat({
+      questions: [anchoredQuestion],
+      answered: [{
+        id: 'answered-anchored',
+        prompt: 'Previously asked detail?',
+        response: 'Previously answered',
+        messageId: 'anchor-message',
+        answeredAt: '2026-07-20T10:10:00Z',
+      }],
+    });
+
+    const chat = await screen.findByTestId('intent-negotiator-chat');
+    await screen.findByText('A later reply');
+    const content = chat.textContent ?? '';
+    expect(content.indexOf('I need one detail.')).toBeLessThan(content.indexOf('Previously asked detail?'));
+    expect(content.indexOf('Previously asked detail?')).toBeLessThan(content.indexOf('Which city should we prioritize?'));
+    expect(content.indexOf('Which city should we prioritize?')).toBeLessThan(content.indexOf('A later reply'));
+
+    fireEvent.click(screen.getByRole('button', { name: 'answer-q-anchored' }));
+    fireEvent.click(screen.getByRole('button', { name: 'dismiss-q-anchored' }));
+    expect(props.onAnswerQuestion).toHaveBeenCalledWith('q-anchored', { selectedOptions: ['Berlin'] });
+    expect(props.onDismissQuestion).toHaveBeenCalledWith('q-anchored');
+  });
+
+  test('interleaves an unanchored answered exchange by timestamp but keeps pending at the end', async () => {
+    mocks.chat.messages = [
+      { id: 'older-assistant', role: 'assistant', content: 'Old agent turn', timestamp: new Date('2026-07-20T10:00:00Z') },
+      { id: 'newer-user', role: 'user', content: 'New user turn', timestamp: new Date('2026-07-20T12:00:00Z') },
+    ];
+    renderChat({
+      questions: [QUESTION],
+      answered: [{
+        id: 'answered-between',
+        prompt: 'Answered between turns?',
+        response: 'Yes',
+        answeredAt: '2026-07-20T11:00:00Z',
+      }],
+    });
+
+    const chat = await screen.findByTestId('intent-negotiator-chat');
+    await screen.findByText('New user turn');
+    const content = chat.textContent ?? '';
+    expect(content.indexOf('Old agent turn')).toBeLessThan(content.indexOf('Answered between turns?'));
+    expect(content.indexOf('Answered between turns?')).toBeLessThan(content.indexOf('New user turn'));
+    expect(content.indexOf('New user turn')).toBeLessThan(content.indexOf('Which city should we prioritize?'));
+  });
+
+  test('uses a deterministic end fallback for an answered exchange without timestamps', async () => {
+    mocks.chat.messages = [
+      { id: 'fallback-message', role: 'assistant', content: 'Last authoritative turn', timestamp: new Date('2026-07-20T12:00:00Z') },
+    ];
+    renderChat({
+      questions: [QUESTION],
+      answered: [{
+        id: 'answered-without-time',
+        prompt: 'Optimistic answer?',
+        response: 'Kept without a fabricated timestamp',
+      }],
+    });
+
+    const chat = await screen.findByTestId('intent-negotiator-chat');
+    await screen.findByText('Last authoritative turn');
+    const content = chat.textContent ?? '';
+    expect(content.indexOf('Last authoritative turn')).toBeLessThan(content.indexOf('Optimistic answer?'));
+    expect(content.indexOf('Optimistic answer?')).toBeLessThan(content.indexOf('Which city should we prioritize?'));
   });
 
   test('keeps answered history visible without the empty state', async () => {
@@ -147,7 +264,7 @@ describe('IntentNegotiatorChat', () => {
       }],
     });
 
-    expect(await screen.findByTestId('negotiator-answered-log')).toBeInTheDocument();
+    expect(await screen.findByTestId('negotiator-answered-exchange')).toBeInTheDocument();
     expect(screen.getByText('What should we prioritize?')).toBeInTheDocument();
     expect(screen.getByText('Berlin')).toBeInTheDocument();
     expect(screen.getByText('noted — updating the search.')).toBeInTheDocument();

--- a/apps/web/tests/intent-page-negotiator.test.tsx
+++ b/apps/web/tests/intent-page-negotiator.test.tsx
@@ -71,6 +71,14 @@ vi.mock('@/components/IntentNegotiatorChat', () => ({
       <div data-testid="intent-negotiator-chat-stub">
         {answered.length > 0 && (
           <div data-testid="negotiator-answered-log">
+            {answered.map((entry) => (
+              <span
+                key={entry.id}
+                data-testid={`answered-entry-${entry.id}`}
+                data-message-id={entry.messageId ?? ''}
+                data-answered-at={entry.answeredAt ?? ''}
+              />
+            ))}
             <AnsweredQuestionLog entries={answered} />
           </div>
         )}
@@ -204,6 +212,14 @@ describe('Intent page — negotiator chat gating', () => {
     mocks.authState.features = { negotiatorChat: true };
     mocks.questionsService.getAnswered.mockResolvedValue([{
       id: 'answered-1',
+      detection: {
+        mode: 'intent',
+        sourceType: 'intent',
+        sourceId: 'intent-1',
+        timestamp: '2026-07-20T10:01:00Z',
+        messageId: 'assistant-anchor-1',
+      },
+      createdAt: '2026-07-20T10:01:00Z',
       payload: {
         title: 'What kind of collaborator?',
         prompt: 'What kind of collaborator?',
@@ -214,7 +230,7 @@ describe('Intent page — negotiator chat gating', () => {
         selectedOptions: ['Technical founder'],
         freeText: 'in Europe',
         answeredBy: 'user-1',
-        answeredAt: new Date().toISOString(),
+        answeredAt: '2026-07-20T10:02:00Z',
       },
       status: 'answered',
     }]);
@@ -222,6 +238,7 @@ describe('Intent page — negotiator chat gating', () => {
 
     await waitFor(() => expect(mocks.questionsService.getAnswered).toHaveBeenCalled());
     expect(await screen.findByTestId('negotiator-answered-log')).toBeInTheDocument();
+    expect(screen.getByTestId('answered-entry-answered-1')).toHaveAttribute('data-message-id', 'assistant-anchor-1');
     expect(screen.getByText('What kind of collaborator?')).toBeInTheDocument();
     expect(screen.getByText('Technical founder, in Europe')).toBeInTheDocument();
   });
@@ -250,6 +267,7 @@ describe('Intent page — negotiator chat gating', () => {
 
     await waitFor(() => expect(screen.getByText('Berlin')).toBeInTheDocument());
     expect(screen.getByText('Technical founder')).toBeInTheDocument();
+    expect(screen.getByTestId('answered-entry-q-1')).toHaveAttribute('data-answered-at', '');
     expect(mocks.questionsService.answer).toHaveBeenCalledWith('q-1', { selectedOptions: ['Berlin'] });
   });
 

--- a/apps/web/tests/negotiator-dm-inbox.test.tsx
+++ b/apps/web/tests/negotiator-dm-inbox.test.tsx
@@ -376,6 +376,37 @@ describe('Negotiator DM question inbox (IND-404)', () => {
     expect(screen.queryByTestId('negotiator-question-inbox')).toBeNull();
   });
 
+  test('ordinary chat keeps a conversation-linked question at its assistant message anchor', async () => {
+    mocks.chat.sessionPersona = 'orchestrator';
+    mocks.chat.messages = [
+      { id: 'ordinary-anchor', role: 'assistant', content: 'Ordinary anchor turn', timestamp: new Date('2026-07-20T10:00:00Z') },
+      { id: 'ordinary-later', role: 'user', content: 'Ordinary later turn', timestamp: new Date('2026-07-20T10:01:00Z') },
+    ];
+    mocks.questionsService.getByConversation.mockResolvedValue([{
+      ...INBOX_QUESTION,
+      id: 'ordinary-anchored-question',
+      conversationId: 'dm-session-1',
+      detection: {
+        ...INBOX_QUESTION.detection,
+        mode: 'chat',
+        timestamp: '2026-07-20T10:00:30Z',
+        messageId: 'ordinary-anchor',
+      },
+      payload: {
+        ...INBOX_QUESTION.payload,
+        title: 'Ordinary anchored question',
+      },
+    }]);
+
+    renderWithRouter(<ChatContent sessionIdParam="dm-session-1" />);
+
+    const anchor = await screen.findByText('Ordinary anchor turn');
+    const question = await screen.findByText('Ordinary anchored question');
+    const later = await screen.findByText('Ordinary later turn');
+    expect(anchor.compareDocumentPosition(question) & Node.DOCUMENT_POSITION_FOLLOWING).not.toBe(0);
+    expect(question.compareDocumentPosition(later) & Node.DOCUMENT_POSITION_FOLLOWING).not.toBe(0);
+  });
+
   test('intent-pinned negotiator sessions keep the intent-scope query (no global inbox)', async () => {
     mocks.chat.sessionPersona = 'negotiator';
     mocks.chat.chatScope = { type: 'intent', id: 'intent-42' };

--- a/bun.lock
+++ b/bun.lock
@@ -19,7 +19,7 @@
     },
     "apps/web": {
       "name": "@indexnetwork/web",
-      "version": "0.28.0",
+      "version": "0.28.1",
       "dependencies": {
         "@radix-ui/react-alert-dialog": "^1.1.15",
         "@radix-ui/react-dialog": "^1.1.14",


### PR DESCRIPTION
## New Features

- None.

## Bug Fixes

- Stop prepending intent-page Personal Agent questions above older chat history.
- Place conversation-linked pending and answered questions immediately after their authoritative assistant-message anchor.
- Keep unanchored pending intent questions at the current end of the conversation, while unanchored answered exchanges use server timestamps and a deterministic no-timestamp fallback.
- Preserve optimistic answers without fabricating an `answeredAt`; server hydration supplies the authoritative answer timestamp.

## Refactors

- Add an intent-page-only question timeline helper that leaves ordinary chat, question generation, ranking, APIs, persistence, flags, and infrastructure unchanged.

## Documentation

- Document the fix in `apps/web/CHANGELOG.md`.
- Bump `@indexnetwork/web` from `0.28.0` to `0.28.1` and align only the `apps/web` workspace version in `bun.lock`.

## Tests

- Reproduced before the fix with `tests/intent-negotiator-chat.test.tsx`: the older assistant response rendered after the pending question (`83` was not less than `36`).
- `bun run test -- tests/intent-negotiator-chat.test.tsx tests/intent-page-negotiator.test.tsx tests/intent-page-lifecycle.test.tsx tests/negotiator-dm-inbox.test.tsx tests/pool-discovery-questions.test.tsx` — **5 files, 70 tests passed**.
- `bunx eslint src/components/IntentNegotiatorChat.tsx src/components/intent-question.timeline.ts src/components/InjectedQuestions/AnsweredQuestionLog.tsx 'src/app/i/[intentId]/page.tsx'` — **0 errors, 1 pre-existing `set-state-in-effect` warning** in the intent page.
- `bun run lint` — **0 errors, 88 existing warnings**.
- `bun run build` — **passed**; emitted existing local-build warnings for unset `VITE_PROTOCOL_URL`, generated CSS `context`, dynamic/static import chunking, and large chunks.


Fixes IND-497
