### PR TITLE
fix(protocol): attribute screened_out reasoning to whoever decided (IND-611 follow-up)

### DIFF
--- a/packages/protocol/CHANGELOG.md
+++ b/packages/protocol/CHANGELOG.md
@@ -41,7 +41,7 @@ See [STABILITY.md](./STABILITY.md) for the public-contract and tier definitions.
   refusal stands and flows into the existing quiet `screened_out` outcome with
   no message persisted, while a genuinely malformed turn-0 opening (e.g.
   `counter`) is still coerced to the opening action.
-- Attribute `outcome.reasoning` to whoever actually decided (IND-611; 7.11.0):
+- Attribute `outcome.reasoning` to whoever actually decided (IND-611; 7.11.1):
   `screened_out` now has two routes — the screen node, and an opening-turn
   refusal. The finalize node preferred `screenDecision.reasoning` for both,
   which is wrong on the new route when the gate returned `reach_out`: the

--- a/packages/protocol/CHANGELOG.md
+++ b/packages/protocol/CHANGELOG.md
@@ -41,6 +41,14 @@ See [STABILITY.md](./STABILITY.md) for the public-contract and tier definitions.
   refusal stands and flows into the existing quiet `screened_out` outcome with
   no message persisted, while a genuinely malformed turn-0 opening (e.g.
   `counter`) is still coerced to the opening action.
+- Attribute `outcome.reasoning` to whoever actually decided (IND-611; 7.11.0):
+  `screened_out` now has two routes — the screen node, and an opening-turn
+  refusal. The finalize node preferred `screenDecision.reasoning` for both,
+  which is wrong on the new route when the gate returned `reach_out`: the
+  outcome would carry the screen's argument *for* the match as the reason the
+  agent did *not* reach out (and IND-610 renders that string in the owner-only
+  gate-decision card). An opening-turn refusal now reports the withdrawing
+  turn's own reasoning; a genuine screen-node block is unchanged.
 - Add canonical shared guidance source and unified MCP_INSTRUCTIONS/read_docs
   (IND-602/603; 7.10.0): The single normative `CANONICAL_GUIDANCE_SUMMARY`
   (1,555 chars, under the 4,500-char MCP context budget) covers Index Network

--- a/packages/protocol/package.json
+++ b/packages/protocol/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@indexnetwork/protocol",
-  "version": "7.11.0",
+  "version": "7.11.1",
   "type": "module",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",

