### PR TITLE
feat(web): live answer outcome UI for intent-mode questions

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@indexnetwork/web",
-  "version": "0.39.0",
+  "version": "0.40.0",
   "license": "MIT",
   "scripts": {
     "dev": "vite --host 127.0.0.1",

--- a/apps/web/src/app/i/[intentId]/page.tsx
+++ b/apps/web/src/app/i/[intentId]/page.tsx
@@ -10,7 +10,7 @@ import ClientLayout from "@/components/ClientLayout";
 import { ContentContainer } from "@/components/layout";
 import OpportunityCard, { NegotiationPresenceChip, OpportunitySkeleton, type NegotiationPresence } from "@/components/chat/OpportunityCardInChat";
 import { AnsweredQuestionLog } from "@/components/InjectedQuestions/AnsweredQuestionLog";
-import type { AnsweredThreadEntry } from "@/components/InjectedQuestions/AnsweredQuestionLog";
+import type { AnsweredThreadEntry, IntentRefinementOutcome } from "@/components/InjectedQuestions/AnsweredQuestionLog";
 import { InjectedQuestions } from "@/components/InjectedQuestions/InjectedQuestions";
 import IntentMemoryStrip from "@/components/IntentMemoryStrip";
 import IntentNegotiatorChat from "@/components/IntentNegotiatorChat";
@@ -66,6 +66,31 @@ function normalizeIntentLifecycleStatus(status: unknown): IntentLifecycleStatus 
     return status;
   }
   return "ACTIVE";
