### PR TITLE
fix(negotiation): report the refusal's own reasoning on a turn-0 screen-out

### DIFF
--- a/packages/protocol/package.json
+++ b/packages/protocol/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@indexnetwork/protocol",
-  "version": "7.11.0",
+  "version": "7.11.1",
   "type": "module",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",

--- a/packages/protocol/src/negotiation/application/negotiation.graph.ts
+++ b/packages/protocol/src/negotiation/application/negotiation.graph.ts
@@ -1135,8 +1135,23 @@ export class NegotiationGraphFactory {
       const outcome: NegotiationOutcome = {
         hasOpportunity,
         agreedRoles,
+        // Which refusal's reasoning is the honest one depends on WHICH path
+        // screened this out. Two now reach `screened_out`:
+        //   - the screen node blocked before any turn → the screen decision is
+        //     the only reasoning that exists;
+        //   - IND-611: the agent refused on its opening turn → the withdrawing
+        //     turn's reasoning is authoritative, and a screen record (if any)
+        //     describes a decision that refusal *overtook*.
+        // Preferring the screen record unconditionally was harmless while the
+        // screen node was the only route here. It is not any more: with
+        // NEGOTIATION_SCREEN_MODE=enforce a `reach_out` screen followed by a
+        // turn-0 withdraw would publish the screen's argument FOR the match as
+        // the reason the agent did not reach out — the owner's gate card
+        // (IND-610) renders exactly this field.
         reasoning: screenedOut
-          ? (state.screenDecision?.reasoning ?? lastTurn?.assessment?.reasoning ?? "")
+          ? (state.firstTurnScreenedOut === true
+              ? (lastTurn?.assessment?.reasoning ?? state.screenDecision?.reasoning ?? "")
+              : (state.screenDecision?.reasoning ?? lastTurn?.assessment?.reasoning ?? ""))
           : (lastTurn?.assessment.reasoning ?? ""),
         turnCount: state.turnCount,
         ...(screenedOut

--- a/packages/protocol/src/negotiation/tests/negotiation.turn0-withdraw.spec.ts
+++ b/packages/protocol/src/negotiation/tests/negotiation.turn0-withdraw.spec.ts
@@ -181,4 +181,45 @@ describe("negotiation graph — turn-0 refusal is not force-rewritten (IND-611)"
     expect(stubs.createdMessages[0].parts[0].data.action).toBe("outreach");
     expect(result.outcome?.reason).not.toBe("screened_out");
   }, 30_000);
+
+  /**
+   * The cross-PR case neither IND-610 nor IND-611 could catch alone.
+   *
+   * IND-611 added a second route to `screened_out` (a turn-0 refusal). The
+   * outcome-reasoning precedence still preferred the screen record, which was
+   * correct while the screen node was the only route. With a `reach_out`
+   * screen followed by a turn-0 withdraw, the outcome would carry the screen's
+   * argument FOR the match — and IND-610's owner-only gate card renders that
+   * field verbatim under "Your agent did not reach out".
+   *
+   * Dev runs NEGOTIATION_SCREEN_MODE=enforce, so this path is reachable in
+   * practice, and the `evaluator` stance makes turn-0 refusals more likely.
+   */
+  it("a reach_out screen overtaken by a turn-0 withdraw reports the REFUSAL's reasoning, not the screen's", async () => {
+    const stubs = mkStubs();
+    agentScript = [{
+      action: "withdraw",
+      assessment: { reasoning: "Bob's ML work does not actually serve Alice's stated need", suggestedRoles: { ownUser: "peer", otherUser: "peer" } },
+      message: null,
+    }];
+
+    // The screen let this through and said why. The agent then refused.
+    const result = await runGraph(stubs, {
+      screenDecision: {
+        decision: "reach_out",
+        reasoning: "strong overlap — worth spending Alice's name on",
+        evidence: { counterpartyPremiseFit: "both in ML", intentAlignment: "aligned" },
+        mode: "enforce",
+        screenedAt: new Date().toISOString(),
+        durationMs: 12,
+      },
+    });
+
+    expect(result.outcome?.reason).toBe("screened_out");
+    // The honest text is the refusal's own.
+    expect(result.outcome?.reasoning).toContain("does not actually serve");
+    // The screen's pro-match argument must never be published as the reason
+    // the agent did not reach out.
+    expect(result.outcome?.reasoning).not.toContain("worth spending Alice's name");
+  }, 30_000);
 });


### PR DESCRIPTION
Follow-up to #1290 (IND-610) and #1291 (IND-611), both merged. This is the seam between them.

## The defect

IND-611 added a second route to the `screened_out` outcome — an honest turn-0 refusal — alongside the pre-existing screen-node block. But `negotiation.graph.ts` still resolved outcome reasoning as:

```ts
reasoning: screenedOut
  ? (state.screenDecision?.reasoning ?? lastTurn?.assessment?.reasoning ?? "")
```

That precedence was correct while the screen node was the **only** way to reach `screened_out`. It is not any more.

Trigger: screen returns `reach_out` with pro-match reasoning → agent refuses on turn 0. `screenedOut` is true via `firstTurnScreenedOut`, so the outcome takes the **screen's argument for the match** and discards the withdrawing turn's actual reasoning.

IND-610's owner-only `GateDecisionCard` renders that field verbatim, so the owner sees:

```
Your agent did not reach out
passed · before any contact
<reasoning arguing the match WAS worth making>
```

which is precisely the dishonesty this line of work exists to remove.

**This is reachable on dev today:** the dev protocol service runs `NEGOTIATION_SCREEN_MODE=enforce`, and the newly-set `NEGOTIATOR_STANCE=evaluator` makes turn-0 refusals *more* likely.

Neither PR could catch it alone — it only exists when both are present, which is why parallel development off a shared pre-merge base missed it.

## The fix

On the `firstTurnScreenedOut` path the withdrawing turn's reasoning is authoritative; a screen record, if any, describes a decision that refusal overtook. The screen-node path is unchanged.

## Verification

- New regression test in `negotiation.turn0-withdraw.spec.ts` pins it. **It fails without the graph change** (`Expected to contain: "does not actually serve"`) and passes with it — verified by stashing the fix and re-running.
- `bun test` across turn0-withdraw + stance + initiator-withdraw-rule + continuation-withdraw: **36 pass, 0 fail, 245 expect() calls**.
- `bun run eval:verify`: **all 10 suites** type-checked and tested, provider-free.
- `bun run build` (protocol) clean.
- `packages/protocol` 7.11.0 → 7.11.1 (fix → patch).

Refs IND-610, IND-611.