### PR TITLE
feat(web): negotiations view modes and realtime updates

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@indexnetwork/web",
-  "version": "0.32.0",
+  "version": "0.33.0",
   "license": "MIT",
   "scripts": {
     "dev": "vite --host 127.0.0.1",

--- a/apps/web/src/components/NegotiationsInbox.tsx
+++ b/apps/web/src/components/NegotiationsInbox.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useState } from 'react';
+import { useEffect, useLayoutEffect, useMemo, useRef, useState } from 'react';
 import { useNavigate } from 'react-router';
 import { Loader2 } from 'lucide-react';
 
@@ -6,7 +6,7 @@ import { ContentContainer } from '@/components/layout';
 import UserAvatar from '@/components/UserAvatar';
 import { useAuthContext } from '@/contexts/AuthContext';
 import { useConversation } from '@/contexts/ConversationContext';
-import { deriveNegotiationInbox, type NegotiationInboxItem, type NegotiationInboxStatus } from '@/lib/negotiation-inbox';
+import { deriveNegotiationInbox, flattenNegotiationInbox, type NegotiationInboxItem, type NegotiationInboxStatus } from '@/lib/negotiation-inbox';
 
 const CHIP_CLASS: Record<NegotiationInboxStatus, string> = {
   answer: 'border-[#041729] bg-[#041729] text-white',
@@ -40,7 +40,37 @@ function StatusChip({ item }: { item: NegotiationInboxItem }) {
   );
 }
 
