### PR TITLE
fix(negotiation): re-stamp protocol version per match instead of inheriting from conversation

### DIFF
--- a/docs/domain/negotiation.md
+++ b/docs/domain/negotiation.md
@@ -46,7 +46,7 @@ Negotiation proceeds in alternating turns.
 
 ### Protocol versions
 
-Each negotiation task carries a `protocolVersion` (`v1` | `v2`) in its metadata. The version is **inherited, never re-stamped**: continuations copy the version from the prior task on the conversation, so an in-flight v1 conversation stays v1 even after the environment moves to v2. Only genuinely fresh negotiations stamp from the `NEGOTIATION_PROTOCOL_VERSION` env switch (default `v1`); rollback is the same single switch.
+Each negotiation task carries a `protocolVersion` (`v1` | `v2`) in its metadata. The version is **pinned per negotiation, re-stamped per match**: a prior task for the same opportunity (an exact ask_user resume or a re-run) pins its version so one negotiation never flips semantics mid-flight (a version-less genuine prior is a pre-v2 task and reads as v1). Every other session — including continuations of older conversations between the same pair — stamps from the `NEGOTIATION_PROTOCOL_VERSION` env switch (default `v1`), so a version cutover reaches existing pairs on their next new match instead of being pinned to v1 forever by conversation history. Rollback is the same single switch, with the same per-opportunity pinning.
 
 Under **v2 (client-advocate seat rules)** the action vocabulary is scoped by seat, keyed on `metadata.initiatorUserId` (the rigid stamp from discovery time — never turn parity):
 

--- a/packages/protocol/package.json
+++ b/packages/protocol/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@indexnetwork/protocol",
-  "version": "6.10.0",
+  "version": "6.11.0",
   "type": "module",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",

--- a/packages/protocol/package.json
+++ b/packages/protocol/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@indexnetwork/protocol",
-  "version": "6.11.0",
+  "version": "6.10.1",
   "type": "module",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",

--- a/packages/protocol/src/negotiation/negotiation.graph.ts
+++ b/packages/protocol/src/negotiation/negotiation.graph.ts
@@ -260,10 +260,9 @@ export class NegotiationGraphFactory {
           return typeof v === 'string' && v.length > 0 ? v : null;
         };
         let initiatorUserId = readInitiator(priorTask?.metadata) ?? state.initiatorUserId ?? state.sourceUser.id;
-        // Conversation-scoped prior task: reused for both the initiator tie-break
-        // (only when active+fresh) and protocol-version inheritance (any prior
-        // task on the conversation pins the version).
-        const convTask = !exactContinuation && (!readInitiator(priorTask?.metadata) || !readProtocolVersion(priorTask?.metadata))
+        // Conversation-scoped prior task: used only for the initiator tie-break
+        // (and only when active+fresh).
+        const convTask = !exactContinuation && !readInitiator(priorTask?.metadata)
           ? await database.getLatestNegotiationTaskForConversation?.(conversation.id).catch(() => null)
           : null;
         if (!readInitiator(priorTask?.metadata)) {
@@ -280,22 +279,18 @@ export class NegotiationGraphFactory {
           }
         }
 
