### PR TITLE
fix(protocol): observe network rollback failures

### DIFF
--- a/packages/protocol/CHANGELOG.md
+++ b/packages/protocol/CHANGELOG.md
@@ -13,6 +13,7 @@ See [STABILITY.md](./STABILITY.md) for the public-contract and tier definitions.
 ## [Unreleased]
 
 ### Fixed
+- Log failed network-create rollback attempts with an allowlisted network correlation ID and rollback step while preserving the original create or owner-membership failure response (IND-519).
 - Move `dotenv` to development dependencies: test/preload environment loading remains available to contributors while published runtime consumers no longer receive it as a direct dependency (IND-518).
 - Stop emitting source-test helpers, test directories, and spec/test files in published protocol build artifacts while preserving source-test execution (IND-515).
 - Allow the private intent-refinement provenance snapshot to identify intent creation as a producer and make the shared refinement prompt independent of no-opportunity process state, enabling creation and authoritative discovery producers to converge on one ordinary intent-page question cadence.

--- a/packages/protocol/package.json
+++ b/packages/protocol/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@indexnetwork/protocol",
-  "version": "6.11.5",
+  "version": "6.11.6",
   "type": "module",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",

--- a/packages/protocol/src/network/network.graph.ts
+++ b/packages/protocol/src/network/network.graph.ts
@@ -154,7 +154,15 @@ export class NetworkGraphFactory {
           const added = await this.database.addMemberToNetwork(index.id, state.userId, 'owner');
           if (!added.success) {
             logger.error("addMemberToNetwork failed; cleaning up orphaned network", { networkId: index.id });
-            try { await this.database.softDeleteNetwork(index.id); } catch {}
+            try {
+              await this.database.softDeleteNetwork(index.id);
+            } catch (rollbackError) {
+              logger.error("Network create rollback failed", {
+                networkId: index.id,
+                rollbackFor: "owner_membership",
+                rollbackErrorKind: rollbackError instanceof Error ? "error" : "non_error",
+              });
+            }
             return { mutationResult: { success: false, error: "Failed to set you as owner. Network was not created." } };
           }
 
@@ -169,7 +177,15 @@ export class NetworkGraphFactory {
         } catch (err) {
           logger.error("Create network failed", { error: err });
           if (createdIndexId) {
-            try { await this.database.softDeleteNetwork(createdIndexId); } catch {}
+            try {
+              await this.database.softDeleteNetwork(createdIndexId);
+            } catch (rollbackError) {
+              logger.error("Network create rollback failed", {
+                networkId: createdIndexId,
+                rollbackFor: "create_operation",
+                rollbackErrorKind: rollbackError instanceof Error ? "error" : "non_error",
+              });
+            }
           }
           return {
             mutationResult: {

--- a/packages/protocol/src/network/tests/network.graph.rollback.spec.ts
+++ b/packages/protocol/src/network/tests/network.graph.rollback.spec.ts
@@ -1,0 +1,77 @@
+import { describe, expect, spyOn, test } from "bun:test";
+
+import type { NetworkGraphDatabase } from "../../shared/interfaces/database.interface.js";
+
+import { NetworkGraphFactory } from "../network.graph.js";
+
+const networkId = "11111111-1111-4111-8111-111111111111";
+const rollbackError = new Error("rollback failed with a secret that must not be logged");
+
+function createGraph(database: Pick<NetworkGraphDatabase, "createNetwork" | "addMemberToNetwork" | "softDeleteNetwork">) {
+  return new NetworkGraphFactory(database as NetworkGraphDatabase).createGraph();
+}
+
+describe("NetworkGraphFactory create rollback failures", () => {
+  test("keeps the owner-membership failure response when its orphan cleanup fails", async () => {
+    const errorSpy = spyOn(console, "error").mockImplementation(() => {});
+    try {
+      const graph = createGraph({
+        createNetwork: async () => ({ id: networkId, title: "Network" }) as never,
+        addMemberToNetwork: async () => ({ success: false }),
+        softDeleteNetwork: async () => { throw rollbackError; },
+      });
+
+      const result = await graph.invoke({
+        userId: "user-1",
+        operationMode: "create",
+        createInput: { title: "Network", prompt: "private prompt" },
+      });
+
+      expect(result.mutationResult).toEqual({
+        success: false,
+        error: "Failed to set you as owner. Network was not created.",
+      });
+      expect(errorSpy).toHaveBeenCalledWith("[NetworkGraphFactory]", "Network create rollback failed", {
+        networkId,
+        rollbackFor: "owner_membership",
+        rollbackErrorKind: "error",
+      });
+      expect(JSON.stringify(errorSpy.mock.calls)).not.toContain("private prompt");
+      expect(JSON.stringify(errorSpy.mock.calls)).not.toContain(rollbackError.message);
+    } finally {
+      errorSpy.mockRestore();
+    }
+  });
+
+  test("keeps the create failure response when its cleanup fails", async () => {
+    const primaryError = new Error("primary create failure");
+    const errorSpy = spyOn(console, "error").mockImplementation(() => {});
+    try {
+      const graph = createGraph({
+        createNetwork: async () => ({ id: networkId, title: "Network" }) as never,
+        addMemberToNetwork: async () => { throw primaryError; },
+        softDeleteNetwork: async () => { throw rollbackError; },
+      });
+
+      const result = await graph.invoke({
+        userId: "user-1",
+        operationMode: "create",
+        createInput: { title: "Network", prompt: "private prompt" },
+      });
+
+      expect(result.mutationResult).toEqual({
+        success: false,
+        error: primaryError.message,
+      });
+      expect(errorSpy).toHaveBeenCalledWith("[NetworkGraphFactory]", "Network create rollback failed", {
+        networkId,
+        rollbackFor: "create_operation",
+        rollbackErrorKind: "error",
+      });
+      expect(JSON.stringify(errorSpy.mock.calls)).not.toContain("private prompt");
+      expect(JSON.stringify(errorSpy.mock.calls)).not.toContain(rollbackError.message);
+    } finally {
+      errorSpy.mockRestore();
+    }
+  });
+});


### PR DESCRIPTION
## Summary

- Replaced both empty network-create rollback catches with safe structured rollback-failure logging.
- Preserved the original owner-membership and create-operation failure responses when rollback also fails.
- Added focused coverage for both rollback sites and bumped @indexnetwork/protocol from 6.11.5 to 6.11.6.

Closes IND-519.

## Verification matrix

| Check | Result |
| --- | --- |
| Network graph rollback failure paths | bun test packages/protocol/src/network/tests/network.graph.rollback.spec.ts - 2 passed |
| Touched production/test lint | bunx eslint packages/protocol/src/network/network.graph.ts packages/protocol/src/network/tests/network.graph.rollback.spec.ts - passed |
| Protocol build | bun run build in packages/protocol - passed |

## Safety and release notes

- Rollback events include only the network correlation ID, a fixed rollback step, and a coarse error kind. They exclude inputs, prompts, profiles, provider data, credentials, and the rollback error message.
- The original failure remains the externally returned failure even if cleanup fails.
- This is a patch release (6.11.5 to 6.11.6): a production observability fix that preserves the public behavior and interfaces.
- No package-boundary or import change: architecture:check was intentionally not run. eval:verify was also intentionally not run under the focused verification policy.
- Ran bun install and bun install --force after resolving the manifest version. Bun regenerated the lockfile without a diff, so bun.lock is intentionally unchanged.