### PR TITLE
refactor(protocol): extract existing opportunity negotiation handler

### DIFF
--- a/packages/protocol/CHANGELOG.md
+++ b/packages/protocol/CHANGELOG.md
@@ -13,6 +13,10 @@ See [STABILITY.md](./STABILITY.md) for the public-contract and tier definitions.
 ## [Unreleased]
 
 ### Changed
+- Extract the existing-opportunity negotiation continuation admission,
+  exact-intent translation, and non-introducer notification handler behind a
+  narrow opportunity persistence port while retaining graph-owned node wiring
+  and observability (IND-530 Batch 3).
 - Extract the owned-intent newborn-opportunity stamping eligibility policy and
   fail-open host callback handler from the opportunity persist node while
   preserving graph-owned persistence and observability (IND-530 Batch 2).

--- a/packages/protocol/package.json
+++ b/packages/protocol/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@indexnetwork/protocol",
-  "version": "6.13.2",
+  "version": "6.13.3",
   "type": "module",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",

--- a/packages/protocol/src/opportunity/opportunity.existing-negotiation.ts
+++ b/packages/protocol/src/opportunity/opportunity.existing-negotiation.ts
@@ -1,0 +1,175 @@
+import type { ActiveIntent, NegotiationContinuationExecution, NegotiationContinuationReceipt, Opportunity, OpportunityGraphDatabase } from '../shared/interfaces/database.interface.js';
+import { resolveOpportunityActorIntent } from './opportunity.actor.js';
+import type { QueueOpportunityNotificationFn } from './opportunity.lifecycle.js';
+
+const NEGOTIATION_INTENT_LIMIT = 5;
+
+interface NegotiationIntentSource {
+  id?: string | null;
+  summary?: string | null;
+  payload?: string | null;
+}
+
+interface ExistingOpportunityNegotiationUser {
+  id: string;
+  intents: Array<{ id: string; title: string; description: string; confidence: number }>;
+  profile: { name?: string; bio?: string; location?: string; interests?: string[]; skills?: string[] };
+}
+
+interface ExistingOpportunityNegotiationCandidate {
+  userId: string;
+  sourceIntentId?: string;
+  candidateIntentId?: string;
+  opportunityId?: string;
+  opportunityStatus?: Opportunity['status'];
+  opportunityUpdatedAt?: Date;
+  reasoning: string;
+  valencyRole: string;
+  networkId?: string;
+  candidateUser: ExistingOpportunityNegotiationUser;
+}
+
+/** Put an opportunity actor's exact intent first, then fill the bounded context without duplicates. */
+export function buildPrioritizedNegotiationIntents(
+  activeIntents: readonly NegotiationIntentSource[],
+  exactIntentId?: string | null,
+  fallbackIntent?: NegotiationIntentSource | null,
+): ExistingOpportunityNegotiationUser['intents'] {
+  const exactId = typeof exactIntentId === 'string' && exactIntentId.trim().length > 0 ? exactIntentId : null;
+  const exactActive = exactId ? activeIntents.find((intent) => intent.id === exactId) : undefined;
+  const ordered = [
+    ...(exactActive ? [exactActive] : []),
+    ...(!exactActive && fallbackIntent?.id === exactId ? [fallbackIntent] : []),
+    ...activeIntents,
+  ];
+  const seen = new Set<string>();
+  const intents: ExistingOpportunityNegotiationUser['intents'] = [];
+  for (const intent of ordered) {
+    if (typeof intent.id !== 'string' || intent.id.trim().length === 0 || seen.has(intent.id)) continue;
+    seen.add(intent.id);
+    intents.push({ id: intent.id, title: intent.summary ?? '', description: intent.payload ?? '', confidence: 1 });
+    if (intents.length === NEGOTIATION_INTENT_LIMIT) break;
+  }
+  return intents;
+}
+
+/** Narrow port for translating one persisted opportunity into a negotiation invocation. */
+export type ExistingOpportunityNegotiationPort = Pick<
+  OpportunityGraphDatabase,
+  'getActiveIntents' | 'getIntent' | 'getNetworkMemberContext' | 'getOpportunity' | 'getProfile' | 'getUser'
+>;
+
+export interface ExistingOpportunityNegotiationInput {
+  opportunityId: string;
+  actorUserId: string;
+  continuation?: NegotiationContinuationExecution;
+}
+
+/** Graph-owned execution port: the handler prepares policy-bound input, while the graph retains negotiation orchestration. */
+export type ExecuteExistingOpportunityNegotiation = (input: {
+  sourceUser: ExistingOpportunityNegotiationUser;
+  candidate: ExistingOpportunityNegotiationCandidate;
+  indexContextOverrides: Map<string, string>;
+  continuation?: NegotiationContinuationExecution;
+}) => Promise<{ accepted: boolean; receipt?: NegotiationContinuationReceipt }>;
+
+export type ExistingOpportunityNegotiationOutcome =
+  | { kind: 'skipped'; reason: 'not_found' | 'stale_continuation' | 'no_source_actor' | 'no_candidate_actor' }
+  | { kind: 'completed'; opportunityId: string; accepted: boolean; continuationFence?: number; receipt?: NegotiationContinuationReceipt };
+
+export interface ExistingOpportunityNegotiationObserver {
+  onNotificationFailure?: (details: { actorId: string; error: unknown }) => void;
+}
+
+/**
+ * Revalidates continuation actor bindings, builds exact intent-prioritized
+ * bilateral negotiation input, and notifies the non-introducer actors only
+ * after an accepted non-continuation negotiation.
+ */
+export async function negotiateExistingOpportunity(
+  database: ExistingOpportunityNegotiationPort,
+  executeNegotiation: ExecuteExistingOpportunityNegotiation,
+  input: ExistingOpportunityNegotiationInput,
+  queueNotification?: QueueOpportunityNotificationFn,
+  observer?: ExistingOpportunityNegotiationObserver,
+): Promise<ExistingOpportunityNegotiationOutcome> {
+  const opportunity = await database.getOpportunity(input.opportunityId);
+  if (!opportunity) return { kind: 'skipped', reason: 'not_found' };
+
+  const nonIntroducerActors = opportunity.actors.filter((actor) => actor.role !== 'introducer');
+  const continuation = input.continuation;
+  if (continuation) {
+    const recipientActor = nonIntroducerActors.find((actor) => actor.userId === input.actorUserId);
+    const counterpartyActor = nonIntroducerActors.find((actor) => actor.userId === continuation.counterpartyUserId);
+    if (
+      !recipientActor
+      || resolveOpportunityActorIntent(recipientActor) !== continuation.recipientIntentId
+      || recipientActor.networkId !== continuation.networkId
+      || !counterpartyActor
+      || resolveOpportunityActorIntent(counterpartyActor) !== continuation.counterpartyIntentId
+      || counterpartyActor.networkId !== continuation.networkId
+    ) return { kind: 'skipped', reason: 'stale_continuation' };
+  }
+
+  const sourceActor = nonIntroducerActors.find((actor) => actor.role === 'patient' || actor.role === 'party') ?? nonIntroducerActors[0];
+  if (!sourceActor) return { kind: 'skipped', reason: 'no_source_actor' };
+  const candidateActor = nonIntroducerActors.find((actor) => actor.userId !== sourceActor.userId);
+  if (!candidateActor) return { kind: 'skipped', reason: 'no_candidate_actor' };
+
+  const sourceIntentId = resolveOpportunityActorIntent(sourceActor);
+  const candidateIntentId = resolveOpportunityActorIntent(candidateActor);
+  const [sourceAccount, sourceProfile, sourceIntents, candidateAccount, candidateProfile, candidateIntents] = await Promise.all([
+    database.getUser(sourceActor.userId).catch(() => null),
+    database.getProfile(sourceActor.userId).catch(() => null),
+    database.getActiveIntents(sourceActor.userId).catch(() => [] as ActiveIntent[]),
+    database.getUser(candidateActor.userId).catch(() => null),
+    database.getProfile(candidateActor.userId).catch(() => null),
+    database.getActiveIntents(candidateActor.userId).catch(() => [] as ActiveIntent[]),
+  ]);
+  const [sourceFallbackIntent, candidateFallbackIntent] = await Promise.all([
+    sourceIntentId && !sourceIntents.some((intent) => intent.id === sourceIntentId) ? database.getIntent(sourceIntentId).catch(() => null) : null,
+    candidateIntentId && !candidateIntents.some((intent) => intent.id === candidateIntentId) ? database.getIntent(candidateIntentId).catch(() => null) : null,
+  ]);
+  const sourceUser = {
+    id: sourceActor.userId,
+    intents: buildPrioritizedNegotiationIntents(sourceIntents, sourceIntentId, sourceFallbackIntent?.userId === sourceActor.userId ? sourceFallbackIntent : null),
+    profile: {
+      name: sourceProfile?.identity?.name ?? sourceAccount?.name,
+      bio: sourceProfile?.identity?.bio ?? sourceAccount?.intro ?? undefined,
+      location: sourceProfile?.identity?.location ?? sourceAccount?.location ?? undefined,
+    },
+  };
+  const candidate: ExistingOpportunityNegotiationCandidate = {
+    userId: candidateActor.userId,
+    ...(sourceIntentId ? { sourceIntentId } : {}),
+    ...(candidateIntentId ? { candidateIntentId } : {}),
+    opportunityId: opportunity.id,
+    opportunityStatus: opportunity.status,
+    opportunityUpdatedAt: opportunity.updatedAt,
+    reasoning: (opportunity.interpretation as { reasoning?: string } | null)?.reasoning ?? '',
+    valencyRole: candidateActor.role ?? 'peer',
+    networkId: candidateActor.networkId,
+    candidateUser: {
+      id: candidateActor.userId,
+      intents: buildPrioritizedNegotiationIntents(candidateIntents, candidateIntentId, candidateFallbackIntent?.userId === candidateActor.userId ? candidateFallbackIntent : null),
+      profile: {
+        name: candidateProfile?.identity?.name ?? candidateAccount?.name,
+        bio: candidateProfile?.identity?.bio ?? candidateAccount?.intro ?? undefined,
+        location: candidateProfile?.identity?.location ?? candidateAccount?.location ?? undefined,
+      },
+    },
+  };
+  const indexContextMap = new Map<string, string>();
+  if (candidate.networkId) {
+    const context = await database.getNetworkMemberContext(candidate.networkId, sourceActor.userId).catch(() => null);
+    const prompt = [context?.indexPrompt, context?.memberPrompt].filter((value): value is string => !!value?.trim()).join('\n\n');
+    if (prompt) indexContextMap.set(candidate.networkId, prompt);
+  }
+  const execution = await executeNegotiation({ sourceUser, candidate, indexContextOverrides: indexContextMap, continuation });
+  if (execution.accepted && queueNotification && !continuation) {
+    for (const actor of nonIntroducerActors) {
+      await queueNotification(opportunity.id, actor.userId, 'high').catch((error) => observer?.onNotificationFailure?.({ actorId: actor.userId, error }));
+    }
+  }
+  return { kind: 'completed', opportunityId: opportunity.id, accepted: execution.accepted, continuationFence: continuation?.fence, ...(execution.receipt ? { receipt: execution.receipt } : {}) };
+}

