### PR TITLE
feat(negotiation): surface the owner's gate decision in the inbox (IND-610)

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@indexnetwork/web",
-  "version": "0.42.0",
+  "version": "0.43.0",
   "license": "MIT",
   "scripts": {
     "dev": "vite --host 127.0.0.1",

--- a/apps/web/src/components/NegotiationsInbox.tsx
+++ b/apps/web/src/components/NegotiationsInbox.tsx
@@ -18,6 +18,10 @@ const CHIP_CLASS: Record<NegotiationInboxStatus, string> = {
   started: 'border-emerald-200 bg-emerald-50 text-emerald-700',
   rejected: 'border-red-200 bg-red-50 text-red-700',
   stalled: 'border-amber-200 bg-amber-50 text-amber-700',
+  // IND-610: a decision by the viewer's own agent, not a counterparty verdict.
+  // Deliberately neutral rather than red — nothing was rejected, and nobody
+  // else was ever involved.
+  not_sent: 'border-gray-200 bg-gray-100 text-gray-600',
 };
 
 function statusLabel(item: NegotiationInboxItem): string {
@@ -30,6 +34,7 @@ function statusLabel(item: NegotiationInboxItem): string {
     case 'started': return 'Chat started';
     case 'rejected': return 'No opportunity';
     case 'stalled': return 'Stalled';
+    case 'not_sent': return 'Not sent';
   }
 }
 

--- a/apps/web/src/lib/__tests__/negotiation-inbox.test.ts
+++ b/apps/web/src/lib/__tests__/negotiation-inbox.test.ts
@@ -17,6 +17,7 @@ function conversation(
     acceptedByViewer?: boolean;
     withMessage?: boolean;
     updatedAt?: string;
+    screenDecision?: NonNullable<ConversationSummary['negotiation']>['screenDecision'];
   } = {},
 ): ConversationSummary {
   const action = input.action ?? 'counter';
@@ -48,9 +49,24 @@ function conversation(
       signalCount: 2,
       outcome: input.outcome ?? null,
       updatedAt: input.updatedAt ?? '2026-07-24T11:00:00.000Z',
+      ...(input.screenDecision ? { screenDecision: input.screenDecision } : {}),
     },
   };
 }
