### PR TITLE
MCP agent-administration split: canonical read_own_agent self-read + enrollment single-purpose (IND-599) — protocol 7.7.0 / API 0.63.0

### DIFF
--- a/packages/protocol/CHANGELOG.md
+++ b/packages/protocol/CHANGELOG.md
@@ -13,6 +13,39 @@ See [STABILITY.md](./STABILITY.md) for the public-contract and tier definitions.
 ## [Unreleased]
 
 ### Added
+- Add the canonical `read_own_agent` MCP tool: a registered active agent's
+  self-read of its OWN sanitized registration record (IND-599; 7.7.0). The input
+  schema is empty — there is no target selector, so a caller can never name
+  another agent — and the handler resolves strictly the authenticated
+  `context.agentId` with an owner match, so a forged target argument is stripped
+  by the schema and never queried. The tool is classified `agent_admin` in the
+  canonical capability matrix and registered in the shared factory (`fast`
+  runtime class).
+
+### Changed
+- Split the `agent_admin` capability family by principal kind (IND-599; 7.7.0).
+  Registered agent principals (global/network/delivery) may now see and call
+  ONLY `read_own_agent` on the admin surface — `list_agents` is no longer
+  visible or callable by an agent (previously it was the sole agent-visible
+  admin tool), and every admin mutation remains denied (`agent_admin_denied`).
+  Session/onboarding humans retain the full owned-agent administration surface
+  (`register_agent`, `list_agents`, `update_agent`, `delete_agent`,
+  `grant_agent_permission`, `revoke_agent_permission`) but are denied the
+  agent-only `read_own_agent` with the new dedicated decision reason
+  `human_read_own_agent_denied`. Enrollment-capable unregistered keys remain
+  single-purpose `register_agent`-only across the entire registry, and plain
+  unregistered keys remain fail-closed. The `agent_admin` decision is made
+  BEFORE the session-human blanket allow, and denials fire before any context
+  DB read or scoped-deps creation. Domain, informational (`read_docs`),
+  permission/network-scope, and delivery capabilities for registered agents are
+  unchanged. Behavior tightening on published MCP tools plus a new public tool
+  name, hence the minor bump.
+- Redact private transport connection material from every agent record
+  projected by the participant-agent tools (IND-599; 7.7.0).
+  `sanitizeAgentForOutput` now empties each transport's `config` (endpoint
+  secrets, auth headers/tokens) while preserving the safe response shape
+  (id/channel/priority/active/failureCount and permissions), covering
+  `read_own_agent`, `register_agent`, `list_agents`, and `update_agent` outputs.
 - Require explicit owner authorization for every owner-gated `update_opportunity`
   transition (send/accept/reject) at a new protocol-owned authoritative boundary
   (IND-593; 7.6.0). The `OpportunityOwnerApprovalAuthority` port is injected by

--- a/packages/protocol/IMPLEMENTATION.md
+++ b/packages/protocol/IMPLEMENTATION.md
@@ -227,7 +227,12 @@ On every tool call the server:
 
 1. Extracts the HTTP request from the MCP `ServerContext`.
 2. Calls `authResolver.resolveIdentity(req)` to get `{ userId, agentId }`.
-3. Gates access: MCP callers without a resolved `agentId` are blocked from every tool except `register_agent`, `read_docs`, and `scrape_url` until they register.
+3. Gates access through the canonical capability policy (`mcp/mcp.authorization-policy.ts`), decided per resolved principal BEFORE any context read or scoped-deps creation:
+   - **Enrollment-capable unregistered API keys** may see and call only `register_agent` — single-purpose across the entire registry.
+   - **Plain unregistered API keys** fail closed on every tool.
+   - **Registered active agents** retain their canonical permission- and network-scope-authorized domain tools, `read_docs`, and (for designated delivery agents) `confirm_opportunity_delivery`; within the agent-administration family (`MCP_AGENT_ADMIN_TOOLS`) they may see and call only `read_own_agent`, which returns the caller's own sanitized record and accepts no target.
+   - **Session humans** administer their owned agents (`register_agent`, `list_agents`, `update_agent`, `delete_agent`, `grant_agent_permission`, `revoke_agent_permission`) but are never offered the agent-only `read_own_agent`.
+   - Contact/Gmail-import tools, `scrape_url`, and the deprecated `*_user_profile`/`*_profile_run` aliases are not registered on the MCP surface at all (IND-596/597/598).
 4. Builds per-request scoped databases via `scopedDepsFactory` and invokes the tool handler through the shared runtime.
 
 ### Runtime controls

--- a/packages/protocol/package.json
+++ b/packages/protocol/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@indexnetwork/protocol",
-  "version": "7.6.0",
+  "version": "7.7.0",
   "type": "module",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",

--- a/packages/protocol/src/README.md
+++ b/packages/protocol/src/README.md
@@ -98,15 +98,22 @@ Tools are registered in `shared/agent/tool.registry.ts` and assembled per sessio
 | `intent/intent.tools.ts` | `read_intents`, `create_intent`, `update_intent`, `delete_intent`, `search_intents`, `create_intent_index`, `read_intent_indexes`, `delete_intent_index` |
 | `network/network.tools.ts` | `read_networks`, `create_network`, `update_network`, `delete_network`, `read_network_memberships`, `create_network_membership`, `delete_network_membership` |
 | `opportunity/opportunity.tools.ts` | `discover_opportunities`, `get_discovery_run`, `cancel_discovery_run`, `list_opportunities`, `update_opportunity`, `confirm_opportunity_delivery`¹ |
-| `contact/contact.tools.ts` | `import_contacts`, `list_contacts`, `add_contact`, `remove_contact`, `search_contacts` |
-| `integration/integration.tools.ts` | `import_gmail_contacts` |
-| `agent/agent.tools.ts` | `register_agent`, `list_agents`, `update_agent`, `delete_agent`, `grant_agent_permission`, `revoke_agent_permission` |
+| `contact/contact.tools.ts`³ | `import_contacts`, `list_contacts`, `add_contact`, `remove_contact`, `search_contacts` |
+| `integration/integration.tools.ts`³ | `import_gmail_contacts` |
+| `agent/agent.tools.ts` | `read_own_agent`, `register_agent`, `list_agents`, `update_agent`, `delete_agent`, `grant_agent_permission`, `revoke_agent_permission` |
 | `negotiation/negotiation.tools.ts`² | `list_negotiations`, `get_negotiation`, `respond_to_negotiation` |
 | `questioner/questioner.tools.ts` | `read_pending_questions` |
-| `shared/agent/utility.tools.ts` | `scrape_url`, `read_docs` |
+| `shared/agent/utility.tools.ts` | `scrape_url`³, `read_docs` |
 
 ¹ `confirm_opportunity_delivery` is an OpenClaw delivery-ledger write — it is filtered out of regular chat sessions and only reachable over MCP.
 ² Negotiation tools are only registered when an `agentDispatcher` is provided.
