### PR TITLE
fix(protocol): screen continuations + guard opening-move withdraw (IND-563, IND-564)

### DIFF
--- a/packages/protocol/package.json
+++ b/packages/protocol/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@indexnetwork/protocol",
-  "version": "6.11.1",
+  "version": "6.11.2",
   "type": "module",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",

--- a/packages/protocol/src/negotiation/negotiation.graph.ts
+++ b/packages/protocol/src/negotiation/negotiation.graph.ts
@@ -425,6 +425,12 @@ export class NegotiationGraphFactory {
       let decision: ScreenDecision;
       let failedOpen = false;
       let screenError: string | undefined;
+      // On continuations the seeded prior turns are the dialogue this pair
+      // already had. Pass them so the gate evaluates the NEW signal
+      // (discoveryQuery / seedAssessment) on its own merits with that context
+      // available — mirroring the continuation policy in negotiation.agent.ts
+      // ("if materially different, evaluate on its own merits").
+      const priorDialogue = state.isContinuation ? turnsFromMessages(state.messages) : [];
       try {
         const counterpartyContext = (await database.getUserContext(counterpartyUser.id, null).catch(() => null))?.text ?? "";
         decision = await screener.invoke({
@@ -437,6 +443,7 @@ export class NegotiationGraphFactory {
           ...(clientIsSource && state.discoveryQuery && { discoveryQuery: state.discoveryQuery }),
           seedAssessment: state.seedAssessment,
           indexContext: state.indexContext,
+          ...(priorDialogue.length > 0 && { isContinuation: true, priorDialogue }),
         });
       } catch (err) {
         // Fail open: a screen failure must never block a negotiation.
@@ -782,6 +789,34 @@ export class NegotiationGraphFactory {
           }
         }
 
+        // ─── IND-564: `withdraw` requires a prior in-task outreach ────────────
+        // `withdraw` semantically retracts an outreach the initiator made. In a
+        // continuation whose first initiator move is `withdraw` (or any withdraw
+        // before this task opened outreach), there is nothing to retract —
+        // persisting it would drop a spurious "connection withdrawn" message
+        // into the shared dm_pair thread as if an accepted connection were
+        // pulled. Seeded prior-task turns (state.messages) do NOT count as an
+        // in-task outreach. Map it to the quiet screen-out outcome instead: no
+        // message persisted, turnCount unchanged, opportunity quietly rejected
+        // in finalize. This is the backstop for whatever the screen gate (IND-
+        // 563) does not catch (screen off/shadow, or a fail-open reach_out).
+        //
+        // Exact ask_user resumes (continuationExecution) are exempt: the
+        // successor task is the SAME logical negotiation resumed after the
+        // client answered, so a post-consultation `withdraw` is a legitimate
+        // terminal decision, not an opening move.
+        if (turn.action === 'withdraw' && !state.outreachOpened && !state.continuationExecution) {
+          turnLog.info('negotiation_opening_withdraw_screened_out', {
+            taskId: state.taskId,
+            opportunityId: state.opportunityId || undefined,
+            seat,
+            turnCount: state.turnCount,
+            isContinuation: state.isContinuation,
+          });
+          traceEmitter?.({ type: "agent_end", name: agentName, durationMs: Date.now() - agentStart, summary: "screened_out: opening withdraw" });
+          return { lastTurn: turn, firstTurnScreenedOut: true };
+        }
+
         const parts = [{ kind: "data" as const, data: turn }];
         const message = await database.createMessage({
           conversationId: state.conversationId,
@@ -962,6 +997,8 @@ export class NegotiationGraphFactory {
           currentSpeaker: (isSource ? "candidate" : "source") as "source" | "candidate",
           lastTurn: turn,
           memoryBySide: { [ownSide]: ownMemory },
+          // Record the in-task outreach so a later `withdraw` is legal (IND-564).
+          ...(turn.action === 'outreach' && { outreachOpened: true }),
           ...(deadlockShiftRecord && { deadlockShift: deadlockShiftRecord }),
         };
       } catch (err) {
@@ -1057,7 +1094,10 @@ export class NegotiationGraphFactory {
       const hasOpportunity = lastTurn?.action === "accept";
       // P2.2: the client's own outreach gate declined before any turn — the
       // negotiation never happened from the counterparty's perspective.
-      const screenedOut = isScreenBlocked(state);
+      // IND-564: an opening-move `withdraw` blocked before any message was
+      // persisted is the same quiet screen-out outcome (no in-task outreach to
+      // retract), reached from the turn node rather than the screen node.
+      const screenedOut = isScreenBlocked(state) || state.firstTurnScreenedOut === true;
       const atCap = !screenedOut && (state.maxTurns ?? 0) > 0 && state.turnCount >= state.maxTurns! && !isTerminalAction(lastTurn?.action);
 
       let agreedRoles: NegotiationOutcome["agreedRoles"] = [];
@@ -1078,7 +1118,7 @@ export class NegotiationGraphFactory {
         hasOpportunity,
         agreedRoles,
         reasoning: screenedOut
-          ? (state.screenDecision?.reasoning ?? "")
+          ? (state.screenDecision?.reasoning ?? lastTurn?.assessment?.reasoning ?? "")
           : (lastTurn?.assessment.reasoning ?? ""),
         turnCount: state.turnCount,
         ...(screenedOut
@@ -1279,9 +1319,14 @@ export class NegotiationGraphFactory {
       })
       .addConditionalEdges("init", (state: typeof NegotiationGraphState.State) => {
         if (state.error) return "finalize";
-        // Screen gate: fresh negotiations only (continuations already passed
-        // the gate when the dialogue opened); off disables the node entirely.
-        if (!state.isContinuation && configuredScreenMode() !== "off") return "screen";
+        // Screen gate (P2.1). Runs on fresh negotiations AND regular
+        // continuations (IND-563): a new opportunity/intent reusing an existing
+        // conversation must still pass the outreach gate before entering the
+        // shared thread — a bad continuation match should be quietly screened
+        // out, never dropped into the dm_pair. Exact ask_user resumes
+        // (continuationExecution) are mid-flight and must never be re-screened.
+        // `off` disables the node entirely.
+        if (configuredScreenMode() !== "off" && !state.continuationExecution) return "screen";
         return "turn";
       }, { screen: "screen", turn: "turn", finalize: "finalize" })
       // P2.2: enforce-mode pass → finalize (screened_out); everything else → turn.

--- a/packages/protocol/src/negotiation/negotiation.screen.ts
+++ b/packages/protocol/src/negotiation/negotiation.screen.ts
@@ -5,6 +5,7 @@ import { invokeWithAbortSignal } from "../shared/agent/model-signal.js";
 import type { UserNegotiationContext, SeedAssessment } from "../shared/schemas/negotiation-state.schema.js";
 import { protocolLogger } from "../shared/observability/protocol.logger.js";
 import { renderNegotiatorMemorySection, type NegotiatorMemoryEntry } from "./negotiation.memory.js";
+import type { NegotiationTurn } from "./negotiation.state.js";
 
 const screenLog = protocolLogger("NegotiationScreener");
 
@@ -93,6 +94,20 @@ export interface NegotiationScreenerInput {
    * → the prompt is byte-identical to before.
    */
   memory?: NegotiatorMemoryEntry[];
+  /**
+   * Whether this screen is for a continuation — a match against a counterparty
+   * this client already has prior dialogue with (IND-563). When set with
+   * `priorDialogue`, the gate evaluates the NEW signal on its own merits with
+   * that dialogue as context. Absent → the prompt is byte-identical to before.
+   */
+  isContinuation?: boolean;
+  /**
+   * Prior negotiation turns with this counterparty (continuations only).
+   * Rendered as read-only context so the gate can tell a materially-new signal
+   * from a rehash of an already-settled one. Never treated as this task's own
+   * outreach.
+   */
+  priorDialogue?: NegotiationTurn[];
 }
 
 const SYSTEM_PROMPT = `You are the outreach gate for {clientName}'s negotiator agent on a discovery network. Before any negotiation turn is exchanged, you decide whether this match is worth reaching out to on {clientName}'s behalf — their name and attention are spent with every outreach.
@@ -157,6 +172,16 @@ export class NegotiationScreener {
     const formatIntents = (intents: UserNegotiationContext["intents"]): string =>
       intents.length > 0 ? intents.map((i) => `- ${i.title}: ${i.description}`).join("\n") : "- (none)";
 
+    const priorDialogue = input.isContinuation && input.priorDialogue && input.priorDialogue.length > 0
+      ? input.priorDialogue
+      : [];
+    const priorDialogueContext = priorDialogue.length > 0
+      ? `\n\n--- Prior dialogue with ${counterpartyName} (already spoken) ---\n${priorDialogue.map((t, i) => {
+          const msgPart = t.message ? ` — ${t.message}` : "";
+          return `Turn ${i + 1}: ${t.action} — ${t.assessment.reasoning}${msgPart}`;
+        }).join("\n")}\n\nThis is a NEW signal against a counterparty ${clientName} has prior dialogue with. Judge the new signal on its own merits: if it is materially the same as what was already discussed, pass unless something concrete changed; if materially different, judge it fresh. Do NOT reach out again on generic overlap just because they spoke before.`
+      : "";
+
     const userMessage = `YOUR CLIENT (${clientName}):
 Bio: ${input.clientUser.profile.bio ?? "N/A"}
 ${input.discoveryQuery ? `Search query: "${input.discoveryQuery}"\nBackground intents (secondary to the query):` : "Active intents:"}
@@ -167,7 +192,7 @@ Bio: ${input.counterpartyUser.profile.bio ?? "N/A"}
 ${input.counterpartyContext ? `Context: ${input.counterpartyContext}\n` : ""}Active intents:
 ${formatIntents(input.counterpartyUser.intents)}
 
-Why this match was suggested: ${input.seedAssessment.reasoning}
+Why this match was suggested: ${input.seedAssessment.reasoning}${priorDialogueContext}
 
 Decide whether reaching out serves ${clientName}.`;
 

--- a/packages/protocol/src/negotiation/negotiation.state.ts
+++ b/packages/protocol/src/negotiation/negotiation.state.ts
@@ -224,6 +224,30 @@ export const NegotiationGraphState = Annotation.Root({
     reducer: (curr, next) => next ?? curr,
     default: () => false,
   }),
+
+  /**
+   * Whether the initiator has actually opened `outreach` within THIS task
+   * (IND-564). Set by the turn node the first time an `outreach` turn is
+   * persisted in the current session; seeded prior-task turns never flip it.
+   * `withdraw` is only legal after an in-task outreach — a withdraw before one
+   * would retract an outreach never made here and drop a spurious message into
+   * the shared thread, so the turn node maps it to a quiet screen-out instead.
+   */
+  outreachOpened: Annotation<boolean>({
+    reducer: (curr, next) => next ?? curr,
+    default: () => false,
+  }),
+
+  /**
+   * Set by the turn node when an opening-move `withdraw` (no in-task outreach)
+   * was blocked (IND-564). Signals finalize to record the quiet screen-out
+   * outcome (`reason: "screened_out"`, opportunity `rejected`) without ever
+   * persisting the withdraw message into the shared `dm_pair` conversation.
+   */
+  firstTurnScreenedOut: Annotation<boolean>({
+    reducer: (curr, next) => next ?? curr,
+    default: () => false,
+  }),
   opportunityId: Annotation<string>({
     reducer: (curr, next) => next ?? curr,
     default: () => "",

--- a/packages/protocol/src/negotiation/tests/negotiation.continuation-screen.spec.ts
+++ b/packages/protocol/src/negotiation/tests/negotiation.continuation-screen.spec.ts
@@ -1,0 +1,260 @@
+import { describe, it, expect, beforeAll, afterAll, beforeEach, afterEach } from "bun:test";
+import { NegotiationGraphFactory } from "../negotiation.graph.js";
+import { NegotiationGraphState } from "../negotiation.state.js";
+import { IndexNegotiator, type NegotiationAgentInput } from "../negotiation.agent.js";
+import { NegotiationScreener, type NegotiationScreenerInput, type ScreenDecision } from "../negotiation.screen.js";
+import type { NegotiationTurn } from "../negotiation.state.js";
+
+/**
+ * IND-563 — the outreach screen runs on continuations, with two guarantees not
+ * covered by the fresh-run routing suite (negotiation.screen-routing.spec.ts):
+ *
+ * 1. A regular continuation (a new opportunity reusing an existing dm_pair
+ *    conversation) forwards its prior dialogue to the screener, so the gate
+ *    judges the NEW signal on its own merits.
+ * 2. An EXACT ask_user resume (continuationExecution present) is NEVER
+ *    re-screened — the successor task is the same logical negotiation resumed
+ *    mid-flight after the client answered, and re-screening it in enforce mode
+ *    could wrongly kill it.
+ */
+
+type FakeMessage = {
+  id: string;
+  senderId: string;
+  role: "agent";
+  parts: unknown[];
+  createdAt: Date;
+};
+
+function priorMsg(senderUserId: string, action: string, idx: number): FakeMessage {
+  return {
+    id: `prior-${idx}`,
+    senderId: `agent:${senderUserId}`,
+    role: "agent",
+    parts: [{ kind: "data", data: { action, assessment: { reasoning: "r", suggestedRoles: { ownUser: "peer", otherUser: "peer" } }, message: null } }],
+    createdAt: new Date(Date.now() - (100 - idx) * 1000),
+  };
+}
+
+const SETTLEMENT_ID = "negotiation-question-settlement-v1-task-paused";
+
+/** Canceled prior task pinning the exact ask_user pause on conv-1. */
+const EXACT_PRIOR_TASK = {
+  id: "task-paused",
+  conversationId: "conv-1",
+  state: "canceled",
+  metadata: {
+    type: "negotiation",
+    protocolVersion: "v2",
+    initiatorUserId: "u-src",
+    sourceUserId: "u-src",
+    candidateUserId: "u-cand",
+    opportunityId: "opp-1",
+    networkId: "net-1",
+    questionSettlement: { version: 1, settlementId: SETTLEMENT_ID, taskId: "task-paused" },
+  },
+  createdAt: new Date(Date.now() - 60_000),
+  updatedAt: new Date(),
+};
+
+/** Preclaimed successor task holding the fenced continuation lease. */
+const EXACT_SUCCESSOR_TASK = {
+  id: "task-successor",
+  conversationId: "conv-1",
+  state: "submitted",
+  metadata: {
+    continuationExecution: {
+      version: 1,
+      priorTaskId: "task-paused",
+      settlementId: SETTLEMENT_ID,
+      successorTaskId: "task-successor",
+      token: "tok-1",
+      fence: 1,
+      status: "claimed",
+      leaseExpiresAt: new Date(Date.now() + 60_000).toISOString(),
+      claimedAt: new Date().toISOString(),
+      heartbeatAt: new Date().toISOString(),
+    },
+  },
+  createdAt: new Date(),
+  updatedAt: new Date(),
+};
+
+const EXACT_CONTINUATION_EXECUTION = {
+  taskId: "task-paused",
+  settlementId: SETTLEMENT_ID,
+  opportunityId: "opp-1",
+  userId: "u-src",
+  recipientIntentId: "intent-src",
+  networkId: "net-1",
+  intentFingerprint: "fp-src",
+  opportunityStatus: "pending",
+  opportunityUpdatedAt: "2026-01-01T00:00:00.000Z",
+  counterpartyUserId: "u-cand",
+  counterpartyIntentId: "intent-cand",
+  successorTaskId: "task-successor",
+  conversationId: "conv-1",
+  token: "tok-1",
+  fence: 1,
+  leaseExpiresAt: new Date(Date.now() + 60_000).toISOString(),
+};
+
+function mkStubs(opts?: { priorMessages?: FakeMessage[]; exact?: boolean }) {
+  const createdMessages: Array<{ senderId: string; parts: Array<{ kind: string; data: NegotiationTurn }> }> = [];
+  const tasksById = new Map<string, Record<string, unknown>>();
+  if (opts?.exact) {
+    tasksById.set("task-paused", EXACT_PRIOR_TASK);
+    tasksById.set("task-successor", EXACT_SUCCESSOR_TASK);
+  }
+  const database = {
+    getOrCreateDM: async () => ({ id: "conv-1" }),
+    createTask: async (conversationId: string) => ({ id: "task-new", conversationId, state: "submitted" }),
+    createMessage: async (p: { senderId: string; parts: Array<{ kind: string; data: NegotiationTurn }> }) => {
+      createdMessages.push(p);
+      return { id: `msg-${createdMessages.length}`, senderId: p.senderId, parts: p.parts, createdAt: new Date() };
+    },
+    updateTaskState: async () => ({ id: "task-successor", conversationId: "conv-1", state: "working" }),
+    createArtifact: async () => ({ id: "art-1" }),
+    setTaskTurnContext: async () => {},
+    setTaskScreenDecision: async () => {},
+    updateOpportunityStatus: async () => ({ id: "opp-1", status: "pending" }),
+    getNegotiationTaskForOpportunity: async () => null,
+    getOpportunityUserAnswers: async () => [],
+    getMessagesForConversation: async () => opts?.priorMessages ?? [],
+    getLatestNegotiationTaskForConversation: async () => null,
+    getUserContext: async () => ({ text: "Bob builds ML systems." }),
+    getTask: async (id: string) => tasksById.get(id) ?? null,
+  } as unknown as ConstructorParameters<typeof NegotiationGraphFactory>[0];
+
+  const dispatcher = {
+    hasExternalAgent: async () => false,
+    dispatch: async () => ({ handled: false, reason: "no_agent" }),
+  } as unknown as ConstructorParameters<typeof NegotiationGraphFactory>[1];
+
+  return { database, dispatcher, createdMessages };
+}
+
+async function runGraph(stubs: ReturnType<typeof mkStubs>, input: Record<string, unknown> = {}) {
+  const graph = new NegotiationGraphFactory(stubs.database, stubs.dispatcher).createGraph();
+  return graph.invoke({
+    sourceUser: { id: "u-src", intents: [{ id: "intent-src", title: "Build AI", description: "collab", confidence: 1 }], profile: { name: "Alice", bio: "PM" } },
+    candidateUser: { id: "u-cand", intents: [{ id: "intent-cand", title: "Apply ML", description: "join", confidence: 1 }], profile: { name: "Bob", bio: "ML engineer" } },
+    sourceIntentId: "intent-src",
+    candidateIntentId: "intent-cand",
+    indexContext: { networkId: "net-1", prompt: "AI network" },
+    seedAssessment: { reasoning: "complementary", valencyRole: "peer" },
+    opportunityId: "opp-1",
+    maxTurns: 4,
+    ...input,
+  } as Partial<typeof NegotiationGraphState.State>);
+}
+
+const screenerInputs: NegotiationScreenerInput[] = [];
+let screenerResult: ScreenDecision = {
+  decision: "reach_out",
+  reasoning: "solid fit",
+  outreachAngle: "shared ML focus",
+  evidence: { counterpartyPremiseFit: "fits", intentAlignment: "aligned" },
+};
+
+describe("negotiation graph — screen on continuations (IND-563)", () => {
+  let origScreenerInvoke: typeof NegotiationScreener.prototype.invoke;
+  let origAgentInvoke: typeof IndexNegotiator.prototype.invoke;
+  const origEnv = process.env.NEGOTIATION_SCREEN_MODE;
+  const origVersion = process.env.NEGOTIATION_PROTOCOL_VERSION;
+
+  beforeAll(() => {
+    origScreenerInvoke = NegotiationScreener.prototype.invoke;
+    NegotiationScreener.prototype.invoke = async function (input: NegotiationScreenerInput) {
+      screenerInputs.push(input);
+      return screenerResult;
+    };
+    origAgentInvoke = IndexNegotiator.prototype.invoke;
+    IndexNegotiator.prototype.invoke = async function (input: NegotiationAgentInput) {
+      // Counterparty (u-cand) accepts to finalize the resumed negotiation fast.
+      return {
+        action: (input.ownUser.id === "u-cand" ? "accept" : "counter") as NegotiationTurn["action"],
+        assessment: { reasoning: "stub", suggestedRoles: { ownUser: "peer" as const, otherUser: "peer" as const } },
+        message: null,
+      };
+    };
+  });
+
+  afterAll(() => {
+    NegotiationScreener.prototype.invoke = origScreenerInvoke;
+    IndexNegotiator.prototype.invoke = origAgentInvoke;
+  });
+
+  beforeEach(() => {
+    screenerInputs.length = 0;
+    screenerResult = {
+      decision: "reach_out",
+      reasoning: "solid fit",
+      outreachAngle: "shared ML focus",
+      evidence: { counterpartyPremiseFit: "fits", intentAlignment: "aligned" },
+    };
+    delete process.env.NEGOTIATION_SCREEN_MODE;
+    delete process.env.NEGOTIATION_PROTOCOL_VERSION;
+  });
+
+  afterEach(() => {
+    if (origEnv === undefined) delete process.env.NEGOTIATION_SCREEN_MODE; else process.env.NEGOTIATION_SCREEN_MODE = origEnv;
+    if (origVersion === undefined) delete process.env.NEGOTIATION_PROTOCOL_VERSION; else process.env.NEGOTIATION_PROTOCOL_VERSION = origVersion;
+  });
+
+  it("regular continuation forwards prior dialogue to the screener", async () => {
+    process.env.NEGOTIATION_SCREEN_MODE = "shadow";
+    const stubs = mkStubs({ priorMessages: [priorMsg("u-src", "outreach", 0), priorMsg("u-cand", "decline", 1)] });
+
+    await runGraph(stubs);
+
+    expect(screenerInputs.length).toBe(1);
+    expect(screenerInputs[0].isContinuation).toBe(true);
+    expect(screenerInputs[0].priorDialogue?.map((t) => t.action)).toEqual(["outreach", "decline"]);
+  }, 30_000);
+
+  it("enforce: a continuation `pass` is screened out — no NEW message in the shared thread", async () => {
+    process.env.NEGOTIATION_SCREEN_MODE = "enforce";
+    screenerResult = {
+      decision: "pass",
+      reasoning: "the new signal rehashes a settled decline",
+      evidence: { counterpartyPremiseFit: "weak", intentAlignment: "none" },
+    };
+    const stubs = mkStubs({ priorMessages: [priorMsg("u-src", "outreach", 0), priorMsg("u-cand", "decline", 1)] });
+
+    const result = await runGraph(stubs);
+
+    expect(screenerInputs.length).toBe(1);
+    // Zero NEW turns persisted — the counterparty is never re-engaged.
+    expect(stubs.createdMessages.length).toBe(0);
+    expect(result.outcome?.hasOpportunity).toBe(false);
+    expect(result.outcome?.reason).toBe("screened_out");
+  }, 30_000);
+
+  it("exact ask_user resume (continuationExecution) is never re-screened, even in enforce mode", async () => {
+    process.env.NEGOTIATION_SCREEN_MODE = "enforce";
+    process.env.NEGOTIATION_PROTOCOL_VERSION = "v2";
+    screenerResult = {
+      decision: "pass",
+      reasoning: "would wrongly kill a mid-flight negotiation if this ran",
+      evidence: { counterpartyPremiseFit: "weak", intentAlignment: "none" },
+    };
+    // Resume the SAME negotiation: source opened outreach, candidate speaks next.
+    const stubs = mkStubs({
+      priorMessages: [priorMsg("u-src", "outreach", 0)],
+      exact: true,
+    });
+
+    const result = await runGraph(stubs, {
+      resumeFromTaskId: "task-paused",
+      continuationSettlementId: SETTLEMENT_ID,
+      continuationExecution: EXACT_CONTINUATION_EXECUTION,
+    });
+
+    // The screen gate never ran on the resume.
+    expect(screenerInputs.length).toBe(0);
+    // The negotiation resumed on the exact successor task and settled normally.
+    expect(result.taskId).toBe("task-successor");
+    expect(result.outcome?.reason).not.toBe("screened_out");
+  }, 30_000);
+});

--- a/packages/protocol/src/negotiation/tests/negotiation.continuation-withdraw.spec.ts
+++ b/packages/protocol/src/negotiation/tests/negotiation.continuation-withdraw.spec.ts
@@ -1,0 +1,200 @@
+import { describe, it, expect, beforeEach, afterEach, afterAll } from "bun:test";
+import { NegotiationGraphFactory } from "../negotiation.graph.js";
+import { NegotiationGraphState } from "../negotiation.state.js";
+import type { NegotiationGraphDatabase } from "../../shared/interfaces/database.interface.js";
+import type { AgentDispatcher } from "../../shared/interfaces/agent-dispatcher.interface.js";
+import { IndexNegotiator, type NegotiationAgentInput } from "../negotiation.agent.js";
+import type { NegotiationTurn } from "../negotiation.state.js";
+
+/**
+ * IND-564 — never emit `withdraw` as an opening move.
+ *
+ * `withdraw` retracts an outreach the initiator made. In a continuation whose
+ * first (and only) initiator move is `withdraw` — retracting an outreach never
+ * made in the current task — persisting it would drop a spurious "connection
+ * withdrawn" message into the shared dm_pair thread. The graph maps such a move
+ * to the quiet screen-out outcome instead:
+ *  - no message persisted into the shared conversation,
+ *  - turnCount stays 0,
+ *  - the opportunity is quietly `rejected` with reason `screened_out`.
+ *
+ * `withdraw` remains legal AFTER the initiator actually opened `outreach` in
+ * the SAME task; prior-task (seeded) turns never count as that outreach.
+ */
+
+type FakeMessage = {
+  id: string;
+  senderId: string;
+  role: "agent";
+  parts: unknown[];
+  createdAt: Date;
+};
+
+function priorMsg(senderUserId: string, action: string, idx: number): FakeMessage {
+  return {
+    id: `prior-${idx}`,
+    senderId: `agent:${senderUserId}`,
+    role: "agent",
+    parts: [{ kind: "data", data: { action, assessment: { reasoning: "r", suggestedRoles: { ownUser: "peer", otherUser: "peer" } }, message: null } }],
+    createdAt: new Date(Date.now() - (100 - idx) * 1000),
+  };
+}
+
+function mkStubs(priorMessages: FakeMessage[] = []) {
+  const createdMessages: Array<{ senderId: string; parts: Array<{ kind: string; data: NegotiationTurn }> }> = [];
+  const statusUpdates: Array<{ opportunityId: string; status: string }> = [];
+  const artifacts: Array<Record<string, unknown>> = [];
+  const database = {
+    getOrCreateDM: async () => ({ id: "conv-1" }),
+    createTask: async (conversationId: string) => ({ id: "task-new", conversationId, state: "submitted" }),
+    createMessage: async (p: { senderId: string; parts: Array<{ kind: string; data: NegotiationTurn }> }) => {
+      createdMessages.push(p);
+      return { id: `msg-${createdMessages.length}`, senderId: p.senderId, parts: p.parts, createdAt: new Date() };
+    },
+    updateTaskState: async () => ({ id: "task-new", conversationId: "conv-1", state: "working" }),
+    createArtifact: async (a: Record<string, unknown>) => { artifacts.push(a); return { id: "art-1" }; },
+    setTaskTurnContext: async () => {},
+    updateOpportunityStatus: async (opportunityId: string, status: string) => {
+      statusUpdates.push({ opportunityId, status });
+      return { id: opportunityId, status };
+    },
+    getNegotiationTaskForOpportunity: async () => null,
+    getOpportunityUserAnswers: async () => [],
+    getMessagesForConversation: async () => priorMessages,
+    getLatestNegotiationTaskForConversation: async () => null,
+    getUserContext: async () => null,
+    getTask: async () => null,
+    getArtifactsForTask: async () => [],
+  } as unknown as NegotiationGraphDatabase;
+
+  const dispatcher = {
+    dispatch: async () => ({ handled: false as const, reason: "no_agent" as const }),
+    hasExternalAgent: async () => false,
+  } as unknown as AgentDispatcher;
+
+  return { database, dispatcher, createdMessages, statusUpdates, artifacts };
+}
+
+const sourceUser = {
+  id: "u-src",
+  intents: [{ id: "intent-src", title: "Build AI", description: "Find a collaborator", confidence: 1 }],
+  profile: { name: "Alice", bio: "PM", skills: ["product"] },
+};
+const candidateUser = {
+  id: "u-cand",
+  intents: [{ id: "intent-cand", title: "Apply ML", description: "Join an AI product", confidence: 1 }],
+  profile: { name: "Bob", bio: "ML engineer", skills: ["ml"] },
+};
+const seed = { reasoning: "complementary", valencyRole: "peer" };
+const indexContext = { networkId: "net-1", prompt: "AI network" };
+
+let agentScript: NegotiationTurn[] = [];
+const origInvoke = IndexNegotiator.prototype.invoke;
+
+async function runGraph(stubs: ReturnType<typeof mkStubs>, input: Record<string, unknown> = {}) {
+  const graph = new NegotiationGraphFactory(stubs.database, stubs.dispatcher).createGraph();
+  return graph.invoke({
+    sourceUser,
+    candidateUser,
+    sourceIntentId: "intent-src",
+    candidateIntentId: "intent-cand",
+    indexContext,
+    seedAssessment: seed,
+    opportunityId: "opp-1",
+    maxTurns: 6,
+    ...input,
+  } as Partial<typeof NegotiationGraphState.State>);
+}
+
+describe("negotiation graph — opening-move withdraw guard (IND-564)", () => {
+  const origVersion = process.env.NEGOTIATION_PROTOCOL_VERSION;
+  const origScreen = process.env.NEGOTIATION_SCREEN_MODE;
+
+  beforeEach(() => {
+    agentScript = [];
+    process.env.NEGOTIATION_PROTOCOL_VERSION = "v2";
+    process.env.NEGOTIATION_SCREEN_MODE = "off"; // isolate the withdraw guard from the screen gate
+    IndexNegotiator.prototype.invoke = async function (_input: NegotiationAgentInput) {
+      const turn = agentScript.shift();
+      if (!turn) throw new Error("agent script exhausted");
+      return turn;
+    };
+  });
+
+  afterEach(() => {
+    if (origVersion === undefined) delete process.env.NEGOTIATION_PROTOCOL_VERSION; else process.env.NEGOTIATION_PROTOCOL_VERSION = origVersion;
+    if (origScreen === undefined) delete process.env.NEGOTIATION_SCREEN_MODE; else process.env.NEGOTIATION_SCREEN_MODE = origScreen;
+  });
+
+  afterAll(() => {
+    IndexNegotiator.prototype.invoke = origInvoke;
+  });
+
+  it("continuation + first-turn withdraw ⇒ no message persisted, opportunity quietly rejected", async () => {
+    // Prior dialogue from an EARLIER task (seeded): u-src outreached, u-cand
+    // countered. Last speaker is u-cand ⇒ u-src (the initiator) speaks first
+    // in this continuation and immediately withdraws.
+    const stubs = mkStubs([priorMsg("u-src", "outreach", 0), priorMsg("u-cand", "counter", 1)]);
+    agentScript = [{
+      action: "withdraw",
+      assessment: { reasoning: "the new signal is a poor fit", suggestedRoles: { ownUser: "peer", otherUser: "peer" } },
+      message: "on reflection, not a fit",
+    }];
+
+    const result = await runGraph(stubs);
+
+    // The withdraw never lands in the shared dm_pair conversation.
+    expect(stubs.createdMessages.length).toBe(0);
+    // Quiet screen-out outcome: rejected, reason screened_out, zero turns.
+    expect(result.outcome?.hasOpportunity).toBe(false);
+    expect(result.outcome?.reason).toBe("screened_out");
+    expect(result.outcome?.turnCount).toBe(0);
+    // The screen-out reasoning falls back to the blocked turn's reasoning.
+    expect(result.outcome?.reasoning).toContain("poor fit");
+    // Opportunity quietly rejected (init flipped it to negotiating first).
+    expect(stubs.statusUpdates).toEqual([
+      { opportunityId: "opp-1", status: "negotiating" },
+      { opportunityId: "opp-1", status: "rejected" },
+    ]);
+  }, 30_000);
+
+  it("withdraw AFTER an in-task outreach is legal — the withdraw message persists", async () => {
+    // Fresh negotiation: turn 0 opens outreach (guard-forced), turn 1 the
+    // counterparty counters, turn 2 the initiator withdraws — now legal.
+    const stubs = mkStubs();
+    agentScript = [
+      { action: "outreach", assessment: { reasoning: "reaching out", suggestedRoles: { ownUser: "peer", otherUser: "peer" } }, message: "hi" },
+      { action: "counter", assessment: { reasoning: "some concerns", suggestedRoles: { ownUser: "peer", otherUser: "peer" } }, message: "but why" },
+      { action: "withdraw", assessment: { reasoning: "decided against", suggestedRoles: { ownUser: "peer", otherUser: "peer" } }, message: "we'll pass" },
+    ];
+
+    const result = await runGraph(stubs);
+
+    // All three turns persisted, including the (legal) withdraw.
+    expect(stubs.createdMessages.length).toBe(3);
+    expect(stubs.createdMessages[2].parts[0].data.action).toBe("withdraw");
+    // A legitimate withdraw is a normal reject-like outcome, NOT a screen-out.
+    expect(result.outcome?.hasOpportunity).toBe(false);
+    expect(result.outcome?.reason).not.toBe("screened_out");
+    // Opportunity rejected via the normal reject-like mapping.
+    expect(stubs.statusUpdates).toEqual([
+      { opportunityId: "opp-1", status: "negotiating" },
+      { opportunityId: "opp-1", status: "rejected" },
+    ]);
+  }, 30_000);
+
+  it("continuation + first-turn counter (not withdraw) is untouched — the turn persists", async () => {
+    const stubs = mkStubs([priorMsg("u-src", "outreach", 0), priorMsg("u-cand", "counter", 1)]);
+    agentScript = [
+      { action: "counter", assessment: { reasoning: "still interested, one concern", suggestedRoles: { ownUser: "peer", otherUser: "peer" } }, message: "what about X" },
+      { action: "decline", assessment: { reasoning: "ok not for us", suggestedRoles: { ownUser: "peer", otherUser: "peer" } }, message: null },
+    ];
+
+    const result = await runGraph(stubs);
+
+    // The opening counter is a normal turn — it persists into the thread.
+    expect(stubs.createdMessages.length).toBeGreaterThanOrEqual(1);
+    expect(stubs.createdMessages[0].parts[0].data.action).toBe("counter");
+    expect(result.outcome?.reason).not.toBe("screened_out");
+  }, 30_000);
+});

--- a/packages/protocol/src/negotiation/tests/negotiation.screen-routing.spec.ts
+++ b/packages/protocol/src/negotiation/tests/negotiation.screen-routing.spec.ts
@@ -14,7 +14,10 @@ import type { NegotiationTurn } from "../negotiation.state.js";
  *   metadata write,
  * - shadow: fresh runs screen exactly once, decision persisted to
  *   metadata.screenDecision, negotiation always proceeds (even on `pass`),
- * - continuations never screen (even in shadow),
+ * - regular continuations DO screen (IND-563): a new opportunity reusing an
+ *   existing conversation must pass the outreach gate; a shadow `pass` still
+ *   proceeds, an enforce `pass` screens it out with zero new messages,
+ * - exact ask_user resumes (continuationExecution) are never re-screened,
  * - screen failure fails OPEN: negotiation proceeds, failedOpen recorded,
  * - enforce (P2.2): a genuine `pass` blocks before the first turn — zero
  *   messages, outcome reason `screened_out`, opportunity quietly `rejected`,
@@ -202,7 +205,7 @@ describe("negotiation graph — screen node routing (IND-398)", () => {
     expect(result.outcome).not.toBeNull();
   });
 
-  it("shadow: continuations never screen", async () => {
+  it("shadow: regular continuations screen once but still proceed (IND-563)", async () => {
     process.env.NEGOTIATION_SCREEN_MODE = "shadow";
     const stubs = mkStubs({
       priorMessages: [priorMsg("u-src", "propose", 0), priorMsg("u-cand", "counter", 1)],
@@ -210,8 +213,13 @@ describe("negotiation graph — screen node routing (IND-398)", () => {
 
     const result = await runGraph(stubs);
 
-    expect(screenerInputs.length).toBe(0);
-    expect(stubs.screenWrites.length).toBe(0);
+    // IND-563: the continuation is screened (prior dialogue forwarded), but a
+    // shadow decision never blocks — the negotiation proceeds to a turn.
+    expect(screenerInputs.length).toBe(1);
+    expect(screenerInputs[0].isContinuation).toBe(true);
+    expect(screenerInputs[0].priorDialogue?.length).toBe(2);
+    expect(stubs.screenWrites.length).toBe(1);
+    expect(stubs.createdMessages.length).toBeGreaterThanOrEqual(1);
     expect(result.outcome).not.toBeNull();
   });
 
@@ -326,24 +334,30 @@ describe("negotiation graph — screen node routing (IND-398)", () => {
     expect(result.outcome?.reason).not.toBe("screened_out");
   });
 
-  it("enforce (P2.2): continuations never screen — enforcement cannot touch in-flight dialogues", async () => {
+  it("enforce (P2.2): a regular continuation `pass` screens out — zero new messages, rejected (IND-563)", async () => {
     process.env.NEGOTIATION_SCREEN_MODE = "enforce";
     screenerResult = {
       decision: "pass",
-      reasoning: "would block if it ran",
+      reasoning: "stale premise; not worth reaching out again",
       evidence: { counterpartyPremiseFit: "weak", intentAlignment: "none" },
     };
     const stubs = mkStubs({
       priorMessages: [priorMsg("u-src", "propose", 0), priorMsg("u-cand", "counter", 1)],
     });
 
-    const result = await runGraph(stubs);
+    const result = await runGraph(stubs, { opportunityId: "opp-1" });
 
-    expect(screenerInputs.length).toBe(0);
-    expect(stubs.screenWrites.length).toBe(0);
-    expect(stubs.createdMessages.length).toBeGreaterThanOrEqual(1);
-    expect(result.outcome).not.toBeNull();
-    expect(result.outcome?.reason).not.toBe("screened_out");
+    // IND-563: the continuation is screened and, on a genuine enforce `pass`,
+    // blocked before any turn — no NEW message lands in the shared thread.
+    expect(screenerInputs.length).toBe(1);
+    expect(screenerInputs[0].isContinuation).toBe(true);
+    expect(stubs.createdMessages.length).toBe(0);
+    expect(result.outcome?.hasOpportunity).toBe(false);
+    expect(result.outcome?.reason).toBe("screened_out");
+    expect(stubs.statusUpdates).toEqual([
+      { opportunityId: "opp-1", status: "negotiating" },
+      { opportunityId: "opp-1", status: "rejected" },
+    ]);
   });
 
   it("emits a negotiation_screen trace event when an opportunityId is present", async () => {

--- a/packages/protocol/src/negotiation/tests/negotiation.screen.spec.ts
+++ b/packages/protocol/src/negotiation/tests/negotiation.screen.spec.ts
@@ -163,4 +163,45 @@ describe("NegotiationScreener.invoke", () => {
     const user = screener.capturedMessages.find((m) => m.role === "user")!.content;
     expect(user).toContain('Search query: "ML engineers"');
   });
+
+  it("renders prior dialogue + the continuation policy for continuations (IND-563)", async () => {
+    const screener = new SeamScreener({
+      decision: "pass",
+      reasoning: "stale premise",
+      evidence: { counterpartyPremiseFit: "", intentAlignment: "" },
+    });
+    await screener.invoke({
+      ...baseInput,
+      isContinuation: true,
+      priorDialogue: [
+        { action: "outreach", assessment: { reasoning: "initial reach", suggestedRoles: { ownUser: "peer", otherUser: "peer" } }, message: "hello Bob" },
+        { action: "decline", assessment: { reasoning: "not now", suggestedRoles: { ownUser: "peer", otherUser: "peer" } }, message: null },
+      ],
+    });
+
+    const user = screener.capturedMessages.find((m) => m.role === "user")!.content;
+    expect(user).toContain("Prior dialogue with Bob");
+    expect(user).toContain("Turn 1: outreach");
+    expect(user).toContain("hello Bob");
+    expect(user).toContain("NEW signal");
+    expect(user).toContain("on its own merits");
+  });
+
+  it("omits the prior-dialogue section when not a continuation (byte-identical path)", async () => {
+    const screener = new SeamScreener({
+      decision: "pass",
+      reasoning: "r",
+      evidence: { counterpartyPremiseFit: "", intentAlignment: "" },
+    });
+    // priorDialogue present but isContinuation not set → still omitted.
+    await screener.invoke({
+      ...baseInput,
+      priorDialogue: [
+        { action: "outreach", assessment: { reasoning: "x", suggestedRoles: { ownUser: "peer", otherUser: "peer" } }, message: null },
+      ],
+    });
+
+    const user = screener.capturedMessages.find((m) => m.role === "user")!.content;
+    expect(user).not.toContain("Prior dialogue with");
+  });
 });


### PR DESCRIPTION
Draft PR into the **`feat/opportunity-scoped-negotiations`** integration branch (not `dev`). Root flips to ready after its verification pass.

## What changed

### IND-563 — run the outreach screen on continuation negotiations
- The screen node (P2.1 outreach gate) now runs on **regular continuations** (a new opportunity/intent reusing an existing `dm_pair` conversation), not just fresh runs. Previously routing skipped the screen on `isContinuation: true`, so a bad match against an already-talked-to counterparty bypassed the quiet screen-out and entered the shared thread.
- The screener receives the **prior dialogue** so it evaluates the **new signal** (discovery query / seed assessment) on its own merits — mirroring the continuation policy in `negotiation.agent.ts` ("if materially different, evaluate on its own merits").
- A screened-out continuation persists **no message** into the shared `dm_pair` conversation; the opportunity is quietly `rejected` (`reason: "screened_out"`).
- **Exact ask_user resumes (`continuationExecution`) are never re-screened** — the successor task is the same logical negotiation resumed mid-flight after the client answered; re-screening in enforce mode could wrongly kill it.
- `NEGOTIATION_SCREEN_MODE` (off/shadow/enforce) semantics preserved; still fails open.

### IND-564 — never emit `withdraw` as an opening move
- The turn node blocks `withdraw` when **no `outreach` was opened within the current task**; seeded prior-task turns do **not** count. Such a move is mapped to the quiet screen-out outcome (no message persisted, `turnCount` unchanged, opportunity quietly `rejected`) instead of dropping a spurious "connection withdrawn" message into the shared thread.
- `withdraw` remains legal after an in-task `outreach`. Exact ask_user resumes are exempt (a post-consultation `withdraw` is a legitimate terminal decision).
- Builds on IND-563: with the screen in place most such cases never reach a turn; this guarantees the invariant for whatever still does (screen off/shadow, screen fail-open).

## Files
- `negotiation.graph.ts` — screen routing on continuations (excl. exact resumes); prior-dialogue forwarding; withdraw guard; finalize screened-out handling.
- `negotiation.screen.ts` — `isContinuation` + `priorDialogue` screener input and prompt section.
- `negotiation.state.ts` — `outreachOpened`, `firstTurnScreenedOut` graph-state fields.
- Specs: new `negotiation.continuation-screen.spec.ts` (IND-563), new `negotiation.continuation-withdraw.spec.ts` (IND-564); updated `negotiation.screen-routing.spec.ts` + `negotiation.screen.spec.ts`.
- `packages/protocol/package.json` — patch bump `6.11.1` → `6.11.2` (bug fixes).

## Local gate results (CI does not run on internal PRs)
- `bun run --filter @indexnetwork/protocol build` (tsc) — **pass** (exit 0).
- `bun run lint` (production `eslint .`) — **0 errors** (394 pre-existing warnings, none in changed files).
- `architecture:check` — **no such script in this repo**; protocol self-containment is enforced via eslint import rules (covered by lint). Changes add zero app imports.
- Targeted tests `bun test packages/protocol/src/negotiation` — **288 pass** including all new/updated specs. The only 2 failures are pre-existing **live-LLM** nondeterministic tests (`negotiator-discovery-query.spec.ts`, `negotiation.agent.spec.ts` final-turn) — real-model calls (one 15s timeout, one LLM-assertion drift), unrelated to these deterministic graph/screen/state changes.

## Caveats
- The withdraw guard lives in the graph turn node (system-agent path — the described bug locus). The external-agent `respond_to_negotiation` path is not covered because `getMessagesForConversation` does not return `taskId`, so "outreach opened in *this* task" cannot be isolated there without an interface change (out of scope). In enforce mode the IND-563 screen prevents most such continuations from reaching a turn at all.
- Diff kept tightly scoped to screen/withdraw logic to avoid conflict with the concurrent `negotiation-archival` wave.