### PR TITLE
refactor(protocol): extract opportunity update admission

### DIFF
--- a/packages/protocol/CHANGELOG.md
+++ b/packages/protocol/CHANGELOG.md
@@ -13,6 +13,10 @@ See [STABILITY.md](./STABILITY.md) for the public-contract and tier definitions.
 ## [Unreleased]
 
 ### Changed
+- Extract `update_opportunity` actor, lifecycle, network, and selected-intent
+  admission behind a narrow persistence-read port while retaining tool schema,
+  uptake advisory, graph invocation, and telemetry wiring in the tools facade
+  (IND-530 Batch 5).
 - Extract final opportunity-persistence admission (authoritative scope,
   participant-pair eligibility, and guarded reactivation anchors) behind a
   narrow port while keeping dedup routing, writes, and graph observability in

--- a/packages/protocol/package.json
+++ b/packages/protocol/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@indexnetwork/protocol",
-  "version": "6.13.4",
+  "version": "6.13.5",
   "type": "module",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",

--- a/packages/protocol/src/opportunity/opportunity.tools.ts
+++ b/packages/protocol/src/opportunity/opportunity.tools.ts
@@ -14,6 +14,7 @@ import { runDiscoverFromQuery, continueDiscovery } from "./opportunity.discover.
 import { isDiscoveryQuestionsEnabled, isUptakeGuardEnabled } from "../capabilities/questions.runtime.facade.js";
 import { OpportunityPresenter, gatherPresenterContext, type PresenterDatabase } from "./opportunity.presenter.js";
 import { loadNegotiationContext } from "./negotiation-context.loader.js";
+import { admitOpportunityUpdate } from './opportunity.update-admission.js';
 
 function stripLeadingNarratorName(remark: string, narratorName: string): string {
   let t = remark.trim();
@@ -209,19 +210,6 @@ export async function attachActionableLinks(
   }
 }
 
-/**
- * Statuses for which `update_opportunity` must refuse mutations.
- * - `accepted` / `rejected` / `expired`: terminal outcomes.
- * - `negotiating`: in-flight system-driven turn; user-driven mutations would
- *   race the negotiation graph. The graph itself transitions out of this state.
- */
-const UPDATE_OPPORTUNITY_BLOCKED_STATUSES = new Set<OpportunityStatus>([
-  "accepted",
-  "rejected",
-  "expired",
-  "negotiating",
-]);
-
 interface PublicUptakeQuestion {
   id: string;
   title: string;
@@ -252,16 +240,6 @@ function uptakeAdvisory(opportunityId: string, questions: PublicUptakeQuestion[]
       acknowledgedUptakeQuestionIds: questions.map((question) => question.id),
     },
   });
