### PR TITLE
feat(web): negotiations inbox

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@indexnetwork/web",
-  "version": "0.31.1",
+  "version": "0.32.0",
   "license": "MIT",
   "scripts": {
     "dev": "vite --host 127.0.0.1",

--- a/apps/web/src/app/negotiations/page.tsx
+++ b/apps/web/src/app/negotiations/page.tsx
@@ -1,0 +1,19 @@
+import { useEffect } from 'react';
+import { useNavigate } from 'react-router';
+
+import NegotiationsInbox from '@/components/NegotiationsInbox';
+import { useAuthContext } from '@/contexts/AuthContext';
+
+export default function NegotiationsPage() {
+  const navigate = useNavigate();
+  const { isAuthenticated, isLoading } = useAuthContext();
+
+  useEffect(() => {
+    if (!isLoading && !isAuthenticated) navigate('/', { replace: true });
+  }, [isAuthenticated, isLoading, navigate]);
+
+  if (isLoading || !isAuthenticated) return null;
+  return <NegotiationsInbox />;
+}
+
+export const Component = NegotiationsPage;

--- a/apps/web/src/components/ClientWrapper.tsx
+++ b/apps/web/src/components/ClientWrapper.tsx
@@ -14,7 +14,7 @@ export default function ClientWrapper({ children }: PropsWithChildren) {
   const { pathname } = useLocation();
   const { isAuthenticated } = useAuthContext();
 
-  const appRoutes = ['/', '/d', '/i', '/u', '/networks', '/mynetwork', '/chat', '/settings', '/agents', '/agent', '/questions'];
+  const appRoutes = ['/', '/d', '/i', '/u', '/networks', '/mynetwork', '/chat', '/negotiations', '/settings', '/agents', '/agent', '/questions'];
   const publicRoutes = ['/c', '/l', '/index'];
   const bareRoutes = ['/', '/i/new', '/onboarding', '/oauth/callback', '/found-in-translation', '/overview', '/protocol', '/blog', '/about', '/pages'];
 

--- a/apps/web/src/components/NegotiationsInbox.tsx
+++ b/apps/web/src/components/NegotiationsInbox.tsx
@@ -1,0 +1,153 @@
+import { useEffect, useMemo, useState } from 'react';
+import { useNavigate } from 'react-router';
+import { Loader2 } from 'lucide-react';
+
+import { ContentContainer } from '@/components/layout';
+import UserAvatar from '@/components/UserAvatar';
+import { useAuthContext } from '@/contexts/AuthContext';
+import { useConversation } from '@/contexts/ConversationContext';
+import { deriveNegotiationInbox, type NegotiationInboxItem, type NegotiationInboxStatus } from '@/lib/negotiation-inbox';
+
+const CHIP_CLASS: Record<NegotiationInboxStatus, string> = {
+  answer: 'border-[#041729] bg-[#041729] text-white',
+  agreed: 'border-emerald-200 bg-emerald-50 text-emerald-700',
+  live: 'border-amber-200 bg-amber-50 text-amber-700',
+  waiting: 'border-gray-200 bg-gray-100 text-gray-600',
+  accepted: 'border-emerald-200 bg-emerald-50 text-emerald-700',
+  started: 'border-emerald-200 bg-emerald-50 text-emerald-700',
+  rejected: 'border-red-200 bg-red-50 text-red-700',
+  stalled: 'border-amber-200 bg-amber-50 text-amber-700',
+};
+
+function statusLabel(item: NegotiationInboxItem): string {
+  switch (item.status) {
+    case 'answer': return 'Answer your agent';
+    case 'agreed': return 'Agents agreed';
+    case 'live': return `● Live · turn ${item.turnCount} of ${item.maxTurns}`;
+    case 'waiting': return 'Waiting on their agent';
+    case 'accepted': return 'Accepted by you';
+    case 'started': return 'Chat started';
+    case 'rejected': return 'No opportunity';
+    case 'stalled': return 'Stalled';
+  }
+}
+
+function StatusChip({ item }: { item: NegotiationInboxItem }) {
+  return (
+    <span className={`inline-flex shrink-0 items-center whitespace-nowrap rounded-full border px-2.5 py-1 text-[10px] font-semibold font-ibm-plex-mono ${CHIP_CLASS[item.status]}`}>
+      {statusLabel(item)}
+    </span>
+  );
+}
+
+function NegotiationRow({ item }: { item: NegotiationInboxItem }) {
+  const navigate = useNavigate();
+  const openTranscript = () => navigate(`/chat/${item.conversationId}`);
+  const isResolved = item.group === 'resolved';
+
+  return (
+    <button
+      type="button"
+      onClick={openTranscript}
+      className={`group flex w-full flex-wrap items-center gap-3 px-4 py-3 text-left transition-colors hover:bg-gray-50 focus:outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-[#4091BB] sm:flex-nowrap ${isResolved ? 'bg-gray-50/60 opacity-80' : 'bg-white'}`}
+      aria-label={`Open negotiation with ${item.counterpart.name}`}
+    >
+      <UserAvatar
+        id={item.counterpart.id}
+        name={item.counterpart.name}
+        avatar={item.counterpart.avatar}
+        size={28}
+        className="shrink-0"
+      />
+
+      <div className="min-w-0 flex-1">
+        <p className="truncate text-sm font-semibold text-[#041729] font-ibm-plex-mono">
+          {item.counterpart.name}
+        </p>
+        <p className="mt-0.5 truncate text-xs text-gray-400 font-ibm-plex-mono">
+          {item.signalCount} mutual {item.signalCount === 1 ? 'signal' : 'signals'} · {item.lastAction} · {item.timeAgo}
+        </p>
+      </div>
+
+      <div className="ml-auto flex shrink-0 items-center gap-2">
+        <StatusChip item={item} />
+        {item.status === 'agreed' && (
+          <span className="rounded-sm bg-[#041729] px-3 py-1.5 text-xs font-semibold text-white">
+            Review
+          </span>
+        )}
+        {(item.status === 'live' || item.status === 'waiting') && (
+          <span className="h-2 w-2 rounded-full bg-amber-400 animate-pulse" aria-hidden="true" />
+        )}
+      </div>
+    </button>
+  );
+}
+
+function InboxGroup({ label, items }: { label: string; items: NegotiationInboxItem[] }) {
+  return (
+    <section aria-labelledby={`negotiations-${label.toLowerCase().replace(/\s+/g, '-')}`}>
+      <h2
+        id={`negotiations-${label.toLowerCase().replace(/\s+/g, '-')}`}
+        className="mb-2 font-ibm-plex-mono text-[10px] font-semibold uppercase tracking-[0.18em] text-gray-400"
+      >
+        {label} · {items.length}
+      </h2>
+      {items.length > 0 && (
+        <div className="divide-y divide-gray-100 overflow-hidden rounded-md border border-gray-200 bg-white">
+          {items.map((item) => <NegotiationRow key={item.conversationId} item={item} />)}
+        </div>
+      )}
+    </section>
+  );
+}
+
+export default function NegotiationsInbox() {
+  const { user } = useAuthContext();
+  const { negotiations, refreshNegotiations } = useConversation();
+  const [refreshing, setRefreshing] = useState(negotiations.length === 0);
+
+  useEffect(() => {
+    let cancelled = false;
+    refreshNegotiations().finally(() => {
+      if (!cancelled) setRefreshing(false);
+    });
+    return () => { cancelled = true; };
+  }, [refreshNegotiations]);
+
+  const groups = useMemo(
+    () => deriveNegotiationInbox(negotiations, user?.id),
+    [negotiations, user?.id],
+  );
+  const totalCount = groups.yourMove.length + groups.inProgress.length + groups.resolved.length;
+
+  return (
+    <div className="px-6 pb-12 lg:px-8">
+      <ContentContainer className="text-left" size="wide">
+        <div className="mb-6 mt-12 text-center">
+          <h1 className="text-[28px] font-bold text-black font-ibm-plex-mono">Negotiations</h1>
+          <p className="mt-2 text-xs text-gray-400 font-ibm-plex-mono">
+            {groups.yourMove.length} your move · {groups.inProgress.length} in progress · {groups.resolved.length} resolved
+          </p>
+        </div>
+
+        {refreshing && totalCount === 0 ? (
+          <div className="flex justify-center py-16" aria-label="Loading negotiations">
+            <Loader2 className="h-5 w-5 animate-spin text-gray-400" />
+          </div>
+        ) : totalCount === 0 ? (
+          <div className="rounded-md border border-dashed border-gray-200 py-12 text-center text-sm text-gray-500 font-ibm-plex-mono">
+            <p>No negotiations yet</p>
+            <p className="mt-2 text-xs text-gray-400">Your agents’ connection work will appear here.</p>
+          </div>
+        ) : (
+          <div className="space-y-8">
+            <InboxGroup label="Your move" items={groups.yourMove} />
+            <InboxGroup label="In progress" items={groups.inProgress} />
+            <InboxGroup label="Resolved" items={groups.resolved} />
+          </div>
+        )}
+      </ContentContainer>
+    </div>
+  );
+}

--- a/apps/web/src/components/TopBar.tsx
+++ b/apps/web/src/components/TopBar.tsx
@@ -10,14 +10,15 @@ import { useQuestions } from '@/contexts/QuestionsContext';
 import { useConversation } from '@/contexts/ConversationContext';
 import UserAvatar from '@/components/UserAvatar';
 import { isVisibleH2HConversation } from '@/lib/conversation-visibility';
+import { countNegotiationsRequiringAction } from '@/lib/negotiation-inbox';
 import { log } from '@/lib/logger';
 
 const logger = log.ui.from('TopBar');
 
 /**
  * Top navigation bar. Replaces the retired left sidebar: logo on the left
- * (links to Discover), primary nav (Signals / Chat / Networks / Agent) and the
- * profile menu on the right. Signals is the Discover home, also reachable via
+ * (links to Discover), primary nav (Signals / Chat / Negotiations / Networks /
+ * Agent) and the profile menu on the right. Signals is the Discover home, also reachable via
  * the logo.
  */
 export default function TopBar() {
@@ -28,10 +29,11 @@ export default function TopBar() {
   const { clearChat } = useAIChat();
   const { setSelectedNetworkIds } = useNetworkFilter();
   const { personalAgentPending } = useQuestions();
-  const { conversations } = useConversation();
+  const { conversations, negotiations } = useConversation();
   const unreadConversationCount = conversations.filter(
     (conversation) => isVisibleH2HConversation(conversation) && conversation.unreadCount > 0,
   ).length;
+  const yourMoveCount = countNegotiationsRequiringAction(negotiations, user?.id);
 
   const [userDropdownOpen, setUserDropdownOpen] = useState(false);
   const [mobileMenuOpen, setMobileMenuOpen] = useState(false);
@@ -42,6 +44,7 @@ export default function TopBar() {
   // Signals covers Discover (/) plus the signal detail and creation routes.
   const isSignalsView = pathname === '/' || pathname?.startsWith('/i/');
   const isMessagesView = pathname === '/chat' || (pathname?.includes('/chat') && pathname?.startsWith('/u/'));
+  const isNegotiationsView = pathname === '/negotiations';
   const isNetworksView = pathname?.startsWith('/networks');
   const isAgentView = pathname?.startsWith('/agent') || pathname?.startsWith('/d/');
   const isSettingsView = pathname?.startsWith('/settings');
@@ -125,6 +128,17 @@ export default function TopBar() {
             className="ml-1.5 inline-block min-w-[20px] rounded-full bg-[#041729] px-2 py-0.5 text-center text-xs text-white"
           >
             {unreadConversationCount > 99 ? '99+' : unreadConversationCount}
+          </span>
+        )}
+      </button>
+      <button onClick={() => navigate('/negotiations')} className={navItemClass(isNegotiationsView)}>
+        Negotiations
+        {yourMoveCount > 0 && (
+          <span
+            data-testid="negotiations-your-move-badge"
+            className="ml-1.5 inline-block min-w-[20px] rounded-full bg-[#041729] px-2 py-0.5 text-center text-xs text-white"
+          >
+            {yourMoveCount > 99 ? '99+' : yourMoveCount}
           </span>
         )}
       </button>

--- a/apps/web/src/lib/__tests__/negotiation-inbox.test.ts
+++ b/apps/web/src/lib/__tests__/negotiation-inbox.test.ts
@@ -1,0 +1,114 @@
+import { describe, expect, it } from 'vitest';
+
+import { countNegotiationsRequiringAction, deriveNegotiationInbox } from '@/lib/negotiation-inbox';
+import type { ConversationSummary } from '@/services/conversation';
+
+const NOW = new Date('2026-07-24T12:00:00.000Z').getTime();
+
+function conversation(
+  id: string,
+  input: {
+    state?: NonNullable<ConversationSummary['negotiation']>['state'];
+    opportunityStatus?: NonNullable<ConversationSummary['negotiation']>['opportunityStatus'];
+    action?: string;
+    senderId?: string;
+    turnCount?: number;
+    outcome?: NonNullable<ConversationSummary['negotiation']>['outcome'];
+    acceptedByViewer?: boolean;
+    withMessage?: boolean;
+  } = {},
+): ConversationSummary {
+  const action = input.action ?? 'counter';
+  return {
+    id,
+    participants: [
+      { participantId: 'agent:viewer', participantType: 'agent', name: 'Index Negotiator', avatar: null, ownerName: 'Viewer' },
+      { participantId: `agent:${id}-peer`, participantType: 'agent', name: 'Index Negotiator', avatar: null, ownerName: `${id} person` },
+    ],
+    lastMessage: input.withMessage === false ? null : {
+      parts: [{ kind: 'data', data: { action } }],
+      senderId: input.senderId ?? `agent:${id}-peer`,
+      createdAt: '2026-07-24T11:00:00.000Z',
+    },
+    metadata: null,
+    via: [],
+    unreadCount: 0,
+    lastMessageAt: '2026-07-24T11:00:00.000Z',
+    createdAt: '2026-07-24T10:00:00.000Z',
+    negotiation: {
+      taskId: `${id}-task`,
+      state: input.state ?? 'working',
+      statusTimestamp: '2026-07-24T11:00:00.000Z',
+      opportunityId: `${id}-opportunity`,
+      opportunityStatus: input.opportunityStatus ?? 'negotiating',
+      acceptedByViewer: input.acceptedByViewer ?? false,
+      turnCount: input.turnCount ?? 1,
+      maxTurns: 6,
+      signalCount: 2,
+      outcome: input.outcome ?? null,
+      updatedAt: '2026-07-24T11:00:00.000Z',
+    },
+  };
+}
+
+describe('negotiations inbox presentation', () => {
+  it('puts consultations before agent agreements in Your move', () => {
+    const groups = deriveNegotiationInbox([
+      conversation('agreement', { state: 'completed', opportunityStatus: 'pending', action: 'accept', outcome: { hasOpportunity: true, reason: null } }),
+      conversation('question', { state: 'input_required', action: 'ask_user', senderId: 'agent:viewer' }),
+    ], 'viewer', NOW);
+
+    expect(groups.yourMove.map((item) => [item.conversationId, item.status])).toEqual([
+      ['question', 'answer'],
+      ['agreement', 'agreed'],
+    ]);
+    expect(countNegotiationsRequiringAction([
+      conversation('question', { state: 'input_required', action: 'ask_user', senderId: 'agent:viewer' }),
+      conversation('agreement', { state: 'completed', opportunityStatus: 'pending', action: 'accept' }),
+    ], 'viewer')).toBe(2);
+    expect(countNegotiationsRequiringAction([
+      conversation('their-question', { state: 'input_required', action: 'ask_user' }),
+    ], 'viewer')).toBe(0);
+  });
+
+  it('keeps agent agreement distinct from human acceptance', () => {
+    const groups = deriveNegotiationInbox([
+      conversation('pending', { state: 'completed', opportunityStatus: 'pending', action: 'accept' }),
+      conversation('accepted', { state: 'completed', opportunityStatus: 'accepted', action: 'accept', acceptedByViewer: true }),
+    ], 'viewer', NOW);
+
+    expect(groups.yourMove[0]?.status).toBe('agreed');
+    expect(groups.resolved[0]?.status).toBe('accepted');
+    expect(groups.resolved[0]?.lastAction).toBe('you started the chat');
+
+    const counterpartStarted = deriveNegotiationInbox([
+      conversation('counterpart-started', { state: 'completed', opportunityStatus: 'accepted', action: 'accept' }),
+    ], 'viewer', NOW);
+    expect(counterpartStarted.resolved[0]?.status).toBe('started');
+    expect(counterpartStarted.resolved[0]?.lastAction).toBe('the chat was started');
+  });
+
+  it('maps active and negative outcomes to calm lifecycle labels', () => {
+    const groups = deriveNegotiationInbox([
+      conversation('live', { turnCount: 3 }),
+      conversation('waiting', { turnCount: 0 }),
+      conversation('rejected', { state: 'completed', opportunityStatus: 'rejected', action: 'decline', outcome: { hasOpportunity: false, reason: null } }),
+      conversation('stalled', { state: 'completed', opportunityStatus: 'stalled', outcome: { hasOpportunity: false, reason: 'turn_cap' } }),
+    ], 'viewer', NOW);
+
+    expect(groups.inProgress.map((item) => item.status).sort()).toEqual(['live', 'waiting']);
+    expect(groups.resolved.map((item) => item.status).sort()).toEqual(['rejected', 'stalled']);
+    expect(groups.resolved.find((item) => item.status === 'stalled')?.lastAction)
+      .toBe('agents could not reach agreement within the turn limit');
+    expect(groups.resolved.find((item) => item.status === 'rejected')?.lastAction)
+      .toBe('agents did not recommend moving forward');
+  });
+
+  it('does not surface zero-turn private or abandoned rows', () => {
+    const groups = deriveNegotiationInbox([
+      conversation('screened', { state: 'completed', withMessage: false, outcome: { hasOpportunity: false, reason: 'screened_out' } }),
+    ], 'viewer', NOW);
+
+    expect(groups).toEqual({ yourMove: [], inProgress: [], resolved: [] });
+  });
+});

--- a/apps/web/src/lib/negotiation-inbox.ts
+++ b/apps/web/src/lib/negotiation-inbox.ts
@@ -1,0 +1,194 @@
+import type { ConversationSummary } from '@/services/conversation';
+
+export type NegotiationInboxGroup = 'your_move' | 'in_progress' | 'resolved';
+export type NegotiationInboxStatus =
+  | 'answer'
+  | 'agreed'
+  | 'live'
+  | 'waiting'
+  | 'accepted'
+  | 'started'
+  | 'rejected'
+  | 'stalled';
+
+export interface NegotiationInboxItem {
+  conversationId: string;
+  counterpart: { id: string; name: string; avatar: string | null };
+  group: NegotiationInboxGroup;
+  status: NegotiationInboxStatus;
+  signalCount: number;
+  lastAction: string;
+  timeAgo: string;
+  sortTimestamp: number;
+  turnCount: number | null;
+  maxTurns: number;
+}
+
+export interface NegotiationInboxGroups {
+  yourMove: NegotiationInboxItem[];
+  inProgress: NegotiationInboxItem[];
+  resolved: NegotiationInboxItem[];
+}
+
+interface LastTurnData {
+  action: string | null;
+}
+
+const REJECT_ACTIONS = new Set(['reject', 'decline', 'withdraw']);
+const STALL_REASONS = new Set(['turn_cap', 'timeout']);
+
+function readLastTurn(parts: unknown[]): LastTurnData {
+  for (const part of parts) {
+    if (typeof part !== 'object' || part === null || Array.isArray(part)) continue;
+    const record = part as Record<string, unknown>;
+    if (record.kind !== 'data' || typeof record.data !== 'object' || record.data === null || Array.isArray(record.data)) continue;
+    const action = (record.data as Record<string, unknown>).action;
+    return { action: typeof action === 'string' ? action : null };
+  }
+  return { action: null };
+}
+
+function formatTimeAgo(timestamp: number, now: number): string {
+  const seconds = Math.max(0, Math.floor((now - timestamp) / 1000));
+  if (seconds < 60) return 'just now';
+  const minutes = Math.floor(seconds / 60);
+  if (minutes < 60) return `${minutes}m ago`;
+  const hours = Math.floor(minutes / 60);
+  if (hours < 24) return `${hours}h ago`;
+  const days = Math.floor(hours / 24);
+  if (days < 30) return `${days}d ago`;
+  const months = Math.floor(days / 30);
+  return `${months}mo ago`;
+}
+
+function describeAction(action: string | null, isOwnAgent: boolean): string {
+  const actor = isOwnAgent ? 'your agent' : 'their agent';
+  switch (action) {
+    case 'ask_user': return `${actor} asked for guidance`;
+    case 'propose': return `${actor} proposed a connection`;
+    case 'counter': return `${actor} countered`;
+    case 'question': return `${actor} asked a question`;
+    case 'accept': return `${actor} recommended moving forward`;
+    case 'reject':
+    case 'decline': return `${actor} did not recommend proceeding`;
+    case 'withdraw': return `${actor} stepped back`;
+    case 'outreach': return `${actor} opened the dialogue`;
+    default: return 'agents exchanged a turn';
+  }
+}
+
+function describeResolved(status: NegotiationInboxStatus, reason: string | null): string {
+  if (status === 'accepted') return 'you started the chat';
+  if (status === 'started') return 'the chat was started';
+  if (status === 'stalled') {
+    return reason === 'timeout'
+      ? 'the dialogue ended before the agents reached agreement'
+      : 'agents could not reach agreement within the turn limit';
+  }
+  if (reason === 'screened_out') return 'agents did not find enough mutual value to continue';
+  return 'agents did not recommend moving forward';
+}
+
+function classifyConversation(conversation: ConversationSummary, action: string | null, viewerUserId: string | undefined): {
+  group: NegotiationInboxGroup;
+  status: NegotiationInboxStatus;
+} {
+  const lifecycle = conversation.negotiation;
+  const opportunityStatus = lifecycle?.opportunityStatus;
+
+  if (opportunityStatus === 'accepted') {
+    return { group: 'resolved', status: lifecycle?.acceptedByViewer ? 'accepted' : 'started' };
+  }
+  if (opportunityStatus === 'rejected') return { group: 'resolved', status: 'rejected' };
+  if (opportunityStatus === 'stalled' || opportunityStatus === 'expired') {
+    return { group: 'resolved', status: 'stalled' };
+  }
+  if (lifecycle?.state === 'input_required' && action === 'ask_user' && conversation.lastMessage?.senderId === `agent:${viewerUserId}`) {
+    return { group: 'your_move', status: 'answer' };
+  }
+  if (opportunityStatus === 'pending') return { group: 'your_move', status: 'agreed' };
+
+  if (lifecycle?.outcome?.hasOpportunity === true) return { group: 'your_move', status: 'agreed' };
+  if (lifecycle?.outcome?.hasOpportunity === false) {
+    return STALL_REASONS.has(lifecycle.outcome.reason ?? '')
+      ? { group: 'resolved', status: 'stalled' }
+      : { group: 'resolved', status: 'rejected' };
+  }
+  if (lifecycle && ['failed', 'canceled', 'auth_required'].includes(lifecycle.state)) {
+    return { group: 'resolved', status: 'stalled' };
+  }
+  if (lifecycle?.state === 'rejected' || (action && REJECT_ACTIONS.has(action))) {
+    return { group: 'resolved', status: 'rejected' };
+  }
+  if (action === 'accept') return { group: 'your_move', status: 'agreed' };
+
+  return lifecycle?.turnCount && lifecycle.turnCount > 0
+    ? { group: 'in_progress', status: 'live' }
+    : { group: 'in_progress', status: 'waiting' };
+}
+
+/** Derive user-facing inbox groups without exposing raw task or opportunity states. */
+export function deriveNegotiationInbox(
+  negotiations: ConversationSummary[],
+  viewerUserId: string | undefined,
+  now = Date.now(),
+): NegotiationInboxGroups {
+  const ownAgentId = viewerUserId ? `agent:${viewerUserId}` : null;
+  const items = negotiations.flatMap<NegotiationInboxItem>((conversation) => {
+    // Zero-turn rows include private screened-out attempts and abandoned task
+    // shells. Keep the same invisibility rule as ChatSidebar's A2A mode.
+    if (!conversation.lastMessage) return [];
+
+    const counterpart = conversation.participants.find((participant) => participant.participantId !== ownAgentId);
+    if (!counterpart) return [];
+
+    const lastTurn = readLastTurn(conversation.lastMessage.parts);
+    const classification = classifyConversation(conversation, lastTurn.action, viewerUserId);
+    const lifecycle = conversation.negotiation;
+    const sortTimestamp = new Date(
+      lifecycle?.updatedAt
+        ?? conversation.lastMessage.createdAt
+        ?? conversation.lastMessageAt
+        ?? conversation.createdAt,
+    ).getTime();
+    const safeTimestamp = Number.isFinite(sortTimestamp) ? sortTimestamp : 0;
+    const reason = lifecycle?.outcome?.reason ?? null;
+
+    return [{
+      conversationId: conversation.id,
+      counterpart: {
+        id: counterpart.participantId.replace(/^agent:/, ''),
+        name: counterpart.ownerName ?? conversation.metadata?.title ?? counterpart.name ?? 'Unknown user',
+        avatar: counterpart.avatar,
+      },
+      group: classification.group,
+      status: classification.status,
+      signalCount: Math.max(lifecycle?.signalCount ?? 0, conversation.via.length),
+      lastAction: classification.group === 'resolved'
+        ? describeResolved(classification.status, reason)
+        : describeAction(lastTurn.action, conversation.lastMessage.senderId === ownAgentId),
+      timeAgo: formatTimeAgo(safeTimestamp, now),
+      sortTimestamp: safeTimestamp,
+      turnCount: lifecycle ? lifecycle.turnCount : null,
+      maxTurns: lifecycle?.maxTurns ?? 6,
+    }];
+  });
+
+  const byNewest = (left: NegotiationInboxItem, right: NegotiationInboxItem) => right.sortTimestamp - left.sortTimestamp;
+  const yourMove = items
+    .filter((item) => item.group === 'your_move')
+    .sort((left, right) => (left.status === right.status ? byNewest(left, right) : left.status === 'answer' ? -1 : 1));
+
+  return {
+    yourMove,
+    inProgress: items.filter((item) => item.group === 'in_progress').sort(byNewest),
+    resolved: items.filter((item) => item.group === 'resolved').sort(byNewest),
+  };
+}
+
+export function countNegotiationsRequiringAction(
+  negotiations: ConversationSummary[],
+  viewerUserId: string | undefined,
+): number {
+  return deriveNegotiationInbox(negotiations, viewerUserId).yourMove.length;
+}

--- a/apps/web/src/routes.tsx
+++ b/apps/web/src/routes.tsx
@@ -81,6 +81,10 @@ export const router = createBrowserRouter([
         lazy: lazyRoute("/chat/:conversationId", () => import("@/app/chat/[conversationId]/page")),
       },
       {
+        path: "/negotiations",
+        lazy: lazyRoute("/negotiations", () => import("@/app/negotiations/page")),
+      },
+      {
         path: "/d/:id",
         lazy: lazyRoute("/d/:id", () => import("@/app/d/[id]/page")),
       },

--- a/apps/web/src/services/conversation.ts
+++ b/apps/web/src/services/conversation.ts
@@ -2,6 +2,42 @@
  * Conversation service — typed API client for the conversations endpoints.
  */
 
+export type NegotiationTaskState =
+  | 'submitted'
+  | 'working'
+  | 'input_required'
+  | 'completed'
+  | 'failed'
+  | 'canceled'
+  | 'rejected'
+  | 'auth_required'
+  | 'waiting_for_agent'
+  | 'claimed';
+
+export type NegotiationOpportunityStatus =
+  | 'latent'
+  | 'draft'
+  | 'negotiating'
+  | 'pending'
+  | 'stalled'
+  | 'accepted'
+  | 'rejected'
+  | 'expired';
+
+export interface ConversationNegotiationLifecycle {
+  taskId: string;
+  state: NegotiationTaskState;
+  statusTimestamp: string | null;
+  opportunityId: string | null;
+  opportunityStatus: NegotiationOpportunityStatus | null;
+  acceptedByViewer: boolean;
+  turnCount: number;
+  maxTurns: number | null;
+  signalCount: number;
+  outcome: { hasOpportunity: boolean; reason: string | null } | null;
+  updatedAt: string;
+}
+
 export interface ConversationSummary {
   id: string;
   participants: { participantId: string; participantType: 'user' | 'agent'; name: string | null; avatar: string | null; ownerName?: string | null }[];
@@ -13,6 +49,8 @@ export interface ConversationSummary {
   unreadCount: number;
   lastMessageAt: string | null;
   createdAt: string;
+  /** Latest task and opportunity lifecycle for A2A negotiation summaries. */
+  negotiation?: ConversationNegotiationLifecycle | null;
 }
 
 export interface ConversationMessage {

--- a/apps/web/tests/topbar.test.tsx
+++ b/apps/web/tests/topbar.test.tsx
@@ -10,10 +10,12 @@ import { MemoryRouter } from 'react-router';
 import { beforeEach, describe, expect, test, vi } from 'vitest';
 
 import TopBar from '@/components/TopBar';
+import type { ConversationSummary } from '@/services/conversation';
 
 const mocks = vi.hoisted(() => ({
   questionsState: { personalAgentPending: 0 },
-  conversations: [] as Array<Record<string, unknown>>,
+  conversations: [] as Array<ConversationSummary & { persona: string }>,
+  negotiations: [] as Array<ConversationSummary & { persona: string }>,
   navigate: vi.fn(),
 }));
 
@@ -49,7 +51,7 @@ vi.mock('@/contexts/QuestionsContext', () => ({
 }));
 
 vi.mock('@/contexts/ConversationContext', () => ({
-  useConversation: () => ({ conversations: mocks.conversations }),
+  useConversation: () => ({ conversations: mocks.conversations, negotiations: mocks.negotiations }),
 }));
 
 vi.mock('@/components/UserAvatar', () => ({
@@ -61,7 +63,7 @@ function conversationSummary(
   unreadCount: number,
   participantTypes: Array<'user' | 'agent'> = ['user', 'user'],
   persona = 'orchestrator',
-) {
+): ConversationSummary & { persona: string } {
   return {
     id,
     persona,
@@ -93,6 +95,7 @@ describe('TopBar Personal Agent badge', () => {
     vi.clearAllMocks();
     mocks.questionsState.personalAgentPending = 0;
     mocks.conversations = [];
+    mocks.negotiations = [];
   });
 
   test('renders primary nav including Signals and Agent', () => {
@@ -133,6 +136,33 @@ describe('TopBar Personal Agent badge', () => {
     ];
     renderTopBar();
     expect(screen.queryByTestId('chat-unread-badge')).toBeNull();
+  });
+
+  test('Negotiations badge counts rows that require the user to act', () => {
+    const question = conversationSummary('negotiation-question', 0, ['agent', 'agent']);
+    question.lastMessage = {
+      parts: [{ kind: 'data', data: { action: 'ask_user' } }],
+      senderId: 'agent:user-1',
+      createdAt: new Date().toISOString(),
+    };
+    question.negotiation = {
+      taskId: 'task-1',
+      state: 'input_required',
+      statusTimestamp: new Date().toISOString(),
+      opportunityId: 'opportunity-1',
+      opportunityStatus: 'negotiating',
+      acceptedByViewer: false,
+      turnCount: 2,
+      maxTurns: 6,
+      signalCount: 2,
+      outcome: null,
+      updatedAt: new Date().toISOString(),
+    };
+    mocks.negotiations = [question];
+
+    renderTopBar();
+
+    expect(screen.getByTestId('negotiations-your-move-badge')).toHaveTextContent('1');
   });
 
   test('pending-question badge renders on the Agent entry when the inbox has open questions', () => {

--- a/services/api/package.json
+++ b/services/api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@indexnetwork/api",
-  "version": "0.57.1",
+  "version": "0.58.0",
   "license": "MIT",
   "private": true,
   "scripts": {

--- a/services/api/src/adapters/conversation.database.adapter.ts
+++ b/services/api/src/adapters/conversation.database.adapter.ts
@@ -71,6 +71,46 @@ function isMatchProvenanceEntry(value: unknown): value is MatchProvenanceEntry {
     });
 }
 
+function readNegotiationOutcome(parts: unknown): { hasOpportunity: boolean; reason: string | null; turnCount: number | null } | null {
+  if (!Array.isArray(parts)) return null;
+  for (const part of parts) {
+    if (typeof part !== 'object' || part === null || Array.isArray(part)) continue;
+    const partRecord = part as Record<string, unknown>;
+    if (partRecord.kind !== 'data' || typeof partRecord.data !== 'object' || partRecord.data === null || Array.isArray(partRecord.data)) continue;
+    const data = partRecord.data as Record<string, unknown>;
+    const hasOpportunity = typeof data.hasOpportunity === 'boolean'
+      ? data.hasOpportunity
+      : typeof data.consensus === 'boolean'
+        ? data.consensus
+        : null;
+    if (hasOpportunity === null) continue;
+    return {
+      hasOpportunity,
+      reason: typeof data.reason === 'string' ? data.reason : null,
+      turnCount: typeof data.turnCount === 'number' && Number.isFinite(data.turnCount) ? data.turnCount : null,
+    };
+  }
+  return null;
+}
+
+function readNegotiationSignalCount(metadata: unknown): number {
+  if (typeof metadata !== 'object' || metadata === null || Array.isArray(metadata)) return 0;
+  const record = metadata as Record<string, unknown>;
+  const intentIds = new Set<string>();
+  if (Array.isArray(record.participantBindings)) {
+    for (const binding of record.participantBindings) {
+      if (typeof binding !== 'object' || binding === null || Array.isArray(binding)) continue;
+      const intentId = (binding as Record<string, unknown>).intentId;
+      if (typeof intentId === 'string' && intentId) intentIds.add(intentId);
+    }
+  }
+  for (const key of ['sourceIntentId', 'candidateIntentId']) {
+    const intentId = record[key];
+    if (typeof intentId === 'string' && intentId) intentIds.add(intentId);
+  }
+  return intentIds.size;
+}
+
 type PersistedOpportunity = typeof opportunities.$inferSelect;
 type PersistedOpportunityStatus = PersistedOpportunity['status'];
 
@@ -308,11 +348,14 @@ export class ConversationDatabaseAdapter {
    * can be an `agent:<userId>` identity for A2A negotiations.
    * @param viewerUserId - The human owner whose intent provenance may be
    * projected into the summary. Defaults to `participantId` for ordinary DMs.
+   * @param includeNegotiationLifecycle - Whether to project the latest task and
+   * related opportunity lifecycle for the negotiations inbox.
    * @returns Summaries with participant lists
    */
   async getConversationsForUser(
     participantId: string,
     viewerUserId = participantId,
+    includeNegotiationLifecycle = false,
   ): Promise<ConversationSummary[]> {
     // Include conversations that are not hidden OR have new messages since hiding
     const rows = await db
@@ -346,7 +389,16 @@ export class ConversationDatabaseAdapter {
     // Everything below only needs `ids` — run the lookups in one parallel
     // wave instead of sequential round trips; this method is on the chat
     // sidebar's critical path (GET /conversations and /conversations/negotiations).
-    const [convs, allParticipants, negotiatorRow, claimRows, lastMessages, allMeta, unreadRows] = await Promise.all([
+    const [
+      convs,
+      allParticipants,
+      negotiatorRow,
+      claimRows,
+      lastMessages,
+      allMeta,
+      unreadRows,
+      latestNegotiationTasks,
+    ] = await Promise.all([
       db
         .select()
         .from(schema.conversations)
@@ -425,6 +477,39 @@ export class ConversationDatabaseAdapter {
           ),
         ))
         .groupBy(schema.messages.conversationId),
+      includeNegotiationLifecycle
+        ? db
+          .selectDistinctOn([schema.tasks.conversationId], {
+            conversationId: schema.tasks.conversationId,
+            taskId: schema.tasks.id,
+            state: schema.tasks.state,
+            statusTimestamp: schema.tasks.statusTimestamp,
+            metadata: schema.tasks.metadata,
+            updatedAt: schema.tasks.updatedAt,
+            artifactParts: schema.artifacts.parts,
+            opportunityStatus: opportunities.status,
+            opportunityAcceptedBy: opportunities.acceptedBy,
+            currentTurnCount: sql<number>`(
+              SELECT count(*)::int
+              FROM ${schema.messages}
+              WHERE ${schema.messages.taskId} = ${schema.tasks.id}
+            )`,
+          })
+          .from(schema.tasks)
+          .leftJoin(
+            schema.artifacts,
+            and(
+              eq(schema.artifacts.taskId, schema.tasks.id),
+              eq(schema.artifacts.name, 'negotiation-outcome'),
+            ),
+          )
+          .leftJoin(opportunities, sql`${schema.tasks.metadata}->>'opportunityId' = ${opportunities.id}`)
+          .where(and(
+            inArray(schema.tasks.conversationId, ids),
+            sql`${schema.tasks.metadata}->>'type' = 'negotiation'`,
+          ))
+          .orderBy(schema.tasks.conversationId, desc(schema.tasks.createdAt), desc(schema.tasks.id))
+        : Promise.resolve([]),
     ]);
 
     const unreadCountByConv = new Map(
@@ -558,6 +643,40 @@ export class ConversationDatabaseAdapter {
       viaByConv.set(metadataRow.conversationId, via);
     }
 
+    const negotiationByConv = new Map<string, NonNullable<ConversationSummary['negotiation']>>();
+    for (const row of latestNegotiationTasks) {
+      const metadata = typeof row.metadata === 'object' && row.metadata !== null && !Array.isArray(row.metadata)
+        ? row.metadata as Record<string, unknown>
+        : {};
+      const outcome = readNegotiationOutcome(row.artifactParts);
+      const priorTurnCount = typeof metadata.priorTurnCount === 'number' && Number.isFinite(metadata.priorTurnCount)
+        ? metadata.priorTurnCount
+        : 0;
+      const maxTurns = typeof metadata.maxTurns === 'number' && Number.isFinite(metadata.maxTurns)
+        ? metadata.maxTurns
+        : null;
+      // A screened-out outreach gate is private to the client that initiated
+      // it. Never project its lifecycle to the counterparty through the shared
+      // A2A conversation.
+      const initiatorUserId = typeof metadata.initiatorUserId === 'string'
+        ? metadata.initiatorUserId
+        : metadata.sourceUserId;
+      if (outcome?.reason === 'screened_out' && initiatorUserId !== viewerUserId) continue;
+      negotiationByConv.set(row.conversationId, {
+        taskId: row.taskId,
+        state: row.state,
+        statusTimestamp: row.statusTimestamp,
+        opportunityId: typeof metadata.opportunityId === 'string' ? metadata.opportunityId : null,
+        opportunityStatus: row.opportunityStatus,
+        acceptedByViewer: row.opportunityAcceptedBy === viewerUserId,
+        turnCount: priorTurnCount + (outcome?.turnCount ?? Number(row.currentTurnCount)),
+        maxTurns,
+        signalCount: readNegotiationSignalCount(metadata),
+        outcome: outcome ? { hasOpportunity: outcome.hasOpportunity, reason: outcome.reason } : null,
+        updatedAt: row.updatedAt,
+      });
+    }
+
     return convs.map((c) => ({
       ...c,
       participants: participantsByConv.get(c.id) ?? [],
@@ -565,6 +684,7 @@ export class ConversationDatabaseAdapter {
       metadata: metaByConv.get(c.id) ?? null,
       via: viaByConv.get(c.id) ?? [],
       unreadCount: unreadCountByConv.get(c.id) ?? 0,
+      ...(includeNegotiationLifecycle ? { negotiation: negotiationByConv.get(c.id) ?? null } : {}),
     }));
   }
 

--- a/services/api/src/adapters/database.shared.ts
+++ b/services/api/src/adapters/database.shared.ts
@@ -634,6 +634,21 @@ export interface ResolvedParticipant {
   ownerName?: string | null;
 }
 
+export interface NegotiationLifecycleSummary {
+  taskId: string;
+  state: 'submitted' | 'working' | 'input_required' | 'completed' | 'failed' | 'canceled' | 'rejected' | 'auth_required' | 'waiting_for_agent' | 'claimed';
+  statusTimestamp: Date | null;
+  opportunityId: string | null;
+  opportunityStatus: 'latent' | 'draft' | 'negotiating' | 'pending' | 'stalled' | 'accepted' | 'rejected' | 'expired' | null;
+  /** Whether the authenticated owner, rather than their counterpart, started the chat. */
+  acceptedByViewer: boolean;
+  turnCount: number;
+  maxTurns: number | null;
+  signalCount: number;
+  outcome: { hasOpportunity: boolean; reason: string | null } | null;
+  updatedAt: Date;
+}
+
 /** Summary returned by getConversationsForUser. */
 export interface ConversationSummary {
   id: string;
@@ -645,6 +660,8 @@ export interface ConversationSummary {
   metadata: Record<string, unknown> | null;
   via: Array<{ intentId: string; opportunityId: string; title: string }>;
   unreadCount: number;
+  /** Present only when negotiation lifecycle projection was requested. */
+  negotiation?: NegotiationLifecycleSummary | null;
 }
 
 /**

--- a/services/api/src/adapters/tests/conversation.database.adapter.spec.ts
+++ b/services/api/src/adapters/tests/conversation.database.adapter.spec.ts
@@ -343,6 +343,77 @@ describe('ConversationDatabaseAdapter', () => {
     }, 10000);
   });
 
+  describe('negotiation conversation summaries', () => {
+    it('projects the latest task, opportunity, turn, and signal lifecycle', async () => {
+      const suffix = `${Date.now()}-${crypto.randomUUID()}`;
+      const ownerId = `inbox-owner-${suffix}`;
+      const counterpartId = `inbox-counterpart-${suffix}`;
+      const opportunityId = `inbox-opportunity-${suffix}`;
+      const conversation = await adapter.createConversation([
+        { participantId: `agent:${ownerId}`, participantType: 'agent' },
+        { participantId: `agent:${counterpartId}`, participantType: 'agent' },
+      ]);
+      createdIds.push(conversation.id);
+
+      await db.insert(schema.opportunities).values({
+        id: opportunityId,
+        detection: { source: 'manual', timestamp: new Date().toISOString() },
+        actors: [
+          { networkId: 'inbox-network', userId: ownerId, role: 'peer' },
+          { networkId: 'inbox-network', userId: counterpartId, role: 'peer' },
+        ],
+        interpretation: { category: 'test', reasoning: 'Inbox lifecycle test.', confidence: 0.8 },
+        context: {},
+        confidence: '0.8',
+        status: 'pending',
+      });
+      createdOpportunityIds.push(opportunityId);
+
+      const task = await adapter.createTask(conversation.id, {
+        type: 'negotiation',
+        sourceUserId: ownerId,
+        candidateUserId: counterpartId,
+        sourceIntentId: 'source-intent',
+        candidateIntentId: 'candidate-intent',
+        participantBindings: [
+          { userId: ownerId, intentId: 'source-intent' },
+          { userId: counterpartId, intentId: 'candidate-intent' },
+        ],
+        opportunityId,
+        maxTurns: 6,
+        priorTurnCount: 1,
+      });
+      await adapter.createMessage({
+        conversationId: conversation.id,
+        senderId: `agent:${ownerId}`,
+        role: 'agent',
+        taskId: task.id,
+        parts: [{ kind: 'data', data: { action: 'accept' } }],
+      });
+      await adapter.updateTaskState(task.id, 'completed');
+      await adapter.createArtifact({
+        taskId: task.id,
+        name: 'negotiation-outcome',
+        parts: [{ kind: 'data', data: { hasOpportunity: true, turnCount: 2 } }],
+      });
+
+      const summary = (await adapter.getConversationsForUser(`agent:${ownerId}`, ownerId, true))
+        .find((candidate) => candidate.id === conversation.id);
+
+      expect(summary?.negotiation).toMatchObject({
+        taskId: task.id,
+        state: 'completed',
+        opportunityId,
+        opportunityStatus: 'pending',
+        acceptedByViewer: false,
+        turnCount: 2,
+        maxTurns: 6,
+        signalCount: 2,
+        outcome: { hasOpportunity: true, reason: null },
+      });
+    }, 20000);
+  });
+
   describe('getLatestNegotiationTaskForConversation', () => {
     it('returns the negotiation task, ignoring non-negotiation tasks, and null for fresh conversations', async () => {
       const conv = await adapter.createConversation([

--- a/services/api/src/services/conversation.service.ts
+++ b/services/api/src/services/conversation.service.ts
@@ -82,7 +82,7 @@ export class ConversationService {
   async getAgentConversations(userId: string) {
     // The agent participant authenticates the A2A thread, while the owning
     // human is the only identity permitted to see intent provenance.
-    return this.db.getConversationsForUser(`agent:${userId}`, userId);
+    return this.db.getConversationsForUser(`agent:${userId}`, userId, true);
   }
 
   /**

--- a/services/api/src/services/tests/conversation.service.spec.ts
+++ b/services/api/src/services/tests/conversation.service.spec.ts
@@ -26,18 +26,22 @@ afterAll(async () => {
 }, 30000);
 
 describe('ConversationService', () => {
-  it('uses the agent participant but projects the human owner for negotiations', async () => {
-    let received: [string, string | undefined] | undefined;
+  it('uses the agent participant and negotiation projection for negotiations', async () => {
+    let received: [string, string | undefined, boolean | undefined] | undefined;
     const service = new ConversationService({
-      getConversationsForUser: async (participantId: string, viewerUserId?: string) => {
-        received = [participantId, viewerUserId];
+      getConversationsForUser: async (
+        participantId: string,
+        viewerUserId?: string,
+        includeNegotiationLifecycle?: boolean,
+      ) => {
+        received = [participantId, viewerUserId, includeNegotiationLifecycle];
         return [];
       },
     } as unknown as ConversationDatabaseAdapter);
 
     await service.getAgentConversations('owner-1');
 
-    expect(received).toEqual(['agent:owner-1', 'owner-1']);
+    expect(received).toEqual(['agent:owner-1', 'owner-1', true]);
   });
 
   it('creates conversation and sends message', async () => {


### PR DESCRIPTION
## Summary
- Adds a first-class `/negotiations` inbox with Your move, In progress, and Resolved groups, backed by the existing A2A transcript route.
- Adds the TopBar Negotiations item and viewer-specific Your move badge while retaining the ChatSidebar toggle.
- Adds a minimal lifecycle projection to `GET /conversations/negotiations` for authoritative task/opportunity grouping, turn counts, human acceptance attribution, and screened-out privacy.

## Design
Implements option A from `docs/design/negotiation-ui-proposals.html` (canonical root design reference).

## Verification
- `cd apps/web && bun run lint` — passed (87 existing warnings, no errors).
- `cd apps/web && bun run test -- tests/topbar.test.tsx src/lib/__tests__/negotiation-inbox.test.ts` — passed (13 tests).
- `cd apps/web && bun run build` — passed.
- `cd apps/web && bun run test` — fails on 53 pre-existing failures in DecisionQuestions and signal/routes suites; the new focused tests pass.
- `cd apps/web && bunx tsc --noEmit` — fails on existing broken `src/types` symlink/missing legacy exports and existing test mocks; no errors in inbox files.

## Caveats
The task/opportunity lifecycle fields were absent from the existing conversation summary DTO, so this includes a minimal additive `services/api` projection. No migration or new dependency is required.