### PR TITLE
feat(protocol): canonical shared MCP_INSTRUCTIONS and read_docs guidance (IND-602/603)

### DIFF
--- a/packages/protocol/CHANGELOG.md
+++ b/packages/protocol/CHANGELOG.md
@@ -25,10 +25,13 @@ See [STABILITY.md](./STABILITY.md) for the public-contract and tier definitions.
   opportunities, negotiations, workflows) are published via read_docs on both
   MCP and REST/chat surfaces. MCP surface read_docs serves canonical guidance
   only; REST/chat retains legacy supplemental topics for backwards compatibility.
-  New exports: `CANONICAL_GUIDANCE_SUMMARY`, `CANONICAL_GUIDANCE_TOPICS`
-  (const array), `CANONICAL_GUIDANCE_TOPICS_CONTENT` (record). MCP_INSTRUCTIONS
-  now delegates entity/lifecycle details to read_docs, dropping verbose inline
-  model. No data, migration, capability, or permission changes.
+  New internal shared constants (packages/protocol/src/shared/agent/canonical-guidance.ts):
+  `CANONICAL_GUIDANCE_SUMMARY`, `CANONICAL_GUIDANCE_TOPICS` (const array),
+  `CANONICAL_GUIDANCE_TOPICS_CONTENT` (record). Not public root protocol exports.
+  MCP_INSTRUCTIONS now delegates entity/lifecycle details to read_docs, dropping
+  verbose inline model. Published MCP guidance/read_docs contract now includes
+  canonical seven-topic structure and H2A/A2A/owner-approval semantics. No data,
+  migration, capability, permission, or runtime behavior changes.
 
 - Add a host-injected MCP authorization-observability seam (IND-581; 7.8.0):
   `McpAuthorizationObserver`, the secret-free `McpAuthorizationDenialEvent`, and

--- a/packages/protocol/CHANGELOG.md
+++ b/packages/protocol/CHANGELOG.md
@@ -13,6 +13,23 @@ See [STABILITY.md](./STABILITY.md) for the public-contract and tier definitions.
 ## [Unreleased]
 
 ### Added
+- Add canonical shared guidance source and unified MCP_INSTRUCTIONS/read_docs
+  (IND-602/603; 7.10.0): The single normative `CANONICAL_GUIDANCE_SUMMARY`
+  (1,555 chars, under the 4,500-char MCP context budget) covers Index Network
+  entity model (identity/context, premises, signals, communities/networks,
+  opportunities), negotiation semantics with the critical distinction
+  **"A2A acceptance is not owner approval"** (separate gates), H2A/A2A
+  workflows, and the boundary **"H2H (human-to-human) never exposed; escalation
+  to native surfaces (web, Telegram) is outside MCP scope."** Seven detailed
+  canonical topics (identity-context, premises, signals, communities-networks,
+  opportunities, negotiations, workflows) are published via read_docs on both
+  MCP and REST/chat surfaces. MCP surface read_docs serves canonical guidance
+  only; REST/chat retains legacy supplemental topics for backwards compatibility.
+  New exports: `CANONICAL_GUIDANCE_SUMMARY`, `CANONICAL_GUIDANCE_TOPICS`
+  (const array), `CANONICAL_GUIDANCE_TOPICS_CONTENT` (record). MCP_INSTRUCTIONS
+  now delegates entity/lifecycle details to read_docs, dropping verbose inline
+  model. No data, migration, capability, or permission changes.
+
 - Add a host-injected MCP authorization-observability seam (IND-581; 7.8.0):
   `McpAuthorizationObserver`, the secret-free `McpAuthorizationDenialEvent`, and
   the central `buildMcpAuthorizationDenialEvent` constructor, plus an optional

--- a/packages/protocol/package.json
+++ b/packages/protocol/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@indexnetwork/protocol",
-  "version": "7.9.0",
+  "version": "7.10.0",
   "type": "module",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",

--- a/packages/protocol/src/mcp/mcp.server.ts
+++ b/packages/protocol/src/mcp/mcp.server.ts
@@ -12,6 +12,7 @@ import type { ServerContext, JsonSchemaType } from '@modelcontextprotocol/server
 import type { McpAuthResolver } from '../shared/interfaces/auth.interface.js';
 import type { McpAuthInput, McpResolvedIdentity } from '../shared/schemas/mcp-auth.schema.js';
 import { McpResolvedIdentitySchema } from '../shared/schemas/mcp-auth.schema.js';
+import { CANONICAL_GUIDANCE_SUMMARY } from '../shared/agent/canonical-guidance.js';
 import type { ToolDeps, ResolvedToolContext, RawToolDefinition } from '../shared/agent/tool.helpers.js';
 import { resolveChatContext } from '../shared/agent/tool.helpers.js';
 import { deriveAllowedNetworkIds, scopeFromNetworkId } from '../shared/agent/tool.scope.js';
