### PR TITLE
feat(ops): make deployment verification asynchronous

### DIFF
--- a/.pi/herdr-team.json
+++ b/.pi/herdr-team.json
@@ -1,0 +1,252 @@
+{
+  "version": 1,
+  "project": {
+    "name": "Index Network",
+    "repository": "index-monorepo",
+    "primaryBranch": "dev",
+    "stack": [
+      "Bun",
+      "TypeScript",
+      "React",
+      "Drizzle",
+      "PostgreSQL/pgvector",
+      "Redis/BullMQ",
+      "Railway"
+    ]
+  },
+  "requestedByRole": "CTO/Founding Engineer/System Architect",
+  "status": "implementation_team_configured",
+  "setupMetadata": {
+    "initializedAt": "2026-07-23T12:31:05.300Z",
+    "reconfiguredAt": "2026-07-23T13:16:06.699Z",
+    "method": "repository-derived autonomous-implementation topology",
+    "notes": "Converted from read-only investigation bootstrap to an autonomous-implementation team. Protocol/API is the priority surface and gets a dedicated writer. Worktree-per-writer; canonical root stays read-only on dev."
+  },
+  "topology": {
+    "mode": "direct-hierarchy",
+    "root": {
+      "role": "orchestrator",
+      "displayName": "index-root",
+      "owns": [
+        "policy",
+        "prioritization",
+        "task delegation",
+        "cross-surface coordination",
+        "merge approval gating",
+        "final synthesis"
+      ]
+    },
+    "workers": [
+      {
+        "role": "protocol-engineer",
+        "displayName": "protocol-engineer",
+        "mode": "implement",
+        "priority": true,
+        "owns": [
+          "packages/protocol",
+          "services/api services/adapters/queues/controllers/events",
+          "services/api database schema + drizzle migrations",
+          "protocol eval harness"
+        ],
+        "independent": true
+      },
+      {
+        "role": "web-client-engineer",
+        "displayName": "web-client-engineer",
+        "mode": "implement",
+        "owns": [
+          "apps/web",
+          "packages/cli",
+          "packages/claude-plugin",
+          "packages/hermes-plugin",
+          "apps/mac"
+        ],
+        "independent": true,
+        "dependsOn": [
+          "protocol-engineer (API contracts; coordinate via root, never edit protocol paths directly)"
+        ]
+      },
+      {
+        "role": "reviewer",
+        "displayName": "reviewer",
+        "mode": "read-only",
+        "owns": [
+          "PR review / GitHub Copilot address-code-review flow",
+          "eval:verify + targeted test/eval verification",
+          "pr:snapshot",
+          "pre-merge verify-production-release checks"
+        ],
+        "independent": true
+      },
+      {
+        "role": "release-verifier",
+        "displayName": "release-verifier",
+        "mode": "read-only",
+        "owns": [
+          "bounded GitHub/Railway deployment verification",
+          "release status reporting",
+          "issue closeout recommendation only after terminal success"
+        ],
+        "independent": true
+      }
+    ]
+  },
+  "externalGatePolicy": {
+    "mode": "non-blocking-one-shot",
+    "immediateSnapshot": true,
+    "nonterminalAction": "delegate read-only release-verifier, report merged; verification pending, and return control",
+    "recheckTrigger": "durable external terminal event or natural orchestration tick",
+    "prohibited": ["--watch", "wait", "sleep", "polling", "watcher daemon", "Railway mutation"],
+    "issueCloseout": "fail-closed until bound GitHub and Railway checks both reach terminal success",
+    "mcpFallback": "Railway unavailable means unverified; keep issues open and do not infer success"
+  },
+  "worktreePolicy": {
+    "canonicalRoot": "read-only for source mutations; remains on dev",
+    "implementationRequiresWorktree": true,
+    "worktreeDirectory": ".worktrees/<dashed-branch-name>",
+    "branchPattern": "<type>/<short-description>",
+    "oneWriterPerWorktree": true,
+    "readOnlyReviewMayUseSharedCheckout": true,
+    "visibleHerdrSessionRequiredForImplementation": true,
+    "openWithoutFocus": true,
+    "verifyBeforeMutation": [
+      "pwd",
+      "git branch --show-current",
+      "git status --short --branch"
+    ],
+    "neverMutateProduction": true
+  },
+  "limits": {
+    "maxWorkers": 3,
+    "maxConcurrentWorkers": 3,
+    "maxHierarchyDepth": 1,
+    "nestedDelegation": false,
+    "backgroundCoordinationOnly": true,
+    "pollingForCoordination": false,
+    "hiddenImplementationAgents": false
+  },
+  "modelPolicy": {
+    "mode": "ask-per-role",
+    "editable": true,
+    "instructions": "Model choices are per-role and editable here. Re-run /setup-herdr or edit roleProfiles[*].model to change."
+  },
+  "modelChoices": {
+    "protocol-engineer": "gpt-5.6-terra",
+    "web-client-engineer": "gpt-5.6-terra",
+    "reviewer": "gpt-5.6-sol",
+    "release-verifier": "gpt-5.6-luna"
+  },
+  "roleProfiles": {
+    "protocol-engineer": {
+      "model": "gpt-5.6-terra",
+      "mode": "implement",
+      "paths": [
+        "packages/protocol/**",
+        "services/api/src/**",
+        "services/api/drizzle/**",
+        "services/api/tests/**"
+      ],
+      "mission": "Implement protocol agent graphs, evaluators, services, adapters, queues, controllers, events, and Drizzle schema/migrations. Priority surface. Work in a dedicated worktree; keep the canonical dev checkout untouched.",
+      "verification": [
+        "run targeted `bun test path/to/test.ts` for affected areas",
+        "run relevant `bun run eval:*` and `bun run eval:verify` when protocol logic changes",
+        "regenerate + rename migrations per the schema-change checklist",
+        "conventional commits; open PR into dev"
+      ],
+      "completion": [
+        "cite changed file paths",
+        "attach test/eval evidence (commands + results)",
+        "reference commit and PR"
+      ]
+    },
+    "web-client-engineer": {
+      "model": "gpt-5.6-terra",
+      "mode": "implement",
+      "paths": [
+        "apps/web/**",
+        "packages/cli/**",
+        "packages/claude-plugin/**",
+        "packages/hermes-plugin/**",
+        "apps/mac/**"
+      ],
+      "mission": "Implement web (Vite/React 19), CLI, plugin, and mac-client surfaces. Consume protocol API contracts; coordinate contract changes through root rather than editing protocol paths.",
+      "verification": [
+        "run `bun run lint` and relevant build for the touched package",
+        "bump package.json version for touched npm-published packages",
+        "conventional commits; open PR into dev"
+      ],
+      "completion": [
+        "cite changed file paths",
+        "attach lint/build evidence",
+        "reference commit and PR"
+      ]
+    },
+    "release-verifier": {
+      "model": "gpt-5.6-luna",
+      "mode": "read-only",
+      "paths": [
+        ".pi/skills/finish-pr/**",
+        ".pi/skills/verify-deployment-async/**",
+        ".pi/herdr-team.json"
+      ],
+      "mission": "Perform one bounded, read-only GitHub and Railway verification for the exact PR/base/head/merge SHA and Railway project/environment/service/deployment IDs. Report terminal success/failure or fail-closed pending status; never mutate infrastructure, merge, or close issues.",
+      "verification": [
+        "take one GitHub snapshot and one Railway MCP read per explicit trigger",
+        "report identity-bound evidence with team_report",
+        "keep issues open unless both bound gates are terminal-success"
+      ],
+      "completion": [
+        "state exact IDs, statuses, and evidence",
+        "report verification pending when nonterminal",
+        "never infer success from merge or notifications"
+      ]
+    },
+    "reviewer": {
+      "model": "gpt-5.6-sol",
+      "mode": "read-only",
+      "paths": [],
+      "mission": "Review PRs (including the GitHub Copilot address-code-review flow), verify tests/evals, run eval:verify and pr:snapshot, and run pre-merge verify-production-release checks. Never mutate source, git state, infrastructure, or credentials.",
+      "verification": [
+        "state which commands were run and their results",
+        "flag pre-existing dirty/untracked state without changing it"
+      ],
+      "completion": [
+        "report pass/fail per check with evidence",
+        "recommend merge / block with reasoning",
+        "never infer merge approval"
+      ]
+    }
+  },
+  "completionRequirements": {
+    "allWorkers": [
+      "finish asynchronously (team_report / team_send)",
+      "never use herdr --wait, agent wait, pane wait-output, sleep, or polling",
+      "implementers mutate only inside their own worktree; reviewer mutates nothing",
+      "never touch production data or infrastructure",
+      "send a concise report to the root with verification evidence"
+    ],
+    "reportFormat": [
+      "scope",
+      "changes with file paths",
+      "verification performed (commands + results)",
+      "risks/gaps",
+      "commit + PR reference",
+      "recommended next action"
+    ],
+    "root": [
+      "delegate only concrete, independent tasks",
+      "keep canonical dev checkout stable and read-only",
+      "gate merges on explicit human approval",
+      "synthesize worker reports for the human",
+      "surface genuine product/architecture ambiguity to the human"
+    ]
+  },
+  "setup": {
+    "goal": "Handle work",
+    "workflow": "Autonomous implementation",
+    "focus": "Protocol is the most important. We already have a workflow using git worktrees.",
+    "modelPolicy": "ask-per-role",
+    "launchSuggestedTeam": true,
+    "requestedAt": "2026-07-23T13:16:06.699Z"
+  }
+}

