### PR TITLE
refactor(protocol): extract negotiation task lock policy

### DIFF
--- a/packages/protocol/CHANGELOG.md
+++ b/packages/protocol/CHANGELOG.md
@@ -13,6 +13,9 @@ See [STABILITY.md](./STABILITY.md) for the public-contract and tier definitions.
 ## [Unreleased]
 
 ### Changed
+- Extract state-aware negotiation conversation-lock admission, including the
+  full consultation answer-window hold, into a narrow lifecycle policy while
+  retaining graph-owned task reads and busy routing (IND-530 Batch 9).
 - Extract immutable negotiation task intent-snapshot provenance into a narrow
   persistence handler while retaining LangGraph init-node task wiring and
   lifecycle boundaries (IND-530 Batch 8).

--- a/packages/protocol/package.json
+++ b/packages/protocol/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@indexnetwork/protocol",
-  "version": "6.13.8",
+  "version": "6.13.9",
   "type": "module",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",

--- a/packages/protocol/src/negotiation/negotiation.graph.ts
+++ b/packages/protocol/src/negotiation/negotiation.graph.ts
@@ -7,7 +7,7 @@ import type { NegotiationTimeoutQueue } from "../shared/interfaces/negotiation-e
 import type { AgentDispatcher, NegotiationTurnPayload } from "../shared/interfaces/agent-dispatcher.interface.js";
 import { NegotiationGraphState, type NegotiationTurn, type NegotiationOutcome, type UserNegotiationContext, type NegotiationGraphLike } from "./negotiation.state.js";
 import { IndexNegotiator } from "./negotiation.agent.js";
-import { ASK_USER_LOCK_SLACK_MS, allowedActionsFor, askUserAnswerWindowMs, configuredAskUserEnabled, configuredProtocolVersion, fallbackActionFor, isRejectLikeAction, isTerminalAction, readProtocolVersion, rejectActionFor } from "./negotiation.protocol.js";
+import { allowedActionsFor, askUserAnswerWindowMs, configuredAskUserEnabled, configuredProtocolVersion, fallbackActionFor, isRejectLikeAction, isTerminalAction, readProtocolVersion, rejectActionFor } from "./negotiation.protocol.js";
 import { assessConsultationEligibility, consultationPromptFor, negotiationConsultationPolicyMode, type NegotiationConsultationReason } from "./negotiation.consultation-policy.js";
 import { NegotiationScreener, configuredScreenMode, type ScreenDecision, type ScreenDecisionRecord } from "./negotiation.screen.js";
 import { assessDeadlock, configuredDeadlockShiftEnabled, configuredDeadlockThreshold, type DeadlockAssessment, type DeadlockShiftRecord } from "./negotiation.deadlock.js";
@@ -18,6 +18,7 @@ import type { ReflectEnqueueFn } from "./negotiation.reflect.js";
 import type { NegotiatorMemoryEntry, NegotiatorMemoryRetrieveFn, NegotiatorMemoryScope } from "./negotiation.memory.js";
 import { NEGOTIATION_QUESTION_GENERIC_COUNTERPARTY, NEGOTIATION_QUESTION_GENERIC_NETWORK, negotiationQuestionSettlementId, validateInflightAskUserFields } from './negotiation.question-safety.js';
 import { buildIntentSnapshots } from "./negotiation.intent-snapshot-provenance.js";
+import { holdsNegotiationConversationLock } from "./negotiation.task-lock-policy.js";
 
 const logger = protocolLogger("NegotiationGraph");
 const initLog = protocolLogger("NegotiationGraph:Init");
