### PR TITLE
fix: restore intent refinement questions

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@indexnetwork/web",
-  "version": "0.28.3",
+  "version": "0.28.4",
   "license": "MIT",
   "scripts": {
     "dev": "vite --host 127.0.0.1",

--- a/apps/web/src/components/intent-question.timeline.spec.ts
+++ b/apps/web/src/components/intent-question.timeline.spec.ts
@@ -1,0 +1,43 @@
+import { describe, expect, it } from 'vitest';
+
+import { buildIntentQuestionTimeline } from './intent-question.timeline';
+import type { PendingQuestion } from '@/services/questions';
+
+function question(id: string, mode: 'intent' | 'pool_discovery'): PendingQuestion {
+  return {
+    id,
+    detection: {
+      mode,
+      sourceType: 'intent',
+      sourceId: 'intent-1',
+      timestamp: '2026-07-22T12:00:00.000Z',
+    },
+    actors: [{ userId: 'user-1', role: 'subject' }],
+    payload: {
+      title: `${mode} question`,
+      prompt: 'What matters most?',
+      options: [],
+      multiSelect: false,
+    },
+    status: 'pending',
+    answer: null,
+    expiresAt: '2026-07-29T12:00:00.000Z',
+    createdAt: '2026-07-22T12:00:00.000Z',
+    conversationId: null,
+  };
+}
+
+describe('buildIntentQuestionTimeline', () => {
+  it('keeps canonical refinement and pool discriminator questions together for the intent page', () => {
+    const refinement = question('refinement-question', 'intent');
+    const discriminator = question('pool-question', 'pool_discovery');
+
+    const timeline = buildIntentQuestionTimeline([], [refinement, discriminator], []);
+
+    expect(timeline.trailingPending).toEqual([discriminator, refinement]);
+    expect(timeline.trailingPending.map((item) => item.detection.mode)).toEqual([
+      'pool_discovery',
+      'intent',
+    ]);
+  });
+});

--- a/services/api/package.json
+++ b/services/api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@indexnetwork/api",
-  "version": "0.53.2",
+  "version": "0.53.3",
   "license": "MIT",
   "private": true,
   "scripts": {

--- a/services/api/src/controllers/tests/question.inbox.spec.ts
+++ b/services/api/src/controllers/tests/question.inbox.spec.ts
@@ -218,6 +218,61 @@ describe("Pending question inbox (IND-404)", () => {
     });
   });
 
