### PR TITLE
fix(protocol): make questioner evidence field strict-serializable (nullable+optional, null->undefined)

### DIFF
--- a/packages/protocol/CHANGELOG.md
+++ b/packages/protocol/CHANGELOG.md
@@ -13,6 +13,7 @@ See [STABILITY.md](./STABILITY.md) for the public-contract and tier definitions.
 ## [Unreleased]
 
 ### Fixed
+- Make the Questioner clarifying-questions schema survive strict structured-output conversion: the `Question.evidence` provenance field is now declared `.nullable().optional()` (was bare `.optional()`, which OpenAI/OpenRouter strict mode rejects), so every `QuestionerAgent` LLM call no longer failed client-side before any network I/O. A `.transform()` normalizes an LLM-returned `null` back to `undefined` so a null is never persisted or treated as "evidence present"; real string evidence chips (pool_discovery) flow through unchanged and the intent-recovery `!question.evidence` selection filter is unaffected (regression from the IND-418 pool_discovery work).
 - Allow the private intent-refinement provenance snapshot to identify intent creation as a producer and make the shared refinement prompt independent of no-opportunity process state, enabling creation and authoritative discovery producers to converge on one ordinary intent-page question cadence.
 
 ### Added

--- a/packages/protocol/package.json
+++ b/packages/protocol/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@indexnetwork/protocol",
-  "version": "6.12.0",
+  "version": "6.12.1",
   "type": "module",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",

--- a/packages/protocol/src/shared/schemas/question.schema.ts
+++ b/packages/protocol/src/shared/schemas/question.schema.ts
@@ -30,8 +30,18 @@ export const QuestionSchema = z.object({
    * Optional provenance line rendered as a muted chip above the prompt
    * (e.g. "based on 18 people matching this intent"). Aggregate counts only —
    * never individual identities (pool_discovery k-anonymity invariant).
+   *
+   * Declared `.nullable().optional()` (not bare `.optional()`) so the schema
+   * survives OpenAI/OpenRouter strict structured-output conversion, which
+   * rejects optional-without-nullable fields (see createStructuredModel in the
+   * questioner agent). The `.transform()` normalizes an LLM-returned `null`
+   * back to `undefined` so a null is NEVER persisted or treated as
+   * "evidence present": real string evidence flows through unchanged, while
+   * both `null` and omitted read as absent everywhere downstream
+   * (e.g. the intent-recovery `!question.evidence` selection filter and the
+   * pool_discovery provenance chip).
    */
-  evidence: z.string().min(1).max(160).optional(),
+  evidence: z.string().min(1).max(160).nullable().optional().transform((value) => value ?? undefined),
 });
 
 /** Canonical QUD repair categories for underspecified intents/questions. */

--- a/packages/protocol/src/shared/schemas/tests/question.schema.spec.ts
+++ b/packages/protocol/src/shared/schemas/tests/question.schema.spec.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect } from "bun:test";
+import { createRequire } from "node:module";
 
 import { QuestionOptionSchema, QuestionSchema, UnderspecificationTypeSchema, QuestionStrategySchema, QuestionWithStrategySchema, QuestionGeneratorResponseSchema, QuestionPurposeSchema, QuestionModeSchema, QuestionDetectionSchema, QuestionPoolSnapshotSchema, QuestionPoolPushSchema, QuestionVoidedReasonSchema, QuestionPoolPushRequestReasonSchema, QuestionActorSchema, QuestionAnswerSchema } from "../question.schema.js";
 
@@ -71,6 +72,27 @@ describe("QuestionSchema", () => {
   it("rejects missing multiSelect", () => {
     const { multiSelect: _, ...rest } = okQuestion;
     expect(() => QuestionSchema.parse(rest)).toThrow();
+  });
+
+  it("accepts a real string evidence chip unchanged", () => {
+    const parsed = QuestionSchema.parse({ ...okQuestion, evidence: "based on 18 people matching this intent" });
+    expect(parsed.evidence).toBe("based on 18 people matching this intent");
+  });
+
+  it("normalizes evidence: null to undefined (never 'evidence present')", () => {
+    const parsed = QuestionSchema.parse({ ...okQuestion, evidence: null });
+    expect(parsed.evidence).toBeUndefined();
+    // Behaves exactly like no evidence for the `!question.evidence` selection filter.
+    expect(!parsed.evidence).toBe(true);
+  });
+
+  it("treats omitted evidence as undefined", () => {
+    const parsed = QuestionSchema.parse(okQuestion);
+    expect(parsed.evidence).toBeUndefined();
+  });
+
+  it("rejects empty-string evidence", () => {
+    expect(() => QuestionSchema.parse({ ...okQuestion, evidence: "" })).toThrow();
   });
 });
 
@@ -151,6 +173,39 @@ describe("QuestionGeneratorResponseSchema", () => {
       underspecificationType: null,
     }));
     expect(() => QuestionGeneratorResponseSchema.parse({ questions: four })).toThrow();
