### PR TITLE
MCP identity/premises/signals: canonical-only permission input schemas + boundary proofs (IND-582/583/585/588/589)

### DIFF
--- a/packages/protocol/CHANGELOG.md
+++ b/packages/protocol/CHANGELOG.md
@@ -12,6 +12,18 @@ See [STABILITY.md](./STABILITY.md) for the public-contract and tier definitions.
 
 ## [Unreleased]
 
+## [7.4.0] — 2026-07-25
+
+### Changed
+- Make the public participant-agent permission INPUT schemas canonical-only:
+  `register_agent.permissions` and `grant_agent_permission.actions` are now a
+  `z.enum` of the six canonical `manage:*` actions instead of `z.array(z.string())`.
+  Retired `manage:profile` / `manage:contacts` strings are rejected at the schema
+  seam (the handler's `isValidAction` check is retained as defense in depth). This
+  narrows the published tool input schemas exposed via `tools/list`, hence the
+  minor bump. No change to the temporary stored-row compatibility projection,
+  which still interprets residual legacy STORED rows.
+
 ## [7.3.0] — 2026-07-25
 
 ### Added

--- a/packages/protocol/package.json
+++ b/packages/protocol/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@indexnetwork/protocol",
-  "version": "7.3.0",
+  "version": "7.4.0",
   "type": "module",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",

--- a/packages/protocol/src/mcp/tests/mcp.authorization-policy.spec.ts
+++ b/packages/protocol/src/mcp/tests/mcp.authorization-policy.spec.ts
@@ -568,3 +568,159 @@ describe('rolling-data legacy permission projection (IND-607)', () => {
     expect(subject.permissions).toEqual(['manage:identity', 'manage:premises', 'manage:intents']);
   });
 });
+
+// Helper: a global agent holding exactly the given canonical actions.
+function globalAgentSubject(actions: string[]) {
+  return resolveMcpCapabilitySubject({
+    identity: identity({ agentId: AGENT_ID }),
+    isOnboarding: false,
+    agent: agentSnapshot({
+      permissions: [{
+        agentId: AGENT_ID,
+        userId: USER_ID,
+        scope: 'global',
+        scopeId: null,
+        actions,
+      }],
+    }),
+  });
+}
+
+describe('human-only onboarding privacy consent (IND-583)', () => {
+  const CONSENT_TOOLS = ['record_onboarding_privacy_consent', 'complete_onboarding'] as const;
+
+  test('the canonical matrix classifies both consent tools human_only', () => {
+    for (const tool of CONSENT_TOOLS) {
+      expect(CANONICAL_MCP_TOOL_ACCESS_RULES.get(tool)).toEqual({ access: 'human_only', reach: 'principal' });
+    }
+  });
+
+  test('the session human is admitted to both consent tools', () => {
+    const human = resolveMcpCapabilitySubject({
+      identity: identity({ isSessionAuth: true }),
+      isOnboarding: false,
+    });
+    for (const tool of CONSENT_TOOLS) {
+      expect(policy.authorize(human, tool).allowed).toBe(true);
+    }
+    expect(policy.visibleToolNames(human, [...CONSENT_TOOLS])).toEqual([...CONSENT_TOOLS]);
+  });
+
+  test('the onboarding human is admitted (both consent tools are onboarding-allowed)', () => {
+    const onboardingHuman = resolveMcpCapabilitySubject({
+      identity: identity({ isSessionAuth: true }),
+      isOnboarding: true,
+    });
+    for (const tool of CONSENT_TOOLS) {
+      expect(policy.authorize(onboardingHuman, tool).allowed).toBe(true);
+    }
+  });
+
+  test('an agent holding identity+premises grants is denied both consent tools and never lists them', () => {
+    // manage:identity + manage:premises is exactly what the retired manage:profile
+    // grant projects to; holding both must not unlock the human-only consent flow.
+    const agent = globalAgentSubject(['manage:identity', 'manage:premises']);
+    expect(agent.profile).toBe('registered_global_agent');
+    for (const tool of CONSENT_TOOLS) {
+      expect(policy.authorize(agent, tool)).toMatchObject({ allowed: false, reason: 'human_only' });
+    }
+    expect(policy.visibleToolNames(agent, [...CONSENT_TOOLS])).toEqual([]);
+  });
+
+  test('a network agent, an enrollment key, and an invalid agent are all denied the consent tools', () => {
+    const networkAgent = resolveMcpCapabilitySubject({
+      identity: identity({ agentId: AGENT_ID, networkScopeId: NETWORK_ID }),
+      isOnboarding: false,
+      agent: agentSnapshot({
+        permissions: [{
+          agentId: AGENT_ID,
+          userId: USER_ID,
+          scope: 'network',
+          scopeId: NETWORK_ID,
+          actions: ['manage:identity', 'manage:premises'],
+        }],
+      }),
+    });
+    const enrollmentKey = resolveMcpCapabilitySubject({
+      identity: identity({ enrollmentCapable: true }),
+      isOnboarding: false,
+    });
+    const invalidAgent = resolveMcpCapabilitySubject({
+      identity: identity({ agentId: AGENT_ID }),
+      isOnboarding: false,
+      agent: null,
+    });
+    for (const subject of [networkAgent, enrollmentKey, invalidAgent]) {
+      for (const tool of CONSENT_TOOLS) {
+        expect(policy.authorize(subject, tool).allowed).toBe(false);
+      }
+      expect(policy.visibleToolNames(subject, [...CONSENT_TOOLS])).toEqual([]);
+    }
+  });
+});
+
+describe('signals read/write split (IND-588)', () => {
+  const SIGNAL_READ_TOOLS = ['read_intents', 'search_intents', 'read_intent_indexes'] as const;
+  const SIGNAL_WRITE_TOOLS = [
+    'create_intent',
+    'update_intent',
+    'delete_intent',
+    'create_intent_index',
+    'delete_intent_index',
+  ] as const;
+
+  test('read tools are authenticated and write/community-assignment tools require manage:intents', () => {
+    for (const tool of SIGNAL_READ_TOOLS) {
+      expect(CANONICAL_MCP_TOOL_ACCESS_RULES.get(tool)).toEqual({ access: 'authenticated', reach: 'network' });
+    }
+    for (const tool of SIGNAL_WRITE_TOOLS) {
+      expect(CANONICAL_MCP_TOOL_ACCESS_RULES.get(tool)).toEqual({
+        access: 'permission',
+        actions: ['manage:intents'],
+        reach: 'network',
+      });
+    }
+  });
+
+  test('an authenticated agent without manage:intents may read every signal tool but mutate none', () => {
+    const agent = globalAgentSubject(['manage:opportunities']);
+    for (const tool of SIGNAL_READ_TOOLS) {
+      expect(policy.authorize(agent, tool), tool).toMatchObject({ allowed: true, reason: 'authenticated' });
+    }
+    for (const tool of SIGNAL_WRITE_TOOLS) {
+      expect(policy.authorize(agent, tool), tool).toMatchObject({ allowed: false, reason: 'permission_missing' });
+    }
+    expect(policy.visibleToolNames(agent, [...SIGNAL_READ_TOOLS, ...SIGNAL_WRITE_TOOLS])).toEqual([...SIGNAL_READ_TOOLS]);
+  });
+
+  test('a manage:intents agent may read and mutate every signal tool, all at network reach', () => {
+    const agent = globalAgentSubject(['manage:intents']);
+    for (const tool of [...SIGNAL_READ_TOOLS, ...SIGNAL_WRITE_TOOLS]) {
+      expect(policy.authorize(agent, tool), tool).toMatchObject({ allowed: true, reach: 'network' });
+    }
+  });
+
+  test('a network-scoped grant does not authorize signal mutation from a differently-bound agent', () => {
+    // The agent is bound to network-1 but its manage:intents grant is scoped to
+    // another network, so the grant does not apply: it retains authenticated read
+    // but no signal-write capability (indirect scope cannot bypass the clamp).
+    const agent = resolveMcpCapabilitySubject({
+      identity: identity({ agentId: AGENT_ID, networkScopeId: NETWORK_ID }),
+      isOnboarding: false,
+      agent: agentSnapshot({
+        permissions: [{
+          agentId: AGENT_ID,
+          userId: USER_ID,
+          scope: 'network',
+          scopeId: 'another-network',
+          actions: ['manage:intents'],
+        }],
+      }),
+    });
+    expect(agent.permissions).toEqual([]);
+    expect(policy.authorize(agent, 'read_intents').allowed).toBe(true);
+    for (const tool of SIGNAL_WRITE_TOOLS) {
+      expect(policy.authorize(agent, tool), tool).toMatchObject({ allowed: false, reason: 'permission_missing' });
+    }
+  });
+});

