### PR TITLE
feat(protocol): isolate autonomous negotiation intents

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -114,6 +114,10 @@ OPENROUTER_API_KEY=your-openrouter-api-key
 # PREMISE_DEDUP_SIMILARITY=                 # Premise dedup similarity threshold, 0..1 (protocol runtime)
 # NEGOTIATION_MAX_TURNS_CHAT=4
 # NEGOTIATION_MAX_TURNS_AMBIENT=6
+# NEGOTIATION_INCLUDE_OTHER_INTENTS=true   # Strict true|false. Default true preserves bounded active-intent context (exact
+                                           # opportunity-bound intent first, then up to four other active intents per participant).
+                                           # Set false to give autonomous opportunity negotiations only each participant's exact
+                                           # opportunity-bound intent; if that exact intent is absent, no unrelated fallback is sent.
 # NEGOTIATION_PROTOCOL_VERSION=v1          # Protocol version stamped on NEW negotiations: v1 (legacy) | v2 (seat rules:
                                            # initiator outreach/counter/question/withdraw, counterparty accept/decline/counter/question).
                                            # In-flight conversations inherit their stamped version; flipping this only affects fresh negotiations.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -355,7 +355,7 @@ IND-426 adds a default-off frame-v1 path behind `HYDE_FRAME_CONSTRAINTS_ENABLED=
 
 ### OpenRouter Configuration
 
