### PR TITLE
refactor(protocol): extract newborn stamping policy

### DIFF
--- a/packages/protocol/CHANGELOG.md
+++ b/packages/protocol/CHANGELOG.md
@@ -13,6 +13,9 @@ See [STABILITY.md](./STABILITY.md) for the public-contract and tier definitions.
 ## [Unreleased]
 
 ### Changed
+- Extract the owned-intent newborn-opportunity stamping eligibility policy and
+  fail-open host callback handler from the opportunity persist node while
+  preserving graph-owned persistence and observability (IND-530 Batch 2).
 - Extract opportunity lifecycle admission rules and persistence handlers from
   the graph while retaining its LangGraph node routing and externally visible
   lifecycle semantics (IND-530).

--- a/packages/protocol/package.json
+++ b/packages/protocol/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@indexnetwork/protocol",
-  "version": "6.13.1",
+  "version": "6.13.2",
   "type": "module",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",

--- a/packages/protocol/src/opportunity/opportunity.graph.ts
+++ b/packages/protocol/src/opportunity/opportunity.graph.ts
@@ -62,8 +62,10 @@ import type { OpportunityEvidence } from '../shared/schemas/network-assignment.s
 import { mergeOpportunityEvidence, withCandidateEvidence, withMatchedStrategies } from './opportunity.evidence.js';
 import { normalizeOpportunityActorIntent, resolveOpportunityActorIntent } from './opportunity.actor.js';
 import { approveOpportunityIntroduction, deleteOpportunityLifecycle, sendOpportunityLifecycle, updateOpportunityLifecycle, type QueueOpportunityNotificationFn } from './opportunity.lifecycle.js';
+import { stampEligibleNewbornOpportunities, type StampNewbornOpportunitiesFn } from './opportunity.newborn-stamping.js';
 
 export type { QueueOpportunityNotificationFn } from './opportunity.lifecycle.js';
+export type { StampNewbornOpportunitiesFn, StampNewbornOpportunitiesInput } from './opportunity.newborn-stamping.js';
 
 const logger = protocolLogger('OpportunityGraph');
 const prepLog = protocolLogger('OpportunityGraph:Prep');
