### PR TITLE
fix: surface realtime negotiations in Radar

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@indexnetwork/web",
-  "version": "0.29.1",
+  "version": "0.29.2",
   "license": "MIT",
   "scripts": {
     "dev": "vite --host 127.0.0.1",

--- a/apps/web/src/app/i/[intentId]/page.tsx
+++ b/apps/web/src/app/i/[intentId]/page.tsx
@@ -26,6 +26,7 @@ import type { IntentLifecycleStatus, MutableIntentLifecycleStatus } from "@/serv
 import type { AnswerBody, PendingQuestion, QuestionAnswer } from "@/services/questions";
 import { cn } from "@/lib/utils";
 import { intentNegotiationActivityRevision } from "@/lib/intent-negotiation-activity";
+import { DEFAULT_RADAR_BUCKET, radarBucketBadgeTone } from "@/lib/radar-buckets";
 
 /** Raw opportunity status -> radar display bucket (mirrors the Hermes dashboard). */
 const STATUS_BUCKET: Record<string, string> = {
@@ -132,11 +133,13 @@ function ActionChip({
 
 /** Selectable radar status filter tab: a label with a subtle count badge. */
 function StatPill({
+  bucketKey,
   value,
   label,
   active,
   onSelect,
 }: {
+  bucketKey: string;
   value: number;
   label: string;
   active: boolean;
@@ -158,7 +161,7 @@ function StatPill({
       <span
         className={cn(
           "min-w-[18px] rounded-full px-1 py-px text-center text-[10px] font-semibold tabular-nums",
-          active ? "bg-white/20 text-white" : "bg-gray-100 text-gray-500",
+          radarBucketBadgeTone(bucketKey, value, active),
         )}
       >
         {value}
@@ -358,7 +361,7 @@ export default function IntentDetailPage() {
   const [refineText, setRefineText] = useState("");
   const [refining, setRefining] = useState(false);
   const [showRefine, setShowRefine] = useState(false);
-  const [selectedBucket, setSelectedBucket] = useState("pending");
+  const [selectedBucket, setSelectedBucket] = useState(DEFAULT_RADAR_BUCKET);
   // Backend-surfaced flag (features on /auth/me): when on, the static
   // questions block becomes the negotiator chat window (P4.2/IND-403).
   // `chatUnavailable` is the runtime fallback if the bootstrap fails.
@@ -1199,6 +1202,7 @@ export default function IntentDetailPage() {
                     {RADAR_BUCKETS.map((bucket) => (
                       <StatPill
                         key={bucket.key}
+                        bucketKey={bucket.key}
                         value={bucketCounts[bucket.key] ?? 0}
                         label={bucket.label}
                         active={selectedBucket === bucket.key}

--- a/apps/web/src/lib/__tests__/radar-buckets.test.ts
+++ b/apps/web/src/lib/__tests__/radar-buckets.test.ts
@@ -1,0 +1,19 @@
+import { describe, expect, it } from 'vitest';
+
+import { DEFAULT_RADAR_BUCKET, radarBucketBadgeTone } from '@/lib/radar-buckets';
+
+describe('Radar bucket presentation', () => {
+  it('opens on live negotiations', () => {
+    expect(DEFAULT_RADAR_BUCKET).toBe('negotiating');
+  });
+
+  it('gives a non-zero Awaiting you badge an attention tone', () => {
+    expect(radarBucketBadgeTone('pending', 1, false)).toBe('bg-amber-200 text-amber-950');
+    expect(radarBucketBadgeTone('pending', 3, true)).toBe('bg-amber-200 text-amber-950');
+  });
+
+  it('keeps zero and other badges neutral or selected', () => {
+    expect(radarBucketBadgeTone('pending', 0, false)).toBe('bg-gray-100 text-gray-500');
+    expect(radarBucketBadgeTone('negotiating', 2, true)).toBe('bg-white/20 text-white');
+  });
+});

--- a/apps/web/src/lib/radar-buckets.ts
+++ b/apps/web/src/lib/radar-buckets.ts
@@ -1,0 +1,17 @@
+/** The Radar opens on live broker activity instead of a passive backlog. */
+export const DEFAULT_RADAR_BUCKET = 'negotiating';
+
+/**
+ * Pending opportunities need a visible call to action even when another Radar
+ * tab is selected. Other count badges remain neutral (or inherit selection).
+ */
+export function radarBucketBadgeTone(
+  bucketKey: string,
+  value: number,
+  active: boolean,
+): string {
+  if (bucketKey === 'pending' && value > 0) {
+    return 'bg-amber-200 text-amber-950';
+  }
+  return active ? 'bg-white/20 text-white' : 'bg-gray-100 text-gray-500';
+}

--- a/services/api/package.json
+++ b/services/api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@indexnetwork/api",
-  "version": "0.56.3",
+  "version": "0.56.4",
   "license": "MIT",
   "private": true,
   "scripts": {

--- a/services/api/src/adapters/conversation.database.adapter.ts
+++ b/services/api/src/adapters/conversation.database.adapter.ts
@@ -303,10 +303,16 @@ export class ConversationDatabaseAdapter {
 
   /**
    * Lists conversations for a user, ordered by most recent message.
-   * @param userId - The user whose conversations to list
+   * @param participantId - The participant whose conversations to list. This
+   * can be an `agent:<userId>` identity for A2A negotiations.
+   * @param viewerUserId - The human owner whose intent provenance may be
+   * projected into the summary. Defaults to `participantId` for ordinary DMs.
    * @returns Summaries with participant lists
    */
-  async getConversationsForUser(userId: string): Promise<ConversationSummary[]> {
+  async getConversationsForUser(
+    participantId: string,
+    viewerUserId = participantId,
+  ): Promise<ConversationSummary[]> {
     // Include conversations that are not hidden OR have new messages since hiding
     const rows = await db
       .select({
@@ -320,7 +326,7 @@ export class ConversationDatabaseAdapter {
       )
       .where(
         and(
-          eq(schema.conversationParticipants.participantId, userId),
+          eq(schema.conversationParticipants.participantId, participantId),
           or(
             isNull(schema.conversationParticipants.hiddenAt),
             gt(schema.conversations.lastMessageAt, schema.conversationParticipants.hiddenAt),
@@ -406,12 +412,12 @@ export class ConversationDatabaseAdapter {
           schema.conversationParticipants,
           and(
             eq(schema.conversationParticipants.conversationId, schema.messages.conversationId),
-            eq(schema.conversationParticipants.participantId, userId),
+            eq(schema.conversationParticipants.participantId, participantId),
           ),
         )
         .where(and(
           inArray(schema.messages.conversationId, ids),
-          ne(schema.messages.senderId, userId),
+          ne(schema.messages.senderId, participantId),
           or(
             isNull(schema.conversationParticipants.lastReadAt),
             gt(schema.messages.createdAt, schema.conversationParticipants.lastReadAt),
@@ -506,7 +512,7 @@ export class ConversationDatabaseAdapter {
         for (const rawEntry of metadata.matchProvenance) {
           if (!isMatchProvenanceEntry(rawEntry)) continue;
           for (const intent of rawEntry.intents) {
-            if (intent.userId === userId) provenanceIntentIds.add(intent.intentId);
+            if (intent.userId === viewerUserId) provenanceIntentIds.add(intent.intentId);
           }
         }
       }
@@ -521,7 +527,7 @@ export class ConversationDatabaseAdapter {
         .from(schema.intents)
         .where(and(
           inArray(schema.intents.id, [...provenanceIntentIds]),
-          eq(schema.intents.userId, userId),
+          eq(schema.intents.userId, viewerUserId),
         ))
       : [];
     const viewerIntentTitles = new Map(
@@ -544,7 +550,7 @@ export class ConversationDatabaseAdapter {
       const via: Array<{ intentId: string; opportunityId: string; title: string }> = [];
       for (const { entry } of entries) {
         for (const intent of entry.intents) {
-          const title = intent.userId === userId ? viewerIntentTitles.get(intent.intentId) : undefined;
+          const title = intent.userId === viewerUserId ? viewerIntentTitles.get(intent.intentId) : undefined;
           if (title) via.push({ intentId: intent.intentId, opportunityId: entry.opportunityId, title });
         }
       }

--- a/services/api/src/adapters/tests/conversation.database.adapter.spec.ts
+++ b/services/api/src/adapters/tests/conversation.database.adapter.spec.ts
@@ -549,5 +549,45 @@ describe('ConversationDatabaseAdapter', () => {
       expect(summary?.via).toEqual([{ intentId: viewerIntentId, opportunityId: 'opp-private-signal', title: 'Viewer signal' }]);
       expect(summary?.metadata).not.toHaveProperty('matchProvenance');
     }, 20000);
+
+    it('projects owner intent provenance when listing an agent negotiation', async () => {
+      const run = crypto.randomUUID();
+      const viewerId = `agent-provenance-viewer-${run}`;
+      const counterpartId = `agent-provenance-counterpart-${run}`;
+      const viewerIntentId = `agent-provenance-viewer-intent-${run}`;
+      const counterpartIntentId = `agent-provenance-counterpart-intent-${run}`;
+      createdUserIds.push(viewerId, counterpartId);
+      createdIntentIds.push(viewerIntentId, counterpartIntentId);
+
+      await db.insert(schema.users).values([
+        { id: viewerId, email: `${viewerId}@test.com`, name: 'Agent Provenance Viewer' },
+        { id: counterpartId, email: `${counterpartId}@test.com`, name: 'Agent Provenance Counterpart' },
+      ]);
+      await db.insert(schema.intents).values([
+        { id: viewerIntentId, userId: viewerId, payload: 'Viewer private framing', summary: 'Viewer signal' },
+        { id: counterpartIntentId, userId: counterpartId, payload: 'Counterpart private framing', summary: 'Counterpart signal' },
+      ]);
+      const negotiation = await adapter.createConversation([
+        { participantId: `agent:${viewerId}`, participantType: 'agent' },
+        { participantId: `agent:${counterpartId}`, participantType: 'agent' },
+      ]);
+      createdIds.push(negotiation.id);
+      await adapter.appendMatchProvenance(negotiation.id, {
+        opportunityId: 'opp-agent-private-signal',
+        intents: [
+          { userId: viewerId, intentId: viewerIntentId },
+          { userId: counterpartId, intentId: counterpartIntentId },
+        ],
+        recordedAt: new Date().toISOString(),
+      });
+
+      const summary = (await adapter.getConversationsForUser(`agent:${viewerId}`, viewerId))
+        .find((conversation) => conversation.id === negotiation.id);
+
+      expect(summary?.via).toEqual([
+        { intentId: viewerIntentId, opportunityId: 'opp-agent-private-signal', title: 'Viewer signal' },
+      ]);
+      expect(summary?.metadata).not.toHaveProperty('matchProvenance');
+    }, 20000);
   });
 });

--- a/services/api/src/services/conversation.service.ts
+++ b/services/api/src/services/conversation.service.ts
@@ -80,7 +80,9 @@ export class ConversationService {
    * Used to surface negotiation conversations to the user whose agent participated.
    */
   async getAgentConversations(userId: string) {
-    return this.db.getConversationsForUser(`agent:${userId}`);
+    // The agent participant authenticates the A2A thread, while the owning
+    // human is the only identity permitted to see intent provenance.
+    return this.db.getConversationsForUser(`agent:${userId}`, userId);
   }
 
   /**

--- a/services/api/src/services/tests/conversation.service.spec.ts
+++ b/services/api/src/services/tests/conversation.service.spec.ts
@@ -8,6 +8,7 @@ import { artifacts, tasks } from '../../schemas/database.schema';
 
 import { ConversationService } from '../conversation.service';
 import { TaskService } from '../task.service';
+import type { ConversationDatabaseAdapter } from '../../adapters/database.adapter';
 
 const conversationService = new ConversationService();
 const taskService = new TaskService();
@@ -25,6 +26,20 @@ afterAll(async () => {
 }, 30000);
 
 describe('ConversationService', () => {
+  it('uses the agent participant but projects the human owner for negotiations', async () => {
+    let received: [string, string | undefined] | undefined;
+    const service = new ConversationService({
+      getConversationsForUser: async (participantId: string, viewerUserId?: string) => {
+        received = [participantId, viewerUserId];
+        return [];
+      },
+    } as unknown as ConversationDatabaseAdapter);
+
+    await service.getAgentConversations('owner-1');
+
+    expect(received).toEqual(['agent:owner-1', 'owner-1']);
+  });
+
   it('creates conversation and sends message', async () => {
     const conv = await conversationService.createConversation([
       { participantId: 'svc-user-1', participantType: 'user' as const },


### PR DESCRIPTION
## Summary
- Preserve owner intent provenance when refreshing agent-backed negotiation conversations, so realtime events invalidate the matching intent Radar.
- Open intent Radar on the Negotiating tab and highlight non-zero Awaiting you counts.
- Bump `@indexnetwork/web` to `0.29.2` and `@indexnetwork/api` to `0.56.4`.

## Root cause
Negotiation summaries were queried through `agent:<ownerId>` and then used that agent identity to filter intent provenance. The resulting empty `via` array failed the intent page scoped-negotiation filter.

## Verification
- Rebased onto `origin/dev` (including #1226).
- `bun install` (no `bun.lock` change).
- `cd apps/web && bun test src/lib/__tests__/intent-negotiation-activity.test.ts src/lib/__tests__/radar-buckets.test.ts`
- `cd services/api && bun run build`
- Pre-commit ESLint and adapter naming checks.

## Caveat
The database-backed API adapter regression suite was not run because this worktree does not set `TEST_DATABASE_SAFE=1`; the guard was not bypassed.