### PR TITLE
feat(mcp): remove legacy contact, Gmail, scrape_url, and profile-alias MCP surfaces (IND-596/597/598)

### DIFF
--- a/docs/design/architecture-overview.md
+++ b/docs/design/architecture-overview.md
@@ -260,7 +260,7 @@ System agents are seeded with fixed UUIDs and granted their default permissions 
 
 #### MCP auth resolver
 
-MCP requests authenticate via an `x-api-key` header. The resolver reads the Better Auth `metadata.agentId` stored on the token and hands back `{ userId, agentId }` to the MCP server factory. Tool handlers receive both on the `ResolvedToolContext`, so every tool call is attributable to a concrete agent identity — not just a user. MCP callers without a resolved `agentId` are blocked from all tools except `register_agent`, `read_docs`, and `scrape_url` by the agent-registration gate inside `createMcpServer`.
+MCP requests authenticate via an `x-api-key` header. The resolver reads the Better Auth `metadata.agentId` stored on the token and hands back `{ userId, agentId }` to the MCP server factory. Tool handlers receive both on the `ResolvedToolContext`, so every tool call is attributable to a concrete agent identity — not just a user. MCP callers without a resolved `agentId` are blocked from all tools except `register_agent` and `read_docs` by the principal-aware capability policy inside `createMcpServer`. (Contact/Gmail tools, `scrape_url`, and the deprecated profile/profile-run aliases are not exposed on the MCP surface at all — they remain available via the direct HTTP Tool API and chat.)
 
 #### Permission-gated tool access
 

--- a/docs/design/protocol-deep-dive.md
+++ b/docs/design/protocol-deep-dive.md
@@ -628,7 +628,7 @@ Every registered tool goes through the same lifecycle on every call:
 1. Extract the HTTP request from `ServerContext.http.req`.
 2. Resolve `{ userId, agentId }` via the auth resolver.
 3. Build the `ResolvedToolContext`, set `isMcp = true` and attach `agentId`.
-4. Run the agent-registration gate: unless the tool is on the exempt list (`register_agent`, `read_docs`, `scrape_url`), a missing `agentId` produces an `Agent not registered` error that tells the caller to register first.
+4. Run the agent-registration gate: unless the tool is on the exempt list (`register_agent`, `read_docs`), a missing `agentId` produces an `Agent not registered` error that tells the caller to register first. (`scrape_url`, contact/Gmail tools, and the deprecated profile/profile-run aliases are omitted from the MCP surface entirely; they remain on the direct HTTP Tool API and chat.)
 5. Build per-request scoped databases via `scopedDepsFactory` and rebuild the tool registry with them.
 6. Validate arguments against the tool's original Zod schema.
 7. Invoke the raw tool handler through `ToolInvocationRuntime`, which attaches a shared `AbortSignal`, wall-clock deadline, trace/progress bridge, and output-size cap.

--- a/packages/claude-plugin/package.json
+++ b/packages/claude-plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@indexnetwork/claude-plugin",
-  "version": "0.1.6",
+  "version": "0.2.0",
   "description": "Index Network Claude Code plugin — orchestrator and negotiator skills",
   "type": "module",
   "homepage": "https://index.network",

--- a/packages/claude-plugin/skills/index-orchestrator/SKILL.md
+++ b/packages/claude-plugin/skills/index-orchestrator/SKILL.md
@@ -142,17 +142,16 @@ IF specific ("contribute to an open-source LLM project in Python"):
 
 Specificity test: Does it contain a concrete domain, action, or scope? "Find a job" = vague. "Senior UX role at a climate tech startup in Berlin" = specific.
 
-## Pattern 3: URL in message → scrape before intent
+## Pattern 3: URL in message → intent
 
 When the user pastes a URL alongside an intent request:
 
 ```
-1. scrape_url(url, objective="Extract key details for an intent")
-2. Synthesize a conceptual description from scraped content
-3. create_intent(description=synthesized_summary)
+1. Synthesize a conceptual description from the URL and the context the user provided
+2. create_intent(description=synthesized_summary)
 ```
 
-Exception: for profile creation, pass URLs directly to `create_user_context` — it handles scraping internally.
+Exception: for profile creation, pass URLs directly to `create_user_context` — it enriches from social links internally.
 
 ## Pattern 4: Update or delete an intent
 
@@ -189,13 +188,7 @@ When the user asks "who should I introduce to @Person" or "find connections for 
 
 Do NOT use Pattern 5 here. Do NOT ask for a second person. Do NOT suggest creating a signal — the search reflects the other person's needs, not the user's.
 