--- a/packages/protocol/src/opportunity/opportunity.graph.ts
+++ b/packages/protocol/src/opportunity/opportunity.graph.ts
@@ -52,7 +52,7 @@ import { persistOpportunities } from './opportunity.persist.js';
 import { INTRODUCER_DISCOVERY_SOURCE } from './opportunity.introducer.js';
 import { negotiateCandidates, type NegotiationCandidate, type OnNegotiationResolved, ASK_USER_LOCK_SLACK_MS, askUserAnswerWindowMs, AMBIENT_PARK_WINDOW_MS } from "../capabilities/negotiation.discovery.facade.js";
 import { buildDiscoverySummary, toDiscoveryNegotiation, type NegotiationResolution } from "./negotiation-summary.builder.js";
-import type { NegotiationGraphLike, UserNegotiationContext } from "../capabilities/negotiation.discovery.facade.js";
+import type { NegotiationGraphLike } from "../capabilities/negotiation.discovery.facade.js";
 import type { AgentDispatcher } from "../shared/interfaces/agent-dispatcher.interface.js";
 import { protocolLogger, withCallLogging } from '../shared/observability/protocol.logger.js';
 import { timed } from '../shared/observability/performance.js';
@@ -63,9 +63,11 @@ import { mergeOpportunityEvidence, withCandidateEvidence, withMatchedStrategies 
 import { normalizeOpportunityActorIntent, resolveOpportunityActorIntent } from './opportunity.actor.js';
 import { approveOpportunityIntroduction, deleteOpportunityLifecycle, sendOpportunityLifecycle, updateOpportunityLifecycle, type QueueOpportunityNotificationFn } from './opportunity.lifecycle.js';
 import { stampEligibleNewbornOpportunities, type StampNewbornOpportunitiesFn } from './opportunity.newborn-stamping.js';
+import { buildPrioritizedNegotiationIntents, negotiateExistingOpportunity } from './opportunity.existing-negotiation.js';
 
 export type { QueueOpportunityNotificationFn } from './opportunity.lifecycle.js';
 export type { StampNewbornOpportunitiesFn, StampNewbornOpportunitiesInput } from './opportunity.newborn-stamping.js';
+export { buildPrioritizedNegotiationIntents } from './opportunity.existing-negotiation.js';
 
 const logger = protocolLogger('OpportunityGraph');
 const prepLog = protocolLogger('OpportunityGraph:Prep');
@@ -89,7 +91,6 @@ const routingLog = protocolLogger('OpportunityGraph:Routing');
 
 /** Time window for persist-node dedup. Suppresses a second opportunity with the same person while a recent one (within 30 days) is still in flight, so a person is not re-surfaced multiple times within a month (EDG-23). */
 const DEDUP_WINDOW_MS = 30 * 24 * 60 * 60 * 1000;
-const NEGOTIATION_INTENT_LIMIT = 5;
 const ACTIVE_NEGOTIATION_TASK_STATES = new Set([
   'submitted',
   'working',
@@ -119,47 +120,6 @@ function belongsToOwnedIntent(
   return opportunity.detection.triggeredBy === triggerIntentId
     || opportunity.actors.some((actor) =>
       actor.userId === ownerUserId && actor.intent === triggerIntentId);
-}
-
-interface NegotiationIntentSource {
-  id?: string | null;
-  summary?: string | null;
-  payload?: string | null;
-}
-
-/** Put an opportunity actor's exact intent first, then fill the bounded context without duplicates. */
-export function buildPrioritizedNegotiationIntents(
-  activeIntents: readonly NegotiationIntentSource[],
-  exactIntentId?: string | null,
-  fallbackIntent?: NegotiationIntentSource | null,
-): UserNegotiationContext['intents'] {
-  const exactId = typeof exactIntentId === 'string' && exactIntentId.trim().length > 0
-    ? exactIntentId
-    : null;
-  const exactActive = exactId
-    ? activeIntents.find((intent) => intent.id === exactId)
-    : undefined;
-  const ordered = [
-    ...(exactActive ? [exactActive] : []),
-    ...(!exactActive && fallbackIntent?.id === exactId ? [fallbackIntent] : []),
-    ...activeIntents,
-  ];
-  const seen = new Set<string>();
-  const intents: UserNegotiationContext['intents'] = [];
-
-  for (const intent of ordered) {
-    if (typeof intent.id !== 'string' || intent.id.trim().length === 0 || seen.has(intent.id)) continue;
-    seen.add(intent.id);
-    intents.push({
-      id: intent.id,
-      title: intent.summary ?? '',
-      description: intent.payload ?? '',
-      confidence: 1,
-    });
-    if (intents.length === NEGOTIATION_INTENT_LIMIT) break;
-  }
-
-  return intents;
 }
 
 /** Default cap for source premises used by premise-to-premise discovery. Prevents BACKEND-5-style fan-out. */
@@ -3874,164 +3834,64 @@ export class OpportunityGraphFactory {
       }
 
       try {
-        const opp = await this.database.getOpportunity(state.opportunityId as string);
-        if (!opp) {
-          negotiateExistingLog.warn('Opportunity not found', { opportunityId: state.opportunityId });
-          return {};
-        }
-
-        const actors = opp.actors as Array<OpportunityActor & { intentId?: string }>;
-        const nonIntroducerActors = actors.filter(a => a.role !== 'introducer');
         const continuation = state.options.negotiationContinuation;
-        if (continuation) {
-          const recipientActor = nonIntroducerActors.find((actor) => actor.userId === state.userId);
-          const counterpartyActor = nonIntroducerActors.find((actor) => actor.userId === continuation.counterpartyUserId);
-          if (
-            !recipientActor
-            || resolveOpportunityActorIntent(recipientActor) !== continuation.recipientIntentId
-            || recipientActor.networkId !== continuation.networkId
-            || !counterpartyActor
-            || resolveOpportunityActorIntent(counterpartyActor) !== continuation.counterpartyIntentId
-            || counterpartyActor.networkId !== continuation.networkId
-          ) {
-            negotiateExistingLog.warn('Exact continuation actor binding is stale', {
-              opportunityId: state.opportunityId,
-              taskId: continuation.taskId,
-            });
-            return {};
-          }
-        }
-
-        // Find the sourceActor: non-introducer with role patient or party, fallback to first non-introducer
-        const sourceActor = nonIntroducerActors.find(a => a.role === 'patient' || a.role === 'party')
-          ?? nonIntroducerActors[0];
-        if (!sourceActor) {
-          negotiateExistingLog.warn('No source actor found', { opportunityId: state.opportunityId });
-          return {};
-        }
-
-        // Find the candidateActor: non-introducer that is NOT the sourceActor
-        const candidateActor = nonIntroducerActors.find(a => a.userId !== sourceActor.userId);
-        if (!candidateActor) {
-          negotiateExistingLog.warn('No candidate actor found', { opportunityId: state.opportunityId });
-          return {};
-        }
-
-        const sourceIntentId = resolveOpportunityActorIntent(sourceActor);
-        const candidateIntentId = resolveOpportunityActorIntent(candidateActor);
-
-        // Load user data for both actors in parallel
-        const [sourceUserAccount, sourceProfile, sourceIntents, candidateAccount, candidateProfile, candidateIntents] =
-          await Promise.all([
-            this.database.getUser(sourceActor.userId).catch(() => null),
-            this.database.getProfile(sourceActor.userId).catch(() => null),
-            this.database.getActiveIntents(sourceActor.userId).catch(() => [] as ActiveIntent[]),
-            this.database.getUser(candidateActor.userId).catch(() => null),
-            this.database.getProfile(candidateActor.userId).catch(() => null),
-            this.database.getActiveIntents(candidateActor.userId).catch(() => [] as ActiveIntent[]),
-          ]);
-
-        const sourceHasExactIntent = sourceIntents.some((intent) => intent.id === sourceIntentId);
-        const candidateHasExactIntent = candidateIntents.some((intent) => intent.id === candidateIntentId);
-        const [sourceFallbackIntent, candidateFallbackIntent] = await Promise.all([
-          sourceIntentId && !sourceHasExactIntent
-            ? this.database.getIntent(sourceIntentId).catch(() => null)
-            : null,
-          candidateIntentId && !candidateHasExactIntent
-            ? this.database.getIntent(candidateIntentId).catch(() => null)
-            : null,
-        ]);
-
-        const sourceUser = {
-          id: sourceActor.userId,
-          intents: buildPrioritizedNegotiationIntents(
-            sourceIntents,
-            sourceIntentId,
-            sourceFallbackIntent?.userId === sourceActor.userId ? sourceFallbackIntent : null,
-          ),
-          profile: {
-            name: sourceProfile?.identity?.name ?? sourceUserAccount?.name,
-            bio: sourceProfile?.identity?.bio ?? sourceUserAccount?.intro ?? undefined,
-            location: sourceProfile?.identity?.location ?? sourceUserAccount?.location ?? undefined,
+        const result = await negotiateExistingOpportunity(
+          this.database,
+          async ({ sourceUser, candidate, indexContextOverrides, continuation: execution }) => {
+            let receipt: NegotiationContinuationReceipt | undefined;
+            // Deliberately no `initiatorUserId`: re-entries inherit the prior task's
+            // stamped seat in negotiation initialization, never re-deriving it here.
+            const acceptedResults = await negotiateCandidates(
+              this.negotiationGraph!,
+              sourceUser,
+              [candidate],
+              { networkId: '', prompt: '' },
+              {
+                maxTurns: Number(process.env.NEGOTIATION_MAX_TURNS_AMBIENT) || 6,
+                indexContextOverrides,
+                timeoutMs: AMBIENT_PARK_WINDOW_MS,
+                trigger: 'ambient',
+                ...(execution ? {
+                  resumeFromTaskId: execution.taskId,
+                  continuationSettlementId: execution.settlementId,
+                  continuationExecution: execution,
+                  onCandidateResolved: async ({ continuationReceipt }) => {
+                    if (continuationReceipt?.successorTaskId === execution.successorTaskId) receipt = continuationReceipt;
+                  },
+                } : {}),
+              },
+            );
+            return { accepted: acceptedResults.length > 0, ...(receipt ? { receipt } : {}) };
           },
-        };
-
-        const candidateIntentsForNeg = buildPrioritizedNegotiationIntents(
-          candidateIntents,
-          candidateIntentId,
-          candidateFallbackIntent?.userId === candidateActor.userId ? candidateFallbackIntent : null,
-        );
-
-        const candidate: NegotiationCandidate = {
-          userId: candidateActor.userId,
-          ...(sourceIntentId ? { sourceIntentId } : {}),
-          ...(candidateIntentId ? { candidateIntentId } : {}),
-          opportunityId: opp.id as string,
-          opportunityStatus: opp.status,
-          opportunityUpdatedAt: opp.updatedAt,
-          reasoning: (opp.interpretation as { reasoning?: string } | null)?.reasoning ?? '',
-          valencyRole: candidateActor.role ?? 'peer',
-          networkId: (candidateActor as { networkId?: string }).networkId as string,
-          candidateUser: {
-            id: candidateActor.userId,
-            intents: candidateIntentsForNeg,
-            profile: {
-              name: candidateProfile?.identity?.name ?? candidateAccount?.name,
-              bio: candidateProfile?.identity?.bio ?? candidateAccount?.intro ?? undefined,
-              location: candidateProfile?.identity?.location ?? candidateAccount?.location ?? undefined,
+          { opportunityId: state.opportunityId, actorUserId: state.userId, continuation },
+          this.queueNotification,
+          {
+            onNotificationFailure: ({ actorId, error }) => {
+              negotiateExistingLog.warn('Failed to queue notification', { actorId, error });
             },
           },
-        };
-
-        // Load index context for the candidate's network
-        const indexContextMap = new Map<string, string>();
-        if (candidate.networkId) {
-          const ctx = await this.database.getNetworkMemberContext(candidate.networkId, sourceActor.userId).catch(() => null);
-          const prompt = [ctx?.indexPrompt, ctx?.memberPrompt]
-            .filter((v): v is string => !!v?.trim())
-            .join('\n\n');
-          if (prompt) indexContextMap.set(candidate.networkId, prompt);
-        }
-
-        // Deliberately no `initiatorUserId` here: re-entries inherit the stamp
-        // from the prior task's metadata inside the negotiation init node
-        // (continuations never re-derive the seat). The role heuristic above
-        // remains only as the fallback for pre-stamp tasks.
-        let continuationReceipt: NegotiationContinuationReceipt | undefined;
-        const acceptedResults = await negotiateCandidates(
-          this.negotiationGraph, sourceUser, [candidate],
-          { networkId: '', prompt: '' },
-          {
-            maxTurns: Number(process.env.NEGOTIATION_MAX_TURNS_AMBIENT) || 6,
-            indexContextOverrides: indexContextMap,
-            timeoutMs: AMBIENT_PARK_WINDOW_MS,
-            trigger: 'ambient',
-            ...(continuation ? {
-              resumeFromTaskId: continuation.taskId,
-              continuationSettlementId: continuation.settlementId,
-              continuationExecution: continuation,
-              onCandidateResolved: async ({ continuationReceipt: receipt }) => {
-                if (receipt?.successorTaskId === continuation.successorTaskId) continuationReceipt = receipt;
-              },
-            } : {}),
-          },
         );
 
-        // Send notifications to non-introducer actors if negotiation was accepted
-        if (acceptedResults.length > 0 && this.queueNotification && !continuation) {
-          for (const actor of nonIntroducerActors) {
-            await this.queueNotification(opp.id, actor.userId, 'high').catch((err) => {
-              negotiateExistingLog.warn('Failed to queue notification', { actorId: actor.userId, error: err });
-            });
-          }
+        if (result.kind === 'skipped') {
+          const messages = {
+            not_found: 'Opportunity not found',
+            stale_continuation: 'Exact continuation actor binding is stale',
+            no_source_actor: 'No source actor found',
+            no_candidate_actor: 'No candidate actor found',
+          } as const;
+          negotiateExistingLog.warn(messages[result.reason], {
+            opportunityId: state.opportunityId,
+            ...(result.reason === 'stale_continuation' && continuation ? { taskId: continuation.taskId } : {}),
+          });
+          return {};
         }
 
         negotiateExistingLog.info('Negotiation complete', {
-          opportunityId: opp.id,
-          accepted: acceptedResults.length > 0,
-          continuationFence: continuation?.fence,
+          opportunityId: result.opportunityId,
+          accepted: result.accepted,
+          continuationFence: result.continuationFence,
         });
-        return continuationReceipt ? { negotiationContinuationReceipt: continuationReceipt } : {};
+        return result.receipt ? { negotiationContinuationReceipt: result.receipt } : {};
       } catch (err) {
         negotiateExistingLog.error('Failed', { opportunityId: state.opportunityId, error: err });
         return { error: `Failed to load opportunity: ${err instanceof Error ? err.message : String(err)}` };

--- a/packages/protocol/src/opportunity/tests/opportunity.existing-negotiation.spec.ts
+++ b/packages/protocol/src/opportunity/tests/opportunity.existing-negotiation.spec.ts
@@ -1,0 +1,51 @@
+import { describe, expect, test } from 'bun:test';
+import type { Id, Opportunity } from '../../shared/interfaces/database.interface.js';
+import { negotiateExistingOpportunity, type ExistingOpportunityNegotiationPort } from '../opportunity.existing-negotiation.js';
+
+describe('negotiateExistingOpportunity', () => {
+  test('fails closed before negotiation when a continuation actor binding is stale', async () => {
+    const opportunity = {
+      id: 'opp-existing',
+      actors: [
+        { userId: 'recipient' as Id<'users'>, role: 'patient' as const, networkId: 'network-1' as Id<'networks'>, intent: 'intent-recipient' as Id<'intents'> },
+        { userId: 'counterparty' as Id<'users'>, role: 'agent' as const, networkId: 'network-1' as Id<'networks'>, intent: 'intent-counterparty' as Id<'intents'> },
+      ],
+    } as unknown as Opportunity;
+    const database = {
+      getOpportunity: async () => opportunity,
+    } as unknown as ExistingOpportunityNegotiationPort;
+    const executeNegotiation = async () => {
+        throw new Error('stale continuation must not invoke negotiation');
+      };
+
+    const result = await negotiateExistingOpportunity(
+      database,
+      executeNegotiation,
+      {
+        opportunityId: 'opp-existing',
+        actorUserId: 'recipient',
+        continuation: {
+          taskId: 'task-1',
+          settlementId: 'settlement-1',
+          opportunityId: 'opp-existing',
+          userId: 'recipient',
+          recipientIntentId: 'intent-recipient',
+          networkId: 'network-1',
+          intentFingerprint: 'fingerprint',
+          opportunityStatus: 'negotiating',
+          opportunityUpdatedAt: new Date().toISOString(),
+          counterpartyUserId: 'counterparty',
+          counterpartyIntentId: 'different-intent',
+          successorTaskId: 'task-2',
+          conversationId: 'conversation-1',
+          token: 'token',
+          fence: 1,
+          leaseExpiresAt: new Date().toISOString(),
+          consultation: { recipientUserId: 'recipient', recipientIntentId: 'intent-recipient', kind: 'answer', selectedOptions: [] },
+        },
+      },
+    );
+
+    expect(result).toEqual({ kind: 'skipped', reason: 'stale_continuation' });
+  });
+});


### PR DESCRIPTION
## IND-530 — Batch 3

Extracts the existing-opportunity negotiation handler from `opportunity.graph.ts`.

- Keeps LangGraph node wiring, orchestration, timeout, continuation receipt handling, and logging in the graph.
- Moves continuation actor-binding admission, exact intent prioritization/fallback reads, persisted opportunity translation, and accepted non-introducer notification policy behind a six-method persistence port.
- Preserves the public `buildPrioritizedNegotiationIntents` deep export.
- The handler has no runtime negotiation-facade import; graph injects the typed executor to preserve Protocol cycle boundaries.

## Verification

- `bunx eslint packages/protocol/src/opportunity/opportunity.graph.ts packages/protocol/src/opportunity/opportunity.existing-negotiation.ts packages/protocol/src/opportunity/tests/opportunity.existing-negotiation.spec.ts` — pass with 3 pre-existing graph warnings, no errors.
- Focused Bun tests (stale continuation fail-closed; exact-intent fallback/order; introducer approval → existing negotiation → non-introducer notifications) — 3 pass, 0 fail.
- `cd packages/protocol && bun run build` — pass.
- `cd packages/protocol && bun run architecture:check` — pass.
- `git diff --check` — pass.

### Metrics (reproducible normalized 7-line-window script against `HEAD`)

| Metric | Before | After |
| --- | ---: | ---: |
| opportunity.graph.ts LOC | 4,221 | 4,081 |
| Approx. cyclomatic complexity | 658 | 605 |
| Function starts / LOC per function | 118 / 35.8 | 109 / 37.4 |
| Direct import fan-out | 27 | 28 |
| Duplicate normalized 7-line windows | 48 | 47 |
| negotiateExistingNode LOC / CC | 175 / 52 | 75 / 8 |

The extracted handler is 87 LOC / approx. CC 43, with a six-method persistence port and zero runtime negotiation-facade imports.

## Release / lockfile

Protocol SemVer: `6.13.2 → 6.13.3` (compatible substantive extraction, patch).
`bun.lock` unchanged: package resolution did not change.

## Residual IND-530 scope

- Remaining opportunity graph persistence/dedup seams.
- `opportunity/opportunity.tools.ts`.
- `negotiation/negotiation.graph.ts` and `negotiation/negotiation.tools.ts`.
- `opportunity/opportunity.discover.ts` and feed orchestration.

Batch 3 only; IND-530 remains In Progress.