### PR TITLE
feat(radar): show live agent negotiation messages

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@indexnetwork/web",
-  "version": "0.30.0",
+  "version": "0.31.0",
   "license": "MIT",
   "scripts": {
     "dev": "vite --host 127.0.0.1",

--- a/apps/web/src/app/i/[intentId]/page.tsx
+++ b/apps/web/src/app/i/[intentId]/page.tsx
@@ -14,18 +14,22 @@ import type { AnsweredThreadEntry } from "@/components/InjectedQuestions/Answere
 import { InjectedQuestions } from "@/components/InjectedQuestions/InjectedQuestions";
 import IntentMemoryStrip from "@/components/IntentMemoryStrip";
 import IntentNegotiatorChat from "@/components/IntentNegotiatorChat";
+import NegotiationActivity from "@/components/NegotiationActivity";
 import { useAuthContext } from "@/contexts/AuthContext";
-import { useIntents, useOpportunities, useQuestionsService } from "@/contexts/APIContext";
+import { useConversations, useIntents, useOpportunities, useQuestionsService } from "@/contexts/APIContext";
 import { useConversation } from "@/contexts/ConversationContext";
 import { useNotifications } from "@/contexts/NotificationContext";
 import { useQuestions } from "@/contexts/QuestionsContext";
 import { useOpportunityActions } from "@/hooks/useOpportunityActions";
+import { useRadarLiveRefresh } from "@/hooks/useRadarLiveRefresh";
 import { useIntentVisitPing } from "@/hooks/useIntentVisitPing";
+import type { NegotiationActivityGroup } from "@/services/conversation";
 import type { HomeViewCardItem, OpportunityLifecycleStatus } from "@/services/opportunities";
 import type { IntentLifecycleStatus, MutableIntentLifecycleStatus } from "@/services/intents";
 import type { AnswerBody, PendingQuestion, QuestionAnswer } from "@/services/questions";
 import { cn } from "@/lib/utils";
 import { intentNegotiationActivityRevision } from "@/lib/intent-negotiation-activity";
+import { normalizeNegotiationActivity } from "@/lib/negotiation-activity";
 import { DEFAULT_RADAR_BUCKET, radarBucketBadgeTone } from "@/lib/radar-buckets";
 
 /** Raw opportunity status -> radar display bucket (mirrors the Hermes dashboard). */
@@ -303,6 +307,7 @@ export default function IntentDetailPage() {
   const { intentId } = useParams<{ intentId: string }>();
   const intentsService = useIntents();
   const opportunitiesService = useOpportunities();
+  const conversationsService = useConversations();
   const questionsService = useQuestionsService();
   useIntentVisitPing(intentId);
   const { refresh: refreshQuestionCounts, pendingRevision } = useQuestions();
@@ -326,6 +331,9 @@ export default function IntentDetailPage() {
   const activeIntentIdRef = useRef(intentId);
   const [opportunities, setOpportunities] = useState<HomeViewCardItem[]>([]);
   const [opportunitiesLoading, setOpportunitiesLoading] = useState(true);
+  const [negotiationActivity, setNegotiationActivity] = useState<NegotiationActivityGroup[]>([]);
+  const [negotiationActivityLoading, setNegotiationActivityLoading] = useState(true);
+  const [negotiationActivityError, setNegotiationActivityError] = useState(false);
   const [questions, setQuestions] = useState<PendingQuestion[]>([]);
   // Interview-mode chaining (IND-418): after a pool_discovery answer, the
   // backend may synchronously persist a follow-up — show a typing indicator,
@@ -425,6 +433,26 @@ export default function IntentDetailPage() {
   const loadSeqRef = useRef(0);
   const questionLoadSeqRef = useRef(0);
   const answeredLoadSeqRef = useRef(0);
+  const activityLoadSeqRef = useRef(0);
+
+  const loadNegotiationActivity = useCallback(async (showLoading = false) => {
+    if (!intentId) return;
+    const seq = ++activityLoadSeqRef.current;
+    if (showLoading) setNegotiationActivityLoading(true);
+    try {
+      const groups = await conversationsService.getNegotiationActivity(intentId);
+      if (activeIntentIdRef.current !== intentId || activityLoadSeqRef.current !== seq) return;
+      setNegotiationActivity(normalizeNegotiationActivity(groups));
+      setNegotiationActivityError(false);
+    } catch {
+      if (activeIntentIdRef.current !== intentId || activityLoadSeqRef.current !== seq) return;
+      setNegotiationActivityError(true);
+    } finally {
+      if (activeIntentIdRef.current === intentId && activityLoadSeqRef.current === seq) {
+        setNegotiationActivityLoading(false);
+      }
+    }
+  }, [conversationsService, intentId]);
 
   const loadQuestions = useCallback(async (appendOnly = false, passive = false) => {
     if (!intentId) return;
@@ -547,25 +575,16 @@ export default function IntentDetailPage() {
     () => intentNegotiationActivityRevision(negotiations, intentId),
     [intentId, negotiations],
   );
-  const seenNegotiationActivityRef = useRef<string | null>(null);
-
-  // ConversationProvider receives persisted A2A turns over SSE and refreshes
-  // owner-filtered negotiation provenance. A scoped revision means only this
-  // intent's own negotiations invalidate Radar; unrelated conversations never
-  // trigger a fetch or become visible here.
-  useEffect(() => {
-    if (!negotiationActivityRevision) {
-      seenNegotiationActivityRef.current = null;
-      return;
-    }
-    if (seenNegotiationActivityRef.current === null) {
-      seenNegotiationActivityRef.current = negotiationActivityRevision;
-      return;
-    }
-    if (seenNegotiationActivityRef.current === negotiationActivityRevision) return;
-    seenNegotiationActivityRef.current = negotiationActivityRevision;
+  const refreshLiveRadar = useCallback(() => {
     void loadOpportunities(true);
-  }, [loadOpportunities, negotiationActivityRevision]);
+    void loadNegotiationActivity();
+  }, [loadNegotiationActivity, loadOpportunities]);
+
+  useRadarLiveRefresh({
+    intentId,
+    activityRevision: negotiationActivityRevision,
+    onRefresh: refreshLiveRadar,
+  });
 
   useEffect(() => {
     if (!intentId) return;
@@ -585,10 +604,11 @@ export default function IntentDetailPage() {
     void loadQuestions();
     void loadAnswered();
     void loadOpportunities();
+    void loadNegotiationActivity(true);
     return () => {
       active = false;
     };
-  }, [intentId, intentsService, loadQuestions, loadAnswered, loadOpportunities]);
+  }, [intentId, intentsService, loadQuestions, loadAnswered, loadOpportunities, loadNegotiationActivity]);
 
   // Reuse the application-wide 30s poll only as an invalidation signal. A
   // changed authoritative pending set causes one passive exact-intent pending
@@ -1211,6 +1231,15 @@ export default function IntentDetailPage() {
                     ))}
                   </div>
                   <div className="min-h-0 flex-1 lg:overflow-y-auto lg:pr-1">
+                  {selectedBucket === "negotiating" && (
+                    <div className="mb-3">
+                      <NegotiationActivity
+                        groups={negotiationActivity}
+                        loading={negotiationActivityLoading}
+                        error={negotiationActivityError}
+                      />
+                    </div>
+                  )}
                   {opportunitiesLoading ? (
                     <div className="space-y-3" data-testid="radar-skeleton">
                       <OpportunitySkeleton />

--- a/apps/web/src/components/NegotiationActivity.test.tsx
+++ b/apps/web/src/components/NegotiationActivity.test.tsx
@@ -1,0 +1,39 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+
+import { normalizeNegotiationActivity } from "@/lib/negotiation-activity";
+
+import NegotiationActivity from "./NegotiationActivity";
+
+const messages = [4, 1, 3, 2].map((value) => ({
+  id: `m-${value}`,
+  opportunityId: "opp-1",
+  sender: value % 2 ? "theirs" as const : "yours" as const,
+  parts: [{ text: `message ${value}` }],
+  createdAt: `2026-07-24T00:00:0${value}.000Z`,
+}));
+
+describe("NegotiationActivity", () => {
+  it("groups by stable correspondent and renders exactly the latest three in chronological order", () => {
+    const groups = normalizeNegotiationActivity([{
+      correspondentUserId: "user-b",
+      correspondentLabel: "Ada's agent",
+      correspondentAvatar: null,
+      messages,
+    }]);
+    render(<NegotiationActivity groups={groups} loading={false} error={false} />);
+
+    expect(screen.getByRole("region", { name: "Negotiation with Ada's agent" })).toBeTruthy();
+    expect(screen.queryByText("message 1")).toBeNull();
+    const rendered = screen.getAllByText(/message [234]/).map((node) => node.textContent);
+    expect(rendered).toEqual(["message 2", "message 3", "message 4"]);
+    expect(screen.getAllByText("Your agent")).toHaveLength(2);
+    expect(screen.getAllByText("Their agent")).toHaveLength(1);
+  });
+
+  it("does not fabricate messages while activity is empty", () => {
+    render(<NegotiationActivity groups={[]} loading={false} error={false} />);
+    expect(screen.getByText(/Messages will appear here as they are persisted/)).toBeTruthy();
+    expect(screen.queryByText(/message 1/)).toBeNull();
+  });
+});

--- a/apps/web/src/components/NegotiationActivity.tsx
+++ b/apps/web/src/components/NegotiationActivity.tsx
@@ -1,0 +1,63 @@
+import type { NegotiationActivityGroup } from "@/services/conversation";
+
+function messageText(parts: unknown[]): string {
+  return parts
+    .map((part) => {
+      if (typeof part === "string") return part;
+      if (!part || typeof part !== "object") return "";
+      const value = part as Record<string, unknown>;
+      return typeof value.text === "string" ? value.text : "";
+    })
+    .filter(Boolean)
+    .join("\n")
+    .trim();
+}
+
+export default function NegotiationActivity({
+  groups,
+  loading,
+  error,
+}: {
+  groups: NegotiationActivityGroup[];
+  loading: boolean;
+  error: boolean;
+}) {
+  if (loading) {
+    return <p role="status" className="text-xs text-gray-500">Loading agent messages…</p>;
+  }
+  if (error) {
+    return <p role="status" className="text-xs text-red-600">Agent messages could not be loaded. Radar will retry automatically.</p>;
+  }
+  if (groups.length === 0) {
+    return <p className="text-xs text-gray-500">Your agent is still talking with theirs. Messages will appear here as they are persisted.</p>;
+  }
+
+  return (
+    <div className="space-y-3" aria-live="polite" aria-label="Live agent negotiation messages">
+      {groups.map((group) => (
+        <section
+          key={group.correspondentUserId}
+          aria-label={`Negotiation with ${group.correspondentLabel}`}
+          className="rounded-lg border border-gray-200 bg-gray-50/60 p-3"
+        >
+          <h4 className="mb-2 text-xs font-semibold text-gray-700">{group.correspondentLabel}</h4>
+          <ol className="space-y-2">
+            {group.messages.map((message) => {
+              const text = messageText(message.parts);
+              if (!text) return null;
+              const yours = message.sender === "yours";
+              return (
+                <li key={message.id} className="text-xs">
+                  <span className="font-semibold text-gray-600">
+                    {yours ? "Your agent" : "Their agent"}
+                  </span>
+                  <p className="mt-0.5 whitespace-pre-wrap text-gray-800">{text}</p>
+                </li>
+              );
+            })}
+          </ol>
+        </section>
+      ))}
+    </div>
+  );
+}

--- a/apps/web/src/hooks/useRadarLiveRefresh.test.tsx
+++ b/apps/web/src/hooks/useRadarLiveRefresh.test.tsx
@@ -1,0 +1,43 @@
+import { act, renderHook } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { RADAR_REFRESH_INTERVAL_MS, useRadarLiveRefresh } from "./useRadarLiveRefresh";
+
+afterEach(() => vi.useRealTimers());
+
+describe("useRadarLiveRefresh", () => {
+  it("refreshes on a matching scoped SSE revision and on the lifecycle timer", () => {
+    vi.useFakeTimers();
+    const refresh = vi.fn();
+    const { rerender } = renderHook(
+      ({ revision }) => useRadarLiveRefresh({
+        intentId: "intent-a",
+        activityRevision: revision,
+        onRefresh: refresh,
+      }),
+      { initialProps: { revision: "conversation:one" } },
+    );
+    rerender({ revision: "conversation:two" });
+    expect(refresh).toHaveBeenCalledTimes(1);
+    act(() => vi.advanceTimersByTime(RADAR_REFRESH_INTERVAL_MS));
+    expect(refresh).toHaveBeenCalledTimes(2);
+  });
+
+  it("resets stale event state and cleans the previous timer on intent navigation", () => {
+    vi.useFakeTimers();
+    const refresh = vi.fn();
+    const { rerender, unmount } = renderHook(
+      ({ intentId, revision }) => useRadarLiveRefresh({
+        intentId,
+        activityRevision: revision,
+        onRefresh: refresh,
+      }),
+      { initialProps: { intentId: "intent-a", revision: "a:one" } },
+    );
+    rerender({ intentId: "intent-b", revision: "b:one" });
+    expect(refresh).not.toHaveBeenCalled();
+    unmount();
+    act(() => vi.advanceTimersByTime(RADAR_REFRESH_INTERVAL_MS * 2));
+    expect(refresh).not.toHaveBeenCalled();
+  });
+});

--- a/apps/web/src/hooks/useRadarLiveRefresh.ts
+++ b/apps/web/src/hooks/useRadarLiveRefresh.ts
@@ -1,0 +1,42 @@
+import { useEffect, useRef } from "react";
+
+export const RADAR_REFRESH_INTERVAL_MS = 5_000;
+
+/**
+ * Refreshes an exact-intent Radar immediately when its scoped SSE revision
+ * changes and periodically as a lifecycle-event fallback.
+ */
+export function useRadarLiveRefresh({
+  intentId,
+  activityRevision,
+  onRefresh,
+}: {
+  intentId: string | undefined;
+  activityRevision: string;
+  onRefresh: () => void;
+}) {
+  const seenRevision = useRef<string | null>(null);
+  const seenIntentId = useRef<string | undefined>(intentId);
+
+  useEffect(() => {
+    if (seenIntentId.current !== intentId) {
+      seenIntentId.current = intentId;
+      seenRevision.current = activityRevision || null;
+      return;
+    }
+    if (!activityRevision) return;
+    if (seenRevision.current === null) {
+      seenRevision.current = activityRevision;
+      return;
+    }
+    if (seenRevision.current === activityRevision) return;
+    seenRevision.current = activityRevision;
+    onRefresh();
+  }, [activityRevision, intentId, onRefresh]);
+
+  useEffect(() => {
+    if (!intentId) return;
+    const timer = setInterval(onRefresh, RADAR_REFRESH_INTERVAL_MS);
+    return () => clearInterval(timer);
+  }, [intentId, onRefresh]);
+}

--- a/apps/web/src/lib/negotiation-activity.ts
+++ b/apps/web/src/lib/negotiation-activity.ts
@@ -1,0 +1,15 @@
+import type { NegotiationActivityGroup } from "@/services/conversation";
+
+export function normalizeNegotiationActivity(
+  groups: NegotiationActivityGroup[],
+): NegotiationActivityGroup[] {
+  return groups.map((group) => ({
+    ...group,
+    messages: [...group.messages]
+      .sort((left, right) =>
+        Date.parse(left.createdAt) - Date.parse(right.createdAt)
+        || left.id.localeCompare(right.id),
+      )
+      .slice(-3),
+  }));
+}

--- a/apps/web/src/services/conversation.ts
+++ b/apps/web/src/services/conversation.ts
@@ -27,6 +27,21 @@ export interface ConversationMessage {
   createdAt: string;
 }
 
+export interface NegotiationActivityMessage {
+  id: string;
+  opportunityId: string;
+  sender: 'yours' | 'theirs';
+  parts: unknown[];
+  createdAt: string;
+}
+
+export interface NegotiationActivityGroup {
+  correspondentUserId: string;
+  correspondentLabel: string;
+  correspondentAvatar: string | null;
+  messages: NegotiationActivityMessage[];
+}
+
 export const createConversationService = (api: ReturnType<typeof import('../lib/api').useAuthenticatedAPI>) => ({
   /** List all conversations for the authenticated user. */
   getConversations: async (): Promise<ConversationSummary[]> => {
@@ -38,6 +53,13 @@ export const createConversationService = (api: ReturnType<typeof import('../lib/
   getNegotiations: async (): Promise<ConversationSummary[]> => {
     const response = await api.get<{ conversations: ConversationSummary[] }>('/conversations/negotiations');
     return response.conversations;
+  },
+
+  getNegotiationActivity: async (intentId: string): Promise<NegotiationActivityGroup[]> => {
+    const response = await api.get<{ groups: NegotiationActivityGroup[] }>(
+      `/conversations/negotiations/activity?intentId=${encodeURIComponent(intentId)}`,
+    );
+    return response.groups;
   },
 
   /** Create a new conversation. */

--- a/docs/specs/api-reference.md
+++ b/docs/specs/api-reference.md
@@ -1253,6 +1253,36 @@ List A2A agent-to-agent negotiation conversations for the authenticated user.
 }
 ```
 
+### GET /api/conversations/negotiations/activity
+
+Return persisted agent-to-agent negotiation activity for one intent owned by
+the authenticated user.
+
+**Auth**: AuthGuard
+
+**Query**: `intentId` (required UUID)
+
+The response groups activity by stable correspondent identity. Each group
+contains exactly the latest three messages in chronological order, with
+`sender: "yours" | "theirs"`, `parts`, `createdAt`, and `opportunityId`.
+Reads are scoped through the authenticated user, exact intent actor,
+opportunity, and negotiation task, so turns cannot bleed across intents or
+shared correspondent conversations. Invalid IDs return `400`; unknown or
+non-owned intents return `404`.
+
+```json
+{
+  "groups": [
+    {
+      "correspondentUserId": "uuid",
+      "correspondentLabel": "Ada's agent",
+      "correspondentAvatar": null,
+      "messages": []
+    }
+  ]
+}
+```
+
 ### POST /api/conversations
 
 Create a new conversation with participants.

--- a/services/api/.test-isolated
+++ b/services/api/.test-isolated
@@ -106,3 +106,4 @@ src/services/tests/agent-action.service.isolated.ts
 src/services/tests/intent-recovery-refinement.service.isolated.ts
 src/adapters/tests/agent-action-proposal.database.adapter.isolated.ts
 src/adapters/tests/conversation.reporter.isolated.ts
+src/controllers/tests/conversation.negotiation-activity.isolated.ts

--- a/services/api/package.json
+++ b/services/api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@indexnetwork/api",
-  "version": "0.56.4",
+  "version": "0.57.0",
   "license": "MIT",
   "private": true,
   "scripts": {

--- a/services/api/src/adapters/conversation.database.adapter.ts
+++ b/services/api/src/adapters/conversation.database.adapter.ts
@@ -3,6 +3,7 @@ import { emitOpportunityPendingBestEffort } from '../events/opportunity.event';
 import { publishConversationMessageEvent } from '../lib/conversation-events';
 import { computeIntentFingerprint } from '../lib/intent/intent.fingerprint';
 import { log } from '../lib/log';
+import { projectNegotiationActivity } from '../lib/negotiation-activity';
 import { assertContinuationExecutionEffect } from './negotiation-continuation.atomic';
 import type { ContinuationExecutionFence } from './negotiation-continuation.atomic';
 import { acquireNegotiationAttemptLock, acquireNegotiationPairLock, qualifyingNegotiationAttemptTaskWhere, qualifyingPairNegotiationTaskWhere, type NegotiationAttemptTransaction } from './negotiation-attempt.atomic';
@@ -1903,6 +1904,81 @@ export class ConversationDatabaseAdapter {
       createdAt: r.createdAt,
       updatedAt: r.updatedAt,
     }));
+  }
+
+  /**
+   * Builds the private Radar transcript projection for one owned intent.
+   * Messages are joined through the exact opportunity negotiation task so
+   * shared agent-pair conversations cannot leak turns across intents.
+   */
+  async getNegotiationActivityForIntent(userId: string, intentId: string): Promise<Array<{
+    correspondentUserId: string;
+    correspondentLabel: string;
+    correspondentAvatar: string | null;
+    messages: Array<{
+      id: string;
+      opportunityId: string;
+      sender: 'yours' | 'theirs';
+      parts: unknown[];
+      createdAt: Date;
+    }>;
+  }> | null> {
+    const [ownedIntent] = await db
+      .select({ id: schema.intents.id })
+      .from(schema.intents)
+      .where(and(eq(schema.intents.id, intentId), eq(schema.intents.userId, userId)))
+      .limit(1);
+    if (!ownedIntent) return null;
+
+    const opportunityRows = await db
+      .select({ id: schema.opportunities.id, actors: schema.opportunities.actors })
+      .from(schema.opportunities)
+      .where(sql`${schema.opportunities.actors} @> ${JSON.stringify([{ userId, intent: intentId }])}::jsonb`);
+    if (opportunityRows.length === 0) return [];
+
+    const opportunityIds = opportunityRows.map((row) => row.id);
+    const taskRows = await db
+      .select({
+        id: schema.tasks.id,
+        opportunityId: sql<string>`${schema.tasks.metadata}->>'opportunityId'`,
+      })
+      .from(schema.tasks)
+      .where(and(
+        sql`${schema.tasks.metadata}->>'type' = 'negotiation'`,
+        inArray(sql`${schema.tasks.metadata}->>'opportunityId'`, opportunityIds),
+      ));
+    if (taskRows.length === 0) return [];
+
+    const opportunityByTask = new Map(taskRows.map((task) => [task.id, task.opportunityId]));
+    const messageRows = await db
+      .select({
+        id: schema.messages.id,
+        taskId: schema.messages.taskId,
+        senderId: schema.messages.senderId,
+        parts: schema.messages.parts,
+        createdAt: schema.messages.createdAt,
+      })
+      .from(schema.messages)
+      .where(inArray(schema.messages.taskId, taskRows.map((task) => task.id)))
+      .orderBy(asc(schema.messages.createdAt), asc(schema.messages.id));
+
+    const counterpartIds = [...new Set(opportunityRows.flatMap((row) =>
+      row.actors.filter((actor) => actor.userId !== userId).map((actor) => actor.userId),
+    ))];
+    const counterpartRows = counterpartIds.length > 0
+      ? await db
+        .select({ id: schema.users.id, name: schema.users.name, avatar: schema.users.avatar })
+        .from(schema.users)
+        .where(inArray(schema.users.id, counterpartIds))
+      : [];
+    const counterpartById = new Map(counterpartRows.map((row) => [row.id, row]));
+    return projectNegotiationActivity(
+      userId,
+      opportunityRows,
+      opportunityByTask,
+      messageRows.map((message) => ({ ...message, parts: (message.parts as unknown[]) ?? [] })),
+      counterpartById,
+    );
   }
 
   /**

--- a/services/api/src/controllers/conversation.controller.ts
+++ b/services/api/src/controllers/conversation.controller.ts
@@ -57,6 +57,22 @@ export class ConversationController {
   }
 
   /**
+   * GET /conversations/negotiations/activity?intentId=... — latest three
+   * persisted turns per correspondent for an owned intent.
+   */
+  @Get('/negotiations/activity')
+  @UseGuards(RateLimit('read'), AuthGuard)
+  async getNegotiationActivity(req: Request, user: AuthenticatedUser) {
+    const intentId = new URL(req.url).searchParams.get('intentId');
+    if (!intentId || !/^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i.test(intentId)) {
+      return Response.json({ error: 'A valid intentId is required' }, { status: 400 });
+    }
+    const groups = await this.conversationService.getNegotiationActivityForIntent(user.id, intentId);
+    if (groups === null) return Response.json({ error: 'Intent not found' }, { status: 404 });
+    return Response.json({ groups });
+  }
+
+  /**
    * POST /conversations — create a new conversation with participants.
    *
    * @param req - Must include `participants` array in JSON body

--- a/services/api/src/controllers/tests/conversation.negotiation-activity.isolated.ts
+++ b/services/api/src/controllers/tests/conversation.negotiation-activity.isolated.ts
@@ -1,0 +1,58 @@
+import { describe, expect, it, mock } from 'bun:test';
+
+import type { ConversationService } from '../../services/conversation.service';
+import type { TaskService } from '../../services/task.service';
+
+mock.module('../../guards/limiter.guard', () => ({ RateLimit: () => () => undefined }));
+mock.module('../../guards/auth.guard', () => ({ AuthGuard: () => undefined }));
+mock.module('../../services/conversation.service', () => ({ ConversationService: class {} }));
+mock.module('../../services/task.service', () => ({ TaskService: class {} }));
+
+const { ConversationController } = await import('../conversation.controller');
+
+const INTENT_ID = '11111111-1111-4111-8111-111111111111';
+
+describe('ConversationController negotiation activity', () => {
+  it('returns 400 for an invalid UUID without calling the service', async () => {
+    const read = mock(async () => []);
+    const controller = new ConversationController(
+      { getNegotiationActivityForIntent: read } as unknown as ConversationService,
+      {} as TaskService,
+    );
+    const response = await controller.getNegotiationActivity(
+      new Request('http://localhost/conversations/negotiations/activity?intentId=not-a-uuid'),
+      { id: 'owner', email: null, name: 'Owner' },
+    );
+    expect(response.status).toBe(400);
+    expect(read).not.toHaveBeenCalled();
+  });
+
+  it('returns 404 for a non-owned intent without exposing groups', async () => {
+    const controller = new ConversationController(
+      { getNegotiationActivityForIntent: mock(async () => null) } as unknown as ConversationService,
+      {} as TaskService,
+    );
+    const response = await controller.getNegotiationActivity(
+      new Request(`http://localhost/conversations/negotiations/activity?intentId=${INTENT_ID}`),
+      { id: 'other', email: null, name: 'Other' },
+    );
+    expect(response.status).toBe(404);
+    expect(await response.json()).toEqual({ error: 'Intent not found' });
+  });
+
+  it('returns the exact owned groups response', async () => {
+    const groups = [{ correspondentUserId: 'ada', correspondentLabel: "Ada's agent", correspondentAvatar: null, messages: [] }];
+    const read = mock(async () => groups);
+    const controller = new ConversationController(
+      { getNegotiationActivityForIntent: read } as unknown as ConversationService,
+      {} as TaskService,
+    );
+    const response = await controller.getNegotiationActivity(
+      new Request(`http://localhost/conversations/negotiations/activity?intentId=${INTENT_ID}`),
+      { id: 'owner', email: null, name: 'Owner' },
+    );
+    expect(response.status).toBe(200);
+    expect(read).toHaveBeenCalledWith('owner', INTENT_ID);
+    expect(await response.json()).toEqual({ groups });
+  });
+});

--- a/services/api/src/lib/negotiation-activity.ts
+++ b/services/api/src/lib/negotiation-activity.ts
@@ -1,0 +1,70 @@
+export interface NegotiationActivityOpportunity {
+  id: string;
+  actors: Array<{ userId: string }>;
+}
+
+export interface NegotiationActivityMessageRow {
+  id: string;
+  taskId: string | null;
+  senderId: string;
+  parts: unknown[];
+  createdAt: Date;
+}
+
+/**
+ * Projects already-authorized intent opportunities into correspondent groups.
+ * Only messages bound to a task mapped to one of those opportunities survive.
+ */
+export function projectNegotiationActivity(
+  userId: string,
+  opportunities: NegotiationActivityOpportunity[],
+  opportunityByTask: Map<string, string>,
+  messages: NegotiationActivityMessageRow[],
+  counterparts: Map<string, { name: string; avatar: string | null }>,
+) {
+  const opportunityById = new Map(opportunities.map((row) => [row.id, row]));
+  const groups = new Map<string, {
+    correspondentUserId: string;
+    correspondentLabel: string;
+    correspondentAvatar: string | null;
+    messages: Array<{
+      id: string;
+      opportunityId: string;
+      sender: 'yours' | 'theirs';
+      parts: unknown[];
+      createdAt: Date;
+    }>;
+  }>();
+
+  for (const message of messages) {
+    if (!message.taskId) continue;
+    const opportunityId = opportunityByTask.get(message.taskId);
+    const opportunity = opportunityId ? opportunityById.get(opportunityId) : undefined;
+    const correspondentUserId = opportunity?.actors.find((actor) => actor.userId !== userId)?.userId;
+    if (!opportunityId || !correspondentUserId) continue;
+    const counterpart = counterparts.get(correspondentUserId);
+    const group = groups.get(correspondentUserId) ?? {
+      correspondentUserId,
+      correspondentLabel: `${counterpart?.name?.trim() || 'Correspondent'}'s agent`,
+      correspondentAvatar: counterpart?.avatar ?? null,
+      messages: [],
+    };
+    group.messages.push({
+      id: message.id,
+      opportunityId,
+      sender: message.senderId === `agent:${userId}` ? 'yours' : 'theirs',
+      parts: message.parts,
+      createdAt: message.createdAt,
+    });
+    groups.set(correspondentUserId, group);
+  }
+
+  return [...groups.values()]
+    .map((group) => ({
+      ...group,
+      messages: group.messages
+        .sort((left, right) => left.createdAt.getTime() - right.createdAt.getTime() || left.id.localeCompare(right.id))
+        .slice(-3),
+    }))
+    .sort((left, right) => left.correspondentLabel.localeCompare(right.correspondentLabel));
+}

--- a/services/api/src/lib/tests/negotiation-activity.spec.ts
+++ b/services/api/src/lib/tests/negotiation-activity.spec.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it } from 'bun:test';
+
+import { projectNegotiationActivity } from '../negotiation-activity';
+
+const date = (second: number) => new Date(`2026-07-24T00:00:0${second}.000Z`);
+
+describe('projectNegotiationActivity', () => {
+  it('isolates exact task/opportunity mappings, groups correspondents, and keeps latest three chronologically', () => {
+    const result = projectNegotiationActivity(
+      'owner',
+      [
+        { id: 'opp-a', actors: [{ userId: 'owner' }, { userId: 'ada' }] },
+        { id: 'opp-b', actors: [{ userId: 'owner' }, { userId: 'bob' }] },
+      ],
+      new Map([['task-a', 'opp-a'], ['task-b', 'opp-b'], ['foreign-task', 'foreign-opp']]),
+      [
+        { id: 'a4', taskId: 'task-a', senderId: 'agent:ada', parts: ['four'], createdAt: date(4) },
+        { id: 'foreign', taskId: 'foreign-task', senderId: 'agent:other', parts: ['secret'], createdAt: date(5) },
+        { id: 'a1', taskId: 'task-a', senderId: 'agent:owner', parts: ['one'], createdAt: date(1) },
+        { id: 'b1', taskId: 'task-b', senderId: 'agent:bob', parts: ['bob'], createdAt: date(1) },
+        { id: 'a3', taskId: 'task-a', senderId: 'agent:ada', parts: ['three'], createdAt: date(3) },
+        { id: 'a2', taskId: 'task-a', senderId: 'agent:owner', parts: ['two'], createdAt: date(2) },
+      ],
+      new Map([
+        ['ada', { name: 'Ada', avatar: null }],
+        ['bob', { name: 'Bob', avatar: null }],
+      ]),
+    );
+
+    expect(result.map((group) => group.correspondentUserId)).toEqual(['ada', 'bob']);
+    expect(result[0]?.messages.map((message) => message.id)).toEqual(['a2', 'a3', 'a4']);
+    expect(result[0]?.messages.map((message) => message.sender)).toEqual(['yours', 'theirs', 'theirs']);
+    expect(JSON.stringify(result)).not.toContain('secret');
+  });
+});

--- a/services/api/src/services/conversation.service.ts
+++ b/services/api/src/services/conversation.service.ts
@@ -86,6 +86,14 @@ export class ConversationService {
   }
 
   /**
+   * Returns the latest persisted A2A turns grouped by correspondent for one
+   * intent owned by the authenticated user.
+   */
+  async getNegotiationActivityForIntent(userId: string, intentId: string) {
+    return this.db.getNegotiationActivityForIntent(userId, intentId);
+  }
+
+  /**
    * Finds an existing DM between two users, or creates one if none exists.
    * @param userA - First user ID
    * @param userB - Second user ID


### PR DESCRIPTION
## New Features
- render persisted agent-to-agent negotiation messages in Radar, grouped by stable correspondent with clear sender attribution
- keep exactly the latest three messages per correspondent in chronological order
- refresh matching intent activity immediately through the existing conversation SSE invalidation path
- refresh opportunity cards, status tabs, and counts every 5 seconds as a lifecycle fallback with navigation cleanup and stale-response guards

## API & Privacy
- add `GET /api/conversations/negotiations/activity?intentId=...`
- enforce authenticated intent ownership and join messages through the exact intent actor, opportunity, and negotiation task
- document the response contract and isolation guarantees

## Tests
- `API_TEST_DATABASE_READY=1 API_TEST_ISOLATED_CHILD=1 API_TEST_PARENT_PID=$PPID NODE_ENV=test bun test ./src/controllers/tests/conversation.negotiation-activity.isolated.ts` — 3 passed, 0 failed
- `bun test src/lib/tests/negotiation-activity.spec.ts` — 1 passed, 0 failed
- `bun --bun vitest run src/components/NegotiationActivity.test.tsx src/hooks/useRadarLiveRefresh.test.tsx` — 2 files, 4 tests passed
- focused ESLint on changed API and web TypeScript/TSX — passed (existing page set-state warning excluded from introduced-file recheck)
- `bun run build` in `apps/web` — passed (2232 modules transformed)

## Versions
- `@indexnetwork/api`: 0.56.4 → 0.57.0
- `@indexnetwork/web`: 0.30.0 → 0.31.0