### PR TITLE
fix(opportunity): bind scoped actor intent to trigger

### DIFF
--- a/packages/protocol/package.json
+++ b/packages/protocol/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@indexnetwork/protocol",
-  "version": "6.10.1",
+  "version": "6.10.2",
   "type": "module",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",

--- a/packages/protocol/src/opportunity/opportunity.persist.ts
+++ b/packages/protocol/src/opportunity/opportunity.persist.ts
@@ -12,6 +12,38 @@ import { protocolLogger } from '../shared/observability/protocol.logger.js';
 
 const logger = protocolLogger('OpportunityPersist');
 
+/** Bind owned-intent discovery actors to the already-authorized trigger intent. */
+function bindOwnedIntentActors(
+  data: CreateOpportunityData,
+  ownerUserId: string,
+  triggerIntentId: string,
+): CreateOpportunityData {
+  const actors: CreateOpportunityData['actors'] = [];
+  const boundActorIndexes = new Map<string, number>();
+
+  for (const actor of data.actors) {
+    if (actor.userId !== ownerUserId || actor.role === 'introducer') {
+      actors.push(actor);
+      continue;
+    }
+
+    const boundActor = {
+      ...actor,
+      intent: triggerIntentId as NonNullable<typeof actor.intent>,
+    };
+    const key = JSON.stringify([boundActor.networkId, boundActor.userId, triggerIntentId]);
+    const existingIndex = boundActorIndexes.get(key);
+    if (existingIndex === undefined) {
+      boundActorIndexes.set(key, actors.length);
+      actors.push(boundActor);
+    } else {
+      actors[existingIndex] = boundActor;
+    }
+  }
+
+  return { ...data, actors };
+}
+
 export type PersistOpportunityDatabase = EnricherDatabase & {
   createOpportunity(data: CreateOpportunityData): Promise<Opportunity>;
   createOpportunityIfNetworkEligible?(
@@ -88,7 +120,14 @@ export async function persistOpportunities(params: PersistOpportunitiesParams): 
       ) {
         throw new Error('Intent-scoped dedup trigger must match network eligibility');
       }
-      const enrichment = await enrichOrCreate(database, embedder, normalizedData, intentDedupScope && networkEligibility
+      const scopedData = intentDedupScope && networkEligibility
+        ? bindOwnedIntentActors(
+            normalizedData,
+            networkEligibility.ownerUserId,
+            intentDedupScope.triggerIntentId,
+          )
+        : normalizedData;
+      const enrichment = await enrichOrCreate(database, embedder, scopedData, intentDedupScope && networkEligibility
         ? {
             ownedIntentScope: {
               triggerIntentId: intentDedupScope.triggerIntentId,
@@ -96,7 +135,14 @@ export async function persistOpportunities(params: PersistOpportunitiesParams): 
             },
           }
         : undefined);
-      const toCreate = normalizeCreateOpportunityActorIntents(enrichment.data);
+      const normalizedToCreate = normalizeCreateOpportunityActorIntents(enrichment.data);
+      const toCreate = intentDedupScope && networkEligibility
+        ? bindOwnedIntentActors(
+            normalizedToCreate,
+            networkEligibility.ownerUserId,
+            intentDedupScope.triggerIntentId,
+          )
+        : normalizedToCreate;
       if (enrichment.enriched) {
         toCreate.status = enrichment.resolvedStatus;
       }

--- a/packages/protocol/src/opportunity/tests/opportunity.persist.spec.ts
+++ b/packages/protocol/src/opportunity/tests/opportunity.persist.spec.ts
@@ -338,6 +338,74 @@ describe('persistOpportunities', () => {
       .toBe('Intent-scoped dedup trigger must match network eligibility');
   });
 
+  it('replaces evaluator and enriched stale owner intents with the authorized trigger', async () => {
+    const triggerIntentId = 'af813171-6ca6-4ca3-8a2e-b8b48471acd2';
+    const staleIntentId = 'af813171-6ca6-4ca3-8a2e-b8b48441acd2';
+    const counterpartIntentId = 'counterpart-intent';
+    const existing = makeOpportunity({
+      id: 'opp-existing-stale-intent',
+      detection: {
+        source: 'opportunity_graph',
+        timestamp: new Date().toISOString(),
+        triggeredBy: triggerIntentId,
+      },
+      actors: [
+        { networkId: 'net-1', userId: 'user-1', role: 'patient', intent: staleIntentId },
+        { networkId: 'net-1', userId: 'user-2', role: 'agent', intent: counterpartIntentId },
+      ] as never,
+      interpretation: {
+        category: 'collaboration', reasoning: 'Existing match reasoning', confidence: 0.8, signals: [],
+      },
+    });
+    let persisted: CreateOpportunityData | undefined;
+    let receivedExpireIds: string[] | undefined;
+    const database: PersistOpportunityDatabase = {
+      findOpportunitiesByActors: async () => [existing],
+      createOpportunity: async () => makeOpportunity(),
+      updateOpportunityStatus: async () => {},
+      persistIntentScopedOpportunityIfNetworkEligible: async (data, expireIds) => {
+        persisted = data;
+        receivedExpireIds = expireIds;
+        return { created: makeOpportunity({ id: 'opp-rebound', actors: data.actors }), expired: [existing] };
+      },
+    };
+    const item = makeCreateData({
+      detection: {
+        source: 'opportunity_graph',
+        timestamp: new Date().toISOString(),
+        triggeredBy: triggerIntentId as never,
+      },
+      actors: [
+        { networkId: 'net-1', userId: 'user-1', role: 'patient', intent: staleIntentId },
+        { networkId: 'net-1', userId: 'user-2', role: 'agent', intent: counterpartIntentId },
+      ] as never,
+    });
+
+    const result = await persistOpportunities({
+      database,
+      embedder: mockEmbedder,
+      items: [item],
+      networkEligibility: {
+        ownerUserId: 'user-1',
+        allowedNetworkIds: ['net-1'],
+        triggerIntentId,
+      },
+      intentDedupScope: { triggerIntentId, dedupWindowMs: 30 * 24 * 60 * 60 * 1000 },
+    });
+
+    expect(result.errors).toBeUndefined();
+    expect(result.created.map((opportunity) => opportunity.id)).toEqual(['opp-rebound']);
+    expect(receivedExpireIds).toEqual(['opp-existing-stale-intent']);
+    expect(persisted?.actors.filter((actor) => actor.userId === 'user-1')).toEqual([{
+      networkId: 'net-1',
+      userId: 'user-1',
+      role: 'patient',
+      intent: triggerIntentId,
+    }]);
+    expect(persisted?.actors.some((actor) => actor.intent === staleIntentId)).toBe(false);
+    expect(item.actors[0]?.intent).toBe(staleIntentId);
+  });
+
   it('uses the owned-intent atomic boundary and returns typed final conflicts', async () => {
     const existingCreatedAt = new Date(Date.now() - 60_000);
     let atomicCalls = 0;

--- a/services/api/package.json
+++ b/services/api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@indexnetwork/api",
-  "version": "0.56.2",
+  "version": "0.56.3",
   "license": "MIT",
   "private": true,
   "scripts": {

--- a/services/api/src/adapters/opportunity.database.adapter.ts
+++ b/services/api/src/adapters/opportunity.database.adapter.ts
@@ -365,6 +365,10 @@ export class OpportunityDatabaseAdapter {
       || actorNetworkIds.length === 0
       || actorNetworkIds.some((id) => !allowedNetworkIds.has(id))
       || actorUserIds.length < 2
+      || !data.actors.some((actor) =>
+        actor.userId === eligibility.ownerUserId
+        && actor.role !== 'introducer'
+        && actor.intent === eligibility.triggerIntentId)
       || !Number.isFinite(dedupWindowMs)
       || dedupWindowMs <= 0
     ) return null;

--- a/services/api/src/adapters/tests/database.adapter.isolated.ts
+++ b/services/api/src/adapters/tests/database.adapter.isolated.ts
@@ -1283,6 +1283,37 @@ describe('OpportunityDatabaseAdapter', () => {
       expect(inserted).toEqual([]);
     });
 
+    it('fails closed when the owner actor is not bound to the eligibility trigger', async () => {
+      const marker = `${TEST_PREFIX}stale-owner-intent-${uuidv4()}`;
+      const result = await adapter.persistIntentScopedOpportunityIfNetworkEligible({
+        detection: {
+          source: 'opportunity_graph',
+          createdBy: marker,
+          timestamp: new Date().toISOString(),
+          triggeredBy: fixture.intent1Id,
+        },
+        actors: [
+          { networkId: fixture.networkId, userId: fixture.userAId, role: 'patient', intent: uuidv4() },
+          { networkId: fixture.networkId, userId: fixture.userBId, role: 'agent' },
+        ],
+        interpretation: { category: 'collaboration', reasoning: 'Stale owner intent must not persist', confidence: 0.9 },
+        context: { networkId: fixture.networkId },
+        confidence: '0.9',
+        status: 'latent',
+      }, [], {
+        ownerUserId: fixture.userAId,
+        allowedNetworkIds: [fixture.networkId],
+        triggerIntentId: fixture.intent1Id,
+      }, 30 * 24 * 60 * 60 * 1000);
+      const inserted = await db
+        .select({ id: opportunities.id })
+        .from(opportunities)
+        .where(sql`${opportunities.detection}->>'createdBy' = ${marker}`);
+
+      expect(result).toBeNull();
+      expect(inserted).toEqual([]);
+    });
+
     it('blocks final persistence while another trigger has a fresh active negotiation', async () => {
       const triggerIntentId = uuidv4();
       fixture.extraIntentIds.push(triggerIntentId);


### PR DESCRIPTION
## Bug Fixes
- bind the owned actor on intent-scoped discovery opportunities to the already ownership-checked trigger intent instead of trusting the evaluator's free-form intent ID
- re-apply the binding after enrichment so malformed historical actor references are not propagated into newly persisted rows
- fail closed at the final database boundary unless the owner actor is exactly bound to the authorized trigger intent

## Tests
- `cd packages/protocol && bun test ./src/opportunity/tests/opportunity.persist.spec.ts` — 14 pass
- intent-scoped adapter persistence tests — 4 pass
- `OutcomeFeedbackRecorder` tests — 14 pass
- `bunx eslint --no-warn-ignored ...` — pass
- `cd services/api && bun run build` — pass

## Notes
- No dev or production data was mutated.
- Existing malformed rows require a separate, reviewed, idempotent remediation keyed by authoritative `detection.triggeredBy` ownership; this PR intentionally does not backfill data.
- A full adapter-file run reached 108 passing tests before an unrelated HyDE stale-document test exceeded its 45s budget; that exact test passed on isolated retry in 36.7s.
