### PR TITLE
fix(api): rate-limit /intents/intake/proposal as a synthesizing route

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -340,7 +340,7 @@ CONTACTS_ENABLED=false
 LIMITER_AUTH_WRITE_PER_MIN=100
 LIMITER_READ_PER_MIN=1200
 LIMITER_WRITE_PER_MIN=600
-# Routes that launch an LLM synthesis + intent graph per call (/intents/intake/prepare, /revise).
+# Routes that launch an LLM synthesis + intent graph per call (/intents/intake/prepare, /revise, /proposal).
 LIMITER_INTAKE_SYNTHESIS_PER_MIN=20
 # Comma-separated; first matching IPv4/IPv6 wins. Default chain handles Envoy + most edge proxies.
 LIMITER_IP_HEADERS=x-envoy-external-address,x-forwarded-for,x-original-forwarded-for,x-real-ip

--- a/services/api/package.json
+++ b/services/api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@indexnetwork/api",
-  "version": "0.68.0",
+  "version": "0.68.1",
   "license": "MIT",
   "private": true,
   "scripts": {

--- a/services/api/src/controllers/intent-intake.controller.ts
+++ b/services/api/src/controllers/intent-intake.controller.ts
@@ -115,7 +115,7 @@ export class IntentIntakeController {
 
   /** Resolve the speculative proposal, or redo it when the where-text changed it. */
   @Post('/proposal')
-  @UseGuards(RateLimit('write'), FastSignalIntakeEnabledGuard, AuthGuard)
+  @UseGuards(RateLimit('intake_synthesis'), FastSignalIntakeEnabledGuard, AuthGuard)
   async proposal(req: Request, user: AuthenticatedUser) {
     if (!isFastSignalIntakeEnabled()) return new Response(null, { status: 404 });
     const parsed = ProposalSchema.safeParse(await req.json().catch(() => ({})));

--- a/services/api/src/controllers/tests/intent-intake.controller.isolated.ts
+++ b/services/api/src/controllers/tests/intent-intake.controller.isolated.ts
@@ -63,16 +63,20 @@ describe('IntentIntakeController flag gating', () => {
     for (const response of responses) expect(response.status).toBe(404);
   });
 
-  it('rate-limits the two synthesizing routes far tighter than ordinary writes', () => {
-    // /prepare answers 202 and then launches an uncapped background synthesis
-    // plus a full intent-graph run and a durable proposal write; /revise does the
-    // same synchronously. The 600/min `write` budget is not a meaningful cap on
-    // that, so both carry the dedicated class.
-    for (const method of ['prepare', 'revise'] as const) {
+  it('rate-limits every synthesizing route far tighter than ordinary writes', () => {
+    // Each of these can launch an LLM synthesis plus a full intent-graph run and
+    // a durable proposal write: /prepare answers 202 and then does it in the
+    // background, /revise does it synchronously, and /proposal does it whenever
+    // `whereText` is supplied or the speculative run is unusable. `resolveProposal`
+    // also accepts the same runId repeatedly, so the 600/min `write` budget is not
+    // a meaningful cap on any of them.
+    for (const method of ['prepare', 'revise', 'proposal'] as const) {
       const names = RouteRegistry.getGuards(IntentIntakeController, method).map((guard) => guard.name);
       expect(names[0]).toBe('RateLimit(intake_synthesis)');
     }
-    for (const method of ['start', 'question', 'proposal'] as const) {
+    // /start and /question never synthesize: one is a pack lookup, the other is a
+    // single structured question call with no durable write.
+    for (const method of ['start', 'question'] as const) {
       const names = RouteRegistry.getGuards(IntentIntakeController, method).map((guard) => guard.name);
       expect(names[0]).toBe('RateLimit(write)');
     }


### PR DESCRIPTION
Closes follow-up #2 from #1307.

`/intents/intake/prepare` and `/revise` were moved onto the dedicated `intake_synthesis` limiter (20/min), but `/proposal` was left on `write` (600/min). That was too narrow a reading of which routes synthesize.

`/proposal` synthesizes too:
- its `whereText` branch discards the speculative run and re-synthesizes,
- the poll-timeout fallback synthesizes serially when speculation hasn't settled,
- and `resolveProposal` accepts the same `runId` repeatedly.

So one authenticated caller could drive roughly 600 LLM syntheses, full intent-graph runs, and durable `intent_proposals` writes per minute through `/proposal` after a single `/prepare`. That's the same abuse channel the `intake_synthesis` class was introduced to close.

## Bug Fixes

- `/intents/intake/proposal` now carries `RateLimit('intake_synthesis')`.

## Tests

- The guard test previously asserted `/proposal` was on `write`; it now pins all three synthesizing routes (`prepare`, `revise`, `proposal`) to `intake_synthesis`, and keeps `start`/`question` on `write` since neither synthesizes. Verified RED: reverting the one-line controller change fails the test.
- `intent-intake.controller.isolated.ts` 15/15, `fast-intake.guard.isolated.ts` 5/5, `services/api` typecheck clean, lint 0 errors.

## Documentation

- `.env.example` comment for `LIMITER_INTAKE_SYNTHESIS_PER_MIN` now lists `/proposal`.

## Note on the lockfile

`services/api` is bumped 0.68.0 → 0.68.1 (patch, per the versioning policy). `bun.lock` is deliberately unchanged: `bun install` leaves it byte-identical, and a forced full regeneration re-resolved the whole dependency graph (718-line diff, new packages pulled in) — unacceptable churn for a one-line fix. `bun install --frozen-lockfile` passes as-is.
