### PR TITLE
fix(negotiation): make the v2 initiator withdraw when clarification disqualifies the match

### DIFF
--- a/docs/domain/negotiation.md
+++ b/docs/domain/negotiation.md
@@ -50,7 +50,7 @@ Each negotiation task carries a `protocolVersion` (`v1` | `v2`) in its metadata.
 
 Under **v2 (client-advocate seat rules)** the action vocabulary is scoped by seat, keyed on `metadata.initiatorUserId` (the rigid stamp from discovery time — never turn parity):
 
-- **Initiator seat** (`outreach | counter | question | withdraw`): the side that surfaced the match. It reaches out and may walk away, but it can **never accept** — this is schema-enforced, not prompt-enforced.
+- **Initiator seat** (`outreach | counter | question | withdraw`): the side that surfaced the match. It reaches out and may walk away, but it can **never accept** — this is schema-enforced, not prompt-enforced. Walking away is also the seat's explicit duty after clarification: when information arriving through either clarification channel — the counterparty's answer to a `question`, or the user's own answers / private consultation surfaced between sessions — reveals a reason the match no longer serves its user, the seat is instructed to `withdraw` rather than counter or question again. This is a prompt-level decision rule (the seat rules), not a coercion of model output.
 - **Counterparty seat** (`accept | decline | counter | question`): the receiving side. Acceptance is this seat's decision alone.
 - **Final turn**: initiator `withdraw | counter`; counterparty `accept | decline` (must decide).
 

--- a/packages/protocol/package.json
+++ b/packages/protocol/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@indexnetwork/protocol",
-  "version": "7.10.0",
+  "version": "7.10.1",
   "type": "module",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",

--- a/packages/protocol/src/negotiation/application/negotiation.agent.ts
+++ b/packages/protocol/src/negotiation/application/negotiation.agent.ts
@@ -34,13 +34,27 @@ const V1_ACTION_RULES = `- On the FIRST turn: Propose the connection case. Expla
   - "accept" if the match genuinely benefits {userName}
   - "reject" if the match does not serve {userName}'s needs`;
 
