### PR TITLE
refactor(protocol): extract opportunity persistence admission

### DIFF
--- a/packages/protocol/CHANGELOG.md
+++ b/packages/protocol/CHANGELOG.md
@@ -13,6 +13,10 @@ See [STABILITY.md](./STABILITY.md) for the public-contract and tier definitions.
 ## [Unreleased]
 
 ### Changed
+- Extract final opportunity-persistence admission (authoritative scope,
+  participant-pair eligibility, and guarded reactivation anchors) behind a
+  narrow port while keeping dedup routing, writes, and graph observability in
+  the opportunity graph (IND-530 Batch 4).
 - Extract the existing-opportunity negotiation continuation admission,
   exact-intent translation, and non-introducer notification handler behind a
   narrow opportunity persistence port while retaining graph-owned node wiring

--- a/packages/protocol/package.json
+++ b/packages/protocol/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@indexnetwork/protocol",
-  "version": "6.13.3",
+  "version": "6.13.4",
   "type": "module",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",

--- a/packages/protocol/src/opportunity/opportunity.graph.ts
+++ b/packages/protocol/src/opportunity/opportunity.graph.ts
@@ -47,7 +47,7 @@ export type OpportunityEvaluatorLike = {
   }>>;
 };
 import type { Embedder, LensEmbedding } from '../shared/interfaces/embedder.interface.js';
-import type { ActiveIntent, CreateOpportunityData, Opportunity, OpportunityActor, OpportunityNetworkEligibility, OpportunityStatus } from '../shared/interfaces/database.interface.js';
+import type { ActiveIntent, CreateOpportunityData, Opportunity, OpportunityActor, OpportunityStatus } from '../shared/interfaces/database.interface.js';
 import { persistOpportunities } from './opportunity.persist.js';
 import { INTRODUCER_DISCOVERY_SOURCE } from './opportunity.introducer.js';
 import { negotiateCandidates, type NegotiationCandidate, type OnNegotiationResolved, ASK_USER_LOCK_SLACK_MS, askUserAnswerWindowMs, AMBIENT_PARK_WINDOW_MS } from "../capabilities/negotiation.discovery.facade.js";
@@ -64,6 +64,7 @@ import { normalizeOpportunityActorIntent, resolveOpportunityActorIntent } from '
 import { approveOpportunityIntroduction, deleteOpportunityLifecycle, sendOpportunityLifecycle, updateOpportunityLifecycle, type QueueOpportunityNotificationFn } from './opportunity.lifecycle.js';
 import { stampEligibleNewbornOpportunities, type StampNewbornOpportunitiesFn } from './opportunity.newborn-stamping.js';
 import { buildPrioritizedNegotiationIntents, negotiateExistingOpportunity } from './opportunity.existing-negotiation.js';
+import { admitOpportunityPersistence, createEligibleOpportunityStatusUpdater } from './opportunity.persistence-admission.js';
 
 export type { QueueOpportunityNotificationFn } from './opportunity.lifecycle.js';
 export type { StampNewbornOpportunitiesFn, StampNewbornOpportunitiesInput } from './opportunity.newborn-stamping.js';
