### PR TITLE
feat(web): per-opportunity negotiation sections and accurate outcome banners (IND-565 + IND-566)

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@indexnetwork/web",
-  "version": "0.37.0",
+  "version": "0.38.0",
   "license": "MIT",
   "scripts": {
     "dev": "vite --host 127.0.0.1",

--- a/apps/web/src/app/chat/[conversationId]/page.tsx
+++ b/apps/web/src/app/chat/[conversationId]/page.tsx
@@ -11,7 +11,7 @@ import TurnRail from '@/components/negotiations/TurnRail';
 import OutcomeBanner from '@/components/negotiations/OutcomeBanner';
 import ResolvedBanner, { type ResolvedBannerVariant } from '@/components/negotiations/ResolvedBanner';
 import { useTickingNow } from '@/components/negotiations/use-ticking-now';
-import { extractTurn, formatRelativeTime, viewerRoleLabel, type TranscriptTurn } from '@/components/negotiations/negotiation-turns';
+import { extractTurn, formatRelativeTime, groupTurnsBySession, viewerRoleLabel, type TranscriptTurn } from '@/components/negotiations/negotiation-turns';
 
 const STALL_REASONS = new Set(['turn_cap', 'timeout']);
 
@@ -75,18 +75,34 @@ export default function NegotiationDetailPage() {
   );
   const negotiatedRole = useMemo(() => viewerRoleLabel(turns, ownAgentId), [turns, ownAgentId]);
 
+  // IND-565: group turns by negotiation session (one session = one task = one opportunity).
+  const sessionGroups = useMemo(() => groupTurnsBySession(turns), [turns]);
+  const isMultiSession = sessionGroups.length > 1;
+
   const opportunityId = lifecycle?.opportunityId ?? null;
   const localStatus = opportunityId ? opportunityStatusMap[opportunityId] : undefined;
   const effectiveOpportunityStatus = localStatus ?? lifecycle?.opportunityStatus ?? null;
   const outcomeReason = lifecycle?.outcome?.reason ?? null;
 
+  // IND-566: Per-task turn count — turns in the latest session only, not cumulative
+  // across all prior tasks in this dm_pair. lifecycle.turnCount folds in priorTurnCount
+  // from earlier negotiations, so we recount from the loaded session groups instead.
+  const latestSessionTurns = useMemo(
+    () => sessionGroups[sessionGroups.length - 1]?.turns ?? turns,
+    [sessionGroups, turns],
+  );
+  const latestTaskTurnCount = latestSessionTurns.length > 0 ? latestSessionTurns.length : null;
+
   // The viewer's last ask_user turn — anchor for the missed-window decay line.
+  // Scoped to the latest session (the active task) only.
   const lastAskUserTurnId = useMemo(() => {
-    for (let i = turns.length - 1; i >= 0; i -= 1) {
-      if (turns[i].action === 'ask_user' && turns[i].senderId === ownAgentId) return turns[i].id;
+    for (let i = latestSessionTurns.length - 1; i >= 0; i -= 1) {
+      if (latestSessionTurns[i].action === 'ask_user' && latestSessionTurns[i].senderId === ownAgentId) {
+        return latestSessionTurns[i].id;
+      }
     }
     return null;
-  }, [turns, ownAgentId]);
+  }, [latestSessionTurns, ownAgentId]);
 
   // Missed-window decay (IND-559): the negotiation left input_required after
   // an ask_user pause with no answered consultation — the window lapsed (or
@@ -179,36 +195,107 @@ export default function NegotiationDetailPage() {
               </div>
             ) : null}
 
