### PR TITLE
fix(api): reconcile orphaned intent indexing

### DIFF
--- a/docs/design/intent-indexing-integrity.md
+++ b/docs/design/intent-indexing-integrity.md
@@ -1,0 +1,53 @@
+# Intent indexing admission integrity
+
+## Admission invariant
+
+For a normal active intent create, the only successful path is:
+
+```text
+assignment -> intent HyDE generation -> from-intent discovery enqueue -> discovery completion stamp
+```
+
+Promptless, assignment-eligible memberships are deliberately assigned with
+`finalScore=1.0` and no `rawScores`; this is a deterministic successful
+assignment, not an evaluator failure. A prompted network can validly have zero
+assignments when its evaluated score is below the unified threshold. Those two
+states must never be conflated.
+
+The first-discovery success stamp is permitted only after discovery finishes and
+the same active assignment/membership admission predicate still holds. A
+membership removal or unassignment that happens while discovery runs leaves the
+stamp unset and causes the BullMQ job to retry.
+
+## Incident causal proof (IND-586)
+
+The historical source is deterministic and directly explains the affected dev
+shape (no `intent_networks`, no intent HyDE documents, but a success stamp):
+
+1. Commit `1f54b7f666bd590903a67bed93b6af2257d743bc` (2026-07-21) added
+   `first_discovery_succeeded_at` stamping after any successful
+   `FromIntentQueue` run.
+2. At that point `IntentEvents.onCreated` independently enqueued
+   `fromIntentQueue` before assignment or HyDE. The queue accepted an omitted
+   network scope, so this path could complete and stamp without indexing
+   artifacts.
+3. Commit `7fd003809733564c5044fa6468951c5f57f0d44f` (2026-07-22) removed
+   that alternate create-time enqueue explicitly because it raced assignment and
+   produced misleading success.
+4. The confirmation service also persisted first and caught a rejected
+   `addGenerateHydeJob` call. That fail-open acknowledgement gap independently
+   stranded successful confirmations with neither assignments nor HyDE.
+
+Focused regression tests reproduce the two prevented conditions: failed
+confirmation admission is returned as retryable, and an assignment disappearing
+between discovery admission and completion cannot receive a success stamp.
+
+## Reconciliation
+
+`reconcile_orphaned_intent` is idempotent. It re-reads owner, active lifecycle,
+scope, current assignments, and intent HyDE documents at execution time. It
+skips missing, foreign, paused, and archived intents; does nothing once both
+artifacts exist; otherwise it invokes the ordinary admission path. Its scope is
+narrowing-only, so it cannot widen a scoped agent's reachable networks. Queue
+failures use BullMQ's three-attempt exponential backoff and retain failures for
+seven days for inspection.