@@ -2755,65 +2756,22 @@ export class OpportunityGraphFactory {
         }
 
         try {
-          // Recompute the authoritative owner-side scope at the final boundary.
-          // The adapter receives this immutable request scope and locks current
-          // memberships plus trigger-intent assignments through commit.
-          const currentOwnerMemberships = await this.database.getNetworkMemberships(state.userId);
-          let finalAllowedNetworkIds = currentOwnerMemberships.map((membership) => membership.networkId);
-          // Only an explicit trigger intent is an authoritative network boundary.
-          // Ad-hoc global discovery may heuristically resolve a matching intent
-          // for ranking, but must retain its all-membership reach.
           const finalTriggerIntentId = state.triggerIntentId;
-          if (finalTriggerIntentId) {
-            const currentAssignments = new Set(
-              await this.database.getNetworkIdsForIntent(finalTriggerIntentId),
-            );
-            finalAllowedNetworkIds = finalAllowedNetworkIds.filter((networkId) =>
-              currentAssignments.has(networkId));
-          }
-          const explicitScope = state.networkId
-            ? [state.networkId]
-            : state.indexScope;
-          if (explicitScope !== undefined) {
-            const explicitlyAllowed = new Set(explicitScope);
-            finalAllowedNetworkIds = finalAllowedNetworkIds.filter((networkId) =>
-              explicitlyAllowed.has(networkId));
-          }
-          finalAllowedNetworkIds = [...new Set(finalAllowedNetworkIds)];
-          if (finalAllowedNetworkIds.length === 0) {
+          const admission = await admitOpportunityPersistence(this.database, {
+            ownerUserId: state.userId,
+            triggerIntentId: finalTriggerIntentId,
+            networkId: state.networkId,
+            indexScope: state.indexScope,
+            evaluatedOpportunities: state.evaluatedOpportunities,
+          });
+          if (admission.kind === 'empty_scope') {
             persistLog.info('Skipped persistence because final discovery scope is empty', {
               userId: state.userId,
               triggerIntentId: finalTriggerIntentId,
             });
             return { opportunities: [] };
           }
-          const finalAllowedNetworks = new Set(finalAllowedNetworkIds);
-          const networkEligibility: OpportunityNetworkEligibility = {
-            ownerUserId: state.userId,
-            allowedNetworkIds: finalAllowedNetworkIds,
-            ...(finalTriggerIntentId ? { triggerIntentId: finalTriggerIntentId } : {}),
-          };
-
-          // Recheck evaluator participants before any dedup/reactivation/write.
-          // Persistence-only introducers are deliberately absent here: personal-
-          // network contact discovery validates the evaluated owner/candidate
-          // pairs without requiring the owner actor that is added below.
-          const requestedPairs = state.evaluatedOpportunities.flatMap((evaluated) =>
-            evaluated.actors.flatMap((actor) => actor.networkId
-              ? [{ userId: actor.userId, networkId: actor.networkId }]
-              : []),
-          );
-          const activePairs = await this.database.getActiveNetworkMembershipPairs(requestedPairs);
-          const activePairKeys = new Set(
-            activePairs.map((pair) => networkMembershipPairKey(pair.userId, pair.networkId)),
-          );
-          const evaluatedToPersist = state.evaluatedOpportunities.filter((evaluated) =>
-            evaluated.actors.length > 0
-            && evaluated.actors.every((actor) =>
-              actor.networkId != null
-              && finalAllowedNetworks.has(actor.networkId)
-              && activePairKeys.has(networkMembershipPairKey(actor.userId, actor.networkId))),
-          );
+          const { allowedNetworkIds: finalAllowedNetworkIds, networkEligibility, evaluatedOpportunities: evaluatedToPersist } = admission;
           if (evaluatedToPersist.length < state.evaluatedOpportunities.length) {
             persistLog.info('Skipped opportunities with inactive participant network pairs', {
               before: state.evaluatedOpportunities.length,
@@ -2823,33 +2781,16 @@ export class OpportunityGraphFactory {
           }
           if (evaluatedToPersist.length === 0) return { opportunities: [] };
 
-          const updateStatusIfStillEligible = async (
-            opportunityId: string,
-            status: Opportunity['status'],
-            existingActors: OpportunityActor[],
-            expectedStatus: Opportunity['status'],
-          ): Promise<Opportunity | null> => {
-            // Reactivation preserves the existing opportunity row, so lock the
-            // existing participant anchors rather than the evaluator's current
-            // (often network-less) actor output. Introducers do not participate
-            // in matching eligibility and must not suppress a valid pair.
-            const anchors = existingActors.filter((actor) => actor.role !== 'introducer');
-            if (anchors.length === 0 || anchors.some((actor) =>
-              !finalAllowedNetworks.has(actor.networkId))) {
-              return null;
-            }
-            if (!this.database.updateOpportunityStatusIfNetworkEligible) {
-              persistLog.error('Network-eligible status update adapter is unavailable; failing closed');
-              return null;
-            }
-            return this.database.updateOpportunityStatusIfNetworkEligible(
-              opportunityId,
-              status,
-              anchors,
-              networkEligibility,
-              expectedStatus,
-            );
-          };
+          const updateStatusIfStillEligible = createEligibleOpportunityStatusUpdater(
+            this.database,
+            finalAllowedNetworkIds,
+            networkEligibility,
+            {
+              onUnavailableAdapter: () => {
+                persistLog.error('Network-eligible status update adapter is unavailable; failing closed');
+              },
+            },
+          );
 
           const itemsToPersist: CreateOpportunityData[] = [];
           const reactivatedOpportunities: Opportunity[] = [];

--- a/packages/protocol/src/opportunity/opportunity.persistence-admission.ts
+++ b/packages/protocol/src/opportunity/opportunity.persistence-admission.ts
@@ -1,0 +1,117 @@
+import type { Id, Opportunity, OpportunityActor, OpportunityGraphDatabase, OpportunityNetworkEligibility } from '../shared/interfaces/database.interface.js';
+
+/** Narrow final-boundary port for opportunity persistence admission and guarded reactivation. */
+export type OpportunityPersistenceAdmissionPort = Pick<
+  OpportunityGraphDatabase,
+  'getActiveNetworkMembershipPairs' | 'getNetworkIdsForIntent' | 'getNetworkMemberships' | 'updateOpportunityStatusIfNetworkEligible'
+>;
+
+type EvaluatedPersistenceCandidate = {
+  actors: Array<{ userId: Id<'users'>; networkId?: Id<'networks'> | null }>;
+};
+
+export interface OpportunityPersistenceAdmissionInput<T extends EvaluatedPersistenceCandidate> {
+  ownerUserId: Id<'users'>;
+  triggerIntentId?: Id<'intents'>;
+  networkId?: Id<'networks'>;
+  indexScope?: readonly Id<'networks'>[];
+  evaluatedOpportunities: readonly T[];
+}
+
+export type OpportunityPersistenceAdmission<T extends EvaluatedPersistenceCandidate> =
+  | { kind: 'empty_scope' }
+  | {
+    kind: 'admitted';
+    allowedNetworkIds: Id<'networks'>[];
+    networkEligibility: OpportunityNetworkEligibility;
+    evaluatedOpportunities: T[];
+  };
+
+/**
+ * Recomputes the owner-side scope at the final write boundary and removes
+ * evaluator outputs whose actor/network anchors are no longer active.
+ */
+export async function admitOpportunityPersistence<T extends EvaluatedPersistenceCandidate>(
+  database: OpportunityPersistenceAdmissionPort,
+  input: OpportunityPersistenceAdmissionInput<T>,
+): Promise<OpportunityPersistenceAdmission<T>> {
+  const memberships = await database.getNetworkMemberships(input.ownerUserId);
+  let allowedNetworkIds = memberships.map((membership) => membership.networkId);
+  if (input.triggerIntentId) {
+    const assignments = new Set(await database.getNetworkIdsForIntent(input.triggerIntentId));
+    allowedNetworkIds = allowedNetworkIds.filter((networkId) => assignments.has(networkId));
+  }
+  const explicitScope = input.networkId ? [input.networkId] : input.indexScope;
+  if (explicitScope !== undefined) {
+    const explicitlyAllowed = new Set(explicitScope);
+    allowedNetworkIds = allowedNetworkIds.filter((networkId) => explicitlyAllowed.has(networkId));
+  }
+  allowedNetworkIds = [...new Set(allowedNetworkIds)];
+  if (allowedNetworkIds.length === 0) return { kind: 'empty_scope' };
+
+  const allowedNetworks = new Set(allowedNetworkIds);
+  const requestedPairs = input.evaluatedOpportunities.flatMap((evaluated) =>
+    evaluated.actors.flatMap((actor) => actor.networkId
+      ? [{ userId: actor.userId, networkId: actor.networkId }]
+      : []),
+  );
+  const activePairs = await database.getActiveNetworkMembershipPairs(requestedPairs);
+  const activePairKeys = new Set(activePairs.map((pair) => `${pair.userId}\u0000${pair.networkId}`));
+  const evaluatedOpportunities = input.evaluatedOpportunities.filter((evaluated) =>
+    evaluated.actors.length > 0
+    && evaluated.actors.every((actor) =>
+      actor.networkId != null
+      && allowedNetworks.has(actor.networkId)
+      && activePairKeys.has(`${actor.userId}\u0000${actor.networkId}`)),
+  );
+  return {
+    kind: 'admitted',
+    allowedNetworkIds,
+    networkEligibility: {
+      ownerUserId: input.ownerUserId,
+      allowedNetworkIds,
+      ...(input.triggerIntentId ? { triggerIntentId: input.triggerIntentId } : {}),
+    },
+    evaluatedOpportunities,
+  };
+}
+
+export interface EligibleStatusUpdateObserver {
+  onUnavailableAdapter?: () => void;
+}
+
+/**
+ * Produces the guarded status-update handler used when dedup reactivates an
+ * existing row. Existing non-introducer actor anchors are rechecked in the
+ * same adapter operation as the status transition.
+ */
+export function createEligibleOpportunityStatusUpdater(
+  database: OpportunityPersistenceAdmissionPort,
+  allowedNetworkIds: readonly Id<'networks'>[],
+  networkEligibility: OpportunityNetworkEligibility,
+  observer?: EligibleStatusUpdateObserver,
+): (
+  opportunityId: string,
+  status: Opportunity['status'],
+  existingActors: OpportunityActor[],
+  expectedStatus: Opportunity['status'],
+) => Promise<Opportunity | null> {
+  const allowedNetworks = new Set(allowedNetworkIds);
+  return async (opportunityId, status, existingActors, expectedStatus) => {
+    const anchors = existingActors.filter((actor) => actor.role !== 'introducer');
+    if (anchors.length === 0 || anchors.some((actor) => !allowedNetworks.has(actor.networkId))) {
+      return null;
+    }
+    if (!database.updateOpportunityStatusIfNetworkEligible) {
+      observer?.onUnavailableAdapter?.();
+      return null;
+    }
+    return database.updateOpportunityStatusIfNetworkEligible(
+      opportunityId,
+      status,
+      anchors,
+      networkEligibility,
+      expectedStatus,
+    );
+  };
+}

--- a/packages/protocol/src/opportunity/tests/opportunity.persistence-admission.spec.ts
+++ b/packages/protocol/src/opportunity/tests/opportunity.persistence-admission.spec.ts
@@ -1,0 +1,59 @@
+import { describe, expect, test } from 'bun:test';
+import type { Id, Opportunity, OpportunityActor } from '../../shared/interfaces/database.interface.js';
+import { admitOpportunityPersistence, createEligibleOpportunityStatusUpdater, type OpportunityPersistenceAdmissionPort } from '../opportunity.persistence-admission.js';
+
+describe('opportunity persistence admission', () => {
+  test('intersects current owner membership, trigger assignment, explicit scope, and active actor pairs', async () => {
+    const database = {
+      getNetworkMemberships: async () => [
+        { networkId: 'idx-allowed' as Id<'networks'> },
+        { networkId: 'idx-outside-trigger' as Id<'networks'> },
+      ],
+      getNetworkIdsForIntent: async () => ['idx-allowed' as Id<'networks'>],
+      getActiveNetworkMembershipPairs: async (pairs: Array<{ userId: string; networkId: string }>) =>
+        pairs.filter((pair) => pair.userId !== 'inactive-user'),
+    } as unknown as OpportunityPersistenceAdmissionPort;
+
+    const result = await admitOpportunityPersistence(database, {
+      ownerUserId: 'owner' as Id<'users'>,
+      triggerIntentId: 'intent-owner' as Id<'intents'>,
+      indexScope: ['idx-allowed' as Id<'networks'>, 'idx-outside-trigger' as Id<'networks'>],
+      evaluatedOpportunities: [
+        { actors: [{ userId: 'owner' as Id<'users'>, networkId: 'idx-allowed' as Id<'networks'> }, { userId: 'candidate' as Id<'users'>, networkId: 'idx-allowed' as Id<'networks'> }] },
+        { actors: [{ userId: 'owner' as Id<'users'>, networkId: 'idx-allowed' as Id<'networks'> }, { userId: 'inactive-user' as Id<'users'>, networkId: 'idx-allowed' as Id<'networks'> }] },
+      ],
+    });
+
+    expect(result.kind).toBe('admitted');
+    if (result.kind !== 'admitted') return;
+    expect(result.allowedNetworkIds).toEqual(['idx-allowed']);
+    expect(result.evaluatedOpportunities).toHaveLength(1);
+    expect(result.evaluatedOpportunities[0]?.actors[1]?.userId).toBe('candidate');
+  });
+
+  test('reactivates through existing non-introducer anchors and the eligibility lock only', async () => {
+    const calls: unknown[][] = [];
+    const database = {
+      updateOpportunityStatusIfNetworkEligible: async (...args: unknown[]) => {
+        calls.push(args);
+        return { id: 'opp-1', status: 'pending' } as Opportunity;
+      },
+    } as unknown as OpportunityPersistenceAdmissionPort;
+    const update = createEligibleOpportunityStatusUpdater(
+      database,
+      ['idx-allowed' as Id<'networks'>],
+      { ownerUserId: 'owner' as Id<'users'>, allowedNetworkIds: ['idx-allowed' as Id<'networks'>] },
+    );
+    const actors: OpportunityActor[] = [
+      { userId: 'owner' as Id<'users'>, networkId: 'idx-allowed' as Id<'networks'>, role: 'patient' },
+      { userId: 'candidate' as Id<'users'>, networkId: 'idx-allowed' as Id<'networks'>, role: 'agent' },
+      { userId: 'introducer' as Id<'users'>, networkId: 'idx-outside-scope' as Id<'networks'>, role: 'introducer' },
+    ];
+
+    const result = await update('opp-1', 'pending', actors, 'expired');
+
+    expect(result?.status).toBe('pending');
+    expect(calls).toHaveLength(1);
+    expect((calls[0]?.[2] as OpportunityActor[]).map((actor) => actor.userId)).toEqual(['owner', 'candidate']);
+  });
+});


### PR DESCRIPTION
## IND-530 — Batch 4

Extracts the final persistence-admission policy from `opportunity.graph.ts`.

- Moves authoritative owner scope recomputation, trigger-assignment and explicit-scope intersection, current participant-pair admission, and guarded reactivation-anchor selection behind a four-method port.
- Keeps graph node wiring, dedup routing, persistence/transaction boundaries, timing, idempotency decisions, writes, and observability in the graph.
- The handler is capability-owned and has no runtime facade imports.

## Verification

- `bunx eslint packages/protocol/src/opportunity/opportunity.graph.ts packages/protocol/src/opportunity/opportunity.persistence-admission.ts packages/protocol/src/opportunity/tests/opportunity.persistence-admission.spec.ts` — no errors; 3 pre-existing graph warnings.
- Focused Bun tests for persistence admission plus pending dedup, eligibility-locked expiry reactivation, and explicit-scope rejection — 5 pass, 0 fail.
- `cd packages/protocol && bun run build` — pass.
- `cd packages/protocol && bun run architecture:check` — pass.
- `git diff --check` — pass.

### Metrics (reproducible normalized 7-line-window script against `HEAD`)

| Metric | Before | After |
| --- | ---: | ---: |
| opportunity.graph.ts LOC | 4,081 | 4,022 |
| Approx. cyclomatic complexity | 605 | 596 |
| Function starts / LOC per function | 109 / 37.4 | 105 / 38.3 |
| Direct import fan-out | 28 | 29 |
| Duplicate normalized 7-line windows | 47 | 47 |
| Inline persistence-admission LOC / CC | 87 / 12 | 35 / 4 |

The handler is 117 LOC / approx. CC 11 with a four-method persistence port and zero runtime facade imports.

## Release / lockfile

Protocol SemVer: `6.13.3 → 6.13.4` (compatible substantive extraction, patch).
`bun.lock` unchanged: package resolution did not change.

## Residual IND-530 scope

- Remaining opportunity.graph dedup resolution and persistence-path seams.
- `opportunity/opportunity.tools.ts`.
- `negotiation/negotiation.graph.ts` and `negotiation/negotiation.tools.ts`.
- `opportunity/opportunity.discover.ts` and feed orchestration.

Batch 4 only; IND-530 remains In Progress.