### PR TITLE
feat(signals): preview and revise signal drafts

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@indexnetwork/web",
-  "version": "0.29.2",
+  "version": "0.30.0",
   "license": "MIT",
   "scripts": {
     "dev": "vite --host 127.0.0.1",

--- a/apps/web/src/components/signals/GuidedSignalIntake.test.tsx
+++ b/apps/web/src/components/signals/GuidedSignalIntake.test.tsx
@@ -1,0 +1,63 @@
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import type { ComponentProps } from "react";
+import { describe, expect, it, vi } from "vitest";
+
+import { ProposalCard, type GuidedProposal } from "./GuidedSignalIntake";
+
+const proposal: GuidedProposal = {
+  proposalId: "proposal-1",
+  description: "Meet climate founders who need a technical cofounder.",
+};
+
+function renderProposalCard(overrides: Partial<ComponentProps<typeof ProposalCard>> = {}) {
+  const onConfirm = vi.fn().mockResolvedValue(undefined);
+  const onFeedback = vi.fn().mockResolvedValue(undefined);
+  render(
+    <ProposalCard
+      proposal={proposal}
+      networkTitle="Everywhere"
+      onConfirm={onConfirm}
+      onFeedback={onFeedback}
+      onSkip={vi.fn().mockResolvedValue(undefined)}
+      busy={false}
+      error={null}
+      {...overrides}
+    />,
+  );
+  return { onConfirm, onFeedback };
+}
+
+describe("ProposalCard", () => {
+  it("confirms the exact edited signal description", async () => {
+    const { onConfirm } = renderProposalCard();
+    const description = "Meet climate founders who need a technical cofounder in Berlin.";
+
+    fireEvent.change(screen.getByLabelText("YOUR SIGNAL"), { target: { value: description } });
+    fireEvent.click(screen.getByRole("button", { name: "Confirm signal" }));
+
+    await waitFor(() => expect(onConfirm).toHaveBeenCalledWith(description));
+  });
+
+  it("sends feedback to request a replacement proposal rather than confirming the current draft", async () => {
+    const { onConfirm, onFeedback } = renderProposalCard();
+
+    fireEvent.change(screen.getByLabelText("Want your agent to revise it?"), {
+      target: { value: "Make it clear that I can help with fundraising strategy." },
+    });
+    fireEvent.click(screen.getByRole("button", { name: "Revise with agent" }));
+
+    await waitFor(() => expect(onFeedback).toHaveBeenCalledWith("Make it clear that I can help with fundraising strategy."));
+    expect(onConfirm).not.toHaveBeenCalled();
+  });
+
+  it("shows feedback failures and lets the user retry", async () => {
+    const onFeedback = vi.fn().mockRejectedValue(new Error("offline"));
+    renderProposalCard({ onFeedback });
+
+    fireEvent.change(screen.getByLabelText("Want your agent to revise it?"), { target: { value: "Be more specific." } });
+    fireEvent.click(screen.getByRole("button", { name: "Revise with agent" }));
+
+    expect(await screen.findByRole("alert")).toHaveTextContent("Couldn't send your feedback. Please try again.");
+    expect(screen.getByRole("button", { name: "Revise with agent" })).toBeEnabled();
+  });
+});

--- a/apps/web/src/components/signals/GuidedSignalIntake.tsx
+++ b/apps/web/src/components/signals/GuidedSignalIntake.tsx
@@ -180,12 +180,13 @@ export function GuidedQuestion({
   );
 }
 
-function ProposalCard({
+export function ProposalCard({
   proposal,
   networkTitle,
   lookingFor,
   youBring,
   onConfirm,
+  onFeedback,
   onSkip,
   busy,
   error,
@@ -194,29 +195,83 @@ function ProposalCard({
   networkTitle: string;
   lookingFor?: string;
   youBring?: string;
-  onConfirm: () => Promise<void>;
+  onConfirm: (description: string) => Promise<void>;
+  onFeedback: (feedback: string) => Promise<void>;
   onSkip: () => Promise<void>;
   busy: boolean;
   error: string | null;
 }) {
+  const [description, setDescription] = useState(proposal.description);
+  const [feedback, setFeedback] = useState("");
+  const [sendingFeedback, setSendingFeedback] = useState(false);
   const [skipping, setSkipping] = useState(false);
+  const [feedbackError, setFeedbackError] = useState<string | null>(null);
   const resolvedLookingFor = lookingFor ?? proposal.lookingFor ?? proposal.description;
   const resolvedYouBring = youBring ?? proposal.youBring ?? proposal.offering;
+
+  const submitFeedback = async () => {
+    const trimmedFeedback = feedback.trim();
+    if (!trimmedFeedback || busy || sendingFeedback || skipping) return;
+    setSendingFeedback(true);
+    setFeedbackError(null);
+    try {
+      await onFeedback(trimmedFeedback);
+    } catch {
+      setFeedbackError("Couldn't send your feedback. Please try again.");
+    } finally {
+      setSendingFeedback(false);
+    }
+  };
+
   return (
     <section aria-label="Confirm signal" className="mt-10 rounded-3xl border border-gray-200 bg-white p-6 shadow-sm sm:p-8">
       <p className="text-xs font-semibold uppercase tracking-[0.18em] text-gray-400">One last look</p>
       <h1 className="mt-3 text-2xl font-semibold text-[#041729]">Does this feel right?</h1>
       <div className="mt-7 space-y-5">
+        <div>
+          <label htmlFor="signal-description" className="text-[10px] font-semibold tracking-[0.18em] text-gray-400">YOUR SIGNAL</label>
+          <textarea
+            id="signal-description"
+            value={description}
+            onChange={(event) => setDescription(event.target.value)}
+            disabled={busy || sendingFeedback || skipping}
+            rows={4}
+            className="mt-2 w-full resize-y rounded-2xl border border-gray-200 bg-white px-4 py-3 text-base leading-relaxed text-gray-800 outline-none transition focus:border-[#041729] focus:ring-2 focus:ring-[#041729]/10 disabled:opacity-60"
+          />
+          <p className="mt-2 text-xs text-gray-500">This is exactly what will be shared after you confirm. Edit it directly, or ask your agent to revise it.</p>
+        </div>
         <Summary label="LOOKING FOR" value={resolvedLookingFor} />
         <Summary label="YOU BRING" value={resolvedYouBring ?? "Not specified"} />
         <Summary label="NETWORKS" value={networkTitle} />
       </div>
       {error && <p role="alert" className="mt-5 rounded-xl bg-red-50 px-3 py-2 text-sm text-red-700">{error}</p>}
+      {feedbackError && <p role="alert" className="mt-5 rounded-xl bg-red-50 px-3 py-2 text-sm text-red-700">{feedbackError}</p>}
+      <div className="mt-6">
+        <label htmlFor="signal-feedback" className="text-sm font-medium text-[#041729]">Want your agent to revise it?</label>
+        <div className="mt-2 flex flex-col gap-3 sm:flex-row">
+          <input
+            id="signal-feedback"
+            value={feedback}
+            onChange={(event) => setFeedback(event.target.value)}
+            disabled={busy || sendingFeedback || skipping}
+            placeholder="Tell it what to change"
+            className="min-w-0 flex-1 rounded-full border border-gray-200 px-4 py-2.5 text-sm text-gray-800 outline-none transition placeholder:text-gray-400 focus:border-[#041729] focus:ring-2 focus:ring-[#041729]/10 disabled:opacity-60"
+          />
+          <button
+            type="button"
+            disabled={!feedback.trim() || busy || sendingFeedback || skipping}
+            onClick={() => void submitFeedback()}
+            className="rounded-full border border-[#041729] px-4 py-2.5 text-sm font-medium text-[#041729] hover:bg-[#041729] hover:text-white disabled:cursor-not-allowed disabled:opacity-40"
+          >
+            {sendingFeedback ? "Sending…" : "Revise with agent"}
+          </button>
+        </div>
+      </div>
       <div className="mt-7 flex flex-wrap items-center gap-3">
         <button
           type="button"
-          disabled={busy || skipping}
-          onClick={() => void onConfirm()}
+          disabled={!description.trim() || busy || sendingFeedback || skipping}
+          onClick={() => void onConfirm(description.trim())}
           className="inline-flex items-center gap-2 rounded-full bg-[#041729] px-5 py-2.5 text-sm font-medium text-white hover:bg-[#0a2d4a] disabled:opacity-50"
         >
           {busy ? <Loader2 className="h-4 w-4 animate-spin" /> : <Check className="h-4 w-4" />}
@@ -357,7 +412,7 @@ export function GuidedSignalIntake({
     }
   }, [currentQuestion, isLoading, questionsService, sendFollowup]);
 
-  const handleConfirm = useCallback(async () => {
+  const handleConfirm = useCallback(async (description: string) => {
     if ((!proposal && !confirmedIntentId) || confirming) return;
     setConfirming(true);
     setProposalError(null);
@@ -367,7 +422,7 @@ export function GuidedSignalIntake({
         if (!proposal) return;
         const response = await apiClient.post<{ intentId: string }>("/intents/confirm", {
           proposalId: proposal.proposalId,
-          description: proposal.description,
+          description,
           ...(selectedNetwork?.id ? { networkId: selectedNetwork.id } : {}),
         });
         persistedIntentId = response.intentId;
@@ -383,6 +438,13 @@ export function GuidedSignalIntake({
       setConfirming(false);
     }
   }, [confirmedIntentId, confirming, finishConfirmation, proposal, selectedNetwork, showError]);
+
+  const handleFeedback = useCallback(async (feedback: string) => {
+    // This marker keeps a fresh chat turn in the completed guided-signal
+    // stage, where the Signal Agent must call create_intent for a replacement
+    // proposal. The feedback itself is never persisted.
+    await sendFollowup(`new-signal-preview-feedback: ${feedback}`);
+  }, [sendFollowup]);
 
   const handleSkip = useCallback(async () => {
     if (!proposal) return;
@@ -456,11 +518,13 @@ export function GuidedSignalIntake({
         </section>
       ) : proposal ? (
         <ProposalCard
+          key={proposal.proposalId}
           proposal={proposal}
           networkTitle={networkTitle}
           lookingFor={lookingFor}
           youBring={answeredContribution}
           onConfirm={handleConfirm}
+          onFeedback={handleFeedback}
           onSkip={handleSkip}
           busy={confirming}
           error={proposalError}

--- a/packages/protocol/package.json
+++ b/packages/protocol/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@indexnetwork/protocol",
-  "version": "6.10.2",
+  "version": "6.11.0",
   "type": "module",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",

--- a/packages/protocol/src/chat/signal.prompt.ts
+++ b/packages/protocol/src/chat/signal.prompt.ts
@@ -3,6 +3,12 @@ import type { IterationContext } from "./chat.prompt.modules.js";
 
 /** Stable user-message marker for opening the guided New Signal intake. */
 export const SIGNAL_NEW_SIGNAL_KICKOFF = "new-signal-kickoff";
+const SIGNAL_NEW_SIGNAL_FEEDBACK_PREFIX = "new-signal-preview-feedback:";
+
+/** Returns whether a message is feedback on the unpersisted guided-signal draft. */
+export function isSignalNewSignalFeedback(message?: string): boolean {
+  return message?.trim().toLocaleLowerCase().startsWith(SIGNAL_NEW_SIGNAL_FEEDBACK_PREFIX) ?? false;
+}
 
 /**
  * Recognizes the one-shot kickoff sent by a New Signal surface. The aliases are
@@ -40,6 +46,10 @@ export type SignalIntakeStage = "who" | "contribution" | "where" | "proposal" | 
  * @returns The next intake stage, or null for ordinary Signal chats
  */
 export function getSignalIntakeStage(iterCtx?: IterationContext): SignalIntakeStage | null {
+  // Feedback arrives as a fresh chat turn, so its prior tool calls are not in
+  // recentTools. Preserve the complete stage explicitly to make it produce a
+  // replacement proposal rather than restarting the guided interview.
+  if (isSignalNewSignalFeedback(iterCtx?.currentMessage)) return "complete";
   if (!isSignalNewSignalKickoff(iterCtx?.currentMessage)) return null;
 
   if (iterCtx?.recentTools.some((toolCall) => toolCall.name === "create_intent")) {
@@ -91,7 +101,7 @@ The guided intake has completed its blocking question rounds. Do not ask another
 
   return `
 ## NEW SIGNAL INTAKE (COMPLETE)
-The proposal tool has already been called. Do not call it again or create a second signal. Pass the tool-produced \`\`\`intent_proposal\`\`\` block through verbatim, then briefly confirm that the user can approve or skip it.`;
+The browser is showing the proposed signal before it is saved. If the user gives feedback on that draft, use it to revise the signal and call \`create_intent\` again with the revised description. This produces a replacement proposal only; never persist or auto-approve either draft. Pass the newest tool-produced \`\`\`intent_proposal\`\`\` block through verbatim and tell the user to review it. If the user has no feedback, briefly confirm that they can approve, edit, or skip the visible draft.`;
 }
 
 /**

--- a/packages/protocol/src/chat/tests/signal.persona.spec.ts
+++ b/packages/protocol/src/chat/tests/signal.persona.spec.ts
@@ -5,7 +5,7 @@ import { describe, expect, it, mock } from "bun:test";
 
 import { ORCHESTRATOR_PERSONA, ORCHESTRATOR_PERSONA_ID } from "../chat.persona.js";
 import { SIGNAL_PERSONA, SIGNAL_PERSONA_ID, SIGNAL_TOOL_NAMES, filterSignalTools, narrowSignalTools } from "../signal.persona.js";
-import { buildSignalSystemContent, getSignalIntakeStage, isSignalNewSignalKickoff, SIGNAL_NEW_SIGNAL_KICKOFF } from "../signal.prompt.js";
+import { buildSignalSystemContent, getSignalIntakeStage, isSignalNewSignalFeedback, isSignalNewSignalKickoff, SIGNAL_NEW_SIGNAL_KICKOFF } from "../signal.prompt.js";
 import type { ChatTools, ResolvedToolContext } from "../../shared/agent/tool.factory.js";
 import type { SystemDatabase, UserDatabase } from "../../shared/interfaces/database.interface.js";
 
@@ -239,6 +239,12 @@ describe("guided New Signal intake", () => {
     expect(isSignalNewSignalKickoff("please tell me about my new signal")).toBe(false);
   });
 
+  it("keeps preview feedback in the completed intake stage", () => {
+    const feedback = "new-signal-preview-feedback: Make the location Berlin-specific.";
+    expect(isSignalNewSignalFeedback(feedback)).toBe(true);
+    expect(getSignalIntakeStage({ ...iteration(), currentMessage: feedback, recentTools: [] })).toBe("complete");
+  });
+
   it("advances through three blocking rounds and then proposal synthesis", () => {
     expect(getSignalIntakeStage(iteration())).toBe("who");
     expect(getSignalIntakeStage(iteration([{ name: "ask_user_question" }]))).toBe("contribution");
@@ -287,6 +293,18 @@ describe("guided New Signal intake", () => {
     expect(proposal).toContain("Call `create_intent` now");
     expect(proposal).toContain("```intent_proposal");
     expect(proposal).toContain("proposal-only");
+  });
+
+  it("asks the Signal Agent to return a replacement proposal when preview feedback arrives", () => {
+    const complete = buildSignalSystemContent(context, {
+      ...iteration(),
+      currentMessage: "new-signal-preview-feedback: Make the location Berlin-specific.",
+      recentTools: [],
+    });
+
+    expect(complete).toContain("feedback on that draft");
+    expect(complete).toContain("call `create_intent` again");
+    expect(complete).toContain("replacement proposal only");
   });
 });
 


### PR DESCRIPTION
## Summary
- show the exact signal draft before confirmation and allow direct editing
- route preview feedback through the Signal Agent to return a replacement proposal
- add focused web and protocol coverage

## Verification
- `bun --bun vitest run src/components/signals/GuidedSignalIntake.test.tsx`
- `bun test src/chat/tests/signal.persona.spec.ts`
- targeted ESLint and `bun run build` (web)