-## Pattern 6: Contacts
-
-- **Import many**: `import_contacts(contacts=[{name, email}, ...])` — for CSV or bulk input; use `import_gmail_contacts` for Gmail
-- **Add one**: `add_contact(email=..., name=...)` — creates or links the person, then adds them as a contact
-- **Remove one**: first `list_contacts` or `search_contacts(query=name)` to find the userId, then `remove_contact(contactUserId=...)`
-
-## Pattern 7: Community / index management
+## Pattern 6: Community / index management
 
 ```
 # Explore a community

--- a/packages/hermes-plugin/dashboard/manifest.json
+++ b/packages/hermes-plugin/dashboard/manifest.json
@@ -3,7 +3,7 @@
   "label": "Index",
   "description": "Intent-centric Index Network overview: each intent carries its own questions and opportunity radar, with a separate Networks view.",
   "icon": "Sparkles",
-  "version": "0.10.0",
+  "version": "0.11.0",
   "tab": {
     "path": "/index-network",
     "position": "after:skills"

--- a/packages/hermes-plugin/package.json
+++ b/packages/hermes-plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@indexnetwork/hermes-plugin",
-  "version": "0.10.0",
+  "version": "0.11.0",
   "description": "Hermes-native Index Network plugin with MCP and personal-agent tools",
   "license": "MIT",
   "type": "module",

--- a/packages/hermes-plugin/plugin.yaml
+++ b/packages/hermes-plugin/plugin.yaml
@@ -1,5 +1,5 @@
 name: index-network
-version: 0.10.0
+version: 0.11.0
 description: Index Network Hermes plugin with native tools backed by Index MCP and personal-agent APIs.
 provides_tools:
   - index_read_intents
@@ -11,11 +11,6 @@ provides_tools:
   - index_revoke_agent_permission
   - index_list_conversations
   - index_get_conversation
-  - index_import_contacts
-  - index_list_contacts
-  - index_add_contact
-  - index_remove_contact
-  - index_search_contacts
   - index_read_user_contexts
   - index_record_onboarding_privacy_consent
   - index_preview_user_context
@@ -25,7 +20,6 @@ provides_tools:
   - index_get_enrichment_run
   - index_cancel_enrichment_run
   - index_complete_onboarding
-  - index_import_gmail_contacts
   - index_create_intent
   - index_update_intent
   - index_delete_intent
@@ -54,7 +48,6 @@ provides_tools:
   - index_update_premise
   - index_retract_premise
   - index_read_pending_questions
-  - index_scrape_url
   - index_read_docs
   - index_agent_me
   - index_pickup_negotiation

--- a/packages/hermes-plugin/schemas.py
+++ b/packages/hermes-plugin/schemas.py
@@ -56,11 +56,6 @@ FORWARDED_MCP_TOOLS = (
     "revoke_agent_permission",
     "list_conversations",
     "get_conversation",
-    "import_contacts",
-    "list_contacts",
-    "add_contact",
-    "remove_contact",
-    "search_contacts",
     "read_user_contexts",
     "record_onboarding_privacy_consent",
     "preview_user_context",
@@ -70,7 +65,6 @@ FORWARDED_MCP_TOOLS = (
     "get_enrichment_run",
     "cancel_enrichment_run",
     "complete_onboarding",
-    "import_gmail_contacts",
     "create_intent",
     "update_intent",
     "delete_intent",
@@ -99,7 +93,6 @@ FORWARDED_MCP_TOOLS = (
     "update_premise",
     "retract_premise",
     "read_pending_questions",
-    "scrape_url",
     "read_docs",
 )
 

--- a/packages/hermes-plugin/tools.py
+++ b/packages/hermes-plugin/tools.py
@@ -30,11 +30,6 @@ _FORWARDED_MCP_TOOLS = frozenset(
         "revoke_agent_permission",
         "list_conversations",
         "get_conversation",
-        "import_contacts",
-        "list_contacts",
-        "add_contact",
-        "remove_contact",
-        "search_contacts",
         "read_user_contexts",
         "record_onboarding_privacy_consent",
         "preview_user_context",
@@ -44,7 +39,6 @@ _FORWARDED_MCP_TOOLS = frozenset(
         "get_enrichment_run",
         "cancel_enrichment_run",
         "complete_onboarding",
-        "import_gmail_contacts",
         "create_intent",
         "update_intent",
         "delete_intent",
@@ -73,7 +67,6 @@ _FORWARDED_MCP_TOOLS = frozenset(
         "update_premise",
         "retract_premise",
         "read_pending_questions",
-        "scrape_url",
         "read_docs",
     }
 )

--- a/packages/protocol/CHANGELOG.md
+++ b/packages/protocol/CHANGELOG.md
@@ -12,6 +12,32 @@ See [STABILITY.md](./STABILITY.md) for the public-contract and tier definitions.
 
 ## [Unreleased]
 
+## [7.1.0] — 2026-07-25
+
+### Changed
+- Complete the MCP legacy-surface removal declared in 7.0.0 (IND-596/597/598).
+  `createToolRegistry` is now surface-aware: the default `'rest'` profile (direct
+  HTTP Tool API + chat) retains contact/Gmail-import tools, `scrape_url`, and the
+  deprecated `*_user_profile` / `*_profile_run` compatibility aliases, while the
+  restricted `'mcp'` profile omits all of them. The MCP server builds both its
+  `tools/list` metadata and its `tools/call` lookup from the `'mcp'` profile, so
+  the removed names are no longer registered on the MCP surface — a direct
+  `tools/call` for any of them now fails as an unknown tool before any work.
+- MCP `read_docs` guidance is sanitized by the MCP surface profile (never by
+  `CONTACTS_ENABLED`) so it no longer advertises the removed contact/Gmail
+  workflows; REST/chat `read_docs` retains the full guidance.
+- `CONTACTS_ENABLED` no longer shapes the MCP registry or its metadata cache key.
+
+### Removed
+- The `add_contact`, `import_contacts`, `import_gmail_contacts`, `list_contacts`,
+  `remove_contact`, `search_contacts`, `scrape_url`, `read_user_profiles`,
+  `create_user_profile`, `update_user_profile`, `confirm_user_profile`,
+  `preview_user_profile`, `get_profile_run`, and `cancel_profile_run` entries are
+  removed from the canonical MCP capability matrix; the tools are omitted from the
+  MCP registry rather than classified. Their non-MCP implementations (REST Tool
+  API, dedicated contact REST endpoints, chat agent, shared runtime
+  classifications) are unchanged.
+
 ## [7.0.0] — 2026-07-25
 
 ### Breaking

--- a/packages/protocol/package.json
+++ b/packages/protocol/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@indexnetwork/protocol",
-  "version": "7.0.0",
+  "version": "7.1.0",
   "type": "module",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",

--- a/packages/protocol/src/mcp/mcp.authorization-policy.ts
+++ b/packages/protocol/src/mcp/mcp.authorization-policy.ts
@@ -184,23 +184,14 @@ export const CANONICAL_MCP_TOOL_ACCESS_RULES = defineMcpToolAccessRules({
   // Protocol guidance.
   read_docs: { access: 'informational', reach: 'principal' },
 
-  // Removed/restricted MCP surfaces. Implementations stay available to other
-  // consumers until their owning sibling removes registry exposure.
-  add_contact: { access: 'removed', reach: 'principal' },
-  import_contacts: { access: 'removed', reach: 'principal' },
-  import_gmail_contacts: { access: 'removed', reach: 'principal' },
-  list_contacts: { access: 'removed', reach: 'principal' },
-  remove_contact: { access: 'removed', reach: 'principal' },
-  search_contacts: { access: 'removed', reach: 'principal' },
-  scrape_url: { access: 'removed', reach: 'principal' },
+  // Restricted MCP surface still registered by the shared registry. The contact
+  // and Gmail-import tools, scrape_url, and the deprecated profile/profile-run
+  // aliases are no longer classified here because they are omitted from the MCP
+  // registry composition entirely (IND-596/597/598) — an unregistered tool is
+  // rejected as unknown before any authorization work. report_agent_activity
+  // remains registered on the MCP surface and stays denied via 'removed' until
+  // its owning sibling removes its registry exposure.
   report_agent_activity: { access: 'removed', reach: 'principal' },
-  read_user_profiles: { access: 'removed', reach: 'principal' },
-  create_user_profile: { access: 'removed', reach: 'principal' },
-  update_user_profile: { access: 'removed', reach: 'principal' },
-  confirm_user_profile: { access: 'removed', reach: 'principal' },
-  preview_user_profile: { access: 'removed', reach: 'principal' },
-  get_profile_run: { access: 'removed', reach: 'principal' },
-  cancel_profile_run: { access: 'removed', reach: 'principal' },
 });
 
 /** Tools visible while a session-authenticated human completes onboarding. */

--- a/packages/protocol/src/mcp/mcp.server.ts
+++ b/packages/protocol/src/mcp/mcp.server.ts
@@ -49,10 +49,12 @@ const mcpToolMetadataCache = new Map<string, McpToolRegistrationMetadata[]>();
  * the cached metadata set is automatically invalidated.
  */
 export function getMcpToolMetadataCacheKey(deps: Pick<ToolDeps,
-  'contactsEnabled' | 'chatSession' | 'agentDatabase' | 'agentDispatcher' | 'questionerEnqueue'
+  'chatSession' | 'agentDatabase' | 'agentDispatcher' | 'questionerEnqueue'
 >): string {
+  // CONTACTS_ENABLED deliberately does NOT shape the MCP registry: contact and
+  // Gmail-import tools are omitted from the MCP surface entirely (IND-596), so
+  // the flag can never change the MCP tool set.
   return [
-    `contacts:${deps.contactsEnabled === true ? '1' : '0'}`,
     `chat:${deps.chatSession ? '1' : '0'}`,
     `agent:${deps.agentDatabase ? '1' : '0'}`,
     `negotiation:${deps.agentDispatcher ? '1' : '0'}`,
@@ -81,7 +83,7 @@ export function getCachedMcpToolMetadata(deps: ToolDeps): readonly McpToolRegist
   const cached = mcpToolMetadataCache.get(cacheKey);
   if (cached) return cached;
 
-  const registry = createToolRegistry(deps);
+  const registry = createToolRegistry(deps, { surface: 'mcp' });
   const metadata = Array.from(registry.values()).map((toolDef): McpToolRegistrationMetadata => {
     const jsonSchema = zodToJsonSchema(toolDef.schema) as JsonSchemaType;
     return {
@@ -342,7 +344,7 @@ export function buildMcpOnboardingMessage(ctx: ResolvedToolContext): string {
     `5. Present the profile draft and ask "Does that look right?" On approval/correction, call confirm_user_context(...).\n` +
     `${communityStep}\n` +
     `6. Ask what the user is looking for and call create_intent(description="...", autoApprove=true) so the first signal is persisted.\n` +
-    `7. Call complete_onboarding() to finish setup. Gmail/contact import and discovery are optional after onboarding, never mandatory.`
+    `7. Call complete_onboarding() to finish setup. Discovery is optional after onboarding, never mandatory.`
   );
 }
 
@@ -714,8 +716,9 @@ export function createMcpServer(
 
           // Re-create registry with per-request deps for scoped database access.
           // Do not use cached registration metadata handlers here: tool handlers
-          // close over userDb/systemDb when the registry is created.
-          const requestRegistry = createToolRegistry(requestDeps);
+          // close over userDb/systemDb when the registry is created. The MCP
+          // surface profile keeps the tools/call lookup identical to tools/list.
+          const requestRegistry = createToolRegistry(requestDeps, { surface: 'mcp' });
           const requestTool = requestRegistry.get(toolName);
 
           if (!requestTool) {

--- a/packages/protocol/src/mcp/tests/mcp.authorization-policy.spec.ts
+++ b/packages/protocol/src/mcp/tests/mcp.authorization-policy.spec.ts
@@ -333,7 +333,18 @@ describe('MCP capability permission extension point', () => {
     });
   });
 
-  test('canonical matrix explicitly classifies removed surfaces', () => {
+  test('report_agent_activity remains classified as removed', () => {
+    expect(CANONICAL_MCP_TOOL_ACCESS_RULES.get('report_agent_activity')?.access).toBe('removed');
+  });
+
+  test('contact/Gmail, scrape_url, and deprecated profile aliases are unclassified and denied', () => {
+    // These surfaces are omitted from the MCP registry composition entirely
+    // (IND-596/597/598), so they carry no access rule and resolve to the
+    // fail-closed 'tool_unclassified' denial for even the broadest caller.
+    const sessionHuman = resolveMcpCapabilitySubject({
+      identity: identity({ isSessionAuth: true }),
+      isOnboarding: false,
+    });
     for (const toolName of [
       'add_contact',
       'import_contacts',
@@ -342,7 +353,6 @@ describe('MCP capability permission extension point', () => {
       'remove_contact',
       'search_contacts',
       'scrape_url',
-      'report_agent_activity',
       'read_user_profiles',
       'create_user_profile',
       'update_user_profile',
@@ -351,7 +361,11 @@ describe('MCP capability permission extension point', () => {
       'get_profile_run',
       'cancel_profile_run',
     ]) {
-      expect(CANONICAL_MCP_TOOL_ACCESS_RULES.get(toolName)?.access).toBe('removed');
+      expect(CANONICAL_MCP_TOOL_ACCESS_RULES.get(toolName)).toBeUndefined();
+      expect(policy.authorize(sessionHuman, toolName)).toEqual({
+        allowed: false,
+        reason: 'tool_unclassified',
+      });
     }
   });
 

--- a/packages/protocol/src/mcp/tests/mcp.server.spec.ts
+++ b/packages/protocol/src/mcp/tests/mcp.server.spec.ts
@@ -248,7 +248,6 @@ describe("extractBearerToken", () => {
 
 describe('getMcpToolMetadataCacheKey', () => {
   const baseDeps = {
-    contactsEnabled: false,
     chatSession: undefined,
     agentDatabase: undefined,
     agentDispatcher: undefined,
@@ -258,11 +257,18 @@ describe('getMcpToolMetadataCacheKey', () => {
   test('changes when registry-shaping dependencies change', () => {
     const base = getMcpToolMetadataCacheKey(baseDeps);
 
-    expect(getMcpToolMetadataCacheKey({ ...baseDeps, contactsEnabled: true })).not.toBe(base);
     expect(getMcpToolMetadataCacheKey({ ...baseDeps, chatSession: {} as never })).not.toBe(base);
     expect(getMcpToolMetadataCacheKey({ ...baseDeps, agentDatabase: {} as never })).not.toBe(base);
     expect(getMcpToolMetadataCacheKey({ ...baseDeps, agentDispatcher: {} as never })).not.toBe(base);
     expect(getMcpToolMetadataCacheKey({ ...baseDeps, questionerEnqueue: (async () => undefined) as never })).not.toBe(base);
+  });
+
+  test('CONTACTS_ENABLED never shapes the MCP registry cache key', () => {
+    // Contact/Gmail tools are omitted from the MCP surface entirely, so the flag
+    // can never change the MCP tool set or its metadata cache key (IND-596).
+    const base = getMcpToolMetadataCacheKey(baseDeps);
+    const withContacts = { ...baseDeps, contactsEnabled: true } as Parameters<typeof getMcpToolMetadataCacheKey>[0];
+    expect(getMcpToolMetadataCacheKey(withContacts)).toBe(base);
   });
 });
 

--- a/packages/protocol/src/runtime/foreground/composition/tool.registry.ts
+++ b/packages/protocol/src/runtime/foreground/composition/tool.registry.ts
@@ -7,6 +7,7 @@ import { createIntentTools } from '../signals/intent.tools.js';
 import { createNetworkTools } from '../../../capabilities/communities.facade.js';
 import { createOpportunityTools } from '../../../capabilities/opportunities.facade.js';
 import { createUtilityTools } from '../../../shared/agent/utility.tools.js';
+import type { ToolSurface } from '../../../shared/agent/utility.tools.js';
 import { createIntegrationTools } from '../../../capabilities/integrations.facade.js';
 import { createContactTools } from '../../../capabilities/contacts.facade.js';
 import { createAgentTools } from '../../../capabilities/participant-agents.tools.facade.js';
@@ -19,17 +20,29 @@ import { requestContext } from '../../../shared/observability/request-context.js
 
 const logger = protocolLogger('ToolRegistry');
 
+export interface CreateToolRegistryOptions {
+  /**
+   * Tool-surface profile. The default `'rest'` profile (direct HTTP Tool API)
+   * exposes the full tool set — contact/Gmail tools, `scrape_url`, and the
+   * deprecated profile/profile-run compatibility aliases. The restricted
+   * `'mcp'` profile omits exactly those surfaces (IND-596/597/598); their
+   * non-MCP implementations remain intact for REST and chat.
+   */
+  surface?: ToolSurface;
+}
+
 /**
  * Creates a tool registry containing all tool handlers indexed by name.
  * Handlers are raw async functions (not LangChain tool() wrappers) that
  * accept { context, query } and return a JSON string.
  *
  * @param deps - Shared tool dependencies (graphs, database, embedder, etc.)
- * @param context - Resolved user context for this request.
+ * @param options - Surface profile selecting the MCP-restricted or full REST set.
  * @returns Map of tool name to raw tool definition.
  */
-export function createToolRegistry(deps: ToolDeps): ToolRegistry {
+export function createToolRegistry(deps: ToolDeps, options: CreateToolRegistryOptions = {}): ToolRegistry {
   const registry: ToolRegistry = new Map();
+  const isMcpSurface = options.surface === 'mcp';
 
   // defineTool that captures raw handlers into the registry
   function defineTool<T extends z.ZodType>(opts: {
@@ -78,9 +91,15 @@ export function createToolRegistry(deps: ToolDeps): ToolRegistry {
   createIntentTools(dt, deps);
   createNetworkTools(dt, deps);
   createOpportunityTools(dt, deps);
-  createUtilityTools(dt, deps);
-  createIntegrationTools(dt, deps);
-  createContactTools(dt, deps);
+  // Utility tools always register read_docs + report_agent_activity; on the MCP
+  // surface scrape_url is omitted and read_docs guidance is sanitized (IND-597).
+  createUtilityTools(dt, deps, { surface: isMcpSurface ? 'mcp' : 'rest' });
+  // Contact/Gmail import tools are omitted from the MCP surface (IND-596). Their
+  // implementations remain available to the REST Tool API and chat agent.
+  if (!isMcpSurface) {
+    createIntegrationTools(dt, deps);
+    createContactTools(dt, deps);
+  }
   createAgentTools(dt, deps);
   createNegotiationTools(dt, deps);
   createPremiseTools(dt, deps);
@@ -89,33 +108,36 @@ export function createToolRegistry(deps: ToolDeps): ToolRegistry {
     createChatTools(dt, deps);
   }
 
-  // Deprecated tool-name aliases (IND-371). The canonical implementations are now
-  // registered under their *_user_context / *_enrichment_run names; we expose the
-  // legacy *_user_profile / *_profile_run names as thin aliases that delegate to the
-  // exact same handler + schema, so existing MCP clients keep working while they
-  // migrate. The old names are removed in IND-373.
-  const DEPRECATED_TOOL_ALIASES: ReadonlyArray<readonly [oldName: string, canonicalName: string]> = [
-    ["read_user_profiles", "read_user_contexts"],
-    ["create_user_profile", "create_user_context"],
-    ["update_user_profile", "update_user_context"],
-    ["confirm_user_profile", "confirm_user_context"],
-    ["preview_user_profile", "preview_user_context"],
-    ["get_profile_run", "get_enrichment_run"],
-    ["cancel_profile_run", "cancel_enrichment_run"],
-  ];
-  for (const [oldName, canonicalName] of DEPRECATED_TOOL_ALIASES) {
-    const canonical = registry.get(canonicalName);
-    if (!canonical) {
-      logger.warn('Cannot register deprecated alias: canonical tool not found', { alias: oldName, canonicalName });
-      continue;
+  // Deprecated tool-name aliases (IND-371). The canonical implementations are
+  // registered under their *_user_context / *_enrichment_run names; the legacy
+  // *_user_profile / *_profile_run names are retained as thin aliases that
+  // delegate to the exact same handler + schema so existing direct HTTP Tool
+  // API clients keep working. These aliases are NOT exposed on the MCP surface
+  // (IND-598) — MCP callers must use the canonical names.
+  if (!isMcpSurface) {
+    const DEPRECATED_TOOL_ALIASES: ReadonlyArray<readonly [oldName: string, canonicalName: string]> = [
+      ["read_user_profiles", "read_user_contexts"],
+      ["create_user_profile", "create_user_context"],
+      ["update_user_profile", "update_user_context"],
+      ["confirm_user_profile", "confirm_user_context"],
+      ["preview_user_profile", "preview_user_context"],
+      ["get_profile_run", "get_enrichment_run"],
+      ["cancel_profile_run", "cancel_enrichment_run"],
+    ];
+    for (const [oldName, canonicalName] of DEPRECATED_TOOL_ALIASES) {
+      const canonical = registry.get(canonicalName);
+      if (!canonical) {
+        logger.warn('Cannot register deprecated alias: canonical tool not found', { alias: oldName, canonicalName });
+        continue;
+      }
+      registry.set(oldName, {
+        ...canonical,
+        name: oldName,
+        description: `[DEPRECATED — use \`${canonicalName}\` instead; this alias is retained for backward compatibility and will be removed.] ${canonical.description}`,
+      });
     }
