### PR TITLE
fix(api): make the intent-verification backfill write path executable

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -104,7 +104,7 @@
     },
     "services/api": {
       "name": "@indexnetwork/api",
-      "version": "0.68.0",
+      "version": "0.68.1",
       "dependencies": {
         "@aws-sdk/client-s3": "^3.939.0",
         "@aws-sdk/s3-request-presigner": "^3.983.0",

--- a/services/api/package.json
+++ b/services/api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@indexnetwork/api",
-  "version": "0.68.0",
+  "version": "0.68.1",
   "license": "MIT",
   "private": true,
   "scripts": {

--- a/services/api/src/cli/backfill-intent-verification-analysis.ts
+++ b/services/api/src/cli/backfill-intent-verification-analysis.ts
@@ -56,11 +56,17 @@ export type Candidate = {
     sourceId: string | null;
     sourceType: string | null;
     embedding: string | null;
-    createdAt: Date;
-    updatedAt: Date;
-    archivedAt: Date | null;
-    lastVisitedAt: Date | null;
-    firstDiscoverySucceededAt: Date | null;
+    /**
+     * Timestamps are carried as exact Postgres text, never as JS Date. The driver
+     * cannot bind a Date as a raw parameter, and a Date round-trip truncates to
+     * milliseconds — every candidate row here stores microseconds, so a truncated
+     * comparison would silently match nothing and report unchanged_control.
+     */
+    createdAt: string;
+    updatedAt: string;
+    archivedAt: string | null;
+    lastVisitedAt: string | null;
+    firstDiscoverySucceededAt: string | null;
     status: string | null;
   };
 };
@@ -192,8 +198,8 @@ type CandidateDbRow = {
   semantic_entropy: number | null; referential_anchor: string | null; intent_mode: string | null;
   speech_act_type: string | null; felicity_authority: number | null; felicity_sincerity: number | null;
   felicity_clarity: number | null; summary: string | null; is_incognito: boolean; embedding: string | null;
-  created_at: Date; updated_at: Date; archived_at: Date | null; last_visited_at: Date | null;
-  first_discovery_succeeded_at: Date | null; status: string | null;
+  created_at: string; updated_at: string; archived_at: string | null; last_visited_at: string | null;
+  first_discovery_succeeded_at: string | null; status: string | null;
 };
 
 /**
@@ -374,8 +380,9 @@ export async function createRuntimeDeps(
         SELECT i.id, i.user_id, i.payload, i.source_id, i.source_type, (p.id IS NOT NULL) AS proposal_confirmed, i.semantic_entropy,
           referential_anchor, intent_mode, speech_act_type, felicity_authority,
           felicity_sincerity, felicity_clarity, summary, is_incognito,
-          embedding::text AS embedding, i.created_at AS created_at, updated_at, archived_at,
-          last_visited_at, first_discovery_succeeded_at, i.status AS status
+          embedding::text AS embedding, i.created_at::text AS created_at, updated_at::text AS updated_at,
+          archived_at::text AS archived_at, last_visited_at::text AS last_visited_at,
+          first_discovery_succeeded_at::text AS first_discovery_succeeded_at, i.status AS status
         FROM intents i LEFT JOIN intent_proposals p ON p.consumed_intent_id = i.id AND p.status = 'consumed'
         WHERE i.felicity_authority IS NULL AND i.felicity_sincerity IS NULL AND i.felicity_clarity IS NULL
         ORDER BY i.created_at ASC, i.id ASC LIMIT ${limit}`);
@@ -448,7 +455,7 @@ export async function createRuntimeDeps(
       const { db, sql } = await getRuntime();
       await db.execute(sql`INSERT INTO intent_verification_backfill_attempts
         (run_id, intent_id, partition, status, payload_hash, context_hash, verifier_output, error_code, applied_at)
-        VALUES (${input.runId}, ${input.intentId}, ${input.partition}, ${input.status}, ${input.payloadHash}, ${input.contextHash}, ${input.verifierOutput ? JSON.stringify(input.verifierOutput) : null}::jsonb, ${input.errorCode}, ${input.status === 'updated' ? new Date() : null})
+        VALUES (${input.runId}, ${input.intentId}, ${input.partition}, ${input.status}, ${input.payloadHash}, ${input.contextHash}, ${input.verifierOutput ? JSON.stringify(input.verifierOutput) : null}::jsonb, ${input.errorCode}, ${input.status === 'updated' ? new Date().toISOString() : null}::timestamptz)
         ON CONFLICT (run_id, intent_id) DO UPDATE SET partition = EXCLUDED.partition, status = EXCLUDED.status,
           payload_hash = EXCLUDED.payload_hash, context_hash = EXCLUDED.context_hash,
           verifier_output = EXCLUDED.verifier_output, error_code = EXCLUDED.error_code,
@@ -458,11 +465,14 @@ export async function createRuntimeDeps(
       const { db, sql } = await getRuntime();
       // Fail closed: all source/lifecycle/payload/embedding/timestamp/old-analysis controls
       // must still match the dry-run snapshot. The SET list is intentionally seven fields only.
+      // intent_mode and speech_act_type are Postgres enums, so every bound value for them —
+      // written or compared — carries an explicit cast; a bare text parameter is rejected with
+      // "column is of type intent_mode but expression is of type text" before any row is read.
       const c = candidate.control;
       return db.transaction(async (tx) => {
       const rows = await tx.execute(sql`
         UPDATE intents SET semantic_entropy = ${analysis.semanticEntropy}, referential_anchor = ${analysis.referentialAnchor},
-          intent_mode = ${analysis.intentMode}, speech_act_type = ${analysis.speechActType},
+          intent_mode = ${analysis.intentMode}::intent_mode, speech_act_type = ${analysis.speechActType}::speech_act_type,
           felicity_authority = ${analysis.felicityAuthority}, felicity_sincerity = ${analysis.felicitySincerity},
           felicity_clarity = ${analysis.felicityClarity}
         WHERE id = ${candidate.id} AND user_id = ${c.userId}
@@ -470,14 +480,14 @@ export async function createRuntimeDeps(
           AND is_incognito IS NOT DISTINCT FROM ${c.isIncognito}
           AND source_id IS NOT DISTINCT FROM ${c.sourceId} AND source_type IS NOT DISTINCT FROM ${c.sourceType}
           AND embedding::text IS NOT DISTINCT FROM ${c.embedding}
-          AND created_at IS NOT DISTINCT FROM ${c.createdAt} AND updated_at IS NOT DISTINCT FROM ${c.updatedAt}
-          AND archived_at IS NOT DISTINCT FROM ${c.archivedAt} AND last_visited_at IS NOT DISTINCT FROM ${c.lastVisitedAt}
-          AND first_discovery_succeeded_at IS NOT DISTINCT FROM ${c.firstDiscoverySucceededAt}
+          AND created_at::text IS NOT DISTINCT FROM ${c.createdAt} AND updated_at::text IS NOT DISTINCT FROM ${c.updatedAt}
+          AND archived_at::text IS NOT DISTINCT FROM ${c.archivedAt} AND last_visited_at::text IS NOT DISTINCT FROM ${c.lastVisitedAt}
+          AND first_discovery_succeeded_at::text IS NOT DISTINCT FROM ${c.firstDiscoverySucceededAt}
           AND status IS NOT DISTINCT FROM ${c.status}
           AND semantic_entropy IS NOT DISTINCT FROM ${candidate.semanticEntropy}
           AND referential_anchor IS NOT DISTINCT FROM ${candidate.referentialAnchor}
-          AND intent_mode IS NOT DISTINCT FROM ${candidate.intentMode}
-          AND speech_act_type IS NOT DISTINCT FROM ${candidate.speechActType}
+          AND intent_mode IS NOT DISTINCT FROM ${candidate.intentMode}::intent_mode
+          AND speech_act_type IS NOT DISTINCT FROM ${candidate.speechActType}::speech_act_type
           AND felicity_authority IS NOT DISTINCT FROM ${candidate.felicityAuthority}
           AND felicity_sincerity IS NOT DISTINCT FROM ${candidate.felicitySincerity}
           AND felicity_clarity IS NOT DISTINCT FROM ${candidate.felicityClarity}
@@ -487,7 +497,7 @@ export async function createRuntimeDeps(
         (run_id, intent_id, partition, status, payload_hash, context_hash, verifier_output, error_code, applied_at)
         VALUES (${provenance.runId}, ${candidate.id}, ${provenance.partition}, ${updated ? 'updated' : 'unchanged_control'},
           ${provenance.payloadHash}, ${provenance.contextHash}, ${JSON.stringify(provenance.verifierOutput)}::jsonb,
-          ${updated ? null : 'unchanged_control'}, ${updated ? new Date() : null})
+          ${updated ? null : 'unchanged_control'}, ${updated ? new Date().toISOString() : null}::timestamptz)
         ON CONFLICT (run_id, intent_id) DO UPDATE SET partition = EXCLUDED.partition, status = EXCLUDED.status,
           payload_hash = EXCLUDED.payload_hash, context_hash = EXCLUDED.context_hash,
           verifier_output = EXCLUDED.verifier_output, error_code = EXCLUDED.error_code,

--- a/services/api/src/cli/tests/backfill-intent-verification-analysis.spec.ts
+++ b/services/api/src/cli/tests/backfill-intent-verification-analysis.spec.ts
@@ -1,7 +1,9 @@
 import { describe, expect, it, mock } from 'bun:test';
+import { sql } from 'drizzle-orm';
+import { PgDialect } from 'drizzle-orm/pg-core';
 import path from 'path';
 
-import { classifyCandidate, parseArgs, runBackfill, runCli, validateVerifierOutput, type BackfillDeps, type Candidate } from '../backfill-intent-verification-analysis';
+import { classifyCandidate, createRuntimeDeps, parseArgs, runBackfill, runCli, validateVerifierOutput, type BackfillDeps, type Candidate } from '../backfill-intent-verification-analysis';
 
 const validOutput = {
   reasoning: 'A bounded request.',
@@ -24,7 +26,8 @@ function candidate(overrides: Partial<Candidate> = {}): Candidate {
     control: {
       userId: 'owner-1', payload: 'Find an Index Network collaborator in Istanbul.', summary: null,
       isIncognito: false, sourceId: 'proposal-1', sourceType: 'discovery_form', embedding: null,
-      createdAt: new Date('2026-01-01T00:00:00.000Z'), updatedAt: new Date('2026-01-01T00:00:00.000Z'),
+      // Exact Postgres text, including the microseconds a Date round-trip would drop.
+      createdAt: '2026-01-01 00:00:00.123456+00', updatedAt: '2026-01-01 00:00:00.123456+00',
       archivedAt: null, lastVisitedAt: null, firstDiscoverySucceededAt: null, status: 'ACTIVE',
     },
     ...overrides,
@@ -57,6 +60,35 @@ const dryRunOptions = {
   dryRun: true, limit: 25, confirmProduction: false, verifierModel: 'google/gemini-2.5-flash',
   inputCostPerMillion: 0.3, outputCostPerMillion: 2.5,
 };
+
+/**
+ * Renders the real write-path SQL through the production runtime seam. The
+ * recorder stands in for a database client so the canonical statement can be
+ * inspected without a connection, credentials, or a live schema.
+ */
+async function captureWritePathSql() {
+  const statements: unknown[] = [];
+  const record = { execute: async (query: unknown) => { statements.push(query); return [] as unknown[]; } };
+  const db = {
+    ...record,
+    transaction: async (run: (tx: typeof record) => Promise<unknown>) => run(record),
+  };
+  const deps = await createRuntimeDeps(
+    { dryRun: false },
+    undefined,
+    async () => ({ sql, db: db as never, getProfileContext: async () => ({}) }),
+  );
+  await deps.applyAnalysis(
+    candidate(),
+    {
+      semanticEntropy: 0.31, referentialAnchor: 'Index Network', intentMode: 'REFERENTIAL',
+      speechActType: 'DIRECTIVE', felicityAuthority: 78, felicitySincerity: 80, felicityClarity: 74,
+    },
+    { runId: 'run-1', partition: 'legacy_discovery_missing_analysis', payloadHash: 'p', contextHash: 'c', verifierOutput: validOutput },
+  );
+  const dialect = new PgDialect();
+  return statements.map((statement) => dialect.sqlToQuery(statement as never));
+}
 
 async function runFixture(name: string, databaseUrl = 'postgres://127.0.0.1:1/ind590_dry_run') {
   const fixture = path.resolve(import.meta.dir, 'fixtures', name);
@@ -136,6 +168,59 @@ describe('intent verification analysis maintenance workflow', () => {
     }, expect.objectContaining({ runId: 'run-1', partition: 'proposal_confirm_default_only' }));
     expect(deps.recordAttempt).not.toHaveBeenCalled();
     expect(deps.finishRun).toHaveBeenCalledWith('run-1', 'completed');
+  });
+
+  it('binds no Date parameter anywhere in the write path', async () => {
+    const queries = await captureWritePathSql();
+
+    // postgres.js rejects a Date bound as a raw parameter outright, so a single
+    // Date anywhere in this path turns every candidate into a recorded failure.
+    expect(queries.length).toBeGreaterThan(1);
+    for (const query of queries) {
+      expect(query.params.filter((param) => param instanceof Date)).toEqual([]);
+    }
+  });
+
+  it('casts enum-typed analysis columns so the canonical write is executable on the real schema', async () => {
+    const [{ sql: update }] = await captureWritePathSql();
+
+    // intents.intent_mode and intents.speech_act_type are Postgres enums; a bare
+    // text parameter is rejected outright with "column is of type intent_mode but
+    // expression is of type text", which the run loop can only record as failed.
+    expect(update).toMatch(/SET[\s\S]*intent_mode = \$\d+::intent_mode/);
+    expect(update).toMatch(/SET[\s\S]*speech_act_type = \$\d+::speech_act_type/);
+    // The unchanged-control guard compares the same two enum columns and needs
+    // the identical cast, or every write fails before a single row is examined.
+    expect(update).toMatch(/intent_mode IS NOT DISTINCT FROM \$\d+::intent_mode/);
+    expect(update).toMatch(/speech_act_type IS NOT DISTINCT FROM \$\d+::speech_act_type/);
+  });
+
+  it('compares timestamp controls as exact text so no bound parameter is a Date', async () => {
+    const [{ sql: update }] = await captureWritePathSql();
+
+    // The driver cannot bind a Date as a raw parameter, and a Date round-trip
+    // truncates Postgres microseconds to milliseconds — which would turn every
+    // write into a silent unchanged_control instead of a visible failure.
+    for (const column of ['created_at', 'updated_at', 'archived_at', 'last_visited_at', 'first_discovery_succeeded_at']) {
+      expect(update).toContain(`${column}::text IS NOT DISTINCT FROM $`);
+    }
+  });
+
+  it('selects timestamp controls as exact text rather than driver-parsed dates', async () => {
+    const statements: unknown[] = [];
+    const db = { execute: async (query: unknown) => { statements.push(query); return [] as unknown[]; } };
+    const deps = await createRuntimeDeps(
+      { dryRun: true },
+      undefined,
+      async () => ({ sql, db: db as never, getProfileContext: async () => ({}) }),
+    );
+    await deps.listCandidates(1);
+    const select = new PgDialect().sqlToQuery(statements[0] as never).sql;
+
+
+    for (const column of ['created_at', 'updated_at', 'archived_at', 'last_visited_at', 'first_discovery_succeeded_at']) {
+      expect(select).toContain(`${column}::text AS ${column}`);
+    }
   });
 
   it('skips invalid/non-actionable outputs rather than fabricating analysis', async () => {

--- a/services/api/src/cli/tests/fixtures/backfill-intent-verification-analysis.package-script.harness.ts
+++ b/services/api/src/cli/tests/fixtures/backfill-intent-verification-analysis.package-script.harness.ts
@@ -17,7 +17,7 @@ function candidate(): Candidate {
     felicityAuthority: null, felicitySincerity: null, felicityClarity: null,
     control: {
       userId: 'fixture-owner', payload: 'fixture', summary: null, isIncognito: false, sourceId: null, sourceType: 'fixture', embedding: null,
-      createdAt: new Date(0), updatedAt: new Date(0), archivedAt: null, lastVisitedAt: null, firstDiscoverySucceededAt: null, status: 'ACTIVE',
+      createdAt: '1970-01-01 00:00:00+00', updatedAt: '1970-01-01 00:00:00+00', archivedAt: null, lastVisitedAt: null, firstDiscoverySucceededAt: null, status: 'ACTIVE',
     },
   };
 }
@@ -49,7 +49,9 @@ function productionRuntime(failure?: 'partitions' | 'candidate_listing'): Backfi
       if (statement.includes('ORDER BY i.created_at ASC, i.id ASC')) {
         // The joined tables both expose status and created_at, so PostgreSQL
         // rejects either unqualified projection before a report is available.
-        if (!statement.includes('i.status AS status') || !statement.includes('i.created_at AS created_at')) {
+        // created_at is additionally projected as exact text: the driver cannot
+        // bind a Date control, and a Date round-trip would drop microseconds.
+        if (!statement.includes('i.status AS status') || !statement.includes('i.created_at::text AS created_at')) {
           throw new Error('candidate projection is ambiguous');
         }
         if (failure === 'candidate_listing') throw new Error('fixture candidate-listing failure must not be emitted');
@@ -58,7 +60,7 @@ function productionRuntime(failure?: 'partitions' | 'candidate_listing'): Backfi
           source_type: 'discovery_form', proposal_confirmed: true, semantic_entropy: 1, referential_anchor: null,
           intent_mode: 'ATTRIBUTIVE', speech_act_type: null, felicity_authority: null, felicity_sincerity: null,
           felicity_clarity: null, summary: null, is_incognito: false, embedding: null,
-          created_at: new Date(0), updated_at: new Date(0), archived_at: null, last_visited_at: null,
+          created_at: '1970-01-01 00:00:00+00', updated_at: '1970-01-01 00:00:00+00', archived_at: null, last_visited_at: null,
           first_discovery_succeeded_at: null, status: 'ACTIVE',
         }];
       }


### PR DESCRIPTION
## Problem

`maintenance:backfill-intent-verification-analysis` has never repaired a single row — on dev or prod. The audit tables (`intent_verification_backfill_runs` / `_attempts`) were empty in both environments not because nobody ran it, but because every actionable candidate failed.

Found while auditing the #1305 release: the operational backfill was flagged as outstanding, so I rehearsed it on the Neon dev branch before touching prod. It reported `attempted: 5, updated: 0, failed: 3`.

## Root cause

The write path is raw SQL rather than the Drizzle query builder (it carries ~20 unchanged-control predicates that are awkward in the builder). Three independent binding defects:

1. **Enum columns bound as text.** `intents.intent_mode` and `intents.speech_act_type` are Postgres enums. Both the `SET` list and the control predicates bound bare text parameters:
   ```
   column "intent_mode" is of type intent_mode but expression is of type text
   ```
   Rejected at plan time, before any row is examined.

2. **`Date` bound as a raw parameter.** postgres.js refuses it outright (`ERR_INVALID_ARG_TYPE ... Received an instance of Date`). Note that simply calling `.toISOString()` would **not** have been sufficient: all 123 live candidates store microsecond-precision timestamps, so a millisecond-truncated comparison would have matched zero rows and silently reported `unchanged_control` instead of erroring. Timestamps are now selected and compared as exact text.

3. **`applied_at` bound `new Date()`** in both audit inserts — same driver limitation, rolling back an otherwise successful `UPDATE`.

## Why no test caught it

The run loop records any exception as a generic `failed` attempt with `error_code = 'Error'`, and every existing test injected a stubbed `applyAnalysis`, so the real statement was never rendered.

## Changes

- Explicit `::intent_mode` / `::speech_act_type` casts on every bound enum value, written or compared.
- Timestamp controls selected as `::text` and compared as `::text`, preserving exact microsecond precision.
- `applied_at` bound as an ISO string with `::timestamptz`.
- Tests render the production SQL through the existing `runtimeLoader` seam and assert the enum casts, the exact-text timestamp controls, and the invariant that would have caught all three defects at once: **no bound parameter is a `Date`**.
- Package-script harness updated for the new projection (it guards `i.`-qualified columns against the `intent_proposals` join; the qualification is preserved).

## Verification

- `bun test src/cli/tests/` → 33 pass, 0 fail
- `bun run lint` → 0 errors
- `bun run build` (tsc) → clean
- End to end against the Neon **dev** branch: `updated: 3, skipped: 2 (non_actionable), failed: 0`, run recorded `completed`. Confirmed in the database: repaired rows carry real analysis with `applied_at` stamped; the non-actionable rows were left completely untouched.

Prod has **not** been run and is untouched (0 runs, 0 attempts, still 108/119 missing). The prod repair is queued behind this fix.