### PR TITLE
fix(protocol): graph runtime edges only in the module cycle check

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -181,11 +181,9 @@ jobs:
     # drifting when #1301 deleted the discovery-run interface — both were broken
     # on dev for days without any red check.
     #
-    # NOTE: `architecture:cycles` is deliberately not run here yet. It fails on
-    # dev today (negotiation/application <-> questions/questioner <->
-    # shared/agent/tool.helpers form a 7-module cycle) and breaking that cycle is
-    # a refactor, not a check-wiring change. Add it to this job once that is
-    # fixed, and drop the individual steps for `bun run architecture:check`.
+    #
+    # Steps stay individual rather than one `bun run architecture:check` so a
+    # failure names the violated invariant directly in the checks list.
     runs-on: blacksmith-4vcpu-ubuntu-2404
     steps:
       - uses: actions/checkout@v4
@@ -211,6 +209,9 @@ jobs:
 
       - name: Check capability boundaries
         run: cd packages/protocol && bun run architecture:capabilities
+
+      - name: Check production module cycles
+        run: cd packages/protocol && bun run architecture:cycles
 
       - name: Check published artifact inventory
         run: cd packages/protocol && bun run architecture:artifacts

--- a/bun.lock
+++ b/bun.lock
@@ -88,7 +88,7 @@
     },
     "packages/protocol": {
       "name": "@indexnetwork/protocol",
-      "version": "8.0.2",
+      "version": "8.0.3",
       "dependencies": {
         "@langchain/core": "1.1.48",
         "@langchain/langgraph": "1.3.2",

--- a/packages/protocol/CHANGELOG.md
+++ b/packages/protocol/CHANGELOG.md
@@ -39,6 +39,12 @@ See [STABILITY.md](./STABILITY.md) for the public-contract and tier definitions.
   with that change; this entry and the regenerated export inventory record it.
 
 ### Fixed
+- `architecture:cycles` graphs runtime edges only (8.0.3). It counted `import
+  type` / `export type` edges, which TypeScript erases, so it reported a
+  7-module negotiation/questions cycle that no runtime can observe — penalizing
+  the capability-facade pattern of depending on a port *type* instead of an
+  implementation. Tooling only; no source or public-surface change. The full
+  `architecture:check` suite now passes and runs in CI.
 - Stop force-rewriting an opening-move refusal (IND-611 prerequisite; 7.11.0):
   `negotiation.graph.ts` ran the turn-0 opening force *before* the IND-564
   opening-withdraw guard, so a v2 initiator that judged a match not worth making

--- a/packages/protocol/package.json
+++ b/packages/protocol/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@indexnetwork/protocol",
-  "version": "8.0.2",
+  "version": "8.0.3",
   "type": "module",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
@@ -22,7 +22,7 @@
     "dev": "tsc --watch",
     "test": "bun test",
     "test:isolated": "bun scripts/test.ts",
-    "test:architecture": "bun test src/architecture/tests",
+    "test:architecture": "bun test src/architecture/tests scripts/architecture/tests",
     "architecture:exports": "bun scripts/architecture/export-inventory.ts",
     "architecture:exports:update": "bun scripts/architecture/export-inventory.ts --write",
     "architecture:consumer": "bunx tsc --project architecture/consumer/tsconfig.json",

--- a/packages/protocol/scripts/architecture/cycle-baseline.ts
+++ b/packages/protocol/scripts/architecture/cycle-baseline.ts
@@ -1,10 +1,17 @@
 #!/usr/bin/env bun
 /**
  * Enforces the directed production module graph required after Phase 3.
+ *
+ * Only edges that survive the TypeScript emit are graphed: a cycle matters
+ * because of runtime module initialization (order, TDZ, bundler behavior), and
+ * a type-only import is erased before any of that exists. See
+ * `module-graph.ts` for why the direction-oriented checks keep counting type
+ * edges while this one must not.
  */
 import { readdir, readFile, stat } from "node:fs/promises";
 import { dirname, relative, resolve } from "node:path";
-import ts from "typescript";
+
+import { parseSourceFile, runtimeModuleSpecifiers } from "./module-graph.js";
 
 const packageRoot = resolve(dirname(new URL(import.meta.url).pathname), "../..");
 const sourceRoot = resolve(packageRoot, "src");
@@ -36,21 +43,6 @@ function resolveImportPath(from: string, specifier: string): string | undefined 
   const base = resolve(dirname(from), specifier.replace(/\.js$/, ""));
   const candidates = [`${base}.ts`, resolve(base, "index.ts")];
   return candidates.find((path) => Bun.file(path).size > 0);
-}
-
-function importSpecifiers(sourceFile: ts.SourceFile): string[] {
-  const specifiers: string[] = [];
-  const visit = (node: ts.Node) => {
-    if ((ts.isImportDeclaration(node) || ts.isExportDeclaration(node)) && node.moduleSpecifier && ts.isStringLiteral(node.moduleSpecifier)) {
-      specifiers.push(node.moduleSpecifier.text);
-    }
-    if (ts.isImportTypeNode(node) && ts.isLiteralTypeNode(node.argument) && ts.isStringLiteral(node.argument.literal)) {
-      specifiers.push(node.argument.literal.text);
-    }
-    ts.forEachChild(node, visit);
-  };
-  visit(sourceFile);
-  return specifiers;
 }
 
 function cyclicComponents(graph: Map<string, Set<string>>): string[][] {
@@ -104,8 +96,8 @@ async function resolveImport(from: string, specifier: string): Promise<string[]>
   let targets = facadeTargets.get(candidate);
   if (!targets) {
     targets = (async () => {
-      const facade = ts.createSourceFile(candidate, await readFile(candidate, "utf8"), ts.ScriptTarget.Latest, true);
-      const imports = await Promise.all(importSpecifiers(facade).map((nested) => resolveImport(candidate, nested)));
+      const facade = parseSourceFile(candidate, await readFile(candidate, "utf8"));
+      const imports = await Promise.all(runtimeModuleSpecifiers(facade).map((nested) => resolveImport(candidate, nested)));
       return imports.flat();
     })();
     facadeTargets.set(candidate, targets);
@@ -114,12 +106,12 @@ async function resolveImport(from: string, specifier: string): Promise<string[]>
 }
 
 for (const filePath of files) {
-  const sourceFile = ts.createSourceFile(filePath, await readFile(filePath, "utf8"), ts.ScriptTarget.Latest, true);
-  const imports = await Promise.all(importSpecifiers(sourceFile).map((specifier) => resolveImport(filePath, specifier)));
+  const sourceFile = parseSourceFile(filePath, await readFile(filePath, "utf8"));
+  const imports = await Promise.all(runtimeModuleSpecifiers(sourceFile).map((specifier) => resolveImport(filePath, specifier)));
   graph.set(toModuleId(filePath), new Set(imports.flat()));
 }
 const components = cyclicComponents(graph);
 if (components.length > 0) {
   throw new Error(`Production module cycles are prohibited: ${components.map((component) => component.join(", ")).join("; ")}`);
 }
-console.log("Production module cycle check OK (0 cyclic SCCs).");
+console.log(`Production module cycle check OK (0 cyclic SCCs across ${graph.size} runtime modules).`);

--- a/packages/protocol/scripts/architecture/module-graph.ts
+++ b/packages/protocol/scripts/architecture/module-graph.ts
@@ -1,0 +1,76 @@
+/**
+ * Shared module-reference extraction for the architecture checks.
+ *
+ * Two different questions get asked of the same import statements, and they
+ * need different answers:
+ *
+ * - **Direction** (capability boundaries, host isolation): a `import type`
+ *   still declares that one module is designed against another, so type edges
+ *   count. Those checks keep using their own all-edges collection.
+ * - **Cycles**: a cycle is only a hazard if it survives to runtime (module
+ *   initialization order, TDZ, bundler ordering). TypeScript erases type-only
+ *   imports entirely, so a loop that closes through one cannot exist in the
+ *   emitted graph. Counting them reports cycles that no runtime can observe —
+ *   and it penalizes exactly the capability-facade pattern this package is
+ *   built on, where a module depends on a port *type* instead of an
+ *   implementation.
+ *
+ * `runtimeModuleSpecifiers` answers the second question.
+ */
+import ts from "typescript";
+
+/**
+ * True when a module reference is erased by the TypeScript emit and therefore
+ * cannot participate in a runtime cycle.
+ *
+ * Covers all three erased forms:
+ * - `import type { T } from "./m.js"` / `export type { T } from "./m.js"`
+ * - `import { type A, type B } from "./m.js"` (every binding type-only)
+ * - `export { type A } from "./m.js"` (every binding type-only)
+ *
+ * A bare `import "./m.js"` is a side-effect import and is never type-only. A
+ * mixed `import { type A, b }` keeps a runtime edge because `b` survives emit.
+ */
+export function isErasedModuleReference(node: ts.ImportDeclaration | ts.ExportDeclaration): boolean {
+  if (ts.isImportDeclaration(node)) {
+    const clause = node.importClause;
+    if (!clause) return false; // side-effect import: `import "./m.js"`
+    if (clause.isTypeOnly) return true;
+    const bindings = clause.namedBindings;
+    if (clause.name || !bindings || !ts.isNamedImports(bindings)) return false;
+    return bindings.elements.length > 0 && bindings.elements.every((element) => element.isTypeOnly);
+  }
+
+  if (node.isTypeOnly) return true;
+  const clause = node.exportClause;
+  if (!clause || !ts.isNamedExports(clause)) return false;
+  return clause.elements.length > 0 && clause.elements.every((element) => element.isTypeOnly);
+}
+
+/**
+ * Module specifiers that survive the TypeScript emit — the edges of the runtime
+ * module graph. Type-only imports/exports and `import("./m.js").T` type nodes
+ * are excluded because they leave no trace in the emitted JavaScript.
+ */
+export function runtimeModuleSpecifiers(sourceFile: ts.SourceFile): string[] {
+  const specifiers: string[] = [];
+  const visit = (node: ts.Node) => {
+    if (
+      (ts.isImportDeclaration(node) || ts.isExportDeclaration(node))
+      && node.moduleSpecifier
+      && ts.isStringLiteral(node.moduleSpecifier)
+      && !isErasedModuleReference(node)
+    ) {
+      specifiers.push(node.moduleSpecifier.text);
+    }
+    // `import("./m.js").T` is a type position only; it never emits a require.
+    ts.forEachChild(node, visit);
+  };
+  visit(sourceFile);
+  return specifiers;
+}
+
+/** Parse helper so callers and tests build source files the same way. */
+export function parseSourceFile(path: string, text: string): ts.SourceFile {
+  return ts.createSourceFile(path, text, ts.ScriptTarget.Latest, true);
+}

--- a/packages/protocol/scripts/architecture/tests/module-graph.spec.ts
+++ b/packages/protocol/scripts/architecture/tests/module-graph.spec.ts
@@ -1,0 +1,78 @@
+import { describe, expect, test } from "bun:test";
+import { readFile } from "node:fs/promises";
+import { resolve } from "node:path";
+
+import { parseSourceFile, runtimeModuleSpecifiers } from "../module-graph.js";
+
+const specifiersOf = (source: string): string[] =>
+  runtimeModuleSpecifiers(parseSourceFile("module.ts", source));
+
+describe("runtimeModuleSpecifiers", () => {
+  test("keeps every import form that survives the emit", () => {
+    expect(specifiersOf(`
+      import defaultExport from "./default.js";
+      import { value } from "./named.js";
+      import * as namespace from "./namespace.js";
+      import "./side-effect.js";
+      export { reexported } from "./reexport.js";
+      export * from "./star.js";
+    `)).toEqual([
+      "./default.js",
+      "./named.js",
+      "./namespace.js",
+      "./side-effect.js",
+      "./reexport.js",
+      "./star.js",
+    ]);
+  });
+
+  test("drops every erased form", () => {
+    // These are the edges that made the negotiation/questions SCC appear: a
+    // module depending on a port *type* has no runtime dependency at all.
+    expect(specifiersOf(`
+      import type { Declared } from "./import-type.js";
+      import { type OnlyA, type OnlyB } from "./inline-types.js";
+      export type { Declared } from "./export-type.js";
+      export { type OnlyC } from "./inline-export-types.js";
+      type Deferred = import("./import-type-node.js").Thing;
+    `)).toEqual([]);
+  });
+
+  test("keeps a mixed import, because its value binding still emits", () => {
+    expect(specifiersOf(`import { type Shape, build } from "./mixed.js";`)).toEqual(["./mixed.js"]);
+    expect(specifiersOf(`import defaultExport, { type Shape } from "./mixed-default.js";`)).toEqual(["./mixed-default.js"]);
+    expect(specifiersOf(`export { type Shape, build } from "./mixed-export.js";`)).toEqual(["./mixed-export.js"]);
+  });
+
+  test("keeps a bare side-effect import, which is never type-only", () => {
+    expect(specifiersOf(`import "./polyfill.js";`)).toEqual(["./polyfill.js"]);
+  });
+
+  test("finds specifiers nested below the top level", () => {
+    expect(specifiersOf(`
+      declare module "virtual" {
+        import { nested } from "./nested.js";
+      }
+    `)).toEqual(["./nested.js"]);
+  });
+});
+
+describe("cycle-baseline wiring", () => {
+  test("the cycle check graphs runtime edges only", async () => {
+    // Guards the fix itself: reverting to an all-edges collection would make
+    // the check fail on erased type edges again.
+    const script = await readFile(resolve(import.meta.dir, "../cycle-baseline.ts"), "utf8");
+    expect(script).toContain("runtimeModuleSpecifiers");
+    expect(script).not.toContain("function importSpecifiers");
+  });
+
+  test("the direction checks still count type edges", async () => {
+    // Capability boundaries and host isolation answer a different question:
+    // depending on a type is still a declared direction. They must NOT adopt
+    // the runtime-only collection.
+    for (const script of ["capability-boundaries.ts", "host-isolation.ts"]) {
+      const source = await readFile(resolve(import.meta.dir, "..", script), "utf8");
+      expect(source).not.toContain("runtimeModuleSpecifiers");
+    }
+  });
+});


### PR DESCRIPTION
Follow-up to #1303, which wired six architecture gates into CI but left `architecture:cycles` out because it failed on `dev`.

## The reported cycle does not exist at runtime

```
error: Production module cycles are prohibited: negotiation/application/index.ts,
negotiation/application/negotiation.graph.ts, negotiation/application/negotiation.tools.ts,
negotiation/public/index.ts, questioner/questioner.types.ts,
questions/application/question.input.ts, shared/agent/tool.helpers.ts
```

I originally called this an architectural regression needing a refactor. That was wrong — I repeated the checker's verdict without auditing it.

`importSpecifiers` collected **every** `ImportDeclaration` / `ExportDeclaration` without ever checking `isTypeOnly`, plus every `import("./m.js").T` type node. TypeScript erases all of those. They cannot participate in the hazard a cycle check exists to prevent: module initialization order, TDZ, bundler ordering. Re-running the identical checker with type-only edges excluded:

```
Production module cycle check OK (0 cyclic SCCs).
```

The edge closing the 7-module SCC was a single erased import in `shared/agent/tool.helpers.ts`:

```ts
import type { QuestionerEnqueueFn } from "../../questioner/questioner.types.js";
```

Remove just that edge and the SCC collapses to 4 modules, which closes through another erased import — `import type { QuestionerEnqueueFn }` from `capabilities/questions.enqueue.facade.js` in `negotiation.graph.ts`.

**The check was inverting the incentive this package is built on.** Capability facades exist so a module can depend on a port *type* rather than an implementation. The checker deliberately expands a facade into its owned implementation modules ("facades are contract edges, not implementation vertices") and then charged that type-only port import as a hard runtime dependency — so using the pattern correctly produced a violation.

## Changes

- Extract `runtimeModuleSpecifiers` into `scripts/architecture/module-graph.ts`, excluding type-only imports/exports (declaration-level `import type` and fully-inline `{ type A, type B }`) and import-type nodes, while keeping side-effect and mixed imports.
- **Leave `capability-boundaries` and `host-isolation` on all-edges collection.** They answer a different question — a type dependency is still a declared *direction* — so they must keep counting type edges. A test pins that split so a future refactor cannot quietly unify them.
- Run `architecture:cycles` in the `protocol-architecture` CI job and drop the stale NOTE from #1303.
- Extend `test:architecture` to cover `scripts/architecture/tests`.

## Verification — the gate is narrowed, not disabled

The important risk here is neutering the check. Proven with fabricated probes in `src/`:

| Probe | Expected | Result |
|---|---|---|
| Two modules importing each other's **values** | fail | ✅ `Production module cycles are prohibited: __cycle_probe_a.ts, __cycle_probe_b.ts` |
| The same two modules with **`import type`** only | pass | ✅ `0 cyclic SCCs across 361 runtime modules` |
| Probes removed | pass | ✅ `0 cyclic SCCs across 359 runtime modules` |

Plus 7 unit tests over the extraction covering default/named/namespace/side-effect/re-export/star (kept) and `import type`/inline-type/`export type`/inline-export-type/import-type-node (dropped), and mixed imports (kept — the value binding still emits).

| Check | Result |
|---|---|
| `bun run architecture:check` (full suite, first time end to end) | **pass** |
| `test:architecture` | 25 pass / 0 fail |
| `bun run build` | pass |
| `bun run test:isolated` | 2182 pass / 0 fail across 209 files |
| eslint on changed files | clean |

Version: protocol `8.0.2 → 8.0.3` (tooling only; no source or public-surface change), with `bun.lock` and a CHANGELOG entry.