-    registry.set(oldName, {
-      ...canonical,
-      name: oldName,
-      description: `[DEPRECATED — use \`${canonicalName}\` instead; this alias is retained for backward compatibility and will be removed.] ${canonical.description}`,
-    });
   }
 
-  logger.verbose('Tool registry created', { toolCount: registry.size });
+  logger.verbose('Tool registry created', { toolCount: registry.size, surface: options.surface ?? 'rest' });
   return registry;
 }

--- a/packages/protocol/src/shared/agent/tests/tool.registry.aliases.spec.ts
+++ b/packages/protocol/src/shared/agent/tests/tool.registry.aliases.spec.ts
@@ -4,51 +4,114 @@ import { createToolRegistry } from "../tool.registry.js";
 import type { ToolDeps } from "../tool.helpers.js";
 
 /**
- * IND-371: the canonical *_user_context / *_enrichment_run tool names are the real
- * implementations; the legacy *_user_profile / *_profile_run names are retained as
- * thin DEPRECATED aliases that delegate to the exact same handler. These tests lock
- * in that contract so the aliases cannot silently drift or disappear before IND-373.
+ * Surface-aware tool registry (IND-596/597/598).
+ *
+ * `createToolRegistry` exposes two profiles:
+ *  - the default `'rest'` profile (direct HTTP Tool API + chat) retains the full
+ *    tool set: contact/Gmail-import tools, `scrape_url`, and the deprecated
+ *    profile/profile-run compatibility aliases;
+ *  - the restricted `'mcp'` profile omits exactly those surfaces while keeping
+ *    the canonical identity/context + enrichment-run tools.
+ *
+ * These tests lock in that split so the removed names can never re-appear on the
+ * MCP surface, while the REST/chat surface keeps working unchanged.
  */
