### PR TITLE
feat(web): chat negotiations tab upgrade

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@indexnetwork/web",
-  "version": "0.34.0",
+  "version": "0.35.0",
   "license": "MIT",
   "scripts": {
     "dev": "vite --host 127.0.0.1",

--- a/apps/web/src/components/ChatSidebar.tsx
+++ b/apps/web/src/components/ChatSidebar.tsx
@@ -1,14 +1,15 @@
-import { useEffect, useState, useRef } from 'react';
+import { useEffect, useMemo, useState, useRef } from 'react';
 import { useNavigate, useLocation } from 'react-router';
-import { MoreHorizontal, Trash2 } from 'lucide-react';
+import { EyeOff, MoreHorizontal, Trash2 } from 'lucide-react';
 import UserAvatar from '@/components/UserAvatar';
 import ConversationPreviewLine from '@/components/ConversationPreviewLine';
 import { useAuthContext } from '@/contexts/AuthContext';
 import { useConversation } from '@/contexts/ConversationContext';
+import { apiClient } from '@/lib/api';
 import { isVisibleH2HConversation } from '@/lib/conversation-visibility';
 import { resolveConversationPreview } from '@/lib/conversation-preview';
-
-type NegotiationStatus = 'accepted' | 'rejected' | 'in_progress' | null;
+import { countNegotiationsRequiringAction, deriveNegotiationInbox, type NegotiationInboxItem } from '@/lib/negotiation-inbox';
+import { CHIP_CLASS, statusLabel } from '@/lib/negotiation-chips';
 
 interface RecentChat {
   groupId: string;
@@ -20,15 +21,8 @@ interface RecentChat {
   viaTitle?: string;
   unreadCount: number;
   showUnreadCount: boolean;
-  negotiationStatus: NegotiationStatus;
   sortTimestamp: number;
 }
-
-const STATUS_DOT: Record<Exclude<NegotiationStatus, null>, { cls: string; label: string }> = {
-  accepted: { cls: 'bg-emerald-500', label: 'Accepted' },
-  rejected: { cls: 'bg-red-500', label: 'Rejected' },
-  in_progress: { cls: 'bg-amber-400', label: 'In progress' },
-};
 
 const formatConversationTime = (timestamp: number) => {
   if (!timestamp) return '';
@@ -55,8 +49,8 @@ const formatConversationTime = (timestamp: number) => {
 export default function ChatSidebar() {
   const navigate = useNavigate();
   const { pathname } = useLocation();
-  const { user } = useAuthContext();
-  const { conversations, negotiations, refreshConversations, refreshNegotiations, hideConversation } = useConversation();
+  const { user, features } = useAuthContext();
+  const { conversations, negotiations, isConnected, refreshConversations, refreshNegotiations, hideConversation } = useConversation();
 
   // Background revalidation flag. The ConversationProvider prefetches both
   // lists on auth, so cached data renders immediately; this only gates the
@@ -65,6 +59,14 @@ export default function ChatSidebar() {
   const [chatMenuOpen, setChatMenuOpen] = useState<string | null>(null);
   const [mode, setMode] = useState<'h2h' | 'a2a'>('h2h');
   const chatMenuRef = useRef<HTMLDivElement>(null);
+
+  // 30s tick keeps relative timestamps (subline timeAgo, row times) fresh
+  // instead of frozen at fetch time (IND-555).
+  const [now, setNow] = useState(() => Date.now());
+  useEffect(() => {
+    const interval = setInterval(() => setNow(Date.now()), 30_000);
+    return () => clearInterval(interval);
+  }, []);
 
   useEffect(() => {
     if (!user?.id) return;
@@ -75,60 +77,49 @@ export default function ChatSidebar() {
     return () => { cancelled = true; };
   }, [user?.id, refreshConversations, refreshNegotiations]);
 
-  const filteredConversations = mode === 'h2h'
-    ? conversations.filter(isVisibleH2HConversation)
-    // Negotiations with zero messages are orphaned conversation rows (no turns
-    // ever landed, or the task parked and never completed) — hide them.
-    // Still show ones whose only content is an internal assessment.reasoning.
-    : negotiations.filter((conv) => !!conv.lastMessage);
-  const recentChats: RecentChat[] = filteredConversations.map((conv) => {
-    if (mode === 'a2a') {
-      const counterparts = (conv.participants ?? []).filter((p) => p.participantId !== `agent:${user?.id}`);
-      const counterpartLabels = counterparts.map((p) => p.ownerName ?? p.name ?? p.participantId.replace('agent:', ''));
-      const lastParts = conv.lastMessage?.parts as { kind?: string; text?: string; data?: { action?: string; message?: string; assessment?: { reasoning?: string } } }[] | undefined;
-      const dataPart = lastParts?.find(p => p.kind === 'data');
-      const textPart = lastParts?.find(p => p.text);
-      const messageText = dataPart?.data?.message;
-      const reasoningText = dataPart?.data?.assessment?.reasoning;
-      const fallbackText = textPart?.text ?? '';
-      const preview = messageText ?? reasoningText ?? fallbackText;
-      const lastAction = dataPart?.data?.action;
-      const negotiationStatus: NegotiationStatus = lastAction === 'accept'
-        ? 'accepted'
-        : (lastAction === 'reject' || lastAction === 'withdraw' || lastAction === 'decline')
-          ? 'rejected'
-          : lastAction
-            ? 'in_progress'
-            : null;
+  // One classification source for inbox, tab, TopBar pill, and this toggle
+  // badge — no inline re-derivation here (R1).
+  const yourMoveCount = useMemo(
+    () => countNegotiationsRequiringAction(negotiations, user?.id),
+    [negotiations, user?.id],
+  );
+  const inbox = useMemo(
+    () => (mode === 'a2a' ? deriveNegotiationInbox(negotiations, user?.id, now) : null),
+    [mode, negotiations, user?.id, now],
+  );
+  // Flat posture order — your move → live → waiting → resolved — with
+  // hairline dividers between runs. No group headers in a rail this narrow.
+  const negotiationRuns = useMemo(() => {
+    if (!inbox) return [];
+    return [
+      { key: 'your-move', items: inbox.yourMove },
+      { key: 'live', items: inbox.inProgress.filter((item) => item.status === 'live') },
+      { key: 'waiting', items: inbox.inProgress.filter((item) => item.status === 'waiting') },
+      { key: 'resolved', items: inbox.resolved },
+    ].filter((run) => run.items.length > 0);
+  }, [inbox]);
+  const negotiationCount = inbox
+    ? inbox.yourMove.length + inbox.inProgress.length + inbox.resolved.length
+    : 0;
+
+  const recentChats: RecentChat[] = mode === 'h2h'
+    ? conversations.filter(isVisibleH2HConversation).map((conv) => {
+      const peer = (conv.participants ?? []).find((p) => p.participantId !== user?.id && p.participantType === 'user');
+      const lastText = (conv.lastMessage?.parts as { text?: string }[] | undefined)?.find(p => p.text)?.text ?? '';
       return {
         groupId: conv.id,
-        peerUserId: null,
-        peerAvatar: counterparts[0]?.avatar ?? null,
-        name: conv.metadata?.title ?? counterpartLabels.join(', '),
-        lastMessage: preview,
-        lastMessageIsInternal: !messageText && !!reasoningText,
+        peerUserId: peer?.participantId ?? null,
+        peerAvatar: peer?.avatar ?? null,
+        name: conv.metadata?.title ?? peer?.name ?? 'Conversation',
+        lastMessage: lastText,
+        lastMessageIsInternal: false,
+        viaTitle: conv.via?.[0]?.title,
         unreadCount: conv.unreadCount,
-        showUnreadCount: false,
-        negotiationStatus,
+        showUnreadCount: conv.unreadCount > 0,
         sortTimestamp: new Date(conv.lastMessageAt ?? conv.createdAt).getTime(),
       };
-    }
-    const peer = (conv.participants ?? []).find((p) => p.participantId !== user?.id && p.participantType === 'user');
-    const lastText = (conv.lastMessage?.parts as { text?: string }[] | undefined)?.find(p => p.text)?.text ?? '';
-    return {
-      groupId: conv.id,
-      peerUserId: peer?.participantId ?? null,
-      peerAvatar: peer?.avatar ?? null,
-      name: conv.metadata?.title ?? peer?.name ?? 'Conversation',
-      lastMessage: lastText,
-      lastMessageIsInternal: false,
-      viaTitle: conv.via?.[0]?.title,
-      unreadCount: conv.unreadCount,
-      showUnreadCount: conv.unreadCount > 0,
-      negotiationStatus: null,
-      sortTimestamp: new Date(conv.lastMessageAt ?? conv.createdAt).getTime(),
-    };
-  }).sort((a, b) => b.sortTimestamp - a.sortTimestamp);
+    }).sort((a, b) => b.sortTimestamp - a.sortTimestamp)
+    : [];
 
   useEffect(() => {
     const handleClickOutside = (event: MouseEvent) => {
@@ -140,6 +131,116 @@ export default function ChatSidebar() {
     return () => document.removeEventListener('mousedown', handleClickOutside);
   }, [chatMenuOpen]);
 
+  // Answer rows go to the negotiator DM — the transcript is read-only and
+  // can't take an answer. Falls back to the transcript when the negotiator
+  // surface is unavailable (flag off, session bootstrap failed).
+  const openNegotiatorDm = async (fallbackConversationId: string) => {
+    if (!features?.negotiatorChat) {
+      navigate(`/chat/${fallbackConversationId}`);
+      return;
+    }
+    try {
+      const existing = await apiClient.get<{ sessions: { id: string }[] }>('/chat/sessions?persona=negotiator');
+      const session = existing.sessions?.[0];
+      if (session) {
+        navigate(`/d/${session.id}`);
+        return;
+      }
+      const created = await apiClient.post<{ session: { id: string } }>('/chat/negotiator/session');
+      navigate(`/d/${created.session.id}`);
+    } catch {
+      navigate(`/chat/${fallbackConversationId}`);
+    }
+  };
+
+  const openNegotiation = (item: NegotiationInboxItem) => {
+    if (item.status === 'answer') {
+      void openNegotiatorDm(item.conversationId);
+      return;
+    }
+    // Agreed rows land on the transcript's review affordance; live, waiting,
+    // and resolved rows open the transcript as before.
+    navigate(`/chat/${item.conversationId}`);
+  };
+
+  const renderSkeleton = () => (
+    /* Cold cache — conversation-row skeletons while the first fetch lands. */
+    <div className="space-y-1" data-testid="chat-sidebar-skeleton" aria-hidden="true">
+      {Array.from({ length: 8 }).map((_, i) => (
+        <div key={i} className="flex items-center gap-3 py-2 px-2 -mx-2 animate-pulse">
+          <div className="h-7 w-7 rounded-full bg-gray-200 shrink-0" />
+          <div className="min-w-0 flex-1 space-y-1.5">
+            <div className="h-3.5 w-2/3 rounded bg-gray-200" />
+            <div className="h-3 w-11/12 rounded bg-gray-200" />
+          </div>
+        </div>
+      ))}
+    </div>
+  );
+
+  const renderNegotiationRow = (item: NegotiationInboxItem) => {
+    const isResolved = item.group === 'resolved';
+    return (
+      <div
+        key={item.conversationId}
+        className={`relative group flex items-center py-2 px-2 -mx-2 rounded-md transition-colors hover:bg-gray-50 ${isResolved ? 'opacity-80' : ''}`}
+      >
+        <button
+          onClick={() => openNegotiation(item)}
+          className="flex-1 flex items-center gap-3 text-sm text-left pr-10 min-w-0 text-gray-700 hover:text-black"
+        >
+          <UserAvatar avatar={item.counterpart.avatar} id={item.counterpart.id} name={item.counterpart.name} size={28} className="flex-shrink-0" />
+          <div className="min-w-0 flex-1">
+            <p className="text-sm font-medium text-black flex items-center gap-1.5">
+              <span className="truncate">{item.counterpart.name}</span>
+              <span className={`inline-flex shrink-0 items-center whitespace-nowrap rounded-full border px-2 py-0.5 text-[10px] font-semibold font-ibm-plex-mono ${CHIP_CLASS[item.status]}`}>
+                {statusLabel(item)}
+              </span>
+            </p>
+            <p className="truncate text-[11px] font-ibm-plex-mono text-gray-400">
+              {item.signalCount} signal{item.signalCount === 1 ? '' : 's'} · {item.lastAction} · {item.timeAgo}
+            </p>
+            {(item.status === 'answer' || item.status === 'agreed') && (
+              <p className="truncate text-[11px] text-gray-400">
+                {item.status === 'answer' ? 'Tap to answer in your agent chat' : 'Tap to review and start the chat'}
+              </p>
+            )}
+          </div>
+        </button>
+        <span className="absolute right-8 top-2 text-[11px] leading-none font-normal text-gray-400">
+          {formatConversationTime(item.sortTimestamp)}
+        </span>
+        <button
+          onClick={(e) => {
+            e.stopPropagation();
+            setChatMenuOpen(chatMenuOpen === item.conversationId ? null : item.conversationId);
+          }}
+          aria-label="Negotiation options"
+          className="p-1 opacity-0 group-hover:opacity-100 hover:bg-gray-100 rounded transition-all flex-shrink-0"
+        >
+          <MoreHorizontal className="w-4 h-4 text-gray-400" />
+        </button>
+        {chatMenuOpen === item.conversationId && (
+          <div
+            ref={chatMenuRef}
+            className="absolute right-0 top-full mt-1 bg-white border border-gray-200 rounded-lg shadow-lg py-1 min-w-[140px] z-30"
+          >
+            <button
+              onClick={async (e) => {
+                e.stopPropagation();
+                setChatMenuOpen(null);
+                await hideConversation(item.conversationId);
+              }}
+              className="w-full flex items-center gap-2 px-3 py-2 text-sm text-red-600 hover:bg-red-50 transition-colors"
+            >
+              <EyeOff className="w-4 h-4" /> Hide
+            </button>
+          </div>
+        )}
+      </div>
+    );
+  };
+
   return (
     <div className="flex flex-col h-full overflow-hidden">
       <div className="lg:hidden px-4 py-3 min-h-[68px] flex items-center gap-3">
@@ -147,33 +248,58 @@ export default function ChatSidebar() {
         <h2 className="text-lg font-bold text-black font-ibm-plex-mono">Conversations</h2>
       </div>
       <div className="flex-1 overflow-y-auto px-4 pt-4 lg:pt-4">
-        <div className="flex items-center gap-1 mb-3 bg-gray-100 rounded-md p-0.5">
-          <button
-            onClick={() => setMode('h2h')}
-            className={`flex-1 text-xs font-semibold py-1.5 rounded transition-colors font-ibm-plex-mono ${mode === 'h2h' ? 'bg-white text-black shadow-sm' : 'text-gray-500 hover:text-gray-700'}`}
-          >
-            Messages
-          </button>
-          <button
-            onClick={() => setMode('a2a')}
-            className={`flex-1 text-xs font-semibold py-1.5 rounded transition-colors font-ibm-plex-mono ${mode === 'a2a' ? 'bg-white text-black shadow-sm' : 'text-gray-500 hover:text-gray-700'}`}
-          >
-            Negotiations
-          </button>
-        </div>
-        {recentChats.length === 0 && refreshing ? (
-          /* Cold cache — conversation-row skeletons while the first fetch lands. */
-          <div className="space-y-1" data-testid="chat-sidebar-skeleton" aria-hidden="true">
-            {Array.from({ length: 8 }).map((_, i) => (
-              <div key={i} className="flex items-center gap-3 py-2 px-2 -mx-2 animate-pulse">
-                <div className="h-7 w-7 rounded-full bg-gray-200 shrink-0" />
-                <div className="min-w-0 flex-1 space-y-1.5">
-                  <div className="h-3.5 w-2/3 rounded bg-gray-200" />
-                  <div className="h-3 w-11/12 rounded bg-gray-200" />
-                </div>
-              </div>
-            ))}
+        <div className="flex items-center gap-2 mb-3">
+          <div className="flex flex-1 items-center gap-1 bg-gray-100 rounded-md p-0.5">
+            <button
+              onClick={() => setMode('h2h')}
+              className={`flex-1 text-xs font-semibold py-1.5 rounded transition-colors font-ibm-plex-mono ${mode === 'h2h' ? 'bg-white text-black shadow-sm' : 'text-gray-500 hover:text-gray-700'}`}
+            >
+              Messages
+            </button>
+            <button
+              onClick={() => setMode('a2a')}
+              className={`flex-1 text-xs font-semibold py-1.5 rounded transition-colors font-ibm-plex-mono ${mode === 'a2a' ? 'bg-white text-black shadow-sm' : 'text-gray-500 hover:text-gray-700'}`}
+            >
+              Negotiations
+              {yourMoveCount > 0 && (
+                <span
+                  data-testid="chat-negotiations-your-move-badge"
+                  aria-label={`${yourMoveCount} negotiation${yourMoveCount === 1 ? '' : 's'} need your input`}
+                  className="ml-1 inline-flex h-4 min-w-4 flex-none items-center justify-center rounded-full bg-[#041729] px-1 align-middle text-[10px] font-bold leading-none text-white"
+                >
+                  {yourMoveCount > 99 ? '99+' : yourMoveCount}
+                </span>
+              )}
+            </button>
           </div>
+          <span
+            data-testid="chat-connection-dot"
+            role="status"
+            title={isConnected ? 'live' : 'reconnecting…'}
+            aria-label={isConnected ? 'live' : 'reconnecting…'}
+            className={`h-1.5 w-1.5 flex-none rounded-full ${isConnected ? 'bg-emerald-500' : 'bg-gray-400'}`}
+          />
+        </div>
+        {mode === 'a2a' ? (
+          negotiationCount === 0 && refreshing ? (
+            renderSkeleton()
+          ) : negotiationCount === 0 ? (
+            <div className="py-8 text-center font-ibm-plex-mono">
+              <p className="text-xs font-semibold text-gray-700">No negotiations yet</p>
+              <p className="mt-1.5 text-[11px] leading-relaxed text-gray-400">Your agents’ connection work will appear here.</p>
+            </div>
+          ) : (
+            <div className="space-y-1">
+              {negotiationRuns.map((run, runIndex) => (
+                <div key={run.key}>
+                  {runIndex > 0 && <div className="mx-2 my-1 h-px bg-gray-100" aria-hidden="true" />}
+                  {run.items.map(renderNegotiationRow)}
+                </div>
+              ))}
+            </div>
+          )
+        ) : recentChats.length === 0 && refreshing ? (
+          renderSkeleton()
         ) : recentChats.length === 0 ? (
           <div className="text-sm text-gray-400">No messages yet</div>
         ) : (
@@ -184,19 +310,12 @@ export default function ChatSidebar() {
                 className="relative group flex items-center py-2 px-2 -mx-2 rounded-md transition-colors hover:bg-gray-50"
               >
                 <button
-                  onClick={() => navigate(mode === 'a2a' ? `/chat/${chat.groupId}` : chat.peerUserId ? `/u/${chat.peerUserId}/chat` : `/chat`)}
+                  onClick={() => navigate(chat.peerUserId ? `/u/${chat.peerUserId}/chat` : `/chat`)}
                   className="flex-1 flex items-center gap-3 text-sm text-left pr-10 min-w-0 text-gray-700 hover:text-black"
                 >
                   <UserAvatar avatar={chat.peerAvatar} id={chat.peerUserId ?? chat.groupId} name={chat.name} size={28} className="flex-shrink-0" />
                   <div className="min-w-0 flex-1">
                     <p className={`truncate text-sm flex items-center gap-1.5 ${chat.showUnreadCount ? 'font-bold' : 'font-medium'} text-black`}>
-                      {chat.negotiationStatus && (
-                        <span
-                          className={`inline-block w-2 h-2 rounded-full flex-shrink-0 ${STATUS_DOT[chat.negotiationStatus].cls}`}
-                          title={STATUS_DOT[chat.negotiationStatus].label}
-                          aria-label={STATUS_DOT[chat.negotiationStatus].label}
-                        />
-                      )}
                       <span className="truncate">{chat.name}</span>
                       {chat.showUnreadCount && (
                         <span
@@ -227,6 +346,7 @@ export default function ChatSidebar() {
                     e.stopPropagation();
                     setChatMenuOpen(chatMenuOpen === chat.groupId ? null : chat.groupId);
                   }}
+                  aria-label="Conversation options"
                   className="p-1 opacity-0 group-hover:opacity-100 hover:bg-gray-100 rounded transition-all flex-shrink-0"
                 >
                   <MoreHorizontal className="w-4 h-4 text-gray-400" />
@@ -253,6 +373,16 @@ export default function ChatSidebar() {
                 )}
               </div>
             ))}
+          </div>
+        )}
+        {mode === 'a2a' && (
+          <div className="mt-3 border-t border-gray-100 pt-3">
+            <button
+              onClick={() => navigate('/negotiations')}
+              className="text-[11px] font-ibm-plex-mono text-[#35799C] transition-colors hover:text-[#041729]"
+            >
+              View all in Negotiations inbox &rarr;
+            </button>
           </div>
         )}
       </div>

--- a/apps/web/src/components/__tests__/ChatSidebar.test.tsx
+++ b/apps/web/src/components/__tests__/ChatSidebar.test.tsx
@@ -1,5 +1,6 @@
-import { render, screen } from '@testing-library/react';
-import { MemoryRouter } from 'react-router';
+import { useEffect } from 'react';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { MemoryRouter, useLocation } from 'react-router';
 import { describe, expect, it, vi } from 'vitest';
 
 import ChatSidebar from '../ChatSidebar';
@@ -39,35 +40,112 @@ const messageConversation: ConversationSummary = {
   createdAt: '2025-06-11T12:00:00.000Z',
 };
 
+function negotiation(
+  id: string,
+  counterpartName: string,
+  input: {
+    state?: NonNullable<ConversationSummary['negotiation']>['state'];
+    opportunityStatus?: NonNullable<ConversationSummary['negotiation']>['opportunityStatus'];
+    action?: string;
+    senderId?: string;
+    turnCount?: number;
+  } = {},
+): ConversationSummary {
+  return {
+    id,
+    participants: [
+      { participantId: 'agent:me', participantType: 'agent', name: 'Index Negotiator', avatar: null, ownerName: 'Viewer' },
+      { participantId: `agent:${id}-peer`, participantType: 'agent', name: 'Index Negotiator', avatar: null, ownerName: counterpartName },
+    ],
+    lastMessage: {
+      parts: [{ kind: 'data', data: { action: input.action ?? 'counter' } }],
+      senderId: input.senderId ?? `agent:${id}-peer`,
+      createdAt: '2026-07-24T11:00:00.000Z',
+    },
+    metadata: null,
+    via: [],
+    unreadCount: 0,
+    lastMessageAt: '2026-07-24T11:00:00.000Z',
+    createdAt: '2026-07-24T10:00:00.000Z',
+    negotiation: {
+      taskId: `${id}-task`,
+      state: input.state ?? 'working',
+      statusTimestamp: '2026-07-24T11:00:00.000Z',
+      opportunityId: `${id}-opportunity`,
+      opportunityStatus: input.opportunityStatus ?? 'negotiating',
+      acceptedByViewer: false,
+      turnCount: input.turnCount ?? 1,
+      maxTurns: 6,
+      signalCount: 2,
+      outcome: null,
+      updatedAt: '2026-07-24T11:00:00.000Z',
+    },
+  };
+}
+
+const answerNegotiation = negotiation('question', 'Mira Chen', {
+  state: 'input_required',
+  action: 'ask_user',
+  senderId: 'agent:me',
+});
+
 const mocks = vi.hoisted(() => ({
   conversations: [] as ConversationSummary[],
+  negotiations: [] as ConversationSummary[],
+  features: undefined as { negotiatorChat?: boolean } | undefined,
+  apiGet: vi.fn(),
+  apiPost: vi.fn(),
 }));
 
 vi.mock('@/contexts/AuthContext', () => ({
-  useAuthContext: () => ({ user: viewer }),
+  useAuthContext: () => ({ user: viewer, features: mocks.features }),
 }));
 
 vi.mock('@/contexts/ConversationContext', () => ({
   useConversation: () => ({
     conversations: mocks.conversations,
-    negotiations: [],
+    negotiations: mocks.negotiations,
+    isConnected: true,
     refreshConversations: vi.fn(async () => {}),
     refreshNegotiations: vi.fn(async () => {}),
     hideConversation: vi.fn(async () => {}),
   }),
 }));
 
+vi.mock('@/lib/api', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('@/lib/api')>()),
+  apiClient: { get: mocks.apiGet, post: mocks.apiPost },
+}));
+
+const currentPath = { value: '/' };
+
+function LocationProbe() {
+  const { pathname } = useLocation();
+  useEffect(() => {
+    currentPath.value = pathname;
+  }, [pathname]);
+  return null;
+}
+
 function renderSidebar() {
   return render(
     <MemoryRouter initialEntries={['/chat']}>
+      <LocationProbe />
       <ChatSidebar />
     </MemoryRouter>,
   );
 }
 
+async function openNegotiationsTab() {
+  fireEvent.click(screen.getByRole('button', { name: /^Negotiations/ }));
+  // Wait for the first refresh to settle so empty-state assertions are stable.
+  await waitFor(() => expect(screen.queryByTestId('chat-sidebar-skeleton')).not.toBeInTheDocument());
+}
+
 describe('ChatSidebar conversation preview wiring (IND-504)', () => {
   it('renders the muted placeholder for a row with lastMessage: null and the excerpt for a real message', async () => {
     mocks.conversations = [emptyConversation, messageConversation];
+    mocks.negotiations = [];
     renderSidebar();
 
     // Excerpt row: real last message, standard excerpt styling, no placeholder.
@@ -98,10 +176,121 @@ describe('ChatSidebar conversation preview wiring (IND-504)', () => {
         metadata: { matchReason: 'RAW_MATCH_REASON', interpretation: { reasoning: 'RAW_REASONING' } } as unknown as ConversationSummary['metadata'],
       },
     ];
+    mocks.negotiations = [];
     renderSidebar();
 
     expect(await screen.findByTestId('conversation-preview-empty')).toHaveTextContent('No messages yet');
     expect(screen.queryByText(/RAW_MATCH_REASON/)).not.toBeInTheDocument();
     expect(screen.queryByText(/RAW_REASONING/)).not.toBeInTheDocument();
+  });
+});
+
+describe('ChatSidebar negotiations tab (IND-523)', () => {
+  it('shows the your-move badge on the toggle only when action is needed', () => {
+    mocks.conversations = [];
+    mocks.negotiations = [answerNegotiation];
+    const { unmount } = renderSidebar();
+
+    const badge = screen.getByTestId('chat-negotiations-your-move-badge');
+    expect(badge).toHaveTextContent('1');
+    // Self-scoped pill: fixed 16px height, no segment padding/flex inheritance.
+    expect(badge.className).toContain('h-4');
+    expect(badge.className).toContain('flex-none');
+    unmount();
+
+    mocks.negotiations = [];
+    renderSidebar();
+    expect(screen.queryByTestId('chat-negotiations-your-move-badge')).not.toBeInTheDocument();
+  });
+
+  it('renders chip rows in posture order with muted resolved rows', async () => {
+    mocks.conversations = [];
+    mocks.negotiations = [
+      negotiation('resolved', 'Jonas Berg', { opportunityStatus: 'rejected', action: 'decline' }),
+      negotiation('waiting', 'Tom Wolfe', { turnCount: 0 }),
+      negotiation('live', 'Aisha Khan', { turnCount: 3 }),
+      answerNegotiation,
+    ];
+    renderSidebar();
+    await openNegotiationsTab();
+
+    const names = ['Mira Chen', 'Aisha Khan', 'Tom Wolfe', 'Jonas Berg'];
+    const rows = names.map((name) => screen.getByText(name));
+    for (let i = 1; i < rows.length; i += 1) {
+      expect(rows[i - 1].compareDocumentPosition(rows[i]) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy();
+    }
+
+    // Chip labels come from the shared inbox projection.
+    expect(screen.getByText('Answer your agent')).toBeInTheDocument();
+    expect(screen.getByText('● Live · turn 3 of 6')).toBeInTheDocument();
+    expect(screen.getByText('Waiting on their agent')).toBeInTheDocument();
+    expect(screen.getByText('No opportunity')).toBeInTheDocument();
+
+    // Subline: N signals · last move · timeAgo.
+    expect(screen.getByText(/2 signals · your agent asked for guidance ·/)).toBeInTheDocument();
+
+    // Resolved rows are visually retired.
+    const resolvedRow = screen.getByText('Jonas Berg').closest('div[class*="opacity-80"]');
+    expect(resolvedRow).not.toBeNull();
+  });
+
+  it('shows mode-aware empty copy and the persistent inbox footer link', async () => {
+    mocks.conversations = [];
+    mocks.negotiations = [];
+    renderSidebar();
+    await openNegotiationsTab();
+
+    expect(screen.getByText('No negotiations yet')).toBeInTheDocument();
+    expect(screen.getByText('Your agents’ connection work will appear here.')).toBeInTheDocument();
+    expect(screen.getByText(/View all in Negotiations inbox/)).toBeInTheDocument();
+    expect(screen.queryByText('No messages yet')).not.toBeInTheDocument();
+  });
+
+  it('labels the a2a row menu action Hide', async () => {
+    mocks.conversations = [];
+    mocks.negotiations = [answerNegotiation];
+    renderSidebar();
+    await openNegotiationsTab();
+
+    fireEvent.click(screen.getByRole('button', { name: 'Negotiation options' }));
+    expect(screen.getByText('Hide')).toBeInTheDocument();
+    expect(screen.queryByText('Delete')).not.toBeInTheDocument();
+  });
+
+  it('routes answer rows to the transcript when the negotiator chat is unavailable', async () => {
+    mocks.conversations = [];
+    mocks.negotiations = [answerNegotiation];
+    mocks.features = undefined;
+    renderSidebar();
+    await openNegotiationsTab();
+
+    fireEvent.click(screen.getByText('Mira Chen'));
+    await waitFor(() => expect(currentPath.value).toBe('/chat/question'));
+    expect(mocks.apiGet).not.toHaveBeenCalled();
+  });
+
+  it('routes answer rows to the negotiator DM when the session exists', async () => {
+    mocks.conversations = [];
+    mocks.negotiations = [answerNegotiation];
+    mocks.features = { negotiatorChat: true };
+    mocks.apiGet.mockResolvedValue({ sessions: [{ id: 'negotiator-session' }] });
+    renderSidebar();
+    await openNegotiationsTab();
+
+    fireEvent.click(screen.getByText('Mira Chen'));
+    await waitFor(() => expect(currentPath.value).toBe('/d/negotiator-session'));
+    expect(mocks.apiGet).toHaveBeenCalledWith('/chat/sessions?persona=negotiator');
+    mocks.features = undefined;
+    mocks.apiGet.mockReset();
+  });
+
+  it('routes live rows to the transcript', async () => {
+    mocks.conversations = [];
+    mocks.negotiations = [negotiation('live', 'Aisha Khan', { turnCount: 3 })];
+    renderSidebar();
+    await openNegotiationsTab();
+
+    fireEvent.click(screen.getByText('Aisha Khan'));
+    await waitFor(() => expect(currentPath.value).toBe('/chat/live'));
   });
 });

--- a/apps/web/src/lib/negotiation-chips.ts
+++ b/apps/web/src/lib/negotiation-chips.ts
@@ -1,0 +1,28 @@
+import type { NegotiationInboxItem, NegotiationInboxStatus } from '@/lib/negotiation-inbox';
+
+// Copied from NegotiationsInbox.tsx so the /chat tab renders the same chips as
+// the inbox without the two surfaces diverging. NegotiationsInbox keeps its
+// local copies for now; dedupe into this module is a follow-up cleanup.
+export const CHIP_CLASS: Record<NegotiationInboxStatus, string> = {
+  answer: 'border-[#041729] bg-[#041729] text-white',
+  agreed: 'border-emerald-200 bg-emerald-50 text-emerald-700',
+  live: 'border-amber-200 bg-amber-50 text-amber-700',
+  waiting: 'border-gray-200 bg-gray-100 text-gray-600',
+  accepted: 'border-emerald-200 bg-emerald-50 text-emerald-700',
+  started: 'border-emerald-200 bg-emerald-50 text-emerald-700',
+  rejected: 'border-red-200 bg-red-50 text-red-700',
+  stalled: 'border-amber-200 bg-amber-50 text-amber-700',
+};
+
+export function statusLabel(item: NegotiationInboxItem): string {
+  switch (item.status) {
+    case 'answer': return 'Answer your agent';
+    case 'agreed': return 'Agents agreed';
+    case 'live': return `● Live · turn ${item.turnCount} of ${item.maxTurns}`;
+    case 'waiting': return 'Waiting on their agent';
+    case 'accepted': return 'Accepted by you';
+    case 'started': return 'Chat started';
+    case 'rejected': return 'No opportunity';
+    case 'stalled': return 'Stalled';
+  }
+}


### PR DESCRIPTION
## Summary

Upgrades the /chat Negotiations tab (ChatSidebar a2a mode) per R1–R5 of `docs/design/negotiations-chat-tab-proposals.html` — an ambient watch + jump-off view over the shipped inbox projection, not a second triage surface.

- **R1 · Single source of truth**: deleted the inline last-action derivation in `ChatSidebar.tsx`; the tab now consumes `deriveNegotiationInbox()` from `lib/negotiation-inbox.ts`, the same projection the inbox page and TopBar pill use.
- **R2 · Chip rows**: status chips (shared `lib/negotiation-chips.ts`, copied from `NegotiationsInbox.tsx` — child C owns that file, dedupe is a later cleanup), flat posture order your move → live → waiting → resolved with hairline dividers, muted resolved rows (`opacity-80` inbox idiom), subline "N signals · last move · timeAgo", state-conditional third line for answer/agreed rows, turn counter inside the live chip.
- **R3 · Toggle badge**: navy your-move count pill on the Messages/Negotiations toggle fed by `countNegotiationsRequiringAction()`, hidden at zero, 16px (`h-4`) with self-scoped classes (`flex-none`, own padding) so segment styles can't leak into the badge.
- **R4 · Status-routed row targets**: answer → negotiator DM (`/d/:sessionId`, resolved via `/chat/sessions?persona=negotiator` then `/chat/negotiator/session`, gated on the `negotiatorChat` feature flag with transcript fallback); agreed → transcript `/chat/:id` (review affordance lives in the transcript page, owned by another child); live/waiting/resolved → transcript as today.
- **R5 · Mode-aware empty state** ("No negotiations yet" / "Your agents' connection work will appear here") + persistent "View all in Negotiations inbox" footer link.
- Hover "Delete" → **Hide** (EyeOff icon) for a2a transcripts; Messages rows keep "Delete".
- **IND-554 (tab part)**: emerald "live" / gray "reconnecting…" dot beside the toggle from `isConnected` in ConversationContext.
- **IND-555 (tab part)**: 30s tick re-derives the inbox with a fresh `now`, so `timeAgo` strings and row timestamps stay live.

Version bump: `apps/web` 0.32.0 → 0.34.0 (MINOR over dev's current 0.33.0). `bun install` produced no `bun.lock` change.

## Verification

- `bun run lint` — my files clean; the run still exits 1 on a **pre-existing** `react-hooks/refs` error in `src/lib/api.ts` (untouched, present on dev).
- `bun run test` (ChatSidebar + negotiation-inbox) — 13/13 pass, incl. 7 new a2a-tab tests (badge, posture order, muted resolved, empty state, Hide label, status routing).
- `bunx tsc --noEmit` — 61 errors before and after (byte-identical); no new errors.
- `bun run build` — passes.

## Caveats

- Negotiator-DM routing for answer rows needs the `negotiatorChat` feature flag; without it rows fall back to the transcript.
- `CHIP_CLASS`/`statusLabel` are intentionally duplicated in the new `lib/negotiation-chips.ts`; `NegotiationsInbox.tsx` still has its local copies (owned by child C) — dedupe into the shared module is follow-up cleanup.
- The agreed-row review affordance itself lives in `/chat/:id`, which this PR does not touch (child D owns it).

Closes IND-523
Closes IND-536
Closes IND-537
Closes IND-538
Closes IND-539
Closes IND-540

Also covers the /chat-tab parts of IND-554 (live dot) and IND-555 (ticking timestamps).