@@ -192,52 +194,6 @@ export interface HydeGeneratorInvokeInput {
   sourceText: string;
   forceRegenerate?: boolean;
   profileContext?: string;
-}
-
-/** Input for the host-side newborn pool-preference stamper (IND-420 P4b). */
-export interface StampNewbornOpportunitiesInput {
-  ownerUserId: string;
-  intentId: string;
-  items: CreateOpportunityData[];
-}
-
-/**
- * Optional host callback that stamps call-local create items before INSERT.
- * It must preserve array length/order and may only enrich metadata/signals.
- */
-export type StampNewbornOpportunitiesFn = (
-  input: StampNewbornOpportunitiesInput,
-) => Promise<CreateOpportunityData[]>;
-
-function copyCreateOpportunityData(item: CreateOpportunityData): CreateOpportunityData {
-  return {
-    ...item,
-    detection: { ...item.detection },
-    actors: item.actors.map((actor) => ({ ...actor })),
-    interpretation: {
-      ...item.interpretation,
-      signals: item.interpretation.signals?.map((signal) => ({ ...signal })),
-    },
-    context: { ...item.context },
-    metadata: item.metadata ? { ...item.metadata } : item.metadata,
-  };
-}
-
-/** Fields a stamper is not allowed to change; also protects candidate order. */
-function newbornItemIdentity(item: CreateOpportunityData): string {
-  return JSON.stringify({
-    detection: item.detection,
-    actors: item.actors,
-    interpretation: {
-      category: item.interpretation.category,
-      reasoning: item.interpretation.reasoning,
-      confidence: item.interpretation.confidence,
-    },
-    context: item.context,
-    confidence: item.confidence,
-    status: item.status,
-    expiresAt: item.expiresAt?.toISOString(),
-  });
 }
 
 /**
@@ -3562,58 +3518,31 @@ export class OpportunityGraphFactory {
             itemsToPersist.push(data);
           }
 
-          // P4b seam: only genuinely new, create-mode, owned-intent discovery
-          // items reach the host stamper. Dedup reactivations/upgrades have
-          // already continued above; introductions, on-behalf-of, context-only,
-          // manual, and continuation flows are excluded explicitly.
-          let itemsForPersistence = itemsToPersist;
-          const stampIntentId = state.resolvedTriggerIntentId;
-          const mayStamp = Boolean(
-            this.stampNewbornOpportunities
-            && state.operationMode === 'create'
-            && !state.introductionContext
-            && !state.onBehalfOfUserId
-            && !state.targetUserId
-            && state.discoverySource === 'intent'
-            && stampIntentId
-            && state.indexedIntents.some((intent) => intent.intentId === stampIntentId),
-          );
-          if (mayStamp && stampIntentId && itemsToPersist.length > 0) {
-            const eligibleIndexes = itemsToPersist.flatMap((item, index) =>
-              item.detection.source === 'opportunity_graph' && item.detection.triggeredBy === stampIntentId
-                ? [index]
-                : []);
-            if (eligibleIndexes.length > 0) {
-              const originals = eligibleIndexes.map((index) => itemsToPersist[index]);
-              const callbackItems = originals.map(copyCreateOpportunityData);
-              try {
-                const stamped = await this.stampNewbornOpportunities!({
-                  ownerUserId: state.userId,
-                  intentId: stampIntentId,
-                  items: callbackItems,
-                });
-                const valid = Array.isArray(stamped)
-                  && stamped.length === originals.length
-                  && stamped.every((item, index) => newbornItemIdentity(item) === newbornItemIdentity(originals[index]));
-                if (valid) {
-                  itemsForPersistence = [...itemsToPersist];
-                  eligibleIndexes.forEach((itemIndex, stampedIndex) => {
-                    itemsForPersistence[itemIndex] = stamped[stampedIndex];
-                  });
-                } else {
-                  persistLog.warn('Newborn stamper returned unsafe length/order; persisting originals', {
-                    expected: originals.length,
-                    actual: Array.isArray(stamped) ? stamped.length : null,
-                  });
-                }
-              } catch (error) {
+          const itemsForPersistence = await stampEligibleNewbornOpportunities(
+            itemsToPersist,
+            {
+              ownerUserId: state.userId,
+              operationMode: state.operationMode,
+              hasIntroductionContext: Boolean(state.introductionContext),
+              onBehalfOfUserId: state.onBehalfOfUserId,
+              targetUserId: state.targetUserId,
+              discoverySource: state.discoverySource,
+              resolvedTriggerIntentId: state.resolvedTriggerIntentId,
+              indexedIntentIds: state.indexedIntents.map((intent) => intent.intentId),
+            },
+            this.stampNewbornOpportunities,
+            {
+              onUnsafeResult: ({ expected, actual }) => {
+                persistLog.warn('Newborn stamper returned unsafe length/order; persisting originals', { expected, actual });
+              },
+              onFailure: ({ intentId, error }) => {
                 persistLog.warn('Newborn stamper failed; persisting originals', {
-                  intentId: stampIntentId,
+                  intentId,
                   error: error instanceof Error ? error.message : String(error),
                 });
-              }
-            }
-          }
+              },
+            },
+          );
 
           const intentDedupScope = finalTriggerIntentId && state.discoverySource === 'intent'
             ? { triggerIntentId: finalTriggerIntentId, dedupWindowMs: DEDUP_WINDOW_MS }

--- a/packages/protocol/src/opportunity/opportunity.newborn-stamping.ts
+++ b/packages/protocol/src/opportunity/opportunity.newborn-stamping.ts
@@ -1,0 +1,127 @@
+import type { CreateOpportunityData } from '../shared/interfaces/database.interface.js';
+
+/** Input for the host-side newborn pool-preference stamper (IND-420 P4b). */
+export interface StampNewbornOpportunitiesInput {
+  ownerUserId: string;
+  intentId: string;
+  items: CreateOpportunityData[];
+}
+
+/**
+ * Optional host callback that stamps call-local create items before INSERT.
+ * It must preserve array length/order and may only enrich metadata/signals.
+ */
+export type StampNewbornOpportunitiesFn = (
+  input: StampNewbornOpportunitiesInput,
+) => Promise<CreateOpportunityData[]>;
+
+/** Persist-node facts that determine whether a new item may cross the host stamping boundary. */
+export interface NewbornStampingEligibility {
+  ownerUserId: string;
+  operationMode?: string;
+  hasIntroductionContext: boolean;
+  onBehalfOfUserId?: string;
+  targetUserId?: string;
+  discoverySource?: string;
+  resolvedTriggerIntentId?: string;
+  indexedIntentIds: readonly string[];
+}
+
+/** Fail-open events are injected so the graph retains its owning observability policy. */
+export interface NewbornStampingObserver {
+  onUnsafeResult?: (details: { expected: number; actual: number | null }) => void;
+  onFailure?: (details: { intentId: string; error: unknown }) => void;
+}
+
+function copyCreateOpportunityData(item: CreateOpportunityData): CreateOpportunityData {
+  return {
+    ...item,
+    detection: { ...item.detection },
+    actors: item.actors.map((actor) => ({ ...actor })),
+    interpretation: {
+      ...item.interpretation,
+      signals: item.interpretation.signals?.map((signal) => ({ ...signal })),
+    },
+    context: { ...item.context },
+    metadata: item.metadata ? { ...item.metadata } : item.metadata,
+  };
+}
+
+/** Fields a stamper is not allowed to change; this also protects candidate order. */
+function newbornItemIdentity(item: CreateOpportunityData): string {
+  return JSON.stringify({
+    detection: item.detection,
+    actors: item.actors,
+    interpretation: {
+      category: item.interpretation.category,
+      reasoning: item.interpretation.reasoning,
+      confidence: item.interpretation.confidence,
+    },
+    context: item.context,
+    confidence: item.confidence,
+    status: item.status,
+    expiresAt: item.expiresAt?.toISOString(),
+  });
+}
+
+/**
+ * Stamps only newly-created, owned-intent discovery items. Reactivations and
+ * manual, introducer, on-behalf-of, context-only, and continuation flows never
+ * cross this host boundary. Unsafe callback output and callback failures retain
+ * the original create items without changing their order.
+ */
+export async function stampEligibleNewbornOpportunities(
+  itemsToPersist: CreateOpportunityData[],
+  eligibility: NewbornStampingEligibility,
+  stamper?: StampNewbornOpportunitiesFn,
+  observer?: NewbornStampingObserver,
+): Promise<CreateOpportunityData[]> {
+  const stampIntentId = eligibility.resolvedTriggerIntentId;
+  const mayStamp = Boolean(
+    stamper
+    && eligibility.operationMode === 'create'
+    && !eligibility.hasIntroductionContext
+    && !eligibility.onBehalfOfUserId
+    && !eligibility.targetUserId
+    && eligibility.discoverySource === 'intent'
+    && stampIntentId
+    && eligibility.indexedIntentIds.includes(stampIntentId),
+  );
+  if (!mayStamp || !stampIntentId || itemsToPersist.length === 0 || !stamper) {
+    return itemsToPersist;
+  }
+
+  const eligibleIndexes = itemsToPersist.flatMap((item, index) =>
+    item.detection.source === 'opportunity_graph' && item.detection.triggeredBy === stampIntentId
+      ? [index]
+      : []);
+  if (eligibleIndexes.length === 0) return itemsToPersist;
+
+  const originals = eligibleIndexes.map((index) => itemsToPersist[index]);
+  try {
+    const stamped = await stamper({
+      ownerUserId: eligibility.ownerUserId,
+      intentId: stampIntentId,
+      items: originals.map(copyCreateOpportunityData),
+    });
+    const valid = Array.isArray(stamped)
+      && stamped.length === originals.length
+      && stamped.every((item, index) => newbornItemIdentity(item) === newbornItemIdentity(originals[index]));
+    if (!valid) {
+      observer?.onUnsafeResult?.({
+        expected: originals.length,
+        actual: Array.isArray(stamped) ? stamped.length : null,
+      });
+      return itemsToPersist;
+    }
+
+    const itemsForPersistence = [...itemsToPersist];
+    eligibleIndexes.forEach((itemIndex, stampedIndex) => {
+      itemsForPersistence[itemIndex] = stamped[stampedIndex];
+    });
+    return itemsForPersistence;
+  } catch (error) {
+    observer?.onFailure?.({ intentId: stampIntentId, error });
+    return itemsToPersist;
+  }
+}