+  });
+
+  it("normalizes evidence: null to undefined inside a nested question", () => {
+    const parsed = QuestionGeneratorResponseSchema.parse({
+      questions: [{
+        ...okQuestion,
+        evidence: null,
+        strategy: "refine_intent" as const,
+        underspecificationType: null,
+      }],
+    });
+    expect(parsed.questions[0].evidence).toBeUndefined();
+  });
+});
+
+/**
+ * Regression guard for the questioner LLM binding. `createStructuredModel`
+ * (see questioner.agent.ts) hands QuestionGeneratorResponseSchema to
+ * `@langchain/openai`, which converts it via OpenAI's zodResponseFormat in
+ * strict structured-output mode. Strict mode throws on any
+ * optional-without-nullable field, which previously made every QuestionerAgent
+ * call fail client-side before any network I/O. Run the exact conversion here
+ * (resolving the openai package @langchain/openai actually uses) so the binding
+ * cannot silently regress. A bare `.optional()` evidence field fails this test.
+ */
+describe("QuestionGeneratorResponseSchema strict structured-output conversion", () => {
+  const langchainRequire = createRequire(require.resolve("@langchain/openai/package.json"));
+  const { zodResponseFormat } = langchainRequire("openai/helpers/zod") as {
+    zodResponseFormat: (schema: unknown, name: string) => unknown;
+  };
+
+  it("serializes under OpenAI strict mode without throwing", () => {
+    expect(() => zodResponseFormat(QuestionGeneratorResponseSchema, "clarifying_questions")).not.toThrow();
   });
 });
 


### PR DESCRIPTION
## Bug
Every `QuestionerAgent` LLM call failed **deterministically, client-side, before any network I/O**:

```
Zod field at `#/definitions/clarifying_questions/properties/questions/items/properties/evidence`
uses `.optional()` without `.nullable()` which is not supported by the API
```

`QuestionerAgent` binds `QuestionGeneratorResponseSchema` via `createStructuredModel("questioner", …)` (questioner.agent.ts:39). LangChain converts that zod schema through OpenAI's `zodResponseFormat` in **strict** structured-output mode, which throws on any optional-without-nullable field. The offending field was `evidence: z.string().min(1).max(160).optional()` (question.schema.ts:34), added by PR #1123 (IND-418 pool_discovery). Retry + fallback bind the same schema, so failure was 100%. The agent caught the error, logged `QuestionerAgent LLM call failed`, and the job "succeeded" with no question — so **all** questioner-produced questions (creation-time intent, post-discovery recovery/expansion, uptake, negotiation, discovery modes) silently returned null. Chat-mode questions bypass QuestionerAgent and were unaffected.

## Fix (null-normalization design)
`evidence: z.string().min(1).max(160).nullable().optional().transform((value) => value ?? undefined)`

- `.nullable().optional()` makes the field pass strict conversion (`isNullable()` is now true).
- The field-level `.transform()` normalizes an LLM-returned `null` back to `undefined` **at parse time**, centrally, so **every** parse path (the agent's `safeParse`, any consumer) gets `undefined` — a `null` is never persisted or treated as "evidence present".
- Chosen field-level (not object-level) transform so `QuestionSchema` stays a `ZodObject` and `QuestionWithStrategySchema = QuestionSchema.extend(...)` keeps working. Inferred output type is unchanged (`evidence?: string`), so no downstream type churn.

Invariants held:
- (a) strict serialization no longer throws;
- (b) `evidence: null` behaves exactly like no evidence — the intent-recovery `!question.evidence` selection filter (intent-recovery-refinement.service.ts) still evaluates true, and the evidence is stripped before persist;
- (c) real string evidence still flows through pool_discovery provenance chips unchanged (transform only maps `null → undefined`; strings pass through).

## Secondary audit
`rg` over every schema passed to `createStructuredModel` (including imported output schemas) for bare `.optional()` without `.nullable()`. **No other identical case exists.** Two nearby hits are out of the exact class:
- `contact.inviter.ts` `referrerName` — on `InviteInputSchema` (an **input** schema), never strict-converted;
- `opportunity.evaluator.ts:580-581` `candidatesJson` / `minScore` — a `tool(...)` / `bindTools` **tool schema**, not a strict structured-output response schema.

Additionally ran the real `zodResponseFormat` strict conversion against 7 exported output schemas (QuestionGenerator, DiscoveryNegotiationDigest, ChatContextDigest, ReflectionResult, ScreenDecision, NetworkRecommenderOutput, HydeValidationResponse) — all convert cleanly. No fixes required beyond the questioner.

## Tests
- **Regression (fails on old schema):** a hermetic test resolving the exact `openai/helpers/zod` package `@langchain/openai` uses and running `zodResponseFormat(QuestionGeneratorResponseSchema, "clarifying_questions")`, asserting it does not throw.
- **Null normalization:** `QuestionSchema.parse({ evidence: null })` → `undefined`; nested `QuestionGeneratorResponseSchema` case; real-string passthrough; omitted → undefined; empty-string still rejected.
- **Proof:** against the pre-fix schema, exactly these 3 tests fail; with the fix all **58** schema tests pass.

## Verification
- `packages/protocol` `bun run build` (tsc): ✅
- `packages/protocol` schema + questioner tests: 177 pass, 1 fail — the 1 failure (`ask_user_question > generates, persists, streams…`) is **pre-existing on the clean base tree** (streamed prompt `undefined` in the ask-tool mock), unrelated to this change.
- `packages/protocol` lint (eslint) on touched files: ✅
- `services/api` `tsc --noEmit`: ✅ (confirms the updated protocol types don't break the recovery-service consumer)
- No `bun.lock` delta.

## Version
`@indexnetwork/protocol` patch bump **6.11.1 → 6.11.2** + CHANGELOG `[Unreleased] > Fixed` entry. No `packages/cli` dependency on protocol, so no lockstep bump.

Do not merge — merge is owned by the parent.
