### PR TITLE
docs(pi): add run-agent-orchestration skill for hierarchical Herdr waves

### DIFF
--- a/.pi/skills/create-worktree/SKILL.md
+++ b/.pi/skills/create-worktree/SKILL.md
@@ -108,11 +108,22 @@ herdr pane get "$PANE_ID"
 herdr agent get "$PANE_ID"
 ```
 
-If the root pane is an interactive shell with no Pi agent, start one. The stable agent
-name is the same dashed folder:
+If the root pane is an interactive shell with no Pi agent, start one. The default
+stable agent name is the dashed folder, but Herdr live agent names must match
+`[a-z][a-z0-9_-]{0,31}` (32 chars max) — when the folder exceeds the limit, use a
+shorter unique alias (e.g. `agent-orchestration`) and keep the longer dashed
+workspace label unchanged; the label and the agent alias are independent:
 
 ```bash
-herdr agent start "$FOLDER" --kind pi --pane "$PANE_ID"
+herdr agent start "$AGENT_ALIAS" --kind pi --pane "$PANE_ID"
+```
+
+To preselect a model and thinking level at launch (chosen per
+`run-agent-orchestration`'s model routing — never switched mid-implementation), pass
+an explicit agent argument after `--`:
+
+```bash
+herdr agent start "$AGENT_ALIAS" --kind pi --pane "$PANE_ID" -- --model provider/model:thinking
 ```
 
 If Pi already exists in that pane, reuse it only when its cwd is `WORKTREE` and its
@@ -151,5 +162,6 @@ Never use plain `git config commit.gpgsign false`, which affects every worktree.
 
 ## See also
 
-- `run-worktree-session` — visible handoff, polling, question handling, and fix loops.
+- `run-worktree-session` — visible handoff, event-driven waits, question handling, and fix loops.
+- `run-agent-orchestration` — multi-task waves: one root orchestrator, role profiles, model routing.
 - `finish-pr` — explicit merge approval and post-merge verification.

--- a/.pi/skills/finish-pr/references/post-merge-operations.md
+++ b/.pi/skills/finish-pr/references/post-merge-operations.md
@@ -89,21 +89,31 @@ Removal procedure:
    cd /Users/yanek/Projects/index
    ```
 
-2. Before removing the worktree, inspect and restore any external local pointers that target it. Example: a local Hermes plugin install may be a symlink to the PR worktree; repoint it to the canonical package before deletion so local tooling does not reference a removed path:
+2. Close the exact Herdr workspace for the finished worktree **before** removing the Git worktree. A removed worktree leaves its Herdr workspace and idle Pi agent behind as a stale sidebar entry; closing the workspace stops the Pi/terminal and removes that entry. Use the workspace ID recorded when the session was opened and re-verify identity before closing — never guess from the label alone, and never close the canonical root workspace (or any other active workspace):
+
+   ```bash
+   herdr workspace get "$WORKSPACE_ID"   # path/branch must match the finished worktree
+   herdr workspace close "$WORKSPACE_ID"
+   herdr workspace list                   # verify the workspace is gone
+   ```
+
+   If the recorded ID's path/branch does not match the finished worktree, or the close fails, **stop and report** — do not close another workspace or remove the Git worktree until identity is resolved. Verify the workspace disappeared from `herdr workspace list` before proceeding.
+
+3. Before removing the worktree, inspect and restore any external local pointers that target it. Example: a local Hermes plugin install may be a symlink to the PR worktree; repoint it to the canonical package before deletion so local tooling does not reference a removed path:
 
    ```bash
    ls -ld "$HOME/.hermes/plugins/index-network" || true
    ln -sfn "/Users/yanek/Projects/index/packages/hermes-plugin" "$HOME/.hermes/plugins/index-network"
    ```
 
-3. Remove the PR's worktree. Use `--force` only when it carries disposable leftovers that are already preserved on the merged PR/base:
+4. Remove the PR's worktree. Use `--force` only when it carries disposable leftovers that are already preserved on the merged PR/base:
 
    ```bash
    git fetch origin <base-branch>
    git worktree remove --force .worktrees/WORKTREE_NAME
    ```
 