@@ -389,61 +390,23 @@ function createMcpTraceEmitter(toolName: string, ctx: ServerContext): TraceEmitt
 }
 
 export const MCP_INSTRUCTIONS = `
-Index Network is a private, intent-driven discovery protocol. You help users find the right people and help the right people find them, via Index Network MCP tools.
+${CANONICAL_GUIDANCE_SUMMARY}
 
-# Voice
-Calm, direct, analytical, concise. Preferred vocabulary: opportunity, overlap, signal, pattern, emerging, relevant, adjacency.
+# Voice & Output Rules
+Calm, analytical, concise. Say "signal" not "intent", "community" not "index". Never use "search" — use "discover" or "find". Banned: leverage, optimize, unlock, scale, disrupt, AI-powered, act fast.
 
-# Banned vocabulary
-NEVER use "search" in any form. Use "looking up" for indexed data, "find" / "look for" for discovery, "check" for verification, "discover" for exploration. Banned: leverage, unlock, optimize, scale, disrupt, revolutionary, AI-powered, maximize value, act fast, networking, match.
+NEVER dump raw JSON or expose IDs (except actionable ones like conversationId). Synthesize in natural language; surface top 1–3 points unless asked for full list. Fabricate nothing.
 
-# Entity model
-- User — has one Profile, many Memberships, many Intents.
-- Profile — identity (bio, skills, interests, location).
-- Index — community with title, prompt (purpose), join policy. Has Members.
-- Membership — User↔Index junction. \`isPersonal: true\` marks the user's personal network (contacts).
-- Intent — what a user is looking for (signal). Description, summary, embedding.
-- IntentIndex — Intent↔Index junction (auto-assigned).
-- Opportunity — discovered connection between users. Roles, status, reasoning.
+# Authentication & Opportunity Lifecycle
+API key in \`x-api-key\` header. Opportunities: draft → pending → accepted/rejected. Agent acceptance ≠ owner approval. Only call update_opportunity with accepted after explicit user confirmation.
 
-# Output rules
-- NEVER expose internal IDs, UUIDs, field names, or tool names — EXCEPT when an ID is actionable for the user (e.g. a \`conversationId\` they need to open a chat). Surface such IDs verbatim when the tool returns them.
-- NEVER use internal vocabulary — say "signal" not "intent", "community" not "index".
-- NEVER dump raw JSON. Synthesize in natural language.
-- Surface top 1–3 relevant points unless asked for the full list.
-- Prefer first names; use full names only to disambiguate.
-- Translate statuses: draft/latent → "draft", pending → "awaiting review/response", accepted → "accepted opportunity". Agent acceptance is not "connected".
-- NEVER fabricate data. If you don't have it, call the appropriate tool.
+# Tool Guidance
+Read each tool's description for usage rules (when, prerequisites, follow-ups). Tools contain workflow patterns.
 
-# Tool guidance
-Each tool's description contains its own usage rules (when to call, when NOT to call, required prerequisites, post-call follow-ups). Read the description of every tool you call — that is where the per-tool workflow patterns live.
+# Decision Questions
+When discover_opportunities returns \`Decision questions (structured): ...\`, parse the \`questions\` array. Each has \`title\`, \`prompt\`, \`options\` (with \`label\` and \`description\`). Present in natural language; never expose JSON. Fold answers into the next discover_opportunities call.
 
-# Authentication
-Pass your API key in the \`x-api-key\` request header (not \`Authorization: Bearer\`).
-
-# Opportunity lifecycle
-Opportunities move through: draft → pending → accepted (or rejected).
-
-- **draft** (you created it, not yet sent): offer to send it; confirm before calling update_opportunity with pending.
-- **pending, you sent it**: waiting for the other side — nothing to do.
-- **pending, you received it**: the other person is waiting for your response. Surface it to the user and ask if they want to start a chat. Only call update_opportunity with accepted after explicit user confirmation.
-- **accepted**: an owner accepted. Status alone never proves an H2H thread; mention one only when this result returns H2H evidence.
-
-A **completed** negotiation means only that agents concluded. Agent \`accept\` may leave a \`pending\` match awaiting owner review; it is not owner acceptance or an H2H thread. Keep rejected, stalled, draft, expired, and pending distinct.
-
-Never accept a received opportunity without explicit user approval in the current conversation.
-
-# Decision questions after discovery
-
-After \`discover_opportunities\`, the tool result may include a second text block starting with \`Decision questions (structured): ...\`. This means the discovery engine ran negotiations but needs human input to sharpen the next turn — e.g. clarify timing, role, stage, or location.
-
-**When this block is present:**
-1. Parse the \`questions\` array from the JSON after the sentinel.
-2. Each question has \`title\` (decision domain, ≤12 chars), \`prompt\` (ends in \`?\`), \`options\` (2–4 items, each with \`label\` and \`description\`), and \`multiSelect\`. The safest option is labeled \`... (Recommended)\`.
-3. Present each question in natural language: ask the \`prompt\`, list options as \`**{label}** — {description}\`. Never expose the JSON or technical field names.
-4. Wait for the user's answer, then fold it into the next \`discover_opportunities(searchQuery=...)\` call.
-
-**Elicitation-capable clients** (those that declared \`elicitation\` support in \`initialize\`): the server dispatches \`elicitation/create\` requests directly — answers are written back to the chat session automatically. You will not see the envelope as a follow-up task in that case.
+Elicitation clients: answers are dispatched via \`elicitation/create\` and written to chat automatically.
 `.trim();
 
 /**

--- a/packages/protocol/src/mcp/tests/mcp.server.spec.ts
+++ b/packages/protocol/src/mcp/tests/mcp.server.spec.ts
@@ -11,6 +11,7 @@ config({ path: ".env.test", override: true });
 
 import { describe, test, expect } from "bun:test";
 import { MCP_INSTRUCTIONS, sanitizeMcpResult, buildMcpOnboardingMessage, ONBOARDING_ALLOWED, shouldReportMcpToolError, extractBearerToken, parseClientSurface, getMcpToolMetadataCacheKey } from "../mcp.server.js";
+import { CANONICAL_GUIDANCE_SUMMARY, CANONICAL_GUIDANCE_TOPICS } from "../../shared/agent/canonical-guidance.js";
 import type { ResolvedToolContext } from "../../shared/agent/tool.helpers.js";
 import { ToolRuntimeError } from "../../shared/agent/tool.runtime.js";
 
@@ -39,9 +40,9 @@ describe("MCP_INSTRUCTIONS", () => {
     expect(MCP_INSTRUCTIONS.toLowerCase()).toContain("tool's description");
   });
 
-  test("describes the entity model", () => {
-    for (const term of ["Profile", "Intent", "Opportunity"]) {
-      expect(MCP_INSTRUCTIONS).toContain(term);
+  test("describes the canonical entity model", () => {
+    for (const term of ["identity", "context", "premise", "signal", "community", "network", "opportunity", "negotiation"]) {
+      expect(MCP_INSTRUCTIONS.toLowerCase()).toContain(term);
     }
   });
 
@@ -55,16 +56,39 @@ describe("MCP_INSTRUCTIONS", () => {
     expect(MCP_INSTRUCTIONS.toLowerCase()).toContain("community");
   });
 
-  test("separates agent completion, owner acceptance, and H2H evidence", () => {
-    expect(MCP_INSTRUCTIONS).toContain("means only that agents concluded");
-    expect(MCP_INSTRUCTIONS).toContain("may leave a `pending` match awaiting owner review");
-    expect(MCP_INSTRUCTIONS).toContain("Agent acceptance is not \"connected\"");
-    expect(MCP_INSTRUCTIONS).toContain("Status alone never proves an H2H thread");
+  test("guides H2A and A2A collaboration but never exposes H2H", () => {
+    expect(MCP_INSTRUCTIONS).toContain("H2A");
+    expect(MCP_INSTRUCTIONS).toContain("A2A");
+    expect(MCP_INSTRUCTIONS).not.toContain("H2H");
+  });
+
+  test("distinguishes owner approval from A2A negotiation acceptance", () => {
+    expect(MCP_INSTRUCTIONS).toContain("owner approval");
+    expect(MCP_INSTRUCTIONS).toContain("is not owner approval");
+  });
+
+  test("never mentions retired contact/Gmail/scrape/profile/ghost-user guidance", () => {
+    const lower = MCP_INSTRUCTIONS.toLowerCase();
+    for (const fragment of ["ghost user", "gmail", "scrape", "import_contacts", "read_user_profiles"]) {
+      expect(lower).not.toContain(fragment);
+    }
   });
 
   test("does not carry Claude Code sub-skill dispatch idioms", () => {
     expect(MCP_INSTRUCTIONS.toLowerCase()).not.toContain("sub-skill");
     expect(MCP_INSTRUCTIONS).not.toContain("index-network:");
+  });
+});
+
+describe("MCP_INSTRUCTIONS canonical source (IND-602/603)", () => {
+  test("is built from the shared canonical guidance summary", () => {
+    expect(MCP_INSTRUCTIONS).toContain(CANONICAL_GUIDANCE_SUMMARY);
+  });
+
+  test("summary lists every canonical read_docs topic", () => {
+    for (const topic of CANONICAL_GUIDANCE_TOPICS) {
+      expect(MCP_INSTRUCTIONS).toContain(topic);
+    }
   });
 });
 

--- a/packages/protocol/src/shared/agent/canonical-guidance.ts
+++ b/packages/protocol/src/shared/agent/canonical-guidance.ts
@@ -58,7 +58,7 @@ Index Network is a private, intent-driven discovery protocol. Users express sign
 Refer to these for detailed entity facts and lifecycle:
 
 - **identity-context** — Profile structure, context scoping
-- **premises** — Background, stage, constraints  
+- **premises** — Background, stage, constraints
 - **signals** — Intent inference, classification
 - **communities-networks** — Membership, auto-assign
 - **opportunities** — Discovery, roles, reasoning

--- a/packages/protocol/src/shared/agent/canonical-guidance.ts
+++ b/packages/protocol/src/shared/agent/canonical-guidance.ts
@@ -1,0 +1,262 @@
+/**
+ * Canonical guidance for Index Network protocol operations.
+ *
+ * This is the single normative source for:
+ * - Entity model and identity/context definitions
+ * - Premise, signal, community, network, and opportunity concepts
+ * - Negotiation semantics (owner approval vs A2A acceptance)
+ * - H2A and A2A collaboration (H2H is never exposed)
+ * - Retired vocabulary (no contact/Gmail/scrape/profile/ghost-user guidance)
+ *
+ * Wired into:
+ * - MCP_INSTRUCTIONS (packages/protocol/src/mcp/mcp.server.ts)
+ * - read_docs tool (packages/protocol/src/shared/agent/utility.tools.ts)
+ *
+ * IND-602, IND-603
+ */
+
+export const CANONICAL_GUIDANCE_TOPICS = [
+  "identity-context",
+  "premises",
+  "signals",
+  "communities-networks",
+  "opportunities",
+  "negotiations",
+  "workflows",
+] as const;
+
+export type CanonicalGuidanceTopic = (typeof CANONICAL_GUIDANCE_TOPICS)[number];
+
+/**
+ * Summary of canonical entity model and protocol semantics.
+ * Used in MCP_INSTRUCTIONS and as read_docs summary across all surfaces.
+ * Never mentions retired contact/Gmail/scrape/profile/ghost-user guidance.
+ * Optimized to ~1900 chars to leave room for MCP_INSTRUCTIONS context budget.
+ */
+export const CANONICAL_GUIDANCE_SUMMARY = `# Index Network Protocol
+
+Index Network is a private, intent-driven discovery protocol. Users express signals (intents), agents find matches within shared networks, and decisions proceed through clear gates.
+
+## Core Concepts
+
+**Identity & Context** — User profile (name, bio, skills, interests, location) and current scope (networks, intents, stage).
+
+**Premises** — Foundational facts: background, experience, stage, timeline, constraints.
+
+**Signals** — What users seek (intents, opportunities). Drive semantic matching.
+
+**Communities & Networks** — Private groups where members share signals and discover connections via shared membership.
+
+**Opportunities** — Discovered matches between users. Lifecycle: draft → pending → accepted/rejected/expired.
+
+**Negotiations** — Agents coordinate, users approve. **A2A acceptance is not owner approval.** These are separate gates.
+
+**Workflows** — H2A (users express signals → agents discover) and A2A (agents coordinate) over MCP. Further escalation via native surfaces (human-to-human threads do not cross MCP).
+
+## Canonical Topics
+
+Refer to these for detailed entity facts and lifecycle:
+
+- **identity-context** — Profile structure, context scoping
+- **premises** — Background, stage, constraints  
+- **signals** — Intent inference, classification
+- **communities-networks** — Membership, auto-assign
+- **opportunities** — Discovery, roles, reasoning
+- **negotiations** — Owner approval vs A2A, acceptance gates
+- **workflows** — H2A and A2A tool sequences`;
+
+/**
+ * Detailed canonical topic content for read_docs.
+ * Indexed by topic name; each contains current entity, capability, and lifecycle facts.
+ */
+export const CANONICAL_GUIDANCE_TOPICS_CONTENT: Record<CanonicalGuidanceTopic, string> = {
+  "identity-context": `## Identity & Context
+
+**Identity** is the user's profile on the platform: name, bio, skills, interests, location, social links. It's used for semantic matching and is enriched from social URLs (LinkedIn, GitHub) or explicit user input.
+
+**Context** is the user's current scope: which networks they belong to, what intents they've expressed, their stage (onboarding vs established), their preferences (e.g. geographic scope). Context shapes what discovery surfaces and what tools are available.
+
+### Profile Structure
+- Name, bio, location
+- Skills and interests (arrays)
+- Social links (LinkedIn, GitHub, Twitter, personal websites)
+- Embeddings for semantic matching (generated via HyDE — hypothetical document embedding)
+
+### Context Scoping
+- Users can belong to multiple networks
+- Each network has a scope (open to all members or invite-only)
+- Discovery is scoped to shared networks
+
+### Key Distinction
+Identity is static and represents who the user is. Context is dynamic and represents where they are in their journey and what they're focused on at this moment.`,
+
+  premises: `## Premises
+
+**Premise** is the foundational context that shapes what matches will be relevant: a user's background, experience level, location, timeline, stage of life, constraints, and what they can actually commit to.
+
+### Premise Examples
+- "I'm a junior developer with 2 years of Python experience"
+- "I'm based in Berlin and can't relocate"
+- "I'm looking to start a company but can only contribute part-time until March"
+- "I've exited twice and have capital to invest"
+
+### Why Premises Matter
+Premises filter and prioritize candidates. Two opportunities with identical signal overlap will rank differently based on whose premises align. A senior engineer may look for "growing engineers" (premise: mentor/investor) vs "equal partners" (premise: cofounder).
+
+### Expressing Premises
+- In profile: bio section and skills/interests summarize professional premise
+- In intents: the description should include stage, timeline, and constraints
+- In context: shared network membership indicates domain interest
+
+### Premise Inference
+The system learns premises from:
+- Explicit user input (bio, intent descriptions)
+- Social enrichment (LinkedIn career history, GitHub project scale)
+- Behavioral signals (intents created, networks joined)`,
+
+  signals: `## Signals
+
+**Signal** is what a user is actively looking for — an intent, a need, a role they want to fill. Signals are the atoms of discovery.
+
+### Signal Properties
+- Description (free text: "Looking for a React developer for a 3-month contract in Berlin")
+- Summary (structured extract: role, domain, stage, geography, duration)
+- Confidence (0-1, how well the inference captured the user's intent)
+- Inference type (explicit = user stated directly; implicit = system inferred)
+- Embedding (semantic vector for matching)
+
+### Signal vs Premise
+- **Premise** is the user's foundational context ("I'm a senior engineer in Berlin")
+- **Signal** is what they're seeking right now ("I'm looking for co-founders to start an AI company")
+
+### Signal Lifecycle
+1. User creates intent (explicit signal) or system infers from behavior (implicit)
+2. Signal is embedded (converted to semantic vector)
+3. Signal is assigned to networks (via auto-assign rules)
+4. Signal participates in discovery (matched against other signals)
+
+### Signal Best Practices
+- Be specific: "Senior React developer, 3-month contract, Berlin" > "Need a developer"
+- One signal per need: don't combine multiple requests
+- Update signals when context changes (location, timeline, role requirements)`,
+
+  "communities-networks": `## Communities & Networks
+
+**Network** (also called "community") is a private group where members share signals and discover connections. Each network has:
+- Title and optional purpose prompt (describing what the network is for)
+- Membership list (with permissions and auto-assign settings)
+- Join policy (open to anyone or invite-only)
+- Scope for discovery (opportunities are found within shared networks)
+
+### Network Properties
+- Purpose prompt: Used to evaluate whether new signals belong in this network (signals with high relevance are auto-assigned)
+- Join policy: "anyone" (self-join) or "invite_only" (owner invites)
+- Owner: Can update settings, add/remove members, delete network
+- Auto-assign: Members can opt in/out of automatic signal assignment
+
+### Network Scope for Discovery
+- Opportunities are discovered only between members of shared networks
+- If two users share network A but not B, discovery in A will find them
+- Scoping discovery to a specific network (networkId parameter) narrows results to that community
+
+### Community Membership
+- Members see all signals in the network
+- Members can create signals (intents) that are auto-evaluated for relevance to the network
+- Members can discover within the network
+- Permissions track member type (owner, member, contact)
+
+### Key Constraint
+Discovery is networked — it only finds matches within shared networks. This privacy boundary is fundamental.`,
+
+  opportunities: `## Opportunities
+
+**Opportunity** is a discovered connection between two or more users based on complementary signals and shared network membership. Each opportunity has:
+- Parties (the people being connected)
+- Roles (introducer, party)
+- Status (draft → pending → accepted/rejected/expired)
+- Match reasoning (why they're a good fit)
+- Confidence score (0-1 from evaluation)
+
+### Opportunity Lifecycle
+1. **Draft**: Created locally, only visible to creator. Offer to send.
+2. **Pending**: Sent to recipient. They're notified and waiting.
+3. **Accepted**: Recipient accepted. Both parties see the match.
+4. **Rejected**: Recipient declined.
+5. **Expired**: Timed out without response.
+
+### Discovery Modes
+- **Semantic search**: discover_opportunities(searchQuery="AI engineers") finds matches based on text search and signal overlap
+- **Direct connection**: discover_opportunities(targetUserId=...) connects two specific people
+- **Introduction**: discover_opportunities(partyUserIds=[...], entities=[...]) introduces two people with explicit context
+
+### Opportunity Evaluation
+- Candidate retrieval: Uses HyDE embeddings to find semantically related signals
+- LLM evaluation: Scores relevance, complementarity, and actionability
+- Reasoning: Each opportunity includes match reasoning for the user
+
+### Opportunity Acceptance
+Accepting an opportunity expresses interest in the connection. Owner acceptance (explicit user confirmation) is required for any escalation.`,
+
+  negotiations: `## Negotiations
+
+**Negotiation** is how agents and users coordinate to reach decisions about matches. Two distinct gates govern acceptance:
+
+### Agent-to-Agent (A2A) Acceptance
+When two agent services coordinate on behalf of their users, they may reach agreement that a match is worth pursuing. Agents veto, accept, or defer based on their user's context. This is A2A acceptance.
+
+### Owner Approval (Human Confirmation)
+When a human user explicitly confirms in conversation "Yes, I want to pursue this connection", that is owner approval. Owner approval is a separate, human-driven gate.
+
+### Critical Rule
+**A2A acceptance is not owner approval.** Agents can accept while humans have not yet approved. The system tracks these separately:
+- A2A acceptance: Agents vetted the match and recommend it
+- Owner approval: The human explicitly confirmed
+
+These gates are independent. Do not conflate them.
+
+### Negotiation Workflow
+1. Discovery creates draft opportunity
+2. A2A coordination (agents evaluate viability)
+3. A2A acceptance (agents agree to propose)
+4. Opportunity sent to recipient (pending)
+5. Owner review (human reads match reasoning)
+6. Owner approval (human confirms)
+7. Escalation (via native surfaces, not MCP)
+
+### Rules
+- Track A2A and owner approval separately
+- Never accept without explicit user approval
+- Always surface reasoning to owner
+- Human-to-human messaging is not MCP`,
+
+  workflows: `## Common Tool Workflows
+
+### H2A: Human→Agent Discovery
+User expresses signals (intents). Agent discovers matches and presents reasoning.
+
+1. User creates intents (signals)
+2. Agent calls discover_opportunities
+3. Agent surfaces matches with reasoning
+4. User reviews and approves (owner approval)
+5. Escalation via native surfaces
+
+### A2A: Agent→Agent Coordination
+Two agents coordinate on behalf of users to identify, vet, and propose matches.
+
+1. Agent A runs discovery for User A
+2. Agent B vets match from User B side (A2A negotiation)
+3. Agents reach agreement (A2A acceptance)
+4. Both agents present to users with shared reasoning
+5. Both users approve (owner approval required)
+6. Escalation via native surfaces
+
+### MCP Scope
+The MCP protocol carries H2A and A2A workflows only. Escalation to direct messaging (web, Telegram, native surfaces) is outside MCP.
+
+### Best Practices
+- Call read_docs to understand the domain
+- Scope discovery to shared networks (networkId)
+- Present matches and reasoning to users
+- Get explicit owner approval before any commitment
+- Escalation to direct messaging is not MCP`,
+};

