### PR TITLE
refactor(protocol): extract opportunity lifecycle policies

### DIFF
--- a/packages/protocol/CHANGELOG.md
+++ b/packages/protocol/CHANGELOG.md
@@ -13,6 +13,9 @@ See [STABILITY.md](./STABILITY.md) for the public-contract and tier definitions.
 ## [Unreleased]
 
 ### Changed
+- Extract opportunity lifecycle admission rules and persistence handlers from
+  the graph while retaining its LangGraph node routing and externally visible
+  lifecycle semantics (IND-530).
 - Slice tool-factory dependencies into named capability-owned ports for
   enrichment, signals, communities, opportunities, premises, contacts,
   integrations, participant agents, negotiations, and questions. `ToolDeps`

--- a/packages/protocol/package.json
+++ b/packages/protocol/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@indexnetwork/protocol",
-  "version": "6.13.0",
+  "version": "6.13.1",
   "type": "module",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",

--- a/packages/protocol/src/opportunity/opportunity.graph.ts
+++ b/packages/protocol/src/opportunity/opportunity.graph.ts
@@ -61,6 +61,9 @@ import { requestContext } from "../shared/observability/request-context.js";
 import type { OpportunityEvidence } from '../shared/schemas/network-assignment.schema.js';
 import { mergeOpportunityEvidence, withCandidateEvidence, withMatchedStrategies } from './opportunity.evidence.js';
 import { normalizeOpportunityActorIntent, resolveOpportunityActorIntent } from './opportunity.actor.js';
+import { approveOpportunityIntroduction, deleteOpportunityLifecycle, sendOpportunityLifecycle, updateOpportunityLifecycle, type QueueOpportunityNotificationFn } from './opportunity.lifecycle.js';
+
+export type { QueueOpportunityNotificationFn } from './opportunity.lifecycle.js';
 
 const logger = protocolLogger('OpportunityGraph');
 const prepLog = protocolLogger('OpportunityGraph:Prep');
@@ -190,13 +193,6 @@ export interface HydeGeneratorInvokeInput {
   forceRegenerate?: boolean;
   profileContext?: string;
 }
