### PR TITLE
docs(skills): capture the raw-SQL write and release-audit learnings

### DIFF
--- a/.agents/skills/debug-raw-sql-maintenance-writes/SKILL.md
+++ b/.agents/skills/debug-raw-sql-maintenance-writes/SKILL.md
@@ -1,0 +1,129 @@
+---
+name: debug-raw-sql-maintenance-writes
+description: Diagnose and prevent silent no-op writes in maintenance CLIs under services/api/src/cli that use raw drizzle `sql` templates instead of the query builder. Use when a backfill reports attempted > 0 but updated = 0, when attempts land as status "failed" with a generic error_code like "Error", when a write path has never successfully run despite shipping, or before adding a raw-SQL UPDATE against enum, timestamp, or vector columns. Covers the three postgres.js binding traps and how to test the rendered statement without a database.
+---
+
+# debug-raw-sql-maintenance-writes
+
+Maintenance CLIs bypass the Drizzle query builder when they need many
+unchanged-control predicates, and raw `sql` templates bind values as plain
+parameters. Three binding traps make a write path fail **100% of the time** while
+looking like ordinary per-row failures. All three shipped together undetected in
+`backfill-intent-verification-analysis` (IND, 2026-07-30) — the audit tables were
+empty in every environment not because nobody ran it, but because nothing could
+ever succeed.
+
+## The tell
+
+```
+attempted: 5   updated: 0   failed: 3   skipped: 2
+```
+
+A run loop that records `error_code: error.name` reports these as `"Error"`. That is
+not a per-row data problem — a whole-path binding defect looks exactly like this.
+`updated: 0` with `failed > 0` on **every** candidate means suspect the statement,
+not the data.
+
+## The three traps
+
+### 1. Enum columns bound as text
+
+`intents.intent_mode` and `intents.speech_act_type` are Postgres enums
+(`CREATE TYPE ... AS ENUM`, declared as `pgEnum` in `database.schema.ts`). A bound
+parameter arrives as `text`, and Postgres refuses the implicit coercion at plan
+time — before a single row is examined:
+
+```
+column "intent_mode" is of type intent_mode but expression is of type text
+```
+
+Every bound enum value needs an explicit cast, **written and compared**:
+
+```ts
+SET intent_mode = ${analysis.intentMode}::intent_mode
+...
+AND intent_mode IS NOT DISTINCT FROM ${candidate.intentMode}::intent_mode
+```
+
+Reproduce the class of failure in one read-only statement (a literal is coerced
+fine, an explicit `::text` is not):
+
+```sql
+UPDATE intents SET intent_mode = 'REFERENTIAL'::text
+WHERE id = '00000000-0000-0000-0000-000000000000';  -- errors at plan time
+```
+
+### 2. `Date` bound as a raw parameter
+
+postgres.js rejects it outright:
+
+```
+TypeError [ERR_INVALID_ARG_TYPE]: The "string" argument must be of type string
+or an instance of Buffer or ArrayBuffer. Received an instance of Date
+```
+
+Bind an ISO string with an explicit cast instead: `${value.toISOString()}::timestamptz`.
+This applies to audit stamps too (`applied_at`), where the `UPDATE` succeeds and the
+follow-up `INSERT` then rolls the whole transaction back.
+
+### 3. Timestamp *controls* compared after a Date round-trip
+
+The dangerous one, because it **fails silently instead of erroring**. Postgres
+`timestamptz` holds microseconds; a JS `Date` holds milliseconds. Any control
+predicate that round-trips through `Date` (or `.toISOString()`) truncates, matches
+zero rows, and the guard reports `unchanged_control` — indistinguishable from
+"someone else changed the row underneath me".
+
+Check before choosing a fix:
+
+```sql
+SELECT count(*) FILTER (WHERE (extract(microseconds FROM created_at)::bigint % 1000) <> 0)
+FROM intents WHERE <candidate predicate>;
+```
+
+If that is nonzero (it was 123/123 for the live candidate set), carry timestamps as
+**exact text** end to end — select `created_at::text AS created_at`, type the control
+as `string`, and compare `created_at::text IS NOT DISTINCT FROM ${c.createdAt}`. Same
+pattern the file already uses for `embedding::text`.
+
+Keep any `i.`-qualified projection qualified when adding the cast
+(`i.created_at::text AS created_at`) — the candidate query joins `intent_proposals`,
+which exposes `created_at` and `status` too, so an unqualified projection is ambiguous.
+
+## Test the rendered statement, not a stub
+
+The reason all three shipped: every test injected a stubbed `applyAnalysis`, so the
+real statement was never produced. `createRuntimeDeps(options, registerCloseDb, runtimeLoader)`
+takes a runtime seam — pass the real drizzle `sql` tag with a recording `db`, then render:
+
+```ts
+const statements: unknown[] = [];
+const record = { execute: async (q: unknown) => { statements.push(q); return []; } };
+const db = { ...record, transaction: async (run) => run(record) };
+const deps = await createRuntimeDeps({ dryRun: false }, undefined,
+  async () => ({ sql, db: db as never, getProfileContext: async () => ({}) }));
+await deps.applyAnalysis(candidate(), analysis, provenance);
+const { sql: text, params } = new PgDialect().sqlToQuery(statements[0] as never);
+```
+
+Assert the **invariant** that catches all three at once, not just the symptom:
+
+```ts
+expect(params.filter((p) => p instanceof Date)).toEqual([]);
+```
+
+No database, no credentials, no socket.
+
+## Operational rule
+
+Never run a maintenance write against prod without first running the identical
+command (same `NODE_ENV`, same flags, only `DATABASE_URL` differing) against the Neon
+dev branch and confirming `updated > 0` and `failed = 0`. A dry-run report proves the
+*predicate*; only a real write proves the *statement*. Here the dry run was perfectly
+clean — 121 candidates, 431 controls, all `ready_for_verification` — while the write
+path could not update a single row.
+
+## See also
+
+- `backfill-production-data` — the prod write sequence (control group, dev dry-run, backup branch, exact count verification) this feeds into.
+- `verify-production-release` — release-time checks, including operational backfills that shipped but never ran.