-            <TurnRail
-              turns={turns}
-              ownAgentId={ownAgentId}
-              participantInfo={participantInfo}
-              counterpartName={counterpartName}
-              now={now}
-              missedWindowTurnId={windowMissed ? lastAskUserTurnId : null}
-            />
+            {/* IND-565: per-opportunity negotiation sections.
+                Each sessionId group = one negotiation task over one opportunity.
+                Banners are scoped to the latest section so a WITHDRAWN chip in
+                an earlier task can’t be misread as applying to the current one. */}
+            {isMultiSession ? (
+              sessionGroups.map((group, groupIndex) => {
+                const isLatest = groupIndex === sessionGroups.length - 1;
+                const firstTurn = group.turns[0];
 
-            {showOutcomeBanner && opportunityId && (
-              <OutcomeBanner
-                counterpartName={counterpartName}
-                role={negotiatedRole}
-                turnCount={lifecycle?.turnCount ?? null}
-                concludedLabel={lifecycle?.updatedAt ? formatRelativeTime(lifecycle.updatedAt, now) : null}
-                loading={opportunityActionLoading[opportunityId] === true}
-                onStartChat={() => void handleOpportunityAction(opportunityId, 'accepted', counterpartUserId, undefined, counterpartName)}
-                onPass={() => void handleOpportunityAction(opportunityId, 'rejected', counterpartUserId, undefined, counterpartName)}
-              />
-            )}
+                // Older sections: show month/year of first turn as context.
+                // Latest section: use the viewer’s own opportunity intent title
+                // from the conversation’s signal provenance (via[0]).
+                let sectionLabel: string;
+                if (isLatest) {
+                  sectionLabel = conversation?.via[0]?.title ?? 'Current negotiation';
+                } else {
+                  const date = firstTurn ? new Date(firstTurn.createdAt) : null;
+                  const monthYear = date && Number.isFinite(date.getTime())
+                    ? date.toLocaleString('en-US', { month: 'short', year: 'numeric' })
+                    : '';
+                  sectionLabel = `Earlier negotiation${monthYear ? ` · ${monthYear}` : ''}`;
+                }
 
-            {resolvedVariant && (
-              <ResolvedBanner
-                variant={resolvedVariant}
-                reason={outcomeReason}
-                turnCount={lifecycle?.turnCount ?? null}
-                maxTurns={lifecycle?.maxTurns ?? null}
-                onRevive={resolvedVariant === 'stalled' ? () => void handleRevive() : undefined}
-                onLetGo={resolvedVariant === 'stalled' ? () => navigate('/negotiations') : undefined}
-              />
+                return (
+                  <section key={group.sessionId ?? `group-${groupIndex}`} aria-label={sectionLabel}>
+                    {/* Section divider — separates this task from the preceding one */}
+                    <div className="flex items-center gap-3 py-3" role="separator">
+                      <span className="h-px flex-1 bg-gray-200" />
+                      <span className="text-[10px] font-ibm-plex-mono uppercase tracking-[0.12em] text-gray-400">
+                        {sectionLabel}
+                      </span>
+                      <span className="h-px flex-1 bg-gray-200" />
+                    </div>
+                    <TurnRail
+                      turns={group.turns}
+                      ownAgentId={ownAgentId}
+                      participantInfo={participantInfo}
+                      counterpartName={counterpartName}
+                      now={now}
+                      missedWindowTurnId={isLatest && windowMissed ? lastAskUserTurnId : null}
+                    />
+                    {/* Outcome banners are scoped to the latest section (IND-566). */}
+                    {isLatest && showOutcomeBanner && opportunityId && (
+                      <OutcomeBanner
+                        counterpartName={counterpartName}
+                        role={negotiatedRole}
+                        turnCount={latestTaskTurnCount}
+                        concludedLabel={lifecycle?.updatedAt ? formatRelativeTime(lifecycle.updatedAt, now) : null}
+                        loading={opportunityActionLoading[opportunityId] === true}
+                        onStartChat={() => void handleOpportunityAction(opportunityId, 'accepted', counterpartUserId, undefined, counterpartName)}
+                        onPass={() => void handleOpportunityAction(opportunityId, 'rejected', counterpartUserId, undefined, counterpartName)}
+                      />
+                    )}
+                    {isLatest && resolvedVariant && (
+                      <ResolvedBanner
+                        variant={resolvedVariant}
+                        reason={outcomeReason}
+                        turnCount={latestTaskTurnCount}
+                        maxTurns={lifecycle?.maxTurns ?? null}
+                        onRevive={resolvedVariant === 'stalled' ? () => void handleRevive() : undefined}
+                        onLetGo={resolvedVariant === 'stalled' ? () => navigate('/negotiations') : undefined}
+                      />
+                    )}
+                  </section>
+                );
+              })
+            ) : (
+              // Single-session (common case): no section divider, but still use
+              // latestTaskTurnCount so the banner doesn’t inherit priorTurnCount
+              // from earlier tasks that ran before this one (IND-566).
+              <>
+                <TurnRail
+                  turns={turns}
+                  ownAgentId={ownAgentId}
+                  participantInfo={participantInfo}
+                  counterpartName={counterpartName}
+                  now={now}
+                  missedWindowTurnId={windowMissed ? lastAskUserTurnId : null}
+                />
+                {showOutcomeBanner && opportunityId && (
+                  <OutcomeBanner
+                    counterpartName={counterpartName}
+                    role={negotiatedRole}
+                    turnCount={latestTaskTurnCount}
+                    concludedLabel={lifecycle?.updatedAt ? formatRelativeTime(lifecycle.updatedAt, now) : null}
+                    loading={opportunityActionLoading[opportunityId] === true}
+                    onStartChat={() => void handleOpportunityAction(opportunityId, 'accepted', counterpartUserId, undefined, counterpartName)}
+                    onPass={() => void handleOpportunityAction(opportunityId, 'rejected', counterpartUserId, undefined, counterpartName)}
+                  />
+                )}
+                {resolvedVariant && (
+                  <ResolvedBanner
+                    variant={resolvedVariant}
+                    reason={outcomeReason}
+                    turnCount={latestTaskTurnCount}
+                    maxTurns={lifecycle?.maxTurns ?? null}
+                    onRevive={resolvedVariant === 'stalled' ? () => void handleRevive() : undefined}
+                    onLetGo={resolvedVariant === 'stalled' ? () => navigate('/negotiations') : undefined}
+                  />
+                )}
+              </>
             )}
             <div ref={messagesEndRef} />
           </div>

--- a/apps/web/src/components/negotiations/ResolvedBanner.tsx
+++ b/apps/web/src/components/negotiations/ResolvedBanner.tsx
@@ -19,16 +19,21 @@ interface ResolvedBannerProps {
  */
 export function ResolvedBanner({ variant, reason, turnCount, maxTurns, onRevive, onLetGo }: ResolvedBannerProps) {
   if (variant === 'rejected') {
+    let body: string;
+    if (reason === 'screened_out') {
+      body = 'This connection was filtered out before either side reached out, so neither of you was notified.';
+    } else if (!reason) {
+      // Agent voluntarily withdrew — the candidate didn’t match this opportunity’s query.
+      body = `Your agent withdrew after reviewing the opportunity${turnCount != null && turnCount > 0 ? ` (${turnCount} ${turnCount === 1 ? 'turn' : 'turns'})` : ''} — the candidate didn’t align with what you’re looking for. You were never notified while this played out.`;
+    } else {
+      body = `${turnCount != null && turnCount > 0 ? `After ${turnCount} ${turnCount === 1 ? 'turn' : 'turns'}, the` : 'The'} agents couldn’t justify this connection, so it was quietly set aside. You were never notified while this played out.`;
+    }
     return (
       <div className="mt-4 rounded-lg border border-red-200 bg-red-50 px-4 py-4">
         <h3 className="font-ibm-plex-mono text-[13px] font-bold text-[#041729]">
           No opportunity — filtered out for you
         </h3>
-        <p className="mt-1 text-[13px] text-[#3D3D3D]">
-          {reason === 'screened_out'
-            ? 'This connection was filtered out before either side reached out, so neither of you was notified.'
-            : `${turnCount != null && turnCount > 0 ? `After ${turnCount} ${turnCount === 1 ? 'turn' : 'turns'}, the` : 'The'} agents couldn't justify this connection, so it was quietly set aside. You were never notified while this played out.`}
-        </p>
+        <p className="mt-1 text-[13px] text-[#3D3D3D]">{body}</p>
         <p className="mt-2.5 font-ibm-plex-mono text-[11px] text-gray-400">
           The other side never learns the details — declines are quiet by design.
         </p>

--- a/apps/web/src/components/negotiations/TurnRail.tsx
+++ b/apps/web/src/components/negotiations/TurnRail.tsx
@@ -79,19 +79,10 @@ export function TurnRail({ turns, ownAgentId, participantInfo, counterpartName, 
       {turns.map((turn, index) => {
         const isOwn = turn.senderId === ownAgentId;
         const info = participantInfo.get(turn.senderId);
-        const previousTurn = turns[index - 1];
-        const startsSession = previousTurn !== undefined && previousTurn.sessionId !== turn.sessionId;
         const seatLabel = isOwn ? 'Your agent' : `${info?.ownerName ?? counterpartName}'s agent`;
 
         return (
           <div key={turn.id}>
-            {startsSession && (
-              <div className="flex items-center gap-3 py-3" role="separator" aria-label="Earlier chat session">
-                <span className="h-px flex-1 bg-gray-200" />
-                <span className="text-[10px] font-ibm-plex-mono uppercase tracking-[0.12em] text-gray-400">Earlier conversation</span>
-                <span className="h-px flex-1 bg-gray-200" />
-              </div>
-            )}
             <TurnItem
               turn={turn}
               isLast={index === turns.length - 1}

--- a/apps/web/src/components/negotiations/negotiation-turns.ts
+++ b/apps/web/src/components/negotiations/negotiation-turns.ts
@@ -121,6 +121,32 @@ export function viewerRoleLabel(turns: TranscriptTurn[], ownAgentId: string | nu
   return null;
 }
 
+// ─── Session grouping (IND-565) ───────────────────────────────────────────
+
+export interface NegotiationSessionGroup {
+  sessionId: string | null;
+  turns: TranscriptTurn[];
+}
+
+/**
+ * Group turns into per-session (per-task) slices in chronological order.
+ * Each slice corresponds to exactly one negotiation task over one opportunity;
+ * sectioning them prevents action chips (OPENED/WITHDRAWN/…) from one task
+ * bleeding visually into an unrelated adjacent task (IND-565).
+ */
+export function groupTurnsBySession(turns: TranscriptTurn[]): NegotiationSessionGroup[] {
+  const groups: NegotiationSessionGroup[] = [];
+  for (const turn of turns) {
+    const last = groups[groups.length - 1];
+    if (!last || last.sessionId !== turn.sessionId) {
+      groups.push({ sessionId: turn.sessionId, turns: [turn] });
+    } else {
+      last.turns.push(turn);
+    }
+  }
+  return groups;
+}
+
 /** Relative timestamp, recomputed against a ticking `now` (IND-555). */
 export function formatRelativeTime(createdAt: string, now: number): string {
   const timestamp = new Date(createdAt).getTime();


### PR DESCRIPTION
## What changed

### IND-565 — Render negotiation threads per opportunity

The negotiation transcript (`/chat/:conversationId`) previously rendered all messages in a single flat TurnRail with only a faint "Earlier conversation" hairline between tasks. A WITHDRAWN chip from an old negotiation was visually indistinguishable from a WITHDRAWN chip in the current one.

**Changes:**
- Added `groupTurnsBySession()` + `NegotiationSessionGroup` to `negotiation-turns.ts` — groups `TranscriptTurn[]` by `sessionId` (one session = one task = one opportunity).
- Removed the inline `startsSession` "Earlier conversation" divider from `TurnRail.tsx` — this is now superseded by section-level headers.
- `NegotiationDetailPage` (`apps/web/src/app/chat/[conversationId]/page.tsx`) now:
  - **Multi-session**: Renders each group as a `<section>` with an accessible header divider.
    - Latest section: shows the viewer's intent title from `conversation.via[0].title` (or "Current negotiation").
    - Older sections: "Earlier negotiation · MMM YYYY" using the first turn's timestamp.
  - **Single-session (common case)**: Renders exactly as before — no section header, just the turn rail and banners. Zero visual change for existing conversations with a single task.
- Outcome / resolved banners are **scoped to the latest section only**, so a terminal action in an earlier task cannot bleed into the current one.

**Graceful degradation:** legacy tasks with no `sourceIntentId` (i.e., no `via[0].title`) fall back to "Current negotiation". Older sections get at minimum a date-stamped label.

---

### IND-566 — Fix outcome banner: per-task turn count and accurate reason copy

**Two bugs fixed:**

1. **Turn count**: `lifecycle.turnCount` includes `priorTurnCount` from earlier tasks in the same dm_pair — so a 1-turn withdrawal after a 5-turn prior negotiation showed "After 6 turns". Banner now uses `latestTaskTurnCount` = count of turns in the latest session group (from the rendered transcript), which matches the per-task count.

2. **Outcome copy** (`ResolvedBanner`, rejected variant):
   - `reason === null` (agent withdrew voluntarily / non-match) → new copy: _"Your agent withdrew after reviewing the opportunity (N turns) — the candidate didn't align with what you're looking for."_
   - `reason === 'screened_out'` → unchanged: _"filtered out before either side reached out..."_
   - Other reasons → existing generic fallback.

3. **Missed-window decay scoping**: `lastAskUserTurnId` is now searched only within `latestSessionTurns`, preventing a stale `ask_user` from an earlier task triggering a false missed-window decay line on the new task.

---

## Gate results

```
bun run lint       → ✓ 0 errors, 89 warnings (all pre-existing)
bun run build      → ✓ built in 1.58s (no type errors)
targeted tests     → ✓ 17/17 passing (TurnRail, negotiation-turns)
```

## Caveats

- Section header titles for **older** tasks only show the date (month/year of first turn) — per-task opportunity titles for historical tasks would require API changes to expose historical lifecycle data. The latest task gets the full intent title from `conversation.via[0].title`.
- `latestTaskTurnCount` counts rendered turns (filtered through `extractTurn()`), which may be 1-2 turns lower than the protocol's `outcome.turnCount` if some messages have no visible text. This is the correct count from the user's perspective (what they see).
- **Draft**: base = `feat/opportunity-scoped-negotiations`. Do not merge directly — integration-owner child handles internal merging.