-/** v2 initiator seat: reaching stance — accept is structurally unavailable. */
+/**
+ * v2 initiator seat: reaching stance — accept is structurally unavailable.
+ *
+ * The closing rule (IND-570) is the initiator-only decision link between
+ * clarification and walking away: this seat is the one that can end a match it
+ * started, so once information arriving through EITHER clarification channel —
+ * the counterparty's answer to a `question`, or the acting user's own answers /
+ * private consultation surfaced between sessions — disqualifies the match, the
+ * seat should `withdraw` instead of countering indefinitely. It is worded
+ * channel-neutrally (it never names the `ask_user` action) so it renders
+ * correctly whether or not the caller granted `canAskUser`; the answer context
+ * it refers to is injected independently of that grant. It must never reach
+ * `V2_COUNTERPARTY_RULES` (that seat has no `withdraw`) or `V1_ACTION_RULES`.
+ */
 const V2_INITIATOR_RULES = `- You hold the INITIATING seat: your user's side surfaced this match and you are reaching out. Only the counterparty may accept — "accept" is NOT available to you.
 - On the FIRST turn: Make the outreach case. Explain why the connection would benefit both parties. Set action to "outreach".
 - On SUBSEQUENT turns: Evaluate the counterparty's arguments. Either:
   - "counter" if you have specific objections but see potential
   - "question" if you need a specific clarification from the counterparty
-  - "withdraw" if the match does not serve {userName}'s needs`;
+  - "withdraw" if the match does not serve {userName}'s needs
+- WITHDRAW ON DISQUALIFYING INFORMATION: clarification exists to resolve uncertainty, so act on what it returns. When something you have learned since reaching out — the counterparty's answer to one of your questions, or {userName}'s own answers or private consultation provided between sessions — reveals a reason this match no longer serves {userName}, choose "withdraw" rather than countering or questioning again. Once a disqualifying reason is on the table, do not keep negotiating the match.`;
 
 /**
  * v2 client-consult pause rule (P3.2). Appended to either seat's rules only

--- a/packages/protocol/src/negotiation/tests/negotiation.initiator-withdraw-rule.spec.ts
+++ b/packages/protocol/src/negotiation/tests/negotiation.initiator-withdraw-rule.spec.ts
@@ -1,0 +1,125 @@
+import { describe, it, expect } from "bun:test";
+import { IndexNegotiator } from "../negotiation.agent.js";
+import type { NegotiationAgentInput } from "../negotiation.agent.js";
+
+/**
+ * Initiator-only "withdraw on disqualifying information" rule.
+ *
+ * The v2 initiator seat already had `withdraw` in its vocabulary, but nothing
+ * connected information learned through clarification (a counterparty answer to
+ * a `question`, or the user's own between-session answers / private
+ * consultation) to the decision to walk away — so the seat could question,
+ * learn the match was disqualified, and keep countering.
+ *
+ * Uses the same `callModel` seam as `negotiation.agent.ask-user.spec.ts` (no
+ * live provider): the subclass captures the system prompt and returns a
+ * scripted valid turn. Pins:
+ * - the rule is present in the v2 initiator prompt,
+ * - it names BOTH clarification channels,
+ * - it is absent from the v2 counterparty prompt, which still gets no
+ *   `withdraw` at all,
+ * - it is absent from v1,
+ * - it renders identically with `canAskUser` on and off, and never names the
+ *   `ask_user` action (which is conditionally appended and must not be
+ *   referenced by an unconditional rule).
+ */
+
+class CapturingNegotiator extends IndexNegotiator {
+  systemPrompts: string[] = [];
+  constructor(private readonly outputs: unknown[]) {
+    super({ turnTimeoutMs: 1000 });
+  }
+  private calls = 0;
+  protected override async callModel(
+    _model: unknown,
+    chatMessages: Array<{ role: string; content: string }>,
+  ): Promise<unknown> {
+    this.systemPrompts.push(chatMessages[0].content);
+    const out = this.outputs[Math.min(this.calls, this.outputs.length - 1)];
+    this.calls += 1;
+    return out;
+  }
+}
+
+const baseInput: NegotiationAgentInput = {
+  ownUser: { id: "u-init", intents: [], profile: { name: "Alice" } },
+  otherUser: { id: "u-cp", intents: [], profile: { name: "Bob" } },
+  indexContext: { networkId: "net-1", prompt: "" },
+  seedAssessment: { reasoning: "seed", valencyRole: "peer" },
+  history: [
+    { action: "outreach", assessment: { reasoning: "r", suggestedRoles: { ownUser: "peer", otherUser: "peer" } }, message: null },
+    { action: "question", assessment: { reasoning: "r", suggestedRoles: { ownUser: "peer", otherUser: "peer" } }, message: null },
+  ],
+  seat: "initiator",
+  protocolVersion: "v2",
+};
+
+function validTurn(action: string) {
+  return {
+    action,
+    assessment: { reasoning: "ok", suggestedRoles: { ownUser: "peer" as const, otherUser: "peer" as const } },
+    message: null,
+  };
+}
+
+/** Distinctive marker of the rule — absent from the pre-change prompt. */
+const RULE_MARKER = "WITHDRAW ON DISQUALIFYING INFORMATION";
+
+async function promptFor(input: Partial<NegotiationAgentInput>, action = "counter"): Promise<string> {
+  const agent = new CapturingNegotiator([validTurn(action)]);
+  await agent.invoke({ ...baseInput, ...input });
+  return agent.systemPrompts[0];
+}
+
+describe("IndexNegotiator — initiator withdraw-after-clarification rule", () => {
+  it("v2 initiator prompt instructs withdraw when clarification disqualifies the match", async () => {
+    const prompt = await promptFor({});
+    expect(prompt).toContain(RULE_MARKER);
+    expect(prompt).toContain('choose "withdraw" rather than countering or questioning again');
+    expect(prompt).toContain("no longer serves Alice");
+  });
+
+  it("the rule covers BOTH clarification channels", async () => {
+    const prompt = await promptFor({});
+    // counterparty question/answer channel
+    expect(prompt).toContain("the counterparty's answer to one of your questions");
+    // own-user answers / private-consultation channel
+    expect(prompt).toContain("Alice's own answers or private consultation provided between sessions");
+  });
+
+  it("v2 counterparty seat never receives the rule and still has no withdraw", async () => {
+    const prompt = await promptFor({ seat: "counterparty" }, "accept");
+    expect(prompt).not.toContain(RULE_MARKER);
+    expect(prompt).not.toContain("the counterparty's answer to one of your questions");
+    expect(prompt).toContain("RECEIVING seat");
+    expect(prompt).not.toContain('"withdraw"');
+  });
+
+  it("v1 never receives the rule", async () => {
+    const prompt = await promptFor({ protocolVersion: "v1" });
+    expect(prompt).not.toContain(RULE_MARKER);
+    expect(prompt).not.toContain('"withdraw"');
+  });
+
+  it("renders identically with canAskUser off and on, and never names the ask_user action", async () => {
+    const withoutGrant = await promptFor({ canAskUser: false });
+    const withGrant = await promptFor({ canAskUser: true });
+
+    expect(withoutGrant).toContain(RULE_MARKER);
+    expect(withGrant).toContain(RULE_MARKER);
+
+    const ruleOf = (prompt: string) => prompt.slice(prompt.indexOf(RULE_MARKER)).split("\n")[0];
+    expect(ruleOf(withoutGrant)).toBe(ruleOf(withGrant));
+
+    // Unconditional rule must not reference the conditionally-appended action.
+    expect(ruleOf(withoutGrant)).not.toContain("ask_user");
+    expect(withoutGrant).not.toContain("ask_user");
+    expect(withGrant).toContain('"ask_user"');
+  });
+
+  it("still present on the final turn, where the initiator must pick withdraw or counter", async () => {
+    const prompt = await promptFor({ isFinalTurn: true }, "withdraw");
+    expect(prompt).toContain(RULE_MARKER);
+    expect(prompt).toContain("You MUST choose either 'withdraw' or 'counter'");
+  });
+});


### PR DESCRIPTION
## Requirement

A v2 negotiation **initiator** should explicitly use `withdraw` when questioning or clarification reveals a reason the match no longer serves their user.

`withdraw` was already in the initiator seat's vocabulary, but nothing in the prompt connected *information learned through clarification* to the *decision to walk away*. An initiator could ask a `question`, receive an answer that disqualified the match, and keep countering until the turn cap stalled the negotiation.

## Change

One new rule appended to `V2_INITIATOR_RULES` in `packages/protocol/src/negotiation/application/negotiation.agent.ts`:

> `- WITHDRAW ON DISQUALIFYING INFORMATION: clarification exists to resolve uncertainty, so act on what it returns. When something you have learned since reaching out — the counterparty's answer to one of your questions, or {userName}'s own answers or private consultation provided between sessions — reveals a reason this match no longer serves {userName}, choose "withdraw" rather than countering or questioning again. Once a disqualifying reason is on the table, do not keep negotiating the match.`

### Wording decision: both channels, channel-neutral phrasing

The rule covers **both** clarification channels:

1. **counterparty question/answer** — answers arrive as counterparty turns in the shared history;
2. **own-user answers / private consultation** — `userAnswers` and `privateConsultation` on `NegotiationAgentInput`, rendered as dedicated prompt sections.

Reasoning: both are equally capable of surfacing a disqualifying fact, and both are injected into the prompt on exactly the same terms. Critically, `userAnswers` / `privateConsultation` are injected **independently of `canAskUser`** — only the `ASK_USER_RULE` (which grants the *action*) is conditionally appended. So a rule that covers only the counterparty channel would miss the case where the user's own between-session answer is what kills the match.

The wording is therefore **channel-neutral**: it describes the *information that arrived* rather than naming the `ask_user` action, so it reads correctly whether or not `canAskUser` was granted. It deliberately never contains the literal string `ask_user` (also pinned by an existing invariant in `negotiation.agent.ask-user.spec.ts`, which asserts the ungranted prompt does not contain it).

### What this is not

A prompt-instruction change only. No free-text keyword coercion, no post-hoc string matching on model output to force a withdraw.

### Scope guards

- Initiator seat only: the rule reaches neither `V2_COUNTERPARTY_RULES` (that seat still has `accept | decline | counter | question` and **no** `withdraw`) nor `V1_ACTION_RULES`.
- **No graph change needed** — verified, not assumed: `negotiation.graph.ts:714` blocks `withdraw` only before an in-task `outreach` and exempts exact continuations (IND-564). A post-questioning withdraw within a session that already opened outreach, and a post-consultation withdraw on an `ask_user` resume, are both already legal.

## Tests

New deterministic spec `packages/protocol/src/negotiation/tests/negotiation.initiator-withdraw-rule.spec.ts` (6 tests), extending the existing `callModel`-seam harness from `negotiation.agent.ask-user.spec.ts` — no live model calls. Pins: rule present for the v2 initiator; both channels named; **absent** from the counterparty seat, which still gets no `withdraw`; absent from v1; identical rendering with `canAskUser` on/off and never naming `ask_user`; present on the final turn.

### Red→green evidence

With only `negotiation.agent.ts` stashed (spec unchanged):

```
$ git stash push -- packages/protocol/src/negotiation/application/negotiation.agent.ts
$ bun --env-file=../../.env.test test src/negotiation/tests/negotiation.initiator-withdraw-rule.spec.ts
 2 pass / 4 fail          # the 4 rule-presence assertions fail
