### PR TITLE
chore(protocol): make source-map publication explicit

### DIFF
--- a/packages/protocol/CHANGELOG.md
+++ b/packages/protocol/CHANGELOG.md
@@ -12,6 +12,12 @@ See [STABILITY.md](./STABILITY.md) for the public-contract and tier definitions.
 
 ## [Unreleased]
 
+### Changed
+- Publish Protocol tarballs without JavaScript or declaration source maps while
+  retaining map generation for the first-party Sentry upload build. Published
+  declarations remain available for downstream type checking and navigation
+  (IND-521).
+
 ### Fixed
 - Log failed network-create rollback attempts with an allowlisted network correlation ID and rollback step while preserving the original create or owner-membership failure response (IND-519).
 - Move `dotenv` to development dependencies: test/preload environment loading remains available to contributors while published runtime consumers no longer receive it as a direct dependency (IND-518).

--- a/packages/protocol/IMPLEMENTATION.md
+++ b/packages/protocol/IMPLEMENTATION.md
@@ -19,6 +19,26 @@ deep imports are not part of the contract. Every symbol is re-exported explicitl
 See [STABILITY.md](./STABILITY.md) for the full policy and the deprecation path,
 and [CHANGELOG.md](./CHANGELOG.md) for release history.
 
+## Source-map publication policy
+
+Published `@indexnetwork/protocol` tarballs contain **no source maps**: neither
+JavaScript (`*.js.map`) nor declaration (`*.d.ts.map`) maps. The zero-map budget
+is enforced by the `prepack` build (`tsconfig.package.json`) and by
+`architecture:artifacts`; it is intentionally separate from the normal `build`.
+
+This is a registry-size and downstream-support tradeoff. The ordinary build keeps
+maps so the deployment Sentry workflow can upload them for first-party debugging,
+but they are not copied into the npm registry. A downstream runtime stack therefore
+names a `dist/*.js` location rather than the original TypeScript source. Consumers
+should retain the package version with an incident and use the matching source
+revision or their own observability mapping when they need source-level diagnosis.
+
+Declaration navigation is unchanged: `dist/**/*.d.ts` remains published and is the
+supported editor/type-checking surface. Declaration maps are deliberately omitted
+because they are not required to navigate those declarations and would expose the
+same source-map size cost. This policy is reversible by changing only
+`tsconfig.package.json`; do not add maps to the package file list ad hoc.
+
 ## Install
 
 ```bash

--- a/packages/protocol/package.json
+++ b/packages/protocol/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@indexnetwork/protocol",
-  "version": "6.11.6",
+  "version": "6.11.7",
   "type": "module",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
@@ -18,6 +18,7 @@
   ],
   "scripts": {
     "build": "rm -rf dist && tsc",
+    "build:package": "rm -rf dist && tsc --project tsconfig.package.json",
     "dev": "tsc --watch",
     "test": "bun test",
     "test:isolated": "bun scripts/test.ts",
@@ -31,6 +32,7 @@
     "architecture:artifacts": "bun run build && bun scripts/architecture/artifact-inventory.ts",
     "architecture:check": "bun run architecture:exports && bun run architecture:consumer && bun run architecture:host-isolation && bun run architecture:cycles && bun run architecture:artifacts && bun run test:architecture",
     "prepublishOnly": "bun run build",
+    "prepack": "bun run build:package",
     "eval:matching": "bun --env-file=../../.env.test ./eval/matching/matching.eval.ts",
     "eval:hyde": "bun --env-file=../../.env.test ./eval/hyde/hyde.eval.ts",
     "eval:premise": "bun --env-file=../../.env.test ./eval/premise/premise.eval.ts",

--- a/packages/protocol/scripts/architecture/artifact-inventory.ts
+++ b/packages/protocol/scripts/architecture/artifact-inventory.ts
@@ -50,4 +50,9 @@ if (testArtifacts.length > 0) {
   throw new Error(`Published package contains source-test artifacts:\n${testArtifacts.map((path) => `- ${path}`).join("\n")}`);
 }
 
-console.log(`Package artifact inventory OK (${paths.length} files; no source-test artifacts).`);
+const sourceMapArtifacts = paths.filter((path) => path.endsWith(".map"));
+if (sourceMapArtifacts.length > 0) {
+  throw new Error(`Published package contains source maps (the publication budget is zero):\n${sourceMapArtifacts.map((path) => `- ${path}`).join("\n")}`);
+}
+
+console.log(`Package artifact inventory OK (${paths.length} files; no source-test or source-map artifacts).`);

--- a/packages/protocol/tsconfig.base.json
+++ b/packages/protocol/tsconfig.base.json
@@ -1,0 +1,18 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "outDir": "./dist",
+    "rootDir": "./src",
+    "declaration": true,
+    "strict": true,
+    "skipLibCheck": true,
+    "esModuleInterop": true,
+    "experimentalDecorators": true,
+    "emitDecoratorMetadata": true,
+    "types": ["node"]
+  },
+  "include": ["src/**/*"],
+  "exclude": ["**/tests/**", "**/*.spec.ts", "**/*.test.ts", "node_modules", "dist"]
+}

--- a/packages/protocol/tsconfig.json
+++ b/packages/protocol/tsconfig.json
@@ -1,22 +1,9 @@
 {
+  "extends": "./tsconfig.base.json",
   "compilerOptions": {
-    "target": "ES2020",
-    "module": "NodeNext",
-    "moduleResolution": "NodeNext",
-    "outDir": "./dist",
-    "rootDir": "./src",
-    "declaration": true,
     "declarationMap": true,
     "sourceMap": true,
     "inlineSources": true,
-    "sourceRoot": "/",
-    "strict": true,
-    "skipLibCheck": true,
-    "esModuleInterop": true,
-    "experimentalDecorators": true,
-    "emitDecoratorMetadata": true,
-    "types": ["node"]
-  },
-  "include": ["src/**/*"],
-  "exclude": ["**/tests/**", "**/*.spec.ts", "**/*.test.ts", "node_modules", "dist"]
+    "sourceRoot": "/"
+  }
 }

--- a/packages/protocol/tsconfig.package.json
+++ b/packages/protocol/tsconfig.package.json
@@ -1,0 +1,8 @@
+{
+  "extends": "./tsconfig.base.json",
+  "compilerOptions": {
+    "sourceMap": false,
+    "declarationMap": false,
+    "inlineSources": false
+  }
+}


### PR DESCRIPTION
## Summary

- Implements IND-521: npm publication has a zero-source-map budget; normal Protocol builds still emit maps for the first-party Sentry upload workflow.
- The reversible `tsconfig.package.json` is used by `prepack`; `architecture:artifacts` fails if any `.map` reaches the tarball.
- Publishes Protocol 6.11.7 with a changelog entry.

## Decision and tradeoffs

- **Decision:** publish no JavaScript or declaration source maps.
- **Debugging:** downstream runtime stacks retain `dist/*.js` locations rather than original TypeScript locations; consumers should retain the package version and use the matching source revision or their own observability mapping. First-party Sentry mapping is preserved by the normal map-enabled build.
- **Declaration navigation:** unchanged. All `*.d.ts` declarations, including `dist/index.d.ts`, remain published; only optional declaration maps are omitted.
- **Registry size:** baseline package had 380 maps / 3,927,206 map bytes. Pack output falls from 765 files / 7,209,172 uncompressed bytes (1,424,342-byte archive) to 385 files / 3,265,879 bytes (660,209-byte archive): 380 fewer files and 3,943,293 fewer uncompressed bytes.
- **Downstream support:** supported root imports, runtime behavior, and declarations are unchanged; no deep-import or map-file contract is introduced.

## Verification

- Controlled Node consumer stack-trace experiment: map-enabled build resolves `presentOpportunity` to `opportunity.presentation.ts:37`; map-free package build resolves the same error to `dist/opportunity/opportunity.presentation.js:15`.
- `bun run build` — normal/Sentry build retains 380 maps totaling 3,927,206 bytes.
- `bun run build:package` and `bun pm pack --dry-run` — 0 maps, 190 declarations, no `sourceMappingURL` comments.
- `bun run architecture:consumer` — public consumer fixture compiles.
- `bun run architecture:artifacts` — passes with 385 files and no source-test or source-map artifacts.
- `bunx tsc --noEmit --skipLibCheck --module NodeNext --moduleResolution NodeNext --target ES2020 --strict dist/index.d.ts` — packaged declaration entrypoint compiles.
- Touched-file ESLint (including pre-commit lint-staged) and `git diff --check` pass.

## Versioning and lockfile

This deliberately changes the published artifact contract, so it receives a Protocol patch bump to 6.11.7 and a changelog entry. `bun.lock` is unchanged because the package remains a `workspace:*` dependency and no dependency/manifest resolution changed.