### PR TITLE
feat(radar): stream intent negotiation activity

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@indexnetwork/web",
-  "version": "0.29.0",
+  "version": "0.29.1",
   "license": "MIT",
   "scripts": {
     "dev": "vite --host 127.0.0.1",

--- a/apps/web/src/app/i/[intentId]/page.tsx
+++ b/apps/web/src/app/i/[intentId]/page.tsx
@@ -16,6 +16,7 @@ import IntentMemoryStrip from "@/components/IntentMemoryStrip";
 import IntentNegotiatorChat from "@/components/IntentNegotiatorChat";
 import { useAuthContext } from "@/contexts/AuthContext";
 import { useIntents, useOpportunities, useQuestionsService } from "@/contexts/APIContext";
+import { useConversation } from "@/contexts/ConversationContext";
 import { useNotifications } from "@/contexts/NotificationContext";
 import { useQuestions } from "@/contexts/QuestionsContext";
 import { useOpportunityActions } from "@/hooks/useOpportunityActions";
@@ -24,6 +25,7 @@ import type { HomeViewCardItem, OpportunityLifecycleStatus } from "@/services/op
 import type { IntentLifecycleStatus, MutableIntentLifecycleStatus } from "@/services/intents";
 import type { AnswerBody, PendingQuestion, QuestionAnswer } from "@/services/questions";
 import { cn } from "@/lib/utils";
+import { intentNegotiationActivityRevision } from "@/lib/intent-negotiation-activity";
 
 /** Raw opportunity status -> radar display bucket (mirrors the Hermes dashboard). */
 const STATUS_BUCKET: Record<string, string> = {
@@ -303,6 +305,7 @@ export default function IntentDetailPage() {
   const { refresh: refreshQuestionCounts, pendingRevision } = useQuestions();
   const { error: showError } = useNotifications();
   const { user, features } = useAuthContext();
+  const { negotiations } = useConversation();
 
   const [intent, setIntent] = useState<Awaited<
     ReturnType<typeof intentsService.getIntent>
@@ -536,6 +539,30 @@ export default function IntentDetailPage() {
       if (seq === loadSeqRef.current && !preserveExisting) setOpportunitiesLoading(false);
     }
   }, [intentId, opportunitiesService]);
+
+  const negotiationActivityRevision = useMemo(
+    () => intentNegotiationActivityRevision(negotiations, intentId),
+    [intentId, negotiations],
+  );
+  const seenNegotiationActivityRef = useRef<string | null>(null);
+
+  // ConversationProvider receives persisted A2A turns over SSE and refreshes
+  // owner-filtered negotiation provenance. A scoped revision means only this
+  // intent's own negotiations invalidate Radar; unrelated conversations never
+  // trigger a fetch or become visible here.
+  useEffect(() => {
+    if (!negotiationActivityRevision) {
+      seenNegotiationActivityRef.current = null;
+      return;
+    }
+    if (seenNegotiationActivityRef.current === null) {
+      seenNegotiationActivityRef.current = negotiationActivityRevision;
+      return;
+    }
+    if (seenNegotiationActivityRef.current === negotiationActivityRevision) return;
+    seenNegotiationActivityRef.current = negotiationActivityRevision;
+    void loadOpportunities(true);
+  }, [loadOpportunities, negotiationActivityRevision]);
 
   useEffect(() => {
     if (!intentId) return;

--- a/apps/web/src/contexts/ConversationContext.tsx
+++ b/apps/web/src/contexts/ConversationContext.tsx
@@ -51,6 +51,7 @@ export function ConversationProvider({ children }: { children: React.ReactNode }
   const sseGenerationRef = useRef(0);
   const connectSSERef = useRef<() => void>(() => {});
   const refreshConversationsRef = useRef<() => Promise<void>>(() => Promise.resolve());
+  const refreshNegotiationsRef = useRef<() => Promise<void>>(() => Promise.resolve());
 
   // --- REST helpers (use apiClient directly, same pattern as AIChatContext) ---
 
@@ -72,6 +73,7 @@ export function ConversationProvider({ children }: { children: React.ReactNode }
       logger.error('Failed to fetch negotiations', { error: err });
     }
   }, []);
+  useEffect(() => { refreshNegotiationsRef.current = refreshNegotiations; }, [refreshNegotiations]);
 
   const loadMessages = useCallback(async (conversationId: string, opts?: { limit?: number; before?: string }) => {
     try {
@@ -349,6 +351,11 @@ export function ConversationProvider({ children }: { children: React.ReactNode }
                     : c
                 );
               });
+              // Negotiation turns use the same stream but their summaries are
+              // owner-filtered separately (`agent:<ownerId>` participants).
+              // Revalidate once per event so intent provenance and Radar can
+              // react without a polling loop.
+              void refreshNegotiationsRef.current();
               break;
             }
           }
@@ -397,6 +404,7 @@ export function ConversationProvider({ children }: { children: React.ReactNode }
       // eslint-disable-next-line react-hooks/set-state-in-effect
       setIsConnected(false);
       setConversations([]);
+      setNegotiations([]);
       setMessages(new Map());
       setSessionHistory(new Map());
       return;
@@ -417,7 +425,7 @@ export function ConversationProvider({ children }: { children: React.ReactNode }
         retryTimeoutRef.current = null;
       }
     };
-  }, [isAuthenticated, refreshConversations, connectSSE]);
+  }, [isAuthenticated, refreshConversations, refreshNegotiations, connectSSE]);
 
   return (
     <ConversationContext.Provider

--- a/apps/web/src/lib/__tests__/intent-negotiation-activity.test.ts
+++ b/apps/web/src/lib/__tests__/intent-negotiation-activity.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, it } from 'vitest';
+
+import { intentNegotiationActivityRevision } from '@/lib/intent-negotiation-activity';
+import type { ConversationSummary } from '@/services/conversation';
+
+const conversation = (overrides: Partial<ConversationSummary>): ConversationSummary => ({
+  id: 'conversation-1',
+  participants: [],
+  lastMessage: null,
+  metadata: null,
+  via: [],
+  unreadCount: 0,
+  lastMessageAt: null,
+  createdAt: '2026-07-24T00:00:00.000Z',
+  ...overrides,
+});
+
+describe('intentNegotiationActivityRevision', () => {
+  it('includes only the authenticated viewer intent provenance', () => {
+    const revision = intentNegotiationActivityRevision([
+      conversation({
+        id: 'in-scope',
+        lastMessageAt: '2026-07-24T10:00:00.000Z',
+        via: [{ intentId: 'intent-owner', opportunityId: 'opportunity-1', title: 'My intent' }],
+      }),
+      conversation({
+        id: 'out-of-scope',
+        lastMessageAt: '2026-07-24T11:00:00.000Z',
+        via: [{ intentId: 'intent-other', opportunityId: 'opportunity-2', title: 'Other intent' }],
+      }),
+    ], 'intent-owner');
+
+    expect(revision).toBe('in-scope:2026-07-24T10:00:00.000Z');
+    expect(revision).not.toContain('out-of-scope');
+  });
+
+  it('changes when a scoped negotiation receives a newer message', () => {
+    const before = intentNegotiationActivityRevision([
+      conversation({ via: [{ intentId: 'intent-owner', opportunityId: 'opportunity-1', title: 'My intent' }] }),
+    ], 'intent-owner');
+    const after = intentNegotiationActivityRevision([
+      conversation({
+        lastMessageAt: '2026-07-24T10:00:00.000Z',
+        via: [{ intentId: 'intent-owner', opportunityId: 'opportunity-1', title: 'My intent' }],
+      }),
+    ], 'intent-owner');
+
+    expect(after).not.toBe(before);
+  });
+});