-describe("deprecated tool-name aliases (IND-371)", () => {
-  // create*Tools only DEFINE tools at registration time (handlers are not invoked),
-  // but a few read nested deps (e.g. deps.graphs.premise) while wiring. A permissive
-  // deep proxy satisfies any property access without needing a full ToolDeps fixture.
-  const deepStub: unknown = new Proxy(function () {} as object, {
-    get: () => deepStub,
-    apply: () => deepStub,
+
+// create*Tools only DEFINE tools at registration time (handlers are not invoked),
+// but a few read nested deps (e.g. deps.graphs.premise) while wiring. A permissive
+// deep proxy satisfies any property access without needing a full ToolDeps fixture.
+// `contactsEnabled` is answered explicitly so the contact/Gmail import + manual-add
+// tools (which gate on that flag) can be exercised on the REST surface.
+function makeDeps(contactsEnabled: boolean): ToolDeps {
+  const deep: unknown = new Proxy(function () {} as object, {
+    get: (_target, prop) => (prop === "contactsEnabled" ? contactsEnabled : deep),
+    apply: () => deep,
   });
-  const registry = createToolRegistry(deepStub as ToolDeps);
+  return deep as ToolDeps;
+}
 
-  const ALIASES: ReadonlyArray<readonly [string, string]> = [
-    ["read_user_profiles", "read_user_contexts"],
-    ["create_user_profile", "create_user_context"],
-    ["update_user_profile", "update_user_context"],
-    ["confirm_user_profile", "confirm_user_context"],
-    ["preview_user_profile", "preview_user_context"],
-    ["get_profile_run", "get_enrichment_run"],
-    ["cancel_profile_run", "cancel_enrichment_run"],
-  ];
+const ALIASES: ReadonlyArray<readonly [string, string]> = [
+  ["read_user_profiles", "read_user_contexts"],
+  ["create_user_profile", "create_user_context"],
+  ["update_user_profile", "update_user_context"],
+  ["confirm_user_profile", "confirm_user_context"],
+  ["preview_user_profile", "preview_user_context"],
+  ["get_profile_run", "get_enrichment_run"],
+  ["cancel_profile_run", "cancel_enrichment_run"],
+];
 
-  test("both the canonical name and its deprecated alias are registered", () => {
-    for (const [oldName, canonicalName] of ALIASES) {
-      expect(registry.get(canonicalName), `canonical ${canonicalName} must be registered`).toBeDefined();
-      expect(registry.get(oldName), `alias ${oldName} must be registered`).toBeDefined();
+// Every name removed from the MCP surface.
+const MCP_REMOVED_TOOLS: readonly string[] = [
+  // Contact + Gmail import (IND-596)
+  "import_contacts",
+  "list_contacts",
+  "add_contact",
+  "remove_contact",
+  "search_contacts",
+  "import_gmail_contacts",
+  // Scrape (IND-597)
+  "scrape_url",
+  // Deprecated profile/profile-run aliases (IND-598)
+  ...ALIASES.map(([oldName]) => oldName),
+];
+
+// Canonical identity/context + enrichment-run replacements that MUST remain on
+// both surfaces.
+const CANONICAL_PRESERVED: readonly string[] = [
+  "read_user_contexts",
+  "create_user_context",
+  "update_user_context",
+  "confirm_user_context",
+  "preview_user_context",
+  "get_enrichment_run",
+  "cancel_enrichment_run",
+];
+
+describe("tool registry surface profiles", () => {
+  const restRegistry = createToolRegistry(makeDeps(true));
+  const mcpRegistry = createToolRegistry(makeDeps(true), { surface: "mcp" });
+
+  test("default (REST) profile retains contact/Gmail tools, scrape_url, and aliases", () => {
+    for (const name of MCP_REMOVED_TOOLS) {
+      expect(restRegistry.get(name), `REST profile must retain ${name}`).toBeDefined();
     }
   });
 
-  test("the alias delegates to the exact same handler + schema as the canonical tool", () => {
+  test("MCP profile omits every contact/Gmail tool, scrape_url, and deprecated alias", () => {
+    for (const name of MCP_REMOVED_TOOLS) {
+      expect(mcpRegistry.get(name), `MCP profile must omit ${name}`).toBeUndefined();
+    }
+  });
+
+  test("MCP profile omits contact/Gmail tools even when CONTACTS_ENABLED is true", () => {
+    // CONTACTS_ENABLED must never shape the MCP registry.
+    const mcpWithContacts = createToolRegistry(makeDeps(true), { surface: "mcp" });
+    for (const name of ["import_contacts", "add_contact", "import_gmail_contacts", "list_contacts"]) {
+      expect(mcpWithContacts.get(name)).toBeUndefined();
+    }
+  });
+
+  test("canonical identity/context + enrichment-run tools remain on both surfaces", () => {
+    for (const name of CANONICAL_PRESERVED) {
+      expect(restRegistry.get(name), `REST must keep ${name}`).toBeDefined();
+      expect(mcpRegistry.get(name), `MCP must keep ${name}`).toBeDefined();
+    }
+  });
+
+  test("read_docs and report_agent_activity stay registered on both surfaces", () => {
+    for (const name of ["read_docs", "report_agent_activity"]) {
+      expect(restRegistry.get(name)).toBeDefined();
+      expect(mcpRegistry.get(name)).toBeDefined();
+    }
+  });
+
+  test("REST aliases delegate to the exact same handler + schema as the canonical tool", () => {
     for (const [oldName, canonicalName] of ALIASES) {
-      const canonical = registry.get(canonicalName)!;
-      const alias = registry.get(oldName)!;
+      const canonical = restRegistry.get(canonicalName)!;
+      const alias = restRegistry.get(oldName)!;
       expect(alias.handler).toBe(canonical.handler);
       expect(alias.schema).toBe(canonical.schema);
       expect(alias.name).toBe(oldName);
-    }
-  });
-
-  test("the alias description is flagged DEPRECATED and points at the canonical name", () => {
-    for (const [oldName, canonicalName] of ALIASES) {
-      const alias = registry.get(oldName)!;
       expect(alias.description.startsWith("[DEPRECATED")).toBe(true);
       expect(alias.description).toContain(canonicalName);
     }

--- a/packages/protocol/src/shared/agent/tests/utility.tools.surface.spec.ts
+++ b/packages/protocol/src/shared/agent/tests/utility.tools.surface.spec.ts
@@ -1,0 +1,118 @@
+import { describe, expect, test } from "bun:test";
+import type { z } from "zod";
+
+import { createUtilityTools } from "../utility.tools.js";
+import type { DefineTool, ResolvedToolContext } from "../tool.helpers.js";
+
+/**
+ * Surface-aware utility tools (IND-596/597).
+ *
+ * On the restricted MCP surface `scrape_url` is omitted and `read_docs`
+ * guidance never advertises the contact/Gmail tools removed from MCP. The
+ * default REST/chat surface retains both.
+ */
+
+type Captured = {
+  description: string;
+  schema: z.ZodType;
+  handler: (input: { context: ResolvedToolContext; query: unknown }) => Promise<string>;
+};
+
+function capture() {
+  const tools = new Map<string, Captured>();
+  const defineTool = ((opts: {
+    name: string;
+    description: string;
+    querySchema: z.ZodType;
+    handler: (input: { context: ResolvedToolContext; query: unknown }) => Promise<string>;
+  }) => {
+    tools.set(opts.name, { description: opts.description, schema: opts.querySchema, handler: opts.handler });
+    return null;
+  }) as unknown as DefineTool;
+  return { tools, defineTool };
+}
+
+const stubDeps = { scraper: {}, userDb: {} } as unknown as Parameters<typeof createUtilityTools>[1];
+
+// Contact tool names that appear verbatim in the REST/chat read_docs prose.
+const CONTACT_TOOL_NAMES = [
+  "import_contacts",
+  "add_contact",
+  "list_contacts",
+  "remove_contact",
+  "import_gmail_contacts",
+];
+
+// The complete set of 14 names removed from the MCP surface. NONE may appear in
+// any MCP read_docs output, even ones (scrape_url, profile aliases) that were
+// never in the original prose — this guards against future regressions.
+const ALL_MCP_REMOVED_NAMES = [
+  "import_contacts",
+  "list_contacts",
+  "add_contact",
+  "remove_contact",
+  "search_contacts",
+  "import_gmail_contacts",
+  "scrape_url",
+  "read_user_profiles",
+  "create_user_profile",
+  "update_user_profile",
+  "confirm_user_profile",
+  "preview_user_profile",
+  "get_profile_run",
+  "cancel_profile_run",
+];
+
+async function readDocs(tools: Map<string, Captured>, topic?: string): Promise<string> {
+  const tool = tools.get("read_docs")!;
+  return tool.handler({
+    context: {} as ResolvedToolContext,
+    query: topic ? { topic } : {},
+  });
+}
+
+describe("createUtilityTools surface profile", () => {
+  test("REST surface registers scrape_url; MCP surface omits it", () => {
+    const rest = capture();
+    createUtilityTools(rest.defineTool, stubDeps);
+    expect(rest.tools.has("scrape_url")).toBe(true);
+    expect(rest.tools.has("read_docs")).toBe(true);
+    expect(rest.tools.has("report_agent_activity")).toBe(true);
+
+    const mcp = capture();
+    createUtilityTools(mcp.defineTool, stubDeps, { surface: "mcp" });
+    expect(mcp.tools.has("scrape_url")).toBe(false);
+    expect(mcp.tools.has("read_docs")).toBe(true);
+    expect(mcp.tools.has("report_agent_activity")).toBe(true);
+  });
+
+  test("REST read_docs retains contact-tool guidance", async () => {
+    const rest = capture();
+    createUtilityTools(rest.defineTool, stubDeps);
+    const contacts = await readDocs(rest.tools, "contacts");
+    const workflows = await readDocs(rest.tools, "workflows");
+    for (const name of CONTACT_TOOL_NAMES) {
+      expect(contacts + workflows).toContain(name);
+    }
+  });
+
+  test("MCP read_docs (summary, contacts, workflows) never advertises any removed name", async () => {
+    const mcp = capture();
+    createUtilityTools(mcp.defineTool, stubDeps, { surface: "mcp" });
+    // 'undefined' returns the full summary doc (all sections joined).
+    for (const topic of [undefined, "contacts", "workflows"]) {
+      const doc = await readDocs(mcp.tools, topic);
+      for (const name of ALL_MCP_REMOVED_NAMES) {
+        expect(doc, `MCP read_docs(${topic ?? "summary"}) must not mention ${name}`).not.toContain(name);
+      }
+    }
+  });
+
+  test("MCP read_docs keeps the contact concept and personal-network guidance", async () => {
+    const mcp = capture();
+    createUtilityTools(mcp.defineTool, stubDeps, { surface: "mcp" });
+    const contacts = await readDocs(mcp.tools, "contacts");
+    expect(contacts).toContain("Ghost users");
+    expect(contacts).toContain("personal network");
+  });
+});

--- a/packages/protocol/src/shared/agent/utility.tools.ts
+++ b/packages/protocol/src/shared/agent/utility.tools.ts
@@ -8,10 +8,29 @@ import { success, error, normalizeUrl } from "./tool.helpers.js";
 /** Host capabilities consumed by URL and profile utility tools. */
 type UtilityToolDeps = Pick<ToolRegistryCompositionDeps, "scraper" | "userDb">;
 
-export function createUtilityTools(defineTool: DefineTool, deps: UtilityToolDeps) {
-  const { scraper } = deps;
+/**
+ * Tool-surface profile. The restricted `'mcp'` surface omits `scrape_url`
+ * (IND-597) and sanitizes `read_docs` guidance so it never advertises the
+ * contact/Gmail workflows removed from MCP (IND-596). The default `'rest'`
+ * surface (direct HTTP Tool API + chat) retains full behavior.
+ */
+export type ToolSurface = "mcp" | "rest";
 
-  const scrapeUrl = defineTool({
+export interface CreateUtilityToolsOptions {
+  surface?: ToolSurface;
+}
+
+export function createUtilityTools(
+  defineTool: DefineTool,
+  deps: UtilityToolDeps,
+  options: CreateUtilityToolsOptions = {},
+) {
+  const { scraper } = deps;
+  const isMcpSurface = options.surface === "mcp";
+
+  // scrape_url is omitted from the MCP tool surface (IND-597). It remains
+  // available via the direct HTTP Tool API and the chat agent.
+  const scrapeUrl = isMcpSurface ? null : defineTool({
     name: "scrape_url",
     description:
       "Extracts text content from a web URL — articles, LinkedIn/GitHub profiles, documentation, project pages, etc. " +
@@ -72,6 +91,45 @@ export function createUtilityTools(defineTool: DefineTool, deps: UtilityToolDeps
     }),
     handler: async ({ context: _context, query }) => {
       const topic = query.topic?.trim().toLowerCase();
+
+      // Contact management tools are not exposed on the MCP surface (IND-596), so
+      // MCP guidance is composed WITHOUT the contact workflows while retaining the
+      // conceptual personal-network / ghost-user model. REST/chat compose the full
+      // contact guidance. This is structural composition, not post-hoc stripping.
+      const contactsSection = isMcpSurface
+        ? `## Contact Management
+
+Contacts are people in a user's personal network, stored as members of their personal network with 'contact' permission.
+
+- **Ghost users**: When a contact email doesn't match an existing account, a ghost user is created. Ghost users are enriched with public profile data and participate in opportunity matching — they can be discovered even before joining the platform.
+- **Personal network scope**: Pass the personal network networkId to discover_opportunities to scope discovery to just the user's contacts.
+- **Contact data**: Each contact has userId, name, email, avatar, and isGhost flag.
+
+_Managing contacts (adding, importing, listing, and removing) is not available through MCP. Contacts are managed via the Index web app and REST APIs._`
+        : `## Contact Management
+
+Contacts are people in a user's personal network, stored as members of their personal network with 'contact' permission.
+
+- **Adding contacts**: Via import_contacts (bulk), add_contact (single email), or import_gmail_contacts (Google integration).
+- **Ghost users**: When a contact email doesn't match an existing account, a ghost user is created. Ghost users are enriched with public profile data and participate in opportunity matching — they can be discovered even before joining the platform.
+- **Personal network scope**: Pass the personal network networkId to discover_opportunities to scope discovery to just the user's contacts.
+- **Contact data**: Each contact has userId, name, email, avatar, and isGhost flag.
+
+### Contact Workflow
+1. import_contacts or import_gmail_contacts → bulk add to network
+2. list_contacts → view all contacts with userId
+3. discover_opportunities(networkId=personalIndexId) → find matches among contacts
+4. add_contact(email) → add individual contact
+5. remove_contact(contactUserId) → remove from network`;
+
+      const managingContactsWorkflow = isMcpSurface
+        ? ""
+        : `### Managing Contacts
+1. import_gmail_contacts() or import_contacts([...]) → add contacts
+2. list_contacts() → view network
+3. discover_opportunities(networkId=personalIndexId) → find matches among contacts
+
+`;
 
       const sections: Record<string, string> = {
         entities: `## Entity Model & Relationships
@@ -173,21 +231,7 @@ Profiles are the user's identity on the platform, used for semantic matching in 
 - Social links enable enrichment — encourage users to add LinkedIn/GitHub
 - Profiles are recalculated when updated, which may surface new matches`,
 
-        contacts: `## Contact Management
-
-Contacts are people in a user's personal network, stored as members of their personal network with 'contact' permission.
-
-- **Adding contacts**: Via import_contacts (bulk), add_contact (single email), or import_gmail_contacts (Google integration).
-- **Ghost users**: When a contact email doesn't match an existing account, a ghost user is created. Ghost users are enriched with public profile data and participate in opportunity matching — they can be discovered even before joining the platform.
-- **Personal network scope**: Pass the personal network networkId to discover_opportunities to scope discovery to just the user's contacts.
-- **Contact data**: Each contact has userId, name, email, avatar, and isGhost flag.
-
-### Contact Workflow
-1. import_contacts or import_gmail_contacts → bulk add to network
-2. list_contacts → view all contacts with userId
-3. discover_opportunities(networkId=personalIndexId) → find matches among contacts
-4. add_contact(email) → add individual contact
-5. remove_contact(contactUserId) → remove from network`,
+        contacts: contactsSection,
 
         discovery: `## Discovery Mechanics
 
@@ -229,12 +273,7 @@ Discovery is the process of finding meaningful connections between users based o
 3. read_intents(networkId, userId) → get intents of both parties
 4. discover_opportunities(partyUserIds=[id1,id2], entities=[...], hint="reason") → create introduction
 
-### Managing Contacts
-1. import_gmail_contacts() or import_contacts([...]) → add contacts
-2. list_contacts() → view network
-3. discover_opportunities(networkId=personalIndexId) → find matches among contacts
-
-### Creating a Community
+${managingContactsWorkflow}### Creating a Community
 1. create_network(title, prompt) → create network
 2. create_network_membership(networkId, userId) → invite members
 3. Members create intents → auto-indexed
@@ -317,5 +356,7 @@ Discovery is the process of finding meaningful connections between users based o
     },
   });
 
-  return [scrapeUrl, readDocs, reportAgentActivity] as const;
+  return [scrapeUrl, readDocs, reportAgentActivity].filter(
+    (tool): tool is Exclude<typeof tool, null> => tool !== null,
+  );
 }

--- a/services/api/tests/mcp.spec.ts
+++ b/services/api/tests/mcp.spec.ts
@@ -282,7 +282,9 @@ describe('MCP Server Factory', () => {
 
     const first = getCachedMcpToolMetadata(mockDeps);
     const second = getCachedMcpToolMetadata(mockDeps);
-    const registry = createToolRegistry(mockDeps);
+    // The MCP server builds its metadata from the restricted MCP registry
+    // profile, so compare against that same profile (not the full REST set).
+    const registry = createToolRegistry(mockDeps, { surface: 'mcp' });
 
     expect(second).toBe(first);
     expect(first.length).toBe(registry.size);
@@ -300,18 +302,22 @@ describe('MCP Server Factory', () => {
     expect(withoutAgentTools.some((tool) => tool.name === 'list_agents')).toBe(false);
   });
 
-  it('classifies every possible current registry tool in the canonical production matrix', () => {
-    const fullRegistry = createToolRegistry({
+  it('classifies every MCP-surface registry tool in the canonical production matrix', () => {
+    // The canonical matrix must classify exactly the tools exposed on the MCP
+    // surface. Contact/Gmail tools, scrape_url, and the deprecated aliases are
+    // omitted from the MCP registry (IND-596/597/598), so contactsEnabled must
+    // not add them back even when true.
+    const mcpRegistry = createToolRegistry({
       ...mockDeps,
       contactsEnabled: true,
       chatSession: {
         listSessions: async () => [],
         getSession: async () => null,
       },
-    });
+    }, { surface: 'mcp' });
 
     expect([...CANONICAL_MCP_TOOL_ACCESS_RULES.keys()].sort()).toEqual(
-      [...fullRegistry.keys()].sort(),
+      [...mcpRegistry.keys()].sort(),
     );
   });
 
@@ -464,6 +470,37 @@ describe('MCP Server Factory', () => {
     expect(humanNames).not.toContain('list_contacts');
     expect(humanNames).not.toContain('read_user_profiles');
     expect(unregisteredNames).toEqual([]);
+  });
+
+  it('rejects a forged tools/call to a removed MCP surface as an unregistered tool', async () => {
+    clearMcpToolMetadataCacheForTests();
+    const deps = { ...mockDeps, database: resolvedContextDatabase };
+    const server = createMcpServer(
+      deps,
+      {
+        resolveIdentity: async () => ({ userId: 'test-user-id', isSessionAuth: true }),
+        resolveUserId: async () => 'test-user-id',
+      },
+      mockScopedDepsFactory,
+    );
+
+    // Even the broadest caller (session human) cannot reach the removed tools:
+    // they are omitted from the MCP registry, so the SDK rejects tools/call with
+    // a JSON-RPC InvalidParams (-32602) "Tool <name> not found" error BEFORE any
+    // handler runs. This is distinct from a policy denial (which returns a
+    // result with isError + MCP_CAPABILITY_DENIED) or a handler error — both of
+    // which must fail this assertion.
+    for (const removed of ['scrape_url', 'list_contacts', 'read_user_profiles', 'import_gmail_contacts', 'get_profile_run']) {
+      const response = await invokeMcpRequest({
+        server,
+        method: 'tools/call',
+        requestParams: { name: removed, arguments: {} },
+        headers: { authorization: 'Bearer session-token' },
+      });
+      expect(response.result, `${removed} must not execute or return a policy denial`).toBeUndefined();
+      expect(response.error?.code, `${removed} must be rejected as an unregistered tool`).toBe(-32602);
+      expect(response.error?.message).toBe(`Tool ${removed} not found`);
+    }
   });
 
   it('denies forged hidden tools/call before chat DB, scoped DB, registry, or graph work', async () => {


### PR DESCRIPTION
## Summary

Completes the MCP legacy-surface removal declared in protocol `7.0.0` (PR #1271) by making `createToolRegistry` **surface-aware**. The removed tools are omitted from the **MCP profile only**; the direct HTTP Tool API (REST), chat agent, dedicated contact REST endpoints, and shared runtime are all preserved.

Integration base: `feat/mcp-refactoring` @ `a740ec1`.

### Scope (IND-596 / IND-597 / IND-598)
- **IND-596** — Contact + Gmail-import tools (`import_contacts`, `list_contacts`, `add_contact`, `remove_contact`, `search_contacts`, `import_gmail_contacts`) are omitted from the MCP registry composition. `CONTACTS_ENABLED` no longer shapes the MCP registry or its metadata cache key. **Contact REST/internal functionality is unchanged** (`/users/contacts`, `integration.controller` Gmail import, `contactService`, chat tools).
- **IND-597** — `scrape_url` is excluded **at the MCP boundary only**; it stays on the direct HTTP Tool API and chat agent. Internal/chat scraping is untouched.
- **IND-598** — The seven deprecated `*_user_profile` / `*_profile_run` aliases are not registered on the MCP surface. The canonical `*_user_context` / `*_enrichment_run` replacements remain. Aliases are retained on the REST profile for backward compatibility.

### Central enforcement preserved
The MCP server builds **both** `tools/list` metadata **and** `tools/call` lookup from the `{ surface: 'mcp' }` profile. A forged `tools/call` to a removed name now fails as an unregistered tool (`JSON-RPC InvalidParams -32602`, `"Tool <name> not found"`) before any auth/context/DB/handler work — verified by a focused test. The canonical MCP capability matrix drops the vestigial `'removed'` rules for these names; **`report_agent_activity` is preserved** for its separate sibling (activity-summary) track.

### Docs / guidance
MCP `read_docs` is composed by surface (contact workflows omitted by construction on MCP; conceptual personal-network/ghost-user guidance retained). `MCP_INSTRUCTIONS` and onboarding wording no longer imply removed MCP capability. REST/chat `read_docs` retain full guidance.

### Consumers
- `hermes-plugin` (MCP) and `claude-plugin` (MCP skill) drop the removed names.
- MCP-specific design docs updated (`architecture-overview.md`, `protocol-deep-dive.md`).
- **CLI unchanged** — it uses the REST Tool HTTP API, which retains all tools.

## SemVer decision (for integration-owner reconciliation)
- `@indexnetwork/protocol` **7.0.0 → 7.1.0** — surface-aware `createToolRegistry` (backward-compatible optional param); completes the already-declared 7.0.0 MCP removal, **not** a new major (per settled wave decision, no 8.0.0).
- `@indexnetwork/hermes-plugin` **0.10.0 → 0.11.0** — `provides_tools` surface changed (pre-1.0 minor).
- `@indexnetwork/claude-plugin` **0.1.6 → 0.2.0** — removed public skill workflows (pre-1.0 minor); `.claude-plugin` manifests already at 0.2.0.
- Root `bun.lock`, CLI manifests, and unrelated manifests deliberately **untouched**.

## Verification
- Focused protocol tests: `mcp.authorization-policy.spec`, `mcp.server.spec`, `tool.registry.aliases.spec` (surface-paired: REST retains all 14 / MCP omits all 14), new `utility.tools.surface.spec` (read_docs no-leak of all 14 names) — **69 pass**.
- `services/api/tests/mcp.spec.ts` — **14 pass** (incl. new concrete unknown-tool `tools/call` assertion + existing `tools/list` absence).
- hermes-plugin smoke test — **pass**.
- Production lint (changed files), protocol build, API `tsc` — **clean**.
- `architecture:check` — exports / consumer / host-isolation / capabilities / artifacts / test:architecture **pass**. `architecture:cycles` fails on the **pre-existing** negotiation↔questioner↔questions↔`tool.helpers.ts` cycle — none of the changed files are in the cycle component (recorded baseline caveat, unchanged on integration base).

## Not in scope / not done
No merge, deploy, production-data mutation, or held permissions-migration action. Does not touch authorization/chat/activity-summary/identity/opportunities/negotiations/permissions-migration tracks.
