### PR TITLE
refactor(protocol): extract intent snapshot provenance

### DIFF
--- a/packages/protocol/CHANGELOG.md
+++ b/packages/protocol/CHANGELOG.md
@@ -13,6 +13,9 @@ See [STABILITY.md](./STABILITY.md) for the public-contract and tier definitions.
 ## [Unreleased]
 
 ### Changed
+- Extract immutable negotiation task intent-snapshot provenance into a narrow
+  persistence handler while retaining LangGraph init-node task wiring and
+  lifecycle boundaries (IND-530 Batch 8).
 - Extract MCP discovery-run coalescing identity and admission into a narrow
   capability-owned policy while retaining run-store reads, queueing, and tool
   responses in the opportunity tools facade (IND-530 Batch 7).

--- a/packages/protocol/package.json
+++ b/packages/protocol/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@indexnetwork/protocol",
-  "version": "6.13.7",
+  "version": "6.13.8",
   "type": "module",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",

--- a/packages/protocol/src/negotiation/negotiation.graph.ts
+++ b/packages/protocol/src/negotiation/negotiation.graph.ts
@@ -17,6 +17,7 @@ import type { QuestionerEnqueueFn } from "../capabilities/questions.enqueue.faca
 import type { ReflectEnqueueFn } from "./negotiation.reflect.js";
 import type { NegotiatorMemoryEntry, NegotiatorMemoryRetrieveFn, NegotiatorMemoryScope } from "./negotiation.memory.js";
 import { NEGOTIATION_QUESTION_GENERIC_COUNTERPARTY, NEGOTIATION_QUESTION_GENERIC_NETWORK, negotiationQuestionSettlementId, validateInflightAskUserFields } from './negotiation.question-safety.js';
+import { buildIntentSnapshots } from "./negotiation.intent-snapshot-provenance.js";
 
 const logger = protocolLogger("NegotiationGraph");
 const initLog = protocolLogger("NegotiationGraph:Init");
@@ -51,40 +52,6 @@ function hasPriorAskUser(
     const dataPart = (m.parts as Array<{ kind?: string; data?: { action?: string } }>).find((p) => p.kind === "data");
     return dataPart?.data?.action === "ask_user";
   });
-}
-
-interface IntentSnapshot {
-  userId: string;
-  intentId: string;
-  title: string;
-  description: string;
-}
-
-/** Capture immutable, internal-only intent provenance at task creation time. */
-function buildIntentSnapshots(
-  sourceUser: UserNegotiationContext,
-  candidateUser: UserNegotiationContext,
-): IntentSnapshot[] {
-  const snapshots: IntentSnapshot[] = [];
-  const seen = new Set<string>();
-
-  for (const user of [sourceUser, candidateUser]) {
-    if (typeof user.id !== 'string' || user.id.trim().length === 0) continue;
-    for (const intent of Array.isArray(user.intents) ? user.intents : []) {
-      if (typeof intent?.id !== 'string' || intent.id.trim().length === 0) continue;
-      const key = `${user.id}\u0000${intent.id}`;
-      if (seen.has(key)) continue;
-      seen.add(key);
-      snapshots.push({
-        userId: user.id,
-        intentId: intent.id,
-        title: typeof intent.title === 'string' ? intent.title : '',
-        description: typeof intent.description === 'string' ? intent.description : '',
-      });
-    }
-  }
-
-  return snapshots;
 }
 
 /**

--- a/packages/protocol/src/negotiation/negotiation.intent-snapshot-provenance.ts
+++ b/packages/protocol/src/negotiation/negotiation.intent-snapshot-provenance.ts
@@ -1,0 +1,46 @@
+export interface IntentSnapshot {
+  userId: string;
+  intentId: string;
+  title: string;
+  description: string;
+}
+
+type IntentSnapshotSource = {
+  id?: unknown;
+  intents?: Array<{
+    id?: unknown;
+    title?: unknown;
+    description?: unknown;
+  } | null | undefined>;
+};
+
+/**
+ * Captures immutable, internal-only intent provenance at negotiation task
+ * creation. Invalid records are excluded and each participant/intent pair is
+ * kept once, so later mutable user context cannot rewrite task history.
+ */
+export function buildIntentSnapshots(
+  sourceUser: IntentSnapshotSource,
+  candidateUser: IntentSnapshotSource,
+): IntentSnapshot[] {
+  const snapshots: IntentSnapshot[] = [];
+  const seen = new Set<string>();
+
+  for (const user of [sourceUser, candidateUser]) {
+    if (typeof user.id !== "string" || user.id.trim().length === 0) continue;
+    for (const intent of Array.isArray(user.intents) ? user.intents : []) {
+      if (typeof intent?.id !== "string" || intent.id.trim().length === 0) continue;
+      const key = `${user.id}\u0000${intent.id}`;
+      if (seen.has(key)) continue;
+      seen.add(key);
+      snapshots.push({
+        userId: user.id,
+        intentId: intent.id,
+        title: typeof intent.title === "string" ? intent.title : "",
+        description: typeof intent.description === "string" ? intent.description : "",
+      });
+    }
+  }
+
+  return snapshots;
+}


### PR DESCRIPTION
## IND-530 Batch 8

Extracts immutable negotiation task intent-snapshot provenance from `negotiation.graph.ts` into the narrow, capability-owned `negotiation.intent-snapshot-provenance.ts` handler.

The LangGraph init node continues to own task metadata assembly, task creation/attempt claiming, status transitions, and all graph wiring. The extracted handler only validates source/candidate intent records, deduplicates each participant-intent pair, and copies title/description into immutable internal task provenance.

## Characterization and verification

- `cd packages/protocol && bun test src/negotiation/tests/negotiation.graph.spec.ts --test-name-pattern "captures immutable, deduplicated source and candidate intent snapshots at task creation"` — 1 pass, 5 expectations.
- `cd packages/protocol && bunx eslint src/negotiation/negotiation.graph.ts src/negotiation/negotiation.intent-snapshot-provenance.ts` — pass.
- `cd packages/protocol && bun run build` — pass.
- `cd packages/protocol && bun run architecture:check` — pass; host isolation and cycle baseline remain valid.
- `git diff --check` — pass.

No aggregate/full/isolated source suite, eval, provider/live-model, Railway, or database work ran.

## Metrics

Reproducible line-based scan of `negotiation.graph.ts` (function declarations plus const-arrow starts; branch-token CC approximation; unique direct relative imports; normalized 7-line duplicate windows):

| Metric | Before | After graph |
| --- | ---: | ---: |
| LOC | 1,548 | 1,515 |
| Function starts | 14 | 13 |
| Approx. CC | 295 | 288 |
| Direct local fan-out | 17 | 18 |
| Duplicate normalized 7-line windows | 16 | 16 |

Extracted handler: 46 LOC, 1 function start, approximate CC 8, direct local fan-out 0, duplicate windows 0. Net production LOC is +13 because the handler retains a local minimal structural input port and keeps the graph independent of broader state coupling.

## Release and environment

- Protocol SemVer: 6.13.7 → 6.13.8, compatible substantive extraction; CHANGELOG updated.
- `bun.lock` unchanged because package resolution did not change; it was not hand-edited.
- No environment files changed.
- `stash@{0}` remains untouched: `WIP: superseded Batch 5 graph dedup-resolution`.

## Residual scope

IND-530 remains **In Progress**. Explicit residual scope: remaining negotiation.graph lifecycle/persistence/validation/presentation seams; negotiation.tools; remaining opportunity.graph/tools seams; opportunity.discover and feed orchestration. The preserved opportunity-graph WIP stash is not part of this PR.