### PR TITLE
fix(protocol): exclude source test artifacts

### DIFF
--- a/packages/protocol/CHANGELOG.md
+++ b/packages/protocol/CHANGELOG.md
@@ -13,6 +13,7 @@ See [STABILITY.md](./STABILITY.md) for the public-contract and tier definitions.
 ## [Unreleased]
 
 ### Fixed
+- Stop emitting source-test helpers, test directories, and spec/test files in published protocol build artifacts while preserving source-test execution (IND-515).
 - Allow the private intent-refinement provenance snapshot to identify intent creation as a producer and make the shared refinement prompt independent of no-opportunity process state, enabling creation and authoritative discovery producers to converge on one ordinary intent-page question cadence.
 
 ### Added

--- a/packages/protocol/package.json
+++ b/packages/protocol/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@indexnetwork/protocol",
-  "version": "6.11.3",
+  "version": "6.11.4",
   "type": "module",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
@@ -17,7 +17,7 @@
     "CHANGELOG.md"
   ],
   "scripts": {
-    "build": "tsc",
+    "build": "rm -rf dist && tsc",
     "dev": "tsc --watch",
     "test": "bun test",
     "test:isolated": "bun scripts/test.ts",
@@ -28,7 +28,8 @@
     "architecture:host-isolation": "bun scripts/architecture/host-isolation.ts",
     "architecture:cycles": "bun scripts/architecture/cycle-baseline.ts",
     "architecture:cycles:update": "bun scripts/architecture/cycle-baseline.ts --write",
-    "architecture:check": "bun run architecture:exports && bun run architecture:consumer && bun run architecture:host-isolation && bun run architecture:cycles && bun run test:architecture",
+    "architecture:artifacts": "bun run build && bun scripts/architecture/artifact-inventory.ts",
+    "architecture:check": "bun run architecture:exports && bun run architecture:consumer && bun run architecture:host-isolation && bun run architecture:cycles && bun run architecture:artifacts && bun run test:architecture",
     "prepublishOnly": "bun run build",
     "eval:matching": "bun --env-file=../../.env.test ./eval/matching/matching.eval.ts",
     "eval:hyde": "bun --env-file=../../.env.test ./eval/hyde/hyde.eval.ts",

--- a/packages/protocol/scripts/architecture/artifact-inventory.ts
+++ b/packages/protocol/scripts/architecture/artifact-inventory.ts
@@ -1,0 +1,53 @@
+#!/usr/bin/env bun
+/** Ensures source-test helpers never ship in the published package artifact. */
+import { readdir } from "node:fs/promises";
+import { dirname, relative, resolve } from "node:path";
+
+const packageRoot = resolve(dirname(new URL(import.meta.url).pathname), "../..");
+const distRoot = resolve(packageRoot, "dist");
+
+async function filesIn(directory: string): Promise<string[]> {
+  const entries = await readdir(directory, { withFileTypes: true });
+  const files = await Promise.all(entries.map(async (entry) => {
+    const path = resolve(directory, entry.name);
+    return entry.isDirectory() ? filesIn(path) : [path];
+  }));
+  return files.flat();
+}
+
+function isSourceTestArtifact(path: string): boolean {
+  return /^dist\/(?:.*\/)?tests\//.test(path)
+    || /\.spec\.[^/]+$/.test(path)
+    || /\.test\.[^/]+$/.test(path);
+}
+
+const emittedPaths = (await filesIn(distRoot)).map((path) => relative(packageRoot, path));
+const emittedTestArtifacts = emittedPaths.filter(isSourceTestArtifact);
+if (emittedTestArtifacts.length > 0) {
+  throw new Error(`Build emitted source-test artifacts:\n${emittedTestArtifacts.map((path) => `- ${path}`).join("\n")}`);
+}
+
+const proc = Bun.spawn(["bun", "pm", "pack", "--dry-run"], {
+  cwd: packageRoot,
+  stdout: "pipe",
+  stderr: "pipe",
+});
+const [stdout, stderr, exitCode] = await Promise.all([
+  new Response(proc.stdout).text(),
+  new Response(proc.stderr).text(),
+  proc.exited,
+]);
+
+if (exitCode !== 0) throw new Error(`bun pm pack --dry-run failed:\n${stdout}${stderr}`);
+
+const paths = stdout
+  .split("\n")
+  .map((line) => /^packed\s+(.+)$/.exec(line)?.[1])
+  .filter((path): path is string => path !== undefined);
+const testArtifacts = paths.filter(isSourceTestArtifact);
+
+if (testArtifacts.length > 0) {
+  throw new Error(`Published package contains source-test artifacts:\n${testArtifacts.map((path) => `- ${path}`).join("\n")}`);
+}
+
+console.log(`Package artifact inventory OK (${paths.length} files; no source-test artifacts).`);

--- a/packages/protocol/tsconfig.json
+++ b/packages/protocol/tsconfig.json
@@ -18,5 +18,5 @@
     "types": ["node"]
   },
   "include": ["src/**/*"],
-  "exclude": ["**/*.spec.ts", "**/*.test.ts", "node_modules", "dist"]
+  "exclude": ["**/tests/**", "**/*.spec.ts", "**/*.test.ts", "node_modules", "dist"]
 }


### PR DESCRIPTION
## Summary

- Exclude all source `tests/` directories from the protocol TypeScript build and clean `dist/` before compilation, eliminating the audited 12 emitted helper artifacts.
- Add `architecture:artifacts`, which asserts both build output and `bun pm pack --dry-run` contain no `dist/**/tests/**`, `*.spec.*`, or `*.test.*` artifacts.
- Preserve source-test execution and supported root exports; the merged IND-517 hermetic harness remains intact.

## Verification

- Rebased onto `feat/protocol-cleanup` at `d8745848f8994f6d3d1470d94fc6b8b96e5e508a`.
- `bun run architecture:artifacts` — passed; clean build and 765 packaged files with no source-test artifacts.
- `bun run architecture:check` — passed: export inventory unchanged (306 exports: 298 stable, 8 experimental), consumer fixture, host isolation, cycle baseline, artifact gate, and 2 architecture tests.
- `bun run build` — passed.
- `bunx eslint scripts/architecture/artifact-inventory.ts` — passed with zero errors.
- All 14 `src/**/tests/tsconfig.json` projects — passed with `bunx tsc --noEmit --project`.
- `bun run eval:verify` — passed provider-free.
- `env -u OPENROUTER_API_KEY -u OPENAI_API_KEY TEST_CONCURRENCY=4 bun run test:isolated` — passed: **2,059 pass, 0 fail, 0 errors across 194 provider-free files in 2.9s**. The only intentional exclusions are: `chat.prompt.spec.ts`, `contact.inviter.spec.ts`, `insight.generator.spec.ts`, `negotiator-discovery-query.spec.ts`, and `opportunity.graph.spec.ts`; each is an explicit live-model/judge spec.
- `bun pm pack --dry-run` test-path inventory — no matches. Deep-consumer audit found no runtime consumers of the removed helper paths; deep imports remain unsupported by `STABILITY.md`.

## Release rationale

- `@indexnetwork/protocol` is **6.11.4** (base floor was 6.11.3): a patch packaging correction with unchanged supported runtime/declaration exports.
- Ran root `bun install` after resolution. `bun.lock` has no diff because the workspace package version does not change dependency resolution; it was never hand-edited.
- No environment variables, credentials, production paths, or test assertions were changed.

Closes IND-515.