+}
+
+/** Bounded intent-refinement poll: interval (ms) and maximum total wait (ms). */
+const INTENT_POLL_INTERVAL_MS = 4_000;
+const INTENT_POLL_MAX_MS = 90_000;
+
+/**
+ * Derive a short snippet from the updated intent description that is absent in
+ * the pre-answer snapshot.  Returns `undefined` when no clean diff is found.
+ */
+function deriveSnippet(before: string, after: string): string | undefined {
+  if (!after || after === before) return undefined;
+  // Split into phrases on sentence boundaries and commas.
+  const sentencePat = /[.!?]+\s+|,\s+/;
+  const beforePhrases = new Set(
+    before.split(sentencePat).map((s) => s.trim().toLowerCase()).filter(Boolean)
+  );
+  const afterPhrases = after
+    .split(sentencePat)
+    .map((s) => s.trim())
+    .filter((s) => s.length > 8);
+  const novel = afterPhrases.find(
+    (p) => !beforePhrases.has(p.toLowerCase())
+  );
+  return novel;
 }
 
 function formatAnswer(selectedOptions: string[], freeText?: string): string {
@@ -346,6 +371,15 @@ export default function IntentDetailPage() {
   const seenQuestionIdsRef = useRef<Set<string>>(new Set());
   const chainTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const reactionTimersRef = useRef<Array<ReturnType<typeof setTimeout>>>([]);
+  /**
+   * Per-question intent-refinement poll state.  Keyed by questionId.
+   * Stored in a ref (not state) so poll callbacks can read the latest
+   * intentId without stale-closure issues; the poll writes outcome via
+   * setAnswered which re-renders without needing another ref tick.
+   */
+  const intentPollsRef = useRef<
+    Map<string, { timerId: ReturnType<typeof setInterval>; deadline: number }>
+  >(new Map());
   const clearReactionTimers = useCallback(() => {
     for (const timer of reactionTimersRef.current) clearTimeout(timer);
     reactionTimersRef.current = [];
@@ -354,6 +388,8 @@ export default function IntentDetailPage() {
     () => () => {
       if (chainTimerRef.current) clearTimeout(chainTimerRef.current);
       clearReactionTimers();
+      for (const { timerId } of intentPollsRef.current.values()) clearInterval(timerId);
+      intentPollsRef.current.clear();
     },
     [clearReactionTimers],
   );
@@ -501,9 +537,28 @@ export default function IntentDetailPage() {
           return leftTime - rightTime || left.id.localeCompare(right.id);
         });
       setAnswered((current) => {
+        // Entries with an active intentRefinement are optimistic live-status
+        // entries for intent-mode answers still being polled.  Preserve them
+        // if the server hasn't returned them yet (they may not be committed);
+        // and carry their refinement state forward when they do appear.
+        const pendingRefinement = current.filter(
+          (e) => e.intentRefinement && !canonical.some((c) => c.id === e.id)
+        );
+        const mergedCanonical = canonical.map((entry) => {
+          const opt = current.find((e) => e.id === entry.id && e.intentRefinement);
+          return opt ? { ...entry, mode: opt.mode, intentRefinement: opt.intentRefinement } : entry;
+        });
+        const merged = [
+          ...pendingRefinement,
+          ...mergedCanonical,
+        ].sort((a, b) => {
+          const at = Date.parse(a.answeredAt ?? a.detectedAt ?? a.createdAt ?? '') || 0;
+          const bt = Date.parse(b.answeredAt ?? b.detectedAt ?? b.createdAt ?? '') || 0;
+          return at - bt || a.id.localeCompare(b.id);
+        });
         const unchanged =
-          canonical.length === current.length &&
-          canonical.every((entry, index) => {
+          merged.length === current.length &&
+          merged.every((entry, index) => {
             const previous = current[index];
             return (
               previous?.id === entry.id &&
@@ -512,10 +567,11 @@ export default function IntentDetailPage() {
               previous.messageId === entry.messageId &&
               previous.createdAt === entry.createdAt &&
               previous.detectedAt === entry.detectedAt &&
-              previous.answeredAt === entry.answeredAt
+              previous.answeredAt === entry.answeredAt &&
+              previous.intentRefinement === entry.intentRefinement
             );
           });
-        return unchanged ? current : canonical;
+        return unchanged ? current : merged;
       });
     } catch {
       // Best-effort hydration; keep optimistic entries on failure.
@@ -762,6 +818,7 @@ export default function IntentDetailPage() {
       await questionsService.answer(questionId, body);
       // Keep the answered exchange visible in the conversation thread.
       if (answered) {
+        const isIntentMode = answered.detection?.mode === "intent";
         setAnswered((prev) => [
           ...prev.filter((entry) => entry.id !== questionId),
           {
@@ -771,8 +828,57 @@ export default function IntentDetailPage() {
             messageId: answered.detection?.messageId,
             createdAt: answered.createdAt,
             detectedAt: answered.detection?.timestamp,
+            mode: answered.detection?.mode,
+            // Intent-mode answers start in 'pending' so the live outcome
+            // line shows the ⟳ spinner until the poll settles.
+            intentRefinement: isIntentMode
+              ? { status: "pending" }
+              : undefined,
           },
         ]);
+
+        // Start bounded intent-description poll for intent-mode answers.
+        if (isIntentMode && intentId) {
+          // Cancel any previous poll for this question.
+          const existing = intentPollsRef.current.get(questionId);
+          if (existing) clearInterval(existing.timerId);
+
+          const snapshot = intent
+            ? (intent.summary?.trim() || intent.payload || "")
+            : "";
+          const deadline = Date.now() + INTENT_POLL_MAX_MS;
+
+          const resolve = (outcome: IntentRefinementOutcome) => {
+            clearInterval(intentPollsRef.current.get(questionId)?.timerId);
+            intentPollsRef.current.delete(questionId);
+            setAnswered((prev) =>
+              prev.map((e) =>
+                e.id === questionId ? { ...e, intentRefinement: outcome } : e
+              )
+            );
+          };
+
+          const timerId = setInterval(async () => {
+            if (Date.now() >= deadline) {
+              resolve({ status: "fallback" });
+              return;
+            }
+            try {
+              const fresh = await intentsService.getIntent(intentId);
+              const freshDesc = (fresh.summary?.trim() || fresh.payload || "").trim();
+              if (freshDesc && freshDesc !== snapshot) {
+                // Intent updated — refresh the page header and resolve.
+                setIntent(fresh);
+                const snippet = deriveSnippet(snapshot, freshDesc);
+                resolve({ status: "applied", snippet });
+              }
+            } catch {
+              // Transient error — keep polling until the deadline.
+            }
+          }, INTENT_POLL_INTERVAL_MS);
+
+          intentPollsRef.current.set(questionId, { timerId, deadline });
+        }
       }
       setQuestions((prev) => prev.filter((q) => q.id !== questionId));
       void loadAnswered();
@@ -812,7 +918,7 @@ export default function IntentDetailPage() {
         }, 1200);
       }
     },
-    [questions, questionsService, intentId, loadAnswered, refreshQuestionCounts, scheduleBoundedWorkspaceRefresh],
+    [questions, questionsService, intentId, intent, intentsService, loadAnswered, refreshQuestionCounts, scheduleBoundedWorkspaceRefresh],
   );
 
   const handleDismiss = useCallback(

--- a/apps/web/src/components/InjectedQuestions/AnsweredQuestionLog.tsx
+++ b/apps/web/src/components/InjectedQuestions/AnsweredQuestionLog.tsx
@@ -1,3 +1,10 @@
+export interface IntentRefinementOutcome {
+  /** `pending` = still polling; `applied` = intent description changed; `fallback` = no change detected within bound */
+  status: 'pending' | 'applied' | 'fallback';
+  /** New phrase / sentence detected in the updated intent description (applied only). */
+  snippet?: string;
+}
+
 export interface AnsweredThreadEntry {
   id: string;
   prompt: string;
@@ -10,6 +17,17 @@ export interface AnsweredThreadEntry {
   detectedAt?: string;
   /** Authoritative answer timestamp returned by the server after hydration. */
   answeredAt?: string;
+  /**
+   * Detection mode from QuestionDetection.  When `'intent'` and
+   * `intentRefinement` is set, the log renders a live outcome line instead of
+   * the generic "noted" text.
+   */
+  mode?: string;
+  /**
+   * Live refinement outcome for freshly answered intent-mode questions.
+   * Absent for entries hydrated from the server or answered in other modes.
+   */
+  intentRefinement?: IntentRefinementOutcome;
 }
 
 /** Compact relative time for the answered thread, e.g. "just now", "2d ago". */
@@ -24,6 +42,51 @@ function timeAgo(iso?: string): string {
   const hrs = Math.floor(mins / 60);
   if (hrs < 24) return `${hrs}h ago`;
   return `${Math.floor(hrs / 24)}d ago`;
+}
+
+/** Compact inline spinner (pure CSS, no dependency). */
+function InlineSpinner() {
+  return (
+    <span
+      aria-hidden="true"
+      className="inline-block h-3 w-3 animate-spin rounded-full border border-gray-400 border-t-transparent"
+      style={{ verticalAlign: "middle" }}
+    />
+  );
+}
+
+/** Renders the outcome line for a freshly answered intent-mode question. */
+function IntentRefinementLine({ outcome }: { outcome: IntentRefinementOutcome }) {
+  if (outcome.status === "pending") {
+    return (
+      <p
+        data-testid="intent-refinement-pending"
+        className="mt-1 flex items-center gap-1.5 text-[12px] text-gray-400"
+      >
+        <InlineSpinner />
+        <span>folding your answer into the signal…</span>
+      </p>
+    );
+  }
+
+  if (outcome.status === "applied") {
+    return (
+      <p data-testid="intent-refinement-applied" className="mt-1 text-[12px] text-gray-400">
+        <span className="text-gray-500">✓</span>{" "}
+        {outcome.snippet
+          ? <>signal updated — now includes: <span className="text-gray-600 font-ibm-plex-mono">&ldquo;{outcome.snippet}&rdquo;</span></>
+          : "signal updated"
+        }
+      </p>
+    );
+  }
+
+  // fallback
+  return (
+    <p data-testid="intent-refinement-fallback" className="mt-1 text-[12px] text-gray-400">
+      answer saved — it will shape future matches
+    </p>
+  );
 }
 
 /** Renders the user's answered question exchanges in the intent conversation. */
@@ -47,9 +110,13 @@ export function AnsweredQuestionLog({ entries }: { entries: AnsweredThreadEntry[
             <span className="text-gray-400">›</span>
             <span>{entry.response}</span>
           </p>
-          <p className="mt-1 text-[12px] text-gray-400">
-            noted — updating the search.
-          </p>
+          {entry.mode === "intent" && entry.intentRefinement ? (
+            <IntentRefinementLine outcome={entry.intentRefinement} />
+          ) : (
+            <p className="mt-1 text-[12px] text-gray-400">
+              noted — updating the search.
+            </p>
+          )}
         </div>
       ))}
     </div>

--- a/apps/web/tests/intent-page-lifecycle.test.tsx
+++ b/apps/web/tests/intent-page-lifecycle.test.tsx
@@ -69,10 +69,25 @@ vi.mock('@/components/chat/OpportunityCardInChat', () => ({
 }));
 
 vi.mock('@/components/InjectedQuestions/InjectedQuestions', () => ({
-  InjectedQuestions: ({ questions }: { questions: Array<{ id: string; title: string }> }) => (
+  InjectedQuestions: ({
+    questions,
+    onAnswer,
+  }: {
+    questions: Array<{ id: string; payload?: { prompt: string }; title?: string }>;
+    onAnswer?: (id: string, body: { selectedOptions: string[] }) => Promise<void>;
+  }) => (
     <div>
       {questions.map((question) => (
-        <div key={question.id} data-testid={`question-${question.id}`}>{question.title}</div>
+        <div key={question.id} data-testid={`question-${question.id}`}>
+          {question.payload?.prompt ?? (question as { title?: string }).title}
+          {onAnswer && (
+            <button
+              onClick={() => onAnswer(question.id, { selectedOptions: ['Yes'] })}
+            >
+              Answer
+            </button>
+          )}
+        </div>
       ))}
     </div>
   ),
@@ -498,5 +513,121 @@ describe('intent lifecycle service', () => {
     const service = createIntentsService({ patch } as never);
 
     await expect(service.setIntentStatus('intent-1', 'PAUSED')).rejects.toThrow('Invalid signal status response');
+  });
+});
+
+describe('intent-mode answer outcome UI', () => {
+  const makeIntentQuestion = () => ({
+    id: 'q-intent-1',
+    payload: {
+      title: 'What kind of co-founder?',
+      prompt: 'What kind of co-founder?',
+      options: [],
+      multiSelect: false,
+    },
+    detection: {
+      mode: 'intent' as const,
+      sourceType: 'intent',
+      sourceId: 'intent-1',
+      timestamp: new Date().toISOString(),
+    },
+    actors: [{ userId: 'user-1', role: 'subject' as const }],
+    status: 'pending' as const,
+    answer: null,
+    expiresAt: null,
+    createdAt: new Date().toISOString(),
+    conversationId: null,
+  });
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.intent.status = 'ACTIVE';
+    mocks.intent.payload = 'Looking for a co-founder';
+    mocks.intent.summary = 'Looking for a co-founder';
+    mocks.getIntent.mockResolvedValue({ ...mocks.intent });
+    mocks.getHomeView.mockResolvedValue({ sections: [] });
+    mocks.getNegotiationActivity.mockResolvedValue([]);
+    mocks.getAnswered.mockResolvedValue([]);
+    mocks.getPending.mockResolvedValue([makeIntentQuestion()]);
+    mocks.answerQuestion.mockResolvedValue({ success: true });
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  async function clickAnswerAndFlush() {
+    const btn = await screen.findByRole('button', { name: 'Answer' });
+    vi.useFakeTimers();
+    await act(async () => {
+      fireEvent.click(btn);
+      // Flush the questionsService.answer promise chain (resolved via microtask).
+      await Promise.resolve();
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+  }
+
+  test('shows the pending spinner immediately after answering an intent-mode question', async () => {
+    renderIntentPage();
+    await clickAnswerAndFlush();
+
+    expect(screen.getByTestId('intent-refinement-pending')).toBeInTheDocument();
+    expect(screen.queryByTestId('intent-refinement-applied')).toBeNull();
+    expect(screen.queryByTestId('intent-refinement-fallback')).toBeNull();
+    expect(screen.queryByText('noted — updating the search.')).toBeNull();
+  });
+
+  test('resolves to ✓ applied when the intent description changes within the poll bound', async () => {
+    // Initial page load returns the old description; subsequent poll ticks return the updated one.
+    mocks.getIntent
+      .mockResolvedValueOnce({ ...mocks.intent, summary: 'Looking for a co-founder', payload: 'Looking for a co-founder' })
+      .mockResolvedValue({
+        ...mocks.intent,
+        summary: 'Looking for a technical co-founder, specifically with a B2B SaaS background',
+        payload: 'Looking for a technical co-founder, specifically with a B2B SaaS background',
+      });
+
+    renderIntentPage();
+    await clickAnswerAndFlush();
+
+    // Spinner shown while poll is pending.
+    expect(screen.getByTestId('intent-refinement-pending')).toBeInTheDocument();
+
+    // Advance one poll interval — intent now returns the updated description.
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(4_000);
+    });
+
+    expect(screen.getByTestId('intent-refinement-applied')).toBeInTheDocument();
+    expect(screen.getByText(/signal updated/)).toBeInTheDocument();
+    expect(screen.queryByTestId('intent-refinement-pending')).toBeNull();
+    expect(screen.queryByTestId('intent-refinement-fallback')).toBeNull();
+  });
+
+  test('falls back to neutral text when intent description does not change within poll bound', async () => {
+    // getIntent always returns the same description — no refinement applied.
+    mocks.getIntent.mockResolvedValue({
+      ...mocks.intent,
+      summary: 'Looking for a co-founder',
+      payload: 'Looking for a co-founder',
+    });
+
+    renderIntentPage();
+    await clickAnswerAndFlush();
+
+    // Spinner is shown initially.
+    expect(screen.getByTestId('intent-refinement-pending')).toBeInTheDocument();
+
+    // Exhaust the full poll bound (90 s) without a description change.
+    await act(async () => {
+      // INTENT_POLL_MAX_MS = 90_000 ms; interval = 4_000 ms.
+      // The fallback fires on the 23rd tick (23 * 4_000 = 92_000 ms).
+      await vi.advanceTimersByTimeAsync(96_000);
+    });
+
+    expect(screen.getByTestId('intent-refinement-fallback')).toBeInTheDocument();
+    expect(screen.queryByTestId('intent-refinement-pending')).toBeNull();
+    expect(screen.queryByTestId('intent-refinement-applied')).toBeNull();
   });
 });


### PR DESCRIPTION
## Summary

Replaces the static `noted — updating the search.` line under every freshly answered **intent-mode** question with a live, bounded-poll outcome status. Pool-discovery answers and server-hydrated entries keep the neutral line (no regression).

## UX

```
You are looking for a project collaborator… · just now
› Co-founder for a new venture

⟳ folding your answer into the signal…        ← while polling (pending)
✓ signal updated — now includes: "co-founder"  ← intent description changed (applied)
answer saved — it will shape future matches    ← no change within 90 s (fallback)
```

The intent page title/description also refreshes in place when the poll detects a change.

## Changes

### `apps/web/src/components/InjectedQuestions/AnsweredQuestionLog.tsx`
- Added `IntentRefinementOutcome` type (`pending | applied | fallback`) and optional `mode` + `intentRefinement` fields on `AnsweredThreadEntry`.
- New `IntentRefinementLine` component renders the spinner, ✓ applied (with snippet), or fallback copy.
- `AnsweredQuestionLog` uses the live element only when `entry.mode === 'intent' && entry.intentRefinement` is set; all other entries render the existing neutral line.

### `apps/web/src/app/i/[intentId]/page.tsx`
- `handleAnswer`: for intent-mode answers, sets `intentRefinement: { status: 'pending' }` on the optimistic entry, then starts a bounded `setInterval` (4 s interval / 90 s max) polling `intentsService.getIntent`. Compares against a pre-answer snapshot; resolves to `applied` (with a diffed snippet) or `fallback`.
- `loadAnswered` merge: preserves in-flight `intentRefinement` entries not yet committed to the server, and carries refinement state forward when the server entry appears (so the spinner is not wiped by the immediate answered-list sync).
- Intent header refreshes in place (`setIntent(fresh)`) when the poll detects a description change.
- No new API endpoints; no schema/migration changes.

### `apps/web/tests/intent-page-lifecycle.test.tsx`
- Updated `InjectedQuestions` mock to expose an Answer button per question.
- Added 3 new tests under `intent-mode answer outcome UI`: pending spinner, applied ✓ (with fake-timer poll advance), and no-change fallback (96 s advance).

## Verification

```
# Target test files
bun run test -- tests/intent-page-lifecycle.test.tsx tests/intent-negotiator-chat.test.tsx tests/pool-discovery-questions.test.tsx

Results:
  intent-page-lifecycle.test.tsx:   19/19 pass ✅  (16 pre-existing + 3 new)
  intent-negotiator-chat.test.tsx:  16/16 pass ✅
  pool-discovery-questions.test.tsx: 2/6 pass  (4 pre-existing failures unrelated to this PR — missing useConversations mock in that file, present before this PR)

# TypeScript — no new errors in changed files
cd apps/web && bun run tsc --noEmit 2>&1 | grep -E 'intentId|AnsweredQuestion'
(no output)
```

## Scope guardrails
- Frontend only — uses existing `GET /intents/:id` endpoint
- No schema/migration changes
- No protocol package changes
- Styling follows existing `font-ibm-plex-mono` / gray palette patterns
- apps/web version bumped 0.39.0 → 0.40.0