--- a/packages/protocol/src/mcp/tests/mcp.authorization-policy.spec.ts
+++ b/packages/protocol/src/mcp/tests/mcp.authorization-policy.spec.ts
@@ -699,28 +699,4 @@ describe('signals read/write split (IND-588)', () => {
       expect(policy.authorize(agent, tool), tool).toMatchObject({ allowed: true, reach: 'network' });
     }
   });
-
-  test('a network-scoped grant does not authorize signal mutation from a differently-bound agent', () => {
-    // The agent is bound to network-1 but its manage:intents grant is scoped to
-    // another network, so the grant does not apply: it retains authenticated read
-    // but no signal-write capability (indirect scope cannot bypass the clamp).
-    const agent = resolveMcpCapabilitySubject({
-      identity: identity({ agentId: AGENT_ID, networkScopeId: NETWORK_ID }),
-      isOnboarding: false,
-      agent: agentSnapshot({
-        permissions: [{
-          agentId: AGENT_ID,
-          userId: USER_ID,
-          scope: 'network',
-          scopeId: 'another-network',
-          actions: ['manage:intents'],
-        }],
-      }),
-    });
-    expect(agent.permissions).toEqual([]);
-    expect(policy.authorize(agent, 'read_intents').allowed).toBe(true);
-    for (const tool of SIGNAL_WRITE_TOOLS) {
-      expect(policy.authorize(agent, tool), tool).toMatchObject({ allowed: false, reason: 'permission_missing' });
-    }
-  });
 });

--- a/packages/protocol/src/participant-agents/application/agent.tools.ts
+++ b/packages/protocol/src/participant-agents/application/agent.tools.ts
@@ -30,6 +30,13 @@ const AGENT_ACTIONS = [
   'manage:negotiations',
 ] as const;
 
+/**
+ * Canonical permission-action enum for the public tool INPUT schemas. Retired
+ * `manage:profile` / `manage:contacts` strings are rejected at the schema seam
+ * (defense-in-depth: the handler still re-validates via {@link isValidAction}).
+ */
+const AgentPermissionActionSchema = z.enum(AGENT_ACTIONS);
+
 function invalidActionMessage(action: string) {
   return `Invalid action: ${action}. Valid actions: ${AGENT_ACTIONS.join(', ')}`;
 }
