### PR TITLE
refactor(protocol): extract opportunity card presentation

### DIFF
--- a/packages/protocol/CHANGELOG.md
+++ b/packages/protocol/CHANGELOG.md
@@ -13,6 +13,10 @@ See [STABILITY.md](./STABILITY.md) for the public-contract and tier definitions.
 ## [Unreleased]
 
 ### Changed
+- Extract safe opportunity-card presentation translation for web/MCP, including
+  actionable-link ID suppression, digest markers, code-fence escaping, and
+  unsupported-claim/UUID sanitization, while preserving the tools-facade export
+  and IO contract (IND-530 Batch 6).
 - Extract `update_opportunity` actor, lifecycle, network, and selected-intent
   admission behind a narrow persistence-read port while retaining tool schema,
   uptake advisory, graph invocation, and telemetry wiring in the tools facade

--- a/packages/protocol/package.json
+++ b/packages/protocol/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@indexnetwork/protocol",
-  "version": "6.13.5",
+  "version": "6.13.6",
   "type": "module",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",

--- a/packages/protocol/src/opportunity/opportunity.card-presentation.ts
+++ b/packages/protocol/src/opportunity/opportunity.card-presentation.ts
@@ -1,0 +1,138 @@
+import { stripUnsupportedOpportunityClaims } from './opportunity.claim-safety.js';
+import { stripUuids } from './opportunity.presentation.js';
+
+const CODE_FENCE = String.fromCharCode(96, 96, 96);
+
+function sanitizeJsonForCodeFence(json: string): string {
+  return json.replace(/`/g, '\\u0060');
+}
+
+/**
+ * Minimal shape consumed by buildOpportunityPresentation for prose rendering.
+ * Card data objects in the codebase carry additional frontend-only fields;
+ * only these are surfaced to MCP agents.
+ */
+export type OpportunityCardLike = Record<string, unknown> & {
+  opportunityId: string;
+  userId?: string | undefined;
+  name?: string | undefined;
+  mainText?: string | undefined;
+  digestSummary?: string | undefined;
+  status?: string | undefined;
+  feedCategory?: string | undefined;
+  acceptUrl?: string | undefined;
+  profileUrl?: string | undefined;
+  /** Deep-link to the A2A negotiation trace that produced this opportunity. */
+  negotiationUrl?: string | undefined;
+  score?: number | undefined;
+  /** Digest-mode cooldown re-show — the user has seen this card before. */
+  redelivery?: boolean | undefined;
+};
+
+function sanitizeOpportunityCardProse(card: OpportunityCardLike): OpportunityCardLike {
+  const sanitized: OpportunityCardLike = { ...card };
+  for (const key of ['mainText', 'digestSummary', 'headline', 'cta', 'mutualIntentsLabel'] as const) {
+    const value = card[key];
+    if (typeof value === 'string') {
+      sanitized[key] = stripUnsupportedOpportunityClaims(stripUuids(value)) || 'A suggested connection.';
+    }
+  }
+  const narratorChip = card.narratorChip;
+  if (narratorChip && typeof narratorChip === 'object' && !Array.isArray(narratorChip)) {
+    const narrator = narratorChip as Record<string, unknown>;
+    if (typeof narrator.text === 'string') {
+      sanitized.narratorChip = {
+        ...narrator,
+        text: stripUnsupportedOpportunityClaims(stripUuids(narrator.text)) || 'A potential connection worth exploring.',
+      };
+    }
+  }
+  return sanitized;
+}
+
+/**
+ * Format opportunity cards into the "opportunities" portion of a tool response.
+ *
+ * Web chat (`isMcp=false`): emits ```opportunity``` code fences with an
+ * "include EXACTLY as-is" directive so the frontend card renderer can parse
+ * and render interactive cards.
+ *
+ * MCP (`isMcp=true`): emits prose (name, reason, status, profileUrl when
+ * present, acceptUrl when present, feedCategory when present) and includes
+ * `opportunityId` ONLY for cards without an `acceptUrl` — exposing the UUID
+ * alongside an actionable link gave LLMs a foothold to hallucinate bare
+ * `/api/opportunities/<id>/connect` URLs (see IND-271). The trailing
+ * instruction reminds the agent to synthesize in natural language and never
+ * fabricate URLs for cards that don't have them. MCP clients have no card
+ * renderer, so code fences would surface as raw JSON to end users.
+ */
+export function buildOpportunityPresentation(
+  inputCards: OpportunityCardLike[],
+  opts: {
+    isMcp: boolean;
+    leadIn: string;
+    label?: 'opportunity' | 'opportunities';
+    /** Include hidden digest metadata markers so scheduled brief tooling can confirm delivery. */
+    includeDigestMarkers?: boolean;
+  },
+): string {
+  const cards = inputCards.map(sanitizeOpportunityCardProse);
+  if (cards.length === 0) return opts.leadIn;
+
+  if (opts.isMcp) {
+    const prose = cards
+      .map((card, i) => {
+        const lines: string[] = [`${i + 1}. ${card.name ?? "Unknown"}`];
+        if (opts.includeDigestMarkers) {
+          const markerId = String(card.opportunityId).replace(/[\s>]/g, "");
+          if (markerId) lines.push(`   <!-- digest-opportunity:id=${markerId} -->`);
+        }
+        if (opts.includeDigestMarkers && card.digestSummary) {
+          lines.push(`   ${card.digestSummary}`);
+        } else if (card.mainText) {
+          lines.push(`   ${card.mainText}`);
+        }
+        if (card.status) lines.push(`   status: ${card.status}`);
+        if (card.profileUrl) lines.push(`   profileUrl: ${card.profileUrl}`);
+        if (card.acceptUrl) lines.push(`   acceptUrl: ${card.acceptUrl}`);
+        if (opts.includeDigestMarkers && card.negotiationUrl) lines.push(`   negotiationUrl: ${card.negotiationUrl}`);
+        if (card.feedCategory) lines.push(`   feedCategory: ${card.feedCategory}`);
+        if (opts.includeDigestMarkers && card.score != null) lines.push(`   confidence: ${Math.round(card.score * 100)}`);
+        if (opts.includeDigestMarkers && card.redelivery) lines.push(`   redelivery: true`);
+        // Only surface opportunityId when there's no acceptUrl. Exposing the
+        // UUID alongside an actionable link gives the LLM a foothold to
+        // hallucinate bare `/api/opportunities/<id>/connect` URLs.
+        if (!card.acceptUrl) {
+          lines.push(`   opportunityId: ${card.opportunityId}`);
+        }
+        return lines.join("\n");
+      })
+      .join("\n\n");
+    const hasLinks = cards.some((c) => c.acceptUrl);
+    const hasOpportunityIds = cards.some((c) => !c.acceptUrl);
+    const linkInstructions = hasLinks
+      ? `For each card that has an acceptUrl, embed it on a short verb phrase (e.g. "message [Name]" for connection, "make intro" for connector-flow). For each card that has a profileUrl, link the person's name to it. Some cards may have neither — render those as plain text and never fabricate URLs for them. The acceptUrl is opaque and self-contained — embed it verbatim. Do NOT append, encode, or modify any part of any URL. Never render link strips or tables — weave URLs into prose. `
+      : "";
+    const idInstructions = hasOpportunityIds
+      ? `Use opportunityId values only when calling update_opportunity (send/accept/reject) or confirm_opportunity_delivery.`
+      : "";
+    return (
+      `${opts.leadIn}\n\n${prose}\n\n` +
+      `Summarize these for the user in natural prose — mention first names and a brief match reason per connection. ` +
+      `${linkInstructions}` +
+      `Do NOT print raw JSON, field labels, or opportunityIds. ` +
+      `${idInstructions}`
+    );
+  }
+
+  const label = opts.label ?? (cards.length === 1 ? "opportunity" : "opportunities");
+  const blocks = cards
+    .map(
+      (card) =>
+        CODE_FENCE + "opportunity\n" + sanitizeJsonForCodeFence(JSON.stringify(card)) + "\n" + CODE_FENCE,
+    )
+    .join("\n\n");
+  return (
+    `${opts.leadIn} IMPORTANT: Include the following ${CODE_FENCE}${label} code blocks EXACTLY as-is in your response (they render as interactive cards):\n\n${blocks}`
+  );
+}

