### PR TITLE
feat(chat): add durable session sections

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -160,6 +160,8 @@ OPENROUTER_API_KEY=your-openrouter-api-key
 # REPORTER_BRIEFING_TTL_MS=86400000         # Lazy opening-briefing lifetime (IND-484), measured from session creation rather
                                            # than follow-up activity. Positive whole milliseconds; defaults to 24 hours.
                                            # Expired reporter sessions remain readable in ordinary web history.
+# CHAT_SESSION_GAP_MS=86400000              # Strict inactivity gap that opens a new durable H2A/H2H conversation session.
+                                           # Positive whole milliseconds; defaults to 24 hours. A2A sessions always follow task runs.
 # WEB_AGENT_ACTIONS_ENABLED=false          # IND-490 PR1: owner-confirmed reporter cleanup-action proposals. Effective only
                                            # when WEB_AGENT_SURFACE_ENABLED is true; confirm endpoint is session-only.
                                            # Default off; ship dark first. Do not flip on Railway in this PR.

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@indexnetwork/web",
-  "version": "0.28.1",
+  "version": "0.28.2",
   "license": "MIT",
   "scripts": {
     "dev": "vite --host 127.0.0.1",

--- a/apps/web/src/app/chat/[conversationId]/page.tsx
+++ b/apps/web/src/app/chat/[conversationId]/page.tsx
@@ -13,21 +13,22 @@ export default function NegotiationDetailPage() {
   const { conversationId } = useParams();
   const navigate = useNavigate();
   const { user } = useAuthContext();
-  const { negotiations, messages, loadMessages } = useConversation();
+  const { negotiations, messages, loadSessionHistory, loadPreviousSessionMessages, sessionHistory } = useConversation();
   const [loading, setLoading] = useState(true);
   const messagesEndRef = useRef<HTMLDivElement>(null);
 
   const conversation = negotiations.find((c) => c.id === conversationId);
   const conversationMessages = useMemo(() => messages.get(conversationId!) ?? [], [messages, conversationId]);
+  const history = conversationId ? sessionHistory.get(conversationId) : undefined;
 
   useEffect(() => {
     if (!conversationId) return;
     let cancelled = false;
-    loadMessages(conversationId, { limit: 100 }).finally(() => {
+    loadSessionHistory(conversationId).finally(() => {
       if (!cancelled) setLoading(false);
     });
     return () => { cancelled = true; };
-  }, [conversationId, loadMessages]);
+  }, [conversationId, loadSessionHistory]);
 
   useEffect(() => {
     messagesEndRef.current?.scrollIntoView({ behavior: 'smooth' });
@@ -76,6 +77,19 @@ export default function NegotiationDetailPage() {
       <div className="px-6 lg:px-8 pb-32 flex-1">
         <ContentContainer>
           <div className="space-y-4">
+            {history?.hasPreviousSession && conversationId && (
+              <div className="flex justify-center py-2">
+                <button
+                  type="button"
+                  onClick={() => void loadPreviousSessionMessages(conversationId)}
+                  disabled={history.loadingPrevious}
+                  className="rounded-full border border-gray-200 bg-white px-3 py-1.5 text-xs font-ibm-plex-mono text-gray-600 hover:bg-gray-50 disabled:cursor-wait disabled:opacity-60"
+                  aria-label="Load previous messages"
+                >
+                  {history.loadingPrevious ? 'Loading previous messages…' : 'Load Previous Messages'}
+                </button>
+              </div>
+            )}
             {loading ? (
               <div className="flex items-center justify-center py-20">
                 <Loader2 className="w-6 h-6 animate-spin text-gray-400" />
@@ -89,6 +103,8 @@ export default function NegotiationDetailPage() {
             {conversationMessages.map((message, index) => {
               const isOwn = message.senderId === ownAgentId;
               const info = participantInfo.get(message.senderId);
+              const previousMessage = conversationMessages[index - 1];
+              const startsSession = previousMessage !== undefined && previousMessage.sessionId !== message.sessionId;
 
               // Extract text content from message parts — use `message` field from data part, or text part
               const parts = message.parts as { kind?: string; text?: string; data?: { message?: string; assessment?: { reasoning?: string } } }[];
@@ -100,11 +116,17 @@ export default function NegotiationDetailPage() {
               const isInternal = !messageText && !!reasoningText;
               if (!content.trim()) return null;
 
-              const prevMessage = conversationMessages[index - 1];
-              const showTimestamp = index === 0 || (prevMessage && new Date(message.createdAt).getTime() - new Date(prevMessage.createdAt).getTime() > 300_000);
+              const showTimestamp = index === 0 || (previousMessage && new Date(message.createdAt).getTime() - new Date(previousMessage.createdAt).getTime() > 300_000);
 
               return (
                 <div key={message.id}>
+                  {startsSession && (
+                    <div className="flex items-center gap-3 py-3" role="separator" aria-label="Earlier chat session">
+                      <span className="h-px flex-1 bg-gray-200" />
+                      <span className="text-[10px] font-ibm-plex-mono uppercase tracking-[0.12em] text-gray-400">Earlier conversation</span>
+                      <span className="h-px flex-1 bg-gray-200" />
+                    </div>
+                  )}
                   {showTimestamp && message.createdAt && (
                     <div className="text-center text-xs text-gray-400 uppercase tracking-wider my-4">
                       {(() => {

--- a/apps/web/src/components/ChatContent.tsx
+++ b/apps/web/src/components/ChatContent.tsx
@@ -77,6 +77,9 @@ export default function ChatContent({
     clearChat,
     startSignalSession,
     loadSession,
+    loadPreviousMessages,
+    hasPreviousSession,
+    isLoadingPreviousMessages,
     sessionLoadState,
     isSessionReady,
     sessionId,
@@ -1350,8 +1353,28 @@ export default function ChatContent({
       <div className="px-6 lg:px-8 pb-32 flex-1">
         <ContentContainer>
           <div className="space-y-4">
-            {messages.map((msg) => (
+            {hasPreviousSession && (
+              <div className="flex justify-center py-2">
+                <button
+                  type="button"
+                  onClick={() => void loadPreviousMessages()}
+                  disabled={isLoadingPreviousMessages}
+                  className="rounded-full border border-gray-200 bg-white px-3 py-1.5 text-xs font-ibm-plex-mono text-gray-600 hover:bg-gray-50 disabled:cursor-wait disabled:opacity-60"
+                  aria-label="Load previous messages"
+                >
+                  {isLoadingPreviousMessages ? "Loading previous messages…" : "Load Previous Messages"}
+                </button>
+              </div>
+            )}
+            {messages.map((msg, index) => (
               <div key={msg.id}>
+                {index > 0 && msg.conversationSessionId !== messages[index - 1]?.conversationSessionId && (
+                  <div className="flex items-center gap-3 py-3" role="separator" aria-label="Earlier chat session">
+                    <span className="h-px flex-1 bg-gray-200" />
+                    <span className="text-[10px] font-ibm-plex-mono uppercase tracking-[0.12em] text-gray-400">Earlier conversation</span>
+                    <span className="h-px flex-1 bg-gray-200" />
+                  </div>
+                )}
                 <div
                   className={cn(
                     "flex",

--- a/apps/web/src/components/IntentNegotiatorChat.tsx
+++ b/apps/web/src/components/IntentNegotiatorChat.tsx
@@ -90,6 +90,9 @@ export default function IntentNegotiatorChat({
     sendMessage,
     stopStream,
     loadSession,
+    loadPreviousMessages,
+    hasPreviousSession,
+    isLoadingPreviousMessages,
     clearChat,
     sessionId,
   } = useAIChat();
@@ -250,6 +253,19 @@ export default function IntentNegotiatorChat({
           </div>
         ) : (
           <>
+            {hasPreviousSession && (
+              <div className="flex justify-center py-2">
+                <button
+                  type="button"
+                  onClick={() => void loadPreviousMessages()}
+                  disabled={isLoadingPreviousMessages}
+                  className="rounded-full border border-gray-200 bg-white px-3 py-1.5 text-xs font-ibm-plex-mono text-gray-600 hover:bg-gray-50 disabled:cursor-wait disabled:opacity-60"
+                  aria-label="Load previous messages"
+                >
+                  {isLoadingPreviousMessages ? "Loading previous messages…" : "Load Previous Messages"}
+                </button>
+              </div>
+            )}
             {messages.length === 0 && (answered.length > 0 || questions.length === 0) && (
               <div className="flex flex-col gap-3">
                 <div className="flex items-start gap-2 text-sm text-gray-600 font-ibm-plex-mono">
@@ -281,10 +297,21 @@ export default function IntentNegotiatorChat({
               }
 
               const msg = item.message;
+              const messageIndex = messages.findIndex((message) => message.id === msg.id);
+              const previousMessage = messageIndex > 0 ? messages[messageIndex - 1] : undefined;
+              const startsSession = previousMessage !== undefined
+                && previousMessage.conversationSessionId !== msg.conversationSessionId;
               const anchoredAnswered = questionTimeline.answeredByMessageId.get(msg.id) ?? [];
               const anchoredPending = questionTimeline.pendingByMessageId.get(msg.id) ?? [];
               return (
                 <Fragment key={`message-${msg.id}`}>
+                  {startsSession && (
+                    <div className="flex items-center gap-3 py-3" role="separator" aria-label="Earlier chat session">
+                      <span className="h-px flex-1 bg-gray-200" />
+                      <span className="text-[10px] font-ibm-plex-mono uppercase tracking-[0.12em] text-gray-400">Earlier conversation</span>
+                      <span className="h-px flex-1 bg-gray-200" />
+                    </div>
+                  )}
                   {msg.role === "user" ? (
                     <div className="flex justify-end">
                       <div className="max-w-[85%] rounded-2xl rounded-br-md bg-[#041729] px-4 py-2 text-sm text-white whitespace-pre-wrap">

--- a/apps/web/src/components/chat/ChatView.tsx
+++ b/apps/web/src/components/chat/ChatView.tsx
@@ -40,7 +40,9 @@ export default function ChatView({ userId, userName, userAvatar, isGhost = false
     messages: allMessages,
     conversations,
     sendMessage: conversationSend,
-    loadMessages,
+    loadSessionHistory,
+    loadPreviousSessionMessages,
+    sessionHistory,
     getOrCreateDM,
     markConversationRead,
     hideConversation,
@@ -81,6 +83,7 @@ export default function ChatView({ userId, userName, userAvatar, isGhost = false
   );
   const via = conversationSummary?.via ?? [];
   const latestVia = via[0] ?? null;
+  const history = conversationId ? sessionHistory.get(conversationId) : undefined;
 
   useEffect(() => {
     if (!conversationId) return;
@@ -118,13 +121,13 @@ export default function ChatView({ userId, userName, userAvatar, isGhost = false
   useEffect(() => {
     const cid = initialGroupId ?? conversationId;
     if (cid) {
-      loadMessages(cid, { limit: 50 }).finally(() => setMessagesLoading(false));
+      loadSessionHistory(cid).finally(() => setMessagesLoading(false));
     } else {
       // No conversation yet: clear the initial loading state via microtask
       // to satisfy react-hooks/set-state-in-effect.
       queueMicrotask(() => setMessagesLoading(false));
     }
-  }, [initialGroupId, conversationId, loadMessages]);
+  }, [initialGroupId, conversationId, loadSessionHistory]);
 
   // Get or create DM conversation
   useEffect(() => {
@@ -175,7 +178,7 @@ export default function ChatView({ userId, userName, userAvatar, isGhost = false
           const conv = await getOrCreateDM(userId);
           setConversationId(conv.id);
           await conversationSend(conv.id, [{ text }]);
-          loadMessages(conv.id, { limit: 50 });
+          loadSessionHistory(conv.id);
         }
         if (!hasFiredFirstMessageRef.current) {
           hasFiredFirstMessageRef.current = true;
@@ -188,7 +191,7 @@ export default function ChatView({ userId, userName, userAvatar, isGhost = false
         setSending(false);
       }
     })();
-  }, [autoSend, contextLoading, conversationId, initialMessage, conversationSend, getOrCreateDM, userId, loadMessages, onFirstMessageSent]);
+  }, [autoSend, contextLoading, conversationId, initialMessage, conversationSend, getOrCreateDM, userId, loadSessionHistory, onFirstMessageSent]);
 
   const handleSend = useCallback(async () => {
     if (!messageText.trim() || sending) return;
@@ -202,7 +205,7 @@ export default function ChatView({ userId, userName, userAvatar, isGhost = false
         const conv = await getOrCreateDM(userId);
         setConversationId(conv.id);
         await conversationSend(conv.id, [{ text }]);
-        loadMessages(conv.id, { limit: 50 });
+        loadSessionHistory(conv.id);
       }
       if (!hasFiredFirstMessageRef.current) {
         hasFiredFirstMessageRef.current = true;
@@ -215,7 +218,7 @@ export default function ChatView({ userId, userName, userAvatar, isGhost = false
     } finally {
       setSending(false);
     }
-  }, [conversationId, userId, messageText, sending, conversationSend, getOrCreateDM, loadMessages, onFirstMessageSent]);
+  }, [conversationId, userId, messageText, sending, conversationSend, getOrCreateDM, loadSessionHistory, onFirstMessageSent]);
 
   const handleKeyPress = useCallback((e: React.KeyboardEvent) => {
     if (e.key === 'Enter' && !e.shiftKey) { e.preventDefault(); handleSend(); }
@@ -303,6 +306,19 @@ export default function ChatView({ userId, userName, userAvatar, isGhost = false
       <div className="px-6 lg:px-8 pb-32 flex-1">
         <ContentContainer>
           <div className="space-y-4">
+            {history?.hasPreviousSession && conversationId && (
+              <div className="flex justify-center py-2">
+                <button
+                  type="button"
+                  onClick={() => void loadPreviousSessionMessages(conversationId)}
+                  disabled={history.loadingPrevious}
+                  className="rounded-full border border-gray-200 bg-white px-3 py-1.5 text-xs font-ibm-plex-mono text-gray-600 hover:bg-gray-50 disabled:cursor-wait disabled:opacity-60"
+                  aria-label="Load previous messages"
+                >
+                  {history.loadingPrevious ? 'Loading previous messages…' : 'Load Previous Messages'}
+                </button>
+              </div>
+            )}
             {messagesLoading ? (
               <div className="flex items-center justify-center py-20"><Loader2 className="w-6 h-6 animate-spin text-gray-400" /></div>
             ) : messages.length === 0 && via.length > 0 ? (
@@ -349,6 +365,8 @@ export default function ChatView({ userId, userName, userAvatar, isGhost = false
                 }
 
                 const message = item.message;
+                const previousMessage = [...timeline.slice(0, index)].reverse().find((candidate) => candidate.type === 'message')?.message;
+                const startsSession = previousMessage !== undefined && previousMessage.sessionId !== message.sessionId;
                 const isOwn = message.senderId === user?.id;
                 const textPart = (message.parts as { text?: string }[] | undefined)?.find((p) => p.text)?.text;
                 const content = textPart ?? '';
@@ -356,6 +374,13 @@ export default function ChatView({ userId, userName, userAvatar, isGhost = false
 
                 return (
                   <div key={message.id}>
+                    {startsSession && (
+                      <div className="flex items-center gap-3 py-3" role="separator" aria-label="Earlier chat session">
+                        <span className="h-px flex-1 bg-gray-200" />
+                        <span className="text-[10px] font-ibm-plex-mono uppercase tracking-[0.12em] text-gray-400">Earlier conversation</span>
+                        <span className="h-px flex-1 bg-gray-200" />
+                      </div>
+                    )}
                     {showTimestamp && message.createdAt && (
                       <div className="text-center text-xs text-gray-400 uppercase tracking-wider my-4">
                         {`${formatChatDayLabel(message.createdAt)}, ${formatTime(message.createdAt)}`}

--- a/apps/web/src/contexts/AIChatContext.tsx
+++ b/apps/web/src/contexts/AIChatContext.tsx
@@ -1102,44 +1102,33 @@ export function AIChatProvider({ children }: { children: React.ReactNode }) {
                     break;
                   }
                   case "user_question": {
-                    // The orchestrator persisted chat-mode questions and is now
-                    // blocking the turn on them. Shape them like the REST
-                    // PendingQuestion so ChatContent can reuse InjectedQuestions.
+                    // `user_question` carries opaque IDs only. Resolve cards
+                    // through the conversation-scoped canonical read so model
+                    // output can never forge question content or provenance.
                     const eventSessionId =
                       (typeof event.sessionId === "string" && event.sessionId) ||
                       newSessionId ||
                       sessionId ||
                       "";
-                    const incoming: PendingQuestion[] = (event.questions ?? []).map(
-                      (q: { id: string; title: string; prompt: string; options: Array<{ label: string; description: string }>; multiSelect: boolean }) => ({
-                        id: q.id,
-                        detection: {
-                          mode: "chat" as const,
-                          sourceType: "conversation",
-                          sourceId: eventSessionId,
-                          timestamp: new Date().toISOString(),
-                        },
-                        actors: [],
-                        payload: {
-                          title: q.title,
-                          prompt: q.prompt,
-                          options: q.options,
-                          multiSelect: q.multiSelect,
-                        },
-                        status: "pending" as const,
-                        answer: null,
-                        expiresAt: null,
-                        createdAt: new Date().toISOString(),
-                        conversationId: eventSessionId || null,
-                      }),
+                    const requestedIds = new Set(
+                      (event.questions ?? [])
+                        .map((question: { id?: unknown }) => question.id)
+                        .filter((id): id is string => typeof id === "string"),
                     );
-                    if (incoming.length > 0) {
-                      setLiveQuestions((prev) => {
-                        const byId = new Map(prev.map((q) => [q.id, q]));
-                        for (const q of incoming) byId.set(q.id, q);
+                    if (!eventSessionId || requestedIds.size === 0) break;
+                    void apiClient.get<{ questions: PendingQuestion[] }>(
+                      `/questions?conversationId=${encodeURIComponent(eventSessionId)}&mode=chat`,
+                    ).then(({ questions }) => {
+                      const incoming = questions.filter((question) => requestedIds.has(question.id));
+                      if (incoming.length === 0) return;
+                      setLiveQuestions((previous) => {
+                        const byId = new Map(previous.map((question) => [question.id, question]));
+                        for (const question of incoming) byId.set(question.id, question);
                         return [...byId.values()];
                       });
-                    }
+                    }).catch((error: unknown) => {
+                      logger.error("Failed to resolve streamed chat question", { error, eventSessionId });
+                    });
                     break;
                   }
                   case "decision_questions": {

--- a/apps/web/src/contexts/AIChatContext.tsx
+++ b/apps/web/src/contexts/AIChatContext.tsx
@@ -156,6 +156,8 @@ interface ChatMessage {
   isPending?: boolean;
   isQueued?: boolean;
   wasInterrupted?: boolean;
+  /** Durable timeline session that supplied this persisted message. */
+  conversationSessionId?: string | null;
 }
 
 export type ChatScope =
@@ -234,6 +236,12 @@ interface AIChatContextType {
   startReporterSession: (options?: { forceNew?: boolean }) => Promise<boolean>;
   /** Load a session, returning false for failed or superseded requests. */
   loadSession: (sessionId: string) => Promise<boolean>;
+  /** Load exactly one earlier durable timeline session into display history. */
+  loadPreviousMessages: () => Promise<void>;
+  /** Whether a durable session exists before the oldest loaded section. */
+  hasPreviousSession: boolean;
+  /** True while an earlier section is being fetched. */
+  isLoadingPreviousMessages: boolean;
   /** Observable target-specific load state for disabling route interactions until ready. */
   sessionLoadState: ChatSessionLoadState;
   isSessionReady: (sessionId: string) => boolean;
@@ -383,6 +391,9 @@ export function AIChatProvider({ children }: { children: React.ReactNode }) {
 
   const [isOpen, setIsOpen] = useState(false);
   const [messages, setMessages] = useState<ChatMessage[]>([]);
+  const [hasPreviousSession, setHasPreviousSession] = useState(false);
+  const [previousSessionCursor, setPreviousSessionCursor] = useState<string | null>(null);
+  const [isLoadingPreviousMessages, setIsLoadingPreviousMessages] = useState(false);
   const [sessionId, setSessionId] = useState<string | null>(null);
   const [sessionTitle, setSessionTitle] = useState<string | null>(null);
   const [sessionPersona, setSessionPersona] = useState<string | null>(null);
@@ -1410,6 +1421,9 @@ export function AIChatProvider({ children }: { children: React.ReactNode }) {
     setIsLoading(false);
     setSessionLoadState({ status: "idle", targetSessionId: null, error: null });
     setMessages([]);
+    setHasPreviousSession(false);
+    setPreviousSessionCursor(null);
+    setIsLoadingPreviousMessages(false);
     setSuggestions([]);
     setLiveQuestions([]);
     setSessionId(null);
@@ -1444,6 +1458,9 @@ export function AIChatProvider({ children }: { children: React.ReactNode }) {
     setSessionScope(null);
     setSessionNetworkId(null);
     setMessages([]);
+    setHasPreviousSession(false);
+    setPreviousSessionCursor(null);
+    setIsLoadingPreviousMessages(false);
     setSuggestions([]);
     forcePersonaNextSessionRef.current = null;
 
@@ -1466,6 +1483,9 @@ export function AIChatProvider({ children }: { children: React.ReactNode }) {
           scopeType?: "network" | "intent" | null;
           scopeId?: string | null;
         };
+        sessionId: string | null;
+        hasPreviousSession: boolean;
+        previousSessionCursor: string | null;
         messages: Array<{
           id: string;
           role: string;
@@ -1518,6 +1538,7 @@ export function AIChatProvider({ children }: { children: React.ReactNode }) {
           : {}),
         ...(m.decisionQuestionsSubmitted ? { decisionQuestionsSubmitted: true } : {}),
         ...(m.interrupted ? { wasInterrupted: true } : {}),
+        conversationSessionId: data.sessionId,
       }));
 
       if (!ownsOperation(loadToken)) return false;
@@ -1527,6 +1548,8 @@ export function AIChatProvider({ children }: { children: React.ReactNode }) {
       setSessionScope(loadedScope);
       setSessionNetworkId(loadedScope?.type === "network" ? loadedScope.id : null);
       setMessages(loadedMessages);
+      setHasPreviousSession(data.hasPreviousSession);
+      setPreviousSessionCursor(data.previousSessionCursor);
       setSessionLoadState({ status: "ready", targetSessionId: id, error: null });
       operationOwnerRef.current = null;
       return true;
@@ -1539,6 +1562,72 @@ export function AIChatProvider({ children }: { children: React.ReactNode }) {
       return false;
     }
   }, [invalidateActiveSend, ownsOperation]);
+
+  const loadPreviousMessages = useCallback(async (): Promise<void> => {
+    if (!sessionId || !previousSessionCursor || !hasPreviousSession || isLoadingPreviousMessages) return;
+    setIsLoadingPreviousMessages(true);
+    try {
+      const data = await apiClient.post<{
+        sessionId: string | null;
+        hasPreviousSession: boolean;
+        previousSessionCursor: string | null;
+        messages: Array<{
+          id: string;
+          role: string;
+          content: string;
+          createdAt: string;
+          traceEvents?: TraceEvent[];
+          streamingDrafts?: StreamingDraft[] | null;
+          decisionQuestions?: Question[] | null;
+          decisionQuestionsSubmitted?: boolean | null;
+          interrupted?: boolean | null;
+          debugMeta?: {
+            tools?: Array<{
+              name: string;
+              steps?: ToolCallStep[];
+              graphs?: Array<{
+                name: string;
+                durationMs?: number;
+                agents?: Array<{ name: string; durationMs?: number }>;
+              }>;
+            }>;
+          } | null;
+        }>;
+      }>("/chat/web/session", { sessionId, beforeSessionId: previousSessionCursor });
+      if (!data.sessionId) return;
+      const loadedMessages: ChatMessage[] = data.messages.map((message) => ({
+        id: message.id,
+        role: message.role as "user" | "assistant",
+        content: message.content,
+        timestamp: new Date(message.createdAt),
+        isStreaming: false,
+        traceEvents: mergeDebugMetaIntoTraceEvents(message.traceEvents, message.debugMeta) ?? undefined,
+        ...(Array.isArray(message.streamingDrafts) && message.streamingDrafts.length > 0
+          ? { streamingDrafts: message.streamingDrafts }
+          : {}),
+        ...(Array.isArray(message.decisionQuestions) && message.decisionQuestions.length > 0
+          ? { decisionQuestions: message.decisionQuestions }
+          : {}),
+        ...(message.decisionQuestionsSubmitted ? { decisionQuestionsSubmitted: true } : {}),
+        ...(message.interrupted ? { wasInterrupted: true } : {}),
+        conversationSessionId: data.sessionId,
+      }));
+      setMessages((current) => {
+        const knownIds = new Set(current.map((message) => message.id));
+        const combined = [...loadedMessages.filter((message) => !knownIds.has(message.id)), ...current];
+        return combined.sort((left, right) => (
+          left.timestamp.getTime() - right.timestamp.getTime()
+          || left.id.localeCompare(right.id)
+        ));
+      });
+      setHasPreviousSession(data.hasPreviousSession);
+      setPreviousSessionCursor(data.previousSessionCursor);
+    } catch (error) {
+      logger.error("Load previous chat messages error", { error, sessionId });
+    } finally {
+      setIsLoadingPreviousMessages(false);
+    }
+  }, [hasPreviousSession, isLoadingPreviousMessages, previousSessionCursor, sessionId]);
 
   const startReporterSession = useCallback((options?: {
     forceNew?: boolean;
@@ -1645,6 +1734,9 @@ export function AIChatProvider({ children }: { children: React.ReactNode }) {
         startSignalSession,
         startReporterSession,
         loadSession,
+        loadPreviousMessages,
+        hasPreviousSession,
+        isLoadingPreviousMessages,
         sessionLoadState,
         isSessionReady,
         updateSessionTitle,

--- a/apps/web/src/contexts/ConversationContext.tsx
+++ b/apps/web/src/contexts/ConversationContext.tsx
@@ -10,12 +10,21 @@ const logger = log.context.from('ConversationContext');
 const PROTOCOL_BASE = import.meta.env.VITE_PROTOCOL_URL || '';
 const SSE_URL = `${PROTOCOL_BASE}/api/conversations/stream`;
 
+interface ConversationSessionHistoryState {
+  hasPreviousSession: boolean;
+  previousSessionCursor: string | null;
+  loadingPrevious: boolean;
+}
+
 interface ConversationContextType {
   conversations: ConversationSummary[];
   negotiations: ConversationSummary[];
   messages: Map<string, ConversationMessage[]>;
+  sessionHistory: Map<string, ConversationSessionHistoryState>;
   isConnected: boolean;
   loadMessages: (conversationId: string, opts?: { limit?: number; before?: string }) => Promise<void>;
+  loadSessionHistory: (conversationId: string, opts?: { taskId?: string; beforeSessionId?: string }) => Promise<void>;
+  loadPreviousSessionMessages: (conversationId: string, taskId?: string) => Promise<void>;
   sendMessage: (conversationId: string, parts: unknown[]) => Promise<ConversationMessage | null>;
   refreshConversations: () => Promise<void>;
   refreshNegotiations: () => Promise<void>;
@@ -34,6 +43,7 @@ export function ConversationProvider({ children }: { children: React.ReactNode }
   const [conversations, setConversations] = useState<ConversationSummary[]>([]);
   const [negotiations, setNegotiations] = useState<ConversationSummary[]>([]);
   const [messages, setMessages] = useState<Map<string, ConversationMessage[]>>(new Map());
+  const [sessionHistory, setSessionHistory] = useState<Map<string, ConversationSessionHistoryState>>(new Map());
   const [isConnected, setIsConnected] = useState(false);
   const eventSourceRef = useRef<EventSource | null>(null);
   const retryTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
@@ -90,6 +100,67 @@ export function ConversationProvider({ children }: { children: React.ReactNode }
       logger.error('Failed to load messages', { error: err });
     }
   }, []);
+
+  const loadSessionHistory = useCallback(async (
+    conversationId: string,
+    opts?: { taskId?: string; beforeSessionId?: string },
+  ) => {
+    try {
+      const params = new URLSearchParams({ sessionHistory: 'true' });
+      if (opts?.taskId) params.set('taskId', opts.taskId);
+      if (opts?.beforeSessionId) params.set('beforeSessionId', opts.beforeSessionId);
+      const data = await apiClient.get<{
+        messages: ConversationMessage[];
+        sessionId: string | null;
+        hasPreviousSession: boolean;
+        previousSessionCursor: string | null;
+      }>(`/conversations/${conversationId}/messages?${params.toString()}`);
+      setMessages((previous) => {
+        const next = new Map(previous);
+        const existing = next.get(conversationId) ?? [];
+        const received = data.messages.map((message) => ({ ...message, sessionId: data.sessionId }));
+        if (!opts?.beforeSessionId) {
+          next.set(conversationId, received);
+          return next;
+        }
+        const knownIds = new Set(existing.map((message) => message.id));
+        next.set(conversationId, [...received.filter((message) => !knownIds.has(message.id)), ...existing].sort((left, right) => (
+          new Date(left.createdAt).getTime() - new Date(right.createdAt).getTime()
+          || left.id.localeCompare(right.id)
+        )));
+        return next;
+      });
+      setSessionHistory((previous) => {
+        const next = new Map(previous);
+        next.set(conversationId, {
+          hasPreviousSession: data.hasPreviousSession,
+          previousSessionCursor: data.previousSessionCursor,
+          loadingPrevious: false,
+        });
+        return next;
+      });
+    } catch (error) {
+      logger.error('Failed to load conversation session history', { error, conversationId });
+      setSessionHistory((previous) => {
+        const next = new Map(previous);
+        const current = next.get(conversationId);
+        if (current) next.set(conversationId, { ...current, loadingPrevious: false });
+        return next;
+      });
+    }
+  }, []);
+
+  const loadPreviousSessionMessages = useCallback(async (conversationId: string, taskId?: string) => {
+    const current = sessionHistory.get(conversationId);
+    if (!current?.hasPreviousSession || !current.previousSessionCursor || current.loadingPrevious) return;
+    setSessionHistory((previous) => {
+      const next = new Map(previous);
+      const history = next.get(conversationId);
+      if (history) next.set(conversationId, { ...history, loadingPrevious: true });
+      return next;
+    });
+    await loadSessionHistory(conversationId, { taskId, beforeSessionId: current.previousSessionCursor });
+  }, [loadSessionHistory, sessionHistory]);
 
   const sendMessage = useCallback(async (conversationId: string, parts: unknown[]): Promise<ConversationMessage | null> => {
     if (!user?.id) {
@@ -188,6 +259,11 @@ export function ConversationProvider({ children }: { children: React.ReactNode }
       await apiClient.delete(`/conversations/${conversationId}`);
       setConversations((prev) => prev.filter((c) => c.id !== conversationId));
       setMessages((prev) => {
+        const next = new Map(prev);
+        next.delete(conversationId);
+        return next;
+      });
+      setSessionHistory((prev) => {
         const next = new Map(prev);
         next.delete(conversationId);
         return next;
@@ -322,6 +398,7 @@ export function ConversationProvider({ children }: { children: React.ReactNode }
       setIsConnected(false);
       setConversations([]);
       setMessages(new Map());
+      setSessionHistory(new Map());
       return;
     }
 
@@ -348,8 +425,11 @@ export function ConversationProvider({ children }: { children: React.ReactNode }
         conversations,
         negotiations,
         messages,
+        sessionHistory,
         isConnected,
         loadMessages,
+        loadSessionHistory,
+        loadPreviousSessionMessages,
         sendMessage,
         refreshConversations,
         refreshNegotiations,

--- a/apps/web/src/services/conversation.ts
+++ b/apps/web/src/services/conversation.ts
@@ -20,6 +20,8 @@ export interface ConversationMessage {
   conversationId: string;
   senderId: string;
   role: 'user' | 'agent';
+  /** Durable conversation-session binding for sectioned history reads. */
+  sessionId?: string | null;
   parts: unknown[];
   metadata?: Record<string, unknown>;
   createdAt: string;

--- a/apps/web/tests/intent-negotiator-chat.test.tsx
+++ b/apps/web/tests/intent-negotiator-chat.test.tsx
@@ -27,6 +27,9 @@ const mocks = vi.hoisted(() => ({
     sendOnboardingMessage: vi.fn(),
     stopStream: vi.fn(),
     loadSession: vi.fn().mockResolvedValue(undefined),
+    loadPreviousMessages: vi.fn(),
+    hasPreviousSession: false,
+    isLoadingPreviousMessages: false,
     clearChat: vi.fn(),
   },
 }));
@@ -124,6 +127,8 @@ describe('IntentNegotiatorChat', () => {
     mocks.chat.messages = [];
     mocks.chat.isLoading = false;
     mocks.chat.sessionId = null;
+    mocks.chat.hasPreviousSession = false;
+    mocks.chat.isLoadingPreviousMessages = false;
     mocks.chat.loadSession.mockResolvedValue(undefined);
     mocks.apiClient.post.mockResolvedValue(SESSION_RESPONSE);
   });
@@ -154,6 +159,15 @@ describe('IntentNegotiatorChat', () => {
     const divider = await screen.findByTestId('negotiator-restored-history-divider');
     expect(divider).toHaveTextContent('earlier conversation');
     expect(divider).toHaveTextContent('may not reflect current signal state');
+  });
+
+  test('loads the previous durable session from the negotiator timeline', async () => {
+    mocks.chat.hasPreviousSession = true;
+    renderChat();
+
+    const button = await screen.findByRole('button', { name: 'Load previous messages' });
+    fireEvent.click(button);
+    expect(mocks.chat.loadPreviousMessages).toHaveBeenCalledTimes(1);
   });
 
   test('renders pending intent questions through the existing answer pipeline', async () => {

--- a/docs/design/chat-session-sections.md
+++ b/docs/design/chat-session-sections.md
@@ -1,0 +1,39 @@
+---
+title: "Durable chat session sections"
+type: design
+tags: [chat, conversations, privacy]
+---
+
+# Durable chat session sections
+
+`conversations` remain the durable container for H2A, H2H, and A2A traffic. The
+`conversation_sessions` sidecar divides their timeline into display and context
+sections. Every persisted `messages` row is stamped with `session_id` server-side.
+
+- A2A maps one session to one `tasks` row.
+- H2A and H2H open a new session only when the next write is strictly later than
+  `CHAT_SESSION_GAP_MS` (24 hours by default) after the active session's last
+  message.
+- Transaction-scoped advisory locking serializes writers per conversation, so
+  concurrent first writes cannot create two active sections.
+- The backfill migration orders immutable history by `(created_at, id)`, uses the
+  same gap rule for non-task messages, and maps task messages one-to-one.
+
+History endpoints return the latest section first. A previous-session cursor is
+opaque and retrieves exactly one section per request. Earlier sections are display
+state only; send/continue operations always rebuild context from the database.
+
+## Model context
+
+Chat graph context uses a dedicated latest-N query: messages are selected descending
+by `(createdAt, id)`, limited, and reversed before being passed to the model. The
+query is scoped to the active durable section and does not use UI pagination. This
+keeps historical loading from expanding or reordering the model context window.
+
+## In-chat questions
+
+A streamed `user_question` event contains only canonical question IDs. The web client
+resolves cards through a recipient- and conversation-scoped pending-question read;
+model-authored text never becomes a rendered question. When the assistant message is
+persisted, chat questions are stamped with its message ID and durable session ID for
+reload anchoring. Pool-discovery rows remain excluded from this path.

--- a/docs/domain/chat-sessions.md
+++ b/docs/domain/chat-sessions.md
@@ -1,0 +1,19 @@
+---
+title: "Chat sessions"
+type: domain
+tags: [chat, conversations]
+---
+
+# Chat sessions
+
+A **conversation** identifies the people or agents allowed to communicate. A
+**conversation session** is a bounded chronological section within that conversation.
+
+Sessions make long-lived chats readable without changing participants, unread policy,
+or A2A task privacy. H2A and H2H sessions follow a 24-hour inactivity boundary by
+default; each A2A task run is its own session. Opening a chat shows its newest session;
+people may explicitly load older sessions one at a time.
+
+Question cards shown in a chat are canonical pending questions, not text supplied by an
+agent. They belong to a recipient and conversation, and, after persistence, are
+anchored to the assistant message and chat session that produced them.

--- a/docs/specs/api-reference.md
+++ b/docs/specs/api-reference.md
@@ -566,7 +566,9 @@ Compatibility detail for a specific orchestrator session with its messages (incl
 
 ### POST /api/chat/web/session
 
-Session-only main-web detail endpoint using the same request/response shape. It permits the readable web personas (`orchestrator`, `signal`) plus the pinned negotiator conversation and fails closed for unknown personas.
+Session-only main-web detail endpoint. It permits the readable web personas (`orchestrator`, `signal`) plus the pinned negotiator conversation and fails closed for unknown personas.
+
+Both chat detail endpoints now hydrate one durable timeline session only. The first request sends `{ "sessionId": "..." }`; to reveal exactly one older section, send `{ "sessionId": "...", "beforeSessionId": "<oldest loaded durable session id>" }`. Responses retain `{ session, messages }` and add `sessionId` (the loaded durable session), `hasPreviousSession`, and `previousSessionCursor`. The cursor is opaque; callers must not infer ordering from IDs.
 
 **Auth**: SessionOnlyGuard
 
@@ -1277,7 +1279,9 @@ The authenticated user must be included in the participants array.
 
 ### GET /api/conversations/:id/messages
 
-Get messages for a conversation.
+Get messages for a conversation. Existing `limit`, `before`, and `taskId` behavior remains compatible; message cursors use the stable `(createdAt, id)` key.
+
+Set `sessionHistory=true` to receive only the latest durable timeline session and `{ messages, sessionId, hasPreviousSession, previousSessionCursor }`. Add `beforeSessionId=<cursor>` to retrieve exactly one earlier session. A `taskId` session-history read remains constrained to that A2A task segment.
 
 **Auth**: AuthGuard
 

--- a/packages/protocol/package.json
+++ b/packages/protocol/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@indexnetwork/protocol",
-  "version": "6.7.0",
+  "version": "6.7.1",
   "type": "module",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",

--- a/packages/protocol/src/chat/chat-streaming.types.ts
+++ b/packages/protocol/src/chat/chat-streaming.types.ts
@@ -570,11 +570,8 @@ export interface DecisionQuestionsEvent extends ChatStreamEventBase {
  * questions REST endpoints while the turn is still blocked.
  */
 export interface UserQuestionPayload {
+  /** Canonical question identity. The client must resolve all display fields from the server. */
   id: string;
-  title: string;
-  prompt: string;
-  options: Array<{ label: string; description: string }>;
-  multiSelect: boolean;
 }
 
 /**

--- a/packages/protocol/src/chat/chat.agent.ts
+++ b/packages/protocol/src/chat/chat.agent.ts
@@ -177,13 +177,7 @@ export type AgentStreamEvent =
       // Emitted by the ask_user_question tool after persisting chat-mode
       // questions: the turn is blocked awaiting the user's inline answer.
       type: "user_question";
-      questions: Array<{
-        id: string;
-        title: string;
-        prompt: string;
-        options: Array<{ label: string; description: string }>;
-        multiSelect: boolean;
-      }>;
+      questions: Array<{ id: string }>;
     }
   | { type: "status"; message: string }
   | { type: "decision_questions"; questions: Question[] }

--- a/packages/protocol/src/questioner/questioner.ask.tool.ts
+++ b/packages/protocol/src/questioner/questioner.ask.tool.ts
@@ -251,13 +251,9 @@ export function createAskUserQuestionTools(defineTool: DefineTool, deps: ToolDep
       // ── 4. Stream the cards to the frontend ────────────────────────────
       emit({
         type: "user_question",
-        questions: persisted.map((q) => ({
-          id: q.id,
-          title: q.payload.title,
-          prompt: q.payload.prompt,
-          options: q.payload.options,
-          multiSelect: q.payload.multiSelect,
-        })),
+        // The event is an opaque action reference. Question text is canonical
+        // only after the recipient resolves this ID through the server.
+        questions: persisted.map((q) => ({ id: q.id })),
       });
 
       // ── 5. Block until answered / dismissed / timeout / abort ──────────

--- a/packages/protocol/src/shared/observability/request-context.ts
+++ b/packages/protocol/src/shared/observability/request-context.ts
@@ -29,13 +29,7 @@ export type TraceEmitter = (
         // Carries persisted question ids so the frontend can answer them
         // through the questions REST endpoints while the stream is live.
         type: "user_question";
-        questions: Array<{
-          id: string;
-          title: string;
-          prompt: string;
-          options: Array<{ label: string; description: string }>;
-          multiSelect: boolean;
-        }>;
+        questions: Array<{ id: string }>;
       }
     | {
         // Lightweight keep-alive/status line. Used by long-blocking tools

--- a/services/api/drizzle/0103_add_conversation_sessions.sql
+++ b/services/api/drizzle/0103_add_conversation_sessions.sql
@@ -1,0 +1,114 @@
+CREATE TABLE "conversation_sessions" (
+	"id" text PRIMARY KEY NOT NULL,
+	"conversation_id" text NOT NULL,
+	"task_id" text,
+	"started_at" timestamp with time zone NOT NULL,
+	"last_message_at" timestamp with time zone NOT NULL,
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL
+);
+--> statement-breakpoint
+ALTER TABLE "messages" ADD COLUMN "session_id" text;
+--> statement-breakpoint
+ALTER TABLE "conversation_sessions" ADD CONSTRAINT "conversation_sessions_conversation_id_conversations_id_fk" FOREIGN KEY ("conversation_id") REFERENCES "public"."conversations"("id") ON DELETE cascade ON UPDATE no action;
+--> statement-breakpoint
+ALTER TABLE "conversation_sessions" ADD CONSTRAINT "conversation_sessions_task_id_tasks_id_fk" FOREIGN KEY ("task_id") REFERENCES "public"."tasks"("id") ON DELETE set null ON UPDATE no action;
+--> statement-breakpoint
+ALTER TABLE "messages" ADD CONSTRAINT "messages_session_id_conversation_sessions_id_fk" FOREIGN KEY ("session_id") REFERENCES "public"."conversation_sessions"("id") ON DELETE set null ON UPDATE no action;
+--> statement-breakpoint
+-- Backfill deterministic A2A task sessions. A task owns one session even if its
+-- messages share a timestamp with another task; the message ID breaks ties below.
+INSERT INTO "conversation_sessions" ("id", "conversation_id", "task_id", "started_at", "last_message_at")
+SELECT
+  'backfill:a2a:' || "task_id",
+  "conversation_id",
+  "task_id",
+  min("created_at"),
+  max("created_at")
+FROM "messages"
+WHERE "task_id" IS NOT NULL
+GROUP BY "conversation_id", "task_id";
+--> statement-breakpoint
+UPDATE "messages" AS "message"
+SET "session_id" = 'backfill:a2a:' || "message"."task_id"
+WHERE "message"."task_id" IS NOT NULL;
+--> statement-breakpoint
+-- Backfill H2A/H2H sessions using the same strictly-greater-than-24-hour gap
+-- rule as runtime writes. The (created_at, id) order makes equal timestamps stable.
+WITH ordered AS (
+  SELECT
+    "id",
+    "conversation_id",
+    "created_at",
+    lag("created_at") OVER (
+      PARTITION BY "conversation_id"
+      ORDER BY "created_at", "id"
+    ) AS "previous_created_at"
+  FROM "messages"
+  WHERE "task_id" IS NULL
+), grouped AS (
+  SELECT
+    "id",
+    "conversation_id",
+    "created_at",
+    sum(
+      CASE
+        WHEN "previous_created_at" IS NULL
+          OR "created_at" - "previous_created_at" > interval '24 hours'
+        THEN 1
+        ELSE 0
+      END
+    ) OVER (
+      PARTITION BY "conversation_id"
+      ORDER BY "created_at", "id"
+      ROWS BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW
+    ) AS "session_ordinal"
+  FROM ordered
+)
+INSERT INTO "conversation_sessions" ("id", "conversation_id", "started_at", "last_message_at")
+SELECT
+  'backfill:h2:' || "conversation_id" || ':' || "session_ordinal",
+  "conversation_id",
+  min("created_at"),
+  max("created_at")
+FROM grouped
+GROUP BY "conversation_id", "session_ordinal";
+--> statement-breakpoint
+WITH ordered AS (
+  SELECT
+    "id",
+    "conversation_id",
+    "created_at",
+    lag("created_at") OVER (
+      PARTITION BY "conversation_id"
+      ORDER BY "created_at", "id"
+    ) AS "previous_created_at"
+  FROM "messages"
+  WHERE "task_id" IS NULL
+), grouped AS (
+  SELECT
+    "id",
+    "conversation_id",
+    sum(
+      CASE
+        WHEN "previous_created_at" IS NULL
+          OR "created_at" - "previous_created_at" > interval '24 hours'
+        THEN 1
+        ELSE 0
+      END
+    ) OVER (
+      PARTITION BY "conversation_id"
+      ORDER BY "created_at", "id"
+      ROWS BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW
+    ) AS "session_ordinal"
+  FROM ordered
+)
+UPDATE "messages" AS "message"
+SET "session_id" = 'backfill:h2:' || "grouped"."conversation_id" || ':' || "grouped"."session_ordinal"
+FROM grouped
+WHERE "message"."id" = "grouped"."id";
+--> statement-breakpoint
+CREATE INDEX "conversation_sessions_conversation_started_idx" ON "conversation_sessions" USING btree ("conversation_id","started_at","id");
+--> statement-breakpoint
+CREATE UNIQUE INDEX "conversation_sessions_task_id_uniq" ON "conversation_sessions" USING btree ("task_id");
+--> statement-breakpoint
+CREATE INDEX "messages_session_id_created_at_idx" ON "messages" USING btree ("session_id","created_at","id");

--- a/services/api/drizzle/0104_update_message_cursor_index.sql
+++ b/services/api/drizzle/0104_update_message_cursor_index.sql
@@ -1,0 +1,2 @@
+DROP INDEX "messages_conversation_id_created_at_idx";--> statement-breakpoint
+CREATE INDEX "messages_conversation_id_created_at_idx" ON "messages" USING btree ("conversation_id","created_at","id");

--- a/services/api/drizzle/meta/0103_snapshot.json
+++ b/services/api/drizzle/meta/0103_snapshot.json
@@ -1,0 +1,6417 @@
+{
+  "id": "8f957025-4e83-4566-b302-368c6ab8bca6",
+  "prevId": "265e6586-c22a-4fb7-be18-bb0a53a24db4",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.accounts": {
+      "name": "accounts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "id_token": {
+          "name": "id_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "access_token_expires_at": {
+          "name": "access_token_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token_expires_at": {
+          "name": "refresh_token_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "password": {
+          "name": "password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "accounts_user_id_users_id_fk": {
+          "name": "accounts_user_id_users_id_fk",
+          "tableFrom": "accounts",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.agent_action_proposals": {
+      "name": "agent_action_proposals",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "conversation_id": {
+          "name": "conversation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "actions": {
+          "name": "actions",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "agent_action_proposal_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "result": {
+          "name": "result",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "execution_lease_at": {
+          "name": "execution_lease_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "consumed_at": {
+          "name": "consumed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "agent_action_proposals_user_id_idx": {
+          "name": "agent_action_proposals_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "agent_action_proposals_conversation_id_idx": {
+          "name": "agent_action_proposals_conversation_id_idx",
+          "columns": [
+            {
+              "expression": "conversation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "agent_action_proposals_user_id_users_id_fk": {
+          "name": "agent_action_proposals_user_id_users_id_fk",
+          "tableFrom": "agent_action_proposals",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.agent_permissions": {
+      "name": "agent_permissions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "agent_id": {
+          "name": "agent_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scope": {
+          "name": "scope",
+          "type": "permission_scope",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'global'"
+        },
+        "scope_id": {
+          "name": "scope_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "actions": {
+          "name": "actions",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "agent_permissions_agent_id_idx": {
+          "name": "agent_permissions_agent_id_idx",
+          "columns": [
+            {
+              "expression": "agent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "agent_permissions_user_id_idx": {
+          "name": "agent_permissions_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "agent_permissions_agent_user_idx": {
+          "name": "agent_permissions_agent_user_idx",
+          "columns": [
+            {
+              "expression": "agent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "uniq_agent_permissions_global": {
+          "name": "uniq_agent_permissions_global",
+          "columns": [
+            {
+              "expression": "agent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"agent_permissions\".\"scope\" = 'global'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "agent_permissions_agent_id_agents_id_fk": {
+          "name": "agent_permissions_agent_id_agents_id_fk",
+          "tableFrom": "agent_permissions",
+          "tableTo": "agents",
+          "columnsFrom": [
+            "agent_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "agent_permissions_user_id_users_id_fk": {
+          "name": "agent_permissions_user_id_users_id_fk",
+          "tableFrom": "agent_permissions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.agent_test_messages": {
+      "name": "agent_test_messages",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "agent_id": {
+          "name": "agent_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "requested_by_user_id": {
+          "name": "requested_by_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reservation_token": {
+          "name": "reservation_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reserved_at": {
+          "name": "reserved_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "delivered_at": {
+          "name": "delivered_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_agent_test_messages_agent_pending": {
+          "name": "idx_agent_test_messages_agent_pending",
+          "columns": [
+            {
+              "expression": "agent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "reserved_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "agent_test_messages_agent_id_agents_id_fk": {
+          "name": "agent_test_messages_agent_id_agents_id_fk",
+          "tableFrom": "agent_test_messages",
+          "tableTo": "agents",
+          "columnsFrom": [
+            "agent_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "agent_test_messages_requested_by_user_id_users_id_fk": {
+          "name": "agent_test_messages_requested_by_user_id_users_id_fk",
+          "tableFrom": "agent_test_messages",
+          "tableTo": "users",
+          "columnsFrom": [
+            "requested_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.agent_transports": {
+      "name": "agent_transports",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "agent_id": {
+          "name": "agent_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "channel": {
+          "name": "channel",
+          "type": "transport_channel",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "config": {
+          "name": "config",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'{}'::jsonb"
+        },
+        "priority": {
+          "name": "priority",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "active": {
+          "name": "active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "failure_count": {
+          "name": "failure_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "agent_transports_agent_id_idx": {
+          "name": "agent_transports_agent_id_idx",
+          "columns": [
+            {
+              "expression": "agent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "agent_transports_agent_id_agents_id_fk": {
+          "name": "agent_transports_agent_id_agents_id_fk",
+          "tableFrom": "agent_transports",
+          "tableTo": "agents",
+          "columnsFrom": [
+            "agent_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.agents": {
+      "name": "agents",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "owner_id": {
+          "name": "owner_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "type": {
+          "name": "type",
+          "type": "agent_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "agent_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'{}'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "last_seen_at": {
+          "name": "last_seen_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "notify_on_opportunity": {
+          "name": "notify_on_opportunity",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "daily_summary_enabled": {
+          "name": "daily_summary_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "handle_negotiations": {
+          "name": "handle_negotiations",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "last_daily_summary_at": {
+          "name": "last_daily_summary_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "agents_owner_id_idx": {
+          "name": "agents_owner_id_idx",
+          "columns": [
+            {
+              "expression": "owner_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "agents_type_idx": {
+          "name": "agents_type_idx",
+          "columns": [
+            {
+              "expression": "type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "agents_last_seen_at_idx": {
+          "name": "agents_last_seen_at_idx",
+          "columns": [
+            {
+              "expression": "last_seen_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "uniq_agents_personal_per_owner": {
+          "name": "uniq_agents_personal_per_owner",
+          "columns": [
+            {
+              "expression": "owner_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"agents\".\"type\" = 'personal' AND \"agents\".\"deleted_at\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "agents_owner_id_users_id_fk": {
+          "name": "agents_owner_id_users_id_fk",
+          "tableFrom": "agents",
+          "tableTo": "users",
+          "columnsFrom": [
+            "owner_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.apikey": {
+      "name": "apikey",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reference_id": {
+          "name": "reference_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "config_id": {
+          "name": "config_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'default'"
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "prefix": {
+          "name": "prefix",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "start": {
+          "name": "start",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "rate_limit_enabled": {
+          "name": "rate_limit_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "rate_limit_max": {
+          "name": "rate_limit_max",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "rate_limit_time_window": {
+          "name": "rate_limit_time_window",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "request_count": {
+          "name": "request_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "remaining": {
+          "name": "remaining",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refill_amount": {
+          "name": "refill_amount",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refill_interval": {
+          "name": "refill_interval",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_refill_at": {
+          "name": "last_refill_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_request": {
+          "name": "last_request",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "permissions": {
+          "name": "permissions",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "apikey_user_id_users_id_fk": {
+          "name": "apikey_user_id_users_id_fk",
+          "tableFrom": "apikey",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.connect_links": {
+      "name": "connect_links",
+      "schema": "",
+      "columns": {
+        "code": {
+          "name": "code",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "opportunity_id": {
+          "name": "opportunity_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "greeting": {
+          "name": "greeting",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "preferred_surface": {
+          "name": "preferred_surface",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "connect_links_kind_recipient_uq": {
+          "name": "connect_links_kind_recipient_uq",
+          "columns": [
+            {
+              "expression": "opportunity_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "kind",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "connect_links_expires_at_idx": {
+          "name": "connect_links_expires_at_idx",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "connect_links_user_id_users_id_fk": {
+          "name": "connect_links_user_id_users_id_fk",
+          "tableFrom": "connect_links",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "connect_links_opportunity_id_opportunities_id_fk": {
+          "name": "connect_links_opportunity_id_opportunities_id_fk",
+          "tableFrom": "connect_links",
+          "tableTo": "opportunities",
+          "columnsFrom": [
+            "opportunity_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.cross_network_yield_snapshots": {
+      "name": "cross_network_yield_snapshots",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "run_id": {
+          "name": "run_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "network_a_id": {
+          "name": "network_a_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "network_b_id": {
+          "name": "network_b_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "opportunity_count": {
+          "name": "opportunity_count",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "potential_active_intent_pair_count": {
+          "name": "potential_active_intent_pair_count",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "yield_rate": {
+          "name": "yield_rate",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "yield_rate_delta": {
+          "name": "yield_rate_delta",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "prior_bucket_start": {
+          "name": "prior_bucket_start",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "bucket_start": {
+          "name": "bucket_start",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "bucket_end": {
+          "name": "bucket_end",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "captured_at": {
+          "name": "captured_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "cross_network_yield_snapshots_daily_uniq": {
+          "name": "cross_network_yield_snapshots_daily_uniq",
+          "columns": [
+            {
+              "expression": "network_a_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "network_b_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "bucket_start",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "cross_network_yield_snapshots_run_id_frame_drift_observation_runs_id_fk": {
+          "name": "cross_network_yield_snapshots_run_id_frame_drift_observation_runs_id_fk",
+          "tableFrom": "cross_network_yield_snapshots",
+          "tableTo": "frame_drift_observation_runs",
+          "columnsFrom": [
+            "run_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "cross_network_yield_snapshots_network_a_id_networks_id_fk": {
+          "name": "cross_network_yield_snapshots_network_a_id_networks_id_fk",
+          "tableFrom": "cross_network_yield_snapshots",
+          "tableTo": "networks",
+          "columnsFrom": [
+            "network_a_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "cross_network_yield_snapshots_network_b_id_networks_id_fk": {
+          "name": "cross_network_yield_snapshots_network_b_id_networks_id_fk",
+          "tableFrom": "cross_network_yield_snapshots",
+          "tableTo": "networks",
+          "columnsFrom": [
+            "network_b_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "cross_network_yield_snapshots_canonical_pair_check": {
+          "name": "cross_network_yield_snapshots_canonical_pair_check",
+          "value": "\"cross_network_yield_snapshots\".\"network_a_id\" < \"cross_network_yield_snapshots\".\"network_b_id\""
+        },
+        "cross_network_yield_snapshots_opportunity_count_check": {
+          "name": "cross_network_yield_snapshots_opportunity_count_check",
+          "value": "\"cross_network_yield_snapshots\".\"opportunity_count\" >= 0"
+        },
+        "cross_network_yield_snapshots_potential_pair_count_check": {
+          "name": "cross_network_yield_snapshots_potential_pair_count_check",
+          "value": "\"cross_network_yield_snapshots\".\"potential_active_intent_pair_count\" > 0"
+        },
+        "cross_network_yield_snapshots_yield_rate_check": {
+          "name": "cross_network_yield_snapshots_yield_rate_check",
+          "value": "\"cross_network_yield_snapshots\".\"yield_rate\" >= 0"
+        },
+        "cross_network_yield_snapshots_bucket_range_check": {
+          "name": "cross_network_yield_snapshots_bucket_range_check",
+          "value": "\"cross_network_yield_snapshots\".\"bucket_end\" > \"cross_network_yield_snapshots\".\"bucket_start\""
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.enrichment_tool_runs": {
+      "name": "enrichment_tool_runs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "agent_id": {
+          "name": "agent_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "operation": {
+          "name": "operation",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "discovery_run_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'queued'"
+        },
+        "input": {
+          "name": "input",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "context": {
+          "name": "context",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "progress": {
+          "name": "progress",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "result": {
+          "name": "result",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error": {
+          "name": "error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cancel_requested_at": {
+          "name": "cancel_requested_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "enrichment_tool_runs_user_created_idx": {
+          "name": "enrichment_tool_runs_user_created_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "enrichment_tool_runs_status_created_idx": {
+          "name": "enrichment_tool_runs_status_created_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "enrichment_tool_runs_operation_created_idx": {
+          "name": "enrichment_tool_runs_operation_created_idx",
+          "columns": [
+            {
+              "expression": "operation",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "enrichment_tool_runs_expires_at_idx": {
+          "name": "enrichment_tool_runs_expires_at_idx",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "enrichment_tool_runs_user_id_users_id_fk": {
+          "name": "enrichment_tool_runs_user_id_users_id_fk",
+          "tableFrom": "enrichment_tool_runs",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "enrichment_tool_runs_agent_id_agents_id_fk": {
+          "name": "enrichment_tool_runs_agent_id_agents_id_fk",
+          "tableFrom": "enrichment_tool_runs",
+          "tableTo": "agents",
+          "columnsFrom": [
+            "agent_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.files": {
+      "name": "files",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "size": {
+          "name": "size",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "files_user_id_users_id_fk": {
+          "name": "files_user_id_users_id_fk",
+          "tableFrom": "files",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.frame_centroid_snapshots": {
+      "name": "frame_centroid_snapshots",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "run_id": {
+          "name": "run_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "network_id": {
+          "name": "network_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "corpus": {
+          "name": "corpus",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "centroid": {
+          "name": "centroid",
+          "type": "vector(2000)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sample_count": {
+          "name": "sample_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "configured_embedding_model": {
+          "name": "configured_embedding_model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "cosine_drift": {
+          "name": "cosine_drift",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "prior_bucket_start": {
+          "name": "prior_bucket_start",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "bucket_start": {
+          "name": "bucket_start",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "bucket_end": {
+          "name": "bucket_end",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "captured_at": {
+          "name": "captured_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "frame_centroid_snapshots_daily_uniq": {
+          "name": "frame_centroid_snapshots_daily_uniq",
+          "columns": [
+            {
+              "expression": "network_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "corpus",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "configured_embedding_model",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "bucket_start",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "frame_centroid_snapshots_run_id_frame_drift_observation_runs_id_fk": {
+          "name": "frame_centroid_snapshots_run_id_frame_drift_observation_runs_id_fk",
+          "tableFrom": "frame_centroid_snapshots",
+          "tableTo": "frame_drift_observation_runs",
+          "columnsFrom": [
+            "run_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "frame_centroid_snapshots_network_id_networks_id_fk": {
+          "name": "frame_centroid_snapshots_network_id_networks_id_fk",
+          "tableFrom": "frame_centroid_snapshots",
+          "tableTo": "networks",
+          "columnsFrom": [
+            "network_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "frame_centroid_snapshots_corpus_check": {
+          "name": "frame_centroid_snapshots_corpus_check",
+          "value": "\"frame_centroid_snapshots\".\"corpus\" IN ('premise', 'intent', 'user_context')"
+        },
+        "frame_centroid_snapshots_sample_count_check": {
+          "name": "frame_centroid_snapshots_sample_count_check",
+          "value": "\"frame_centroid_snapshots\".\"sample_count\" > 0"
+        },
+        "frame_centroid_snapshots_cosine_drift_check": {
+          "name": "frame_centroid_snapshots_cosine_drift_check",
+          "value": "\"frame_centroid_snapshots\".\"cosine_drift\" IS NULL OR (\"frame_centroid_snapshots\".\"cosine_drift\" >= 0 AND \"frame_centroid_snapshots\".\"cosine_drift\" <= 2)"
+        },
+        "frame_centroid_snapshots_bucket_range_check": {
+          "name": "frame_centroid_snapshots_bucket_range_check",
+          "value": "\"frame_centroid_snapshots\".\"bucket_end\" > \"frame_centroid_snapshots\".\"bucket_start\""
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.frame_drift_execution_attempts": {
+      "name": "frame_drift_execution_attempts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "queue_name": {
+          "name": "queue_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scheduler_id": {
+          "name": "scheduler_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "job_id": {
+          "name": "job_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "job_name": {
+          "name": "job_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scheduled_at": {
+          "name": "scheduled_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "bucket_start": {
+          "name": "bucket_start",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "bucket_end": {
+          "name": "bucket_end",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "attempt": {
+          "name": "attempt",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "max_attempts": {
+          "name": "max_attempts",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "terminal_status": {
+          "name": "terminal_status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "will_retry": {
+          "name": "will_retry",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "failure_category": {
+          "name": "failure_category",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "frame_drift_execution_attempts_job_attempt_uniq": {
+          "name": "frame_drift_execution_attempts_job_attempt_uniq",
+          "columns": [
+            {
+              "expression": "job_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "attempt",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "frame_drift_execution_attempts_bucket_start_idx": {
+          "name": "frame_drift_execution_attempts_bucket_start_idx",
+          "columns": [
+            {
+              "expression": "bucket_start",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "frame_drift_execution_attempts_incomplete_idx": {
+          "name": "frame_drift_execution_attempts_incomplete_idx",
+          "columns": [
+            {
+              "expression": "started_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"frame_drift_execution_attempts\".\"completed_at\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "frame_drift_execution_attempts_identity_check": {
+          "name": "frame_drift_execution_attempts_identity_check",
+          "value": "\n    length(btrim(\"frame_drift_execution_attempts\".\"queue_name\")) > 0\n    AND length(btrim(\"frame_drift_execution_attempts\".\"scheduler_id\")) > 0\n    AND length(btrim(\"frame_drift_execution_attempts\".\"job_id\")) > 0\n    AND length(btrim(\"frame_drift_execution_attempts\".\"job_name\")) > 0\n  "
+        },
+        "frame_drift_execution_attempts_daily_bucket_check": {
+          "name": "frame_drift_execution_attempts_daily_bucket_check",
+          "value": "\n    \"frame_drift_execution_attempts\".\"bucket_end\" = \"frame_drift_execution_attempts\".\"bucket_start\" + interval '1 day'\n    AND date_trunc('day', \"frame_drift_execution_attempts\".\"bucket_start\" AT TIME ZONE 'UTC') = \"frame_drift_execution_attempts\".\"bucket_start\" AT TIME ZONE 'UTC'\n    AND date_trunc('day', \"frame_drift_execution_attempts\".\"bucket_end\" AT TIME ZONE 'UTC') = \"frame_drift_execution_attempts\".\"bucket_end\" AT TIME ZONE 'UTC'\n    AND \"frame_drift_execution_attempts\".\"scheduled_at\" >= \"frame_drift_execution_attempts\".\"bucket_end\"\n    AND \"frame_drift_execution_attempts\".\"scheduled_at\" < \"frame_drift_execution_attempts\".\"bucket_end\" + interval '1 day'\n  "
+        },
+        "frame_drift_execution_attempts_attempt_bounds_check": {
+          "name": "frame_drift_execution_attempts_attempt_bounds_check",
+          "value": "\n    \"frame_drift_execution_attempts\".\"attempt\" BETWEEN 1 AND \"frame_drift_execution_attempts\".\"max_attempts\"\n    AND \"frame_drift_execution_attempts\".\"max_attempts\" BETWEEN 1 AND 100\n  "
+        },
+        "frame_drift_execution_attempts_terminal_status_check": {
+          "name": "frame_drift_execution_attempts_terminal_status_check",
+          "value": "\n    \"frame_drift_execution_attempts\".\"terminal_status\" IS NULL\n    OR \"frame_drift_execution_attempts\".\"terminal_status\" IN ('inserted', 'duplicate', 'skipped', 'failed')\n  "
+        },
+        "frame_drift_execution_attempts_failure_category_check": {
+          "name": "frame_drift_execution_attempts_failure_category_check",
+          "value": "\n    \"frame_drift_execution_attempts\".\"failure_category\" IS NULL OR \"frame_drift_execution_attempts\".\"failure_category\" = 'measurement'\n  "
+        },
+        "frame_drift_execution_attempts_terminal_state_check": {
+          "name": "frame_drift_execution_attempts_terminal_state_check",
+          "value": "\n    (\n      \"frame_drift_execution_attempts\".\"terminal_status\" IS NULL\n      AND \"frame_drift_execution_attempts\".\"completed_at\" IS NULL\n      AND \"frame_drift_execution_attempts\".\"will_retry\" IS NULL\n      AND \"frame_drift_execution_attempts\".\"failure_category\" IS NULL\n    ) OR (\n      \"frame_drift_execution_attempts\".\"terminal_status\" IN ('inserted', 'duplicate', 'skipped')\n      AND \"frame_drift_execution_attempts\".\"completed_at\" IS NOT NULL\n      AND \"frame_drift_execution_attempts\".\"completed_at\" >= \"frame_drift_execution_attempts\".\"started_at\"\n      AND \"frame_drift_execution_attempts\".\"will_retry\" IS NOT NULL\n      AND \"frame_drift_execution_attempts\".\"will_retry\" = false\n      AND \"frame_drift_execution_attempts\".\"failure_category\" IS NULL\n    ) OR (\n      \"frame_drift_execution_attempts\".\"terminal_status\" = 'failed'\n      AND \"frame_drift_execution_attempts\".\"completed_at\" IS NOT NULL\n      AND \"frame_drift_execution_attempts\".\"completed_at\" >= \"frame_drift_execution_attempts\".\"started_at\"\n      AND \"frame_drift_execution_attempts\".\"will_retry\" IS NOT NULL\n      AND \"frame_drift_execution_attempts\".\"failure_category\" IS NOT NULL\n      AND \"frame_drift_execution_attempts\".\"failure_category\" = 'measurement'\n    )\n  "
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.frame_drift_observation_runs": {
+      "name": "frame_drift_observation_runs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "bucket_start": {
+          "name": "bucket_start",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "bucket_end": {
+          "name": "bucket_end",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "captured_at": {
+          "name": "captured_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "configured_embedding_model": {
+          "name": "configured_embedding_model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "max_networks": {
+          "name": "max_networks",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "max_pairs": {
+          "name": "max_pairs",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "min_users": {
+          "name": "min_users",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "stable_cohort_hash": {
+          "name": "stable_cohort_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "aggregate_diagnostics": {
+          "name": "aggregate_diagnostics",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        }
+      },
+      "indexes": {
+        "frame_drift_observation_runs_bucket_start_uniq": {
+          "name": "frame_drift_observation_runs_bucket_start_uniq",
+          "columns": [
+            {
+              "expression": "bucket_start",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "frame_drift_observation_runs_bucket_check": {
+          "name": "frame_drift_observation_runs_bucket_check",
+          "value": "\"frame_drift_observation_runs\".\"bucket_end\" = \"frame_drift_observation_runs\".\"bucket_start\" + interval '1 day' AND \"frame_drift_observation_runs\".\"captured_at\" >= \"frame_drift_observation_runs\".\"bucket_end\""
+        },
+        "frame_drift_observation_runs_configured_embedding_model_check": {
+          "name": "frame_drift_observation_runs_configured_embedding_model_check",
+          "value": "length(btrim(\"frame_drift_observation_runs\".\"configured_embedding_model\")) > 0"
+        },
+        "frame_drift_observation_runs_max_networks_check": {
+          "name": "frame_drift_observation_runs_max_networks_check",
+          "value": "\"frame_drift_observation_runs\".\"max_networks\" BETWEEN 1 AND 200"
+        },
+        "frame_drift_observation_runs_max_pairs_check": {
+          "name": "frame_drift_observation_runs_max_pairs_check",
+          "value": "\"frame_drift_observation_runs\".\"max_pairs\" BETWEEN 1 AND 10000"
+        },
+        "frame_drift_observation_runs_min_users_check": {
+          "name": "frame_drift_observation_runs_min_users_check",
+          "value": "\"frame_drift_observation_runs\".\"min_users\" BETWEEN 2 AND 100"
+        },
+        "frame_drift_observation_runs_stable_cohort_hash_check": {
+          "name": "frame_drift_observation_runs_stable_cohort_hash_check",
+          "value": "\"frame_drift_observation_runs\".\"stable_cohort_hash\" IS NULL OR \"frame_drift_observation_runs\".\"stable_cohort_hash\" ~ '^[0-9a-f]{64}$'"
+        },
+        "frame_drift_observation_runs_aggregate_diagnostics_check": {
+          "name": "frame_drift_observation_runs_aggregate_diagnostics_check",
+          "value": "jsonb_typeof(\"frame_drift_observation_runs\".\"aggregate_diagnostics\") = 'object'"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.hyde_documents": {
+      "name": "hyde_documents",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "source_type": {
+          "name": "source_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_id": {
+          "name": "source_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source_text": {
+          "name": "source_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "strategy": {
+          "name": "strategy",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "target_corpus": {
+          "name": "target_corpus",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "context": {
+          "name": "context",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "hyde_text": {
+          "name": "hyde_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "hyde_embedding": {
+          "name": "hyde_embedding",
+          "type": "vector(2000)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "hyde_source_idx": {
+          "name": "hyde_source_idx",
+          "columns": [
+            {
+              "expression": "source_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "source_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "hyde_strategy_idx": {
+          "name": "hyde_strategy_idx",
+          "columns": [
+            {
+              "expression": "strategy",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "hyde_embedding_idx": {
+          "name": "hyde_embedding_idx",
+          "columns": [
+            {
+              "expression": "hyde_embedding",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "vector_cosine_ops"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "hnsw",
+          "with": {}
+        },
+        "hyde_expires_idx": {
+          "name": "hyde_expires_idx",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "hyde_source_strategy_unique": {
+          "name": "hyde_source_strategy_unique",
+          "columns": [
+            {
+              "expression": "source_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "source_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "strategy",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "target_corpus",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.intent_networks": {
+      "name": "intent_networks",
+      "schema": "",
+      "columns": {
+        "intent_id": {
+          "name": "intent_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "network_id": {
+          "name": "network_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "relevancy_score": {
+          "name": "relevancy_score",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "assignment_metadata": {
+          "name": "assignment_metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "intent_networks_network_id_idx": {
+          "name": "intent_networks_network_id_idx",
+          "columns": [
+            {
+              "expression": "network_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "intent_networks_intent_id_intents_id_fk": {
+          "name": "intent_networks_intent_id_intents_id_fk",
+          "tableFrom": "intent_networks",
+          "tableTo": "intents",
+          "columnsFrom": [
+            "intent_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "intent_networks_network_id_networks_id_fk": {
+          "name": "intent_networks_network_id_networks_id_fk",
+          "tableFrom": "intent_networks",
+          "tableTo": "networks",
+          "columnsFrom": [
+            "network_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "intent_networks_intent_id_network_id_pk": {
+          "name": "intent_networks_intent_id_network_id_pk",
+          "columns": [
+            "intent_id",
+            "network_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.intents": {
+      "name": "intents",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "payload": {
+          "name": "payload",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "summary": {
+          "name": "summary",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_incognito": {
+          "name": "is_incognito",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "archived_at": {
+          "name": "archived_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_visited_at": {
+          "name": "last_visited_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "first_discovery_succeeded_at": {
+          "name": "first_discovery_succeeded_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_id": {
+          "name": "source_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source_type": {
+          "name": "source_type",
+          "type": "source_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "embedding": {
+          "name": "embedding",
+          "type": "vector(2000)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "semantic_entropy": {
+          "name": "semantic_entropy",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 1
+        },
+        "referential_anchor": {
+          "name": "referential_anchor",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "intent_mode": {
+          "name": "intent_mode",
+          "type": "intent_mode",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'ATTRIBUTIVE'"
+        },
+        "speech_act_type": {
+          "name": "speech_act_type",
+          "type": "speech_act_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "felicity_authority": {
+          "name": "felicity_authority",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "felicity_sincerity": {
+          "name": "felicity_sincerity",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "felicity_clarity": {
+          "name": "felicity_clarity",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "intent_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'ACTIVE'"
+        }
+      },
+      "indexes": {
+        "embeddingIndex": {
+          "name": "embeddingIndex",
+          "columns": [
+            {
+              "expression": "embedding",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "vector_cosine_ops"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "hnsw",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "intents_user_id_users_id_fk": {
+          "name": "intents_user_id_users_id_fk",
+          "tableFrom": "intents",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.jwks": {
+      "name": "jwks",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "public_key": {
+          "name": "public_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "private_key": {
+          "name": "private_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.links": {
+      "name": "links",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_sync_at": {
+          "name": "last_sync_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_status": {
+          "name": "last_status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_error": {
+          "name": "last_error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "links_user_id_users_id_fk": {
+          "name": "links_user_id_users_id_fk",
+          "tableFrom": "links",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.negotiator_memories": {
+      "name": "negotiator_memories",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "agent_id": {
+          "name": "agent_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "subject_user_id": {
+          "name": "subject_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "embedding": {
+          "name": "embedding",
+          "type": "vector(2000)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source_refs": {
+          "name": "source_refs",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "confidence": {
+          "name": "confidence",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0.5
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "negotiator_memories_agent_kind_idx": {
+          "name": "negotiator_memories_agent_kind_idx",
+          "columns": [
+            {
+              "expression": "agent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "kind",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "negotiator_memories_user_subject_idx": {
+          "name": "negotiator_memories_user_subject_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "subject_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "negotiator_memories_embedding_idx": {
+          "name": "negotiator_memories_embedding_idx",
+          "columns": [
+            {
+              "expression": "embedding",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "vector_cosine_ops"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "hnsw",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "negotiator_memories_agent_id_agents_id_fk": {
+          "name": "negotiator_memories_agent_id_agents_id_fk",
+          "tableFrom": "negotiator_memories",
+          "tableTo": "agents",
+          "columnsFrom": [
+            "agent_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "negotiator_memories_user_id_users_id_fk": {
+          "name": "negotiator_memories_user_id_users_id_fk",
+          "tableFrom": "negotiator_memories",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "negotiator_memories_subject_user_id_users_id_fk": {
+          "name": "negotiator_memories_subject_user_id_users_id_fk",
+          "tableFrom": "negotiator_memories",
+          "tableTo": "users",
+          "columnsFrom": [
+            "subject_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.network_integrations": {
+      "name": "network_integrations",
+      "schema": "",
+      "columns": {
+        "network_id": {
+          "name": "network_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "toolkit": {
+          "name": "toolkit",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "connected_account_id": {
+          "name": "connected_account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sync_config": {
+          "name": "sync_config",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "network_integrations_network_id_networks_id_fk": {
+          "name": "network_integrations_network_id_networks_id_fk",
+          "tableFrom": "network_integrations",
+          "tableTo": "networks",
+          "columnsFrom": [
+            "network_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "network_integrations_network_id_toolkit_pk": {
+          "name": "network_integrations_network_id_toolkit_pk",
+          "columns": [
+            "network_id",
+            "toolkit"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.network_members": {
+      "name": "network_members",
+      "schema": "",
+      "columns": {
+        "network_id": {
+          "name": "network_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "permissions": {
+          "name": "permissions",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'"
+        },
+        "prompt": {
+          "name": "prompt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "auto_assign": {
+          "name": "auto_assign",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "network_members_network_id_networks_id_fk": {
+          "name": "network_members_network_id_networks_id_fk",
+          "tableFrom": "network_members",
+          "tableTo": "networks",
+          "columnsFrom": [
+            "network_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "network_members_user_id_users_id_fk": {
+          "name": "network_members_user_id_users_id_fk",
+          "tableFrom": "network_members",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "network_members_network_id_user_id_pk": {
+          "name": "network_members_network_id_user_id_pk",
+          "columns": [
+            "network_id",
+            "user_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.networks": {
+      "name": "networks",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "prompt": {
+          "name": "prompt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "image_url": {
+          "name": "image_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_personal": {
+          "name": "is_personal",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "is_experiment": {
+          "name": "is_experiment",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "experiment_master_key_hash": {
+          "name": "experiment_master_key_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "type": {
+          "name": "type",
+          "type": "network_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'community'"
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "permissions": {
+          "name": "permissions",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'{\"joinPolicy\":\"invite_only\",\"invitationLink\":null,\"allowGuestVibeCheck\":false}'::json"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "indexes_key_unique": {
+          "name": "indexes_key_unique",
+          "columns": [
+            {
+              "expression": "key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.oauth_access_token": {
+      "name": "oauth_access_token",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "access_token_expires_at": {
+          "name": "access_token_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "refresh_token_expires_at": {
+          "name": "refresh_token_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scopes": {
+          "name": "scopes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "oauth_access_token_client_id_idx": {
+          "name": "oauth_access_token_client_id_idx",
+          "columns": [
+            {
+              "expression": "client_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "oauth_access_token_user_id_idx": {
+          "name": "oauth_access_token_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "oauth_access_token_client_id_oauth_application_client_id_fk": {
+          "name": "oauth_access_token_client_id_oauth_application_client_id_fk",
+          "tableFrom": "oauth_access_token",
+          "tableTo": "oauth_application",
+          "columnsFrom": [
+            "client_id"
+          ],
+          "columnsTo": [
+            "client_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "oauth_access_token_user_id_users_id_fk": {
+          "name": "oauth_access_token_user_id_users_id_fk",
+          "tableFrom": "oauth_access_token",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "oauth_access_token_access_token_unique": {
+          "name": "oauth_access_token_access_token_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "access_token"
+          ]
+        },
+        "oauth_access_token_refresh_token_unique": {
+          "name": "oauth_access_token_refresh_token_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "refresh_token"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.oauth_application": {
+      "name": "oauth_application",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "icon": {
+          "name": "icon",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "client_secret": {
+          "name": "client_secret",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "redirect_urls": {
+          "name": "redirect_urls",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "disabled": {
+          "name": "disabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "oauth_application_user_id_idx": {
+          "name": "oauth_application_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "oauth_application_user_id_users_id_fk": {
+          "name": "oauth_application_user_id_users_id_fk",
+          "tableFrom": "oauth_application",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "oauth_application_client_id_unique": {
+          "name": "oauth_application_client_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "client_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.oauth_consent": {
+      "name": "oauth_consent",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scopes": {
+          "name": "scopes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "consent_given": {
+          "name": "consent_given",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "oauth_consent_client_id_idx": {
+          "name": "oauth_consent_client_id_idx",
+          "columns": [
+            {
+              "expression": "client_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "oauth_consent_user_id_idx": {
+          "name": "oauth_consent_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "oauth_consent_client_id_oauth_application_client_id_fk": {
+          "name": "oauth_consent_client_id_oauth_application_client_id_fk",
+          "tableFrom": "oauth_consent",
+          "tableTo": "oauth_application",
+          "columnsFrom": [
+            "client_id"
+          ],
+          "columnsTo": [
+            "client_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "oauth_consent_user_id_users_id_fk": {
+          "name": "oauth_consent_user_id_users_id_fk",
+          "tableFrom": "oauth_consent",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.opportunities": {
+      "name": "opportunities",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "detection": {
+          "name": "detection",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "actors": {
+          "name": "actors",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "interpretation": {
+          "name": "interpretation",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "context": {
+          "name": "context",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "confidence": {
+          "name": "confidence",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "opportunity_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "accepted_by": {
+          "name": "accepted_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'{}'::jsonb"
+        }
+      },
+      "indexes": {
+        "opportunities_status_idx": {
+          "name": "opportunities_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "opportunities_accepted_by_users_id_fk": {
+          "name": "opportunities_accepted_by_users_id_fk",
+          "tableFrom": "opportunities",
+          "tableTo": "users",
+          "columnsFrom": [
+            "accepted_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.opportunity_deliveries": {
+      "name": "opportunity_deliveries",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "opportunity_id": {
+          "name": "opportunity_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "agent_id": {
+          "name": "agent_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "channel": {
+          "name": "channel",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "trigger": {
+          "name": "trigger",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "delivered_at_status": {
+          "name": "delivered_at_status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reservation_token": {
+          "name": "reservation_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reserved_at": {
+          "name": "reserved_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "delivered_at": {
+          "name": "delivered_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "uniq_opp_deliveries_committed": {
+          "name": "uniq_opp_deliveries_committed",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "opportunity_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "channel",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "delivered_at_status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"opportunity_deliveries\".\"delivered_at\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_opp_deliveries_open_reservations": {
+          "name": "idx_opp_deliveries_open_reservations",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "channel",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "reserved_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"opportunity_deliveries\".\"delivered_at\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "opportunity_deliveries_opportunity_id_opportunities_id_fk": {
+          "name": "opportunity_deliveries_opportunity_id_opportunities_id_fk",
+          "tableFrom": "opportunity_deliveries",
+          "tableTo": "opportunities",
+          "columnsFrom": [
+            "opportunity_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "opportunity_deliveries_user_id_users_id_fk": {
+          "name": "opportunity_deliveries_user_id_users_id_fk",
+          "tableFrom": "opportunity_deliveries",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "opportunity_deliveries_agent_id_agents_id_fk": {
+          "name": "opportunity_deliveries_agent_id_agents_id_fk",
+          "tableFrom": "opportunity_deliveries",
+          "tableTo": "agents",
+          "columnsFrom": [
+            "agent_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.opportunity_discovery_runs": {
+      "name": "opportunity_discovery_runs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "agent_id": {
+          "name": "agent_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "discovery_run_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'queued'"
+        },
+        "input": {
+          "name": "input",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "context": {
+          "name": "context",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "progress": {
+          "name": "progress",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "result": {
+          "name": "result",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error": {
+          "name": "error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cancel_requested_at": {
+          "name": "cancel_requested_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "opportunity_discovery_runs_user_created_idx": {
+          "name": "opportunity_discovery_runs_user_created_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "opportunity_discovery_runs_status_created_idx": {
+          "name": "opportunity_discovery_runs_status_created_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "opportunity_discovery_runs_expires_at_idx": {
+          "name": "opportunity_discovery_runs_expires_at_idx",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "opportunity_discovery_runs_user_id_users_id_fk": {
+          "name": "opportunity_discovery_runs_user_id_users_id_fk",
+          "tableFrom": "opportunity_discovery_runs",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "opportunity_discovery_runs_agent_id_agents_id_fk": {
+          "name": "opportunity_discovery_runs_agent_id_agents_id_fk",
+          "tableFrom": "opportunity_discovery_runs",
+          "tableTo": "agents",
+          "columnsFrom": [
+            "agent_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.opportunity_outcome_events": {
+      "name": "opportunity_outcome_events",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "recipient_user_id": {
+          "name": "recipient_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "intent_id": {
+          "name": "intent_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "intent_fingerprint": {
+          "name": "intent_fingerprint",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "opportunity_id": {
+          "name": "opportunity_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "network_id": {
+          "name": "network_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "action": {
+          "name": "action",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "candidate_snapshot": {
+          "name": "candidate_snapshot",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "snapshot_hash": {
+          "name": "snapshot_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "dedup_key": {
+          "name": "dedup_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "idempotency_key": {
+          "name": "idempotency_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "uniq_opp_outcome_events_idempotency": {
+          "name": "uniq_opp_outcome_events_idempotency",
+          "columns": [
+            {
+              "expression": "idempotency_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_opp_outcome_events_scope": {
+          "name": "idx_opp_outcome_events_scope",
+          "columns": [
+            {
+              "expression": "recipient_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "intent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "intent_fingerprint",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "opportunity_outcome_events_recipient_user_id_users_id_fk": {
+          "name": "opportunity_outcome_events_recipient_user_id_users_id_fk",
+          "tableFrom": "opportunity_outcome_events",
+          "tableTo": "users",
+          "columnsFrom": [
+            "recipient_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.personal_networks": {
+      "name": "personal_networks",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "network_id": {
+          "name": "network_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "personal_networks_network_id_unique": {
+          "name": "personal_networks_network_id_unique",
+          "columns": [
+            {
+              "expression": "network_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "personal_networks_user_id_users_id_fk": {
+          "name": "personal_networks_user_id_users_id_fk",
+          "tableFrom": "personal_networks",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "personal_networks_network_id_networks_id_fk": {
+          "name": "personal_networks_network_id_networks_id_fk",
+          "tableFrom": "personal_networks",
+          "tableTo": "networks",
+          "columnsFrom": [
+            "network_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "personal_networks_user_id_pk": {
+          "name": "personal_networks_user_id_pk",
+          "columns": [
+            "user_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.premise_networks": {
+      "name": "premise_networks",
+      "schema": "",
+      "columns": {
+        "premise_id": {
+          "name": "premise_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "network_id": {
+          "name": "network_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "relevancy_score": {
+          "name": "relevancy_score",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "assignment_metadata": {
+          "name": "assignment_metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "premise_networks_network_id_idx": {
+          "name": "premise_networks_network_id_idx",
+          "columns": [
+            {
+              "expression": "network_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "premise_networks_premise_id_premises_id_fk": {
+          "name": "premise_networks_premise_id_premises_id_fk",
+          "tableFrom": "premise_networks",
+          "tableTo": "premises",
+          "columnsFrom": [
+            "premise_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "premise_networks_network_id_networks_id_fk": {
+          "name": "premise_networks_network_id_networks_id_fk",
+          "tableFrom": "premise_networks",
+          "tableTo": "networks",
+          "columnsFrom": [
+            "network_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "premise_networks_premise_id_network_id_pk": {
+          "name": "premise_networks_premise_id_network_id_pk",
+          "columns": [
+            "premise_id",
+            "network_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.premises": {
+      "name": "premises",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "assertion": {
+          "name": "assertion",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provenance": {
+          "name": "provenance",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "analysis": {
+          "name": "analysis",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "validity": {
+          "name": "validity",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "embedding": {
+          "name": "embedding",
+          "type": "vector(2000)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "premise_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'ACTIVE'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "retracted_at": {
+          "name": "retracted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "premises_embedding_idx": {
+          "name": "premises_embedding_idx",
+          "columns": [
+            {
+              "expression": "embedding",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "vector_cosine_ops"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "hnsw",
+          "with": {}
+        },
+        "premises_user_id_idx": {
+          "name": "premises_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "premises_status_idx": {
+          "name": "premises_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "premises_user_id_users_id_fk": {
+          "name": "premises_user_id_users_id_fk",
+          "tableFrom": "premises",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.questions": {
+      "name": "questions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "detection": {
+          "name": "detection",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "actors": {
+          "name": "actors",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "payload": {
+          "name": "payload",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "question_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "answer": {
+          "name": "answer",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "conversation_id": {
+          "name": "conversation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "questions_status_idx": {
+          "name": "questions_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "questions_conversation_id_idx": {
+          "name": "questions_conversation_id_idx",
+          "columns": [
+            {
+              "expression": "conversation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "questions_uptake_recipient_source_uniq": {
+          "name": "questions_uptake_recipient_source_uniq",
+          "columns": [
+            {
+              "expression": "(\"actors\"->0->>'userId')",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "(\"detection\"->>'sourceType')",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "(\"detection\"->>'sourceId')",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "(\"detection\"->>'purpose')",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"questions\".\"detection\"->>'purpose' = 'uptake'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "questions_pool_push_recipient_intent_cycle_uniq": {
+          "name": "questions_pool_push_recipient_intent_cycle_uniq",
+          "columns": [
+            {
+              "expression": "(\"detection\"->'push'->>'recipientId')",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "(\"detection\"->'push'->>'intentId')",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "(\"detection\"->'push'->>'cycleKey')",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"questions\".\"detection\"->>'mode' = 'pool_discovery' AND \"questions\".\"detection\"->'push'->>'claimedAt' IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "questions_pool_push_recipient_claimed_at_idx": {
+          "name": "questions_pool_push_recipient_claimed_at_idx",
+          "columns": [
+            {
+              "expression": "(\"actors\"->0->>'userId')",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "(\"detection\"->'push'->>'claimedAt')",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"questions\".\"detection\"->'push'->>'claimedAt' IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.sessions": {
+      "name": "sessions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "ip_address": {
+          "name": "ip_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "sessions_user_id_users_id_fk": {
+          "name": "sessions_user_id_users_id_fk",
+          "tableFrom": "sessions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "sessions_token_unique": {
+          "name": "sessions_token_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_contexts": {
+      "name": "user_contexts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "network_id": {
+          "name": "network_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "text": {
+          "name": "text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "embedding": {
+          "name": "embedding",
+          "type": "vector(2000)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "premise_hash": {
+          "name": "premise_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "generated_at": {
+          "name": "generated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "user_contexts_user_network_uniq": {
+          "name": "user_contexts_user_network_uniq",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "network_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"user_contexts\".\"network_id\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "user_contexts_user_global_uniq": {
+          "name": "user_contexts_user_global_uniq",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"user_contexts\".\"network_id\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "user_contexts_embedding_idx": {
+          "name": "user_contexts_embedding_idx",
+          "columns": [
+            {
+              "expression": "embedding",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "vector_cosine_ops"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "hnsw",
+          "with": {}
+        },
+        "user_contexts_user_id_idx": {
+          "name": "user_contexts_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "user_contexts_network_id_idx": {
+          "name": "user_contexts_network_id_idx",
+          "columns": [
+            {
+              "expression": "network_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "user_contexts_user_id_users_id_fk": {
+          "name": "user_contexts_user_id_users_id_fk",
+          "tableFrom": "user_contexts",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "user_contexts_network_id_networks_id_fk": {
+          "name": "user_contexts_network_id_networks_id_fk",
+          "tableFrom": "user_contexts",
+          "tableTo": "networks",
+          "columnsFrom": [
+            "network_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_notification_settings": {
+      "name": "user_notification_settings",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "preferences": {
+          "name": "preferences",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'{\"connectionUpdates\":true,\"weeklyNewsletter\":true}'::json"
+        },
+        "unsubscribe_token": {
+          "name": "unsubscribe_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "user_notification_settings_user_id_users_id_fk": {
+          "name": "user_notification_settings_user_id_users_id_fk",
+          "tableFrom": "user_notification_settings",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "user_notification_settings_user_id_unique": {
+          "name": "user_notification_settings_user_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id"
+          ]
+        },
+        "user_notification_settings_unsubscribe_token_unique": {
+          "name": "user_notification_settings_unsubscribe_token_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "unsubscribe_token"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_socials": {
+      "name": "user_socials",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "label": {
+          "name": "label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_user_socials_user_id": {
+          "name": "idx_user_socials_user_id",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "uniq_user_socials_user_label": {
+          "name": "uniq_user_socials_user_label",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "label",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"user_socials\".\"label\" <> 'custom'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "user_socials_user_id_users_id_fk": {
+          "name": "user_socials_user_id_users_id_fk",
+          "tableFrom": "user_socials",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email_verified": {
+          "name": "email_verified",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "avatar": {
+          "name": "avatar",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "intro": {
+          "name": "intro",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "location": {
+          "name": "location",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "onboarding": {
+          "name": "onboarding",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'{}'::json"
+        },
+        "timezone": {
+          "name": "timezone",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'UTC'"
+        },
+        "last_weekly_email_sent_at": {
+          "name": "last_weekly_email_sent_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_ghost": {
+          "name": "is_ghost",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "users_email_unique": {
+          "name": "users_email_unique",
+          "columns": [
+            {
+              "expression": "email",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "users_key_unique": {
+          "name": "users_key_unique",
+          "columns": [
+            {
+              "expression": "key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.verifications": {
+      "name": "verifications",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "identifier": {
+          "name": "identifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.artifacts": {
+      "name": "artifacts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "task_id": {
+          "name": "task_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "parts": {
+          "name": "parts",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "extensions": {
+          "name": "extensions",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "artifacts_task_id_idx": {
+          "name": "artifacts_task_id_idx",
+          "columns": [
+            {
+              "expression": "task_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "artifacts_task_id_tasks_id_fk": {
+          "name": "artifacts_task_id_tasks_id_fk",
+          "tableFrom": "artifacts",
+          "tableTo": "tasks",
+          "columnsFrom": [
+            "task_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.chat_session_scopes": {
+      "name": "chat_session_scopes",
+      "schema": "",
+      "columns": {
+        "conversation_id": {
+          "name": "conversation_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scope_type": {
+          "name": "scope_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scope_id": {
+          "name": "scope_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "chat_session_scopes_user_scope_unique": {
+          "name": "chat_session_scopes_user_scope_unique",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "scope_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "scope_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "chat_session_scopes_user_id_idx": {
+          "name": "chat_session_scopes_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "chat_session_scopes_scope_idx": {
+          "name": "chat_session_scopes_scope_idx",
+          "columns": [
+            {
+              "expression": "scope_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "scope_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "chat_session_scopes_conversation_id_conversations_id_fk": {
+          "name": "chat_session_scopes_conversation_id_conversations_id_fk",
+          "tableFrom": "chat_session_scopes",
+          "tableTo": "conversations",
+          "columnsFrom": [
+            "conversation_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.chat_session_summaries": {
+      "name": "chat_session_summaries",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "conversation_id": {
+          "name": "conversation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "from_message_id": {
+          "name": "from_message_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "to_message_id": {
+          "name": "to_message_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "digest": {
+          "name": "digest",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "model": {
+          "name": "model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "chat_session_summaries_session_latest_idx": {
+          "name": "chat_session_summaries_session_latest_idx",
+          "columns": [
+            {
+              "expression": "conversation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "chat_session_summaries_conversation_id_conversations_id_fk": {
+          "name": "chat_session_summaries_conversation_id_conversations_id_fk",
+          "tableFrom": "chat_session_summaries",
+          "tableTo": "conversations",
+          "columnsFrom": [
+            "conversation_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "chat_session_summaries_from_message_id_messages_id_fk": {
+          "name": "chat_session_summaries_from_message_id_messages_id_fk",
+          "tableFrom": "chat_session_summaries",
+          "tableTo": "messages",
+          "columnsFrom": [
+            "from_message_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "chat_session_summaries_to_message_id_messages_id_fk": {
+          "name": "chat_session_summaries_to_message_id_messages_id_fk",
+          "tableFrom": "chat_session_summaries",
+          "tableTo": "messages",
+          "columnsFrom": [
+            "to_message_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.conversation_metadata": {
+      "name": "conversation_metadata",
+      "schema": "",
+      "columns": {
+        "conversation_id": {
+          "name": "conversation_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "conversation_metadata_conversation_id_conversations_id_fk": {
+          "name": "conversation_metadata_conversation_id_conversations_id_fk",
+          "tableFrom": "conversation_metadata",
+          "tableTo": "conversations",
+          "columnsFrom": [
+            "conversation_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.conversation_participants": {
+      "name": "conversation_participants",
+      "schema": "",
+      "columns": {
+        "conversation_id": {
+          "name": "conversation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "participant_id": {
+          "name": "participant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "participant_type": {
+          "name": "participant_type",
+          "type": "participant_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "joined_at": {
+          "name": "joined_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "hidden_at": {
+          "name": "hidden_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_read_at": {
+          "name": "last_read_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "conversation_participants_participant_id_idx": {
+          "name": "conversation_participants_participant_id_idx",
+          "columns": [
+            {
+              "expression": "participant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "conversation_participants_conversation_id_idx": {
+          "name": "conversation_participants_conversation_id_idx",
+          "columns": [
+            {
+              "expression": "conversation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "conversation_participants_conversation_id_conversations_id_fk": {
+          "name": "conversation_participants_conversation_id_conversations_id_fk",
+          "tableFrom": "conversation_participants",
+          "tableTo": "conversations",
+          "columnsFrom": [
+            "conversation_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "conversation_participants_conversation_id_participant_id_pk": {
+          "name": "conversation_participants_conversation_id_participant_id_pk",
+          "columns": [
+            "conversation_id",
+            "participant_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.conversation_sessions": {
+      "name": "conversation_sessions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "conversation_id": {
+          "name": "conversation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "task_id": {
+          "name": "task_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_message_at": {
+          "name": "last_message_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "conversation_sessions_conversation_started_idx": {
+          "name": "conversation_sessions_conversation_started_idx",
+          "columns": [
+            {
+              "expression": "conversation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "started_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "conversation_sessions_task_id_uniq": {
+          "name": "conversation_sessions_task_id_uniq",
+          "columns": [
+            {
+              "expression": "task_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "conversation_sessions_conversation_id_conversations_id_fk": {
+          "name": "conversation_sessions_conversation_id_conversations_id_fk",
+          "tableFrom": "conversation_sessions",
+          "tableTo": "conversations",
+          "columnsFrom": [
+            "conversation_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "conversation_sessions_task_id_tasks_id_fk": {
+          "name": "conversation_sessions_task_id_tasks_id_fk",
+          "tableFrom": "conversation_sessions",
+          "tableTo": "tasks",
+          "columnsFrom": [
+            "task_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.conversations": {
+      "name": "conversations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "dm_pair": {
+          "name": "dm_pair",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "persona": {
+          "name": "persona",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'orchestrator'"
+        },
+        "last_message_at": {
+          "name": "last_message_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "conversations_dm_pair_idx": {
+          "name": "conversations_dm_pair_idx",
+          "columns": [
+            {
+              "expression": "dm_pair",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.messages": {
+      "name": "messages",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "conversation_id": {
+          "name": "conversation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "task_id": {
+          "name": "task_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sender_id": {
+          "name": "sender_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "message_role",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "parts": {
+          "name": "parts",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "extensions": {
+          "name": "extensions",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reference_task_ids": {
+          "name": "reference_task_ids",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "messages_conversation_id_created_at_idx": {
+          "name": "messages_conversation_id_created_at_idx",
+          "columns": [
+            {
+              "expression": "conversation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "messages_sender_id_idx": {
+          "name": "messages_sender_id_idx",
+          "columns": [
+            {
+              "expression": "sender_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "messages_task_id_idx": {
+          "name": "messages_task_id_idx",
+          "columns": [
+            {
+              "expression": "task_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "messages_session_id_created_at_idx": {
+          "name": "messages_session_id_created_at_idx",
+          "columns": [
+            {
+              "expression": "session_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "messages_conversation_id_conversations_id_fk": {
+          "name": "messages_conversation_id_conversations_id_fk",
+          "tableFrom": "messages",
+          "tableTo": "conversations",
+          "columnsFrom": [
+            "conversation_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "messages_task_id_tasks_id_fk": {
+          "name": "messages_task_id_tasks_id_fk",
+          "tableFrom": "messages",
+          "tableTo": "tasks",
+          "columnsFrom": [
+            "task_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "messages_session_id_conversation_sessions_id_fk": {
+          "name": "messages_session_id_conversation_sessions_id_fk",
+          "tableFrom": "messages",
+          "tableTo": "conversation_sessions",
+          "columnsFrom": [
+            "session_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.tasks": {
+      "name": "tasks",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "conversation_id": {
+          "name": "conversation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "state": {
+          "name": "state",
+          "type": "task_state",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'submitted'"
+        },
+        "status_message": {
+          "name": "status_message",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status_timestamp": {
+          "name": "status_timestamp",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "extensions": {
+          "name": "extensions",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "claimed_by_agent_id": {
+          "name": "claimed_by_agent_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "claimed_at": {
+          "name": "claimed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "tasks_conversation_id_idx": {
+          "name": "tasks_conversation_id_idx",
+          "columns": [
+            {
+              "expression": "conversation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "tasks_state_idx": {
+          "name": "tasks_state_idx",
+          "columns": [
+            {
+              "expression": "state",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "tasks_metadata_opportunity_id_idx": {
+          "name": "tasks_metadata_opportunity_id_idx",
+          "columns": [
+            {
+              "expression": "(\"metadata\"->>'opportunityId')",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"tasks\".\"metadata\"->>'type' = 'negotiation'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "tasks_conversation_id_conversations_id_fk": {
+          "name": "tasks_conversation_id_conversations_id_fk",
+          "tableFrom": "tasks",
+          "tableTo": "conversations",
+          "columnsFrom": [
+            "conversation_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.agent_action_proposal_status": {
+      "name": "agent_action_proposal_status",
+      "schema": "public",
+      "values": [
+        "pending",
+        "executing",
+        "consumed"
+      ]
+    },
+    "public.agent_status": {
+      "name": "agent_status",
+      "schema": "public",
+      "values": [
+        "active",
+        "inactive"
+      ]
+    },
+    "public.agent_type": {
+      "name": "agent_type",
+      "schema": "public",
+      "values": [
+        "personal",
+        "external",
+        "system"
+      ]
+    },
+    "public.discovery_run_status": {
+      "name": "discovery_run_status",
+      "schema": "public",
+      "values": [
+        "queued",
+        "running",
+        "succeeded",
+        "failed",
+        "cancelled"
+      ]
+    },
+    "public.intent_mode": {
+      "name": "intent_mode",
+      "schema": "public",
+      "values": [
+        "REFERENTIAL",
+        "ATTRIBUTIVE"
+      ]
+    },
+    "public.intent_status": {
+      "name": "intent_status",
+      "schema": "public",
+      "values": [
+        "ACTIVE",
+        "PAUSED",
+        "FULFILLED",
+        "EXPIRED"
+      ]
+    },
+    "public.network_type": {
+      "name": "network_type",
+      "schema": "public",
+      "values": [
+        "community",
+        "event"
+      ]
+    },
+    "public.opportunity_status": {
+      "name": "opportunity_status",
+      "schema": "public",
+      "values": [
+        "latent",
+        "draft",
+        "negotiating",
+        "pending",
+        "stalled",
+        "accepted",
+        "rejected",
+        "expired"
+      ]
+    },
+    "public.permission_scope": {
+      "name": "permission_scope",
+      "schema": "public",
+      "values": [
+        "global",
+        "node",
+        "network"
+      ]
+    },
+    "public.premise_status": {
+      "name": "premise_status",
+      "schema": "public",
+      "values": [
+        "ACTIVE",
+        "RETRACTED",
+        "EXPIRED"
+      ]
+    },
+    "public.question_status": {
+      "name": "question_status",
+      "schema": "public",
+      "values": [
+        "pending",
+        "answered",
+        "dismissed"
+      ]
+    },
+    "public.source_type": {
+      "name": "source_type",
+      "schema": "public",
+      "values": [
+        "file",
+        "integration",
+        "link",
+        "discovery_form",
+        "enrichment"
+      ]
+    },
+    "public.speech_act_type": {
+      "name": "speech_act_type",
+      "schema": "public",
+      "values": [
+        "COMMISSIVE",
+        "DIRECTIVE"
+      ]
+    },
+    "public.transport_channel": {
+      "name": "transport_channel",
+      "schema": "public",
+      "values": [
+        "mcp"
+      ]
+    },
+    "public.message_role": {
+      "name": "message_role",
+      "schema": "public",
+      "values": [
+        "user",
+        "agent"
+      ]
+    },
+    "public.participant_type": {
+      "name": "participant_type",
+      "schema": "public",
+      "values": [
+        "user",
+        "agent"
+      ]
+    },
+    "public.task_state": {
+      "name": "task_state",
+      "schema": "public",
+      "values": [
+        "submitted",
+        "working",
+        "input_required",
+        "completed",
+        "failed",
+        "canceled",
+        "rejected",
+        "auth_required",
+        "waiting_for_agent",
+        "claimed"
+      ]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/services/api/drizzle/meta/0104_snapshot.json
+++ b/services/api/drizzle/meta/0104_snapshot.json
@@ -1,0 +1,6423 @@
+{
+  "id": "0f468120-bb9e-4b22-9f7c-9f9463dbe60c",
+  "prevId": "8f957025-4e83-4566-b302-368c6ab8bca6",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.accounts": {
+      "name": "accounts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "id_token": {
+          "name": "id_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "access_token_expires_at": {
+          "name": "access_token_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token_expires_at": {
+          "name": "refresh_token_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "password": {
+          "name": "password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "accounts_user_id_users_id_fk": {
+          "name": "accounts_user_id_users_id_fk",
+          "tableFrom": "accounts",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.agent_action_proposals": {
+      "name": "agent_action_proposals",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "conversation_id": {
+          "name": "conversation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "actions": {
+          "name": "actions",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "agent_action_proposal_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "result": {
+          "name": "result",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "execution_lease_at": {
+          "name": "execution_lease_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "consumed_at": {
+          "name": "consumed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "agent_action_proposals_user_id_idx": {
+          "name": "agent_action_proposals_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "agent_action_proposals_conversation_id_idx": {
+          "name": "agent_action_proposals_conversation_id_idx",
+          "columns": [
+            {
+              "expression": "conversation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "agent_action_proposals_user_id_users_id_fk": {
+          "name": "agent_action_proposals_user_id_users_id_fk",
+          "tableFrom": "agent_action_proposals",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.agent_permissions": {
+      "name": "agent_permissions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "agent_id": {
+          "name": "agent_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scope": {
+          "name": "scope",
+          "type": "permission_scope",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'global'"
+        },
+        "scope_id": {
+          "name": "scope_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "actions": {
+          "name": "actions",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "agent_permissions_agent_id_idx": {
+          "name": "agent_permissions_agent_id_idx",
+          "columns": [
+            {
+              "expression": "agent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "agent_permissions_user_id_idx": {
+          "name": "agent_permissions_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "agent_permissions_agent_user_idx": {
+          "name": "agent_permissions_agent_user_idx",
+          "columns": [
+            {
+              "expression": "agent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "uniq_agent_permissions_global": {
+          "name": "uniq_agent_permissions_global",
+          "columns": [
+            {
+              "expression": "agent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"agent_permissions\".\"scope\" = 'global'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "agent_permissions_agent_id_agents_id_fk": {
+          "name": "agent_permissions_agent_id_agents_id_fk",
+          "tableFrom": "agent_permissions",
+          "tableTo": "agents",
+          "columnsFrom": [
+            "agent_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "agent_permissions_user_id_users_id_fk": {
+          "name": "agent_permissions_user_id_users_id_fk",
+          "tableFrom": "agent_permissions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.agent_test_messages": {
+      "name": "agent_test_messages",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "agent_id": {
+          "name": "agent_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "requested_by_user_id": {
+          "name": "requested_by_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reservation_token": {
+          "name": "reservation_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reserved_at": {
+          "name": "reserved_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "delivered_at": {
+          "name": "delivered_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_agent_test_messages_agent_pending": {
+          "name": "idx_agent_test_messages_agent_pending",
+          "columns": [
+            {
+              "expression": "agent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "reserved_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "agent_test_messages_agent_id_agents_id_fk": {
+          "name": "agent_test_messages_agent_id_agents_id_fk",
+          "tableFrom": "agent_test_messages",
+          "tableTo": "agents",
+          "columnsFrom": [
+            "agent_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "agent_test_messages_requested_by_user_id_users_id_fk": {
+          "name": "agent_test_messages_requested_by_user_id_users_id_fk",
+          "tableFrom": "agent_test_messages",
+          "tableTo": "users",
+          "columnsFrom": [
+            "requested_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.agent_transports": {
+      "name": "agent_transports",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "agent_id": {
+          "name": "agent_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "channel": {
+          "name": "channel",
+          "type": "transport_channel",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "config": {
+          "name": "config",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'{}'::jsonb"
+        },
+        "priority": {
+          "name": "priority",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "active": {
+          "name": "active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "failure_count": {
+          "name": "failure_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "agent_transports_agent_id_idx": {
+          "name": "agent_transports_agent_id_idx",
+          "columns": [
+            {
+              "expression": "agent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "agent_transports_agent_id_agents_id_fk": {
+          "name": "agent_transports_agent_id_agents_id_fk",
+          "tableFrom": "agent_transports",
+          "tableTo": "agents",
+          "columnsFrom": [
+            "agent_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.agents": {
+      "name": "agents",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "owner_id": {
+          "name": "owner_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "type": {
+          "name": "type",
+          "type": "agent_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "agent_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'{}'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "last_seen_at": {
+          "name": "last_seen_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "notify_on_opportunity": {
+          "name": "notify_on_opportunity",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "daily_summary_enabled": {
+          "name": "daily_summary_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "handle_negotiations": {
+          "name": "handle_negotiations",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "last_daily_summary_at": {
+          "name": "last_daily_summary_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "agents_owner_id_idx": {
+          "name": "agents_owner_id_idx",
+          "columns": [
+            {
+              "expression": "owner_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "agents_type_idx": {
+          "name": "agents_type_idx",
+          "columns": [
+            {
+              "expression": "type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "agents_last_seen_at_idx": {
+          "name": "agents_last_seen_at_idx",
+          "columns": [
+            {
+              "expression": "last_seen_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "uniq_agents_personal_per_owner": {
+          "name": "uniq_agents_personal_per_owner",
+          "columns": [
+            {
+              "expression": "owner_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"agents\".\"type\" = 'personal' AND \"agents\".\"deleted_at\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "agents_owner_id_users_id_fk": {
+          "name": "agents_owner_id_users_id_fk",
+          "tableFrom": "agents",
+          "tableTo": "users",
+          "columnsFrom": [
+            "owner_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.apikey": {
+      "name": "apikey",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reference_id": {
+          "name": "reference_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "config_id": {
+          "name": "config_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'default'"
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "prefix": {
+          "name": "prefix",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "start": {
+          "name": "start",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "rate_limit_enabled": {
+          "name": "rate_limit_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "rate_limit_max": {
+          "name": "rate_limit_max",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "rate_limit_time_window": {
+          "name": "rate_limit_time_window",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "request_count": {
+          "name": "request_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "remaining": {
+          "name": "remaining",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refill_amount": {
+          "name": "refill_amount",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refill_interval": {
+          "name": "refill_interval",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_refill_at": {
+          "name": "last_refill_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_request": {
+          "name": "last_request",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "permissions": {
+          "name": "permissions",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "apikey_user_id_users_id_fk": {
+          "name": "apikey_user_id_users_id_fk",
+          "tableFrom": "apikey",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.connect_links": {
+      "name": "connect_links",
+      "schema": "",
+      "columns": {
+        "code": {
+          "name": "code",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "opportunity_id": {
+          "name": "opportunity_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "greeting": {
+          "name": "greeting",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "preferred_surface": {
+          "name": "preferred_surface",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "connect_links_kind_recipient_uq": {
+          "name": "connect_links_kind_recipient_uq",
+          "columns": [
+            {
+              "expression": "opportunity_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "kind",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "connect_links_expires_at_idx": {
+          "name": "connect_links_expires_at_idx",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "connect_links_user_id_users_id_fk": {
+          "name": "connect_links_user_id_users_id_fk",
+          "tableFrom": "connect_links",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "connect_links_opportunity_id_opportunities_id_fk": {
+          "name": "connect_links_opportunity_id_opportunities_id_fk",
+          "tableFrom": "connect_links",
+          "tableTo": "opportunities",
+          "columnsFrom": [
+            "opportunity_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.cross_network_yield_snapshots": {
+      "name": "cross_network_yield_snapshots",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "run_id": {
+          "name": "run_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "network_a_id": {
+          "name": "network_a_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "network_b_id": {
+          "name": "network_b_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "opportunity_count": {
+          "name": "opportunity_count",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "potential_active_intent_pair_count": {
+          "name": "potential_active_intent_pair_count",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "yield_rate": {
+          "name": "yield_rate",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "yield_rate_delta": {
+          "name": "yield_rate_delta",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "prior_bucket_start": {
+          "name": "prior_bucket_start",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "bucket_start": {
+          "name": "bucket_start",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "bucket_end": {
+          "name": "bucket_end",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "captured_at": {
+          "name": "captured_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "cross_network_yield_snapshots_daily_uniq": {
+          "name": "cross_network_yield_snapshots_daily_uniq",
+          "columns": [
+            {
+              "expression": "network_a_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "network_b_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "bucket_start",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "cross_network_yield_snapshots_run_id_frame_drift_observation_runs_id_fk": {
+          "name": "cross_network_yield_snapshots_run_id_frame_drift_observation_runs_id_fk",
+          "tableFrom": "cross_network_yield_snapshots",
+          "tableTo": "frame_drift_observation_runs",
+          "columnsFrom": [
+            "run_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "cross_network_yield_snapshots_network_a_id_networks_id_fk": {
+          "name": "cross_network_yield_snapshots_network_a_id_networks_id_fk",
+          "tableFrom": "cross_network_yield_snapshots",
+          "tableTo": "networks",
+          "columnsFrom": [
+            "network_a_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "cross_network_yield_snapshots_network_b_id_networks_id_fk": {
+          "name": "cross_network_yield_snapshots_network_b_id_networks_id_fk",
+          "tableFrom": "cross_network_yield_snapshots",
+          "tableTo": "networks",
+          "columnsFrom": [
+            "network_b_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "cross_network_yield_snapshots_canonical_pair_check": {
+          "name": "cross_network_yield_snapshots_canonical_pair_check",
+          "value": "\"cross_network_yield_snapshots\".\"network_a_id\" < \"cross_network_yield_snapshots\".\"network_b_id\""
+        },
+        "cross_network_yield_snapshots_opportunity_count_check": {
+          "name": "cross_network_yield_snapshots_opportunity_count_check",
+          "value": "\"cross_network_yield_snapshots\".\"opportunity_count\" >= 0"
+        },
+        "cross_network_yield_snapshots_potential_pair_count_check": {
+          "name": "cross_network_yield_snapshots_potential_pair_count_check",
+          "value": "\"cross_network_yield_snapshots\".\"potential_active_intent_pair_count\" > 0"
+        },
+        "cross_network_yield_snapshots_yield_rate_check": {
+          "name": "cross_network_yield_snapshots_yield_rate_check",
+          "value": "\"cross_network_yield_snapshots\".\"yield_rate\" >= 0"
+        },
+        "cross_network_yield_snapshots_bucket_range_check": {
+          "name": "cross_network_yield_snapshots_bucket_range_check",
+          "value": "\"cross_network_yield_snapshots\".\"bucket_end\" > \"cross_network_yield_snapshots\".\"bucket_start\""
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.enrichment_tool_runs": {
+      "name": "enrichment_tool_runs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "agent_id": {
+          "name": "agent_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "operation": {
+          "name": "operation",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "discovery_run_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'queued'"
+        },
+        "input": {
+          "name": "input",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "context": {
+          "name": "context",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "progress": {
+          "name": "progress",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "result": {
+          "name": "result",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error": {
+          "name": "error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cancel_requested_at": {
+          "name": "cancel_requested_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "enrichment_tool_runs_user_created_idx": {
+          "name": "enrichment_tool_runs_user_created_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "enrichment_tool_runs_status_created_idx": {
+          "name": "enrichment_tool_runs_status_created_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "enrichment_tool_runs_operation_created_idx": {
+          "name": "enrichment_tool_runs_operation_created_idx",
+          "columns": [
+            {
+              "expression": "operation",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "enrichment_tool_runs_expires_at_idx": {
+          "name": "enrichment_tool_runs_expires_at_idx",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "enrichment_tool_runs_user_id_users_id_fk": {
+          "name": "enrichment_tool_runs_user_id_users_id_fk",
+          "tableFrom": "enrichment_tool_runs",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "enrichment_tool_runs_agent_id_agents_id_fk": {
+          "name": "enrichment_tool_runs_agent_id_agents_id_fk",
+          "tableFrom": "enrichment_tool_runs",
+          "tableTo": "agents",
+          "columnsFrom": [
+            "agent_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.files": {
+      "name": "files",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "size": {
+          "name": "size",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "files_user_id_users_id_fk": {
+          "name": "files_user_id_users_id_fk",
+          "tableFrom": "files",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.frame_centroid_snapshots": {
+      "name": "frame_centroid_snapshots",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "run_id": {
+          "name": "run_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "network_id": {
+          "name": "network_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "corpus": {
+          "name": "corpus",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "centroid": {
+          "name": "centroid",
+          "type": "vector(2000)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sample_count": {
+          "name": "sample_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "configured_embedding_model": {
+          "name": "configured_embedding_model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "cosine_drift": {
+          "name": "cosine_drift",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "prior_bucket_start": {
+          "name": "prior_bucket_start",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "bucket_start": {
+          "name": "bucket_start",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "bucket_end": {
+          "name": "bucket_end",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "captured_at": {
+          "name": "captured_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "frame_centroid_snapshots_daily_uniq": {
+          "name": "frame_centroid_snapshots_daily_uniq",
+          "columns": [
+            {
+              "expression": "network_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "corpus",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "configured_embedding_model",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "bucket_start",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "frame_centroid_snapshots_run_id_frame_drift_observation_runs_id_fk": {
+          "name": "frame_centroid_snapshots_run_id_frame_drift_observation_runs_id_fk",
+          "tableFrom": "frame_centroid_snapshots",
+          "tableTo": "frame_drift_observation_runs",
+          "columnsFrom": [
+            "run_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "frame_centroid_snapshots_network_id_networks_id_fk": {
+          "name": "frame_centroid_snapshots_network_id_networks_id_fk",
+          "tableFrom": "frame_centroid_snapshots",
+          "tableTo": "networks",
+          "columnsFrom": [
+            "network_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "frame_centroid_snapshots_corpus_check": {
+          "name": "frame_centroid_snapshots_corpus_check",
+          "value": "\"frame_centroid_snapshots\".\"corpus\" IN ('premise', 'intent', 'user_context')"
+        },
+        "frame_centroid_snapshots_sample_count_check": {
+          "name": "frame_centroid_snapshots_sample_count_check",
+          "value": "\"frame_centroid_snapshots\".\"sample_count\" > 0"
+        },
+        "frame_centroid_snapshots_cosine_drift_check": {
+          "name": "frame_centroid_snapshots_cosine_drift_check",
+          "value": "\"frame_centroid_snapshots\".\"cosine_drift\" IS NULL OR (\"frame_centroid_snapshots\".\"cosine_drift\" >= 0 AND \"frame_centroid_snapshots\".\"cosine_drift\" <= 2)"
+        },
+        "frame_centroid_snapshots_bucket_range_check": {
+          "name": "frame_centroid_snapshots_bucket_range_check",
+          "value": "\"frame_centroid_snapshots\".\"bucket_end\" > \"frame_centroid_snapshots\".\"bucket_start\""
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.frame_drift_execution_attempts": {
+      "name": "frame_drift_execution_attempts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "queue_name": {
+          "name": "queue_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scheduler_id": {
+          "name": "scheduler_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "job_id": {
+          "name": "job_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "job_name": {
+          "name": "job_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scheduled_at": {
+          "name": "scheduled_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "bucket_start": {
+          "name": "bucket_start",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "bucket_end": {
+          "name": "bucket_end",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "attempt": {
+          "name": "attempt",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "max_attempts": {
+          "name": "max_attempts",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "terminal_status": {
+          "name": "terminal_status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "will_retry": {
+          "name": "will_retry",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "failure_category": {
+          "name": "failure_category",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "frame_drift_execution_attempts_job_attempt_uniq": {
+          "name": "frame_drift_execution_attempts_job_attempt_uniq",
+          "columns": [
+            {
+              "expression": "job_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "attempt",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "frame_drift_execution_attempts_bucket_start_idx": {
+          "name": "frame_drift_execution_attempts_bucket_start_idx",
+          "columns": [
+            {
+              "expression": "bucket_start",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "frame_drift_execution_attempts_incomplete_idx": {
+          "name": "frame_drift_execution_attempts_incomplete_idx",
+          "columns": [
+            {
+              "expression": "started_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"frame_drift_execution_attempts\".\"completed_at\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "frame_drift_execution_attempts_identity_check": {
+          "name": "frame_drift_execution_attempts_identity_check",
+          "value": "\n    length(btrim(\"frame_drift_execution_attempts\".\"queue_name\")) > 0\n    AND length(btrim(\"frame_drift_execution_attempts\".\"scheduler_id\")) > 0\n    AND length(btrim(\"frame_drift_execution_attempts\".\"job_id\")) > 0\n    AND length(btrim(\"frame_drift_execution_attempts\".\"job_name\")) > 0\n  "
+        },
+        "frame_drift_execution_attempts_daily_bucket_check": {
+          "name": "frame_drift_execution_attempts_daily_bucket_check",
+          "value": "\n    \"frame_drift_execution_attempts\".\"bucket_end\" = \"frame_drift_execution_attempts\".\"bucket_start\" + interval '1 day'\n    AND date_trunc('day', \"frame_drift_execution_attempts\".\"bucket_start\" AT TIME ZONE 'UTC') = \"frame_drift_execution_attempts\".\"bucket_start\" AT TIME ZONE 'UTC'\n    AND date_trunc('day', \"frame_drift_execution_attempts\".\"bucket_end\" AT TIME ZONE 'UTC') = \"frame_drift_execution_attempts\".\"bucket_end\" AT TIME ZONE 'UTC'\n    AND \"frame_drift_execution_attempts\".\"scheduled_at\" >= \"frame_drift_execution_attempts\".\"bucket_end\"\n    AND \"frame_drift_execution_attempts\".\"scheduled_at\" < \"frame_drift_execution_attempts\".\"bucket_end\" + interval '1 day'\n  "
+        },
+        "frame_drift_execution_attempts_attempt_bounds_check": {
+          "name": "frame_drift_execution_attempts_attempt_bounds_check",
+          "value": "\n    \"frame_drift_execution_attempts\".\"attempt\" BETWEEN 1 AND \"frame_drift_execution_attempts\".\"max_attempts\"\n    AND \"frame_drift_execution_attempts\".\"max_attempts\" BETWEEN 1 AND 100\n  "
+        },
+        "frame_drift_execution_attempts_terminal_status_check": {
+          "name": "frame_drift_execution_attempts_terminal_status_check",
+          "value": "\n    \"frame_drift_execution_attempts\".\"terminal_status\" IS NULL\n    OR \"frame_drift_execution_attempts\".\"terminal_status\" IN ('inserted', 'duplicate', 'skipped', 'failed')\n  "
+        },
+        "frame_drift_execution_attempts_failure_category_check": {
+          "name": "frame_drift_execution_attempts_failure_category_check",
+          "value": "\n    \"frame_drift_execution_attempts\".\"failure_category\" IS NULL OR \"frame_drift_execution_attempts\".\"failure_category\" = 'measurement'\n  "
+        },
+        "frame_drift_execution_attempts_terminal_state_check": {
+          "name": "frame_drift_execution_attempts_terminal_state_check",
+          "value": "\n    (\n      \"frame_drift_execution_attempts\".\"terminal_status\" IS NULL\n      AND \"frame_drift_execution_attempts\".\"completed_at\" IS NULL\n      AND \"frame_drift_execution_attempts\".\"will_retry\" IS NULL\n      AND \"frame_drift_execution_attempts\".\"failure_category\" IS NULL\n    ) OR (\n      \"frame_drift_execution_attempts\".\"terminal_status\" IN ('inserted', 'duplicate', 'skipped')\n      AND \"frame_drift_execution_attempts\".\"completed_at\" IS NOT NULL\n      AND \"frame_drift_execution_attempts\".\"completed_at\" >= \"frame_drift_execution_attempts\".\"started_at\"\n      AND \"frame_drift_execution_attempts\".\"will_retry\" IS NOT NULL\n      AND \"frame_drift_execution_attempts\".\"will_retry\" = false\n      AND \"frame_drift_execution_attempts\".\"failure_category\" IS NULL\n    ) OR (\n      \"frame_drift_execution_attempts\".\"terminal_status\" = 'failed'\n      AND \"frame_drift_execution_attempts\".\"completed_at\" IS NOT NULL\n      AND \"frame_drift_execution_attempts\".\"completed_at\" >= \"frame_drift_execution_attempts\".\"started_at\"\n      AND \"frame_drift_execution_attempts\".\"will_retry\" IS NOT NULL\n      AND \"frame_drift_execution_attempts\".\"failure_category\" IS NOT NULL\n      AND \"frame_drift_execution_attempts\".\"failure_category\" = 'measurement'\n    )\n  "
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.frame_drift_observation_runs": {
+      "name": "frame_drift_observation_runs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "bucket_start": {
+          "name": "bucket_start",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "bucket_end": {
+          "name": "bucket_end",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "captured_at": {
+          "name": "captured_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "configured_embedding_model": {
+          "name": "configured_embedding_model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "max_networks": {
+          "name": "max_networks",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "max_pairs": {
+          "name": "max_pairs",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "min_users": {
+          "name": "min_users",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "stable_cohort_hash": {
+          "name": "stable_cohort_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "aggregate_diagnostics": {
+          "name": "aggregate_diagnostics",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        }
+      },
+      "indexes": {
+        "frame_drift_observation_runs_bucket_start_uniq": {
+          "name": "frame_drift_observation_runs_bucket_start_uniq",
+          "columns": [
+            {
+              "expression": "bucket_start",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "frame_drift_observation_runs_bucket_check": {
+          "name": "frame_drift_observation_runs_bucket_check",
+          "value": "\"frame_drift_observation_runs\".\"bucket_end\" = \"frame_drift_observation_runs\".\"bucket_start\" + interval '1 day' AND \"frame_drift_observation_runs\".\"captured_at\" >= \"frame_drift_observation_runs\".\"bucket_end\""
+        },
+        "frame_drift_observation_runs_configured_embedding_model_check": {
+          "name": "frame_drift_observation_runs_configured_embedding_model_check",
+          "value": "length(btrim(\"frame_drift_observation_runs\".\"configured_embedding_model\")) > 0"
+        },
+        "frame_drift_observation_runs_max_networks_check": {
+          "name": "frame_drift_observation_runs_max_networks_check",
+          "value": "\"frame_drift_observation_runs\".\"max_networks\" BETWEEN 1 AND 200"
+        },
+        "frame_drift_observation_runs_max_pairs_check": {
+          "name": "frame_drift_observation_runs_max_pairs_check",
+          "value": "\"frame_drift_observation_runs\".\"max_pairs\" BETWEEN 1 AND 10000"
+        },
+        "frame_drift_observation_runs_min_users_check": {
+          "name": "frame_drift_observation_runs_min_users_check",
+          "value": "\"frame_drift_observation_runs\".\"min_users\" BETWEEN 2 AND 100"
+        },
+        "frame_drift_observation_runs_stable_cohort_hash_check": {
+          "name": "frame_drift_observation_runs_stable_cohort_hash_check",
+          "value": "\"frame_drift_observation_runs\".\"stable_cohort_hash\" IS NULL OR \"frame_drift_observation_runs\".\"stable_cohort_hash\" ~ '^[0-9a-f]{64}$'"
+        },
+        "frame_drift_observation_runs_aggregate_diagnostics_check": {
+          "name": "frame_drift_observation_runs_aggregate_diagnostics_check",
+          "value": "jsonb_typeof(\"frame_drift_observation_runs\".\"aggregate_diagnostics\") = 'object'"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.hyde_documents": {
+      "name": "hyde_documents",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "source_type": {
+          "name": "source_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_id": {
+          "name": "source_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source_text": {
+          "name": "source_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "strategy": {
+          "name": "strategy",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "target_corpus": {
+          "name": "target_corpus",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "context": {
+          "name": "context",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "hyde_text": {
+          "name": "hyde_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "hyde_embedding": {
+          "name": "hyde_embedding",
+          "type": "vector(2000)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "hyde_source_idx": {
+          "name": "hyde_source_idx",
+          "columns": [
+            {
+              "expression": "source_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "source_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "hyde_strategy_idx": {
+          "name": "hyde_strategy_idx",
+          "columns": [
+            {
+              "expression": "strategy",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "hyde_embedding_idx": {
+          "name": "hyde_embedding_idx",
+          "columns": [
+            {
+              "expression": "hyde_embedding",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "vector_cosine_ops"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "hnsw",
+          "with": {}
+        },
+        "hyde_expires_idx": {
+          "name": "hyde_expires_idx",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "hyde_source_strategy_unique": {
+          "name": "hyde_source_strategy_unique",
+          "columns": [
+            {
+              "expression": "source_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "source_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "strategy",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "target_corpus",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.intent_networks": {
+      "name": "intent_networks",
+      "schema": "",
+      "columns": {
+        "intent_id": {
+          "name": "intent_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "network_id": {
+          "name": "network_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "relevancy_score": {
+          "name": "relevancy_score",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "assignment_metadata": {
+          "name": "assignment_metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "intent_networks_network_id_idx": {
+          "name": "intent_networks_network_id_idx",
+          "columns": [
+            {
+              "expression": "network_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "intent_networks_intent_id_intents_id_fk": {
+          "name": "intent_networks_intent_id_intents_id_fk",
+          "tableFrom": "intent_networks",
+          "tableTo": "intents",
+          "columnsFrom": [
+            "intent_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "intent_networks_network_id_networks_id_fk": {
+          "name": "intent_networks_network_id_networks_id_fk",
+          "tableFrom": "intent_networks",
+          "tableTo": "networks",
+          "columnsFrom": [
+            "network_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "intent_networks_intent_id_network_id_pk": {
+          "name": "intent_networks_intent_id_network_id_pk",
+          "columns": [
+            "intent_id",
+            "network_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.intents": {
+      "name": "intents",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "payload": {
+          "name": "payload",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "summary": {
+          "name": "summary",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_incognito": {
+          "name": "is_incognito",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "archived_at": {
+          "name": "archived_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_visited_at": {
+          "name": "last_visited_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "first_discovery_succeeded_at": {
+          "name": "first_discovery_succeeded_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_id": {
+          "name": "source_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source_type": {
+          "name": "source_type",
+          "type": "source_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "embedding": {
+          "name": "embedding",
+          "type": "vector(2000)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "semantic_entropy": {
+          "name": "semantic_entropy",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 1
+        },
+        "referential_anchor": {
+          "name": "referential_anchor",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "intent_mode": {
+          "name": "intent_mode",
+          "type": "intent_mode",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'ATTRIBUTIVE'"
+        },
+        "speech_act_type": {
+          "name": "speech_act_type",
+          "type": "speech_act_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "felicity_authority": {
+          "name": "felicity_authority",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "felicity_sincerity": {
+          "name": "felicity_sincerity",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "felicity_clarity": {
+          "name": "felicity_clarity",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "intent_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'ACTIVE'"
+        }
+      },
+      "indexes": {
+        "embeddingIndex": {
+          "name": "embeddingIndex",
+          "columns": [
+            {
+              "expression": "embedding",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "vector_cosine_ops"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "hnsw",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "intents_user_id_users_id_fk": {
+          "name": "intents_user_id_users_id_fk",
+          "tableFrom": "intents",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.jwks": {
+      "name": "jwks",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "public_key": {
+          "name": "public_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "private_key": {
+          "name": "private_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.links": {
+      "name": "links",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_sync_at": {
+          "name": "last_sync_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_status": {
+          "name": "last_status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_error": {
+          "name": "last_error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "links_user_id_users_id_fk": {
+          "name": "links_user_id_users_id_fk",
+          "tableFrom": "links",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.negotiator_memories": {
+      "name": "negotiator_memories",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "agent_id": {
+          "name": "agent_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "subject_user_id": {
+          "name": "subject_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "embedding": {
+          "name": "embedding",
+          "type": "vector(2000)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source_refs": {
+          "name": "source_refs",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "confidence": {
+          "name": "confidence",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0.5
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "negotiator_memories_agent_kind_idx": {
+          "name": "negotiator_memories_agent_kind_idx",
+          "columns": [
+            {
+              "expression": "agent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "kind",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "negotiator_memories_user_subject_idx": {
+          "name": "negotiator_memories_user_subject_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "subject_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "negotiator_memories_embedding_idx": {
+          "name": "negotiator_memories_embedding_idx",
+          "columns": [
+            {
+              "expression": "embedding",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "vector_cosine_ops"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "hnsw",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "negotiator_memories_agent_id_agents_id_fk": {
+          "name": "negotiator_memories_agent_id_agents_id_fk",
+          "tableFrom": "negotiator_memories",
+          "tableTo": "agents",
+          "columnsFrom": [
+            "agent_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "negotiator_memories_user_id_users_id_fk": {
+          "name": "negotiator_memories_user_id_users_id_fk",
+          "tableFrom": "negotiator_memories",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "negotiator_memories_subject_user_id_users_id_fk": {
+          "name": "negotiator_memories_subject_user_id_users_id_fk",
+          "tableFrom": "negotiator_memories",
+          "tableTo": "users",
+          "columnsFrom": [
+            "subject_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.network_integrations": {
+      "name": "network_integrations",
+      "schema": "",
+      "columns": {
+        "network_id": {
+          "name": "network_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "toolkit": {
+          "name": "toolkit",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "connected_account_id": {
+          "name": "connected_account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sync_config": {
+          "name": "sync_config",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "network_integrations_network_id_networks_id_fk": {
+          "name": "network_integrations_network_id_networks_id_fk",
+          "tableFrom": "network_integrations",
+          "tableTo": "networks",
+          "columnsFrom": [
+            "network_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "network_integrations_network_id_toolkit_pk": {
+          "name": "network_integrations_network_id_toolkit_pk",
+          "columns": [
+            "network_id",
+            "toolkit"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.network_members": {
+      "name": "network_members",
+      "schema": "",
+      "columns": {
+        "network_id": {
+          "name": "network_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "permissions": {
+          "name": "permissions",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'"
+        },
+        "prompt": {
+          "name": "prompt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "auto_assign": {
+          "name": "auto_assign",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "network_members_network_id_networks_id_fk": {
+          "name": "network_members_network_id_networks_id_fk",
+          "tableFrom": "network_members",
+          "tableTo": "networks",
+          "columnsFrom": [
+            "network_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "network_members_user_id_users_id_fk": {
+          "name": "network_members_user_id_users_id_fk",
+          "tableFrom": "network_members",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "network_members_network_id_user_id_pk": {
+          "name": "network_members_network_id_user_id_pk",
+          "columns": [
+            "network_id",
+            "user_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.networks": {
+      "name": "networks",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "prompt": {
+          "name": "prompt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "image_url": {
+          "name": "image_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_personal": {
+          "name": "is_personal",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "is_experiment": {
+          "name": "is_experiment",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "experiment_master_key_hash": {
+          "name": "experiment_master_key_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "type": {
+          "name": "type",
+          "type": "network_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'community'"
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "permissions": {
+          "name": "permissions",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'{\"joinPolicy\":\"invite_only\",\"invitationLink\":null,\"allowGuestVibeCheck\":false}'::json"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "indexes_key_unique": {
+          "name": "indexes_key_unique",
+          "columns": [
+            {
+              "expression": "key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.oauth_access_token": {
+      "name": "oauth_access_token",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "access_token_expires_at": {
+          "name": "access_token_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "refresh_token_expires_at": {
+          "name": "refresh_token_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scopes": {
+          "name": "scopes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "oauth_access_token_client_id_idx": {
+          "name": "oauth_access_token_client_id_idx",
+          "columns": [
+            {
+              "expression": "client_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "oauth_access_token_user_id_idx": {
+          "name": "oauth_access_token_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "oauth_access_token_client_id_oauth_application_client_id_fk": {
+          "name": "oauth_access_token_client_id_oauth_application_client_id_fk",
+          "tableFrom": "oauth_access_token",
+          "tableTo": "oauth_application",
+          "columnsFrom": [
+            "client_id"
+          ],
+          "columnsTo": [
+            "client_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "oauth_access_token_user_id_users_id_fk": {
+          "name": "oauth_access_token_user_id_users_id_fk",
+          "tableFrom": "oauth_access_token",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "oauth_access_token_access_token_unique": {
+          "name": "oauth_access_token_access_token_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "access_token"
+          ]
+        },
+        "oauth_access_token_refresh_token_unique": {
+          "name": "oauth_access_token_refresh_token_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "refresh_token"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.oauth_application": {
+      "name": "oauth_application",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "icon": {
+          "name": "icon",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "client_secret": {
+          "name": "client_secret",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "redirect_urls": {
+          "name": "redirect_urls",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "disabled": {
+          "name": "disabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "oauth_application_user_id_idx": {
+          "name": "oauth_application_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "oauth_application_user_id_users_id_fk": {
+          "name": "oauth_application_user_id_users_id_fk",
+          "tableFrom": "oauth_application",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "oauth_application_client_id_unique": {
+          "name": "oauth_application_client_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "client_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.oauth_consent": {
+      "name": "oauth_consent",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scopes": {
+          "name": "scopes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "consent_given": {
+          "name": "consent_given",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "oauth_consent_client_id_idx": {
+          "name": "oauth_consent_client_id_idx",
+          "columns": [
+            {
+              "expression": "client_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "oauth_consent_user_id_idx": {
+          "name": "oauth_consent_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "oauth_consent_client_id_oauth_application_client_id_fk": {
+          "name": "oauth_consent_client_id_oauth_application_client_id_fk",
+          "tableFrom": "oauth_consent",
+          "tableTo": "oauth_application",
+          "columnsFrom": [
+            "client_id"
+          ],
+          "columnsTo": [
+            "client_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "oauth_consent_user_id_users_id_fk": {
+          "name": "oauth_consent_user_id_users_id_fk",
+          "tableFrom": "oauth_consent",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.opportunities": {
+      "name": "opportunities",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "detection": {
+          "name": "detection",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "actors": {
+          "name": "actors",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "interpretation": {
+          "name": "interpretation",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "context": {
+          "name": "context",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "confidence": {
+          "name": "confidence",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "opportunity_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "accepted_by": {
+          "name": "accepted_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'{}'::jsonb"
+        }
+      },
+      "indexes": {
+        "opportunities_status_idx": {
+          "name": "opportunities_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "opportunities_accepted_by_users_id_fk": {
+          "name": "opportunities_accepted_by_users_id_fk",
+          "tableFrom": "opportunities",
+          "tableTo": "users",
+          "columnsFrom": [
+            "accepted_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.opportunity_deliveries": {
+      "name": "opportunity_deliveries",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "opportunity_id": {
+          "name": "opportunity_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "agent_id": {
+          "name": "agent_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "channel": {
+          "name": "channel",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "trigger": {
+          "name": "trigger",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "delivered_at_status": {
+          "name": "delivered_at_status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reservation_token": {
+          "name": "reservation_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reserved_at": {
+          "name": "reserved_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "delivered_at": {
+          "name": "delivered_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "uniq_opp_deliveries_committed": {
+          "name": "uniq_opp_deliveries_committed",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "opportunity_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "channel",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "delivered_at_status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"opportunity_deliveries\".\"delivered_at\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_opp_deliveries_open_reservations": {
+          "name": "idx_opp_deliveries_open_reservations",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "channel",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "reserved_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"opportunity_deliveries\".\"delivered_at\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "opportunity_deliveries_opportunity_id_opportunities_id_fk": {
+          "name": "opportunity_deliveries_opportunity_id_opportunities_id_fk",
+          "tableFrom": "opportunity_deliveries",
+          "tableTo": "opportunities",
+          "columnsFrom": [
+            "opportunity_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "opportunity_deliveries_user_id_users_id_fk": {
+          "name": "opportunity_deliveries_user_id_users_id_fk",
+          "tableFrom": "opportunity_deliveries",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "opportunity_deliveries_agent_id_agents_id_fk": {
+          "name": "opportunity_deliveries_agent_id_agents_id_fk",
+          "tableFrom": "opportunity_deliveries",
+          "tableTo": "agents",
+          "columnsFrom": [
+            "agent_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.opportunity_discovery_runs": {
+      "name": "opportunity_discovery_runs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "agent_id": {
+          "name": "agent_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "discovery_run_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'queued'"
+        },
+        "input": {
+          "name": "input",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "context": {
+          "name": "context",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "progress": {
+          "name": "progress",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "result": {
+          "name": "result",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error": {
+          "name": "error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cancel_requested_at": {
+          "name": "cancel_requested_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "opportunity_discovery_runs_user_created_idx": {
+          "name": "opportunity_discovery_runs_user_created_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "opportunity_discovery_runs_status_created_idx": {
+          "name": "opportunity_discovery_runs_status_created_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "opportunity_discovery_runs_expires_at_idx": {
+          "name": "opportunity_discovery_runs_expires_at_idx",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "opportunity_discovery_runs_user_id_users_id_fk": {
+          "name": "opportunity_discovery_runs_user_id_users_id_fk",
+          "tableFrom": "opportunity_discovery_runs",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "opportunity_discovery_runs_agent_id_agents_id_fk": {
+          "name": "opportunity_discovery_runs_agent_id_agents_id_fk",
+          "tableFrom": "opportunity_discovery_runs",
+          "tableTo": "agents",
+          "columnsFrom": [
+            "agent_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.opportunity_outcome_events": {
+      "name": "opportunity_outcome_events",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "recipient_user_id": {
+          "name": "recipient_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "intent_id": {
+          "name": "intent_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "intent_fingerprint": {
+          "name": "intent_fingerprint",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "opportunity_id": {
+          "name": "opportunity_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "network_id": {
+          "name": "network_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "action": {
+          "name": "action",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "candidate_snapshot": {
+          "name": "candidate_snapshot",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "snapshot_hash": {
+          "name": "snapshot_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "dedup_key": {
+          "name": "dedup_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "idempotency_key": {
+          "name": "idempotency_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "uniq_opp_outcome_events_idempotency": {
+          "name": "uniq_opp_outcome_events_idempotency",
+          "columns": [
+            {
+              "expression": "idempotency_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_opp_outcome_events_scope": {
+          "name": "idx_opp_outcome_events_scope",
+          "columns": [
+            {
+              "expression": "recipient_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "intent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "intent_fingerprint",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "opportunity_outcome_events_recipient_user_id_users_id_fk": {
+          "name": "opportunity_outcome_events_recipient_user_id_users_id_fk",
+          "tableFrom": "opportunity_outcome_events",
+          "tableTo": "users",
+          "columnsFrom": [
+            "recipient_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.personal_networks": {
+      "name": "personal_networks",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "network_id": {
+          "name": "network_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "personal_networks_network_id_unique": {
+          "name": "personal_networks_network_id_unique",
+          "columns": [
+            {
+              "expression": "network_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "personal_networks_user_id_users_id_fk": {
+          "name": "personal_networks_user_id_users_id_fk",
+          "tableFrom": "personal_networks",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "personal_networks_network_id_networks_id_fk": {
+          "name": "personal_networks_network_id_networks_id_fk",
+          "tableFrom": "personal_networks",
+          "tableTo": "networks",
+          "columnsFrom": [
+            "network_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "personal_networks_user_id_pk": {
+          "name": "personal_networks_user_id_pk",
+          "columns": [
+            "user_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.premise_networks": {
+      "name": "premise_networks",
+      "schema": "",
+      "columns": {
+        "premise_id": {
+          "name": "premise_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "network_id": {
+          "name": "network_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "relevancy_score": {
+          "name": "relevancy_score",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "assignment_metadata": {
+          "name": "assignment_metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "premise_networks_network_id_idx": {
+          "name": "premise_networks_network_id_idx",
+          "columns": [
+            {
+              "expression": "network_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "premise_networks_premise_id_premises_id_fk": {
+          "name": "premise_networks_premise_id_premises_id_fk",
+          "tableFrom": "premise_networks",
+          "tableTo": "premises",
+          "columnsFrom": [
+            "premise_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "premise_networks_network_id_networks_id_fk": {
+          "name": "premise_networks_network_id_networks_id_fk",
+          "tableFrom": "premise_networks",
+          "tableTo": "networks",
+          "columnsFrom": [
+            "network_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "premise_networks_premise_id_network_id_pk": {
+          "name": "premise_networks_premise_id_network_id_pk",
+          "columns": [
+            "premise_id",
+            "network_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.premises": {
+      "name": "premises",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "assertion": {
+          "name": "assertion",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provenance": {
+          "name": "provenance",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "analysis": {
+          "name": "analysis",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "validity": {
+          "name": "validity",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "embedding": {
+          "name": "embedding",
+          "type": "vector(2000)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "premise_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'ACTIVE'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "retracted_at": {
+          "name": "retracted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "premises_embedding_idx": {
+          "name": "premises_embedding_idx",
+          "columns": [
+            {
+              "expression": "embedding",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "vector_cosine_ops"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "hnsw",
+          "with": {}
+        },
+        "premises_user_id_idx": {
+          "name": "premises_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "premises_status_idx": {
+          "name": "premises_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "premises_user_id_users_id_fk": {
+          "name": "premises_user_id_users_id_fk",
+          "tableFrom": "premises",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.questions": {
+      "name": "questions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "detection": {
+          "name": "detection",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "actors": {
+          "name": "actors",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "payload": {
+          "name": "payload",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "question_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "answer": {
+          "name": "answer",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "conversation_id": {
+          "name": "conversation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "questions_status_idx": {
+          "name": "questions_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "questions_conversation_id_idx": {
+          "name": "questions_conversation_id_idx",
+          "columns": [
+            {
+              "expression": "conversation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "questions_uptake_recipient_source_uniq": {
+          "name": "questions_uptake_recipient_source_uniq",
+          "columns": [
+            {
+              "expression": "(\"actors\"->0->>'userId')",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "(\"detection\"->>'sourceType')",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "(\"detection\"->>'sourceId')",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "(\"detection\"->>'purpose')",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"questions\".\"detection\"->>'purpose' = 'uptake'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "questions_pool_push_recipient_intent_cycle_uniq": {
+          "name": "questions_pool_push_recipient_intent_cycle_uniq",
+          "columns": [
+            {
+              "expression": "(\"detection\"->'push'->>'recipientId')",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "(\"detection\"->'push'->>'intentId')",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "(\"detection\"->'push'->>'cycleKey')",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"questions\".\"detection\"->>'mode' = 'pool_discovery' AND \"questions\".\"detection\"->'push'->>'claimedAt' IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "questions_pool_push_recipient_claimed_at_idx": {
+          "name": "questions_pool_push_recipient_claimed_at_idx",
+          "columns": [
+            {
+              "expression": "(\"actors\"->0->>'userId')",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "(\"detection\"->'push'->>'claimedAt')",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"questions\".\"detection\"->'push'->>'claimedAt' IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.sessions": {
+      "name": "sessions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "ip_address": {
+          "name": "ip_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "sessions_user_id_users_id_fk": {
+          "name": "sessions_user_id_users_id_fk",
+          "tableFrom": "sessions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "sessions_token_unique": {
+          "name": "sessions_token_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_contexts": {
+      "name": "user_contexts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "network_id": {
+          "name": "network_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "text": {
+          "name": "text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "embedding": {
+          "name": "embedding",
+          "type": "vector(2000)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "premise_hash": {
+          "name": "premise_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "generated_at": {
+          "name": "generated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "user_contexts_user_network_uniq": {
+          "name": "user_contexts_user_network_uniq",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "network_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"user_contexts\".\"network_id\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "user_contexts_user_global_uniq": {
+          "name": "user_contexts_user_global_uniq",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"user_contexts\".\"network_id\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "user_contexts_embedding_idx": {
+          "name": "user_contexts_embedding_idx",
+          "columns": [
+            {
+              "expression": "embedding",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "vector_cosine_ops"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "hnsw",
+          "with": {}
+        },
+        "user_contexts_user_id_idx": {
+          "name": "user_contexts_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "user_contexts_network_id_idx": {
+          "name": "user_contexts_network_id_idx",
+          "columns": [
+            {
+              "expression": "network_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "user_contexts_user_id_users_id_fk": {
+          "name": "user_contexts_user_id_users_id_fk",
+          "tableFrom": "user_contexts",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "user_contexts_network_id_networks_id_fk": {
+          "name": "user_contexts_network_id_networks_id_fk",
+          "tableFrom": "user_contexts",
+          "tableTo": "networks",
+          "columnsFrom": [
+            "network_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_notification_settings": {
+      "name": "user_notification_settings",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "preferences": {
+          "name": "preferences",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'{\"connectionUpdates\":true,\"weeklyNewsletter\":true}'::json"
+        },
+        "unsubscribe_token": {
+          "name": "unsubscribe_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "user_notification_settings_user_id_users_id_fk": {
+          "name": "user_notification_settings_user_id_users_id_fk",
+          "tableFrom": "user_notification_settings",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "user_notification_settings_user_id_unique": {
+          "name": "user_notification_settings_user_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id"
+          ]
+        },
+        "user_notification_settings_unsubscribe_token_unique": {
+          "name": "user_notification_settings_unsubscribe_token_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "unsubscribe_token"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_socials": {
+      "name": "user_socials",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "label": {
+          "name": "label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_user_socials_user_id": {
+          "name": "idx_user_socials_user_id",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "uniq_user_socials_user_label": {
+          "name": "uniq_user_socials_user_label",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "label",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"user_socials\".\"label\" <> 'custom'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "user_socials_user_id_users_id_fk": {
+          "name": "user_socials_user_id_users_id_fk",
+          "tableFrom": "user_socials",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email_verified": {
+          "name": "email_verified",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "avatar": {
+          "name": "avatar",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "intro": {
+          "name": "intro",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "location": {
+          "name": "location",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "onboarding": {
+          "name": "onboarding",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'{}'::json"
+        },
+        "timezone": {
+          "name": "timezone",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'UTC'"
+        },
+        "last_weekly_email_sent_at": {
+          "name": "last_weekly_email_sent_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_ghost": {
+          "name": "is_ghost",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "users_email_unique": {
+          "name": "users_email_unique",
+          "columns": [
+            {
+              "expression": "email",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "users_key_unique": {
+          "name": "users_key_unique",
+          "columns": [
+            {
+              "expression": "key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.verifications": {
+      "name": "verifications",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "identifier": {
+          "name": "identifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.artifacts": {
+      "name": "artifacts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "task_id": {
+          "name": "task_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "parts": {
+          "name": "parts",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "extensions": {
+          "name": "extensions",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "artifacts_task_id_idx": {
+          "name": "artifacts_task_id_idx",
+          "columns": [
+            {
+              "expression": "task_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "artifacts_task_id_tasks_id_fk": {
+          "name": "artifacts_task_id_tasks_id_fk",
+          "tableFrom": "artifacts",
+          "tableTo": "tasks",
+          "columnsFrom": [
+            "task_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.chat_session_scopes": {
+      "name": "chat_session_scopes",
+      "schema": "",
+      "columns": {
+        "conversation_id": {
+          "name": "conversation_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scope_type": {
+          "name": "scope_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scope_id": {
+          "name": "scope_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "chat_session_scopes_user_scope_unique": {
+          "name": "chat_session_scopes_user_scope_unique",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "scope_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "scope_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "chat_session_scopes_user_id_idx": {
+          "name": "chat_session_scopes_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "chat_session_scopes_scope_idx": {
+          "name": "chat_session_scopes_scope_idx",
+          "columns": [
+            {
+              "expression": "scope_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "scope_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "chat_session_scopes_conversation_id_conversations_id_fk": {
+          "name": "chat_session_scopes_conversation_id_conversations_id_fk",
+          "tableFrom": "chat_session_scopes",
+          "tableTo": "conversations",
+          "columnsFrom": [
+            "conversation_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.chat_session_summaries": {
+      "name": "chat_session_summaries",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "conversation_id": {
+          "name": "conversation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "from_message_id": {
+          "name": "from_message_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "to_message_id": {
+          "name": "to_message_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "digest": {
+          "name": "digest",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "model": {
+          "name": "model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "chat_session_summaries_session_latest_idx": {
+          "name": "chat_session_summaries_session_latest_idx",
+          "columns": [
+            {
+              "expression": "conversation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "chat_session_summaries_conversation_id_conversations_id_fk": {
+          "name": "chat_session_summaries_conversation_id_conversations_id_fk",
+          "tableFrom": "chat_session_summaries",
+          "tableTo": "conversations",
+          "columnsFrom": [
+            "conversation_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "chat_session_summaries_from_message_id_messages_id_fk": {
+          "name": "chat_session_summaries_from_message_id_messages_id_fk",
+          "tableFrom": "chat_session_summaries",
+          "tableTo": "messages",
+          "columnsFrom": [
+            "from_message_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "chat_session_summaries_to_message_id_messages_id_fk": {
+          "name": "chat_session_summaries_to_message_id_messages_id_fk",
+          "tableFrom": "chat_session_summaries",
+          "tableTo": "messages",
+          "columnsFrom": [
+            "to_message_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.conversation_metadata": {
+      "name": "conversation_metadata",
+      "schema": "",
+      "columns": {
+        "conversation_id": {
+          "name": "conversation_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "conversation_metadata_conversation_id_conversations_id_fk": {
+          "name": "conversation_metadata_conversation_id_conversations_id_fk",
+          "tableFrom": "conversation_metadata",
+          "tableTo": "conversations",
+          "columnsFrom": [
+            "conversation_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.conversation_participants": {
+      "name": "conversation_participants",
+      "schema": "",
+      "columns": {
+        "conversation_id": {
+          "name": "conversation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "participant_id": {
+          "name": "participant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "participant_type": {
+          "name": "participant_type",
+          "type": "participant_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "joined_at": {
+          "name": "joined_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "hidden_at": {
+          "name": "hidden_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_read_at": {
+          "name": "last_read_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "conversation_participants_participant_id_idx": {
+          "name": "conversation_participants_participant_id_idx",
+          "columns": [
+            {
+              "expression": "participant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "conversation_participants_conversation_id_idx": {
+          "name": "conversation_participants_conversation_id_idx",
+          "columns": [
+            {
+              "expression": "conversation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "conversation_participants_conversation_id_conversations_id_fk": {
+          "name": "conversation_participants_conversation_id_conversations_id_fk",
+          "tableFrom": "conversation_participants",
+          "tableTo": "conversations",
+          "columnsFrom": [
+            "conversation_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "conversation_participants_conversation_id_participant_id_pk": {
+          "name": "conversation_participants_conversation_id_participant_id_pk",
+          "columns": [
+            "conversation_id",
+            "participant_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.conversation_sessions": {
+      "name": "conversation_sessions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "conversation_id": {
+          "name": "conversation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "task_id": {
+          "name": "task_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_message_at": {
+          "name": "last_message_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "conversation_sessions_conversation_started_idx": {
+          "name": "conversation_sessions_conversation_started_idx",
+          "columns": [
+            {
+              "expression": "conversation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "started_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "conversation_sessions_task_id_uniq": {
+          "name": "conversation_sessions_task_id_uniq",
+          "columns": [
+            {
+              "expression": "task_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "conversation_sessions_conversation_id_conversations_id_fk": {
+          "name": "conversation_sessions_conversation_id_conversations_id_fk",
+          "tableFrom": "conversation_sessions",
+          "tableTo": "conversations",
+          "columnsFrom": [
+            "conversation_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "conversation_sessions_task_id_tasks_id_fk": {
+          "name": "conversation_sessions_task_id_tasks_id_fk",
+          "tableFrom": "conversation_sessions",
+          "tableTo": "tasks",
+          "columnsFrom": [
+            "task_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.conversations": {
+      "name": "conversations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "dm_pair": {
+          "name": "dm_pair",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "persona": {
+          "name": "persona",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'orchestrator'"
+        },
+        "last_message_at": {
+          "name": "last_message_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "conversations_dm_pair_idx": {
+          "name": "conversations_dm_pair_idx",
+          "columns": [
+            {
+              "expression": "dm_pair",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.messages": {
+      "name": "messages",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "conversation_id": {
+          "name": "conversation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "task_id": {
+          "name": "task_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sender_id": {
+          "name": "sender_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "message_role",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "parts": {
+          "name": "parts",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "extensions": {
+          "name": "extensions",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reference_task_ids": {
+          "name": "reference_task_ids",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "messages_conversation_id_created_at_idx": {
+          "name": "messages_conversation_id_created_at_idx",
+          "columns": [
+            {
+              "expression": "conversation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "messages_sender_id_idx": {
+          "name": "messages_sender_id_idx",
+          "columns": [
+            {
+              "expression": "sender_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "messages_task_id_idx": {
+          "name": "messages_task_id_idx",
+          "columns": [
+            {
+              "expression": "task_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "messages_session_id_created_at_idx": {
+          "name": "messages_session_id_created_at_idx",
+          "columns": [
+            {
+              "expression": "session_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "messages_conversation_id_conversations_id_fk": {
+          "name": "messages_conversation_id_conversations_id_fk",
+          "tableFrom": "messages",
+          "tableTo": "conversations",
+          "columnsFrom": [
+            "conversation_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "messages_task_id_tasks_id_fk": {
+          "name": "messages_task_id_tasks_id_fk",
+          "tableFrom": "messages",
+          "tableTo": "tasks",
+          "columnsFrom": [
+            "task_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "messages_session_id_conversation_sessions_id_fk": {
+          "name": "messages_session_id_conversation_sessions_id_fk",
+          "tableFrom": "messages",
+          "tableTo": "conversation_sessions",
+          "columnsFrom": [
+            "session_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.tasks": {
+      "name": "tasks",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "conversation_id": {
+          "name": "conversation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "state": {
+          "name": "state",
+          "type": "task_state",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'submitted'"
+        },
+        "status_message": {
+          "name": "status_message",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status_timestamp": {
+          "name": "status_timestamp",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "extensions": {
+          "name": "extensions",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "claimed_by_agent_id": {
+          "name": "claimed_by_agent_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "claimed_at": {
+          "name": "claimed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "tasks_conversation_id_idx": {
+          "name": "tasks_conversation_id_idx",
+          "columns": [
+            {
+              "expression": "conversation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "tasks_state_idx": {
+          "name": "tasks_state_idx",
+          "columns": [
+            {
+              "expression": "state",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "tasks_metadata_opportunity_id_idx": {
+          "name": "tasks_metadata_opportunity_id_idx",
+          "columns": [
+            {
+              "expression": "(\"metadata\"->>'opportunityId')",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"tasks\".\"metadata\"->>'type' = 'negotiation'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "tasks_conversation_id_conversations_id_fk": {
+          "name": "tasks_conversation_id_conversations_id_fk",
+          "tableFrom": "tasks",
+          "tableTo": "conversations",
+          "columnsFrom": [
+            "conversation_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.agent_action_proposal_status": {
+      "name": "agent_action_proposal_status",
+      "schema": "public",
+      "values": [
+        "pending",
+        "executing",
+        "consumed"
+      ]
+    },
+    "public.agent_status": {
+      "name": "agent_status",
+      "schema": "public",
+      "values": [
+        "active",
+        "inactive"
+      ]
+    },
+    "public.agent_type": {
+      "name": "agent_type",
+      "schema": "public",
+      "values": [
+        "personal",
+        "external",
+        "system"
+      ]
+    },
+    "public.discovery_run_status": {
+      "name": "discovery_run_status",
+      "schema": "public",
+      "values": [
+        "queued",
+        "running",
+        "succeeded",
+        "failed",
+        "cancelled"
+      ]
+    },
+    "public.intent_mode": {
+      "name": "intent_mode",
+      "schema": "public",
+      "values": [
+        "REFERENTIAL",
+        "ATTRIBUTIVE"
+      ]
+    },
+    "public.intent_status": {
+      "name": "intent_status",
+      "schema": "public",
+      "values": [
+        "ACTIVE",
+        "PAUSED",
+        "FULFILLED",
+        "EXPIRED"
+      ]
+    },
+    "public.network_type": {
+      "name": "network_type",
+      "schema": "public",
+      "values": [
+        "community",
+        "event"
+      ]
+    },
+    "public.opportunity_status": {
+      "name": "opportunity_status",
+      "schema": "public",
+      "values": [
+        "latent",
+        "draft",
+        "negotiating",
+        "pending",
+        "stalled",
+        "accepted",
+        "rejected",
+        "expired"
+      ]
+    },
+    "public.permission_scope": {
+      "name": "permission_scope",
+      "schema": "public",
+      "values": [
+        "global",
+        "node",
+        "network"
+      ]
+    },
+    "public.premise_status": {
+      "name": "premise_status",
+      "schema": "public",
+      "values": [
+        "ACTIVE",
+        "RETRACTED",
+        "EXPIRED"
+      ]
+    },
+    "public.question_status": {
+      "name": "question_status",
+      "schema": "public",
+      "values": [
+        "pending",
+        "answered",
+        "dismissed"
+      ]
+    },
+    "public.source_type": {
+      "name": "source_type",
+      "schema": "public",
+      "values": [
+        "file",
+        "integration",
+        "link",
+        "discovery_form",
+        "enrichment"
+      ]
+    },
+    "public.speech_act_type": {
+      "name": "speech_act_type",
+      "schema": "public",
+      "values": [
+        "COMMISSIVE",
+        "DIRECTIVE"
+      ]
+    },
+    "public.transport_channel": {
+      "name": "transport_channel",
+      "schema": "public",
+      "values": [
+        "mcp"
+      ]
+    },
+    "public.message_role": {
+      "name": "message_role",
+      "schema": "public",
+      "values": [
+        "user",
+        "agent"
+      ]
+    },
+    "public.participant_type": {
+      "name": "participant_type",
+      "schema": "public",
+      "values": [
+        "user",
+        "agent"
+      ]
+    },
+    "public.task_state": {
+      "name": "task_state",
+      "schema": "public",
+      "values": [
+        "submitted",
+        "working",
+        "input_required",
+        "completed",
+        "failed",
+        "canceled",
+        "rejected",
+        "auth_required",
+        "waiting_for_agent",
+        "claimed"
+      ]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/services/api/drizzle/meta/_journal.json
+++ b/services/api/drizzle/meta/_journal.json
@@ -722,6 +722,20 @@
       "when": 1784662680411,
       "tag": "0102_add_agent_action_execution_lease",
       "breakpoints": true
+    },
+    {
+      "idx": 103,
+      "version": "7",
+      "when": 1784711542573,
+      "tag": "0103_add_conversation_sessions",
+      "breakpoints": true
+    },
+    {
+      "idx": 104,
+      "version": "7",
+      "when": 1784711827927,
+      "tag": "0104_update_message_cursor_index",
+      "breakpoints": true
     }
   ]
 }

--- a/services/api/package.json
+++ b/services/api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@indexnetwork/api",
-  "version": "0.53.0",
+  "version": "0.53.1",
   "license": "MIT",
   "private": true,
   "scripts": {

--- a/services/api/src/adapters/chat-session.adapter.ts
+++ b/services/api/src/adapters/chat-session.adapter.ts
@@ -2,7 +2,9 @@ import { conversationDatabaseAdapter } from './database.adapter';
 
 export class ChatSessionAdapter {
   async getSessionMessages(sessionId: string, limit?: number): Promise<Array<{ role: string; content: string }>> {
-    const rows = await conversationDatabaseAdapter.getChatSessionMessages(sessionId, limit);
+    const rows = limit
+      ? await conversationDatabaseAdapter.getLatestChatSessionMessages(sessionId, limit)
+      : await conversationDatabaseAdapter.getChatSessionMessages(sessionId);
     return rows.map((m) => ({ role: m.role, content: m.content }));
   }
 

--- a/services/api/src/adapters/conversation.database.adapter.ts
+++ b/services/api/src/adapters/conversation.database.adapter.ts
@@ -2654,16 +2654,53 @@ export class ConversationDatabaseAdapter {
   }
 
   /**
-   * Get chat messages for a session, reconstructing the backward-compatible ChatMessage shape.
+   * Get chat messages for a conversation in chronological order.
+   *
+   * @param sessionId - Conversation identifier retained for the legacy chat-session API.
+   * @param limit - Maximum number of messages to return from the beginning of the conversation.
+   * @returns Chronologically ordered chat messages.
    */
   async getChatSessionMessages(sessionId: string, limit?: number): Promise<ChatMessage[]> {
     const query = db.select()
       .from(schema.messages)
       .where(eq(schema.messages.conversationId, sessionId))
-      .orderBy(asc(schema.messages.createdAt));
+      .orderBy(asc(schema.messages.createdAt), asc(schema.messages.id));
 
     const rows = limit ? await query.limit(limit) : await query;
 
+    return this.toChatMessages(sessionId, rows);
+  }
+
+  /**
+   * Get the latest chat messages for model context while returning them in
+   * chronological order. This deliberately does not share UI pagination reads:
+   * loading older history must never alter the model's context window.
+   *
+   * @param sessionId - Conversation identifier retained for the legacy chat-session API.
+   * @param limit - Maximum number of most-recent messages to return.
+   * @returns Chronologically ordered latest chat messages.
+   */
+  async getLatestChatSessionMessages(sessionId: string, limit: number): Promise<ChatMessage[]> {
+    const rows = await db.select()
+      .from(schema.messages)
+      .where(eq(schema.messages.conversationId, sessionId))
+      .orderBy(desc(schema.messages.createdAt), desc(schema.messages.id))
+      .limit(limit);
+
+    return this.toChatMessages(sessionId, rows.reverse());
+  }
+
+  /**
+   * Reconstruct the backward-compatible ChatMessage shape from message rows.
+   *
+   * @param sessionId - Conversation identifier for the compatibility shape.
+   * @param rows - Persisted message rows in display order.
+   * @returns Compatibility chat messages.
+   */
+  private toChatMessages(
+    sessionId: string,
+    rows: Array<typeof schema.messages.$inferSelect>,
+  ): ChatMessage[] {
     return rows.map((msg) => {
       const parts = msg.parts as Array<{ type?: string; text?: string }>;
       const content =

--- a/services/api/src/adapters/conversation.database.adapter.ts
+++ b/services/api/src/adapters/conversation.database.adapter.ts
@@ -1,4 +1,4 @@
-import { readUserContext, schema, Artifact, ChatConversationMeta, ChatMessage, ChatMessageMeta, ChatScopeType, ChatSession, Conversation, ConversationParticipant, ConversationSummary, CreateMessageInput, CreateSessionInput, Message, ResolvedParticipant, SYSTEM_AGENT_ID, Task, and, asc, count, db, desc, eq, gt, gte, inArray, isNull, lt, ne, opportunities, or, sql } from './database.shared';
+import { readUserContext, schema, Artifact, ChatConversationMeta, ChatMessage, ChatMessageMeta, ChatScopeType, ChatSession, Conversation, ConversationParticipant, ConversationSession, ConversationSummary, CreateMessageInput, CreateSessionInput, Message, ResolvedParticipant, SYSTEM_AGENT_ID, Task, and, asc, count, db, desc, eq, gt, gte, inArray, isNull, lt, ne, opportunities, or, sql } from './database.shared';
 import { emitOpportunityPendingBestEffort } from '../events/opportunity.event';
 import { acquireNegotiationAttemptLock, acquireNegotiationPairLock, qualifyingNegotiationAttemptTaskWhere, qualifyingPairNegotiationTaskWhere, type NegotiationAttemptTransaction } from './negotiation-attempt.atomic';
 
@@ -35,6 +35,15 @@ const NEGOTIATOR_SCOPE = { scopeType: 'persona', scopeId: NEGOTIATOR_PERSONA } a
  * is identical to any intent-scoped session.
  */
 const NEGOTIATOR_INTENT_SCOPE_TYPE = 'negotiator-intent';
+
+const DEFAULT_CHAT_SESSION_GAP_MS = 24 * 60 * 60 * 1000;
+
+function getChatSessionGapMs(): number {
+  const configured = Number.parseInt(process.env.CHAT_SESSION_GAP_MS ?? '', 10);
+  return Number.isFinite(configured) && configured > 0
+    ? configured
+    : DEFAULT_CHAT_SESSION_GAP_MS;
+}
 
 interface MatchProvenanceEntry {
   opportunityId: string;
@@ -635,9 +644,13 @@ export class ConversationDatabaseAdapter {
   // ─────────────────────────────────────────────────────────────────────────
 
   /**
-   * Creates a message and updates the conversation's lastMessageAt.
-   * @param data - Message payload
-   * @returns The inserted message row
+   * Creates a message, stamps its durable conversation session, and updates the
+   * conversation timestamp. A transaction-scoped advisory lock serializes
+   * writers for a conversation so concurrent writes cannot open duplicate
+   * sessions.
+   *
+   * @param data - Message payload.
+   * @returns The inserted and session-stamped message row.
    */
   async createMessage(data: {
     conversationId: string;
@@ -649,26 +662,19 @@ export class ConversationDatabaseAdapter {
     extensions?: string[];
     referenceTaskIds?: string[];
   }): Promise<Message> {
-    const id = crypto.randomUUID();
+    const msg = await this.insertMessageWithConversationSession({
+      id: crypto.randomUUID(),
+      conversationId: data.conversationId,
+      senderId: data.senderId,
+      role: data.role,
+      parts: data.parts,
+      taskId: data.taskId ?? null,
+      metadata: data.metadata ?? null,
+      extensions: data.extensions ?? null,
+      referenceTaskIds: data.referenceTaskIds ?? null,
+    });
 
-    const [msg] = await db
-      .insert(schema.messages)
-      .values({
-        id,
-        conversationId: data.conversationId,
-        senderId: data.senderId,
-        role: data.role,
-        parts: data.parts,
-        taskId: data.taskId ?? null,
-        metadata: data.metadata ?? null,
-        extensions: data.extensions ?? null,
-        referenceTaskIds: data.referenceTaskIds ?? null,
-      })
-      .returning();
-
-    await this.updateLastMessageAt(data.conversationId);
-
-    // Clear hiddenAt for the sender so conversation reappears in their list
+    // Clear hiddenAt for the sender so conversation reappears in their list.
     await db
       .update(schema.conversationParticipants)
       .set({ hiddenAt: null })
@@ -678,6 +684,105 @@ export class ConversationDatabaseAdapter {
       ));
 
     return msg;
+  }
+
+  /**
+   * Persist a message under the durable session selected for its task or
+   * conversation activity window.
+   *
+   * @param data - Fully normalized message fields.
+   * @returns The newly persisted message.
+   */
+  private async insertMessageWithConversationSession(data: {
+    id: string;
+    conversationId: string;
+    senderId: string;
+    role: 'user' | 'agent';
+    parts: unknown[];
+    taskId: string | null;
+    metadata: Record<string, unknown> | null;
+    extensions: string[] | null;
+    referenceTaskIds: string[] | null;
+  }): Promise<Message> {
+    return db.transaction(async (tx) => {
+      await tx.execute(sql`
+        SELECT pg_advisory_xact_lock(
+          hashtextextended(${`conversation-session:${data.conversationId}`}, 0)
+        )
+      `);
+
+      const now = new Date();
+      let sessionId: string;
+
+      if (data.taskId) {
+        const [existingTaskSession] = await tx
+          .select({ id: schema.conversationSessions.id })
+          .from(schema.conversationSessions)
+          .where(eq(schema.conversationSessions.taskId, data.taskId))
+          .limit(1);
+
+        if (existingTaskSession) {
+          sessionId = existingTaskSession.id;
+          await tx
+            .update(schema.conversationSessions)
+            .set({ lastMessageAt: now })
+            .where(eq(schema.conversationSessions.id, sessionId));
+        } else {
+          sessionId = crypto.randomUUID();
+          await tx.insert(schema.conversationSessions).values({
+            id: sessionId,
+            conversationId: data.conversationId,
+            taskId: data.taskId,
+            startedAt: now,
+            lastMessageAt: now,
+          });
+        }
+      } else {
+        const [currentSession] = await tx
+          .select()
+          .from(schema.conversationSessions)
+          .where(and(
+            eq(schema.conversationSessions.conversationId, data.conversationId),
+            isNull(schema.conversationSessions.taskId),
+          ))
+          .orderBy(
+            desc(schema.conversationSessions.lastMessageAt),
+            desc(schema.conversationSessions.startedAt),
+            desc(schema.conversationSessions.id),
+          )
+          .limit(1);
+
+        const startsNewSession = !currentSession
+          || now.getTime() - currentSession.lastMessageAt.getTime() > getChatSessionGapMs();
+        if (startsNewSession) {
+          sessionId = crypto.randomUUID();
+          await tx.insert(schema.conversationSessions).values({
+            id: sessionId,
+            conversationId: data.conversationId,
+            startedAt: now,
+            lastMessageAt: now,
+          });
+        } else {
+          sessionId = currentSession.id;
+          await tx
+            .update(schema.conversationSessions)
+            .set({ lastMessageAt: now })
+            .where(eq(schema.conversationSessions.id, sessionId));
+        }
+      }
+
+      const [message] = await tx
+        .insert(schema.messages)
+        .values({ ...data, sessionId, createdAt: now })
+        .returning();
+
+      await tx
+        .update(schema.conversations)
+        .set({ lastMessageAt: now, updatedAt: now })
+        .where(eq(schema.conversations.id, data.conversationId));
+
+      return message;
+    });
   }
 
   /**
@@ -819,9 +924,43 @@ export class ConversationDatabaseAdapter {
           throw new Error(`Deterministic pool push message ${input.questionId} conflicts with existing data`);
         }
       } else {
+        await tx.execute(sql`
+          SELECT pg_advisory_xact_lock(
+            hashtextextended(${`conversation-session:${input.conversationId}`}, 0)
+          )
+        `);
+        const [currentSession] = await tx
+          .select()
+          .from(schema.conversationSessions)
+          .where(and(
+            eq(schema.conversationSessions.conversationId, input.conversationId),
+            isNull(schema.conversationSessions.taskId),
+          ))
+          .orderBy(
+            desc(schema.conversationSessions.lastMessageAt),
+            desc(schema.conversationSessions.startedAt),
+            desc(schema.conversationSessions.id),
+          )
+          .limit(1);
+        const startsNewSession = !currentSession
+          || transactionNow.getTime() - currentSession.lastMessageAt.getTime() > getChatSessionGapMs();
+        const sessionId = startsNewSession ? crypto.randomUUID() : currentSession.id;
+        if (startsNewSession) {
+          await tx.insert(schema.conversationSessions).values({
+            id: sessionId,
+            conversationId: input.conversationId,
+            startedAt: transactionNow,
+            lastMessageAt: transactionNow,
+          });
+        } else {
+          await tx.update(schema.conversationSessions)
+            .set({ lastMessageAt: transactionNow })
+            .where(eq(schema.conversationSessions.id, sessionId));
+        }
         await tx.insert(schema.messages).values({
           id: input.questionId,
           conversationId: input.conversationId,
+          sessionId,
           senderId: SYSTEM_AGENT_ID,
           role: 'agent',
           parts: expectedParts,
@@ -893,7 +1032,7 @@ export class ConversationDatabaseAdapter {
     if (opts?.before) {
       // Cursor-based: get messages created before the given message
       const [ref] = await db
-        .select({ createdAt: schema.messages.createdAt })
+        .select({ createdAt: schema.messages.createdAt, id: schema.messages.id })
         .from(schema.messages)
         .where(and(
           eq(schema.messages.id, opts.before),
@@ -902,7 +1041,14 @@ export class ConversationDatabaseAdapter {
         .limit(1);
 
       if (ref) {
-        conditions.push(lt(schema.messages.createdAt, ref.createdAt));
+        const beforeCondition = or(
+          lt(schema.messages.createdAt, ref.createdAt),
+          and(
+            eq(schema.messages.createdAt, ref.createdAt),
+            lt(schema.messages.id, ref.id),
+          ),
+        );
+        if (beforeCondition) conditions.push(beforeCondition);
       }
     }
 
@@ -912,7 +1058,7 @@ export class ConversationDatabaseAdapter {
       .select()
       .from(schema.messages)
       .where(and(...conditions))
-      .orderBy(desc(schema.messages.createdAt));
+      .orderBy(desc(schema.messages.createdAt), desc(schema.messages.id));
 
     if (opts?.limit) {
       query = query.limit(opts.limit) as typeof query;
@@ -920,6 +1066,105 @@ export class ConversationDatabaseAdapter {
 
     const rows = await query;
     return rows.reverse();
+  }
+
+  /**
+   * Load one durable conversation session and its messages. Calling without a
+   * cursor selects the latest session; a `beforeSessionId` cursor selects the
+   * immediately preceding session. The message read stays participant-scoped.
+   *
+   * @param conversationId - Conversation to read.
+   * @param opts - Visibility, A2A task, and prior-session cursor constraints.
+   * @returns Exactly one session (when present), its messages, and whether an earlier session exists.
+   */
+  async getConversationSessionHistory(
+    conversationId: string,
+    opts?: { beforeSessionId?: string; taskId?: string; userId?: string },
+  ): Promise<{
+    session: ConversationSession | null;
+    messages: Message[];
+    hasPreviousSession: boolean;
+  }> {
+    const conditions = [eq(schema.conversationSessions.conversationId, conversationId)];
+    if (opts?.taskId) {
+      conditions.push(eq(schema.conversationSessions.taskId, opts.taskId));
+    } else if (opts?.beforeSessionId) {
+      const [cursor] = await db
+        .select({
+          id: schema.conversationSessions.id,
+          startedAt: schema.conversationSessions.startedAt,
+        })
+        .from(schema.conversationSessions)
+        .where(and(
+          eq(schema.conversationSessions.id, opts.beforeSessionId),
+          eq(schema.conversationSessions.conversationId, conversationId),
+        ))
+        .limit(1);
+      if (!cursor) {
+        return { session: null, messages: [], hasPreviousSession: false };
+      }
+      const beforeSessionCondition = or(
+        lt(schema.conversationSessions.startedAt, cursor.startedAt),
+        and(
+          eq(schema.conversationSessions.startedAt, cursor.startedAt),
+          lt(schema.conversationSessions.id, cursor.id),
+        ),
+      );
+      if (beforeSessionCondition) conditions.push(beforeSessionCondition);
+    }
+
+    const [session] = await db
+      .select()
+      .from(schema.conversationSessions)
+      .where(and(...conditions))
+      .orderBy(
+        desc(schema.conversationSessions.startedAt),
+        desc(schema.conversationSessions.id),
+      )
+      .limit(1);
+    if (!session) return { session: null, messages: [], hasPreviousSession: false };
+
+    const messageConditions = [eq(schema.messages.sessionId, session.id)];
+    if (opts?.userId) {
+      const [participant] = await db
+        .select({ hiddenAt: schema.conversationParticipants.hiddenAt })
+        .from(schema.conversationParticipants)
+        .where(and(
+          eq(schema.conversationParticipants.conversationId, conversationId),
+          eq(schema.conversationParticipants.participantId, opts.userId),
+        ))
+        .limit(1);
+      if (participant?.hiddenAt) {
+        messageConditions.push(gt(schema.messages.createdAt, participant.hiddenAt));
+      }
+    }
+
+    const messages = await db
+      .select()
+      .from(schema.messages)
+      .where(and(...messageConditions))
+      .orderBy(asc(schema.messages.createdAt), asc(schema.messages.id));
+
+    const previousConditions = [eq(schema.conversationSessions.conversationId, conversationId)];
+    if (opts?.taskId) {
+      previousConditions.push(eq(schema.conversationSessions.taskId, opts.taskId));
+    } else {
+      const previousSessionCondition = or(
+        lt(schema.conversationSessions.startedAt, session.startedAt),
+        and(
+          eq(schema.conversationSessions.startedAt, session.startedAt),
+          lt(schema.conversationSessions.id, session.id),
+        ),
+      );
+      if (previousSessionCondition) previousConditions.push(previousSessionCondition);
+    }
+    const [previous] = await db
+      .select({ id: schema.conversationSessions.id })
+      .from(schema.conversationSessions)
+      .where(and(...previousConditions))
+      .limit(1);
+
+    return { session, messages, hasPreviousSession: Boolean(previous) };
   }
 
   // ─────────────────────────────────────────────────────────────────────────
@@ -2636,21 +2881,17 @@ export class ConversationDatabaseAdapter {
     if (data.tokenCount !== undefined) msgMeta.tokenCount = data.tokenCount;
     if (data.interrupted) msgMeta.interrupted = true;
 
-    await db.insert(schema.messages).values({
+    await this.insertMessageWithConversationSession({
       id: data.id,
       conversationId: data.sessionId,
       senderId,
       role: isAgent ? 'agent' : 'user',
       parts: [{ type: 'text', text: data.content }],
+      taskId: null,
       metadata: Object.keys(msgMeta).length > 0 ? msgMeta : null,
-      createdAt: new Date(),
+      extensions: null,
+      referenceTaskIds: null,
     });
-
-    // Update conversation.lastMessageAt
-    await db
-      .update(schema.conversations)
-      .set({ lastMessageAt: new Date() })
-      .where(eq(schema.conversations.id, data.sessionId));
   }
 
   /**
@@ -2681,13 +2922,48 @@ export class ConversationDatabaseAdapter {
    * @returns Chronologically ordered latest chat messages.
    */
   async getLatestChatSessionMessages(sessionId: string, limit: number): Promise<ChatMessage[]> {
+    const [latestSession] = await db
+      .select({ id: schema.conversationSessions.id })
+      .from(schema.conversationSessions)
+      .where(eq(schema.conversationSessions.conversationId, sessionId))
+      .orderBy(
+        desc(schema.conversationSessions.lastMessageAt),
+        desc(schema.conversationSessions.startedAt),
+        desc(schema.conversationSessions.id),
+      )
+      .limit(1);
+    if (!latestSession) return [];
+
     const rows = await db.select()
       .from(schema.messages)
-      .where(eq(schema.messages.conversationId, sessionId))
+      .where(eq(schema.messages.sessionId, latestSession.id))
       .orderBy(desc(schema.messages.createdAt), desc(schema.messages.id))
       .limit(limit);
 
     return this.toChatMessages(sessionId, rows.reverse());
+  }
+
+  /**
+   * Load one durable session for a chat conversation in the legacy chat-message shape.
+   *
+   * @param conversationId - Chat conversation identifier.
+   * @param opts - Optional earlier-session cursor.
+   * @returns The selected durable session, mapped messages, and prior-session signal.
+   */
+  async getChatConversationSessionHistory(
+    conversationId: string,
+    opts?: { beforeSessionId?: string },
+  ): Promise<{
+    session: ConversationSession | null;
+    messages: ChatMessage[];
+    hasPreviousSession: boolean;
+  }> {
+    const history = await this.getConversationSessionHistory(conversationId, opts);
+    return {
+      session: history.session,
+      messages: this.toChatMessages(conversationId, history.messages),
+      hasPreviousSession: history.hasPreviousSession,
+    };
   }
 
   /**

--- a/services/api/src/adapters/database.shared.ts
+++ b/services/api/src/adapters/database.shared.ts
@@ -10,7 +10,7 @@ import { traceAppOperation } from '../lib/sentry-performance';
 import { normalizeEmbedding } from '../lib/embedding/vector';
 import { normalizeTelegramSocialValue } from '../lib/telegram/socials';
 import type { User, NotificationPreferences, OnboardingState, TelegramPrefs } from '../schemas/database.schema';
-import type { Conversation, ConversationParticipant, Message, Task, Artifact } from '../schemas/conversation.schema';
+import type { Conversation, ConversationParticipant, ConversationSession, Message, Task, Artifact } from '../schemas/conversation.schema';
 import type { Id } from '../types/common.types';
 import { log } from '../lib/log';
 import { NetworkMembershipEvents } from '../events/network_membership.event';
@@ -19,7 +19,7 @@ import { NetworkMembershipEvents } from '../events/network_membership.event';
 export { schema, db, traceAppOperation, normalizeEmbedding, normalizeTelegramSocialValue, log, NetworkMembershipEvents };
 export { canActorSeeOpportunity } from './opportunity.visibility';
 export { eq, and, or, isNull, isNotNull, sql, count, desc, gt, gte, lt, lte, ne, inArray, ilike, notInArray, asc, not };
-export type { User, NotificationPreferences, OnboardingState, TelegramPrefs, Conversation, ConversationParticipant, Message, Task, Artifact, Id };
+export type { User, NotificationPreferences, OnboardingState, TelegramPrefs, Conversation, ConversationParticipant, ConversationSession, Message, Task, Artifact, Id };
 export const logger = log.lib.from('database.adapter');
 
 export function detectSocialLabel(value: string): string {

--- a/services/api/src/adapters/questioner.adapter.ts
+++ b/services/api/src/adapters/questioner.adapter.ts
@@ -660,6 +660,23 @@ export class QuestionerAdapter {
       if (filters.mode === 'chat') {
         conditions.push(sql`NOT (${questions.detection} ? 'pool')`);
         conditions.push(sql`COALESCE(${questions.detection}->>'voidedReason', '') = ''`);
+        // Unanchored rows may render only while their blocking turn is live.
+        // Once anchoring metadata exists, require both bindings and prove that
+        // the assistant message is in exactly the stamped durable session.
+        conditions.push(sql`(
+          (NOT (${questions.detection} ? 'messageId') AND NOT (${questions.detection} ? 'sessionId'))
+          OR (
+            ${questions.detection} ? 'messageId'
+            AND ${questions.detection} ? 'sessionId'
+            AND EXISTS (
+              SELECT 1
+              FROM ${messages}
+              WHERE ${messages.id} = ${questions.detection}->>'messageId'
+                AND ${messages.conversationId} = ${questions.conversationId}
+                AND ${messages.sessionId} = ${questions.detection}->>'sessionId'
+            )
+          )
+        )`);
       }
     }
     if (filters?.purpose) {

--- a/services/api/src/adapters/questioner.adapter.ts
+++ b/services/api/src/adapters/questioner.adapter.ts
@@ -11,9 +11,9 @@
  * alignment spec.
  */
 
-import { eq, and, sql, or, isNull, desc, count, gt } from 'drizzle-orm/sql';
+import { eq, and, sql, or, isNull, desc, count, gt, inArray } from 'drizzle-orm/sql';
 
-import { intents, questions, opportunities } from '../schemas/database.schema';
+import { intents, messages, questions, opportunities } from '../schemas/database.schema';
 import type { QuestionDetection, QuestionActor } from '../schemas/database.schema';
 import type { DrizzleDB } from '../lib/drizzle/drizzle';
 import { QuestionEvents } from '../events/question.event';
@@ -384,6 +384,46 @@ export class QuestionerAdapter {
   }
 
   /**
+   * Bind chat questions to the persisted assistant message that emitted them.
+   * Only canonical pending/terminal chat rows for the recipient and
+   * conversation are updated; pool and cross-conversation IDs fail closed.
+   *
+   * @param input - Chat question IDs and their authoritative message context.
+   */
+  async bindChatQuestionsToMessage(input: {
+    questionIds: string[];
+    userId: string;
+    conversationId: string;
+    messageId: string;
+  }): Promise<void> {
+    if (input.questionIds.length === 0) return;
+    const [message] = await this.db
+      .select({ sessionId: messages.sessionId })
+      .from(messages)
+      .where(and(
+        eq(messages.id, input.messageId),
+        eq(messages.conversationId, input.conversationId),
+      ))
+      .limit(1);
+    if (!message?.sessionId) return;
+
+    await this.db.update(questions)
+      .set({
+        detection: sql`jsonb_set(
+          jsonb_set(${questions.detection}, '{messageId}', to_jsonb(${input.messageId}::text), true),
+          '{sessionId}', to_jsonb(${message.sessionId}::text), true
+        )`,
+      })
+      .where(and(
+        inArray(questions.id, input.questionIds),
+        eq(questions.conversationId, input.conversationId),
+        sql`${questions.actors}::jsonb @> ${JSON.stringify([{ userId: input.userId }])}::jsonb`,
+        sql`${questions.detection}->>'mode' = 'chat'`,
+        sql`NOT (${questions.detection} ? 'pool')`,
+      ));
+  }
+
+  /**
    * Final queued-artifact gate. The recipient+intent advisory lock serializes
    * competing inserts and lifecycle reconciliation while the transaction
    * rechecks authoritative intent text and the exact live pool.
@@ -617,6 +657,10 @@ export class QuestionerAdapter {
     }
     if (filters?.mode) {
       conditions.push(sql`${questions.detection}->>'mode' = ${filters.mode}`);
+      if (filters.mode === 'chat') {
+        conditions.push(sql`NOT (${questions.detection} ? 'pool')`);
+        conditions.push(sql`COALESCE(${questions.detection}->>'voidedReason', '') = ''`);
+      }
     }
     if (filters?.purpose) {
       conditions.push(sql`${questions.detection}->>'purpose' = ${filters.purpose}`);

--- a/services/api/src/adapters/tests/conversation.database.adapter.spec.ts
+++ b/services/api/src/adapters/tests/conversation.database.adapter.spec.ts
@@ -73,6 +73,30 @@ describe('ConversationDatabaseAdapter', () => {
     }, 10000);
   });
 
+  describe('getLatestChatSessionMessages', () => {
+    it('returns the latest messages chronologically with a same-millisecond id tiebreaker', async () => {
+      const conversation = await adapter.createConversation([
+        { participantId: 'latest-context-user', participantType: 'user' },
+        { participantId: 'system-agent', participantType: 'agent' },
+      ]);
+      createdIds.push(conversation.id);
+
+      const createdAt = new Date('2026-07-22T00:00:00.000Z');
+      await db.insert(schema.messages).values([
+        { id: 'latest-context-a', conversationId: conversation.id, senderId: 'latest-context-user', role: 'user', parts: [{ text: 'oldest' }], createdAt },
+        { id: 'latest-context-b', conversationId: conversation.id, senderId: 'system-agent', role: 'agent', parts: [{ text: 'newer' }], createdAt },
+        { id: 'latest-context-c', conversationId: conversation.id, senderId: 'latest-context-user', role: 'user', parts: [{ text: 'latest' }], createdAt },
+      ]);
+
+      const messages = await adapter.getLatestChatSessionMessages(conversation.id, 2);
+
+      expect(messages.map((message) => message.id)).toEqual([
+        'latest-context-b',
+        'latest-context-c',
+      ]);
+    }, 10000);
+  });
+
   describe('getOrCreateDM', () => {
     it('finds existing DM between two users', async () => {
       const userA = 'dm-user-a-' + Date.now();

--- a/services/api/src/adapters/tests/conversation.database.adapter.spec.ts
+++ b/services/api/src/adapters/tests/conversation.database.adapter.spec.ts
@@ -2,7 +2,7 @@ import { config } from 'dotenv';
 config({ path: '.env.test', override: true });
 
 import { describe, it, expect, afterAll as bunAfterAll } from 'bun:test';
-import { inArray } from 'drizzle-orm';
+import { eq, inArray } from 'drizzle-orm';
 import db from '../../lib/drizzle/drizzle';
 import * as schema from '../../schemas/database.schema';
 
@@ -82,10 +82,17 @@ describe('ConversationDatabaseAdapter', () => {
       createdIds.push(conversation.id);
 
       const createdAt = new Date('2026-07-22T00:00:00.000Z');
+      const durableSessionId = `latest-context-session-${conversation.id}`;
+      await db.insert(schema.conversationSessions).values({
+        id: durableSessionId,
+        conversationId: conversation.id,
+        startedAt: createdAt,
+        lastMessageAt: createdAt,
+      });
       await db.insert(schema.messages).values([
-        { id: 'latest-context-a', conversationId: conversation.id, senderId: 'latest-context-user', role: 'user', parts: [{ text: 'oldest' }], createdAt },
-        { id: 'latest-context-b', conversationId: conversation.id, senderId: 'system-agent', role: 'agent', parts: [{ text: 'newer' }], createdAt },
-        { id: 'latest-context-c', conversationId: conversation.id, senderId: 'latest-context-user', role: 'user', parts: [{ text: 'latest' }], createdAt },
+        { id: 'latest-context-a', conversationId: conversation.id, sessionId: durableSessionId, senderId: 'latest-context-user', role: 'user', parts: [{ text: 'oldest' }], createdAt },
+        { id: 'latest-context-b', conversationId: conversation.id, sessionId: durableSessionId, senderId: 'system-agent', role: 'agent', parts: [{ text: 'newer' }], createdAt },
+        { id: 'latest-context-c', conversationId: conversation.id, sessionId: durableSessionId, senderId: 'latest-context-user', role: 'user', parts: [{ text: 'latest' }], createdAt },
       ]);
 
       const messages = await adapter.getLatestChatSessionMessages(conversation.id, 2);
@@ -94,6 +101,111 @@ describe('ConversationDatabaseAdapter', () => {
         'latest-context-b',
         'latest-context-c',
       ]);
+    }, 10000);
+  });
+
+  describe('durable conversation sessions', () => {
+    it('stamps concurrent H2H writes into one session', async () => {
+      const conversation = await adapter.createConversation([
+        { participantId: 'session-concurrent-user', participantType: 'user' },
+        { participantId: 'session-concurrent-peer', participantType: 'user' },
+      ]);
+      createdIds.push(conversation.id);
+
+      await Promise.all([
+        adapter.createMessage({
+          conversationId: conversation.id,
+          senderId: 'session-concurrent-user',
+          role: 'user',
+          parts: [{ text: 'one' }],
+        }),
+        adapter.createMessage({
+          conversationId: conversation.id,
+          senderId: 'session-concurrent-peer',
+          role: 'user',
+          parts: [{ text: 'two' }],
+        }),
+      ]);
+
+      const sessions = await db.select()
+        .from(schema.conversationSessions)
+        .where(eq(schema.conversationSessions.conversationId, conversation.id));
+      const messages = await adapter.getMessages(conversation.id);
+
+      expect(sessions).toHaveLength(1);
+      expect(new Set(messages.map((message) => message.sessionId)).size).toBe(1);
+      expect(messages.every((message) => message.sessionId === sessions[0]?.id)).toBe(true);
+    }, 10000);
+
+    it('maps all A2A task messages to one task session', async () => {
+      const conversation = await adapter.createConversation([
+        { participantId: 'session-task-agent', participantType: 'agent' },
+        { participantId: 'session-task-peer', participantType: 'agent' },
+      ]);
+      createdIds.push(conversation.id);
+      const task = await adapter.createTask(conversation.id);
+
+      await adapter.createMessage({
+        conversationId: conversation.id,
+        senderId: 'session-task-agent',
+        role: 'agent',
+        taskId: task.id,
+        parts: [{ text: 'first turn' }],
+      });
+      await adapter.createMessage({
+        conversationId: conversation.id,
+        senderId: 'session-task-peer',
+        role: 'agent',
+        taskId: task.id,
+        parts: [{ text: 'second turn' }],
+      });
+
+      const history = await adapter.getConversationSessionHistory(conversation.id, { taskId: task.id });
+
+      expect(history.session?.taskId).toBe(task.id);
+      expect(history.messages).toHaveLength(2);
+      expect(history.messages.every((message) => message.sessionId === history.session?.id)).toBe(true);
+      expect(history.hasPreviousSession).toBe(false);
+    }, 10000);
+
+    it('loads exactly one preceding session without reordering same-millisecond messages', async () => {
+      const conversation = await adapter.createConversation([
+        { participantId: 'session-history-user', participantType: 'user' },
+        { participantId: 'session-history-peer', participantType: 'user' },
+      ]);
+      createdIds.push(conversation.id);
+      const firstAt = new Date('2026-07-20T00:00:00.000Z');
+      const secondAt = new Date('2026-07-21T00:00:00.000Z');
+      const olderSessionId = `history-older-${conversation.id}`;
+      const newerSessionId = `history-newer-${conversation.id}`;
+      await db.insert(schema.conversationSessions).values([
+        { id: olderSessionId, conversationId: conversation.id, startedAt: firstAt, lastMessageAt: firstAt },
+        { id: newerSessionId, conversationId: conversation.id, startedAt: secondAt, lastMessageAt: secondAt },
+      ]);
+      await db.insert(schema.messages).values([
+        { id: `history-a-${conversation.id}`, conversationId: conversation.id, sessionId: olderSessionId, senderId: 'session-history-user', role: 'user', parts: [{ text: 'old a' }], createdAt: firstAt },
+        { id: `history-b-${conversation.id}`, conversationId: conversation.id, sessionId: olderSessionId, senderId: 'session-history-peer', role: 'user', parts: [{ text: 'old b' }], createdAt: firstAt },
+        { id: `history-c-${conversation.id}`, conversationId: conversation.id, sessionId: newerSessionId, senderId: 'session-history-user', role: 'user', parts: [{ text: 'new' }], createdAt: secondAt },
+      ]);
+
+      const newest = await adapter.getConversationSessionHistory(conversation.id);
+      const previous = await adapter.getConversationSessionHistory(conversation.id, {
+        beforeSessionId: newest.session?.id,
+      });
+      const noMore = await adapter.getConversationSessionHistory(conversation.id, {
+        beforeSessionId: previous.session?.id,
+      });
+
+      expect(newest.session?.id).toBe(newerSessionId);
+      expect(newest.messages.map((message) => message.id)).toEqual([`history-c-${conversation.id}`]);
+      expect(newest.hasPreviousSession).toBe(true);
+      expect(previous.session?.id).toBe(olderSessionId);
+      expect(previous.messages.map((message) => message.id)).toEqual([
+        `history-a-${conversation.id}`,
+        `history-b-${conversation.id}`,
+      ]);
+      expect(previous.hasPreviousSession).toBe(false);
+      expect(noMore.session).toBeNull();
     }, 10000);
   });
 

--- a/services/api/src/controllers/chat.controller.ts
+++ b/services/api/src/controllers/chat.controller.ts
@@ -11,6 +11,7 @@ import { chatSessionService, type ChatStreamSurface } from "../services/chat.ser
 import { fileService } from "../services/file.service";
 import { agentService } from "../services/agent.service";
 import { userService } from "../services/user.service";
+import { questionService } from "../services/question.service";
 import { isNegotiatorChatEnabled } from "../lib/negotiator-feature";
 import { isAgentSurfaceEnabled } from '../lib/agent-surface-feature';
 import { negotiationReflectQueue } from "../queues/negotiations/reflect.queue";
@@ -585,6 +586,7 @@ export class ChatController {
           let subgraphResults: Record<string, unknown> | undefined;
           let debugMeta: { graph: string; iterations: number; tools: unknown[]; llm?: unknown; orchestratorNegotiations?: unknown; discoveryQuestions?: DebugMetaDiscoveryQuestions } | undefined;
           let decisionQuestions: import("@indexnetwork/protocol").Question[] | undefined;
+          const streamedChatQuestionIds: string[] = [];
 
           // Use context-aware streaming to load previous messages
 
@@ -640,6 +642,10 @@ export class ChatController {
                 // Event was already forwarded by the default enqueue above; just
                 // capture so the final `done` event can include `decisionQuestions`.
                 decisionQuestions = (event as { questions: import("@indexnetwork/protocol").Question[] }).questions;
+              } else if (event.type === "user_question") {
+                for (const question of event.questions) {
+                  if (typeof question.id === 'string') streamedChatQuestionIds.push(question.id);
+                }
               }
             }
           }
@@ -690,6 +696,15 @@ export class ChatController {
               content: fullResponse,
               routingDecision,
               subgraphResults,
+            });
+          }
+
+          if (assistantMessageId && streamedChatQuestionIds.length > 0) {
+            await questionService.bindChatQuestionsToMessage({
+              questionIds: streamedChatQuestionIds,
+              userId: user.id,
+              conversationId: sessionId,
+              messageId: assistantMessageId,
             });
           }
 

--- a/services/api/src/controllers/chat.controller.ts
+++ b/services/api/src/controllers/chat.controller.ts
@@ -1032,9 +1032,9 @@ export class ChatController {
     user: AuthenticatedUser,
     allowedPersonas: ReadonlySet<string>,
   ) {
-    let body: { sessionId?: string };
+    let body: { sessionId?: string; beforeSessionId?: string };
     try {
-      body = (await req.json()) as { sessionId?: string };
+      body = (await req.json()) as { sessionId?: string; beforeSessionId?: string };
     } catch {
       return Response.json(
         { error: "Invalid request body. Expected { sessionId: string }" },
@@ -1054,9 +1054,11 @@ export class ChatController {
       return Response.json({ error: "Session not found" }, { status: 404 });
     }
 
-    const messages = await chatSessionService.getSessionMessages(
+    const history = await chatSessionService.getConversationSessionHistory(
       body.sessionId,
+      body.beforeSessionId,
     );
+    const messages = history.messages;
 
     // Fetch metadata for assistant messages (traceEvents, debugMeta)
     const assistantIds = messages
@@ -1080,7 +1082,13 @@ export class ChatController {
       };
     });
 
-    return Response.json({ session, messages: enrichedMessages });
+    return Response.json({
+      session,
+      messages: enrichedMessages,
+      sessionId: history.session?.id ?? null,
+      hasPreviousSession: history.hasPreviousSession,
+      previousSessionCursor: history.hasPreviousSession ? history.session?.id ?? null : null,
+    });
   }
 
   /**

--- a/services/api/src/controllers/conversation.controller.ts
+++ b/services/api/src/controllers/conversation.controller.ts
@@ -124,8 +124,23 @@ export class ConversationController {
     const limit = url.searchParams.get('limit') ? parseInt(url.searchParams.get('limit')!, 10) : undefined;
     const before = url.searchParams.get('before') ?? undefined;
     const taskId = url.searchParams.get('taskId') ?? undefined;
+    const beforeSessionId = url.searchParams.get('beforeSessionId') ?? undefined;
+    const sessionHistory = url.searchParams.get('sessionHistory') === 'true' || beforeSessionId !== undefined;
 
     try {
+      if (sessionHistory) {
+        const history = await this.conversationService.getSessionHistory(conversationId, {
+          userId: user.id,
+          taskId,
+          beforeSessionId,
+        });
+        return Response.json({
+          messages: history.messages,
+          sessionId: history.session?.id ?? null,
+          hasPreviousSession: history.hasPreviousSession,
+          previousSessionCursor: history.hasPreviousSession ? history.session?.id ?? null : null,
+        });
+      }
       const messages = await this.conversationService.getMessages(conversationId, { limit, before, taskId, userId: user.id });
       return Response.json({ messages });
     } catch (err: unknown) {

--- a/services/api/src/controllers/question.controller.ts
+++ b/services/api/src/controllers/question.controller.ts
@@ -161,13 +161,18 @@ export class QuestionController {
         return Response.json({ error: 'Question not found' }, { status: 404 });
       }
       const session = await chatSessionService.getSession(conversationId, user.id);
-      if (!session || (rawMode && rawMode !== 'chat')) {
+      if (!session) {
         return Response.json({ error: 'Question not found' }, { status: 404 });
       }
-      // Conversation-anchored rendering is exclusively for canonical chat rows.
-      // This keeps pool and non-chat questions out of injected chat surfaces.
-      filters.mode = 'chat';
+      // Preserve the caller's explicit mode filter: chat-triggered intent,
+      // enrichment, discovery, and negotiation questions are still anchored to
+      // this conversation and must remain answerable. Pool-discovery rows never
+      // render in generic conversation injection.
       filters.conversationId = conversationId;
+      filters.excludeModes = [...new Set([
+        ...(filters.excludeModes ?? []),
+        'pool_discovery' as const,
+      ])];
     }
     if (noConversation === 'true') filters.noConversation = true;
 

--- a/services/api/src/controllers/question.controller.ts
+++ b/services/api/src/controllers/question.controller.ts
@@ -1,6 +1,7 @@
 import { z } from 'zod';
 
 import { questionService } from '../services/question.service';
+import { chatSessionService } from '../services/chat.service';
 import type { AdapterQuestionFilters } from '../services/question.service';
 
 import { hasChatQuestionWaiter } from '../lib/chat-question.events';
@@ -155,7 +156,19 @@ export class QuestionController {
       filters.scopeType = 'intent';
       filters.scopeId = scope.scopeId;
     }
-    if (conversationId) filters.conversationId = conversationId;
+    if (conversationId) {
+      if (!uuidQuerySchema.safeParse(conversationId).success) {
+        return Response.json({ error: 'Question not found' }, { status: 404 });
+      }
+      const session = await chatSessionService.getSession(conversationId, user.id);
+      if (!session || (rawMode && rawMode !== 'chat')) {
+        return Response.json({ error: 'Question not found' }, { status: 404 });
+      }
+      // Conversation-anchored rendering is exclusively for canonical chat rows.
+      // This keeps pool and non-chat questions out of injected chat surfaces.
+      filters.mode = 'chat';
+      filters.conversationId = conversationId;
+    }
     if (noConversation === 'true') filters.noConversation = true;
 
     // Pool questions are intent-page-only rows. Even delivered pushes affect

--- a/services/api/src/controllers/tests/conversation.controller.spec.ts
+++ b/services/api/src/controllers/tests/conversation.controller.spec.ts
@@ -50,3 +50,148 @@ describe('ConversationController mark-read endpoint', () => {
     expect(response.status).toBe(403);
   });
 });
+
+describe('ConversationController session-history reads', () => {
+  const user = { id: 'viewer-1' } as AuthenticatedUser;
+  const latestMessage = {
+    id: 'latest-message',
+    conversationId: 'conv-1',
+    sessionId: 'session-latest',
+    senderId: 'viewer-1',
+    role: 'user' as const,
+    parts: [{ text: 'latest' }],
+    createdAt: new Date('2026-07-22T12:00:00.000Z'),
+  };
+  const previousMessage = {
+    id: 'previous-message',
+    conversationId: 'conv-1',
+    sessionId: 'session-previous',
+    senderId: 'viewer-1',
+    role: 'user' as const,
+    parts: [{ text: 'previous' }],
+    createdAt: new Date('2026-07-21T12:00:00.000Z'),
+  };
+  const latestMessageJson = { ...latestMessage, createdAt: latestMessage.createdAt.toISOString() };
+  const previousMessageJson = { ...previousMessage, createdAt: previousMessage.createdAt.toISOString() };
+
+  test('returns only the latest H2H session with a previous-session signal', async () => {
+    let received: unknown;
+    const service = {
+      resolveId: async () => ({ id: 'conv-1' }),
+      getSessionHistory: async (_conversationId: string, opts: unknown) => {
+        received = opts;
+        return {
+          session: { id: 'session-latest' },
+          messages: [latestMessage],
+          hasPreviousSession: true,
+        };
+      },
+    } as unknown as ConversationService;
+    const controller = new ConversationController(service, {} as TaskService);
+
+    const response = await controller.getMessages(
+      new Request('http://localhost/api/conversations/conv-1/messages?sessionHistory=true'),
+      user,
+      { id: 'conv-1' },
+    );
+
+    expect(response.status).toBe(200);
+    expect(received).toEqual({ userId: 'viewer-1', taskId: undefined, beforeSessionId: undefined });
+    expect(await response.json()).toEqual({
+      messages: [latestMessageJson],
+      sessionId: 'session-latest',
+      hasPreviousSession: true,
+      previousSessionCursor: 'session-latest',
+    });
+  });
+
+  test('returns exactly one previous session and fails closed for a forged cursor', async () => {
+    const received: Array<{ userId: string; taskId?: string; beforeSessionId?: string }> = [];
+    const service = {
+      resolveId: async () => ({ id: 'conv-1' }),
+      getSessionHistory: async (_conversationId: string, opts: { userId: string; taskId?: string; beforeSessionId?: string }) => {
+        received.push(opts);
+        if (opts.beforeSessionId === 'foreign-session') {
+          return { session: null, messages: [], hasPreviousSession: false };
+        }
+        return {
+          session: { id: 'session-previous' },
+          messages: [previousMessage],
+          hasPreviousSession: false,
+        };
+      },
+    } as unknown as ConversationService;
+    const controller = new ConversationController(service, {} as TaskService);
+
+    const previous = await controller.getMessages(
+      new Request('http://localhost/api/conversations/conv-1/messages?sessionHistory=true&beforeSessionId=session-latest'),
+      user,
+      { id: 'conv-1' },
+    );
+    const forged = await controller.getMessages(
+      new Request('http://localhost/api/conversations/conv-1/messages?sessionHistory=true&beforeSessionId=foreign-session'),
+      user,
+      { id: 'conv-1' },
+    );
+
+    expect(received).toEqual([
+      { userId: 'viewer-1', taskId: undefined, beforeSessionId: 'session-latest' },
+      { userId: 'viewer-1', taskId: undefined, beforeSessionId: 'foreign-session' },
+    ]);
+    expect(await previous.json()).toMatchObject({
+      messages: [previousMessageJson],
+      sessionId: 'session-previous',
+      hasPreviousSession: false,
+    });
+    expect(await forged.json()).toEqual({
+      messages: [],
+      sessionId: null,
+      hasPreviousSession: false,
+      previousSessionCursor: null,
+    });
+  });
+
+  test('passes taskId through to the A2A task-session read', async () => {
+    let received: unknown;
+    const service = {
+      resolveId: async () => ({ id: 'conv-1' }),
+      getSessionHistory: async (_conversationId: string, opts: unknown) => {
+        received = opts;
+        return {
+          session: { id: 'task-session', taskId: 'task-1' },
+          messages: [latestMessage],
+          hasPreviousSession: false,
+        };
+      },
+    } as unknown as ConversationService;
+    const controller = new ConversationController(service, {} as TaskService);
+
+    const response = await controller.getMessages(
+      new Request('http://localhost/api/conversations/conv-1/messages?sessionHistory=true&taskId=task-1'),
+      user,
+      { id: 'conv-1' },
+    );
+
+    expect(response.status).toBe(200);
+    expect(received).toEqual({ userId: 'viewer-1', taskId: 'task-1', beforeSessionId: undefined });
+    expect(await response.json()).toMatchObject({ sessionId: 'task-session', messages: [latestMessageJson] });
+  });
+
+  test('rejects non-participants for session-history reads', async () => {
+    const service = {
+      resolveId: async () => ({ id: 'conv-1' }),
+      getSessionHistory: async () => {
+        throw new Error('Forbidden: not a participant in this conversation');
+      },
+    } as unknown as ConversationService;
+    const controller = new ConversationController(service, {} as TaskService);
+
+    const response = await controller.getMessages(
+      new Request('http://localhost/api/conversations/conv-1/messages?sessionHistory=true'),
+      user,
+      { id: 'conv-1' },
+    );
+
+    expect(response.status).toBe(403);
+  });
+});

--- a/services/api/src/controllers/tests/question.inbox.spec.ts
+++ b/services/api/src/controllers/tests/question.inbox.spec.ts
@@ -20,7 +20,7 @@ import { describe, test, expect, beforeAll as bunBeforeAll, afterAll as bunAfter
 import { eq, inArray } from "drizzle-orm/sql";
 import { QuestionController } from "../question.controller";
 import { QuestionerAdapter, type AdapterPersistableQuestion } from "../../adapters/questioner.adapter";
-import { UserDatabaseAdapter } from "../../adapters/database.adapter";
+import { ConversationDatabaseAdapter, UserDatabaseAdapter } from "../../adapters/database.adapter";
 import { questionService } from "../../services/question.service";
 import { QuestionEvents } from "../../events/question.event";
 import db from "../../lib/drizzle/drizzle";
@@ -35,9 +35,11 @@ const afterAll = withMinimumDatabaseHookBudget(bunAfterAll, 30_000);
 describe("Pending question inbox (IND-404)", () => {
   const userAdapter = new UserDatabaseAdapter();
   const questionerAdapter = new QuestionerAdapter(db);
+  const conversationAdapter = new ConversationDatabaseAdapter();
   const controller = new QuestionController();
   let testUserId: string;
   const createdQuestionIds: string[] = [];
+  const createdConversationIds: string[] = [];
   let answeredEvents: Array<{ questionId: string; mode: string; sourceId: string }> = [];
   const prevOnAnswered = QuestionEvents.onAnswered;
 
@@ -114,6 +116,9 @@ describe("Pending question inbox (IND-404)", () => {
     QuestionEvents.onAnswered = prevOnAnswered;
     if (createdQuestionIds.length > 0) {
       await db.delete(questions).where(inArray(questions.id, createdQuestionIds)).catch(() => {});
+    }
+    for (const conversationId of createdConversationIds) {
+      await conversationAdapter.deleteConversation(conversationId).catch(() => {});
     }
     if (testUserId) await userAdapter.deleteById(testUserId);
   });
@@ -261,6 +266,41 @@ describe("Pending question inbox (IND-404)", () => {
     // Without the exclusion the pool question is still reachable (intent page path).
     const all = await questionService.findPending(testUserId, { noConversation: true });
     expect(all.map((q) => q.id)).toContain(poolQuestionId);
+  });
+
+  test("conversation reads retain non-pool modes and reject foreign participants", async () => {
+    const conversationId = crypto.randomUUID();
+    createdConversationIds.push(conversationId);
+    await conversationAdapter.createChatSession({ id: conversationId, userId: testUserId });
+    const intentQuestionId = await persistQuestion({
+      detection: {
+        mode: 'intent',
+        sourceType: 'intent',
+        sourceId: crypto.randomUUID(),
+        timestamp: new Date().toISOString(),
+      },
+      conversationId,
+    });
+    const poolQuestionId = await persistQuestion({
+      detection: {
+        mode: 'pool_discovery',
+        sourceType: 'intent',
+        sourceId: crypto.randomUUID(),
+        timestamp: new Date().toISOString(),
+      },
+      conversationId,
+    });
+    const response = await controller.list(listReq(`conversationId=${conversationId}`), mockUser());
+    expect(response.status).toBe(200);
+    const body = await response.json() as { questions: Array<{ id: string }> };
+    expect(body.questions.map((question) => question.id)).toContain(intentQuestionId);
+    expect(body.questions.map((question) => question.id)).not.toContain(poolQuestionId);
+
+    const foreignResponse = await controller.list(
+      listReq(`conversationId=${conversationId}`),
+      { id: crypto.randomUUID(), email: 'foreign@example.com', name: 'Foreign' },
+    );
+    expect(foreignResponse.status).toBe(404);
   });
 
   test("conversation-bound questions stay out of the DM inbox", async () => {

--- a/services/api/src/schemas/conversation.schema.ts
+++ b/services/api/src/schemas/conversation.schema.ts
@@ -105,6 +105,34 @@ export const tasks = pgTable(
  * `parts` is a JSONB array of A2A message parts (text, data, file, etc.).
  * `referenceTaskIds` optionally links a message to related tasks.
  */
+/**
+ * Durable timeline segment within a conversation.
+ *
+ * A2A task runs map one-to-one to a session through `taskId`. H2A and H2H
+ * sessions are separated by the server-side inactivity boundary.
+ */
+export const conversationSessions = pgTable(
+  'conversation_sessions',
+  {
+    id: text('id').primaryKey().$defaultFn(() => crypto.randomUUID()),
+    conversationId: text('conversation_id')
+      .notNull()
+      .references(() => conversations.id, { onDelete: 'cascade' }),
+    taskId: text('task_id').references(() => tasks.id, { onDelete: 'set null' }),
+    startedAt: timestamp('started_at', { withTimezone: true }).notNull(),
+    lastMessageAt: timestamp('last_message_at', { withTimezone: true }).notNull(),
+    createdAt: timestamp('created_at', { withTimezone: true }).defaultNow().notNull(),
+  },
+  (table) => ({
+    conversationStartedIdx: index('conversation_sessions_conversation_started_idx').on(
+      table.conversationId,
+      table.startedAt,
+      table.id,
+    ),
+    taskIdUnique: uniqueIndex('conversation_sessions_task_id_uniq').on(table.taskId),
+  }),
+);
+
 export const messages = pgTable(
   'messages',
   {
@@ -113,6 +141,7 @@ export const messages = pgTable(
       .notNull()
       .references(() => conversations.id, { onDelete: 'cascade' }),
     taskId: text('task_id').references(() => tasks.id, { onDelete: 'set null' }),
+    sessionId: text('session_id').references(() => conversationSessions.id, { onDelete: 'set null' }),
     senderId: text('sender_id').notNull(),
     role: messageRoleEnum('role').notNull(),
     parts: jsonb('parts').notNull(),
@@ -125,9 +154,15 @@ export const messages = pgTable(
     conversationCreatedAtIdx: index('messages_conversation_id_created_at_idx').on(
       table.conversationId,
       table.createdAt,
+      table.id,
     ),
     senderIdIdx: index('messages_sender_id_idx').on(table.senderId),
     taskIdIdx: index('messages_task_id_idx').on(table.taskId),
+    sessionCreatedAtIdx: index('messages_session_id_created_at_idx').on(
+      table.sessionId,
+      table.createdAt,
+      table.id,
+    ),
   }),
 );
 
@@ -236,6 +271,7 @@ export const chatSessionScopes = pgTable(
 
 export const conversationsRelations = relations(conversations, ({ many, one }) => ({
   participants: many(conversationParticipants),
+  sessions: many(conversationSessions),
   messages: many(messages),
   tasks: many(tasks),
   metadata: one(conversationMetadata, {
@@ -251,10 +287,26 @@ export const conversationParticipantsRelations = relations(conversationParticipa
   }),
 }));
 
+export const conversationSessionsRelations = relations(conversationSessions, ({ one, many }) => ({
+  conversation: one(conversations, {
+    fields: [conversationSessions.conversationId],
+    references: [conversations.id],
+  }),
+  task: one(tasks, {
+    fields: [conversationSessions.taskId],
+    references: [tasks.id],
+  }),
+  messages: many(messages),
+}));
+
 export const messagesRelations = relations(messages, ({ one }) => ({
   conversation: one(conversations, {
     fields: [messages.conversationId],
     references: [conversations.id],
+  }),
+  session: one(conversationSessions, {
+    fields: [messages.sessionId],
+    references: [conversationSessions.id],
   }),
   task: one(tasks, {
     fields: [messages.taskId],
@@ -313,6 +365,9 @@ export const chatSessionSummariesRelations = relations(chatSessionSummaries, ({ 
 
 export type Conversation = typeof conversations.$inferSelect;
 export type NewConversation = typeof conversations.$inferInsert;
+
+export type ConversationSession = typeof conversationSessions.$inferSelect;
+export type NewConversationSession = typeof conversationSessions.$inferInsert;
 
 export type ConversationParticipant = typeof conversationParticipants.$inferSelect;
 export type NewConversationParticipant = typeof conversationParticipants.$inferInsert;

--- a/services/api/src/schemas/database.schema.ts
+++ b/services/api/src/schemas/database.schema.ts
@@ -521,6 +521,8 @@ export interface QuestionDetection {
   underspecificationType?: import('@indexnetwork/protocol').UnderspecificationType | null;
   /** ID of the assistant message that triggered this question. */
   messageId?: string;
+  /** Durable conversation-session binding for verified in-chat rendering. */
+  sessionId?: string;
   /**
    * pool_discovery only: mined pool snapshot (assignments + chain alternates).
    * INTERNAL — stripped from every client-facing read (web + MCP).

--- a/services/api/src/services/chat.service.ts
+++ b/services/api/src/services/chat.service.ts
@@ -703,6 +703,18 @@ export class ChatSessionService {
   }
 
   /**
+   * Loads the active or one immediately previous durable timeline session for an
+   * authorized H2A conversation.
+   *
+   * @param conversationId - Chat conversation identifier.
+   * @param beforeSessionId - Cursor of the currently oldest loaded session.
+   * @returns One session section, its messages, and whether another section precedes it.
+   */
+  async getConversationSessionHistory(conversationId: string, beforeSessionId?: string) {
+    return this.db.getChatConversationSessionHistory(conversationId, { beforeSessionId });
+  }
+
+  /**
    * Delete a session and all its messages (cascade).
    *
    * @param sessionId - The session ID to delete

--- a/services/api/src/services/conversation.service.ts
+++ b/services/api/src/services/conversation.service.ts
@@ -172,6 +172,21 @@ export class ConversationService {
   }
 
   /**
+   * Loads one durable timeline session for an authorized conversation.
+   *
+   * @param conversationId - Conversation identifier.
+   * @param opts - Caller visibility plus optional task or prior-session cursor.
+   * @returns The selected session, messages, and previous-session signal.
+   */
+  async getSessionHistory(
+    conversationId: string,
+    opts: { userId: string; taskId?: string; beforeSessionId?: string },
+  ) {
+    await this.verifyParticipant(opts.userId, conversationId);
+    return this.db.getConversationSessionHistory(conversationId, opts);
+  }
+
+  /**
    * Marks a conversation read for a specific participant.
    * @param userId - The participant marking the conversation read (must be a participant)
    * @param conversationId - Conversation ID

--- a/services/api/src/services/question.service.ts
+++ b/services/api/src/services/question.service.ts
@@ -97,6 +97,21 @@ export class QuestionService {
   }
 
   /**
+   * Stamp canonical chat questions with their persisted assistant-message and
+   * durable-session provenance once a streaming turn has completed.
+   *
+   * @param input - Exact question IDs and authoritative message context.
+   */
+  async bindChatQuestionsToMessage(input: {
+    questionIds: string[];
+    userId: string;
+    conversationId: string;
+    messageId: string;
+  }): Promise<void> {
+    await this.adapter.bindChatQuestionsToMessage(input);
+  }
+
+  /**
    * Return canonical split counts for global and Personal Agent surfaces.
    *
    * @param userId - Authenticated recipient.

--- a/services/api/src/startup.env.ts
+++ b/services/api/src/startup.env.ts
@@ -110,6 +110,7 @@ const envSchema = z.object({
   WEB_SIGNAL_AGENT_ENABLED: optionalBoolean,
   WEB_AGENT_SURFACE_ENABLED: optionalBoolean,
   REPORTER_BRIEFING_TTL_MS: optionalPositiveInt,
+  CHAT_SESSION_GAP_MS: optionalPositiveInt,
   WEB_AGENT_ACTIONS_ENABLED: optionalBoolean,
   NEGOTIATOR_TURN_TIMEOUT_MS: optionalInt,
   NEGOTIATION_SCREEN_MODE: z.union([z.literal(''), z.enum(['off', 'shadow', 'enforce'])]).optional(),

--- a/services/api/src/types/chat-streaming.types.ts
+++ b/services/api/src/types/chat-streaming.types.ts
@@ -563,11 +563,8 @@ export interface DecisionQuestionsEvent extends ChatStreamEventBase {
  * while the turn is still blocked.
  */
 export interface UserQuestionPayload {
+  /** Opaque canonical question reference; resolve display content server-side. */
   id: string;
-  title: string;
-  prompt: string;
-  options: Array<{ label: string; description: string }>;
-  multiSelect: boolean;
 }
 
 /**


### PR DESCRIPTION
## New Features
- Add durable `conversation_sessions`, deterministic history backfill, server-side message stamping, and composite message cursor ordering.
- Hydrate H2A/H2H/A2A history one session at a time with accessible section dividers and Load Previous Messages.
- Resolve streamed in-chat question IDs against canonical recipient/conversation-scoped rows and stamp assistant-message/session provenance.

## Bug Fixes
- Pin model context to the latest messages in the active durable session rather than the oldest rows.

## Documentation
- Document session history APIs and the durable session model.

## Tests
- `cd packages/protocol && bun test src/chat/tests/chat.graph.spec.ts && bun run build`
- `cd services/api && bun run db:generate && bun run lint`
- `cd services/api && TEST_DATABASE_SAFE=1 NODE_ENV=test bun test src/adapters/tests/conversation.database.adapter.spec.ts src/controllers/tests/chat.controller.isolated.ts src/controllers/tests/chat.signal.spec.ts`
- `cd apps/web && bun run lint && bun run build`

References IND-498.