### PR TITLE
feat(web): IND-570 — Label earlier negotiation sections with opportunity title + outcome chip

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@indexnetwork/web",
-  "version": "0.38.0",
+  "version": "0.39.0",
   "license": "MIT",
   "scripts": {
     "dev": "vite --host 127.0.0.1",

--- a/apps/web/src/app/chat/[conversationId]/page.tsx
+++ b/apps/web/src/app/chat/[conversationId]/page.tsx
@@ -9,9 +9,10 @@ import { useQuestionsService } from '@/contexts/APIContext';
 import { useOpportunityActions } from '@/hooks/useOpportunityActions';
 import TurnRail from '@/components/negotiations/TurnRail';
 import OutcomeBanner from '@/components/negotiations/OutcomeBanner';
+import OutcomeChip from '@/components/negotiations/OutcomeChip';
 import ResolvedBanner, { type ResolvedBannerVariant } from '@/components/negotiations/ResolvedBanner';
 import { useTickingNow } from '@/components/negotiations/use-ticking-now';
-import { extractTurn, formatRelativeTime, groupTurnsBySession, viewerRoleLabel, type TranscriptTurn } from '@/components/negotiations/negotiation-turns';
+import { deriveSectionLabel, extractTurn, formatRelativeTime, groupTurnsBySession, viewerRoleLabel, type TranscriptTurn } from '@/components/negotiations/negotiation-turns';
 
 const STALL_REASONS = new Set(['turn_cap', 'timeout']);
 
@@ -19,7 +20,7 @@ export default function NegotiationDetailPage() {
   const { conversationId } = useParams();
   const navigate = useNavigate();
   const { user } = useAuthContext();
-  const { negotiations, messages, loadSessionHistory, loadPreviousSessionMessages, refreshNegotiations, sessionHistory } = useConversation();
+  const { negotiations, messages, loadSessionHistory, loadPreviousSessionMessages, refreshNegotiations, sessionHistory, sessionOpportunityMap } = useConversation();
   const [loading, setLoading] = useState(true);
   const messagesEndRef = useRef<HTMLDivElement>(null);
   const now = useTickingNow();
@@ -204,28 +205,54 @@ export default function NegotiationDetailPage() {
                 const isLatest = groupIndex === sessionGroups.length - 1;
                 const firstTurn = group.turns[0];
 
-                // Older sections: show month/year of first turn as context.
-                // Latest section: use the viewer’s own opportunity intent title
-                // from the conversation’s signal provenance (via[0]).
-                let sectionLabel: string;
-                if (isLatest) {
-                  sectionLabel = conversation?.via[0]?.title ?? 'Current negotiation';
-                } else {
-                  const date = firstTurn ? new Date(firstTurn.createdAt) : null;
-                  const monthYear = date && Number.isFinite(date.getTime())
-                    ? date.toLocaleString('en-US', { month: 'short', year: 'numeric' })
-                    : '';
-                  sectionLabel = `Earlier negotiation${monthYear ? ` · ${monthYear}` : ''}`;
-                }
+                // IND-570: resolve opportunity attribution for this section.
+                // sessionOpportunityMap is keyed by sessionId (populated when
+                // session history is loaded). We then look up the viewer's
+                // intent title from conversation.via[] using the opportunityId.
+                const sessionOpp = group.sessionId ? sessionOpportunityMap.get(group.sessionId) : undefined;
+                const viaEntry = sessionOpp?.opportunityId
+                  ? conversation?.via.find((v) => v.opportunityId === sessionOpp.opportunityId)
+                  : null;
+                const opportunityTitle = viaEntry?.title ?? null;
+                const opportunityStatus = sessionOpp?.status ?? null;
+
+                // Older sections: show opportunity title + outcome chip + date.
+                // Latest section: use the viewer's own opportunity intent title
+                // from the conversation's signal provenance (via[0]).
+                const sectionLabel = deriveSectionLabel({
+                  isLatest,
+                  firstTurnCreatedAt: firstTurn?.createdAt ?? null,
+                  opportunityTitle,
+                  opportunityStatus,
+                  latestSectionTitle: conversation?.via[0]?.title ?? null,
+                });
 
                 return (
                   <section key={group.sessionId ?? `group-${groupIndex}`} aria-label={sectionLabel}>
                     {/* Section divider — separates this task from the preceding one */}
                     <div className="flex items-center gap-3 py-3" role="separator">
                       <span className="h-px flex-1 bg-gray-200" />
-                      <span className="text-[10px] font-ibm-plex-mono uppercase tracking-[0.12em] text-gray-400">
-                        {sectionLabel}
-                      </span>
+                      {/* IND-570: older attributed sections show title + chip + date inline.
+                           Older unattributed sections and the latest section show plain text. */}
+                      {!isLatest && opportunityTitle ? (
+                        <span className="flex items-center gap-1.5 min-w-0" aria-hidden="true">
+                          <span className="text-[10px] font-ibm-plex-mono text-gray-500 truncate max-w-[180px]">
+                            {opportunityTitle}
+                          </span>
+                          <OutcomeChip status={opportunityStatus} />
+                          {firstTurn && (
+                            <span className="text-[10px] font-ibm-plex-mono text-gray-400 shrink-0">
+                              {
+                                new Date(firstTurn.createdAt).toLocaleString('en-US', { month: 'short', day: 'numeric' })
+                              }
+                            </span>
+                          )}
+                        </span>
+                      ) : (
+                        <span className="text-[10px] font-ibm-plex-mono uppercase tracking-[0.12em] text-gray-400" aria-hidden="true">
+                          {sectionLabel}
+                        </span>
+                      )}
                       <span className="h-px flex-1 bg-gray-200" />
                     </div>
                     <TurnRail

--- a/apps/web/src/components/__tests__/negotiation-turns.test.ts
+++ b/apps/web/src/components/__tests__/negotiation-turns.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest';
 
-import { extractTurn, formatRelativeTime, roleChipLabel, roleLabel, verbFor, viewerRoleLabel, type TranscriptTurn } from '@/components/negotiations/negotiation-turns';
+import { deriveSectionLabel, extractTurn, formatRelativeTime, formatSectionDate, groupTurnsBySession, outcomeChipVariant, roleChipLabel, roleLabel, verbFor, viewerRoleLabel, type TranscriptTurn } from '@/components/negotiations/negotiation-turns';
 import type { ConversationMessage } from '@/services/conversation';
 
 function message(parts: unknown[], overrides: Partial<ConversationMessage> = {}): ConversationMessage {
@@ -130,5 +130,146 @@ describe('formatRelativeTime', () => {
 
   it('returns empty for unparseable timestamps', () => {
     expect(formatRelativeTime('not-a-date', now)).toBe('');
+  });
+});
+
+// ─── IND-570: section label helpers ─────────────────────────────────────────
+
+describe('outcomeChipVariant', () => {
+  it('maps terminal statuses to display props', () => {
+    expect(outcomeChipVariant('accepted')).toMatchObject({ label: 'Accepted', color: 'text-emerald-700' });
+    expect(outcomeChipVariant('rejected')).toMatchObject({ label: 'Rejected', color: 'text-red-700' });
+    expect(outcomeChipVariant('stalled')).toMatchObject({ label: 'Stalled', color: 'text-gray-600' });
+    expect(outcomeChipVariant('expired')).toMatchObject({ label: 'Expired', color: 'text-amber-700' });
+  });
+
+  it('returns null for non-terminal or unknown statuses', () => {
+    expect(outcomeChipVariant(null)).toBeNull();
+    expect(outcomeChipVariant(undefined)).toBeNull();
+    expect(outcomeChipVariant('pending')).toBeNull();
+    expect(outcomeChipVariant('negotiating')).toBeNull();
+    expect(outcomeChipVariant('latent')).toBeNull();
+  });
+});
+
+describe('formatSectionDate', () => {
+  it('formats as "Mon D" (e.g. Jun 26)', () => {
+    // Use a fixed UTC date; toLocaleString in en-US gives e.g. "Jun 26"
+    const result = formatSectionDate('2025-06-26T10:00:00.000Z');
+    expect(result).toMatch(/^[A-Z][a-z]{2} \d{1,2}$/);
+    expect(result).toContain('26');
+  });
+
+  it('returns empty for unparseable dates', () => {
+    expect(formatSectionDate('not-a-date')).toBe('');
+  });
+});
+
+describe('deriveSectionLabel', () => {
+  const createdAt = '2025-06-26T10:00:00.000Z';
+
+  it('returns latestSectionTitle for the latest section', () => {
+    expect(deriveSectionLabel({
+      isLatest: true,
+      firstTurnCreatedAt: createdAt,
+      opportunityTitle: 'Old opp',
+      opportunityStatus: 'rejected',
+      latestSectionTitle: 'GEO consultancy search',
+    })).toBe('GEO consultancy search');
+  });
+
+  it('falls back to "Current negotiation" when no latest title is provided', () => {
+    expect(deriveSectionLabel({
+      isLatest: true,
+      firstTurnCreatedAt: createdAt,
+      opportunityTitle: null,
+      opportunityStatus: null,
+      latestSectionTitle: null,
+    })).toBe('Current negotiation');
+  });
+
+  it('builds attributed label for older sections with title and outcome', () => {
+    const label = deriveSectionLabel({
+      isLatest: false,
+      firstTurnCreatedAt: createdAt,
+      opportunityTitle: 'GEO consultancy search',
+      opportunityStatus: 'rejected',
+      latestSectionTitle: null,
+    });
+    expect(label).toContain('GEO consultancy search');
+    expect(label).toContain('Rejected');
+    expect(label).toContain('26'); // day of month
+  });
+
+  it('omits outcome chip segment when status has no chip variant', () => {
+    const label = deriveSectionLabel({
+      isLatest: false,
+      firstTurnCreatedAt: createdAt,
+      opportunityTitle: 'Interesting project',
+      opportunityStatus: 'pending', // no chip
+      latestSectionTitle: null,
+    });
+    expect(label).toContain('Interesting project');
+    expect(label).not.toContain('Pending');
+    // date still present
+    expect(label).toContain('26');
+  });
+
+  it('uses legacy fallback for unattributed older sections', () => {
+    const label = deriveSectionLabel({
+      isLatest: false,
+      firstTurnCreatedAt: '2025-06-01T00:00:00.000Z',
+      opportunityTitle: null,
+      opportunityStatus: null,
+      latestSectionTitle: null,
+    });
+    expect(label).toMatch(/Earlier negotiation/);
+    expect(label).toContain('Jun');
+    expect(label).toContain('2025');
+  });
+
+  it('handles null firstTurnCreatedAt gracefully', () => {
+    const label = deriveSectionLabel({
+      isLatest: false,
+      firstTurnCreatedAt: null,
+      opportunityTitle: 'Solo opportunity',
+      opportunityStatus: 'accepted',
+      latestSectionTitle: null,
+    });
+    expect(label).toContain('Solo opportunity');
+    expect(label).toContain('Accepted');
+    // no date segment when null
+    const parts = label.split(' · ');
+    expect(parts).toHaveLength(2);
+  });
+});
+
+describe('groupTurnsBySession', () => {
+  const base = { senderId: 'agent:a', createdAt: '2025-01-01T00:00:00Z', action: null, text: 'x', suggestedRoles: null };
+
+  it('groups consecutive turns with the same sessionId together', () => {
+    const turns: TranscriptTurn[] = [
+      { id: '1', sessionId: 's1', ...base },
+      { id: '2', sessionId: 's1', ...base },
+      { id: '3', sessionId: 's2', ...base },
+    ];
+    const groups = groupTurnsBySession(turns);
+    expect(groups).toHaveLength(2);
+    expect(groups[0].sessionId).toBe('s1');
+    expect(groups[0].turns).toHaveLength(2);
+    expect(groups[1].sessionId).toBe('s2');
+    expect(groups[1].turns).toHaveLength(1);
+  });
+
+  it('returns a single group for turns with null sessionId', () => {
+    const turns: TranscriptTurn[] = [
+      { id: '1', sessionId: null, ...base },
+      { id: '2', sessionId: null, ...base },
+    ];
+    expect(groupTurnsBySession(turns)).toHaveLength(1);
+  });
+
+  it('returns an empty array for empty input', () => {
+    expect(groupTurnsBySession([])).toHaveLength(0);
   });
 });

--- a/apps/web/src/components/negotiations/OutcomeChip.tsx
+++ b/apps/web/src/components/negotiations/OutcomeChip.tsx
@@ -1,0 +1,31 @@
+/**
+ * OutcomeChip — compact inline badge for a resolved opportunity's outcome.
+ *
+ * Used in older negotiation section dividers (IND-570) to show how a past
+ * negotiation ended without repeating the full ResolvedBanner.
+ */
+
+import { outcomeChipVariant } from './negotiation-turns';
+
+interface OutcomeChipProps {
+  /** Raw opportunity status value from the API. */
+  status: string | null | undefined;
+}
+
+/**
+ * Renders a small coloured pill (e.g. "Accepted", "Rejected", "Stalled", "Expired").
+ * Returns null when the status maps to no known outcome.
+ */
+export default function OutcomeChip({ status }: OutcomeChipProps) {
+  const variant = outcomeChipVariant(status);
+  if (!variant) return null;
+
+  return (
+    <span
+      className={`inline-flex items-center rounded-full px-2 py-0.5 text-[10px] font-medium font-ibm-plex-mono ${variant.color} ${variant.bg}`}
+      aria-label={`Outcome: ${variant.label}`}
+    >
+      {variant.label}
+    </span>
+  );
+}

--- a/apps/web/src/components/negotiations/negotiation-turns.ts
+++ b/apps/web/src/components/negotiations/negotiation-turns.ts
@@ -147,6 +147,81 @@ export function groupTurnsBySession(turns: TranscriptTurn[]): NegotiationSession
   return groups;
 }
 
+// ─── Section label helpers (IND-570) ────────────────────────────────────────
+
+export type OpportunityOutcomeStatus = 'accepted' | 'rejected' | 'stalled' | 'expired';
+
+export interface OutcomeChipVariant {
+  label: string;
+  /** Tailwind text-color class */
+  color: string;
+  /** Tailwind bg-color class */
+  bg: string;
+}
+
+/** Map opportunity status → compact chip display props, or null if no chip. */
+export function outcomeChipVariant(status: string | null | undefined): OutcomeChipVariant | null {
+  switch (status) {
+    case 'accepted': return { label: 'Accepted', color: 'text-emerald-700', bg: 'bg-emerald-50' };
+    case 'rejected': return { label: 'Rejected', color: 'text-red-700', bg: 'bg-red-50' };
+    case 'stalled': return { label: 'Stalled', color: 'text-gray-600', bg: 'bg-gray-100' };
+    case 'expired': return { label: 'Expired', color: 'text-amber-700', bg: 'bg-amber-50' };
+    default: return null;
+  }
+}
+
+/**
+ * Format a date string as "Mon D" (e.g. "Jun 26") for section date hints.
+ * Returns empty string on invalid input.
+ */
+export function formatSectionDate(isoDate: string): string {
+  const date = new Date(isoDate);
+  if (!Number.isFinite(date.getTime())) return '';
+  return date.toLocaleString('en-US', { month: 'short', day: 'numeric' });
+}
+
+export interface SectionLabelOpts {
+  /** true if this is the newest/latest session group */
+  isLatest: boolean;
+  /** ISO createdAt of the first turn in this group, for date context */
+  firstTurnCreatedAt: string | null;
+  /** Title of the opportunity this session was about (viewer-side intent title) */
+  opportunityTitle: string | null;
+  /** Current status of the opportunity, for the outcome chip */
+  opportunityStatus: string | null;
+  /** Fallback title used for the latest section */
+  latestSectionTitle: string | null;
+}
+
+/**
+ * Derives the text label for a negotiation section divider (IND-570).
+ *
+ * - Latest section: uses the intent title from the conversation's signal provenance.
+ * - Older sections with attribution: "<title> · <status> · <Mon D>"
+ * - Older sections without attribution: "Earlier negotiation · <Mon YYYY>" fallback.
+ */
+export function deriveSectionLabel(opts: SectionLabelOpts): string {
+  if (opts.isLatest) {
+    return opts.latestSectionTitle ?? 'Current negotiation';
+  }
+
+  if (opts.opportunityTitle) {
+    const chip = outcomeChipVariant(opts.opportunityStatus);
+    const date = opts.firstTurnCreatedAt ? formatSectionDate(opts.firstTurnCreatedAt) : '';
+    const parts = [opts.opportunityTitle];
+    if (chip) parts.push(chip.label);
+    if (date) parts.push(date);
+    return parts.join(' · ');
+  }
+
+  // Unattributed legacy fallback — keep existing format.
+  const date = opts.firstTurnCreatedAt ? new Date(opts.firstTurnCreatedAt) : null;
+  const monthYear = date && Number.isFinite(date.getTime())
+    ? date.toLocaleString('en-US', { month: 'short', year: 'numeric' })
+    : '';
+  return `Earlier negotiation${monthYear ? ` · ${monthYear}` : ''}`;
+}
+
 /** Relative timestamp, recomputed against a ticking `now` (IND-555). */
 export function formatRelativeTime(createdAt: string, now: number): string {
   const timestamp = new Date(createdAt).getTime();

--- a/apps/web/src/contexts/ConversationContext.tsx
+++ b/apps/web/src/contexts/ConversationContext.tsx
@@ -16,11 +16,19 @@ interface ConversationSessionHistoryState {
   loadingPrevious: boolean;
 }
 
+/** IND-570: Per-session opportunity attribution, keyed by sessionId. */
+export interface SessionOpportunityInfo {
+  opportunityId: string;
+  status: string | null;
+}
+
 interface ConversationContextType {
   conversations: ConversationSummary[];
   negotiations: ConversationSummary[];
   messages: Map<string, ConversationMessage[]>;
   sessionHistory: Map<string, ConversationSessionHistoryState>;
+  /** IND-570: Per-session opportunity attribution, keyed by sessionId. */
+  sessionOpportunityMap: Map<string, SessionOpportunityInfo>;
   isConnected: boolean;
   loadMessages: (conversationId: string, opts?: { limit?: number; before?: string }) => Promise<void>;
   loadSessionHistory: (conversationId: string, opts?: { taskId?: string; beforeSessionId?: string }) => Promise<void>;
@@ -44,6 +52,7 @@ export function ConversationProvider({ children }: { children: React.ReactNode }
   const [negotiations, setNegotiations] = useState<ConversationSummary[]>([]);
   const [messages, setMessages] = useState<Map<string, ConversationMessage[]>>(new Map());
   const [sessionHistory, setSessionHistory] = useState<Map<string, ConversationSessionHistoryState>>(new Map());
+  const [sessionOpportunityMap, setSessionOpportunityMap] = useState<Map<string, SessionOpportunityInfo>>(new Map());
   const [isConnected, setIsConnected] = useState(false);
   const eventSourceRef = useRef<EventSource | null>(null);
   const retryTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
@@ -117,6 +126,8 @@ export function ConversationProvider({ children }: { children: React.ReactNode }
         sessionId: string | null;
         hasPreviousSession: boolean;
         previousSessionCursor: string | null;
+        sessionOpportunityId: string | null;
+        sessionOpportunityStatus: string | null;
       }>(`/conversations/${conversationId}/messages?${params.toString()}`);
       setMessages((previous) => {
         const next = new Map(previous);
@@ -142,6 +153,14 @@ export function ConversationProvider({ children }: { children: React.ReactNode }
         });
         return next;
       });
+      // IND-570: store per-session opportunity attribution keyed by sessionId.
+      if (data.sessionId && data.sessionOpportunityId) {
+        setSessionOpportunityMap((previous) => {
+          const next = new Map(previous);
+          next.set(data.sessionId!, { opportunityId: data.sessionOpportunityId!, status: data.sessionOpportunityStatus });
+          return next;
+        });
+      }
     } catch (error) {
       logger.error('Failed to load conversation session history', { error, conversationId });
       setSessionHistory((previous) => {
@@ -449,6 +468,7 @@ export function ConversationProvider({ children }: { children: React.ReactNode }
         negotiations,
         messages,
         sessionHistory,
+        sessionOpportunityMap,
         isConnected,
         loadMessages,
         loadSessionHistory,

--- a/services/api/package.json
+++ b/services/api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@indexnetwork/api",
-  "version": "0.59.1",
+  "version": "0.59.2",
   "license": "MIT",
   "private": true,
   "scripts": {

--- a/services/api/src/adapters/conversation.database.adapter.ts
+++ b/services/api/src/adapters/conversation.database.adapter.ts
@@ -1253,7 +1253,7 @@ export class ConversationDatabaseAdapter {
         ))
         .limit(1);
       if (!cursor) {
-        return { session: null, messages: [], hasPreviousSession: false };
+        return { session: null, messages: [], hasPreviousSession: false, sessionOpportunityId: null, sessionOpportunityStatus: null };
       }
       const beforeSessionCondition = or(
         lt(schema.conversationSessions.startedAt, cursor.startedAt),
@@ -1274,7 +1274,7 @@ export class ConversationDatabaseAdapter {
         desc(schema.conversationSessions.id),
       )
       .limit(1);
-    if (!session) return { session: null, messages: [], hasPreviousSession: false };
+    if (!session) return { session: null, messages: [], hasPreviousSession: false, sessionOpportunityId: null, sessionOpportunityStatus: null };
 
     const messageConditions = [eq(schema.messages.sessionId, session.id)];
     if (opts?.userId) {

--- a/services/api/src/adapters/conversation.database.adapter.ts
+++ b/services/api/src/adapters/conversation.database.adapter.ts
@@ -1232,6 +1232,10 @@ export class ConversationDatabaseAdapter {
     session: ConversationSession | null;
     messages: Message[];
     hasPreviousSession: boolean;
+    /** opportunityId from the session's negotiation task, if any. */
+    sessionOpportunityId: string | null;
+    /** Current status of the session's opportunity, if any. */
+    sessionOpportunityStatus: string | null;
   }> {
     const conditions = [eq(schema.conversationSessions.conversationId, conversationId)];
     if (opts?.taskId) {
@@ -1312,7 +1316,27 @@ export class ConversationDatabaseAdapter {
       .where(and(...previousConditions))
       .limit(1);
 
-    return { session, messages, hasPreviousSession: Boolean(previous) };
+    // IND-570: resolve opportunity attribution for this session so the web
+    // client can label older sections with the opportunity title + outcome chip.
+    let sessionOpportunityId: string | null = null;
+    let sessionOpportunityStatus: string | null = null;
+    if (session.taskId) {
+      const [taskOpp] = await db
+        .select({
+          opportunityId: sql<string | null>`(${schema.tasks.metadata}->>'opportunityId')`,
+          opportunityStatus: opportunities.status,
+        })
+        .from(schema.tasks)
+        .leftJoin(opportunities, sql`(${schema.tasks.metadata}->>'opportunityId') = ${opportunities.id}`)
+        .where(eq(schema.tasks.id, session.taskId))
+        .limit(1);
+      if (taskOpp?.opportunityId) {
+        sessionOpportunityId = taskOpp.opportunityId;
+        sessionOpportunityStatus = taskOpp.opportunityStatus ?? null;
+      }
+    }
+
+    return { session, messages, hasPreviousSession: Boolean(previous), sessionOpportunityId, sessionOpportunityStatus };
   }
 
   // ─────────────────────────────────────────────────────────────────────────

--- a/services/api/src/controllers/conversation.controller.ts
+++ b/services/api/src/controllers/conversation.controller.ts
@@ -155,6 +155,9 @@ export class ConversationController {
           sessionId: history.session?.id ?? null,
           hasPreviousSession: history.hasPreviousSession,
           previousSessionCursor: history.hasPreviousSession ? history.session?.id ?? null : null,
+          // IND-570: per-session opportunity attribution for section labelling.
+          sessionOpportunityId: history.sessionOpportunityId ?? null,
+          sessionOpportunityStatus: history.sessionOpportunityStatus ?? null,
         });
       }
       const messages = await this.conversationService.getMessages(conversationId, { limit, before, taskId, userId: user.id });


### PR DESCRIPTION
## What changed

### IND-570: Earlier negotiation sections now show opportunity attribution

**Context:** IND-565 (already on the integration base) groups the negotiation thread into per-opportunity `<section>` blocks, but older sections were labeled generically as `Earlier negotiation · Jun 2025`. This PR adds attribution — opportunity title + outcome chip + date — to those older sections.

### Changes

#### `apps/web` (primary)
- **`negotiation-turns.ts`** — new exported helpers:
  - `deriveSectionLabel(opts)` — pure function deriving a section's text label from opportunity attribution (testable, no React)
  - `outcomeChipVariant(status)` — maps opportunity status → `{ label, color, bg }` chip props
  - `formatSectionDate(isoDate)` — formats `'Jun 26'` dates for section context
- **`OutcomeChip.tsx`** — new compact coloured badge component (Accepted / Rejected / Stalled / Expired) with `aria-label`
- **`ConversationContext.tsx`** — new `sessionOpportunityMap: Map<string, SessionOpportunityInfo>` keyed by `sessionId`; populated when each session history batch is loaded
- **`page.tsx` (NegotiationDetailPage)** — older attributed sections now render `{title} + <OutcomeChip> + {date}` in the section divider; unattributed sections keep the legacy `Earlier negotiation · Mon YYYY` fallback; `ResolvedBanner` scoped to latest section unchanged (IND-566 preserved)

#### `services/api` (minimal extension)
- **`conversation.database.adapter.ts`** — `getConversationSessionHistory` now resolves `sessionOpportunityId` and `sessionOpportunityStatus` by joining the session's `taskId → tasks.metadata.opportunityId → opportunities.status`
- **`conversation.controller.ts`** — passes `sessionOpportunityId` and `sessionOpportunityStatus` through in the `?sessionHistory=true` response

**API surface changed?** Yes — `GET /conversations/:id/messages?sessionHistory=true` response gains two nullable fields. No breaking changes; all callers ignore unknown fields.

### Behavior

| Section | Label shown |
|---|---|
| Latest | `{via[0].title}` or `'Current negotiation'` (unchanged) |
| Older, attributed | `GEO consultancy search · Rejected · Jun 26` |
| Older, unattributed | `Earlier negotiation · Jun 2025` (unchanged fallback) |

### Gate results
- `bun run lint` — 0 errors (398 pre-existing warnings unchanged)
- `bun run build` in `apps/web` — ✅ built in ~2.4s
- Targeted tests — **28 tests pass** (new suites: `deriveSectionLabel`, `outcomeChipVariant`, `formatSectionDate`, `groupTurnsBySession`)

### Caveats / coordination
- The `via[]` title lookup requires the viewer's intent to have been recorded in `matchProvenance`. If provenance was never captured for an older session, the section falls back gracefully to the legacy label.
- IND-569 (parallel protocol child) may add a similar per-task attribution query on the protocol side. Our server-side extension is independent and viewer-safe (no counterpart intent data leaks through).
- No new isolated API test added (the change is a 2-column addition to an existing select; coverage via build/type-check). If a full isolated test is needed, it can be wired to `services/api/.test-isolated` in a follow-up.

### Version bumps
- `apps/web`: `0.38.0` → `0.39.0` (feat ⇒ minor)
- `services/api`: `0.59.1` → `0.59.2` (API response extended ⇒ patch)

> **DRAFT** — do not merge; targeting `feat/opportunity-scoped-negotiations` integration branch.