+
+/**
+ * The API projects `screenDecision` ONLY to the negotiation's initiator, so a
+ * fixture carrying it represents what the OWNER receives, and one without it
+ * represents exactly what a counterparty receives for the same negotiation.
+ */
+const OWNER_GATE_DECISION = {
+  source: 'screen' as const,
+  decision: 'pass' as const,
+  reasoning: 'Bob is not working on anything close to what Alice needs.',
+  counterpartyPremiseFit: 'different domain',
+  intentAlignment: 'no overlap',
+  screenedAt: '2026-07-24T11:00:00.000Z',
+};
 
 describe('negotiations inbox presentation', () => {
   it('puts consultations before agent agreements in Your move', () => {
@@ -108,6 +124,49 @@ describe('negotiations inbox presentation', () => {
   it('does not surface zero-turn private or abandoned rows', () => {
     const groups = deriveNegotiationInbox([
       conversation('screened', { state: 'completed', withMessage: false, outcome: { hasOpportunity: false, reason: 'screened_out' } }),
+    ], 'viewer', NOW);
+
+    expect(groups).toEqual({ yourMove: [], inProgress: [], resolved: [] });
+  });
+
+  it('surfaces the owner-only gate decision as a resolved row (IND-610)', () => {
+    const groups = deriveNegotiationInbox([
+      conversation('gated', {
+        state: 'completed',
+        withMessage: false,
+        outcome: { hasOpportunity: false, reason: 'screened_out' },
+        screenDecision: OWNER_GATE_DECISION,
+      }),
+    ], 'viewer', NOW);
+
+    expect(groups.resolved).toHaveLength(1);
+    const [row] = groups.resolved;
+    expect(row.conversationId).toBe('gated');
+    expect(row.status).toBe('not_sent');
+    expect(row.lastAction).toBe('Your agent did not reach out');
+    expect(row.turnCount).toBe(0);
+    // The row is a link to the existing card; it must not leak the reasoning
+    // itself into the list surface.
+    expect(JSON.stringify(row)).not.toContain('not working on anything close');
+  });
+
+  it('gives a NON-OWNER viewer no gate row for the same negotiation', () => {
+    // Identical negotiation, counterparty's view: the API withheld
+    // screenDecision, so nothing here can reconstruct the row.
+    const groups = deriveNegotiationInbox([
+      conversation('gated', {
+        state: 'completed',
+        withMessage: false,
+        outcome: { hasOpportunity: false, reason: 'screened_out' },
+      }),
+    ], 'counterparty', NOW);
+
+    expect(groups).toEqual({ yourMove: [], inProgress: [], resolved: [] });
+  });
+
+  it('still hides a zero-turn shell that carries no gate decision', () => {
+    const groups = deriveNegotiationInbox([
+      conversation('abandoned', { state: 'working', withMessage: false }),
     ], 'viewer', NOW);
 
     expect(groups).toEqual({ yourMove: [], inProgress: [], resolved: [] });

--- a/apps/web/src/lib/negotiation-inbox.ts
+++ b/apps/web/src/lib/negotiation-inbox.ts
@@ -9,7 +9,9 @@ export type NegotiationInboxStatus =
   | 'accepted'
   | 'started'
   | 'rejected'
-  | 'stalled';
+  | 'stalled'
+  /** IND-610: the owner's own agent declined before any contact. Owner-only. */
+  | 'not_sent';
 
 export interface NegotiationInboxItem {
   conversationId: string;
@@ -135,12 +137,45 @@ export function deriveNegotiationInbox(
 ): NegotiationInboxGroups {
   const ownAgentId = viewerUserId ? `agent:${viewerUserId}` : null;
   const items = negotiations.flatMap<NegotiationInboxItem>((conversation) => {
-    // Zero-turn rows include private screened-out attempts and abandoned task
-    // shells. Keep the same invisibility rule as ChatSidebar's A2A mode.
-    if (!conversation.lastMessage) return [];
-
     const counterpart = conversation.participants.find((participant) => participant.participantId !== ownAgentId);
     if (!counterpart) return [];
+
+    // Zero-turn rows are normally invisible (abandoned task shells), matching
+    // ChatSidebar's A2A rule. The one exception is the viewer's OWN outreach
+    // gate decision: it has no messages by definition, so this filter is what
+    // made the IND-610 gate card reachable only by direct link.
+    //
+    // The owner boundary is NOT re-derived here. `negotiation.screenDecision`
+    // is projected by the API only when `initiatorUserId === viewerUserId`
+    // (services/api/src/adapters/negotiation-lifecycle.projection.ts), so its
+    // mere presence IS the owner proof. A counterparty never receives the
+    // field and therefore never gets this row.
+    if (!conversation.lastMessage) {
+      const gateDecision = conversation.negotiation?.screenDecision;
+      if (!gateDecision) return [];
+
+      const gateTimestamp = new Date(
+        conversation.negotiation?.updatedAt ?? conversation.lastMessageAt ?? conversation.createdAt,
+      ).getTime();
+      const gateSafeTimestamp = Number.isFinite(gateTimestamp) ? gateTimestamp : 0;
+
+      return [{
+        conversationId: conversation.id,
+        counterpart: {
+          id: counterpart.participantId.replace(/^agent:/, ''),
+          name: counterpart.ownerName ?? conversation.metadata?.title ?? counterpart.name ?? 'Unknown user',
+          avatar: counterpart.avatar,
+        },
+        group: 'resolved',
+        status: 'not_sent',
+        signalCount: Math.max(conversation.negotiation?.signalCount ?? 0, conversation.via.length),
+        lastAction: 'Your agent did not reach out',
+        timeAgo: formatTimeAgo(gateSafeTimestamp, now),
+        sortTimestamp: gateSafeTimestamp,
+        turnCount: 0,
+        maxTurns: conversation.negotiation?.maxTurns ?? 6,
+      }];
+    }
 
     const lastTurn = readLastTurn(conversation.lastMessage.parts);
     const classification = classifyConversation(conversation, lastTurn.action, viewerUserId);


### PR DESCRIPTION
Follow-up to #1290 (IND-610, merged).

## Problem

The `GateDecisionCard` that shipped in #1290 is **reachable only by direct link**. `deriveNegotiationInbox` opens with:

```ts
if (!conversation.lastMessage) return [];
```

and a screened-out negotiation has no messages by definition. So the card exists, is correct, and no user will ever see it.

## Which layer drops them — verified, not assumed

The server **does** return these rows to the owner. Checked before writing code:

- `getConversationsForUser` (`conversation.database.adapter.ts:366-384`) selects by participant membership with **no message requirement**.
- The `:665` guard strips only the *lifecycle projection*, and only when `initiatorUserId !== viewerUserId` — the owner keeps it.
- The `screenedOutFilter` near `:2513` is in a **different method** and is gated on `opts?.mutualWithUserId`. The web inbox calls `GET /conversations/negotiations` → `getAgentConversations` → `getConversationsForUser`, which never sets that option, so it does not apply.

A conversation row always exists: the graph's init node calls `getOrCreateDM` unconditionally, before the screen node runs.

So this is a client-side fix, as scoped.

## Privacy

**No second privacy rule.** `negotiation.screenDecision` is projected by the API only when `initiatorUserId === viewerUserId`, so its presence *is* the owner proof. A counterparty never receives the field and therefore cannot get the row — the boundary stays in one place, next to the data it protects.

The row links to the existing card and deliberately does **not** carry the reasoning text into the list surface.

## Verification

`bun --bun vitest run src/lib/__tests__/negotiation-inbox.test.ts` → **8 passed**, including:

- `surfaces the owner-only gate decision as a resolved row` — **fails without the change** (verified by stashing it)
- `gives a NON-OWNER viewer no gate row for the same negotiation` — identical negotiation, counterparty view, no `screenDecision` projected, no row
- `still hides a zero-turn shell that carries no gate decision` — abandoned shells stay invisible
- the pre-existing `does not surface zero-turn private or abandoned rows` passes unchanged

`bun run build` clean. `apps/web` 0.42.0 → 0.43.0 (feat → minor).

Refs IND-610.