### PR TITLE
feat(web): ambient negotiation presence

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@indexnetwork/web",
-  "version": "0.33.0",
+  "version": "0.34.0",
   "license": "MIT",
   "scripts": {
     "dev": "vite --host 127.0.0.1",

--- a/apps/web/src/app/i/[intentId]/page.tsx
+++ b/apps/web/src/app/i/[intentId]/page.tsx
@@ -8,7 +8,7 @@ import { FocusScope } from "@radix-ui/react-focus-scope";
 
 import ClientLayout from "@/components/ClientLayout";
 import { ContentContainer } from "@/components/layout";
-import OpportunityCard, { OpportunitySkeleton } from "@/components/chat/OpportunityCardInChat";
+import OpportunityCard, { NegotiationPresenceChip, OpportunitySkeleton, type NegotiationPresence } from "@/components/chat/OpportunityCardInChat";
 import { AnsweredQuestionLog } from "@/components/InjectedQuestions/AnsweredQuestionLog";
 import type { AnsweredThreadEntry } from "@/components/InjectedQuestions/AnsweredQuestionLog";
 import { InjectedQuestions } from "@/components/InjectedQuestions/InjectedQuestions";
@@ -30,6 +30,7 @@ import type { AnswerBody, PendingQuestion, QuestionAnswer } from "@/services/que
 import { cn } from "@/lib/utils";
 import { intentNegotiationActivityRevision } from "@/lib/intent-negotiation-activity";
 import { normalizeNegotiationActivity } from "@/lib/negotiation-activity";
+import { deriveLiveNegotiations, formatLatestMove, liveNegotiationsByOpportunity } from "@/lib/negotiation-presence";
 import { DEFAULT_RADAR_BUCKET, radarBucketBadgeTone } from "@/lib/radar-buckets";
 
 /** Raw opportunity status -> radar display bucket (mirrors the Hermes dashboard). */
@@ -569,6 +570,29 @@ export default function IntentDetailPage() {
   const negotiationActivityRevision = useMemo(
     () => intentNegotiationActivityRevision(negotiations, intentId),
     [intentId, negotiations],
+  );
+
+  // Ambient negotiation presence (Option C): in-flight negotiations, indexed
+  // by opportunity for card chips and filtered to this signal for the Radar panel.
+  const liveNegotiations = useMemo(
+    () => deriveLiveNegotiations(negotiations, user?.id),
+    [negotiations, user?.id],
+  );
+  const presenceByOpportunity = useMemo(() => {
+    const map = new Map<string, NegotiationPresence>();
+    for (const [opportunityId, item] of liveNegotiationsByOpportunity(liveNegotiations)) {
+      map.set(opportunityId, {
+        conversationId: item.conversationId,
+        latestMove: formatLatestMove(item.lastAction, item.timeAgo),
+        turnCount: item.turnCount,
+        maxTurns: item.maxTurns,
+      });
+    }
+    return map;
+  }, [liveNegotiations]);
+  const intentLiveNegotiations = useMemo(
+    () => liveNegotiations.filter((item) => intentId !== undefined && item.intentIds.includes(intentId)),
+    [liveNegotiations, intentId],
   );
   const refreshLiveRadar = useCallback(() => {
     void loadOpportunities(true);
@@ -1213,6 +1237,29 @@ export default function IntentDetailPage() {
                     />
                   }
                 >
+                  {intentLiveNegotiations.length > 0 && (
+                    <div className="mb-3 shrink-0 space-y-2" data-testid="radar-live-negotiations">
+                      {intentLiveNegotiations.map((item) => (
+                        <button
+                          key={item.conversationId}
+                          type="button"
+                          onClick={() => navigate(`/chat/${item.conversationId}`)}
+                          aria-label={`Watch the negotiation with ${item.counterpart.name}`}
+                          className="w-full rounded-md border border-amber-200 bg-amber-50/50 px-3 py-2.5 text-left transition-colors hover:bg-amber-50"
+                        >
+                          <div className="flex flex-wrap items-center justify-between gap-2">
+                            <span className="truncate text-xs font-semibold text-gray-900">
+                              {item.counterpart.name}
+                            </span>
+                            <NegotiationPresenceChip turnCount={item.turnCount} maxTurns={item.maxTurns} />
+                          </div>
+                          <p className="mt-1 text-[11px] text-[#3D3D3D]">
+                            {formatLatestMove(item.lastAction, item.timeAgo)}
+                          </p>
+                        </button>
+                      ))}
+                    </div>
+                  )}
                   <div className="mb-3 flex shrink-0 flex-wrap gap-1.5">
                     {RADAR_BUCKETS.map((bucket) => (
                       <StatPill
@@ -1253,6 +1300,7 @@ export default function IntentDetailPage() {
                           currentStatus={
                             opportunityStatusMap[item.opportunityId]
                           }
+                          negotiationPresence={presenceByOpportunity.get(item.opportunityId)}
                           onPrimaryAction={(
                             oppId,
                             userId,

--- a/apps/web/src/components/DiscoverHome.tsx
+++ b/apps/web/src/components/DiscoverHome.tsx
@@ -1,13 +1,16 @@
-import { useEffect, useState, useCallback, useRef } from "react";
-import { useNavigate } from "react-router";
+import { useEffect, useState, useCallback, useMemo, useRef } from "react";
+import { Link, useNavigate } from "react-router";
 import { Plus } from "lucide-react";
 
 import { apiClient } from "@/lib/api";
+import { useAuthContext } from "@/contexts/AuthContext";
+import { useConversation } from "@/contexts/ConversationContext";
 import { useNotifications } from "@/contexts/NotificationContext";
 import IntentList from "@/components/IntentList";
 import { ContentContainer } from "@/components/layout";
 import { DebugCopyButton } from "@/components/DebugCopyButton";
 import { log } from "@/lib/logger";
+import { deriveNegotiationInbox } from "@/lib/negotiation-inbox";
 
 const logger = log.ui.from("DiscoverHome");
 
@@ -32,10 +35,19 @@ interface HomeIntent {
 export default function DiscoverHome() {
   const navigate = useNavigate();
   const { error: showError } = useNotifications();
+  const { user } = useAuthContext();
+  const { negotiations } = useConversation();
   const [intents, setIntents] = useState<HomeIntent[]>([]);
   const [totalWaitingOpportunities, setTotalWaitingOpportunities] = useState(0);
   const [loading, setLoading] = useState(false);
   const mountedRef = useRef(true);
+
+  // Ambient negotiation presence (Option C): live + your-move counts from the
+  // shared inbox derivation; both link to the /negotiations inbox.
+  const negotiationCounts = useMemo(() => {
+    const groups = deriveNegotiationInbox(negotiations, user?.id);
+    return { live: groups.inProgress.length, yourMove: groups.yourMove.length };
+  }, [negotiations, user?.id]);
 
   const fetchIntents = useCallback(async () => {
     try {
@@ -96,6 +108,22 @@ export default function DiscoverHome() {
         </div>
         <p className="mb-6 text-center text-xs text-gray-400 font-ibm-plex-mono">
           {intents.length} signals · {totalWaitingOpportunities} opportunities
+          {negotiationCounts.live > 0 && (
+            <>
+              {" · "}
+              <Link to="/negotiations" className="font-semibold text-amber-600 hover:underline">
+                {negotiationCounts.live} live {negotiationCounts.live === 1 ? "negotiation" : "negotiations"}
+              </Link>
+            </>
+          )}
+          {negotiationCounts.yourMove > 0 && (
+            <>
+              {" · "}
+              <Link to="/negotiations" className="font-semibold text-[#041729] hover:underline">
+                {negotiationCounts.yourMove} your move
+              </Link>
+            </>
+          )}
         </p>
 
         {/* New signal entry — styled to match IntentList rows */}

--- a/apps/web/src/components/chat/OpportunityCardInChat.tsx
+++ b/apps/web/src/components/chat/OpportunityCardInChat.tsx
@@ -9,6 +9,35 @@ import { toSignalProductLanguage } from "@/lib/product-language";
 import { cn } from "@/lib/utils";
 
 /**
+ * Templated (no-LLM) live-negotiation presence for an opportunity card —
+ * see docs/issues/2-presenter-negotiation-context.md. Derived from
+ * ConversationContext negotiations via `deriveLiveNegotiations`.
+ */
+export interface NegotiationPresence {
+  conversationId: string;
+  /** One-line latest move, e.g. "Their agent countered · 12m ago". */
+  latestMove: string;
+  turnCount: number | null;
+  maxTurns: number;
+}
+
+/** Templated "Currently negotiating · turn N of M" chip (always truthful, never LLM-generated). */
+export function NegotiationPresenceChip({
+  turnCount,
+  maxTurns,
+}: {
+  turnCount: number | null;
+  maxTurns: number;
+}) {
+  return (
+    <span className="inline-flex shrink-0 items-center gap-1.5 whitespace-nowrap rounded-full border border-amber-200 bg-amber-50 px-2.5 py-1 text-[10px] font-semibold font-ibm-plex-mono text-amber-700">
+      <span className="h-1.5 w-1.5 rounded-full bg-amber-400 animate-pulse" aria-hidden="true" />
+      Currently negotiating{turnCount !== null && turnCount > 0 ? ` · turn ${turnCount} of ${maxTurns}` : ""}
+    </span>
+  );
+}
+
+/**
  * Shared opportunity card data structure.
  * Compatible with both HomeViewCardItem and OpportunityCard from chat context.
  * Keep in sync with OpportunityCardPayload in services/api/src/types/chat-streaming.types.ts.
@@ -154,6 +183,8 @@ interface OpportunityCardProps {
   showScore?: boolean;
   /** Current status fetched from server (overrides card.status if provided). */
   currentStatus?: string;
+  /** Live negotiation presence for `negotiating` cards; renders the ambient chip. */
+  negotiationPresence?: NegotiationPresence;
 }
 
 /**
@@ -206,6 +237,7 @@ export default function OpportunityCard({
   isLoading = false,
   showScore = false,
   currentStatus,
+  negotiationPresence,
 }: OpportunityCardProps) {
   const navigate = useNavigate();
   const [actionTaken, setActionTaken] = useState<
@@ -458,6 +490,32 @@ export default function OpportunityCard({
           <span className="inline-flex items-center rounded-full border border-gray-200 bg-gray-100 px-2 py-0.5 text-[11px] font-medium text-gray-500">
             {formatDeprioritizedReason(card.deprioritizedReason)}
           </span>
+        </div>
+      )}
+
+      {/* Ambient negotiation presence (Option C): templated chip + latest move
+          for in-flight negotiations. The human gate stays explicit. */}
+      {negotiationPresence && effectiveStatus === "negotiating" && (
+        <div className="mb-3 rounded-md border border-amber-200 bg-amber-50/50 px-3 py-2.5">
+          <div className="flex flex-wrap items-center justify-between gap-2">
+            <NegotiationPresenceChip
+              turnCount={negotiationPresence.turnCount}
+              maxTurns={negotiationPresence.maxTurns}
+            />
+            <span className="text-[10px] text-gray-400 font-ibm-plex-mono">
+              You&apos;ll be asked before anything is agreed
+            </span>
+          </div>
+          <p className="mt-1.5 text-xs text-[#3D3D3D]">
+            {negotiationPresence.latestMove}
+          </p>
+          <button
+            type="button"
+            onClick={() => navigate(`/chat/${negotiationPresence.conversationId}`)}
+            className="mt-1.5 text-xs font-medium text-[#041729] hover:underline"
+          >
+            Watch the negotiation
+          </button>
         </div>
       )}
 

--- a/apps/web/src/components/chat/__tests__/OpportunityCardInChat.test.tsx
+++ b/apps/web/src/components/chat/__tests__/OpportunityCardInChat.test.tsx
@@ -1,0 +1,65 @@
+import { render, screen } from "@testing-library/react";
+import { MemoryRouter } from "react-router";
+import { describe, expect, it } from "vitest";
+
+import OpportunityCard, { type OpportunityCardData } from "@/components/chat/OpportunityCardInChat";
+
+const baseCard: OpportunityCardData = {
+  opportunityId: "opp-1",
+  userId: "user-2",
+  name: "Aisha Khan",
+  mainText: "Your agents are debating a connection.",
+  status: "negotiating",
+};
+
+const presence = {
+  conversationId: "conv-1",
+  latestMove: "Their agent countered · 12m ago",
+  turnCount: 3,
+  maxTurns: 6,
+};
+
+function renderCard(card: OpportunityCardData, withPresence = false) {
+  return render(
+    <MemoryRouter>
+      <OpportunityCard card={card} {...(withPresence ? { negotiationPresence: presence } : {})} />
+    </MemoryRouter>,
+  );
+}
+
+describe("OpportunityCard negotiation presence", () => {
+  it("renders the templated chip, latest move, and human gate for negotiating cards", () => {
+    renderCard(baseCard, true);
+
+    expect(screen.getByText("Currently negotiating · turn 3 of 6")).toBeTruthy();
+    expect(screen.getByText("Their agent countered · 12m ago")).toBeTruthy();
+    expect(screen.getByText("You'll be asked before anything is agreed")).toBeTruthy();
+    expect(screen.getByRole("button", { name: "Watch the negotiation" })).toBeTruthy();
+  });
+
+  it("omits the turn counter until the first turn completes", () => {
+    render(
+      <MemoryRouter>
+        <OpportunityCard
+          card={baseCard}
+          negotiationPresence={{ ...presence, turnCount: 0 }}
+        />
+      </MemoryRouter>,
+    );
+
+    expect(screen.getByText("Currently negotiating")).toBeTruthy();
+    expect(screen.queryByText(/turn \d+ of \d+/)).toBeNull();
+  });
+
+  it("renders nothing without presence data", () => {
+    renderCard(baseCard);
+
+    expect(screen.queryByText(/Currently negotiating/)).toBeNull();
+  });
+
+  it("renders nothing when the card is no longer negotiating", () => {
+    renderCard({ ...baseCard, status: "pending" }, true);
+
+    expect(screen.queryByText(/Currently negotiating/)).toBeNull();
+  });
+});

--- a/apps/web/src/lib/__tests__/negotiation-presence.test.ts
+++ b/apps/web/src/lib/__tests__/negotiation-presence.test.ts
@@ -1,0 +1,113 @@
+import { describe, expect, it } from 'vitest';
+
+import { deriveLiveNegotiations, formatLatestMove, liveNegotiationsByOpportunity } from '@/lib/negotiation-presence';
+import type { ConversationSummary } from '@/services/conversation';
+
+function conversation(
+  id: string,
+  input: {
+    state?: NonNullable<ConversationSummary['negotiation']>['state'];
+    opportunityStatus?: NonNullable<ConversationSummary['negotiation']>['opportunityStatus'];
+    action?: string;
+    senderId?: string;
+    turnCount?: number;
+    outcome?: NonNullable<ConversationSummary['negotiation']>['outcome'];
+    acceptedByViewer?: boolean;
+    opportunityId?: string | null;
+    via?: ConversationSummary['via'];
+    withMessage?: boolean;
+  } = {},
+): ConversationSummary {
+  const action = input.action ?? 'counter';
+  return {
+    id,
+    participants: [
+      { participantId: 'agent:viewer', participantType: 'agent', name: 'Index Negotiator', avatar: null, ownerName: 'Viewer' },
+      { participantId: `agent:${id}-peer`, participantType: 'agent', name: 'Index Negotiator', avatar: null, ownerName: `${id} person` },
+    ],
+    lastMessage: input.withMessage === false ? null : {
+      parts: [{ kind: 'data', data: { action } }],
+      senderId: input.senderId ?? `agent:${id}-peer`,
+      createdAt: '2026-07-24T11:00:00.000Z',
+    },
+    metadata: null,
+    via: input.via ?? [],
+    unreadCount: 0,
+    lastMessageAt: '2026-07-24T11:00:00.000Z',
+    createdAt: '2026-07-24T10:00:00.000Z',
+    negotiation: {
+      taskId: `${id}-task`,
+      state: input.state ?? 'working',
+      statusTimestamp: '2026-07-24T11:00:00.000Z',
+      opportunityId: input.opportunityId === undefined ? `${id}-opportunity` : input.opportunityId,
+      opportunityStatus: input.opportunityStatus ?? 'negotiating',
+      acceptedByViewer: input.acceptedByViewer ?? false,
+      turnCount: input.turnCount ?? 1,
+      maxTurns: 6,
+      signalCount: 2,
+      outcome: input.outcome ?? null,
+      updatedAt: '2026-07-24T11:00:00.000Z',
+    },
+  };
+}
+
+describe('deriveLiveNegotiations', () => {
+  it('keeps in-flight negotiations and drops agreed/resolved ones', () => {
+    const live = deriveLiveNegotiations([
+      conversation('live', { turnCount: 3 }),
+      conversation('waiting', { turnCount: 0 }),
+      conversation('answer', { state: 'input_required', action: 'ask_user', senderId: 'agent:viewer' }),
+      conversation('agreed', { state: 'completed', opportunityStatus: 'pending', action: 'accept', outcome: { hasOpportunity: true, reason: null } }),
+      conversation('rejected', { state: 'completed', opportunityStatus: 'rejected' }),
+      conversation('stalled', { state: 'completed', opportunityStatus: 'stalled' }),
+      conversation('accepted', { state: 'completed', opportunityStatus: 'accepted', acceptedByViewer: true }),
+    ], 'viewer');
+
+    expect(live.map((item) => [item.conversationId, item.status])).toEqual([
+      ['answer', 'answer'],
+      ['live', 'live'],
+      ['waiting', 'waiting'],
+    ]);
+  });
+
+  it('attaches opportunity and signal linkage from the conversation summary', () => {
+    const via = [
+      { intentId: 'intent-a', opportunityId: 'live-opportunity', title: 'Signal A' },
+      { intentId: 'intent-b', opportunityId: 'live-opportunity', title: 'Signal B' },
+    ];
+    const [item] = deriveLiveNegotiations([conversation('live', { via })], 'viewer');
+
+    expect(item?.opportunityId).toBe('live-opportunity');
+    expect(item?.intentIds).toEqual(['intent-a', 'intent-b']);
+  });
+
+  it('tolerates a missing opportunity id and conversations without lifecycle', () => {
+    const shell = conversation('shell', { opportunityId: null });
+    const noLifecycle = { ...conversation('bare'), negotiation: null };
+    const live = deriveLiveNegotiations([shell, noLifecycle], 'viewer');
+
+    expect(live).toHaveLength(2);
+    expect(live.find((item) => item.conversationId === 'shell')?.opportunityId).toBeNull();
+    expect(live.find((item) => item.conversationId === 'bare')?.opportunityId).toBeNull();
+  });
+});
+
+describe('liveNegotiationsByOpportunity', () => {
+  it('indexes by opportunity id, skips null ids, and keeps the first entry', () => {
+    const live = deriveLiveNegotiations([
+      conversation('first', { opportunityId: 'shared-opportunity' }),
+      conversation('second', { opportunityId: 'shared-opportunity' }),
+      conversation('null-id', { opportunityId: null }),
+    ], 'viewer');
+    const byOpportunity = liveNegotiationsByOpportunity(live);
+
+    expect([...byOpportunity.keys()]).toEqual(['shared-opportunity']);
+    expect(byOpportunity.get('shared-opportunity')?.conversationId).toBe('first');
+  });
+});
+
+describe('formatLatestMove', () => {
+  it('capitalizes the move and appends the time', () => {
+    expect(formatLatestMove('their agent countered', '12m ago')).toBe('Their agent countered · 12m ago');
+  });
+});

--- a/apps/web/src/lib/negotiation-presence.ts
+++ b/apps/web/src/lib/negotiation-presence.ts
@@ -1,0 +1,56 @@
+import { deriveNegotiationInbox, type NegotiationInboxItem, type NegotiationInboxStatus } from '@/lib/negotiation-inbox';
+import type { ConversationSummary } from '@/services/conversation';
+
+/**
+ * In-flight statuses: the agents are still talking (the negotiation has not
+ * resolved and is not waiting on a human accept). 'answer' is in-flight too —
+ * the negotiation continues once the viewer replies.
+ */
+const IN_FLIGHT_STATUSES: ReadonlySet<NegotiationInboxStatus> = new Set(['answer', 'live', 'waiting']);
+
+export interface LiveNegotiation extends NegotiationInboxItem {
+  /** Opportunity this negotiation is about (null for pre-opportunity dialogues). */
+  opportunityId: string | null;
+  /** Signals (intents) that surfaced this negotiation for the viewer. */
+  intentIds: string[];
+}
+
+/**
+ * Live (in-flight) negotiations enriched with opportunity/signal linkage from
+ * the raw conversation summaries. Read-only composition over
+ * `deriveNegotiationInbox` — no LLM, no extra fetches.
+ */
+export function deriveLiveNegotiations(
+  negotiations: ConversationSummary[],
+  viewerUserId: string | undefined,
+): LiveNegotiation[] {
+  const inbox = deriveNegotiationInbox(negotiations, viewerUserId);
+  const byId = new Map(negotiations.map((conversation) => [conversation.id, conversation]));
+  return [...inbox.yourMove, ...inbox.inProgress].flatMap((item) => {
+    if (!IN_FLIGHT_STATUSES.has(item.status)) return [];
+    const conversation = byId.get(item.conversationId);
+    if (!conversation) return [];
+    return [{
+      ...item,
+      opportunityId: conversation.negotiation?.opportunityId ?? null,
+      intentIds: conversation.via.map((via) => via.intentId),
+    }];
+  });
+}
+
+/** Index live negotiations by opportunity id for card-level lookup (first wins). */
+export function liveNegotiationsByOpportunity(live: LiveNegotiation[]): Map<string, LiveNegotiation> {
+  const byOpportunity = new Map<string, LiveNegotiation>();
+  for (const item of live) {
+    if (item.opportunityId && !byOpportunity.has(item.opportunityId)) {
+      byOpportunity.set(item.opportunityId, item);
+    }
+  }
+  return byOpportunity;
+}
+
+/** One-line latest move for the ambient chip, e.g. "Their agent countered · 12m ago". */
+export function formatLatestMove(lastAction: string, timeAgo: string): string {
+  const move = lastAction.charAt(0).toUpperCase() + lastAction.slice(1);
+  return `${move} · ${timeAgo}`;
+}


### PR DESCRIPTION
## Summary

Option C (ambient — in context, no new surface) of `docs/design/negotiation-ui-proposals.html`, prescribed by `docs/issues/2-presenter-negotiation-context.md`. Live negotiations now surface where the user is already looking, using only ConversationContext negotiations + `deriveNegotiationInbox` (read-only) — no LLM, no API changes.

- **Opportunity cards** (`OpportunityCardInChat.tsx`): templated `Currently negotiating · turn N of M` chip for `negotiating` opportunities, one-line latest move (e.g. "Their agent countered · 12m ago"), a "Watch the negotiation" deep link to the transcript, and the "You'll be asked before anything is agreed" gate line.
- **Home caption** (`DiscoverHome.tsx`): "N signals · M opportunities" gains "K live negotiations" (amber) and "N your move" counts, both linking to `/negotiations`.
- **Signal Radar panel** (`app/i/[intentId]/page.tsx`): in-flight negotiations for that signal's opportunities render above the bucket pills with the same chip + counterpart + latest move, deep-linking to the transcript.
- New `lib/negotiation-presence.ts`: read-only composition over `deriveNegotiationInbox` that keeps in-flight items (`answer`/`live`/`waiting`) and attaches opportunity/signal linkage.

Closes IND-527
Closes IND-560
Closes IND-561
Closes IND-562

## Verification

- `bun run lint` (apps/web): 0 errors, 87 warnings — all pre-existing; the files I touched carry only pre-existing `set-state-in-effect` warnings on untouched effects.
- `bun run test`: targeted — `negotiation-presence.test.ts` (5), `OpportunityCardInChat.test.tsx` (4 new), `negotiation-inbox.test.ts` (4) — 13/13 pass.
- `bunx tsc --noEmit`: 61 errors, byte-identical to the clean-checkout baseline (dev has pre-existing errors; none added).
- `bun run build`: ✓ built in 2.24s.
- `services/api` untouched — no API projection change needed.

## Caveats

- Version bumped `0.32.0 → 0.34.0` (dev moved to `0.33.0` after branching; feat → minor of dev's current). `bun.lock` unchanged by `bun install`.
- Chips only appear where this PR owns the wiring: radar cards + home caption + signal page. Chat-stream cards (`ChatContent.tsx`, owned by other children) accept the new optional `negotiationPresence` prop but are not wired in this PR.
