### PR TITLE
fix(protocol): move dotenv to development dependencies

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -19,7 +19,7 @@
     },
     "apps/web": {
       "name": "@indexnetwork/web",
-      "version": "0.29.1",
+      "version": "0.32.0",
       "dependencies": {
         "@radix-ui/react-alert-dialog": "^1.1.15",
         "@radix-ui/react-dialog": "^1.1.14",
@@ -88,23 +88,23 @@
     },
     "packages/protocol": {
       "name": "@indexnetwork/protocol",
-      "version": "6.11.1",
+      "version": "6.11.5",
       "dependencies": {
         "@langchain/core": "^1.1.17",
         "@langchain/langgraph": "^1.1.2",
         "@langchain/openai": "^1.2.3",
         "@modelcontextprotocol/server": "^2.0.0-alpha.2",
-        "dotenv": "^16.3.1",
         "zod": "^3.22.4",
       },
       "devDependencies": {
         "@types/node": "^25.5.2",
+        "dotenv": "^16.3.1",
         "typescript": "^5.0.0",
       },
     },
     "services/api": {
       "name": "@indexnetwork/api",
-      "version": "0.56.2",
+      "version": "0.58.0",
       "dependencies": {
         "@aws-sdk/client-s3": "^3.939.0",
         "@aws-sdk/s3-request-presigner": "^3.983.0",

--- a/packages/protocol/CHANGELOG.md
+++ b/packages/protocol/CHANGELOG.md
@@ -13,6 +13,7 @@ See [STABILITY.md](./STABILITY.md) for the public-contract and tier definitions.
 ## [Unreleased]
 
 ### Fixed
+- Move `dotenv` to development dependencies: test/preload environment loading remains available to contributors while published runtime consumers no longer receive it as a direct dependency (IND-518).
 - Stop emitting source-test helpers, test directories, and spec/test files in published protocol build artifacts while preserving source-test execution (IND-515).
 - Allow the private intent-refinement provenance snapshot to identify intent creation as a producer and make the shared refinement prompt independent of no-opportunity process state, enabling creation and authoritative discovery producers to converge on one ordinary intent-page question cadence.
 

--- a/packages/protocol/package.json
+++ b/packages/protocol/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@indexnetwork/protocol",
-  "version": "6.11.4",
+  "version": "6.11.5",
   "type": "module",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
@@ -46,11 +46,11 @@
     "@langchain/langgraph": "^1.1.2",
     "@langchain/openai": "^1.2.3",
     "@modelcontextprotocol/server": "^2.0.0-alpha.2",
-    "dotenv": "^16.3.1",
     "zod": "^3.22.4"
   },
   "devDependencies": {
     "@types/node": "^25.5.2",
+    "dotenv": "^16.3.1",
     "typescript": "^5.0.0"
   }
 }


### PR DESCRIPTION
## Summary

- Move `dotenv` from `@indexnetwork/protocol` runtime dependencies to development dependencies.
- Bump the published protocol package from `6.11.4` to `6.11.5` and record the packaging fix in its changelog.
- Regenerate `bun.lock` with Bun; its workspace metadata now reflects the protocol dependency classification and current workspace versions.

## Why / SemVer

This is a patch release: it corrects the published runtime dependency contract without changing the public API or runtime behavior. Test/preload environment loading remains development-only.

## Verification

- Focused test preload assertion: root `.env.test` loads through `test-preload.ts` without invoking a model.
- `bun test src/shared/agent/tests/model.config.spec.ts` — 16 passed.
- `bun run build` — passed.
- `bun run architecture:artifacts` — passed (765 artifacts; no source-test artifacts).
- `rg -i dotenv packages/protocol/dist` — no matches after build/artifact verification.
- `bun pm pack --dry-run` — `6.11.5` artifact inventory inspected; package manifest contains `dist` and classifies `dotenv` as development-only.
- `env -u OPENROUTER_API_KEY -u OPENAI_API_KEY bun run eval:verify` — all 9 suites type-checked and tested provider-free.
- `bun install --frozen-lockfile`, `git diff --check` — passed.

Lint was limited to the touched manifest/docs: `package.json` passes Prettier. `CHANGELOG.md` has pre-existing full-file Prettier drift outside this change, so it was not reformatted.

Linear: IND-518.