### PR TITLE
ci: enforce the IND-610 owner-only screenDecision guard in CI

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -115,6 +115,7 @@ jobs:
           cd services/api
           bun test \
             src/adapters/tests/can-actor-see-opportunity.spec.ts \
+            src/adapters/tests/negotiation-lifecycle.projection.spec.ts \
             src/queues/tests/timeout.queue.spec.ts \
             src/queues/tests/claim-timeout.queue.spec.ts
 


### PR DESCRIPTION
## Problem

IND-610 (#1290) is **already merged**, so this gap is live on `dev`.

The `test` job in `.github/workflows/lint.yml` runs a hardcoded three-file list that omitted `services/api/src/adapters/tests/negotiation-lifecycle.projection.spec.ts`. Those **13 tests are what prove a non-owner viewer receives no `screenDecision` fields** — including `gives a non-owner viewer nothing at all` and `fails closed on a missing or empty viewer id`.

They have never run on any PR. The merged privacy guard is currently unenforced against regression: one user's agent's private reasoning about another user must never reach that other user, and nothing in CI would catch a change that broke it.

## Change

One line — add the spec to the pinned hermetic list.

The spec is pure and dependency-free by design (`import type` only, no drizzle client, no database), which is exactly why the projection was extracted into its own module and why it belongs in the hermetic job.

## Verification

Run exactly as CI runs it, from `services/api`:

```
bun test src/adapters/tests/can-actor-see-opportunity.spec.ts \
  src/adapters/tests/negotiation-lifecycle.projection.spec.ts \
  src/queues/tests/timeout.queue.spec.ts \
  src/queues/tests/claim-timeout.queue.spec.ts

46 pass, 0 fail, 123 expect() calls
```

`git diff --stat` → `.github/workflows/lint.yml | 1 +`, one file, one insertion.

Refs IND-610.