### PR DESCRIPTION
## Batch 2 summary
- Extract the owned-intent newborn-opportunity stamping eligibility policy and fail-open host callback handler into `opportunity.newborn-stamping.ts`.
- Keep LangGraph persist-node orchestration, persistence transaction boundaries, and graph-owned logging in `opportunity.graph.ts`.
- Preserve public `StampNewbornOpportunitiesInput` and `StampNewbornOpportunitiesFn` deep exports through graph re-exports.

## Behavioral guarantees
- Only create-mode, owned-intent discovery reaches the injected host stamper; reactivations, manual, introducer, on-behalf-of, target-user, context-only, and continuation flows remain excluded.
- The callback receives cloned items; length/order/identity changes fail open to original items. Callback failures fail open, and graph-owned warning events retain their existing content.

## Verification
- `bunx eslint packages/protocol/src/opportunity/opportunity.graph.ts packages/protocol/src/opportunity/opportunity.newborn-stamping.ts` — pass with 3 pre-existing graph warnings and no errors.
- `cd packages/protocol && bun test src/opportunity/tests/opportunity.graph.dedup.spec.ts` — 19 pass.
- `cd packages/protocol && bun run build` — pass.
- `cd packages/protocol && bun run architecture:check` — pass.
- `git diff --check` — pass.

## Metrics
Reproducible static report (approximate cyclomatic count; normalized seven-line duplicate windows):
- `opportunity.graph.ts`: 4,292 → 4,221 LOC; approximate CC 675 → 658; direct import fan-out 30 → 31; duplicate windows 48 → 48.
- Stamping call path in graph: 52/17 → 25/1 LOC/CC. The named handler is 55 LOC / CC 18 and owns the isolated policy.

## Release
- Protocol patch SemVer: `6.13.1` → `6.13.2`; CHANGELOG updated.
- No package resolution changed; `bun.lock` was not regenerated.

## Exact residual IND-530 scope
- Remaining coherent `opportunity.graph.ts` hotspots (including persistence/dedup and existing-negotiation paths).
- `opportunity.tools.ts`, then negotiation graph/tools, then opportunity discovery/feed orchestration.

This is Batch 2 only. Base is intentionally `feat/protocol-cleanup`, never `dev` or `main`.