### PR TITLE
fix(radar): keep live activity status consistent

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@indexnetwork/web",
-  "version": "0.31.0",
+  "version": "0.31.1",
   "license": "MIT",
   "scripts": {
     "dev": "vite --host 127.0.0.1",

--- a/apps/web/src/app/i/[intentId]/page.tsx
+++ b/apps/web/src/app/i/[intentId]/page.tsx
@@ -526,15 +526,10 @@ export default function IntentDetailPage() {
     const seq = ++loadSeqRef.current;
     if (!preserveExisting) setOpportunitiesLoading(true);
     const applyItems = (items: HomeViewCardItem[]) => {
-      if (!preserveExisting) {
-        setOpportunities(items);
-        return;
-      }
-      setOpportunities((current) => {
-        const merged = new Map(current.map((item) => [item.opportunityId, item]));
-        for (const item of items) merged.set(item.opportunityId, item);
-        return [...merged.values()];
-      });
+      // Every response is an authoritative snapshot for this exact intent.
+      // Passive refreshes avoid loading flicker, but must still remove rows
+      // that changed lifecycle or disappeared from the server response.
+      setOpportunities(items);
     };
     const baseOptions = {
       scopeType: "intent" as const,

--- a/apps/web/src/components/NegotiationActivity.test.tsx
+++ b/apps/web/src/components/NegotiationActivity.test.tsx
@@ -36,4 +36,43 @@ describe("NegotiationActivity", () => {
     expect(screen.getByText(/Messages will appear here as they are persisted/)).toBeTruthy();
     expect(screen.queryByText(/message 1/)).toBeNull();
   });
+
+  it("filters non-displayable records before latest-three and removes empty correspondent groups", () => {
+    const groups = normalizeNegotiationActivity([
+      {
+        correspondentUserId: "ada",
+        correspondentLabel: "Ada's agent",
+        correspondentAvatar: null,
+        messages: [
+          ...messages,
+          {
+            id: "tool-only",
+            opportunityId: "opp-1",
+            sender: "theirs",
+            parts: [{ type: "tool-call" }],
+            createdAt: "2026-07-24T00:00:05.000Z",
+          },
+        ],
+      },
+      {
+        correspondentUserId: "empty",
+        correspondentLabel: "Empty agent",
+        correspondentAvatar: null,
+        messages: [{
+          id: "empty-tool",
+          opportunityId: "opp-empty",
+          sender: "theirs",
+          parts: [{ type: "tool-call" }],
+          createdAt: "2026-07-24T00:00:06.000Z",
+        }],
+      },
+    ]);
+
+    render(<NegotiationActivity groups={groups} loading={false} error={false} />);
+
+    expect(screen.queryByRole("region", { name: "Negotiation with Empty agent" })).toBeNull();
+    expect(screen.queryByText("message 1")).toBeNull();
+    expect(screen.getAllByText(/message [234]/).map((node) => node.textContent))
+      .toEqual(["message 2", "message 3", "message 4"]);
+  });
 });

--- a/apps/web/src/lib/negotiation-activity.ts
+++ b/apps/web/src/lib/negotiation-activity.ts
@@ -1,15 +1,27 @@
 import type { NegotiationActivityGroup } from "@/services/conversation";
 
+function hasDisplayableText(parts: unknown[]): boolean {
+  return parts.some((part) => {
+    if (typeof part === "string") return part.trim().length > 0;
+    if (!part || typeof part !== "object") return false;
+    const text = (part as Record<string, unknown>).text;
+    return typeof text === "string" && text.trim().length > 0;
+  });
+}
+
 export function normalizeNegotiationActivity(
   groups: NegotiationActivityGroup[],
 ): NegotiationActivityGroup[] {
-  return groups.map((group) => ({
-    ...group,
-    messages: [...group.messages]
-      .sort((left, right) =>
-        Date.parse(left.createdAt) - Date.parse(right.createdAt)
-        || left.id.localeCompare(right.id),
-      )
-      .slice(-3),
-  }));
+  return groups
+    .map((group) => ({
+      ...group,
+      messages: group.messages
+        .filter((message) => hasDisplayableText(message.parts))
+        .sort((left, right) =>
+          Date.parse(left.createdAt) - Date.parse(right.createdAt)
+          || left.id.localeCompare(right.id),
+        )
+        .slice(-3),
+    }))
+    .filter((group) => group.messages.length > 0);
 }

--- a/apps/web/tests/intent-page-lifecycle.test.tsx
+++ b/apps/web/tests/intent-page-lifecycle.test.tsx
@@ -26,6 +26,7 @@ const mocks = vi.hoisted(() => {
   const archiveIntent = vi.fn();
   const refineIntent = vi.fn();
   const getHomeView = vi.fn();
+  const getNegotiationActivity = vi.fn();
   const getPending = vi.fn();
   const getAnswered = vi.fn();
   const answerQuestion = vi.fn();
@@ -38,6 +39,7 @@ const mocks = vi.hoisted(() => {
     archiveIntent,
     refineIntent,
     getHomeView,
+    getNegotiationActivity,
     getPending,
     getAnswered,
     answerQuestion,
@@ -45,6 +47,7 @@ const mocks = vi.hoisted(() => {
     notificationError: vi.fn(),
     intentsService: { getIntent, setIntentStatus, archiveIntent, refineIntent, visitIntent: vi.fn(async () => {}) },
     opportunitiesService: { getHomeView },
+    conversationsService: { getNegotiationActivity },
     questionsService: {
       getPending,
       getAnswered,
@@ -94,9 +97,13 @@ vi.mock('@/contexts/AuthContext', () => ({
 vi.mock('@/contexts/APIContext', () => ({
   useIntents: () => mocks.intentsService,
   useOpportunities: () => mocks.opportunitiesService,
+  useConversations: () => mocks.conversationsService,
   useQuestionsService: () => mocks.questionsService,
 }));
 
+vi.mock('@/contexts/ConversationContext', () => ({
+  useConversation: () => ({ negotiations: [] }),
+}));
 
 vi.mock('@/contexts/QuestionsContext', () => ({
   useQuestions: () => ({ refresh: vi.fn(async () => {}) }),
@@ -151,9 +158,10 @@ describe('Intent detail lifecycle', () => {
     mocks.getIntent.mockImplementation(async () => ({ ...mocks.intent }));
     mocks.getHomeView.mockResolvedValue({
       sections: [{
-        items: [{ opportunityId: 'opportunity-1', status: 'pending' }],
+        items: [{ opportunityId: 'opportunity-1', status: 'negotiating' }],
       }],
     });
+    mocks.getNegotiationActivity.mockResolvedValue([]);
     mocks.getAnswered.mockResolvedValue([]);
     mocks.getPending.mockResolvedValue([{
       id: 'question-1',
@@ -219,6 +227,25 @@ describe('Intent detail lifecycle', () => {
     expect(screen.getByRole('button', { name: 'Pause' })).toBeEnabled();
     expect(screen.queryByRole('button', { name: 'Resume' })).toBeNull();
     await expectWorkspacePreserved();
+  });
+
+  test('passive Radar refresh authoritatively removes cards omitted by the server', async () => {
+    vi.useFakeTimers();
+    renderIntentPage();
+
+    await act(async () => {
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+    expect(screen.getByTestId('radar-card-opportunity-1')).toBeInTheDocument();
+
+    mocks.getHomeView.mockResolvedValue({ sections: [] });
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(5_000);
+    });
+
+    expect(screen.queryByTestId('radar-card-opportunity-1')).toBeNull();
+    expect(screen.getByText('No matches here yet.')).toBeInTheDocument();
   });
 
   test('PAUSED renders static paused discovery, Resume with Play, and keeps the workspace', async () => {

--- a/services/api/package.json
+++ b/services/api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@indexnetwork/api",
-  "version": "0.57.0",
+  "version": "0.57.1",
   "license": "MIT",
   "private": true,
   "scripts": {

--- a/services/api/src/adapters/conversation.database.adapter.ts
+++ b/services/api/src/adapters/conversation.database.adapter.ts
@@ -1931,9 +1931,16 @@ export class ConversationDatabaseAdapter {
     if (!ownedIntent) return null;
 
     const opportunityRows = await db
-      .select({ id: schema.opportunities.id, actors: schema.opportunities.actors })
+      .select({
+        id: schema.opportunities.id,
+        status: schema.opportunities.status,
+        actors: schema.opportunities.actors,
+      })
       .from(schema.opportunities)
-      .where(sql`${schema.opportunities.actors} @> ${JSON.stringify([{ userId, intent: intentId }])}::jsonb`);
+      .where(and(
+        eq(schema.opportunities.status, 'negotiating'),
+        sql`${schema.opportunities.actors} @> ${JSON.stringify([{ userId, intent: intentId }])}::jsonb`,
+      ));
     if (opportunityRows.length === 0) return [];
 
     const opportunityIds = opportunityRows.map((row) => row.id);

--- a/services/api/src/lib/negotiation-activity.ts
+++ b/services/api/src/lib/negotiation-activity.ts
@@ -1,5 +1,6 @@
 export interface NegotiationActivityOpportunity {
   id: string;
+  status: string;
   actors: Array<{ userId: string }>;
 }
 
@@ -9,6 +10,15 @@ export interface NegotiationActivityMessageRow {
   senderId: string;
   parts: unknown[];
   createdAt: Date;
+}
+
+function hasDisplayableText(parts: unknown[]): boolean {
+  return parts.some((part) => {
+    if (typeof part === 'string') return part.trim().length > 0;
+    if (!part || typeof part !== 'object') return false;
+    const text = (part as Record<string, unknown>).text;
+    return typeof text === 'string' && text.trim().length > 0;
+  });
 }
 
 /**
@@ -22,7 +32,11 @@ export function projectNegotiationActivity(
   messages: NegotiationActivityMessageRow[],
   counterparts: Map<string, { name: string; avatar: string | null }>,
 ) {
-  const opportunityById = new Map(opportunities.map((row) => [row.id, row]));
+  const opportunityById = new Map(
+    opportunities
+      .filter((row) => row.status === 'negotiating')
+      .map((row) => [row.id, row]),
+  );
   const groups = new Map<string, {
     correspondentUserId: string;
     correspondentLabel: string;
@@ -37,7 +51,11 @@ export function projectNegotiationActivity(
   }>();
 
   for (const message of messages) {
-    if (!message.taskId) continue;
+    if (
+      !message.taskId
+      || !message.senderId.startsWith('agent:')
+      || !hasDisplayableText(message.parts)
+    ) continue;
     const opportunityId = opportunityByTask.get(message.taskId);
     const opportunity = opportunityId ? opportunityById.get(opportunityId) : undefined;
     const correspondentUserId = opportunity?.actors.find((actor) => actor.userId !== userId)?.userId;

--- a/services/api/src/lib/tests/negotiation-activity.spec.ts
+++ b/services/api/src/lib/tests/negotiation-activity.spec.ts
@@ -9,8 +9,8 @@ describe('projectNegotiationActivity', () => {
     const result = projectNegotiationActivity(
       'owner',
       [
-        { id: 'opp-a', actors: [{ userId: 'owner' }, { userId: 'ada' }] },
-        { id: 'opp-b', actors: [{ userId: 'owner' }, { userId: 'bob' }] },
+        { id: 'opp-a', status: 'negotiating', actors: [{ userId: 'owner' }, { userId: 'ada' }] },
+        { id: 'opp-b', status: 'negotiating', actors: [{ userId: 'owner' }, { userId: 'bob' }] },
       ],
       new Map([['task-a', 'opp-a'], ['task-b', 'opp-b'], ['foreign-task', 'foreign-opp']]),
       [
@@ -31,5 +31,40 @@ describe('projectNegotiationActivity', () => {
     expect(result[0]?.messages.map((message) => message.id)).toEqual(['a2', 'a3', 'a4']);
     expect(result[0]?.messages.map((message) => message.sender)).toEqual(['yours', 'theirs', 'theirs']);
     expect(JSON.stringify(result)).not.toContain('secret');
+  });
+
+  it('excludes resolved opportunities and filters non-displayable turns before taking the latest three', () => {
+    const result = projectNegotiationActivity(
+      'owner',
+      [
+        { id: 'active', status: 'negotiating', actors: [{ userId: 'owner' }, { userId: 'ada' }] },
+        { id: 'resolved', status: 'accepted', actors: [{ userId: 'owner' }, { userId: 'bob' }] },
+        { id: 'empty', status: 'negotiating', actors: [{ userId: 'owner' }, { userId: 'eve' }] },
+      ],
+      new Map([
+        ['task-active', 'active'],
+        ['task-resolved', 'resolved'],
+        ['task-empty', 'empty'],
+      ]),
+      [
+        { id: 'a1', taskId: 'task-active', senderId: 'agent:owner', parts: [{ text: 'one' }], createdAt: date(1) },
+        { id: 'a2', taskId: 'task-active', senderId: 'agent:ada', parts: [{ text: 'two' }], createdAt: date(2) },
+        { id: 'tool', taskId: 'task-active', senderId: 'agent:ada', parts: [{ type: 'tool-call' }], createdAt: date(3) },
+        { id: 'user', taskId: 'task-active', senderId: 'owner', parts: [{ text: 'not an agent turn' }], createdAt: date(4) },
+        { id: 'a5', taskId: 'task-active', senderId: 'agent:owner', parts: ['five'], createdAt: date(5) },
+        { id: 'a6', taskId: 'task-active', senderId: 'agent:ada', parts: [{ text: 'six' }], createdAt: date(6) },
+        { id: 'resolved-message', taskId: 'task-resolved', senderId: 'agent:bob', parts: ['resolved'], createdAt: date(6) },
+        { id: 'empty-message', taskId: 'task-empty', senderId: 'agent:eve', parts: [{ type: 'tool-call' }], createdAt: date(6) },
+      ],
+      new Map([
+        ['ada', { name: 'Ada', avatar: null }],
+        ['bob', { name: 'Bob', avatar: null }],
+        ['eve', { name: 'Eve', avatar: null }],
+      ]),
+    );
+
+    expect(result).toHaveLength(1);
+    expect(result[0]?.correspondentUserId).toBe('ada');
+    expect(result[0]?.messages.map((message) => message.id)).toEqual(['a2', 'a5', 'a6']);
   });
 });


### PR DESCRIPTION
## Summary
- scope negotiation activity to the exact owned intent and currently negotiating opportunities
- keep only persisted agent turns with displayable text before grouping and selecting the latest three
- remove empty correspondent groups and replace passive Radar snapshots authoritatively so stale cards/statuses disappear
- repair intent lifecycle test mocks introduced by the live activity dependency

## Verification
- `cd services/api && bun test src/lib/tests/negotiation-activity.spec.ts` (2 passed)
- `cd services/api && bunx eslint src/adapters/conversation.database.adapter.ts src/lib/negotiation-activity.ts src/lib/tests/negotiation-activity.spec.ts`
- `cd services/api && bun run build`
- `cd apps/web && bun --bun vitest run src/components/NegotiationActivity.test.tsx tests/intent-page-lifecycle.test.tsx` (19 passed)
- `cd apps/web && bunx eslint src/app/i/[intentId]/page.tsx src/components/NegotiationActivity.test.tsx src/lib/negotiation-activity.ts tests/intent-page-lifecycle.test.tsx` (passes with one pre-existing React hook warning)
- `cd apps/web && bun run build`

## Versions
- API 0.57.1
- Web 0.31.1