@@ -123,20 +124,6 @@ export class NegotiationGraphFactory {
         // --- Lock gate: check for an active task on this conversation ---
         const priorMessages = await database.getMessagesForConversation(conversation.id);
 
-        const activeStates = ['submitted', 'working', 'input_required', 'waiting_for_agent', 'claimed'];
-        const isActiveAndFresh = (t: { state: string; updatedAt: Date }) => {
-          if (!activeStates.includes(t.state)) return false;
-          // State-aware freshness (IND-401): an `input_required` task is an
-          // ask_user pause — it holds the conversation lock for its full answer
-          // window (+ slack for the expiry worker), not the 5-min turn window.
-          // Otherwise ambient rediscovery / chat negotiate_existing would start
-          // a fresh negotiation right past the pause after 5 minutes.
-          const freshnessMs = t.state === 'input_required'
-            ? askUserAnswerWindowMs() + ASK_USER_LOCK_SLACK_MS
-            : 5 * 60 * 1000;
-          return (Date.now() - new Date(t.updatedAt).getTime()) < freshnessMs;
-        };
-
         if (
           Boolean(state.resumeFromTaskId) !== Boolean(state.continuationSettlementId)
           || Boolean(state.resumeFromTaskId) !== Boolean(execution)
@@ -169,7 +156,7 @@ export class NegotiationGraphFactory {
             || storedExecution?.status !== 'claimed'
           ) return { error: 'invalid exact continuation task' };
         }
-        const isLocked = !exactContinuation && !!priorTask && isActiveAndFresh(priorTask);
+        const isLocked = !exactContinuation && !!priorTask && holdsNegotiationConversationLock(priorTask);
 
         if (isLocked) {
           initLog.info('Conversation locked by active task, returning busy', {
@@ -233,7 +220,7 @@ export class NegotiationGraphFactory {
           ? await database.getLatestNegotiationTaskForConversation?.(conversation.id).catch(() => null)
           : null;
         if (!readInitiator(priorTask?.metadata)) {
-          if (convTask && convTask.id !== priorTask?.id && isActiveAndFresh(convTask)) {
+          if (convTask && convTask.id !== priorTask?.id && holdsNegotiationConversationLock(convTask)) {
             const convInitiator = readInitiator(convTask.metadata);
             if (convInitiator) {
               initLog.info('Conversation-scoped tie-break: inheriting initiator seat from concurrent task', {

--- a/packages/protocol/src/negotiation/negotiation.task-lock-policy.ts
+++ b/packages/protocol/src/negotiation/negotiation.task-lock-policy.ts
@@ -1,0 +1,26 @@
+import { ASK_USER_LOCK_SLACK_MS, askUserAnswerWindowMs } from "./negotiation.protocol.js";
+
+const ACTIVE_NEGOTIATION_TASK_STATES = [
+  "submitted",
+  "working",
+  "input_required",
+  "waiting_for_agent",
+  "claimed",
+];
+
+/**
+ * Whether a persisted negotiation task still admits an exclusive conversation
+ * lock. A paused `ask_user` consultation holds the lock for its complete
+ * answer window plus expiry-worker slack; ordinary active turns use the
+ * existing five-minute freshness window.
+ */
+export function holdsNegotiationConversationLock(
+  task: { state: string; updatedAt: Date },
+  now = Date.now(),
+): boolean {
+  if (!ACTIVE_NEGOTIATION_TASK_STATES.includes(task.state)) return false;
+  const freshnessMs = task.state === "input_required"
+    ? askUserAnswerWindowMs() + ASK_USER_LOCK_SLACK_MS
+    : 5 * 60 * 1000;
+  return now - new Date(task.updatedAt).getTime() < freshnessMs;
+}


### PR DESCRIPTION
## IND-530 Batch 9

Extracts state-aware negotiation conversation-lock admission from `negotiation.graph.ts` into the narrow, capability-owned `negotiation.task-lock-policy.ts` module.

The graph retains task reads, exact-continuation bypass, busy response routing, initiator tie-break wiring, and every transaction/lifecycle boundary. The policy only determines whether an existing task owns the conversation lock: active ordinary work uses the five-minute window, while `input_required` consultations hold through the full answer window plus expiry-worker slack.

## Characterization and verification

- `cd packages/protocol && bun test src/negotiation/tests/negotiation.continuation.spec.ts --test-name-pattern "lock gate: returns error when active task exists within freshness window"` — 1 pass.
- `cd packages/protocol && bun test src/negotiation/tests/negotiation.ask-user.spec.ts --test-name-pattern "lock gate: an input_required task older than 5 min still holds the conversation lock|lock gate: an input_required task past window\\+slack releases the lock"` — 2 pass.
- `cd packages/protocol && bunx eslint src/negotiation/negotiation.graph.ts src/negotiation/negotiation.task-lock-policy.ts` — pass.
- `cd packages/protocol && bun run build` — pass.
- `cd packages/protocol && bun run architecture:check` — pass; host isolation and cycle baseline remain valid.
- `git diff --check` — pass.

No aggregate/full/isolated source suite, eval, provider/live-model, Railway, or database work ran.

## Metrics

Reproducible line-based scan of `negotiation.graph.ts` (function declarations plus const-arrow starts; branch-token CC approximation; unique direct relative imports; normalized 7-line duplicate windows):

| Metric | Before | After graph |
| --- | ---: | ---: |
| LOC | 1,515 | 1,502 |
| Function starts | 13 | 12 |
| Approx. CC | 288 | 285 |
| Direct local fan-out | 18 | 19 |
| Duplicate normalized 7-line windows | 16 | 16 |

Extracted policy: 26 LOC, 1 function start, approximate CC 3, direct local fan-out 1, duplicate windows 0. Net production LOC is +13.

## Release and environment

- Protocol SemVer: 6.13.8 → 6.13.9, compatible substantive extraction; CHANGELOG updated.
- `bun.lock` unchanged because package resolution did not change; it was not hand-edited.
- No environment files changed.
- `stash@{0}` remains untouched: `WIP: superseded Batch 5 graph dedup-resolution`.

## Residual scope

IND-530 remains **In Progress**. Explicit residual scope: remaining negotiation.graph lifecycle/persistence/validation/presentation seams; negotiation.tools; remaining opportunity.graph/tools seams; opportunity.discover and feed orchestration. The preserved opportunity-graph WIP stash is not part of this PR.