### PR TITLE
fix(api): correct intent debug diagnostics

### DIFF
--- a/docs/specs/api-reference.md
+++ b/docs/specs/api-reference.md
@@ -1498,8 +1498,13 @@ Returns a full diagnostic snapshot for a single intent, including the intent rec
     "text": "...",
     "summary": "...",
     "status": "active | archived",
-    "confidence": 0.85,
-    "inferenceType": "...",
+    "semanticEntropy": 0.15,
+    "referentialAnchor": "...",
+    "intentMode": "...",
+    "speechActType": "...",
+    "felicityAuthority": 8,
+    "felicitySincerity": 9,
+    "felicityClarity": 7,
     "sourceType": "...",
     "hasEmbedding": true,
     "createdAt": "...",
@@ -1511,7 +1516,16 @@ Returns a full diagnostic snapshot for a single intent, including the intent rec
     "newestGeneratedAt": "..."
   },
   "indexAssignments": [
-    { "indexId": "...", "indexTitle": "...", "indexPrompt": "..." }
+    {
+      "networkId": "...",
+      "networkTitle": "...",
+      "indexPrompt": "...",
+      "relevancyScore": 0.84,
+      "finalScore": 0.84,
+      "promptPresence": "both",
+      "rawScores": { "indexScore": 0.9, "memberScore": 0.75 },
+      "isDeterministicNoPromptAssignment": false
+    }
   ],
   "opportunities": {
     "total": 5,
@@ -1531,12 +1545,27 @@ Returns a full diagnostic snapshot for a single intent, including the intent rec
     "hasEmbedding": true,
     "hasHydeDocuments": true,
     "isInAtLeastOneIndex": true,
+    "verificationAnalysis": { "status": "complete", "missingFields": [] },
+    "missingVerificationAnalysis": false,
+    "missingAssignment": false,
+    "missingHyde": false,
     "hasOpportunities": true,
     "allOpportunitiesFilteredFromHome": false,
     "filterReasons": []
   }
 }
 ```
+
+`semanticEntropy` is the stored entropy value, not a confidence score; no
+combined verifier score is exposed. `verificationAnalysis.status` is
+`complete`, `default_only`, `partial`, or `missing`, so default schema values
+cannot be mistaken for completed verification. Assignment `finalScore` and
+`promptPresence` are null for legacy rows without persisted assignment metadata;
+`rawScores` is omitted when the assignment policy did not call a model. A
+promptless automatic assignment therefore reports `promptPresence: "none"`,
+`finalScore: 1`, and `isDeterministicNoPromptAssignment: true` without raw scores.
+The three `missing*` diagnosis fields independently identify absent verification,
+assignment, and HyDE artifacts.
 
 ### GET /api/debug/home
 

--- a/services/api/package.json
+++ b/services/api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@indexnetwork/api",
-  "version": "0.59.4",
+  "version": "0.59.5",
   "license": "MIT",
   "private": true,
   "scripts": {

--- a/services/api/src/controllers/debug.controller.ts
+++ b/services/api/src/controllers/debug.controller.ts
@@ -8,6 +8,8 @@ import { intents, hydeDocuments, intentNetworks, networks, networkMembers, oppor
 import { conversations, conversationParticipants, conversationMetadata, messages, tasks } from '../schemas/conversation.schema';
 import { DebugIntentDiscoveryBlockedError, debugService } from '../services/debug.service';
 
+import { buildIntentAssignmentDiagnostic, buildIntentDebugRecord, buildIntentPipelineHealthDiagnostic, buildVerificationAnalysisDiagnostic } from '../services/debug-intent-diagnostics.service';
+
 import { AuthGuard, type AuthenticatedUser } from '../guards/auth.guard';
 import { DebugGuard } from '../guards/debug.guard';
 import { RateLimit } from '../guards/limiter.guard';
@@ -77,8 +79,13 @@ export class DebugController {
         id: intents.id,
         payload: intents.payload,
         summary: intents.summary,
-        confidence: intents.semanticEntropy,
-        inferenceType: intents.intentMode,
+        semanticEntropy: intents.semanticEntropy,
+        referentialAnchor: intents.referentialAnchor,
+        intentMode: intents.intentMode,
+        speechActType: intents.speechActType,
+        felicityAuthority: intents.felicityAuthority,
+        felicitySincerity: intents.felicitySincerity,
+        felicityClarity: intents.felicityClarity,
         sourceType: intents.sourceType,
         hasEmbedding: sql<boolean>`${intents.embedding} IS NOT NULL`.as('has_embedding'),
         createdAt: intents.createdAt,
@@ -114,6 +121,8 @@ export class DebugController {
         networkId: intentNetworks.networkId,
         networkTitle: networks.title,
         indexPrompt: networks.prompt,
+        relevancyScore: intentNetworks.relevancyScore,
+        assignmentMetadata: intentNetworks.assignmentMetadata,
       })
       .from(intentNetworks)
       .innerJoin(networks, eq(intentNetworks.networkId, networks.id))
@@ -137,18 +146,7 @@ export class DebugController {
 
     // ── 5. Build response shapes ──────────────────────────────────────
 
-    const intentResponse = {
-      id: intent.id,
-      text: intent.payload,
-      summary: intent.summary,
-      status: intent.archivedAt ? 'archived' : 'active',
-      confidence: intent.confidence,
-      inferenceType: intent.inferenceType,
-      sourceType: intent.sourceType,
-      hasEmbedding: intent.hasEmbedding,
-      createdAt: intent.createdAt.toISOString(),
-      updatedAt: intent.updatedAt.toISOString(),
-    };
+    const intentResponse = buildIntentDebugRecord(intent);
 
     const hydeDocumentsResponse = {
       count: hydeStats?.count ?? 0,
@@ -156,11 +154,7 @@ export class DebugController {
       newestGeneratedAt: hydeStats?.newestGeneratedAt?.toISOString() ?? null,
     };
 
-    const indexAssignments = indexRows.map((r) => ({
-      networkId: r.networkId,
-      networkTitle: r.networkTitle,
-      indexPrompt: r.indexPrompt,
-    }));
+    const indexAssignments = indexRows.map(buildIntentAssignmentDiagnostic);
 
     // Aggregate opportunities by status
     const byStatus: Record<string, number> = {};
@@ -189,6 +183,7 @@ export class DebugController {
     const hasHydeDocuments = (hydeStats?.count ?? 0) > 0;
     const isInAtLeastOneIndex = indexRows.length > 0;
     const hasOpportunities = opportunityRows.length > 0;
+    const verificationAnalysis = buildVerificationAnalysisDiagnostic(intent);
 
     // Check if all opportunities are filtered from home (using role-aware helpers)
     const actionableCount = opportunityRows.filter((o) => {
@@ -209,9 +204,12 @@ export class DebugController {
     }
 
     const diagnosis = {
-      hasEmbedding: intent.hasEmbedding,
-      hasHydeDocuments,
-      isInAtLeastOneIndex,
+      ...buildIntentPipelineHealthDiagnostic({
+        hasEmbedding: intent.hasEmbedding,
+        verificationAnalysis,
+        hasHydeDocuments,
+        isInAtLeastOneIndex,
+      }),
       hasOpportunities,
       allOpportunitiesFilteredFromHome,
       filterReasons,

--- a/services/api/src/controllers/tests/debug.intent-diagnostics.spec.ts
+++ b/services/api/src/controllers/tests/debug.intent-diagnostics.spec.ts
@@ -1,0 +1,140 @@
+import { describe, expect, test } from 'bun:test';
+
+import { buildIntentAssignmentDiagnostic, buildIntentDebugRecord, buildIntentPipelineHealthDiagnostic, buildVerificationAnalysisDiagnostic } from '../../services/debug-intent-diagnostics.service';
+
+describe('intent debug diagnostics', () => {
+  test('marks default entropy with absent verifier columns as default-only analysis', () => {
+    const diagnostic = buildVerificationAnalysisDiagnostic({
+      semanticEntropy: 1,
+      referentialAnchor: null,
+      intentMode: 'ATTRIBUTIVE',
+      speechActType: null,
+      felicityAuthority: null,
+      felicitySincerity: null,
+      felicityClarity: null,
+    });
+
+    expect(diagnostic).toEqual({
+      status: 'default_only',
+      missingFields: [
+        'referentialAnchor',
+        'speechActType',
+        'felicityAuthority',
+        'felicitySincerity',
+        'felicityClarity',
+      ],
+    });
+  });
+
+  test('keeps all verifier fields distinct when analysis is complete', () => {
+    expect(buildVerificationAnalysisDiagnostic({
+      semanticEntropy: 0.2,
+      referentialAnchor: 'first-person commitment',
+      intentMode: 'DIRECTIVE',
+      speechActType: 'COMMISSIVE',
+      felicityAuthority: 8,
+      felicitySincerity: 9,
+      felicityClarity: 7,
+    })).toEqual({ status: 'complete', missingFields: [] });
+  });
+
+  test('exposes entropy by name and preserves default/null verifier values', () => {
+    const response = buildIntentDebugRecord({
+      id: 'intent-1',
+      payload: 'Need a collaborator',
+      summary: null,
+      semanticEntropy: 1,
+      referentialAnchor: null,
+      intentMode: 'ATTRIBUTIVE',
+      speechActType: null,
+      felicityAuthority: null,
+      felicitySincerity: null,
+      felicityClarity: null,
+      sourceType: 'discovery_form',
+      hasEmbedding: true,
+      createdAt: new Date('2026-07-25T00:00:00.000Z'),
+      updatedAt: new Date('2026-07-25T00:00:00.000Z'),
+      archivedAt: null,
+    });
+
+    expect(response).toMatchObject({
+      semanticEntropy: 1,
+      referentialAnchor: null,
+      intentMode: 'ATTRIBUTIVE',
+      speechActType: null,
+      felicityAuthority: null,
+      felicitySincerity: null,
+      felicityClarity: null,
+    });
+    expect(response).not.toHaveProperty('confidence');
+    expect(response).not.toHaveProperty('inferenceType');
+  });
+
+  test('reports promptless assignment as deterministic without raw model scores', () => {
+    expect(buildIntentAssignmentDiagnostic({
+      networkId: 'network-1',
+      networkTitle: 'No prompts',
+      indexPrompt: null,
+      relevancyScore: '1.0',
+      assignmentMetadata: {
+        resourceType: 'intent',
+        mode: 'automatic',
+        scope: 'global',
+        policy: 'unified-threshold-v1',
+        threshold: 0.7,
+        promptPresence: 'none',
+        finalScore: 1,
+        assigned: true,
+      },
+    })).toEqual({
+      networkId: 'network-1',
+      networkTitle: 'No prompts',
+      indexPrompt: null,
+      relevancyScore: 1,
+      finalScore: 1,
+      promptPresence: 'none',
+      isDeterministicNoPromptAssignment: true,
+    });
+  });
+
+  test('does not fabricate final or raw scores for legacy assignments', () => {
+    expect(buildIntentAssignmentDiagnostic({
+      networkId: 'network-legacy',
+      networkTitle: 'Legacy',
+      indexPrompt: 'people who build tools',
+      relevancyScore: null,
+      assignmentMetadata: null,
+    })).toEqual({
+      networkId: 'network-legacy',
+      networkTitle: 'Legacy',
+      indexPrompt: 'people who build tools',
+      relevancyScore: null,
+      finalScore: null,
+      promptPresence: null,
+      isDeterministicNoPromptAssignment: false,
+    });
+  });
+
+  test('makes missing verification analysis, assignment, and HyDE independently visible', () => {
+    const verificationAnalysis = buildVerificationAnalysisDiagnostic({
+      semanticEntropy: null,
+      referentialAnchor: null,
+      intentMode: null,
+      speechActType: null,
+      felicityAuthority: null,
+      felicitySincerity: null,
+      felicityClarity: null,
+    });
+
+    expect(buildIntentPipelineHealthDiagnostic({
+      hasEmbedding: true,
+      verificationAnalysis,
+      hasHydeDocuments: false,
+      isInAtLeastOneIndex: false,
+    })).toMatchObject({
+      missingVerificationAnalysis: true,
+      missingAssignment: true,
+      missingHyde: true,
+    });
+  });
+});

--- a/services/api/src/services/debug-intent-diagnostics.service.ts
+++ b/services/api/src/services/debug-intent-diagnostics.service.ts
@@ -1,0 +1,131 @@
+import type { NetworkAssignmentMetadata } from '@indexnetwork/protocol';
+
+export interface IntentVerificationFields {
+  semanticEntropy: number | null;
+  referentialAnchor: string | null;
+  intentMode: string | null;
+  speechActType: string | null;
+  felicityAuthority: number | null;
+  felicitySincerity: number | null;
+  felicityClarity: number | null;
+}
+
+export type VerificationAnalysisStatus = 'complete' | 'default_only' | 'partial' | 'missing';
+
+export interface IntentDebugRecordInput extends IntentVerificationFields {
+  id: string;
+  payload: string;
+  summary: string | null;
+  sourceType: string | null;
+  hasEmbedding: boolean;
+  createdAt: Date;
+  updatedAt: Date;
+  archivedAt: Date | null;
+}
+
+/**
+ * Classifies persisted verifier columns without treating schema defaults as evidence
+ * that verification ran. A complete analysis requires every verifier field.
+ */
+export function buildVerificationAnalysisDiagnostic(
+  fields: IntentVerificationFields,
+): { status: VerificationAnalysisStatus; missingFields: string[] } {
+  const requiredFields: Array<[string, unknown]> = [
+    ['semanticEntropy', fields.semanticEntropy],
+    ['referentialAnchor', fields.referentialAnchor],
+    ['intentMode', fields.intentMode],
+    ['speechActType', fields.speechActType],
+    ['felicityAuthority', fields.felicityAuthority],
+    ['felicitySincerity', fields.felicitySincerity],
+    ['felicityClarity', fields.felicityClarity],
+  ];
+  const missingFields = requiredFields
+    .filter(([, value]) => value === null)
+    .map(([name]) => name);
+
+  if (missingFields.length === 0) return { status: 'complete', missingFields };
+
+  const isDefaultOnly = fields.semanticEntropy === 1
+    && fields.intentMode === 'ATTRIBUTIVE'
+    && fields.referentialAnchor === null
+    && fields.speechActType === null
+    && fields.felicityAuthority === null
+    && fields.felicitySincerity === null
+    && fields.felicityClarity === null;
+
+  if (isDefaultOnly) return { status: 'default_only', missingFields };
+  if (missingFields.length === requiredFields.length) return { status: 'missing', missingFields };
+  return { status: 'partial', missingFields };
+}
+
+/**
+ * Projects verifier columns with their persisted names. In particular,
+ * semantic entropy is not a confidence score and is never exposed as one.
+ */
+export function buildIntentDebugRecord(intent: IntentDebugRecordInput) {
+  return {
+    id: intent.id,
+    text: intent.payload,
+    summary: intent.summary,
+    status: intent.archivedAt ? 'archived' : 'active',
+    semanticEntropy: intent.semanticEntropy,
+    referentialAnchor: intent.referentialAnchor,
+    intentMode: intent.intentMode,
+    speechActType: intent.speechActType,
+    felicityAuthority: intent.felicityAuthority,
+    felicitySincerity: intent.felicitySincerity,
+    felicityClarity: intent.felicityClarity,
+    sourceType: intent.sourceType,
+    hasEmbedding: intent.hasEmbedding,
+    createdAt: intent.createdAt.toISOString(),
+    updatedAt: intent.updatedAt.toISOString(),
+  };
+}
+
+/** Builds the independently actionable verification, assignment, and HyDE health signals. */
+export function buildIntentPipelineHealthDiagnostic(input: {
+  hasEmbedding: boolean;
+  verificationAnalysis: ReturnType<typeof buildVerificationAnalysisDiagnostic>;
+  hasHydeDocuments: boolean;
+  isInAtLeastOneIndex: boolean;
+}) {
+  return {
+    hasEmbedding: input.hasEmbedding,
+    hasHydeDocuments: input.hasHydeDocuments,
+    isInAtLeastOneIndex: input.isInAtLeastOneIndex,
+    verificationAnalysis: input.verificationAnalysis,
+    missingVerificationAnalysis: input.verificationAnalysis.status !== 'complete',
+    missingAssignment: !input.isInAtLeastOneIndex,
+    missingHyde: !input.hasHydeDocuments,
+  };
+}
+
+export interface IntentAssignmentDiagnosticInput {
+  networkId: string;
+  networkTitle: string;
+  indexPrompt: string | null;
+  relevancyScore: string | null;
+  assignmentMetadata: NetworkAssignmentMetadata | null;
+}
+
+/**
+ * Serializes stored assignment diagnostics without fabricating a final score for
+ * legacy rows that predate assignment metadata.
+ */
+export function buildIntentAssignmentDiagnostic(row: IntentAssignmentDiagnosticInput) {
+  const metadata = row.assignmentMetadata;
+  const deterministicNoPromptAssignment = metadata?.promptPresence === 'none'
+    && metadata.finalScore === 1
+    && metadata.rawScores === undefined;
+
+  return {
+    networkId: row.networkId,
+    networkTitle: row.networkTitle,
+    indexPrompt: row.indexPrompt,
+    relevancyScore: row.relevancyScore === null ? null : Number(row.relevancyScore),
+    finalScore: metadata?.finalScore ?? null,
+    promptPresence: metadata?.promptPresence ?? null,
+    isDeterministicNoPromptAssignment: deterministicNoPromptAssignment,
+    ...(metadata?.rawScores === undefined ? {} : { rawScores: metadata.rawScores }),
+  };
+}


### PR DESCRIPTION
## Summary

- Replace the misleading intent debug `confidence` projection with `semanticEntropy` and expose referential anchor, intent mode, speech-act type, and all felicity scores.
- Surface assignment `relevancyScore`, metadata `finalScore`, `promptPresence`, optional `rawScores`, and the deterministic no-prompt (`finalScore: 1`) path.
- Distinguish missing verifier analysis, missing assignment, and missing HyDE artifacts; document the debug response contract.

## Root cause

The debug endpoint aliased persisted semantic entropy as confidence, making a default entropy of 1 on rows with absent verifier analysis look like maximum confidence.

## Validation

- `cd services/api && bun test src/controllers/tests/debug.intent-diagnostics.spec.ts` — 6 pass
- `cd services/api && bunx eslint src/controllers/debug.controller.ts src/services/debug-intent-diagnostics.service.ts src/controllers/tests/debug.intent-diagnostics.spec.ts`
- `cd services/api && bun run lint` — pass with 34 existing warnings
- `cd services/api && bun run build`
- `bun install --lockfile-only` — lockfile reconciled; no diff
- `git diff --check`

The API package version is bumped from `0.59.4` to `0.59.5`.