--- a/services/api/package.json
+++ b/services/api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@indexnetwork/api",
-  "version": "0.59.5",
+  "version": "0.59.6",
   "license": "MIT",
   "private": true,
   "scripts": {

--- a/services/api/package.json
+++ b/services/api/package.json
@@ -30,6 +30,7 @@
     "maintenance:backfill-intent-questions": "bun ./src/cli/backfill-intent-questions.ts",
     "maintenance:backfill-personal-index-prompts": "bun ./src/cli/backfill-personal-index-prompts.ts",
     "maintenance:backfill-intent-networks": "bun ./src/cli/backfill-intent-networks.ts",
+    "maintenance:reconcile-orphaned-intent-indexing": "bun ./src/cli/reconcile-orphaned-intent-indexing.ts",
     "test:opportunity-three-user": "bun ./src/cli/opportunity-three-user-test.ts",
     "test": "NODE_ENV=test bash scripts/test-safe.sh",
     "test:raw": "NODE_ENV=test bun test"

--- a/services/api/src/cli/reconcile-orphaned-intent-indexing.ts
+++ b/services/api/src/cli/reconcile-orphaned-intent-indexing.ts
@@ -1,0 +1,56 @@
+#!/usr/bin/env bun
+/**
+ * Enqueue the guarded IND-586 reconciliation for explicitly named dev intents.
+ *
+ * This command intentionally has no broad sweep mode and refuses production.
+ * Run only after the fixed API is deployed and verified on dev:
+ *
+ * bun run maintenance:reconcile-orphaned-intent-indexing -- --confirm-dev --intent <uuid> --intent <uuid>
+ */
+import { closeDb } from '../lib/drizzle/drizzle';
+import { intentQueue } from '../queues/intent.queue';
+import { ChatDatabaseAdapter } from '../adapters/database.adapter';
+
+function valuesFor(flag: string): string[] {
+  const values: string[] = [];
+  for (let index = 0; index < process.argv.length; index += 1) {
+    if (process.argv[index] === flag && process.argv[index + 1]) values.push(process.argv[index + 1]!);
+  }
+  return values;
+}
+
+async function main(): Promise<void> {
+  if (process.env.NODE_ENV === 'production') {
+    throw new Error('Refusing to reconcile production data');
+  }
+  if (!process.argv.includes('--confirm-dev')) {
+    throw new Error('Pass --confirm-dev after the deployed dev fix has been verified');
+  }
+  const intentIds = valuesFor('--intent');
+  if (intentIds.length === 0) {
+    throw new Error('Provide one or more explicit --intent UUID values; broad reconciliation is intentionally unavailable');
+  }
+
+  const adapter = new ChatDatabaseAdapter();
+  for (const intentId of intentIds) {
+    const intent = await adapter.getIntentForIndexing(intentId);
+    if (!intent) throw new Error(`Intent not found: ${intentId}`);
+    if (intent.archivedAt || (intent.status != null && intent.status !== 'ACTIVE')) {
+      throw new Error(`Intent is not active and cannot be reconciled: ${intentId}`);
+    }
+    await intentQueue.addOrphanReconciliationJob({ intentId, userId: intent.userId });
+    console.log(`Enqueued guarded orphan reconciliation for ${intentId}`);
+  }
+}
+
+main()
+  .then(async () => {
+    await intentQueue.close();
+    await closeDb();
+  })
+  .catch(async (error: unknown) => {
+    console.error(error instanceof Error ? error.message : String(error));
+    await intentQueue.close().catch(() => {});
+    await closeDb().catch(() => {});
+    process.exit(1);
+  });

--- a/services/api/src/controllers/intent.controller.ts
+++ b/services/api/src/controllers/intent.controller.ts
@@ -5,7 +5,7 @@ import { AuthGuard, SessionOnlyGuard, type AuthenticatedUser } from '../guards/a
 import { RateLimit } from '../guards/limiter.guard';
 import { log } from '../lib/log';
 import { Controller, Get, Patch, Post, UseGuards } from '../lib/router/router.decorators';
-import { IntentNetworkMembershipError, intentService } from '../services/intent.service';
+import { IntentAdmissionEnqueueError, IntentNetworkMembershipError, intentService } from '../services/intent.service';
 
 const logger = log.controller.from('intent');
 
@@ -114,6 +114,21 @@ export class IntentController {
           detail: err.message,
           networkId: err.networkId,
         }, { status: 403 });
+      }
+      if (err instanceof IntentAdmissionEnqueueError) {
+        logger.error('Intent confirmation indexing admission was not acknowledged', {
+          event: 'intent_admission_enqueue_failed',
+          userId: user.id,
+          proposalId,
+          intentId: err.intentId,
+          error: err.cause,
+        });
+        return Response.json({
+          error: 'Intent was saved but indexing could not be queued',
+          code: err.code,
+          intentId: err.intentId,
+          retryable: true,
+        }, { status: 503 });
       }
       logger.error('Intent confirm failed', { userId: user.id, proposalId, error: err });
       return Response.json({ error: 'Failed to process intent confirmation' }, { status: 500 });