+  test('intent-scoped pending reads retain canonical and pool questions while excluding wrong intent and recipient rows', async () => {
+    const intentId = crypto.randomUUID();
+    const otherIntentId = crypto.randomUUID();
+    const canonicalIntentId = await persistQuestion({
+      detection: {
+        mode: 'intent',
+        sourceType: 'intent',
+        sourceId: intentId,
+        timestamp: new Date().toISOString(),
+      },
+    });
+    const poolQuestionId = await persistQuestion({
+      detection: {
+        mode: 'pool_discovery',
+        sourceType: 'intent',
+        sourceId: intentId,
+        triggeredBy: intentId,
+        timestamp: new Date().toISOString(),
+      },
+    });
+    const wrongIntentId = await persistQuestion({
+      detection: {
+        mode: 'intent',
+        sourceType: 'intent',
+        sourceId: otherIntentId,
+        timestamp: new Date().toISOString(),
+      },
+    });
+    const foreignRecipientId = await persistQuestion({
+      actors: [{ userId: crypto.randomUUID(), role: 'subject' }],
+      detection: {
+        mode: 'intent',
+        sourceType: 'intent',
+        sourceId: intentId,
+        timestamp: new Date().toISOString(),
+      },
+    });
+
+    const response = await controller.list(
+      listReq(`status=pending&scopeType=intent&scopeId=${intentId}`),
+      mockUser(),
+    );
+    expect(response.status).toBe(200);
+    const body = await response.json() as { questions: Array<{ id: string; detection: { mode: string } }> };
+    const returned = new Set(body.questions.map((question) => question.id));
+
+    expect(returned).toContain(canonicalIntentId);
+    expect(returned).toContain(poolQuestionId);
+    expect(returned).not.toContain(wrongIntentId);
+    expect(returned).not.toContain(foreignRecipientId);
+    expect(body.questions.map((question) => question.detection.mode)).toEqual(
+      expect.arrayContaining(['intent', 'pool_discovery']),
+    );
+  });
+
   test("status=answered without an intent filter still scopes to the caller", async () => {
     const ownedQuestionId = await persistQuestion();
     const foreignUserId = crypto.randomUUID();
@@ -301,6 +356,38 @@ describe("Pending question inbox (IND-404)", () => {
       { id: crypto.randomUUID(), email: 'foreign@example.com', name: 'Foreign' },
     );
     expect(foreignResponse.status).toBe(404);
+  }, 15_000);
+
+  test('chat-mode reads fail closed for a forged durable message/session binding', async () => {
+    const forgedQuestionId = crypto.randomUUID();
+    createdQuestionIds.push(forgedQuestionId);
+    await db.insert(questions).values({
+      id: forgedQuestionId,
+      detection: {
+        mode: 'chat',
+        sourceType: 'conversation',
+        sourceId: crypto.randomUUID(),
+        timestamp: new Date().toISOString(),
+        messageId: crypto.randomUUID(),
+        sessionId: crypto.randomUUID(),
+      },
+      actors: [{ userId: testUserId, role: 'subject' }],
+      payload: {
+        title: 'Forged question',
+        prompt: 'This row must not render.',
+        options: [],
+        multiSelect: false,
+      },
+      status: 'pending',
+      conversationId: crypto.randomUUID(),
+      expiresAt: new Date(Date.now() + 60_000),
+      createdAt: new Date(),
+    });
+
+    const response = await controller.list(listReq('status=pending&mode=chat'), mockUser());
+    expect(response.status).toBe(200);
+    const body = await response.json() as { questions: Array<{ id: string }> };
+    expect(body.questions.map((question) => question.id)).not.toContain(forgedQuestionId);
   });
 
   test("conversation-bound questions stay out of the DM inbox", async () => {

--- a/services/api/src/services/intent.service.ts
+++ b/services/api/src/services/intent.service.ts
@@ -1,9 +1,10 @@
 import { log } from '../lib/log';
 import { IntentGraphFactory } from '@indexnetwork/protocol';
-import type { IntentGraphDatabase } from '@indexnetwork/protocol';
+import type { IntentGraphDatabase, QuestionerEnqueueFn } from '@indexnetwork/protocol';
 import { IntentDatabaseAdapter, intentDatabaseAdapter } from '../adapters/database.adapter';
 import { EmbedderAdapter } from '../adapters/embedder.adapter';
 import { intentQueue } from '../queues/intent.queue';
+import { questionerEnqueueIfEnabled } from '../queues/questioner.queue';
 import { IntentEvents } from '../events/intent.event';
 
 const logger = log.service.from("IntentService");
@@ -36,6 +37,7 @@ export class IntentService {
   private adapter: IntentDatabaseAdapter;
   private embedder: EmbedderAdapter;
   private proposalQueue: Pick<typeof intentQueue, 'addGenerateHydeJob'>;
+  private questionerEnqueue?: QuestionerEnqueueFn;
   private emitProposalCreated: (intentId: string, userId: string) => void;
 
   /**
@@ -45,14 +47,16 @@ export class IntentService {
     adapter?: IntentDatabaseAdapter;
     embedder?: EmbedderAdapter;
     proposalQueue?: Pick<typeof intentQueue, 'addGenerateHydeJob'>;
+    questionerEnqueue?: QuestionerEnqueueFn;
     emitProposalCreated?: (intentId: string, userId: string) => void;
   }) {
     this.adapter = deps?.adapter ?? intentDatabaseAdapter;
     this.db = this.adapter;
     this.embedder = deps?.embedder ?? new EmbedderAdapter();
     this.proposalQueue = deps?.proposalQueue ?? intentQueue;
+    this.questionerEnqueue = deps?.questionerEnqueue ?? questionerEnqueueIfEnabled();
     this.emitProposalCreated = deps?.emitProposalCreated ?? ((intentId, userId) => IntentEvents.onCreated(intentId, userId));
-    this.factory = new IntentGraphFactory(this.db, this.embedder, intentQueue);
+    this.factory = new IntentGraphFactory(this.db, this.embedder, intentQueue, this.questionerEnqueue);
   }
 
   /**
@@ -279,7 +283,7 @@ export class IntentService {
    * Bypasses the full intent graph (no LLM re-inference/verification).
    * Idempotent under concurrent confirmation: the adapter serializes one exact
    * user + proposal pair and returns the transaction winner to every caller.
-   * Generates embedding, inserts into DB, optionally associates with index, and enqueues HyDE job.
+   * Generates embedding, inserts into DB, optionally associates with index, and enqueues HyDE and intent-refinement jobs.
    * Embedder and queue failures are logged but do not abort creation.
    *
    * @param userId - The user ID
@@ -322,14 +326,39 @@ export class IntentService {
     if (confirmation.kind === 'existing') return confirmation.intent;
 
     const created = confirmation.intent;
+    const scope = networkId ? { scopeType: 'network' as const, scopeId: networkId } : {};
     try {
       await this.proposalQueue.addGenerateHydeJob({
         intentId: created.id,
         userId,
-        ...(networkId ? { scopeType: 'network' as const, scopeId: networkId } : {}),
+        ...scope,
       });
     } catch (err) {
       logger.warn('Failed to enqueue HyDE job', { intentId: created.id, userId, error: err });
+    }
+
+    if (this.questionerEnqueue) {
+      try {
+        const userContext = (await this.db.getUserContext(userId, null))?.text ?? '';
+        await this.questionerEnqueue({
+          mode: 'intent',
+          userId,
+          sourceType: 'intent',
+          sourceId: created.id,
+          ...scope,
+          context: {
+            intentId: created.id,
+            payload: description,
+            userContext,
+          },
+        });
+      } catch (err) {
+        logger.warn('Failed to enqueue intent question generation', {
+          intentId: created.id,
+          userId,
+          error: err,
+        });
+      }
     }
 
     this.emitProposalCreated(created.id, userId);

--- a/services/api/src/services/tests/intent.service.proposal.spec.ts
+++ b/services/api/src/services/tests/intent.service.proposal.spec.ts
@@ -27,6 +27,7 @@ function makeHarness(
   result: 'created' | 'existing' | 'membership_required' = 'created',
   committedReplay = false,
   isMember = true,
+  questionerThrows = false,
 ) {
   const getIntentBySourceId = mock(async () => committedReplay
     ? { id: INTENT_ID, archivedAt: null }
@@ -42,7 +43,11 @@ function makeHarness(
     return { kind: 'created' as const, intent: createdIntent() };
   });
   const generate = mock(async () => [0.5, 0.5]);
+  const getUserContext = mock(async () => ({ text: 'Climate founder operator' }));
   const addGenerateHydeJob = mock(async () => 'job-id');
+  const questionerEnqueue = mock(async () => {
+    if (questionerThrows) throw new Error('questioner unavailable');
+  });
   const emitProposalCreated = mock(() => {});
 
   const service = new IntentService({
@@ -50,9 +55,11 @@ function makeHarness(
       getIntentBySourceId,
       isNetworkMember,
       confirmProposalIntent,
+      getUserContext,
     } as unknown as IntentDatabaseAdapter,
     embedder: { generate } as unknown as EmbedderAdapter,
     proposalQueue: { addGenerateHydeJob } as never,
+    questionerEnqueue,
     emitProposalCreated,
   });
 
@@ -63,7 +70,9 @@ function makeHarness(
       isNetworkMember,
       confirmProposalIntent,
       generate,
+      getUserContext,
       addGenerateHydeJob,
+      questionerEnqueue,
       emitProposalCreated,
     },
   };
@@ -93,6 +102,19 @@ describe('IntentService.createFromProposal atomic confirmation', () => {
       scopeType: 'network',
       scopeId: NETWORK_ID,
     });
+    expect(harness.calls.questionerEnqueue).toHaveBeenCalledWith({
+      mode: 'intent',
+      userId: USER_ID,
+      sourceType: 'intent',
+      sourceId: INTENT_ID,
+      scopeType: 'network',
+      scopeId: NETWORK_ID,
+      context: {
+        intentId: INTENT_ID,
+        payload: 'Find climate founders',
+        userContext: 'Climate founder operator',
+      },
+    });
     expect(harness.calls.emitProposalCreated).toHaveBeenCalledWith(INTENT_ID, USER_ID);
   });
 
@@ -110,6 +132,7 @@ describe('IntentService.createFromProposal atomic confirmation', () => {
     expect(harness.calls.generate).not.toHaveBeenCalled();
     expect(harness.calls.confirmProposalIntent).not.toHaveBeenCalled();
     expect(harness.calls.addGenerateHydeJob).not.toHaveBeenCalled();
+    expect(harness.calls.questionerEnqueue).not.toHaveBeenCalled();
     expect(harness.calls.emitProposalCreated).not.toHaveBeenCalled();
   });
 
@@ -127,6 +150,7 @@ describe('IntentService.createFromProposal atomic confirmation', () => {
     expect(harness.calls.generate).toHaveBeenCalledTimes(1);
     expect(harness.calls.confirmProposalIntent).toHaveBeenCalledTimes(1);
     expect(harness.calls.addGenerateHydeJob).not.toHaveBeenCalled();
+    expect(harness.calls.questionerEnqueue).not.toHaveBeenCalled();
     expect(harness.calls.emitProposalCreated).not.toHaveBeenCalled();
   });
 
@@ -145,6 +169,17 @@ describe('IntentService.createFromProposal atomic confirmation', () => {
       undefined,
     );
     expect(harness.calls.addGenerateHydeJob).toHaveBeenCalledWith({ intentId: INTENT_ID, userId: USER_ID });
+    expect(harness.calls.questionerEnqueue).toHaveBeenCalledWith({
+      mode: 'intent',
+      userId: USER_ID,
+      sourceType: 'intent',
+      sourceId: INTENT_ID,
+      context: {
+        intentId: INTENT_ID,
+        payload: 'Find climate founders',
+        userContext: 'Climate founder operator',
+      },
+    });
     expect(harness.calls.emitProposalCreated).toHaveBeenCalledWith(INTENT_ID, USER_ID);
   });
 
@@ -164,6 +199,7 @@ describe('IntentService.createFromProposal atomic confirmation', () => {
     expect(harness.calls.generate).not.toHaveBeenCalled();
     expect(harness.calls.confirmProposalIntent).not.toHaveBeenCalled();
     expect(harness.calls.addGenerateHydeJob).not.toHaveBeenCalled();
+    expect(harness.calls.questionerEnqueue).not.toHaveBeenCalled();
     expect(harness.calls.emitProposalCreated).not.toHaveBeenCalled();
   });
 
@@ -180,7 +216,22 @@ describe('IntentService.createFromProposal atomic confirmation', () => {
     expect(result.id).toBe(INTENT_ID);
     expect(harness.calls.confirmProposalIntent).toHaveBeenCalledTimes(1);
     expect(harness.calls.addGenerateHydeJob).not.toHaveBeenCalled();
+    expect(harness.calls.questionerEnqueue).not.toHaveBeenCalled();
     expect(harness.calls.emitProposalCreated).not.toHaveBeenCalled();
+  });
+
+  it('logs a refinement enqueue failure without rolling back the confirmed intent', async () => {
+    const harness = makeHarness('created', false, true, true);
+
+    const result = await harness.service.createFromProposal(
+      USER_ID,
+      'Find climate founders',
+      'proposal-questioner-failure',
+    );
+
+    expect(result.id).toBe(INTENT_ID);
+    expect(harness.calls.questionerEnqueue).toHaveBeenCalledTimes(1);
+    expect(harness.calls.emitProposalCreated).toHaveBeenCalledWith(INTENT_ID, USER_ID);
   });
 
   it('lets one concurrent winner enqueue and emit while both calls return the same ID', async () => {

--- a/services/api/src/services/tool.service.ts
+++ b/services/api/src/services/tool.service.ts
@@ -249,7 +249,12 @@ export class ToolService {
 
     logger.verbose('Compiling graphs (first call, will be cached)');
 
-    const intentGraph = new IntentGraphFactory(database, this.embedder, intentQueue).createGraph();
+    const intentGraph = new IntentGraphFactory(
+      database,
+      this.embedder,
+      intentQueue,
+      questionerEnqueueIfEnabled(),
+    ).createGraph();
     const profileGraph = new EnrichmentGraphFactory(database, this.scraper).createGraph();
     const hydeCache = new RedisCacheAdapter();
     const compiledHydeGraph = new HydeGraphFactory(


### PR DESCRIPTION
## Bug Fixes
- Restore canonical `mode='intent'` refinement-question enqueueing after web proposal confirmation.
- Inject the same flag-gated enqueue into `ToolService` intent graphs.

## Tests
- Cover proposal-generated refinement questions, intent-scope recipient isolation, coexistence of canonical and pool questions in the intent timeline, and fail-closed forged chat bindings.
- Audited root cause: proposal-confirmation and `ToolService` paths omitted `questionerEnqueue`; intent-page retrieval/rendering was verified regression-free and retains both question classes.

References IND-502.