### PR TITLE
fix(home): correct pending opportunity counts

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@indexnetwork/web",
-  "version": "0.28.2",
+  "version": "0.28.3",
   "license": "MIT",
   "scripts": {
     "dev": "vite --host 127.0.0.1",

--- a/apps/web/src/components/DiscoverHome.tsx
+++ b/apps/web/src/components/DiscoverHome.tsx
@@ -33,16 +33,26 @@ export default function DiscoverHome() {
   const navigate = useNavigate();
   const { error: showError } = useNotifications();
   const [intents, setIntents] = useState<HomeIntent[]>([]);
+  const [totalWaitingOpportunities, setTotalWaitingOpportunities] = useState(0);
   const [loading, setLoading] = useState(false);
   const mountedRef = useRef(true);
 
   const fetchIntents = useCallback(async () => {
     try {
-      const res = await apiClient.post<{ intents?: HomeIntent[] }>("/intents/list", { page: 1, limit: 100 });
-      if (mountedRef.current) setIntents(res.intents ?? []);
+      const res = await apiClient.post<{
+        intents?: HomeIntent[];
+        totalWaitingOpportunities?: number;
+      }>("/intents/list", { page: 1, limit: 100 });
+      if (mountedRef.current) {
+        setIntents(res.intents ?? []);
+        setTotalWaitingOpportunities(res.totalWaitingOpportunities ?? 0);
+      }
     } catch (err) {
       logger.error("Failed to load signals", { error: err });
-      if (mountedRef.current) setIntents([]);
+      if (mountedRef.current) {
+        setIntents([]);
+        setTotalWaitingOpportunities(0);
+      }
     }
   }, []);
 
@@ -85,7 +95,7 @@ export default function DiscoverHome() {
           <DebugCopyButton fetchPath="/debug/home" title="Copy home debug JSON" iconSize="w-5 h-5" />
         </div>
         <p className="mb-6 text-center text-xs text-gray-400 font-ibm-plex-mono">
-          {intents.length} signals · {intents.reduce((total, intent) => total + (intent.waitingOpportunityCount ?? 0), 0)} opportunities
+          {intents.length} signals · {totalWaitingOpportunities} opportunities
         </p>
 
         {/* New signal entry — styled to match IntentList rows */}

--- a/apps/web/src/components/IntentList.tsx
+++ b/apps/web/src/components/IntentList.tsx
@@ -18,8 +18,8 @@ interface BaseIntent {
   /** Networks this intent is currently registered to. */
   networks?: { id: string; title: string }[];
   /**
-   * Count of `pending` opportunities anchored on this intent, awaiting the user.
-   * Shown next to the date. Undefined/0 renders nothing.
+   * Count of distinct `pending` opportunities awaiting the user and attributed
+   * to this signal. Shown next to the date. Undefined/0 renders nothing.
    */
   waitingOpportunityCount?: number;
   /**

--- a/apps/web/tests/discover-home.test.tsx
+++ b/apps/web/tests/discover-home.test.tsx
@@ -47,17 +47,36 @@ describe('DiscoverHome', () => {
     vi.useRealTimers();
   });
 
-  test('renders header totals from listed signals and their opportunities', async () => {
+  test('renders the deduplicated header total rather than summing signal badges', async () => {
     mocks.apiClient.post.mockResolvedValueOnce({
       intents: [
         intent({ id: 'intent-1', waitingOpportunityCount: 2 }),
         intent({ id: 'intent-2', waitingOpportunityCount: 1 }),
       ],
+      totalWaitingOpportunities: 2,
     });
 
     renderHome();
 
-    expect(await screen.findByText('2 signals · 3 opportunities')).toBeInTheDocument();
+    expect(await screen.findByText('2 signals · 2 opportunities')).toBeInTheDocument();
+  });
+
+  test('renders only positive opportunity badges', async () => {
+    mocks.apiClient.post.mockResolvedValueOnce({
+      intents: [
+        intent({ id: 'zero', summary: 'Zero count', waitingOpportunityCount: 0 }),
+        intent({ id: 'undefined', summary: 'Undefined count', waitingOpportunityCount: undefined }),
+        intent({ id: 'positive', summary: 'Positive count', waitingOpportunityCount: 2 }),
+      ],
+      totalWaitingOpportunities: 2,
+    });
+
+    renderHome();
+
+    expect(await screen.findByText('3 signals · 2 opportunities')).toBeInTheDocument();
+    expect(screen.getByTitle('2 opportunities for you')).toBeInTheDocument();
+    expect(screen.getAllByTitle(/opportunities for you/)).toHaveLength(1);
+    expect(screen.queryByTitle('0 opportunities for you')).not.toBeInTheDocument();
   });
 
   test('renders WARMING and an unknown opportunity count without a live dot', async () => {

--- a/docs/specs/api-reference.md
+++ b/docs/specs/api-reference.md
@@ -2460,12 +2460,19 @@ List intents with pagination and filters.
       "summary": "...",
       "createdAt": "...",
       "updatedAt": "...",
-      "archivedAt": "... | null"
+      "archivedAt": "... | null",
+      "waitingOpportunityCount": "number"
     }
   ],
+  "totalWaitingOpportunities": "number",
   "pagination": { ... }
 }
 ```
+
+`waitingOpportunityCount` includes only distinct, still-pending opportunities
+awaiting the authenticated user that are attributed to that signal. The top-level
+`totalWaitingOpportunities` deduplicates rows that are attributed to more than one
+listed signal.
 
 ### POST /api/intents/confirm
 

--- a/services/api/.test-isolated
+++ b/services/api/.test-isolated
@@ -41,6 +41,7 @@ src/adapters/tests/auth.adapter.isolated.ts
 src/adapters/tests/database.adapter.isolated.ts
 src/adapters/tests/chat-summary.database.adapter.isolated.ts
 src/adapters/tests/agent-activity.database.adapter.isolated.ts
+src/adapters/tests/intent-opportunity-counts.database.isolated.ts
 src/controllers/tests/chat.controller.isolated.ts
 src/controllers/tests/invitation-gaps.controller.isolated.ts
 src/controllers/tests/invitation.controller.isolated.ts

--- a/services/api/package.json
+++ b/services/api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@indexnetwork/api",
-  "version": "0.53.1",
+  "version": "0.53.2",
   "license": "MIT",
   "private": true,
   "scripts": {

--- a/services/api/src/adapters/database.shared.ts
+++ b/services/api/src/adapters/database.shared.ts
@@ -172,7 +172,11 @@ export interface IntentListRow {
   networks: { id: string; title: string }[];
   /** Count of pending intent-scoped questions awaiting the user for this intent. */
   pendingQuestionCount: number;
-  /** Count of `pending` opportunities anchored on this intent, awaiting the user. */
+  /**
+   * Count of distinct `pending` opportunities awaiting this owner that are
+   * attributed to this signal by `detection.triggeredBy` or the owner's
+   * non-introducer actor intent. Rows the owner already acted on are excluded.
+   */
   waitingOpportunityCount: number;
   /** True while a fresh intent has not completed its first discovery run. */
   warming: boolean;

--- a/services/api/src/adapters/intent.database.adapter.ts
+++ b/services/api/src/adapters/intent.database.adapter.ts
@@ -524,7 +524,7 @@ export class IntentDatabaseAdapter {
     limit: number;
     archived: boolean;
     sourceType?: string;
-  }): Promise<{ rows: IntentListRow[]; total: number }> {
+  }): Promise<{ rows: IntentListRow[]; total: number; totalWaitingOpportunities: number }> {
     const offset = (options.page - 1) * options.limit;
     const where = ownIntentsListWhere(userId, { archived: options.archived, sourceType: options.sourceType });
 
@@ -550,8 +550,12 @@ export class IntentDatabaseAdapter {
       db.select({ count: count() }).from(schema.intents).where(where),
     ]);
 
-    const withExtras = await this.attachIntentExtras(rows, userId);
-    return { rows: withExtras, total: Number(totalResult[0]?.count ?? 0) };
+    const { rows: withExtras, totalWaitingOpportunities } = await this.attachIntentExtras(rows, userId);
+    return {
+      rows: withExtras,
+      total: Number(totalResult[0]?.count ?? 0),
+      totalWaitingOpportunities,
+    };
   }
 
   /**
@@ -563,8 +567,9 @@ export class IntentDatabaseAdapter {
    *
    * @param rows - The paginated base intent rows to enrich.
    * @param userId - Owner, used to scope the waiting-opportunity actor match.
-   * @returns The same rows, each with `networks`, `pendingQuestionCount`, and
-   *   `waitingOpportunityCount` populated (empty/zero when none).
+   * @returns The rows with `networks`, `pendingQuestionCount`, and
+   *   `waitingOpportunityCount` populated (empty/zero when none), plus a
+   *   deduplicated total of waiting opportunities across the page's signals.
    */
   private async attachIntentExtras(
     rows: (Omit<IntentListRow, 'networks' | 'pendingQuestionCount' | 'waitingOpportunityCount' | 'warming'> & {
@@ -572,8 +577,8 @@ export class IntentDatabaseAdapter {
       firstDiscoverySucceededAt: Date | null;
     })[],
     userId: string,
-  ): Promise<IntentListRow[]> {
-    if (rows.length === 0) return [];
+  ): Promise<{ rows: IntentListRow[]; totalWaitingOpportunities: number }> {
+    if (rows.length === 0) return { rows: [], totalWaitingOpportunities: 0 };
     const intentIds = rows.map(r => r.id);
     const warmingCutoff = new Date(Date.now() - 24 * 60 * 60 * 1000);
     // Only rows that are fresh AND not already stamped need the legacy
@@ -581,21 +586,24 @@ export class IntentDatabaseAdapter {
     const freshIntentIds = rows
       .filter(r => r.createdAt > warmingCutoff && r.firstDiscoverySucceededAt == null)
       .map(r => r.id);
-    const [networks, counts, succeededDiscoveryIntentIds] = await Promise.all([
+    const [networks, countResult, succeededDiscoveryIntentIds] = await Promise.all([
       this.networksByIntent(intentIds),
       this.countsByIntent(intentIds, userId),
       this.succeededDiscoveryIntentIds(freshIntentIds),
     ]);
     const succeededIds = new Set(succeededDiscoveryIntentIds);
-    return rows.map(({ firstDiscoverySucceededAt, ...r }) => ({
-      ...r,
-      networks: networks.get(r.id) ?? [],
-      pendingQuestionCount: counts.get(r.id)?.questions ?? 0,
-      waitingOpportunityCount: counts.get(r.id)?.opportunities ?? 0,
-      warming: r.createdAt > warmingCutoff
-        && firstDiscoverySucceededAt == null
-        && !succeededIds.has(r.id),
-    }));
+    return {
+      rows: rows.map(({ firstDiscoverySucceededAt, ...r }) => ({
+        ...r,
+        networks: networks.get(r.id) ?? [],
+        pendingQuestionCount: countResult.byIntent.get(r.id)?.questions ?? 0,
+        waitingOpportunityCount: countResult.byIntent.get(r.id)?.opportunities ?? 0,
+        warming: r.createdAt > warmingCutoff
+          && firstDiscoverySucceededAt == null
+          && !succeededIds.has(r.id),
+      })),
+      totalWaitingOpportunities: countResult.totalWaitingOpportunities,
+    };
   }
 
   /**
@@ -642,17 +650,21 @@ export class IntentDatabaseAdapter {
   }
 
   /**
-   * Per-intent counts of pending intent-scoped questions and `pending`
-   * opportunities awaiting the user. Two grouped jsonb queries; every requested
-   * intent id is present in the returned map (zero when it has none).
+   * Per-intent counts of pending intent-scoped questions and opportunities
+   * awaiting the viewer. The opportunity query also returns one deduplicated
+   * total across every requested signal. Every requested ID is present in the
+   * returned map (zero when it has none).
    */
   private async countsByIntent(
     intentIds: string[],
     userId: string,
-  ): Promise<Map<string, { questions: number; opportunities: number }>> {
-    const map = new Map<string, { questions: number; opportunities: number }>();
-    if (intentIds.length === 0) return map;
-    for (const id of intentIds) map.set(id, { questions: 0, opportunities: 0 });
+  ): Promise<{
+    byIntent: Map<string, { questions: number; opportunities: number }>;
+    totalWaitingOpportunities: number;
+  }> {
+    const byIntent = new Map<string, { questions: number; opportunities: number }>();
+    if (intentIds.length === 0) return { byIntent, totalWaitingOpportunities: 0 };
+    for (const id of intentIds) byIntent.set(id, { questions: 0, opportunities: 0 });
     const idList = sql.join(intentIds.map(id => sql`${id}`), sql`, `);
 
     const [questionRows, oppRows] = await Promise.all([
@@ -679,24 +691,42 @@ export class IntentDatabaseAdapter {
         GROUP BY key
       `) as unknown as Array<{ intent_id: string; cnt: number }>,
       db.execute(sql`
-        SELECT actor->>'intent' AS intent_id, COUNT(DISTINCT ${schema.opportunities.id})::int AS cnt
-        FROM ${schema.opportunities}, jsonb_array_elements(${schema.opportunities.actors}) AS actor
-        WHERE actor->>'userId' = ${userId}
-          AND actor->>'intent' IN (${idList})
-          AND ${schema.opportunities.status} = 'pending'
-        GROUP BY actor->>'intent'
-      `) as unknown as Array<{ intent_id: string; cnt: number }>,
+        WITH matching AS (
+          SELECT DISTINCT
+            ${schema.opportunities.id} AS opportunity_id,
+            requested.intent_id
+          FROM ${schema.opportunities}
+          CROSS JOIN LATERAL jsonb_array_elements(${schema.opportunities.actors}) AS actor
+          CROSS JOIN LATERAL unnest(ARRAY[${idList}]::text[]) AS requested(intent_id)
+          WHERE ${schema.opportunities.status} = 'pending'
+            AND actor->>'userId' = ${userId}
+            AND actor->>'role' IS DISTINCT FROM 'introducer'
+            AND actor->>'actedAt' IS NULL
+            AND (
+              ${schema.opportunities.detection}->>'triggeredBy' = requested.intent_id
+              OR actor->>'intent' = requested.intent_id
+            )
+        )
+        SELECT intent_id, COUNT(DISTINCT opportunity_id)::int AS cnt
+        FROM matching
+        GROUP BY GROUPING SETS ((intent_id), ())
+      `) as unknown as Array<{ intent_id: string | null; cnt: number }>,
     ]);
 
     for (const r of questionRows) {
-      const entry = map.get(r.intent_id);
+      const entry = byIntent.get(r.intent_id);
       if (entry) entry.questions = Number(r.cnt);
     }
+    let totalWaitingOpportunities = 0;
     for (const r of oppRows) {
-      const entry = map.get(r.intent_id);
+      if (r.intent_id == null) {
+        totalWaitingOpportunities = Number(r.cnt);
+        continue;
+      }
+      const entry = byIntent.get(r.intent_id);
       if (entry) entry.opportunities = Number(r.cnt);
     }
-    return map;
+    return { byIntent, totalWaitingOpportunities };
   }
 
   async getIntentById(intentId: string, userId: string): Promise<IntentListRow | null> {
@@ -718,8 +748,8 @@ export class IntentDatabaseAdapter {
       .limit(1);
 
     if (!row[0]) return null;
-    const [withExtras] = await this.attachIntentExtras(row, userId);
-    return withExtras;
+    const { rows: [withExtras] } = await this.attachIntentExtras(row, userId);
+    return withExtras ?? null;
   }
 
   /**

--- a/services/api/src/adapters/tests/intent-opportunity-counts.database.isolated.ts
+++ b/services/api/src/adapters/tests/intent-opportunity-counts.database.isolated.ts
@@ -1,0 +1,127 @@
+import { afterAll, beforeAll, describe, expect, test } from 'bun:test';
+import { eq, inArray } from 'drizzle-orm/sql';
+
+import { IntentDatabaseAdapter } from '../database.adapter';
+import db from '../../lib/drizzle/drizzle';
+import { intents, opportunities, users } from '../../schemas/database.schema';
+
+const ownerId = crypto.randomUUID();
+const counterpartyId = crypto.randomUUID();
+const foreignOwnerId = crypto.randomUUID();
+const intentAId = crypto.randomUUID();
+const intentBId = crypto.randomUUID();
+const foreignIntentId = crypto.randomUUID();
+const opportunityIds = Array.from({ length: 17 }, () => crypto.randomUUID());
+const [
+  triggeredOnlyId,
+  actorOnlyId,
+  matchedByBothSignalsId,
+  duplicateActorRowsId,
+  recentSignalId,
+  viewerActedId,
+  counterpartyActedId,
+  counterpartyIntentId,
+  viewerIntroducerId,
+  nonActorId,
+  foreignIntentIdOpportunity,
+  pendingTransitionId,
+  latentId,
+  draftId,
+  negotiatingId,
+  stalledId,
+  terminalId,
+] = opportunityIds;
+
+const adapter = new IntentDatabaseAdapter();
+const now = new Date();
+
+function opportunity(
+  id: string,
+  actors: typeof opportunities.$inferInsert.actors,
+  detection: typeof opportunities.$inferInsert.detection,
+  status: typeof opportunities.$inferInsert.status = 'pending',
+) {
+  return {
+    id,
+    actors,
+    detection,
+    interpretation: { category: 'test', reasoning: 'IND-499 count fixture', confidence: 0.8 },
+    context: {},
+    confidence: '0.8',
+    status,
+    createdAt: now,
+    updatedAt: now,
+  };
+}
+
+beforeAll(async () => {
+  await db.insert(users).values([
+    { id: ownerId, email: `ind499-owner-${ownerId}@example.com`, name: 'IND-499 owner' },
+    { id: counterpartyId, email: `ind499-counterparty-${counterpartyId}@example.com`, name: 'IND-499 counterparty' },
+    { id: foreignOwnerId, email: `ind499-foreign-${foreignOwnerId}@example.com`, name: 'IND-499 foreign owner' },
+  ]);
+  await db.insert(intents).values([
+    { id: intentAId, userId: ownerId, payload: 'Signal A', status: 'ACTIVE' },
+    { id: intentBId, userId: ownerId, payload: 'Signal B', status: 'ACTIVE' },
+    { id: foreignIntentId, userId: foreignOwnerId, payload: 'Foreign signal', status: 'ACTIVE' },
+  ]);
+  const timestamp = now.toISOString();
+  const ownerA = { userId: ownerId, networkId: crypto.randomUUID(), role: 'peer', intent: intentAId };
+  const ownerB = { userId: ownerId, networkId: crypto.randomUUID(), role: 'peer', intent: intentBId };
+  const counterparty = { userId: counterpartyId, networkId: crypto.randomUUID(), role: 'peer' };
+
+  await db.insert(opportunities).values([
+    // Attribution through detection alone.
+    opportunity(triggeredOnlyId, [{ userId: ownerId, networkId: crypto.randomUUID(), role: 'peer' }, counterparty], { source: 'opportunity_graph', triggeredBy: intentAId, timestamp }),
+    // Attribution through the viewer's actor intent alone.
+    opportunity(actorOnlyId, [ownerB, counterparty], { source: 'opportunity_graph', timestamp }),
+    // One row is allowed under each matching signal, but only once within either.
+    opportunity(matchedByBothSignalsId, [ownerB, counterparty], { source: 'opportunity_graph', triggeredBy: intentAId, timestamp }),
+    opportunity(duplicateActorRowsId, [ownerA, { ...ownerA }, counterparty], { source: 'opportunity_graph', timestamp }),
+    // Created just now: count semantics have no age window.
+    opportunity(recentSignalId, [ownerA, counterparty], { source: 'opportunity_graph', timestamp }),
+    // A viewer who already acted is awaiting the counterparty, not a home count.
+    opportunity(viewerActedId, [{ ...ownerA, actedAt: timestamp }, counterparty], { source: 'opportunity_graph', timestamp }),
+    // A counterparty acting must not hide the viewer's pending card.
+    opportunity(counterpartyActedId, [ownerA, { ...counterparty, actedAt: timestamp }], { source: 'opportunity_graph', timestamp }),
+    // A counterparty's intent cannot be attributed to the viewer's signal.
+    opportunity(counterpartyIntentId, [{ ...counterparty, intent: intentAId }, { userId: ownerId, networkId: crypto.randomUUID(), role: 'peer' }], { source: 'opportunity_graph', timestamp }),
+    opportunity(viewerIntroducerId, [{ ...ownerA, role: 'introducer' }, counterparty], { source: 'opportunity_graph', triggeredBy: intentAId, timestamp }),
+    opportunity(nonActorId, [counterparty], { source: 'opportunity_graph', triggeredBy: intentAId, timestamp }),
+    // The caller only lists owner-scoped signal IDs, so foreign provenance fails closed.
+    opportunity(foreignIntentIdOpportunity, [{ userId: ownerId, networkId: crypto.randomUUID(), role: 'peer', intent: foreignIntentId }, counterparty], { source: 'opportunity_graph', triggeredBy: foreignIntentId, timestamp }),
+    opportunity(pendingTransitionId, [ownerA, counterparty], { source: 'opportunity_graph', timestamp }),
+    ...(['latent', 'draft', 'negotiating', 'stalled'] as const).map((status, index) =>
+      opportunity([latentId, draftId, negotiatingId, stalledId][index], [ownerA, counterparty], { source: 'opportunity_graph', triggeredBy: intentAId, timestamp }, status),
+    ),
+    opportunity(terminalId, [ownerA, counterparty], { source: 'opportunity_graph', triggeredBy: intentAId, timestamp }, 'accepted'),
+  ]);
+});
+
+afterAll(async () => {
+  await db.delete(opportunities).where(inArray(opportunities.id, opportunityIds));
+  await db.delete(intents).where(inArray(intents.id, [intentAId, intentBId, foreignIntentId]));
+  await db.delete(users).where(inArray(users.id, [ownerId, counterpartyId, foreignOwnerId]));
+});
+
+describe('IntentDatabaseAdapter pending opportunity counts', () => {
+  test('counts only recipient-awaiting pending rows with owner-scoped dual attribution', async () => {
+    const result = await adapter.listIntents(ownerId, { page: 1, limit: 20, archived: false });
+    const counts = new Map(result.rows.map((row) => [row.id, row.waitingOpportunityCount]));
+
+    expect(counts.get(intentAId)).toBe(6);
+    expect(counts.get(intentBId)).toBe(2);
+    expect(result.totalWaitingOpportunities).toBe(7);
+    expect(result.rows.some((row) => row.id === foreignIntentId)).toBe(false);
+
+    await db.update(opportunities)
+      .set({ status: 'accepted' })
+      .where(eq(opportunities.id, pendingTransitionId));
+
+    const afterTransition = await adapter.listIntents(ownerId, { page: 1, limit: 20, archived: false });
+    const transitionedCounts = new Map(afterTransition.rows.map((row) => [row.id, row.waitingOpportunityCount]));
+    expect(transitionedCounts.get(intentAId)).toBe(5);
+    expect(transitionedCounts.get(intentBId)).toBe(2);
+    expect(afterTransition.totalWaitingOpportunities).toBe(6);
+  });
+});

--- a/services/api/src/controllers/intent.controller.ts
+++ b/services/api/src/controllers/intent.controller.ts
@@ -67,6 +67,7 @@ export class IntentController {
         updatedAt: r.updatedAt.toISOString(),
         archivedAt: r.archivedAt?.toISOString() ?? null,
       })),
+      totalWaitingOpportunities: result.totalWaitingOpportunities,
       pagination: result.pagination,
     });
   }

--- a/services/api/src/controllers/tests/intent.controller.isolated.ts
+++ b/services/api/src/controllers/tests/intent.controller.isolated.ts
@@ -1,5 +1,5 @@
 import { afterAll as bunAfterAll, beforeAll as bunBeforeAll, describe, expect, mock, test as bunTest } from 'bun:test';
-import { and, eq } from 'drizzle-orm/sql';
+import { and, eq, inArray } from 'drizzle-orm/sql';
 
 import { IntentController } from "../intent.controller";
 import { IntentDatabaseAdapter, UserDatabaseAdapter, EnrichmentDatabaseAdapter, ChatDatabaseAdapter } from "../../adapters/database.adapter";
@@ -9,7 +9,7 @@ import { ScopeViolationError } from '../../guards/agent-scope.guard';
 import { IntentNetworkMembershipError } from '../../services/intent.service';
 import db from '../../lib/drizzle/drizzle';
 import { IntentEvents } from '../../events/intent.event';
-import { intentNetworks as intentNetworksTable, intents as intentsTable, networkMembers as networkMembersTable, opportunityDiscoveryRuns as opportunityDiscoveryRunsTable } from '../../schemas/database.schema';
+import { intentNetworks as intentNetworksTable, intents as intentsTable, networkMembers as networkMembersTable, opportunities as opportunitiesTable, opportunityDiscoveryRuns as opportunityDiscoveryRunsTable } from '../../schemas/database.schema';
 import { withMinimumDatabaseHookBudget, withMinimumDatabaseTestBudget } from '../../lib/testing/database-test-budget';
 
 const afterAll = withMinimumDatabaseHookBudget(bunAfterAll, 90_000);
@@ -552,6 +552,64 @@ describe("IntentController Integration", () => {
     const intent = data.intents!.find((intent) => intent.id === testIntentId);
     expect(typeof intent?.warming).toBe('boolean');
     expect(intent).not.toHaveProperty('firstDiscoverySucceededAt');
+  });
+
+  test('list returns per-signal waiting counts and a deduplicated total', async () => {
+    const secondIntent = await intentAdapter.createIntent({
+      userId: testUserId,
+      payload: 'Second controller count signal',
+      summary: 'Second count signal',
+    });
+    const opportunityIds = [crypto.randomUUID(), crypto.randomUUID(), crypto.randomUUID()];
+    const timestamp = new Date().toISOString();
+    try {
+      await db.insert(opportunitiesTable).values([
+        {
+          id: opportunityIds[0],
+          detection: { source: 'opportunity_graph', triggeredBy: testIntentId, timestamp },
+          actors: [{ userId: testUserId, networkId: crypto.randomUUID(), role: 'peer' }],
+          interpretation: { category: 'test', reasoning: 'controller count fixture', confidence: 0.8 },
+          context: {},
+          confidence: '0.8',
+          status: 'pending',
+        },
+        {
+          id: opportunityIds[1],
+          detection: { source: 'opportunity_graph', timestamp },
+          actors: [{ userId: testUserId, networkId: crypto.randomUUID(), role: 'peer', intent: secondIntent.id }],
+          interpretation: { category: 'test', reasoning: 'controller count fixture', confidence: 0.8 },
+          context: {},
+          confidence: '0.8',
+          status: 'pending',
+        },
+        {
+          id: opportunityIds[2],
+          detection: { source: 'opportunity_graph', triggeredBy: testIntentId, timestamp },
+          actors: [{ userId: testUserId, networkId: crypto.randomUUID(), role: 'peer', intent: secondIntent.id }],
+          interpretation: { category: 'test', reasoning: 'controller count fixture', confidence: 0.8 },
+          context: {},
+          confidence: '0.8',
+          status: 'pending',
+        },
+      ]);
+
+      const response = await controller.list(new Request('http://localhost/intents/list', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ page: 1, limit: 20 }),
+      }), mockUser());
+      const body = (await response.json()) as {
+        intents: Array<{ id: string; waitingOpportunityCount: number }>;
+        totalWaitingOpportunities: number;
+      };
+
+      expect(body.intents.find((intent) => intent.id === testIntentId)?.waitingOpportunityCount).toBe(2);
+      expect(body.intents.find((intent) => intent.id === secondIntent.id)?.waitingOpportunityCount).toBe(2);
+      expect(body.totalWaitingOpportunities).toBe(3);
+    } finally {
+      await db.delete(opportunitiesTable).where(inArray(opportunitiesTable.id, opportunityIds));
+      await db.delete(intentsTable).where(eq(intentsTable.id, secondIntent.id));
+    }
   });
 
   test("getById should return 404 when intent not found", async () => {

--- a/services/api/src/services/intent.service.ts
+++ b/services/api/src/services/intent.service.ts
@@ -122,7 +122,7 @@ export class IntentService {
 
     logger.verbose('Listing intents', { userId, page, limit, archived });
 
-    const { rows, total } = await this.adapter.listIntents(userId, {
+    const { rows, total, totalWaitingOpportunities } = await this.adapter.listIntents(userId, {
       page,
       limit,
       archived,
@@ -134,6 +134,7 @@ export class IntentService {
         ...intent,
         status: intent.status ?? 'ACTIVE' as const,
       })),
+      totalWaitingOpportunities,
       pagination: {
         current: page,
         total: Math.ceil(total / limit),


### PR DESCRIPTION
## Bug Fixes
- Correct home signal-card counts to include only still-pending, recipient-awaiting opportunities attributed by trigger or the viewer actor intent.
- Exclude viewer-acted and introducer rows, preserve per-signal deduplication, and add a distinct top-level home total.
- Render the API-provided total instead of summing overlapping signal badges.

## Tests
- Added adapter coverage for status, attribution, role, actedAt, ownership, transition, and distinct-total cases.
- Added controller and Discover Home coverage.

## Documentation
- Documented `totalWaitingOpportunities` on `POST /api/intents/list`.

## Deliberate non-goals
- Does not recover stranded latent opportunities; that requires the separately approved operational backfill.
- Does not mirror Radar's network participant-anchoring guard in this unscoped home aggregate. Adding only part of that scoped guard here would risk semantic/performance drift; Radar/list/MCP queries remain unchanged.

Closes IND-499