--- a/.pi/herdr-team.json
+++ b/.pi/herdr-team.json
@@ -94,8 +94,9 @@
   "externalGatePolicy": {
     "mode": "non-blocking-one-shot",
     "immediateSnapshot": true,
-    "nonterminalAction": "delegate read-only release-verifier, report merged; verification pending, and return control",
-    "recheckTrigger": "durable external terminal event or natural orchestration tick",
+    "nonterminalAction": "explicitly team_delegate one release-verifier with exact PR/base/head/merge SHA plus Railway project/environment/service/deployment IDs, return user control immediately, then team_block the same task after one bounded read",
+    "recheckTrigger": "resume only that exact blocked worker via durable external terminal event or explicit natural-tick team_send",
+    "reportDeduplication": "identity tuple plus observed status; emit at most one pending report per composite key",
     "prohibited": ["--watch", "wait", "sleep", "polling", "watcher daemon", "Railway mutation"],
     "issueCloseout": "fail-closed until bound GitHub and Railway checks both reach terminal success",
     "mcpFallback": "Railway unavailable means unverified; keep issues open and do not infer success"
@@ -189,7 +190,7 @@
         ".pi/skills/verify-deployment-async/**",
         ".pi/herdr-team.json"
       ],
-      "mission": "Perform one bounded, read-only GitHub and Railway verification for the exact PR/base/head/merge SHA and Railway project/environment/service/deployment IDs. Report terminal success/failure or fail-closed pending status; never mutate infrastructure, merge, or close issues.",
+      "mission": "Perform one bounded, read-only GitHub and Railway verification for the exact PR/base/head/merge SHA and Railway project/environment/service/deployment IDs. Emit at most one deduplicated pending report, team_block the same task when nonterminal, and resume only through a matching durable event or explicit natural-tick team_send; never mutate infrastructure, merge, or close issues.",
       "verification": [
         "take one GitHub snapshot and one Railway MCP read per explicit trigger",
         "report identity-bound evidence with team_report",

--- a/.pi/skills/finish-pr/SKILL.md
+++ b/.pi/skills/finish-pr/SKILL.md
@@ -16,7 +16,7 @@ Safely finish a PR end-to-end from the canonical/root session: identify the PR/i
 - Do not merge without explicit user confirmation in the current session.
 - Do not deploy, restart, rollback, or mutate Railway resources unless the user explicitly asked for that action. Verification is okay; mutation needs confirmation.
 - Do not close Linear or GitHub issues until the PR is merged and post-merge deployment checks pass, unless the user explicitly asks to close them earlier.
-- Never claim deployment success from a queued/in-progress status. Wait for a terminal success state or report that it is still pending.
+- Never claim deployment success from a queued/in-progress status. Take one immediate status snapshot; if GitHub/Railway is nonterminal, invoke the project-local `verify-deployment-async` workflow and report `merged; verification pending`, then return control immediately. Never use `--watch`, waits, sleeps, or polling. Keep issues open until a later durable terminal event or explicit orchestration tick supplies another bounded read.
 - If Railway MCP tools are unavailable, report deployment as unverified; do not claim success or close related issues until it can be verified. GitHub merge safety does not depend on MCP availability.
 - If checks fail, keep issues open and report the blocker.
 - Never edit files or run mutating git commands (commit, rebase, push, force-push) from the canonical root. When a worktree change is needed, `index` first delegates through a dedicated canonical-root coordinator; that root sends one consolidated prompt to the existing visible Herdr-managed Pi session for the PR worktree. The root/child handoff is fire-and-return without `--wait`; while the bridge is removed, `index` explicitly ticks the dedicated root on a later natural turn. That child session verifies the worktree's absolute path and feature branch before mutation. GitHub-side actions (review-thread replies/resolutions, the merge itself, issue updates) and read-only verification (builds, tests, diffs against remote refs) are fine.
@@ -197,11 +197,12 @@ Record the user's decisions for the step-6 summary.
 
 ### 5. Check GitHub readiness before merge
 
-Wait for checks when needed, then refresh the same factual snapshot before each
-readiness decision and after every pushed fix/rebase:
+Before merge, take one factual snapshot and make the readiness decision from it. Do not
+wait for external gates in the root session. If required checks are nonterminal, report
+the pending state and hand off a bounded read-only verifier through
+`verify-deployment-async`; do not merge until normal readiness requirements are met.
 
 ```bash
-gh pr checks PR_NUMBER --watch
 bun run pr:snapshot -- PR_NUMBER [--repo owner/repo]
 ```
 
@@ -254,7 +255,8 @@ If the PR should use merge commit or rebase instead, use the user/repo preferenc
 
 ### 7. Verify post-merge GitHub checks
 
-After merge, identify the merge/base branch commit:
+After merge, identify the merge/base branch commit and take one immediate post-merge
+GitHub status snapshot:
 
 ```bash
 gh pr view PR_NUMBER --json state,mergedAt,mergeCommit,url
@@ -270,20 +272,20 @@ Check workflow runs for the target branch/commit:
 gh run list --branch BASE_BRANCH --limit 10
 ```
 
-If needed, watch the relevant run:
-
-```bash
-gh run watch RUN_ID
-```
-
-Do not proceed to issue closure until required post-merge checks have passed or the user explicitly accepts a pending state.
+If the relevant run is nonterminal, do not watch or poll it. Invoke
+`verify-deployment-async` for one bounded read, report `merged; verification pending`,
+and return control. A later durable terminal event or natural orchestration tick may
+trigger another one-shot read. Do not proceed to issue closure until required
+post-merge checks have terminal success.
 
 ### 8. Verify post-merge deployment, finish issues, and clean up worktrees
 
-Follow `references/post-merge-operations.md` for the detailed Railway MCP verification, GitHub/Linear issue closure, and mandatory worktree cleanup procedure. Key invariants:
+Follow `references/post-merge-operations.md` and the project-local
+`verify-deployment-async` skill for bounded Railway MCP verification, GitHub/Linear issue
+closure, and mandatory worktree cleanup procedure. Key invariants:
 
 - Verify Railway with MCP only; do not mutate Railway resources without explicit user approval.
-- Wait for terminal deployment success before closing issues or claiming the deploy is healthy.
+- Require terminal deployment success before closing issues or claiming the deploy is healthy; do not wait in-session for it.
 - For squash-merged PRs, the local branch may not appear in `git branch --merged`; use the PR merged state and merge commit as the source of truth.
 - Before removing a finished worktree, restore any external local pointers that target it (for example `~/.hermes/plugins/index-network` symlinked to a PR worktree).
 - Remove the finished PR worktree, prune, and report it. Report other apparently finished worktrees for separate cleanup; do not turn this PR closeout into an unrelated sweep.

--- a/.pi/skills/finish-pr/SKILL.md
+++ b/.pi/skills/finish-pr/SKILL.md
@@ -16,7 +16,7 @@ Safely finish a PR end-to-end from the canonical/root session: identify the PR/i
 - Do not merge without explicit user confirmation in the current session.
 - Do not deploy, restart, rollback, or mutate Railway resources unless the user explicitly asked for that action. Verification is okay; mutation needs confirmation.
 - Do not close Linear or GitHub issues until the PR is merged and post-merge deployment checks pass, unless the user explicitly asks to close them earlier.
-- Never claim deployment success from a queued/in-progress status. Take one immediate status snapshot; if GitHub/Railway is nonterminal, invoke the project-local `verify-deployment-async` workflow and report `merged; verification pending`, then return control immediately. Never use `--watch`, waits, sleeps, or polling. Keep issues open until a later durable terminal event or explicit orchestration tick supplies another bounded read.
+- Never claim deployment success from a queued/in-progress status. Take one immediate status snapshot; if GitHub/Railway is nonterminal, explicitly call `team_delegate` for one read-only `release-verifier`, passing the exact PR/base/head/merge SHA and Railway project/environment/service/deployment tuple. Return user control immediately. The verifier performs one bounded read, emits at most one deduplicated pending report keyed by identity tuple plus observed status, then `team_block`s that same task. Resume only that exact blocked worker from a durable terminal event or an explicit natural-tick `team_send`; never use `--watch`, waits, sleeps, or polling. Keep issues open until terminal success.
 - If Railway MCP tools are unavailable, report deployment as unverified; do not claim success or close related issues until it can be verified. GitHub merge safety does not depend on MCP availability.
 - If checks fail, keep issues open and report the blocker.
 - Never edit files or run mutating git commands (commit, rebase, push, force-push) from the canonical root. When a worktree change is needed, `index` first delegates through a dedicated canonical-root coordinator; that root sends one consolidated prompt to the existing visible Herdr-managed Pi session for the PR worktree. The root/child handoff is fire-and-return without `--wait`; while the bridge is removed, `index` explicitly ticks the dedicated root on a later natural turn. That child session verifies the worktree's absolute path and feature branch before mutation. GitHub-side actions (review-thread replies/resolutions, the merge itself, issue updates) and read-only verification (builds, tests, diffs against remote refs) are fine.
@@ -198,9 +198,10 @@ Record the user's decisions for the step-6 summary.
 ### 5. Check GitHub readiness before merge
 
 Before merge, take one factual snapshot and make the readiness decision from it. Do not
-wait for external gates in the root session. If required checks are nonterminal, report
-the pending state and hand off a bounded read-only verifier through
-`verify-deployment-async`; do not merge until normal readiness requirements are met.
+wait for external gates in the root session. If required checks are nonterminal, explicitly
+call `team_delegate` for a read-only `release-verifier` with the exact PR/base/head/merge
+SHA and Railway project/environment/service/deployment tuple. Return control immediately;
+do not merge until normal readiness requirements are met.
 
 ```bash
 bun run pr:snapshot -- PR_NUMBER [--repo owner/repo]
@@ -272,11 +273,13 @@ Check workflow runs for the target branch/commit:
 gh run list --branch BASE_BRANCH --limit 10
 ```
 
-If the relevant run is nonterminal, do not watch or poll it. Invoke
-`verify-deployment-async` for one bounded read, report `merged; verification pending`,
-and return control. A later durable terminal event or natural orchestration tick may
-trigger another one-shot read. Do not proceed to issue closure until required
-post-merge checks have terminal success.
+If the relevant run is nonterminal, do not watch or poll it. Explicitly call
+`team_delegate` for the exact read-only `release-verifier` identity tuple described in
+`verify-deployment-async`, then return control immediately. That worker gets one bounded
+read, emits at most one identity-plus-status-deduplicated pending report, and
+`team_block`s the same task. Only a durable terminal event or explicit natural-tick
+`team_send` may resume that exact blocked worker. Do not proceed to issue closure until
+required post-merge checks have terminal success.
 
 ### 8. Verify post-merge deployment, finish issues, and clean up worktrees
 

--- a/.pi/skills/finish-pr/references/post-merge-operations.md
+++ b/.pi/skills/finish-pr/references/post-merge-operations.md
@@ -22,7 +22,7 @@ Then use the available Railway MCP tool(s) to verify:
 - recent logs for startup/runtime errors,
 - app health URL or smoke endpoint if available.
 
-If a Railway deployment is still building/deploying, do one bounded status read and report `merged; verification pending` with the deployment URL/status. Do not wait, watch, sleep, or poll; return control and let a later durable terminal event or natural orchestration tick trigger another bounded read. Do not claim success.
+If a Railway deployment is still building/deploying, explicitly call `team_delegate` for one read-only `release-verifier` with the exact PR/base/head/merge SHA and Railway project/environment/service/deployment tuple, then return user control immediately. The worker performs one bounded status read, emits at most one pending report deduplicated by identity tuple plus observed status, and `team_block`s the same task. Do not wait, watch, sleep, or poll; resume only that exact blocked worker via a durable terminal event or explicit natural-tick `team_send`. Do not claim success.
 
 If Railway MCP is not configured or does not expose enough tools to verify status/logs, report deployment verification as incomplete. Do not claim success or close related issues, but do not treat MCP unavailability alone as a reason to undo or delay an otherwise-safe GitHub merge.
 

--- a/.pi/skills/finish-pr/references/post-merge-operations.md
+++ b/.pi/skills/finish-pr/references/post-merge-operations.md
@@ -22,7 +22,7 @@ Then use the available Railway MCP tool(s) to verify:
 - recent logs for startup/runtime errors,
 - app health URL or smoke endpoint if available.
 
-If a Railway deployment is still building/deploying, wait only as long as is reasonable, then report it as pending with the deployment URL/status. Do not claim success.
+If a Railway deployment is still building/deploying, do one bounded status read and report `merged; verification pending` with the deployment URL/status. Do not wait, watch, sleep, or poll; return control and let a later durable terminal event or natural orchestration tick trigger another bounded read. Do not claim success.
 
 If Railway MCP is not configured or does not expose enough tools to verify status/logs, report deployment verification as incomplete. Do not claim success or close related issues, but do not treat MCP unavailability alone as a reason to undo or delay an otherwise-safe GitHub merge.
 
@@ -41,14 +41,14 @@ gh issue comment ISSUE_NUMBER --body "Shipped in PR PR_URL and verified after de
 gh issue close ISSUE_NUMBER --reason completed
 ```
 
-If deployment is pending or failed, leave the issue open and comment with the blocker/status only if useful.
+If deployment is pending or failed, leave the issue open and comment with the blocker/status only if useful. Issue closure is gated on terminal success, never on merge or notifications.
 
 ### 10. Finish related Linear issues
 
 For each related Linear issue:
 
 1. Add a comment with PR URL, merge commit, verification commands, and Railway deployment status.
-2. Move the issue to the appropriate done/completed status only after merge and deployment verification succeed.
+2. Move the issue to the appropriate done/completed status only after merge and deployment verification reach terminal success. A nonterminal result remains fail-closed and pending.
 
 Use Linear tools rather than guessing API calls:
 

--- a/.pi/skills/verify-deployment-async/SKILL.md
+++ b/.pi/skills/verify-deployment-async/SKILL.md
@@ -9,7 +9,7 @@ Use this workflow from the release-operations role or a delegated read-only
 `release-verifier`. It is deliberately one-shot: never use `--watch`, waits, sleeps,
 polling loops, daemons, or infrastructure mutation.
 
-## Identity binding
+## Identity binding and delegation
 
 Before any read, record and preserve the exact identity tuple:
 
@@ -19,6 +19,22 @@ Before any read, record and preserve the exact identity tuple:
 
 A result applies only to that tuple. A notification, merge event, Slack message, or
 unrelated deployment cannot establish success.
+
+When a gate is nonterminal, explicitly call `team_delegate` with `role:
+release-verifier`, `model: gpt-5.6-luna`, and a prompt containing every tuple field:
+
+```json
+{
+  "role": "release-verifier",
+  "description": "One-shot deployment verification",
+  "prompt": "Verify exactly PR=<pr>, base=<base>, head=<head>, mergeSHA=<sha>; Railway project=<projectId>, environment=<environmentId>, service=<serviceId>, deployment=<deploymentId>. Perform one bounded read only, report status, then block this task if nonterminal.",
+  "paths": [".pi/skills/verify-deployment-async/**", ".pi/skills/finish-pr/**"],
+  "worktree": false
+}
+```
+
+Return user control immediately after delegation; do not inline the worker or wait for
+its result.
 
 ## One bounded read
 
@@ -42,10 +58,11 @@ unrelated deployment cannot establish success.
   (or `verification incomplete` when identity/evidence is unavailable), keep issues
   open, and return immediately.
 
-Use `team_report` (and `team_send` when coordination needs a direct handoff) with the
-bound identity, one-shot evidence, and a concise next-action note. The verifier may
-perform another bounded read only after an explicit durable terminal event or a natural
-orchestration tick; it must not create its own trigger or watcher.
+After the one bounded read, emit at most one pending `team_report` for the identity
+tuple plus observed status. Deduplicate repeat reports by that composite key. Then call
+`team_block` on the same task; do not spawn a replacement worker. Resume only that exact
+blocked worker after a durable terminal event or an explicit natural-tick `team_send`
+carrying the same identity tuple. The worker must not create its own trigger or watcher.
 
 ## Closeout gate
 
@@ -57,5 +74,5 @@ the release coordinator's explicit closeout action.
 
 The workflow is read-only: no deploy, restart, rollback, variable change, environment
 mutation, merge, rebase, push, or issue close. Full automatic completion still requires
-a durable external terminal-event adapter (or a later natural orchestration tick) to
-invoke another one-shot verification.
+a durable external terminal-event adapter (or a later natural orchestration tick sent to
+the exact blocked worker) to invoke another one-shot verification.

--- a/.pi/skills/verify-deployment-async/SKILL.md
+++ b/.pi/skills/verify-deployment-async/SKILL.md
@@ -1,0 +1,61 @@
+---
+name: verify-deployment-async
+description: "Performs one-shot, read-only GitHub and Railway deployment verification without blocking orchestration. Use after a merge or deployment event when external checks may still be nonterminal; bind the exact PR, base/head refs, merge SHA, and Railway target before reporting status or closing issues."
+---
+
+# Verify Deployment Async
+
+Use this workflow from the release-operations role or a delegated read-only
+`release-verifier`. It is deliberately one-shot: never use `--watch`, waits, sleeps,
+polling loops, daemons, or infrastructure mutation.
+
+## Identity binding
+
+Before any read, record and preserve the exact identity tuple:
+
+- GitHub repository, PR number, base ref, head ref, and merge SHA (when merged).
+- Railway project ID, environment ID, service ID, and deployment ID. Resolve IDs from
+  the release context or a read-only Railway lookup; never guess from display names.
+
+A result applies only to that tuple. A notification, merge event, Slack message, or
+unrelated deployment cannot establish success.
+
+## One bounded read
+
+1. Take one immediate GitHub snapshot (`pr:snapshot`, `gh pr view`, or one `gh run
+   list`/`gh run view` read) for the bound PR/SHA.
+2. Take one Railway MCP status/log/health read for the bound project, environment,
+   service, and deployment. Discover Railway tools first; do not mutate resources.
+3. If Railway MCP is unavailable or cannot identify the deployment, report
+   `verification incomplete` / `unverified` and keep issues open. Do not substitute
+   guessed CLI output or claim success. GitHub-only evidence never proves Railway
+   health.
+
+## Terminal handling
+
+- **Terminal success:** report the exact successful GitHub and Railway statuses, IDs,
+  SHA, and evidence. Only then may the release coordinator close related GitHub or
+  Linear issues.
+- **Terminal failure/cancellation:** report the exact failure and blocker; keep issues
+  open and do not retry by polling or mutate infrastructure.
+- **Nonterminal or missing evidence:** report exactly `merged; verification pending`
+  (or `verification incomplete` when identity/evidence is unavailable), keep issues
+  open, and return immediately.
+
+Use `team_report` (and `team_send` when coordination needs a direct handoff) with the
+bound identity, one-shot evidence, and a concise next-action note. The verifier may
+perform another bounded read only after an explicit durable terminal event or a natural
+orchestration tick; it must not create its own trigger or watcher.
+
+## Closeout gate
+
+Issue closure requires all of: the bound PR is merged, post-merge GitHub checks are
+terminal-success, and the bound Railway deployment is terminal-success. A pending,
+failed, cancelled, unverified, or mismatched result is fail-closed. The verifier may
+recommend closeout after success, but must not infer or silently close issues without
+the release coordinator's explicit closeout action.
+
+The workflow is read-only: no deploy, restart, rollback, variable change, environment
+mutation, merge, rebase, push, or issue close. Full automatic completion still requires
+a durable external terminal-event adapter (or a later natural orchestration tick) to
+invoke another one-shot verification.


### PR DESCRIPTION
## Summary
- make finish-pr external gate checks one-shot and non-blocking
- add verify-deployment-async skill with identity-bound GitHub/Railway checks and fail-closed issue gating
- add read-only release-verifier role and external-gate policy

## Validation
- `bun .pi/skills/learn-skill/scripts/skillctl.ts validate .pi/skills/verify-deployment-async`
- `bun run skills:validate`
- `python3 -m json.tool .pi/herdr-team.json`

Full automatic completion still requires a durable external terminal-event adapter or natural orchestration tick.