-}
-
-function matchesSelectedIntentScope(
-  opportunity: Opportunity,
-  viewerId: string,
-  scope?: { scopeType?: 'intent'; scopeId?: string },
-): boolean {
-  if (scope?.scopeType !== 'intent' || !scope.scopeId) return true;
-  if (opportunity.detection?.triggeredBy === scope.scopeId) return true;
-  return opportunity.actors.some((actor) => actor.userId === viewerId && actor.intent === scope.scopeId);
 }
 
 /**
@@ -2412,43 +2390,14 @@ export function createOpportunityTools(defineTool: DefineTool, deps: Opportunity
           ? { scopeType: 'intent' as const, scopeId: rawScopeId }
           : {};
 
-      // Always fetch the opportunity — needed for actor guard and state machine
-      const opportunity = await systemDb.getOpportunity(opportunityId);
-      if (!opportunity) {
-        return error("Opportunity not found.");
-      }
-
-      // Actor guard: caller must be a party to the opportunity
-      const isActor = opportunity.actors?.some((a) => a.userId === context.userId);
-      if (!isActor) {
-        return error("Opportunity not found.");
-      }
-
-      // Terminal-state and in-flight-negotiation guard.
-      // Not a full state-machine: the Zod enum already constrains the target status,
-      // and source statuses like `draft` / `latent` remain permitted.
-      if (UPDATE_OPPORTUNITY_BLOCKED_STATUSES.has(opportunity.status)) {
-        return error(`This opportunity is already ${opportunity.status} and cannot be updated.`);
-      }
-
-      // Strict scope enforcement: when chat is network-scoped, the caller's own
-      // actor entry on this opportunity must be anchored on the bound network.
-      // Mirrors the per-actor filter in getOpportunitiesForUser — relying on
-      // a focus-scope id or any-actor matches would let a counterpart's network
-      // presence shadow a viewer whose own actor is elsewhere.
       const scopedNetworkId = focusedNetworkId(context) ?? context.networkId?.trim();
-      if (scopedNetworkId) {
-        const callerOnBoundNetwork = opportunity.actors?.some(
-          (a) => a.userId === context.userId && a.networkId === scopedNetworkId,
-        );
-        if (!callerOnBoundNetwork) {
-          return error("Opportunity not found.");
-        }
-      }
-
-      if (!matchesSelectedIntentScope(opportunity, context.userId, effectiveIntentScope)) {
-        return error("Opportunity not found.");
-      }
+      const admission = await admitOpportunityUpdate(systemDb, {
+        opportunityId,
+        viewerId: context.userId,
+        scopedNetworkId,
+        selectedIntentScope: effectiveIntentScope,
+      });
+      if (admission.kind === 'denied') return error(admission.message);
 
       // The caller actor's own network is the exact question lookup boundary,
       // even for an otherwise unscoped request. A focused network may only be

--- a/packages/protocol/src/opportunity/opportunity.update-admission.ts
+++ b/packages/protocol/src/opportunity/opportunity.update-admission.ts
@@ -1,0 +1,63 @@
+import type { Opportunity, OpportunityGraphDatabase, OpportunityStatus } from '../shared/interfaces/database.interface.js';
+
+/** Narrow persistence read port for authorizing a user-driven opportunity update. */
+export type OpportunityUpdateAdmissionPort = Pick<OpportunityGraphDatabase, 'getOpportunity'>;
+
+const BLOCKED_UPDATE_STATUSES = new Set<OpportunityStatus>([
+  'accepted',
+  'rejected',
+  'expired',
+  'negotiating',
+]);
+
+export interface OpportunityUpdateAdmissionInput {
+  opportunityId: string;
+  viewerId: string;
+  scopedNetworkId?: string;
+  selectedIntentScope?: { scopeType?: 'intent'; scopeId?: string };
+}
+
+export type OpportunityUpdateAdmission =
+  | { kind: 'admitted'; opportunity: Opportunity }
+  | { kind: 'denied'; message: string };
+
+function matchesSelectedIntentScope(
+  opportunity: Opportunity,
+  viewerId: string,
+  scope?: { scopeType?: 'intent'; scopeId?: string },
+): boolean {
+  if (scope?.scopeType !== 'intent' || !scope.scopeId) return true;
+  if (opportunity.detection?.triggeredBy === scope.scopeId) return true;
+  return opportunity.actors?.some((actor) => actor.userId === viewerId && actor.intent === scope.scopeId) ?? false;
+}
+
+/**
+ * Authorizes mutation only after an opaque existence/actor check, then applies
+ * lifecycle, viewer-network, and selected-intent boundaries in that order.
+ */
+export async function admitOpportunityUpdate(
+  database: OpportunityUpdateAdmissionPort,
+  input: OpportunityUpdateAdmissionInput,
+): Promise<OpportunityUpdateAdmission> {
+  const opportunity = await database.getOpportunity(input.opportunityId);
+  if (!opportunity) return { kind: 'denied', message: 'Opportunity not found.' };
+
+  if (!opportunity.actors?.some((actor) => actor.userId === input.viewerId)) {
+    return { kind: 'denied', message: 'Opportunity not found.' };
+  }
+  if (BLOCKED_UPDATE_STATUSES.has(opportunity.status)) {
+    return {
+      kind: 'denied',
+      message: `This opportunity is already ${opportunity.status} and cannot be updated.`,
+    };
+  }
+  if (input.scopedNetworkId && !opportunity.actors?.some(
+    (actor) => actor.userId === input.viewerId && actor.networkId === input.scopedNetworkId,
+  )) {
+    return { kind: 'denied', message: 'Opportunity not found.' };
+  }
+  if (!matchesSelectedIntentScope(opportunity, input.viewerId, input.selectedIntentScope)) {
+    return { kind: 'denied', message: 'Opportunity not found.' };
+  }
+  return { kind: 'admitted', opportunity };
+}

