### PR TITLE
chore(protocol): restore the public export inventory and gate architecture checks in CI

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -174,3 +174,46 @@ jobs:
 
       - name: Verify eval suites (typecheck + provider-free tests)
         run: cd packages/protocol && bun run eval:verify
+
+  protocol-architecture:
+    # The packages/protocol architecture gates ran local-only until now, so
+    # nothing stopped the public export inventory and its consumer fixture from
+    # drifting when #1301 deleted the discovery-run interface — both were broken
+    # on dev for days without any red check.
+    #
+    # NOTE: `architecture:cycles` is deliberately not run here yet. It fails on
+    # dev today (negotiation/application <-> questions/questioner <->
+    # shared/agent/tool.helpers form a 7-module cycle) and breaking that cycle is
+    # a refactor, not a check-wiring change. Add it to this job once that is
+    # fixed, and drop the individual steps for `bun run architecture:check`.
+    runs-on: blacksmith-4vcpu-ubuntu-2404
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: "1.3.14"
+          no-cache: true
+
+      - name: Install dependencies
+        run: |
+          bun pm cache rm || true
+          bun install --frozen-lockfile
+
+      - name: Check public export inventory
+        run: cd packages/protocol && bun run architecture:exports
+
+      - name: Type check the external consumer fixture
+        run: cd packages/protocol && bun run architecture:consumer
+
+      - name: Check host isolation
+        run: cd packages/protocol && bun run architecture:host-isolation
+
+      - name: Check capability boundaries
+        run: cd packages/protocol && bun run architecture:capabilities
+
+      - name: Check published artifact inventory
+        run: cd packages/protocol && bun run architecture:artifacts
+
+      - name: Run architecture tests
+        run: cd packages/protocol && bun run test:architecture

--- a/bun.lock
+++ b/bun.lock
@@ -88,7 +88,7 @@
     },
     "packages/protocol": {
       "name": "@indexnetwork/protocol",
-      "version": "8.0.1",
+      "version": "8.0.2",
       "dependencies": {
         "@langchain/core": "1.1.48",
         "@langchain/langgraph": "1.3.2",

--- a/packages/protocol/CHANGELOG.md
+++ b/packages/protocol/CHANGELOG.md
@@ -31,6 +31,13 @@ See [STABILITY.md](./STABILITY.md) for the public-contract and tier definitions.
   `bun run eval:stance` measures decline rate on low-value versus high-value
   fixtures per stance.
 
+### Removed
+- **BREAKING:** `DiscoveryRunInput` and `DiscoveryRunRecord` (8.0.0). Background-only
+  opportunity matching (#1301) deleted `shared/interfaces/discovery-run.interface.ts`
+  along with the discovery-run queue, adapter, and coalescing domain, so the two
+  stable types are no longer part of the public surface. The major bump shipped
+  with that change; this entry and the regenerated export inventory record it.
+
 ### Fixed
 - Stop force-rewriting an opening-move refusal (IND-611 prerequisite; 7.11.0):
   `negotiation.graph.ts` ran the turn-0 opening force *before* the IND-564

--- a/packages/protocol/architecture/consumer/public-api.ts
+++ b/packages/protocol/architecture/consumer/public-api.ts
@@ -263,8 +263,6 @@ import type {
   ToolActionResponse,
   IntentGraphQueue,
   Scraper,
-  DiscoveryRunInput,
-  DiscoveryRunRecord,
   EnrichmentRunInput,
   EnrichmentRunRecord,
   NegotiationTimeoutQueue,

--- a/packages/protocol/architecture/exports.snapshot.json
+++ b/packages/protocol/architecture/exports.snapshot.json
@@ -405,18 +405,6 @@
       "source": "./shared/interfaces/scraper.interface.js"
     },
     {
-      "name": "DiscoveryRunInput",
-      "kind": "type",
-      "stability": "stable",
-      "source": "./shared/interfaces/discovery-run.interface.js"
-    },
-    {
-      "name": "DiscoveryRunRecord",
-      "kind": "type",
-      "stability": "stable",
-      "source": "./shared/interfaces/discovery-run.interface.js"
-    },
-    {
       "name": "EnrichmentRunInput",
       "kind": "type",
       "stability": "stable",

--- a/packages/protocol/package.json
+++ b/packages/protocol/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@indexnetwork/protocol",
-  "version": "8.0.1",
+  "version": "8.0.2",
   "type": "module",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",


### PR DESCRIPTION
Follow-up to #1302 (issue 2 of the pre-existing failures found there).

## Problem

`#1301` deleted `shared/interfaces/discovery-run.interface.ts` — along with the discovery-run queue, adapter, and coalescing domain — but left the two stable types it exported in the architecture snapshot and the consumer fixture. Two gates have failed on `dev` ever since:

```
$ bun run architecture:exports
error: Protocol public API inventory changed. Review it, then run: bun run architecture:exports:update

$ bun run architecture:consumer
architecture/consumer/public-api.ts(266,3): error TS2305: Module '"../../src/index.js"' has no exported member 'DiscoveryRunInput'.
architecture/consumer/public-api.ts(267,3): error TS2305: Module '"../../src/index.js"' has no exported member 'DiscoveryRunRecord'.
```

**Root cause of the drift:** no architecture gate runs in CI. `grep -rn architecture .github/workflows/` returns nothing — the whole `architecture:check` suite was local-only, so the snapshot could rot silently.

## Changes

- **Regenerate** the export inventory and consumer fixture → 388 exports (380 stable, 8 experimental).
- **Record the removal in `CHANGELOG.md`.** Per `STABILITY.md`, removing a stable export is a MAJOR change. #1301 did bump `7.12.0 → 8.0.0`, but the changelog never said what broke — a problem for a published package whose `[Unreleased]` section is the release contract.
- **Add a `protocol-architecture` CI job** running `exports`, `consumer`, `host-isolation`, `capabilities`, `artifacts`, and `test:architecture`.

## Third pre-existing failure found — deliberately not fixed here

`architecture:cycles` also fails on `dev`:

```
error: Production module cycles are prohibited: negotiation/application/index.ts,
negotiation/application/negotiation.graph.ts, negotiation/application/negotiation.tools.ts,
negotiation/public/index.ts, questioner/questioner.types.ts,
questions/application/question.input.ts, shared/agent/tool.helpers.ts
```

Breaking that 7-module cycle is a refactor, not a check-wiring change, so the job runs the six green gates and carries a comment saying to add `cycles` (and collapse the steps back to `bun run architecture:check`) once it is fixed. Wiring six gates now beats wiring none while a refactor is scheduled.

## Verification

| Gate | Before (dev) | After |
|---|---|---|
| `architecture:exports` | ❌ | ✅ |
| `architecture:consumer` | ❌ | ✅ |
| `architecture:host-isolation` | ✅ | ✅ |
| `architecture:capabilities` | ✅ | ✅ |
| `architecture:artifacts` | ✅ | ✅ (783 files) |
| `test:architecture` | ✅ | ✅ 18 pass |
| `architecture:cycles` | ❌ | ❌ not wired, see above |

Workflow YAML lints clean.