-
-/** Optional notifier for opportunity send; when omitted, the real queue is used via dynamic import. */
-export type QueueOpportunityNotificationFn = (
-  opportunityId: string,
-  recipientId: string,
-  priority: 'immediate' | 'high' | 'low'
-) => Promise<unknown>;
 
 /** Input for the host-side newborn pool-preference stamper (IND-420 P4b). */
 export interface StampNewbornOpportunitiesInput {
@@ -3872,67 +3868,12 @@ export class OpportunityGraphFactory {
         });
 
         try {
-          if (!state.opportunityId) {
-            return { mutationResult: { success: false, error: 'opportunityId is required.' } };
-          }
-          if (!state.newStatus || !['accepted', 'rejected', 'expired'].includes(state.newStatus)) {
-            return { mutationResult: { success: false, error: 'newStatus must be one of: accepted, rejected, expired.' } };
-          }
-
-          const opp = await this.database.getOpportunity(state.opportunityId);
-          if (!opp) {
-            return { mutationResult: { success: false, error: 'Opportunity not found.' } };
-          }
-          const callerActor = opp.actors.find((a: OpportunityActor) => a.userId === state.userId);
-          if (!callerActor) {
-            return { mutationResult: { success: false, error: 'You are not part of this opportunity.' } };
-          }
-
-          // Self-accept guard: only applies to the 'accepted' transition. Reject/expire
-          // remain available to all actors regardless of prior actedAt.
-          if (state.newStatus === 'accepted' && callerActor.actedAt) {
-            return {
-              mutationResult: {
-                success: false,
-                error: 'You have already acted on this opportunity. The other party must accept.',
-              },
-            };
-          }
-
-          let conversationId: string | undefined;
-          if (state.newStatus === 'accepted') {
-            const counterpart = opp.actors.find(
-              (a: OpportunityActor) => a.userId !== state.userId && a.role !== 'introducer'
-            );
-            if (counterpart) {
-              const dm = await this.database.getOrCreateDM(state.userId, counterpart.userId);
-              conversationId = dm.id;
-            }
-          }
-
-          if (state.newStatus === 'accepted') {
-            await this.database.stampOpportunityActorAction(
-              state.opportunityId,
-              state.userId,
-              'accepted',
-              state.userId,
-            );
-          } else {
-            // Reject/expire do not stamp actedAt on the caller; they are
-            // terminal flips, not commit signals. Keep the legacy path.
-            await this.database.updateOpportunityStatus(
-              state.opportunityId,
-              state.newStatus as 'rejected' | 'expired',
-            );
-          }
-
           return {
-            mutationResult: {
-              success: true,
+            mutationResult: await updateOpportunityLifecycle(this.database, {
               opportunityId: state.opportunityId,
-              message: `Opportunity status updated to ${state.newStatus}.`,
-              ...(conversationId && { conversationId }),
-            },
+              actorUserId: state.userId,
+              newStatus: state.newStatus,
+            }),
           };
         } catch (err) {
           updateLog.error('Failed', { error: err });
@@ -3952,27 +3893,11 @@ export class OpportunityGraphFactory {
         });
 
         try {
-          if (!state.opportunityId) {
-            return { mutationResult: { success: false, error: 'opportunityId is required.' } };
-          }
-
-          const opp = await this.database.getOpportunity(state.opportunityId);
-          if (!opp) {
-            return { mutationResult: { success: false, error: 'Opportunity not found.' } };
-          }
-          const isActor = opp.actors.some((a: OpportunityActor) => a.userId === state.userId);
-          if (!isActor) {
-            return { mutationResult: { success: false, error: 'You are not part of this opportunity.' } };
-          }
-
-          await this.database.updateOpportunityStatus(state.opportunityId, 'expired');
-
           return {
-            mutationResult: {
-              success: true,
+            mutationResult: await deleteOpportunityLifecycle(this.database, {
               opportunityId: state.opportunityId,
-              message: 'Opportunity archived (expired).',
-            },
+              actorUserId: state.userId,
+            }),
           };
         } catch (err) {
           deleteLog.error('Failed', { error: err });
@@ -3992,69 +3917,12 @@ export class OpportunityGraphFactory {
         });
 
         try {
-          if (!state.opportunityId) {
-            return { mutationResult: { success: false, error: 'opportunityId is required.' } };
-          }
-
-          const opp = await this.database.getOpportunity(state.opportunityId);
-          if (!opp) {
-            return { mutationResult: { success: false, error: 'Opportunity not found.' } };
-          }
-          const canSendStatus = opp.status === 'latent' || opp.status === 'draft';
-          if (!canSendStatus) {
-            return {
-              mutationResult: {
-                success: false,
-                error: `Opportunity is already ${opp.status}; only latent or draft opportunities can be sent.`,
-              },
-            };
-          }
-          const senderActor = opp.actors.find((a: OpportunityActor) => a.userId === state.userId);
-          const hasIntroducer = opp.actors.some((a: OpportunityActor) => a.role === 'introducer');
-          const canSend =
-            senderActor?.role === 'introducer' ||
-            senderActor?.role === 'peer' ||
-            (senderActor?.role === 'patient' && !hasIntroducer) ||
-            (senderActor?.role === 'party' && !hasIntroducer);
-          if (!senderActor) {
-            return { mutationResult: { success: false, error: 'You are not part of this opportunity.' } };
-          }
-          if (!canSend) {
-            return { mutationResult: { success: false, error: 'You cannot send this opportunity.' } };
-          }
-
-          await this.database.stampOpportunityActorAction(
-            state.opportunityId,
-            state.userId,
-            'pending',
-          );
-
-          // Notify only the role that becomes visible at the next tier
-          let recipients: OpportunityActor[];
-          if (senderActor.role === 'introducer') {
-            recipients = opp.actors.filter((a: OpportunityActor) => a.role === 'patient' || a.role === 'party');
-          } else if (senderActor.role === 'peer') {
-            recipients = opp.actors.filter((a: OpportunityActor) => a.role === 'peer' && a.userId !== state.userId);
-          } else {
-            recipients = opp.actors.filter((a: OpportunityActor) => a.role === 'agent');
-          }
-
-          // queueNotification is injected via constructor; if not provided, notifications are skipped.
-          const notifier: QueueOpportunityNotificationFn | undefined = this.queueNotification;
-          if (notifier) {
-            for (const recipient of recipients) {
-              await notifier(opp.id, recipient.userId, 'high');
-            }
-          }
-
-          const recipientIds = recipients.map((a: OpportunityActor) => a.userId);
           return {
-            mutationResult: {
-              success: true,
-              opportunityId: opp.id,
-              notified: recipientIds,
-              message: 'Opportunity sent. The other person has been notified.',
-            },
+            mutationResult: await sendOpportunityLifecycle(
+              this.database,
+              { opportunityId: state.opportunityId, actorUserId: state.userId },
+              this.queueNotification,
+            ),
           };
         } catch (err) {
           sendLog.error('Failed', { error: err });
@@ -4250,40 +4118,13 @@ export class OpportunityGraphFactory {
      * enqueues a negotiate_existing job so the parties negotiate normally.
      */
     const approveIntroductionNode = async (state: typeof OpportunityGraphState.State) => {
-      const { opportunityId, userId } = state;
-      if (!opportunityId) {
-        return { mutationResult: { success: false, error: 'opportunityId required for approve_introduction' } };
-      }
-
-      let opp;
-      try {
-        opp = await this.database.getOpportunity(opportunityId as string);
-      } catch (err) {
-        return { mutationResult: { success: false, error: `Failed to load opportunity: ${err instanceof Error ? err.message : String(err)}` } };
-      }
-      if (!opp) {
-        return { mutationResult: { success: false, error: 'Opportunity not found' } };
-      }
-
-      const introducerActor = (opp.actors as OpportunityActor[])
-        .find(a => a.role === 'introducer' && a.userId === userId);
-      if (!introducerActor) {
-        return { mutationResult: { success: false, error: 'You are not the introducer for this opportunity' } };
-      }
-      if (introducerActor.approved === true) {
-        return { mutationResult: { success: false, error: 'Introduction already approved' } };
-      }
-
-      const updated = await this.database.updateOpportunityActorApproval(opportunityId as string, userId as string, true);
-      if (!updated) {
-        return { mutationResult: { success: false, error: 'Failed to update approval' } };
-      }
-
-      if (this.queueNegotiateExisting) {
-        await this.queueNegotiateExisting(opportunityId as string, userId as string);
-      }
-
-      return { mutationResult: { success: true, opportunityId } };
+      return {
+        mutationResult: await approveOpportunityIntroduction(
+          this.database,
+          { opportunityId: state.opportunityId, actorUserId: state.userId },
+          this.queueNegotiateExisting,
+        ),
+      };
     };
 
     // ═══════════════════════════════════════════════════════════════

--- a/packages/protocol/src/opportunity/opportunity.lifecycle.ts
+++ b/packages/protocol/src/opportunity/opportunity.lifecycle.ts
@@ -1,0 +1,276 @@
+import type { Opportunity, OpportunityActor, OpportunityGraphDatabase } from '../shared/interfaces/database.interface.js';
+
+/** The mutation result shape returned by opportunity lifecycle graph nodes. */
+export interface OpportunityMutationResult {
+  success: boolean;
+  message?: string;
+  opportunityId?: string;
+  notified?: string[];
+  conversationId?: string;
+  error?: string;
+}
+
+/** Narrow persistence boundary for user-driven opportunity lifecycle actions. */
+export type OpportunityLifecyclePort = Pick<
+  OpportunityGraphDatabase,
+  | 'getOpportunity'
+  | 'getOrCreateDM'
+  | 'stampOpportunityActorAction'
+  | 'updateOpportunityActorApproval'
+  | 'updateOpportunityStatus'
+>;
+
+/** Host callback used to notify an actor after an opportunity becomes visible to them. */
+export type QueueOpportunityNotificationFn = (
+  opportunityId: string,
+  recipientId: string,
+  priority: 'immediate' | 'high' | 'low',
+) => Promise<unknown>;
+
+type StatusTransitionPlan =
+  | { kind: 'stamp_accepted'; counterpartUserId?: string }
+  | { kind: 'set_terminal_status'; status: 'rejected' | 'expired' };
+
+type SendOpportunityPlan = {
+  sender: OpportunityActor;
+  recipients: OpportunityActor[];
+};
+
+/**
+ * Applies status-transition admission rules before lifecycle persistence.
+ * Acceptance is a two-party action: an actor that already acted cannot accept
+ * again, while rejection and expiry remain available to any participating actor.
+ */
+export function assessOpportunityStatusTransition(
+  opportunity: Opportunity,
+  actorUserId: string,
+  newStatus: string | undefined,
+): StatusTransitionPlan | OpportunityMutationResult {
+  if (newStatus !== 'accepted' && newStatus !== 'rejected' && newStatus !== 'expired') {
+    return { success: false, error: 'newStatus must be one of: accepted, rejected, expired.' };
+  }
+
+  const callerActor = opportunity.actors.find((actor) => actor.userId === actorUserId);
+  if (!callerActor) {
+    return { success: false, error: 'You are not part of this opportunity.' };
+  }
+
+  if (newStatus === 'accepted') {
+    if (callerActor.actedAt) {
+      return {
+        success: false,
+        error: 'You have already acted on this opportunity. The other party must accept.',
+      };
+    }
+    return {
+      kind: 'stamp_accepted',
+      counterpartUserId: opportunity.actors.find(
+        (actor) => actor.userId !== actorUserId && actor.role !== 'introducer',
+      )?.userId,
+    };
+  }
+
+  return { kind: 'set_terminal_status', status: newStatus };
+}
+
+/**
+ * Applies send admission and recipient-routing rules without performing writes.
+ * Introducers, peers, and direct patient/party flows each reveal the next tier
+ * to a distinct audience.
+ */
+export function assessOpportunitySend(
+  opportunity: Opportunity,
+  actorUserId: string,
+): SendOpportunityPlan | OpportunityMutationResult {
+  if (opportunity.status !== 'latent' && opportunity.status !== 'draft') {
+    return {
+      success: false,
+      error: `Opportunity is already ${opportunity.status}; only latent or draft opportunities can be sent.`,
+    };
+  }
+
+  const sender = opportunity.actors.find((actor) => actor.userId === actorUserId);
+  if (!sender) {
+    return { success: false, error: 'You are not part of this opportunity.' };
+  }
+
+  const hasIntroducer = opportunity.actors.some((actor) => actor.role === 'introducer');
+  const canSend =
+    sender.role === 'introducer'
+    || sender.role === 'peer'
+    || (sender.role === 'patient' && !hasIntroducer)
+    || (sender.role === 'party' && !hasIntroducer);
+  if (!canSend) {
+    return { success: false, error: 'You cannot send this opportunity.' };
+  }
+
+  const recipients = sender.role === 'introducer'
+    ? opportunity.actors.filter((actor) => actor.role === 'patient' || actor.role === 'party')
+    : sender.role === 'peer'
+      ? opportunity.actors.filter((actor) => actor.role === 'peer' && actor.userId !== actorUserId)
+      : opportunity.actors.filter((actor) => actor.role === 'agent');
+  return { sender, recipients };
+}
+
+/** Checks whether a caller may approve this opportunity's introducer gate. */
+export function assessIntroductionApproval(
+  opportunity: Opportunity,
+  actorUserId: string,
+): OpportunityMutationResult | { kind: 'approve' } {
+  const introducerActor = opportunity.actors.find(
+    (actor) => actor.role === 'introducer' && actor.userId === actorUserId,
+  );
+  if (!introducerActor) {
+    return { success: false, error: 'You are not the introducer for this opportunity' };
+  }
+  if (introducerActor.approved === true) {
+    return { success: false, error: 'Introduction already approved' };
+  }
+  return { kind: 'approve' };
+}
+
+function isMutationResult(
+  value: StatusTransitionPlan | SendOpportunityPlan | OpportunityMutationResult | { kind: 'approve' },
+): value is OpportunityMutationResult {
+  return 'success' in value;
+}
+
+/** Persists an admitted status transition, preserving accept-before-write DM ordering. */
+export async function updateOpportunityLifecycle(
+  database: OpportunityLifecyclePort,
+  input: { opportunityId?: string; actorUserId: string; newStatus?: string },
+): Promise<OpportunityMutationResult> {
+  if (!input.opportunityId) {
+    return { success: false, error: 'opportunityId is required.' };
+  }
+  // Preserve the graph's legacy validation order: invalid transitions do not
+  // read persistence and always return the input error before actor checks.
+  if (input.newStatus !== 'accepted' && input.newStatus !== 'rejected' && input.newStatus !== 'expired') {
+    return { success: false, error: 'newStatus must be one of: accepted, rejected, expired.' };
+  }
+
+  const opportunity = await database.getOpportunity(input.opportunityId);
+  if (!opportunity) {
+    return { success: false, error: 'Opportunity not found.' };
+  }
+
+  const plan = assessOpportunityStatusTransition(opportunity, input.actorUserId, input.newStatus);
+  if (isMutationResult(plan)) return plan;
+
+  let conversationId: string | undefined;
+  if (plan.kind === 'stamp_accepted') {
+    if (plan.counterpartUserId) {
+      const dm = await database.getOrCreateDM(input.actorUserId, plan.counterpartUserId);
+      conversationId = dm.id;
+    }
+    await database.stampOpportunityActorAction(
+      input.opportunityId,
+      input.actorUserId,
+      'accepted',
+      input.actorUserId,
+    );
+  } else {
+    await database.updateOpportunityStatus(input.opportunityId, plan.status);
+  }
+
+  return {
+    success: true,
+    opportunityId: input.opportunityId,
+    message: `Opportunity status updated to ${input.newStatus}.`,
+    ...(conversationId && { conversationId }),
+  };
+}
+
+/** Expires an opportunity after verifying the caller is one of its actors. */
+export async function deleteOpportunityLifecycle(
+  database: OpportunityLifecyclePort,
+  input: { opportunityId?: string; actorUserId: string },
+): Promise<OpportunityMutationResult> {
+  if (!input.opportunityId) {
+    return { success: false, error: 'opportunityId is required.' };
+  }
+
+  const opportunity = await database.getOpportunity(input.opportunityId);
+  if (!opportunity) {
+    return { success: false, error: 'Opportunity not found.' };
+  }
+  if (!opportunity.actors.some((actor) => actor.userId === input.actorUserId)) {
+    return { success: false, error: 'You are not part of this opportunity.' };
+  }
+
+  await database.updateOpportunityStatus(input.opportunityId, 'expired');
+  return {
+    success: true,
+    opportunityId: input.opportunityId,
+    message: 'Opportunity archived (expired).',
+  };
+}
+
+/** Persists a send transition, then notifies only the actors exposed by its routing policy. */
+export async function sendOpportunityLifecycle(
+  database: OpportunityLifecyclePort,
+  input: { opportunityId?: string; actorUserId: string },
+  queueNotification?: QueueOpportunityNotificationFn,
+): Promise<OpportunityMutationResult> {
+  if (!input.opportunityId) {
+    return { success: false, error: 'opportunityId is required.' };
+  }
+
+  const opportunity = await database.getOpportunity(input.opportunityId);
+  if (!opportunity) {
+    return { success: false, error: 'Opportunity not found.' };
+  }
+
+  const plan = assessOpportunitySend(opportunity, input.actorUserId);
+  if (isMutationResult(plan)) return plan;
+
+  await database.stampOpportunityActorAction(input.opportunityId, input.actorUserId, 'pending');
+  if (queueNotification) {
+    for (const recipient of plan.recipients) {
+      await queueNotification(opportunity.id, recipient.userId, 'high');
+    }
+  }
+
+  return {
+    success: true,
+    opportunityId: opportunity.id,
+    notified: plan.recipients.map((actor) => actor.userId),
+    message: 'Opportunity sent. The other person has been notified.',
+  };
+}
+
+/** Approves an introducer gate before enqueuing the existing-opportunity negotiation. */
+export async function approveOpportunityIntroduction(
+  database: OpportunityLifecyclePort,
+  input: { opportunityId?: string; actorUserId: string },
+  queueNegotiateExisting?: (opportunityId: string, userId: string) => Promise<void>,
+): Promise<OpportunityMutationResult> {
+  if (!input.opportunityId) {
+    return { success: false, error: 'opportunityId required for approve_introduction' };
+  }
+
+  let opportunity: Opportunity | null;
+  try {
+    opportunity = await database.getOpportunity(input.opportunityId);
+  } catch (error) {
+    return {
+      success: false,
+      error: `Failed to load opportunity: ${error instanceof Error ? error.message : String(error)}`,
+    };
+  }
+  if (!opportunity) {
+    return { success: false, error: 'Opportunity not found' };
+  }
+
+  const admission = assessIntroductionApproval(opportunity, input.actorUserId);
+  if (isMutationResult(admission)) return admission;
+
+  const updated = await database.updateOpportunityActorApproval(input.opportunityId, input.actorUserId, true);
+  if (!updated) {
+    return { success: false, error: 'Failed to update approval' };
+  }
+  if (queueNegotiateExisting) {
+    await queueNegotiateExisting(input.opportunityId, input.actorUserId);
+  }
+  return { success: true, opportunityId: input.opportunityId };
+}

--- a/packages/protocol/src/opportunity/tests/opportunity.lifecycle.spec.ts
+++ b/packages/protocol/src/opportunity/tests/opportunity.lifecycle.spec.ts
@@ -1,0 +1,91 @@
+import { describe, expect, test } from 'bun:test';
+import type { Opportunity } from '../../shared/interfaces/database.interface.js';
+import { assessIntroductionApproval, assessOpportunitySend, assessOpportunityStatusTransition, updateOpportunityLifecycle, type OpportunityLifecyclePort } from '../opportunity.lifecycle.js';
+
+const OWNER_ID = 'u0000000-0000-4000-8000-000000000001';
+const COUNTERPARTY_ID = 'u0000000-0000-4000-8000-000000000002';
+const INTRODUCER_ID = 'u0000000-0000-4000-8000-000000000003';
+
+function buildOpportunity(overrides: Partial<Opportunity> = {}): Opportunity {
+  return {
+    id: 'op000000-0000-4000-8000-000000000001',
+    status: 'draft',
+    actors: [
+      { userId: OWNER_ID, role: 'patient', networkId: 'net00000-0000-4000-8000-000000000001' },
+      { userId: COUNTERPARTY_ID, role: 'agent', networkId: 'net00000-0000-4000-8000-000000000001' },
+    ],
+    detection: { source: 'manual' },
+    interpretation: { reasoning: '', confidence: 1 },
+    context: {},
+    confidence: '1',
+    createdAt: new Date(),
+    updatedAt: new Date(),
+    expiresAt: null,
+    ...overrides,
+  };
+}
+
+describe('opportunity lifecycle policies', () => {
+  test('rejects an invalid status before reading persistence', async () => {
+    let readCalled = false;
+    const port = {
+      getOpportunity: async () => {
+        readCalled = true;
+        return null;
+      },
+    } as OpportunityLifecyclePort;
+
+    const result = await updateOpportunityLifecycle(port, {
+      opportunityId: 'op000000-0000-4000-8000-000000000001',
+      actorUserId: OWNER_ID,
+      newStatus: 'pending',
+    });
+
+    expect(result).toEqual({ success: false, error: 'newStatus must be one of: accepted, rejected, expired.' });
+    expect(readCalled).toBe(false);
+  });
+
+  test('keeps acceptance two-party while allowing a prior actor to reject', () => {
+    const opportunity = buildOpportunity({
+      status: 'pending',
+      actors: [
+        { userId: OWNER_ID, role: 'patient', networkId: 'net00000-0000-4000-8000-000000000001', actedAt: new Date() },
+        { userId: COUNTERPARTY_ID, role: 'agent', networkId: 'net00000-0000-4000-8000-000000000001' },
+      ],
+    });
+
+    expect(assessOpportunityStatusTransition(opportunity, OWNER_ID, 'accepted')).toMatchObject({
+      success: false,
+      error: expect.stringMatching(/already acted/i),
+    });
+    expect(assessOpportunityStatusTransition(opportunity, OWNER_ID, 'rejected')).toEqual({
+      kind: 'set_terminal_status',
+      status: 'rejected',
+    });
+  });
+
+  test('routes an introducer send only to patient and party actors', () => {
+    const opportunity = buildOpportunity({
+      actors: [
+        { userId: OWNER_ID, role: 'patient', networkId: 'net00000-0000-4000-8000-000000000001' },
+        { userId: COUNTERPARTY_ID, role: 'agent', networkId: 'net00000-0000-4000-8000-000000000001' },
+        { userId: INTRODUCER_ID, role: 'introducer', networkId: 'net00000-0000-4000-8000-000000000001' },
+      ],
+    });
+
+    const plan = assessOpportunitySend(opportunity, INTRODUCER_ID);
+    expect('recipients' in plan && plan.recipients.map((actor) => actor.userId)).toEqual([OWNER_ID]);
+  });
+
+  test('only the unapproved assigned introducer passes the approval gate', () => {
+    const opportunity = buildOpportunity({
+      actors: [
+        { userId: OWNER_ID, role: 'patient', networkId: 'net00000-0000-4000-8000-000000000001' },
+        { userId: INTRODUCER_ID, role: 'introducer', networkId: 'net00000-0000-4000-8000-000000000001', approved: false },
+      ],
+    });
+
+    expect(assessIntroductionApproval(opportunity, INTRODUCER_ID)).toEqual({ kind: 'approve' });
+    expect(assessIntroductionApproval(opportunity, OWNER_ID)).toMatchObject({ success: false });
+  });
+});


### PR DESCRIPTION
## Summary
- Extract opportunity status, send, delete, and introducer-approval admission/persistence handlers into `opportunity.lifecycle.ts` behind a five-method `OpportunityLifecyclePort`.
- Keep LangGraph node wiring, logging, transaction boundaries, acceptance ordering, notification sequencing, and public `QueueOpportunityNotificationFn` export in place.
- Add focused policy tests and preserve invalid-status validation before any persistence read.

## Verification
- `bunx eslint packages/protocol/src/opportunity/opportunity.graph.ts packages/protocol/src/opportunity/opportunity.lifecycle.ts packages/protocol/src/opportunity/tests/opportunity.lifecycle.spec.ts` — pass (three pre-existing graph warnings; no errors).
- `cd packages/protocol && bun test src/opportunity/tests/opportunity.lifecycle.spec.ts src/opportunity/tests/opportunity.graph.update.spec.ts src/opportunity/tests/opportunity.graph.self-accept-guard.spec.ts src/opportunity/tests/opportunity.graph.send-actedAt.spec.ts src/opportunity/tests/introducer-gating-lifecycle.spec.ts` — 12 pass.
- `cd packages/protocol && bun run build` — pass.
- `cd packages/protocol && bun run architecture:check` — pass; host isolation, capability boundaries, cycles, artifacts, and architecture tests all pass.
- `git diff --check` — pass.

## Metrics
Reproducible static report (normalized seven-line duplicate windows; approximate cyclomatic count):
- `opportunity.graph.ts`: 4,451 → 4,292 LOC; 719 → 675 approximate file cyclomatic; 29 → 30 direct import fan-out; duplicate windows 55 → 48.
- Extracted lifecycle nodes: update 77/14 → 22/2 LOC/CC; delete 36/5 → 20/2; send 78/20 → 21/2; introducer approval 36/11 → 9/1. Combined: 227/50 → 72/7.

## Release
- Protocol patch SemVer: `6.13.0` → `6.13.1`; CHANGELOG updated.
- No dependency resolution changed, so `bun.lock` was not regenerated.

## Residual IND-530 scope
This PR is the first coherent, independently revertible opportunity-graph lifecycle batch. Remaining: other `opportunity.graph.ts` hotspots, `opportunity.tools.ts`, negotiation graph/tools, then discovery/feed orchestration.

Base branch is intentionally `feat/protocol-cleanup`; this draft must not target `dev` or `main`.