-Model settings centralized in `packages/protocol/src/shared/agent/model.config.ts`. Key env vars: `OPENROUTER_API_KEY` (required), `CHAT_MODEL` (override), `CHAT_REASONING_EFFORT` (`minimal|low|medium|high|xhigh`), `RUN_OPPORTUNITY_EVAL_IN_PARALLEL` (experimental), `NEGOTIATION_MAX_TURNS_CHAT` (default 4, chat-path negotiations), `NEGOTIATION_MAX_TURNS_AMBIENT` (default 6, ambient/background negotiations). Use `ToolContext.modelConfig` to inject config per-request via `ChatAgent.create`; only `ChatAgent` reads `ModelConfig` from `ToolContext` — most other protocol agents rely on `OPENROUTER_API_KEY` in the environment (some accept an explicit `ModelConfig` as a direct parameter to `createModel()`).
+Model settings centralized in `packages/protocol/src/shared/agent/model.config.ts`. Key env vars: `OPENROUTER_API_KEY` (required), `CHAT_MODEL` (override), `CHAT_REASONING_EFFORT` (`minimal|low|medium|high|xhigh`), `RUN_OPPORTUNITY_EVAL_IN_PARALLEL` (experimental), `NEGOTIATION_MAX_TURNS_CHAT` (default 4, chat-path negotiations), `NEGOTIATION_MAX_TURNS_AMBIENT` (default 6, ambient/background negotiations), and strict `NEGOTIATION_INCLUDE_OTHER_INTENTS` (default `true`; `false` restricts autonomous opportunity negotiations to each participant's exact opportunity-bound intent before screen/prompt/dispatch/persistence). Use `ToolContext.modelConfig` to inject config per-request via `ChatAgent.create`; only `ChatAgent` reads `ModelConfig` from `ToolContext` — most other protocol agents rely on `OPENROUTER_API_KEY` in the environment (some accept an explicit `ModelConfig` as a direct parameter to `createModel()`).
 
 ### Rate Limiting
 

--- a/docs/design/protocol-deep-dive.md
+++ b/docs/design/protocol-deep-dive.md
@@ -313,6 +313,16 @@ The health scorer considers connection count, connector flow count, expired coun
 
 The graph creates an A2A conversation, alternates between proposer and responder agents, and records each turn as a message with structured data parts. The finalize node determines whether an opportunity was produced, computes agreed roles and average fit score, then persists the outcome as an artifact.
 
+Autonomous opportunity negotiation builds each participant context from the
+opportunity's exact actor-intent binding. `NEGOTIATION_INCLUDE_OTHER_INTENTS`
+defaults to `true`, preserving the exact-first bounded fallback of up to five
+active intents per participant. With the strict value `false`, only an owned
+exact bound intent is admitted; an actor without an exact binding receives no
+unrelated fallback. This pruning happens before the outreach screen,
+negotiator, dispatcher/polling context, persisted `turnContext`, and intent
+snapshot derivation. Personal negotiator chat keeps its explicit authenticated
+`read_intents` capability unchanged.
+
 **Dependencies:** `NegotiationGraphDatabase`, proposer agent, responder agent
 
 ### 3.12 Premise Graph

--- a/packages/protocol/CHANGELOG.md
+++ b/packages/protocol/CHANGELOG.md
@@ -12,6 +12,15 @@ See [STABILITY.md](./STABILITY.md) for the public-contract and tier definitions.
 
 ## [Unreleased]
 
+## [6.14.0] — 2026-07-25
+
+### Added
+- Add `NEGOTIATION_INCLUDE_OTHER_INTENTS` (IND-571), a strict boolean
+  deployment policy for autonomous opportunity negotiation. The default
+  preserves exact-first bounded active-intent context; `false` isolates each
+  participant to its exact opportunity-bound intent across fresh and
+  continuation negotiation contexts.
+
 ## [6.13.22] — 2026-07-25
 
 ### Added

--- a/packages/protocol/package.json
+++ b/packages/protocol/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@indexnetwork/protocol",
-  "version": "6.13.22",
+  "version": "6.14.0",
   "type": "module",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",

--- a/packages/protocol/src/negotiation/application/negotiation.graph.ts
+++ b/packages/protocol/src/negotiation/application/negotiation.graph.ts
@@ -1350,6 +1350,8 @@ export interface NegotiationCandidate {
   /** Exact opportunity-bound source and candidate intent IDs. */
   sourceIntentId?: string;
   candidateIntentId?: string;
+  /** Per-opportunity source context when its exact actor intent differs across a fan-out. */
+  sourceUser?: UserNegotiationContext;
   reasoning: string;
   valencyRole: string;
   networkId?: string;
@@ -1447,15 +1449,16 @@ export async function negotiateCandidates(
   const results = await Promise.all(
     candidates.map(async (candidate) => {
       const start = Date.now();
+      const candidateSourceUser = candidate.sourceUser ?? sourceUser;
       if (candidate.opportunityId) {
         const candidateName = candidate.candidateUser?.profile?.name;
         emitWide({
           type: "negotiation_session_start",
           opportunityId: candidate.opportunityId,
           negotiationConversationId: "", // filled in on session_end
-          sourceUserId: sourceUser.id,
+          sourceUserId: candidateSourceUser.id,
           candidateUserId: candidate.userId,
-          initiatorUserId: initiatorUserId ?? sourceUser.id,
+          initiatorUserId: initiatorUserId ?? candidateSourceUser.id,
           ...(candidateName && { candidateName }),
           trigger: trigger ?? "ambient",
           startedAt: start,
@@ -1469,7 +1472,7 @@ export async function negotiateCandidates(
           : indexContext;
 
         const result = await invokeWithAbortSignal(negotiationGraph, {
-          sourceUser,
+          sourceUser: candidateSourceUser,
           candidateUser: candidate.candidateUser,
           ...(candidate.sourceIntentId && { sourceIntentId: candidate.sourceIntentId }),
           ...(candidate.candidateIntentId && { candidateIntentId: candidate.candidateIntentId }),

--- a/packages/protocol/src/opportunity/application/opportunity.existing-negotiation.ts
+++ b/packages/protocol/src/opportunity/application/opportunity.existing-negotiation.ts
@@ -4,6 +4,11 @@ import type { QueueOpportunityNotificationFn } from './opportunity.lifecycle.js'
 
 const NEGOTIATION_INTENT_LIMIT = 5;
 
+/** Default-compatible deployment policy for autonomous opportunity negotiation. */
+export function negotiationIncludesOtherIntents(): boolean {
+  return process.env.NEGOTIATION_INCLUDE_OTHER_INTENTS !== 'false';
+}
+
 interface NegotiationIntentSource {
   id?: string | null;
   summary?: string | null;
@@ -34,13 +39,14 @@ export function buildPrioritizedNegotiationIntents(
   activeIntents: readonly NegotiationIntentSource[],
   exactIntentId?: string | null,
   fallbackIntent?: NegotiationIntentSource | null,
+  includeOtherIntents = true,
 ): ExistingOpportunityNegotiationUser['intents'] {
   const exactId = typeof exactIntentId === 'string' && exactIntentId.trim().length > 0 ? exactIntentId : null;
   const exactActive = exactId ? activeIntents.find((intent) => intent.id === exactId) : undefined;
   const ordered = [
     ...(exactActive ? [exactActive] : []),
     ...(!exactActive && fallbackIntent?.id === exactId ? [fallbackIntent] : []),
-    ...activeIntents,
+    ...(includeOtherIntents ? activeIntents : []),
   ];
   const seen = new Set<string>();
   const intents: ExistingOpportunityNegotiationUser['intents'] = [];
@@ -118,13 +124,18 @@ export async function negotiateExistingOpportunity(
 
   const sourceIntentId = resolveOpportunityActorIntent(sourceActor);
   const candidateIntentId = resolveOpportunityActorIntent(candidateActor);
+  const includeOtherIntents = negotiationIncludesOtherIntents();
   const [sourceAccount, sourceProfile, sourceIntents, candidateAccount, candidateProfile, candidateIntents] = await Promise.all([
     database.getUser(sourceActor.userId).catch(() => null),
     database.getProfile(sourceActor.userId).catch(() => null),
-    database.getActiveIntents(sourceActor.userId).catch(() => [] as ActiveIntent[]),
+    includeOtherIntents
+      ? database.getActiveIntents(sourceActor.userId).catch(() => [] as ActiveIntent[])
+      : Promise.resolve([] as ActiveIntent[]),
     database.getUser(candidateActor.userId).catch(() => null),
     database.getProfile(candidateActor.userId).catch(() => null),
-    database.getActiveIntents(candidateActor.userId).catch(() => [] as ActiveIntent[]),
+    includeOtherIntents
+      ? database.getActiveIntents(candidateActor.userId).catch(() => [] as ActiveIntent[])
+      : Promise.resolve([] as ActiveIntent[]),
   ]);
   const [sourceFallbackIntent, candidateFallbackIntent] = await Promise.all([
     sourceIntentId && !sourceIntents.some((intent) => intent.id === sourceIntentId) ? database.getIntent(sourceIntentId).catch(() => null) : null,
@@ -132,7 +143,12 @@ export async function negotiateExistingOpportunity(
   ]);
   const sourceUser = {
     id: sourceActor.userId,
-    intents: buildPrioritizedNegotiationIntents(sourceIntents, sourceIntentId, sourceFallbackIntent?.userId === sourceActor.userId ? sourceFallbackIntent : null),
+    intents: buildPrioritizedNegotiationIntents(
+      sourceIntents,
+      sourceIntentId,
+      sourceFallbackIntent?.userId === sourceActor.userId ? sourceFallbackIntent : null,
+      includeOtherIntents,
+    ),
     profile: {
       name: sourceProfile?.identity?.name ?? sourceAccount?.name,
       bio: sourceProfile?.identity?.bio ?? sourceAccount?.intro ?? undefined,
@@ -151,7 +167,12 @@ export async function negotiateExistingOpportunity(
     networkId: candidateActor.networkId,
     candidateUser: {
       id: candidateActor.userId,
-      intents: buildPrioritizedNegotiationIntents(candidateIntents, candidateIntentId, candidateFallbackIntent?.userId === candidateActor.userId ? candidateFallbackIntent : null),
+      intents: buildPrioritizedNegotiationIntents(
+        candidateIntents,
+        candidateIntentId,
+        candidateFallbackIntent?.userId === candidateActor.userId ? candidateFallbackIntent : null,
+        includeOtherIntents,
+      ),
       profile: {
         name: candidateProfile?.identity?.name ?? candidateAccount?.name,
         bio: candidateProfile?.identity?.bio ?? candidateAccount?.intro ?? undefined,

--- a/packages/protocol/src/opportunity/application/opportunity.graph.ts
+++ b/packages/protocol/src/opportunity/application/opportunity.graph.ts
@@ -63,7 +63,7 @@ import { mergeOpportunityEvidence, withCandidateEvidence, withMatchedStrategies 
 import { normalizeOpportunityActorIntent, resolveOpportunityActorIntent } from '../domain/opportunity.actor.js';
 import { approveOpportunityIntroduction, deleteOpportunityLifecycle, sendOpportunityLifecycle, updateOpportunityLifecycle, type QueueOpportunityNotificationFn } from './opportunity.lifecycle.js';
 import { stampEligibleNewbornOpportunities, type StampNewbornOpportunitiesFn } from './opportunity.newborn-stamping.js';
-import { buildPrioritizedNegotiationIntents, negotiateExistingOpportunity } from './opportunity.existing-negotiation.js';
+import { buildPrioritizedNegotiationIntents, negotiateExistingOpportunity, negotiationIncludesOtherIntents } from './opportunity.existing-negotiation.js';
 import { admitOpportunityPersistence, createEligibleOpportunityStatusUpdater } from './opportunity.persistence-admission.js';
 
 export type { QueueOpportunityNotificationFn } from './opportunity.lifecycle.js';
@@ -2085,6 +2085,7 @@ export class OpportunityGraphFactory {
       try {
         // Use the same discoveryUserId pattern as evaluationNode
         const discoveryUserId = (state.onBehalfOfUserId ?? state.userId) as string;
+        const includeOtherIntents = negotiationIncludesOtherIntents();
 
         const sourceAccount = await this.database.getUser(discoveryUserId).catch(() => null);
         const sourceIntentInputs = (state.indexedIntents ?? []).map((intent) => ({
@@ -2106,6 +2107,7 @@ export class OpportunityGraphFactory {
             sourceIntentInputs,
             state.triggerIntentId,
             ownedSourceFallback,
+            includeOtherIntents,
           ),
           profile: {
             name: state.sourceProfile?.identity?.name ?? sourceAccount?.name,
@@ -2171,26 +2173,45 @@ export class OpportunityGraphFactory {
             const userId = candidateActor.userId as string;
             const sourceIntentId = resolveOpportunityActorIntent(sourceActor);
             const candidateIntentId = resolveOpportunityActorIntent(candidateActor);
-            const [profile, user, activeIntents, intent] = await Promise.all([
+            const sourceExactActive = sourceIntentId
+              ? sourceIntentInputs.find((sourceIntent) => sourceIntent.id === sourceIntentId)
+              : undefined;
+            const [profile, user, activeIntents, intent, sourceIntent] = await Promise.all([
               this.database.getProfile(userId).catch(() => null),
               this.database.getUser(userId).catch(() => null),
-              this.database.getActiveIntents(userId).catch(() => []),
+              includeOtherIntents
+                ? this.database.getActiveIntents(userId).catch(() => [])
+                : Promise.resolve([] as ActiveIntent[]),
               candidateIntentId
                 ? this.database.getIntent(candidateIntentId).catch(() => null)
+                : null,
+              sourceIntentId && !sourceExactActive
+                ? this.database.getIntent(sourceIntentId).catch(() => null)
                 : null,
             ]);
 
             const ownedFallbackIntent = intent?.userId === userId ? intent : null;
+            const ownedSourceIntent = sourceIntent?.userId === discoveryUserId ? sourceIntent : null;
             const candidateIntents = buildPrioritizedNegotiationIntents(
               activeIntents,
               candidateIntentId,
               ownedFallbackIntent,
+              includeOtherIntents,
             );
 
             return {
               userId,
               ...(sourceIntentId ? { sourceIntentId } : {}),
               ...(candidateIntentId ? { candidateIntentId } : {}),
+              sourceUser: {
+                ...sourceUser,
+                intents: buildPrioritizedNegotiationIntents(
+                  sourceIntentInputs,
+                  sourceIntentId,
+                  ownedSourceIntent,
+                  includeOtherIntents,
+                ),
+              },
               opportunityId: opp.id as string,
               opportunityStatus: opp.status,
               opportunityUpdatedAt: opp.updatedAt,

--- a/packages/protocol/src/opportunity/tests/opportunity.existing-negotiation.spec.ts
+++ b/packages/protocol/src/opportunity/tests/opportunity.existing-negotiation.spec.ts
@@ -1,18 +1,85 @@
 import { describe, expect, test } from 'bun:test';
-import type { Id, Opportunity } from '../../shared/interfaces/database.interface.js';
+import type { ActiveIntent, Id, IntentRecord, Opportunity } from '../../shared/interfaces/database.interface.js';
 import { negotiateExistingOpportunity, type ExistingOpportunityNegotiationPort } from '../opportunity.existing-negotiation.js';
+
+const FLAG = 'NEGOTIATION_INCLUDE_OTHER_INTENTS';
+
+async function withFlag(value: string | undefined, run: () => Promise<void>): Promise<void> {
+  const previous = process.env[FLAG];
+  if (value === undefined) delete process.env[FLAG];
+  else process.env[FLAG] = value;
+  try {
+    await run();
+  } finally {
+    if (previous === undefined) delete process.env[FLAG];
+    else process.env[FLAG] = previous;
+  }
+}
+
+function opportunity(overrides?: Partial<Opportunity>): Opportunity {
+  return {
+    id: 'opp-existing',
+    actors: [
+      { userId: 'recipient' as Id<'users'>, role: 'patient', networkId: 'network-1' as Id<'networks'>, intent: 'intent-recipient' as Id<'intents'> },
+      { userId: 'counterparty' as Id<'users'>, role: 'agent', networkId: 'network-1' as Id<'networks'>, intent: 'intent-counterparty' as Id<'intents'> },
+    ],
+    detection: { source: 'manual', createdBy: 'recipient' as Id<'users'> },
+    interpretation: { reasoning: 'Strong fit' },
+    context: null,
+    confidence: 1,
+    status: 'negotiating',
+    createdAt: new Date(),
+    updatedAt: new Date(),
+    expiresAt: null,
+    ...overrides,
+  };
+}
+
+function activeIntent(_userId: string, id: string): ActiveIntent {
+  return {
+    id: id as Id<'intents'>,
+    payload: `Payload for ${id}`,
+    summary: `Summary for ${id}`,
+    createdAt: new Date(),
+  };
+}
+
+function exactIntent(userId: string, id: string): IntentRecord {
+  return {
+    ...activeIntent(userId, id),
+    userId,
+    isIncognito: false,
+    updatedAt: new Date(),
+    archivedAt: null,
+  };
+}
+
+function databaseFor(
+  persistedOpportunity: Opportunity,
+  options?: {
+    activeIntents?: Record<string, ActiveIntent[]>;
+    exactIntents?: Record<string, IntentRecord | null>;
+    onActiveIntentRead?: (userId: string) => void;
+  },
+): ExistingOpportunityNegotiationPort {
+  return {
+    getOpportunity: async () => persistedOpportunity,
+    getUser: async (userId) => ({ id: userId, name: userId, email: `${userId}@example.com`, socials: [] }),
+    getProfile: async () => null,
+    getActiveIntents: async (userId) => {
+      options?.onActiveIntentRead?.(userId);
+      return options?.activeIntents?.[userId] ?? [];
+    },
+    getIntent: async (intentId) => options?.exactIntents?.[intentId] ?? null,
+    getNetworkMemberContext: async () => null,
+  } as ExistingOpportunityNegotiationPort;
+}
 
 describe('negotiateExistingOpportunity', () => {
   test('fails closed before negotiation when a continuation actor binding is stale', async () => {
-    const opportunity = {
-      id: 'opp-existing',
-      actors: [
-        { userId: 'recipient' as Id<'users'>, role: 'patient' as const, networkId: 'network-1' as Id<'networks'>, intent: 'intent-recipient' as Id<'intents'> },
-        { userId: 'counterparty' as Id<'users'>, role: 'agent' as const, networkId: 'network-1' as Id<'networks'>, intent: 'intent-counterparty' as Id<'intents'> },
-      ],
-    } as unknown as Opportunity;
+    const persistedOpportunity = opportunity();
     const database = {
-      getOpportunity: async () => opportunity,
+      getOpportunity: async () => persistedOpportunity,
     } as unknown as ExistingOpportunityNegotiationPort;
     const executeNegotiation = async () => {
         throw new Error('stale continuation must not invoke negotiation');
@@ -47,5 +114,133 @@ describe('negotiateExistingOpportunity', () => {
     );
 
     expect(result).toEqual({ kind: 'skipped', reason: 'stale_continuation' });
+  });
+
+  test('unset flag preserves exact-first unrelated active-intent fallback for both sides', async () => {
+    await withFlag(undefined, async () => {
+      const captured: Array<{ source: string[]; candidate: string[] }> = [];
+      const database = databaseFor(opportunity(), {
+        activeIntents: {
+          recipient: [
+            activeIntent('recipient', 'other-recipient'),
+            activeIntent('recipient', 'intent-recipient'),
+          ],
+          counterparty: [
+            activeIntent('counterparty', 'other-counterparty'),
+            activeIntent('counterparty', 'intent-counterparty'),
+          ],
+        },
+      });
+
+      await negotiateExistingOpportunity(
+        database,
+        async ({ sourceUser, candidate }) => {
+          captured.push({
+            source: sourceUser.intents.map((intent) => intent.id),
+            candidate: candidate.candidateUser.intents.map((intent) => intent.id),
+          });
+          return { accepted: false };
+        },
+        { opportunityId: 'opp-existing', actorUserId: 'recipient' },
+      );
+
+      expect(captured).toEqual([{
+        source: ['intent-recipient', 'other-recipient'],
+        candidate: ['intent-counterparty', 'other-counterparty'],
+      }]);
+    });
+  });
+
+  test('false flag isolates both sides on an exact continuation and skips unrelated active-intent reads', async () => {
+    await withFlag('false', async () => {
+      const activeIntentReads: string[] = [];
+      const captured: Array<{ source: string[]; candidate: string[] }> = [];
+      const database = databaseFor(opportunity(), {
+        exactIntents: {
+          'intent-recipient': exactIntent('recipient', 'intent-recipient'),
+          'intent-counterparty': exactIntent('counterparty', 'intent-counterparty'),
+        },
+        onActiveIntentRead: (userId) => activeIntentReads.push(userId),
+      });
+
+      await negotiateExistingOpportunity(
+        database,
+        async ({ sourceUser, candidate, continuation }) => {
+          expect(continuation?.taskId).toBe('task-1');
+          captured.push({
+            source: sourceUser.intents.map((intent) => intent.id),
+            candidate: candidate.candidateUser.intents.map((intent) => intent.id),
+          });
+          return { accepted: false };
+        },
+        {
+          opportunityId: 'opp-existing',
+          actorUserId: 'recipient',
+          continuation: {
+            taskId: 'task-1',
+            settlementId: 'settlement-1',
+            opportunityId: 'opp-existing',
+            userId: 'recipient',
+            recipientIntentId: 'intent-recipient',
+            networkId: 'network-1',
+            intentFingerprint: 'fingerprint',
+            opportunityStatus: 'negotiating',
+            opportunityUpdatedAt: new Date().toISOString(),
+            counterpartyUserId: 'counterparty',
+            counterpartyIntentId: 'intent-counterparty',
+            successorTaskId: 'task-2',
+            conversationId: 'conversation-1',
+            token: 'token',
+            fence: 1,
+            leaseExpiresAt: new Date().toISOString(),
+            consultation: { recipientUserId: 'recipient', recipientIntentId: 'intent-recipient', kind: 'answer', selectedOptions: [] },
+          },
+        },
+      );
+
+      expect(activeIntentReads).toEqual([]);
+      expect(captured).toEqual([{
+        source: ['intent-recipient'],
+        candidate: ['intent-counterparty'],
+      }]);
+    });
+  });
+
+  test('false flag sends no unrelated fallback for an actor with no exact opportunity-bound intent', async () => {
+    await withFlag('false', async () => {
+      const captured: Array<{ source: string[]; candidate: string[] }> = [];
+      const persistedOpportunity = opportunity({
+        actors: [
+          { userId: 'recipient' as Id<'users'>, role: 'patient', networkId: 'network-1' as Id<'networks'> },
+          { userId: 'counterparty' as Id<'users'>, role: 'agent', networkId: 'network-1' as Id<'networks'>, intent: 'intent-counterparty' as Id<'intents'> },
+        ],
+      });
+      const database = databaseFor(persistedOpportunity, {
+        activeIntents: {
+          recipient: [activeIntent('recipient', 'unrelated-recipient')],
+          counterparty: [activeIntent('counterparty', 'unrelated-counterparty')],
+        },
+        exactIntents: {
+          'intent-counterparty': exactIntent('counterparty', 'intent-counterparty'),
+        },
+      });
+
+      await negotiateExistingOpportunity(
+        database,
+        async ({ sourceUser, candidate }) => {
+          captured.push({
+            source: sourceUser.intents.map((intent) => intent.id),
+            candidate: candidate.candidateUser.intents.map((intent) => intent.id),
+          });
+          return { accepted: false };
+        },
+        { opportunityId: 'opp-existing', actorUserId: 'recipient' },
+      );
+
+      expect(captured).toEqual([{
+        source: [],
+        candidate: ['intent-counterparty'],
+      }]);
+    });
   });
 });

--- a/packages/protocol/src/opportunity/tests/opportunity.graph.spec.ts
+++ b/packages/protocol/src/opportunity/tests/opportunity.graph.spec.ts
@@ -7,7 +7,7 @@
 import { config } from "dotenv";
 config({ path: '.env.test', override: true });
 
-import { afterAll, beforeAll, describe, test, it, expect, mock, spyOn } from 'bun:test';
+import { afterAll, afterEach, beforeAll, describe, test, it, expect, mock, spyOn } from 'bun:test';
 import { OpportunityGraphFactory, type OpportunityEvaluatorLike, buildDiscovererContext, buildPrioritizedNegotiationIntents } from '../opportunity.graph.js';
 import type { Id } from '../../shared/interfaces/database.interface.js';
 import type { CreateOpportunityData, HydeDocument, OpportunityGraphDatabase, OpportunityActor, Opportunity } from '../../shared/interfaces/database.interface.js';
@@ -25,9 +25,18 @@ type OpportunityGraphInvokeInput = Parameters<ReturnType<OpportunityGraphFactory
 type OpportunityGraphInvokeResult = Awaited<ReturnType<ReturnType<OpportunityGraphFactory['createGraph']>['invoke']>>;
 
 const dummyEmbedding = new Array(2000).fill(0.1);
+const originalNegotiationIncludeOtherIntents = process.env.NEGOTIATION_INCLUDE_OTHER_INTENTS;
+
+afterEach(() => {
+  if (originalNegotiationIncludeOtherIntents === undefined) {
+    delete process.env.NEGOTIATION_INCLUDE_OTHER_INTENTS;
+  } else {
+    process.env.NEGOTIATION_INCLUDE_OTHER_INTENTS = originalNegotiationIncludeOtherIntents;
+  }
+});
 
 describe('buildPrioritizedNegotiationIntents', () => {
-  test('prioritizes an exact fallback intent, removes duplicates, and keeps the five-intent cap', () => {
+  test('defaults to exact-first bounded fallback behavior', () => {
     const intents = buildPrioritizedNegotiationIntents(
       [
         { id: 'other-1', summary: 'Other 1', payload: 'one' },
@@ -48,6 +57,34 @@ describe('buildPrioritizedNegotiationIntents', () => {
       'other-3',
       'other-4',
     ]);
+  });
+
+  test('restricts context to the exact active or owned fallback intent', () => {
+    expect(buildPrioritizedNegotiationIntents(
+      [
+        { id: 'other-1', summary: 'Other 1', payload: 'one' },
+        { id: 'exact-intent', summary: 'Exact active', payload: 'exact active payload' },
+      ],
+      'exact-intent',
+      null,
+      false,
+    ).map((intent) => intent.id)).toEqual(['exact-intent']);
+
+    expect(buildPrioritizedNegotiationIntents(
+      [{ id: 'other-1', summary: 'Other 1', payload: 'one' }],
+      'exact-intent',
+      { id: 'exact-intent', summary: 'Exact fallback', payload: 'exact fallback payload' },
+      false,
+    ).map((intent) => intent.id)).toEqual(['exact-intent']);
+  });
+
+  test('provides no unrelated fallback when a restrictive context has no exact binding', () => {
+    expect(buildPrioritizedNegotiationIntents(
+      [{ id: 'other-1', summary: 'Other 1', payload: 'one' }],
+      undefined,
+      null,
+      false,
+    )).toEqual([]);
   });
 });
 
@@ -2612,7 +2649,8 @@ describe('Opportunity Graph', () => {
       expect(negotiationInvocations).toHaveLength(0);
     });
 
-    test('invokes negotiation and ignores a null-like exact actor intent from persisted data', async () => {
+    test('fresh negotiation preserves exact-first fallback when true and isolates both sides when false', async () => {
+      process.env.NEGOTIATION_INCLUDE_OTHER_INTENTS = 'false';
       const negotiationInvocations: unknown[] = [];
       const exactIntentLookups: string[] = [];
 
@@ -2743,7 +2781,7 @@ describe('Opportunity Graph', () => {
           {
             userId: 'a0000000-0000-4000-8000-000000000001',
             role: 'patient',
-            intentId: null,
+            intentId: 'intent-1',
           },
           {
             userId: 'b0000000-0000-4000-8000-000000000002',
@@ -2772,6 +2810,32 @@ describe('Opportunity Graph', () => {
       expect(negotiationInvocations.length).toBeGreaterThan(0);
       expect(exactIntentLookups.length).toBeGreaterThan(0);
       expect(new Set(exactIntentLookups)).toEqual(new Set(['intent-bob']));
+      const invocation = negotiationInvocations[0] as {
+        sourceUser: { intents: Array<{ id: string }> };
+        candidateUser: { intents: Array<{ id: string }> };
+      };
+      expect(invocation.sourceUser.intents.map((intent) => intent.id)).toEqual(['intent-1']);
+      expect(invocation.candidateUser.intents.map((intent) => intent.id)).toEqual(['intent-bob']);
+
+      process.env.NEGOTIATION_INCLUDE_OTHER_INTENTS = 'true';
+      negotiationInvocations.length = 0;
+      exactIntentLookups.length = 0;
+      await compiledGraph.invoke({
+        userId: 'a0000000-0000-4000-8000-000000000001' as Id<'users'>,
+        searchQuery: 'co-founder',
+        operationMode: 'create' as const,
+        options: { initialStatus: 'latent' as const },
+      });
+
+      const compatibleInvocation = negotiationInvocations[0] as {
+        sourceUser: { intents: Array<{ id: string }> };
+        candidateUser: { intents: Array<{ id: string }> };
+      };
+      expect(compatibleInvocation.sourceUser.intents.map((intent) => intent.id)).toEqual(['intent-1']);
+      expect(compatibleInvocation.candidateUser.intents.map((intent) => intent.id)).toEqual([
+        'intent-bob',
+        'intent-1',
+      ]);
     });
   });
 

--- a/services/api/src/startup.env.ts
+++ b/services/api/src/startup.env.ts
@@ -105,6 +105,7 @@ const envSchema = z.object({
   NEGOTIATION_SUMMARY_TIMEOUT_MS: optionalInt,
   NEGOTIATION_MAX_TURNS_CHAT: optionalInt,
   NEGOTIATION_MAX_TURNS_AMBIENT: optionalInt,
+  NEGOTIATION_INCLUDE_OTHER_INTENTS: z.enum(['true', 'false']).optional(),
   NEGOTIATION_PROTOCOL_VERSION: z.union([z.literal(''), z.enum(['v1', 'v2'])]).optional(),
   NEGOTIATOR_CHAT_ENABLED: optionalBoolean,
   WEB_SIGNAL_AGENT_ENABLED: optionalBoolean,

--- a/services/api/tests/env-example-drift.spec.ts
+++ b/services/api/tests/env-example-drift.spec.ts
@@ -63,6 +63,7 @@ function schemaVars(): Set<string> {
 describe('root .env.example ↔ startup.env.ts schema', () => {
   const example = exampleVars();
   const schema = schemaVars();
+  const schemaSource = readFileSync(schemaPath, 'utf8');
 
   it('sanity: parsers found a plausible number of vars', () => {
     expect(example.size).toBeGreaterThan(50);
@@ -89,5 +90,11 @@ describe('root .env.example ↔ startup.env.ts schema', () => {
       unvalidated,
       `Vars documented in the root .env.example but missing from the envSchema in src/startup.env.ts — add them to the schema (or to NON_API_PATTERNS if not read by the API): ${unvalidated.join(', ')}`,
     ).toEqual([]);
+  });
+
+  it('strictly validates NEGOTIATION_INCLUDE_OTHER_INTENTS as true or false', () => {
+    expect(schemaSource).toContain(
+      "NEGOTIATION_INCLUDE_OTHER_INTENTS: z.enum(['true', 'false']).optional()",
+    );
   });
 });


### PR DESCRIPTION
## New Features

- implement IND-571 with strict deployment config `NEGOTIATION_INCLUDE_OTHER_INTENTS`
- preserve exact-first, five-intent behavior when unset or `true`
- restrict fresh and existing/continuation opportunity negotiations to each actor exact owned intent when `false`
- keep per-opportunity source binding correct across fresh fan-out and skip unrelated active-intent reads on restrictive continuation reconstruction
- bump `@indexnetwork/protocol` from `6.13.22` to `6.14.0`

## Privacy contract

Participant intent arrays are pruned before the negotiation graph, so the outreach screener, IndexNegotiator prompts, dispatch/polling context, persisted `turnContext`, and task intent snapshots cannot receive unrelated intents in restrictive mode. Missing exact bindings produce an empty intent context. Personal negotiator chat `read_intents` remains unchanged.

## Documentation

- document the strict boolean and default in `.env.example`
- update protocol design guidance, repository agent guidance, and package changelog

## Verification

Passed:
- `cd packages/protocol && bun run build`
- `cd services/api && bun run build`
- focused opportunity isolation tests: 4 passed
- existing/continuation isolation tests: 4 passed
- negotiation graph snapshot tests: 11 passed
- continuation-screen, ask-user/turnContext, and resolved-payload tests: 60 passed
- `cd services/api && bun test tests/env-example-drift.spec.ts`: 4 passed
- startup validation: literal `false` accepted; uppercase `TRUE` rejected
- `cd services/api && bun run lint`: 0 errors, 34 pre-existing warnings
- `cd packages/protocol && bun run eval:verify`: all 9 provider-free suites passed
- `git diff --check`

Known repository baseline failures observed and left unchanged:
- isolated `opportunity.graph.spec.ts` test `when search returns unsupported profile type, profile candidates are ignored` expects 0 candidates but receives 1; this is outside the negotiation path changed here
- `bun run architecture:check` passes export inventory, consumer compilation, host isolation, and capability boundaries, then fails the existing production-module cycle spanning negotiation/questions/tool helper modules
- database-backed polling service tests refuse to start without `TEST_DATABASE_SAFE=1`; no unsafe database override was supplied

No merge is requested by this draft PR.