--- a/packages/protocol/src/opportunity/tests/opportunity.update-admission.spec.ts
+++ b/packages/protocol/src/opportunity/tests/opportunity.update-admission.spec.ts
@@ -1,0 +1,66 @@
+import { describe, expect, test } from 'bun:test';
+import type { Opportunity } from '../../shared/interfaces/database.interface.js';
+import { admitOpportunityUpdate, type OpportunityUpdateAdmissionPort } from '../opportunity.update-admission.js';
+
+const OWNER = 'owner';
+const COUNTERPART = 'counterpart';
+
+function port(opportunity: Opportunity | null): OpportunityUpdateAdmissionPort {
+  return { getOpportunity: async () => opportunity } as OpportunityUpdateAdmissionPort;
+}
+
+function opportunity(overrides: Partial<Opportunity> = {}): Opportunity {
+  return {
+    id: 'opp-1',
+    status: 'pending',
+    actors: [
+      { userId: OWNER, role: 'party', networkId: 'network-owner', intent: 'intent-owner' },
+      { userId: COUNTERPART, role: 'party', networkId: 'network-counterpart' },
+    ],
+    detection: { source: 'opportunity_graph', triggeredBy: 'intent-owner' },
+    ...overrides,
+  } as unknown as Opportunity;
+}
+
+describe('admitOpportunityUpdate', () => {
+  test('returns an opaque denial before later scope checks for a non-actor', async () => {
+    const result = await admitOpportunityUpdate(port(opportunity()), {
+      opportunityId: 'opp-1',
+      viewerId: 'outsider',
+      scopedNetworkId: 'network-counterpart',
+    });
+
+    expect(result).toEqual({ kind: 'denied', message: 'Opportunity not found.' });
+  });
+
+  test('blocks terminal and negotiating lifecycle states', async () => {
+    for (const status of ['accepted', 'rejected', 'expired', 'negotiating'] as const) {
+      const result = await admitOpportunityUpdate(port(opportunity({ status })), {
+        opportunityId: 'opp-1',
+        viewerId: OWNER,
+      });
+      expect(result).toEqual({
+        kind: 'denied',
+        message: `This opportunity is already ${status} and cannot be updated.`,
+      });
+    }
+  });
+
+  test('requires the caller’s own bound network and selected intent anchor', async () => {
+    const allowed = await admitOpportunityUpdate(port(opportunity()), {
+      opportunityId: 'opp-1',
+      viewerId: OWNER,
+      scopedNetworkId: 'network-owner',
+      selectedIntentScope: { scopeType: 'intent', scopeId: 'intent-owner' },
+    });
+    const denied = await admitOpportunityUpdate(port(opportunity()), {
+      opportunityId: 'opp-1',
+      viewerId: OWNER,
+      scopedNetworkId: 'network-owner',
+      selectedIntentScope: { scopeType: 'intent', scopeId: 'other-intent' },
+    });
+
+    expect(allowed.kind).toBe('admitted');
+    expect(denied).toEqual({ kind: 'denied', message: 'Opportunity not found.' });
+  });
+});


### PR DESCRIPTION
## IND-530 — Batch 5

Extracts the `update_opportunity` admission policy from `opportunity.tools.ts`.

- Moves opaque actor authorization, blocked lifecycle states, caller-owned network scope, and selected-intent scope checks behind a one-method persistence-read port.
- Keeps tool declaration/schema, tool I/O errors, uptake-advisory fail-open behavior, graph invocation, cancellation propagation, and telemetry in the tools facade.
- No deletion was safe: each selected guard is existing privacy/lifecycle behavior with focused tests.

## Verification

- `bunx eslint packages/protocol/src/opportunity/opportunity.tools.ts packages/protocol/src/opportunity/opportunity.update-admission.ts packages/protocol/src/opportunity/tests/opportunity.update-admission.spec.ts` — pass.
- Focused direct-admission and `update_opportunity` actor/lifecycle/network/uptake-order tests — 8 pass, 0 fail.
- `cd packages/protocol && bun run build` — pass.
- `cd packages/protocol && bun run architecture:check` — pass.
- `git diff --check` — pass.
- Lockfile and env diff check — no changes.

### Metrics (reproducible normalized 7-line-window script against `HEAD`)

| Metric | Before | After |
| --- | ---: | ---: |
| opportunity.tools.ts LOC | 2,640 | 2,589 |
| Function starts / LOC per function | 36 / 73.3 | 34 / 76.1 |
| Approx. cyclomatic complexity | 532 | 520 |
| Direct local fan-out | 21 | 22 |
| Duplicate normalized 7-line windows | 130 | 130 |

The handler is 63 LOC / approximate CC 14, uses a one-method port, and has zero runtime facade imports. Net production LOC is +12 (facade −51, named policy +63).

## Release / lockfile / env

Protocol SemVer: `6.13.4 → 6.13.5` (compatible substantive extraction, patch).
`bun.lock` unchanged: resolution did not change. No environment changes.

## Scope correction inventory

A superseded graph dedup-resolution WIP was preserved (not discarded and not included here) in local `stash@{0}`: one graph edit (+46/−67) and a 54-line policy module. Batch 5 production scope is tools-only.

## Residual IND-530 scope

- Evidence-backed remaining `opportunity.graph.ts` dedup-resolution/persistence seams.
- Remaining `opportunity.tools.ts` presentation/discovery seams.
- `negotiation/negotiation.graph.ts` and `negotiation/negotiation.tools.ts`.
- `opportunity/opportunity.discover.ts` and feed orchestration.

Batch 5 only; IND-530 remains In Progress.