--- a/apps/web/src/lib/intent-negotiation-activity.ts
+++ b/apps/web/src/lib/intent-negotiation-activity.ts
@@ -1,0 +1,22 @@
+import type { ConversationSummary } from '@/services/conversation';
+
+/**
+ * Derives a stable revision from negotiation conversations that the API has
+ * already proven belong to the current viewer's intent. Keeping this filter at
+ * the boundary prevents unrelated negotiation activity from refreshing Radar.
+ *
+ * @param conversations - Authenticated viewer's negotiation summaries.
+ * @param intentId - The viewer-owned intent displayed by Radar.
+ * @returns Stable revision or an empty string when no conversation is in scope.
+ */
+export function intentNegotiationActivityRevision(
+  conversations: ConversationSummary[],
+  intentId: string | undefined,
+): string {
+  if (!intentId) return '';
+  return conversations
+    .filter((conversation) => conversation.via.some((entry) => entry.intentId === intentId))
+    .map((conversation) => `${conversation.id}:${conversation.lastMessageAt ?? ''}`)
+    .sort()
+    .join('|');
+}

--- a/bun.lock
+++ b/bun.lock
@@ -19,7 +19,7 @@
     },
     "apps/web": {
       "name": "@indexnetwork/web",
-      "version": "0.29.0",
+      "version": "0.29.1",
       "dependencies": {
         "@radix-ui/react-alert-dialog": "^1.1.15",
         "@radix-ui/react-dialog": "^1.1.14",
@@ -104,7 +104,7 @@
     },
     "services/api": {
       "name": "@indexnetwork/api",
-      "version": "0.56.0",
+      "version": "0.56.2",
       "dependencies": {
         "@aws-sdk/client-s3": "^3.939.0",
         "@aws-sdk/s3-request-presigner": "^3.983.0",

--- a/services/api/package.json
+++ b/services/api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@indexnetwork/api",
-  "version": "0.56.1",
+  "version": "0.56.2",
   "license": "MIT",
   "private": true,
   "scripts": {

--- a/services/api/src/adapters/conversation.database.adapter.ts
+++ b/services/api/src/adapters/conversation.database.adapter.ts
@@ -1,6 +1,8 @@
 import { readUserContext, schema, Artifact, ChatConversationMeta, ChatMessage, ChatMessageMeta, ChatScopeType, ChatSession, Conversation, ConversationParticipant, ConversationSession, ConversationSummary, CreateMessageInput, CreateSessionInput, Message, ResolvedParticipant, SYSTEM_AGENT_ID, Task, and, asc, count, db, desc, eq, gt, gte, inArray, isNull, lt, ne, opportunities, or, sql } from './database.shared';
 import { emitOpportunityPendingBestEffort } from '../events/opportunity.event';
+import { publishConversationMessageEvent } from '../lib/conversation-events';
 import { computeIntentFingerprint } from '../lib/intent/intent.fingerprint';
+import { log } from '../lib/log';
 import { assertContinuationExecutionEffect } from './negotiation-continuation.atomic';
 import type { ContinuationExecutionFence } from './negotiation-continuation.atomic';
 import { acquireNegotiationAttemptLock, acquireNegotiationPairLock, qualifyingNegotiationAttemptTaskWhere, qualifyingPairNegotiationTaskWhere, type NegotiationAttemptTransaction } from './negotiation-attempt.atomic';
@@ -10,6 +12,7 @@ const ORCHESTRATOR_PERSONA = 'orchestrator';
 const SIGNAL_PERSONA = 'signal';
 const NEGOTIATOR_PERSONA = 'negotiator';
 const REPORTER_PERSONA = 'reporter';
+const logger = log.lib.from('conversation-database');
 
 /** Persona-specific registry key for Signal Agent's canonical intent scope. */
 const SIGNAL_INTENT_SCOPE_TYPE = 'signal-intent';
@@ -666,7 +669,7 @@ export class ConversationDatabaseAdapter {
     referenceTaskIds?: string[];
     continuationExecution?: ContinuationExecutionFence;
   }): Promise<Message> {
-    return this.insertMessageWithConversationSession({
+    const message = await this.insertMessageWithConversationSession({
       id: crypto.randomUUID(),
       conversationId: data.conversationId,
       senderId: data.senderId,
@@ -677,6 +680,20 @@ export class ConversationDatabaseAdapter {
       extensions: data.extensions ?? null,
       referenceTaskIds: data.referenceTaskIds ?? null,
     }, data.continuationExecution);
+
+    // All message writers (including the protocol negotiation graph) converge
+    // here. Publish only after persistence, and only to authenticated owners
+    // represented by the stored participant rows.
+    try {
+      await publishConversationMessageEvent(message, await this.getParticipants(data.conversationId));
+    } catch (error) {
+      logger.error('Failed to publish conversation SSE event', {
+        conversationId: data.conversationId,
+        error: error instanceof Error ? error.message : String(error),
+      });
+    }
+
+    return message;
   }
 
   /**

--- a/services/api/src/lib/conversation-events.ts
+++ b/services/api/src/lib/conversation-events.ts
@@ -1,0 +1,54 @@
+import { getRedisClient } from '../adapters/cache.adapter';
+
+interface ConversationEventParticipant {
+  participantId: string;
+}
+
+interface ConversationEventMessage {
+  conversationId: string;
+  id: string;
+  senderId: string;
+  role: 'user' | 'agent';
+  parts: unknown;
+  createdAt: Date;
+}
+
+/**
+ * Resolves the authenticated user channels entitled to receive an event for a
+ * conversation. Agent participants represent their owner as `agent:<userId>`.
+ *
+ * @param participants - Persisted conversation participants.
+ * @returns Unique authenticated user IDs authorized for the conversation.
+ */
+export function conversationEventRecipientUserIds(
+  participants: ConversationEventParticipant[],
+): string[] {
+  return [...new Set(participants
+    .map(({ participantId }) => participantId.startsWith('agent:')
+      ? participantId.slice('agent:'.length)
+      : participantId)
+    .filter(Boolean))];
+}
+
+/**
+ * Publishes a persisted message to each authorized participant's existing
+ * conversation SSE channel. The channel is user-scoped, never intent-scoped,
+ * so the API remains the final provenance/privacy filter.
+ *
+ * @param message - Persisted conversation message.
+ * @param participants - Persisted conversation participants.
+ */
+export async function publishConversationMessageEvent(
+  message: ConversationEventMessage,
+  participants: ConversationEventParticipant[],
+): Promise<void> {
+  const event = JSON.stringify({
+    type: 'message',
+    conversationId: message.conversationId,
+    message,
+  });
+  const publisher = getRedisClient();
+  await Promise.all(conversationEventRecipientUserIds(participants).map((userId) => (
+    publisher.publish(`conversations:user:${userId}`, event)
+  )));
+}

--- a/services/api/src/lib/tests/conversation-events.spec.ts
+++ b/services/api/src/lib/tests/conversation-events.spec.ts
@@ -1,0 +1,20 @@
+import { describe, expect, test } from 'bun:test';
+
+import { conversationEventRecipientUserIds } from '../conversation-events';
+
+describe('conversationEventRecipientUserIds', () => {
+  test('maps negotiation agents to their owners without exposing agent IDs', () => {
+    expect(conversationEventRecipientUserIds([
+      { participantId: 'agent:owner-a' },
+      { participantId: 'agent:owner-b' },
+      { participantId: 'agent:owner-a' },
+    ])).toEqual(['owner-a', 'owner-b']);
+  });
+
+  test('retains ordinary participant IDs and drops empty channels', () => {
+    expect(conversationEventRecipientUserIds([
+      { participantId: 'owner-a' },
+      { participantId: '' },
+    ])).toEqual(['owner-a']);
+  });
+});

--- a/services/api/src/services/conversation.service.ts
+++ b/services/api/src/services/conversation.service.ts
@@ -1,6 +1,6 @@
 import { log } from '../lib/log';
 
-import { createRedisClient, getRedisClient } from '../adapters/cache.adapter';
+import { createRedisClient } from '../adapters/cache.adapter';
 import { conversationDatabaseAdapter, ConversationDatabaseAdapter } from '../adapters/database.adapter';
 
 const logger = log.service.from('ConversationService');
@@ -122,25 +122,6 @@ export class ConversationService {
     });
 
     const participants = await this.db.getParticipants(conversationId);
-
-    // Publish to all participants' SSE channels (best-effort)
-    try {
-      const event = JSON.stringify({
-        type: 'message',
-        conversationId,
-        message: msg,
-      });
-      const pubClient = getRedisClient();
-      for (const p of participants) {
-        if (p.participantId === senderId) continue;
-        await pubClient.publish(`conversations:user:${p.participantId}`, event);
-      }
-    } catch (err) {
-      logger.error('Failed to publish SSE event', {
-        conversationId,
-        error: err instanceof Error ? err.message : String(err),
-      });
-    }
 
     // Ghost invite email: on first user message to a ghost, send an invite
     if (role === 'user') {


### PR DESCRIPTION
## New Features

- Stream persisted A2A negotiation turns through the existing conversation SSE channel.
- Refresh the intent Radar only for the authenticated owner’s matching intent provenance.

## Refactors

- Centralize conversation message event publication at the database persistence boundary so protocol negotiations and standard conversation messages share one delivery path.

## Tests

- Add focused recipient privacy and intent-provenance filtering tests.
- Verify API/web builds, lint, and frozen lockfile installation.