-function NegotiationRow({ item }: { item: NegotiationInboxItem }) {
+type ViewMode = 'grouped' | 'last-updated';
+const VIEW_MODE_STORAGE_KEY = 'negotiations-view-mode';
+
+function readViewMode(): ViewMode {
+  try {
+    return window.localStorage.getItem(VIEW_MODE_STORAGE_KEY) === 'last-updated' ? 'last-updated' : 'grouped';
+  } catch {
+    return 'grouped';
+  }
+}
+
+// 1.6s update flash on changed rows (design §3 R2): amber-tinted for content
+// updates, steel-tinted for posture moves. Keyed per-flash so the overlay
+// remounts and restarts the animation on consecutive updates.
+const FLASH_STYLES = `
+@keyframes negotiations-flash-amber { from { background: #fff3d6; } to { background: transparent; } }
+@keyframes negotiations-flash-steel { from { background: #dceefb; } to { background: transparent; } }
+.negotiations-flash-amber { animation: negotiations-flash-amber 1.6s ease-out; }
+.negotiations-flash-steel { animation: negotiations-flash-steel 1.6s ease-out; }
+`;
+
+interface RowFlash {
+  kind: 'amber' | 'steel';
+  nonce: number;
+}
+
+function NegotiationRow({ item, flash, rowRef }: {
+  item: NegotiationInboxItem;
+  flash?: RowFlash;
+  rowRef?: (element: HTMLButtonElement | null) => void;
+}) {
   const navigate = useNavigate();
   const openTranscript = () => navigate(`/chat/${item.conversationId}`);
   const isResolved = item.group === 'resolved';
@@ -48,10 +78,18 @@ function NegotiationRow({ item }: { item: NegotiationInboxItem }) {
   return (
     <button
       type="button"
+      ref={rowRef}
       onClick={openTranscript}
-      className={`group flex w-full flex-wrap items-center gap-3 px-4 py-3 text-left transition-colors hover:bg-gray-50 focus:outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-[#4091BB] sm:flex-nowrap ${isResolved ? 'bg-gray-50/60 opacity-80' : 'bg-white'}`}
+      className={`group relative flex w-full flex-wrap items-center gap-3 px-4 py-3 text-left transition-colors hover:bg-gray-50 focus:outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-[#4091BB] sm:flex-nowrap ${isResolved ? 'bg-gray-50/60 opacity-80' : 'bg-white'}`}
       aria-label={`Open negotiation with ${item.counterpart.name}`}
     >
+      {flash && (
+        <span
+          key={flash.nonce}
+          aria-hidden="true"
+          className={`pointer-events-none absolute inset-0 ${flash.kind === 'steel' ? 'negotiations-flash-steel' : 'negotiations-flash-amber'}`}
+        />
+      )}
       <UserAvatar
         id={item.counterpart.id}
         name={item.counterpart.name}
@@ -84,7 +122,11 @@ function NegotiationRow({ item }: { item: NegotiationInboxItem }) {
   );
 }
 
-function InboxGroup({ label, items }: { label: string; items: NegotiationInboxItem[] }) {
+function InboxGroup({ label, items, flashes }: {
+  label: string;
+  items: NegotiationInboxItem[];
+  flashes: ReadonlyMap<string, RowFlash>;
+}) {
   return (
     <section aria-labelledby={`negotiations-${label.toLowerCase().replace(/\s+/g, '-')}`}>
       <h2
@@ -95,7 +137,7 @@ function InboxGroup({ label, items }: { label: string; items: NegotiationInboxIt
       </h2>
       {items.length > 0 && (
         <div className="divide-y divide-gray-100 overflow-hidden rounded-md border border-gray-200 bg-white">
-          {items.map((item) => <NegotiationRow key={item.conversationId} item={item} />)}
+          {items.map((item) => <NegotiationRow key={item.conversationId} item={item} flash={flashes.get(item.conversationId)} />)}
         </div>
       )}
     </section>
@@ -104,8 +146,17 @@ function InboxGroup({ label, items }: { label: string; items: NegotiationInboxIt
 
 export default function NegotiationsInbox() {
   const { user } = useAuthContext();
-  const { negotiations, refreshNegotiations } = useConversation();
+  const { negotiations, refreshNegotiations, isConnected } = useConversation();
   const [refreshing, setRefreshing] = useState(negotiations.length === 0);
+  const [viewMode, setViewMode] = useState<ViewMode>(readViewMode);
+  const [now, setNow] = useState(() => Date.now());
+  const [flashes, setFlashes] = useState<ReadonlyMap<string, RowFlash>>(new Map());
+  const previousRowsRef = useRef<Map<string, { group: string; status: string; sortTimestamp: number }> | null>(null);
+  const flashTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const flashNonceRef = useRef(0);
+  const flatListRef = useRef<HTMLDivElement | null>(null);
+  const rowElementsRef = useRef(new Map<string, HTMLButtonElement>());
+  const previousTopsRef = useRef(new Map<string, number>());
 
   useEffect(() => {
     let cancelled = false;
@@ -115,20 +166,112 @@ export default function NegotiationsInbox() {
     return () => { cancelled = true; };
   }, [refreshNegotiations]);
 
+  // Ticking relative timestamps (design §3 R5): re-derive "Xm ago" every 30s.
+  useEffect(() => {
+    const interval = setInterval(() => setNow(Date.now()), 30_000);
+    return () => clearInterval(interval);
+  }, []);
+
   const groups = useMemo(
-    () => deriveNegotiationInbox(negotiations, user?.id),
-    [negotiations, user?.id],
+    () => deriveNegotiationInbox(negotiations, user?.id, now),
+    [negotiations, user?.id, now],
   );
+  const flatItems = useMemo(() => flattenNegotiationInbox(groups), [groups]);
   const totalCount = groups.yourMove.length + groups.inProgress.length + groups.resolved.length;
+
+  // Diff each refetch against the previous rows and flash what changed
+  // (design §3 R2): posture moves (group/status) in steel, content updates
+  // (a turn landed → updatedAt moved) and new arrivals in amber.
+  useEffect(() => {
+    const previous = previousRowsRef.current;
+    previousRowsRef.current = new Map(
+      flatItems.map((item) => [item.conversationId, { group: item.group, status: item.status, sortTimestamp: item.sortTimestamp }]),
+    );
+    if (!previous) return;
+
+    const changed: Array<[string, RowFlash['kind']]> = [];
+    for (const item of flatItems) {
+      const before = previous.get(item.conversationId);
+      if (!before) changed.push([item.conversationId, 'amber']);
+      else if (before.group !== item.group || before.status !== item.status) changed.push([item.conversationId, 'steel']);
+      else if (before.sortTimestamp !== item.sortTimestamp) changed.push([item.conversationId, 'amber']);
+    }
+    if (changed.length === 0) return;
+
+    flashNonceRef.current += 1;
+    const nonce = flashNonceRef.current;
+    setFlashes(new Map(changed.map(([id, kind]) => [id, { kind, nonce }])));
+    if (flashTimeoutRef.current) clearTimeout(flashTimeoutRef.current);
+    flashTimeoutRef.current = setTimeout(() => {
+      flashTimeoutRef.current = null;
+      setFlashes(new Map());
+    }, 1600);
+    return () => {
+      if (flashTimeoutRef.current) clearTimeout(flashTimeoutRef.current);
+    };
+  }, [flatItems]);
+
+  // FLIP reorder in Last updated mode (design §3 R2): stable keys keep rows
+  // mounted; offset each moved row back to its previous spot, then transition
+  // to the new one so reorders glide instead of vanishing/reappearing.
+  useLayoutEffect(() => {
+    if (viewMode !== 'last-updated' || !flatListRef.current) return;
+    const listTop = flatListRef.current.getBoundingClientRect().top;
+    rowElementsRef.current.forEach((element, id) => {
+      const top = element.getBoundingClientRect().top - listTop;
+      const previousTop = previousTopsRef.current.get(id);
+      if (previousTop !== undefined && previousTop !== top) {
+        element.style.transition = 'none';
+        element.style.transform = `translateY(${previousTop - top}px)`;
+        requestAnimationFrame(() => {
+          element.style.transition = 'transform 0.3s ease';
+          element.style.transform = '';
+        });
+      }
+      previousTopsRef.current.set(id, top);
+    });
+  });
+
+  const selectViewMode = (mode: ViewMode) => {
+    setViewMode(mode);
+    try {
+      window.localStorage.setItem(VIEW_MODE_STORAGE_KEY, mode);
+    } catch {
+      // Storage unavailable — keep the in-memory choice.
+    }
+  };
 
   return (
     <div className="px-6 pb-12 lg:px-8">
+      <style>{FLASH_STYLES}</style>
       <ContentContainer className="text-left" size="wide">
         <div className="mb-6 mt-12 text-center">
           <h1 className="text-[28px] font-bold text-black font-ibm-plex-mono">Negotiations</h1>
           <p className="mt-2 text-xs text-gray-400 font-ibm-plex-mono">
             {groups.yourMove.length} your move · {groups.inProgress.length} in progress · {groups.resolved.length} resolved
+            <span className="ml-3 inline-flex items-center gap-1.5" role="status">
+              <span className={`h-1.5 w-1.5 rounded-full ${isConnected ? 'bg-emerald-500' : 'bg-gray-400'}`} aria-hidden="true" />
+              {isConnected ? 'live' : 'reconnecting…'}
+            </span>
           </p>
+          <div className="mx-auto mt-4 flex w-full max-w-[300px] items-center gap-1 rounded-md bg-gray-100 p-0.5" aria-label="View mode">
+            <button
+              type="button"
+              onClick={() => selectViewMode('grouped')}
+              aria-pressed={viewMode === 'grouped'}
+              className={`flex-1 text-xs font-semibold py-1.5 rounded transition-colors font-ibm-plex-mono ${viewMode === 'grouped' ? 'bg-white text-black shadow-sm' : 'text-gray-500 hover:text-gray-700'}`}
+            >
+              Grouped
+            </button>
+            <button
+              type="button"
+              onClick={() => selectViewMode('last-updated')}
+              aria-pressed={viewMode === 'last-updated'}
+              className={`flex-1 text-xs font-semibold py-1.5 rounded transition-colors font-ibm-plex-mono ${viewMode === 'last-updated' ? 'bg-white text-black shadow-sm' : 'text-gray-500 hover:text-gray-700'}`}
+            >
+              Last updated
+            </button>
+          </div>
         </div>
 
         {refreshing && totalCount === 0 ? (
@@ -140,11 +283,25 @@ export default function NegotiationsInbox() {
             <p>No negotiations yet</p>
             <p className="mt-2 text-xs text-gray-400">Your agents’ connection work will appear here.</p>
           </div>
-        ) : (
+        ) : viewMode === 'grouped' ? (
           <div className="space-y-8">
-            <InboxGroup label="Your move" items={groups.yourMove} />
-            <InboxGroup label="In progress" items={groups.inProgress} />
-            <InboxGroup label="Resolved" items={groups.resolved} />
+            <InboxGroup label="Your move" items={groups.yourMove} flashes={flashes} />
+            <InboxGroup label="In progress" items={groups.inProgress} flashes={flashes} />
+            <InboxGroup label="Resolved" items={groups.resolved} flashes={flashes} />
+          </div>
+        ) : (
+          <div ref={flatListRef} className="divide-y divide-gray-100 overflow-hidden rounded-md border border-gray-200 bg-white">
+            {flatItems.map((item) => (
+              <NegotiationRow
+                key={item.conversationId}
+                item={item}
+                flash={flashes.get(item.conversationId)}
+                rowRef={(element) => {
+                  if (element) rowElementsRef.current.set(item.conversationId, element);
+                  else rowElementsRef.current.delete(item.conversationId);
+                }}
+              />
+            ))}
           </div>
         )}
       </ContentContainer>

--- a/apps/web/src/contexts/ConversationContext.tsx
+++ b/apps/web/src/contexts/ConversationContext.tsx
@@ -52,6 +52,7 @@ export function ConversationProvider({ children }: { children: React.ReactNode }
   const connectSSERef = useRef<() => void>(() => {});
   const refreshConversationsRef = useRef<() => Promise<void>>(() => Promise.resolve());
   const refreshNegotiationsRef = useRef<() => Promise<void>>(() => Promise.resolve());
+  const negotiationsRefreshTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
   // --- REST helpers (use apiClient directly, same pattern as AIChatContext) ---
 
@@ -353,9 +354,15 @@ export function ConversationProvider({ children }: { children: React.ReactNode }
               });
               // Negotiation turns use the same stream but their summaries are
               // owner-filtered separately (`agent:<ownerId>` participants).
-              // Revalidate once per event so intent provenance and Radar can
-              // react without a polling loop.
-              void refreshNegotiationsRef.current();
+              // Trailing-debounce revalidation so a multi-turn burst refetches
+              // once; intent provenance and Radar still react without polling.
+              if (negotiationsRefreshTimeoutRef.current) {
+                clearTimeout(negotiationsRefreshTimeoutRef.current);
+              }
+              negotiationsRefreshTimeoutRef.current = setTimeout(() => {
+                negotiationsRefreshTimeoutRef.current = null;
+                void refreshNegotiationsRef.current();
+              }, 500);
               break;
             }
           }
@@ -400,6 +407,10 @@ export function ConversationProvider({ children }: { children: React.ReactNode }
         clearTimeout(retryTimeoutRef.current);
         retryTimeoutRef.current = null;
       }
+      if (negotiationsRefreshTimeoutRef.current) {
+        clearTimeout(negotiationsRefreshTimeoutRef.current);
+        negotiationsRefreshTimeoutRef.current = null;
+      }
       // Intentional synchronous reset on logout — not a cascading render issue
       // eslint-disable-next-line react-hooks/set-state-in-effect
       setIsConnected(false);
@@ -423,6 +434,10 @@ export function ConversationProvider({ children }: { children: React.ReactNode }
       if (retryTimeoutRef.current) {
         clearTimeout(retryTimeoutRef.current);
         retryTimeoutRef.current = null;
+      }
+      if (negotiationsRefreshTimeoutRef.current) {
+        clearTimeout(negotiationsRefreshTimeoutRef.current);
+        negotiationsRefreshTimeoutRef.current = null;
       }
     };
   }, [isAuthenticated, refreshConversations, refreshNegotiations, connectSSE]);

--- a/apps/web/src/lib/__tests__/negotiation-inbox.test.ts
+++ b/apps/web/src/lib/__tests__/negotiation-inbox.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest';
 
-import { countNegotiationsRequiringAction, deriveNegotiationInbox } from '@/lib/negotiation-inbox';
+import { countNegotiationsRequiringAction, deriveNegotiationInbox, flattenNegotiationInbox } from '@/lib/negotiation-inbox';
 import type { ConversationSummary } from '@/services/conversation';
 
 const NOW = new Date('2026-07-24T12:00:00.000Z').getTime();
@@ -16,6 +16,7 @@ function conversation(
     outcome?: NonNullable<ConversationSummary['negotiation']>['outcome'];
     acceptedByViewer?: boolean;
     withMessage?: boolean;
+    updatedAt?: string;
   } = {},
 ): ConversationSummary {
   const action = input.action ?? 'counter';
@@ -46,7 +47,7 @@ function conversation(
       maxTurns: 6,
       signalCount: 2,
       outcome: input.outcome ?? null,
-      updatedAt: '2026-07-24T11:00:00.000Z',
+      updatedAt: input.updatedAt ?? '2026-07-24T11:00:00.000Z',
     },
   };
 }
@@ -110,5 +111,19 @@ describe('negotiations inbox presentation', () => {
     ], 'viewer', NOW);
 
     expect(groups).toEqual({ yourMove: [], inProgress: [], resolved: [] });
+  });
+
+  it('flattens groups into a last-updated ordering across groups', () => {
+    const groups = deriveNegotiationInbox([
+      conversation('agreed', { state: 'completed', opportunityStatus: 'pending', action: 'accept', updatedAt: '2026-07-24T09:00:00.000Z' }),
+      conversation('live', { turnCount: 2, updatedAt: '2026-07-24T11:30:00.000Z' }),
+      conversation('resolved', { state: 'completed', opportunityStatus: 'rejected', action: 'decline', outcome: { hasOpportunity: false, reason: null }, updatedAt: '2026-07-24T10:30:00.000Z' }),
+    ], 'viewer', NOW);
+
+    expect(flattenNegotiationInbox(groups).map((item) => [item.conversationId, item.group])).toEqual([
+      ['live', 'in_progress'],
+      ['resolved', 'resolved'],
+      ['agreed', 'your_move'],
+    ]);
   });
 });

--- a/apps/web/src/lib/negotiation-inbox.ts
+++ b/apps/web/src/lib/negotiation-inbox.ts
@@ -186,6 +186,15 @@ export function deriveNegotiationInbox(
   };
 }
 
+/**
+ * Flat last-updated ordering across all groups — a re-sort of the derived rows
+ * for the Last updated view mode, not a new derivation.
+ */
+export function flattenNegotiationInbox(groups: NegotiationInboxGroups): NegotiationInboxItem[] {
+  return [...groups.yourMove, ...groups.inProgress, ...groups.resolved]
+    .sort((left, right) => right.sortTimestamp - left.sortTimestamp);
+}
+
 export function countNegotiationsRequiringAction(
   negotiations: ConversationSummary[],
   viewerUserId: string | undefined,


### PR DESCRIPTION
## Summary

Wave: Negotiations Re-design — child C (view modes + realtime), per `docs/design/negotiations-realtime-views.html` §3 R1–R6.

- **Grouped / Last updated toggle** under the /negotiations header, same segmented idiom as the chat sidebar, persisted in localStorage (`negotiations-view-mode`), Grouped default.
- **Last updated mode**: additive `flattenNegotiationInbox()` re-sorts the `deriveNegotiationInbox` output flat by `lifecycle.updatedAt` desc — no new derivation; status chip keeps group visible, agreed rows keep the Review CTA.
- **500ms trailing debounce** on the SSE-triggered `refreshNegotiations()` in `ConversationContext.tsx` (R3), cleared on logout/unmount.
- **1.6s update flash** on changed rows: amber for content updates, steel for posture moves; nonce-keyed overlay restarts on consecutive updates (R2).
- **FLIP smooth reorder** in Last-updated mode — stable keys + transform transition, no vanish/reappear (R2/R6); keyed rendering preserves scroll/hover across refetches.
- **Live dot** in the /negotiations header: emerald "live" ↔ gray "reconnecting…" from `isConnected` (R4, inbox part of IND-554).
- **30s ticking relative timestamps** via the existing `now` param of `deriveNegotiationInbox` (R5, inbox part of IND-555).

Version bump: `@indexnetwork/web` 0.32.0 → 0.33.0 (MINOR, feat). `bun install` run at root — no `bun.lock` change (workspace versions aren't recorded there).

Closes IND-524
Closes IND-541
Closes IND-542
Closes IND-525
Closes IND-552
Closes IND-553
Closes IND-556

Inbox halves of IND-554 (live dot) and IND-555 (ticking timestamps) included; their /chat-tab parts belong to a sibling PR.

## Verification (worktree)

- `bun run lint` — 0 errors (88 pre-existing warnings; none new from changed files)
- `bun run test` — 293 passed / 45 failed; the 45 failures are pre-existing on the clean checkout (45/292 there), my diff adds 1 passing test
- `bunx tsc --noEmit` (apps/web) — 64 lines before and after, byte-identical; no new errors
- `bun run build` — ✓ built in 2.27s

## Caveats

- FLIP transform briefly animates inside an `overflow-hidden` card; visually negligible.
- `page.tsx` needed no changes (inbox header owns the live dot + toggle).