--- a/packages/protocol/src/opportunity/opportunity.tools.ts
+++ b/packages/protocol/src/opportunity/opportunity.tools.ts
@@ -9,12 +9,14 @@ import { deriveDiscoveryNetworkIds, focusedIntentId, focusedNetworkId, focusedNe
 import { MINIMAL_MAIN_TEXT_MAX_CHARS, getPrimaryActionLabel, SECONDARY_ACTION_LABEL } from "./opportunity.labels.js";
 import { narratorRemarkFromReasoning, stripUuids } from "./opportunity.presentation.js";
 import { safeFallbackSummary, getSafePresentationOrSkip } from "./opportunity.safe-presentation.js";
-import { stripUnsupportedOpportunityClaims } from "./opportunity.claim-safety.js";
+import { buildOpportunityPresentation } from "./opportunity.card-presentation.js";
 import { runDiscoverFromQuery, continueDiscovery } from "./opportunity.discover.js";
 import { isDiscoveryQuestionsEnabled, isUptakeGuardEnabled } from "../capabilities/questions.runtime.facade.js";
 import { OpportunityPresenter, gatherPresenterContext, type PresenterDatabase } from "./opportunity.presenter.js";
 import { loadNegotiationContext } from "./negotiation-context.loader.js";
 import { admitOpportunityUpdate } from './opportunity.update-admission.js';
+
+export { buildOpportunityPresentation } from "./opportunity.card-presentation.js";
 
 function stripLeadingNarratorName(remark: string, narratorName: string): string {
   let t = remark.trim();
@@ -262,17 +264,6 @@ const CHAT_FETCH_LIMIT = 30;
  */
 const ACCEPTED_SUPPRESSION_FETCH_LIMIT = 200;
 
-/** Markdown code fence (three backticks). Avoids embedding ``` in string literals so TS parser stays in sync. */
-const CODE_FENCE = String.fromCharCode(96, 96, 96);
-
-/**
- * Sanitize JSON string for use inside a markdown code fence (```). Escapes backticks
- * so embedded ``` cannot close the fence prematurely.
- */
-function sanitizeJsonForCodeFence(json: string): string {
-  return json.replace(/`/g, "\\u0060");
-}
-
 /**
  * Build minimal opportunity card data for chat without calling the LLM presenter.
  * Uses only required fields from the opportunity record and counterpart name/avatar
@@ -378,139 +369,6 @@ export function buildMinimalOpportunityCard(
         }
       : {}),
   };
-}
-
-/**
- * Minimal shape consumed by buildOpportunityPresentation for prose rendering.
- * Card data objects in the codebase carry additional frontend-only fields;
- * only these are surfaced to MCP agents.
- */
-type OpportunityCardLike = Record<string, unknown> & {
-  opportunityId: string;
-  userId?: string | undefined;
-  name?: string | undefined;
-  mainText?: string | undefined;
-  digestSummary?: string | undefined;
-  status?: string | undefined;
-  feedCategory?: string | undefined;
-  acceptUrl?: string | undefined;
-  profileUrl?: string | undefined;
-  /** Deep-link to the A2A negotiation trace that produced this opportunity. */
-  negotiationUrl?: string | undefined;
-  score?: number | undefined;
-  /** Digest-mode cooldown re-show — the user has seen this card before. */
-  redelivery?: boolean | undefined;
-};
-
-/**
- * Format opportunity cards into the "opportunities" portion of a tool response.
- *
- * Web chat (`isMcp=false`): emits ```opportunity``` code fences with an
- * "include EXACTLY as-is" directive so the frontend card renderer can parse
- * and render interactive cards.
- *
- * MCP (`isMcp=true`): emits prose (name, reason, status, profileUrl when
- * present, acceptUrl when present, feedCategory when present) and includes
- * `opportunityId` ONLY for cards without an `acceptUrl` — exposing the UUID
- * alongside an actionable link gave LLMs a foothold to hallucinate bare
- * `/api/opportunities/<id>/connect` URLs (see IND-271). The trailing
- * instruction reminds the agent to synthesize in natural language and never
- * fabricate URLs for cards that don't have them. MCP clients have no card
- * renderer, so code fences would surface as raw JSON to end users.
- */
-function sanitizeOpportunityCardProse(card: OpportunityCardLike): OpportunityCardLike {
-  const sanitized: OpportunityCardLike = { ...card };
-  for (const key of ['mainText', 'digestSummary', 'headline', 'cta', 'mutualIntentsLabel'] as const) {
-    const value = card[key];
-    if (typeof value === 'string') {
-      sanitized[key] =
-        stripUnsupportedOpportunityClaims(stripUuids(value)) || 'A suggested connection.';
-    }
-  }
-  const narratorChip = card.narratorChip;
-  if (narratorChip && typeof narratorChip === 'object' && !Array.isArray(narratorChip)) {
-    const narrator = narratorChip as Record<string, unknown>;
-    if (typeof narrator.text === 'string') {
-      sanitized.narratorChip = {
-        ...narrator,
-        text:
-          stripUnsupportedOpportunityClaims(stripUuids(narrator.text)) ||
-          'A potential connection worth exploring.',
-      };
-    }
-  }
-  return sanitized;
-}
-
-export function buildOpportunityPresentation(
-  inputCards: OpportunityCardLike[],
-  opts: {
-    isMcp: boolean;
-    leadIn: string;
-    label?: "opportunity" | "opportunities";
-    /** Include hidden digest metadata markers so scheduled brief tooling can confirm delivery. */
-    includeDigestMarkers?: boolean;
-  },
-): string {
-  const cards = inputCards.map(sanitizeOpportunityCardProse);
-  if (cards.length === 0) return opts.leadIn;
-
-  if (opts.isMcp) {
-    const prose = cards
-      .map((card, i) => {
-        const lines: string[] = [`${i + 1}. ${card.name ?? "Unknown"}`];
-        if (opts.includeDigestMarkers) {
-          const markerId = String(card.opportunityId).replace(/[\s>]/g, "");
-          if (markerId) lines.push(`   <!-- digest-opportunity:id=${markerId} -->`);
-        }
-        if (opts.includeDigestMarkers && card.digestSummary) {
-          lines.push(`   ${card.digestSummary}`);
-        } else if (card.mainText) {
-          lines.push(`   ${card.mainText}`);
-        }
-        if (card.status) lines.push(`   status: ${card.status}`);
-        if (card.profileUrl) lines.push(`   profileUrl: ${card.profileUrl}`);
-        if (card.acceptUrl) lines.push(`   acceptUrl: ${card.acceptUrl}`);
-        if (opts.includeDigestMarkers && card.negotiationUrl) lines.push(`   negotiationUrl: ${card.negotiationUrl}`);
-        if (card.feedCategory) lines.push(`   feedCategory: ${card.feedCategory}`);
-        if (opts.includeDigestMarkers && card.score != null) lines.push(`   confidence: ${Math.round(card.score * 100)}`);
-        if (opts.includeDigestMarkers && card.redelivery) lines.push(`   redelivery: true`);
-        // Only surface opportunityId when there's no acceptUrl. Exposing the
-        // UUID alongside an actionable link gives the LLM a foothold to
-        // hallucinate bare `/api/opportunities/<id>/connect` URLs.
-        if (!card.acceptUrl) {
-          lines.push(`   opportunityId: ${card.opportunityId}`);
-        }
-        return lines.join("\n");
-      })
-      .join("\n\n");
-    const hasLinks = cards.some((c) => c.acceptUrl);
-    const hasOpportunityIds = cards.some((c) => !c.acceptUrl);
-    const linkInstructions = hasLinks
-      ? `For each card that has an acceptUrl, embed it on a short verb phrase (e.g. "message [Name]" for connection, "make intro" for connector-flow). For each card that has a profileUrl, link the person's name to it. Some cards may have neither — render those as plain text and never fabricate URLs for them. The acceptUrl is opaque and self-contained — embed it verbatim. Do NOT append, encode, or modify any part of any URL. Never render link strips or tables — weave URLs into prose. `
-      : "";
-    const idInstructions = hasOpportunityIds
-      ? `Use opportunityId values only when calling update_opportunity (send/accept/reject) or confirm_opportunity_delivery.`
-      : "";
-    return (
-      `${opts.leadIn}\n\n${prose}\n\n` +
-      `Summarize these for the user in natural prose — mention first names and a brief match reason per connection. ` +
-      `${linkInstructions}` +
-      `Do NOT print raw JSON, field labels, or opportunityIds. ` +
-      `${idInstructions}`
-    );
-  }
-
-  const label = opts.label ?? (cards.length === 1 ? "opportunity" : "opportunities");
-  const blocks = cards
-    .map(
-      (card) =>
-        CODE_FENCE + "opportunity\n" + sanitizeJsonForCodeFence(JSON.stringify(card)) + "\n" + CODE_FENCE,
-    )
-    .join("\n\n");
-  return (
-    `${opts.leadIn} IMPORTANT: Include the following ${CODE_FENCE}${label} code blocks EXACTLY as-is in your response (they render as interactive cards):\n\n${blocks}`
-  );
 }
 
 /**


### PR DESCRIPTION
## IND-530 Batch 6

Extracts the safe opportunity-card presentation translator from `opportunity.tools.ts` into the narrow, capability-owned `opportunity.card-presentation.ts` module.

The tools facade retains tool declarations, IO, call-site wiring, and a compatibility re-export of `buildOpportunityPresentation`. The translator preserves web-card fences and MCP prose behavior, including unsupported-claim/UUID sanitization, actionable-card ID suppression, digest markers, and opaque-link instructions.

## Metrics

Reproducible line-based scan of `opportunity.tools.ts` (function declarations plus const-arrow starts; branch-token CC approximation; unique direct relative imports; normalized 7-line duplicate windows):

| Metric | Before | After tools |
| --- | ---: | ---: |
| LOC | 2,589 | 2,447 |
| Function starts | 17 | 14 |
| Approx. CC | 520 | 484 |
| Direct local fan-out | 22 | 22 |
| Duplicate normalized 7-line windows | 148 | 148 |

Extracted module: 138 LOC, 3 function starts, approximate CC 36, direct local fan-out 2, 0 duplicate windows. Net production LOC: -4.

## Verification

- `cd packages/protocol && bun test src/opportunity/tests/opportunity.tools.spec.ts --test-name-pattern "omits opportunityId line when card has an acceptUrl|includes hidden digest marker for actionable cards only when requested|keeps opportunityId line when card has NO acceptUrl|strips unsupported claims from MCP card prose|mixed actionability: keeps id only for non-actionable cards, keeps instruction"` — 5 pass
- `cd packages/protocol && bunx eslint src/opportunity/opportunity.tools.ts src/opportunity/opportunity.card-presentation.ts` — pass
- `cd packages/protocol && bun run build` — pass
- `cd packages/protocol && bun run architecture:check` — pass; module boundary and host-isolation/cycle checks remain valid
- `git diff --check` — pass

## Release and environment

- Protocol SemVer: 6.13.5 → 6.13.6, compatible substantive extraction; CHANGELOG updated.
- `bun.lock` unchanged: no package-resolution change; it was not hand-edited.
- No environment files changed; no provider, live-model, Railway, or database work ran.
- Preserved untouched: `stash@{0}` (`WIP: superseded Batch 5 graph dedup-resolution`).

## Residual scope

IND-530 remains **In Progress**. Explicit residual scope: evidence-backed opportunity-graph persistence/dedup seams; remaining opportunity.tools discovery/admission/presentation seams; negotiation graph/tools; opportunity.discover and feed orchestration. The preserved graph WIP stash is not part of this PR.