-4. Prune stale administrative entries and report the remaining worktrees; leave unrelated worktrees in place:
+5. Prune stale administrative entries and report the remaining worktrees; leave unrelated worktrees in place:
 
    ```bash
    git worktree prune

--- a/.pi/skills/run-agent-orchestration/SKILL.md
+++ b/.pi/skills/run-agent-orchestration/SKILL.md
@@ -103,6 +103,17 @@ to the user. Never infer merge approval. Full flow:
   (GPT-5.6 Sol/Terra/Luna and Claude variants — never GPT-5.5), reading visible footer
   quota first. See `references/model-routing.md`.
 
+## Wave cleanup invariant
+
+A finished PR is not done until its execution plane is gone: `finish-pr` must close
+the child's exact Herdr workspace (verified by ID — this stops the Pi/terminal and
+removes the stale sidebar entry) **and** remove its Git worktree, in that order.
+Removing the worktree without closing the workspace leaves idle agents visible in
+the sidebar. After the wave, the root orchestrator verifies with
+`herdr workspace list` that no finished child workspaces/agents remain — but never
+sweeps unrelated active workspaces, and keeps the root orchestrator workspace (the
+user-facing coordination plane) unless the user explicitly ends the wave.
+
 ## Sub-workflows the root orchestrator runs
 
 The root orchestrator does not re-implement session mechanics; it invokes the existing

--- a/.pi/skills/run-agent-orchestration/SKILL.md
+++ b/.pi/skills/run-agent-orchestration/SKILL.md
@@ -1,0 +1,120 @@
+---
+name: run-agent-orchestration
+description: >-
+  Orchestrate a multi-task or multi-PR wave by delegating repository work from the
+  user-facing main agent to exactly one visible Herdr root orchestrator in the
+  canonical root, which fans out to path-roled child worktree sessions. Use when the
+  user asks for several coordinated Index changes/PRs at once, for delegated
+  orchestration, or when role profiles, model routing, or blocked structured-question
+  escalation across Herdr agents are needed.
+---
+
+# run-agent-orchestration
+
+One user-facing main agent delegates repository orchestration to **exactly one**
+visible Herdr root orchestrator. The root orchestrator fans work out to child Pi
+sessions in isolated worktrees selected by path-triggered role profiles — not
+long-lived frontend/backend/protocol personas.
+
+## Topology
+
+- **Main agent (you)** — stays user-facing. Owns the user conversation, collects
+  decisions, sends one complete wave handoff to the root orchestrator, waits, and
+  reports results. Never orchestrates worktrees or children directly.
+- **Root orchestrator (exactly one)** — a visible Pi agent in the canonical root
+  (`/Users/yanek/Projects/index`, branch `dev`). Sole owner for the wave of: worktree
+  creation, child handoffs, PR finishing, GitHub/Linear/Railway coordination, and
+  cleanup. It never edits source in the canonical root; implementation always happens
+  in child worktrees.
+- **Children** — one writer per Git worktree, each launched with a role profile chosen
+  by the paths it will change (see `references/role-profiles.md`) and a model chosen at
+  launch time (see `references/model-routing.md`).
+
+## Launching the root orchestrator
+
+Run the Herdr preflight (`herdr status server`, `herdr integration status`), then open
+the canonical root as a workspace and start one Pi agent in its root pane:
+
+```bash
+herdr worktree open --path /Users/yanek/Projects/index --label root --focus --json
+herdr agent start root-orch --kind pi --pane "$PANE_ID" -- --model anthropic/claude-fable-5:high
+```
+
+The agent name must match Herdr's live-name limit `[a-z][a-z0-9_-]{0,31}` (32 chars
+max) — keep the alias short (e.g. `root-orch`); the longer dashed workspace label
+stays independent. Reuse an existing root orchestrator only when its cwd is the
+canonical root, its branch is `dev`, and its identity belongs to this wave. Read the
+visible Pi footer quota before choosing the model; never switch models
+mid-implementation.
+
+## Handoffs and waits (event-driven, never `sleep`)
+
+Both hops — main → root orchestrator and root orchestrator → child — use **one
+complete handoff** followed by **event-driven Herdr waits**:
+
+```bash
+herdr agent prompt root-orch "$(< /absolute/path/to/wave-handoff.md)" --wait
+```
+
+- `agent prompt --wait` is atomic (text + encoded Enter, honoring bracketed paste) and
+  waits for the first settled `idle`, `done`, or `blocked` state. Do not repeat those
+  defaults with `--until`. A handoff sent from a non-working state must show activity
+  within five seconds or Herdr returns `agent_prompt_stalled`.
+- **NEVER use `sleep` to poll Herdr agents.** Waits are server-owned; `sleep` polling
+  is banned at every tier.
+- For an already-running agent (follow-up after a timeout checkpoint or a resolved
+  question), use `herdr agent wait NAME --timeout <ms>`. A timeout is a checkpoint,
+  not a failure — read new output and wait again.
+- For parallel children, issue multiple `herdr agent prompt NAME "..." --wait` tool
+  calls in one turn so the server-owned waits run concurrently. Do not create a
+  background watcher process or watcher pane.
+
+## Settled states are not success
+
+`idle` and `done` are both settled states (`done` is unseen idle after background
+work); `blocked` means Herdr recognized an approval or question UI — inspect the
+active pane UI. A settled state is **not** proof of success: read the transcript and
+verify the git/PR/test facts (branch head, pushed commits, PR number, checks, targeted
+tests) before reporting to the user.
+
+Require every child to end with a concise **structured result envelope**: status,
+branch/head/PR, verification performed, unresolved blockers. If transcript rows are
+missing (alternate-screen rendering), fall back to asking the agent for a report file
+in a temp directory — never request file output in the initial prompt. Full contract:
+`references/completion-and-questions.md`.
+
+## Structured questions propagate, not stall
+
+When a child is `blocked`, the root orchestrator reads its pane and answers routine
+safe/recommended choices through targeted pane UI (`pane read`, `pane send-text`,
+`pane send-keys`) — never a new agent prompt into an active question. Genuine
+product/architecture ambiguity, destructive/external mutation, credentials, or merge
+approval is re-raised by the root orchestrator with its **own** `ask_user_question`,
+which makes the root `blocked`, returns the main agent's wait, and safely propagates
+to the user. Never infer merge approval. Full flow:
+`references/completion-and-questions.md`.
+
+## Roles and models
+
+- Role is selected per task by changed paths (`packages/protocol/**`,
+  `services/api/**`, `apps/web/**`, release/review) and injected as a handoff
+  checklist — no persistent personas. See `references/role-profiles.md`.
+- Model is chosen at child launch time from the balanced routing table
+  (GPT-5.6 Sol/Terra/Luna and Claude variants — never GPT-5.5), reading visible footer
+  quota first. See `references/model-routing.md`.
+
+## Sub-workflows the root orchestrator runs
+
+The root orchestrator does not re-implement session mechanics; it invokes the existing
+skills:
+
+- `create-worktree` — worktree/workspace/agent identity contracts per child.
+- `run-worktree-session` — single-session handoff, waits, question handling, fix loops.
+- `address-code-review` — Copilot review threads and visible fix rounds.
+- `finish-pr` — readiness, explicit merge confirmation, post-merge verification, cleanup.
+
+## See also
+
+- `create-worktree` and `run-worktree-session` — the single-session mechanics this
+  skill composes across a wave.
+- `finish-pr` — merge approval and post-merge operations owned per PR.

--- a/.pi/skills/run-agent-orchestration/references/completion-and-questions.md
+++ b/.pi/skills/run-agent-orchestration/references/completion-and-questions.md
@@ -1,0 +1,87 @@
+# Completion, verification, and structured questions
+
+## Waits are event-driven — never `sleep`
+
+Herdr waits are server-owned: `agent prompt --wait` and `agent wait` block until the
+first requested settled state (`idle`, `done`, `blocked` by default) and return the
+current agent at `.result.agent`. There is no default timeout — pass an explicit
+`--timeout <ms>` as a checkpoint rhythm; a timeout exit is a polling checkpoint, not
+a failure. Read new output, then wait again.
+
+- **`sleep` polling is banned at every tier** (main, root orchestrator, child). It
+  wastes wall-clock, desynchronizes from agent state, and hides `blocked` states.
+- **Parallel children:** issue multiple `herdr agent prompt NAME "..." --wait` tool
+  calls in one turn — the waits run concurrently on the server. Never spawn a
+  background watcher process or watcher pane to observe agents.
+- `agent wait` returns immediately if the current status already matches; add
+  `--until unknown` explicitly only when you also need to catch unclassifiable states.
+
+## Settled states and truth
+
+- `idle` — ready for input after its tab has been seen in the focused Herdr UI.
+- `done` — the same underlying idle state after unseen background work finishes.
+  CLI reads do not mark an agent seen; `idle`/`done` carry no quality signal.
+- `blocked` — Herdr recognized an approval or question UI. Inspect the pane.
+- `unknown` — present but unclassifiable; not proof of completion or failure.
+
+A settled state is **not** proof of success. After every settle, the orchestrator
+reads the transcript and independently verifies facts: `git log`/`git status` for
+commits, `gh pr view` for PR state and checks, and the targeted test/lint/build
+output the child claims to have run.
+
+## Child result envelope
+
+Require every child (and the root orchestrator toward the main agent) to end its
+final response with a concise structured envelope:
+
+```
+RESULT
+status: done | blocked | failed
+branch: <branch> @ <head-sha>
+pr: <number-or-none> (<url-or-reason>)
+verification: <tests/lint/build actually run, with outcomes>
+blockers: <unresolved items, or none>
+```
+
+**Alternate-screen caveat:** full-screen agents may render in the terminal's
+alternate screen; those rows never enter Herdr's host scrollback and `--lines`
+cannot recover them. If a transcript read comes back short, only then ask the agent
+to write its full report as Markdown in a temp directory and reply with the path —
+read the file directly. Never request file output in the initial prompt.
+
+## Structured questions: the escalation ladder
+
+`agent prompt --wait` can return `blocked` when a question or approval UI appears.
+Handle it at the tier that owns the agent:
+
+1. **Read first.** `herdr pane read "$PANE_ID" --source visible --lines 120` (or
+   `agent read`) to see the actual question and its options.
+2. **Routine choices are answered in place.** Ordinary implementation questions —
+   file edits, targeted tests, commits, pushes, PR creation — are decided by the
+   supervising agent choosing the safe/recommended project-compliant option, then
+   answering through the targeted pane UI:
+
+   ```bash
+   herdr pane send-text "$PANE_ID" "<safe answer>"
+   herdr pane send-keys "$PANE_ID" enter
+   ```
+
+   For a selector, send only the navigation/confirmation keys the visible UI needs,
+   then re-read the pane to confirm the answer landed in the intended control.
+   **Never** answer an active structured question with `agent prompt` — it appends
+   text to stale input.
+3. **Genuine escalation re-raises upward.** Escalate only: genuine product or
+   architecture ambiguity; destructive operations; external infrastructure mutation;
+   credentials or secrets; merge approval. **Never infer merge approval.**
+   - Child → root: the child surfaces its question; the root decides routine vs.
+     genuine as above.
+   - Root → main → user: when the root orchestrator judges a question genuine, it
+     asks its **own** `ask_user_question` with the full context. That makes the root
+     `blocked`, which returns the main agent's `agent wait`/`prompt --wait`, and the
+     main agent relays the question to the user verbatim (via its own
+     `ask_user_question`). The user's answer travels back down the same path as a
+     targeted pane answer — never as a fresh agent prompt.
+
+This propagation is why the chain stays synchronous and safe: every tier's wait is
+event-driven, so a blocked child surfaces through the root to the user without
+polling, timeouts-as-errors, or lost context.

--- a/.pi/skills/run-agent-orchestration/references/model-routing.md
+++ b/.pi/skills/run-agent-orchestration/references/model-routing.md
@@ -1,0 +1,52 @@
+# Model routing (launch-time, balanced, no GPT-5.5)
+
+Models are chosen **at child launch time** and never switched mid-implementation —
+a child that needs a stronger model is stopped and relaunched with a fresh handoff,
+not hot-swapped.
+
+Before every launch, read the visible Pi footer quota/headroom and route by the table
+below. Routing is deterministic skill logic based on visible footer state; do not
+parse quota UI with a brittle extension. (A preset/model-routing extension is a later
+option only if a stable quota API becomes available.)
+
+**GPT-5.5 is banned.** Use the GPT-5.6 Sol/Terra/Luna variants instead.
+
+## Launch syntax
+
+Pass the model as an explicit agent argument after `--`:
+
+```bash
+herdr agent start NAME --kind pi --pane ID -- --model provider/model:thinking
+```
+
+## Default balanced routing
+
+| Agent / role | Model | Fallback |
+|---|---|---|
+| Root orchestrator | `anthropic/claude-fable-5:high` | `openai-codex/gpt-5.6-terra:high` |
+| Protocol specialist / privacy-critical | `anthropic/claude-opus-4-8:high` | `openai-codex/gpt-5.6-sol:high` |
+| API backend implementation | `openai-codex/gpt-5.6-terra:high` | escalate to Sol only for cross-cutting, concurrency, or rebase failures |
+| Web implementation (normal) | `openai-codex/gpt-5.6-terra:high` | `:medium` allowed for tightly scoped changes; Sol escalation as above |
+| Mechanical UI / tests / docs / recon | `openai-codex/gpt-5.6-luna:medium` or `kimi-coding/k3:high` | Kimi preferred for broad reconnaissance/mechanical work when quality risk is low |
+| Release / review / rebase | `anthropic/claude-fable-5:high` | Opus for protocol/privacy review; `openai-codex/gpt-5.6-sol:high` as fallback |
+
+Notes:
+
+- **Sol is escalation, not the normal default.** Reach for it only after a
+  Terra/Fable attempt demonstrably fails on cross-cutting, concurrency, or rebase
+  work, or for protocol/privacy-critical review where the table says so.
+- Luna/Kimi tier is for low-risk mechanical work; never for protocol, auth, or
+  data-mutation code.
+
+## Provider headroom reserve
+
+Preserve provider headroom: if a provider's visible weekly remaining quota is below
+the documented reserve — **recommend 20%** — route ordinary new work to that row's
+fallback instead. Exceptions are allowed only for high-risk work (protocol/privacy,
+destructive-adjacent operations); when an exception is taken, report it to the user
+with the quota reading that justified it.
+
+## Overrides
+
+A user model override always wins — record it in the wave handoff so the root
+orchestrator and all children honor it for the whole wave.

--- a/.pi/skills/run-agent-orchestration/references/role-profiles.md
+++ b/.pi/skills/run-agent-orchestration/references/role-profiles.md
@@ -1,0 +1,80 @@
+# Role profiles (path-triggered, not personas)
+
+Do **not** create separate persistent frontend/backend/protocol personas. A role is
+selected per child task by the paths it will change, and the role-specific checklist
+below is injected into that child's handoff. The same child keeps its role for its
+whole session (including fix rounds); a new task with different paths gets a new role
+selection.
+
+## Selecting a role
+
+1. List the paths the task will touch.
+2. If all paths fall under one trigger, that role is primary.
+3. Mixed-path tasks use **one primary role** (the riskiest/most architectural area)
+   and explicitly attach the secondary roles' checklists to the same handoff.
+4. Split into multiple children only when ownership is genuinely independent
+   (disjoint files, separable verification, no shared migration/lockfile). Otherwise
+   one child with attached checklists beats two writers racing one checkout.
+
+## protocol-specialist
+
+Trigger: `packages/protocol/**` (and protocol-adjacent evals/skills under it).
+
+Highest architectural scrutiny. Checklist for the handoff:
+
+- Protocol layer stays fully self-contained — zero imports from the app; adapters
+  arrive via constructor injection through interfaces.
+- Graph/interface/schema/prompt purity: agents keep pure (no direct DB access), Zod
+  schemas for all agent I/O, `createModel()` from `model.config.ts`.
+- Privacy and provenance: no user-data leaks across scopes, no fabricated
+  attendance/membership inference in prompts, provenance metadata preserved.
+- Prompt-injection awareness for any text that crosses trust boundaries.
+- `@indexnetwork/protocol` package semver: bump `packages/protocol/package.json` per
+  SemVer when the package is touched; flag breaking changes explicitly.
+- Run the relevant `packages/protocol` eval harness or focused tests as verification.
+
+## api-backend
+
+Trigger: `services/api/**`.
+
+- Strict layering: controllers → services → adapters; controllers never import
+  adapters, services never import other services (use events, queues, shared lib).
+- Queues/events: BullMQ dedup/JobId semantics, retry/backoff, event emission after
+  DB transactions.
+- DB safety: migrations renamed + `_journal.json` tag updated, locking/idempotency on
+  write paths, soft deletes over hard deletes.
+- Tests: guarded, isolated, targeted files only (`bun test path/to/test.ts`); clean up
+  in `afterAll`; mock externals.
+- Consult the layer template files before adding controller/service/queue code.
+- API surface changes mean API semver and `docs/specs/` updates.
+
+## web-frontend
+
+Trigger: `apps/web/**`.
+
+- React 19 state/hydration correctness; no server-only assumptions in client bundles.
+- Auth expiry and session handling on every new fetch path.
+- Lazy routes stay lazy; question/chat surfaces (`InjectedQuestions`, SSE) keep their
+  conversation-scoping invariants.
+- Accessibility on new interactive elements.
+- Verification: focused tests plus `bun run build` (catches route/type regressions).
+- Web package semver when the package is versioned.
+
+## release-review
+
+Trigger: release prep, rebase/conflict resolution, cross-package compatibility,
+deploy verification. This role does **no source implementation** unless a fix handoff
+is explicitly issued.
+
+- Rebase/conflict review: every conflict resolution re-verified against intent.
+- Root `bun.lock` freshness (`--frozen-lockfile` parity with prod builds) and Drizzle
+  migration safety (destructive migrations need the operational backfill verified).
+- Cross-package compatibility: protocol/cli version bumps coherent with consumers.
+- GitHub checks green; Railway terminal/deployment verification per `finish-pr` and
+  `verify-production-release`.
+
+## Attaching secondary checklists
+
+When attaching, copy only the checklist bullets of the secondary role into the
+handoff under an "Also applies:" heading, and state which role is primary and why.
+The primary role owns architectural judgment calls.

--- a/.pi/skills/run-worktree-session/SKILL.md
+++ b/.pi/skills/run-worktree-session/SKILL.md
@@ -146,7 +146,8 @@ After verification succeeds, the visible Pi:
 
 Opening a PR is not merge approval. The coordinator's `finish-pr` workflow owns
 readiness, explicit merge confirmation, deployment verification, issue updates, and
-cleanup.
+cleanup — including closing this Herdr workspace (by verified ID, never the canonical
+root) before removing the Git worktree, so no stale sidebar entry survives.
 
 ## 6. Reuse for fix rounds
 

--- a/.pi/skills/run-worktree-session/SKILL.md
+++ b/.pi/skills/run-worktree-session/SKILL.md
@@ -27,8 +27,14 @@ The installed CLI contract is:
 
 ```bash
 herdr worktree open --path "$WORKTREE" --label "$FOLDER" --focus --json
-herdr agent start "$FOLDER" --kind pi --pane "$PANE_ID"
+herdr agent start "$AGENT_ALIAS" --kind pi --pane "$PANE_ID"
+# optional preselected model/thinking at launch:
+herdr agent start "$AGENT_ALIAS" --kind pi --pane "$PANE_ID" -- --model provider/model:thinking
 ```
+
+`AGENT_ALIAS` defaults to the dashed folder but must fit Herdr's live-name limit
+`[a-z][a-z0-9_-]{0,31}`; shorten it when the folder is longer (the workspace label
+stays the full dashed folder).
 
 Capture the returned workspace and pane IDs. Reuse the existing workspace/Pi when
 Herdr reports the worktree is already open. Reject a cwd, branch, workspace, pane, or
@@ -52,32 +58,40 @@ herdr agent get "$AGENT_NAME"
 herdr agent read "$AGENT_NAME" --source recent-unwrapped --lines 200
 ```
 
-Send the full handoff as one prompt only when the agent is ready and no structured
-question or editor draft is active:
+Send the full handoff as one atomic prompt only when the agent is ready and no
+structured question or editor draft is active. `--wait` submits and waits in one call
+for the first settled `idle`, `done`, or `blocked` state:
 
 ```bash
-herdr agent prompt "$AGENT_NAME" "$(< /absolute/path/to/handoff.md)"
+herdr agent prompt "$AGENT_NAME" "$(< /absolute/path/to/handoff.md)" --wait
 ```
 
 Do not commit task-specific handoff files under `.pi`.
 
-## 3. Poll directly from the coordinator
+## 3. Wait event-driven from the coordinator
 
-The coordinator stays active while implementation runs. Poll the same visible agent;
-do not delegate observation to a background watcher:
+The coordinator stays active while implementation runs and waits on the same visible
+agent. **`sleep` polling is banned** — Herdr waits are server-owned and event-driven,
+and `sleep` both wastes wall-clock and hides `blocked` states. Do not delegate
+observation to a background watcher process or watcher pane.
+
+`agent prompt --wait` usually carries the whole turn. When a follow-up wait is needed
+(after a timeout checkpoint or a resolved question), poll directly:
 
 ```bash
 herdr agent get "$AGENT_NAME"
 herdr agent read "$AGENT_NAME" --source recent-unwrapped --lines 200
-herdr agent wait "$AGENT_NAME" \
-  --until blocked --until idle --until done \
-  --timeout 30000
+herdr agent wait "$AGENT_NAME" --timeout 30000
 ```
 
 A wait timeout is a polling checkpoint, not a failure. Read new output, handle any
-question, and continue polling until the agent reports completion or a real blocker.
+question, and wait again until the agent reports completion or a real blocker.
 Ground decisions in the visible output rather than assuming that `working`, `idle`, or
-`done` alone proves success.
+`done` alone proves success — `idle` and `done` are both settled states, and a settled
+state still requires transcript and git/PR/test verification.
+
+For parallel agents, issue multiple `herdr agent prompt NAME "..." --wait` (or
+`agent wait`) tool calls in one turn so the server-owned waits run concurrently.
 
 ## 4. Answer questions safely
 
@@ -95,9 +109,10 @@ Escalate to the user only for:
 
 Never infer merge approval.
 
-If a structured question, selector, or editor draft is active, do **not** use
-`herdr agent prompt`: it can append text to stale input. Read the pane, then answer the
-active UI through its pane ID with targeted text/keys:
+`agent prompt --wait` and `agent wait` return `blocked` when Herdr recognizes an
+approval or question UI. If a structured question, selector, or editor draft is
+active, do **not** use `herdr agent prompt`: it can append text to stale input. Read
+the pane, then answer the active UI through its pane ID with targeted text/keys:
 
 ```bash
 herdr pane read "$PANE_ID" --source visible --lines 120
@@ -147,5 +162,7 @@ agents mutate one checkout.
 ## See also
 
 - `create-worktree` — branch, setup, Herdr-open, and collision contracts.
+- `run-agent-orchestration` — multi-task waves, role profiles, model routing, and the
+  full blocked-question escalation ladder across agents.
 - `address-code-review` — factual thread inspection and visible fix-loop workflow.
 - `finish-pr` — merge approval and post-merge operations.


### PR DESCRIPTION
## Documentation

Captures the project's new hierarchical Herdr orchestration workflow as project-local Pi skills, following the `learn-skill` capture workflow (dedup check, modularization audit, focused + repo-wide validation).

### New: `run-agent-orchestration`

Lean `SKILL.md` (86 body lines) plus three on-demand references:

- **Topology** — the main agent stays user-facing and delegates a multi-task/multi-PR wave to **exactly one** visible Herdr root orchestrator in the canonical root (`/Users/yanek/Projects/index`, branch `dev`). The root orchestrator solely owns worktree creation, child handoffs, PR finishing, GitHub/Linear/Railway coordination, and cleanup; it never edits source in the canonical root.
- **`references/role-profiles.md`** — path-triggered roles injected as handoff checklists instead of persistent personas: `protocol-specialist` (`packages/protocol/**`, highest scrutiny), `api-backend` (`services/api/**`), `web-frontend` (`apps/web/**`), `release-review` (rebase/lockfile/migration/deploy verification, no implementation). Mixed-path tasks take one primary role plus attached secondary checklists; split only on genuinely independent ownership.
- **`references/model-routing.md`** — launch-time-only model selection (no mid-implementation switches). Balanced routing: root orchestrator `claude-fable-5:high`; protocol/privacy `claude-opus-4-8:high`; backend/web `gpt-5.6-terra:high` (Sol escalation only); mechanical/recon `gpt-5.6-luna:medium` or `kimi-coding/k3:high`; release/review `claude-fable-5:high`. **GPT-5.5 banned.** 20% provider weekly-quota reserve with reported high-risk exceptions; user override always wins; routing is deterministic on visible footer state (no brittle quota-UI parsing extension yet).
- **`references/completion-and-questions.md`** — event-driven Herdr semantics sourced from the official docs: atomic `agent prompt --wait` (idle/done/blocked), **explicit `sleep`-polling ban**, parallel waits via multiple `prompt --wait` calls in one turn (no watcher processes/panes), settled-state ≠ success (transcript + git/PR/test verification), child structured result envelope with alternate-screen report-file fallback, and the blocked structured-question escalation ladder: pane-targeted answers for routine choices, root re-raises genuine ambiguity with its own `ask_user_question` so it propagates safely to the user. Never infer merge approval.

### Surgical updates to existing skills

- **`create-worktree`** — documents Herdr's 32-char live agent-name limit (`[a-z][a-z0-9_-]{0,31}`) with a short alias independent from the dashed workspace label, and the optional preselected `-- --model provider/model:thinking` launch syntax.
- **`run-worktree-session`** — replaces prompt-then-poll guidance with atomic `agent prompt --wait`, bans `sleep`, documents concurrent server-owned waits for parallel agents and the `blocked` structured-question flow; preserves direct coordinator polling for follow-up waits.
- **`finish-pr`** (`references/post-merge-operations.md`) — the cleanup procedure now closes the finished worktree's exact Herdr workspace (verified by recorded workspace ID via `herdr workspace get` → `herdr workspace close` → confirmed gone from `herdr workspace list`) **before** `git worktree remove`. This stops the Pi/terminal and removes the sidebar entry — preventing the empirically observed stale-sidebar state where five merged PRs had their Git worktrees removed but their Herdr workspaces/idle agents stayed visible. Ambiguous identity or a failed close stops the procedure with a report; the canonical root workspace is never closed.
- **`run-agent-orchestration`** also carries a wave-cleanup invariant: every finished PR closes its child workspace + removes its worktree; the post-wave sweep verifies no finished child workspaces/agents remain without touching unrelated active workspaces; the root orchestrator workspace is kept (user-facing coordination plane) unless the user explicitly ends the wave.
- All touched skills cross-link to `run-agent-orchestration` (and vice versa, plus `address-code-review`/`finish-pr`).

No `CLAUDE.md` edit: reviewed for duplication/contradiction — the new content refines (does not contradict) the existing Herdr sections. No package version bump: project workflow/skill docs only.

### Sources

Herdr semantics verified against https://herdr.dev/docs/agent-automation/, https://herdr.dev/docs/cli-reference/, https://herdr.dev/docs/socket-api/, and the official `herdr` SKILL.md (`agent prompt --wait` atomicity and default settled states, server-owned waits, 32-char name limit, `done` = unseen idle, alternate-screen caveat and report-file fallback).

## Tests

- `bun .pi/skills/learn-skill/scripts/skillctl.ts audit run-agent-orchestration` → 95 lines, ok; no duplicate blocks ≥4 lines
- `skillctl.ts validate` on all touched skills (`run-agent-orchestration`, `create-worktree`, `run-worktree-session`, `finish-pr`) → OK
- `bun run skills:validate` → all skills OK
- `bun run test:scripts` → 37 pass, 0 fail
