### PR TITLE
fix(web): restore Personal Agent desktop visibility

### DIFF
--- a/apps/web/CHANGELOG.md
+++ b/apps/web/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
 
 ### Fixed
 
+- Restore the initially closed Personal Agent/Questions column on desktop intent workspaces by limiting drawer-only hidden, non-interactive, and translated state styles to mobile viewports (IND-505).
 - Conversation-list rows with no messages no longer render a visually empty subtitle: they now show a muted, italic one-line `No messages yet` placeholder, truncated like a real excerpt and distinct from real last-message styling. No raw evaluator reasoning, match reasons, or fabricated text is ever rendered (IND-504).
 - Place intent-page Personal Agent questions in the conversation timeline: anchored questions follow their triggering assistant message, unanchored pending questions stay at the current end, and answered exchanges use authoritative anchors or timestamps instead of a permanent pre-chat block.
 - Persist Reporter Agent opening briefings across reloads for 24 hours by default, hydrate the server-resolved session without replaying the hidden kickoff, and make **New conversation** atomically create and bind one fresh briefing while aborting and quarantining stale streams (IND-484).

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@indexnetwork/web",
-  "version": "0.28.5",
+  "version": "0.28.6",
   "license": "MIT",
   "scripts": {
     "dev": "vite --host 127.0.0.1",

--- a/apps/web/src/app/i/[intentId]/page.tsx
+++ b/apps/web/src/app/i/[intentId]/page.tsx
@@ -1002,7 +1002,7 @@ export default function IntentDetailPage() {
                   className={cn(
                     "fixed inset-y-0 right-0 z-[100] flex w-[min(85vw,24rem)] flex-col overflow-y-auto bg-white p-4 shadow-xl outline-none",
                     "transition-all duration-300 ease-[cubic-bezier(0.4,0,0.2,1)]",
-                    "data-[state=closed]:pointer-events-none data-[state=closed]:invisible data-[state=closed]:translate-x-full",
+                    "max-lg:data-[state=closed]:pointer-events-none max-lg:data-[state=closed]:invisible max-lg:data-[state=closed]:translate-x-full",
                     "lg:static lg:z-auto lg:min-h-0 lg:min-w-0 lg:w-auto lg:flex-1 lg:translate-x-0 lg:visible lg:pointer-events-auto lg:overflow-visible lg:bg-transparent lg:p-0 lg:shadow-none",
                   )}
                 >

--- a/apps/web/tests/e2e/intent-page-responsive.spec.ts
+++ b/apps/web/tests/e2e/intent-page-responsive.spec.ts
@@ -1,0 +1,90 @@
+import { expect, test } from '@playwright/test';
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+
+const intentPageSource = readFileSync(
+  resolve(process.cwd(), 'src/app/i/[intentId]/page.tsx'),
+  'utf8',
+);
+
+/**
+ * Read the production sheet class list so the browser fixture exercises the
+ * exact responsive/state selectors shipped by the intent page rather than a
+ * test-only copy that could drift from the component.
+ */
+function getPersonalAgentSheetClasses(): string {
+  const sheetMarker = 'data-testid="personal-agent-sheet"';
+  const sheetOffset = intentPageSource.indexOf(sheetMarker);
+  const classOffset = intentPageSource.indexOf('className={cn(', sheetOffset);
+  const classEnd = intentPageSource.indexOf('\n                  )}', classOffset);
+
+  if (sheetOffset < 0 || classOffset < 0 || classEnd < 0) {
+    throw new Error('Unable to locate the Personal Agent sheet class list');
+  }
+
+  const classBlock = intentPageSource.slice(classOffset, classEnd);
+  return [...classBlock.matchAll(/"([^"]+)"/g)]
+    .map((match) => match[1])
+    .join(' ');
+}
+
+test('desktop closed state keeps Personal Agent visible beside equal-width Radar', async ({ page }) => {
+  await page.setViewportSize({ width: 1440, height: 900 });
+  const cssResponse = await fetch('http://127.0.0.1:3000/src/app/globals.css?direct');
+  expect(cssResponse.ok).toBe(true);
+  const generatedCss = (await cssResponse.text()).replace(/@import url\([^;]+;\s*/g, '');
+
+  const sheetClasses = getPersonalAgentSheetClasses();
+  await page.setContent('<body></body>');
+  await page.addStyleTag({ content: generatedCss });
+  await page.evaluate((classes) => {
+    const fixture = document.createElement('main');
+    fixture.id = 'intent-workspace-fixture';
+    fixture.className = 'flex min-h-0 flex-1 flex-col gap-8 lg:flex-row';
+    fixture.style.width = '1200px';
+    fixture.style.height = '600px';
+    fixture.innerHTML = `
+      <section data-testid="personal-agent-sheet" data-state="closed">
+        <div data-testid="intent-negotiator-chat-stub">Personal Agent</div>
+      </section>
+      <section
+        data-testid="radar-column"
+        class="flex min-h-0 min-w-0 flex-1 flex-col overflow-y-auto lg:flex-1"
+      >Radar</section>
+    `;
+    const sheet = fixture.querySelector<HTMLElement>('[data-testid="personal-agent-sheet"]');
+    if (!sheet) throw new Error('Fixture sheet was not created');
+    sheet.className = classes;
+    document.body.replaceChildren(fixture);
+  }, sheetClasses);
+
+  const sheet = page.getByTestId('personal-agent-sheet');
+
+  await expect(sheet).toHaveAttribute('data-state', 'closed');
+  await expect(sheet).toBeVisible();
+  await expect(sheet).toHaveCSS('display', 'flex');
+  await expect(sheet).toHaveCSS('visibility', 'visible');
+  await expect(sheet).toHaveCSS('pointer-events', 'auto');
+  await expect(sheet).toHaveCSS('transform', 'none');
+
+  const layout = await page.evaluate(() => {
+    const sheetElement = document.querySelector<HTMLElement>('[data-testid="personal-agent-sheet"]');
+    const radarElement = document.querySelector<HTMLElement>('[data-testid="radar-column"]');
+    if (!sheetElement || !radarElement) throw new Error('Responsive fixture is incomplete');
+
+    const sheetStyle = getComputedStyle(sheetElement);
+    const sheetRect = sheetElement.getBoundingClientRect();
+    const radarRect = radarElement.getBoundingClientRect();
+    return {
+      translate: sheetStyle.translate,
+      sheet: { x: sheetRect.x, width: sheetRect.width },
+      radar: { x: radarRect.x, width: radarRect.width },
+      chatCount: document.querySelectorAll('[data-testid="intent-negotiator-chat-stub"]').length,
+    };
+  });
+
+  expect(layout.translate).not.toBe('100%');
+  expect(layout.sheet.x).toBeLessThan(layout.radar.x);
+  expect(Math.abs(layout.sheet.width - layout.radar.width)).toBeLessThanOrEqual(1);
+  expect(layout.chatCount).toBe(1);
+});

--- a/apps/web/tests/intent-page-responsive.test.tsx
+++ b/apps/web/tests/intent-page-responsive.test.tsx
@@ -1,5 +1,5 @@
 /**
- * Intent page responsive layout (IND-503, review round 2 — a11y).
+ * Intent page responsive layout (IND-503, IND-505 desktop visibility fix).
  *
  * Desktop (lg+): Personal Agent and Radar columns are equal width (50/50);
  * the left column is a plain labelled region with no dialog semantics.
@@ -190,7 +190,7 @@ describe('Intent page — responsive Personal Agent / Radar layout (IND-503)', (
 
     // Fixed off-canvas below lg, translated out when closed; static column at lg+.
     expect(sheet.className).toContain('fixed');
-    expect(sheet.className).toContain('data-[state=closed]:translate-x-full');
+    expect(sheet.className).toContain('max-lg:data-[state=closed]:translate-x-full');
     expect(sheet.className).toContain('lg:static');
     expect(sheet.getAttribute('data-state')).toBe('closed');
 
@@ -408,7 +408,7 @@ describe('Intent page — responsive Personal Agent / Radar layout (IND-503)', (
     renderIntentPage();
 
     const sheet = await screen.findByTestId('personal-agent-sheet');
-    expect(sheet.className).toContain('data-[state=closed]:translate-x-full');
+    expect(sheet.className).toContain('max-lg:data-[state=closed]:translate-x-full');
     expect(sheet.getAttribute('role')).toBe('dialog');
 
     const trigger = await screen.findByTestId('personal-agent-trigger');

--- a/bun.lock
+++ b/bun.lock
@@ -19,7 +19,7 @@
     },
     "apps/web": {
       "name": "@indexnetwork/web",
-      "version": "0.28.5",
+      "version": "0.28.6",
       "dependencies": {
         "@radix-ui/react-alert-dialog": "^1.1.15",
         "@radix-ui/react-dialog": "^1.1.14",


### PR DESCRIPTION
## Bug Fixes

- restore the initially closed Personal Agent/Questions column on desktop intent workspaces
- scope drawer-only hidden, non-interactive, and translated state styles to mobile viewports, removing the Tailwind selector-specificity conflict at `lg+`
- preserve the single mounted chat, equal-width desktop layout, mobile drawer behavior, Questions fallback, and existing accessibility semantics

## Regression Evidence

At a 1440×900 real Chromium viewport with the actual generated Tailwind stylesheet and `data-state="closed"`:

- before: `visibility: hidden`, `pointer-events: none`, `translate: 100%`; both flex items still measured 584px wide and one chat remained mounted
- after: `visibility: visible`, `pointer-events: auto`, `translate: 0px`, `transform: none`; Personal Agent and Radar each measure 584px and one chat remains mounted

The new Playwright regression failed before the fix with `Expected: visible / Received: hidden` and passes after the fix.

## Tests

- `cd apps/web && bunx playwright test tests/e2e/intent-page-responsive.spec.ts --reporter=line` — 1 passed
- `cd apps/web && bun run test tests/intent-page-responsive.test.tsx tests/intent-page-negotiator.test.tsx tests/intent-negotiator-chat.test.tsx` — 3 files, 31 tests passed
- `cd apps/web && bunx eslint tests/e2e/intent-page-responsive.spec.ts` — passed
- `cd apps/web && bun run lint` — passed with 0 errors and 88 pre-existing warnings
- `cd apps/web && bun run build` — passed; existing local-build warnings remain for missing `VITE_PROTOCOL_URL`, unsupported generated `context` CSS, and mixed static/dynamic `api.ts` imports
- `bun install --frozen-lockfile` — passed; 873 installs checked across 986 packages with no changes
- `git diff --check origin/dev` — passed

## Notes

- Web package version: `0.28.6`
- No environment-variable changes
- No API, protocol, database, feature-flag, dependency, or Railway changes

Fixes IND-505

Linear: https://linear.app/indexnetwork/issue/IND-505/personal-agent-chat-disappears-from-intent-page-after-responsive