-        // --- Protocol version: inherited, never re-stamped ---
-        // Every session (including continuations) creates a new task row, so a
-        // naïve "stamp from env at init" would flip a v1 conversation to v2
-        // mid-flight. Rule: any prior negotiation task on this conversation pins
-        // the version (absent field on a genuine prior = pre-v2 task = v1);
-        // prior turns without a readable task also grandfather to v1; only
-        // genuinely fresh negotiations stamp from NEGOTIATION_PROTOCOL_VERSION.
-        let protocolVersion: NegotiationProtocolVersion;
-        const priorVersionSource = priorTask ?? convTask;
-        if (priorVersionSource) {
-          protocolVersion = readProtocolVersion(priorVersionSource.metadata) ?? 'v1';
-        } else if (isContinuation) {
-          protocolVersion = 'v1';
-        } else {
-          protocolVersion = configuredProtocolVersion();
-        }
+        // --- Protocol version: pinned per negotiation, re-stamped per match ---
+        // A prior task for this same negotiation (exact continuation resume or
+        // a re-run of the same opportunity) pins the version, so one
+        // negotiation never flips semantics mid-flight (absent field on a
+        // genuine prior = pre-v2 task = v1). Everything else — including
+        // continuations of older conversations between the same pair — stamps
+        // fresh from NEGOTIATION_PROTOCOL_VERSION, so a version cutover
+        // reaches existing pairs on their next new match instead of being
+        // pinned to v1 forever by conversation history.
+        const protocolVersion: NegotiationProtocolVersion = priorTask
+          ? (readProtocolVersion(priorTask.metadata) ?? 'v1')
+          : configuredProtocolVersion();
 
         const taskMetadata = {
           type: 'negotiation',

--- a/packages/protocol/src/negotiation/negotiation.protocol.ts
+++ b/packages/protocol/src/negotiation/negotiation.protocol.ts
@@ -190,9 +190,11 @@ export function readProtocolVersion(
 }
 
 /**
- * Protocol version for genuinely fresh negotiations, from the
- * `NEGOTIATION_PROTOCOL_VERSION` env switch. Defaults to `v1` when unset —
- * v2 is opt-in per environment, and rolling back is the same single switch.
+ * Protocol version for negotiations without a prior task for the same
+ * opportunity, from the `NEGOTIATION_PROTOCOL_VERSION` env switch. Defaults
+ * to `v1` when unset — v2 is opt-in per environment, and rolling back is the
+ * same single switch (only in-flight negotiations stay pinned to their
+ * stamped version).
  */
 export function configuredProtocolVersion(): NegotiationProtocolVersion {
   return process.env.NEGOTIATION_PROTOCOL_VERSION === "v2" ? "v2" : "v1";

--- a/packages/protocol/src/negotiation/tests/negotiation.seat-rules.spec.ts
+++ b/packages/protocol/src/negotiation/tests/negotiation.seat-rules.spec.ts
@@ -8,8 +8,9 @@ import type { NegotiationTurn } from "../negotiation.state.js";
  * IND-397 — seat-scoped turn schemas + counterparty-only accept (graph level).
  *
  * Pins:
- * - protocolVersion stamping for fresh runs (env switch) and inheritance for
- *   continuations (a v1 conversation stays v1 mid-flight even with env=v2),
+ * - protocolVersion stamping from the env switch for every new match, with
+ *   pinning only for a prior task on the same opportunity (one negotiation
+ *   never flips version mid-flight; conversation history does not pin),
  * - turn-0 opening action per version (v1 propose, v2 initiator outreach),
  * - seat + version propagation into the system agent and dispatch payload,
  * - v2 coercion of out-of-seat personal-agent turns (initiator accept →
@@ -167,7 +168,7 @@ describe("negotiation graph — seat rules + protocol version (IND-397)", () => 
     expect(agentInputs[0].protocolVersion).toBe("v1");
   });
 
-  it("version inheritance: continuation of a v1 conversation stays v1 even with env=v2", async () => {
+  it("version pinning: re-run of a v1 opportunity stays v1 even with env=v2", async () => {
     process.env.NEGOTIATION_PROTOCOL_VERSION = "v2";
     const stubs = mkStubs({
       priorOpportunityTask: mkTask({
@@ -183,7 +184,7 @@ describe("negotiation graph — seat rules + protocol version (IND-397)", () => 
     expect(agentInputs[0].protocolVersion).toBe("v1");
   });
 
-  it("version inheritance: prior task without a version field grandfathers to v1 under env=v2", async () => {
+  it("version pinning: same-opportunity prior task without a version field grandfathers to v1 under env=v2", async () => {
     process.env.NEGOTIATION_PROTOCOL_VERSION = "v2";
     const stubs = mkStubs({
       priorOpportunityTask: mkTask({
@@ -197,7 +198,7 @@ describe("negotiation graph — seat rules + protocol version (IND-397)", () => 
     expect(stubs.createdTasks[0].metadata.protocolVersion).toBe("v1");
   });
 
-  it("version inheritance: prior conversation turns without any readable task grandfather to v1", async () => {
+  it("no conversation inheritance: continuation without a same-opportunity task stamps from env", async () => {
     process.env.NEGOTIATION_PROTOCOL_VERSION = "v2";
     const stubs = mkStubs({
       priorMessages: [priorMsg("u-src", "propose", 0), priorMsg("u-cand", "counter", 1)],
@@ -205,10 +206,25 @@ describe("negotiation graph — seat rules + protocol version (IND-397)", () => 
 
     await runGraph(stubs, { opportunityId: "opp-1" });
 
-    expect(stubs.createdTasks[0].metadata.protocolVersion).toBe("v1");
+    expect(stubs.createdTasks[0].metadata.protocolVersion).toBe("v2");
   });
 
-  it("version inheritance: a v2 conversation stays v2 even after env rollback to v1", async () => {
+  it("no conversation inheritance: a v1 task on the same DM does not pin a new match's version", async () => {
+    process.env.NEGOTIATION_PROTOCOL_VERSION = "v2";
+    const stubs = mkStubs({
+      conversationTask: mkTask({
+        id: "task-other-opp",
+        metadata: { type: "negotiation", sourceUserId: "u-src", protocolVersion: "v1" },
+      }),
+      priorMessages: [priorMsg("u-src", "propose", 0), priorMsg("u-cand", "counter", 1)],
+    });
+
+    await runGraph(stubs, { opportunityId: "opp-2" });
+
+    expect(stubs.createdTasks[0].metadata.protocolVersion).toBe("v2");
+  });
+
+  it("version pinning: a v2 opportunity stays v2 even after env rollback to v1", async () => {
     process.env.NEGOTIATION_PROTOCOL_VERSION = "v1";
     const stubs = mkStubs({
       priorOpportunityTask: mkTask({


### PR DESCRIPTION
## Bug Fixes

- **Break v1 protocol-version inheritance.** Protocol version was pinned by *any* prior negotiation task on the agent-pair DM conversation, and prior turns without a readable task grandfathered to v1. Since the same user pairs keep negotiating on the same DM, existing pairs could never reach v2 — no outreach screening, no seat rules (either side could accept), no `ask_user` inflight consultation — even with `NEGOTIATION_PROTOCOL_VERSION=v2` set. Observed on dev: a fresh intent produced 22 negotiations, all `v1` continuations, 21 instant accepts / 1 reject / 0 interruptions.
- New rule: version is pinned **only by a prior task for the same opportunity** (exact ask_user resume or a re-run), so one negotiation never flips semantics mid-flight; a version-less genuine prior still reads as v1. Every other session — including continuations of older conversations between the same pair — stamps fresh from `NEGOTIATION_PROTOCOL_VERSION`. Rollback keeps the same per-opportunity pinning (a v2 opportunity stays v2 under env=v1).
- The conversation-scoped task lookup is now used only for the initiator-seat tie-break.

## Tests

- Updated `negotiation.seat-rules.spec.ts`: continuation without a same-opportunity task now stamps from env; added a pin that a v1 task on the same DM (different opportunity) does not pin a new match's version; same-opportunity pinning and pre-v2 grandfathering unchanged.
- Full negotiation suite: 284 pass / 0 fail.
- Finish pass after rebasing onto current `dev`: targeted seat-rules suite 12 pass / 0 fail; protocol TypeScript build passed; all refreshed GitHub checks passed.

## Documentation

- `docs/domain/negotiation.md` protocol-versions section rewritten for the per-match stamping rule.

## Chores

- `@indexnetwork/protocol` 6.10.0 → 6.10.1.