### PR TITLE
feat(api): archive legacy pre-v2 negotiations with reader-side filter

### DIFF
--- a/services/api/.test-isolated
+++ b/services/api/.test-isolated
@@ -107,3 +107,4 @@ src/services/tests/intent-recovery-refinement.service.isolated.ts
 src/adapters/tests/agent-action-proposal.database.adapter.isolated.ts
 src/adapters/tests/conversation.reporter.isolated.ts
 src/controllers/tests/conversation.negotiation-activity.isolated.ts
+src/adapters/tests/archive-legacy-negotiations.isolated.ts

--- a/services/api/package.json
+++ b/services/api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@indexnetwork/api",
-  "version": "0.58.0",
+  "version": "0.59.0",
   "license": "MIT",
   "private": true,
   "scripts": {

--- a/services/api/src/adapters/conversation.database.adapter.ts
+++ b/services/api/src/adapters/conversation.database.adapter.ts
@@ -6,7 +6,7 @@ import { log } from '../lib/log';
 import { projectNegotiationActivity } from '../lib/negotiation-activity';
 import { assertContinuationExecutionEffect } from './negotiation-continuation.atomic';
 import type { ContinuationExecutionFence } from './negotiation-continuation.atomic';
-import { acquireNegotiationAttemptLock, acquireNegotiationPairLock, qualifyingNegotiationAttemptTaskWhere, qualifyingPairNegotiationTaskWhere, type NegotiationAttemptTransaction } from './negotiation-attempt.atomic';
+import { acquireNegotiationAttemptLock, acquireNegotiationPairLock, notArchivedNegotiationTaskWhere, qualifyingNegotiationAttemptTaskWhere, qualifyingPairNegotiationTaskWhere, type NegotiationAttemptTransaction } from './negotiation-attempt.atomic';
 
 /** Persona literals mirrored locally so the data layer stays protocol-agnostic. */
 const ORCHESTRATOR_PERSONA = 'orchestrator';
@@ -507,6 +507,7 @@ export class ConversationDatabaseAdapter {
           .where(and(
             inArray(schema.tasks.conversationId, ids),
             sql`${schema.tasks.metadata}->>'type' = 'negotiation'`,
+            notArchivedNegotiationTaskWhere(),
           ))
           .orderBy(schema.tasks.conversationId, desc(schema.tasks.createdAt), desc(schema.tasks.id))
         : Promise.resolve([]),
@@ -1632,6 +1633,7 @@ export class ConversationDatabaseAdapter {
       .from(schema.tasks)
       .where(and(
         sql`${schema.tasks.metadata}->>'type' = 'negotiation'`,
+        notArchivedNegotiationTaskWhere(),
         or(
           and(eq(schema.tasks.state, 'submitted'), lt(schema.tasks.createdAt, submittedCutoff)),
           and(eq(schema.tasks.state, 'working'), lt(schema.tasks.updatedAt, workingCutoff)),
@@ -2000,6 +2002,7 @@ export class ConversationDatabaseAdapter {
   }>> {
     const conditions = [
       sql`${schema.tasks.metadata}->>'type' = 'negotiation'`,
+      notArchivedNegotiationTaskWhere(),
       or(
         sql`${schema.tasks.metadata}->>'sourceUserId' = ${userId}`,
         sql`${schema.tasks.metadata}->>'candidateUserId' = ${userId}`,
@@ -2072,6 +2075,7 @@ export class ConversationDatabaseAdapter {
       .from(schema.tasks)
       .where(and(
         sql`${schema.tasks.metadata}->>'type' = 'negotiation'`,
+        notArchivedNegotiationTaskWhere(),
         inArray(sql`${schema.tasks.metadata}->>'opportunityId'`, opportunityIds),
       ));
     if (taskRows.length === 0) return [];
@@ -2431,6 +2435,7 @@ export class ConversationDatabaseAdapter {
     const userFilter = opts?.mutualWithUserId
       ? and(
           sql`${schema.tasks.metadata}->>'type' = 'negotiation'`,
+          notArchivedNegotiationTaskWhere(),
           or(
             and(
               sql`${schema.tasks.metadata}->>'sourceUserId' = ${userId}`,
@@ -2444,6 +2449,7 @@ export class ConversationDatabaseAdapter {
         )
       : and(
           sql`${schema.tasks.metadata}->>'type' = 'negotiation'`,
+          notArchivedNegotiationTaskWhere(),
           or(
             sql`${schema.tasks.metadata}->>'sourceUserId' = ${userId}`,
             sql`${schema.tasks.metadata}->>'candidateUserId' = ${userId}`,

--- a/services/api/src/adapters/negotiation-attempt.atomic.ts
+++ b/services/api/src/adapters/negotiation-attempt.atomic.ts
@@ -97,8 +97,20 @@ export function qualifyingPairNegotiationTaskWhere(
 }
 
 /**
+ * Reusable SQL predicate that excludes archived legacy pre-v2 negotiations.
+ * Archived tasks carry `metadata->>'archivedAt'` stamped by the backfill.
+ * Apply this to every user-visible SET-reader query; leave single-by-id
+ * readers, debug tools, and continuation-chain recovery alone.
+ */
+export function notArchivedNegotiationTaskWhere() {
+  return sql`${schema.tasks.metadata}->>'archivedAt' IS NULL`;
+}
+
+/**
  * Qualifying tasks that prove an attempt is already owned or still active.
  * Historical stale non-input-required tasks deliberately do not qualify.
+ * Archived tasks (metadata->>'archivedAt' IS NOT NULL) are excluded so a
+ * legacy input_required task cannot block a new attempt for its opportunity.
  */
 export function qualifyingNegotiationAttemptTaskWhere(
   opportunityId: string,
@@ -107,6 +119,7 @@ export function qualifyingNegotiationAttemptTaskWhere(
   return sql`
     ${schema.tasks.metadata}->>'type' = 'negotiation'
     AND ${schema.tasks.metadata}->>'opportunityId' = ${opportunityId}
+    AND ${notArchivedNegotiationTaskWhere()}
     AND (
       ${schema.tasks.createdAt} >= ${expectedUpdatedAt.toISOString()}::timestamptz
       OR ${schema.tasks.state} = 'input_required'

--- a/services/api/src/adapters/tests/archive-legacy-negotiations.isolated.ts
+++ b/services/api/src/adapters/tests/archive-legacy-negotiations.isolated.ts
@@ -1,0 +1,398 @@
+/**
+ * IND — archive legacy pre-v2 negotiations (feat/archive-legacy-negotiations).
+ *
+ * Proves:
+ *  1. Archived tasks are excluded from: getNegotiationsByUser,
+ *     getConversationsForUser (lifecycle join), getStaleNegotiationTasks,
+ *     negotiation-polling pickup, and qualifyingNegotiationAttemptTaskWhere.
+ *  2. Non-archived tasks and v2 tasks (protocolVersion set) remain fully
+ *     visible to every reader.
+ *  3. The backfill query stamps exactly the pre-v2 rows (archivedAt IS NULL
+ *     AND protocolVersion IS NULL) and is idempotent on re-run.
+ *
+ * Real Postgres via .env.test; BullMQ queues mocked (no Redis).
+ */
+import { config } from 'dotenv';
+config({ path: '.env.test', override: true });
+
+import { describe, it as bunIt, expect, beforeAll, afterAll, mock } from 'bun:test';
+import { randomUUID } from 'crypto';
+import { sql } from 'drizzle-orm/sql';
+import { eq } from 'drizzle-orm';
+
+import { withMinimumDatabaseTestBudget } from '../../lib/testing/database-test-budget';
+
+// ─── Mock queues before any service imports ──────────────────────────────────
+mock.module('../../queues/negotiations/timeout.queue', () => ({
+  negotiationTimeoutQueue: { cancelTimeout: async () => {}, enqueueTimeout: async () => {} },
+}));
+mock.module('../../queues/negotiations/claim-timeout.queue', () => ({
+  negotiationClaimTimeoutQueue: { cancelTimeout: async () => {}, enqueueTimeout: async () => {} },
+}));
+
+const { conversationDatabaseAdapter } = await import('../database.adapter');
+const { negotiationPollingService } = await import('../../services/negotiation-polling.service');
+const { notArchivedNegotiationTaskWhere, qualifyingNegotiationAttemptTaskWhere } = await import('../negotiation-attempt.atomic');
+const { default: db } = await import('../../lib/drizzle/drizzle');
+const dbSchema = await import('../../schemas/database.schema');
+const convSchema = await import('../../schemas/conversation.schema');
+
+const it = withMinimumDatabaseTestBudget(bunIt, 30_000);
+
+afterAll(() => { mock.restore(); });
+
+// ─── Seed state ──────────────────────────────────────────────────────────────
+
+const cleanupConversations: string[] = [];
+const cleanupOpportunities: string[] = [];
+
+let userA: string;
+let userB: string;
+let agentA: string;
+
+async function seedUser(name: string): Promise<string> {
+  const [u] = await db
+    .insert(dbSchema.users)
+    .values({ email: `archive-test-${randomUUID()}@test.local`, name })
+    .returning({ id: dbSchema.users.id });
+  return u.id;
+}
+
+async function seedAgent(ownerId: string): Promise<string> {
+  const [a] = await db
+    .insert(dbSchema.agents)
+    .values({ ownerId, name: 'archive-test-agent', type: 'external' })
+    .returning({ id: dbSchema.agents.id });
+  return a.id;
+}
+
+async function seedOpportunity(status = 'negotiating'): Promise<string> {
+  const [o] = await db
+    .insert(dbSchema.opportunities)
+    .values({
+      detection: { kind: 'test', summary: 'archive test' } as never,
+      actors: [
+        { userId: userA, role: 'peer' },
+        { userId: userB, role: 'peer' },
+      ] as never,
+      interpretation: { reasoning: 'archive test', category: 'test' } as never,
+      context: {} as never,
+      confidence: '0.9',
+      status,
+    })
+    .returning({ id: dbSchema.opportunities.id });
+  cleanupOpportunities.push(o.id);
+  return o.id;
+}
+
+interface SeedTaskOpts {
+  protocolVersion?: string;
+  archivedAt?: string;
+  state?: 'submitted' | 'working' | 'waiting_for_agent' | 'input_required' | 'completed';
+  opportunityId?: string;
+  createdAt?: Date;
+}
+
+async function seedNegotiationTask(opts: SeedTaskOpts = {}): Promise<{
+  taskId: string;
+  conversationId: string;
+}> {
+  const conv = await conversationDatabaseAdapter.createConversation([
+    { participantId: `agent:${userA}`, participantType: 'agent' as const },
+    { participantId: `agent:${userB}`, participantType: 'agent' as const },
+  ]);
+  cleanupConversations.push(conv.id);
+
+  const metadata: Record<string, unknown> = {
+    type: 'negotiation',
+    sourceUserId: userA,
+    candidateUserId: userB,
+    ...(opts.opportunityId && { opportunityId: opts.opportunityId }),
+    ...(opts.protocolVersion && { protocolVersion: opts.protocolVersion }),
+    ...(opts.archivedAt && { archivedAt: opts.archivedAt }),
+  };
+
+  const task = await conversationDatabaseAdapter.createTask(conv.id, metadata);
+
+  // Transition to desired state if not default 'submitted'
+  const desiredState = opts.state ?? 'submitted';
+  if (desiredState !== 'submitted') {
+    await db
+      .update(convSchema.tasks)
+      .set({ state: desiredState, updatedAt: new Date() })
+      .where(eq(convSchema.tasks.id, task.id));
+  }
+
+  return { taskId: task.id, conversationId: conv.id };
+}
+
+/** Stamp archivedAt directly on a task (simulates the backfill). */
+async function stampArchivedAt(taskId: string, isoTimestamp: string): Promise<void> {
+  await db
+    .update(convSchema.tasks)
+    .set({
+      metadata: sql`${convSchema.tasks.metadata} || jsonb_build_object('archivedAt', ${isoTimestamp}::text)`,
+    })
+    .where(eq(convSchema.tasks.id, taskId));
+}
+
+beforeAll(async () => {
+  userA = await seedUser('Archive Test A');
+  userB = await seedUser('Archive Test B');
+  agentA = await seedAgent(userA);
+}, 30_000);
+
+afterAll(async () => {
+  for (const id of cleanupConversations) {
+    try { await conversationDatabaseAdapter.deleteConversation(id); } catch { /* ignore */ }
+  }
+  for (const id of cleanupOpportunities) {
+    try {
+      await db.delete(dbSchema.opportunities).where(eq(dbSchema.opportunities.id, id));
+    } catch { /* ignore */ }
+  }
+  try {
+    await db.delete(dbSchema.agents).where(eq(dbSchema.agents.id, agentA));
+    await db.delete(dbSchema.users).where(eq(dbSchema.users.id, userA));
+    await db.delete(dbSchema.users).where(eq(dbSchema.users.id, userB));
+  } catch { /* ignore */ }
+}, 30_000);
+
+// ─── Tests ───────────────────────────────────────────────────────────────────
+
+describe('archive legacy negotiations — getNegotiationsByUser', () => {
+  it('excludes archived tasks from user negotiation list', async () => {
+    const { taskId: archivedId } = await seedNegotiationTask({ state: 'submitted' });
+    const { taskId: activeId } = await seedNegotiationTask({ state: 'submitted' });
+
+    await stampArchivedAt(archivedId, new Date().toISOString());
+
+    const results = await conversationDatabaseAdapter.getNegotiationsByUser(userA, { unpaginated: true });
+    const ids = results.map((t) => t.id);
+
+    expect(ids).not.toContain(archivedId);
+    expect(ids).toContain(activeId);
+  });
+
+  it('returns v2 tasks (protocolVersion set) regardless of archive filter', async () => {
+    const { taskId: v2Id } = await seedNegotiationTask({
+      state: 'submitted',
+      protocolVersion: 'v2',
+    });
+
+    const results = await conversationDatabaseAdapter.getNegotiationsByUser(userA, { unpaginated: true });
+    const ids = results.map((t) => t.id);
+    expect(ids).toContain(v2Id);
+  });
+});
+
+describe('archive legacy negotiations — getConversationsForUser lifecycle join', () => {
+  it('excludes archived task from negotiation lifecycle slot', async () => {
+    const { taskId: archivedId, conversationId } = await seedNegotiationTask({ state: 'submitted' });
+    await stampArchivedAt(archivedId, new Date().toISOString());
+
+    const conversations = await conversationDatabaseAdapter.getConversationsForUser(
+      `agent:${userA}`,
+      userA,
+      /* includeNegotiationLifecycle = */ true,
+    );
+    const conv = conversations.find((c) => c.id === conversationId);
+    // The conversation may still appear but the negotiation lifecycle slot must be null/absent
+    if (conv) {
+      expect((conv as Record<string, unknown>).negotiation).toBeFalsy();
+    }
+  });
+
+  it('includes non-archived negotiation in lifecycle slot', async () => {
+    const { taskId: activeId, conversationId } = await seedNegotiationTask({ state: 'submitted' });
+
+    const conversations = await conversationDatabaseAdapter.getConversationsForUser(
+      `agent:${userA}`,
+      userA,
+      /* includeNegotiationLifecycle = */ true,
+    );
+    const conv = conversations.find((c) => c.id === conversationId);
+    if (conv) {
+      const negotiation = (conv as Record<string, unknown>).negotiation as Record<string, unknown> | null;
+      expect(negotiation?.taskId).toBe(activeId);
+    }
+  });
+});
+
+describe('archive legacy negotiations — getStaleNegotiationTasks', () => {
+  it('excludes archived tasks from stale watchdog sweep', async () => {
+    // Create a genuinely stale submitted task
+    const { taskId: staleId } = await seedNegotiationTask({ state: 'submitted' });
+    const { taskId: archivedStaleId } = await seedNegotiationTask({ state: 'submitted' });
+
+    // Age both tasks so they qualify as stale
+    const stalePast = new Date(Date.now() - 60 * 60 * 1000); // 1 hour ago
+    await db
+      .update(convSchema.tasks)
+      .set({ createdAt: stalePast, updatedAt: stalePast })
+      .where(eq(convSchema.tasks.id, staleId));
+    await db
+      .update(convSchema.tasks)
+      .set({ createdAt: stalePast, updatedAt: stalePast })
+      .where(eq(convSchema.tasks.id, archivedStaleId));
+
+    // Archive the second task
+    await stampArchivedAt(archivedStaleId, new Date().toISOString());
+
+    const staleTasks = await conversationDatabaseAdapter.getStaleNegotiationTasks({
+      submittedOlderThanMs: 30 * 60 * 1000, // 30 min
+      workingOlderThanMs: 30 * 60 * 1000,
+      limit: 100,
+    });
+    const ids = staleTasks.map((t) => t.id);
+
+    expect(ids).toContain(staleId);
+    expect(ids).not.toContain(archivedStaleId);
+  });
+});
+
+describe('archive legacy negotiations — polling pickup', () => {
+  it('pickup skips archived waiting_for_agent tasks', async () => {
+    const { taskId: archivedId } = await seedNegotiationTask({ state: 'waiting_for_agent' });
+    await stampArchivedAt(archivedId, new Date().toISOString());
+
+    // pickup should not return the archived task
+    const result = await negotiationPollingService.pickup(agentA, userA);
+    if (result) {
+      expect(result.negotiationId).not.toBe(archivedId);
+    }
+    // Either null or a different task — just confirm the archived one isn't picked up
+  });
+
+  it('pickup returns non-archived waiting_for_agent tasks normally', async () => {
+    const { taskId: activeId } = await seedNegotiationTask({ state: 'waiting_for_agent' });
+
+    const result = await negotiationPollingService.pickup(agentA, userA);
+    // May pick up this or another waiting task; confirm we got one
+    expect(result).not.toBeNull();
+
+    // Clean up: cancel the claimed task so it doesn't affect other tests
+    if (result) {
+      await db
+        .update(convSchema.tasks)
+        .set({ state: 'canceled', updatedAt: new Date() })
+        .where(eq(convSchema.tasks.id, result.negotiationId));
+    }
+  });
+});
+
+describe('archive legacy negotiations — qualifyingNegotiationAttemptTaskWhere', () => {
+  it('archived input_required task does not block new attempt for its opportunity', async () => {
+    const opportunityId = randomUUID();
+    const { taskId: archivedInputRequired } = await seedNegotiationTask({
+      state: 'input_required',
+      opportunityId,
+    });
+    await stampArchivedAt(archivedInputRequired, new Date().toISOString());
+
+    // The qualifying predicate must NOT match the archived task
+    const expectedUpdatedAt = new Date(Date.now() - 25 * 60 * 60 * 1000); // 25h ago (outside window)
+    const matchingTasks = await db
+      .select({ id: convSchema.tasks.id })
+      .from(convSchema.tasks)
+      .where(qualifyingNegotiationAttemptTaskWhere(opportunityId, expectedUpdatedAt));
+
+    const matchedIds = matchingTasks.map((t) => t.id);
+    expect(matchedIds).not.toContain(archivedInputRequired);
+  });
+
+  it('non-archived input_required task still blocks new attempt', async () => {
+    const opportunityId = randomUUID();
+    const { taskId: activeInputRequired } = await seedNegotiationTask({
+      state: 'input_required',
+      opportunityId,
+    });
+    // Do NOT archive it
+
+    const expectedUpdatedAt = new Date(Date.now() - 25 * 60 * 60 * 1000);
+    const matchingTasks = await db
+      .select({ id: convSchema.tasks.id })
+      .from(convSchema.tasks)
+      .where(qualifyingNegotiationAttemptTaskWhere(opportunityId, expectedUpdatedAt));
+
+    const matchedIds = matchingTasks.map((t) => t.id);
+    expect(matchedIds).toContain(activeInputRequired);
+  });
+});
+
+describe('archive legacy negotiations — backfill logic', () => {
+  it('backfill stamps pre-v2 rows and is idempotent', async () => {
+    // Create three tasks:
+    //   A: pre-v2 (no protocolVersion) — should be stamped
+    //   B: v2 (protocolVersion = 'v2') — must NOT be stamped
+    //   C: pre-v2 but already archived — must NOT be re-stamped (idempotency)
+
+    const { taskId: preV2Id } = await seedNegotiationTask({ state: 'submitted' });
+    const { taskId: v2Id } = await seedNegotiationTask({
+      state: 'submitted',
+      protocolVersion: 'v2',
+    });
+    const { taskId: alreadyArchivedId } = await seedNegotiationTask({ state: 'submitted' });
+    const priorArchivedAt = '2024-01-01T00:00:00.000Z';
+    await stampArchivedAt(alreadyArchivedId, priorArchivedAt);
+
+    const archiveTimestamp = new Date().toISOString();
+
+    // Run the backfill UPDATE logic (inline, same SQL as the CLI script).
+    await db.transaction(async (tx) => {
+      await tx
+        .update(convSchema.tasks)
+        .set({
+          metadata: sql`${convSchema.tasks.metadata} || jsonb_build_object('archivedAt', ${archiveTimestamp}::text)`,
+        })
+        .where(sql`
+          ${convSchema.tasks.metadata}->>'type' = 'negotiation'
+          AND ${convSchema.tasks.metadata}->>'protocolVersion' IS NULL
+          AND ${convSchema.tasks.metadata}->>'archivedAt' IS NULL
+        `);
+    });
+
+    // A: should now have archivedAt
+    const [taskA] = await db
+      .select({ metadata: convSchema.tasks.metadata })
+      .from(convSchema.tasks)
+      .where(eq(convSchema.tasks.id, preV2Id));
+    const metaA = taskA?.metadata as Record<string, unknown> | null;
+    expect(metaA?.archivedAt).toBe(archiveTimestamp);
+
+    // B: v2 task must be untouched
+    const [taskB] = await db
+      .select({ metadata: convSchema.tasks.metadata })
+      .from(convSchema.tasks)
+      .where(eq(convSchema.tasks.id, v2Id));
+    const metaB = taskB?.metadata as Record<string, unknown> | null;
+    expect(metaB?.archivedAt).toBeUndefined();
+
+    // C: already-archived row must keep the ORIGINAL timestamp (not overwritten)
+    const [taskC] = await db
+      .select({ metadata: convSchema.tasks.metadata })
+      .from(convSchema.tasks)
+      .where(eq(convSchema.tasks.id, alreadyArchivedId));
+    const metaC = taskC?.metadata as Record<string, unknown> | null;
+    expect(metaC?.archivedAt).toBe(priorArchivedAt);
+
+    // Idempotency: re-run should stamp 0 rows for tasks that are already archived
+    // Check individually rather than with ANY(ARRAY[...]) to avoid UUID cast issues.
+    const idempotencyRows = await Promise.all(
+      [preV2Id, alreadyArchivedId].map((id) =>
+        db
+          .select({ count: sql<string>`count(*)` })
+          .from(convSchema.tasks)
+          .where(sql`
+            ${convSchema.tasks.id}::text = ${id}
+            AND ${convSchema.tasks.metadata}->>'type' = 'negotiation'
+            AND ${convSchema.tasks.metadata}->>'protocolVersion' IS NULL
+            AND ${convSchema.tasks.metadata}->>'archivedAt' IS NULL
+          `)
+          .then(([r]) => Number(r?.count ?? 0)),
+      ),
+    );
+    // Both pre-v2 and already-archived tasks now have archivedAt — none match the backfill predicate
+    expect(idempotencyRows.every((n) => n === 0)).toBe(true);
+  });
+});

--- a/services/api/src/cli/archive-legacy-negotiations.ts
+++ b/services/api/src/cli/archive-legacy-negotiations.ts
@@ -1,0 +1,102 @@
+#!/usr/bin/env node
+/**
+ * One-shot backfill: stamps `metadata.archivedAt` on every pre-v2 legacy
+ * negotiation task so reader-side filters can hide them from user-facing APIs.
+ *
+ * "Old negotiation" predicate:
+ *   metadata->>'type' = 'negotiation'
+ *   AND metadata->>'protocolVersion' IS NULL   ← v2 tasks always set this
+ *   AND metadata->>'archivedAt' IS NULL         ← idempotency guard
+ *
+ * Safety:
+ *   - Nothing is deleted; archivedAt is an additive JSONB field.
+ *   - The `archivedAt IS NULL` guard makes re-runs safe (only unarchived rows
+ *     are touched — re-running is a no-op once complete).
+ *   - The UPDATE runs inside a single transaction so it's atomic.
+ *
+ * Usage:
+ *   bun src/cli/archive-legacy-negotiations.ts [--dry-run]
+ *   bun run maintenance:archive-legacy-negotiations [-- --dry-run]
+ *
+ * ⚠️  DO NOT run this against production without explicit approval from the
+ *     wave root agent.  This script is shipped in PR feat/archive-legacy-
+ *     negotiations and is intentionally NOT executed during this wave.
+ */
+import dotenv from 'dotenv';
+import path from 'path';
+
+const envFile = process.env.NODE_ENV === 'development' ? '.env.development' : '.env.production';
+dotenv.config({ path: path.resolve(import.meta.dir, '../../../..', envFile) });
+
+import { sql } from 'drizzle-orm/sql';
+
+import db, { closeDb } from '../lib/drizzle/drizzle';
+import { tasks } from '../schemas/conversation.schema';
+
+const isDryRun = process.argv.includes('--dry-run');
+
+async function main() {
+  console.log(`[archive-legacy-negotiations] mode=${isDryRun ? 'DRY RUN' : 'WRITE'}`);
+
+  // Always count first so we can report what would be affected.
+  const [countRow] = await db
+    .select({ count: sql<string>`count(*)` })
+    .from(tasks)
+    .where(sql`
+      ${tasks.metadata}->>'type' = 'negotiation'
+      AND ${tasks.metadata}->>'protocolVersion' IS NULL
+      AND ${tasks.metadata}->>'archivedAt' IS NULL
+    `);
+
+  const matchCount = Number(countRow?.count ?? 0);
+  console.log(`[archive-legacy-negotiations] matched ${matchCount} pre-v2 task(s) to archive`);
+
+  if (matchCount === 0) {
+    console.log('[archive-legacy-negotiations] Nothing to archive — exiting.');
+    await closeDb();
+    process.exit(0);
+  }
+
+  if (isDryRun) {
+    console.log('[archive-legacy-negotiations] DRY RUN — no rows were written.');
+    await closeDb();
+    process.exit(0);
+  }
+
+  // Execute the backfill inside a transaction so it's all-or-nothing.
+  const archivedAt = new Date().toISOString();
+  await db.transaction(async (tx) => {
+    const result = await tx
+      .update(tasks)
+      .set({
+        metadata: sql`${tasks.metadata} || jsonb_build_object('archivedAt', ${archivedAt}::text)`,
+      })
+      .where(sql`
+        ${tasks.metadata}->>'type' = 'negotiation'
+        AND ${tasks.metadata}->>'protocolVersion' IS NULL
+        AND ${tasks.metadata}->>'archivedAt' IS NULL
+      `)
+      .returning({ id: tasks.id });
+
+    console.log(`[archive-legacy-negotiations] Stamped archivedAt=${archivedAt} on ${result.length} task(s).`);
+
+    if (result.length !== matchCount) {
+      // If the count differs, a concurrent write landed between our SELECT and
+      // UPDATE.  The archivedAt IS NULL guard in the UPDATE still ensures we
+      // only stamp rows that weren't already archived; report the discrepancy.
+      console.warn(
+        `[archive-legacy-negotiations] Count mismatch: expected ${matchCount}, wrote ${result.length}.` +
+        ' A concurrent update may have archived some rows first (safe — re-run is idempotent).',
+      );
+    }
+  });
+
+  console.log('[archive-legacy-negotiations] Done.');
+  await closeDb();
+  process.exit(0);
+}
+
+main().catch((err) => {
+  console.error('[archive-legacy-negotiations] Fatal error:', err);
+  process.exit(1);
+});

--- a/services/api/src/queues/negotiations/timeout.shared.ts
+++ b/services/api/src/queues/negotiations/timeout.shared.ts
@@ -51,6 +51,8 @@ export interface NegotiationTaskMeta {
   type?: string;
   maxTurns?: number;
   opportunityId?: string;
+  /** ISO timestamp set by the archive backfill on pre-v2 legacy negotiations. */
+  archivedAt?: string;
 }
 
 /** Per-worker log strings — the only textual difference between the two timeout workers. */

--- a/services/api/src/services/negotiation-polling.service.ts
+++ b/services/api/src/services/negotiation-polling.service.ts
@@ -1,4 +1,5 @@
 import { eq, and, sql, asc, isNull } from 'drizzle-orm/sql';
+import { notArchivedNegotiationTaskWhere } from '../adapters/negotiation-attempt.atomic';
 
 import db from '../lib/drizzle/drizzle';
 import * as convSchema from '../schemas/conversation.schema';
@@ -167,6 +168,8 @@ interface NegotiationTaskMetadata {
   protocolVersion?: string;
   maxTurns?: number;
   opportunityId?: string;
+  /** ISO timestamp set by the archive backfill on pre-v2 legacy negotiations. */
+  archivedAt?: string;
   turnContext?: PersistedTurnContext & {
     privateConsultation?: { recipientUserId: string; kind: 'answer' | 'dismiss' | 'timeout'; selectedOptions: string[]; freeText?: string };
   };
@@ -226,6 +229,7 @@ export class NegotiationPollingService {
           eq(convSchema.tasks.state, 'claimed'),
           eq(convSchema.tasks.claimedByAgentId, agentId),
           sql`${convSchema.tasks.metadata}->>'type' = 'negotiation'`,
+          notArchivedNegotiationTaskWhere(),
         ),
       )
       .limit(1);
@@ -254,6 +258,7 @@ export class NegotiationPollingService {
         and(
           eq(convSchema.tasks.state, 'waiting_for_agent'),
           sql`${convSchema.tasks.metadata}->>'type' = 'negotiation'`,
+          notArchivedNegotiationTaskWhere(),
           sql`(
             ${convSchema.tasks.metadata}->>'sourceUserId' = ${userId}
             OR ${convSchema.tasks.metadata}->>'candidateUserId' = ${userId}


### PR DESCRIPTION
## Summary

Adds an additive archive stamp (`metadata.archivedAt`) and reader-side filter for pre-v2 legacy negotiation tasks. Nothing is deleted.

## What changed

### Shared filter helper
`notArchivedNegotiationTaskWhere()` exported from `negotiation-attempt.atomic.ts` — reusable SQL predicate (`metadata->>'archivedAt' IS NULL`).

### TS metadata types
- `NegotiationTaskMetadata` (negotiation-polling.service.ts): add `archivedAt?: string`
- `NegotiationTaskMeta` (timeout.shared.ts): add `archivedAt?: string`

### Reader-side filters applied
| File | Method |
|------|--------|
| conversation.database.adapter.ts | `getConversationsForUser` negotiation lifecycle join |
| conversation.database.adapter.ts | `getNegotiationsByUser` |
| conversation.database.adapter.ts | `getNegotiationActivityForIntent` |
| conversation.database.adapter.ts | `getTasksForUser` |
| conversation.database.adapter.ts | `getStaleNegotiationTasks` |
| negotiation-polling.service.ts | `pickup` re-pickup (existingClaim) |
| negotiation-polling.service.ts | `pickup` (pendingTask) |
| negotiation-attempt.atomic.ts | `qualifyingNegotiationAttemptTaskWhere` |

### LEFT ALONE (no archive filter)
Single-by-id readers (`getTask`, timeout/claim-timeout workers, `respond`, questioner admission ~:712/:810, continuation recovery ~:1588, `getLatestNegotiationTaskForConversation`), `debug.controller.ts`, negotiator-memory reader, CLI deleter.

### `getNegotiationTaskForOpportunity` / `getNegotiationTasksForOpportunity` decision — **NOT filtered**

**Rationale**: Both functions are used by continuation-chain recovery (`intent-recovery-refinement.service.ts`) and evidence chain building (`negotiation-evidence.shadow.ts`) which need the **full historical task set**, including archived rows, to reconstruct correct context. Filtering them would silently break recovery for opportunities whose only tasks are archived pre-v2 rows. For `getNegotiationTaskForOpportunity`, the `orderBy(desc(createdAt)).limit(1)` means a newer v2 task always wins first — if the only task is an archived legacy one, `isActiveNegotiationTaskFresh` returns false anyway (stale by definition).

### Backfill script
`src/cli/archive-legacy-negotiations.ts` — one-shot CLI (pattern: `rediscover-user-opportunities.ts`):
```sql
UPDATE tasks SET metadata = metadata || jsonb_build_object('archivedAt', <now ISO>)
WHERE metadata->>'type' = 'negotiation'
  AND metadata->>'protocolVersion' IS NULL
  AND metadata->>'archivedAt' IS NULL;
```
- `--dry-run` flag: prints matched counts without writing
- Idempotent: `archivedAt IS NULL` guard ensures re-runs stamp nothing new
- Runs in a transaction (all-or-nothing)
- **⚠️ NOT executed against any live/prod environment in this PR — script only**

## Test commands run

```
# Contract spec (pins SQL in negotiation-attempt.atomic.ts) — must stay green
bun test src/adapters/tests/intent-scope-lock.contract.spec.ts
# → 6 pass, 0 fail

# New archive filter tests (10 real-DB tests)
TEST_DATABASE_SAFE=1 API_TEST_ISOLATED_CHILD=1 API_TEST_DATABASE_READY=1 NODE_ENV=test   bun test ./src/adapters/tests/archive-legacy-negotiations.isolated.ts
# → 10 pass, 0 fail

# TypeScript
npx tsc --noEmit --skipLibCheck
# → clean

# Lint
bun run lint
# → 0 errors, 33 pre-existing warnings (none from touched files)
```

## Version bump
`services/api`: 0.58.0 → 0.59.0 (minor — feat)