### PR TITLE
chore(protocol): remove unused locals

### DIFF
--- a/packages/protocol/package.json
+++ b/packages/protocol/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@indexnetwork/protocol",
-  "version": "6.11.1",
+  "version": "6.11.2",
   "type": "module",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",

--- a/packages/protocol/src/chat/chat-streaming.types.ts
+++ b/packages/protocol/src/chat/chat-streaming.types.ts
@@ -654,7 +654,7 @@ export type ChatStreamEvent =
 export function formatSSEEvent(event: ChatStreamEvent): string {
   try {
     return `data: ${JSON.stringify(event)}\n\n`;
-  } catch (serializeError) {
+  } catch {
     const fallback: ErrorEvent = {
       type: "error",
       sessionId:

--- a/packages/protocol/src/intent/intent.inferrer.ts
+++ b/packages/protocol/src/intent/intent.inferrer.ts
@@ -127,7 +127,6 @@ const responseFormat = z.object({
 // 3. TYPE DEFINITIONS
 // ──────────────────────────────────────────────────────────────
 
-type ResponseType = z.infer<typeof responseFormat>;
 export type InferredIntent = z.infer<typeof InferredIntentSchema>;
 
 // ──────────────────────────────────────────────────────────────

--- a/packages/protocol/src/opportunity/opportunity.discover.ts
+++ b/packages/protocol/src/opportunity/opportunity.discover.ts
@@ -16,7 +16,7 @@ import type { DiscoveryNegotiation, DiscoverySummary } from "../shared/schemas/d
 import type { QuestionerEnqueueFn } from "../questioner/questioner.types.js";
 import { discoveryQuestionsInputMode, discoveryQuestionsTimeoutMs } from "../questioner/questioner.env.js";
 import type { ToolScopeType } from "../shared/agent/tool.scope.js";
-import { OpportunityPresenter, gatherPresenterContext, type OpportunityPresentationResult, type HomeCardPresentationResult, type HomeCardLLMResult, type HomeCardPresenterInput } from "./opportunity.presenter.js";
+import { OpportunityPresenter, gatherPresenterContext, type OpportunityPresentationResult, type HomeCardPresentationResult, type HomeCardPresenterInput } from "./opportunity.presenter.js";
 import { MINIMAL_MAIN_TEXT_MAX_CHARS, getPrimaryActionLabel, SECONDARY_ACTION_LABEL } from "./opportunity.labels.js";
 import { narratorRemarkFromReasoning } from "./opportunity.presentation.js";
 import { safeFallbackSummary } from "./opportunity.safe-presentation.js";
@@ -441,7 +441,6 @@ async function enrichOpportunities(
         }
       }
 
-      const isCounterpartGhost = isGhostByUserId.get(item.candidateUserId) ?? false;
       // Shared sanitization standard — see opportunity.safe-presentation.ts.
       const personalizedSummary = safeFallbackSummary(reasoning, {
         counterpartName: name,
@@ -968,7 +967,7 @@ export async function runDiscoverFromQuery(
       };
     },
     { context: { userId }, logOutput: false },
-  ).catch((err) => {
+  ).catch(() => {
     return {
       found: false,
       count: 0,

--- a/packages/protocol/src/opportunity/opportunity.evaluator.ts
+++ b/packages/protocol/src/opportunity/opportunity.evaluator.ts
@@ -248,8 +248,6 @@ export type EvaluatorOutputBundle = z.infer<typeof entityBundleResponseFormat>;
 // ──────────────────────────────────────────────────────────────
 
 type Opportunity = z.infer<typeof OpportunitySchema>;
-type EvaluatorOutput = z.infer<typeof responseFormat>;
-
 // Define CandidateProfile type (simplified for now, ideally imported from shared types)
 export interface CandidateProfile {
   userId: string;
@@ -561,7 +559,7 @@ ${renderOpportunityEvidenceForPrompt(e.evidence ?? [])}`;
         if (args.candidatesJson) {
           try {
             candidates = JSON.parse(args.candidatesJson);
-          } catch (e) {
+          } catch {
             logger.error("Failed to parse candidates JSON");
           }
         }

--- a/packages/protocol/src/opportunity/opportunity.graph.ts
+++ b/packages/protocol/src/opportunity/opportunity.graph.ts
@@ -12,10 +12,10 @@
  * Constructor injects Database, Embedder, and compiled HyDE graph.
  */
 
-import { StateGraph, START, END, Annotation } from '@langchain/langgraph';
+import { StateGraph, START, END } from '@langchain/langgraph';
 import type { Id, NegotiationContinuationReceipt } from '../shared/interfaces/database.interface.js';
 import type { DebugMetaAgent } from '../chat/chat-streaming.types.js';
-import { OpportunityGraphState, type IndexedIntent, type SourceProfileData, type TargetNetwork, type CandidateMatch, type EvaluatedCandidate, type EvaluatedOpportunity, type EvaluatedOpportunityActor } from './opportunity.state.js';
+import { OpportunityGraphState, type IndexedIntent, type SourceProfileData, type TargetNetwork, type CandidateMatch, type EvaluatedOpportunity, type EvaluatedOpportunityActor } from './opportunity.state.js';
 import { resolveInitialStatus } from './opportunity.state.js';
 import { OpportunityEvaluator, type CandidateProfile, type EvaluatedOpportunityWithActors, type EvaluatorEntity, type EvaluatorInput } from './opportunity.evaluator.js';
 import type { OpportunityGraphDatabase } from '../shared/interfaces/database.interface.js';

--- a/packages/protocol/src/premise/premise.analyzer.ts
+++ b/packages/protocol/src/premise/premise.analyzer.ts
@@ -5,7 +5,6 @@ import { Timed } from "../shared/observability/performance.js";
 import { createStructuredModel } from "../shared/agent/model.config.js";
 import { invokeWithAbortSignal } from "../shared/agent/model-signal.js";
 
-const logger = protocolLogger("PremiseAnalyzer");
 const invokeLog = protocolLogger("PremiseAnalyzer:invoke");
 
 const systemPrompt = `

--- a/packages/protocol/src/premise/premise.decomposer.ts
+++ b/packages/protocol/src/premise/premise.decomposer.ts
@@ -5,7 +5,6 @@ import { Timed } from "../shared/observability/performance.js";
 import { createStructuredModel } from "../shared/agent/model.config.js";
 import { invokeWithAbortSignal } from "../shared/agent/model-signal.js";
 
-const logger = protocolLogger("PremiseDecomposer");
 const invokeLog = protocolLogger("PremiseDecomposer:invoke");
 
 const systemPrompt = `

--- a/packages/protocol/src/premise/premise.graph.ts
+++ b/packages/protocol/src/premise/premise.graph.ts
@@ -14,7 +14,6 @@ import { protocolLogger } from "../shared/observability/protocol.logger.js";
 import { timed } from "../shared/observability/performance.js";
 import type { DebugMetaAgent } from "../chat/chat-streaming.types.js";
 
-const logger = protocolLogger("PremiseGraphFactory");
 const queryLog = protocolLogger("PremiseGraph:query");
 const analyzeLog = protocolLogger("PremiseGraph:analyze");
 const embedLog = protocolLogger("PremiseGraph:embed");

--- a/packages/protocol/src/premise/premise.indexer.ts
+++ b/packages/protocol/src/premise/premise.indexer.ts
@@ -5,7 +5,6 @@ import { Timed } from "../shared/observability/performance.js";
 import { createStructuredModel } from "../shared/agent/model.config.js";
 import { invokeWithAbortSignal } from "../shared/agent/model-signal.js";
 
-const logger = protocolLogger("PremiseIndexer");
 const invokeLog = protocolLogger("PremiseIndexer:invoke");
 
 const systemPrompt = `

--- a/packages/protocol/src/premise/premise.tools.ts
+++ b/packages/protocol/src/premise/premise.tools.ts
@@ -6,7 +6,6 @@ import { protocolLogger } from "../shared/observability/protocol.logger.js";
 import type { PremiseRecord, PremiseValidity } from "../shared/interfaces/database.interface.js";
 import { invokeWithAbortSignal } from "../shared/agent/model-signal.js";
 
-const logger = protocolLogger("ChatTools:Premise");
 const createPremiseLog = protocolLogger("ChatTools:Premise:createPremise");
 const readPremisesLog = protocolLogger("ChatTools:Premise:readPremises");
 const updatePremiseLog = protocolLogger("ChatTools:Premise:updatePremise");


### PR DESCRIPTION
## IND-516

Removes the 14 audited production unused declarations/imports/assignments across 10 protocol files, without changing behavior or deleting supported root exports.

The removed unused bindings are: `serializeError`; `ResponseType`; `HomeCardLLMResult`, `isCounterpartGhost`, and `err`; `EvaluatorOutput` and `e`; `Annotation` and `EvaluatedCandidate`; and five unused premise logger locals. Catch handlers retain their fallback/error behavior, and retained logger initializers are still used.

## Verification

- Production protocol ESLint: zero `@typescript-eslint/no-unused-vars` warnings; 11 pre-existing warnings remain under other rules, with zero errors.
- Focused deterministic tests: 145 passed, 1 integration test skipped, 0 failed.
- `bun run build`: passed.
- Export inventory: passed (306 exports: 298 stable, 8 experimental).
- Host isolation: passed (zero API/web/schema/queue/concrete-adapter imports).
- Consumer compilation, cycle baseline, and architecture tests: passed.
- Pre-commit ESLint hook: passed.

## SemVer and lockfile

Bumps `@indexnetwork/protocol` from `6.11.1` to `6.11.2`: a patch release is appropriate for behavior-preserving production cleanup. `bun install --lockfile-only` regenerated the lockfile normally and produced no `bun.lock` diff, so no lockfile was hand-edited and there is no dependency-resolution change.

## Caveat

The separately run live-model `src/premise/tests/premise.analyzer.spec.ts` remains failing in the unchanged vague-premise assertion because the model returned `felicityClarity: 60` while the test requires `<50` (3 passed, 1 failed). This failure reproduces without touching analyzer logic and is not addressed by IND-516.