### PR TITLE
feat(web): negotiation transcript turn rail

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@indexnetwork/web",
-  "version": "0.35.0",
+  "version": "0.36.0",
   "license": "MIT",
   "scripts": {
     "dev": "vite --host 127.0.0.1",

--- a/apps/web/src/app/chat/[conversationId]/page.tsx
+++ b/apps/web/src/app/chat/[conversationId]/page.tsx
@@ -1,25 +1,37 @@
-import { useEffect, useRef, useState, useMemo } from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { useParams, useNavigate } from 'react-router';
 import { Loader2 } from 'lucide-react';
-import ReactMarkdown from 'react-markdown';
-import remarkGfm from 'remark-gfm';
-import { cn } from '@/lib/utils';
+import { apiClient } from '@/lib/api';
 import { ContentContainer } from '@/components/layout';
-import UserAvatar from '@/components/UserAvatar';
 import { useAuthContext } from '@/contexts/AuthContext';
 import { useConversation } from '@/contexts/ConversationContext';
+import { useOpportunityActions } from '@/hooks/useOpportunityActions';
+import TurnRail from '@/components/negotiations/TurnRail';
+import OutcomeBanner from '@/components/negotiations/OutcomeBanner';
+import ResolvedBanner, { type ResolvedBannerVariant } from '@/components/negotiations/ResolvedBanner';
+import { useTickingNow } from '@/components/negotiations/use-ticking-now';
+import { extractTurn, formatRelativeTime, viewerRoleLabel, type TranscriptTurn } from '@/components/negotiations/negotiation-turns';
+
+const STALL_REASONS = new Set(['turn_cap', 'timeout']);
 
 export default function NegotiationDetailPage() {
   const { conversationId } = useParams();
   const navigate = useNavigate();
   const { user } = useAuthContext();
-  const { negotiations, messages, loadSessionHistory, loadPreviousSessionMessages, sessionHistory } = useConversation();
+  const { negotiations, messages, loadSessionHistory, loadPreviousSessionMessages, refreshNegotiations, sessionHistory } = useConversation();
   const [loading, setLoading] = useState(true);
   const messagesEndRef = useRef<HTMLDivElement>(null);
+  const now = useTickingNow();
 
   const conversation = negotiations.find((c) => c.id === conversationId);
   const conversationMessages = useMemo(() => messages.get(conversationId!) ?? [], [messages, conversationId]);
   const history = conversationId ? sessionHistory.get(conversationId) : undefined;
+  const lifecycle = conversation?.negotiation ?? null;
+
+  const { handleOpportunityAction, opportunityStatusMap, opportunityActionLoading, inviteModalElement } =
+    useOpportunityActions({
+      onRemove: () => { void refreshNegotiations(); },
+    });
 
   useEffect(() => {
     if (!conversationId) return;
@@ -52,10 +64,47 @@ export default function NegotiationDetailPage() {
   // Determine which participant represents "our" side (the current user's agent)
   const ownAgentId = user?.id ? `agent:${user.id}` : null;
 
-  const formatTime = (createdAt: string) => {
-    if (!createdAt) return '';
-    return new Date(createdAt).toLocaleTimeString([], { hour: 'numeric', minute: '2-digit' });
-  };
+  const counterpart = participants.find((p) => p.participantId !== ownAgentId);
+  const counterpartUserId = counterpart?.participantId.replace(/^agent:/, '') ?? '';
+  const counterpartName = counterpart?.ownerName ?? conversation?.metadata?.title ?? counterpart?.name ?? 'them';
+
+  const turns = useMemo(
+    () => conversationMessages.map(extractTurn).filter((turn): turn is TranscriptTurn => turn !== null),
+    [conversationMessages],
+  );
+  const negotiatedRole = useMemo(() => viewerRoleLabel(turns, ownAgentId), [turns, ownAgentId]);
+
+  const opportunityId = lifecycle?.opportunityId ?? null;
+  const localStatus = opportunityId ? opportunityStatusMap[opportunityId] : undefined;
+  const effectiveOpportunityStatus = localStatus ?? lifecycle?.opportunityStatus ?? null;
+  const outcomeReason = lifecycle?.outcome?.reason ?? null;
+
+  // Resolved-state banner derivation, mirroring lib/negotiation-inbox classification.
+  const resolvedVariant = useMemo<ResolvedBannerVariant | null>(() => {
+    if (!lifecycle) return null;
+    if (effectiveOpportunityStatus === 'rejected') return 'rejected';
+    if (effectiveOpportunityStatus === 'stalled' || effectiveOpportunityStatus === 'expired') return 'stalled';
+    if (effectiveOpportunityStatus === 'pending' || effectiveOpportunityStatus === 'accepted') return null;
+    if (lifecycle.outcome?.hasOpportunity === false) {
+      return STALL_REASONS.has(outcomeReason ?? '') ? 'stalled' : 'rejected';
+    }
+    if (['failed', 'canceled', 'auth_required'].includes(lifecycle.state)) return 'stalled';
+    if (lifecycle.state === 'rejected') return 'rejected';
+    return null;
+  }, [lifecycle, effectiveOpportunityStatus, outcomeReason]);
+
+  const showOutcomeBanner = !resolvedVariant && effectiveOpportunityStatus === 'pending' && !!opportunityId;
+
+  // Revival CTA routes through the user's own agent (the negotiator DM), with
+  // the questions inbox as fallback when no negotiator session exists yet.
+  const handleRevive = useCallback(async () => {
+    try {
+      const { sessions } = await apiClient.get<{ sessions: { id: string }[] }>('/chat/sessions?persona=negotiator');
+      navigate(sessions[0]?.id ? `/d/${sessions[0].id}` : '/questions');
+    } catch {
+      navigate('/questions');
+    }
+  }, [navigate]);
 
   return (
     <>
@@ -73,7 +122,7 @@ export default function NegotiationDetailPage() {
         </div>
       </div>
 
-      {/* Messages */}
+      {/* Transcript */}
       <div className="px-6 lg:px-8 pb-32 flex-1">
         <ContentContainer>
           <div className="space-y-4">
@@ -100,103 +149,41 @@ export default function NegotiationDetailPage() {
               </div>
             ) : null}
 
-            {conversationMessages.map((message, index) => {
-              const isOwn = message.senderId === ownAgentId;
-              const info = participantInfo.get(message.senderId);
-              const previousMessage = conversationMessages[index - 1];
-              const startsSession = previousMessage !== undefined && previousMessage.sessionId !== message.sessionId;
+            <TurnRail
+              turns={turns}
+              ownAgentId={ownAgentId}
+              participantInfo={participantInfo}
+              counterpartName={counterpartName}
+              now={now}
+            />
 
-              // Extract text content from message parts — use `message` field from data part, or text part
-              const parts = message.parts as { kind?: string; text?: string; data?: { message?: string; assessment?: { reasoning?: string } } }[];
-              const dataPart = parts?.find((p) => p.kind === 'data');
-              const textPart = parts?.find((p) => p.text);
-              const messageText = dataPart?.data?.message;
-              const reasoningText = dataPart?.data?.assessment?.reasoning;
-              const content = messageText ?? reasoningText ?? textPart?.text ?? '';
-              const isInternal = !messageText && !!reasoningText;
-              if (!content.trim()) return null;
+            {showOutcomeBanner && opportunityId && (
+              <OutcomeBanner
+                counterpartName={counterpartName}
+                role={negotiatedRole}
+                turnCount={lifecycle?.turnCount ?? null}
+                concludedLabel={lifecycle?.updatedAt ? formatRelativeTime(lifecycle.updatedAt, now) : null}
+                loading={opportunityActionLoading[opportunityId] === true}
+                onStartChat={() => void handleOpportunityAction(opportunityId, 'accepted', counterpartUserId, undefined, counterpartName)}
+                onPass={() => void handleOpportunityAction(opportunityId, 'rejected', counterpartUserId, undefined, counterpartName)}
+              />
+            )}
 
-              const showTimestamp = index === 0 || (previousMessage && new Date(message.createdAt).getTime() - new Date(previousMessage.createdAt).getTime() > 300_000);
-
-              return (
-                <div key={message.id}>
-                  {startsSession && (
-                    <div className="flex items-center gap-3 py-3" role="separator" aria-label="Earlier chat session">
-                      <span className="h-px flex-1 bg-gray-200" />
-                      <span className="text-[10px] font-ibm-plex-mono uppercase tracking-[0.12em] text-gray-400">Earlier conversation</span>
-                      <span className="h-px flex-1 bg-gray-200" />
-                    </div>
-                  )}
-                  {showTimestamp && message.createdAt && (
-                    <div className="text-center text-xs text-gray-400 uppercase tracking-wider my-4">
-                      {(() => {
-                        const d = new Date(message.createdAt);
-                        const now = new Date();
-                        const yesterday = new Date(now);
-                        yesterday.setDate(yesterday.getDate() - 1);
-
-                        let label: string;
-                        if (d.toDateString() === now.toDateString()) {
-                          label = 'Today';
-                        } else if (d.toDateString() === yesterday.toDateString()) {
-                          label = 'Yesterday';
-                        } else {
-                          label = d.toLocaleDateString([], { month: 'short', day: 'numeric' });
-                        }
-                        return `${label}, ${formatTime(message.createdAt)}`;
-                      })()}
-                    </div>
-                  )}
-                  <div className={cn('flex items-end gap-2', isOwn ? 'justify-end' : 'justify-start')}>
-                    {!isOwn && info && (
-                      <div className="flex-shrink-0">
-                        <UserAvatar avatar={info.avatar} id={message.senderId} name={info.ownerName} size={32} />
-                      </div>
-                    )}
-                    <div className="max-w-[70%]">
-                      {!isOwn && info && (
-                        <p className="text-xs text-gray-400 mb-1 ml-1">
-                          {info.agentName} <span className="text-gray-300">for</span> {info.ownerName}
-                        </p>
-                      )}
-                      <div
-                        className={cn(
-                          'rounded-2xl px-4 py-2',
-                          isInternal
-                            ? 'bg-transparent border border-dashed border-gray-300 text-gray-500 italic'
-                            : isOwn
-                              ? 'bg-gray-900 text-white'
-                              : 'bg-gray-100 text-gray-900',
-                        )}
-                      >
-                        {isInternal && (
-                          <p className="not-italic text-[10px] uppercase tracking-wider text-gray-400 mb-1">
-                            Internal assessment
-                          </p>
-                        )}
-                        <article className={cn('text-sm', !isInternal && isOwn && 'text-white')}>
-                          <ReactMarkdown remarkPlugins={[remarkGfm]}>{content}</ReactMarkdown>
-                        </article>
-                      </div>
-                      {isOwn && info && (
-                        <p className="text-xs text-gray-400 mt-1 mr-1 text-right">
-                          {info.agentName} <span className="text-gray-300">for</span> {info.ownerName}
-                        </p>
-                      )}
-                    </div>
-                    {isOwn && info && (
-                      <div className="flex-shrink-0">
-                        <UserAvatar avatar={info.avatar} id={message.senderId} name={info.ownerName} size={32} />
-                      </div>
-                    )}
-                  </div>
-                </div>
-              );
-            })}
+            {resolvedVariant && (
+              <ResolvedBanner
+                variant={resolvedVariant}
+                reason={outcomeReason}
+                turnCount={lifecycle?.turnCount ?? null}
+                maxTurns={lifecycle?.maxTurns ?? null}
+                onRevive={resolvedVariant === 'stalled' ? () => void handleRevive() : undefined}
+                onLetGo={resolvedVariant === 'stalled' ? () => navigate('/negotiations') : undefined}
+              />
+            )}
             <div ref={messagesEndRef} />
           </div>
         </ContentContainer>
       </div>
+      {inviteModalElement}
     </>
   );
 }

--- a/apps/web/src/components/__tests__/negotiation-turns.test.ts
+++ b/apps/web/src/components/__tests__/negotiation-turns.test.ts
@@ -1,0 +1,134 @@
+import { describe, expect, it } from 'vitest';
+
+import { extractTurn, formatRelativeTime, roleChipLabel, roleLabel, verbFor, viewerRoleLabel, type TranscriptTurn } from '@/components/negotiations/negotiation-turns';
+import type { ConversationMessage } from '@/services/conversation';
+
+function message(parts: unknown[], overrides: Partial<ConversationMessage> = {}): ConversationMessage {
+  return {
+    id: 'm1',
+    conversationId: 'c1',
+    senderId: 'agent:own',
+    role: 'agent',
+    parts,
+    createdAt: '2026-07-24T12:00:00.000Z',
+    ...overrides,
+  };
+}
+
+describe('extractTurn', () => {
+  it('prefers the data message and captures action + suggested roles', () => {
+    const turn = extractTurn(message([
+      {
+        kind: 'data',
+        data: {
+          action: 'propose',
+          message: 'Proposing a connection.',
+          assessment: { reasoning: 'hidden', suggestedRoles: { ownUser: 'agent', otherUser: 'patient' } },
+        },
+      },
+    ]));
+    expect(turn).toMatchObject({
+      action: 'propose',
+      text: 'Proposing a connection.',
+      suggestedRoles: { ownUser: 'agent', otherUser: 'patient' },
+    });
+  });
+
+  it('falls back to assessment reasoning when there is no message', () => {
+    const turn = extractTurn(message([
+      { kind: 'data', data: { action: 'counter', assessment: { reasoning: 'Bandwidth confirmed.' } } },
+    ]));
+    expect(turn?.text).toBe('Bandwidth confirmed.');
+    expect(turn?.suggestedRoles).toBeNull();
+  });
+
+  it('falls back to a text part', () => {
+    const turn = extractTurn(message([{ kind: 'text', text: 'Hello there' }]));
+    expect(turn?.text).toBe('Hello there');
+    expect(turn?.action).toBeNull();
+  });
+
+  it('drops messages without visible text', () => {
+    expect(extractTurn(message([{ kind: 'data', data: { action: 'accept' } }]))).toBeNull();
+    expect(extractTurn(message([]))).toBeNull();
+  });
+});
+
+describe('verbFor', () => {
+  it('maps actions to the §2.3 palette', () => {
+    expect(verbFor('propose')).toMatchObject({ label: 'PROPOSED', color: 'text-blue-600' });
+    expect(verbFor('counter')?.color).toBe('text-amber-600');
+    expect(verbFor('question')?.color).toBe('text-[#35799C]');
+    expect(verbFor('accept')?.color).toBe('text-emerald-600');
+    expect(verbFor('decline')?.color).toBe('text-red-600');
+    expect(verbFor('withdraw')?.color).toBe('text-red-600');
+  });
+
+  it('returns null without an action and a neutral fallback for unknown ones', () => {
+    expect(verbFor(null)).toBeNull();
+    expect(verbFor('mystery_move')).toMatchObject({ label: 'MYSTERY MOVE', color: 'text-gray-500' });
+  });
+});
+
+describe('roleLabel', () => {
+  it('uses Helper/Seeker/Peer vocabulary, never agent/patient', () => {
+    expect(roleLabel('agent')).toBe('Helper');
+    expect(roleLabel('patient')).toBe('Seeker');
+    expect(roleLabel('peer')).toBe('Peer');
+  });
+});
+
+describe('roleChipLabel', () => {
+  it('labels roles viewer-first from the sender perspective', () => {
+    expect(roleChipLabel({ ownUser: 'agent', otherUser: 'patient' }, true, 'Dan'))
+      .toBe('you → Helper · Dan → Seeker');
+  });
+
+  it('flips the mapping when the counterpart authored the turn', () => {
+    expect(roleChipLabel({ ownUser: 'patient', otherUser: 'agent' }, false, 'Dan'))
+      .toBe('you → Helper · Dan → Seeker');
+  });
+
+  it('returns null when no roles were suggested', () => {
+    expect(roleChipLabel(null, true, 'Dan')).toBeNull();
+    expect(roleChipLabel({}, true, 'Dan')).toBeNull();
+  });
+});
+
+describe('viewerRoleLabel', () => {
+  const turns: TranscriptTurn[] = [
+    { id: '1', sessionId: null, senderId: 'agent:own', createdAt: '', action: 'propose', text: 'x', suggestedRoles: { ownUser: 'agent', otherUser: 'patient' } },
+    { id: '2', sessionId: null, senderId: 'agent:other', createdAt: '', action: 'accept', text: 'y', suggestedRoles: { ownUser: 'patient', otherUser: 'agent' } },
+  ];
+
+  it('reads the viewer role from the latest role-suggesting turn', () => {
+    expect(viewerRoleLabel(turns, 'agent:own')).toBe('Helper');
+  });
+
+  it('returns null when no turn suggested roles', () => {
+    expect(viewerRoleLabel([{ ...turns[0], suggestedRoles: null }], 'agent:own')).toBeNull();
+  });
+});
+
+describe('formatRelativeTime', () => {
+  const now = new Date('2026-07-24T12:00:00.000Z').getTime();
+
+  it('formats relative buckets', () => {
+    expect(formatRelativeTime('2026-07-24T11:59:40.000Z', now)).toBe('just now');
+    expect(formatRelativeTime('2026-07-24T11:55:00.000Z', now)).toBe('5m ago');
+    expect(formatRelativeTime('2026-07-24T09:00:00.000Z', now)).toBe('3h ago');
+    expect(formatRelativeTime('2026-07-22T12:00:00.000Z', now)).toBe('2d ago');
+    expect(formatRelativeTime('2026-03-24T12:00:00.000Z', now)).toBe('4mo ago');
+  });
+
+  it('ticks forward with `now`', () => {
+    const created = '2026-07-24T11:59:40.000Z';
+    expect(formatRelativeTime(created, now)).toBe('just now');
+    expect(formatRelativeTime(created, now + 30_000)).toBe('just now');
+    expect(formatRelativeTime(created, now + 90_000)).toBe('1m ago');
+  });
+
+  it('returns empty for unparseable timestamps', () => {
+    expect(formatRelativeTime('not-a-date', now)).toBe('');
+  });
+});

--- a/apps/web/src/components/negotiations/OutcomeBanner.tsx
+++ b/apps/web/src/components/negotiations/OutcomeBanner.tsx
@@ -1,0 +1,68 @@
+interface OutcomeBannerProps {
+  counterpartName: string;
+  /** Viewer's negotiated role label (Helper/Seeker/Peer), if any turn suggested roles. */
+  role: string | null;
+  turnCount: number | null;
+  /** Pre-formatted conclusion time label. */
+  concludedLabel: string | null;
+  loading: boolean;
+  onStartChat: () => void;
+  onPass: () => void;
+}
+
+/**
+ * Outcome banner for a `pending` opportunity (proposals §2.3): separates what
+ * the agents agreed from the human gate. Only "Start chat" writes `accepted`.
+ */
+export function OutcomeBanner({
+  counterpartName,
+  role,
+  turnCount,
+  concludedLabel,
+  loading,
+  onStartChat,
+  onPass,
+}: OutcomeBannerProps) {
+  const summaryParts: string[] = [];
+  if (turnCount != null && turnCount > 0) summaryParts.push(`${turnCount} ${turnCount === 1 ? 'turn' : 'turns'}`);
+  if (concludedLabel) summaryParts.push(`concluded ${concludedLabel}`);
+
+  return (
+    <div className="mt-4 rounded-lg border border-[#bfe9d5] bg-[#f2fbf6] px-4 py-4">
+      <h3 className="font-ibm-plex-mono text-[13px] font-bold text-[#041729]">
+        Agents agreed — opportunity pending
+      </h3>
+      <p className="mt-1 text-[13px] text-[#3D3D3D]">
+        {role && (
+          <>
+            Your negotiated role: <b>{role}</b>.{' '}
+          </>
+        )}
+        {summaryParts.length > 0 && `${summaryParts.join(' · ')}.`}
+      </p>
+      <div className="mt-3 flex items-center gap-2.5">
+        <button
+          type="button"
+          onClick={onStartChat}
+          disabled={loading}
+          className="rounded-sm bg-[#041729] px-3.5 py-2 text-xs font-semibold text-white transition-colors hover:bg-[#0A2D4A] disabled:opacity-50"
+        >
+          Start chat with {counterpartName}
+        </button>
+        <button
+          type="button"
+          onClick={onPass}
+          disabled={loading}
+          className="rounded-sm border border-gray-200 bg-transparent px-3.5 py-2 text-xs font-semibold text-[#3D3D3D] transition-colors hover:bg-gray-50 disabled:opacity-50"
+        >
+          Pass
+        </button>
+      </div>
+      <p className="mt-2.5 font-ibm-plex-mono text-[11px] text-gray-400">
+        Your agent&apos;s accept is a recommendation, not a commitment. Only &quot;Start chat&quot; makes it real.
+      </p>
+    </div>
+  );
+}
+
+export default OutcomeBanner;

--- a/apps/web/src/components/negotiations/ResolvedBanner.tsx
+++ b/apps/web/src/components/negotiations/ResolvedBanner.tsx
@@ -1,0 +1,78 @@
+export type ResolvedBannerVariant = 'rejected' | 'stalled';
+
+interface ResolvedBannerProps {
+  variant: ResolvedBannerVariant;
+  /** outcome.reason (screened_out / turn_cap / timeout / …) drives the phrasing. */
+  reason: string | null;
+  turnCount: number | null;
+  maxTurns: number | null;
+  /** Stalled only: route to the user's agent to answer the open question. */
+  onRevive?: () => void;
+  /** Stalled only: leave the transcript. */
+  onLetGo?: () => void;
+}
+
+/**
+ * Resolved-state banners (proposals §2.4). Negative outcomes are framed as
+ * filtering done for you, with hedged, reason-based phrasing — a screened-out
+ * thread never names who screened, so the counterparty learns nothing.
+ */
+export function ResolvedBanner({ variant, reason, turnCount, maxTurns, onRevive, onLetGo }: ResolvedBannerProps) {
+  if (variant === 'rejected') {
+    return (
+      <div className="mt-4 rounded-lg border border-red-200 bg-red-50 px-4 py-4">
+        <h3 className="font-ibm-plex-mono text-[13px] font-bold text-[#041729]">
+          No opportunity — filtered out for you
+        </h3>
+        <p className="mt-1 text-[13px] text-[#3D3D3D]">
+          {reason === 'screened_out'
+            ? 'This connection was filtered out before either side reached out, so neither of you was notified.'
+            : `${turnCount != null && turnCount > 0 ? `After ${turnCount} ${turnCount === 1 ? 'turn' : 'turns'}, the` : 'The'} agents couldn't justify this connection, so it was quietly set aside. You were never notified while this played out.`}
+        </p>
+        <p className="mt-2.5 font-ibm-plex-mono text-[11px] text-gray-400">
+          The other side never learns the details — declines are quiet by design.
+        </p>
+      </div>
+    );
+  }
+
+  const timedOut = reason === 'timeout';
+  return (
+    <div className="mt-4 rounded-lg border border-amber-200 bg-amber-50 px-4 py-4">
+      <h3 className="font-ibm-plex-mono text-[13px] font-bold text-[#041729]">
+        {timedOut ? 'Stalled — the dialogue timed out' : 'Stalled — agents ran out of turns'}
+      </h3>
+      <p className="mt-1 text-[13px] text-[#3D3D3D]">
+        {timedOut
+          ? 'The dialogue ended before the agents reached agreement.'
+          : `The dialogue hit its ${maxTurns ?? 6}-turn budget without agreement.`}
+        {' '}Sometimes a stalled thread is one answer away from resolving.
+      </p>
+      <div className="mt-3 flex items-center gap-2.5">
+        {onRevive && (
+          <button
+            type="button"
+            onClick={onRevive}
+            className="rounded-sm border border-gray-200 bg-white px-3.5 py-2 text-xs font-semibold text-[#041729] transition-colors hover:bg-gray-50"
+          >
+            Answer the open question
+          </button>
+        )}
+        {onLetGo && (
+          <button
+            type="button"
+            onClick={onLetGo}
+            className="rounded-sm border border-gray-200 bg-transparent px-3.5 py-2 text-xs font-semibold text-[#3D3D3D] transition-colors hover:bg-gray-50"
+          >
+            Let it go
+          </button>
+        )}
+      </div>
+      <p className="mt-2.5 font-ibm-plex-mono text-[11px] text-gray-400">
+        Answering routes through your agent and can revive the negotiation.
+      </p>
+    </div>
+  );
+}
+
+export default ResolvedBanner;

--- a/apps/web/src/components/negotiations/TurnRail.tsx
+++ b/apps/web/src/components/negotiations/TurnRail.tsx
@@ -1,0 +1,106 @@
+import ReactMarkdown from 'react-markdown';
+import remarkGfm from 'remark-gfm';
+
+import UserAvatar from '@/components/UserAvatar';
+import { formatRelativeTime, roleChipLabel, verbFor, type TranscriptTurn } from '@/components/negotiations/negotiation-turns';
+
+export interface TurnParticipantInfo {
+  ownerName: string;
+  avatar: string | null;
+}
+
+interface TurnItemProps {
+  turn: TranscriptTurn;
+  isLast: boolean;
+  seatLabel: string;
+  avatar: string | null;
+  avatarName: string;
+  roleChip: string | null;
+  now: number;
+}
+
+function TurnItem({ turn, isLast, seatLabel, avatar, avatarName, roleChip, now }: TurnItemProps) {
+  const verb = verbFor(turn.action);
+
+  return (
+    <div className="relative flex gap-3 py-3">
+      {!isLast && (
+        <span aria-hidden="true" className="absolute left-[13px] top-[44px] -bottom-3 w-px bg-gray-200" />
+      )}
+      <div className="shrink-0">
+        <UserAvatar avatar={avatar} id={turn.senderId} name={avatarName} size={28} />
+      </div>
+      <div className="min-w-0 flex-1">
+        <div className="flex flex-wrap items-center gap-2">
+          <span className="font-ibm-plex-mono text-xs font-semibold text-[#3D3D3D]">{seatLabel}</span>
+          {verb && (
+            <span className={`font-ibm-plex-mono text-[11px] font-bold tracking-wide ${verb.color}`}>
+              {verb.label}
+            </span>
+          )}
+          {roleChip && (
+            <span className="rounded-full border border-[#8EC3D8] bg-[#e8f3f9] px-2 py-px font-ibm-plex-mono text-[10px] font-semibold text-[#35799C]">
+              {roleChip}
+            </span>
+          )}
+          <span className="flex-1" />
+          <span className="font-ibm-plex-mono text-[10px] text-gray-400">
+            {formatRelativeTime(turn.createdAt, now)}
+          </span>
+        </div>
+        <article className="mt-1 text-sm text-[#3D3D3D]">
+          <ReactMarkdown remarkPlugins={[remarkGfm]}>{turn.text}</ReactMarkdown>
+        </article>
+      </div>
+    </div>
+  );
+}
+
+interface TurnRailProps {
+  turns: TranscriptTurn[];
+  ownAgentId: string | null;
+  participantInfo: Map<string, TurnParticipantInfo>;
+  counterpartName: string;
+  now: number;
+}
+
+/**
+ * Vertical turn rail (proposals §2.3): avatar + seat label + colored action
+ * verb + role chips + reasoning per turn. No DM bubbles, no own/other alignment.
+ */
+export function TurnRail({ turns, ownAgentId, participantInfo, counterpartName, now }: TurnRailProps) {
+  return (
+    <div>
+      {turns.map((turn, index) => {
+        const isOwn = turn.senderId === ownAgentId;
+        const info = participantInfo.get(turn.senderId);
+        const previousTurn = turns[index - 1];
+        const startsSession = previousTurn !== undefined && previousTurn.sessionId !== turn.sessionId;
+        const seatLabel = isOwn ? 'Your agent' : `${info?.ownerName ?? counterpartName}'s agent`;
+
+        return (
+          <div key={turn.id}>
+            {startsSession && (
+              <div className="flex items-center gap-3 py-3" role="separator" aria-label="Earlier chat session">
+                <span className="h-px flex-1 bg-gray-200" />
+                <span className="text-[10px] font-ibm-plex-mono uppercase tracking-[0.12em] text-gray-400">Earlier conversation</span>
+                <span className="h-px flex-1 bg-gray-200" />
+              </div>
+            )}
+            <TurnItem
+              turn={turn}
+              isLast={index === turns.length - 1}
+              seatLabel={seatLabel}
+              avatar={info?.avatar ?? null}
+              avatarName={info?.ownerName ?? counterpartName}
+              roleChip={roleChipLabel(turn.suggestedRoles, isOwn, counterpartName)}
+              now={now}
+            />
+          </div>
+        );
+      })}
+    </div>
+  );
+}
+
+export default TurnRail;

--- a/apps/web/src/components/negotiations/negotiation-turns.ts
+++ b/apps/web/src/components/negotiations/negotiation-turns.ts
@@ -1,0 +1,138 @@
+import type { ConversationMessage } from '@/services/conversation';
+
+/** User-facing role vocabulary — internal agent/patient labels never surface. */
+export const ROLE_LABELS: Record<string, string> = {
+  agent: 'Helper',
+  patient: 'Seeker',
+  peer: 'Peer',
+};
+
+export function roleLabel(role: string): string {
+  return ROLE_LABELS[role] ?? role;
+}
+
+export interface ActionVerb {
+  label: string;
+  color: string;
+}
+
+/** Colored action verbs for the turn rail (proposals §2.3 palette). */
+export const ACTION_VERBS: Record<string, ActionVerb> = {
+  propose: { label: 'PROPOSED', color: 'text-blue-600' },
+  counter: { label: 'COUNTERED', color: 'text-amber-600' },
+  question: { label: 'QUESTIONED', color: 'text-[#35799C]' },
+  ask_user: { label: 'ASKED YOU', color: 'text-[#35799C]' },
+  outreach: { label: 'OPENED', color: 'text-[#35799C]' },
+  accept: { label: 'ACCEPTED', color: 'text-emerald-600' },
+  reject: { label: 'DECLINED', color: 'text-red-600' },
+  decline: { label: 'DECLINED', color: 'text-red-600' },
+  withdraw: { label: 'WITHDRAWN', color: 'text-red-600' },
+};
+
+export function verbFor(action: string | null): ActionVerb | null {
+  if (!action) return null;
+  return ACTION_VERBS[action] ?? { label: action.replace(/_/g, ' ').toUpperCase(), color: 'text-gray-500' };
+}
+
+export interface SuggestedRoles {
+  ownUser?: string;
+  otherUser?: string;
+}
+
+export interface TranscriptTurn {
+  id: string;
+  sessionId: string | null;
+  senderId: string;
+  createdAt: string;
+  action: string | null;
+  text: string;
+  suggestedRoles: SuggestedRoles | null;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+/**
+ * Extract one renderable turn from an A2A message. Reasoning is shown verbatim
+ * (transparency is the trust mechanism); messages without visible text are dropped.
+ */
+export function extractTurn(message: ConversationMessage): TranscriptTurn | null {
+  const parts = Array.isArray(message.parts) ? message.parts : [];
+  let data: Record<string, unknown> | null = null;
+  let textPart: string | null = null;
+  for (const part of parts) {
+    if (!isRecord(part)) continue;
+    if (part.kind === 'data' && isRecord(part.data)) data = part.data;
+    if (typeof part.text === 'string' && part.text.trim()) textPart = part.text;
+  }
+  const assessment = data && isRecord(data.assessment) ? data.assessment : null;
+  const messageText = typeof data?.message === 'string' ? data.message : null;
+  const reasoningText = typeof assessment?.reasoning === 'string' ? assessment.reasoning : null;
+  const text = messageText ?? reasoningText ?? textPart ?? '';
+  if (!text.trim()) return null;
+
+  const suggestedRolesRaw = assessment?.suggestedRoles;
+  const suggestedRoles = isRecord(suggestedRolesRaw)
+    ? {
+        ownUser: typeof suggestedRolesRaw.ownUser === 'string' ? suggestedRolesRaw.ownUser : undefined,
+        otherUser: typeof suggestedRolesRaw.otherUser === 'string' ? suggestedRolesRaw.otherUser : undefined,
+      }
+    : null;
+
+  return {
+    id: message.id,
+    sessionId: message.sessionId ?? null,
+    senderId: message.senderId,
+    createdAt: message.createdAt,
+    action: typeof data?.action === 'string' ? data.action : null,
+    text,
+    suggestedRoles,
+  };
+}
+
+/**
+ * Role-suggestion chip label, viewer-first: "you → Helper · Dan → Seeker".
+ * suggestedRoles is recorded from the sending agent's perspective, so the
+ * mapping flips when the counterpart's agent authored the turn.
+ */
+export function roleChipLabel(
+  suggestedRoles: SuggestedRoles | null,
+  senderIsOwn: boolean,
+  counterpartName: string,
+): string | null {
+  if (!suggestedRoles) return null;
+  const viewerRole = senderIsOwn ? suggestedRoles.ownUser : suggestedRoles.otherUser;
+  const counterpartRole = senderIsOwn ? suggestedRoles.otherUser : suggestedRoles.ownUser;
+  const segments: string[] = [];
+  if (viewerRole) segments.push(`you → ${roleLabel(viewerRole)}`);
+  if (counterpartRole) segments.push(`${counterpartName} → ${roleLabel(counterpartRole)}`);
+  return segments.length > 0 ? segments.join(' · ') : null;
+}
+
+/** Viewer's negotiated role from the latest turn that suggested roles. */
+export function viewerRoleLabel(turns: TranscriptTurn[], ownAgentId: string | null): string | null {
+  for (let i = turns.length - 1; i >= 0; i -= 1) {
+    const turn = turns[i];
+    if (!turn.suggestedRoles) continue;
+    const role = turn.senderId === ownAgentId ? turn.suggestedRoles.ownUser : turn.suggestedRoles.otherUser;
+    if (role) return roleLabel(role);
+  }
+  return null;
+}
+
+/** Relative timestamp, recomputed against a ticking `now` (IND-555). */
+export function formatRelativeTime(createdAt: string, now: number): string {
+  const timestamp = new Date(createdAt).getTime();
+  if (!Number.isFinite(timestamp)) return '';
+  const seconds = Math.max(0, Math.floor((now - timestamp) / 1000));
+  if (seconds < 60) return 'just now';
+  const minutes = Math.floor(seconds / 60);
+  if (minutes < 60) return `${minutes}m ago`;
+  const hours = Math.floor(minutes / 60);
+  if (hours < 24) return `${hours}h ago`;
+  const days = Math.floor(hours / 24);
+  if (days < 30) return `${days}d ago`;
+  const months = Math.floor(days / 30);
+  return `${months}mo ago`;
+}

--- a/apps/web/src/components/negotiations/use-ticking-now.ts
+++ b/apps/web/src/components/negotiations/use-ticking-now.ts
@@ -1,0 +1,16 @@
+import { useEffect, useState } from 'react';
+
+/**
+ * Re-render relative timestamps on a fixed interval (IND-555) so `timeAgo`
+ * strings don't freeze at fetch time. Returns the current epoch-ms.
+ */
+export function useTickingNow(intervalMs = 30_000): number {
+  const [now, setNow] = useState(() => Date.now());
+
+  useEffect(() => {
+    const interval = setInterval(() => setNow(Date.now()), intervalMs);
+    return () => clearInterval(interval);
+  }, [intervalMs]);
+
+  return now;
+}


### PR DESCRIPTION
## Summary

Replaces the human-DM bubble rendering on the negotiation transcript page (`apps/web/src/app/chat/[conversationId]/page.tsx`) with the **turn rail** from `docs/design/negotiation-ui-proposals.html` §2.3, plus the §2.4 resolved-state banners.

- **Turn rail (IND-522, IND-532):** avatar + seat label per turn ("Your agent" / "{counterparty}'s agent"), colored action verbs (propose=blue, counter=amber, question=steel, accept=emerald, decline/withdraw=red), verbatim reasoning, per-turn timestamps. No `rounded-2xl` bubbles, no own/other left-right alignment. Session separators and "Load Previous Messages" retained.
- **Role chips (IND-533):** per-turn `suggestedRoles` rendered viewer-first ("you → Helper · Dan → Seeker") using Helper/Seeker/Peer vocabulary — internal agent/patient labels never surface.
- **Outcome banner (IND-534):** shown when the opportunity is `pending` — verdict, negotiated role, turn count, "Start chat" (navy) / "Pass" (ghost), and the note that the agent's accept is a recommendation, not a commitment. Wired to the existing `useOpportunityActions` mutation (`startChat` writes `accepted` and navigates to the h2h chat; `updateStatus` writes `rejected`). No new API endpoint.
- **Resolved banners (IND-535):** rejected (red) and stalled (amber) banners phrased from `outcome.reason` with hedged, filtered-for-you framing; `screened_out` is never attributed to either side. Stalled gets the revival CTA "Answer the open question" routing through the user's agent (negotiator DM via `/chat/sessions?persona=negotiator`, `/questions` fallback) plus a "Let it go" back to the inbox.
- **Ticking timestamps (IND-555, transcript part):** small local `useTickingNow` hook re-renders relative timestamps on a 30s interval. Scoped to the transcript page per wave split.

New files under `apps/web/src/components/negotiations/`: `TurnRail.tsx`, `OutcomeBanner.tsx`, `ResolvedBanner.tsx`, `negotiation-turns.ts` (pure extraction/vocabulary helpers), `use-ticking-now.ts`. Version bumped to 0.34.0 (MINOR over dev's 0.33.0 at PR time).

Closes IND-522
Closes IND-532
Closes IND-533
Closes IND-534
Closes IND-535

(Transcript-page portion of IND-555; inbox/sidebar ticking belongs to sibling PRs.)

## Verification (from this worktree, after rebase onto latest origin/dev)

- `cd apps/web && bun run lint` — 0 errors (87 pre-existing warnings)
- `cd apps/web && bun run test` — targeted suites pass (20/20: new `negotiation-turns.test.ts` 15 tests + existing `negotiation-inbox.test.ts`). Full suite: 45 failures in 11 files, byte-identical to the dev baseline without my changes (pre-existing, unrelated: DecisionQuestions, intent-page, chat-signal-provenance, …)
- `bunx tsc --noEmit` — error set identical to the pre-edit baseline (stash/baseline/pop compared); zero errors in touched files
- `cd apps/web && bun run build` — passes

## Caveats

- Accept/reject mutations already existed (`useOpportunityActions`), so no new endpoint was built. Ghost-counterpart accepts follow the non-ghost `startChat` path (same as the onboarding caller, which also omits `isGhost`); the invite-modal element is rendered in case the hook raises it.
- "Let it go" on the stalled banner navigates back to `/negotiations` rather than hiding the conversation (soft-delete felt too destructive for a first pass).
- `bun install` produced no `bun.lock` change (version-only bump).
