### PR TITLE
test(protocol): close host-isolation dynamic import bypass

### DIFF
--- a/docs/design/protocol-architecture-gates.md
+++ b/docs/design/protocol-architecture-gates.md
@@ -10,7 +10,7 @@ The consumer fixture imports every root value and type name, and `bun run archit
 
 ## Dependency and execution characterization
 
-`bun run architecture:host-isolation` rejects protocol source imports that escape `packages/protocol/src`, direct API/web implementation imports, or concrete Drizzle, queue, and database-driver packages. Protocol continues to receive host behavior through interfaces.
+`bun run architecture:host-isolation` rejects static or literal dynamic protocol source imports that escape `packages/protocol/src`, direct API/web implementation imports, or concrete Drizzle, queue, and database-driver packages. Protocol continues to receive host behavior through interfaces.
 
 `packages/protocol/architecture/cycles.baseline.json` records the audited topology: **18 reported circular paths and 2 cyclic SCCs**. `bun run architecture:cycles` permits those audited components only to shrink; it rejects a third component or a component outside the audited members. Phase 3 replaces this gate with a zero-cycle requirement.
 

--- a/packages/protocol/scripts/architecture/host-isolation.ts
+++ b/packages/protocol/scripts/architecture/host-isolation.ts
@@ -36,6 +36,17 @@ function importSpecifiers(sourceFile: ts.SourceFile): string[] {
     if (ts.isImportTypeNode(node) && ts.isLiteralTypeNode(node.argument) && ts.isStringLiteral(node.argument.literal)) {
       specifiers.push(node.argument.literal.text);
     }
+    if (
+      ts.isCallExpression(node)
+      && node.arguments.length === 1
+      && ts.isStringLiteral(node.arguments[0])
+      && (
+        node.expression.kind === ts.SyntaxKind.ImportKeyword
+        || (ts.isIdentifier(node.expression) && node.expression.text === "require")
+      )
+    ) {
+      specifiers.push(node.arguments[0].text);
+    }
     ts.forEachChild(node, visit);
   };
   visit(sourceFile);


### PR DESCRIPTION
## Summary

- extend the protocol host-isolation architecture gate to inspect literal `import()` and CommonJS `require()` specifiers, closing a bypass around the API/web/schema/queue/concrete-adapter boundary
- document that static and literal dynamic imports are covered

## Verification

- `cd packages/protocol && env -u OPENROUTER_API_KEY -u OPENAI_API_KEY bun run architecture:check` — PASS: 306 exports (298 stable, 8 experimental), consumer compile, zero host-isolation violations, 18 audited circular paths / 2 of 2 allowed SCCs, 2 architecture-matrix tests
- `cd packages/protocol && env -u OPENROUTER_API_KEY -u OPENAI_API_KEY bun run build` — PASS
- `cd packages/protocol && env -u OPENROUTER_API_KEY -u OPENAI_API_KEY bunx eslint src --format json` — PASS: 0 errors, 251 warnings
- `cd packages/protocol && env -u OPENROUTER_API_KEY -u OPENAI_API_KEY bun run eval:verify` — PASS: provider-free inventory and all 9 suites
- The IND-514 merged baseline remains credential-free: `TEST_CONCURRENCY=4 bun run test:isolated` recorded 2,155 pass, 27 fail, 0 errors across 199 files in 279.8s. In this pane, the runner children detach/hang after partial output, so no new aggregate baseline is claimed.

## SemVer and lockfile

No `@indexnetwork/protocol` version bump: this only strengthens an unshipped development architecture check and its documentation; it does not change the emitted package API, runtime behavior, or dependencies. `bun.lock` is unchanged and was not hand-merged.

## Caveats

- Literal dynamic specifiers are now covered; computed runtime module names cannot be statically classified and remain outside this source-level gate.
- The cycle baseline remains intentionally non-zero until Phase 3; it allows only the two audited SCCs to shrink.