--- a/.agents/skills/debug-raw-sql-maintenance-writes/agents/openai.yaml
+++ b/.agents/skills/debug-raw-sql-maintenance-writes/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Debug Raw SQL Maintenance Writes"
+  short_description: "Index project workflow: Debug Raw SQL Maintenance Writes"
+  default_prompt: "Use $debug-raw-sql-maintenance-writes to diagnose a maintenance CLI whose raw-SQL write path reports attempted rows but zero updates."

--- a/.agents/skills/verify-production-release/SKILL.md
+++ b/.agents/skills/verify-production-release/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: verify-production-release
-description: "Pre-merge and post-merge safety checks for promoting a dev→main release in this monorepo, capturing two non-obvious ways a release can break or lose data: (1) a stale root bun.lock fails the prod build under --frozen-lockfile even though dev never caught it, and (2) a destructive Drizzle migration (e.g. DROP TABLE) silently loses prod data when the operational backfill never ran on prod. Use when cutting/merging a release PR to main, when a prod deploy build fails on 'lockfile is frozen', or before merging any PR carrying a DROP/destructive migration."
+description: "Pre-merge and post-merge safety checks for promoting a dev→main release in this monorepo, capturing non-obvious ways a release can break, lose data, or silently ship nothing: a stale root bun.lock failing the prod build under --frozen-lockfile, a destructive Drizzle migration losing prod data when the operational backfill never ran, dev→prod feature-flag drift leaving prod on older behavior, and removed queue workers orphaning jobs in prod Redis. Use when cutting/merging a release PR to main, when auditing a merge someone else performed, when a prod deploy build fails on 'lockfile is frozen', or before merging any PR carrying a DROP/destructive migration."
 ---
 
 # verify-production-release
@@ -37,9 +37,54 @@ A `DROP TABLE`/column migration is a blind schema op — it does **no** data bac
 
 **Gotchas:**
 - Migrations are sequential — you usually can't "skip" the destructive one mid-sequence, so pre-flight remediation beats splitting the release.
-- Auto-`db:migrate` on deploy means there's no window to backfill *after* the drop — do it before.
+- Auto-`db:migrate` on deploy means there's no window to backfill *after* the drop — do it before. On the `main` environment this is real: `RAILWAY_BUILD_COMMAND` ends with `cd backend && bun run db:migrate`, so migrations apply during the build. (Two `RAILWAY_*_PRE_DEPLOY_COMMAND` vars once claimed "migrations applied manually via neon mcp" and contradicted this; they were removed 2026-07-30. Do not reintroduce a note that disagrees with the build command.)
 - Successful MCP tool calls may not be logged by name; for "is the old thing still used?" prefer a **persisted** signal (a runs/operations table) over app-log greps.
