### PR TITLE
feat(mcp): durable permission migration, exact question authz, rolling-safe rollout (IND-606/607/608/609)

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@indexnetwork/web",
-  "version": "0.39.0",
+  "version": "0.40.0",
   "license": "MIT",
   "scripts": {
     "dev": "vite --host 127.0.0.1",

--- a/apps/web/src/app/agents/[id]/page.tsx
+++ b/apps/web/src/app/agents/[id]/page.tsx
@@ -27,10 +27,10 @@ const SYSTEM_AGENT_IDS = {
 type TabValue = "overview" | "api-keys" | "permissions";
 
 const PERMISSION_LABELS: Record<string, string> = {
-  "manage:profile": "Profile",
+  "manage:identity": "Identity",
+  "manage:premises": "Premises",
   "manage:intents": "Signals",
   "manage:networks": "Networks",
-  "manage:contacts": "Contacts",
   "manage:opportunities": "Opportunities",
   "manage:negotiations": "Negotiations",
 };

--- a/apps/web/src/app/agents/page.tsx
+++ b/apps/web/src/app/agents/page.tsx
@@ -28,14 +28,14 @@ function maskKey(start: string): string {
 
 function permissionLabel(action: string): string {
   switch (action) {
-    case 'manage:profile':
-      return 'Profile';
+    case 'manage:identity':
+      return 'Identity';
+    case 'manage:premises':
+      return 'Premises';
     case 'manage:intents':
       return 'Signals';
     case 'manage:networks':
       return 'Networks';
-    case 'manage:contacts':
-      return 'Contacts';
     case 'manage:opportunities':
       return 'Opportunities';
     case 'manage:negotiations':

--- a/docs/rollout/IND-609-mcp-permission-rollout.md
+++ b/docs/rollout/IND-609-mcp-permission-rollout.md
@@ -1,0 +1,190 @@
+# IND-609 — MCP breaking-change rollout, release & post-deploy verification
+
+Coordinates the MCP permission-model migration (IND-606/607), the exact
+question affected-domain enforcement and authorization tests (IND-608), and the
+breaking MCP tool removals already merged on `feat/mcp-refactoring`, across the
+protocol package, the API deployment, and the generated plugins.
+
+> **Production execution requires a separate, explicit user authorization** and
+> MUST follow the `backfill-production-data` workflow (Neon project `Protocol`,
+> database `protocol_prod`). Nothing in this document may be run against Neon,
+> dev, shared, staging, or production without that authorization. The wave that
+> produced this plan ran **no** database mutation, Neon action, or deploy.
+
+## 0. Scope & artifacts
+
+| Concern | Artifact |
+| --- | --- |
+| Durable permission migration | `services/api/drizzle/0109_migrate_agent_permission_actions.sql` (+ journal `0109`) |
+| Backfill runbook (predicate/dry-run/recovery/sweep) | `services/api/drizzle/0109_migrate_agent_permission_actions.md` |
+| Transform + static/journal invariants (DB-free) | `services/api/src/lib/drizzle/tests/permission-action-migration.spec.ts` |
+| Actual-SQL behavior (TEST_DATABASE_SAFE-gated, skipped locally) | `services/api/src/lib/drizzle/tests/permission-action-migration.integration.spec.ts` |
+| Transport `tools/call` authz matrix | `services/api/tests/mcp.spec.ts` |
+| Central policy matrix | `packages/protocol/src/mcp/tests/mcp.authorization-policy.spec.ts` |
+| Question provenance / exact-domain / clamps | `packages/protocol/src/questions/tests/question.tools.authz.spec.ts` |
+| Discovery-run ownership | `packages/protocol/src/opportunity/tests/discovery-run-ownership.spec.ts` |
+| Opportunity approval forgery/replay | `packages/protocol/src/opportunity/tests/opportunity.lifecycle.spec.ts` |
+| Negotiation participant-only A2A | `packages/protocol/src/negotiation/tests/negotiation.tools.spec.ts` |
+
+## 1. Release & versioning
+
+- **Protocol package.** The public `QUESTION_MODE_TO_DOMAIN.enrichment` value
+  changes (`identity` → `premises`) and question authorization is hardened, so
+  the next `@indexnetwork/protocol` release is a **minor** bump (≥ 7.3.0) from
+  the 7.2.0 floor. `[Unreleased]` in `packages/protocol/CHANGELOG.md` records the
+  MCP permission migration, exact question affected-domain inheritance, and the
+  mapping correction. The integration owner finalizes the version and the root
+  `bun.lock` (not hand-edited here).
+- **SemVer floors respected:** `@indexnetwork/protocol` ≥ 7.2.0, Hermes ≥ 0.12.0,
+  Claude plugin ≥ 0.2.0. This change set touches only `@indexnetwork/protocol`
+  (behavior) plus `services/api` and a minimal `apps/web` label surface.
+- **Generated plugin wrappers.** No MCP tool was added or removed by this change
+  set (the breaking tool removals landed earlier on `feat/mcp-refactoring`), and
+  the canonical registry ↔ matrix parity test still passes
+  (`classifies every MCP-surface registry tool in the canonical production
+  matrix`). Therefore the generated plugin wrappers remain compatible with the
+  final registry; regenerate and diff them at release time to confirm an empty
+  diff. Hermes and the Claude plugin need no bump for this change set.
+
+## 2. Mixed-version ordering — preDeploy migration is not the completeness proof
+
+`railway.toml` runs `db:migrate` as `preDeployCommand`, so migration `0109`
+executes **before** the new release drains the old replicas. The currently
+deployed code (`origin/dev`) still WRITES `manage:profile` / `manage:contacts`
+(agent service and network-invitation defaults, participant-agent
+`register_agent`). So during the rolling window, old replicas can re-introduce
+retired-action rows **after** `0109` has already run.
+
+The coherent mixed-version-safe design:
+
+1. **New code is canonical-only.** Issuers (`AgentService`, `agent.tools`,
+   `db-seed`), validation, tool schemas, and the MCP policy emit/accept only the
+   canonical action set and reject the retired actions. Legacy names are never
+   re-exposed as input or in `tools/list`/docs.
+2. **New runtime interprets residual legacy STORED rows** at the
+   capability-loading boundary — `projectStoredPermissionActions`
+   (`packages/protocol/src/mcp/mcp.authorization-policy.ts`): `manage:profile` →
+   `manage:identity` + `manage:premises`; `manage:contacts` → no capability;
+   owner/scope matching preserved; unknown actions fail closed. This is temporary
+   rolling-data compatibility for stored rows only, **not** a public alias.
+3. **`0109` runs at preDeploy** as a first convergence pass, but is **not** the
+   completeness proof (old replicas may write new retired rows afterward).
+4. **A mandatory post-drain final sweep** (§5) proves `retired_remaining = 0`.
+
+Why no **access loss**: the read-time projection means a residual (or
+old-replica-rewritten) `manage:profile` row still grants identity+premises
+capabilities during the window; `0109` and the final sweep converge the durable
+rows. Why no **over-authorization**: projection/expansion is exactly
+profile → identity + premises (never broader), `manage:contacts` → nothing
+(removed tools are unregistered and fail closed), scope matching is preserved,
+and control rows are untouched.
+
+## 3. Recovery points (before deploy) — see the 0109 runbook §3
+
+Two mandatory artifacts, captured **before** the deploy that runs `0109`; the
+migration itself creates **no** table and leaves **no** durable app schema:
+
+- **Neon backup branch** of `protocol_prod` (record `branchId` + timestamp) —
+  coarse incident restore via the approved Neon branch restore/reset workflow.
+- **Protected offline artifact** exported from the dry-run: exact affected rows
+  as `(id, before_actions, after_actions)`, plus row count and a content
+  checksum, in secure offline storage owned by the release owner. Fine-grained
+  incident restore replays `before_actions` by `id` via a controlled one-off
+  `VALUES`-driven `UPDATE` (no table, no cross-branch join).
+
+## 4. Dev verification (before production)
+
+Run the full predicate → control-group → dry-run → execute → idempotent-sweep
+sequence from the 0109 runbook on **dev** first, and record exact counts:
+
+1. `affected_rows`, `control_rows`, `total_rows` (runbook §1).
+2. Dry-run preview: confirm `after_actions` for every distinct legacy shape
+   (runbook §2) equals `migrateAgentPermissionActions`.
+3. Execute `0109` (via `drizzle-kit migrate` on the dev deploy).
+4. **`tools/list` + representative `tools/call` on dev:** for a migrated agent,
+   confirm `tools/list` shows the expected permission-projected inventory and
+   representative calls succeed — `read_premises` (now backed by the expanded
+   `manage:premises`), a `manage:identity` call, and a previously
+   `manage:profile`-only agent regaining identity+premises. Confirm removed tools
+   (`add_contact`, `import_gmail_contacts`, `scrape_url`, profile aliases) are
+   rejected as unknown.
+5. Idempotent sweep: `retired_remaining = 0`, `total_rows` unchanged, and a
+   re-run of `0109` reports 0 rows.
+
+## 5. Production execution (separate explicit authorization)
+
+Only after dev sign-off and explicit user authorization, via the
+`backfill-production-data` workflow:
+
+1. Take the mandatory Neon backup branch and export + checksum the protected
+   offline affected-row artifact (§3) **before** the deploy.
+2. Deploy the release train. The preDeploy `db:migrate` applies `0109` as a first
+   convergence pass. During the rolling window, old replicas may still write
+   retired rows; the new runtime's read-time projection keeps those agents
+   correctly authorized (no access loss / over-auth) — runbook §6.
+3. **Wait for full drain** — every old replica gone, only canonical-only writers
+   remain.
+4. **Run the mandatory post-drain final sweep** (runbook §6) via the approved
+   backfill workflow, with its own backup/artifact/recovery: inventory retired
+   rows, apply the idempotent `0109` transform, and re-inventory until
+   `retired_remaining = 0`. This final sweep — not the preDeploy migration —
+   proves completeness, independent of any Railway/`drizzle-kit` UPDATE count.
+5. Do **not** remove the temporary read-time projection in this release; it is
+   gated on the compatibility-removal conditions in §6.
+
+## 6. Post-deploy monitoring, final-sweep gate & compatibility removal
+
+- **Post-drain final sweep is mandatory and is NOT the automatic `db:migrate`.**
+  Completeness (`retired_remaining = 0`) is proven only by the separately approved
+  post-drain sweep, after every old replica has drained.
+- **Backfill counts:** after the final sweep, `retired_remaining = 0`; count of
+  rows now holding `manage:identity` + `manage:premises` matches the artifact's
+  previously-profile set; `total_rows` unchanged. Re-run the sweep during the
+  monitoring window.
+- **Legacy-write watch:** track the retired-row inventory across the monitoring
+  window; it must stay at 0 (a rise means a still-live old replica — investigate
+  drain).
+- **Compatibility-removal gate.** Remove the temporary read-time projection
+  (`projectStoredPermissionActions`) only in a follow-up release, and only once:
+  (1) all old replicas are drained; (2) the final sweep is complete and
+  `retired_remaining = 0`; (3) the monitoring window elapsed with no new legacy
+  writes. The single cutover deploy does **not** remove compatibility.
+- **Auth denials & error rates:** watch MCP `MCP_CAPABILITY_DENIED` rates and
+  tool error rates for a spike. An expected, benign uptick is possible for agents
+  that previously leaned on removed tools; a sustained spike on core tools
+  (`read_premises`, `create_intent`) indicates an under-granted cohort — remediate
+  by confirming their `0109` expansion applied (owner/scope preserved).
+- **No removed-tool traffic:** confirm no `tools/call` for removed surfaces
+  (contacts/Gmail/scrape_url/profile aliases) is being attempted; if a client
+  still calls them, it receives an unknown-tool rejection — coordinate a client
+  update rather than re-registering the tool.
+- **Remediation / rollback:** if a postcondition fails, restore from the offline
+  artifact (fine-grained) or the Neon backup branch (coarse), both per §3; the
+  migration is idempotent, so re-running after a fix is safe.
+- **Cleanup:** after the monitoring window, the release owner deletes the offline
+  artifact and expires the Neon backup branch, and confirms
+  `to_regclass('public.agent_permissions_recovery_0109') IS NULL` (no durable
+  recovery schema was ever created).
+
+## 7. The three chat classes (MCP boundaries)
+
+The authorization matrix keeps the three conversation classes separate on the
+MCP surface (covered by IND-608 tests):
+
+- **H2A (human ↔ agent) chat history** is `human_only`: `list_conversations` /
+  `get_conversation` are available to the owning session human and denied to any
+  agent key, even a permissioned one (mcp.spec.ts: *H2A chat history human-only*).
+- **A2A (agent ↔ agent) negotiations** are participant-only: `get_negotiation` /
+  `respond_to_negotiation` require `manage:negotiations` and admit only the
+  negotiation's source or candidate; a third party is denied and the A2A
+  transcript is never read (negotiation.tools.spec.ts: *participant-only A2A
+  visibility*). `readAuthorizedNegotiationDetail` projects the counterparty seat.
+- **H2H (human ↔ human)** threads are **absent** from the MCP surface: agent
+  completion and owner acceptance never imply an H2H connection, and negotiation
+  detail carries `directConversationEvidence: 'not_provided'` unless independently
+  evidenced (negotiation detail projection asserts no H2H claim).
+
+Question-answer provenance ties an answer to the authenticated caller
+(`context.userId` threaded to both lookup and write), rejects foreign/replayed
+question ids, fails closed for network-scoped agents, and enforces exact
+affected-domain permission per question mode (question.tools.authz.spec.ts).

--- a/packages/protocol/CHANGELOG.md
+++ b/packages/protocol/CHANGELOG.md
@@ -12,10 +12,41 @@ See [STABILITY.md](./STABILITY.md) for the public-contract and tier definitions.
 
 ## [Unreleased]
 
+## [7.3.0] — 2026-07-25
+
 ### Added
 - Add the injected `IntentProposalStore` host boundary so web proposal cards are
   emitted only after the normalized description, optional network scope, and
   complete verifier output have been durably bound to their owner.
+- Add `projectStoredPermissionActions` at the MCP capability-loading boundary:
+  temporary rolling-data compatibility that interprets residual **stored** legacy
+  grant rows during a mixed-version deploy (`manage:profile` →
+  `manage:identity` + `manage:premises`; `manage:contacts` → no capability;
+  owner/scope preserved; unknown actions fail closed). Not a public alias — legacy
+  names remain rejected as input and absent from `tools/list`/docs. Removed only
+  after the post-drain final sweep and compatibility gate (see the IND-609
+  rollout doc).
+
+### Changed
+- **MCP permission migration (IND-606/607).** Retire issuance of the legacy
+  `manage:profile` and `manage:contacts` grant actions in favor of
+  `manage:identity` and `manage:premises`. Issuers, defaults, validation, and the
+  capability policy emit/accept only the canonical action set; the durable data
+  migration (`services/api/drizzle/0109_migrate_agent_permission_actions.sql`)
+  converges existing grants (`manage:profile` → `manage:identity` + `manage:premises`;
+  `manage:contacts` removed). No public protocol type changes.
+- **Exact question affected-domain inheritance (IND-608).** `read_pending_questions`
+  and `answer_pending_question` now enforce each question's exact affected-domain
+  permission at the handler, not merely the union that admits the tool. A global
+  `manage:intents` agent can no longer read or answer negotiation/enrichment/
+  discovery questions it does not manage; the owning human is unaffected.
+- **Corrected `QUESTION_MODE_TO_DOMAIN` mapping.** `enrichment` now maps to the
+  `premises` domain (`manage:premises`), matching the enrichment answer pipeline
+  that runs the PremiseGraph lifecycle. Previously mapped to `identity`. This
+  changes the exported constant's `enrichment` value and the
+  `read_activity_summary` projection of enrichment question counts from the
+  identity domain to the premises domain — the deliberate public-constant change
+  motivating this minor bump from the 7.2.0 floor.
 
 ## [7.2.0] — 2026-07-25
 

--- a/packages/protocol/package.json
+++ b/packages/protocol/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@indexnetwork/protocol",
-  "version": "7.2.0",
+  "version": "7.3.0",
   "type": "module",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",

--- a/packages/protocol/src/mcp/mcp.authorization-policy.ts
+++ b/packages/protocol/src/mcp/mcp.authorization-policy.ts
@@ -293,6 +293,53 @@ export type ResolveMcpCapabilitySubjectInput = {
   agent?: McpPolicyAgentSnapshot | null;
 };
 
+/**
+ * Retired durable grant actions and the canonical capabilities each projects to
+ * at the permission-loading boundary. TEMPORARY rolling-data compatibility
+ * (IND-607): while a mixed-version fleet is live, old replicas (current `dev`)
+ * still WRITE `manage:profile` / `manage:contacts` rows AFTER the pre-deploy
+ * `0109` migration runs, and un-migrated rows may also remain. The new runtime
+ * must therefore interpret these residual STORED rows so no agent loses access
+ * during the rolling window and none is over-authorized:
+ *
+ *   - `manage:profile`  -> `manage:identity` + `manage:premises`
+ *   - `manage:contacts` -> (no capability)
+ *
+ * This is NOT a public alias: the legacy names are never accepted as INPUT
+ * (grant validation and tool schemas are canonical-only) and never surfaced in
+ * documentation or `tools/list`. They are tolerated ONLY as pre-existing stored
+ * data, and only until the post-drain final sweep sets `retired_remaining = 0`
+ * and the compatibility-removal gate is met (see the IND-609 rollout doc).
+ */
+const LEGACY_STORED_ACTION_PROJECTION: Readonly<Record<string, readonly McpPermissionAction[]>> = {
+  'manage:profile': ['manage:identity', 'manage:premises'],
+  'manage:contacts': [],
+};
+
+/**
+ * Central capability-loading interpretation of a stored permission row's raw
+ * actions. Canonical actions pass through; retired actions project per
+ * {@link LEGACY_STORED_ACTION_PROJECTION}; every unknown action fails closed
+ * (ignored). Owner/scope matching is applied by the caller BEFORE this runs, so
+ * this function never widens the scope a grant applies to.
+ */
+export function projectStoredPermissionActions(
+  actions: readonly string[],
+): McpPermissionAction[] {
+  const granted = new Set<McpPermissionAction>();
+  for (const action of actions) {
+    const projected = LEGACY_STORED_ACTION_PROJECTION[action];
+    if (projected !== undefined) {
+      for (const capability of projected) granted.add(capability);
+      continue;
+    }
+    const parsed = McpPermissionActionSchema.safeParse(action);
+    if (parsed.success) granted.add(parsed.data);
+    // Unknown actions are ignored — fail closed.
+  }
+  return [...granted];
+}
+
 function resolveAgentPermissions(
   identity: McpResolvedIdentity,
   agent: McpPolicyAgentSnapshot,
@@ -311,9 +358,10 @@ function resolveAgentPermissions(
       );
     if (!scopeApplies) continue;
 
-    for (const action of permission.actions) {
-      const parsed = McpPermissionActionSchema.safeParse(action);
-      if (parsed.success) granted.add(parsed.data);
+    // Canonical-only going forward, plus temporary interpretation of residual
+    // legacy stored rows during the mixed-version rolling window.
+    for (const action of projectStoredPermissionActions(permission.actions)) {
+      granted.add(action);
     }
   }
   return [...granted];

--- a/packages/protocol/src/mcp/tests/mcp.authorization-policy.spec.ts
+++ b/packages/protocol/src/mcp/tests/mcp.authorization-policy.spec.ts
@@ -2,7 +2,7 @@ import { describe, expect, test } from 'bun:test';
 
 import type { McpResolvedIdentity } from '../../shared/schemas/mcp-auth.schema.js';
 import type { McpPolicyAgentSnapshot } from '../mcp.authorization-policy.js';
-import { CANONICAL_MCP_TOOL_ACCESS_RULES, MCP_PERMISSION_ACTIONS, McpCapabilityPolicy, defineMcpToolAccessRules, defineMcpToolPermissionMap, resolveMcpCapabilitySubject } from '../mcp.authorization-policy.js';
+import { CANONICAL_MCP_TOOL_ACCESS_RULES, MCP_PERMISSION_ACTIONS, McpCapabilityPolicy, defineMcpToolAccessRules, defineMcpToolPermissionMap, projectStoredPermissionActions, resolveMcpCapabilitySubject } from '../mcp.authorization-policy.js';
 
 const USER_ID = 'user-1';
 const AGENT_ID = 'agent-1';
@@ -456,5 +456,115 @@ describe('MCP capability permission extension point', () => {
       agent: snapshot,
     });
     expect(policy.authorize(resolvedAfterRefresh, 'create_intent').allowed).toBe(true);
+  });
+});
+
+describe('rolling-data legacy permission projection (IND-607)', () => {
+  test('projects a stored manage:profile row to manage:identity + manage:premises', () => {
+    expect(projectStoredPermissionActions(['manage:profile'])).toEqual([
+      'manage:identity',
+      'manage:premises',
+    ]);
+  });
+
+  test('projects a stored manage:contacts row to no capability', () => {
+    expect(projectStoredPermissionActions(['manage:contacts'])).toEqual([]);
+    expect(projectStoredPermissionActions(['manage:intents', 'manage:contacts'])).toEqual([
+      'manage:intents',
+    ]);
+  });
+
+  test('passes canonical actions through unchanged and de-duplicates the profile overlap', () => {
+    expect(projectStoredPermissionActions(['manage:intents', 'manage:negotiations'])).toEqual([
+      'manage:intents',
+      'manage:negotiations',
+    ]);
+    expect(projectStoredPermissionActions(['manage:identity', 'manage:profile'])).toEqual([
+      'manage:identity',
+      'manage:premises',
+    ]);
+  });
+
+  test('ignores unknown actions (fail closed)', () => {
+    expect(projectStoredPermissionActions(['manage:profile', 'manage:bogus', 'manage:contacts'])).toEqual([
+      'manage:identity',
+      'manage:premises',
+    ]);
+    expect(projectStoredPermissionActions(['totally:unknown'])).toEqual([]);
+  });
+
+  test('a residual legacy manage:profile row still grants identity + premises capabilities at the loading boundary', () => {
+    // No access loss during the rolling window: an un-migrated (or old-replica
+    // re-written) manage:profile grant is interpreted at capability-load time.
+    const subject = resolveMcpCapabilitySubject({
+      identity: identity({ agentId: AGENT_ID }),
+      isOnboarding: false,
+      agent: agentSnapshot({
+        permissions: [{
+          agentId: AGENT_ID,
+          userId: USER_ID,
+          scope: 'global',
+          scopeId: null,
+          actions: ['manage:profile', 'manage:contacts'],
+        }],
+      }),
+    });
+
+    expect(subject.permissions).toEqual(['manage:identity', 'manage:premises']);
+    expect(policy.authorize(subject, 'read_premises').allowed).toBe(true);
+    expect(policy.authorize(subject, 'read_user_contexts').allowed).toBe(true);
+    // manage:contacts projected to nothing — no contact-era capability leaks.
+  });
+
+  test('preserves owner/network scope matching for legacy rows (no scope widening)', () => {
+    // A legacy manage:profile grant scoped to another network must NOT apply to
+    // an agent bound to network-1 — scope matching runs before projection.
+    const wrongNetwork = resolveMcpCapabilitySubject({
+      identity: identity({ agentId: AGENT_ID, networkScopeId: NETWORK_ID }),
+      isOnboarding: false,
+      agent: agentSnapshot({
+        permissions: [{
+          agentId: AGENT_ID,
+          userId: USER_ID,
+          scope: 'network',
+          scopeId: 'another-network',
+          actions: ['manage:profile'],
+        }],
+      }),
+    });
+    expect(wrongNetwork.permissions).toEqual([]);
+
+    // The same legacy grant scoped to the bound network DOES project.
+    const boundNetwork = resolveMcpCapabilitySubject({
+      identity: identity({ agentId: AGENT_ID, networkScopeId: NETWORK_ID }),
+      isOnboarding: false,
+      agent: agentSnapshot({
+        permissions: [{
+          agentId: AGENT_ID,
+          userId: USER_ID,
+          scope: 'network',
+          scopeId: NETWORK_ID,
+          actions: ['manage:profile'],
+        }],
+      }),
+    });
+    expect(boundNetwork.permissions).toEqual(['manage:identity', 'manage:premises']);
+  });
+
+  test('a canonical-only row is unchanged by the projection', () => {
+    const subject = resolveMcpCapabilitySubject({
+      identity: identity({ agentId: AGENT_ID }),
+      isOnboarding: false,
+      agent: agentSnapshot({
+        permissions: [{
+          agentId: AGENT_ID,
+          userId: USER_ID,
+          scope: 'global',
+          scopeId: null,
+          actions: ['manage:identity', 'manage:premises', 'manage:intents'],
+        }],
+      }),
+    });
+    expect(subject.permissions).toEqual(['manage:identity', 'manage:premises', 'manage:intents']);
   });
 });

--- a/packages/protocol/src/negotiation/tests/negotiation.tools.spec.ts
+++ b/packages/protocol/src/negotiation/tests/negotiation.tools.spec.ts
@@ -1069,6 +1069,58 @@ describe("get_negotiation — network scope", () => {
   });
 });
 