--- a/packages/protocol/src/negotiation/application/negotiation.graph.ts
+++ b/packages/protocol/src/negotiation/application/negotiation.graph.ts
@@ -1115,7 +1115,17 @@ export class NegotiationGraphFactory {
       // IND-564: an opening-move `withdraw` blocked before any message was
       // persisted is the same quiet screen-out outcome (no in-task outreach to
       // retract), reached from the turn node rather than the screen node.
-      const screenedOut = blocksNegotiationBeforeFirstTurn(state.screenDecision, state.turnCount) || state.firstTurnScreenedOut === true;
+      // Two DISTINCT routes reach the same quiet `screened_out` outcome, and
+      // they disagree about who authored the decision:
+      //  - the screen node blocked before any turn was drafted → the screen
+      //    decision is the reason;
+      //  - the acting agent refused on its opening turn (IND-611) → the
+      //    withdrawing TURN is the reason.
+      // They are collapsed into `screenedOut` for status/lifecycle purposes but
+      // must stay separate when attributing `outcome.reasoning` below.
+      const blockedByScreenNode = blocksNegotiationBeforeFirstTurn(state.screenDecision, state.turnCount);
+      const refusedAtOpeningTurn = state.firstTurnScreenedOut === true;
+      const screenedOut = blockedByScreenNode || refusedAtOpeningTurn;
       const atCap = !screenedOut && (state.maxTurns ?? 0) > 0 && state.turnCount >= state.maxTurns! && !isTerminalAction(lastTurn?.action);
 
       let agreedRoles: NegotiationOutcome["agreedRoles"] = [];
@@ -1135,9 +1145,19 @@ export class NegotiationGraphFactory {
       const outcome: NegotiationOutcome = {
         hasOpportunity,
         agreedRoles,
-        reasoning: screenedOut
+        // IND-611: attribute the reasoning to whoever actually made the
+        // decision. Before the turn-0 refusal path existed, `screenedOut`
+        // implied the screen node, so preferring `screenDecision.reasoning`
+        // was always right. It is now wrong for an opening-turn refusal taken
+        // while the screen said `reach_out`: that record argues FOR the match,
+        // and surfacing it as the reason the agent did NOT reach out is exactly
+        // the dishonesty this work removes (IND-610 renders this string in the
+        // owner-only gate-decision card). The screen-node branch is unchanged.
+        reasoning: blockedByScreenNode
           ? (state.screenDecision?.reasoning ?? lastTurn?.assessment?.reasoning ?? "")
-          : (lastTurn?.assessment.reasoning ?? ""),
+          : refusedAtOpeningTurn
+            ? (lastTurn?.assessment?.reasoning ?? state.screenDecision?.reasoning ?? "")
+            : (lastTurn?.assessment.reasoning ?? ""),
         turnCount: state.turnCount,
         ...(screenedOut
           ? { reason: "screened_out" as const }

--- a/packages/protocol/src/negotiation/tests/negotiation.turn0-withdraw.spec.ts
+++ b/packages/protocol/src/negotiation/tests/negotiation.turn0-withdraw.spec.ts
@@ -4,6 +4,7 @@ import { NegotiationGraphState } from "../negotiation.state.js";
 import type { NegotiationGraphDatabase } from "../../shared/interfaces/database.interface.js";
 import type { AgentDispatcher } from "../../shared/interfaces/agent-dispatcher.interface.js";
 import { IndexNegotiator, type NegotiationAgentInput } from "../negotiation.agent.js";
+import { NegotiationScreener, type ScreenDecision } from "../negotiation.screen.js";
 import type { NegotiationTurn } from "../negotiation.state.js";
 
 /**
@@ -43,6 +44,7 @@ function mkStubs(priorMessages: FakeMessage[] = []) {
   const createdMessages: Array<{ senderId: string; parts: Array<{ kind: string; data: NegotiationTurn }> }> = [];
   const statusUpdates: Array<{ opportunityId: string; status: string }> = [];
   const artifacts: Array<Record<string, unknown>> = [];
+  const screenWrites: Array<{ taskId: string; record: Record<string, unknown> }> = [];
   const database = {
     getOrCreateDM: async () => ({ id: "conv-1" }),
     createTask: async (conversationId: string) => ({ id: "task-new", conversationId, state: "submitted" }),
@@ -53,6 +55,9 @@ function mkStubs(priorMessages: FakeMessage[] = []) {
     updateTaskState: async () => ({ id: "task-new", conversationId: "conv-1", state: "working" }),
     createArtifact: async (a: Record<string, unknown>) => { artifacts.push(a); return { id: "art-1" }; },
     setTaskTurnContext: async () => {},
+    setTaskScreenDecision: async (taskId: string, record: Record<string, unknown>) => {
+      screenWrites.push({ taskId, record });
+    },
     updateOpportunityStatus: async (opportunityId: string, status: string) => {
       statusUpdates.push({ opportunityId, status });
       return { id: opportunityId, status };
@@ -71,7 +76,7 @@ function mkStubs(priorMessages: FakeMessage[] = []) {
     hasExternalAgent: async () => false,
   } as unknown as AgentDispatcher;
 
-  return { database, dispatcher, createdMessages, statusUpdates, artifacts };
+  return { database, dispatcher, createdMessages, statusUpdates, artifacts, screenWrites };
 }
 
 const sourceUser = {
@@ -166,6 +171,80 @@ describe("negotiation graph — turn-0 refusal is not force-rewritten (IND-611)"
 
     expect(result.lastTurn?.action).toBe("withdraw");
     expect(result.lastTurn?.action).not.toBe("outreach");
+  }, 30_000);
+
+  it("outcome.reasoning is the WITHDRAWING TURN's reasoning, not a reach_out screen's pro-match text", async () => {
+    // Cross-PR regression guard (IND-611 x IND-610).
+    //
+    // `outcome.reasoning` used to prefer `screenDecision.reasoning` whenever
+    // `screenedOut` was set, which was safe only while the screen node was the
+    // ONLY route to that outcome. The turn-0 refusal path adds a second route,
+    // and on it the screen record can say `reach_out` with reasoning arguing
+    // FOR the match. IND-610's negotiation-lifecycle projection surfaces
+    // `outcome.reasoning` whenever the screen record is not a `pass`, so the
+    // owner's gate-decision card would have read "your agent did not reach out"
+    // above text explaining why the match WAS worth making — the exact
+    // dishonesty this work exists to remove.
+    process.env.NEGOTIATION_SCREEN_MODE = "enforce";
+    const origScreenerInvoke = NegotiationScreener.prototype.invoke;
+    const reachOut: ScreenDecision = {
+      decision: "reach_out",
+      reasoning: "strong overlap on evaluation tooling; this is worth Alice's time",
+      outreachAngle: "shared evaluation focus",
+      evidence: { counterpartyPremiseFit: "fits", intentAlignment: "aligned" },
+    };
+    NegotiationScreener.prototype.invoke = async () => reachOut;
+
+    try {
+      const stubs = mkStubs();
+      agentScript = [{
+        action: "withdraw",
+        assessment: { reasoning: "on closer reading Bob is not actually available this quarter", suggestedRoles: { ownUser: "peer", otherUser: "peer" } },
+        message: null,
+      }];
+
+      const result = await runGraph(stubs);
+
+      // The gate genuinely ran and said reach_out — this is the real seam.
+      expect(stubs.screenWrites.length).toBe(1);
+      expect(stubs.screenWrites[0].record.decision).toBe("reach_out");
+
+      expect(result.outcome?.reason).toBe("screened_out");
+      expect(result.outcome?.reasoning).toBe("on closer reading Bob is not actually available this quarter");
+      expect(result.outcome?.reasoning).not.toContain("worth Alice's time");
+      expect(result.outcome?.reasoning).not.toBe(reachOut.reasoning);
+      // Still the quiet path: nothing reached the counterparty.
+      expect(stubs.createdMessages.length).toBe(0);
+    } finally {
+      NegotiationScreener.prototype.invoke = origScreenerInvoke;
+    }
+  }, 30_000);
+
+  it("a genuine screen-node block still reports the SCREEN's reasoning (unchanged)", async () => {
+    // The other half of the contract: when the gate itself passed on the match,
+    // no turn was ever drafted, so the screen decision remains authoritative.
+    process.env.NEGOTIATION_SCREEN_MODE = "enforce";
+    const origScreenerInvoke = NegotiationScreener.prototype.invoke;
+    NegotiationScreener.prototype.invoke = async (): Promise<ScreenDecision> => ({
+      decision: "pass",
+      reasoning: "generic overlap only; not worth the outreach",
+      outreachAngle: null,
+      evidence: { counterpartyPremiseFit: "thin", intentAlignment: "vague" },
+    });
+
+    try {
+      const stubs = mkStubs();
+      agentScript = []; // no turn should ever be drafted
+
+      const result = await runGraph(stubs);
+
+      expect(result.outcome?.reason).toBe("screened_out");
+      expect(result.outcome?.reasoning).toBe("generic overlap only; not worth the outreach");
+      expect(result.outcome?.turnCount).toBe(0);
+      expect(stubs.createdMessages.length).toBe(0);
+    } finally {
+      NegotiationScreener.prototype.invoke = origScreenerInvoke;
+    }
   }, 30_000);
 
   it("a malformed turn-0 opening (counter) is STILL coerced to outreach", async () => {


### PR DESCRIPTION
## Follow-up to #1291 — cross-PR defect at the IND-611 × IND-610 seam

#1291 merged as `330990b0d` at its **pre-rebase** head, so this fix did not land with it. It is a one-function change plus two regression tests, on top of current `dev`.

### The defect

`negotiation.graph.ts` finalize:

```ts
reasoning: screenedOut
  ? (state.screenDecision?.reasoning ?? lastTurn?.assessment?.reasoning ?? '')
  : (lastTurn?.assessment.reasoning ?? ''),
```

That precedence predates IND-611 and was harmless, because the **only** way to reach `screenedOut` was the screen node itself. IND-611 added a second route — `firstTurnScreenedOut`, the agent refusing on turn 0 — and on that route the precedence is wrong in one specific case:

> screen mode is on → the gate returns `decision: 'reach_out'` with pro-match reasoning → the agent **then** refuses on turn 0.

`screenedOut` is true via `firstTurnScreenedOut`, so `outcome.reasoning` takes `screenDecision.reasoning` — the screen's argument **for** the match — and the withdrawing turn's actual reasoning is discarded.

### Why it matters beyond the protocol

IND-610 (#1290) renders this string. Its projection (`services/api/src/adapters/negotiation-lifecycle.projection.ts`) does:

```ts
if (fromOutcome && (!screenRecord || screenRecord.decision !== 'pass')) return fromOutcome;
```

With a `reach_out` screen record it takes the outcome reasoning — the pro-match text. The owner's `GateDecisionCard` would then read **"your agent did not reach out / passed · before any contact"** followed by reasoning **arguing the match was worth making**.

That is the precise dishonesty this whole line of work exists to remove, reappearing at the seam between the two PRs. Neither PR could catch it alone — it only exists once both are present.

### The fix

Split the collapsed predicate:

```ts
const blockedByScreenNode  = blocksNegotiationBeforeFirstTurn(state.screenDecision, state.turnCount);
const refusedAtOpeningTurn = state.firstTurnScreenedOut === true;
const screenedOut = blockedByScreenNode || refusedAtOpeningTurn;
```

An opening-turn refusal reports the **withdrawing turn's** reasoning; a genuine screen-node block keeps the existing expression **verbatim**. Status, lifecycle, opportunity mapping, and the collapsed `screened_out` outcome reason are all unchanged — only attribution of the reasoning string moves.

Protocol-only. No `services/api` or `apps/web` change; IND-610's projection needs no edit once the protocol reports the right author.

### Tests

Two cases added to `negotiation.turn0-withdraw.spec.ts`, driving the **real** screen node with a stubbed `NegotiationScreener`:

- `reach_out` screen + turn-0 withdraw ⇒ `outcome.reasoning` is the withdrawing turn's text and never the screen's, and no message reaches the counterparty. **Verified to fail on the old precedence and pass on the new one** by reverting only the fix (4 pass / 1 fail → 5 pass / 0 fail).
- a genuine `pass` screen-node block still reports the **screen's** reasoning, `turnCount` 0 — the unchanged half of the contract.

### Gates

- `bunx tsc --noEmit` clean for `packages/protocol`.
- CI-equivalent `env -u OPENROUTER_API_KEY -u OPENAI_API_KEY TEST_CONCURRENCY=4 bun run test:isolated`: **2319 pass, 0 fail, 0 errors across 219 files**.
- `bun run eval:verify`: **all 10 suites** type-checked and tested provider-free.
- Focused negotiation specs re-run under **all three stances** (`advocate`/`evaluator`/`skeptic`): 109 pass, 0 fail across 11 files, including `negotiation.stance.spec.ts` (advocate byte-identical golden), `negotiation.initiator-withdraw-rule.spec.ts`, `negotiation.screen-routing.spec.ts`, `negotiation.screen.spec.ts`, and `negotiation.graph.spec.ts`.

No stance flipped by this PR; `advocate` remains the code default and the committed default in `.env.example` and `startup.env.ts`.