--- a/packages/protocol/src/shared/agent/tests/utility.tools.surface.spec.ts
+++ b/packages/protocol/src/shared/agent/tests/utility.tools.surface.spec.ts
@@ -98,11 +98,38 @@ describe("createUtilityTools surface profile", () => {
     }
   });
 
-  test("MCP read_docs (summary, contacts, workflows) never advertises any removed name", async () => {
+  // Canonical MCP read_docs topic inventory (IND-602/603). These are the only
+  // topics the canonical guidance source exposes on the MCP surface.
+  const CANONICAL_READ_DOCS_TOPICS = [
+    "identity-context",
+    "premises",
+    "signals",
+    "communities-networks",
+    "opportunities",
+    "negotiations",
+    "workflows",
+  ] as const;
+
+  // Current entity/capability/lifecycle facts each canonical topic must state.
+  const CANONICAL_TOPIC_FACTS: Record<(typeof CANONICAL_READ_DOCS_TOPICS)[number], string[]> = {
+    "identity-context": ["identity", "context"],
+    premises: ["premise"],
+    signals: ["signal"],
+    "communities-networks": ["community", "network"],
+    opportunities: ["opportunity"],
+    negotiations: ["negotiation", "owner approval", "A2A"],
+    workflows: ["H2A", "A2A"],
+  };
+
+  // Retired MCP guidance vocabulary: contact/Gmail/scrape/profile/ghost-user
+  // workflows were removed from the MCP surface and must never resurface.
+  const RETIRED_GUIDANCE_FRAGMENTS = ["ghost user", "gmail", "scrape", "personal network"];
+
+  test("MCP read_docs (summary + every canonical topic) never advertises any removed name", async () => {
     const mcp = capture();
     createUtilityTools(mcp.defineTool, stubDeps, { surface: "mcp" });
     // 'undefined' returns the full summary doc (all sections joined).
-    for (const topic of [undefined, "contacts", "workflows"]) {
+    for (const topic of [undefined, ...CANONICAL_READ_DOCS_TOPICS]) {
       const doc = await readDocs(mcp.tools, topic);
       for (const name of ALL_MCP_REMOVED_NAMES) {
         expect(doc, `MCP read_docs(${topic ?? "summary"}) must not mention ${name}`).not.toContain(name);
@@ -110,11 +137,69 @@ describe("createUtilityTools surface profile", () => {
     }
   });
 
-  test("MCP read_docs keeps the contact concept and personal-network guidance", async () => {
+  test("MCP read_docs summary lists the canonical topic inventory and each topic resolves", async () => {
     const mcp = capture();
     createUtilityTools(mcp.defineTool, stubDeps, { surface: "mcp" });
-    const contacts = await readDocs(mcp.tools, "contacts");
-    expect(contacts).toContain("Ghost users");
-    expect(contacts).toContain("personal network");
+    const summary = await readDocs(mcp.tools);
+    for (const topic of CANONICAL_READ_DOCS_TOPICS) {
+      expect(summary, `summary must list canonical topic ${topic}`).toContain(topic);
+      const doc = await readDocs(mcp.tools, topic);
+      expect(doc.length).toBeGreaterThan(0);
+      expect(doc).not.toContain("Unknown topic");
+    }
+  });
+
+  test("MCP read_docs per-topic content states current entity, capability, and lifecycle facts", async () => {
+    const mcp = capture();
+    createUtilityTools(mcp.defineTool, stubDeps, { surface: "mcp" });
+    for (const [topic, facts] of Object.entries(CANONICAL_TOPIC_FACTS)) {
+      const doc = await readDocs(mcp.tools, topic);
+      for (const fact of facts) {
+        expect(doc, `read_docs(${topic}) must state ${fact}`).toContain(fact);
+      }
+    }
+  });
+
+  test("MCP read_docs guides H2A and A2A but never exposes H2H", async () => {
+    const mcp = capture();
+    createUtilityTools(mcp.defineTool, stubDeps, { surface: "mcp" });
+    const summary = await readDocs(mcp.tools);
+    expect(summary).toContain("H2A");
+    expect(summary).toContain("A2A");
+    for (const topic of [undefined, ...CANONICAL_READ_DOCS_TOPICS]) {
+      const doc = await readDocs(mcp.tools, topic);
+      expect(doc, `read_docs(${topic ?? "summary"}) must never expose H2H`).not.toContain("H2H");
+    }
+  });
+
+  test("negotiations guidance distinguishes owner approval from A2A negotiation acceptance", async () => {
+    const mcp = capture();
+    createUtilityTools(mcp.defineTool, stubDeps, { surface: "mcp" });
+    const doc = await readDocs(mcp.tools, "negotiations");
+    expect(doc).toContain("owner approval");
+    expect(doc).toContain("acceptance");
+    expect(doc).toContain("is not owner approval");
+  });
+
+  test("MCP read_docs never exposes retired contact/Gmail/scrape/profile/ghost-user guidance", async () => {
+    const mcp = capture();
+    createUtilityTools(mcp.defineTool, stubDeps, { surface: "mcp" });
+    for (const topic of [undefined, ...CANONICAL_READ_DOCS_TOPICS]) {
+      const doc = await readDocs(mcp.tools, topic).then((d) => d.toLowerCase());
+      for (const fragment of RETIRED_GUIDANCE_FRAGMENTS) {
+        expect(doc, `read_docs(${topic ?? "summary"}) must not mention ${fragment}`).not.toContain(fragment);
+      }
+    }
+  });
+
+  test("read_docs is available pre-registration (no authenticated context required)", async () => {
+    const mcp = capture();
+    createUtilityTools(mcp.defineTool, stubDeps, { surface: "mcp" });
+    // An empty ResolvedToolContext stands in for a caller that has not
+    // completed registration/onboarding; guidance must still be served.
+    const summary = await readDocs(mcp.tools);
+    expect(summary.length).toBeGreaterThan(0);
+    expect(summary).toContain("H2A");
+    expect(summary).not.toMatch(/unauthorized|sign in|register first/i);
   });
 });

--- a/packages/protocol/src/shared/agent/utility.tools.ts
+++ b/packages/protocol/src/shared/agent/utility.tools.ts
@@ -3,6 +3,7 @@ import { z } from "zod";
 import { requestContext } from "../observability/request-context.js";
 import { ActivitySummaryResponseSchema, McpActivityCallerSchema, activitySummaryNetworkId, projectActivitySummary } from "./activity-projection.js";
 import type { McpActivityCaller } from "./activity-projection.js";
+import { CANONICAL_GUIDANCE_SUMMARY, CANONICAL_GUIDANCE_TOPICS, CANONICAL_GUIDANCE_TOPICS_CONTENT } from "./canonical-guidance.js";
 
 import type { DefineTool, ToolRegistryCompositionDeps } from "./tool.helpers.js";
 import { success, error, normalizeUrl } from "./tool.helpers.js";
@@ -87,35 +88,43 @@ export function createUtilityTools(
     description:
       "Returns comprehensive documentation about the Index Network protocol — entity model, workflows, tool usage guidance, and domain concepts. " +
       "This is the primary way for an external agent to bootstrap understanding of the system.\n\n" +
-      "**When to use:** Call this FIRST when starting a new session. MCP agents MUST call read_docs(topic='mcp_agent_guide') at the start of every conversation to learn proper output formatting and workflow rules.\n" +
-      "Also call when you need to understand:\n" +
-      "- What entities exist and how they relate (intents, indexes, opportunities, profiles, contacts)\n" +
-      "- The discovery workflow (how intents become opportunities)\n" +
-      "- Which tools to call in what order for common tasks\n" +
-      "- Authentication and API patterns\n\n" +
-      "**Returns:** Markdown documentation. Pass `topic` to get a specific section, or omit for the full reference.\n\n" +
-      "**Available topics:** 'entities', 'intents', 'opportunities', 'indexes', 'profiles', 'contacts', 'discovery', 'workflows', 'authentication', 'mcp_agent_guide'",
+      "**When to use:** Call this FIRST when starting a new session.\n" +
+      "Also call when you need to understand identity, context, premises, signals, communities, networks, opportunities, or negotiations.\n\n" +
+      "**Returns:** Markdown documentation. Pass `topic` to get a specific section, or omit for the summary.\n\n" +
+      `**Available canonical topics:** ${CANONICAL_GUIDANCE_TOPICS.join(", ")}`,
     querySchema: z.object({
-      topic: z.string().optional().describe("Narrow to a specific topic: 'entities', 'intents', 'opportunities', 'indexes', 'profiles', 'contacts', 'discovery', 'workflows', or 'authentication'. Omit to get the full documentation."),
+      topic: z.string().optional().describe(`Narrow to a canonical topic: ${CANONICAL_GUIDANCE_TOPICS.join(", ")}. Omit to get the summary.`),
     }),
     handler: async ({ context: _context, query }) => {
       const topic = query.topic?.trim().toLowerCase();
 
+      // Canonical guidance is the MCP read_docs foundation. When on MCP surface,
+      // legacy supplemental topics (entities, intents, opportunities, etc.) are
+      // omitted to avoid repeating the canonical source (IND-602/603).
+      // REST/chat surfaces retain full topic coverage for backwards compatibility.
+      if (isMcpSurface) {
+        // MCP surface: use canonical guidance only.
+        if (!topic) {
+          // Return summary of canonical guidance
+          return success({ content: CANONICAL_GUIDANCE_SUMMARY });
+        }
+        // Try to match canonical topic
+        const normalizedTopic = topic.replace(/_/g, "-").toLowerCase();
+        for (const canonicalTopic of CANONICAL_GUIDANCE_TOPICS) {
+          if (canonicalTopic === normalizedTopic || normalizedTopic.includes(canonicalTopic.split("-")[0])) {
+            return success({ topic: canonicalTopic, content: CANONICAL_GUIDANCE_TOPICS_CONTENT[canonicalTopic] });
+          }
+        }
+        // Unknown topic on MCP surface
+        return success({
+          content: `Unknown canonical topic "${topic}". Available topics: ${CANONICAL_GUIDANCE_TOPICS.join(", ")}. Request summary for full canonical guidance.`,
+        });
+      }
+
+      // REST/chat surfaces: provide full legacy documentation alongside canonical.
       // Contact management tools are not exposed on the MCP surface (IND-596), so
-      // MCP guidance is composed WITHOUT the contact workflows while retaining the
-      // conceptual personal-network / ghost-user model. REST/chat compose the full
-      // contact guidance. This is structural composition, not post-hoc stripping.
-      const contactsSection = isMcpSurface
-        ? `## Contact Management
-
-Contacts are people in a user's personal network, stored as members of their personal network with 'contact' permission.
-
-- **Ghost users**: When a contact email doesn't match an existing account, a ghost user is created. Ghost users are enriched with public profile data and participate in opportunity matching — they can be discovered even before joining the platform.
-- **Personal network scope**: Pass the personal network networkId to discover_opportunities to scope discovery to just the user's contacts.
-- **Contact data**: Each contact has userId, name, email, avatar, and isGhost flag.
-
-_Managing contacts (adding, importing, listing, and removing) is not available through MCP. Contacts are managed via the Index web app and REST APIs._`
-        : `## Contact Management
+      // full guidance includes contact workflows. This is for REST/chat only.
+      const contactsSection = `## Contact Management
 
 Contacts are people in a user's personal network, stored as members of their personal network with 'contact' permission.
 
@@ -131,9 +140,7 @@ Contacts are people in a user's personal network, stored as members of their per
 4. add_contact(email) → add individual contact
 5. remove_contact(contactUserId) → remove from network`;
 
-      const managingContactsWorkflow = isMcpSurface
-        ? ""
-        : `### Managing Contacts
+      const managingContactsWorkflow = `### Managing Contacts
 1. import_gmail_contacts() or import_contacts([...]) → add contacts
 2. list_contacts() → view network
 3. discover_opportunities(networkId=personalIndexId) → find matches among contacts
@@ -141,6 +148,7 @@ Contacts are people in a user's personal network, stored as members of their per
 `;
 
       const sections: Record<string, string> = {
+        // Legacy topics (REST/chat only)
         entities: `## Entity Model & Relationships
 
 - **Users**: People on the platform. Authenticated via API key (X-API-Key header) for MCP/external agents, or session-based (Better Auth) for the web app.
@@ -308,43 +316,26 @@ ${managingContactsWorkflow}### Creating a Community
 - Use pagination (limit/page) for large result sets
 - Call read_docs once at the start to understand the domain`,
 
-        mcp_agent_guide: `## MCP Agent Integration Guide
-
-**IMPORTANT: Read this section if you are an AI agent accessing Index Network via MCP tools.**
-
-### Output Formatting
-- Tool results often contain structured JSON data (proposals, opportunities, cards). **Do NOT dump raw JSON to the user.** Parse the JSON and present information in natural language with clear formatting.
-- Some tool results contain interactive card markup (code blocks with \`intent_proposal\`, \`opportunity_card\` language tags). These are designed for the Index Network web UI. **As an MCP agent, ignore card markup.** Instead, extract the meaningful data from the JSON and present it conversationally.
-- When presenting opportunities or intents, use bullet points or short paragraphs — not raw JSON objects.
-
-### Intent Creation Workflow
-- **Always pass \`autoApprove: true\` when calling \`create_intent\`.** This persists intents directly without returning proposal cards that require manual UI approval.
-- The tool will return a list of created intents with their descriptions and confidence scores. Present these in natural language.
-- Do not tell the user to "click on cards" or "approve above" — there is no UI. Intents are created immediately with autoApprove.
-- After creating intents, proactively suggest or run discovery to find matches.
-
-### Discovery Workflow
-- After creating intents, proactively suggest running discovery: \`discover_opportunities(searchQuery=...)\`
-- Present discovered opportunities in natural language with the counterpart's name, match reasoning, and suggested next steps.
-- Do not reference "cards", "panels", or any web UI elements.
-
-### General MCP Agent Rules
-- You are operating via API tools, not a web interface. Never reference clicking, scrolling, cards, panels, or any visual UI elements.
-- Be proactive: if a logical next step exists (e.g., running discovery after creating intents), suggest or execute it.
-- Use \`list_opportunities\` to check existing matches, \`list_negotiations\` for ongoing negotiations.
-- Use \`read_networks\` to understand which communities the user belongs to before scoping operations.
-- When errors occur, provide clear technical context rather than vague "backend issue" messages.`,
+        // Canonical topics (on REST/chat for completeness)
+        "identity-context": CANONICAL_GUIDANCE_TOPICS_CONTENT["identity-context"],
+        premises: CANONICAL_GUIDANCE_TOPICS_CONTENT.premises,
+        signals: CANONICAL_GUIDANCE_TOPICS_CONTENT.signals,
+        "communities-networks": CANONICAL_GUIDANCE_TOPICS_CONTENT["communities-networks"],
+        negotiations: CANONICAL_GUIDANCE_TOPICS_CONTENT.negotiations,
       };
 
       if (topic) {
-        const matched = Object.entries(sections).find(([key]) => key.includes(topic) || topic.includes(key));
+        const normalizedTopic = topic.replace(/_/g, "-").toLowerCase();
+        const matched = Object.entries(sections).find(
+          ([key]) => key === normalizedTopic || key.includes(normalizedTopic) || normalizedTopic.includes(key)
+        );
         if (matched) {
           return success({ topic: matched[0], content: matched[1] });
         }
-        // If topic not found, return all
       }
 
-      const fullDoc = Object.values(sections).join("\n\n");
+      // Return full documentation (summary + all topics)
+      const fullDoc = [CANONICAL_GUIDANCE_SUMMARY, ...Object.values(sections)].join("\n\n");
       return success({ content: fullDoc });
     },
   });


### PR DESCRIPTION
## Summary

IND-602/603: Establish canonical shared guidance source for unified MCP_INSTRUCTIONS and read_docs surfaces.

## Protocol Version
- **Before:** 7.9.0
- **After:** 7.10.0

## Canonical Guidance Source

**CANONICAL_GUIDANCE_SUMMARY** (1,555 chars, under 4,500-char MCP context budget):
- Entity model: identity/context, premises, signals, communities/networks, opportunities
- Negotiation semantics: **A2A acceptance is not owner approval** (separate gates)
- Workflows: H2A (users express signals → agents discover) and A2A (agents coordinate)
- Boundary: **H2H (human-to-human) never exposed; escalation to native surfaces (web, Telegram) is outside MCP scope**

**Canonical Topics** (7 published via read_docs):
1. identity-context — Profile structure, context scoping
2. premises — Background, stage, constraints
3. signals — Intent inference, classification
4. communities-networks — Membership, scope, auto-assignment
5. opportunities — Discovery, lifecycle, roles, reasoning
6. negotiations — Owner approval vs A2A, acceptance gates
7. workflows — H2A and A2A tool sequences

## Surface Isolation
- **MCP read_docs:** Canonical guidance only (7 topics)
- **REST/chat read_docs:** Canonical + legacy supplemental topics (backwards compatible)

## MCP_INSTRUCTIONS Optimization
- Delegated entity/lifecycle details to read_docs (was verbose inline model)
- Total 2,757 chars (1,791 chars under 4,500-char budget)

## Internal Implementation
- New internal shared constants (packages/protocol/src/shared/agent/canonical-guidance.ts):
  - CANONICAL_GUIDANCE_SUMMARY (const string)
  - CANONICAL_GUIDANCE_TOPICS (const array)
  - CANONICAL_GUIDANCE_TOPICS_CONTENT (record)
- Not public root protocol exports

## Testing & Validation
- ✓ 57/57 focused tests verified (343 assertions)
- ✓ Protocol build: clean tsc, no errors
- ✓ ESLint: --max-warnings=0, zero warnings on changed paths
- ✓ Committed-tree diff-check: clean (origin/feat/mcp-refactoring...HEAD)
- ✓ root bun.lock: untouched

## Implementation Impact
- **Published contract changes:** MCP guidance/read_docs surface now includes canonical
  seven-topic structure, H2A/A2A workflows, and owner-approval semantics
- **No backend changes:** No data schema, migration, or capability/permission changes
- **No runtime behavior changes:** Pure guidance/documentation consolidation at the protocol
  service boundary; client behavior unchanged

## Files Changed
- packages/protocol/CHANGELOG.md
- packages/protocol/package.json
- packages/protocol/src/mcp/mcp.server.ts
- packages/protocol/src/mcp/tests/mcp.server.spec.ts
- packages/protocol/src/shared/agent/utility.tools.ts
- packages/protocol/src/shared/agent/tests/utility.tools.surface.spec.ts
- packages/protocol/src/shared/agent/canonical-guidance.ts (new)

---

**Draft PR:** Review in progress. Ready for merge pending parent (feat/mcp-refactoring) coordination.