+describe("get_negotiation — participant-only A2A visibility (IND-608)", () => {
+  test("denies a third party who is neither source nor candidate, without reading the transcript", async () => {
+    let messageReads = 0;
+    let artifactReads = 0;
+    const task = makeTask("working", "user-src", "user-cand");
+    const deps = {
+      negotiationDatabase: {
+        getTask: async () => task,
+        getMessagesForConversation: async () => { messageReads += 1; return []; },
+        getArtifactsForTask: async () => { artifactReads += 1; return []; },
+      },
+    };
+
+    const tool = captureTool("get_negotiation", deps);
+    const result = JSON.parse(
+      await tool.handler({
+        // A logged-in user who is not a party to this A2A negotiation.
+        context: makeContext("user-outsider"),
+        query: { negotiationId: "task-1" },
+      })
+    );
+
+    expect(result.success).toBe(false);
+    expect(result.error).toMatch(/not a party to this negotiation/i);
+    // The A2A transcript and artifacts are never read for a non-participant.
+    expect(messageReads).toBe(0);
+    expect(artifactReads).toBe(0);
+  });
+
+  test("admits a participating party (candidate) and projects the counterparty seat", async () => {
+    const task = makeTask("working", "user-src", "user-cand");
+    const deps = {
+      negotiationDatabase: {
+        getTask: async () => task,
+        getMessagesForConversation: async () => [],
+        getArtifactsForTask: async () => [],
+      },
+    };
+
+    const tool = captureTool("get_negotiation", deps);
+    const result = JSON.parse(
+      await tool.handler({
+        context: makeContext("user-cand"),
+        query: { negotiationId: "task-1" },
+      })
+    );
+
+    expect(result.success).toBe(true);
+    expect(result.data.id).toBe("task-1");
+  });
+});
+
 describe("respond_to_negotiation — network scope", () => {
   test("refuses to respond on a task from a different network", async () => {
     const outOfScope = {

--- a/packages/protocol/src/opportunity/tests/discovery-run-ownership.spec.ts
+++ b/packages/protocol/src/opportunity/tests/discovery-run-ownership.spec.ts
@@ -1,0 +1,141 @@
+import { config } from 'dotenv';
+config({ path: '.env.test', override: true });
+process.env.OPENROUTER_API_KEY ??= 'test';
+
+import { describe, test, expect } from 'bun:test';
+
+import { createOpportunityTools } from '../opportunity.tools.js';
+import type { ToolDeps, ResolvedToolContext } from '../../shared/agent/tool.helpers.js';
+import type { DiscoveryRunRecord } from '../../shared/interfaces/discovery-run.interface.js';
+
+/**
+ * IND-608 — discovery-run ownership at the tool/handler seam (DB-free).
+ *
+ * get_discovery_run and cancel_discovery_run must always scope the store lookup
+ * to the authenticated caller (`context.userId`). A run owned by another user is
+ * invisible ("not found") and never cancellable, and every store access records
+ * the caller userId so ownership cannot be bypassed by supplying a foreign run id.
+ */
+
+function parse(raw: string) {
+  return JSON.parse(raw) as { success: boolean; data?: Record<string, unknown>; error?: string };
+}
+
+/** Store whose reads are scoped by userId, like the production adapter. */
+function makeOwnedRunStore(ownerUserId: string) {
+  const getCalls: Array<{ id: string; userId: string }> = [];
+  const requestCancelCalls: Array<{ id: string; userId: string }> = [];
+  const run = {
+    id: 'run-1',
+    userId: ownerUserId,
+    agentId: null,
+    status: 'queued' as const,
+    input: {},
+    context: {},
+    createdAt: new Date('2026-01-01T00:00:00.000Z'),
+  } as unknown as DiscoveryRunRecord;
+
+  return {
+    getCalls,
+    requestCancelCalls,
+    async get(id: string, userId: string): Promise<DiscoveryRunRecord | null> {
+      getCalls.push({ id, userId });
+      // Ownership scoping: only the owner sees the run.
+      return id === run.id && userId === ownerUserId ? run : null;
+    },
+    async requestCancel(id: string, userId: string): Promise<DiscoveryRunRecord | null> {
+      requestCancelCalls.push({ id, userId });
+      return id === run.id && userId === ownerUserId ? run : null;
+    },
+    async create() { throw new Error('unused'); },
+    async listActive() { return []; },
+    async markRunning() { return null; },
+    async updateProgress() {},
+    async markSucceeded() {},
+    async markFailed() {},
+    async markCancelled() {},
+    async isCancelRequested() { return false; },
+  };
+}
+
+function makeContext(userId: string): ResolvedToolContext {
+  return {
+    userId,
+    user: { id: userId, name: 'U', email: 'u@test' } as never,
+    userProfile: null,
+    userNetworks: [],
+    isMcp: true,
+  } as unknown as ResolvedToolContext;
+}
+
+function makeDeps(runStore: ReturnType<typeof makeOwnedRunStore>): ToolDeps {
+  return {
+    database: {} as never,
+    systemDb: {} as never,
+    userDb: {} as never,
+    cache: {} as never,
+    graphs: { opportunity: { invoke: async () => ({}) } as never } as never,
+    discoveryRuns: runStore as never,
+    discoveryRunQueue: { async enqueue() {}, async cancel() { return true; } } as never,
+  } as unknown as ToolDeps;
+}
+
+function captureTool(name: string, deps: ToolDeps) {
+  let captured: { handler: (i: { context: ResolvedToolContext; query: Record<string, unknown> }) => Promise<string> } | undefined;
+  const defineTool = (def: { name: string }) => {
+    if (def.name === name) captured = def as never;
+    return def;
+  };
+  createOpportunityTools(defineTool as never, deps);
+  if (!captured) throw new Error(`${name} tool not registered`);
+  return captured;
+}
+
+describe('get_discovery_run — ownership scoping (IND-608)', () => {
+  test('the owner sees their run and the store is queried with the owner userId', async () => {
+    const store = makeOwnedRunStore('owner');
+    const tool = captureTool('get_discovery_run', makeDeps(store));
+
+    const result = parse(await tool.handler({
+      context: makeContext('owner'),
+      query: { discoveryRunId: 'run-1' },
+    }));
+
+    expect(result.success).toBe(true);
+    expect(result.data!.discoveryRunId).toBe('run-1');
+    expect(store.getCalls).toEqual([{ id: 'run-1', userId: 'owner' }]);
+  });
+
+  test('a non-owner cannot see another user\u2019s run (scoped lookup returns not found)', async () => {
+    const store = makeOwnedRunStore('owner');
+    const tool = captureTool('get_discovery_run', makeDeps(store));
+
+    const result = parse(await tool.handler({
+      context: makeContext('intruder'),
+      query: { discoveryRunId: 'run-1' },
+    }));
+
+    expect(result.success).toBe(false);
+    expect(result.error).toMatch(/discovery run not found/i);
+    // The lookup was still scoped to the caller, never widened to the owner.
+    expect(store.getCalls).toEqual([{ id: 'run-1', userId: 'intruder' }]);
+  });
+});
+
+describe('cancel_discovery_run — ownership scoping (IND-608)', () => {
+  test('a non-owner cannot cancel another user\u2019s run and no cancellation is attempted', async () => {
+    const store = makeOwnedRunStore('owner');
+    const tool = captureTool('cancel_discovery_run', makeDeps(store));
+
+    const result = parse(await tool.handler({
+      context: makeContext('intruder'),
+      query: { discoveryRunId: 'run-1' },
+    }));
+
+    expect(result.success).toBe(false);
+    expect(result.error).toMatch(/discovery run not found/i);
+    expect(store.getCalls).toEqual([{ id: 'run-1', userId: 'intruder' }]);
+    // Ownership fails closed before any state-changing cancellation call.
+    expect(store.requestCancelCalls).toEqual([]);
+  });
+});

--- a/packages/protocol/src/opportunity/tests/opportunity.lifecycle.spec.ts
+++ b/packages/protocol/src/opportunity/tests/opportunity.lifecycle.spec.ts
@@ -88,4 +88,55 @@ describe('opportunity lifecycle policies', () => {
     expect(assessIntroductionApproval(opportunity, INTRODUCER_ID)).toEqual({ kind: 'approve' });
     expect(assessIntroductionApproval(opportunity, OWNER_ID)).toMatchObject({ success: false });
   });
+
+  test('explicit introduction approval cannot be replayed once approved (IND-608)', () => {
+    // Anti-replay: an already-approved introducer re-approving is rejected
+    // before any persistence, so a forged/replayed approval cannot re-trigger
+    // negotiation.
+    const opportunity = buildOpportunity({
+      actors: [
+        { userId: OWNER_ID, role: 'patient', networkId: 'net00000-0000-4000-8000-000000000001' },
+        { userId: INTRODUCER_ID, role: 'introducer', networkId: 'net00000-0000-4000-8000-000000000001', approved: true },
+      ],
+    });
+
+    expect(assessIntroductionApproval(opportunity, INTRODUCER_ID)).toEqual({
+      success: false,
+      error: 'Introduction already approved',
+    });
+  });
+
+  test('explicit approval cannot be forged by a non-introducer actor (IND-608)', () => {
+    // A counterparty/agent actor that is not the assigned introducer cannot
+    // forge the introducer approval, regardless of the gate state.
+    const opportunity = buildOpportunity({
+      actors: [
+        { userId: OWNER_ID, role: 'patient', networkId: 'net00000-0000-4000-8000-000000000001' },
+        { userId: COUNTERPARTY_ID, role: 'agent', networkId: 'net00000-0000-4000-8000-000000000001' },
+        { userId: INTRODUCER_ID, role: 'introducer', networkId: 'net00000-0000-4000-8000-000000000001', approved: false },
+      ],
+    });
+
+    expect(assessIntroductionApproval(opportunity, COUNTERPARTY_ID)).toEqual({
+      success: false,
+      error: 'You are not the introducer for this opportunity',
+    });
+  });
+
+  test('send cannot be replayed on an already-sent opportunity (IND-608)', () => {
+    // Once an opportunity has left latent/draft, re-sending is rejected — a
+    // replayed send cannot re-notify recipients.
+    const opportunity = buildOpportunity({
+      status: 'pending',
+      actors: [
+        { userId: OWNER_ID, role: 'patient', networkId: 'net00000-0000-4000-8000-000000000001' },
+        { userId: COUNTERPARTY_ID, role: 'agent', networkId: 'net00000-0000-4000-8000-000000000001' },
+      ],
+    });
+
+    expect(assessOpportunitySend(opportunity, OWNER_ID)).toMatchObject({
+      success: false,
+      error: expect.stringMatching(/already pending/i),
+    });
+  });
 });

--- a/packages/protocol/src/questions/application/question.tools.ts
+++ b/packages/protocol/src/questions/application/question.tools.ts
@@ -15,10 +15,11 @@
  */
 import { z } from "zod";
 
-import type { DefineTool } from "../../shared/agent/tool.helpers.js";
+import type { DefineTool, ResolvedToolContext } from "../../shared/agent/tool.helpers.js";
 import type { QuestionerToolDeps } from "../ports/question.tools.port.js";
 import { error, success } from "../../shared/agent/tool.helpers.js";
 import { focusedIntentId, focusedNetworkId, focusedNetworkLabel } from "../../shared/agent/tool.scope.js";
+import { callerMayAccessQuestionMode } from "../../shared/agent/activity-projection.js";
 import type { PendingQuestionSummary } from "../../shared/schemas/pending-question.schema.js";
 import type { QuestionMode } from "../domain/question.schema.js";
 
@@ -33,6 +34,23 @@ const SELF_OWNED_MODES: QuestionMode[] = ["enrichment", "intent", "discovery"];
 
 function isVisibleInScopedNetwork(question: PendingQuestionSummary, userId: string, networkId: string): boolean {
   return question.actors?.some((actor) => actor.userId === userId && actor.networkId === networkId) === true;
+}
+
+/**
+ * Exact affected-domain permission gate for a single question mode.
+ *
+ * The canonical MCP matrix admits both question tools with a UNION of domain
+ * actions (so any question-holding agent can reach the handler), but exact
+ * inheritance must be enforced here: a global `manage:intents` agent must not
+ * read or answer a `negotiation` question. Reuses the shared
+ * `callerMayAccessQuestionMode` mapping so this matches the read_activity_summary
+ * projection. A caller context without an `mcpCaller` (REST/chat surfaces) is
+ * owner-trusted and passes; MCP humans own their data and also pass.
+ */
+function callerMayAccessQuestion(context: ResolvedToolContext, mode: QuestionMode): boolean {
+  const caller = context.mcpCaller;
+  if (!caller) return true;
+  return callerMayAccessQuestionMode(caller, mode);
 }
 
 function stripInternalQuestionFields(
@@ -94,13 +112,17 @@ export function createQuestionerTools(defineTool: DefineTool, deps: QuestionerTo
           ...(isIntentScoped ? { scopeType: 'intent' as const, scopeId: scopedIntentId } : {}),
           limit,
         });
+        // Exact affected-domain permission projection: an agent sees only the
+        // question modes backed by one of its permissions (a global intents-only
+        // agent never sees negotiation questions). The owning human passes.
+        const permitted = fetched.filter((q) => callerMayAccessQuestion(context, q.mode));
         const visible = isNetworkScoped
-          ? fetched.filter(
+          ? permitted.filter(
               (q) =>
                 (SELF_OWNED_MODES as string[]).includes(q.mode) &&
                 isVisibleInScopedNetwork(q, context.userId, scopedNetworkId!),
             )
-          : fetched;
+          : permitted;
         const limited = visible.slice(0, limit).map(stripInternalQuestionFields);
 
         if (isIntentScoped) {
@@ -190,6 +212,16 @@ export function createQuestionerTools(defineTool: DefineTool, deps: QuestionerTo
         if (!target) {
           return error(
             "Question not found among the client's pending questions — it may already be answered or dismissed. Re-check with read_pending_questions.",
+          );
+        }
+
+        // Enforce exact affected-domain inheritance on the resolved target BEFORE
+        // any write: the union admission that let this tool run does not grant
+        // cross-domain answering (e.g. a manage:intents agent cannot answer a
+        // negotiation question). Fail closed with nothing persisted.
+        if (!callerMayAccessQuestion(context, target.mode)) {
+          return error(
+            "You are not authorized to answer this question — it belongs to a domain your agent key does not manage.",
           );
         }
 

--- a/packages/protocol/src/questions/tests/question.tools.authz.spec.ts
+++ b/packages/protocol/src/questions/tests/question.tools.authz.spec.ts
@@ -1,0 +1,410 @@
+import { describe, expect, test } from 'bun:test';
+import { z } from 'zod';
+
+import { createQuestionerTools } from '../application/question.tools.js';
+import type { QuestionerToolDeps } from '../ports/question.tools.port.js';
+import type { ResolvedToolContext } from '../../shared/agent/tool.helpers.js';
+import type { PendingQuestionSummary } from '../../shared/schemas/pending-question.schema.js';
+
+/**
+ * IND-608 — question-answer provenance and authorization at the tool/handler
+ * seam (DB-free). Covers: authenticated-user provenance (the caller's own
+ * userId is always threaded to the pipeline), foreign-question rejection (a
+ * questionId not among the caller's pending set is refused), replay rejection
+ * (an already-answered question records nothing), affected-domain network clamp
+ * (network-scoped agents cannot answer and read only self-owned, in-network
+ * questions), and that no answer is written on any rejection path.
+ */
+
+interface CapturedTool {
+  handler: (input: { context: ResolvedToolContext; query: unknown }) => Promise<string>;
+  querySchema?: z.ZodType;
+}
+
+function captureTools(deps: Partial<QuestionerToolDeps>): Record<string, CapturedTool> {
+  const captured: Record<string, CapturedTool> = {};
+  const defineTool = (def: { name: string } & CapturedTool) => {
+    captured[def.name] = def;
+    return def;
+  };
+  createQuestionerTools(defineTool as never, deps as QuestionerToolDeps);
+  return captured;
+}
+
+function makeContext(
+  userId = 'user-owner',
+  scope?: {
+    networkId?: string;
+    intentId?: string;
+    /** MCP caller context; omit for the owner-trusted (REST/chat) path. */
+    mcpCaller?: { kind: 'human' | 'agent'; permissions: string[]; networkScopeId?: string | null };
+  },
+): ResolvedToolContext {
+  return {
+    userId,
+    user: { id: userId, name: 'Owner', email: 'o@test' } as never,
+    userProfile: null,
+    userNetworks: [],
+    isMcp: true,
+    ...(scope?.mcpCaller
+      ? { mcpCaller: { networkScopeId: null, ...scope.mcpCaller } }
+      : {}),
+    ...(scope?.intentId
+      ? { scopeType: 'intent' as const, scopeId: scope.intentId }
+      : scope?.networkId
+        ? { scopeType: 'network' as const, scopeId: scope.networkId }
+        : {}),
+  } as unknown as ResolvedToolContext;
+}
+
+const intentsAgent = { kind: 'agent' as const, permissions: ['manage:intents'] };
+const negotiationsAgent = { kind: 'agent' as const, permissions: ['manage:negotiations'] };
+const identityAgent = { kind: 'agent' as const, permissions: ['manage:identity'] };
+const premisesAgent = { kind: 'agent' as const, permissions: ['manage:premises'] };
+const opportunitiesAgent = { kind: 'agent' as const, permissions: ['manage:opportunities'] };
+
+function question(overrides: Partial<PendingQuestionSummary> = {}): PendingQuestionSummary {
+  return {
+    id: 'q1',
+    title: 'Title',
+    prompt: 'Prompt',
+    mode: 'intent',
+    options: [],
+    multiSelect: false,
+    sourceType: 'intent',
+    sourceId: 'intent-1',
+    createdAt: new Date('2026-01-01T00:00:00.000Z'),
+    ...overrides,
+  } as PendingQuestionSummary;
+}
+
+function parse(result: string) {
+  return JSON.parse(result) as { success: boolean; error?: string; data?: Record<string, unknown> };
+}
+
+describe('answer_pending_question — provenance & authorization (IND-608)', () => {
+  test('threads the authenticated caller userId to both lookup and answer (provenance)', async () => {
+    const findCalls: string[] = [];
+    const answerCalls: Array<{ userId: string; questionId: string }> = [];
+    const tools = captureTools({
+      findPendingQuestions: async (userId: string) => {
+        findCalls.push(userId);
+        return [question({ id: 'q1' })];
+      },
+      answerPendingQuestion: async (userId: string, questionId: string) => {
+        answerCalls.push({ userId, questionId });
+        return true;
+      },
+    });
+
+    const result = parse(await tools.answer_pending_question!.handler({
+      context: makeContext('user-owner'),
+      query: { questionId: 'q1', freeText: 'my explicit answer' },
+    }));
+
+    expect(result.success).toBe(true);
+    // The pipeline is always scoped to the authenticated caller, never a
+    // client-supplied identity.
+    expect(findCalls).toEqual(['user-owner']);
+    expect(answerCalls).toEqual([{ userId: 'user-owner', questionId: 'q1' }]);
+  });
+
+  test('rejects a foreign question id not among the caller pending set, writing nothing', async () => {
+    let answered = 0;
+    const tools = captureTools({
+      findPendingQuestions: async () => [question({ id: 'q-own' })],
+      answerPendingQuestion: async () => {
+        answered += 1;
+        return true;
+      },
+    });
+
+    const result = parse(await tools.answer_pending_question!.handler({
+      context: makeContext('user-owner'),
+      query: { questionId: 'q-belongs-to-someone-else', freeText: 'answer' },
+    }));
+
+    expect(result.success).toBe(false);
+    expect(result.error).toMatch(/not found among the client's pending questions/i);
+    expect(answered).toBe(0);
+  });
+
+  test('rejects replay of an already-answered question', async () => {
+    const tools = captureTools({
+      findPendingQuestions: async () => [question({ id: 'q1' })],
+      // The pipeline reports "no row updated" for an already-settled question.
+      answerPendingQuestion: async () => false,
+    });
+
+    const result = parse(await tools.answer_pending_question!.handler({
+      context: makeContext('user-owner'),
+      query: { questionId: 'q1', freeText: 'answer' },
+    }));
+
+    expect(result.success).toBe(false);
+    expect(result.error).toMatch(/already answered or dismissed/i);
+  });
+
+  test('network-scoped agents cannot answer questions (affected-domain clamp), writing nothing', async () => {
+    let findCalled = 0;
+    let answered = 0;
+    const tools = captureTools({
+      findPendingQuestions: async () => {
+        findCalled += 1;
+        return [question({ id: 'q1' })];
+      },
+      answerPendingQuestion: async () => {
+        answered += 1;
+        return true;
+      },
+    });
+
+    const result = parse(await tools.answer_pending_question!.handler({
+      context: makeContext('user-owner', { networkId: 'network-1' }),
+      query: { questionId: 'q1', freeText: 'answer' },
+    }));
+
+    expect(result.success).toBe(false);
+    expect(result.error).toMatch(/not available for network-scoped agents/i);
+    expect(findCalled).toBe(0);
+    expect(answered).toBe(0);
+  });
+
+  test('denies a global manage:intents agent answering a negotiation question, writing nothing', async () => {
+    let answered = 0;
+    const tools = captureTools({
+      findPendingQuestions: async () => [question({ id: 'neg-1', mode: 'negotiation' })],
+      answerPendingQuestion: async () => {
+        answered += 1;
+        return true;
+      },
+    });
+
+    const result = parse(await tools.answer_pending_question!.handler({
+      context: makeContext('user-owner', { mcpCaller: intentsAgent }),
+      query: { questionId: 'neg-1', freeText: 'answer' },
+    }));
+
+    expect(result.success).toBe(false);
+    expect(result.error).toMatch(/not authorized to answer this question/i);
+    expect(answered).toBe(0);
+  });
+
+  test('admits a manage:negotiations agent answering a negotiation question (matching domain)', async () => {
+    const answerCalls: Array<{ userId: string; questionId: string }> = [];
+    const tools = captureTools({
+      findPendingQuestions: async () => [question({ id: 'neg-1', mode: 'negotiation' })],
+      answerPendingQuestion: async (userId: string, questionId: string) => {
+        answerCalls.push({ userId, questionId });
+        return true;
+      },
+    });
+
+    const result = parse(await tools.answer_pending_question!.handler({
+      context: makeContext('user-owner', { mcpCaller: negotiationsAgent }),
+      query: { questionId: 'neg-1', freeText: 'answer' },
+    }));
+
+    expect(result.success).toBe(true);
+    expect(answerCalls).toEqual([{ userId: 'user-owner', questionId: 'neg-1' }]);
+  });
+
+  test('enrichment affects premises: identity-only agent is denied and writes nothing; premises agent is admitted', async () => {
+    const attempt = async (mcpCaller: { kind: 'agent'; permissions: string[] }) => {
+      let answered = 0;
+      const tools = captureTools({
+        findPendingQuestions: async () => [question({ id: 'enrich-1', mode: 'enrichment' })],
+        answerPendingQuestion: async () => {
+          answered += 1;
+          return true;
+        },
+      });
+      const result = parse(await tools.answer_pending_question!.handler({
+        context: makeContext('user-owner', { mcpCaller }),
+        query: { questionId: 'enrich-1', freeText: 'answer' },
+      }));
+      return { result, answered };
+    };
+
+    // Enrichment maps to premises, so an identity-only agent cannot answer it.
+    const identity = await attempt(identityAgent);
+    expect(identity.result.success).toBe(false);
+    expect(identity.result.error).toMatch(/not authorized to answer this question/i);
+    expect(identity.answered).toBe(0);
+
+    // A premises agent can.
+    const premises = await attempt(premisesAgent);
+    expect(premises.result.success).toBe(true);
+    expect(premises.answered).toBe(1);
+  });
+
+  test('discovery affects opportunities: an intents-only agent is denied, an opportunities agent is admitted', async () => {
+    const attempt = async (mcpCaller: { kind: 'agent'; permissions: string[] }) => {
+      let answered = 0;
+      const tools = captureTools({
+        findPendingQuestions: async () => [question({ id: 'disc-1', mode: 'discovery' })],
+        answerPendingQuestion: async () => {
+          answered += 1;
+          return true;
+        },
+      });
+      const result = parse(await tools.answer_pending_question!.handler({
+        context: makeContext('user-owner', { mcpCaller }),
+        query: { questionId: 'disc-1', freeText: 'answer' },
+      }));
+      return { result, answered };
+    };
+
+    const intents = await attempt(intentsAgent);
+    expect(intents.result.success).toBe(false);
+    expect(intents.answered).toBe(0);
+
+    const opportunities = await attempt(opportunitiesAgent);
+    expect(opportunities.result.success).toBe(true);
+    expect(opportunities.answered).toBe(1);
+  });
+
+  test('chat and unknown modes are human-only: no agent permission can answer them, no write', async () => {
+    const allPermsAgent = {
+      kind: 'agent' as const,
+      permissions: ['manage:identity', 'manage:premises', 'manage:intents', 'manage:opportunities', 'manage:negotiations'],
+    };
+    for (const mode of ['chat', 'future_unknown_mode'] as const) {
+      let answered = 0;
+      const tools = captureTools({
+        findPendingQuestions: async () => [question({ id: 'q1', mode: mode as never })],
+        answerPendingQuestion: async () => {
+          answered += 1;
+          return true;
+        },
+      });
+      const result = parse(await tools.answer_pending_question!.handler({
+        context: makeContext('user-owner', { mcpCaller: allPermsAgent }),
+        query: { questionId: 'q1', freeText: 'answer' },
+      }));
+      expect(result.success).toBe(false);
+      expect(answered).toBe(0);
+    }
+  });
+
+  test('the owning human (mcpCaller.kind=human) may answer any domain', async () => {
+    let answered = 0;
+    const tools = captureTools({
+      findPendingQuestions: async () => [question({ id: 'neg-1', mode: 'negotiation' })],
+      answerPendingQuestion: async () => {
+        answered += 1;
+        return true;
+      },
+    });
+
+    const result = parse(await tools.answer_pending_question!.handler({
+      context: makeContext('user-owner', { mcpCaller: { kind: 'human', permissions: [] } }),
+      query: { questionId: 'neg-1', freeText: 'answer' },
+    }));
+
+    expect(result.success).toBe(true);
+    expect(answered).toBe(1);
+  });
+
+  test('refuses to fabricate an answer with neither selectedOptions nor freeText', async () => {
+    let answered = 0;
+    const tools = captureTools({
+      findPendingQuestions: async () => [question({ id: 'q1' })],
+      answerPendingQuestion: async () => {
+        answered += 1;
+        return true;
+      },
+    });
+
+    const result = parse(await tools.answer_pending_question!.handler({
+      context: makeContext('user-owner'),
+      query: { questionId: 'q1' },
+    }));
+
+    expect(result.success).toBe(false);
+    expect(result.error).toMatch(/no answer provided/i);
+    expect(answered).toBe(0);
+  });
+});
+
+describe('read_pending_questions — exact affected-domain permission projection (IND-608)', () => {
+  test('a global manage:intents agent sees intent questions but not negotiation questions', async () => {
+    const tools = captureTools({
+      findPendingQuestions: async () => [
+        question({ id: 'intent-q', mode: 'intent' }),
+        question({ id: 'neg-q', mode: 'negotiation' }),
+        question({ id: 'enrich-q', mode: 'enrichment' }),
+      ],
+    });
+
+    const result = parse(await tools.read_pending_questions!.handler({
+      context: makeContext('user-owner', { mcpCaller: intentsAgent }),
+      query: {},
+    }));
+
+    expect(result.success).toBe(true);
+    const ids = (result.data!.questions as Array<{ id: string }>).map((q) => q.id);
+    expect(ids).toEqual(['intent-q']);
+  });
+
+  test('the owning human sees every mode', async () => {
+    const tools = captureTools({
+      findPendingQuestions: async () => [
+        question({ id: 'intent-q', mode: 'intent' }),
+        question({ id: 'neg-q', mode: 'negotiation' }),
+      ],
+    });
+
+    const result = parse(await tools.read_pending_questions!.handler({
+      context: makeContext('user-owner', { mcpCaller: { kind: 'human', permissions: [] } }),
+      query: {},
+    }));
+
+    expect(result.success).toBe(true);
+    const ids = (result.data!.questions as Array<{ id: string }>).map((q) => q.id);
+    expect(ids).toEqual(['intent-q', 'neg-q']);
+  });
+});
+
+describe('read_pending_questions — network visibility clamp (IND-608)', () => {
+  test('a network-scoped agent only sees self-owned questions whose actor matches user+network', async () => {
+    const tools = captureTools({
+      findPendingQuestions: async () => [
+        // Visible: self-owned mode, actor is the caller in the bound network.
+        question({
+          id: 'visible',
+          mode: 'intent',
+          actors: [{ userId: 'user-owner', networkId: 'network-1' }],
+        } as Partial<PendingQuestionSummary>),
+        // Hidden: correct user but a different network.
+        question({
+          id: 'foreign-network',
+          mode: 'intent',
+          actors: [{ userId: 'user-owner', networkId: 'network-2' }],
+        } as Partial<PendingQuestionSummary>),
+        // Hidden: negotiation mode is never self-owned for a network agent.
+        question({
+          id: 'negotiation-mode',
+          mode: 'negotiation',
+          actors: [{ userId: 'user-owner', networkId: 'network-1' }],
+        } as Partial<PendingQuestionSummary>),
+        // Hidden: a different user's question in the same network.
+        question({
+          id: 'other-user',
+          mode: 'intent',
+          actors: [{ userId: 'someone-else', networkId: 'network-1' }],
+        } as Partial<PendingQuestionSummary>),
+      ],
+    });
+
+    const result = parse(await tools.read_pending_questions!.handler({
+      context: makeContext('user-owner', { networkId: 'network-1' }),
+      query: {},
+    }));
+
+    expect(result.success).toBe(true);
+    const ids = (result.data!.questions as Array<{ id: string }>).map((q) => q.id);
+    expect(ids).toEqual(['visible']);
+    expect(result.data!.scopeRestriction).toBeDefined();
+  });
+});

--- a/packages/protocol/src/shared/agent/activity-projection.ts
+++ b/packages/protocol/src/shared/agent/activity-projection.ts
@@ -62,7 +62,9 @@ export type ActivityQuestionDomain = z.infer<typeof ActivityQuestionDomainSchema
  * bucket so a future protocol mode can never leak to an agent caller.
  */
 export const QUESTION_MODE_TO_DOMAIN: Readonly<Record<string, ActivityQuestionDomain>> = {
-  enrichment: "identity",
+  // Enrichment answers run the PremiseGraph lifecycle (createPremiseFromAnswer →
+  // PremiseEvents.onCreated), so enrichment questions affect the premises domain.
+  enrichment: "premises",
   intent: "intents",
   discovery: "opportunities",
   pool_discovery: "opportunities",
@@ -121,6 +123,38 @@ const QUESTION_DOMAIN_PERMISSIONS: Readonly<Partial<Record<ActivityQuestionDomai
   opportunities: "manage:opportunities",
   negotiations: "manage:negotiations",
 };
+
+/**
+ * Canonical affected-domain permission an agent must hold to read or answer a
+ * question of the given mode. Returns `null` for human-owner-only questions
+ * (`chat`, and any unrecognized mode, which fail closed to the human-only
+ * bucket) — no agent permission can release those.
+ *
+ * This is the single shared mode → affected-domain → permission mapping, reusing
+ * `QUESTION_MODE_TO_DOMAIN` and `QUESTION_DOMAIN_PERMISSIONS` so question
+ * read/answer inheritance is identical to the `read_activity_summary`
+ * projection. It keys on `mode` only: the canonical question model does not vary
+ * a question's owning domain by `purpose` (purpose refines generation and
+ * provenance, not the affected domain), so purpose is intentionally not a
+ * discriminant here rather than being guessed at.
+ */
+export function questionModeRequiredPermission(mode: string): string | null {
+  const domain = QUESTION_MODE_TO_DOMAIN[mode] ?? "chat";
+  return QUESTION_DOMAIN_PERMISSIONS[domain] ?? null;
+}
+
+/**
+ * Whether an MCP caller may read or answer a question of the given mode. Human
+ * (owner) callers see every mode; agents are confined to modes backed by one of
+ * their exact affected-domain permissions. A network agent's binding is applied
+ * separately by the caller (network/intent clamp); this is purely the
+ * affected-domain permission gate.
+ */
+export function callerMayAccessQuestionMode(caller: McpActivityCaller, mode: string): boolean {
+  if (caller.kind === "human") return true;
+  const required = questionModeRequiredPermission(mode);
+  return required !== null && caller.permissions.includes(required);
+}
 
 /**
  * Explicit response contract for `read_activity_summary`. Every domain field

--- a/packages/protocol/src/shared/agent/tests/activity-projection.spec.ts
+++ b/packages/protocol/src/shared/agent/tests/activity-projection.spec.ts
@@ -52,7 +52,7 @@ describe("MCP activity-summary permission projection", () => {
       opportunitiesSurfaced: 5,
       opportunitiesBySignal: FULL_SUMMARY.opportunitiesBySignal,
       pendingQuestionsByDomain: { intents: 2, negotiations: 1, chat: 4 },
-      answeredQuestionsByDomain: { identity: 3, opportunities: 5 },
+      answeredQuestionsByDomain: { premises: 3, opportunities: 5 },
       negotiationsStarted: 6,
       negotiationsCompleted: 7,
     });
@@ -76,7 +76,7 @@ describe("MCP activity-summary permission projection", () => {
       opportunitiesSurfaced: 5,
       // intent-mode pending counts stay hidden without manage:intents; chat is human-only.
       pendingQuestionsByDomain: { negotiations: 1 },
-      // enrichment counts stay hidden without manage:identity.
+      // enrichment counts stay hidden without manage:premises.
       answeredQuestionsByDomain: { opportunities: 5 },
       negotiationsStarted: 6,
       negotiationsCompleted: 7,
@@ -104,19 +104,28 @@ describe("MCP activity-summary permission projection", () => {
   });
 
   test("question counts inherit the permission of the affected domain — no any-of all-count", () => {
-    // An identity-only agent sees only identity-affected question counts, never
-    // an undifferentiated total that would include intent/negotiation questions.
+    // A premises-only agent sees only premises-affected question counts
+    // (enrichment), never an undifferentiated total that would include
+    // intent/negotiation questions.
     const caller = McpActivityCallerSchema.parse({
       kind: "agent",
-      permissions: ["manage:identity"],
+      permissions: ["manage:premises"],
       networkScopeId: null,
     });
 
     expect(resolveActivitySummaryDomains(caller)).toEqual(["questions"]);
     expect(projectActivitySummary(caller, FULL_SUMMARY)).toEqual({
       sinceHours: 24,
-      answeredQuestionsByDomain: { identity: 3 },
+      answeredQuestionsByDomain: { premises: 3 },
     });
+
+    // An identity-only agent sees NO enrichment counts (enrichment is premises).
+    const identityOnly = McpActivityCallerSchema.parse({
+      kind: "agent",
+      permissions: ["manage:identity"],
+      networkScopeId: null,
+    });
+    expect("answeredQuestionsByDomain" in projectActivitySummary(identityOnly, FULL_SUMMARY)).toBe(false);
   });
 
   test("chat-mode and unrecognized question modes are human-owner-only", () => {

--- a/services/api/drizzle/0109_migrate_agent_permission_actions.md
+++ b/services/api/drizzle/0109_migrate_agent_permission_actions.md
@@ -1,0 +1,290 @@
+# 0109 — Agent-permission action backfill runbook (IND-606 / IND-607)
+
+Operational, auditable procedure for applying
+`0109_migrate_agent_permission_actions.sql` to a live database. The SQL itself
+is deterministic and idempotent; this runbook adds the predicate / control-group
+/ dry-run / snapshot / execute / postcondition discipline required by IND-607.
+
+> **Safety.** Production execution requires a **separate explicit user
+> authorization** and MUST follow the `backfill-production-data` skill workflow
+> (Neon project `Protocol`, database `protocol_prod`, `branchId` +
+> `databaseName=protocol_prod`). Nothing here may be run against Neon, dev,
+> shared, staging, or production without that authorization. The wave that
+> produced this migration ran **no** database mutation.
+
+## Transformation (per row)
+
+| Legacy action     | Result                                   |
+| ----------------- | ---------------------------------------- |
+| `manage:profile`  | `manage:identity` **and** `manage:premises` |
+| `manage:contacts` | removed                                  |
+| any other action  | preserved verbatim                       |
+
+Row identity and authority (`id`, `agent_id`, `user_id`, `scope`, `scope_id`)
+are never modified. Known canonical actions are emitted first, in canonical
+order; any unknown/residual action strings are intentionally preserved and
+sorted after the canonical block (they are neither dropped nor promoted to
+canonical grants). Output is de-duplicated. A row whose only action was
+`manage:contacts` becomes an empty (non-null) `actions` array; no row is
+deleted.
+
+Only rows matching the retired-action overlap predicate are rewritten. Every
+other row (the control group) is left **byte-for-byte unchanged** — the
+migration does not re-order or normalize control rows even if they are not in
+canonical order.
+
+## 1. Validate the predicate and a control group (read-only)
+
+```sql
+-- Rows that WILL change (predicate == SQL overlap filter).
+SELECT COUNT(*) AS affected_rows
+FROM agent_permissions
+WHERE actions && ARRAY['manage:profile', 'manage:contacts']::text[];
+
+-- Control group that MUST remain byte-for-byte unchanged.
+SELECT COUNT(*) AS control_rows
+FROM agent_permissions
+WHERE NOT (actions && ARRAY['manage:profile', 'manage:contacts']::text[]);
+
+-- Sanity: affected + control == total.
+SELECT COUNT(*) AS total_rows FROM agent_permissions;
+
+-- Distinct legacy shapes, for an auditable before/after review.
+SELECT actions, COUNT(*) AS n
+FROM agent_permissions
+WHERE actions && ARRAY['manage:profile', 'manage:contacts']::text[]
+GROUP BY actions
+ORDER BY n DESC;
+```
+
+Record `affected_rows`, `control_rows`, and `total_rows`. These are the exact
+expected counts for the dry run and postconditions.
+
+## 2. Dry-run on dev (read-only preview of every rewrite)
+
+Run inside a transaction you will `ROLLBACK`, or as a pure `SELECT` preview:
+
+```sql
+SELECT
+  ap.id,
+  ap.actions AS before_actions,
+  ARRAY(
+    SELECT expanded.action
+    FROM (
+      SELECT DISTINCT
+        m.action AS action,
+        CASE m.action
+          WHEN 'manage:identity' THEN 1
+          WHEN 'manage:premises' THEN 2
+          WHEN 'manage:intents' THEN 3
+          WHEN 'manage:networks' THEN 4
+          WHEN 'manage:opportunities' THEN 5
+          WHEN 'manage:negotiations' THEN 6
+          ELSE 99
+        END AS ord
+      FROM unnest(ap.actions) AS orig(action)
+      CROSS JOIN LATERAL unnest(
+        CASE orig.action
+          WHEN 'manage:profile' THEN ARRAY['manage:identity', 'manage:premises']
+          WHEN 'manage:contacts' THEN ARRAY[]::text[]
+          ELSE ARRAY[orig.action]
+        END
+      ) AS m(action)
+    ) AS expanded
+    ORDER BY expanded.ord, expanded.action
+  ) AS after_actions
+FROM agent_permissions AS ap
+WHERE ap.actions && ARRAY['manage:profile', 'manage:contacts']::text[]
+ORDER BY ap.id;
+```
+
+Confirm the preview `after_actions` matches expectations for every distinct
+legacy shape from step 1. The preview expression is identical to the migration's
+rewrite expression and to the `migrateAgentPermissionActions` unit helper.
+
+## 3. Recovery points (Neon backup branch + protected offline artifact)
+
+The migration is intentionally not auto-reversible and is a pure `UPDATE`: it
+creates **no** table and leaves **no** durable app schema behind. Recovery
+therefore uses two artifacts captured **before the deploy** that runs `0109` —
+never an in-database recovery table and never a cross-branch join (Neon branches
+are separate endpoints).
+
+**(a) Mandatory Neon backup branch.** Per the `backfill-production-data`
+workflow, take a backup branch of `protocol_prod` and record its `branchId` and
+timestamp. Coarse incident restore = the approved Neon branch **restore/reset**
+workflow (an operational action, not SQL).
+
+**(b) Mandatory protected offline artifact.** Export the exact affected rows
+from the step-2 dry-run — before the migration runs — as
+`(id, before_actions, after_actions)`, plus the row count and a content
+checksum, to secure **offline** storage (not a DB table):
+
+```sql
+-- Run the step-2 dry-run SELECT and export its rows verbatim to the artifact.
+-- Then compute the integrity metadata that the artifact must record:
+WITH affected AS (
+  SELECT id, actions AS before_actions
+  FROM agent_permissions
+  WHERE actions && ARRAY['manage:profile', 'manage:contacts']::text[]
+)
+SELECT
+  COUNT(*) AS affected_rows,
+  md5(string_agg(id || ':' || array_to_string(before_actions, ','), '|'
+                 ORDER BY id)) AS before_checksum
+FROM affected;
+```
+
+Artifact contract:
+
+- **Exact fields:** `id`, `before_actions` (text[]), `after_actions` (text[]),
+  captured from the step-2 dry-run (whose `after_actions` expression is
+  identical to the migration and to `migrateAgentPermissionActions`).
+- **Counts & checksum:** `affected_rows` and `before_checksum` above; record
+  them in the artifact header and in the release ticket.
+- **Secure storage / access owner:** store in the team's protected secrets/
+  artifact store; the **release owner** is the named access owner.
+- **Timing:** exported and checksum-verified **before** the auto migration runs.
+
+**Fine-grained incident restore** replays `before_actions` by `id` from the
+artifact via a controlled one-off script (idempotent, keyed on `id`), e.g. a
+`VALUES`-driven `UPDATE ... FROM (VALUES ...) AS restore(id, actions)`. This
+leaves no lingering table and performs no cross-branch join.
+
+**Retention & cleanup.** Retain both artifacts through the post-deploy
+verification window plus the monitoring window in the IND-609 rollout doc. After
+sign-off, the **release owner** deletes the offline artifact and expires the
+Neon backup branch. Because the migration creates no table, confirm no durable
+recovery schema remains:
+
+```sql
+SELECT to_regclass('public.agent_permissions_recovery_0109') AS should_be_null;
+-- expect NULL (no recovery table is ever created by this migration)
+```
+
+## 4. Execute transactionally
+
+Applied automatically by `drizzle-kit migrate` during deploy (journal entry
+`0109`), or manually:
+
+```sql
+BEGIN;
+\i services/api/drizzle/0109_migrate_agent_permission_actions.sql
+-- verify step 5 postconditions here, then:
+COMMIT;  -- or ROLLBACK on any mismatch
+```
+
+The `UPDATE` reports its affected row count; it MUST equal `affected_rows`.
+
+## 5. Verify with an idempotent post-cutover sweep
+
+Verification is an **idempotent sweep** on the current table plus the recorded
+step-1 counts and the offline artifact from step 3. It is **independent of the
+deploy's reported UPDATE count** (Railway/`drizzle-kit` may not surface it), so
+it can be re-run at any time and by any operator. No in-DB recovery table and no
+cross-branch join are used.
+
+```sql
+-- (1) Zero rows may still carry a retired action. Re-runnable; must stay 0.
+SELECT COUNT(*) AS retired_remaining
+FROM agent_permissions
+WHERE actions && ARRAY['manage:profile', 'manage:contacts']::text[];
+-- expect 0
+
+-- (2) Row count is unchanged (no row dropped or duplicated).
+SELECT COUNT(*) AS total_rows FROM agent_permissions;  -- expect recorded step-1 total
+
+-- (3) Every row that the artifact recorded as previously-profile now holds
+--     identity AND premises. Driven by the OFFLINE artifact, replayed as
+--     inline VALUES (no recovery table, no cross-branch join):
+--       SELECT COUNT(*) FROM (VALUES ('id-1'), ('id-2'), ...) AS prof(id)
+--       JOIN agent_permissions ap ON ap.id = prof.id
+--       WHERE NOT (ap.actions @> ARRAY['manage:identity','manage:premises']::text[]);
+--     expect 0
+```
+
+**Idempotence sweep (the primary, count-independent check).** Re-applying the
+migration SQL affects **0** rows once convergence is reached, because no row
+overlaps the retired-action predicate anymore:
+
+```sql
+BEGIN;
+\i services/api/drizzle/0109_migrate_agent_permission_actions.sql  -- reports 0 rows
+ROLLBACK;
+```
+
+Control-group integrity is asserted by construction: the migration's
+`WHERE actions && ARRAY['manage:profile','manage:contacts']` filter touches only
+affected rows, so `total_rows` unchanged plus `retired_remaining = 0` plus a
+zero-row re-run proves no control row was modified — without relying on the
+deploy's UPDATE count. Diff the retained artifact counts before/after for an
+independent record; never join across Neon branches.
+
+## 6. Mixed-version rolling deploy — the pre-deploy migration is NOT the proof
+
+`railway.toml` runs `db:migrate` as `preDeployCommand`, i.e. migration `0109`
+executes **before** the new release replaces/drains the old replicas. The
+currently deployed code (`origin/dev`) still WRITES `manage:profile` /
+`manage:contacts` grants (agent service defaults, network-invitation defaults,
+participant-agent `register_agent`). Therefore, during the rolling window, old
+replicas can re-introduce retired-action rows **after** `0109` has run.
+
+**Consequences (do not skip):**
+
+1. The pre-deploy `0109` run + a zero-row re-run at deploy time **cannot** prove
+   backfill completeness. New retired rows may appear until the last old replica
+   drains. `retired_remaining = 0` is proven only by the **post-drain final
+   sweep** (below), never by the automatic `db:migrate` alone.
+2. **No access loss / no over-authorization in the meantime.** The new runtime
+   interprets residual legacy stored rows at the capability-loading boundary
+   (`projectStoredPermissionActions` in
+   `packages/protocol/src/mcp/mcp.authorization-policy.ts`):
+   `manage:profile` → `manage:identity` + `manage:premises`; `manage:contacts` →
+   no capability; owner/scope matching preserved; unknown actions fail closed.
+   This is temporary rolling-data compatibility for STORED rows only — the legacy
+   names are never accepted as input or surfaced.
+
+### Mandatory post-drain final sweep (separately approved)
+
+> The post-drain final sweep is MANDATORY and is NOT the automatic preDeploy
+> `db:migrate`. `db:migrate` runs `0109` once, before drain; only the separately
+> approved post-drain sweep proves `retired_remaining = 0`.
+
+After **all** old replicas have drained (only new, canonical-only writers
+remain), run — via the separately approved `backfill-production-data` workflow,
+with the pre-action Neon backup branch and protected offline artifact from §3:
+
+```sql
+-- Inventory: retired rows remaining after drain (expected > 0 only if old
+-- replicas wrote new ones during the window; the sweep converges them).
+SELECT COUNT(*) AS retired_remaining
+FROM agent_permissions
+WHERE actions && ARRAY['manage:profile', 'manage:contacts']::text[];
+```
+
+Then apply the same idempotent transform (`0109`'s SQL) as the final sweep and
+re-run the inventory until `retired_remaining = 0`. This final-sweep result — not
+the pre-deploy migration — is what proves completeness. Backup / offline
+artifact / recovery requirements from §3 apply to the final sweep exactly as to
+the initial run.
+
+### Compatibility-removal gate
+
+The read-time legacy projection is **temporary**. It may be removed only after
+ALL of the following hold (do not claim the single deploy removes it):
+
+1. all old replicas are drained (no instance running pre-cutover code);
+2. the post-drain final sweep is complete and `retired_remaining = 0`;
+3. a monitoring window has elapsed with **no new legacy writes** observed
+   (retired-row inventory stays at 0 across the window).
+
+Only then may `projectStoredPermissionActions` (and this compatibility note) be
+retired in a follow-up release.
+
+## Automated verification
+
+- DB-free exactness + static/journal invariants:
+  `services/api/src/lib/drizzle/tests/permission-action-migration.spec.ts`
+- Actual-SQL behavior (owner/scope preservation, control group, idempotence),
+  `TEST_DATABASE_SAFE`-gated (skipped where no disposable DB is proven):
+  `services/api/src/lib/drizzle/tests/permission-action-migration.integration.spec.ts`

--- a/services/api/drizzle/0109_migrate_agent_permission_actions.sql
+++ b/services/api/drizzle/0109_migrate_agent_permission_actions.sql
@@ -1,0 +1,83 @@
+-- Durable agent-permission model migration (IND-606 / IND-607).
+--
+-- Retires the legacy `manage:profile` and `manage:contacts` grant actions from
+-- the durable permission model and rewrites every affected row onto the
+-- canonical action model. Known canonical actions are emitted first in canonical
+-- order; any unknown/residual action strings are preserved (never dropped and
+-- never promoted to canonical grants) and sorted after the canonical block:
+--
+--   * `manage:profile`  -> `manage:identity` + `manage:premises`
+--   * `manage:contacts` -> removed
+--   * every other action -> preserved verbatim
+--
+-- Per-row invariants (verified by the migration integration spec and the pure
+-- transform unit spec that mirrors this SQL):
+--   * owner (`user_id`), `agent_id`, `scope`, and `scope_id` are never touched;
+--   * no valid grant is dropped and no action is broadened beyond the explicit
+--     profile -> identity+premises expansion;
+--   * results are de-duplicated and emitted in a deterministic canonical order
+--     (identity, premises, intents, networks, opportunities, negotiations, then
+--     any residual/unknown actions alphabetically);
+--   * rows whose only action was `manage:contacts` become an empty (non-null)
+--     action array — no row is deleted;
+--   * the statement is idempotent: after it runs no row overlaps the retired
+--     action set, so a re-run matches zero rows.
+--
+-- RECOVERY PATH (this data migration is intentionally not auto-reversible):
+--   `manage:contacts` removal and the `manage:profile` -> identity+premises
+--   expansion are lossy (a down migration cannot distinguish a backfilled
+--   identity/premises pair from an independently granted one). This migration is
+--   a pure UPDATE: it creates NO table and leaves NO durable app schema behind.
+--
+--   Recovery does NOT use an in-database recovery table (none is created) and
+--   NEVER a cross-branch join (Neon branches are separate endpoints). Instead:
+--     1. MANDATORY Neon backup branch of protocol_prod, taken BEFORE the deploy
+--        that runs this migration (per the backfill-production-data workflow).
+--        Incident restore = the approved Neon branch restore/reset workflow.
+--     2. MANDATORY protected OFFLINE artifact exported BEFORE the deploy: the
+--        exact affected rows as (id, before_actions, after_actions), plus row
+--        count and a sha256 checksum, stored in secure offline storage with a
+--        named access owner. Fine-grained incident restore replays
+--        before_actions by id from this artifact via a controlled one-off script
+--        (never a cross-branch join, never a lingering table).
+--   Verification is an idempotent post-cutover sweep independent of the deploy's
+--   reported UPDATE count (retired_remaining = 0 and a re-run affects 0 rows).
+--
+--   See services/api/drizzle/0109_migrate_agent_permission_actions.md and
+--   docs/rollout/IND-609-mcp-permission-rollout.md for the full predicate /
+--   control-group / dry-run / artifact / execute / idempotent-sweep sequence,
+--   rolling-deploy writer behavior, retention, and artifact cleanup owner.
+UPDATE "agent_permissions" AS ap
+SET "actions" = rewrite.actions
+FROM (
+  SELECT
+    src.id AS id,
+    ARRAY(
+      SELECT expanded.action
+      FROM (
+        SELECT DISTINCT
+          m.action AS action,
+          CASE m.action
+            WHEN 'manage:identity' THEN 1
+            WHEN 'manage:premises' THEN 2
+            WHEN 'manage:intents' THEN 3
+            WHEN 'manage:networks' THEN 4
+            WHEN 'manage:opportunities' THEN 5
+            WHEN 'manage:negotiations' THEN 6
+            ELSE 99
+          END AS ord
+        FROM unnest(src.actions) AS orig(action)
+        CROSS JOIN LATERAL unnest(
+          CASE orig.action
+            WHEN 'manage:profile' THEN ARRAY['manage:identity', 'manage:premises']
+            WHEN 'manage:contacts' THEN ARRAY[]::text[]
+            ELSE ARRAY[orig.action]
+          END
+        ) AS m(action)
+      ) AS expanded
+      ORDER BY expanded.ord, expanded.action
+    ) AS actions
+  FROM "agent_permissions" AS src
+  WHERE src.actions && ARRAY['manage:profile', 'manage:contacts']::text[]
+) AS rewrite
+WHERE ap.id = rewrite.id;

--- a/services/api/drizzle/meta/_journal.json
+++ b/services/api/drizzle/meta/_journal.json
@@ -764,6 +764,13 @@
       "when": 1784975313173,
       "tag": "0108_add_intent_proposals",
       "breakpoints": true
+    },
+    {
+      "idx": 109,
+      "version": "7",
+      "when": 1784975500000,
+      "tag": "0109_migrate_agent_permission_actions",
+      "breakpoints": true
     }
   ]
 }

--- a/services/api/package.json
+++ b/services/api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@indexnetwork/api",
-  "version": "0.60.0",
+  "version": "0.61.0",
   "license": "MIT",
   "private": true,
   "scripts": {

--- a/services/api/src/cli/db-seed.ts
+++ b/services/api/src/cli/db-seed.ts
@@ -39,7 +39,7 @@ const SYSTEM_AGENT_DEFS = [
   {
     id: SYSTEM_AGENT_IDS.chatOrchestrator,
     name: 'Index Chat Orchestrator',
-    description: 'Built-in chat agent that manages profiles, intents, networks, and contacts on behalf of users.',
+    description: 'Built-in chat agent that manages identity, premises, intents, networks, and opportunities on behalf of users.',
     actions: ['manage:identity', 'manage:premises', 'manage:intents', 'manage:networks', 'manage:opportunities'],
   },
   {

--- a/services/api/src/guards/tests/agent-scope.guard.spec.ts
+++ b/services/api/src/guards/tests/agent-scope.guard.spec.ts
@@ -45,7 +45,7 @@ describe('agent-scope.guard', () => {
     scopedAgentId = scopedAgent.id;
     await agentDatabaseAdapter.grantPermission({
       agentId: scopedAgent.id, userId, scope: 'network', scopeId: networkId,
-      actions: ['manage:profile', 'manage:intents', 'manage:networks', 'manage:contacts', 'manage:opportunities'],
+      actions: ['manage:identity', 'manage:premises', 'manage:intents', 'manage:networks', 'manage:opportunities'],
     });
     scopedKey = (await agentTokenAdapter.create(userId, { name: 'scoped', agentId: scopedAgent.id })).key;
 
@@ -55,7 +55,7 @@ describe('agent-scope.guard', () => {
     globalAgentId = globalAgent.id;
     await agentDatabaseAdapter.grantPermission({
       agentId: globalAgent.id, userId, scope: 'global',
-      actions: ['manage:profile', 'manage:intents', 'manage:networks', 'manage:contacts', 'manage:opportunities'],
+      actions: ['manage:identity', 'manage:premises', 'manage:intents', 'manage:networks', 'manage:opportunities'],
     });
     globalKey = (await agentTokenAdapter.create(userId, { name: 'global', agentId: globalAgent.id })).key;
   });
@@ -104,7 +104,7 @@ describe('agent-scope.guard', () => {
       agentId: scopedAgentId,
       userId,
       scope: 'global',
-      actions: ['manage:profile'],
+      actions: ['manage:identity'],
     });
 
     expect(await resolveAgentNetworkScopeById(scopedAgentId)).toBe(networkId);

--- a/services/api/src/guards/tests/session-only.guard.spec.ts
+++ b/services/api/src/guards/tests/session-only.guard.spec.ts
@@ -29,7 +29,7 @@ describe('session-only.guard', () => {
     });
     await agentDatabaseAdapter.grantPermission({
       agentId: agent.id, userId, scope: 'global',
-      actions: ['manage:profile', 'manage:intents', 'manage:networks', 'manage:contacts', 'manage:opportunities'],
+      actions: ['manage:identity', 'manage:premises', 'manage:intents', 'manage:networks', 'manage:opportunities'],
     });
     validKey = (await agentTokenAdapter.create(userId, { name: 'session-only', agentId: agent.id })).key;
   });

--- a/services/api/src/lib/drizzle/permission-action-migration.ts
+++ b/services/api/src/lib/drizzle/permission-action-migration.ts
@@ -1,0 +1,93 @@
+/**
+ * Deterministic, idempotent transform for the durable agent-permission model
+ * migration (IND-606 / IND-607).
+ *
+ * This TypeScript helper mirrors the per-row semantics of the SQL data
+ * migration in `drizzle/0109_migrate_agent_permission_actions.sql` so the exact
+ * transformation can be unit-tested without a database. The SQL migration
+ * remains the source of truth for the production/dev backfill; this helper is
+ * verification/tooling-only and MUST stay in lockstep with the SQL ordering and
+ * mapping rules.
+ *
+ * Row-level fields (`user_id`, `agent_id`, `scope`, `scope_id`) are owned by the
+ * row, not by this array transform, and are never touched by either the SQL or
+ * this helper.
+ */
+
+/** Canonical post-migration action set, in canonical (deterministic) order. */
+export const CANONICAL_AGENT_ACTIONS = [
+  'manage:identity',
+  'manage:premises',
+  'manage:intents',
+  'manage:networks',
+  'manage:opportunities',
+  'manage:negotiations',
+] as const;
+
+export type CanonicalAgentAction = (typeof CANONICAL_AGENT_ACTIONS)[number];
+
+/** Legacy actions retired from the durable model by this migration. */
+export const RETIRED_AGENT_ACTIONS = ['manage:profile', 'manage:contacts'] as const;
+
+export type RetiredAgentAction = (typeof RETIRED_AGENT_ACTIONS)[number];
+
+/**
+ * Canonical sort index. Mirrors the `CASE ... ORDER BY ord, action` ordering in
+ * the SQL migration: canonical actions come first in this fixed order, and any
+ * residual/unknown actions sort after them, alphabetically.
+ */
+const CANONICAL_ORDER = new Map<string, number>(
+  CANONICAL_AGENT_ACTIONS.map((action, index) => [action, index + 1]),
+);
+const RESIDUAL_ORDER = 99;
+
+/**
+ * Expand a single legacy action into zero or more canonical actions:
+ *   - `manage:profile`  -> `manage:identity` + `manage:premises`
+ *   - `manage:contacts` -> removed (empty expansion)
+ *   - anything else      -> preserved verbatim (including unknown actions)
+ */
+function expandAction(action: string): string[] {
+  if (action === 'manage:profile') return ['manage:identity', 'manage:premises'];
+  if (action === 'manage:contacts') return [];
+  return [action];
+}
+
+function compareByCanonicalOrder(a: string, b: string): number {
+  const aOrd = CANONICAL_ORDER.get(a) ?? RESIDUAL_ORDER;
+  const bOrd = CANONICAL_ORDER.get(b) ?? RESIDUAL_ORDER;
+  if (aOrd !== bOrd) return aOrd - bOrd;
+  if (a < b) return -1;
+  if (a > b) return 1;
+  return 0;
+}
+
+/**
+ * The retired-action predicate matching the SQL migration's
+ * `actions && ARRAY['manage:profile', 'manage:contacts']` overlap filter.
+ * Rows for which this is `false` form the control group and MUST remain
+ * byte-for-byte unchanged.
+ */
+export function actionsNeedMigration(actions: readonly string[]): boolean {
+  return actions.some(
+    (action) => action === 'manage:profile' || action === 'manage:contacts',
+  );
+}
+
+/**
+ * Transform one `agent_permissions.actions` array onto the canonical action
+ * model. Known canonical actions are emitted first, in canonical order; any
+ * unknown/residual action strings are intentionally preserved and sorted after
+ * the canonical block (never dropped, never promoted to canonical grants). The
+ * output is therefore not guaranteed to be a subset of CANONICAL_AGENT_ACTIONS.
+ *
+ * Deterministic and idempotent: duplicates are removed and a second application
+ * is a no-op because no retired action survives the first.
+ */
+export function migrateAgentPermissionActions(actions: readonly string[]): string[] {
+  const seen = new Set<string>();
+  for (const action of actions) {
+    for (const mapped of expandAction(action)) seen.add(mapped);
+  }
+  return [...seen].sort(compareByCanonicalOrder);
+}

--- a/services/api/src/lib/drizzle/tests/permission-action-migration.integration.spec.ts
+++ b/services/api/src/lib/drizzle/tests/permission-action-migration.integration.spec.ts
@@ -1,0 +1,237 @@
+import { describe, expect, it } from 'bun:test';
+import { randomUUID } from 'node:crypto';
+import { readFileSync } from 'node:fs';
+import path from 'node:path';
+
+import postgres from 'postgres';
+
+import { migrateAgentPermissionActions } from '../permission-action-migration';
+import { validateTestDatabaseUrl } from '../test-database-readiness';
+
+/**
+ * Actual-SQL verification for the durable permission migration (IND-606/607).
+ *
+ * A pure transform unit spec cannot prove the SQL itself is correct, so this
+ * spec runs `0109_migrate_agent_permission_actions.sql` against a real Postgres
+ * instance inside a disposable scratch schema (mirrors the API-key migration
+ * spec pattern).
+ *
+ * It is gated on `TEST_DATABASE_SAFE=1` and a disposable `DATABASE_URL`. This
+ * gate is intentionally left UNSET in the wave — no disposable database is
+ * proven — so this spec is SKIPPED locally and its DB gate is reported as such.
+ * Never point it at Neon, dev, shared, staging, or production.
+ */
+const apiRoot = path.resolve(import.meta.dir, '../../../..');
+const migrationSql = readFileSync(
+  path.join(apiRoot, 'drizzle/0109_migrate_agent_permission_actions.sql'),
+  'utf8',
+);
+
+type MigrationClient = ReturnType<typeof postgres>;
+
+interface PermissionRow {
+  id: string;
+  agent_id: string;
+  user_id: string;
+  scope: string;
+  scope_id: string | null;
+  actions: string[];
+}
+
+async function withScratchSchema(
+  run: (client: MigrationClient) => Promise<void>,
+): Promise<void> {
+  if (process.env.TEST_DATABASE_SAFE !== '1') {
+    throw new Error(
+      'Permission-action migration integration tests require TEST_DATABASE_SAFE=1 and a disposable database.',
+    );
+  }
+  const schema = `test_perm_actions_${randomUUID().replaceAll('-', '')}`;
+  const client = postgres(validateTestDatabaseUrl(process.env.DATABASE_URL), {
+    max: 1,
+    prepare: false,
+  });
+
+  try {
+    await client.unsafe(`CREATE SCHEMA "${schema}"`);
+    await client.unsafe(`SET search_path TO "${schema}"`);
+    // Standalone shape of agent_permissions; the migration is a pure UPDATE on
+    // `actions`, so FKs to agents/users are unnecessary for behavior coverage.
+    await client.unsafe(`
+      CREATE TABLE "agent_permissions" (
+        "id" text PRIMARY KEY,
+        "agent_id" text NOT NULL,
+        "user_id" text NOT NULL,
+        "scope" text NOT NULL DEFAULT 'global',
+        "scope_id" text,
+        "actions" text[] NOT NULL,
+        "created_at" timestamptz NOT NULL DEFAULT now()
+      )
+    `);
+    await run(client);
+  } finally {
+    await client.unsafe('SET search_path TO public').catch(() => undefined);
+    await client.unsafe(`DROP SCHEMA IF EXISTS "${schema}" CASCADE`).catch(() => undefined);
+    await client.end({ timeout: 1 }).catch(() => undefined);
+  }
+}
+
+async function seed(client: MigrationClient, rows: Omit<PermissionRow, 'id'>[]): Promise<string[]> {
+  const ids: string[] = [];
+  for (const row of rows) {
+    const id = randomUUID();
+    ids.push(id);
+    await client`
+      INSERT INTO "agent_permissions"
+        ("id", "agent_id", "user_id", "scope", "scope_id", "actions")
+      VALUES (
+        ${id}, ${row.agent_id}, ${row.user_id}, ${row.scope}, ${row.scope_id},
+        ${client.array(row.actions)}
+      )
+    `;
+  }
+  return ids;
+}
+
+async function readRows(client: MigrationClient): Promise<Map<string, PermissionRow>> {
+  const rows = await client<PermissionRow[]>`
+    SELECT "id", "agent_id", "user_id", "scope", "scope_id", "actions"
+    FROM "agent_permissions"
+  `;
+  return new Map(rows.map((row) => [row.id, row]));
+}
+
+// Cleanly SKIP (not fail) when the disposable-database gate is absent, so the
+// DB gate is reported as skipped rather than red. The withScratchSchema guard
+// remains as defense-in-depth if the gate is ever set without a real DB.
+describe.skipIf(process.env.TEST_DATABASE_SAFE !== '1')('0109 agent-permission action migration (SQL)', () => {
+  it(
+    'rewrites affected rows, preserves owner/scope, leaves the control group untouched, and is idempotent',
+    async () => {
+      await withScratchSchema(async (client) => {
+        const [profileId, contactsOnlyId, mixedId, controlId, negOnlyId, unorderedControlId] = await seed(client, [
+          // Legacy default pairing: profile + contacts + others.
+          {
+            agent_id: 'agent-1',
+            user_id: 'owner-1',
+            scope: 'global',
+            scope_id: null,
+            actions: ['manage:profile', 'manage:contacts', 'manage:intents', 'manage:networks', 'manage:opportunities'],
+          },
+          // Contacts-only -> collapses to empty, row preserved.
+          {
+            agent_id: 'agent-2',
+            user_id: 'owner-2',
+            scope: 'network',
+            scope_id: 'net-1',
+            actions: ['manage:contacts'],
+          },
+          // Profile overlaps an existing premises grant -> dedupe, no broadening.
+          {
+            agent_id: 'agent-3',
+            user_id: 'owner-3',
+            scope: 'network',
+            scope_id: 'net-2',
+            actions: ['manage:premises', 'manage:profile'],
+          },
+          // Control group: already canonical, must not change at all.
+          {
+            agent_id: 'agent-4',
+            user_id: 'owner-4',
+            scope: 'global',
+            scope_id: null,
+            actions: ['manage:identity', 'manage:premises', 'manage:intents'],
+          },
+          // Control group: negotiations-only.
+          {
+            agent_id: 'agent-5',
+            user_id: 'owner-5',
+            scope: 'network',
+            scope_id: 'net-3',
+            actions: ['manage:negotiations'],
+          },
+          // Control group, deliberately NOT in canonical order: the SQL must
+          // leave it byte-for-byte unchanged (it does not re-order control rows,
+          // even though the pure helper would normalize the order).
+          {
+            agent_id: 'agent-6',
+            user_id: 'owner-6',
+            scope: 'global',
+            scope_id: null,
+            actions: ['manage:networks', 'manage:intents'],
+          },
+        ]);
+
+        const before = await readRows(client);
+
+        const firstRun = await client.unsafe(migrationSql);
+        // Only the three affected rows are updated; the four control rows
+        // (including the unordered one) are never touched.
+        expect(firstRun.count).toBe(3);
+
+        const after = await readRows(client);
+
+        // Affected rows match the pure transform exactly.
+        expect(after.get(profileId)!.actions).toEqual(
+          migrateAgentPermissionActions(before.get(profileId)!.actions),
+        );
+        expect(after.get(profileId)!.actions).toEqual([
+          'manage:identity',
+          'manage:premises',
+          'manage:intents',
+          'manage:networks',
+          'manage:opportunities',
+        ]);
+        expect(after.get(contactsOnlyId)!.actions).toEqual([]);
+        expect(after.get(mixedId)!.actions).toEqual(['manage:identity', 'manage:premises']);
+
+        // Owner/scope/scopeId preserved on every affected row.
+        for (const id of [profileId, contactsOnlyId, mixedId]) {
+          const b = before.get(id)!;
+          const a = after.get(id)!;
+          expect(a.user_id).toBe(b.user_id);
+          expect(a.agent_id).toBe(b.agent_id);
+          expect(a.scope).toBe(b.scope);
+          expect(a.scope_id).toBe(b.scope_id);
+        }
+
+        // Control group is byte-for-byte unchanged — including the row whose
+        // actions are not in canonical order (the SQL does not normalize it).
+        expect(after.get(controlId)!.actions).toEqual(before.get(controlId)!.actions);
+        expect(after.get(negOnlyId)!.actions).toEqual(before.get(negOnlyId)!.actions);
+        expect(after.get(unorderedControlId)!.actions).toEqual(['manage:networks', 'manage:intents']);
+
+        // No surviving retired action anywhere (postcondition).
+        const retired = await client<Array<{ count: number }>>`
+          SELECT COUNT(*)::int AS count FROM "agent_permissions"
+          WHERE "actions" && ARRAY['manage:profile', 'manage:contacts']::text[]
+        `;
+        expect(retired[0]!.count).toBe(0);
+
+        // Idempotent: a second run changes nothing.
+        const secondRun = await client.unsafe(migrationSql);
+        expect(secondRun.count).toBe(0);
+        expect(await readRows(client)).toEqual(after);
+      });
+    },
+    30_000,
+  );
+
+  it(
+    'never drops, duplicates, or reassigns a row',
+    async () => {
+      await withScratchSchema(async (client) => {
+        await seed(client, [
+          { agent_id: 'a', user_id: 'u1', scope: 'global', scope_id: null, actions: ['manage:profile'] },
+          { agent_id: 'a', user_id: 'u2', scope: 'global', scope_id: null, actions: ['manage:contacts'] },
+          { agent_id: 'a', user_id: 'u3', scope: 'global', scope_id: null, actions: ['manage:intents'] },
+        ]);
+        const before = await client<Array<{ count: number }>>`SELECT COUNT(*)::int AS count FROM "agent_permissions"`;
+        await client.unsafe(migrationSql);
+        const after = await client<Array<{ count: number }>>`SELECT COUNT(*)::int AS count FROM "agent_permissions"`;
+        expect(after[0]!.count).toBe(before[0]!.count);
+      });
+    },
+    30_000,
+  );
+});

--- a/services/api/src/lib/drizzle/tests/permission-action-migration.spec.ts
+++ b/services/api/src/lib/drizzle/tests/permission-action-migration.spec.ts
@@ -1,0 +1,250 @@
+import { describe, expect, it } from 'bun:test';
+import { readFileSync } from 'node:fs';
+import path from 'node:path';
+
+import { CANONICAL_AGENT_ACTIONS, RETIRED_AGENT_ACTIONS, actionsNeedMigration, migrateAgentPermissionActions } from '../permission-action-migration';
+
+const apiRoot = path.resolve(import.meta.dir, '../../../..');
+const migrationSql = readFileSync(
+  path.join(apiRoot, 'drizzle/0109_migrate_agent_permission_actions.sql'),
+  'utf8',
+);
+const runbookMd = readFileSync(
+  path.join(apiRoot, 'drizzle/0109_migrate_agent_permission_actions.md'),
+  'utf8',
+);
+
+/**
+ * DB-free coverage for the durable permission-model migration (IND-606/607).
+ *
+ * The pure transform mirrors the SQL migration's per-row semantics; the
+ * actual-SQL behavior is separately verified by the TEST_DATABASE_SAFE-gated
+ * integration spec. These tests run everywhere with no database.
+ */
+describe('migrateAgentPermissionActions (mirrors 0109 SQL)', () => {
+  it('expands manage:profile into manage:identity + manage:premises', () => {
+    expect(migrateAgentPermissionActions(['manage:profile'])).toEqual([
+      'manage:identity',
+      'manage:premises',
+    ]);
+  });
+
+  it('removes manage:contacts entirely', () => {
+    expect(migrateAgentPermissionActions(['manage:contacts'])).toEqual([]);
+    expect(migrateAgentPermissionActions(['manage:intents', 'manage:contacts'])).toEqual([
+      'manage:intents',
+    ]);
+  });
+
+  it('preserves every other valid grant exactly and in canonical order', () => {
+    expect(
+      migrateAgentPermissionActions([
+        'manage:negotiations',
+        'manage:intents',
+        'manage:networks',
+      ]),
+    ).toEqual(['manage:intents', 'manage:networks', 'manage:negotiations']);
+  });
+
+  it('handles the legacy default profile+contacts pairing without broadening', () => {
+    // Legacy chat orchestrator / personal-agent defaults granted
+    // profile + contacts + intents + networks + opportunities.
+    expect(
+      migrateAgentPermissionActions([
+        'manage:profile',
+        'manage:contacts',
+        'manage:intents',
+        'manage:networks',
+        'manage:opportunities',
+      ]),
+    ).toEqual([
+      'manage:identity',
+      'manage:premises',
+      'manage:intents',
+      'manage:networks',
+      'manage:opportunities',
+    ]);
+  });
+
+  it('de-duplicates when profile expansion overlaps existing grants', () => {
+    expect(
+      migrateAgentPermissionActions([
+        'manage:identity',
+        'manage:profile',
+        'manage:premises',
+      ]),
+    ).toEqual(['manage:identity', 'manage:premises']);
+  });
+
+  it('de-duplicates repeated raw actions deterministically', () => {
+    expect(
+      migrateAgentPermissionActions(['manage:intents', 'manage:intents']),
+    ).toEqual(['manage:intents']);
+  });
+
+  it('is idempotent — a second application is a no-op', () => {
+    const once = migrateAgentPermissionActions([
+      'manage:profile',
+      'manage:contacts',
+      'manage:intents',
+    ]);
+    expect(migrateAgentPermissionActions(once)).toEqual(once);
+  });
+
+  it('leaves empty input empty (contacts-only rows collapse to an empty set)', () => {
+    expect(migrateAgentPermissionActions([])).toEqual([]);
+  });
+
+  it('preserves unknown/residual actions after the canonical block, alphabetically', () => {
+    expect(
+      migrateAgentPermissionActions([
+        'manage:zeta',
+        'manage:profile',
+        'manage:alpha',
+      ]),
+    ).toEqual([
+      'manage:identity',
+      'manage:premises',
+      'manage:alpha',
+      'manage:zeta',
+    ]);
+  });
+
+  it('never emits a retired action, and preserves the canonical action alongside the expansion', () => {
+    // CANONICAL_AGENT_ACTIONS never contains a retired action, so each canonical
+    // input survives verbatim while profile expands and contacts is dropped.
+    for (const action of CANONICAL_AGENT_ACTIONS) {
+      const out = migrateAgentPermissionActions([action, 'manage:profile', 'manage:contacts']);
+      for (const retired of RETIRED_AGENT_ACTIONS) {
+        expect(out).not.toContain(retired);
+      }
+      expect(out).toContain(action);
+      expect(out).toContain('manage:identity');
+      expect(out).toContain('manage:premises');
+    }
+  });
+});
+
+describe('actionsNeedMigration predicate (mirrors SQL overlap filter)', () => {
+  it('matches rows containing a retired action', () => {
+    expect(actionsNeedMigration(['manage:profile'])).toBe(true);
+    expect(actionsNeedMigration(['manage:intents', 'manage:contacts'])).toBe(true);
+  });
+
+  it('excludes the control group (no retired action)', () => {
+    expect(actionsNeedMigration(['manage:identity', 'manage:premises'])).toBe(false);
+    expect(actionsNeedMigration([])).toBe(false);
+  });
+
+  it('flags rows purely by retired-action membership, independent of ordering', () => {
+    // The SQL migration selects affected rows ONLY by retired-action membership
+    // (the `&&` overlap filter) and leaves every control row byte-for-byte
+    // unchanged. That predicate is deliberately NOT the same as "the pure helper
+    // would rewrite this array": the helper also normalizes ordering, but the
+    // SQL does not re-order control rows. This test pins that distinction so the
+    // two are never conflated.
+    const unorderedControl = ['manage:networks', 'manage:intents'];
+    expect(actionsNeedMigration(unorderedControl)).toBe(false);
+    // The helper would normalize ordering, but the SQL leaves this control row
+    // exactly as-is because it does not match the predicate.
+    expect(migrateAgentPermissionActions(unorderedControl)).toEqual([
+      'manage:intents',
+      'manage:networks',
+    ]);
+  });
+});
+
+describe('0109 migration SQL static invariants', () => {
+  it('filters on the retired-action overlap predicate', () => {
+    expect(migrationSql).toContain(
+      "src.actions && ARRAY['manage:profile', 'manage:contacts']::text[]",
+    );
+  });
+
+  it('expands profile to identity + premises and removes contacts', () => {
+    expect(migrationSql).toContain(
+      "WHEN 'manage:profile' THEN ARRAY['manage:identity', 'manage:premises']",
+    );
+    expect(migrationSql).toContain("WHEN 'manage:contacts' THEN ARRAY[]::text[]");
+  });
+
+  it('emits a deterministic canonical ordering', () => {
+    expect(migrationSql).toContain('ORDER BY expanded.ord, expanded.action');
+    expect(migrationSql).toContain('SELECT DISTINCT');
+  });
+
+  it('documents the snapshot-based recovery path', () => {
+    expect(migrationSql).toContain('RECOVERY PATH');
+    expect(migrationSql.toLowerCase()).toContain('backfill-production-data');
+  });
+
+  it('only rewrites the actions column, never owner/scope', () => {
+    // A single SET target on `actions` guarantees the transform cannot touch
+    // user_id / agent_id / scope / scope_id.
+    expect(migrationSql).toContain('SET "actions" = rewrite.actions');
+    expect(migrationSql).not.toMatch(/SET[^;]*"(user_id|agent_id|scope|scope_id)"/);
+  });
+
+  it('does not map anything onto a retired action (expansions are canonical only)', () => {
+    // Retired actions may only appear as CASE match keys, the overlap predicate,
+    // or documentation — never as an expansion output (`THEN ARRAY['manage:profile'`).
+    expect(migrationSql).not.toContain("THEN ARRAY['manage:profile'");
+    expect(migrationSql).not.toContain("THEN ARRAY['manage:contacts'");
+  });
+});
+
+describe('0109 runbook mixed-version rolling-deploy invariants', () => {
+  it('documents the preDeploy db:migrate old-replica writer race', () => {
+    expect(runbookMd).toContain('preDeployCommand');
+    expect(runbookMd.toLowerCase()).toContain('old replicas');
+    // The pre-deploy run cannot prove completeness on its own.
+    expect(runbookMd.toLowerCase()).toMatch(/cannot[\s\S]{0,40}prove/);
+  });
+
+  it('makes the post-drain final sweep mandatory and NOT the automatic db:migrate', () => {
+    expect(runbookMd).toContain('post-drain final sweep');
+    expect(runbookMd).toContain('MANDATORY and is NOT the automatic preDeploy');
+    expect(runbookMd).toMatch(/post-drain[\s\S]*proves `retired_remaining = 0`/);
+    expect(runbookMd).toMatch(/never by the automatic `db:migrate`/);
+  });
+
+  it('requires a mandatory retired-row inventory before the final sweep', () => {
+    expect(runbookMd.toLowerCase()).toContain('retired_remaining');
+    expect(runbookMd.toLowerCase()).toContain('inventory');
+  });
+
+  it('documents the temporary read-time projection and its removal gate', () => {
+    expect(runbookMd).toContain('projectStoredPermissionActions');
+    expect(runbookMd).toContain('Compatibility-removal gate');
+    // Must not claim the single deploy removes compatibility.
+    expect(runbookMd.toLowerCase()).toMatch(/only after|only once|do not claim/);
+  });
+
+  it('keeps the offline artifact + Neon backup recovery model (no in-DB recovery table)', () => {
+    expect(runbookMd.toLowerCase()).toContain('offline');
+    expect(runbookMd.toLowerCase()).toContain('neon backup branch');
+    // No durable in-database recovery table is created.
+    expect(runbookMd).toContain("to_regclass('public.agent_permissions_recovery_0109')");
+  });
+});
+
+describe('0109 journal registration', () => {
+  const journal = JSON.parse(
+    readFileSync(path.join(apiRoot, 'drizzle/meta/_journal.json'), 'utf8'),
+  ) as { entries: Array<{ idx: number; tag: string; when: number }> };
+
+  it('appends 0109 after the prior tip with a monotonic timestamp', () => {
+    const entry = journal.entries.find(
+      (e) => e.tag === '0109_migrate_agent_permission_actions',
+    );
+    expect(entry).toBeDefined();
+    const previous = journal.entries.find((e) => e.idx === entry!.idx - 1);
+    expect(previous).toBeDefined();
+    expect(entry!.when).toBeGreaterThan(previous!.when);
+  });
+
+  it('keeps journal idx and tag sets unique', () => {
+    expect(new Set(journal.entries.map((e) => e.idx)).size).toBe(journal.entries.length);
+    expect(new Set(journal.entries.map((e) => e.tag)).size).toBe(journal.entries.length);
+  });
+});

--- a/services/api/tests/mcp.spec.ts
+++ b/services/api/tests/mcp.spec.ts
@@ -724,7 +724,7 @@ describe('MCP Server Factory', () => {
       opportunitiesSurfaced: 4,
       opportunitiesBySignal: fullSummary.opportunitiesBySignal,
       pendingQuestionsByDomain: { intents: 1, negotiations: 2, chat: 5 },
-      answeredQuestionsByDomain: { identity: 3 },
+      answeredQuestionsByDomain: { premises: 3 },
       negotiationsStarted: 5,
       negotiationsCompleted: 6,
     });
@@ -816,5 +816,355 @@ describe('MCP Server Factory', () => {
     };
     expect(callResponse.result?.isError).toBe(true);
     expect(payload.code).toBe('MCP_CAPABILITY_DENIED');
+  });
+
+  // ── IND-608: independent tools/call authorization & scope matrix ────────────
+  //
+  // These exercise capability authorization at the transport boundary via real
+  // tools/call requests with SCHEMA-VALID arguments (the MCP SDK validates the
+  // registered input schema BEFORE the handler runs, so empty args on a tool
+  // with required fields would surface as a schema error, not a policy result).
+  // Positive admission is proven by reaching the scoped-deps/handler seam (the
+  // scopedDepsFactory.create spy), never merely by the absence of a denial code.
+
+  /** Builds an agent registry snapshot with a single permission row. */
+  function agentDbWith(permission: {
+    agentId: string;
+    scope: 'global' | 'network';
+    scopeId: string | null;
+    actions: string[];
+  }): AgentDatabase {
+    return {
+      ...mockAgentDb,
+      getAgentWithRelations: async () => ({
+        id: permission.agentId,
+        ownerId: 'test-user-id',
+        name: 'Agent',
+        description: null,
+        type: 'external',
+        status: 'active',
+        metadata: {},
+        createdAt: new Date('2026-01-01T00:00:00.000Z'),
+        updatedAt: new Date('2026-01-01T00:00:00.000Z'),
+        transports: [],
+        permissions: [{
+          id: 'permission-1',
+          agentId: permission.agentId,
+          userId: 'test-user-id',
+          scope: permission.scope,
+          scopeId: permission.scopeId,
+          actions: permission.actions,
+          createdAt: new Date('2026-01-01T00:00:00.000Z'),
+        }],
+      }),
+    };
+  }
+
+  /** A context database whose reads throw, proving denial happens before DB work. */
+  function guardReads(counter: { reads: number }): ToolDeps['database'] {
+    return new Proxy(resolvedContextDatabase, {
+      get(target, property, receiver) {
+        if (typeof property === 'string' && property.startsWith('get')) {
+          return async () => {
+            counter.reads += 1;
+            throw new Error('chat database must not be reached');
+          };
+        }
+        return Reflect.get(target, property, receiver);
+      },
+    });
+  }
+
+  interface CallToolOutcome {
+    isError?: boolean;
+    code?: string;
+    text: string;
+    /** Records each scopedDepsFactory.create(userId, allowedNetworkIds) call. */
+    scopedCreateArgs: Array<{ userId: string; allowedNetworkIds: string[] }>;
+  }
+
+  async function callTool(params: {
+    identity: Record<string, unknown>;
+    toolName: string;
+    arguments: Record<string, unknown>;
+    agentDatabase?: AgentDatabase;
+    database?: ToolDeps['database'];
+    extraDeps?: Partial<ToolDeps>;
+    headers?: Record<string, string>;
+    /** When true, the scoped-deps factory throws if the handler seam is reached. */
+    scopedThrows?: boolean;
+  }): Promise<CallToolOutcome> {
+    clearMcpToolMetadataCacheForTests();
+    const scopedCreateArgs: Array<{ userId: string; allowedNetworkIds: string[] }> = [];
+    const scopedFactory: ScopedDepsFactory = {
+      create: (userId: string, allowedNetworkIds: string[]) => {
+        scopedCreateArgs.push({ userId, allowedNetworkIds });
+        if (params.scopedThrows) throw new Error('scoped database must not be created');
+        return { userDb: {} as ToolDeps['userDb'], systemDb: {} as ToolDeps['systemDb'] };
+      },
+    };
+    const server = createMcpServer(
+      {
+        ...mockDeps,
+        database: params.database ?? resolvedContextDatabase,
+        agentDatabase: params.agentDatabase ?? mockAgentDb,
+        ...params.extraDeps,
+      },
+      {
+        resolveIdentity: async () => params.identity,
+        resolveUserId: async () => 'test-user-id',
+      } as McpAuthResolver,
+      scopedFactory,
+    );
+    const response = await invokeMcpRequest({
+      server,
+      method: 'tools/call',
+      requestParams: { name: params.toolName, arguments: params.arguments },
+      headers: params.headers ?? { 'x-api-key': 'agent-key' },
+    });
+    const text = response.result?.content?.[0]?.text ?? '';
+    let code: string | undefined;
+    try {
+      code = (JSON.parse(text || '{}') as { code?: string }).code;
+    } catch {
+      code = undefined;
+    }
+    return { isError: response.result?.isError, code, text, scopedCreateArgs };
+  }
+
+  it('denies a forged cross-network create_intent before context, scoped DB, or graph work', async () => {
+    // The agent is bound to network-1 but its only manage:intents grant is scoped
+    // to network-2, so the grant does not apply. With schema-valid arguments the
+    // SDK schema passes and the capability layer denies at the preliminary stage,
+    // before any chat context read, scoped DB creation, or graph work.
+    const counter = { reads: 0 };
+    const result = await callTool({
+      identity: { userId: 'test-user-id', agentId: 'agent-x', networkScopeId: 'network-1' },
+      agentDatabase: agentDbWith({ agentId: 'agent-x', scope: 'network', scopeId: 'network-2', actions: ['manage:intents'] }),
+      database: guardReads(counter),
+      scopedThrows: true,
+      toolName: 'create_intent',
+      arguments: { description: 'A specific valid discovery intent' },
+    });
+    expect(result.isError).toBe(true);
+    expect(result.code).toBe('MCP_CAPABILITY_DENIED');
+    expect(counter.reads).toBe(0);
+    expect(result.scopedCreateArgs).toEqual([]);
+  });
+
+  it('admits a network agent whose grant matches its binding and reaches the scoped handler seam', async () => {
+    // With a matching network-1 grant and schema-valid arguments, create_intent
+    // is authorized and dispatch reaches the scoped-deps/handler seam.
+    const result = await callTool({
+      identity: { userId: 'test-user-id', agentId: 'agent-x', networkScopeId: 'network-1' },
+      agentDatabase: agentDbWith({ agentId: 'agent-x', scope: 'network', scopeId: 'network-1', actions: ['manage:intents'] }),
+      toolName: 'create_intent',
+      arguments: { description: 'A specific valid discovery intent' },
+    });
+    expect(result.code).not.toBe('MCP_CAPABILITY_DENIED');
+    expect(result.scopedCreateArgs.length).toBe(1);
+  });
+
+  it('clamps a bound network-1 principal away from a network it is a member of (resource clamp)', async () => {
+    // The user is a member of BOTH network-1 and network-2, but the agent is
+    // bound to network-1. The scoped-deps factory must be constructed with only
+    // the bound network in allowedNetworkIds, so no network-2 resource, graph, or
+    // adapter work is reachable — the clamp is at scoped-deps construction, not a
+    // per-row permission check.
+    const memberDb = {
+      ...resolvedContextDatabase,
+      getNetworkMemberships: async () => ([
+        { networkId: 'network-1', networkTitle: 'N1', isPersonal: false, permissions: [] },
+        { networkId: 'network-2', networkTitle: 'N2', isPersonal: false, permissions: [] },
+      ]),
+    } as unknown as ToolDeps['database'];
+    const result = await callTool({
+      identity: { userId: 'test-user-id', agentId: 'agent-c', networkScopeId: 'network-1' },
+      agentDatabase: agentDbWith({ agentId: 'agent-c', scope: 'network', scopeId: 'network-1', actions: ['manage:intents'] }),
+      database: memberDb,
+      toolName: 'read_intents',
+      arguments: {},
+    });
+    expect(result.scopedCreateArgs.length).toBe(1);
+    const allowed = result.scopedCreateArgs[0]!.allowedNetworkIds;
+    expect(allowed).toContain('network-1');
+    expect(allowed).not.toContain('network-2');
+  });
+
+  it('restricts confirm_opportunity_delivery to designated delivery agents, before DB work', async () => {
+    // Ordinary agent with manage:opportunities and schema-valid arguments is
+    // denied by the delivery_only rule before context/scoped DB work.
+    const counter = { reads: 0 };
+    const denied = await callTool({
+      identity: { userId: 'test-user-id', agentId: 'agent-d' },
+      agentDatabase: agentDbWith({ agentId: 'agent-d', scope: 'global', scopeId: null, actions: ['manage:opportunities'] }),
+      database: guardReads(counter),
+      scopedThrows: true,
+      toolName: 'confirm_opportunity_delivery',
+      arguments: { opportunityId: '00000000-0000-4000-8000-000000000001', trigger: 'ambient' },
+    });
+    expect(denied.isError).toBe(true);
+    expect(denied.code).toBe('MCP_CAPABILITY_DENIED');
+    expect(counter.reads).toBe(0);
+    expect(denied.scopedCreateArgs).toEqual([]);
+
+    // A designated delivery agent is admitted and reaches the scoped handler seam.
+    const allowed = await callTool({
+      identity: { userId: 'test-user-id', agentId: 'agent-d', isDeliveryAgent: true },
+      agentDatabase: agentDbWith({ agentId: 'agent-d', scope: 'global', scopeId: null, actions: ['manage:opportunities'] }),
+      toolName: 'confirm_opportunity_delivery',
+      arguments: { opportunityId: '00000000-0000-4000-8000-000000000001', trigger: 'ambient' },
+    });
+    expect(allowed.code).not.toBe('MCP_CAPABILITY_DENIED');
+    expect(allowed.scopedCreateArgs.length).toBe(1);
+  });
+
+  it('lets a network agent reach meta-network premises with manage:premises (principal reach)', async () => {
+    // Premises are meta-network: a network-bound agent holding manage:premises
+    // retains principal reach for read_premises and reaches the scoped seam.
+    const result = await callTool({
+      identity: { userId: 'test-user-id', agentId: 'agent-p', networkScopeId: 'network-1' },
+      agentDatabase: agentDbWith({ agentId: 'agent-p', scope: 'network', scopeId: 'network-1', actions: ['manage:premises'] }),
+      toolName: 'read_premises',
+      arguments: {},
+    });
+    expect(result.code).not.toBe('MCP_CAPABILITY_DENIED');
+    expect(result.scopedCreateArgs.length).toBe(1);
+  });
+
+  it('denies a network agent premises access when it lacks manage:premises, before DB work', async () => {
+    const counter = { reads: 0 };
+    const result = await callTool({
+      identity: { userId: 'test-user-id', agentId: 'agent-p', networkScopeId: 'network-1' },
+      agentDatabase: agentDbWith({ agentId: 'agent-p', scope: 'network', scopeId: 'network-1', actions: ['manage:intents'] }),
+      database: guardReads(counter),
+      scopedThrows: true,
+      toolName: 'read_premises',
+      arguments: {},
+    });
+    expect(result.isError).toBe(true);
+    expect(result.code).toBe('MCP_CAPABILITY_DENIED');
+    expect(counter.reads).toBe(0);
+    expect(result.scopedCreateArgs).toEqual([]);
+  });
+
+  it('keeps H2A chat history human-only: a permissioned agent is denied, the owning human is admitted', async () => {
+    // list_conversations is human_only. It is only registered when chatSession is
+    // present, so include it and prove the agent is capability-denied while the
+    // owning session human reaches the handler seam.
+    const chatSession = {
+      listSessions: async () => [],
+      getSession: async () => null,
+    } as unknown as ToolDeps['chatSession'];
+
+    const counter = { reads: 0 };
+    const agentDenied = await callTool({
+      identity: { userId: 'test-user-id', agentId: 'agent-h' },
+      agentDatabase: agentDbWith({ agentId: 'agent-h', scope: 'global', scopeId: null, actions: ['manage:intents'] }),
+      extraDeps: { chatSession },
+      database: guardReads(counter),
+      scopedThrows: true,
+      toolName: 'list_conversations',
+      arguments: {},
+    });
+    expect(agentDenied.isError).toBe(true);
+    expect(agentDenied.code).toBe('MCP_CAPABILITY_DENIED');
+    expect(counter.reads).toBe(0);
+    expect(agentDenied.scopedCreateArgs).toEqual([]);
+
+    const humanAllowed = await callTool({
+      identity: { userId: 'test-user-id', isSessionAuth: true },
+      extraDeps: { chatSession },
+      headers: { authorization: 'Bearer session-token' },
+      toolName: 'list_conversations',
+      arguments: {},
+    });
+    expect(humanAllowed.code).not.toBe('MCP_CAPABILITY_DENIED');
+    expect(humanAllowed.scopedCreateArgs.length).toBe(1);
+  });
+
+  it('enforces exact question affected-domain inheritance on answer_pending_question at tools/call', async () => {
+    // The canonical matrix admits answer_pending_question with a UNION of domain
+    // actions, so a global manage:intents agent passes capability policy and
+    // reaches the handler. The handler must then deny answering a NEGOTIATION
+    // question (wrong affected domain) and write nothing.
+    const negotiationQuestion = {
+      id: 'neg-1',
+      title: 'Negotiation question',
+      prompt: 'Prompt',
+      options: [],
+      multiSelect: false,
+      mode: 'negotiation',
+      sourceType: 'negotiation',
+      sourceId: 'task-1',
+      createdAt: '2026-01-01T00:00:00.000Z',
+    };
+    let answerWrites = 0;
+    const answerCalls: Array<{ userId: string; questionId: string }> = [];
+    const questionDeps: Partial<ToolDeps> = {
+      findPendingQuestions: (async (userId: string) => {
+        void userId;
+        return [negotiationQuestion];
+      }) as unknown as ToolDeps['findPendingQuestions'],
+      answerPendingQuestion: (async (userId: string, questionId: string) => {
+        answerWrites += 1;
+        answerCalls.push({ userId, questionId });
+        return true;
+      }) as unknown as ToolDeps['answerPendingQuestion'],
+    };
+
+    // Wrong-domain global agent: admitted by policy, denied by the handler gate,
+    // nothing written.
+    const denied = await callTool({
+      identity: { userId: 'test-user-id', agentId: 'agent-q' },
+      agentDatabase: agentDbWith({ agentId: 'agent-q', scope: 'global', scopeId: null, actions: ['manage:intents'] }),
+      extraDeps: questionDeps,
+      toolName: 'answer_pending_question',
+      arguments: { questionId: 'neg-1', freeText: 'the client\u2019s explicit answer' },
+    });
+    // Reached the handler (not a capability denial), but refused with no write.
+    expect(denied.code).not.toBe('MCP_CAPABILITY_DENIED');
+    const deniedPayload = JSON.parse(denied.text) as { success: boolean; error?: string };
+    expect(deniedPayload.success).toBe(false);
+    expect(deniedPayload.error).toMatch(/not authorized to answer this question/i);
+    expect(answerWrites).toBe(0);
+
+    // Matching-domain agent: admitted and the write is threaded with the
+    // authenticated caller userId (provenance).
+    const allowed = await callTool({
+      identity: { userId: 'test-user-id', agentId: 'agent-q' },
+      agentDatabase: agentDbWith({ agentId: 'agent-q', scope: 'global', scopeId: null, actions: ['manage:negotiations'] }),
+      extraDeps: questionDeps,
+      toolName: 'answer_pending_question',
+      arguments: { questionId: 'neg-1', freeText: 'the client\u2019s explicit answer' },
+    });
+    const allowedPayload = JSON.parse(allowed.text) as { success: boolean; data?: Record<string, unknown> };
+    expect(allowedPayload.success).toBe(true);
+    expect(answerWrites).toBe(1);
+    expect(answerCalls).toEqual([{ userId: 'test-user-id', questionId: 'neg-1' }]);
+  });
+
+  it('projects read_pending_questions by exact affected domain at tools/call', async () => {
+    // A global manage:intents agent sees intent questions but never negotiation
+    // questions, even though the tool is union-admitted.
+    const questions = [
+      { id: 'intent-q', title: 'I', prompt: 'p', options: [], multiSelect: false, mode: 'intent', sourceType: 'intent', sourceId: 'i1', createdAt: '2026-01-01T00:00:00.000Z' },
+      { id: 'neg-q', title: 'N', prompt: 'p', options: [], multiSelect: false, mode: 'negotiation', sourceType: 'negotiation', sourceId: 't1', createdAt: '2026-01-01T00:00:00.000Z' },
+    ];
+    const questionDeps: Partial<ToolDeps> = {
+      findPendingQuestions: (async () => questions) as unknown as ToolDeps['findPendingQuestions'],
+    };
+
+    const result = await callTool({
+      identity: { userId: 'test-user-id', agentId: 'agent-q' },
+      agentDatabase: agentDbWith({ agentId: 'agent-q', scope: 'global', scopeId: null, actions: ['manage:intents'] }),
+      extraDeps: questionDeps,
+      toolName: 'read_pending_questions',
+      arguments: {},
+    });
+    const payload = JSON.parse(result.text) as { success: boolean; data?: { questions?: Array<{ id: string }> } };
+    expect(payload.success).toBe(true);
+    const ids = (payload.data?.questions ?? []).map((q) => q.id);
+    expect(ids).toEqual(['intent-q']);
   });
 });


### PR DESCRIPTION
Draft PR into `feat/mcp-refactoring` (integration branch). **Do not merge** —
child implementation handoff for the MCP permission-migration wave.

Base: `feat/mcp-refactoring` @ `1de7cb989d`. Linear: IND-606, IND-607, IND-608,
IND-609 (parent IND-577).

## Scope
Durable agent-permission model migration to `manage:identity` + `manage:premises`
(retiring `manage:profile`/`manage:contacts`), exact question-domain
authorization, an independent `tools/call` authz matrix, and a mixed-version-safe
rollout plan.

### IND-606/607 — migration + backfill
- `services/api/drizzle/0109_migrate_agent_permission_actions.sql` (+ journal
  `0109`): deterministic, idempotent data migration. `manage:profile` →
  `manage:identity` + `manage:premises`; `manage:contacts` removed; other grants
  preserved exactly; deduplicated; owner/scope untouched; control rows
  byte-for-byte unchanged.
- Pure transform helper mirroring the SQL + DB-free exactness/static/journal
  tests; `TEST_DATABASE_SAFE`-gated actual-SQL integration spec.
- Auditable backfill runbook (`…0109….md`).

### Rolling-deploy safety (preDeploy `db:migrate` vs old `dev` writers)
`railway.toml` runs `db:migrate` at preDeploy, before old replicas drain, and
`origin/dev` still writes `manage:profile`/`manage:contacts`. So the preDeploy
migration cannot prove completeness.
- `projectStoredPermissionActions` at the MCP capability-loading boundary
  interprets residual **stored** legacy rows (profile → identity+premises;
  contacts → none; scope preserved; unknown fails closed). Temporary rolling-data
  compatibility, **not** a public alias.
- Mandatory **post-drain** retired-row inventory + protected **offline** exact-row
  artifact + separately approved idempotent **final sweep** prove
  `retired_remaining = 0` — never the automatic `db:migrate`. Explicit
  compatibility-removal gate documented.

### IND-608 — authorization/scope matrix
- Exact per-question affected-domain enforcement in `read_pending_questions` /
  `answer_pending_question` (union admits; handler enforces). One shared
  `mode → domain → permission` mapping; corrected `enrichment → premises`
  (PremiseGraph), `discovery/pool → opportunities`; `chat`/unknown human-only.
- Transport `tools/call` matrix (schema-valid, spy-proven admission): cross-network
  forgery denied before DB, resource network clamp, delivery-agent restriction,
  meta-network premises, H2A human-only, question exact-domain. Plus discovery-run
  ownership, negotiation participant-only A2A, opportunity approval forgery/replay,
  question provenance/foreign/replay.

### IND-609 — release
- `docs/rollout/IND-609-mcp-permission-rollout.md` (ordering, dev verification,
  prod execution via `backfill-production-data`, monitoring, H2A/A2A/H2H classes).
- SemVer minors: `@indexnetwork/protocol` **7.3.0**, `services/api` **0.61.0**,
  `apps/web` **0.40.0** + changelog. Root `bun.lock` left for the integration owner.

## Verification (all local, non-DB)
- Focused tests: protocol `146 pass` (policy/projection/question-authz/lifecycle/
  discovery-ownership/negotiation), api `51 pass` (mcp transport + migration).
- `2 skip` = DB-gated actual-SQL integration spec — **skipped: no proven
  disposable DB; `TEST_DATABASE_SAFE` never set**.
- Lint clean (changed files); `git diff --check` clean.
- Typecheck/build: protocol + `services/api` `tsc` OK; `apps/web` `vite build` OK.
- Protocol `architecture:check`: exports/consumer/host-isolation/capabilities/
  artifacts/test:architecture pass. **Baseline caveat:** the pre-existing
  negotiation/question module cycle fails — all seven cycle-member files are
  byte-identical to the integration base (0 diff); no new cycle introduced.

## Guarded / not performed
No `TEST_DATABASE_SAFE`, no Neon/branch lifecycle, no migration/backfill execution,
no dev/shared/prod data mutation, no deploy, no root `bun.lock` edit, no merge.
Production execution requires separate explicit authorization + the
`backfill-production-data` workflow.
