### PR TITLE
fix(api): stop the MCP authorization suite from calling OpenRouter

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -104,7 +104,7 @@
     },
     "services/api": {
       "name": "@indexnetwork/api",
-      "version": "0.67.1",
+      "version": "0.67.2",
       "dependencies": {
         "@aws-sdk/client-s3": "^3.939.0",
         "@aws-sdk/s3-request-presigner": "^3.983.0",

--- a/services/api/package.json
+++ b/services/api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@indexnetwork/api",
-  "version": "0.67.1",
+  "version": "0.67.2",
   "license": "MIT",
   "private": true,
   "scripts": {

--- a/services/api/tests/mcp.permission-refresh.spec.ts
+++ b/services/api/tests/mcp.permission-refresh.spec.ts
@@ -1,8 +1,9 @@
 import '../src/startup.env';
-import { describe, it, expect } from 'bun:test';
+import { describe, it, expect, beforeAll, afterAll } from 'bun:test';
 import { WebStandardStreamableHTTPServerTransport } from '@modelcontextprotocol/server';
 
 import { createMcpServer, clearMcpToolMetadataCacheForTests } from '../../../packages/protocol/src/mcp/mcp.server';
+import { setIntentClarifierForTesting } from '../../../packages/protocol/src/signals/application/intent.tools';
 import type { ScopedDepsFactory } from '../../../packages/protocol/src/mcp/mcp.server';
 import type { McpAuthorizationDenialEvent, McpAuthorizationObserver } from '../../../packages/protocol/src/mcp/mcp.authorization-policy';
 import type { ToolDeps } from '../../../packages/protocol/src/shared/agent/tool.helpers';
@@ -289,6 +290,39 @@ const AGENT_ID = 'agent-1';
 const AGENT_HEADERS = { 'x-api-key': SECRET_API_KEY };
 
 describe('IND-581 MCP authorization refresh + isolation + telemetry', () => {
+  const realFetch = globalThis.fetch;
+
+  beforeAll(() => {
+    // The granted create_intent case runs the real tool against a stub intent
+    // graph that verifies nothing, so `create_intent` falls into its
+    // clarification branch. Left unstubbed, that constructs the real
+    // IntentClarifier and calls OpenRouter — this suite is about authorization,
+    // not about the model, and a live call made it time out at 5s.
+    setIntentClarifierForTesting({
+      invoke: async () => ({
+        needsClarification: false,
+        underspecificationType: 'none',
+        suggestedDescription: '',
+        clarificationMessage: '',
+      }),
+    } as Parameters<typeof setIntentClarifierForTesting>[0]);
+
+    // Enforce the hermeticity this file claims: any escape to the network is a
+    // failure, not a slow test. Transport requests are same-process URLs.
+    globalThis.fetch = (async (input: Parameters<typeof fetch>[0], init?: Parameters<typeof fetch>[1]) => {
+      const url = typeof input === 'string' ? input : input instanceof URL ? input.href : input.url;
+      if (!url.startsWith('https://example.test')) {
+        throw new Error(`hermetic test attempted a network request: ${url}`);
+      }
+      return realFetch(input, init);
+    }) as typeof fetch;
+  });
+
+  afterAll(() => {
+    globalThis.fetch = realFetch;
+    setIntentClarifierForTesting(null);
+  });
+
   it('freshly resolves granted → revoked → deactivated across reconnects, denying before adapter work', async () => {
     const state: MutableAgentState = {
       status: 'active',


### PR DESCRIPTION
Follow-up to #1302 (issue 1 of the pre-existing failures found there).

## Problem

`tests/mcp.permission-refresh.spec.ts` → "freshly resolves granted → revoked → deactivated across reconnects" times out at 5s. **3/3 runs on a clean `dev` checkout.**

## Root cause

Not slowness — **the test is not hermetic**, despite its own header:

> Every case drives REAL tools/list / tools/call requests through the MCP transport... **No DB, Redis, or network**

The granted leg drives the real `create_intent` tool against a stub intent graph returning `{}`, so `verifiedIntents` is empty and the tool takes its clarification branch (`intent.tools.ts` → `buildTypedClarificationResult`). That lazily constructs the real `IntentClarifier` — three `createStructuredModel` instances — and calls the provider.

Proven with a `fetch` probe rather than inferred:

```
[NET] OUTBOUND POST https://openrouter.ai/api/v1/chat/completions
(fail) freshly resolves granted → revoked → deactivated across reconnects [5001.67ms]
  ^ this test timed out after 5000ms.
```

So an authorization assertion was gated on live model latency: it passes when the provider answers in <5s and fails when it doesn't. That also explains the machine-dependent behavior (3/3 fail on `dev`, 2/5 on another checkout).

## Fix

- **Install the existing `setIntentClarifierForTesting` double** — the same seam `packages/protocol/src/intent/tests/update-intent.spec.ts` already uses. The test asserts admission, denial codes, and scoped-deps construction; it never asserts clarifier output, so stubbing changes nothing it is testing.
- **Enforce the hermeticity claim with a fetch guard** that throws on any request leaving the process. A future tool path reaching for a model now fails loudly instead of degrading into a flaky timeout.

## Verification

| | Before | After |
|---|---|---|
| Consecutive runs green | 0/3 on `dev` | **8/8** |
| File runtime | ~5.4s (timing out) | **~0.53s** |
| Outbound requests (fetch probe) | 1 × `openrouter.ai` | **0** |
| Whole `services/api` suite | 98 fail / 752 | **97 fail / 752** |

The suite delta is exactly this test flipping to pass — no new failures, and the fetch guard triggers in no other file (`grep -c "attempted a network request"` → 0).

The remaining 97 are pre-existing and infra-gated (mostly `TEST_DATABASE_SAFE=1` refusals), untouched here.