$ git stash pop
$ bun --env-file=../../.env.test test src/negotiation/tests/negotiation.initiator-withdraw-rule.spec.ts
 6 pass / 0 fail
```

(The 2 that pass pre-change are the negative-scope guards — correctly invariant before and after.)

### Affected-suite run

```
$ cd packages/protocol
$ bun --env-file=../../.env.test test     src/negotiation/tests/negotiation.seat-rules.spec.ts     src/negotiation/tests/negotiation.initiator.spec.ts     src/negotiation/tests/negotiation.agent.spec.ts     src/negotiation/tests/negotiation.agent.ask-user.spec.ts     src/negotiation/tests/negotiation.agent.retry.spec.ts     src/negotiation/tests/negotiation.continuation-withdraw.spec.ts     src/negotiation/tests/negotiation.question-safety.spec.ts     src/negotiation/tests/negotiation.prior-dialogue-attribution.spec.ts     src/negotiation/tests/negotiation.initiator-withdraw-rule.spec.ts
 60 pass / 0 fail (167 expect() calls, 9 files)

$ bun run build                    # tsc, exit 0
$ bun run architecture:exports     # OK (389 exports)
$ bun run architecture:consumer    # OK
$ bun run architecture:host-isolation  # OK
$ bun run architecture:capabilities    # OK (43 named directions)
$ bun run architecture:artifacts   # OK (801 files)
$ bun run test:architecture        # 18 pass / 0 fail
```

**Pre-existing failure, not from this PR:** `bun run architecture:cycles` fails with a production module cycle (`negotiation/application/index.ts … shared/agent/tool.helpers.ts`). Reproduced identically at the baseline commit `22c6ca5164` with all changes stashed.

## Docs

`docs/domain/negotiation.md` — the Initiator seat bullet gains the decision rule, since the documented initiator decision model genuinely changed (walking away after disqualifying clarification is now an explicit duty of the seat, not just an available action).

## Versioning

`@indexnetwork/protocol` 7.10.0 → **7.10.1** (patch). Behavioral prompt fix with no change to the exported API surface, matching the repo convention where `fix(protocol): …` commits take a patch bump (e.g. 6.12.1) and `feat(protocol): …` take a minor.