+
+## 3. The release shipped, but prod still runs the old behavior
+
+A green deploy proves the *code* landed, not that the *feature* is on. Flags default
+off, and Railway variables are per-environment, so `main` keeps whatever it had.
+Audit drift explicitly — comparing the two services is a two-call check:
+
+```
+railway_list_variables({service_id:"protocol", environment_id:"<dev>"})
+railway_list_variables({service_id:"protocol", environment_id:"<main>"})
+```
+
+On 2026-07-30 this surfaced 26 flags set on dev and absent on prod — including
+`NEGOTIATION_PROTOCOL_VERSION` (prod was defaulting to v1), the whole
+`POOL_QUESTIONS_*` family, and the web agent surfaces. Prod had been running an
+older product for weeks with every release "successful".
+
+When mirroring dev→prod, two categories must **not** be copied blindly:
+- **Operational** values (`LOG_LEVEL=verbose`) — dev noise, prod cost.
+- **Disable switches**, where dev's value turns a prod feature *off*. `DISCOVERY_SOURCE_PREMISE_LIMIT=0`
+  is an explicit disable (`opportunity.graph.ts`), not a smaller limit; prod running unset
+  means the default is active.
+
+Set the rest in one `railway_set_variables` call (one redeploy), then confirm
+`SUCCESS` + health + a boot log line proving the flag took effect (e.g.
+`PoolQuestionPushQueue ... newClaimsEnabled=true`).
+
+## 4. A removed queue worker orphans jobs in prod Redis
+
+When a release deletes a queue's worker, producer, and bull-board panel (as #1301 did
+for `opportunity-discovery-run`), anything left in Redis becomes both unprocessable
+and invisible. Check before assuming it's harmless — via the Redis service's TCP proxy
+(`railway_list_tcp_proxies`), scan `bull:<queue>:*` and read `wait`/`active`/`delayed`/`failed`,
+with a live queue as a control. Guard any cleanup so it aborts if pending state exists.
+(That instance: 5 keys, one completed job from weeks earlier, zero stranded work.)
+
+## 5. "Shipped" ≠ "ran" for operational backfills
+
+A migration that creates audit tables for a backfill does not run the backfill. Empty
+`*_runs`/`*_attempts` tables are ambiguous: nobody ran it, **or** it cannot work. Distinguish
+by rehearsing on the Neon dev branch — see `debug-raw-sql-maintenance-writes`, where
+exactly that check exposed a write path that had never functioned since it shipped.
 
 ## See also
 - `manage-pr` — merge + post-merge deploy/Railway verification (run these checks as part of finishing a release PR).
+- `manage-feature-flags` — the four flag surfaces and the ship-dark→flip order behind check 3.
+- `debug-raw-sql-maintenance-writes` — when a shipped backfill reports attempts but zero updates.
+- `backfill-production-data` — the prod write sequence for check 5.
 - `open-release-pr` — cut the dated `release/<date>` PR into `main`.


### PR DESCRIPTION
Follow-up to #1309. Captures what the #1305 release audit and the prod backfill repair taught, so neither is rediscovered the hard way.

## New: `debug-raw-sql-maintenance-writes`

The three postgres.js binding traps that make a raw-SQL maintenance write path fail on **every** candidate while presenting as ordinary per-row failures:

1. **Enum columns bound as text** — rejected at plan time (`column "intent_mode" is of type intent_mode but expression is of type text`), before any row is read.
2. **`Date` bound as a raw parameter** — postgres.js refuses it (`ERR_INVALID_ARG_TYPE ... Received an instance of Date`).
3. **Timestamp controls truncated by a Date round-trip** — the dangerous one: it *fails silently*. `timestamptz` holds microseconds, `Date` holds milliseconds, so the control predicate matches zero rows and reports `unchanged_control`, which is indistinguishable from a legitimate concurrent modification.

Also documents the `createRuntimeDeps` recording seam for asserting the rendered statement with no database or credentials, and the single invariant that would have caught all three: **no bound parameter is a `Date`**.

## Updated: `verify-production-release`

Three checks the audit needed and the skill did not have:

- **dev→prod flag drift.** A green deploy proves the code landed, not that the feature is on. 26 flags were set on dev and absent on prod — including `NEGOTIATION_PROTOCOL_VERSION` (prod defaulting to v1) and the entire `POOL_QUESTIONS_*` family. Prod had been running an older product across successive "successful" releases. Includes the two categories that must not be mirrored blindly: operational values, and disable switches like `DISCOVERY_SOURCE_PREMISE_LIMIT=0` where dev's value turns a prod feature *off*.
- **Orphaned Redis keys** after a release deletes a queue's worker, producer, and bull-board panel — how to scan them via the TCP proxy and guard the cleanup.
- **"Shipped" ≠ "ran"** for operational backfills, and how to tell an unrun backfill from an unrunnable one.

Plus a correction: prod really does auto-migrate during the build (`RAILWAY_BUILD_COMMAND` ends in `db:migrate`). The `RAILWAY_*_PRE_DEPLOY_COMMAND` vars that claimed migrations were applied manually contradicted this and were removed on 2026-07-30.

## Verification

- `bun .agents/skills/learn-skill/scripts/skillctl.ts validate` → OK
- `audit` → both skills within the 120-line body budget, no duplicate blocks
- `bun run skills:validate` → 16 Agent Skills, 16 Codex skills, all valid