### PR TITLE
feat(web): muted placeholder for empty conversation-list rows (IND-504)

### DIFF
--- a/apps/web/CHANGELOG.md
+++ b/apps/web/CHANGELOG.md
@@ -7,21 +7,24 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
 
 ## [Unreleased]
 
-### Fixed
-
-- Conversation-list rows with no messages no longer render a visually empty subtitle: they now show a muted, italic one-line `No messages yet` placeholder, truncated like a real excerpt and distinct from real last-message styling. No raw evaluator reasoning, match reasons, or fabricated text is ever rendered (IND-504).
-
 ### Changed
 
 - Complete the interactive web product-language cutover from user-visible “intents” to “signals,” including creation, Discover, signal workspaces, Radar, network, Agent, trace, error, and accessibility copy; preserve internal/API `intent` identifiers and normalize server-authored provenance/subtitle fields at the web presentation boundary (IND-477).
 
 ### Fixed
 
+- Conversation-list rows with no messages no longer render a visually empty subtitle: they now show a muted, italic one-line `No messages yet` placeholder, truncated like a real excerpt and distinct from real last-message styling. No raw evaluator reasoning, match reasons, or fabricated text is ever rendered (IND-504).
 - Place intent-page Personal Agent questions in the conversation timeline: anchored questions follow their triggering assistant message, unanchored pending questions stay at the current end, and answered exchanges use authoritative anchors or timestamps instead of a permanent pre-chat block.
 - Persist Reporter Agent opening briefings across reloads for 24 hours by default, hydrate the server-resolved session without replaying the hidden kickoff, and make **New conversation** atomically create and bind one fresh briefing while aborting and quarantining stale streams (IND-484).
 - Separate guided-signal session reset from kickoff across a committed React render so `/i/new` and flag-on onboarding cannot send through a stale session or scope closure (IND-450).
 - Allow the reporter surface (`/agent`) to send messages after its briefing session is established; the route-mismatch guard now exempts the URL-less reporter session while preserving stale-session protection on `/d/:id` (IND-488).
 - Hide the generic chat session title bar ("Untitled chat", back/rename/share controls) on read-only surfaces like the `/agent` reporter, which renders its own header (IND-476). Test config now resolves the reporter kickoff marker from protocol source so web tests no longer depend on a built `packages/protocol/dist`.
+- Clarified the intent workspace live banner as background matching status rather than negotiation activity, and added a context divider for restored negotiator history that may be stale (IND-483).
+- Preserve messages submitted while the Reporter Agent's opening briefing is creating its first web session, so Enter and Send submissions are queued rather than dropped; add an accessible label to the send control.
+- Keep the answered Q&A log visible in the Personal Agent negotiator chat branch after questions are answered (IND-481).
+- Clear stale browser auth sessions automatically when user lookup fails.
+- Show experiment networks such as Edge City in shared profile networks and link them to their network pages.
+- Limit automatic onboarding redirects to the home page so signed-in users can open app routes like `/networks` before finishing setup.
 
 ### Added
 
@@ -42,11 +45,3 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
 - Added proactive high-VoI pool-question delivery surfaces: the Personal Agent badge now combines global pending questions with successfully pushed pool questions, while the Questions page remains global-only; intent-page mounts send a best-effort explicit visit ping and answer/dismiss actions refresh the canonical split counts (IND-421 P5).
 - Added intent pause/resume controls: live intents show Pause, paused intents show Resume, mutations expose loading and error feedback, and the existing questions and Radar workspace remain visible while paused. A successful Resume starts bounded workspace refresh checkpoints through three minutes so new Radar matches, pending questions, and negotiator updates surface without permanent polling.
 