@@ -84,7 +91,7 @@ export function createAgentTools(defineTool: DefineTool, deps: AgentToolDeps) {
     querySchema: z.object({
       name: z.string().min(1).describe('Display name for the agent.'),
       description: z.string().optional().describe('What the agent does.'),
-      permissions: z.array(z.string()).optional().describe('Optional initial permission actions to grant.'),
+      permissions: z.array(AgentPermissionActionSchema).optional().describe('Optional initial permission actions to grant. Valid values: manage:identity, manage:premises, manage:intents, manage:networks, manage:opportunities, manage:negotiations.'),
     }),
     handler: async ({ context, query }) => {
       if (context.agentId) {
@@ -263,7 +270,7 @@ export function createAgentTools(defineTool: DefineTool, deps: AgentToolDeps) {
       'Valid actions: manage:identity, manage:premises, manage:intents, manage:networks, manage:opportunities, manage:negotiations.',
     querySchema: z.object({
       agent_id: z.string().min(1).describe('The agent ID to grant permissions to.'),
-      actions: z.array(z.string()).min(1).describe('Permission actions to grant. Valid values: manage:identity, manage:premises, manage:intents, manage:networks, manage:opportunities, manage:negotiations.'),
+      actions: z.array(AgentPermissionActionSchema).min(1).describe('Permission actions to grant. Valid values: manage:identity, manage:premises, manage:intents, manage:networks, manage:opportunities, manage:negotiations.'),
       scope: z.enum(['global', 'node', 'network']).optional().describe('Optional permission scope.'),
       scope_id: z.string().optional().describe('Scope target ID for node/network scopes.'),
     }),

--- a/packages/protocol/src/participant-agents/tests/agent.tools.canonical-actions.spec.ts
+++ b/packages/protocol/src/participant-agents/tests/agent.tools.canonical-actions.spec.ts
@@ -1,4 +1,5 @@
 import { describe, expect, test } from 'bun:test';
+import type { z } from 'zod';
 
 import { createAgentTools } from '../application/agent.tools.js';
 import type { AgentToolDeps } from '../ports/index.js';
@@ -20,6 +21,7 @@ import type { AgentToolDeps } from '../ports/index.js';
 interface CapturedTool {
   name: string;
   handler: (input: { context: Record<string, unknown>; query: unknown }) => Promise<string>;
+  querySchema?: z.ZodType;
 }
 
 function captureAgentTools(deps: AgentToolDeps): Record<string, CapturedTool> {
@@ -106,8 +108,34 @@ function parse(result: string) {
 }
 
 const RETIRED_ACTIONS = ['manage:profile', 'manage:contacts'] as const;
+const CANONICAL_ACTIONS = ['manage:identity', 'manage:premises'] as const;
 const EXPECTED_MESSAGE =
   'Valid actions: manage:identity, manage:premises, manage:intents, manage:networks, manage:opportunities, manage:negotiations';
+
+describe('public permission INPUT schemas are canonical-only (IND-582)', () => {
+  // The public tool input schemas reject retired strings at the schema seam
+  // (defense-in-depth ahead of the retained handler validation).
+  const tools = captureAgentTools(makeDeps({ createAgentCalls: [], grantCalls: [] }));
+
+  test('register_agent.permissions rejects retired strings and accepts canonical actions', () => {
+    const schema = tools.register_agent!.querySchema!;
+    for (const retired of RETIRED_ACTIONS) {
+      expect(schema.safeParse({ name: 'Agent', permissions: [retired] }).success, retired).toBe(false);
+    }
+    expect(schema.safeParse({ name: 'Agent', permissions: [...CANONICAL_ACTIONS] }).success).toBe(true);
+    // A retired string mixed with a canonical one still fails the whole array.
+    expect(schema.safeParse({ name: 'Agent', permissions: ['manage:identity', 'manage:contacts'] }).success).toBe(false);
+  });
+
+  test('grant_agent_permission.actions rejects retired strings and accepts canonical actions', () => {
+    const schema = tools.grant_agent_permission!.querySchema!;
+    for (const retired of RETIRED_ACTIONS) {
+      expect(schema.safeParse({ agent_id: AGENT_ID, actions: [retired] }).success, retired).toBe(false);
+    }
+    expect(schema.safeParse({ agent_id: AGENT_ID, actions: [...CANONICAL_ACTIONS] }).success).toBe(true);
+    expect(schema.safeParse({ agent_id: AGENT_ID, actions: ['manage:profile', 'manage:identity'] }).success).toBe(false);
+  });
+});
 
 describe('register_agent — canonical-only permission input (IND-582)', () => {
   for (const retired of RETIRED_ACTIONS) {

--- a/packages/protocol/src/participant-agents/tests/agent.tools.canonical-actions.spec.ts
+++ b/packages/protocol/src/participant-agents/tests/agent.tools.canonical-actions.spec.ts
@@ -1,0 +1,191 @@
+import { describe, expect, test } from 'bun:test';
+
+import { createAgentTools } from '../application/agent.tools.js';
+import type { AgentToolDeps } from '../ports/index.js';
+
+/**
+ * IND-582 — canonical-only permission actions at the public participant-agent
+ * input seam (DB-free).
+ *
+ * The MCP registry, tool schemas, and grant validation are canonical-only. The
+ * retired `manage:profile` / `manage:contacts` strings are tolerated ONLY as
+ * pre-existing STORED rows (interpreted by projectStoredPermissionActions during
+ * the rolling window); they must never be accepted as public INPUT to
+ * `register_agent` or `grant_agent_permission`. These tests prove the retired
+ * strings are rejected with the canonical validation message and that no agent
+ * is created and no permission granted on the rejected path, while the canonical
+ * `manage:identity` / `manage:premises` actions are accepted.
+ */
+
+interface CapturedTool {
+  name: string;
+  handler: (input: { context: Record<string, unknown>; query: unknown }) => Promise<string>;
+}
+
+function captureAgentTools(deps: AgentToolDeps): Record<string, CapturedTool> {
+  const captured: Record<string, CapturedTool> = {};
+  const defineTool = (def: CapturedTool) => {
+    captured[def.name] = def;
+    return def;
+  };
+  createAgentTools(defineTool as never, deps);
+  return captured;
+}
+
+const OWNER_ID = 'user-owner';
+const AGENT_ID = 'agent-1';
+
+/** Records every write so rejected paths can assert nothing was persisted. */
+interface WriteLog {
+  createAgentCalls: Array<{ ownerId: string; name: string }>;
+  grantCalls: Array<{ agentId: string; actions: string[] }>;
+}
+
+function makeDeps(log: WriteLog): AgentToolDeps {
+  return {
+    agentDatabase: {
+      createAgent: async (input: { ownerId: string; name: string }) => {
+        log.createAgentCalls.push({ ownerId: input.ownerId, name: input.name });
+        return {
+          id: AGENT_ID,
+          ownerId: input.ownerId,
+          name: input.name,
+          description: null,
+          type: 'external',
+          status: 'active',
+          metadata: {},
+          createdAt: new Date('2026-01-01T00:00:00.000Z'),
+          updatedAt: new Date('2026-01-01T00:00:00.000Z'),
+        };
+      },
+      grantPermission: async (input: { agentId: string; actions: string[] }) => {
+        log.grantCalls.push({ agentId: input.agentId, actions: [...input.actions] });
+        return {
+          id: 'permission-1',
+          agentId: input.agentId,
+          userId: OWNER_ID,
+          scope: 'global',
+          scopeId: null,
+          actions: input.actions,
+          createdAt: new Date('2026-01-01T00:00:00.000Z'),
+        };
+      },
+      deleteAgent: async () => undefined,
+      getAgent: async () => ({
+        id: AGENT_ID,
+        ownerId: OWNER_ID,
+        name: 'Agent',
+        description: null,
+        type: 'external',
+        status: 'active',
+        metadata: {},
+        createdAt: new Date('2026-01-01T00:00:00.000Z'),
+        updatedAt: new Date('2026-01-01T00:00:00.000Z'),
+      }),
+      getAgentWithRelations: async () => ({
+        id: AGENT_ID,
+        ownerId: OWNER_ID,
+        name: 'Agent',
+        description: null,
+        type: 'external',
+        status: 'active',
+        metadata: {},
+        createdAt: new Date('2026-01-01T00:00:00.000Z'),
+        updatedAt: new Date('2026-01-01T00:00:00.000Z'),
+        transports: [],
+        permissions: [],
+      }),
+    } as unknown as AgentToolDeps['agentDatabase'],
+  } as AgentToolDeps;
+}
+
+const sessionContext = { userId: OWNER_ID };
+
+function parse(result: string) {
+  return JSON.parse(result) as { success: boolean; error?: string; data?: Record<string, unknown> };
+}
+
+const RETIRED_ACTIONS = ['manage:profile', 'manage:contacts'] as const;
+const EXPECTED_MESSAGE =
+  'Valid actions: manage:identity, manage:premises, manage:intents, manage:networks, manage:opportunities, manage:negotiations';
+
+describe('register_agent — canonical-only permission input (IND-582)', () => {
+  for (const retired of RETIRED_ACTIONS) {
+    test(`rejects a retired ${retired} permission and creates no agent`, async () => {
+      const log: WriteLog = { createAgentCalls: [], grantCalls: [] };
+      const tools = captureAgentTools(makeDeps(log));
+
+      const result = parse(await tools.register_agent!.handler({
+        context: sessionContext,
+        query: { name: 'Agent', permissions: [retired] },
+      }));
+
+      expect(result.success).toBe(false);
+      expect(result.error).toContain(`Invalid action: ${retired}.`);
+      expect(result.error).toContain(EXPECTED_MESSAGE);
+      // Retired input is rejected before any write.
+      expect(log.createAgentCalls).toEqual([]);
+      expect(log.grantCalls).toEqual([]);
+    });
+  }
+
+  test('accepts canonical manage:identity + manage:premises and grants them', async () => {
+    const log: WriteLog = { createAgentCalls: [], grantCalls: [] };
+    const tools = captureAgentTools(makeDeps(log));
+
+    const result = parse(await tools.register_agent!.handler({
+      context: sessionContext,
+      query: { name: 'Agent', permissions: ['manage:identity', 'manage:premises'] },
+    }));
+
+    expect(result.success).toBe(true);
+    expect(log.createAgentCalls).toEqual([{ ownerId: OWNER_ID, name: 'Agent' }]);
+    expect(log.grantCalls).toEqual([{ agentId: AGENT_ID, actions: ['manage:identity', 'manage:premises'] }]);
+  });
+});
+
+describe('grant_agent_permission — canonical-only permission input (IND-582)', () => {
+  for (const retired of RETIRED_ACTIONS) {
+    test(`rejects a retired ${retired} permission and grants nothing`, async () => {
+      const log: WriteLog = { createAgentCalls: [], grantCalls: [] };
+      const tools = captureAgentTools(makeDeps(log));
+
+      const result = parse(await tools.grant_agent_permission!.handler({
+        context: sessionContext,
+        query: { agent_id: AGENT_ID, actions: [retired] },
+      }));
+
+      expect(result.success).toBe(false);
+      expect(result.error).toContain(`Invalid action: ${retired}.`);
+      expect(result.error).toContain(EXPECTED_MESSAGE);
+      expect(log.grantCalls).toEqual([]);
+    });
+  }
+
+  test('rejects a retired action mixed with a canonical one, granting nothing', async () => {
+    const log: WriteLog = { createAgentCalls: [], grantCalls: [] };
+    const tools = captureAgentTools(makeDeps(log));
+
+    const result = parse(await tools.grant_agent_permission!.handler({
+      context: sessionContext,
+      query: { agent_id: AGENT_ID, actions: ['manage:identity', 'manage:contacts'] },
+    }));
+
+    expect(result.success).toBe(false);
+    expect(result.error).toContain('Invalid action: manage:contacts.');
+    expect(log.grantCalls).toEqual([]);
+  });
+
+  test('accepts canonical manage:identity + manage:premises and grants them', async () => {
+    const log: WriteLog = { createAgentCalls: [], grantCalls: [] };
+    const tools = captureAgentTools(makeDeps(log));
+
+    const result = parse(await tools.grant_agent_permission!.handler({
+      context: sessionContext,
+      query: { agent_id: AGENT_ID, actions: ['manage:identity', 'manage:premises'] },
+    }));
+
+    expect(result.success).toBe(true);
+    expect(log.grantCalls).toEqual([{ agentId: AGENT_ID, actions: ['manage:identity', 'manage:premises'] }]);
+  });
+});

--- a/services/api/tests/mcp.spec.ts
+++ b/services/api/tests/mcp.spec.ts
@@ -893,6 +893,10 @@ describe('MCP Server Factory', () => {
     headers?: Record<string, string>;
     /** When true, the scoped-deps factory throws if the handler seam is reached. */
     scopedThrows?: boolean;
+    /** Functional scoped databases for handlers that must run past the seam
+     *  (e.g. a resource-level clamp fired inside the tool handler). */
+    scopedUserDb?: ToolDeps['userDb'];
+    scopedSystemDb?: ToolDeps['systemDb'];
   }): Promise<CallToolOutcome> {
     clearMcpToolMetadataCacheForTests();
     const scopedCreateArgs: Array<{ userId: string; allowedNetworkIds: string[] }> = [];
@@ -900,7 +904,10 @@ describe('MCP Server Factory', () => {
       create: (userId: string, allowedNetworkIds: string[]) => {
         scopedCreateArgs.push({ userId, allowedNetworkIds });
         if (params.scopedThrows) throw new Error('scoped database must not be created');
-        return { userDb: {} as ToolDeps['userDb'], systemDb: {} as ToolDeps['systemDb'] };
+        return {
+          userDb: params.scopedUserDb ?? ({} as ToolDeps['userDb']),
+          systemDb: params.scopedSystemDb ?? ({} as ToolDeps['systemDb']),
+        };
       },
     };
     const server = createMcpServer(
@@ -1341,23 +1348,61 @@ describe('MCP Server Factory', () => {
     expect(allowed).not.toContain('network-2');
   });
 
-  it('denies a schema-valid out-of-scope update_intent whose manage:intents grant is bound elsewhere, before DB work', async () => {
-    // The agent is bound to network-1 but its only manage:intents grant is scoped
-    // to network-2, so the grant does not apply and the mutation is denied at the
-    // preliminary capability stage — a distinct tool (update_intent) from the
-    // existing create_intent out-of-scope case.
-    const counter = { reads: 0 };
+  it('admits a bound network agent to create_intent_index then resource-clamps a schema-valid out-of-network assignment before the write', async () => {
+    // Production-reachable resource-level denial (not a permission-row-loss case):
+    // the agent is bound to network-1 AND holds an applicable network-1
+    // manage:intents grant, so capability policy ADMITS and dispatch reaches the
+    // scoped handler seam. It then asks to assign an intent to network-2 (an
+    // explicit out-of-network community). The tool's own network/resource clamp
+    // rejects with a stable domain message BEFORE any intent-index graph/write.
+    let intentIndexGraphCalls = 0;
+    const scopedSystemDb = {
+      // Member of the bound network, so ensureScopedMembership passes.
+      isNetworkMember: async () => true,
+    } as unknown as ToolDeps['systemDb'];
+    const graphs = {
+      ...mockDeps.graphs,
+      intentIndex: {
+        invoke: async () => {
+          intentIndexGraphCalls += 1;
+          return {};
+        },
+      },
+    } as unknown as ToolDeps['graphs'];
+    // The user is a member of the bound network-1 (so allowedNetworkIds resolves
+    // to network-1); the requested network-2 is out of the binding.
+    const memberDb = {
+      ...resolvedContextDatabase,
+      getNetworkMemberships: async () => ([
+        { networkId: 'network-1', networkTitle: 'N1', isPersonal: false, permissions: [] },
+      ]),
+    } as unknown as ToolDeps['database'];
+
     const result = await callTool({
-      identity: { userId: 'test-user-id', agentId: 'agent-os', networkScopeId: 'network-1' },
-      agentDatabase: agentDbWith({ agentId: 'agent-os', scope: 'network', scopeId: 'network-2', actions: ['manage:intents'] }),
-      database: guardReads(counter),
-      scopedThrows: true,
-      toolName: 'update_intent',
-      arguments: { intentId: '00000000-0000-4000-8000-000000000010', description: 'a refined specific signal' },
+      identity: { userId: 'test-user-id', agentId: 'agent-ci', networkScopeId: 'network-1' },
+      agentDatabase: agentDbWith({ agentId: 'agent-ci', scope: 'network', scopeId: 'network-1', actions: ['manage:intents'] }),
+      database: memberDb,
+      extraDeps: { graphs },
+      scopedSystemDb,
+      toolName: 'create_intent_index',
+      arguments: {
+        intentId: '00000000-0000-4000-8000-000000000010',
+        networkId: '00000000-0000-4000-8000-000000000020',
+      },
     });
-    expect(result.isError).toBe(true);
-    expect(result.code).toBe('MCP_CAPABILITY_DENIED');
-    expect(counter.reads).toBe(0);
-    expect(result.scopedCreateArgs).toEqual([]);
+
+    // Admission happened (not a capability denial) and the handler seam was reached.
+    expect(result.code).not.toBe('MCP_CAPABILITY_DENIED');
+    expect(result.scopedCreateArgs.length).toBe(1);
+    // The bound-network clamp allowed only network-1 into the scoped deps.
+    const allowed = result.scopedCreateArgs[0]!.allowedNetworkIds;
+    expect(allowed).toContain('network-1');
+    expect(allowed).not.toContain('00000000-0000-4000-8000-000000000020');
+    // Stable resource/domain denial, not merely MCP_CAPABILITY_DENIED.
+    const payload = JSON.parse(result.text) as { success: boolean; error?: string };
+    expect(payload.success).toBe(false);
+    expect(payload.error).toMatch(/you can only link intents to this community/i);
+    // Rejected before the intent-index graph/write.
+    expect(intentIndexGraphCalls).toBe(0);
   });
 });

--- a/services/api/tests/mcp.spec.ts
+++ b/services/api/tests/mcp.spec.ts
@@ -1167,4 +1167,197 @@ describe('MCP Server Factory', () => {
     const ids = (payload.data?.questions ?? []).map((q) => q.id);
     expect(ids).toEqual(['intent-q']);
   });
+
+  // ── IND-583: human-only onboarding privacy consent at the transport seam ────
+  //
+  // record_onboarding_privacy_consent and complete_onboarding are human_only. A
+  // registered agent — even one holding BOTH manage:identity and manage:premises
+  // (the exact pair the retired manage:profile grant projected to) — must neither
+  // see them in tools/list nor reach them via tools/call, and the denial must
+  // land before any chat DB, scoped DB, registry, or graph work. The session
+  // human is admitted and reaches the scoped handler seam. tools/list and
+  // tools/call therefore agree for both principals.
+  const IDENTITY_PREMISES_ACTIONS = ['manage:identity', 'manage:premises'];
+  const HUMAN_ONLY_ONBOARDING_TOOLS = ['record_onboarding_privacy_consent', 'complete_onboarding'] as const;
+
+  it('hides onboarding privacy consent tools from an agent holding identity+premises grants (tools/list)', async () => {
+    clearMcpToolMetadataCacheForTests();
+    const deps = {
+      ...mockDeps,
+      database: resolvedContextDatabase,
+      agentDatabase: agentDbWith({ agentId: 'agent-ip', scope: 'global', scopeId: null, actions: IDENTITY_PREMISES_ACTIONS }),
+    };
+    const server = createMcpServer(
+      deps,
+      {
+        resolveIdentity: async () => ({ userId: 'test-user-id', agentId: 'agent-ip' }),
+        resolveUserId: async () => 'test-user-id',
+      },
+      mockScopedDepsFactory,
+    );
+    const response = await invokeMcpRequest({ server, method: 'tools/list', headers: { 'x-api-key': 'agent-key' } });
+    const names = response.result?.tools?.map((tool) => tool.name) ?? [];
+    for (const tool of HUMAN_ONLY_ONBOARDING_TOOLS) {
+      expect(names, `${tool} must be hidden from an identity+premises agent`).not.toContain(tool);
+    }
+  });
+
+  it('denies an identity+premises agent calling onboarding consent tools before any DB or graph work', async () => {
+    for (const tool of HUMAN_ONLY_ONBOARDING_TOOLS) {
+      const counter = { reads: 0 };
+      const result = await callTool({
+        identity: { userId: 'test-user-id', agentId: 'agent-ip' },
+        agentDatabase: agentDbWith({ agentId: 'agent-ip', scope: 'global', scopeId: null, actions: IDENTITY_PREMISES_ACTIONS }),
+        database: guardReads(counter),
+        scopedThrows: true,
+        toolName: tool,
+        arguments: {},
+      });
+      expect(result.isError, `${tool} must be denied`).toBe(true);
+      expect(result.code, `${tool} must be a capability denial`).toBe('MCP_CAPABILITY_DENIED');
+      expect(counter.reads, `${tool} must deny before chat DB`).toBe(0);
+      expect(result.scopedCreateArgs, `${tool} must deny before scoped DB`).toEqual([]);
+    }
+  });
+
+  it('admits the session human to onboarding privacy consent tools and reaches the scoped handler seam', async () => {
+    // Schema-valid arguments; the session human passes policy and reaches the
+    // scoped-deps/handler seam (scopedCreateArgs), which is the admission
+    // boundary — the exact parity partner of the agent denial above.
+    const consent = await callTool({
+      identity: { userId: 'test-user-id', isSessionAuth: true },
+      headers: { authorization: 'Bearer session-token' },
+      toolName: 'record_onboarding_privacy_consent',
+      arguments: { publicProfileLookupGranted: true },
+    });
+    expect(consent.code).not.toBe('MCP_CAPABILITY_DENIED');
+    expect(consent.scopedCreateArgs.length).toBe(1);
+
+    const complete = await callTool({
+      identity: { userId: 'test-user-id', isSessionAuth: true },
+      headers: { authorization: 'Bearer session-token' },
+      toolName: 'complete_onboarding',
+      arguments: {},
+    });
+    expect(complete.code).not.toBe('MCP_CAPABILITY_DENIED');
+    expect(complete.scopedCreateArgs.length).toBe(1);
+  });
+
+  // ── IND-588: signals read/write split at the transport seam ─────────────────
+  //
+  // Signal READ tools (read_intents, search_intents, read_intent_indexes) are
+  // `authenticated`; every MUTATION and community-assignment tool requires
+  // manage:intents. An authenticated registered agent WITHOUT manage:intents may
+  // reach the read seam but is capability-denied on every mutation before DB or
+  // graph work, and those mutations are absent from its tools/list. (The
+  // create_intent cross-network case is covered above; these prove the
+  // read-allow-vs-write-deny split, the network read clamp, and one out-of-scope
+  // non-create mutation denial.)
+  const NON_INTENT_AGENT_ACTIONS = ['manage:opportunities'];
+
+  it('lets an authenticated agent without manage:intents reach the read_intents seam', async () => {
+    const result = await callTool({
+      identity: { userId: 'test-user-id', agentId: 'agent-sr' },
+      agentDatabase: agentDbWith({ agentId: 'agent-sr', scope: 'global', scopeId: null, actions: NON_INTENT_AGENT_ACTIONS }),
+      toolName: 'read_intents',
+      arguments: {},
+    });
+    expect(result.code).not.toBe('MCP_CAPABILITY_DENIED');
+    expect(result.scopedCreateArgs.length).toBe(1);
+  });
+
+  it('hides signal mutation and community-assignment tools from an agent without manage:intents (tools/list)', async () => {
+    clearMcpToolMetadataCacheForTests();
+    const deps = {
+      ...mockDeps,
+      database: resolvedContextDatabase,
+      agentDatabase: agentDbWith({ agentId: 'agent-sr', scope: 'global', scopeId: null, actions: NON_INTENT_AGENT_ACTIONS }),
+    };
+    const server = createMcpServer(
+      deps,
+      {
+        resolveIdentity: async () => ({ userId: 'test-user-id', agentId: 'agent-sr' }),
+        resolveUserId: async () => 'test-user-id',
+      },
+      mockScopedDepsFactory,
+    );
+    const response = await invokeMcpRequest({ server, method: 'tools/list', headers: { 'x-api-key': 'agent-key' } });
+    const names = response.result?.tools?.map((tool) => tool.name) ?? [];
+    // Reads remain usable.
+    expect(names).toContain('read_intents');
+    expect(names).toContain('search_intents');
+    expect(names).toContain('read_intent_indexes');
+    // Mutations and community assignment are absent.
+    for (const tool of ['create_intent', 'update_intent', 'delete_intent', 'create_intent_index', 'delete_intent_index']) {
+      expect(names, `${tool} must be hidden without manage:intents`).not.toContain(tool);
+    }
+  });
+
+  it('denies signal mutations and community assignment for an agent without manage:intents before DB work', async () => {
+    const writes: Array<{ tool: string; args: Record<string, unknown> }> = [
+      { tool: 'update_intent', args: { intentId: '00000000-0000-4000-8000-000000000010', description: 'a refined specific signal' } },
+      { tool: 'delete_intent', args: { intentId: '00000000-0000-4000-8000-000000000010' } },
+      { tool: 'create_intent_index', args: { intentId: '00000000-0000-4000-8000-000000000010', networkId: '00000000-0000-4000-8000-000000000020' } },
+      { tool: 'delete_intent_index', args: { intentId: '00000000-0000-4000-8000-000000000010', networkId: '00000000-0000-4000-8000-000000000020' } },
+    ];
+    for (const { tool, args } of writes) {
+      const counter = { reads: 0 };
+      const result = await callTool({
+        identity: { userId: 'test-user-id', agentId: 'agent-sr' },
+        agentDatabase: agentDbWith({ agentId: 'agent-sr', scope: 'global', scopeId: null, actions: NON_INTENT_AGENT_ACTIONS }),
+        database: guardReads(counter),
+        scopedThrows: true,
+        toolName: tool,
+        arguments: args,
+      });
+      expect(result.isError, `${tool} must be denied`).toBe(true);
+      expect(result.code, `${tool} must be a capability denial`).toBe('MCP_CAPABILITY_DENIED');
+      expect(counter.reads, `${tool} must deny before chat DB`).toBe(0);
+      expect(result.scopedCreateArgs, `${tool} must deny before scoped DB`).toEqual([]);
+    }
+  });
+
+  it('clamps a network-scoped read-only agent to its bound network on read_intents', async () => {
+    // Distinct from the manage:intents clamp case above: even an authenticated
+    // read-only network agent is clamped at scoped-deps construction to its bound
+    // network, never the other network the user also belongs to.
+    const memberDb = {
+      ...resolvedContextDatabase,
+      getNetworkMemberships: async () => ([
+        { networkId: 'network-1', networkTitle: 'N1', isPersonal: false, permissions: [] },
+        { networkId: 'network-2', networkTitle: 'N2', isPersonal: false, permissions: [] },
+      ]),
+    } as unknown as ToolDeps['database'];
+    const result = await callTool({
+      identity: { userId: 'test-user-id', agentId: 'agent-srn', networkScopeId: 'network-1' },
+      agentDatabase: agentDbWith({ agentId: 'agent-srn', scope: 'network', scopeId: 'network-1', actions: NON_INTENT_AGENT_ACTIONS }),
+      database: memberDb,
+      toolName: 'read_intents',
+      arguments: {},
+    });
+    expect(result.scopedCreateArgs.length).toBe(1);
+    const allowed = result.scopedCreateArgs[0]!.allowedNetworkIds;
+    expect(allowed).toContain('network-1');
+    expect(allowed).not.toContain('network-2');
+  });
+
+  it('denies a schema-valid out-of-scope update_intent whose manage:intents grant is bound elsewhere, before DB work', async () => {
+    // The agent is bound to network-1 but its only manage:intents grant is scoped
+    // to network-2, so the grant does not apply and the mutation is denied at the
+    // preliminary capability stage — a distinct tool (update_intent) from the
+    // existing create_intent out-of-scope case.
+    const counter = { reads: 0 };
+    const result = await callTool({
+      identity: { userId: 'test-user-id', agentId: 'agent-os', networkScopeId: 'network-1' },
+      agentDatabase: agentDbWith({ agentId: 'agent-os', scope: 'network', scopeId: 'network-2', actions: ['manage:intents'] }),
+      database: guardReads(counter),
+      scopedThrows: true,
+      toolName: 'update_intent',
+      arguments: { intentId: '00000000-0000-4000-8000-000000000010', description: 'a refined specific signal' },
+    });
+    expect(result.isError).toBe(true);
+    expect(result.code).toBe('MCP_CAPABILITY_DENIED');
+    expect(counter.reads).toBe(0);
+    expect(result.scopedCreateArgs).toEqual([]);
+  });
 });


### PR DESCRIPTION
## Summary

Proves and hardens the caller/permission/network boundaries of the merged MCP
**identity, premises, and signals** surface for parent **IND-573**
(IND-582/583/585/588/589) into `feat/mcp-refactoring` @ `27158ef`. Mostly focused
DB-free tests supplying the missing independent proof, plus one small
public-schema hardening (correction round).

## Production change (minor)

- **IND-582 — canonical-only permission INPUT schemas.** `register_agent.permissions`
  and `grant_agent_permission.actions` now use a local `z.enum` of the six canonical
  `manage:*` actions instead of `z.array(z.string())`. Retired `manage:profile` /
  `manage:contacts` are rejected at the schema seam; the handler `isValidAction`
  check is retained as defense in depth. This narrows the published tool input
  schemas exposed via `tools/list`, so **protocol 7.3.0 → 7.4.0** (changelog
  updated). Root `bun.lock` untouched.

## Test proof (DB-free)

- **IND-583 — human-only onboarding consent.** Transport tests prove an agent
  holding `manage:identity`+`manage:premises` neither lists nor calls
  `record_onboarding_privacy_consent` / `complete_onboarding`, with denial before
  any chat DB, scoped DB, or graph work; the session human is admitted and reaches
  the scoped seam (tools/list ↔ tools/call parity). Policy tests cover `human_only`
  classification and agent/network/enrollment/invalid denial.
- **IND-588 — signals read/write split + resource clamp.** Transport + policy tests
  prove an authenticated agent without `manage:intents` may reach the signal read
  tools but every mutation and community-assignment tool is hidden and denied
  before DB work. Includes a network read clamp and a **production-reachable
  resource-level denial**: a network-1 agent with an applicable network-1
  `manage:intents` grant is admitted to `create_intent_index`, reaches the handler
  seam, then is rejected on a schema-valid network-2 assignment with a stable
  domain message before the intent-index graph/write. (Replaces the earlier
  permission-row-loss `update_intent` case that duplicated the base `create_intent`
  proof.)
- **IND-582 handler + schema.** New participant-agent tests prove `register_agent` /
  `grant_agent_permission` reject retired `manage:profile` / `manage:contacts` at
  both the schema seam and the handler (no agent created, nothing granted) and
  accept canonical `manage:identity` / `manage:premises`.
- **IND-585 / IND-589** premises `manage:premises` reach and the shared question
  mode→domain→permission map remain covered by existing handler/transport tests.

Preserves the merged MCP registry, temporary stored-row compatibility projection,
question handler/domain map, activity-summary naming/policy, and the
no-contact/no-scrape/no-profile-alias boundary. Reuses existing transport/handler
seams and helpers; no new policy matrices or abstractions.

## Verification

- Focused tests pass: protocol `mcp.authorization-policy.spec.ts` (31), new
  `agent.tools.canonical-actions.spec.ts` (9), API `tests/mcp.spec.ts` (33) — 0
  failures. No regression across existing agent/persona specs (55 + 66 pass).
- Affected production lint clean; protocol + API builds pass.
- Architecture check passes exports/consumer/host-isolation/capabilities; halts only
  at the pre-existing 7-file negotiation/question baseline cycle whose members are
  **byte-identical to base** (exact base-cycle comparison — only `agent.tools.ts`,
  `package.json`, `CHANGELOG.md`, and `tests/` changed; `agent.tools.ts` is not a
  cycle member and adds no imports).
- `git diff --check` clean; local/remote parity `0 0`.

No merge. Draft PR into `feat/mcp-refactoring` (not dev/main).