--- a/services/api/src/queues/intent.queue.ts
+++ b/services/api/src/queues/intent.queue.ts
@@ -50,7 +50,7 @@ function deriveIntentDiscoveryNetworkIds(memberships: AssignmentNetworkMembershi
 /** Minimal database interface for intent queue (used when deps provided in tests). */
 export type IntentQueueDatabase = Pick<
   ChatDatabaseAdapter,
-  'getIntentForIndexing' | 'getAssignmentNetworkMembershipsForUser' | 'getAssignmentNetworkIdsForUser' | 'assignIntentToNetworkIfMember' | 'deleteHydeDocumentsForSource' | 'getNetworkAssignmentContext' | 'getProfile' | 'getActiveIntents'
+  'getIntentForIndexing' | 'getAssignmentNetworkMembershipsForUser' | 'getAssignmentNetworkIdsForUser' | 'assignIntentToNetworkIfMember' | 'deleteHydeDocumentsForSource' | 'getHydeDocumentsForSource' | 'getNetworkIdsForIntent' | 'getNetworkAssignmentContext' | 'getProfile' | 'getActiveIntents'
 >;
 
 /**
@@ -150,7 +150,7 @@ export class IntentQueue implements IntentGraphQueue {
    * @returns The BullMQ job
    */
   async addJob(
-    name: 'generate_hyde' | 'delete_hyde' | 'reconcile_intent_networks',
+    name: 'generate_hyde' | 'delete_hyde' | 'reconcile_intent_networks' | 'reconcile_orphaned_intent',
     data: IntentJobData | IntentDeleteData,
     options?: { jobId?: string; priority?: number }
   ): Promise<Job<IntentJobPayload>> {
@@ -177,6 +177,9 @@ export class IntentQueue implements IntentGraphQueue {
       case 'reconcile_intent_networks':
         await this.handleReconcileNetworks(data as IntentJobData);
         break;
+      case 'reconcile_orphaned_intent':
+        await this.handleReconcileOrphanedIntent(data as IntentJobData);
+        break;
       case 'delete_hyde':
         await this.handleDeleteHyde(data as IntentDeleteData);
         break;
@@ -198,6 +201,18 @@ export class IntentQueue implements IntentGraphQueue {
   addReconcileJob(data: IntentJobData): Promise<Job<IntentJobPayload>> {
     return this.addJob('reconcile_intent_networks', data, {
       jobId: `reconcile-${data.intentId}-${data.scopeId ?? data.networkScopeId ?? 'global'}`,
+    });
+  }
+
+  /**
+   * Re-admit an active intent only when an indexing prerequisite is absent.
+   * The worker rechecks lifecycle, ownership, membership, scope, assignments,
+   * and HyDE state at execution time, making retries safe after pauses,
+   * archives, unassignments, or scoped-agent changes.
+   */
+  addOrphanReconciliationJob(data: IntentJobData): Promise<Job<IntentJobPayload>> {
+    return this.addJob('reconcile_orphaned_intent', data, {
+      jobId: `reconcile-orphaned-${data.intentId}-${data.scopeId ?? data.networkScopeId ?? 'global'}`,
     });
   }
 
@@ -326,27 +341,37 @@ export class IntentQueue implements IntentGraphQueue {
       this.hydeLogger.warn('Failed to fetch discoverer context for HyDE, proceeding without', { intentId, userId, error: ctxErr });
     }
 
-    if (this.deps?.invokeHyde) {
-      await this.deps.invokeHyde({
-        sourceText: intent.payload,
-        sourceType: 'intent',
-        sourceId: intentId,
-        forceRegenerate: true,
-        profileContext,
+    try {
+      if (this.deps?.invokeHyde) {
+        await this.deps.invokeHyde({
+          sourceText: intent.payload,
+          sourceType: 'intent',
+          sourceId: intentId,
+          forceRegenerate: true,
+          profileContext,
+        });
+      } else {
+        const embedder = new EmbedderAdapter();
+        const cache = new RedisCacheAdapter();
+        const inferrer = new LensInferrer();
+        const generator = new HydeGenerator();
+        const hydeGraph = new HydeGraphFactory(this.graphDb, embedder, cache, inferrer, generator).createGraph();
+        await hydeGraph.invoke({
+          sourceText: intent.payload,
+          sourceType: 'intent',
+          sourceId: intentId,
+          forceRegenerate: true,
+          profileContext,
+        });
+      }
+    } catch (error) {
+      this.hydeLogger.error('HyDE generation failed; BullMQ will retry admission', {
+        event: 'intent_hyde_generation_failed',
+        intentId,
+        userId,
+        error,
       });
-    } else {
-      const embedder = new EmbedderAdapter();
-      const cache = new RedisCacheAdapter();
-      const inferrer = new LensInferrer();
-      const generator = new HydeGenerator();
-      const hydeGraph = new HydeGraphFactory(this.graphDb, embedder, cache, inferrer, generator).createGraph();
-      await hydeGraph.invoke({
-        sourceText: intent.payload,
-        sourceType: 'intent',
-        sourceId: intentId,
-        forceRegenerate: true,
-        profileContext,
-      });
+      throw error;
     }
     this.hydeLogger.info('HyDE generation complete, enqueuing opportunity discovery', { intentId, userId });
     const addJob =
@@ -364,13 +389,21 @@ export class IntentQueue implements IntentGraphQueue {
         return scope.scopeType && scope.scopeId ? { networkIds: [scope.scopeId] } : {};
       }
     })();
-    await addJob({
-      intentId,
-      userId,
-      ...discoveryScope,
-    }).catch((err: unknown) =>
-      this.hydeLogger.error('Failed to enqueue opportunity discovery', { intentId, error: err })
-    );
+    try {
+      await addJob({
+        intentId,
+        userId,
+        ...discoveryScope,
+      });
+    } catch (error) {
+      this.hydeLogger.error('Discovery enqueue failed; BullMQ will retry admission', {
+        event: 'intent_discovery_enqueue_failed',
+        intentId,
+        userId,
+        error,
+      });
+      throw error;
+    }
   }
 
   /**
@@ -519,7 +552,15 @@ export class IntentQueue implements IntentGraphQueue {
       // Explicit orphan signal: an intent registered to no network is invisible
       // in every network UI. Surface it so it can be alerted on or swept rather
       // than silently lost.
-      this.assignLogger.warn('Intent assigned to NO networks', { intentId, userId, scopeType: scope.scopeType, scopeId: scope.scopeId, evaluatedCount });
+      this.assignLogger.warn('Intent assigned to no networks', {
+        event: 'intent_network_assignment_zero',
+        intentId,
+        userId,
+        scopeType: scope.scopeType,
+        scopeId: scope.scopeId,
+        evaluatedCount,
+        reason: evaluatedCount === 0 ? 'no_eligible_memberships' : 'below_threshold_or_assignment_failure',
+      });
     }
     return { assignedNetworkIds, evaluatedCount };
   }
@@ -533,6 +574,59 @@ export class IntentQueue implements IntentGraphQueue {
   private async handleReconcileNetworks(data: IntentJobData): Promise<void> {
     const { intentId, userId } = data;
     await this.assignIntentToNetworks(intentId, userId, { ...resolveIntentJobScope(data), source: 'intent-reconcile-queue' });
+  }
+
+  /**
+   * Re-run the normal admission sequence for an active intent whose assignment
+   * or intent HyDE artifact is missing. This deliberately does not treat a
+   * prompted below-threshold result as an error: the normal assignment policy
+   * remains authoritative, including deterministic 1.0 promptless assignment.
+   */
+  private async handleReconcileOrphanedIntent(data: IntentJobData): Promise<void> {
+    const { intentId, userId } = data;
+    const db = this.deps?.database ?? this.database;
+    const scope = resolveIntentJobScope(data);
+    const intent = await db.getIntentForIndexing(intentId);
+    if (!intent || intent.userId !== userId || intent.archivedAt || (intent.status != null && intent.status !== 'ACTIVE')) {
+      this.reconcileLogger.info('Orphan reconciliation skipped by lifecycle admission', {
+        event: 'intent_orphan_reconciliation_skipped',
+        intentId,
+        userId,
+        scopeType: scope.scopeType,
+        scopeId: scope.scopeId,
+        reason: !intent ? 'missing' : intent.userId !== userId ? 'owner_mismatch' : intent.archivedAt ? 'archived' : 'not_active',
+      });
+      return;
+    }
+
+    const [assignedNetworkIds, hydeDocuments, memberships] = await Promise.all([
+      db.getNetworkIdsForIntent(intentId),
+      db.getHydeDocumentsForSource('intent', intentId),
+      this.getAssignmentMemberships(userId),
+    ]);
+    const eligibleNetworkIds = new Set(resolveAssignmentNetworkScope({ memberships, ...scope }));
+    const validAssignedNetworkIds = assignedNetworkIds.filter((networkId) => eligibleNetworkIds.has(networkId));
+    if (validAssignedNetworkIds.length > 0 && hydeDocuments.length > 0) {
+      this.reconcileLogger.info('Orphan reconciliation already satisfied', {
+        event: 'intent_orphan_reconciliation_noop',
+        intentId,
+        userId,
+        assignedNetworkCount: validAssignedNetworkIds.length,
+        hydeDocumentCount: hydeDocuments.length,
+      });
+      return;
+    }
+
+    this.reconcileLogger.warn('Orphan reconciliation re-admitting intent', {
+      event: 'intent_orphan_reconciliation_started',
+      intentId,
+      userId,
+      scopeType: scope.scopeType,
+      scopeId: scope.scopeId,
+      assignedNetworkCount: validAssignedNetworkIds.length,
+      hydeDocumentCount: hydeDocuments.length,
+    });
+    await this.handleGenerateHyde({ intentId, userId, ...scope });
   }
 
   private async handleDeleteHyde(data: IntentDeleteData): Promise<void> {

--- a/services/api/src/queues/opportunity/from-intent.queue.ts
+++ b/services/api/src/queues/opportunity/from-intent.queue.ts
@@ -141,16 +141,7 @@ export class FromIntentQueue {
       return;
     }
 
-    const [assignedNetworkIds, ownerMemberships] = await Promise.all([
-      this.database.getNetworkIdsForIntent(intentId),
-      this.database.getAssignmentNetworkMembershipsForUser(userId),
-    ]);
-    const activeOwnerNetworkIds = new Set(ownerMemberships.map((membership) => membership.networkId));
-    const explicitNetworkIds = networkIds == null ? null : new Set(networkIds);
-    const validNetworkIds = [...new Set(assignedNetworkIds)]
-      .filter((networkId) => activeOwnerNetworkIds.has(networkId))
-      .filter((networkId) => explicitNetworkIds == null || explicitNetworkIds.has(networkId))
-      .sort();
+    const validNetworkIds = await this.getValidDiscoveryNetworkIds(intentId, userId, networkIds);
 
     // A trigger intent is authoritative for admission: omitted scope means all
     // of its still-valid assignments, never all owner memberships. Explicit
@@ -160,9 +151,7 @@ export class FromIntentQueue {
       this.logger.warn('Intent has no valid discovery networks, skipping fail-closed', {
         intentId,
         userId,
-        assignedNetworkCount: assignedNetworkIds.length,
-        activeOwnerMembershipCount: activeOwnerNetworkIds.size,
-        explicitNetworkCount: explicitNetworkIds?.size,
+        requestedNetworkCount: networkIds?.length,
       });
       return;
     }
@@ -205,6 +194,22 @@ export class FromIntentQueue {
       errorLabel: 'from-intent',
       logContext: { intentId, userId },
     });
+
+    // A successful graph is not enough to clear WARMING: assignment and
+    // membership can change while it runs. Re-check the same authoritative
+    // admission predicate immediately before the irreversible success stamp.
+    const stampNetworkIds = await this.getValidDiscoveryNetworkIds(intentId, userId, networkIds);
+    if (stampNetworkIds.length === 0) {
+      const error = new Error('Intent discovery stamp precondition failed: no active assigned networks remain');
+      this.logger.error('Discovery success stamp precondition violated; BullMQ will retry', {
+        event: 'intent_discovery_stamp_precondition_violation',
+        intentId,
+        userId,
+        requestedNetworkCount: networkIds?.length,
+        error,
+      });
+      throw error;
+    }
 
     // Discovery completed without throwing: stamp first-discovery success so
     // the read-side WARMING derivation clears immediately instead of waiting
@@ -265,6 +270,20 @@ export class FromIntentQueue {
         newCandidates: summary?.opportunitiesCreated ?? null,
       });
     }
+  }
+
+  /** Resolve the assignment + current-membership intersection used for both admission and stamping. */
+  private async getValidDiscoveryNetworkIds(intentId: string, userId: string, networkIds?: string[]): Promise<string[]> {
+    const [assignedNetworkIds, ownerMemberships] = await Promise.all([
+      this.database.getNetworkIdsForIntent(intentId),
+      this.database.getAssignmentNetworkMembershipsForUser(userId),
+    ]);
+    const activeOwnerNetworkIds = new Set(ownerMemberships.map((membership) => membership.networkId));
+    const explicitNetworkIds = networkIds == null ? null : new Set(networkIds);
+    return [...new Set(assignedNetworkIds)]
+      .filter((networkId) => activeOwnerNetworkIds.has(networkId))
+      .filter((networkId) => explicitNetworkIds == null || explicitNetworkIds.has(networkId))
+      .sort();
   }
 
   startWorker(): void {

--- a/services/api/src/queues/tests/from-intent.queue.isolated.ts
+++ b/services/api/src/queues/tests/from-intent.queue.isolated.ts
@@ -261,6 +261,24 @@ describe('FromIntentQueue', () => {
       expect(recoverAfterCompletion).not.toHaveBeenCalled();
     });
 
+    it('discover: does not stamp when assignment disappears after the graph completes', async () => {
+      const markIntentFirstDiscoverySucceeded = mock(async () => {});
+      const getNetworkIdsForIntent = mock()
+        .mockResolvedValueOnce(['idx1'])
+        .mockResolvedValueOnce([]);
+      const queue = new FromIntentQueue({
+        database: asDb({
+          getIntentForIndexing: async () => ({ id: 'i1', payload: 'P', userId: 'u1', sourceType: null, sourceId: null }),
+          getNetworkIdsForIntent,
+          markIntentFirstDiscoverySucceeded,
+        }),
+        invokeOpportunityGraph: async () => {},
+      });
+      await expect(queue.processJob('discover_opportunities', { intentId: 'i1', userId: 'u1' }))
+        .rejects.toThrow('stamp precondition failed');
+      expect(markIntentFirstDiscoverySucceeded).not.toHaveBeenCalled();
+    });
+
     it('pool-answer discovery appends all durable answer context and narrates after mining', async () => {
       const callOrder: string[] = [];
       const invokeOpportunityGraph = mock(async (_opts: FromIntentGraphInvokeOptions) => {

--- a/services/api/src/queues/tests/intent.queue.isolated.ts
+++ b/services/api/src/queues/tests/intent.queue.isolated.ts
@@ -57,6 +57,8 @@ const asIntentDb = (db: IntentQueueTestDatabase): IntentQueueDatabase => ({
     return { kind: 'assigned' };
   },
   deleteHydeDocumentsForSource: async () => 0,
+  getHydeDocumentsForSource: async () => [],
+  getNetworkIdsForIntent: async () => [],
   getProfile: async () => null,
   getActiveIntents: async () => [],
   ...db,
@@ -133,6 +135,16 @@ describe('IntentQueue', () => {
         'reconcile_intent_networks',
         { intentId: 'i1', userId: 'u1', scopeType: 'network', scopeId: 'net-x' },
         expect.objectContaining({ jobId: 'reconcile-i1-net-x' }),
+      );
+    });
+
+    it('adds a stable orphan-reconciliation job', async () => {
+      const queue = new IntentQueue();
+      await queue.addOrphanReconciliationJob({ intentId: 'i1', userId: 'u1', scopeType: 'network', scopeId: 'net-x' });
+      expect(mockAdd).toHaveBeenCalledWith(
+        'reconcile_orphaned_intent',
+        { intentId: 'i1', userId: 'u1', scopeType: 'network', scopeId: 'net-x' },
+        expect.objectContaining({ jobId: 'reconcile-orphaned-i1-net-x' }),
       );
     });
 
@@ -294,7 +306,7 @@ describe('IntentQueue', () => {
       expect(addOpportunityJob).toHaveBeenCalled();
     });
 
-    it('generate_hyde: addOpportunityJob reject is caught and logged', async () => {
+    it('generate_hyde: discovery enqueue failure rejects so BullMQ retries admission', async () => {
       const invokeHyde = mock(async () => {});
       const addOpportunityJob = mock(async () => {
         throw new Error('opportunity queue full');
@@ -306,8 +318,23 @@ describe('IntentQueue', () => {
         deleteHydeDocumentsForSource: async () => 0,
       };
       const queue = new IntentQueue({ database: asIntentDb(db), invokeHyde, addOpportunityJob });
-      await queue.processJob('generate_hyde', { intentId: 'i1', userId: 'u1' });
+      await expect(queue.processJob('generate_hyde', { intentId: 'i1', userId: 'u1' }))
+        .rejects.toThrow('opportunity queue full');
       expect(invokeHyde).toHaveBeenCalled();
+    });
+
+    it('generate_hyde: HyDE failure rejects before discovery so BullMQ retries admission', async () => {
+      const addOpportunityJob = mock(async () => ({}));
+      const queue = new IntentQueue({
+        database: asIntentDb({
+          getIntentForIndexing: async () => ({ id: 'i1', payload: 'P', userId: 'u1', sourceType: null, sourceId: null }),
+        }),
+        invokeHyde: async () => { throw new Error('hyde unavailable'); },
+        addOpportunityJob,
+      });
+      await expect(queue.processJob('generate_hyde', { intentId: 'i1', userId: 'u1' }))
+        .rejects.toThrow('hyde unavailable');
+      expect(addOpportunityJob).not.toHaveBeenCalled();
     });
 
     it('generate_hyde: network scope assigns focused plus personal but discovers focused only', async () => {
@@ -375,6 +402,23 @@ describe('IntentQueue', () => {
 
       expect(evaluateIntentAssignment).toHaveBeenCalled();
       expect(assignIntentToNetwork).toHaveBeenCalledWith('i1', 'n1', 0.72, expect.objectContaining({ finalScore: 0.72, promptPresence: 'both' }));
+    });
+
+    it('generate_hyde: a prompted below-threshold evaluation remains an intentional zero assignment', async () => {
+      const assignIntentToNetwork = mock(async () => {});
+      const queue = new IntentQueue({
+        database: asIntentDb({
+          getIntentForIndexing: async () => ({ id: 'i1', payload: 'P', userId: 'u1', sourceType: null, sourceId: null }),
+          getAssignmentNetworkIdsForUser: async () => ['n1'],
+          getNetworkAssignmentContext: async () => ({ networkId: 'n1', indexPrompt: 'Climate', memberPrompt: 'Operators' }),
+          assignIntentToNetwork,
+        }),
+        invokeHyde: async () => {},
+        addOpportunityJob: async () => {},
+        evaluateIntentAssignment: async () => ({ indexScore: 0.1, memberScore: 0.1, reasoning: 'Not relevant' }),
+      });
+      await queue.processJob('generate_hyde', { intentId: 'i1', userId: 'u1' });
+      expect(assignIntentToNetwork).not.toHaveBeenCalled();
     });
 
     describe('network assignment domain invariants', () => {
@@ -533,6 +577,68 @@ describe('IntentQueue', () => {
       expect(invokeHyde).not.toHaveBeenCalled();
       expect(addOpportunityJob).not.toHaveBeenCalled();
       expect(assignIntentToNetwork.mock.calls[0][3]).toMatchObject({ source: 'intent-reconcile-queue', assigned: true });
+    });
+
+    it('reconcile_orphaned_intent: re-admits missing artifacts in normal assignment → HyDE → discovery order', async () => {
+      const sequence: string[] = [];
+      const queue = new IntentQueue({
+        database: asIntentDb({
+          getIntentForIndexing: async () => ({ id: 'i1', payload: 'P', userId: 'u1', sourceType: null, sourceId: null }),
+          getAssignmentNetworkIdsForUser: async () => ['n1'],
+          getNetworkIdsForIntent: async () => [],
+          getHydeDocumentsForSource: async () => [],
+          assignIntentToNetwork: async () => { sequence.push('assignment'); },
+        }),
+        invokeHyde: async () => { sequence.push('hyde'); },
+        addOpportunityJob: async () => { sequence.push('discovery'); },
+      });
+      await queue.processJob('reconcile_orphaned_intent', { intentId: 'i1', userId: 'u1' });
+      expect(sequence).toEqual(['assignment', 'hyde', 'discovery']);
+    });
+
+    it('reconcile_orphaned_intent: skips paused intents before assignment or regeneration', async () => {
+      const invokeHyde = mock(async () => {});
+      const queue = new IntentQueue({
+        database: asIntentDb({
+          getIntentForIndexing: async () => ({ id: 'i1', payload: 'P', userId: 'u1', sourceType: null, sourceId: null, status: 'PAUSED', archivedAt: null }),
+        }),
+        invokeHyde,
+      });
+      await queue.processJob('reconcile_orphaned_intent', { intentId: 'i1', userId: 'u1' });
+      expect(invokeHyde).not.toHaveBeenCalled();
+    });
+
+    it('reconcile_orphaned_intent: re-admits when an old assignment is no longer an active membership', async () => {
+      const invokeHyde = mock(async () => {});
+      const queue = new IntentQueue({
+        database: asIntentDb({
+          getIntentForIndexing: async () => ({ id: 'i1', payload: 'P', userId: 'u1', sourceType: null, sourceId: null }),
+          getNetworkIdsForIntent: async () => ['former-network'],
+          getHydeDocumentsForSource: async () => [{ id: 'hyde-1' }] as never,
+          getAssignmentNetworkMembershipsForUser: async () => [],
+        }),
+        invokeHyde,
+        addOpportunityJob: async () => {},
+      });
+      await queue.processJob('reconcile_orphaned_intent', { intentId: 'i1', userId: 'u1' });
+      expect(invokeHyde).toHaveBeenCalledTimes(1);
+    });
+
+    it('generate_hyde: material re-admission forces HyDE regeneration after a payload update', async () => {
+      let payload = 'First material payload';
+      const invokeHyde = mock(async () => {});
+      const queue = new IntentQueue({
+        database: asIntentDb({
+          getIntentForIndexing: async () => ({ id: 'i1', payload, userId: 'u1', sourceType: null, sourceId: null }),
+        }),
+        invokeHyde,
+        addOpportunityJob: async () => {},
+      });
+      await queue.processJob('generate_hyde', { intentId: 'i1', userId: 'u1' });
+      payload = 'Updated material payload';
+      await queue.processJob('generate_hyde', { intentId: 'i1', userId: 'u1' });
+      expect(invokeHyde).toHaveBeenNthCalledWith(1, expect.objectContaining({ sourceText: 'First material payload', forceRegenerate: true }));
+      expect(invokeHyde).toHaveBeenNthCalledWith(2, expect.objectContaining({ sourceText: 'Updated material payload', forceRegenerate: true }));
     });
 
     it('reconcile_intent_networks: networkScopeId restricts evaluation to that network', async () => {

--- a/services/api/src/services/intent.service.ts
+++ b/services/api/src/services/intent.service.ts
@@ -20,6 +20,22 @@ export class IntentNetworkMembershipError extends Error {
 }
 
 /**
+ * A confirmation committed its intent row but could not obtain acknowledgement
+ * from the post-transaction indexing admission queue. Callers must retry the
+ * same confirmation; replay re-attempts admission without creating a second
+ * intent row.
+ */
+export class IntentAdmissionEnqueueError extends Error {
+  readonly code = 'intent_admission_enqueue_failed' as const;
+
+  constructor(readonly intentId: string, cause: unknown) {
+    super('Intent confirmation was persisted, but indexing admission could not be queued');
+    this.name = 'IntentAdmissionEnqueueError';
+    this.cause = cause;
+  }
+}
+
+/**
  * IntentService
  *
  * Manages intent processing through the Intent Graph and CRUD operations.
@@ -296,7 +312,25 @@ export class IntentService {
     logger.verbose('Creating intent from proposal', { userId, proposalId });
 
     const existing = await this.adapter.getIntentBySourceId(proposalId, userId);
-    if (existing) return existing;
+    if (existing) {
+      // A previous response can have failed after persistence but before Redis
+      // acknowledged admission. Replay is intentionally the repair mechanism:
+      // it does not create another row, and the queue path is idempotent.
+      try {
+        await this.proposalQueue.addGenerateHydeJob({ intentId: existing.id, userId });
+      } catch (error) {
+        logger.error('Intent admission enqueue failed during confirmation replay', {
+          event: 'intent_admission_enqueue_failed',
+          intentId: existing.id,
+          userId,
+          proposalId,
+          replay: true,
+          error,
+        });
+        throw new IntentAdmissionEnqueueError(existing.id, error);
+      }
+      return existing;
+    }
 
     // Cheap advisory preflight avoids embedding/transaction/queue/event work
     // for clear denials. confirmProposalIntent still re-checks membership under
@@ -333,8 +367,16 @@ export class IntentService {
         userId,
         ...scope,
       });
-    } catch (err) {
-      logger.warn('Failed to enqueue HyDE job', { intentId: created.id, userId, error: err });
+    } catch (error) {
+      logger.error('Intent admission enqueue failed after confirmation persistence', {
+        event: 'intent_admission_enqueue_failed',
+        intentId: created.id,
+        userId,
+        proposalId,
+        replay: false,
+        error,
+      });
+      throw new IntentAdmissionEnqueueError(created.id, error);
     }
 
     if (this.questionerEnqueue) {

--- a/services/api/src/services/tests/intent.service.proposal.spec.ts
+++ b/services/api/src/services/tests/intent.service.proposal.spec.ts
@@ -5,7 +5,7 @@ import { describe, expect, it, mock } from 'bun:test';
 
 import { IntentDatabaseAdapter } from '../../adapters/database.adapter';
 import { EmbedderAdapter } from '../../adapters/embedder.adapter';
-import { IntentNetworkMembershipError, IntentService } from '../intent.service';
+import { IntentAdmissionEnqueueError, IntentNetworkMembershipError, IntentService } from '../intent.service';
 
 const USER_ID = '11111111-1111-4111-8111-111111111111';
 const NETWORK_ID = '22222222-2222-4222-8222-222222222222';
@@ -198,8 +198,20 @@ describe('IntentService.createFromProposal atomic confirmation', () => {
     expect(harness.calls.isNetworkMember).not.toHaveBeenCalled();
     expect(harness.calls.generate).not.toHaveBeenCalled();
     expect(harness.calls.confirmProposalIntent).not.toHaveBeenCalled();
-    expect(harness.calls.addGenerateHydeJob).not.toHaveBeenCalled();
+    expect(harness.calls.addGenerateHydeJob).toHaveBeenCalledWith({ intentId: INTENT_ID, userId: USER_ID });
     expect(harness.calls.questionerEnqueue).not.toHaveBeenCalled();
+    expect(harness.calls.emitProposalCreated).not.toHaveBeenCalled();
+  });
+
+  it('makes a persisted confirmation whose admission enqueue fails observable and retryable', async () => {
+    const harness = makeHarness('created');
+    harness.calls.addGenerateHydeJob.mockImplementation(async () => {
+      throw new Error('redis unavailable');
+    });
+
+    await expect(harness.service.createFromProposal(USER_ID, 'Find climate founders', 'proposal-enqueue-failed'))
+      .rejects.toBeInstanceOf(IntentAdmissionEnqueueError);
+    expect(harness.calls.confirmProposalIntent).toHaveBeenCalledTimes(1);
     expect(harness.calls.emitProposalCreated).not.toHaveBeenCalled();
   });
 


### PR DESCRIPTION
## Summary

- Make confirmed-intent indexing admission acknowledgement observable and retryable: a persisted confirmation whose HyDE admission enqueue fails returns retryable `503 intent_admission_enqueue_failed`; a replay re-attempts admission without inserting a second intent.
- Let HyDE generation and discovery-enqueue failures fail their BullMQ job, retaining the existing three-attempt exponential retry and retained failures instead of silently stranding the intent.
- Recheck the active assignment/membership admission predicate immediately before `first_discovery_succeeded_at` is stamped; a changed/unassigned state is logged and retried rather than stamped.
- Add a guarded, idempotent `reconcile_orphaned_intent` job and an explicit dev-only reconciliation command. It rechecks owner/lifecycle/current memberships/scope/artifacts and never widens scoped-agent reach.
- Document the incident causal proof and assignment invariant. Promptless eligible memberships remain deterministic `finalScore=1.0` with absent `rawScores`; prompted below-threshold zero assignment remains valid.

## Causal proof

Historical source history proves the affected dev state: the 2026-07-21 first-discovery stamp accepted a successful `FromIntentQueue` run while `IntentEvents.onCreated` independently enqueued discovery before assignment and HyDE. The 2026-07-22 fix removed that alternate enqueue. Separately, proposal confirmation persisted then swallowed rejected HyDE enqueue acknowledgement. Focused regressions cover the prevented enqueue and stamp conditions. Details: `docs/design/intent-indexing-integrity.md`.

## Verification

- `TEST_DATABASE_SAFE=1 bun test ./src/queues/tests/intent.queue.isolated.ts` — 37 pass
- `TEST_DATABASE_SAFE=1 bun test ./src/services/tests/intent.service.proposal.spec.ts` — 9 pass
- `TEST_DATABASE_SAFE=1 bun test ./src/queues/tests/from-intent.queue.isolated.ts` — 28 pass
- `bun run lint` — 0 errors; 34 pre-existing warnings
- `bun run build` — pass

## Holds

No production query or mutation, Railway action, Linear mutation, or dev-row repair was performed. The two stated dev rows remain held until this forward path is deployed and verified; the dev-only command requires explicit `--confirm-dev` and explicit intent IDs.