### PR TITLE
feat(web): ask_user consultation card

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@indexnetwork/web",
-  "version": "0.36.0",
+  "version": "0.37.0",
   "license": "MIT",
   "scripts": {
     "dev": "vite --host 127.0.0.1",

--- a/apps/web/src/app/chat/[conversationId]/page.tsx
+++ b/apps/web/src/app/chat/[conversationId]/page.tsx
@@ -5,6 +5,7 @@ import { apiClient } from '@/lib/api';
 import { ContentContainer } from '@/components/layout';
 import { useAuthContext } from '@/contexts/AuthContext';
 import { useConversation } from '@/contexts/ConversationContext';
+import { useQuestionsService } from '@/contexts/APIContext';
 import { useOpportunityActions } from '@/hooks/useOpportunityActions';
 import TurnRail from '@/components/negotiations/TurnRail';
 import OutcomeBanner from '@/components/negotiations/OutcomeBanner';
@@ -78,6 +79,35 @@ export default function NegotiationDetailPage() {
   const localStatus = opportunityId ? opportunityStatusMap[opportunityId] : undefined;
   const effectiveOpportunityStatus = localStatus ?? lifecycle?.opportunityStatus ?? null;
   const outcomeReason = lifecycle?.outcome?.reason ?? null;
+
+  // The viewer's last ask_user turn — anchor for the missed-window decay line.
+  const lastAskUserTurnId = useMemo(() => {
+    for (let i = turns.length - 1; i >= 0; i -= 1) {
+      if (turns[i].action === 'ask_user' && turns[i].senderId === ownAgentId) return turns[i].id;
+    }
+    return null;
+  }, [turns, ownAgentId]);
+
+  // Missed-window decay (IND-559): the negotiation left input_required after
+  // an ask_user pause with no answered consultation — the window lapsed (or
+  // the question was dismissed) and the negotiator continued without an answer.
+  const questionsService = useQuestionsService();
+  const [windowMissed, setWindowMissed] = useState(false);
+  useEffect(() => {
+    if (!opportunityId || !lastAskUserTurnId || lifecycle?.state === 'input_required') {
+      setWindowMissed(false);
+      return;
+    }
+    let cancelled = false;
+    questionsService.getAnswered({
+      mode: 'negotiation_inflight',
+      sourceType: 'opportunity',
+      sourceId: opportunityId,
+    }).then((answered) => {
+      if (!cancelled) setWindowMissed(answered.length === 0);
+    }).catch(() => {});
+    return () => { cancelled = true; };
+  }, [questionsService, opportunityId, lastAskUserTurnId, lifecycle?.state]);
 
   // Resolved-state banner derivation, mirroring lib/negotiation-inbox classification.
   const resolvedVariant = useMemo<ResolvedBannerVariant | null>(() => {
@@ -155,6 +185,7 @@ export default function NegotiationDetailPage() {
               participantInfo={participantInfo}
               counterpartName={counterpartName}
               now={now}
+              missedWindowTurnId={windowMissed ? lastAskUserTurnId : null}
             />
 
             {showOutcomeBanner && opportunityId && (

--- a/apps/web/src/components/InjectedQuestions/InjectedQuestions.tsx
+++ b/apps/web/src/components/InjectedQuestions/InjectedQuestions.tsx
@@ -1,5 +1,6 @@
 import { useState, useCallback } from 'react';
 import { OptionRow } from '@/components/DecisionQuestions/OptionRow';
+import { ConsultationCard } from '@/components/PendingQuestions/ConsultationCard';
 import { toSignalProductLanguage } from '@/lib/product-language';
 import type { PendingQuestion, AnswerBody } from '@/services/questions';
 
@@ -188,15 +189,21 @@ export function InjectedQuestions({
 
   return (
     <div className="flex flex-col gap-2">
-      {questions.map((q) => (
-        <InjectedQuestionCard
-          key={q.id}
-          question={q}
-          onAnswer={onAnswer}
-          onDismiss={onDismiss}
-          showAskedKicker={showAskedKicker}
-        />
-      ))}
+      {questions.map((q) =>
+        // ask_user consultations get the priority card (§2.2); everything
+        // else keeps the generic option-row card.
+        q.detection.mode === 'negotiation_inflight' ? (
+          <ConsultationCard key={q.id} question={q} onAnswer={onAnswer} />
+        ) : (
+          <InjectedQuestionCard
+            key={q.id}
+            question={q}
+            onAnswer={onAnswer}
+            onDismiss={onDismiss}
+            showAskedKicker={showAskedKicker}
+          />
+        ),
+      )}
       {showTypingIndicator && <TypingDots />}
     </div>
   );

--- a/apps/web/src/components/NegotiationsInbox.tsx
+++ b/apps/web/src/components/NegotiationsInbox.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useLayoutEffect, useMemo, useRef, useState } from 'react';
+import { useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState } from 'react';
 import { useNavigate } from 'react-router';
 import { Loader2 } from 'lucide-react';
 
@@ -7,6 +7,7 @@ import UserAvatar from '@/components/UserAvatar';
 import { useAuthContext } from '@/contexts/AuthContext';
 import { useConversation } from '@/contexts/ConversationContext';
 import { deriveNegotiationInbox, flattenNegotiationInbox, type NegotiationInboxItem, type NegotiationInboxStatus } from '@/lib/negotiation-inbox';
+import { getNegotiatorDmSessionId } from '@/lib/negotiator-dm';
 
 const CHIP_CLASS: Record<NegotiationInboxStatus, string> = {
   answer: 'border-[#041729] bg-[#041729] text-white',
@@ -66,20 +67,19 @@ interface RowFlash {
   nonce: number;
 }
 
-function NegotiationRow({ item, flash, rowRef }: {
+function NegotiationRow({ item, flash, rowRef, onOpen }: {
   item: NegotiationInboxItem;
   flash?: RowFlash;
   rowRef?: (element: HTMLButtonElement | null) => void;
+  onOpen: (item: NegotiationInboxItem) => void;
 }) {
-  const navigate = useNavigate();
-  const openTranscript = () => navigate(`/chat/${item.conversationId}`);
   const isResolved = item.group === 'resolved';
 
   return (
     <button
       type="button"
       ref={rowRef}
-      onClick={openTranscript}
+      onClick={() => onOpen(item)}
       className={`group relative flex w-full flex-wrap items-center gap-3 px-4 py-3 text-left transition-colors hover:bg-gray-50 focus:outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-[#4091BB] sm:flex-nowrap ${isResolved ? 'bg-gray-50/60 opacity-80' : 'bg-white'}`}
       aria-label={`Open negotiation with ${item.counterpart.name}`}
     >
@@ -122,10 +122,11 @@ function NegotiationRow({ item, flash, rowRef }: {
   );
 }
 
-function InboxGroup({ label, items, flashes }: {
+function InboxGroup({ label, items, flashes, onOpen }: {
   label: string;
   items: NegotiationInboxItem[];
   flashes: ReadonlyMap<string, RowFlash>;
+  onOpen: (item: NegotiationInboxItem) => void;
 }) {
   return (
     <section aria-labelledby={`negotiations-${label.toLowerCase().replace(/\s+/g, '-')}`}>
@@ -137,7 +138,7 @@ function InboxGroup({ label, items, flashes }: {
       </h2>
       {items.length > 0 && (
         <div className="divide-y divide-gray-100 overflow-hidden rounded-md border border-gray-200 bg-white">
-          {items.map((item) => <NegotiationRow key={item.conversationId} item={item} flash={flashes.get(item.conversationId)} />)}
+          {items.map((item) => <NegotiationRow key={item.conversationId} item={item} flash={flashes.get(item.conversationId)} onOpen={onOpen} />)}
         </div>
       )}
     </section>
@@ -145,7 +146,8 @@ function InboxGroup({ label, items, flashes }: {
 }
 
 export default function NegotiationsInbox() {
-  const { user } = useAuthContext();
+  const navigate = useNavigate();
+  const { user, features } = useAuthContext();
   const { negotiations, refreshNegotiations, isConnected } = useConversation();
   const [refreshing, setRefreshing] = useState(negotiations.length === 0);
   const [viewMode, setViewMode] = useState<ViewMode>(readViewMode);
@@ -178,6 +180,23 @@ export default function NegotiationsInbox() {
   );
   const flatItems = useMemo(() => flattenNegotiationInbox(groups), [groups]);
   const totalCount = groups.yourMove.length + groups.inProgress.length + groups.resolved.length;
+
+  // "Answer your agent" rows deep-link to the negotiator DM — the transcript
+  // is read-only and can't take an answer. /questions is the fallback when
+  // the negotiator surface is unavailable (IND-558).
+  const openNegotiation = useCallback((item: NegotiationInboxItem) => {
+    if (item.status !== 'answer') {
+      navigate(`/chat/${item.conversationId}`);
+      return;
+    }
+    if (!features?.negotiatorChat) {
+      navigate('/questions');
+      return;
+    }
+    void getNegotiatorDmSessionId().then((sessionId) => {
+      navigate(sessionId ? `/d/${sessionId}` : '/questions');
+    });
+  }, [navigate, features]);
 
   // Diff each refetch against the previous rows and flash what changed
   // (design §3 R2): posture moves (group/status) in steel, content updates
@@ -285,9 +304,9 @@ export default function NegotiationsInbox() {
           </div>
         ) : viewMode === 'grouped' ? (
           <div className="space-y-8">
-            <InboxGroup label="Your move" items={groups.yourMove} flashes={flashes} />
-            <InboxGroup label="In progress" items={groups.inProgress} flashes={flashes} />
-            <InboxGroup label="Resolved" items={groups.resolved} flashes={flashes} />
+            <InboxGroup label="Your move" items={groups.yourMove} flashes={flashes} onOpen={openNegotiation} />
+            <InboxGroup label="In progress" items={groups.inProgress} flashes={flashes} onOpen={openNegotiation} />
+            <InboxGroup label="Resolved" items={groups.resolved} flashes={flashes} onOpen={openNegotiation} />
           </div>
         ) : (
           <div ref={flatListRef} className="divide-y divide-gray-100 overflow-hidden rounded-md border border-gray-200 bg-white">
@@ -296,6 +315,7 @@ export default function NegotiationsInbox() {
                 key={item.conversationId}
                 item={item}
                 flash={flashes.get(item.conversationId)}
+                onOpen={openNegotiation}
                 rowRef={(element) => {
                   if (element) rowElementsRef.current.set(item.conversationId, element);
                   else rowElementsRef.current.delete(item.conversationId);

--- a/apps/web/src/components/PendingQuestions/ConsultationCard.tsx
+++ b/apps/web/src/components/PendingQuestions/ConsultationCard.tsx
@@ -1,0 +1,116 @@
+import { useCallback, useState } from 'react';
+import type { PendingQuestion, AnswerBody } from '@/services/questions';
+import { useTickingNow } from '@/components/negotiations/use-ticking-now';
+
+/**
+ * Server-side ask_user answer window — mirrors DEFAULT_ASK_USER_WINDOW_MS in
+ * packages/protocol/src/negotiation/negotiation.protocol.ts (24h). The window
+ * starts when the consultation question is created.
+ */
+const ASK_USER_WINDOW_MS = 24 * 60 * 60 * 1000;
+
+/** "23h left" / "45m left" countdown label for the consultation window. */
+export function formatConsultationTimeLeft(createdAt: string, now: number): string {
+  const startedAt = new Date(createdAt).getTime();
+  if (!Number.isFinite(startedAt)) return '';
+  const remainingMinutes = Math.max(1, Math.ceil((startedAt + ASK_USER_WINDOW_MS - now) / 60_000));
+  if (remainingMinutes >= 60) return `${Math.floor(remainingMinutes / 60)}h left`;
+  return `${remainingMinutes}m left`;
+}
+
+interface ConsultationCardProps {
+  question: PendingQuestion;
+  onAnswer: (questionId: string, body: AnswerBody) => Promise<void>;
+  /** Injectable clock for tests; defaults to a 30s ticking now. */
+  now?: number;
+}
+
+/**
+ * The ask_user consultation card (proposals §2.2): a negotiator paused
+ * mid-negotiation to consult its own client — the strongest visual priority
+ * in the system. Amber left border, navy "Your move" chip, 24h countdown,
+ * inline answer field, and the privacy promise rendered as part of the card.
+ */
+export function ConsultationCard({ question, onAnswer, now: nowProp }: ConsultationCardProps) {
+  const tickingNow = useTickingNow();
+  const now = nowProp ?? tickingNow;
+  const [answerText, setAnswerText] = useState('');
+  const [submitting, setSubmitting] = useState(false);
+
+  const canSubmit = answerText.trim().length > 0 && !submitting;
+
+  const handleSubmit = useCallback(async () => {
+    if (!canSubmit) return;
+    setSubmitting(true);
+    try {
+      await onAnswer(question.id, { selectedOptions: [], freeText: answerText.trim() });
+    } finally {
+      setSubmitting(false);
+    }
+  }, [canSubmit, onAnswer, question.id, answerText]);
+
+  const timeLeft = formatConsultationTimeLeft(question.createdAt, now);
+
+  return (
+    <div
+      data-testid="consultation-card"
+      className="rounded-lg border border-amber-200 border-l-[3px] border-l-amber-400 bg-[#fffdf7] p-4"
+    >
+      <div className="flex flex-wrap items-center gap-2">
+        <span className="inline-flex items-center whitespace-nowrap rounded-full border border-[#041729] bg-[#041729] px-2.5 py-1 font-ibm-plex-mono text-[10px] font-semibold text-white">
+          Your move
+        </span>
+        <span className="font-ibm-plex-mono text-[11px] text-gray-500">Your agent is asking</span>
+        <span className="flex-1" />
+        {timeLeft && (
+          <span
+            data-testid="consultation-countdown"
+            className="inline-flex items-center whitespace-nowrap rounded-full border border-amber-200 bg-amber-50 px-2.5 py-1 font-ibm-plex-mono text-[10px] font-semibold text-amber-700"
+          >
+            {timeLeft}
+          </span>
+        )}
+      </div>
+
+      <p className="mt-2 text-[15px] font-semibold leading-snug text-gray-900">
+        {question.payload.prompt}
+      </p>
+      <p className="mt-1 text-xs text-gray-500">
+        Your agent paused the negotiation to check with you.
+      </p>
+
+      <div className="mt-3 flex gap-2">
+        <input
+          type="text"
+          value={answerText}
+          disabled={submitting}
+          placeholder="Type your answer…"
+          aria-label="Answer your agent"
+          onChange={(event) => setAnswerText(event.target.value)}
+          onKeyDown={(event) => {
+            if (event.key === 'Enter') {
+              event.preventDefault();
+              void handleSubmit();
+            }
+          }}
+          className="flex-1 rounded-lg border border-gray-200 bg-white px-3.5 py-2.5 text-sm text-gray-800 placeholder:text-gray-400 focus:border-[#041729] focus:outline-none focus:ring-2 focus:ring-[#041729]/10"
+        />
+        <button
+          type="button"
+          onClick={() => void handleSubmit()}
+          disabled={!canSubmit}
+          className="rounded-sm bg-[#041729] px-3.5 py-2 text-xs font-medium text-white transition-colors hover:bg-[#0a2d4a] disabled:cursor-not-allowed disabled:opacity-60"
+        >
+          {submitting ? 'Sending…' : 'Send'}
+        </button>
+      </div>
+
+      <div className="mt-2.5 flex items-center gap-1.5">
+        <span aria-hidden="true" className="text-xs">🔒</span>
+        <span className="font-ibm-plex-mono text-[10.5px] text-gray-400">
+          Only your agent sees this — it decides what to disclose.
+        </span>
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/components/PendingQuestions/QuestionGroup.tsx
+++ b/apps/web/src/components/PendingQuestions/QuestionGroup.tsx
@@ -1,5 +1,6 @@
 import { useState, useId } from 'react';
 import { QuestionCard } from '@/components/DecisionQuestions/QuestionCard';
+import { ConsultationCard } from '@/components/PendingQuestions/ConsultationCard';
 import type { PendingQuestion } from '@/services/questions';
 import type { Answer } from '@/components/DecisionQuestions/flatten';
 import type { AnswerBody } from '@/services/questions';
@@ -54,6 +55,11 @@ export function QuestionGroup({ label, questions, onAnswer, onDismiss }: Questio
         {label}
       </h3>
       {questions.map((q) => {
+        // ask_user consultations render the priority card (§2.2) instead of
+        // the generic option-row card.
+        if (q.detection.mode === 'negotiation_inflight') {
+          return <ConsultationCard key={q.id} question={q} onAnswer={onAnswer} />;
+        }
         const answer = answers[q.id] ?? null;
         const isSubmitting = submitting[q.id] ?? false;
         const hasAnswer = answer?.kind === 'selection'

--- a/apps/web/src/components/TopBar.tsx
+++ b/apps/web/src/components/TopBar.tsx
@@ -11,6 +11,7 @@ import { useConversation } from '@/contexts/ConversationContext';
 import UserAvatar from '@/components/UserAvatar';
 import { isVisibleH2HConversation } from '@/lib/conversation-visibility';
 import { countNegotiationsRequiringAction } from '@/lib/negotiation-inbox';
+import { getNegotiatorDmSessionId } from '@/lib/negotiator-dm';
 import { log } from '@/lib/logger';
 
 const logger = log.ui.from('TopBar');
@@ -24,11 +25,11 @@ const logger = log.ui.from('TopBar');
 export default function TopBar() {
   const navigate = useNavigate();
   const { pathname } = useLocation();
-  const { user, signOut } = useAuthContext();
+  const { user, signOut, features } = useAuthContext();
   const opportunitiesService = useOpportunities();
   const { clearChat } = useAIChat();
   const { setSelectedNetworkIds } = useNetworkFilter();
-  const { personalAgentPending } = useQuestions();
+  const { personalAgentPending, questions } = useQuestions();
   const { conversations, negotiations } = useConversation();
   const unreadConversationCount = conversations.filter(
     (conversation) => isVisibleH2HConversation(conversation) && conversation.unreadCount > 0,
@@ -103,6 +104,18 @@ export default function TopBar() {
   const handleAgentClick = () => {
     clearChat({ abortStream: false });
     setSelectedNetworkIds([]);
+    // A pending ask_user consultation outranks the Agent home: deep-link to
+    // the negotiator DM thread, with /questions as the fallback (IND-558).
+    if (questions.some((q) => q.detection.mode === 'negotiation_inflight')) {
+      if (!features?.negotiatorChat) {
+        navigate('/questions');
+        return;
+      }
+      void getNegotiatorDmSessionId().then((sessionId) => {
+        navigate(sessionId ? `/d/${sessionId}` : '/questions');
+      });
+      return;
+    }
     navigate('/agent');
   };
 

--- a/apps/web/src/components/__tests__/ConsultationCard.test.tsx
+++ b/apps/web/src/components/__tests__/ConsultationCard.test.tsx
@@ -1,0 +1,107 @@
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+
+import { ConsultationCard, formatConsultationTimeLeft } from '../PendingQuestions/ConsultationCard';
+import type { PendingQuestion } from '@/services/questions';
+
+const CREATED_AT = '2026-07-24T12:00:00.000Z';
+const createdAtMs = new Date(CREATED_AT).getTime();
+
+function consultation(overrides: Partial<PendingQuestion> = {}): PendingQuestion {
+  return {
+    id: 'q-1',
+    detection: {
+      mode: 'negotiation_inflight',
+      sourceType: 'opportunity',
+      sourceId: 'opportunity-1',
+      timestamp: CREATED_AT,
+    },
+    actors: [{ userId: 'user-1', role: 'subject' }],
+    payload: {
+      title: 'Consultation',
+      prompt: 'How much time could you realistically give a collaboration?',
+      options: [],
+      multiSelect: false,
+    },
+    status: 'pending',
+    answer: null,
+    expiresAt: null,
+    createdAt: CREATED_AT,
+    conversationId: null,
+    ...overrides,
+  };
+}
+
+describe('formatConsultationTimeLeft', () => {
+  it('formats hours remaining in the 24h window', () => {
+    expect(formatConsultationTimeLeft(CREATED_AT, createdAtMs + 30 * 60_000)).toBe('23h left');
+  });
+
+  it('formats minutes remaining under an hour', () => {
+    expect(formatConsultationTimeLeft(CREATED_AT, createdAtMs + 23 * 3_600_000 + 15 * 60_000)).toBe('45m left');
+  });
+
+  it('clamps to one minute once the window has lapsed', () => {
+    expect(formatConsultationTimeLeft(CREATED_AT, createdAtMs + 25 * 3_600_000)).toBe('1m left');
+  });
+
+  it('returns an empty label for an unparseable creation time', () => {
+    expect(formatConsultationTimeLeft('not-a-date', createdAtMs)).toBe('');
+  });
+});
+
+describe('ConsultationCard', () => {
+  it('renders the priority framing: navy chip, question, countdown, privacy line', () => {
+    render(
+      <ConsultationCard
+        question={consultation()}
+        onAnswer={vi.fn()}
+        now={createdAtMs + 60 * 60_000}
+      />,
+    );
+    expect(screen.getByTestId('consultation-card')).toBeInTheDocument();
+    expect(screen.getByText('Your move')).toBeInTheDocument();
+    expect(screen.getByText('Your agent is asking')).toBeInTheDocument();
+    expect(screen.getByText('How much time could you realistically give a collaboration?')).toBeInTheDocument();
+    expect(screen.getByTestId('consultation-countdown')).toHaveTextContent('23h left');
+    expect(screen.getByText('Only your agent sees this — it decides what to disclose.')).toBeInTheDocument();
+  });
+
+  it('submits the inline answer as free text', async () => {
+    const onAnswer = vi.fn().mockResolvedValue(undefined);
+    render(<ConsultationCard question={consultation()} onAnswer={onAnswer} now={createdAtMs} />);
+
+    fireEvent.change(screen.getByLabelText('Answer your agent'), {
+      target: { value: 'A few hours a month, async only' },
+    });
+    fireEvent.click(screen.getByRole('button', { name: 'Send' }));
+
+    await waitFor(() =>
+      expect(onAnswer).toHaveBeenCalledWith('q-1', {
+        selectedOptions: [],
+        freeText: 'A few hours a month, async only',
+      }),
+    );
+  });
+
+  it('submits on Enter', async () => {
+    const onAnswer = vi.fn().mockResolvedValue(undefined);
+    render(<ConsultationCard question={consultation()} onAnswer={onAnswer} now={createdAtMs} />);
+
+    const input = screen.getByLabelText('Answer your agent');
+    fireEvent.change(input, { target: { value: 'Yes, tell them yes' } });
+    fireEvent.keyDown(input, { key: 'Enter' });
+
+    await waitFor(() =>
+      expect(onAnswer).toHaveBeenCalledWith('q-1', {
+        selectedOptions: [],
+        freeText: 'Yes, tell them yes',
+      }),
+    );
+  });
+
+  it('keeps Send disabled until an answer is typed', () => {
+    render(<ConsultationCard question={consultation()} onAnswer={vi.fn()} now={createdAtMs} />);
+    expect(screen.getByRole('button', { name: 'Send' })).toBeDisabled();
+  });
+});

--- a/apps/web/src/components/__tests__/NegotiationsInbox.test.tsx
+++ b/apps/web/src/components/__tests__/NegotiationsInbox.test.tsx
@@ -1,0 +1,144 @@
+import { useEffect } from 'react';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { MemoryRouter, useLocation } from 'react-router';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import NegotiationsInbox from '../NegotiationsInbox';
+import type { ConversationSummary } from '@/services/conversation';
+
+const viewer = { id: 'me', name: 'Viewer' };
+
+function negotiation(
+  id: string,
+  counterpartName: string,
+  input: {
+    state?: NonNullable<ConversationSummary['negotiation']>['state'];
+    action?: string;
+    senderId?: string;
+    turnCount?: number;
+  } = {},
+): ConversationSummary {
+  return {
+    id,
+    participants: [
+      { participantId: 'agent:me', participantType: 'agent', name: 'Index Negotiator', avatar: null, ownerName: 'Viewer' },
+      { participantId: `agent:${id}-peer`, participantType: 'agent', name: 'Index Negotiator', avatar: null, ownerName: counterpartName },
+    ],
+    lastMessage: {
+      parts: [{ kind: 'data', data: { action: input.action ?? 'counter' } }],
+      senderId: input.senderId ?? `agent:${id}-peer`,
+      createdAt: '2026-07-24T11:00:00.000Z',
+    },
+    metadata: null,
+    via: [],
+    unreadCount: 0,
+    lastMessageAt: '2026-07-24T11:00:00.000Z',
+    createdAt: '2026-07-24T10:00:00.000Z',
+    negotiation: {
+      taskId: `${id}-task`,
+      state: input.state ?? 'working',
+      statusTimestamp: '2026-07-24T11:00:00.000Z',
+      opportunityId: `${id}-opportunity`,
+      opportunityStatus: 'negotiating',
+      acceptedByViewer: false,
+      turnCount: input.turnCount ?? 1,
+      maxTurns: 6,
+      signalCount: 2,
+      outcome: null,
+      updatedAt: '2026-07-24T11:00:00.000Z',
+    },
+  };
+}
+
+const answerNegotiation = negotiation('question', 'Mira Chen', {
+  state: 'input_required',
+  action: 'ask_user',
+  senderId: 'agent:me',
+});
+
+const mocks = vi.hoisted(() => ({
+  negotiations: [] as ConversationSummary[],
+  features: { negotiatorChat: true } as { negotiatorChat?: boolean } | undefined,
+  apiGet: vi.fn(),
+}));
+
+vi.mock('@/contexts/AuthContext', () => ({
+  useAuthContext: () => ({ user: viewer, features: mocks.features }),
+}));
+
+vi.mock('@/contexts/ConversationContext', () => ({
+  useConversation: () => ({
+    negotiations: mocks.negotiations,
+    isConnected: true,
+    refreshNegotiations: vi.fn(async () => {}),
+  }),
+}));
+
+vi.mock('@/lib/api', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('@/lib/api')>()),
+  apiClient: { get: mocks.apiGet, post: vi.fn() },
+}));
+
+const currentPath = { value: '/' };
+
+function LocationProbe() {
+  const { pathname } = useLocation();
+  useEffect(() => {
+    currentPath.value = pathname;
+  }, [pathname]);
+  return null;
+}
+
+function renderInbox() {
+  return render(
+    <MemoryRouter initialEntries={['/negotiations']}>
+      <LocationProbe />
+      <NegotiationsInbox />
+    </MemoryRouter>,
+  );
+}
+
+describe('NegotiationsInbox answer-row deep links (IND-558)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    currentPath.value = '/negotiations';
+    mocks.features = { negotiatorChat: true };
+    mocks.apiGet.mockResolvedValue({ sessions: [{ id: 'negotiator-session' }] });
+  });
+
+  it('routes answer rows to the negotiator DM when the session exists', async () => {
+    mocks.negotiations = [answerNegotiation];
+    renderInbox();
+
+    fireEvent.click(await screen.findByRole('button', { name: 'Open negotiation with Mira Chen' }));
+    await waitFor(() => expect(currentPath.value).toBe('/d/negotiator-session'));
+    expect(mocks.apiGet).toHaveBeenCalledWith('/chat/sessions?persona=negotiator');
+  });
+
+  it('falls back to /questions when no negotiator session exists', async () => {
+    mocks.negotiations = [answerNegotiation];
+    mocks.apiGet.mockResolvedValue({ sessions: [] });
+    renderInbox();
+
+    fireEvent.click(await screen.findByRole('button', { name: 'Open negotiation with Mira Chen' }));
+    await waitFor(() => expect(currentPath.value).toBe('/questions'));
+  });
+
+  it('falls back to /questions when the negotiator chat flag is off', async () => {
+    mocks.negotiations = [answerNegotiation];
+    mocks.features = { negotiatorChat: false };
+    renderInbox();
+
+    fireEvent.click(await screen.findByRole('button', { name: 'Open negotiation with Mira Chen' }));
+    await waitFor(() => expect(currentPath.value).toBe('/questions'));
+    expect(mocks.apiGet).not.toHaveBeenCalled();
+  });
+
+  it('routes live rows to the transcript', async () => {
+    mocks.negotiations = [negotiation('live', 'Aisha Khan', { turnCount: 3 })];
+    renderInbox();
+
+    fireEvent.click(await screen.findByRole('button', { name: 'Open negotiation with Aisha Khan' }));
+    await waitFor(() => expect(currentPath.value).toBe('/chat/live'));
+  });
+});

--- a/apps/web/src/components/__tests__/TurnRail.test.tsx
+++ b/apps/web/src/components/__tests__/TurnRail.test.tsx
@@ -1,0 +1,65 @@
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+
+import TurnRail from '../negotiations/TurnRail';
+import type { TranscriptTurn } from '../negotiations/negotiation-turns';
+
+vi.mock('@/components/UserAvatar', () => ({
+  default: () => <div data-testid="avatar" />,
+}));
+
+const NOW = new Date('2026-07-24T12:00:00.000Z').getTime();
+
+function turn(id: string, action: string | null, text: string, senderId = 'agent:me'): TranscriptTurn {
+  return {
+    id,
+    sessionId: 'session-1',
+    senderId,
+    createdAt: '2026-07-24T11:00:00.000Z',
+    action,
+    text,
+    suggestedRoles: null,
+  };
+}
+
+const turns = [
+  turn('t-ask', 'ask_user', 'Their agent asked about your availability. What should I say?'),
+  turn('t-next', 'counter', 'We can offer an async collaboration.', 'agent:peer'),
+];
+
+const participantInfo = new Map([
+  ['agent:me', { ownerName: 'Viewer', avatar: null }],
+  ['agent:peer', { ownerName: 'Mira Chen', avatar: null }],
+]);
+
+function renderRail(missedWindowTurnId?: string | null) {
+  return render(
+    <TurnRail
+      turns={turns}
+      ownAgentId="agent:me"
+      participantInfo={participantInfo}
+      counterpartName="Mira Chen"
+      now={NOW}
+      missedWindowTurnId={missedWindowTurnId}
+    />,
+  );
+}
+
+describe('TurnRail missed-window decay (IND-559)', () => {
+  it('renders no decay line by default', () => {
+    renderRail();
+    expect(screen.queryByTestId('consultation-window-missed')).not.toBeInTheDocument();
+  });
+
+  it('renders the quiet decay line right after the ask_user turn', () => {
+    renderRail('t-ask');
+    const line = screen.getByTestId('consultation-window-missed');
+    expect(line).toHaveTextContent('Window missed — negotiation continued without an answer.');
+
+    // Anchored after the consultation turn, before the negotiation continues.
+    const askText = screen.getByText(/Their agent asked about your availability/);
+    const nextText = screen.getByText(/We can offer an async collaboration/);
+    expect(askText.compareDocumentPosition(line) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy();
+    expect(line.compareDocumentPosition(nextText) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy();
+  });
+});

--- a/apps/web/src/components/negotiations/TurnRail.tsx
+++ b/apps/web/src/components/negotiations/TurnRail.tsx
@@ -62,13 +62,18 @@ interface TurnRailProps {
   participantInfo: Map<string, TurnParticipantInfo>;
   counterpartName: string;
   now: number;
+  /**
+   * Turn id after which the missed-window decay line renders (IND-559): the
+   * ask_user consultation lapsed and the negotiation continued unanswered.
+   */
+  missedWindowTurnId?: string | null;
 }
 
 /**
  * Vertical turn rail (proposals §2.3): avatar + seat label + colored action
  * verb + role chips + reasoning per turn. No DM bubbles, no own/other alignment.
  */
-export function TurnRail({ turns, ownAgentId, participantInfo, counterpartName, now }: TurnRailProps) {
+export function TurnRail({ turns, ownAgentId, participantInfo, counterpartName, now, missedWindowTurnId }: TurnRailProps) {
   return (
     <div>
       {turns.map((turn, index) => {
@@ -96,6 +101,15 @@ export function TurnRail({ turns, ownAgentId, participantInfo, counterpartName, 
               roleChip={roleChipLabel(turn.suggestedRoles, isOwn, counterpartName)}
               now={now}
             />
+            {missedWindowTurnId === turn.id && (
+              // Quiet decay state (§2.2) — never styled as a user-caused error.
+              <p
+                data-testid="consultation-window-missed"
+                className="py-2 text-center font-ibm-plex-mono text-[11px] text-gray-400"
+              >
+                Window missed — negotiation continued without an answer.
+              </p>
+            )}
           </div>
         );
       })}

--- a/apps/web/src/lib/negotiator-dm.ts
+++ b/apps/web/src/lib/negotiator-dm.ts
@@ -1,0 +1,15 @@
+import { apiClient } from '@/lib/api';
+
+/**
+ * Resolve the existing negotiator DM session id, or null when none exists or
+ * the lookup fails. Navigation hints never create a session here — callers
+ * fall back to /questions, where pending consultations are also answerable.
+ */
+export async function getNegotiatorDmSessionId(): Promise<string | null> {
+  try {
+    const { sessions } = await apiClient.get<{ sessions: { id: string }[] }>('/chat/sessions?persona=negotiator');
+    return sessions?.[0]?.id ?? null;
+  } catch {
+    return null;
+  }
+}

--- a/apps/web/src/services/questions.ts
+++ b/apps/web/src/services/questions.ts
@@ -126,13 +126,19 @@ export const createQuestionsService = (
     return res.questions ?? [];
   },
 
-  /** Fetch answered questions for an intent-scoped conversation log. */
+  /** Fetch answered questions, optionally narrowed by mode/source or intent scope. */
   getAnswered: async (filters?: {
     scopeType?: 'intent';
     scopeId?: string;
+    mode?: QuestionDetection['mode'];
+    sourceType?: string;
+    sourceId?: string;
     passive?: boolean;
   }): Promise<AnsweredQuestion[]> => {
     const params = new URLSearchParams({ status: 'answered' });
+    if (filters?.mode) params.set('mode', filters.mode);
+    if (filters?.sourceType) params.set('sourceType', filters.sourceType);
+    if (filters?.sourceId) params.set('sourceId', filters.sourceId);
     if (filters?.scopeType) params.set('scopeType', filters.scopeType);
     if (filters?.scopeId) params.set('scopeId', filters.scopeId);
     if (filters?.passive) params.set('passive', 'true');

--- a/apps/web/tests/topbar.test.tsx
+++ b/apps/web/tests/topbar.test.tsx
@@ -5,15 +5,18 @@
  * item when the Personal Agent inbox has open questions, caps at 99+, and
  * disappears at zero.
  */
-import { render, screen } from '@testing-library/react';
+import { render, screen, waitFor } from '@testing-library/react';
 import { MemoryRouter } from 'react-router';
 import { beforeEach, describe, expect, test, vi } from 'vitest';
 
 import TopBar from '@/components/TopBar';
 import type { ConversationSummary } from '@/services/conversation';
+import type { PendingQuestion } from '@/services/questions';
 
 const mocks = vi.hoisted(() => ({
-  questionsState: { personalAgentPending: 0 },
+  questionsState: { personalAgentPending: 0, questions: [] as PendingQuestion[] },
+  features: { negotiatorChat: true } as { negotiatorChat?: boolean },
+  apiGet: vi.fn(),
   conversations: [] as Array<ConversationSummary & { persona: string }>,
   negotiations: [] as Array<ConversationSummary & { persona: string }>,
   navigate: vi.fn(),
@@ -31,7 +34,13 @@ vi.mock('@/contexts/AuthContext', () => ({
   useAuthContext: () => ({
     user: { id: 'user-1', name: 'Alice Smith', avatar: null },
     signOut: vi.fn(),
+    features: mocks.features,
   }),
+}));
+
+vi.mock('@/lib/api', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('@/lib/api')>()),
+  apiClient: { get: mocks.apiGet, post: vi.fn() },
 }));
 
 vi.mock('@/contexts/APIContext', () => ({
@@ -47,7 +56,10 @@ vi.mock('@/contexts/IndexFilterContext', () => ({
 }));
 
 vi.mock('@/contexts/QuestionsContext', () => ({
-  useQuestions: () => ({ personalAgentPending: mocks.questionsState.personalAgentPending }),
+  useQuestions: () => ({
+    personalAgentPending: mocks.questionsState.personalAgentPending,
+    questions: mocks.questionsState.questions,
+  }),
 }));
 
 vi.mock('@/contexts/ConversationContext', () => ({
@@ -82,6 +94,25 @@ function conversationSummary(
   };
 }
 
+function consultationQuestion(id = 'q-consultation'): PendingQuestion {
+  return {
+    id,
+    detection: {
+      mode: 'negotiation_inflight',
+      sourceType: 'opportunity',
+      sourceId: 'opportunity-1',
+      timestamp: new Date().toISOString(),
+    },
+    actors: [{ userId: 'user-1', role: 'subject' }],
+    payload: { title: 'Consultation', prompt: 'What should I say?', options: [], multiSelect: false },
+    status: 'pending',
+    answer: null,
+    expiresAt: null,
+    createdAt: new Date().toISOString(),
+    conversationId: null,
+  };
+}
+
 function renderTopBar(initialPath = '/') {
   return render(
     <MemoryRouter initialEntries={[initialPath]}>
@@ -94,6 +125,9 @@ describe('TopBar Personal Agent badge', () => {
   beforeEach(() => {
     vi.clearAllMocks();
     mocks.questionsState.personalAgentPending = 0;
+    mocks.questionsState.questions = [];
+    mocks.features = { negotiatorChat: true };
+    mocks.apiGet.mockResolvedValue({ sessions: [{ id: 'negotiator-session' }] });
     mocks.conversations = [];
     mocks.negotiations = [];
   });
@@ -186,5 +220,32 @@ describe('TopBar Personal Agent badge', () => {
     renderTopBar();
     screen.getByRole('button', { name: /^Agent$/ }).click();
     expect(mocks.navigate).toHaveBeenCalledWith('/agent');
+  });
+
+  test('Agent click deep-links to the negotiator DM when a consultation is pending', async () => {
+    mocks.questionsState.personalAgentPending = 1;
+    mocks.questionsState.questions = [consultationQuestion()];
+    renderTopBar();
+    screen.getByRole('button', { name: /Agent/ }).click();
+    await waitFor(() => expect(mocks.navigate).toHaveBeenCalledWith('/d/negotiator-session'));
+    expect(mocks.apiGet).toHaveBeenCalledWith('/chat/sessions?persona=negotiator');
+  });
+
+  test('Agent click falls back to /questions when no negotiator session exists', async () => {
+    mocks.questionsState.personalAgentPending = 1;
+    mocks.questionsState.questions = [consultationQuestion()];
+    mocks.apiGet.mockResolvedValue({ sessions: [] });
+    renderTopBar();
+    screen.getByRole('button', { name: /Agent/ }).click();
+    await waitFor(() => expect(mocks.navigate).toHaveBeenCalledWith('/questions'));
+  });
+
+  test('Agent click falls back to /questions when the negotiator chat flag is off', () => {
+    mocks.questionsState.personalAgentPending = 1;
+    mocks.questionsState.questions = [consultationQuestion()];
+    mocks.features = { negotiatorChat: false };
+    renderTopBar();
+    screen.getByRole('button', { name: /Agent/ }).click();
+    expect(mocks.navigate).toHaveBeenCalledWith('/questions');
   });
 });


### PR DESCRIPTION
## Summary

Wave 2 of Negotiations Re-design — the ask_user consultation card (`docs/design/negotiation-ui-proposals.html` §2.2), built on the merged wave-1 surfaces.

- **Consultation card (IND-526, IND-557)**: new `ConsultationCard` rendered wherever `negotiation_inflight` pending questions surface — the negotiator DM (`ChatContent` → `InjectedQuestions`), the intent negotiator chat, and the `/questions` page (`QuestionGroup`). Navy "Your move" chip, the question, disclosure context, inline answer field (submit via Send or Enter), 24h countdown chip (`createdAt` + 24h window), amber left border, and the privacy line "Only your agent sees this — it decides what to disclose."
- **Deep links (IND-558)**: "Answer your agent" rows in the `/negotiations` inbox now deep-link to the negotiator DM (new shared `lib/negotiator-dm.ts` helper), falling back to `/questions`. The TopBar Agent badge does the same when a consultation is pending; otherwise it keeps going to `/agent`. The `/chat` tab already had this routing from wave 1 (unchanged).
- **Missed-window decay (IND-559)**: when the negotiation left `input_required` after an own-agent `ask_user` turn with no answered consultation (answered-check via `GET /questions?status=answered&mode=negotiation_inflight&sourceId=<opportunityId>`), the transcript's `TurnRail` renders a quiet "Window missed — negotiation continued without an answer." line anchored after the ask_user turn — gray mono, never error-styled.
- Version bump: `apps/web` 0.36.0 → 0.37.0 (MINOR, feat). `bun install` at root produced no `bun.lock` change.

Closes IND-526
Closes IND-557
Closes IND-558
Closes IND-559

## Verification

- `bun run lint` — 0 errors, 89 warnings (all pre-existing)
- Targeted tests — 35 passed: new `ConsultationCard.test.tsx` (8), `NegotiationsInbox.test.tsx` (4), `TurnRail.test.tsx` (2), plus updated `topbar.test.tsx` (12) and `ChatSidebar.test.tsx` (9)
- Related suites — `intent-negotiator-chat` (14), `negotiator-dm-inbox`, `intent-page-negotiator`, `negotiation-inbox`, `negotiation-presence`, `routes` all match clean-tree results
- Full suite — 335 passed; 51 failures in 13 files are identical to clean `origin/dev` (pre-existing, verified by re-running on a stashed tree)
- `bunx tsc --noEmit` — 61 errors before and after (identical set, no new errors)
- `bun run build` — passes

## Caveats

- The 24h countdown is computed client-side as `question.createdAt + 24h`, mirroring `DEFAULT_ASK_USER_WINDOW_MS` in `packages/protocol`; if the server overrides `NEGOTIATION_ASK_USER_WINDOW_MS`, the chip would drift from the real deadline (the negotiations API exposes no `askUserExpiresAt` today).
- "Window missed" also covers a manually dismissed consultation — both paths continue the negotiation without an answer, so the quiet line stays accurate.
- ChatSidebar's answer-row fallback remains the transcript (wave-1 behavior, covered by its merged tests); only the inbox and TopBar use the `/questions` fallback from IND-558.