### PR TITLE
feat(negotiation): show the owner why their agent never reached out (IND-610)

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@indexnetwork/web",
-  "version": "0.41.0",
+  "version": "0.42.0",
   "license": "MIT",
   "scripts": {
     "dev": "vite --host 127.0.0.1",

--- a/apps/web/src/app/chat/[conversationId]/page.tsx
+++ b/apps/web/src/app/chat/[conversationId]/page.tsx
@@ -11,6 +11,8 @@ import TurnRail from '@/components/negotiations/TurnRail';
 import OutcomeBanner from '@/components/negotiations/OutcomeBanner';
 import OutcomeChip from '@/components/negotiations/OutcomeChip';
 import ResolvedBanner, { type ResolvedBannerVariant } from '@/components/negotiations/ResolvedBanner';
+import GateDecisionCard from '@/components/negotiations/GateDecisionCard';
+import { resolveGateDecision } from '@/components/negotiations/gate-decision';
 import { useTickingNow } from '@/components/negotiations/use-ticking-now';
 import { deriveSectionLabel, extractTurn, formatRelativeTime, groupTurnsBySession, viewerRoleLabel, type TranscriptTurn } from '@/components/negotiations/negotiation-turns';
 
@@ -142,6 +144,26 @@ export default function NegotiationDetailPage() {
 
   const showOutcomeBanner = !resolvedVariant && effectiveOpportunityStatus === 'pending' && !!opportunityId;
 
+  // IND-610: the owner-only outreach-gate card. A `screened_out` negotiation
+  // with no turns is the one case where the transcript has nothing to show —
+  // it dead-ended at "No messages in this negotiation" — yet a real decision
+  // was made on the viewer's behalf. `screenDecision` is projected by the API
+  // only to the negotiation's initiator, so a non-owner never has one; both
+  // the screen-node pass and an opening-turn refusal arrive here, since they
+  // collapse into the same `screened_out` outcome.
+  //
+  // Not gated on `loading`: the JSX already renders the spinner first, and
+  // keeping this stable across the load avoids flashing the generic rejected
+  // banner for one frame before the card replaces it.
+  const gateDecision = useMemo(
+    () => resolveGateDecision({
+      turnCount: turns.length,
+      outcomeReason,
+      screenDecision: lifecycle?.screenDecision ?? null,
+    }),
+    [turns.length, outcomeReason, lifecycle?.screenDecision],
+  );
+
   // Revival CTA routes through the user's own agent (the negotiator DM), with
   // the questions inbox as fallback when no negotiator session exists yet.
   const handleRevive = useCallback(async () => {
@@ -190,6 +212,11 @@ export default function NegotiationDetailPage() {
               <div className="flex items-center justify-center py-20">
                 <Loader2 className="w-6 h-6 animate-spin text-gray-400" />
               </div>
+            ) : gateDecision ? (
+              // The gate card replaces both the empty state and the generic
+              // rejected banner below: it says the same thing with the actual
+              // reasoning, and stacking them would double-report one decision.
+              <GateDecisionCard decision={gateDecision} counterpartName={counterpartName} />
             ) : conversationMessages.length === 0 ? (
               <div className="flex flex-col items-center justify-center py-20 text-[#3D3D3D]">
                 <p className="text-sm">No messages in this negotiation</p>
@@ -312,7 +339,7 @@ export default function NegotiationDetailPage() {
                     onPass={() => void handleOpportunityAction(opportunityId, 'rejected', counterpartUserId, undefined, counterpartName)}
                   />
                 )}
-                {resolvedVariant && (
+                {resolvedVariant && !gateDecision && (
                   <ResolvedBanner
                     variant={resolvedVariant}
                     reason={outcomeReason}

--- a/apps/web/src/components/__tests__/GateDecisionCard.test.tsx
+++ b/apps/web/src/components/__tests__/GateDecisionCard.test.tsx
@@ -1,0 +1,101 @@
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+
+import GateDecisionCard from '../negotiations/GateDecisionCard';
+import { resolveGateDecision, type GateDecision } from '../negotiations/gate-decision';
+
+const screenDecision: GateDecision = {
+  source: 'screen',
+  decision: 'pass',
+  reasoning: 'Alice is raising a seed round, not hiring — this is not the help you asked for.',
+  counterpartyPremiseFit: 'Fundraising focus, no engineering need stated.',
+  intentAlignment: 'No overlap with your open backend role.',
+  screenedAt: '2026-07-24T11:00:00.000Z',
+};
+
+describe('resolveGateDecision (IND-610)', () => {
+  const screenedOut = { turnCount: 0, outcomeReason: 'screened_out', screenDecision };
+
+  it('shows the card on a zero-turn screened_out negotiation with reasoning', () => {
+    expect(resolveGateDecision(screenedOut)).toBe(screenDecision);
+  });
+
+  it('shows nothing to a non-owner, who is never given a screenDecision', () => {
+    expect(resolveGateDecision({ ...screenedOut, screenDecision: null })).toBeNull();
+    expect(resolveGateDecision({ ...screenedOut, screenDecision: undefined })).toBeNull();
+  });
+
+  it('stays hidden when the negotiation actually happened', () => {
+    // Turns exist: the rail tells the story, and a "did not reach out" card
+    // would flatly contradict it.
+    expect(resolveGateDecision({ ...screenedOut, turnCount: 2 })).toBeNull();
+  });
+
+  it('stays hidden for a shadow-mode pass that did not block the negotiation', () => {
+    // decision === 'pass' but the outcome is not screened_out — outreach did
+    // happen, so claiming otherwise would be a lie.
+    expect(resolveGateDecision({ ...screenedOut, outcomeReason: null })).toBeNull();
+    expect(resolveGateDecision({ ...screenedOut, outcomeReason: 'turn_cap' })).toBeNull();
+  });
+
+  it('falls back to the generic banner when there is no reasoning to show', () => {
+    expect(resolveGateDecision({
+      ...screenedOut,
+      screenDecision: { ...screenDecision, reasoning: '   ' },
+    })).toBeNull();
+  });
+});
+
+describe('GateDecisionCard (IND-610)', () => {
+  it('shows the reasoning and both evidence lines for a screen-node pass', () => {
+    render(<GateDecisionCard decision={screenDecision} counterpartName="Alice" />);
+
+    const card = screen.getByTestId('gate-decision-card');
+    expect(card).toHaveTextContent('Your agent did not reach out');
+    expect(card).toHaveTextContent('Passed · before any contact');
+    expect(card).toHaveTextContent('Alice is raising a seed round');
+    expect(card).toHaveTextContent('what fit');
+    expect(card).toHaveTextContent('Fundraising focus, no engineering need stated.');
+    expect(card).toHaveTextContent('intent');
+    expect(card).toHaveTextContent('No overlap with your open backend role.');
+  });
+
+  it('always states the one-sidedness, naming the counterparty', () => {
+    render(<GateDecisionCard decision={screenDecision} counterpartName="Alice" />);
+    expect(screen.getByTestId('gate-decision-card'))
+      .toHaveTextContent('Alice was not contacted and cannot see this.');
+  });
+
+  it('renders without evidence rows for an opening-turn refusal, which has none', () => {
+    // Work item 2 collapses a turn-0 withdraw into the same `screened_out`
+    // outcome, but it never runs the screen node, so `evidence.*` is null.
+    render(
+      <GateDecisionCard
+        decision={{
+          source: 'outcome',
+          decision: 'pass',
+          reasoning: 'Not worth spending your name on this one.',
+          counterpartyPremiseFit: null,
+          intentAlignment: null,
+          screenedAt: null,
+        }}
+        counterpartName="Alice"
+      />,
+    );
+
+    const card = screen.getByTestId('gate-decision-card');
+    expect(card).toHaveTextContent('Not worth spending your name on this one.');
+    expect(card).toHaveTextContent('Alice was not contacted and cannot see this.');
+    expect(card).not.toHaveTextContent('what fit');
+    expect(card).not.toHaveTextContent('intent    ');
+  });
+
+  it('is not a message bubble — it is a labelled non-turn region', () => {
+    const { container } = render(<GateDecisionCard decision={screenDecision} counterpartName="Alice" />);
+    const card = screen.getByTestId('gate-decision-card');
+    expect(card.tagName).toBe('SECTION');
+    expect(card).toHaveAttribute('aria-label', "Your agent's outreach decision");
+    // House style for this surface: no own/other alignment classes.
+    expect(container.querySelector('.justify-end, .ml-auto, .self-end')).toBeNull();
+  });
+});

--- a/apps/web/src/components/negotiations/GateDecisionCard.tsx
+++ b/apps/web/src/components/negotiations/GateDecisionCard.tsx
@@ -1,0 +1,71 @@
+import type { GateDecision } from './gate-decision';
+
+interface GateDecisionCardProps {
+  decision: GateDecision;
+  /** The counterparty's owner name — used verbatim in the one-sidedness line. */
+  counterpartName: string;
+}
+
+/**
+ * IND-610 — the owner-only outreach-gate card.
+ *
+ * A zero-turn `screened_out` negotiation is a decision the viewer's own agent
+ * made *for* them and, until now, never told them about: the transcript
+ * dead-ended at "No messages in this negotiation". This surfaces the reasoning
+ * the gate already persisted.
+ *
+ * Three invariants hold this together:
+ * - **It is not a message.** House style for this surface is the turn rail
+ *   (`TurnRail.tsx`: "verb + role chips + reasoning per turn. No DM bubbles"),
+ *   and the precedent for an inline non-turn element is the missed-window decay
+ *   line. Rendering a withdraw as a message would push it into `state.messages`,
+ *   the thread both sides read back as `priorDialogue` — leaking "your agent
+ *   judged me not worth it" to the counterparty. This component only reads
+ *   already-projected data; it writes nothing.
+ * - **It is one-sided, and says so.** The closing line is required, not
+ *   decoration: without it a card naming the counterparty reads like a leak.
+ * - **The data is owner-only.** The API projects `screenDecision` only when
+ *   `initiatorUserId === viewerUserId`; a non-owner never receives the fields
+ *   this component renders.
+ */
+export function GateDecisionCard({ decision, counterpartName }: GateDecisionCardProps) {
+  const reasoning = decision.reasoning.trim();
+  const evidence: Array<{ label: string; value: string }> = [];
+  if (decision.counterpartyPremiseFit?.trim()) {
+    evidence.push({ label: 'what fit', value: decision.counterpartyPremiseFit.trim() });
+  }
+  if (decision.intentAlignment?.trim()) {
+    evidence.push({ label: 'intent', value: decision.intentAlignment.trim() });
+  }
+
+  return (
+    <section
+      data-testid="gate-decision-card"
+      aria-label="Your agent's outreach decision"
+      className="mt-4 rounded-lg border border-gray-200 bg-gray-50 px-4 py-4"
+    >
+      <h3 className="font-ibm-plex-mono text-[13px] font-bold text-[#041729]">
+        Your agent did not reach out
+      </h3>
+      <p className="mt-1 font-ibm-plex-mono text-[11px] uppercase tracking-[0.12em] text-gray-400">
+        Passed · before any contact
+      </p>
+      {reasoning && <p className="mt-2 text-[13px] text-[#3D3D3D]">{reasoning}</p>}
+      {evidence.length > 0 && (
+        <dl className="mt-3 space-y-1.5">
+          {evidence.map((item) => (
+            <div key={item.label} className="flex gap-2 text-[12px]">
+              <dt className="w-20 shrink-0 font-ibm-plex-mono text-gray-400">{item.label}</dt>
+              <dd className="text-[#3D3D3D]">{item.value}</dd>
+            </div>
+          ))}
+        </dl>
+      )}
+      <p className="mt-2.5 font-ibm-plex-mono text-[11px] text-gray-400">
+        {counterpartName} was not contacted and cannot see this.
+      </p>
+    </section>
+  );
+}
+
+export default GateDecisionCard;

--- a/apps/web/src/components/negotiations/gate-decision.ts
+++ b/apps/web/src/components/negotiations/gate-decision.ts
@@ -1,0 +1,36 @@
+import type { ConversationNegotiationLifecycle } from '@/services/conversation';
+
+/** The owner-only outreach-gate decision, as projected by the API (IND-610). */
+export type GateDecision = NonNullable<ConversationNegotiationLifecycle['screenDecision']>;
+
+/**
+ * Whether the negotiation show page should replace its zero-turn dead end with
+ * the gate card, and with which decision.
+ *
+ * Kept pure and separate from rendering so the branch that decides to expose a
+ * private decision is directly testable. Three conditions, all required:
+ * - **no turns** — the only branch where the transcript has nothing to show;
+ *   a negotiation that produced turns tells its own story through the rail,
+ *   and a "did not reach out" card there would flatly contradict it;
+ * - **`screened_out`** — the outcome that means no contact was ever made. Both
+ *   refusal paths (screen-node pass, opening-turn withdraw) collapse to it,
+ *   and a shadow-mode `pass` that did *not* block is correctly excluded here
+ *   even though its `screenDecision.decision` reads `pass`;
+ * - **reasoning present** — a card with nothing to say is worse than the
+ *   existing generic resolved banner, so we fall back to that instead.
+ *
+ * The owner check is deliberately not repeated here: `screenDecision` is absent
+ * for a non-owner because the API never projects it to one. That guarantee is
+ * enforced server-side, where it cannot be bypassed by a crafted request.
+ */
+export function resolveGateDecision(params: {
+  turnCount: number;
+  outcomeReason: string | null;
+  screenDecision: ConversationNegotiationLifecycle['screenDecision'];
+}): GateDecision | null {
+  const { turnCount, outcomeReason, screenDecision } = params;
+  if (turnCount !== 0) return null;
+  if (outcomeReason !== 'screened_out') return null;
+  if (!screenDecision || screenDecision.reasoning.trim() === '') return null;
+  return screenDecision;
+}

--- a/apps/web/src/services/conversation.ts
+++ b/apps/web/src/services/conversation.ts
@@ -37,16 +37,22 @@ export interface ConversationNegotiationLifecycle {
   outcome: { hasOpportunity: boolean; reason: string | null } | null;
   updatedAt: string;
   /**
-   * IND-610: the owner-facing outreach-gate decision (`tasks.metadata.screenDecision`),
-   * named-field projected. Present only when the viewer is the negotiation's
-   * initiator — never populated for a non-owner viewer, even for `screened_out`
+   * IND-610: the owner-facing outreach-gate decision, named-field projected by
+   * the API. Present only when the viewer is the negotiation's initiator —
+   * never populated for a non-owner viewer, even for `screened_out`
    * negotiations that are otherwise visible in a mutual conversation.
+   *
+   * `source` distinguishes the two refusals that collapse into the same
+   * `screened_out` outcome: `screen` (the outreach gate passed before any
+   * contact, so `evidence.*` is present) and `outcome` (the agent refused on
+   * its opening turn, so only reasoning exists).
    */
   screenDecision?: {
+    source: 'screen' | 'outcome';
     decision: 'reach_out' | 'pass';
     reasoning: string;
-    counterpartyPremiseFit: string;
-    intentAlignment: string;
+    counterpartyPremiseFit: string | null;
+    intentAlignment: string | null;
     screenedAt: string | null;
   } | null;
 }

--- a/apps/web/src/services/conversation.ts
+++ b/apps/web/src/services/conversation.ts
@@ -36,6 +36,19 @@ export interface ConversationNegotiationLifecycle {
   signalCount: number;
   outcome: { hasOpportunity: boolean; reason: string | null } | null;
   updatedAt: string;
+  /**
+   * IND-610: the owner-facing outreach-gate decision (`tasks.metadata.screenDecision`),
+   * named-field projected. Present only when the viewer is the negotiation's
+   * initiator — never populated for a non-owner viewer, even for `screened_out`
+   * negotiations that are otherwise visible in a mutual conversation.
+   */
+  screenDecision?: {
+    decision: 'reach_out' | 'pass';
+    reasoning: string;
+    counterpartyPremiseFit: string;
+    intentAlignment: string;
+    screenedAt: string | null;
+  } | null;
 }
 
 export interface ConversationSummary {

--- a/docs/specs/api-reference.md
+++ b/docs/specs/api-reference.md
@@ -1253,6 +1253,42 @@ List A2A agent-to-agent negotiation conversations for the authenticated user.
 }
 ```
 
+Each conversation may carry a `negotiation` lifecycle object. Its optional
+`screenDecision` field (IND-610) is **owner-only**: it is projected solely when
+the authenticated viewer is the negotiation's initiator, and is `null` for every
+other viewer, so a counterparty never learns that an outreach gate ran or what
+it concluded. The ownership check is applied inside the projection itself
+(`services/api/src/adapters/negotiation-lifecycle.projection.ts`), independently
+of the separate listing rule that hides `screened_out` rows from non-initiators.
+
+Only named fields are projected; the underlying `tasks.metadata` blob is never
+returned.
+
+```json
+{
+  "screenDecision": {
+    "source": "screen",
+    "decision": "pass",
+    "reasoning": "...",
+    "counterpartyPremiseFit": "... | null",
+    "intentAlignment": "... | null",
+    "screenedAt": "2026-07-24T11:00:00.000Z | null"
+  }
+}
+```
+
+`source` records where the decision came from, because two different refusals
+collapse into the same `screened_out` outcome:
+
+- `screen` — the outreach gate declined before any contact
+  (`tasks.metadata.screenDecision`); structured evidence fields are present.
+- `outcome` — the agent refused on its opening turn, so no screen record
+  blocked and only the negotiation-outcome `reasoning` exists; the evidence
+  fields are `null`.
+
+Reasoning is only ever taken from a `screened_out` outcome. Ordinary declines
+and turn-cap stalls do not populate this field.
+
 ### GET /api/conversations/negotiations/activity
 
 Return persisted agent-to-agent negotiation activity for one intent owned by

--- a/services/api/package.json
+++ b/services/api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@indexnetwork/api",
-  "version": "0.64.0",
+  "version": "0.65.0",
   "license": "MIT",
   "private": true,
   "scripts": {

--- a/services/api/src/adapters/conversation.database.adapter.ts
+++ b/services/api/src/adapters/conversation.database.adapter.ts
@@ -1,3 +1,4 @@
+import { projectOwnerScreenDecision, readInitiatorUserId } from './negotiation-lifecycle.projection';
 import { readUserContext, schema, Artifact, ChatConversationMeta, ChatMessage, ChatMessageMeta, ChatScopeType, ChatSession, Conversation, ConversationParticipant, ConversationSession, ConversationSummary, CreateMessageInput, CreateSessionInput, Message, ResolvedParticipant, SYSTEM_AGENT_ID, Task, and, asc, count, db, desc, eq, gt, gte, inArray, isNull, lt, ne, opportunities, or, sql } from './database.shared';
 import { emitOpportunityPendingBestEffort } from '../events/opportunity.event';
 import { publishConversationMessageEvent } from '../lib/conversation-events';
@@ -71,7 +72,7 @@ function isMatchProvenanceEntry(value: unknown): value is MatchProvenanceEntry {
     });
 }
 
-function readNegotiationOutcome(parts: unknown): { hasOpportunity: boolean; reason: string | null; turnCount: number | null } | null {
+function readNegotiationOutcome(parts: unknown): { hasOpportunity: boolean; reason: string | null; turnCount: number | null; reasoning: string | null } | null {
   if (!Array.isArray(parts)) return null;
   for (const part of parts) {
     if (typeof part !== 'object' || part === null || Array.isArray(part)) continue;
@@ -88,6 +89,10 @@ function readNegotiationOutcome(parts: unknown): { hasOpportunity: boolean; reas
       hasOpportunity,
       reason: typeof data.reason === 'string' ? data.reason : null,
       turnCount: typeof data.turnCount === 'number' && Number.isFinite(data.turnCount) ? data.turnCount : null,
+      // IND-610: owner-only — never projected into the shared `outcome` field.
+      // Only ever reaches a caller through `projectScreenDecision`, which is
+      // itself gated on the viewer being the negotiation's initiator.
+      reasoning: typeof data.reasoning === 'string' ? data.reasoning : null,
     };
   }
   return null;
@@ -109,30 +114,6 @@ function readNegotiationSignalCount(metadata: unknown): number {
     if (typeof intentId === 'string' && intentId) intentIds.add(intentId);
   }
   return intentIds.size;
-}
-
-/**
- * Projects the owner-visible `screenDecision` fields out of `tasks.metadata`.
- * IND-610: named-field projection only — never returns the raw metadata
- * blob, so unrelated/internal keys on the task can never leak through this
- * surface. Callers must independently gate this on `initiatorUserId ===
- * viewerUserId` before invoking it.
- */
-function projectScreenDecision(metadata: Record<string, unknown>): NonNullable<ConversationSummary['negotiation']>['screenDecision'] {
-  const raw = metadata.screenDecision;
-  if (typeof raw !== 'object' || raw === null || Array.isArray(raw)) return null;
-  const record = raw as Record<string, unknown>;
-  if (record.decision !== 'pass' && record.decision !== 'reach_out') return null;
-  const evidence = typeof record.evidence === 'object' && record.evidence !== null && !Array.isArray(record.evidence)
-    ? record.evidence as Record<string, unknown>
-    : {};
-  return {
-    decision: record.decision,
-    reasoning: typeof record.reasoning === 'string' ? record.reasoning : '',
-    counterpartyPremiseFit: typeof evidence.counterpartyPremiseFit === 'string' ? evidence.counterpartyPremiseFit : '',
-    intentAlignment: typeof evidence.intentAlignment === 'string' ? evidence.intentAlignment : '',
-    screenedAt: typeof record.screenedAt === 'string' ? record.screenedAt : null,
-  };
 }
 
 type PersistedOpportunity = typeof opportunities.$inferSelect;
@@ -683,9 +664,7 @@ export class ConversationDatabaseAdapter {
       // A screened-out outreach gate is private to the client that initiated
       // it. Never project its lifecycle to the counterparty through the shared
       // A2A conversation.
-      const initiatorUserId = typeof metadata.initiatorUserId === 'string'
-        ? metadata.initiatorUserId
-        : metadata.sourceUserId;
+      const initiatorUserId = readInitiatorUserId(metadata);
       if (outcome?.reason === 'screened_out' && initiatorUserId !== viewerUserId) continue;
       negotiationByConv.set(row.conversationId, {
         taskId: row.taskId,
@@ -698,15 +677,13 @@ export class ConversationDatabaseAdapter {
         maxTurns,
         signalCount: readNegotiationSignalCount(metadata),
         outcome: outcome ? { hasOpportunity: outcome.hasOpportunity, reason: outcome.reason } : null,
-        // IND-610: the owner-facing outreach-gate decision. Independently
-        // re-checked here (not merely inherited from the `screened_out`
-        // continue above) so a future caller of this projection can never
-        // leak the stored reasoning/evidence to a non-initiator by relying
-        // solely on the outer mutual-list skip. Named-field projection only
-        // — the raw `tasks.metadata` blob is never returned.
-        screenDecision: initiatorUserId === viewerUserId
-          ? projectScreenDecision(metadata)
-          : null,
+        // IND-610: the owner-facing outreach-gate decision. The ownership
+        // check lives inside the projection and is re-applied there — it is
+        // not inherited from the `screened_out` skip above, which is a listing
+        // rule for this one query rather than a privacy guarantee any caller
+        // of the projection can rely on. Named-field projection only; the raw
+        // `tasks.metadata` blob is never returned.
+        screenDecision: projectOwnerScreenDecision(metadata, outcome, viewerUserId),
         updatedAt: row.updatedAt,
       });
     }

--- a/services/api/src/adapters/conversation.database.adapter.ts
+++ b/services/api/src/adapters/conversation.database.adapter.ts
@@ -111,6 +111,30 @@ function readNegotiationSignalCount(metadata: unknown): number {
   return intentIds.size;
 }
 
+/**
+ * Projects the owner-visible `screenDecision` fields out of `tasks.metadata`.
+ * IND-610: named-field projection only — never returns the raw metadata
+ * blob, so unrelated/internal keys on the task can never leak through this
+ * surface. Callers must independently gate this on `initiatorUserId ===
+ * viewerUserId` before invoking it.
+ */
+function projectScreenDecision(metadata: Record<string, unknown>): NonNullable<ConversationSummary['negotiation']>['screenDecision'] {
+  const raw = metadata.screenDecision;
+  if (typeof raw !== 'object' || raw === null || Array.isArray(raw)) return null;
+  const record = raw as Record<string, unknown>;
+  if (record.decision !== 'pass' && record.decision !== 'reach_out') return null;
+  const evidence = typeof record.evidence === 'object' && record.evidence !== null && !Array.isArray(record.evidence)
+    ? record.evidence as Record<string, unknown>
+    : {};
+  return {
+    decision: record.decision,
+    reasoning: typeof record.reasoning === 'string' ? record.reasoning : '',
+    counterpartyPremiseFit: typeof evidence.counterpartyPremiseFit === 'string' ? evidence.counterpartyPremiseFit : '',
+    intentAlignment: typeof evidence.intentAlignment === 'string' ? evidence.intentAlignment : '',
+    screenedAt: typeof record.screenedAt === 'string' ? record.screenedAt : null,
+  };
+}
+
 type PersistedOpportunity = typeof opportunities.$inferSelect;
 type PersistedOpportunityStatus = PersistedOpportunity['status'];
 
@@ -674,6 +698,15 @@ export class ConversationDatabaseAdapter {
         maxTurns,
         signalCount: readNegotiationSignalCount(metadata),
         outcome: outcome ? { hasOpportunity: outcome.hasOpportunity, reason: outcome.reason } : null,
+        // IND-610: the owner-facing outreach-gate decision. Independently
+        // re-checked here (not merely inherited from the `screened_out`
+        // continue above) so a future caller of this projection can never
+        // leak the stored reasoning/evidence to a non-initiator by relying
+        // solely on the outer mutual-list skip. Named-field projection only
+        // — the raw `tasks.metadata` blob is never returned.
+        screenDecision: initiatorUserId === viewerUserId
+          ? projectScreenDecision(metadata)
+          : null,
         updatedAt: row.updatedAt,
       });
     }

--- a/services/api/src/adapters/database.shared.ts
+++ b/services/api/src/adapters/database.shared.ts
@@ -634,6 +634,27 @@ export interface ResolvedParticipant {
   ownerName?: string | null;
 }
 
+/**
+ * IND-610: owner-only projection of the outreach-gate decision.
+ *
+ * `source` keeps the provenance honest — the same `screened_out` outcome is
+ * reachable from two places, and the card that renders this must not claim
+ * screen-node evidence it does not have:
+ * - `screen`  — `tasks.metadata.screenDecision`, written by the outreach gate
+ *   before any contact; carries structured `evidence.*`.
+ * - `outcome` — the negotiation-outcome artifact's `reasoning`, used when the
+ *   agent refused on the opening turn instead (no screen-node evidence).
+ */
+export interface ProjectedScreenDecision {
+  source: 'screen' | 'outcome';
+  decision: 'reach_out' | 'pass';
+  reasoning: string;
+  /** Screen-node evidence; null when the decision came from the outcome. */
+  counterpartyPremiseFit: string | null;
+  intentAlignment: string | null;
+  screenedAt: string | null;
+}
+
 export interface NegotiationLifecycleSummary {
   taskId: string;
   state: 'submitted' | 'working' | 'input_required' | 'completed' | 'failed' | 'canceled' | 'rejected' | 'auth_required' | 'waiting_for_agent' | 'claimed';
@@ -649,17 +670,13 @@ export interface NegotiationLifecycleSummary {
   updatedAt: Date;
   /**
    * IND-610: the owner-facing outreach-gate decision, named-field projected
-   * from `tasks.metadata.screenDecision`. Populated only when the caller has
-   * independently verified the viewer is the negotiation's initiator — never
-   * the raw metadata blob.
+   * from `tasks.metadata.screenDecision` (or, when the refusal happened at the
+   * opening turn instead of the screen node, from the negotiation-outcome
+   * artifact's `reasoning`). Populated only when the caller has independently
+   * verified the viewer is the negotiation's initiator — never the raw
+   * metadata blob.
    */
-  screenDecision?: {
-    decision: 'reach_out' | 'pass';
-    reasoning: string;
-    counterpartyPremiseFit: string;
-    intentAlignment: string;
-    screenedAt: string | null;
-  } | null;
+  screenDecision?: ProjectedScreenDecision | null;
 }
 
 /** Summary returned by getConversationsForUser. */

--- a/services/api/src/adapters/database.shared.ts
+++ b/services/api/src/adapters/database.shared.ts
@@ -647,6 +647,19 @@ export interface NegotiationLifecycleSummary {
   signalCount: number;
   outcome: { hasOpportunity: boolean; reason: string | null } | null;
   updatedAt: Date;
+  /**
+   * IND-610: the owner-facing outreach-gate decision, named-field projected
+   * from `tasks.metadata.screenDecision`. Populated only when the caller has
+   * independently verified the viewer is the negotiation's initiator — never
+   * the raw metadata blob.
+   */
+  screenDecision?: {
+    decision: 'reach_out' | 'pass';
+    reasoning: string;
+    counterpartyPremiseFit: string;
+    intentAlignment: string;
+    screenedAt: string | null;
+  } | null;
 }
 
 /** Summary returned by getConversationsForUser. */

--- a/services/api/src/adapters/negotiation-lifecycle.projection.ts
+++ b/services/api/src/adapters/negotiation-lifecycle.projection.ts
@@ -1,0 +1,121 @@
+/**
+ * IND-610 — owner-only projection of a negotiation's outreach-gate decision.
+ *
+ * Deliberately a standalone, dependency-free module rather than a private
+ * helper inside `conversation.database.adapter.ts`: this is the privacy
+ * boundary that decides whether one user's agent's private reasoning about
+ * another user is disclosed, and it must be provable without a live database.
+ * Everything here is pure, so the guard is covered by hermetic tests that CI
+ * actually runs, not only by DB-backed specs that require a disposable
+ * database to exercise.
+ *
+ * `import type` only — nothing in this module pulls the drizzle client in.
+ */
+import type { ProjectedScreenDecision } from './database.shared';
+
+/** The subset of the negotiation-outcome artifact this projection needs. */
+export interface NegotiationOutcomeFacts {
+  reason: string | null;
+  reasoning: string | null;
+}
+
+/**
+ * The user whose agent initiated the negotiation, and therefore the only user
+ * entitled to the outreach-gate reasoning.
+ *
+ * `initiatorUserId` is the explicit field; `sourceUserId` is the pre-initiator
+ * fallback for tasks written before it existed. Returns null rather than
+ * `undefined` for a malformed task so a comparison against an equally
+ * malformed viewer id can never accidentally succeed.
+ */
+export function readInitiatorUserId(metadata: Record<string, unknown>): string | null {
+  if (typeof metadata.initiatorUserId === 'string' && metadata.initiatorUserId !== '') {
+    return metadata.initiatorUserId;
+  }
+  if (typeof metadata.sourceUserId === 'string' && metadata.sourceUserId !== '') {
+    return metadata.sourceUserId;
+  }
+  return null;
+}
+
+/**
+ * Reads the named `tasks.metadata.screenDecision` fields written by the
+ * outreach gate. Named-field projection only — the raw metadata blob is never
+ * returned, so unrelated or internal keys on the task cannot leak through this
+ * surface (`docs/design/negotiation-dialogue-game.md:87`).
+ */
+function readScreenDecisionRecord(metadata: Record<string, unknown>): ProjectedScreenDecision | null {
+  const raw = metadata.screenDecision;
+  if (typeof raw !== 'object' || raw === null || Array.isArray(raw)) return null;
+  const record = raw as Record<string, unknown>;
+  if (record.decision !== 'pass' && record.decision !== 'reach_out') return null;
+  const evidence = typeof record.evidence === 'object' && record.evidence !== null && !Array.isArray(record.evidence)
+    ? record.evidence as Record<string, unknown>
+    : {};
+  const named = (value: unknown): string | null => (typeof value === 'string' && value.trim() !== '' ? value : null);
+  return {
+    source: 'screen',
+    decision: record.decision,
+    reasoning: typeof record.reasoning === 'string' ? record.reasoning : '',
+    counterpartyPremiseFit: named(evidence.counterpartyPremiseFit),
+    intentAlignment: named(evidence.intentAlignment),
+    screenedAt: named(record.screenedAt),
+  };
+}
+
+/**
+ * Picks the honest text for the decision, without regard to who is asking.
+ *
+ * Two distinct refusals collapse into the same `screened_out` outcome:
+ * - the screen node passed before any contact — reasoning and structured
+ *   evidence live on `tasks.metadata.screenDecision`;
+ * - the agent refused on its opening turn — no screen record blocked, and the
+ *   only reasoning lives on the negotiation-outcome artifact.
+ *
+ * When the outcome is `screened_out` but the screen record did not itself pass,
+ * that record describes a decision which was *overtaken* by the opening
+ * refusal, so the outcome reasoning wins; otherwise the richer screen record
+ * does. `source` records which one, so the card never claims screen-node
+ * evidence it does not have.
+ */
+function selectScreenDecision(
+  metadata: Record<string, unknown>,
+  outcome: NegotiationOutcomeFacts | null,
+): ProjectedScreenDecision | null {
+  const screenRecord = readScreenDecisionRecord(metadata);
+  const outcomeReasoning = outcome?.reason === 'screened_out' ? (outcome.reasoning ?? '').trim() : '';
+  const fromOutcome: ProjectedScreenDecision | null = outcomeReasoning === '' ? null : {
+    source: 'outcome',
+    // `screened_out` means, definitionally, that no outreach was ever made.
+    decision: 'pass',
+    reasoning: outcomeReasoning,
+    counterpartyPremiseFit: null,
+    intentAlignment: null,
+    screenedAt: null,
+  };
+
+  if (fromOutcome && (!screenRecord || screenRecord.decision !== 'pass')) return fromOutcome;
+  return screenRecord ?? fromOutcome;
+}
+
+/**
+ * The owner gate. Returns the projected decision only when the viewer is the
+ * negotiation's initiator, and null for everyone else.
+ *
+ * This check is deliberately independent, not inherited: the list query also
+ * skips `screened_out` rows for non-initiators, but that skip is a *listing*
+ * rule for one query. A conversation fetched directly, or any future caller of
+ * this projection, must not depend on it for its privacy guarantee — so the
+ * ownership comparison lives here, next to the data it protects.
+ */
+export function projectOwnerScreenDecision(
+  metadata: Record<string, unknown>,
+  outcome: NegotiationOutcomeFacts | null,
+  viewerUserId: string | null | undefined,
+): ProjectedScreenDecision | null {
+  const initiatorUserId = readInitiatorUserId(metadata);
+  if (initiatorUserId === null) return null;
+  if (typeof viewerUserId !== 'string' || viewerUserId === '') return null;
+  if (initiatorUserId !== viewerUserId) return null;
+  return selectScreenDecision(metadata, outcome);
+}

--- a/services/api/src/adapters/tests/conversation.database.adapter.spec.ts
+++ b/services/api/src/adapters/tests/conversation.database.adapter.spec.ts
@@ -518,6 +518,70 @@ describe('ConversationDatabaseAdapter', () => {
     }, 30000);
   });
 
+  describe('getConversationsForUser — screenDecision privacy (IND-610)', () => {
+    it('projects named screenDecision fields to the initiator only, never to the non-owner counterparty, even for a mutually-visible negotiation', async () => {
+      const run = `${Date.now()}-${crypto.randomUUID()}`;
+      const initiator = `screendecision-initiator-${run}`;
+      const counterpart = `screendecision-counterpart-${run}`;
+
+      const conversation = await adapter.createConversation([
+        { participantId: `agent:${initiator}`, participantType: 'agent' as const },
+        { participantId: `agent:${counterpart}`, participantType: 'agent' as const },
+      ]);
+      createdIds.push(conversation.id);
+
+      // An ordinary (non screened_out) negotiation that stays mutually visible
+      // to both sides — the outer screened_out skip does NOT apply here, so
+      // the screenDecision projection is the only thing standing between the
+      // counterparty and the initiator's private outreach-gate reasoning.
+      const task = await adapter.createTask(conversation.id, {
+        type: 'negotiation',
+        sourceUserId: initiator,
+        candidateUserId: counterpart,
+        initiatorUserId: initiator,
+        screenDecision: {
+          decision: 'reach_out',
+          reasoning: 'Strong overlap on ML tooling need.',
+          mode: 'enforce',
+          evidence: {
+            counterpartyPremiseFit: 'Counterpart actively seeks ML engineering help.',
+            intentAlignment: 'Both intents describe the same collaboration shape.',
+          },
+          screenedAt: new Date().toISOString(),
+          durationMs: 120,
+        },
+      });
+      await adapter.updateTaskState(task.id, 'completed');
+      await adapter.createArtifact({
+        taskId: task.id,
+        name: 'negotiation-outcome',
+        parts: [{ kind: 'data', data: { hasOpportunity: true, turnCount: 1 } }],
+      });
+
+      // Owner (initiator) view: named fields are present verbatim.
+      const ownerSummary = (await adapter.getConversationsForUser(`agent:${initiator}`, initiator, true))
+        .find((c) => c.id === conversation.id);
+      expect(ownerSummary?.negotiation?.screenDecision).toMatchObject({
+        decision: 'reach_out',
+        reasoning: 'Strong overlap on ML tooling need.',
+        counterpartyPremiseFit: 'Counterpart actively seeks ML engineering help.',
+        intentAlignment: 'Both intents describe the same collaboration shape.',
+      });
+
+      // Counterparty (non-owner) direct fetch: the negotiation itself remains
+      // visible (this is not a screened_out row), but no screenDecision field
+      // — named or raw — is present at all.
+      const counterpartSummary = (await adapter.getConversationsForUser(`agent:${counterpart}`, counterpart, true))
+        .find((c) => c.id === conversation.id);
+      expect(counterpartSummary?.negotiation).toBeTruthy();
+      expect(counterpartSummary?.negotiation?.screenDecision).toBeFalsy();
+      // Defense in depth: the raw metadata blob must never surface either.
+      expect(JSON.stringify(counterpartSummary?.negotiation)).not.toContain('reasoning');
+      expect(JSON.stringify(counterpartSummary?.negotiation)).not.toContain('counterpartyPremiseFit');
+      expect(JSON.stringify(counterpartSummary?.negotiation)).not.toContain('intentAlignment');
+    }, 30000);
+  });
+
   describe('unread tracking', () => {
     it('counts only counterpart messages and clears only the viewer cursor', async () => {
       const viewerId = `unread-viewer-${Date.now()}`;

--- a/services/api/src/adapters/tests/conversation.database.adapter.spec.ts
+++ b/services/api/src/adapters/tests/conversation.database.adapter.spec.ts
@@ -580,6 +580,119 @@ describe('ConversationDatabaseAdapter', () => {
       expect(JSON.stringify(counterpartSummary?.negotiation)).not.toContain('counterpartyPremiseFit');
       expect(JSON.stringify(counterpartSummary?.negotiation)).not.toContain('intentAlignment');
     }, 30000);
+
+    it('gives the owner the screen reasoning on a zero-turn screened_out negotiation, hides the whole negotiation from the counterparty, and creates no messages', async () => {
+      const run = `${Date.now()}-${crypto.randomUUID()}`;
+      const initiator = `screenedout-initiator-${run}`;
+      const counterpart = `screenedout-counterpart-${run}`;
+
+      const conversation = await adapter.createConversation([
+        { participantId: `agent:${initiator}`, participantType: 'agent' as const },
+        { participantId: `agent:${counterpart}`, participantType: 'agent' as const },
+      ]);
+      createdIds.push(conversation.id);
+
+      const task = await adapter.createTask(conversation.id, {
+        type: 'negotiation',
+        sourceUserId: initiator,
+        candidateUserId: counterpart,
+        initiatorUserId: initiator,
+        screenDecision: {
+          decision: 'pass',
+          reasoning: 'Their focus is fundraising, not the hiring help you asked for.',
+          mode: 'enforce',
+          evidence: {
+            counterpartyPremiseFit: 'Counterpart is raising a seed round.',
+            intentAlignment: 'No overlap with your open engineering role.',
+          },
+          screenedAt: new Date().toISOString(),
+          durationMs: 90,
+        },
+      });
+      await adapter.updateTaskState(task.id, 'completed');
+      await adapter.createArtifact({
+        taskId: task.id,
+        name: 'negotiation-outcome',
+        parts: [{
+          kind: 'data',
+          data: { hasOpportunity: false, reason: 'screened_out', turnCount: 0, reasoning: 'Their focus is fundraising, not the hiring help you asked for.' },
+        }],
+      });
+
+      const ownerSummary = (await adapter.getConversationsForUser(`agent:${initiator}`, initiator, true))
+        .find((c) => c.id === conversation.id);
+      expect(ownerSummary?.negotiation?.outcome).toMatchObject({ hasOpportunity: false, reason: 'screened_out' });
+      expect(ownerSummary?.negotiation?.screenDecision).toMatchObject({
+        source: 'screen',
+        decision: 'pass',
+        reasoning: 'Their focus is fundraising, not the hiring help you asked for.',
+        counterpartyPremiseFit: 'Counterpart is raising a seed round.',
+        intentAlignment: 'No overlap with your open engineering role.',
+      });
+
+      // The counterparty never learns a gate decision was made at all.
+      const counterpartSummary = (await adapter.getConversationsForUser(`agent:${counterpart}`, counterpart, true))
+        .find((c) => c.id === conversation.id);
+      expect(counterpartSummary?.negotiation ?? null).toBeNull();
+      expect(JSON.stringify(counterpartSummary ?? {})).not.toContain('fundraising');
+
+      // HARD CONSTRAINT: surfacing the decline must add zero message rows, or
+      // it would enter the shared thread both sides read back as priorDialogue.
+      const messageRows = await db
+        .select({ id: schema.messages.id })
+        .from(schema.messages)
+        .where(eq(schema.messages.conversationId, conversation.id));
+      expect(messageRows).toHaveLength(0);
+    }, 30000);
+
+    it('falls back to the outcome reasoning when the refusal happened at the opening turn instead of the screen node', async () => {
+      const run = `${Date.now()}-${crypto.randomUUID()}`;
+      const initiator = `openingwithdraw-initiator-${run}`;
+      const counterpart = `openingwithdraw-counterpart-${run}`;
+
+      const conversation = await adapter.createConversation([
+        { participantId: `agent:${initiator}`, participantType: 'agent' as const },
+        { participantId: `agent:${counterpart}`, participantType: 'agent' as const },
+      ]);
+      createdIds.push(conversation.id);
+
+      // No metadata.screenDecision at all — this is the shape a turn-0 withdraw
+      // leaves behind: same `screened_out` outcome, reasoning only on the artifact.
+      const task = await adapter.createTask(conversation.id, {
+        type: 'negotiation',
+        sourceUserId: initiator,
+        candidateUserId: counterpart,
+        initiatorUserId: initiator,
+      });
+      await adapter.updateTaskState(task.id, 'completed');
+      await adapter.createArtifact({
+        taskId: task.id,
+        name: 'negotiation-outcome',
+        parts: [{
+          kind: 'data',
+          data: { hasOpportunity: false, reason: 'screened_out', turnCount: 0, reasoning: 'Not worth spending your name on this one.' },
+        }],
+      });
+
+      const ownerSummary = (await adapter.getConversationsForUser(`agent:${initiator}`, initiator, true))
+        .find((c) => c.id === conversation.id);
+      expect(ownerSummary?.negotiation?.screenDecision).toMatchObject({
+        source: 'outcome',
+        decision: 'pass',
+        reasoning: 'Not worth spending your name on this one.',
+        counterpartyPremiseFit: null,
+        intentAlignment: null,
+      });
+
+      // The shared `outcome` projection must not carry the reasoning: it is the
+      // owner-only field that does, and only via the initiator-gated branch.
+      expect(Object.keys(ownerSummary?.negotiation?.outcome ?? {})).toEqual(['hasOpportunity', 'reason']);
+
+      const counterpartSummary = (await adapter.getConversationsForUser(`agent:${counterpart}`, counterpart, true))
+        .find((c) => c.id === conversation.id);
+      expect(counterpartSummary?.negotiation ?? null).toBeNull();
+      expect(JSON.stringify(counterpartSummary ?? {})).not.toContain('Not worth spending');
+    }, 30000);
   });
 
   describe('unread tracking', () => {

--- a/services/api/src/adapters/tests/negotiation-lifecycle.projection.spec.ts
+++ b/services/api/src/adapters/tests/negotiation-lifecycle.projection.spec.ts
@@ -1,0 +1,200 @@
+/**
+ * IND-610 — hermetic cover for the outreach-gate privacy boundary.
+ *
+ * No database, no credentials, no network: the projection is pure, so the
+ * guarantee "a non-owner receives no screenDecision fields" is proven here on
+ * every run rather than only in the DB-backed adapter spec, which needs a
+ * disposable database that CI does not provision.
+ */
+import { describe, it, expect } from 'bun:test';
+
+import { projectOwnerScreenDecision, readInitiatorUserId } from '../negotiation-lifecycle.projection';
+
+const OWNER = 'user-owner';
+const COUNTERPART = 'user-counterpart';
+
+const screenMetadata = (overrides: Record<string, unknown> = {}) => ({
+  type: 'negotiation',
+  sourceUserId: OWNER,
+  candidateUserId: COUNTERPART,
+  initiatorUserId: OWNER,
+  // Deliberately noisy: internal keys that must never reach any viewer.
+  turnContext: { secretInternalNote: 'do-not-leak' },
+  screenDecision: {
+    decision: 'pass',
+    reasoning: 'They are raising a round, not hiring.',
+    mode: 'enforce',
+    outreachAngle: null,
+    evidence: {
+      counterpartyPremiseFit: 'Fundraising focus.',
+      intentAlignment: 'No overlap with your open role.',
+      memoryHints: 'internal-memory-hint',
+    },
+    screenedAt: '2026-07-24T11:00:00.000Z',
+    durationMs: 90,
+  },
+  ...overrides,
+});
+
+const screenedOutOutcome = { reason: 'screened_out', reasoning: 'They are raising a round, not hiring.' };
+
+describe('projectOwnerScreenDecision — owner gate (IND-610)', () => {
+  it('gives the initiator the named screen fields', () => {
+    expect(projectOwnerScreenDecision(screenMetadata(), screenedOutOutcome, OWNER)).toEqual({
+      source: 'screen',
+      decision: 'pass',
+      reasoning: 'They are raising a round, not hiring.',
+      counterpartyPremiseFit: 'Fundraising focus.',
+      intentAlignment: 'No overlap with your open role.',
+      screenedAt: '2026-07-24T11:00:00.000Z',
+    });
+  });
+
+  it('gives a non-owner viewer nothing at all', () => {
+    expect(projectOwnerScreenDecision(screenMetadata(), screenedOutOutcome, COUNTERPART)).toBeNull();
+    expect(projectOwnerScreenDecision(screenMetadata(), screenedOutOutcome, 'unrelated-user')).toBeNull();
+  });
+
+  it('fails closed on a missing or empty viewer id', () => {
+    // An unauthenticated/blank viewer must never match a blank initiator.
+    expect(projectOwnerScreenDecision(screenMetadata(), screenedOutOutcome, null)).toBeNull();
+    expect(projectOwnerScreenDecision(screenMetadata(), screenedOutOutcome, undefined)).toBeNull();
+    expect(projectOwnerScreenDecision(screenMetadata(), screenedOutOutcome, '')).toBeNull();
+    expect(projectOwnerScreenDecision(
+      screenMetadata({ initiatorUserId: '', sourceUserId: '' }),
+      screenedOutOutcome,
+      '',
+    )).toBeNull();
+  });
+
+  it('falls back to sourceUserId for tasks written before initiatorUserId existed', () => {
+    const legacy = screenMetadata();
+    delete (legacy as Record<string, unknown>).initiatorUserId;
+    expect(readInitiatorUserId(legacy)).toBe(OWNER);
+    expect(projectOwnerScreenDecision(legacy, screenedOutOutcome, OWNER)).not.toBeNull();
+    expect(projectOwnerScreenDecision(legacy, screenedOutOutcome, COUNTERPART)).toBeNull();
+  });
+
+  it('projects named fields only — never the metadata blob', () => {
+    const projected = projectOwnerScreenDecision(screenMetadata(), screenedOutOutcome, OWNER);
+    expect(Object.keys(projected ?? {}).sort()).toEqual([
+      'counterpartyPremiseFit',
+      'decision',
+      'intentAlignment',
+      'reasoning',
+      'screenedAt',
+      'source',
+    ]);
+    const serialized = JSON.stringify(projected);
+    expect(serialized).not.toContain('do-not-leak');
+    expect(serialized).not.toContain('internal-memory-hint');
+    expect(serialized).not.toContain('durationMs');
+    expect(serialized).not.toContain('candidateUserId');
+  });
+});
+
+describe('projectOwnerScreenDecision — which reasoning is the honest one', () => {
+  it('uses the outcome reasoning when the refusal happened at the opening turn', () => {
+    // A turn-0 withdraw leaves no screenDecision behind, only the artifact.
+    const metadata = { initiatorUserId: OWNER, sourceUserId: OWNER };
+    expect(projectOwnerScreenDecision(
+      metadata,
+      { reason: 'screened_out', reasoning: 'Not worth spending your name on this one.' },
+      OWNER,
+    )).toEqual({
+      source: 'outcome',
+      decision: 'pass',
+      reasoning: 'Not worth spending your name on this one.',
+      counterpartyPremiseFit: null,
+      intentAlignment: null,
+      screenedAt: null,
+    });
+  });
+
+  it('prefers the opening-turn reasoning over a screen record that let the outreach through', () => {
+    // The screen said reach_out; the agent then refused on its opening turn.
+    // Showing the screen's positive reasoning would misdescribe the refusal.
+    const metadata = screenMetadata({
+      screenDecision: {
+        decision: 'reach_out',
+        reasoning: 'Looks like a strong fit.',
+        mode: 'shadow',
+        evidence: { counterpartyPremiseFit: 'Fit.', intentAlignment: 'Aligned.' },
+        screenedAt: '2026-07-24T11:00:00.000Z',
+      },
+    });
+    expect(projectOwnerScreenDecision(
+      metadata,
+      { reason: 'screened_out', reasoning: 'On reflection, their ask is unrelated.' },
+      OWNER,
+    )).toMatchObject({ source: 'outcome', reasoning: 'On reflection, their ask is unrelated.' });
+  });
+
+  it('keeps the screen record when the screen itself is what blocked', () => {
+    expect(projectOwnerScreenDecision(screenMetadata(), screenedOutOutcome, OWNER))
+      .toMatchObject({ source: 'screen' });
+  });
+
+  it('still reports a reach_out screen on a negotiation that was never screened out', () => {
+    const metadata = screenMetadata({
+      screenDecision: {
+        decision: 'reach_out',
+        reasoning: 'Strong overlap on ML tooling.',
+        mode: 'enforce',
+        evidence: { counterpartyPremiseFit: 'Seeks ML help.', intentAlignment: 'Same shape.' },
+        screenedAt: '2026-07-24T11:00:00.000Z',
+      },
+    });
+    expect(projectOwnerScreenDecision(metadata, { reason: null, reasoning: null }, OWNER))
+      .toMatchObject({ source: 'screen', decision: 'reach_out' });
+  });
+
+  it('never borrows reasoning from a non-screened_out outcome', () => {
+    // turn_cap / ordinary declines carry counterparty-visible dialogue
+    // reasoning; it must not be relabelled as an outreach-gate decision.
+    expect(projectOwnerScreenDecision(
+      { initiatorUserId: OWNER },
+      { reason: 'turn_cap', reasoning: 'They would not budge on scope.' },
+      OWNER,
+    )).toBeNull();
+    expect(projectOwnerScreenDecision(
+      { initiatorUserId: OWNER },
+      { reason: null, reasoning: 'Agent decided against it.' },
+      OWNER,
+    )).toBeNull();
+  });
+
+  it('returns null rather than an empty card when there is no reasoning anywhere', () => {
+    expect(projectOwnerScreenDecision({ initiatorUserId: OWNER }, { reason: 'screened_out', reasoning: '  ' }, OWNER))
+      .toBeNull();
+    expect(projectOwnerScreenDecision({ initiatorUserId: OWNER }, null, OWNER)).toBeNull();
+  });
+});
+
+describe('projectOwnerScreenDecision — malformed input', () => {
+  it('ignores a screenDecision that is not a well-formed record', () => {
+    for (const bad of [null, 'pass', 42, [], { decision: 'maybe' }, { reasoning: 'no decision' }]) {
+      expect(projectOwnerScreenDecision(
+        { initiatorUserId: OWNER, screenDecision: bad },
+        { reason: null, reasoning: null },
+        OWNER,
+      )).toBeNull();
+    }
+  });
+
+  it('drops non-string evidence rather than rendering it', () => {
+    const projected = projectOwnerScreenDecision(
+      {
+        initiatorUserId: OWNER,
+        screenDecision: {
+          decision: 'pass',
+          reasoning: 'Passed.',
+          evidence: { counterpartyPremiseFit: { nested: 'object' }, intentAlignment: '   ' },
+        },
+      },
+      screenedOutOutcome,
+      OWNER,
+    );
+    expect(projected).toMatchObject({ counterpartyPremiseFit: null, intentAlignment: null });
+  });
+});


### PR DESCRIPTION
Closes IND-610.

## The gap

A `screened_out` negotiation is a decision the user's own agent made *for* them and never told them about. The reasoning was already persisted — `tasks.metadata.screenDecision` was **write-only**, read by nothing in the repo but two test assertions — and the negotiation show page dead-ended at *"No messages in this negotiation"*.

That is the evidence asymmetry: every `accept` produces an opportunity object flowing into cards, deliveries and digests; every decline path is invisible. This closes it on the owner's side only. Surfacing only — no protocol, prompt, schema, or migration changes.

## Two links

**1. Project the decision, owner-only.** New `services/api/src/adapters/negotiation-lifecycle.projection.ts` — a dependency-free module rather than a private helper inside the adapter, because this is the boundary that decides whether one user's agent's private reasoning *about another user* is disclosed, and it must be provable without a live database.

The ownership check (`initiatorUserId === viewerUserId`) is applied **inside** the projection, independently of the existing listing rule that skips `screened_out` rows for non-initiators. That rule is a property of one query; a projection must not lean on it for its privacy guarantee. Named fields only — the raw `tasks.metadata` blob is never returned (`docs/design/negotiation-dialogue-game.md:87`). It also fails closed on a blank/absent viewer id, so a malformed task can never match a malformed viewer.

**2. Render it.** New `GateDecisionCard`, sibling of `OutcomeBanner`/`ResolvedBanner`, on the zero-turn branch:

```
┌─ Your agent did not reach out ───────────────┐
│ passed · before any contact                  │
│ <reasoning>                                  │
│ what fit  <evidence.counterpartyPremiseFit>  │
│ intent    <evidence.intentAlignment>         │
│ Alice was not contacted and cannot see this. │
└──────────────────────────────────────────────┘
```

It is a labelled non-turn `<section>`, not a message bubble. That is load-bearing, not styling: turns persist through `createMessage` into `state.messages`, the shared thread both sides read back as `priorDialogue`, so a withdraw rendered as a message would leak *"your agent judged me not worth it"* to the counterparty. **This change adds zero write paths of any kind.** The closing line always names the counterparty as not contacted and unable to see this — that is what makes the one-sidedness legible instead of feeling like a leak.

## Both refusal paths

A screen-node pass and a turn-0 withdraw collapse into the identical `screened_out` outcome, so the card covers both, with no code dependency on the sibling `NEGOTIATOR_STANCE` work:

| `source` | origin | evidence |
|---|---|---|
| `screen` | outreach gate declined before any contact | `evidence.*` present |
| `outcome` | agent refused on its opening turn | `null` — none exists |

`source` keeps the provenance honest so the card never claims screen-node evidence it does not have. When the outcome is `screened_out` but the screen record said `reach_out`, the screen decision was *overtaken* by the opening refusal, so the outcome reasoning wins. Reasoning is only ever taken from a `screened_out` outcome — turn-cap stalls and ordinary declines carry counterparty-visible dialogue reasoning and must not be relabelled as an outreach-gate decision. A shadow-mode `pass` that did not block is excluded, even though its `decision` field reads `pass`.

## Verification

| Check | Result |
|---|---|
| `bun test src/adapters/tests/negotiation-lifecycle.projection.spec.ts` | **13 pass, 0 fail** |
| `bun run test src/components/__tests__/GateDecisionCard.test.tsx` | **9 pass, 0 fail** |
| `bun run test src/lib/__tests__/negotiation-inbox.test.ts` | **5 pass, 0 fail** |
| `bun run build` (web) | ✅ built in 3.67s |
| `bun run build` (API tsc) | ✅ exit 0 |
| `eslint boundaries/dependencies` | **0 violations** |
| `check-adapter-names.sh` | passed |
| full web suite vs. baseline | identical 51 pre-existing failures, **+9 passing** |

The acceptance criterion *"a non-owner viewer receives no `screenDecision` fields, asserted at the API layer"* is covered **hermetically** — no database, no credentials, no network — so it is runnable anywhere rather than only where a disposable database exists. Note that CI's `test` job runs an explicit three-file pinned list, so this spec is not yet gated there; adding `src/adapters/tests/negotiation-lifecycle.projection.spec.ts` to that list in `.github/workflows/lint.yml` is a one-line follow-up, left out of this PR because the workflow is outside its agreed file scope. The DB-backed cases in `conversation.database.adapter.spec.ts` were extended alongside it (owner sees it, counterparty sees no negotiation at all, **zero message rows**, opening-turn fallback).

## Not verified in this run

- `services/api/tests/negotiation.e2e.isolated.ts` and the extended `conversation.database.adapter.spec.ts` were **not executed**. The only `.env.test` available on this machine points at `protocol_prod`, and no disposable database, local Postgres, or Neon provisioning credential exists here; `TEST_DATABASE_SAFE=1` exists precisely to refuse that run, and it was not overridden. Both files typecheck clean under `bun run build`. Neither is run by CI today. (`negotiation.e2e.isolated.ts` is additionally `skipIf` without `RUN_PAID_INTEGRATION_TESTS=1`.) It is untouched by this PR.

## Follow-up, not fixed here

Zero-turn rows are filtered out of the negotiations inbox (`negotiation-inbox.ts`: `if (!conversation.lastMessage) return []`), so the card is currently only reachable by direct link to the show page. Making these quiet declines *discoverable* is a product decision about how loud a decline should be, deliberately left to the user rather than assumed here.

## Semver

`services/api` 0.64.0 → **0.65.0**, `apps/web` 0.41.0 → **0.42.0** (additive API surface). `docs/specs/api-reference.md` documents the new owner-only field.