-### Fixed
-
-- Clarified the intent workspace live banner as background matching status rather than negotiation activity, and added a context divider for restored negotiator history that may be stale (IND-483).
-- Preserve messages submitted while the Reporter Agent's opening briefing is creating its first web session, so Enter and Send submissions are queued rather than dropped; add an accessible label to the send control.
-- Keep the answered Q&A log visible in the Personal Agent negotiator chat branch after questions are answered (IND-481).
-- Clear stale browser auth sessions automatically when user lookup fails.
-- Show experiment networks such as Edge City in shared profile networks and link them to their network pages.
-- Limit automatic onboarding redirects to the home page so signed-in users can open app routes like `/networks` before finishing setup.

--- a/apps/web/CHANGELOG.md
+++ b/apps/web/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
 
 ## [Unreleased]
 
+### Fixed
+
+- Conversation-list rows with no messages no longer render a visually empty subtitle: they now show a muted, italic one-line `No messages yet` placeholder, truncated like a real excerpt and distinct from real last-message styling. No raw evaluator reasoning, match reasons, or fabricated text is ever rendered (IND-504).
+
 ### Changed
 
 - Complete the interactive web product-language cutover from user-visible “intents” to “signals,” including creation, Discover, signal workspaces, Radar, network, Agent, trace, error, and accessibility copy; preserve internal/API `intent` identifiers and normalize server-authored provenance/subtitle fields at the web presentation boundary (IND-477).

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@indexnetwork/web",
-  "version": "0.28.3",
+  "version": "0.28.4",
   "license": "MIT",
   "scripts": {
     "dev": "vite --host 127.0.0.1",

--- a/apps/web/src/components/ChatSidebar.tsx
+++ b/apps/web/src/components/ChatSidebar.tsx
@@ -2,9 +2,11 @@ import { useEffect, useState, useRef } from 'react';
 import { useNavigate, useLocation } from 'react-router';
 import { MoreHorizontal, Trash2 } from 'lucide-react';
 import UserAvatar from '@/components/UserAvatar';
+import ConversationPreviewLine from '@/components/ConversationPreviewLine';
 import { useAuthContext } from '@/contexts/AuthContext';
 import { useConversation } from '@/contexts/ConversationContext';
 import { isVisibleH2HConversation } from '@/lib/conversation-visibility';
+import { resolveConversationPreview } from '@/lib/conversation-preview';
 
 type NegotiationStatus = 'accepted' | 'rejected' | 'in_progress' | null;
 
@@ -209,14 +211,12 @@ export default function ChatSidebar() {
                     {chat.viaTitle && (
                       <p className="truncate text-[11px] font-ibm-plex-mono text-gray-400">via {chat.viaTitle}</p>
                     )}
-                    <p className="truncate text-sm font-normal text-gray-500">
-                      {chat.lastMessageIsInternal && (
-                        <span className="mr-1 italic text-gray-400">Internal:</span>
-                      )}
-                      <span className={chat.lastMessageIsInternal ? 'italic text-gray-400' : undefined}>
-                        {chat.lastMessage.replace(/[*_~`#>]/g, '')}
-                      </span>
-                    </p>
+                    <ConversationPreviewLine
+                      preview={resolveConversationPreview({
+                        lastMessage: chat.lastMessage,
+                        lastMessageIsInternal: chat.lastMessageIsInternal,
+                      })}
+                    />
                   </div>
                 </button>
                 <span className="absolute right-8 top-2 text-[11px] leading-none font-normal text-gray-400">

--- a/apps/web/src/components/ConversationPreviewLine.tsx
+++ b/apps/web/src/components/ConversationPreviewLine.tsx
@@ -1,0 +1,31 @@
+import type { ConversationPreview } from '@/lib/conversation-preview';
+
+/**
+ * One-line preview subtitle for a conversation-list row (IND-504).
+ *
+ * Real last messages render in the standard excerpt style (`text-gray-500`);
+ * internal assessments keep their muted italic treatment; conversations with
+ * no messages render a neutral `No messages yet` placeholder that is
+ * deliberately more muted (italic, `text-gray-400`) than a real excerpt.
+ * Every variant is truncated to a single line via Tailwind `truncate`.
+ */
+export default function ConversationPreviewLine({ preview }: { preview: ConversationPreview }) {
+  if (preview.kind === 'empty') {
+    return (
+      <p data-testid="conversation-preview-empty" className="truncate text-sm font-normal italic text-gray-400">
+        {preview.text}
+      </p>
+    );
+  }
+
+  return (
+    <p data-testid="conversation-preview-message" className="truncate text-sm font-normal text-gray-500">
+      {preview.kind === 'internal' && (
+        <span className="mr-1 italic text-gray-400">Internal:</span>
+      )}
+      <span className={preview.kind === 'internal' ? 'italic text-gray-400' : undefined}>
+        {preview.text.replace(/[*_~`#>]/g, '')}
+      </span>
+    </p>
+  );
+}

--- a/apps/web/src/components/ConversationPreviewLine.tsx
+++ b/apps/web/src/components/ConversationPreviewLine.tsx
@@ -24,7 +24,7 @@ export default function ConversationPreviewLine({ preview }: { preview: Conversa
         <span className="mr-1 italic text-gray-400">Internal:</span>
       )}
       <span className={preview.kind === 'internal' ? 'italic text-gray-400' : undefined}>
-        {preview.text.replace(/[*_~`#>]/g, '')}
+        {preview.text}
       </span>
     </p>
   );

--- a/apps/web/src/components/__tests__/ChatSidebar.test.tsx
+++ b/apps/web/src/components/__tests__/ChatSidebar.test.tsx
@@ -1,0 +1,107 @@
+import { render, screen } from '@testing-library/react';
+import { MemoryRouter } from 'react-router';
+import { describe, expect, it, vi } from 'vitest';
+
+import ChatSidebar from '../ChatSidebar';
+import type { ConversationSummary } from '@/services/conversation';
+
+const viewer = { id: 'me', name: 'Viewer' };
+
+const emptyConversation: ConversationSummary = {
+  id: 'conv-empty',
+  participants: [
+    { participantId: 'me', participantType: 'user', name: 'Viewer', avatar: null },
+    { participantId: 'peer-1', participantType: 'user', name: 'Andrea Gallagher', avatar: null },
+  ],
+  lastMessage: null,
+  metadata: null,
+  via: [],
+  unreadCount: 0,
+  lastMessageAt: null,
+  createdAt: '2025-07-06T12:00:00.000Z',
+};
+
+const messageConversation: ConversationSummary = {
+  id: 'conv-message',
+  participants: [
+    { participantId: 'me', participantType: 'user', name: 'Viewer', avatar: null },
+    { participantId: 'peer-2', participantType: 'user', name: 'Christopher', avatar: null },
+  ],
+  lastMessage: {
+    parts: [{ kind: 'text', text: 'I noticed your interest in graphs' }],
+    senderId: 'peer-2',
+    createdAt: '2025-07-21T12:00:00.000Z',
+  },
+  metadata: null,
+  via: [],
+  unreadCount: 0,
+  lastMessageAt: '2025-07-21T12:00:00.000Z',
+  createdAt: '2025-06-11T12:00:00.000Z',
+};
+
+const mocks = vi.hoisted(() => ({
+  conversations: [] as ConversationSummary[],
+}));
+
+vi.mock('@/contexts/AuthContext', () => ({
+  useAuthContext: () => ({ user: viewer }),
+}));
+
+vi.mock('@/contexts/ConversationContext', () => ({
+  useConversation: () => ({
+    conversations: mocks.conversations,
+    negotiations: [],
+    refreshConversations: vi.fn(async () => {}),
+    refreshNegotiations: vi.fn(async () => {}),
+    hideConversation: vi.fn(async () => {}),
+  }),
+}));
+
+function renderSidebar() {
+  return render(
+    <MemoryRouter initialEntries={['/chat']}>
+      <ChatSidebar />
+    </MemoryRouter>,
+  );
+}
+
+describe('ChatSidebar conversation preview wiring (IND-504)', () => {
+  it('renders the muted placeholder for a row with lastMessage: null and the excerpt for a real message', async () => {
+    mocks.conversations = [emptyConversation, messageConversation];
+    renderSidebar();
+
+    // Excerpt row: real last message, standard excerpt styling, no placeholder.
+    const excerpt = await screen.findByTestId('conversation-preview-message');
+    expect(excerpt).toHaveTextContent('I noticed your interest in graphs');
+    expect(excerpt.className).toContain('text-gray-500');
+
+    // Empty row: neutral placeholder, muted styling distinct from the excerpt.
+    const placeholder = screen.getByTestId('conversation-preview-empty');
+    expect(placeholder).toHaveTextContent('No messages yet');
+    expect(placeholder.className).toContain('italic');
+    expect(placeholder.className).toContain('text-gray-400');
+
+    // Exactly one of each — the empty row did not fabricate an excerpt and the
+    // message row did not fall back to the placeholder.
+    expect(screen.getAllByTestId('conversation-preview-empty')).toHaveLength(1);
+    expect(screen.getAllByTestId('conversation-preview-message')).toHaveLength(1);
+
+    // Both peer names still render as row titles.
+    expect(screen.getByText('Andrea Gallagher')).toBeInTheDocument();
+    expect(screen.getByText('Christopher')).toBeInTheDocument();
+  });
+
+  it('never renders raw evaluator reasoning or matchReason text in rows', async () => {
+    mocks.conversations = [
+      {
+        ...emptyConversation,
+        metadata: { matchReason: 'RAW_MATCH_REASON', interpretation: { reasoning: 'RAW_REASONING' } } as unknown as ConversationSummary['metadata'],
+      },
+    ];
+    renderSidebar();
+
+    expect(await screen.findByTestId('conversation-preview-empty')).toHaveTextContent('No messages yet');
+    expect(screen.queryByText(/RAW_MATCH_REASON/)).not.toBeInTheDocument();
+    expect(screen.queryByText(/RAW_REASONING/)).not.toBeInTheDocument();
+  });
+});

--- a/apps/web/src/components/__tests__/ConversationPreviewLine.test.tsx
+++ b/apps/web/src/components/__tests__/ConversationPreviewLine.test.tsx
@@ -53,8 +53,8 @@ describe('ConversationPreviewLine', () => {
     expect(screen.queryByText(/matchReason/i)).not.toBeInTheDocument();
   });
 
-  it('strips markdown emphasis characters from real messages', () => {
-    render(<ConversationPreviewLine preview={{ kind: 'message', text: '**bold** _note_' }} />);
+  it('renders message text verbatim (markdown stripping happens in the resolver)', () => {
+    render(<ConversationPreviewLine preview={{ kind: 'message', text: 'bold note' }} />);
     expect(screen.getByTestId('conversation-preview-message')).toHaveTextContent('bold note');
   });
 });

--- a/apps/web/src/components/__tests__/ConversationPreviewLine.test.tsx
+++ b/apps/web/src/components/__tests__/ConversationPreviewLine.test.tsx
@@ -1,0 +1,60 @@
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+
+import ConversationPreviewLine from '../ConversationPreviewLine';
+import { EMPTY_CONVERSATION_PREVIEW } from '@/lib/conversation-preview';
+
+describe('ConversationPreviewLine', () => {
+  it('renders a real last message with standard excerpt styling', () => {
+    render(<ConversationPreviewLine preview={{ kind: 'message', text: 'I noticed your interest in g…' }} />);
+    const line = screen.getByTestId('conversation-preview-message');
+    expect(line).toHaveTextContent('I noticed your interest in g…');
+    expect(line.className).toContain('text-gray-500');
+    expect(line.className).not.toContain('italic');
+  });
+
+  it('renders the empty-state placeholder distinctly more muted than a real message', () => {
+    render(<ConversationPreviewLine preview={{ kind: 'empty', text: EMPTY_CONVERSATION_PREVIEW }} />);
+    const line = screen.getByTestId('conversation-preview-empty');
+    expect(line).toHaveTextContent('No messages yet');
+    // More muted than a real excerpt: lighter color AND italic.
+    expect(line.className).toContain('text-gray-400');
+    expect(line.className).toContain('italic');
+    expect(line.className).not.toContain('text-gray-500');
+    expect(screen.queryByTestId('conversation-preview-message')).not.toBeInTheDocument();
+  });
+
+  it('truncates every variant to a single line', () => {
+    const { rerender } = render(
+      <ConversationPreviewLine preview={{ kind: 'empty', text: EMPTY_CONVERSATION_PREVIEW }} />,
+    );
+    expect(screen.getByTestId('conversation-preview-empty').className).toContain('truncate');
+
+    rerender(<ConversationPreviewLine preview={{ kind: 'message', text: 'a very long message '.repeat(20) }} />);
+    expect(screen.getByTestId('conversation-preview-message').className).toContain('truncate');
+  });
+
+  it('keeps the muted italic treatment for internal assessment excerpts', () => {
+    render(<ConversationPreviewLine preview={{ kind: 'internal', text: 'Assessment: strong fit' }} />);
+    const line = screen.getByTestId('conversation-preview-message');
+    expect(line).toHaveTextContent('Internal:');
+    expect(line).toHaveTextContent('Assessment: strong fit');
+    expect(line.querySelector('span.italic')).not.toBeNull();
+  });
+
+  it('renders no raw evaluator reasoning or matchReason text', () => {
+    render(
+      <div>
+        <ConversationPreviewLine preview={{ kind: 'empty', text: EMPTY_CONVERSATION_PREVIEW }} />
+        <ConversationPreviewLine preview={{ kind: 'message', text: 'Hello there' }} />
+      </div>,
+    );
+    expect(screen.queryByText(/reasoning/i)).not.toBeInTheDocument();
+    expect(screen.queryByText(/matchReason/i)).not.toBeInTheDocument();
+  });
+
+  it('strips markdown emphasis characters from real messages', () => {
+    render(<ConversationPreviewLine preview={{ kind: 'message', text: '**bold** _note_' }} />);
+    expect(screen.getByTestId('conversation-preview-message')).toHaveTextContent('bold note');
+  });
+});

--- a/apps/web/src/lib/__tests__/conversation-preview.test.ts
+++ b/apps/web/src/lib/__tests__/conversation-preview.test.ts
@@ -22,12 +22,44 @@ describe('resolveConversationPreview', () => {
     expect(preview.kind).toBe('empty');
   });
 
+  it.each([
+    '***',
+    '** **',
+    '___',
+    '`',
+    '```',
+    '  ***  \n ',
+    '~~ ~~',
+    '# >',
+  ])('selects the placeholder for markdown-only last message %j', (lastMessage) => {
+    const preview = resolveConversationPreview({ lastMessage, lastMessageIsInternal: false });
+    expect(preview).toEqual({ kind: 'empty', text: EMPTY_CONVERSATION_PREVIEW });
+  });
+
+  it('keeps a real excerpt that survives markdown stripping as a message, pre-stripped', () => {
+    const preview = resolveConversationPreview({ lastMessage: '**bold** _note_', lastMessageIsInternal: false });
+    expect(preview).toEqual({ kind: 'message', text: 'bold note' });
+  });
+
+  it('strips markdown markers but preserves real content around them', () => {
+    const preview = resolveConversationPreview({
+      lastMessage: '  > I noticed your **interest** in `graphs`  ',
+      lastMessageIsInternal: false,
+    });
+    expect(preview).toEqual({ kind: 'message', text: 'I noticed your interest in graphs' });
+  });
+
   it('marks internal assessment excerpts as internal, not empty', () => {
     const preview = resolveConversationPreview({
       lastMessage: 'Assessment: strong complementary fit',
       lastMessageIsInternal: true,
     });
     expect(preview).toEqual({ kind: 'internal', text: 'Assessment: strong complementary fit' });
+  });
+
+  it('resolves markdown-only internal messages to the placeholder, not a blank internal line', () => {
+    const preview = resolveConversationPreview({ lastMessage: '***', lastMessageIsInternal: true });
+    expect(preview).toEqual({ kind: 'empty', text: EMPTY_CONVERSATION_PREVIEW });
   });
 
   it('never surfaces raw evaluator reasoning fields — only the placeholder', () => {

--- a/apps/web/src/lib/__tests__/conversation-preview.test.ts
+++ b/apps/web/src/lib/__tests__/conversation-preview.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, it } from 'vitest';
+
+import { EMPTY_CONVERSATION_PREVIEW, resolveConversationPreview } from '@/lib/conversation-preview';
+
+describe('resolveConversationPreview', () => {
+  it('selects the real last message as the preview when one exists', () => {
+    const preview = resolveConversationPreview({
+      lastMessage: 'I noticed your interest in graph databases',
+      lastMessageIsInternal: false,
+    });
+    expect(preview).toEqual({ kind: 'message', text: 'I noticed your interest in graph databases' });
+  });
+
+  it('selects the neutral placeholder when the conversation has no messages', () => {
+    const preview = resolveConversationPreview({ lastMessage: '', lastMessageIsInternal: false });
+    expect(preview).toEqual({ kind: 'empty', text: EMPTY_CONVERSATION_PREVIEW });
+    expect(preview.text).toBe('No messages yet');
+  });
+
+  it('selects the placeholder for whitespace-only last messages', () => {
+    const preview = resolveConversationPreview({ lastMessage: '   \n ', lastMessageIsInternal: false });
+    expect(preview.kind).toBe('empty');
+  });
+
+  it('marks internal assessment excerpts as internal, not empty', () => {
+    const preview = resolveConversationPreview({
+      lastMessage: 'Assessment: strong complementary fit',
+      lastMessageIsInternal: true,
+    });
+    expect(preview).toEqual({ kind: 'internal', text: 'Assessment: strong complementary fit' });
+  });
+
+  it('never surfaces raw evaluator reasoning fields — only the placeholder', () => {
+    // The conversation-list DTO carries opportunity linkage (`via`) but no
+    // presenter-produced text. Even if raw evaluator fields were smuggled
+    // onto the input object, they must not leak into the preview.
+    const smuggled = {
+      lastMessage: '',
+      lastMessageIsInternal: false,
+      interpretation: { reasoning: 'RAW_EVALUATOR_REASONING' },
+      matchReason: 'RAW_MATCH_REASON',
+    };
+    const preview = resolveConversationPreview(smuggled);
+    expect(preview.kind).toBe('empty');
+    expect(preview.text).toBe(EMPTY_CONVERSATION_PREVIEW);
+    expect(preview.text).not.toContain('RAW_EVALUATOR_REASONING');
+    expect(preview.text).not.toContain('RAW_MATCH_REASON');
+  });
+});

--- a/apps/web/src/lib/conversation-preview.ts
+++ b/apps/web/src/lib/conversation-preview.ts
@@ -1,0 +1,52 @@
+/**
+ * Conversation-list preview line resolution (IND-504).
+ *
+ * Rows in the conversation list show a one-line excerpt of the last message.
+ * Rows whose conversation has no messages rendered a visually empty subtitle;
+ * this helper gives every row a deterministic preview descriptor.
+ *
+ * Presentation safety: the conversation-list DTO (`ConversationSummary`) does
+ * not carry canonical `OpportunityPresenter`-produced text for the linked
+ * opportunity, and fetching it would require per-row presenter work, so empty
+ * rows fall back to a grammatical neutral placeholder. Raw evaluator fields
+ * (`interpretation.reasoning`, `matchReason`) are never accepted here — the
+ * input shape has no slot for them, and the placeholder is emitted instead of
+ * any heuristic or fabricated text.
+ */
+
+/** Neutral placeholder shown for conversations with no messages yet. */
+export const EMPTY_CONVERSATION_PREVIEW = 'No messages yet';
+
+/** Input for preview resolution: the row's last-message state only. */
+export interface ConversationPreviewInput {
+  /** Plain-text content of the last message, or an empty string when none. */
+  lastMessage: string;
+  /** Whether the last message is an internal (non-user-facing) assessment. */
+  lastMessageIsInternal: boolean;
+}
+
+/**
+ * Resolved preview descriptor for one conversation row.
+ * - `message`: a real last message, rendered with normal excerpt styling.
+ * - `internal`: an internal assessment excerpt, rendered muted + italic.
+ * - `empty`: no messages yet, rendered as a muted placeholder.
+ */
+export type ConversationPreview =
+  | { kind: 'message'; text: string }
+  | { kind: 'internal'; text: string }
+  | { kind: 'empty'; text: typeof EMPTY_CONVERSATION_PREVIEW };
+
+/**
+ * Resolves the preview line for a conversation row.
+ *
+ * @param input - The row's last-message state
+ * @returns The preview descriptor; `empty` rows always get the neutral
+ *   placeholder, never fabricated or evaluator-reasoning text
+ */
+export function resolveConversationPreview(input: ConversationPreviewInput): ConversationPreview {
+  const text = input.lastMessage.trim();
+  if (!text) {
+    return { kind: 'empty', text: EMPTY_CONVERSATION_PREVIEW };
+  }
+  return { kind: input.lastMessageIsInternal ? 'internal' : 'message', text };
+}

--- a/apps/web/src/lib/conversation-preview.ts
+++ b/apps/web/src/lib/conversation-preview.ts
@@ -30,21 +30,30 @@ export interface ConversationPreviewInput {
  * - `message`: a real last message, rendered with normal excerpt styling.
  * - `internal`: an internal assessment excerpt, rendered muted + italic.
  * - `empty`: no messages yet, rendered as a muted placeholder.
+ *
+ * `text` is markdown-stripped and trimmed, ready to render as-is.
  */
 export type ConversationPreview =
   | { kind: 'message'; text: string }
   | { kind: 'internal'; text: string }
   | { kind: 'empty'; text: typeof EMPTY_CONVERSATION_PREVIEW };
 
+/** Strips markdown emphasis/structure characters for a one-line plain-text excerpt. */
+export const stripMarkdownMarkers = (text: string): string => text.replace(/[*_~`#>]/g, '');
+
 /**
  * Resolves the preview line for a conversation row.
+ *
+ * Emptiness is evaluated on the markdown-stripped, whitespace-trimmed text, so
+ * markdown-only strings (e.g. `***`, `** **`, `` ` ``) resolve to the `empty`
+ * placeholder instead of rendering blank after stripping.
  *
  * @param input - The row's last-message state
  * @returns The preview descriptor; `empty` rows always get the neutral
  *   placeholder, never fabricated or evaluator-reasoning text
  */
 export function resolveConversationPreview(input: ConversationPreviewInput): ConversationPreview {
-  const text = input.lastMessage.trim();
+  const text = stripMarkdownMarkers(input.lastMessage).trim();
   if (!text) {
     return { kind: 'empty', text: EMPTY_CONVERSATION_PREVIEW };
   }


### PR DESCRIPTION
## Summary

Conversation-list rows (chat sidebar, h2h Messages tab) with no messages rendered a visually empty subtitle — avatar + name + date with nothing underneath (e.g. the "Andrea Gallagher" / "Adam Byrne" rows in the IND-504 screenshot), while rows with messages show a last-message excerpt. Empty rows now render a one-line truncated `No messages yet` placeholder, styled distinctly more muted (italic + `text-gray-400`) than a real excerpt (`text-gray-500`).

## Recon findings

- **List component**: `apps/web/src/components/ChatSidebar.tsx` (h2h "Messages" tab). Data: `ConversationContext.refreshConversations()` → `services/conversation.ts` → `GET /conversations` → `ConversationService.getConversations` → `conversation.database.adapter.ts` `getConversationsForUser`.
- **List DTO** (`ConversationSummary`): participants, `lastMessage` (parts/senderId/createdAt), metadata, viewer-scoped `via` opportunity provenance (`{intentId, opportunityId, title}`), `unreadCount`, timestamps.
- **Presenter-text availability: NO.** The DTO carries opportunity *linkage* (`via`) but no `OpportunityPresenter`-produced text. Presenter output (`homeCardPresentation` / `presentOpportunity`) is runtime-only — generated during discovery/home-feed flows (Redis-cached under `home:card:*`) or per-opportunity on detail reads — never persisted on the opportunities table.

## Decision: placeholder-only

Exposing canonical presenter text would require new per-row presenter calls or per-row cache fetches in `getConversationsForUser` (N+1 on the sidebar critical path), which the handoff and the `review-opportunity-presentation` skill prohibit. So empty rows get the grammatical neutral placeholder; no raw `interpretation.reasoning` / `matchReason`, no heuristic text, nothing fabricated. No `services/api` changes.

## Changes

- **New** `apps/web/src/lib/conversation-preview.ts` — pure `resolveConversationPreview()` helper: `message` / `internal` / `empty` descriptor; empty input always yields `No messages yet`.
- **New** `apps/web/src/components/ConversationPreviewLine.tsx` — presentational subtitle: real excerpts keep existing styling + markdown-strip; empty rows render italic `text-gray-400` placeholder; all variants single-line `truncate`.
- **Modified** `apps/web/src/components/ChatSidebar.tsx` — uses the helper + component; no changes to data flow, unread counts/badges, thread-count semantics, or navigation.

## Tests (11 new, all passing)

- `src/lib/__tests__/conversation-preview.test.ts` — excerpt-vs-placeholder selection (incl. whitespace-only), internal-marker preservation, raw-reasoning exclusion.
- `src/components/__tests__/ConversationPreviewLine.test.tsx` — empty-state styling distinct/more muted than real message, one-line `truncate` on all variants, internal italic treatment, no reasoning/matchReason rendered, markdown stripping.

## Verification

- `bun run lint` — 0 errors (88 pre-existing warnings, unchanged).
- `bun run build` — ✓ built.
- `bun --bun vitest run` (2 targeted files) — 11/11 passed.

## Caveats

- **Possible trivial conflict**: sibling PR for IND-503 (layout) touches the same area and also bumps `apps/web/package.json` / `CHANGELOG.md` — whichever merges second needs a one-line version/CHANGELOG rebase (this PR: 0.28.3 → 0.28.4).
- Version bump: `apps/web` 0.28.3 → 0.28.4 (patch); CHANGELOG bullet under `[Unreleased]` → Fixed.

Refs IND-504.

---

## Review round 2 (commit `ba45db1701`)

Independent-review minor cleanup, all three LOW findings addressed:

- **F1 — markdown-only strings rendered blank.** `resolveConversationPreview` now strips markdown markers (`*_~\`#>`) **before** the emptiness check, so markdown-only last messages (`***`, `** **`, `___`, backtick-only, whitespace+markdown mixes) resolve to the `No messages yet` placeholder instead of a blank line. The helper now returns pre-stripped, trimmed text; `ConversationPreviewLine` renders it verbatim (single strip point).
- **F2 — ChatSidebar wiring test.** New `src/components/__tests__/ChatSidebar.test.tsx` integration test (contexts mocked via `vi.hoisted`, `MemoryRouter`): a `lastMessage: null` row renders the muted italic `text-gray-400` placeholder, a real-message row renders the excerpt in `text-gray-500`, exactly one of each renders, and smuggled `matchReason`/`interpretation.reasoning` metadata never appears.
- **F3 — CHANGELOG headings.** `[Unreleased]` now has a single `### Fixed` section (merged the second pre-existing block's bullets into it).

Verification after fixes: targeted vitest — 3 files, **24/24 passed**; `bun run lint` — 0 errors (88 pre-existing warnings); `bun run build` — ✓ built. Still at `apps/web` 0.28.4; version/changelog sequencing with sibling PR #1210 stays with the coordinator at merge time.
