### PR TITLE
fix(skills): update claude-plugin orchestrator template to post-IND-596/597/598 MCP surface

### DIFF
--- a/packages/protocol/skills/claude-plugin/index-orchestrator.template.md
+++ b/packages/protocol/skills/claude-plugin/index-orchestrator.template.md
@@ -101,17 +101,16 @@ IF specific ("contribute to an open-source LLM project in Python"):
 
 Specificity test: Does it contain a concrete domain, action, or scope? "Find a job" = vague. "Senior UX role at a climate tech startup in Berlin" = specific.
 
-## Pattern 3: URL in message → scrape before intent
+## Pattern 3: URL in message → intent
 
 When the user pastes a URL alongside an intent request:
 
 ```
-1. scrape_url(url, objective="Extract key details for an intent")
-2. Synthesize a conceptual description from scraped content
-3. create_intent(description=synthesized_summary)
+1. Synthesize a conceptual description from the URL and the context the user provided
+2. create_intent(description=synthesized_summary)
 ```
 
-Exception: for profile creation, pass URLs directly to `create_user_context` — it handles scraping internally.
+Exception: for profile creation, pass URLs directly to `create_user_context` — it enriches from social links internally.
 
 ## Pattern 4: Update or delete an intent
 
@@ -148,13 +147,7 @@ When the user asks "who should I introduce to @Person" or "find connections for 
 
 Do NOT use Pattern 5 here. Do NOT ask for a second person. Do NOT suggest creating a signal — the search reflects the other person's needs, not the user's.
 
-## Pattern 6: Contacts
-
-- **Import many**: `import_contacts(contacts=[{name, email}, ...])` — for CSV or bulk input; use `import_gmail_contacts` for Gmail
-- **Add one**: `add_contact(email=..., name=...)` — creates or links the person, then adds them as a contact
-- **Remove one**: first `list_contacts` or `search_contacts(query=name)` to find the userId, then `remove_contact(contactUserId=...)`
-
-## Pattern 7: Community / index management
+## Pattern 6: Community / index management
 
 ```
 # Explore a community


### PR DESCRIPTION
## Problem

PR #1284 (generated-skills CI) fails because IND-596/597/598 updated the generated `packages/claude-plugin/skills/index-orchestrator/SKILL.md` to remove retired MCP tools, but the canonical source template `packages/protocol/skills/claude-plugin/index-orchestrator.template.md` was left stale.

When CI runs `bun run build:skills` it regenerates from the stale template — reintroducing `scrape_url`, `import_contacts`, `add_contact`, `remove_contact` and the Contacts pattern — then `git diff --exit-code` detects drift and fails.

## Fix

Update the canonical Claude orchestrator template to reflect the post-IND-596/597/598 MCP surface:

- **Pattern 3** (URL → intent): remove `scrape_url` call; synthesize intent from URL + context only
- **Pattern 6 (Contacts)**: remove entirely — `import_contacts`, `add_contact`, `remove_contact`, `import_gmail_contacts`, `list_contacts`, `search_contacts` are retired from the MCP surface
- **Pattern 7 → Pattern 6**: Community/index management renumbered

The generated `packages/claude-plugin/skills/index-orchestrator/SKILL.md` is unchanged (already correct from IND-596/597/598). The Hermes template and generated SKILL.md have no drift.

## Verification

### Negative (retired terms absent from template and both generated outputs)
`scrape_url`, `import_contacts`, `add_contact`, `remove_contact`, `import_gmail`, `list_contacts`, `search_contacts`, `Pattern 7` — all absent ✓

### Positive (canonical MCP workflow guidance retained in generated outputs)
`discover_opportunities`, `read_intents`, `create_intent`, `Pattern 6: Community` present in Claude output ✓  
`index_read_docs`, `index_discover_opportunities` present in Hermes output ✓

Note: H2A/A2A/H2H collaboration policy is **not** present in these skill templates and was not added. That policy lives in the canonical MCP guidance source (`packages/protocol/src/shared/agent/canonical-guidance.ts`, IND-602/603) — outside this template-parity slice.

### CI simulation
```
bun run build:skills && git diff --exit-code
✓ Generated skill files match templates.
```

### Test suite
38 tests pass, 0 fail (`test:scripts`). `skills:validate` — 17 skills OK.

## Scope

Template only — no source code, data, migration, lockfile, or unrelated changes.