+³ Chat/REST-only: the contact and Gmail-import tools and `scrape_url` are omitted
+  from the MCP registry entirely (IND-596/597), as are the deprecated
+  `*_user_profile`/`*_profile_run` aliases (IND-598) — none of these are MCP
+  tools. On the MCP surface, agent administration follows the IND-599 split:
+  registered agents get `read_own_agent` only; session humans get the owned
+  admin tools but never `read_own_agent`; enrollment-capable keys are
+  `register_agent`-only; unregistered keys fail closed.
 
 ## Core Concepts
 

--- a/packages/protocol/src/mcp/mcp.authorization-policy.ts
+++ b/packages/protocol/src/mcp/mcp.authorization-policy.ts
@@ -176,6 +176,7 @@ export const CANONICAL_MCP_TOOL_ACCESS_RULES = defineMcpToolAccessRules({
   get_conversation: { access: 'human_only', reach: 'principal' },
 
   // Agent administration.
+  read_own_agent: { access: 'agent_admin', reach: 'principal' },
   register_agent: { access: 'agent_admin', reach: 'principal' },
   list_agents: { access: 'agent_admin', reach: 'principal' },
   update_agent: { access: 'agent_admin', reach: 'principal' },
@@ -231,6 +232,7 @@ export const ONBOARDING_ALLOWED: ReadonlySet<string> = new Set([
 
 /** Agent administration inventory. */
 export const MCP_AGENT_ADMIN_TOOLS: ReadonlySet<string> = new Set([
+  'read_own_agent',
   'register_agent',
   'list_agents',
   'update_agent',
@@ -460,6 +462,7 @@ export const McpCapabilityDecisionReasonSchema = z.enum([
   'unregistered_principal',
   'invalid_agent',
   'agent_admin_denied',
+  'human_read_own_agent_denied',
   'human_only',
   'permission_missing',
   'delivery_required',
@@ -521,6 +524,38 @@ export class McpCapabilityPolicy {
         ? { allowed: true, reason: 'delivery', reach: rule.reach }
         : { allowed: false, reason: 'delivery_required', reach: rule.reach };
     }
+    // Agent administration is split by principal kind and must be decided
+    // BEFORE the generic session-human blanket allow below — otherwise a
+    // session human would be admitted to read_own_agent (an agent-only tool)
+    // by the blanket allow before this rule is ever reached (IND-599).
+    if (rule.access === 'agent_admin') {
+      // read_own_agent is the ONLY agent_admin tool available to a registered
+      // active agent, and it returns that agent's own record (no target). Every
+      // other agent_admin tool is an owner/admin action reserved for humans.
+      if (
+        subject.profile === 'registered_global_agent' ||
+        subject.profile === 'registered_network_agent' ||
+        subject.profile === 'delivery_agent'
+      ) {
+        return toolName === 'read_own_agent'
+          ? { allowed: true, reason: 'agent_self_read', reach: rule.reach }
+          : { allowed: false, reason: 'agent_admin_denied', reach: rule.reach };
+      }
+      // Session/onboarding humans get every agent_admin tool EXCEPT
+      // read_own_agent, which is reserved for agent principals.
+      if (subject.profile === 'session_human' || subject.profile === 'onboarding_human') {
+        return toolName === 'read_own_agent'
+          ? { allowed: false, reason: 'human_read_own_agent_denied', reach: rule.reach }
+          : {
+              allowed: true,
+              reason: subject.profile === 'onboarding_human' ? 'onboarding' : 'session_human',
+              reach: rule.reach,
+            };
+      }
+      // Every other profile (enrollment/unregistered/invalid) is handled above
+      // and never reaches here; fail closed for completeness.
+      return { allowed: false, reason: 'agent_admin_denied', reach: rule.reach };
+    }
     if (subject.profile === 'session_human' || subject.profile === 'onboarding_human') {
       return {
         allowed: true,
@@ -530,11 +565,6 @@ export class McpCapabilityPolicy {
     }
     if (rule.access === 'human_only') {
       return { allowed: false, reason: 'human_only', reach: rule.reach };
-    }
-    if (rule.access === 'agent_admin') {
-      return toolName === 'list_agents'
-        ? { allowed: true, reason: 'agent_self_read', reach: rule.reach }
-        : { allowed: false, reason: 'agent_admin_denied', reach: rule.reach };
     }
     if (rule.access === 'informational') {
       return { allowed: true, reason: 'informational', reach: rule.reach };

--- a/packages/protocol/src/mcp/tests/mcp.authorization-policy.spec.ts
+++ b/packages/protocol/src/mcp/tests/mcp.authorization-policy.spec.ts
@@ -112,7 +112,10 @@ describe('MCP capability policy principal inventory', () => {
     });
 
     expect(subject.profile).toBe('registered_global_agent');
+    // IND-599: a registered agent is self-read-only on the admin surface — it
+    // sees read_own_agent (its OWN record), never list_agents or any mutation.
     expect(policy.visibleToolNames(subject, [
+      'read_own_agent',
       'register_agent',
       'list_agents',
       'update_agent',
@@ -121,7 +124,7 @@ describe('MCP capability policy principal inventory', () => {
       'revoke_agent_permission',
       'read_intents',
       'create_intent',
-    ])).toEqual(['list_agents', 'read_intents', 'create_intent']);
+    ])).toEqual(['read_own_agent', 'read_intents', 'create_intent']);
   });
 
   test('network agents honor only matching-scope or global permission rows', () => {
@@ -188,13 +191,15 @@ describe('MCP capability policy principal inventory', () => {
     });
 
     expect(subject.profile).toBe('delivery_agent');
+    // IND-599: a delivery agent is still a registered agent principal — its
+    // agent-admin surface is read_own_agent only (not list_agents).
     expect(policy.visibleToolNames(subject, [
-      'list_agents',
+      'read_own_agent',
       'read_docs',
       'confirm_opportunity_delivery',
       'discover_opportunities',
     ])).toEqual([
-      'list_agents',
+      'read_own_agent',
       'read_docs',
       'confirm_opportunity_delivery',
       'discover_opportunities',
@@ -655,6 +660,176 @@ describe('human-only onboarding privacy consent (IND-583)', () => {
         expect(policy.authorize(subject, tool).allowed).toBe(false);
       }
       expect(policy.visibleToolNames(subject, [...CONSENT_TOOLS])).toEqual([]);
+    }
+  });
+});
+
+describe('agent administration policy (IND-599)', () => {
+  test('registered agent sees/calls only read_own_agent (agent_self_read), never list_agents or mutations', () => {
+    // Agents receive read_own_agent (their own record) but not list_agents (admin view)
+    // and cannot mutate any admin settings.
+    const subject = resolveMcpCapabilitySubject({
+      identity: identity({ agentId: AGENT_ID }),
+      isOnboarding: false,
+      agent: agentSnapshot({
+        permissions: [{
+          agentId: AGENT_ID,
+          userId: USER_ID,
+          scope: 'global',
+          scopeId: null,
+          actions: ['manage:intents'],
+        }],
+      }),
+    });
+
+    expect(subject.profile).toBe('registered_global_agent');
+    // Agent can read its own record with agent_self_read reason.
+    const decision = policy.authorize(subject, 'read_own_agent');
+    expect(decision.allowed).toBe(true);
+    expect(decision.reason).toBe('agent_self_read');
+    // All other agent admin tools denied for agents.
+    expect(policy.visibleToolNames(subject, [
+      'read_own_agent',
+      'register_agent',
+      'list_agents',
+      'update_agent',
+      'delete_agent',
+      'grant_agent_permission',
+      'revoke_agent_permission',
+    ])).toEqual(['read_own_agent']);
+    // Verify each admin tool is explicitly denied for agents.
+    for (const tool of ['register_agent', 'list_agents', 'update_agent', 'delete_agent', 'grant_agent_permission', 'revoke_agent_permission']) {
+      expect(policy.authorize(subject, tool)).toMatchObject({ allowed: false, reason: 'agent_admin_denied' });
+    }
+  });
+
+  test('session human sees all agent admin tools except read_own_agent, which is agent-only', () => {
+    const subject = resolveMcpCapabilitySubject({
+      identity: identity({ isSessionAuth: true }),
+      isOnboarding: false,
+    });
+
+    expect(subject.profile).toBe('session_human');
+    // Session humans receive full agent administration mutations but NOT read_own_agent.
+    const adminTools = [
+      'register_agent',
+      'list_agents',
+      'update_agent',
+      'delete_agent',
+      'grant_agent_permission',
+      'revoke_agent_permission',
+    ];
+    expect(policy.visibleToolNames(subject, ['read_own_agent', ...adminTools])).toEqual(adminTools);
+    // Humans get all admin tools but not read_own_agent.
+    for (const tool of adminTools) {
+      expect(policy.authorize(subject, tool).allowed).toBe(true);
+    }
+    // read_own_agent explicitly denied for humans (agent-only).
+    expect(policy.authorize(subject, 'read_own_agent')).toMatchObject({ allowed: false, reason: 'human_read_own_agent_denied' });
+  });
+
+  test('enrollment-capable key receives only register_agent, denies all admin mutations', () => {
+    const subject = resolveMcpCapabilitySubject({
+      identity: identity({ enrollmentCapable: true }),
+      isOnboarding: false,
+    });
+
+    expect(subject.profile).toBe('enrollment_key');
+    expect(policy.visibleToolNames(subject, [
+      'register_agent',
+      'list_agents',
+      'update_agent',
+      'delete_agent',
+      'grant_agent_permission',
+      'revoke_agent_permission',
+    ])).toEqual(['register_agent']);
+  });
+
+  test('enrollment key is register_agent-only across the ENTIRE canonical matrix — every domain tool is denied', () => {
+    // Whole-registry proof (not just the agent-admin subset): iterate every
+    // classified tool in the canonical production matrix and require that an
+    // enrollment-capable unregistered key sees and may call ONLY register_agent.
+    const subject = resolveMcpCapabilitySubject({
+      identity: identity({ enrollmentCapable: true }),
+      isOnboarding: false,
+    });
+    expect(subject.profile).toBe('enrollment_key');
+
+    const allToolNames = [...CANONICAL_MCP_TOOL_ACCESS_RULES.keys()];
+    expect(allToolNames.length).toBeGreaterThan(30);
+    expect(policy.visibleToolNames(subject, allToolNames)).toEqual(['register_agent']);
+    for (const toolName of allToolNames) {
+      if (toolName === 'register_agent') {
+        expect(policy.authorize(subject, toolName)).toMatchObject({ allowed: true, reason: 'enrollment' });
+        continue;
+      }
+      expect(policy.authorize(subject, toolName), `${toolName} must be enrollment_required`)
+        .toMatchObject({ allowed: false, reason: 'enrollment_required' });
+    }
+  });
+
+  test('plain unregistered key fails closed across the ENTIRE canonical matrix', () => {
+    const subject = resolveMcpCapabilitySubject({
+      identity: identity(),
+      isOnboarding: false,
+    });
+    expect(subject.profile).toBe('unregistered_key');
+
+    const allToolNames = [...CANONICAL_MCP_TOOL_ACCESS_RULES.keys()];
+    expect(policy.visibleToolNames(subject, allToolNames)).toEqual([]);
+    for (const toolName of allToolNames) {
+      expect(policy.authorize(subject, toolName), `${toolName} must be unregistered_principal`)
+        .toMatchObject({ allowed: false, reason: 'unregistered_principal' });
+    }
+  });
+
+  test('plain unregistered key fails closed on all admin tools', () => {
+    const subject = resolveMcpCapabilitySubject({
+      identity: identity(),
+      isOnboarding: false,
+    });
+
+    expect(subject.profile).toBe('unregistered_key');
+    expect(policy.visibleToolNames(subject, [
+      'register_agent',
+      'list_agents',
+      'update_agent',
+      'delete_agent',
+      'grant_agent_permission',
+      'revoke_agent_permission',
+    ])).toEqual([]);
+  });
+
+  test('invalid/inactive/mismatched agent denies all admin tools', () => {
+    const baseIdentity = identity({ agentId: AGENT_ID });
+    const subjects = [
+      resolveMcpCapabilitySubject({
+        identity: baseIdentity,
+        isOnboarding: false,
+        agent: null,
+      }),
+      resolveMcpCapabilitySubject({
+        identity: baseIdentity,
+        isOnboarding: false,
+        agent: agentSnapshot({ status: 'inactive' }),
+      }),
+      resolveMcpCapabilitySubject({
+        identity: baseIdentity,
+        isOnboarding: false,
+        agent: agentSnapshot({ ownerId: 'other-user' }),
+      }),
+    ];
+
+    for (const subject of subjects) {
+      expect(subject.profile).toBe('invalid_agent');
+      expect(policy.visibleToolNames(subject, [
+        'register_agent',
+        'list_agents',
+        'update_agent',
+        'delete_agent',
+        'grant_agent_permission',
+        'revoke_agent_permission',
+      ])).toEqual([]);
     }
   });
 });

--- a/packages/protocol/src/participant-agents/application/agent.tools.ts
+++ b/packages/protocol/src/participant-agents/application/agent.tools.ts
@@ -64,7 +64,11 @@ function ensureAgentScopedAccess(context: { agentId?: string }, requestedAgentId
 function sanitizeAgentForOutput<T extends { transports?: Array<{ channel: string; config: Record<string, unknown> }> }>(agent: T): T {
   return {
     ...agent,
-    transports: agent.transports,
+    // Transport config carries private connection material (endpoint secrets,
+    // auth headers/tokens). It is never projected to ANY MCP caller — including
+    // the agent reading its own record via read_own_agent (IND-599). Channel,
+    // priority, and health metadata remain visible; config is fully redacted.
+    transports: agent.transports?.map((transport) => ({ ...transport, config: {} })),
   };
 }
 
@@ -148,6 +152,36 @@ export function createAgentTools(defineTool: DefineTool, deps: AgentToolDeps) {
       } catch (err) {
         logger.error('Failed to register agent', { err });
         return error('Failed to register agent. Please try again.');
+      }
+    },
+  });
+
+  const readOwnAgent = defineTool({
+    name: 'read_own_agent',
+    description:
+      "Read the calling agent's own registration record \u2014 its identity, " +
+      'transports, and granted permissions. Returns only the authenticated ' +
+      'agent\u2019s own record; no other agent can be named or targeted. Use this ' +
+      'when an agent needs to inspect its own configuration.',
+    querySchema: z.object({}),
+    handler: async ({ context }) => {
+      // Defense-in-depth: the capability policy only admits registered active
+      // agent principals here, but never trust the caller — require an agent
+      // context and resolve strictly the caller's OWN record (no target input).
+      if (!context.agentId) {
+        return error('read_own_agent is only available to a registered agent principal.');
+      }
+
+      try {
+        const agent = await agentDb.getAgentWithRelations(context.agentId);
+        if (!agent || agent.ownerId !== context.userId) {
+          return error('Agent not found');
+        }
+
+        return success({ agent: sanitizeAgentForOutput(agent) });
+      } catch (err) {
+        logger.error('Failed to read own agent', { err });
+        return error('Failed to read agent. Please try again.');
       }
     },
   });
@@ -351,6 +385,7 @@ export function createAgentTools(defineTool: DefineTool, deps: AgentToolDeps) {
   });
 
   return [
+    readOwnAgent,
     registerAgent,
     listAgents,
     updateAgent,

--- a/packages/protocol/src/participant-agents/application/index.ts
+++ b/packages/protocol/src/participant-agents/application/index.ts
@@ -6,9 +6,11 @@
  *
  * ## Foreground adapters (participant-directed, authenticated)
  *
- * - {@link createAgentTools} — `register_agent`, `list_agents`, `update_agent`,
- *   `delete_agent`, `grant_agent_permission`, `revoke_agent_permission` MCP
- *   tools for the authenticated registration and permission management path.
+ * - {@link createAgentTools} — `read_own_agent`, `register_agent`,
+ *   `list_agents`, `update_agent`, `delete_agent`, `grant_agent_permission`,
+ *   `revoke_agent_permission` MCP tools for the authenticated registration
+ *   and permission management path (IND-599: `read_own_agent` is the
+ *   agent-principal self-read; the rest are human owner/admin actions).
  *
  * ## Boundary
  *

--- a/packages/protocol/src/shared/agent/tool.runtime.ts
+++ b/packages/protocol/src/shared/agent/tool.runtime.ts
@@ -52,6 +52,7 @@ const FAST_TOOLS = new Set([
   "get_profile_run",
   "cancel_profile_run",
   "remove_contact",
+  "read_own_agent",
   "register_agent",
   "list_agents",
   "update_agent",

--- a/services/api/CHANGELOG.md
+++ b/services/api/CHANGELOG.md
@@ -10,6 +10,23 @@ section before promoting to `main`).
 ## [Unreleased]
 
 ### Added
+- Prove the IND-599 agent-administration split end-to-end at the MCP transport
+  (IND-599; protocol 7.7.0, API 0.63.0). New DB-free `tests/mcp.spec.ts`
+  evidence: registered agents list/call only `read_own_agent` (empty input
+  schema, forged-target argument never queried, own sanitized record only)
+  while every human admin tool is capability-denied before any context-DB read
+  or scoped-deps creation; session humans retain the full owned-agent admin
+  surface but never `read_own_agent`; enrollment-capable keys advertise exactly
+  `['register_agent']` across the whole registry and are denied schema-valid
+  representative tools of every access class (authenticated/permission/
+  informational/delivery_only/human_only) with zero resource work; plain
+  unregistered keys fail closed. Owned-versus-foreign handler matrix proves
+  each target-bearing mutation (`update`/`delete`/`grant`/`revoke`) persists
+  exactly once for an owned target and never for a foreign one (opaque "not
+  found"), `list_agents` queries only the caller's own userId, and transport
+  `config` secrets never leak from any agent projection. No API runtime source
+  change; version moves with the protocol floor (7.7.0).
+
 - Enforce explicit owner-issued approval for agent-driven opportunity `send`/`accept`/
   `reject` transitions and add the session-only issuance route
   `POST /api/opportunities/:id/owner-approvals` (IND-593; protocol 7.6.0, API 0.62.0).

--- a/services/api/package.json
+++ b/services/api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@indexnetwork/api",
-  "version": "0.62.0",
+  "version": "0.63.0",
   "license": "MIT",
   "private": true,
   "scripts": {

--- a/services/api/tests/mcp.spec.ts
+++ b/services/api/tests/mcp.spec.ts
@@ -418,7 +418,10 @@ describe('MCP Server Factory', () => {
 
     expect(response.error).toBeUndefined();
     expect(names).toContain('create_intent');
-    expect(names).toContain('list_agents');
+    // IND-599: a registered agent's agent-admin surface is read_own_agent only
+    // — never list_agents (human admin view) or any mutation.
+    expect(names).toContain('read_own_agent');
+    expect(names).not.toContain('list_agents');
     expect(names).toContain('read_docs');
     expect(names).not.toContain('update_agent');
     expect(names).not.toContain('discover_opportunities');
@@ -2518,5 +2521,487 @@ describe('MCP Server Factory', () => {
     const respondPayload = JSON.parse(respond.text) as { success: boolean; error?: string };
     expect(respondPayload.success).toBe(false);
     expect(respondPayload.error).toMatch(/negotiation not found/i);
+  });
+
+  // ── IND-599: agent administration authorization policy ────────────────────
+  //
+  // Canonical read_own_agent is available ONLY to a registered active agent and
+  // returns that agent's OWN sanitized record. Its input schema is empty — there
+  // is no target selector, so a caller can never name another agent. Session
+  // humans get list_agents plus owned-only register/update/delete/grant/revoke
+  // and NEVER read_own_agent. Enrollment-capable unregistered keys get
+  // register_agent only. Plain unregistered keys fail closed. Every denial is
+  // enforced at the capability layer (MCP_CAPABILITY_DENIED) BEFORE any context
+  // DB read, scoped-deps creation, or handler work — proven with a read-guarded
+  // context database (guardReads) and a throwing scoped-deps factory
+  // (scopedThrows). All tools/call payloads are SCHEMA-VALID (snake_case
+  // agent_id / scope_id / permission_id, canonical `actions` array) so the SDK
+  // schema passes and the policy layer is the thing under test.
+
+  /** The canonical self-read tool, available only to registered agents. */
+  const AGENT_SELF_TOOL = 'read_own_agent';
+  /** Admin list + mutations reserved for session humans (never for agents). */
+  const HUMAN_ADMIN_TOOLS = ['register_agent', 'list_agents', 'update_agent', 'delete_agent', 'grant_agent_permission', 'revoke_agent_permission'] as const;
+  /** Every agent-admin tool in the matrix (self-read plus human admin surface). */
+  const ALL_AGENT_ADMIN_TOOLS = [AGENT_SELF_TOOL, ...HUMAN_ADMIN_TOOLS] as const;
+  const OWNED_AGENT_ID = 'agent-owned';
+  const FOREIGN_AGENT_ID = 'agent-foreign';
+  /** Private transport connection material that must NEVER appear in any tool output. */
+  const SENSITIVE_TRANSPORT_SECRET = 'sk-transport-super-secret-token-599';
+
+  /** Schema-valid tools/call arguments for every human admin tool. */
+  const HUMAN_ADMIN_CALLS = [
+    { tool: 'register_agent', args: { name: 'New Agent' } },
+    { tool: 'list_agents', args: {} },
+    { tool: 'update_agent', args: { agent_id: OWNED_AGENT_ID, name: 'Renamed' } },
+    { tool: 'delete_agent', args: { agent_id: OWNED_AGENT_ID } },
+    { tool: 'grant_agent_permission', args: { agent_id: OWNED_AGENT_ID, actions: ['manage:intents'], scope: 'global' } },
+    { tool: 'revoke_agent_permission', args: { agent_id: OWNED_AGENT_ID, permission_id: 'permission-1' } },
+  ] as const;
+
+  /** A full agent record owned by the given user. */
+  const agentRecord = (agentId: string, ownerId: string) => ({
+    id: agentId,
+    ownerId,
+    name: ownerId === 'test-user-id' ? 'Owned Agent' : 'Foreign Agent',
+    description: null,
+    type: 'external' as const,
+    status: 'active' as const,
+    metadata: {},
+    createdAt: new Date('2026-01-01T00:00:00.000Z'),
+    updatedAt: new Date('2026-01-01T00:00:00.000Z'),
+    // A live transport whose config carries private connection material — the
+    // sanitizer must project the transport (safe shape) with config redacted.
+    transports: [{
+      id: 'transport-1',
+      agentId,
+      channel: 'mcp' as const,
+      config: { endpoint: 'https://agent.example/mcp', authToken: SENSITIVE_TRANSPORT_SECRET },
+      priority: 0,
+      active: true,
+      failureCount: 0,
+    }],
+    permissions: ownerId === 'test-user-id'
+      ? [{
+          id: 'permission-1',
+          agentId,
+          userId: ownerId,
+          scope: 'global' as const,
+          scopeId: null,
+          actions: ['manage:intents'],
+          createdAt: new Date('2026-01-01T00:00:00.000Z'),
+        }]
+      : [],
+  });
+
+  /**
+   * Agent registry that resolves the caller's OWN active record and records
+   * exactly which agentId each lookup received, so a read_own_agent call can be
+   * shown to read the caller's own id (context.agentId) and never a forged
+   * target smuggled through the (empty) tool arguments.
+   */
+  const ownedAgentDb = (resolvedIds?: string[]): AgentDatabase => ({
+    ...mockAgentDb,
+    getAgent: async (id: string) => { resolvedIds?.push(id); return agentRecord(id, 'test-user-id'); },
+    getAgentWithRelations: async (id: string) => { resolvedIds?.push(id); return agentRecord(id, 'test-user-id'); },
+  });
+
+  /** Agent registry whose records are owned by another user (foreign). */
+  const foreignAgentDb = (): AgentDatabase => ({
+    ...mockAgentDb,
+    getAgent: async (id: string) => agentRecord(id, 'other-user-id'),
+    getAgentWithRelations: async (id: string) => agentRecord(id, 'other-user-id'),
+  });
+
+  it('registered agent tools/list exposes only read_own_agent — no admin, no domain admin', async () => {
+    const names = await listToolNamesFor({
+      identity: { userId: 'test-user-id', agentId: OWNED_AGENT_ID },
+      agentDatabase: ownedAgentDb(),
+    });
+    // read_own_agent is the ONLY agent-admin tool a registered agent may see.
+    expect(names).toContain(AGENT_SELF_TOOL);
+    for (const tool of HUMAN_ADMIN_TOOLS) {
+      expect(names, `${tool} must be hidden from a registered agent`).not.toContain(tool);
+    }
+  });
+
+  it('read_own_agent input schema is empty — there is no caller-selectable target', async () => {
+    clearMcpToolMetadataCacheForTests();
+    const server = createMcpServer(
+      { ...mockDeps, database: resolvedContextDatabase, agentDatabase: ownedAgentDb() },
+      {
+        resolveIdentity: async () => ({ userId: 'test-user-id', agentId: OWNED_AGENT_ID }),
+        resolveUserId: async () => 'test-user-id',
+      } as McpAuthResolver,
+      mockScopedDepsFactory,
+    );
+    const response = await invokeMcpRequest({ server, method: 'tools/list', headers: { 'x-api-key': 'agent-key' } });
+    const tool = response.result?.tools?.find((t) => t.name === AGENT_SELF_TOOL) as
+      | { name: string; inputSchema?: { properties?: Record<string, unknown> } }
+      | undefined;
+    expect(tool, 'read_own_agent must be advertised to a registered agent').toBeDefined();
+    // No properties → no agent_id / target field the caller could set.
+    expect(Object.keys(tool?.inputSchema?.properties ?? {})).toEqual([]);
+  });
+
+  it('read_own_agent returns the caller\u2019s own sanitized record, reading only context.agentId', async () => {
+    const resolvedIds: string[] = [];
+    const result = await callTool({
+      identity: { userId: 'test-user-id', agentId: OWNED_AGENT_ID },
+      agentDatabase: ownedAgentDb(resolvedIds),
+      toolName: AGENT_SELF_TOOL,
+      // A forged target in the arguments is stripped by the empty input schema.
+      arguments: { agent_id: FOREIGN_AGENT_ID },
+    });
+    expect(result.code).not.toBe('MCP_CAPABILITY_DENIED');
+    const payload = parseToolResult(result.text);
+    expect(payload.success).toBe(true);
+    const agent = payload.data?.agent as { id: string; ownerId: string } | undefined;
+    // The record returned is the CALLER's own agent, never the forged target.
+    expect(agent?.id).toBe(OWNED_AGENT_ID);
+    expect(agent?.id).not.toBe(FOREIGN_AGENT_ID);
+    expect(agent?.ownerId).toBe('test-user-id');
+    // Every registry lookup used context.agentId only — the forged FOREIGN id
+    // was never queried.
+    expect(resolvedIds.length).toBeGreaterThan(0);
+    expect(resolvedIds.every((id) => id === OWNED_AGENT_ID)).toBe(true);
+  });
+
+  it('read_own_agent redacts private transport config while preserving the safe response shape', async () => {
+    const result = await callTool({
+      identity: { userId: 'test-user-id', agentId: OWNED_AGENT_ID },
+      agentDatabase: ownedAgentDb(),
+      toolName: AGENT_SELF_TOOL,
+      arguments: {},
+    });
+    const payload = parseToolResult(result.text);
+    expect(payload.success).toBe(true);
+    const agent = payload.data?.agent as {
+      id: string;
+      transports: Array<{ id: string; channel: string; config: Record<string, unknown>; priority: number; active: boolean; failureCount: number }>;
+      permissions: unknown[];
+    };
+    // Safe response shape preserved: the transport row is still projected with
+    // its channel/priority/health fields, and permissions remain visible.
+    expect(agent.transports).toHaveLength(1);
+    expect(agent.transports[0]).toMatchObject({
+      id: 'transport-1',
+      channel: 'mcp',
+      priority: 0,
+      active: true,
+      failureCount: 0,
+    });
+    expect(agent.permissions).toHaveLength(1);
+    // The private field itself is fully redacted…
+    expect(agent.transports[0]!.config).toEqual({});
+    // …and the sensitive VALUE does not leak anywhere in the raw payload.
+    expect(result.text).not.toContain(SENSITIVE_TRANSPORT_SECRET);
+  });
+
+  it('registered agent is denied every human admin tool with MCP_CAPABILITY_DENIED before context DB', async () => {
+    for (const { tool, args } of HUMAN_ADMIN_CALLS) {
+      const counter = { reads: 0 };
+      const result = await callTool({
+        identity: { userId: 'test-user-id', agentId: OWNED_AGENT_ID },
+        agentDatabase: ownedAgentDb(),
+        database: guardReads(counter),
+        scopedThrows: true,
+        toolName: tool,
+        arguments: args,
+      });
+      expect(result.isError, `${tool} must reach policy`).toBe(true);
+      expect(result.code, `${tool} must be MCP_CAPABILITY_DENIED`).toBe('MCP_CAPABILITY_DENIED');
+      expect(counter.reads, `${tool} must deny before context DB`).toBe(0);
+    }
+  });
+
+  it('session human tools/list exposes the full human admin surface but never read_own_agent', async () => {
+    const names = await listToolNamesFor({
+      identity: { userId: 'test-user-id', isSessionAuth: true },
+      headers: { authorization: 'Bearer session-token' },
+    });
+    for (const tool of HUMAN_ADMIN_TOOLS) {
+      expect(names, `${tool} must be visible to a session human`).toContain(tool);
+    }
+    expect(names, 'read_own_agent is agent-only and must be hidden from humans').not.toContain(AGENT_SELF_TOOL);
+  });
+
+  it('session human is admitted to every human admin tool; the handler owns the owned-only check', async () => {
+    // Policy admits all human admin tools; ownership is a handler concern. Proven
+    // by reaching the handler with an owned fixture (no capability denial).
+    for (const { tool, args } of HUMAN_ADMIN_CALLS) {
+      const result = await callTool({
+        identity: { userId: 'test-user-id', isSessionAuth: true },
+        headers: { authorization: 'Bearer session-token' },
+        agentDatabase: ownedAgentDb(),
+        toolName: tool,
+        arguments: args,
+      });
+      expect(result.code, `${tool} must not be MCP_CAPABILITY_DENIED`).not.toBe('MCP_CAPABILITY_DENIED');
+    }
+  });
+
+  it('session human read_own_agent is denied at the capability layer before context DB', async () => {
+    const counter = { reads: 0 };
+    const result = await callTool({
+      identity: { userId: 'test-user-id', isSessionAuth: true },
+      headers: { authorization: 'Bearer session-token' },
+      database: guardReads(counter),
+      scopedThrows: true,
+      toolName: AGENT_SELF_TOOL,
+      arguments: {},
+    });
+    expect(result.isError).toBe(true);
+    expect(result.code).toBe('MCP_CAPABILITY_DENIED');
+    expect(counter.reads, 'read_own_agent denial must precede any context DB read').toBe(0);
+  });
+
+  it('session human mutating a FOREIGN agent is admitted by policy but rejected by the handler (not a policy denial)', async () => {
+    // Owned-vs-foreign is a handler distinction: the policy admits the call, and
+    // the handler returns "Agent not found" for another user's agent.
+    const result = await callTool({
+      identity: { userId: 'test-user-id', isSessionAuth: true },
+      headers: { authorization: 'Bearer session-token' },
+      agentDatabase: foreignAgentDb(),
+      toolName: 'update_agent',
+      arguments: { agent_id: FOREIGN_AGENT_ID, name: 'Hijacked' },
+    });
+    expect(result.code).not.toBe('MCP_CAPABILITY_DENIED');
+    const payload = parseToolResult(result.text);
+    expect(payload.success).toBe(false);
+    expect(payload.error).toMatch(/not found/i);
+  });
+
+  /** Persistence/mutation call counters for the owned-vs-foreign handler matrix. */
+  type MutationCounts = { updates: number; deletes: number; grants: number; revokes: number };
+  const zeroMutations = (): MutationCounts => ({ updates: 0, deletes: 0, grants: 0, revokes: 0 });
+
+  /**
+   * Agent registry whose records belong to `ownerId` and whose every mutation
+   * method increments a counter — proving foreign targets are rejected BEFORE
+   * persistence while owned targets reach exactly one mutation.
+   */
+  const auditedAgentDb = (
+    ownerId: string,
+    counts: MutationCounts,
+    listRequestedUserIds?: string[],
+  ): AgentDatabase => ({
+    ...mockAgentDb,
+    getAgent: async (id: string) => agentRecord(id, ownerId),
+    getAgentWithRelations: async (id: string) => agentRecord(id, ownerId),
+    listAgentsForUser: async (userId: string) => {
+      listRequestedUserIds?.push(userId);
+      return [agentRecord(OWNED_AGENT_ID, userId)];
+    },
+    updateAgent: async (id: string) => { counts.updates += 1; return agentRecord(id, ownerId); },
+    deleteAgent: async () => { counts.deletes += 1; },
+    grantPermission: async () => {
+      counts.grants += 1;
+      return {
+        id: 'permission-2',
+        agentId: OWNED_AGENT_ID,
+        userId: 'test-user-id',
+        scope: 'global' as const,
+        scopeId: null,
+        actions: ['manage:intents'],
+        createdAt: new Date('2026-01-01T00:00:00.000Z'),
+      };
+    },
+    revokePermission: async () => { counts.revokes += 1; },
+  });
+
+  it('list_agents queries ONLY the caller\u2019s own userId and returns no foreign record (and no transport secrets)', async () => {
+    const requestedUserIds: string[] = [];
+    const counts = zeroMutations();
+    const result = await callTool({
+      identity: { userId: 'test-user-id', isSessionAuth: true },
+      headers: { authorization: 'Bearer session-token' },
+      agentDatabase: auditedAgentDb('test-user-id', counts, requestedUserIds),
+      toolName: 'list_agents',
+      arguments: {},
+    });
+    const payload = parseToolResult(result.text);
+    expect(payload.success).toBe(true);
+    // The registry lookup is keyed strictly by the authenticated caller.
+    expect(requestedUserIds).toEqual(['test-user-id']);
+    const agents = payload.data?.agents as Array<{ id: string; ownerId: string }>;
+    expect(agents.length).toBeGreaterThan(0);
+    expect(agents.every((agent) => agent.ownerId === 'test-user-id')).toBe(true);
+    expect(agents.some((agent) => agent.id === FOREIGN_AGENT_ID)).toBe(false);
+    // The list projection is sanitized too — no transport secret leaks.
+    expect(result.text).not.toContain(SENSITIVE_TRANSPORT_SECRET);
+  });
+
+  it('each target-bearing mutation admits an OWNED target and persists exactly once', async () => {
+    const ownedMutations = [
+      { tool: 'update_agent', args: { agent_id: OWNED_AGENT_ID, name: 'Renamed' }, count: (c: MutationCounts) => c.updates },
+      { tool: 'delete_agent', args: { agent_id: OWNED_AGENT_ID }, count: (c: MutationCounts) => c.deletes },
+      { tool: 'grant_agent_permission', args: { agent_id: OWNED_AGENT_ID, actions: ['manage:intents'], scope: 'global' }, count: (c: MutationCounts) => c.grants },
+      { tool: 'revoke_agent_permission', args: { agent_id: OWNED_AGENT_ID, permission_id: 'permission-1' }, count: (c: MutationCounts) => c.revokes },
+    ] as const;
+
+    for (const { tool, args, count } of ownedMutations) {
+      const counts = zeroMutations();
+      const result = await callTool({
+        identity: { userId: 'test-user-id', isSessionAuth: true },
+        headers: { authorization: 'Bearer session-token' },
+        agentDatabase: auditedAgentDb('test-user-id', counts),
+        toolName: tool,
+        arguments: args,
+      });
+      const payload = parseToolResult(result.text);
+      expect(payload.success, `${tool} must admit the owned target`).toBe(true);
+      expect(count(counts), `${tool} must persist exactly once for the owned target`).toBe(1);
+      const others = counts.updates + counts.deletes + counts.grants + counts.revokes - count(counts);
+      expect(others, `${tool} must not trigger unrelated mutations`).toBe(0);
+    }
+  });
+
+  it('each target-bearing mutation rejects a FOREIGN target with zero persistence', async () => {
+    const foreignMutations = [
+      { tool: 'update_agent', args: { agent_id: FOREIGN_AGENT_ID, name: 'Hijacked' } },
+      { tool: 'delete_agent', args: { agent_id: FOREIGN_AGENT_ID } },
+      { tool: 'grant_agent_permission', args: { agent_id: FOREIGN_AGENT_ID, actions: ['manage:intents'], scope: 'global' } },
+      { tool: 'revoke_agent_permission', args: { agent_id: FOREIGN_AGENT_ID, permission_id: 'permission-1' } },
+    ] as const;
+
+    for (const { tool, args } of foreignMutations) {
+      const counts = zeroMutations();
+      const result = await callTool({
+        identity: { userId: 'test-user-id', isSessionAuth: true },
+        headers: { authorization: 'Bearer session-token' },
+        agentDatabase: auditedAgentDb('other-user-id', counts),
+        toolName: tool,
+        arguments: args,
+      });
+      expect(result.code, `${tool} is admitted by policy (ownership is a handler concern)`).not.toBe('MCP_CAPABILITY_DENIED');
+      const payload = parseToolResult(result.text);
+      expect(payload.success, `${tool} must reject the foreign target`).toBe(false);
+      expect(payload.error, `${tool} must not reveal the foreign record`).toMatch(/not found/i);
+      expect(counts.updates + counts.deletes + counts.grants + counts.revokes, `${tool} must never persist for a foreign target`).toBe(0);
+    }
+  });
+
+  it('enrollment-capable unregistered key sees only register_agent (no read_own_agent, no admin)', async () => {
+    clearMcpToolMetadataCacheForTests();
+    const server = createMcpServer(
+      { ...mockDeps, database: resolvedContextDatabase },
+      {
+        resolveIdentity: async () => ({ userId: 'test-user-id', enrollmentCapable: true }),
+        resolveUserId: async () => 'test-user-id',
+      } as McpAuthResolver,
+      mockScopedDepsFactory,
+    );
+    const response = await invokeMcpRequest({
+      server,
+      method: 'tools/list',
+      headers: { 'x-api-key': 'enrollment-key' },
+    });
+    const names = response.result?.tools?.map((tool) => tool.name) ?? [];
+    // Whole-registry proof: the enrollment credential is single-purpose. Across
+    // the ENTIRE MCP registry — domain, informational, delivery, and admin —
+    // exactly one tool is advertised.
+    expect(names).toEqual(['register_agent']);
+  });
+
+  it('enrollment-capable key is denied representative domain tools of every access class before any resource', async () => {
+    // Schema-valid calls across authenticated / permission / informational /
+    // delivery_only / human_only access classes: each is denied at the
+    // capability layer with zero context-DB reads and zero scoped-deps
+    // creation — no adapter or resource work is reachable.
+    const enrollmentDomainCalls = [
+      { tool: 'read_intents', args: {} },
+      { tool: 'create_intent', args: { description: 'A specific valid discovery intent' } },
+      { tool: 'read_docs', args: {} },
+      { tool: 'confirm_opportunity_delivery', args: { opportunityId: '00000000-0000-4000-8000-000000000001', trigger: 'ambient' } },
+      // human_only representative registered on this surface (chat-history tools
+      // are chat-session-only and never in this MCP registry).
+      { tool: 'record_onboarding_privacy_consent', args: { publicProfileLookupGranted: true } },
+    ] as const;
+
+    for (const { tool, args } of enrollmentDomainCalls) {
+      const counter = { reads: 0 };
+      const result = await callTool({
+        identity: { userId: 'test-user-id', enrollmentCapable: true },
+        database: guardReads(counter),
+        scopedThrows: true,
+        toolName: tool,
+        arguments: args,
+        headers: { 'x-api-key': 'enrollment-key' },
+      });
+      expect(result.isError, `${tool} must reach policy`).toBe(true);
+      expect(result.code, `${tool} must be MCP_CAPABILITY_DENIED`).toBe('MCP_CAPABILITY_DENIED');
+      expect(counter.reads, `${tool} must deny before context DB`).toBe(0);
+      expect(result.scopedCreateArgs, `${tool} must never create scoped deps`).toEqual([]);
+    }
+  });
+
+  it('enrollment-capable key is denied read_own_agent and every non-register admin tool before context DB', async () => {
+    const deniedForEnrollment = [
+      { tool: AGENT_SELF_TOOL, args: {} },
+      { tool: 'list_agents', args: {} },
+      { tool: 'update_agent', args: { agent_id: OWNED_AGENT_ID } },
+      { tool: 'delete_agent', args: { agent_id: OWNED_AGENT_ID } },
+      { tool: 'grant_agent_permission', args: { agent_id: OWNED_AGENT_ID, actions: ['manage:intents'], scope: 'global' } },
+      { tool: 'revoke_agent_permission', args: { agent_id: OWNED_AGENT_ID, permission_id: 'permission-1' } },
+    ] as const;
+
+    for (const { tool, args } of deniedForEnrollment) {
+      const counter = { reads: 0 };
+      const result = await callTool({
+        identity: { userId: 'test-user-id', enrollmentCapable: true },
+        database: guardReads(counter),
+        scopedThrows: true,
+        toolName: tool,
+        arguments: args,
+        headers: { 'x-api-key': 'enrollment-key' },
+      });
+      expect(result.isError, `${tool} must reach policy`).toBe(true);
+      expect(result.code, `${tool} must be MCP_CAPABILITY_DENIED`).toBe('MCP_CAPABILITY_DENIED');
+      expect(counter.reads, `${tool} must deny before context DB`).toBe(0);
+    }
+  });
+
+  it('plain unregistered key fails closed on every agent-admin tool with MCP_CAPABILITY_DENIED before context DB', async () => {
+    const failClosedCalls = [
+      { tool: AGENT_SELF_TOOL, args: {} },
+      ...HUMAN_ADMIN_CALLS,
+    ] as const;
+
+    for (const { tool, args } of failClosedCalls) {
+      const counter = { reads: 0 };
+      const result = await callTool({
+        identity: { userId: 'test-user-id' },
+        database: guardReads(counter),
+        scopedThrows: true,
+        toolName: tool,
+        arguments: args,
+        headers: { 'x-api-key': 'ordinary-key' },
+      });
+      expect(result.isError, `${tool} must reach policy`).toBe(true);
+      expect(result.code, `${tool} must be MCP_CAPABILITY_DENIED`).toBe('MCP_CAPABILITY_DENIED');
+      expect(counter.reads, `${tool} must deny before context DB`).toBe(0);
+    }
+  });
+
+  it('plain unregistered key sees zero agent-admin tools in tools/list', async () => {
+    clearMcpToolMetadataCacheForTests();
+    const server = createMcpServer(
+      { ...mockDeps, database: resolvedContextDatabase },
+      {
+        resolveIdentity: async () => ({ userId: 'test-user-id' }),
+        resolveUserId: async () => 'test-user-id',
+      } as McpAuthResolver,
+      mockScopedDepsFactory,
+    );
+    const response = await invokeMcpRequest({
+      server,
+      method: 'tools/list',
+      headers: { 'x-api-key': 'ordinary-key' },
+    });
+    const names = response.result?.tools?.map((tool) => tool.name) ?? [];
+    for (const tool of ALL_AGENT_ADMIN_TOOLS) {
+      expect(names, `${tool} must be hidden`).not.toContain(tool);
+    }
   });
 });


### PR DESCRIPTION
## Summary

Implements the accepted IND-599 contract on the MCP surface (base `492cf109` — byte-identical seven-file base cycle caveat recorded below):

- **Registered active agents** (global/network/delivery): within `MCP_AGENT_ADMIN_TOOLS`, see/call **only** the new canonical `read_own_agent` — their own sanitized record, empty input schema, no target selector; `list_agents` and every admin mutation are denied (`agent_admin_denied`). Canonical permission/network-scope domain tools, `read_docs`, and delivery behavior are **unchanged**.
- **Session/onboarding humans**: full owned-agent administration (`register_agent`, `list_agents`, `update_agent`, `delete_agent`, `grant_agent_permission`, `revoke_agent_permission`), never `read_own_agent` (`human_read_own_agent_denied`).
- **Enrollment-capable unregistered keys**: whole-registry `register_agent`-only.
- **Plain unregistered keys**: fail closed.
- The `agent_admin` decision is made **before** the session-human blanket allow; all denials fire before any context-DB read or scoped-deps creation.
- `sanitizeAgentForOutput` now redacts private transport `config` (endpoint secrets/auth tokens) from every agent projection while preserving the safe response shape.
- Docs: `src/README.md` tool inventory (+ MCP-surface footnote) and `IMPLEMENTATION.md` capability-gate description updated to the canonical matrix (no `scrape_url`/contacts/aliases advertised as MCP tools).

## Versions

- `@indexnetwork/protocol` 7.6.0 → **7.7.0** (new public tool name + behavior tightening; changelog updated)
- `@indexnetwork/api` 0.62.0 → **0.63.0** (transport-proof tests; moves with protocol floor; changelog updated)
- Root `bun.lock` untouched — integration owner reconciles deliberately.

## Evidence

| Gate | Result |
|---|---|
| protocol `mcp.authorization-policy.spec.ts` + `agent.tools.canonical-actions.spec.ts` | **47 pass / 0 fail** (305 expects) |
| API `tests/mcp.spec.ts` (DB-free) | **72 pass / 0 fail** (610 expects) |
| protocol build / API build (`tsc`) | clean |
| changed-path `eslint` | clean |
| `architecture:exports` | OK (385 exports) |
| `architecture:consumer` / `host-isolation` / `capabilities` | OK |
| `architecture:artifacts` | OK (799 files) |
| `test:architecture` | 18 pass / 0 fail |
| `architecture:cycles` | fails **only** on the documented pre-existing integration-base negotiation/question cycle; all seven involved modules + checker script verified byte-identical to base `492cf109` |
| `git diff --check` | clean |

Key proofs in the test batch: tools/list ↔ schema-valid tools/call parity per principal; forged-target argument schema-stripped and never queried (instrumented registry); capability denial before context DB/scoped deps/adapters (`guardReads` + throwing scoped factory); whole-registry enrollment/unregistered sweeps over the entire canonical matrix; owned-vs-foreign persistence boundary for each target-bearing mutation (owned persists exactly once, foreign zero with opaque not-found); sensitive transport-secret non-leak fixtures.

## Scope guarantees

- REST/chat surfaces preserved (policy is MCP-only; contacts/scrape/aliases untouched there).
- No blanket agent-domain denial, no `agent_self_read_only`, no permission-machinery changes.
- No DB/data/migration/deployment action; no root `bun.lock` change.

**Draft — do not mark ready or merge.** Root review required.

IND-599