### PR TITLE
docs(protocol): reconcile the changelog with what actually shipped

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -88,7 +88,7 @@
     },
     "packages/protocol": {
       "name": "@indexnetwork/protocol",
-      "version": "8.1.0",
+      "version": "8.1.1",
       "dependencies": {
         "@langchain/core": "1.1.48",
         "@langchain/langgraph": "1.3.2",

--- a/packages/protocol/CHANGELOG.md
+++ b/packages/protocol/CHANGELOG.md
@@ -10,7 +10,44 @@ See [STABILITY.md](./STABILITY.md) for the public-contract and tier definitions.
 > itemized. From `2.0.0` onward, keep this file updated as part of every release
 > (bump `package.json` and the `[Unreleased]` section before promoting to `main`).
 
+## Release model
+
+Every push to `dev` publishes `<package.json version>-rc.<run>.<attempt>` under
+the npm `rc` tag; `latest` moves only when `main` is promoted, and only if that
+exact version is not already on npm. **Stable releases are therefore sparse and
+skip versions on purpose** — most versions only ever exist as an `rc`. `latest`
+went 6.7.1 → 8.0.2 with no 7.x in between because the whole 7.x line shipped as
+prereleases between the two promotions. To track every change, read `rc`; to
+pin a supported release, use `latest`.
+
 ## [Unreleased]
+
+### Added
+- Deterministic fast signal intake (#1307; 8.1.0). `SignalIntakePackGenerator`
+  precomputes a per-user intake brief plus round-1 question, and
+  `SignalIntakeOrchestrator` drives the funnel as a deterministic state machine
+  on flash instead of sequential pro turns, with synthesis speculated during a
+  deterministic community picker. New stable exports from the `signals` facade:
+  `SignalIntakePackGenerator`, `normalizeIntakePack`, `SignalIntakeOrchestrator`,
+  `answerLabel`, `FALLBACK_WHO_QUESTION`, `FALLBACK_BRING_QUESTION`, and the
+  `IntakePack` / `IntakePackInput` / `IntakePackQuestion` /
+  `IntakePackQuestionOption` / `IntakeAnswer` / `SynthesisInput` /
+  `SynthesisResult` types. Minor bump: additive surface only.
+
+### Fixed
+- `architecture:cycles` graphs runtime edges only (8.0.3). It counted `import
+  type` / `export type` edges, which TypeScript erases, so it reported a
+  7-module negotiation/questions cycle that no runtime can observe — penalizing
+  the capability-facade pattern of depending on a port *type* instead of an
+  implementation. Tooling only; no source or public-surface change. The full
+  `architecture:check` suite now passes and runs in CI.
+
+## [8.0.2] — 2026-07-30
+
+Promoted to npm `latest` on 2026-07-30, carrying the whole 7.6.0 → 8.0.2 line.
+Those intermediate versions were published as `-rc` prereleases from `dev`
+only, so `latest` moved 6.7.1 → 8.0.2 in one step; see **Release model**
+above. Entries below keep the version they were developed under.
 
 ### Added
 - Configurable negotiator stance `NEGOTIATOR_STANCE` (IND-611; 7.11.0), shipped
@@ -39,12 +76,6 @@ See [STABILITY.md](./STABILITY.md) for the public-contract and tier definitions.
   with that change; this entry and the regenerated export inventory record it.
 
 ### Fixed
-- `architecture:cycles` graphs runtime edges only (8.0.3). It counted `import
-  type` / `export type` edges, which TypeScript erases, so it reported a
-  7-module negotiation/questions cycle that no runtime can observe — penalizing
-  the capability-facade pattern of depending on a port *type* instead of an
-  implementation. Tooling only; no source or public-surface change. The full
-  `architecture:check` suite now passes and runs in CI.
 - Stop force-rewriting an opening-move refusal (IND-611 prerequisite; 7.11.0):
   `negotiation.graph.ts` ran the turn-0 opening force *before* the IND-564
   opening-withdraw guard, so a v2 initiator that judged a match not worth making
@@ -710,7 +741,16 @@ the matching/opportunity/premise eval harnesses, premise source tracking and
 cascade retraction, network-scoped agents, and the agent registry. Reconstructed
 from git history; not itemized.
 
-[Unreleased]: https://github.com/indexnetwork/protocol/compare/v4.3.0...HEAD
+<!--
+Release tags stopped being created when publishing moved to the automated
+subtree workflow: only v0.2.1 and v0.3.0 still exist in indexnetwork/protocol,
+so every `compare/vX.Y.Z` link below 404s. They are kept for historical intent.
+New entries link to the npm release instead, and [Unreleased] compares the
+branches that actually define it.
+-->
+
+[Unreleased]: https://github.com/indexnetwork/protocol/compare/main...dev
+[8.0.2]: https://www.npmjs.com/package/@indexnetwork/protocol/v/8.0.2
 [4.3.0]: https://github.com/indexnetwork/protocol/compare/v4.2.0...v4.3.0
 [4.2.0]: https://github.com/indexnetwork/protocol/compare/v4.1.0...v4.2.0
 [4.1.0]: https://github.com/indexnetwork/protocol/compare/v4.0.0...v4.1.0

--- a/packages/protocol/package.json
+++ b/packages/protocol/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@indexnetwork/protocol",
-  "version": "8.1.0",
+  "version": "8.1.1",
   "type": "module",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",


### PR DESCRIPTION
Follow-up from the 6.7.1 → 8.0.2 jump I flagged. **The jump itself is fine** — but chasing it surfaced four bookkeeping defects in the published package's release contract.

## What I checked first

The published artifact is healthy. Fresh install of `@indexnetwork/protocol@8.0.2` from npm:

```
version 8.0.2
deps {"@langchain/core":"1.1.48","@langchain/langgraph":"1.3.2","@langchain/openai":"1.4.7",
      "@modelcontextprotocol/server":"2.0.0","zod":"3.25.76"}
resolved SDK: 2.0.0
named exports: 204     has createMcpServer: function
```

So the exact-pin fix from #1302 propagated into the published tarball, and the first stable release since `6.7.1` installs and imports cleanly. **No consumer is affected by the version jump** — the only dependant in the repo is `services/api`, which uses `workspace:*` and never resolves from npm.

## Defects fixed

1. **Shipped code was filed as unreleased.** Everything from 7.6.0 through 8.0.2 sat under `[Unreleased]` while 8.0.2 has been npm `latest` since 2026-07-30. Moved into a dated `## [8.0.2]` section; only the 8.0.3 tooling fix stays unreleased.

2. **8.1.0 shipped undocumented.** #1307 bumped the version and added **13 stable exports** (`SignalIntakePackGenerator`, `SignalIntakeOrchestrator`, `normalizeIntakePack`, `answerLabel`, the fallback questions, and 7 types) with no changelog entry — the same gap #1301 left. Entry written from the diff and the new `signals` facade surface.

3. **The version jump looked like data loss.** It isn't: `dev` publishes `-rc` per push and `latest` only moves on a `main` promotion, so most versions never exist as stable and the whole 7.x line shipped as prereleases. Now stated under a new **Release model** heading, so a consumer reading the file understands the sparse line instead of hunting for a missing 7.x.

4. **Every `compare/vX.Y.Z` link 404s.** Release tags stopped being created when publishing moved to the subtree workflow — `git ls-remote --tags indexnetwork/protocol` returns only `v0.2.1` and `v0.3.0`. Repointed `[Unreleased]` at `main...dev` (the branches that actually define it), linked `[8.0.2]` to its npm release, and marked the historical tag block as such.

## Verification

- **No content lost or reworded**: bullet count 152 → 153, the single addition being the 8.1.0 entry.
- `bun run architecture:check` — full suite passes.
- `bun run check:subtree-parity` — 9 pinned ranges clean.
- Version `8.1.0 → 8.1.1` with `bun.lock`, since `CHANGELOG.md` ships in the package `files`.

## Also done outside this PR

Deleted the stale remote branch `feat/mcp-permission-refresh-audit`. Its PR **#1282 was merged** on 2026-07-27 into the `feat/mcp-refactoring` integration branch, which reached `dev` via #1284 — so it was squash-merged twice over and never cleaned up. Verified containment before deleting: all 26 files it added exist on `dev`, the sole exception being `discovery-run-ownership.spec.ts`, which #1301 deliberately deleted along with the discovery-run subsystem. Tip recorded as `02be940d8` if it is ever wanted back.