### PR TITLE
feat: restrict the eval ops site to verified @index.network identities

### DIFF
--- a/apps/eval-ops/README.md
+++ b/apps/eval-ops/README.md
@@ -29,9 +29,23 @@ unchanged — which the API requires (see below).
 `.env.test` and the fixture target is the test database. There is no combined launcher: two
 terminals is the whole story.
 
+First load shows a sign-in screen: the site requires a verified `@index.network` Index
+account (see [Authentication](#authentication) below). In this two-process setup the API
+answers the sign-in callback on `:4321` but serves no UI, so a completed sign-in redirects
+to `EVAL_OPS_UI_URL`, which defaults to `http://127.0.0.1:5174` — the Vite dev server above.
+
 For a built single-process variant, `bun run build:eval-ops` (typecheck + `vite build`) and
 `bun run start:eval-ops` serve the SPA and the API from one Bun server on the same port.
-That entrypoint has exactly the same loopback binding and the same lack of authentication.
+That entrypoint has exactly the same loopback binding and the same identity gate; because
+both are on one origin, sign-in redirects to `/` there. `site.ts` owns which requests go to
+the API: everything under `/api` **and** `/callback`, which is not under `/api` and cannot
+be — the bridge's own validator accepts that pathname and no other. Serving `/callback`
+from the SPA instead would leave a freshly minted API key sitting in the browser's URL bar
+and history for a sign-in that could never complete.
+
+Unlike `eval:web`, `start:eval-ops` does **not** load `.env.test`, so `WEB_APP_URL` and
+`API_URL` come from the ambient environment or from their local defaults
+(`http://localhost:3000` and `http://localhost:3001`).
 
 ## Pages
 
@@ -61,18 +75,42 @@ consumer resets its accumulator on reconnect instead of rendering the log twice.
 
 - **It binds loopback.** `127.0.0.1` unless `EVAL_OPS_BIND` is set (`EVAL_OPS_PORT` changes
   the port).
-- **There is no authentication.** Any local process can drive it: launch runs that spend
-  real money, cancel them, and flush the test database. That is an explicit trust decision
-  about *local* processes.
-- **Do not change `EVAL_OPS_BIND` until authentication exists.** It is the hook where auth
-  must land. Setting it alone would not help anyway: the API refuses state-changing requests
-  whose `Origin` is not loopback, so a browser on another host would have every write
-  refused (fail-closed).
+- **Every route needs an Index session** except the two that make signing in possible. See
+  [Authentication](#authentication) below.
+- **Do not change `EVAL_OPS_BIND`.** Authentication is defence in depth, not permission to
+  expose this: the loopback bind, the `Host` check and the `Origin` allowlist are what keep
+  the site local, and it has never been reviewed for exposure beyond loopback. Setting it
+  alone would not work anyway — the API refuses requests addressed to a foreign `Host` and
+  state-changing requests whose `Origin` is not loopback (fail-closed).
 - **Client POSTs must send `Content-Type: application/json`** or the API answers 415.
   `src/api/client.ts` does this; anything else talking to the API must too.
 - **`src/api/client.ts` types are hand-maintained mirrors** of the server's types. They are
   not generated, so they can drift; three had already diverged and were corrected during
   development. Check the server types when changing either side.
+
+## Authentication
+
+Only a verified `@index.network` Index account may use this site. The domain check runs
+server-side; the browser is never trusted for identity. `packages/protocol/eval/ops/README.md`
+is the security model of record — this section is what an operator needs to run it.
+
+- **Signing in** posts `/api/auth/login` and navigates to the returned bridge URL
+  (`<WEB_APP_URL>/cli-auth?…`), which mints a revocable API key against your existing
+  browser session and redirects it to this server's `/callback`. The server exchanges the
+  key for an identity, applies the domain policy and discards the key. It never reaches
+  this app.
+- **`WEB_APP_URL` and `API_URL` are one pair.** The first mints the key, the second
+  verifies it, so a key minted by one deployment cannot be verified by another. The server
+  refuses to start if only one is set, or if one is local and the other is not.
+- **401 and 403 are different screens.** 401 offers sign-in; 403 (`permitted: false`) says
+  the account is not permitted and deliberately offers no sign-in button, which would loop.
+  The discriminator is the body's `permitted: false`, not the status code — the same server
+  answers 403 for a cross-origin write and for a refused fixture target.
+- **Sessions are in memory.** Restarting the ops server signs you out.
+- **The session cookie is visible to every port on `127.0.0.1`.** Cookies are not
+  port-scoped, so another local HTTP service you visit in the same browser receives it.
+  `HttpOnly` keeps it out of JavaScript and the `Host` guard stops it being replayed
+  against this server from a foreign host, so exposure is low — but it is worth knowing.
 
 ## Not part of the production deployment
 

--- a/apps/eval-ops/server.ts
+++ b/apps/eval-ops/server.ts
@@ -1,24 +1,25 @@
 /**
  * Production entrypoint: the ops API plus the built SPA from one Bun server.
- * Binds loopback unless EVAL_OPS_BIND is set explicitly — that variable is the
- * hook where authentication must land before any non-local deployment.
+ *
+ * Binds loopback unless EVAL_OPS_BIND is set explicitly, and every request is
+ * still gated on a verified @index.network Index session — this entrypoint
+ * mounts the same handler, with the same guards, as the standalone API.
+ *
+ * Because the SPA and the API share one origin here, a completed sign-in returns
+ * the browser to `/`; the two-process dev flow serves the UI elsewhere, which is
+ * why the target is configuration rather than a constant. `createSiteFetch` owns
+ * the forwarding rule, so `/callback` cannot be answered with index.html.
  */
 import path from 'node:path';
 
 import { createDefaultOpsContext, createOpsHandler } from '../../packages/protocol/eval/ops/ops.server.js';
+import { createSiteFetch } from './site';
 
 const repoRoot = path.resolve(import.meta.dir, '../..');
-const api = createOpsHandler(await createDefaultOpsContext({ repoRoot }));
-const dist = path.join(import.meta.dir, 'dist');
+const api = createOpsHandler(await createDefaultOpsContext({ repoRoot, uiUrl: '/' }));
 
 Bun.serve({
   hostname: process.env.EVAL_OPS_BIND ?? '127.0.0.1',
   port: Number(process.env.EVAL_OPS_PORT ?? 4321),
-  async fetch(request) {
-    const url = new URL(request.url);
-    if (url.pathname.startsWith('/api/')) return api(request);
-    const asset = Bun.file(path.join(dist, url.pathname === '/' ? 'index.html' : url.pathname));
-    if (await asset.exists()) return new Response(asset);
-    return new Response(Bun.file(path.join(dist, 'index.html')));
-  },
+  fetch: createSiteFetch({ api, distDir: path.join(import.meta.dir, 'dist') }),
 });

--- a/apps/eval-ops/site.ts
+++ b/apps/eval-ops/site.ts
@@ -1,0 +1,39 @@
+/**
+ * The single-process request routing: which requests the ops API answers, and
+ * which ones are the built SPA.
+ *
+ * Separated from server.ts so the decision is testable without starting a
+ * listener or building a real ops context. The rule is `isOpsServerPath`, which
+ * lives with the API rather than here — a bare `startsWith('/api/')` at this
+ * mount point silently swallowed `/callback`, so the SPA answered the sign-in
+ * bridge with index.html and the freshly minted API key was left in the URL bar
+ * and browser history for a sign-in that could never complete.
+ */
+import path from 'node:path';
+
+import { isOpsServerPath } from '../../packages/protocol/eval/ops/ops.paths';
+
+export interface SiteOptions {
+  /** The ops API handler: everything `isOpsServerPath` claims goes here. */
+  api: (request: Request) => Promise<Response>;
+  /** Directory holding the built SPA. */
+  distDir: string;
+}
+
+/**
+ * Builds the fetch handler that serves the ops API and the built SPA together.
+ *
+ * Anything the API does not own is a file if one exists, and the SPA's
+ * index.html otherwise — client-side routes have no file of their own, so the
+ * fallback is what makes `/launch` and `/r/:id` work on a hard refresh.
+ */
+export function createSiteFetch(options: SiteOptions): (request: Request) => Promise<Response> {
+  const { api, distDir } = options;
+  return async (request: Request): Promise<Response> => {
+    const url = new URL(request.url);
+    if (isOpsServerPath(url.pathname)) return api(request);
+    const asset = Bun.file(path.join(distDir, url.pathname === '/' ? 'index.html' : url.pathname));
+    if (await asset.exists()) return new Response(asset);
+    return new Response(Bun.file(path.join(distDir, 'index.html')));
+  };
+}

--- a/apps/eval-ops/src/api/client.ts
+++ b/apps/eval-ops/src/api/client.ts
@@ -187,6 +187,18 @@ async function postJson<T>(url: string, body: unknown): Promise<T> {
 }
 
 export const api = {
+  async authStatus(): Promise<{ authenticated: boolean; email?: string; name?: string }> {
+    return fetchJson('/api/auth/status');
+  },
+
+  async login(): Promise<{ url: string }> {
+    return postJson('/api/auth/login', {});
+  },
+
+  async logout(): Promise<void> {
+    await postJson('/api/auth/logout', {});
+  },
+
   async harnesses(): Promise<{ harnesses: HarnessDescriptor[] }> {
     return fetchJson('/api/harnesses');
   },

--- a/apps/eval-ops/src/api/client.ts
+++ b/apps/eval-ops/src/api/client.ts
@@ -202,6 +202,11 @@ export function onAuthRefusal(listener: (refusal: AuthRefusal) => void): () => v
   };
 }
 
+/** Publishes a refusal to every subscriber. */
+function notifyAuthRefusal(refusal: AuthRefusal): void {
+  for (const listener of authRefusalListeners) listener(refusal);
+}
+
 /** Returns the refusal a failed response reports, or null when it reports something else. */
 function classifyAuthRefusal(status: number, body: unknown): AuthRefusal | null {
   if (typeof body !== 'object' || body === null) return null;
@@ -217,9 +222,7 @@ async function fetchJson<T>(url: string, init?: RequestInit): Promise<T> {
   if (!response.ok) {
     const body = await response.json().catch(() => ({ error: response.statusText }));
     const refusal = classifyAuthRefusal(response.status, body);
-    if (refusal !== null) {
-      for (const listener of authRefusalListeners) listener(refusal);
-    }
+    if (refusal !== null) notifyAuthRefusal(refusal);
     throw new Error(body.error ?? `HTTP ${response.status}`);
   }
   return response.json();
@@ -303,6 +306,14 @@ export const api = {
  * EventSource will auto-reconnect on network failures. Each reconnect replays from
  * byte 0, so consumers may see duplicate log lines. The stream ends when the run
  * reaches a terminal status.
+ *
+ * The stream is gated like every other route, but `EventSource` exposes no status
+ * code — a 401 arrives as the same bare `error` event as a dropped connection, so
+ * it never reaches `fetchJson` and never reaches `onAuthRefusal`. A stream that
+ * fails before any status frame is therefore checked against the public status
+ * route: when nobody is signed in, the refusal is published here so the shell
+ * demotes, instead of the run page reporting "no run with that id" for what is an
+ * expired session and EventSource reconnecting against a 401 forever.
  */
 export function subscribeToRun(
   id: string,
@@ -313,6 +324,8 @@ export function subscribeToRun(
   },
 ): () => void {
   const source = new EventSource(`/api/runs/${id}/stream`);
+  let sawStatus = false;
+  let probed = false;
 
   source.addEventListener('log', (event) => {
     try {
@@ -326,6 +339,7 @@ export function subscribeToRun(
   source.addEventListener('status', (event) => {
     try {
       const record = JSON.parse((event as MessageEvent<string>).data);
+      sawStatus = true;
       handlers.onStatus(record);
     } catch {
       // Malformed frame: ignore to keep the stream alive
@@ -333,8 +347,31 @@ export function subscribeToRun(
   });
 
   source.addEventListener('error', (event) => {
+    // Once only, and only before a status frame: a mid-stream reconnect is an
+    // ordinary drop, and probing on every retry would be a request loop of its own.
+    if (!sawStatus && !probed) {
+      probed = true;
+      void publishRefusalIfSignedOut();
+    }
     handlers.onError(event);
   });
 
   return () => source.close();
+}
+
+/**
+ * Asks the public status route who is signed in, and publishes the refusal the
+ * SSE stream could not report.
+ *
+ * Silent on anything else. A status call that fails or answers `authenticated:
+ * true` says the stream failed for some other reason, and claiming a refusal
+ * there would throw the operator out of a working session.
+ */
+async function publishRefusalIfSignedOut(): Promise<void> {
+  try {
+    const status = await api.authStatus();
+    if (!status.authenticated) notifyAuthRefusal('unauthenticated');
+  } catch {
+    // Unanswerable is not refused: leave the stream's own error reporting alone.
+  }
 }

--- a/apps/eval-ops/src/api/client.ts
+++ b/apps/eval-ops/src/api/client.ts
@@ -167,11 +167,59 @@ export type CompareResult =
       aggregate: { reference: number; subject: number; delta: number };
     };
 
+/**
+ * The two ways the server can tell this app that its session does not admit it.
+ *
+ * `GET /api/auth/status` is public and only ever answers `authenticated` true or
+ * false, so it cannot report the domain refusal at all. The 403 in the HTTP
+ * contract is produced in exactly one place — the server's auth gate, on a route
+ * that requires a session — so a gated API call is the only surface where a
+ * browser observes it. A sign-in the domain policy refuses never gets that far:
+ * it is refused at /callback, which renders the server's own refusal page and
+ * establishes no session, so this app is never loaded for that identity.
+ *
+ * The status code alone is not the signal. The same server answers 403 for a
+ * cross-origin write, for a foreign `Host`, and for a fixture reset against a
+ * database that is not disposable; showing "your account is not permitted" for
+ * any of those would be a lie. The discriminator is the `permitted: false` field,
+ * which only the auth gate sets.
+ */
+export type AuthRefusal = 'unauthenticated' | 'not-permitted';
+
+const authRefusalListeners = new Set<(refusal: AuthRefusal) => void>();
+
+/**
+ * Subscribes to session refusals seen by any API call. Returns an unsubscribe.
+ *
+ * This exists so the shell can stop rendering the dashboard the moment a call
+ * comes back refused, rather than leaving every route to render its own 401 as
+ * an ordinary error message.
+ */
+export function onAuthRefusal(listener: (refusal: AuthRefusal) => void): () => void {
+  authRefusalListeners.add(listener);
+  return () => {
+    authRefusalListeners.delete(listener);
+  };
+}
+
+/** Returns the refusal a failed response reports, or null when it reports something else. */
+function classifyAuthRefusal(status: number, body: unknown): AuthRefusal | null {
+  if (typeof body !== 'object' || body === null) return null;
+  const frame = body as { authenticated?: unknown; permitted?: unknown };
+  if (status === 401 && frame.authenticated === false) return 'unauthenticated';
+  if (status === 403 && frame.authenticated === true && frame.permitted === false) return 'not-permitted';
+  return null;
+}
+
 /** Fetch helper that throws an Error containing the server's error field on non-2xx. */
 async function fetchJson<T>(url: string, init?: RequestInit): Promise<T> {
   const response = await fetch(url, init);
   if (!response.ok) {
     const body = await response.json().catch(() => ({ error: response.statusText }));
+    const refusal = classifyAuthRefusal(response.status, body);
+    if (refusal !== null) {
+      for (const listener of authRefusalListeners) listener(refusal);
+    }
     throw new Error(body.error ?? `HTTP ${response.status}`);
   }
   return response.json();

--- a/apps/eval-ops/src/components/Shell.tsx
+++ b/apps/eval-ops/src/components/Shell.tsx
@@ -1,6 +1,9 @@
 import { Link, Outlet } from 'react-router';
 import { useState, useEffect } from 'react';
-import { api } from '../api/client';
+import { api, onAuthRefusal } from '../api/client';
+import { Frame } from './Frame';
+import { SignIn } from '../routes/SignIn';
+import { NotPermitted } from '../routes/NotPermitted';
 
 const LINKS: ReadonlyArray<{ to: string; label: string }> = [
   { to: '/', label: 'overview' },
@@ -10,31 +13,64 @@ const LINKS: ReadonlyArray<{ to: string; label: string }> = [
   { to: '/fixture', label: 'fixture' },
 ];
 
-interface AuthStatus {
-  authenticated: boolean;
-  email?: string;
-  name?: string;
-}
+/**
+ * What the shell knows about the operator, and therefore what it may render.
+ *
+ * `unknown` is a real state rather than an optimistic "assume signed in": every
+ * route fetches on mount, so rendering the dashboard before the answer arrives
+ * would fire a screenful of calls that all come back 401 and leave the operator
+ * reading error frames behind a login prompt.
+ */
+type Access =
+  | { kind: 'unknown' }
+  | { kind: 'signed-out' }
+  | { kind: 'not-permitted' }
+  | { kind: 'signed-in'; email?: string; name?: string };
 
 /**
- * The application shell. Every route an operator needs is reachable from here by
- * mouse: these are real links with real hrefs, not keyboard shortcuts.
+ * The application shell, and the one place the dashboard is gated.
+ *
+ * Every route an operator needs is reachable from here by mouse: these are real
+ * links with real hrefs, not keyboard shortcuts. The header chrome stays put in
+ * every state so the browser's own back and forward keep working, but `<Outlet />`
+ * — and with it every route's data fetching — mounts only once the server has
+ * said this browser holds a session it admits.
  */
 export function Shell() {
-  const [authStatus, setAuthStatus] = useState<AuthStatus | null>(null);
+  const [access, setAccess] = useState<Access>({ kind: 'unknown' });
   const [signingOut, setSigningOut] = useState(false);
 
   useEffect(() => {
-    async function checkAuth() {
-      try {
-        const data = await api.authStatus();
-        setAuthStatus(data);
-      } catch {
-        // If status check fails, assume unauthenticated
-        setAuthStatus({ authenticated: false });
-      }
-    }
-    checkAuth();
+    let mounted = true;
+
+    // A refusal seen by any later API call demotes the shell: a session can end
+    // while the page is open (the server restarts, or sign-out happens in another
+    // tab), and 403 with permitted:false is the only way the domain refusal is
+    // observable in a browser at all.
+    const unsubscribe = onAuthRefusal((refusal) => {
+      if (!mounted) return;
+      setAccess(refusal === 'not-permitted' ? { kind: 'not-permitted' } : { kind: 'signed-out' });
+    });
+
+    api
+      .authStatus()
+      .then((status) => {
+        if (!mounted) return;
+        setAccess(
+          status.authenticated
+            ? { kind: 'signed-in', email: status.email, name: status.name }
+            : { kind: 'signed-out' },
+        );
+      })
+      .catch(() => {
+        // Fail closed: an unanswerable status question is not permission.
+        if (mounted) setAccess({ kind: 'signed-out' });
+      });
+
+    return () => {
+      mounted = false;
+      unsubscribe();
+    };
   }, []);
 
   const handleSignOut = async () => {
@@ -61,9 +97,9 @@ export function Shell() {
             ))}
           </nav>
         </div>
-        {authStatus?.authenticated && (
+        {access.kind === 'signed-in' && (
           <div className="flex items-baseline gap-4 text-sm">
-            <span className="text-term-dim">{authStatus.email}</span>
+            <span className="text-term-dim">{access.email}</span>
             <button
               onClick={handleSignOut}
               disabled={signingOut}
@@ -76,8 +112,24 @@ export function Shell() {
         )}
       </header>
       <main className="flex-1">
-        <Outlet />
+        {access.kind === 'unknown' && <CheckingSession />}
+        {access.kind === 'signed-out' && <SignIn />}
+        {access.kind === 'not-permitted' && <NotPermitted />}
+        {access.kind === 'signed-in' && <Outlet />}
       </main>
+    </div>
+  );
+}
+
+/** The neutral state between asking who is signed in and being told. */
+function CheckingSession() {
+  return (
+    <div className="flex items-center justify-center min-h-screen">
+      <div className="w-full max-w-md p-4">
+        <Frame label="session">
+          <p className="text-term-dim py-4">Checking your Index session...</p>
+        </Frame>
+      </div>
     </div>
   );
 }

--- a/apps/eval-ops/src/components/Shell.tsx
+++ b/apps/eval-ops/src/components/Shell.tsx
@@ -35,6 +35,9 @@ type Access =
  * every state so the browser's own back and forward keep working, but `<Outlet />`
  * — and with it every route's data fetching — mounts only once the server has
  * said this browser holds a session it admits.
+ *
+ * The nav is part of what mounts only then: a link that changes the URL and still
+ * shows the sign-in prompt offers the operator a choice that does not exist.
  */
 export function Shell() {
   const [access, setAccess] = useState<Access>({ kind: 'unknown' });
@@ -89,13 +92,15 @@ export function Shell() {
       <header className="border-b border-[var(--color-term-rule)] px-4 py-2 flex items-baseline gap-4 justify-between">
         <div className="flex items-baseline gap-4">
           <h1 className="text-sm">index eval ops</h1>
-          <nav className="flex gap-4 text-sm">
-            {LINKS.map((link) => (
-              <Link key={link.to} to={link.to} className="text-term-blue hover:underline">
-                {link.label}
-              </Link>
-            ))}
-          </nav>
+          {access.kind === 'signed-in' && (
+            <nav className="flex gap-4 text-sm">
+              {LINKS.map((link) => (
+                <Link key={link.to} to={link.to} className="text-term-blue hover:underline">
+                  {link.label}
+                </Link>
+              ))}
+            </nav>
+          )}
         </div>
         {access.kind === 'signed-in' && (
           <div className="flex items-baseline gap-4 text-sm">

--- a/apps/eval-ops/src/components/Shell.tsx
+++ b/apps/eval-ops/src/components/Shell.tsx
@@ -1,4 +1,6 @@
 import { Link, Outlet } from 'react-router';
+import { useState, useEffect } from 'react';
+import { api } from '../api/client';
 
 const LINKS: ReadonlyArray<{ to: string; label: string }> = [
   { to: '/', label: 'overview' },
@@ -8,22 +10,70 @@ const LINKS: ReadonlyArray<{ to: string; label: string }> = [
   { to: '/fixture', label: 'fixture' },
 ];
 
+interface AuthStatus {
+  authenticated: boolean;
+  email?: string;
+  name?: string;
+}
+
 /**
  * The application shell. Every route an operator needs is reachable from here by
  * mouse: these are real links with real hrefs, not keyboard shortcuts.
  */
 export function Shell() {
+  const [authStatus, setAuthStatus] = useState<AuthStatus | null>(null);
+  const [signingOut, setSigningOut] = useState(false);
+
+  useEffect(() => {
+    async function checkAuth() {
+      try {
+        const data = await api.authStatus();
+        setAuthStatus(data);
+      } catch {
+        // If status check fails, assume unauthenticated
+        setAuthStatus({ authenticated: false });
+      }
+    }
+    checkAuth();
+  }, []);
+
+  const handleSignOut = async () => {
+    setSigningOut(true);
+    try {
+      await api.logout();
+      // Reload to trigger the unauthenticated flow
+      window.location.reload();
+    } catch {
+      setSigningOut(false);
+    }
+  };
+
   return (
     <div className="min-h-screen flex flex-col">
-      <header className="border-b border-[var(--color-term-rule)] px-4 py-2 flex items-baseline gap-4">
-        <h1 className="text-sm">index eval ops</h1>
-        <nav className="flex gap-4 text-sm">
-          {LINKS.map((link) => (
-            <Link key={link.to} to={link.to} className="text-term-blue hover:underline">
-              {link.label}
-            </Link>
-          ))}
-        </nav>
+      <header className="border-b border-[var(--color-term-rule)] px-4 py-2 flex items-baseline gap-4 justify-between">
+        <div className="flex items-baseline gap-4">
+          <h1 className="text-sm">index eval ops</h1>
+          <nav className="flex gap-4 text-sm">
+            {LINKS.map((link) => (
+              <Link key={link.to} to={link.to} className="text-term-blue hover:underline">
+                {link.label}
+              </Link>
+            ))}
+          </nav>
+        </div>
+        {authStatus?.authenticated && (
+          <div className="flex items-baseline gap-4 text-sm">
+            <span className="text-term-dim">{authStatus.email}</span>
+            <button
+              onClick={handleSignOut}
+              disabled={signingOut}
+              className="text-term-cyan hover:underline disabled:opacity-50"
+              aria-label="Sign out"
+            >
+              {signingOut ? 'signing out...' : 'sign out'}
+            </button>
+          </div>
+        )}
       </header>
       <main className="flex-1">
         <Outlet />

--- a/apps/eval-ops/src/routes/NotPermitted.tsx
+++ b/apps/eval-ops/src/routes/NotPermitted.tsx
@@ -1,0 +1,31 @@
+import { Frame } from '../components/Frame';
+
+/**
+ * Shown when a user is authenticated but their account is not @index.network.
+ *
+ * This is distinct from the sign-in screen (401) and must not suggest signing in
+ * again — that would be a loop. The domain check runs server-side and is
+ * fail-closed, so the browser never learns why it was refused beyond the
+ * requirement named here.
+ */
+export function NotPermitted() {
+  return (
+    <div className="flex items-center justify-center min-h-screen">
+      <div className="w-full max-w-md p-4">
+        <Frame label="not permitted">
+          <div className="flex flex-col gap-4 py-4">
+            <p className="text-term-red font-bold">
+              Access Denied
+            </p>
+            <p className="text-term-fg">
+              The eval ops site is restricted to <span className="text-term-cyan">@index.network</span> accounts.
+            </p>
+            <p className="text-term-dim text-sm">
+              Your account does not have permission to access this tool.
+            </p>
+          </div>
+        </Frame>
+      </div>
+    </div>
+  );
+}

--- a/apps/eval-ops/src/routes/SignIn.tsx
+++ b/apps/eval-ops/src/routes/SignIn.tsx
@@ -1,0 +1,53 @@
+import { useState } from 'react';
+import { Frame } from '../components/Frame';
+import { api } from '../api/client';
+
+/**
+ * Sign-in screen shown when the operator has no ops session.
+ *
+ * The server redirects unauthenticated requests to the Index web app's /cli-auth
+ * bridge, which mints a revocable API key from the user's existing browser session
+ * and redirects back to /callback where the ops server establishes its own session.
+ */
+export function SignIn() {
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const handleSignIn = async () => {
+    setLoading(true);
+    setError(null);
+    try {
+      const data = await api.login();
+      // Navigate to the bridge URL
+      window.location.href = data.url;
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Sign-in failed');
+      setLoading(false);
+    }
+  };
+
+  return (
+    <div className="flex items-center justify-center min-h-screen">
+      <div className="w-full max-w-md p-4">
+        <Frame label="index eval ops">
+          <div className="flex flex-col gap-4 py-4">
+            <p className="text-term-fg">
+              Sign in with your Index account to access the eval ops dashboard.
+            </p>
+            <button
+              onClick={handleSignIn}
+              disabled={loading}
+              className="px-4 py-2 bg-term-panel border border-term-rule text-term-cyan hover:bg-term-rule disabled:opacity-50 disabled:cursor-not-allowed"
+              aria-label="Sign in with Index"
+            >
+              {loading ? 'Redirecting...' : 'Sign in with Index'}
+            </button>
+            {error && (
+              <p className="text-term-red text-sm">{error}</p>
+            )}
+          </div>
+        </Frame>
+      </div>
+    </div>
+  );
+}

--- a/apps/eval-ops/src/routes/SignIn.tsx
+++ b/apps/eval-ops/src/routes/SignIn.tsx
@@ -29,7 +29,10 @@ export function SignIn() {
   return (
     <div className="flex items-center justify-center min-h-screen">
       <div className="w-full max-w-md p-4">
-        <Frame label="index eval ops">
+        {/* Labelled "sign in", not "index eval ops": the shell header already
+            carries the site title, and two copies of it would read as a heading
+            duplicated by mistake. */}
+        <Frame label="sign in">
           <div className="flex flex-col gap-4 py-4">
             <p className="text-term-fg">
               Sign in with your Index account to access the eval ops dashboard.

--- a/apps/eval-ops/tests/auth-gate.test.tsx
+++ b/apps/eval-ops/tests/auth-gate.test.tsx
@@ -1,0 +1,144 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { cleanup, render, screen, waitFor } from '@testing-library/react';
+
+import { App } from '../src/App';
+
+/**
+ * The gate, exercised through the real app rather than through the two screens.
+ *
+ * Rendering `SignIn` directly proves only that the component exists; it says
+ * nothing about whether anything mounts it. These tests render `<App />` — the
+ * real router, the real shell, the real routes — against a stubbed
+ * `GET /api/auth/status`, which is exactly the surface where "built but never
+ * wired" is visible.
+ */
+
+/** Every dashboard frame Overview renders. None may appear behind a login prompt. */
+const DASHBOARD_CONTENT = [/harness health/i, /recent runs/i, /fixture status/i];
+
+const AUTHENTICATED = { authenticated: true, email: 'ops@index.network', name: 'Ops' };
+
+/** Empty-but-valid bodies for the routes Overview fetches on mount. */
+function dashboardResponse(url: string): Response | null {
+  if (url.endsWith('/api/harnesses')) return new Response(JSON.stringify({ harnesses: [] }));
+  if (url.endsWith('/api/artifacts')) return new Response(JSON.stringify({ refs: [], issues: [] }));
+  if (url.endsWith('/api/runs')) return new Response(JSON.stringify({ runs: [], issues: [] }));
+  if (url.endsWith('/api/fixture')) return new Response(JSON.stringify({ allowed: false, reason: 'not configured' }));
+  return null;
+}
+
+afterEach(() => {
+  cleanup();
+  vi.unstubAllGlobals();
+});
+
+describe('the shell gates the dashboard on the server\'s answer', () => {
+  it('renders the sign-in prompt and no dashboard content while unauthenticated', async () => {
+    const fetchMock = vi.fn(async (url: string) => {
+      if (String(url).endsWith('/api/auth/status')) {
+        return new Response(JSON.stringify({ authenticated: false }));
+      }
+      // What the server would really answer: the gate refuses every other route.
+      return new Response(
+        JSON.stringify({ error: 'Sign in with your Index account to use the eval ops site.', authenticated: false }),
+        { status: 401 },
+      );
+    });
+    vi.stubGlobal('fetch', fetchMock);
+
+    render(<App />);
+
+    expect(await screen.findByRole('button', { name: /sign in with index/i })).toBeInTheDocument();
+    for (const content of DASHBOARD_CONTENT) {
+      expect(screen.queryByText(content)).not.toBeInTheDocument();
+    }
+
+    // The stronger claim: the routes never mounted, so nothing was even asked for.
+    const requested = fetchMock.mock.calls.map((call) => String(call[0]));
+    expect(requested.filter((path) => !path.startsWith('/api/auth/'))).toEqual([]);
+  });
+
+  it('renders neither the dashboard nor the sign-in prompt while the answer is outstanding', async () => {
+    // A status request that never settles: the shell must sit in its neutral state
+    // rather than guessing, in either direction.
+    vi.stubGlobal('fetch', vi.fn(() => new Promise<Response>(() => {})));
+
+    render(<App />);
+
+    expect(await screen.findByText(/checking your index session/i)).toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: /sign in with index/i })).not.toBeInTheDocument();
+    for (const content of DASHBOARD_CONTENT) {
+      expect(screen.queryByText(content)).not.toBeInTheDocument();
+    }
+  });
+
+  it('renders the dashboard once the operator is authenticated', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async (url: string) => {
+        const path = String(url);
+        if (path.endsWith('/api/auth/status')) return new Response(JSON.stringify(AUTHENTICATED));
+        return dashboardResponse(path) ?? new Response(JSON.stringify({ error: 'not found' }), { status: 404 });
+      }),
+    );
+
+    render(<App />);
+
+    for (const content of DASHBOARD_CONTENT) {
+      expect(await screen.findByText(content)).toBeInTheDocument();
+    }
+    expect(screen.queryByRole('button', { name: /sign in with index/i })).not.toBeInTheDocument();
+  });
+
+  it('replaces the dashboard with the refusal screen when a gated route answers 403 permitted:false', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async (url: string) => {
+        const path = String(url);
+        if (path.endsWith('/api/auth/status')) return new Response(JSON.stringify(AUTHENTICATED));
+        if (path.endsWith('/api/runs')) {
+          // Exactly what the server's auth gate emits for a session the domain
+          // policy no longer admits.
+          return new Response(
+            JSON.stringify({ error: 'not an @index.network account', authenticated: true, permitted: false }),
+            { status: 403 },
+          );
+        }
+        return dashboardResponse(path) ?? new Response(JSON.stringify({ error: 'not found' }), { status: 404 });
+      }),
+    );
+
+    render(<App />);
+
+    expect(await screen.findByText(/not permitted/i)).toBeInTheDocument();
+    for (const content of DASHBOARD_CONTENT) {
+      expect(screen.queryByText(content)).not.toBeInTheDocument();
+    }
+    // A refusal is not an invitation to sign in again: that would loop.
+    expect(screen.queryByRole('button', { name: /sign in with index/i })).not.toBeInTheDocument();
+  });
+
+  it('does not mistake some other 403 for a domain refusal', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async (url: string) => {
+        const path = String(url);
+        if (path.endsWith('/api/auth/status')) return new Response(JSON.stringify(AUTHENTICATED));
+        if (path.endsWith('/api/fixture')) {
+          // The fixture guard's refusal: a 403 with no `permitted` field, which
+          // says nothing about who is signed in.
+          return new Response(JSON.stringify({ error: 'that database is not disposable' }), { status: 403 });
+        }
+        return dashboardResponse(path) ?? new Response(JSON.stringify({ error: 'not found' }), { status: 404 });
+      }),
+    );
+
+    render(<App />);
+
+    expect(await screen.findByText(/that database is not disposable/i)).toBeInTheDocument();
+    await waitFor(() => {
+      expect(screen.getByRole('button', { name: /sign out/i })).toBeInTheDocument();
+    });
+    expect(screen.queryByText(/not permitted/i)).not.toBeInTheDocument();
+  });
+});

--- a/apps/eval-ops/tests/auth.test.tsx
+++ b/apps/eval-ops/tests/auth.test.tsx
@@ -7,8 +7,31 @@ import { SignIn } from '../src/routes/SignIn';
 import { NotPermitted } from '../src/routes/NotPermitted';
 import { Shell } from '../src/components/Shell';
 
+/**
+ * The real `window.location`, saved while a test is standing in for it.
+ *
+ * happy-dom's `location` is not assignable, so the navigation test below replaces
+ * the whole property. Vitest runs every file in a worker against one `window`, so
+ * leaving the stub in place would hand a later test — anything driving
+ * react-router's history, for instance — a plain object with no `assign`, no
+ * `reload` and no origin.
+ */
+let realLocation: PropertyDescriptor | undefined;
+
+/** Replaces `window.location` with a recording stub, remembering the real one. */
+function stubLocation(): void {
+  realLocation = Object.getOwnPropertyDescriptor(window, 'location');
+  delete (window as unknown as { location?: unknown }).location;
+  (window as unknown as { location: { href: string } }).location = { href: '' };
+}
+
 afterEach(() => {
   cleanup();
+  if (realLocation !== undefined) {
+    delete (window as unknown as { location?: unknown }).location;
+    Object.defineProperty(window, 'location', realLocation);
+    realLocation = undefined;
+  }
 });
 
 describe('SignIn', () => {
@@ -33,9 +56,7 @@ describe('SignIn', () => {
     });
     vi.stubGlobal('fetch', mockFetch);
 
-    // Mock window.location.href assignment
-    delete (window as unknown as { location?: unknown }).location;
-    (window as unknown as { location: { href: string } }).location = { href: '' };
+    stubLocation();
 
     render(
       <BrowserRouter>
@@ -114,6 +135,29 @@ describe('NotPermitted', () => {
 });
 
 describe('Shell with auth', () => {
+  it('offers no nav links while signed out', async () => {
+    // A link that changes the URL and still renders the sign-in prompt offers a
+    // choice that does not exist.
+    globalThis.fetch = vi.fn(async (url: string) => {
+      if (String(url).endsWith('/api/auth/status')) {
+        return new Response(JSON.stringify({ authenticated: false }));
+      }
+      return new Response('{}');
+    }) as unknown as typeof fetch;
+
+    render(
+      <BrowserRouter>
+        <Shell />
+      </BrowserRouter>
+    );
+
+    await waitFor(() => {
+      expect(screen.getByRole('button', { name: /sign in with index/i })).toBeInTheDocument();
+    });
+    expect(screen.queryByRole('link', { name: 'overview' })).not.toBeInTheDocument();
+    expect(screen.queryByRole('link', { name: 'fixture' })).not.toBeInTheDocument();
+  });
+
   it('shows user email when authenticated', async () => {
     globalThis.fetch = vi.fn(async (url: string) => {
       if (String(url).endsWith('/api/auth/status')) {

--- a/apps/eval-ops/tests/auth.test.tsx
+++ b/apps/eval-ops/tests/auth.test.tsx
@@ -1,0 +1,188 @@
+import { describe, expect, it, vi, afterEach } from 'vitest';
+import { render, screen, waitFor, cleanup } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { BrowserRouter } from 'react-router';
+
+import { SignIn } from '../src/routes/SignIn';
+import { NotPermitted } from '../src/routes/NotPermitted';
+import { Shell } from '../src/components/Shell';
+
+afterEach(() => {
+  cleanup();
+});
+
+describe('SignIn', () => {
+  it('shows the sign-in button when unauthenticated', () => {
+    globalThis.fetch = vi.fn() as unknown as typeof fetch;
+    render(
+      <BrowserRouter>
+        <SignIn />
+      </BrowserRouter>
+    );
+
+    expect(screen.getByRole('button', { name: /sign in with index/i })).toBeInTheDocument();
+  });
+
+  it('calls POST /api/auth/login and navigates to the returned URL', async () => {
+    const user = userEvent.setup();
+    const mockFetch = vi.fn(async (url: string, init?: RequestInit) => {
+      if (String(url).endsWith('/api/auth/login') && init?.method === 'POST') {
+        return new Response(JSON.stringify({ url: 'https://index.network/cli-auth?callback=http://127.0.0.1:4321/callback&version=2&state=abc' }));
+      }
+      return new Response('{}');
+    });
+    vi.stubGlobal('fetch', mockFetch);
+
+    // Mock window.location.href assignment
+    delete (window as unknown as { location?: unknown }).location;
+    (window as unknown as { location: { href: string } }).location = { href: '' };
+
+    render(
+      <BrowserRouter>
+        <SignIn />
+      </BrowserRouter>
+    );
+
+    const button = screen.getByRole('button', { name: /sign in/i });
+    await user.click(button);
+
+    await waitFor(() => {
+      expect(mockFetch).toHaveBeenCalledWith(
+        expect.stringContaining('/api/auth/login'),
+        expect.objectContaining({ method: 'POST' })
+      );
+    });
+
+    await waitFor(() => {
+      expect(window.location.href).toContain('/cli-auth');
+    });
+  });
+
+  it('never renders server-supplied strings as HTML', () => {
+    globalThis.fetch = vi.fn() as unknown as typeof fetch;
+    const { container } = render(
+      <BrowserRouter>
+        <SignIn />
+      </BrowserRouter>
+    );
+
+    // React escapes by default, so any attempt to render HTML would appear as text
+    expect(container.innerHTML).not.toContain('dangerouslySetInnerHTML');
+  });
+});
+
+describe('NotPermitted', () => {
+  it('explains that only @index.network accounts are allowed', () => {
+    render(
+      <BrowserRouter>
+        <NotPermitted />
+      </BrowserRouter>
+    );
+
+    expect(screen.getByText(/index\.network/i)).toBeInTheDocument();
+    expect(screen.getByText(/not permitted/i)).toBeInTheDocument();
+  });
+
+  it('does not suggest signing in again (that would be a loop)', () => {
+    render(
+      <BrowserRouter>
+        <NotPermitted />
+      </BrowserRouter>
+    );
+
+    expect(screen.queryByText(/sign in/i)).not.toBeInTheDocument();
+  });
+
+  it('is visually distinct from the sign-in screen', () => {
+    const { container, unmount } = render(
+      <BrowserRouter>
+        <SignIn />
+      </BrowserRouter>
+    );
+    const signinText = container.textContent;
+    unmount();
+
+    const { container: notPermittedContainer } = render(
+      <BrowserRouter>
+        <NotPermitted />
+      </BrowserRouter>
+    );
+
+    // They should have different content
+    expect(signinText).not.toBe(notPermittedContainer.textContent);
+  });
+});
+
+describe('Shell with auth', () => {
+  it('shows user email when authenticated', async () => {
+    globalThis.fetch = vi.fn(async (url: string) => {
+      if (String(url).endsWith('/api/auth/status')) {
+        return new Response(JSON.stringify({ authenticated: true, email: 'test@index.network', name: 'Test User' }));
+      }
+      return new Response('{}');
+    }) as unknown as typeof fetch;
+
+    render(
+      <BrowserRouter>
+        <Shell />
+      </BrowserRouter>
+    );
+
+    await waitFor(() => {
+      expect(screen.getByText('test@index.network')).toBeInTheDocument();
+    });
+  });
+
+  it('shows a sign-out button when authenticated', async () => {
+    globalThis.fetch = vi.fn(async (url: string) => {
+      if (String(url).endsWith('/api/auth/status')) {
+        return new Response(JSON.stringify({ authenticated: true, email: 'test@index.network', name: 'Test User' }));
+      }
+      return new Response('{}');
+    }) as unknown as typeof fetch;
+
+    render(
+      <BrowserRouter>
+        <Shell />
+      </BrowserRouter>
+    );
+
+    await waitFor(() => {
+      expect(screen.getByRole('button', { name: /sign out/i })).toBeInTheDocument();
+    });
+  });
+
+  it('calls POST /api/auth/logout when sign-out is clicked', async () => {
+    const user = userEvent.setup();
+    const mockFetch = vi.fn(async (url: string, init?: RequestInit) => {
+      if (String(url).endsWith('/api/auth/status')) {
+        return new Response(JSON.stringify({ authenticated: true, email: 'test@index.network', name: 'Test User' }));
+      }
+      if (String(url).endsWith('/api/auth/logout') && init?.method === 'POST') {
+        return new Response('{}');
+      }
+      return new Response('{}');
+    });
+    vi.stubGlobal('fetch', mockFetch);
+
+    render(
+      <BrowserRouter>
+        <Shell />
+      </BrowserRouter>
+    );
+
+    await waitFor(() => {
+      expect(screen.getByRole('button', { name: /sign out/i })).toBeInTheDocument();
+    });
+
+    const button = screen.getByRole('button', { name: /sign out/i });
+    await user.click(button);
+
+    await waitFor(() => {
+      expect(mockFetch).toHaveBeenCalledWith(
+        expect.stringContaining('/api/auth/logout'),
+        expect.objectContaining({ method: 'POST' })
+      );
+    });
+  });
+});

--- a/apps/eval-ops/tests/client.test.ts
+++ b/apps/eval-ops/tests/client.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it, vi, beforeEach, afterEach } from 'vitest';
-import { subscribeToRun, encodeArtifactId } from '../src/api/client';
+import { onAuthRefusal, subscribeToRun, encodeArtifactId } from '../src/api/client';
 
 describe('subscribeToRun', () => {
   let mockSource: {
@@ -20,6 +20,13 @@ describe('subscribeToRun', () => {
     };
 
     vi.stubGlobal('EventSource', EventSourceMock);
+    // The stream now asks who is signed in when it fails, so every test in this
+    // suite needs an answer: an unstubbed fetch would reach the network and print
+    // a connection error over an otherwise clean run.
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async () => new Response(JSON.stringify({ authenticated: true, email: 'ops@index.network' }))),
+    );
   });
 
   afterEach(() => {
@@ -118,6 +125,66 @@ describe('subscribeToRun', () => {
 
     expect(onError).toHaveBeenCalledOnce();
     expect(onError).toHaveBeenCalledWith(fakeErrorEvent);
+  });
+
+  /**
+   * The stream is gated like every other route, but EventSource surfaces no
+   * status code: a 401 arrives as the same bare `error` event as a dropped
+   * connection. It never passes through `fetchJson`, so without this the shell's
+   * refusal channel never fires, the run page blames the run id, and EventSource
+   * reconnects against the 401 every few seconds forever.
+   */
+  describe('a stream that fails before any status frame', () => {
+    const errorListener = () =>
+      mockSource.addEventListener.mock.calls.find(([event]) => event === 'error')?.[1];
+    const statusListener = () =>
+      mockSource.addEventListener.mock.calls.find(([event]) => event === 'status')?.[1];
+
+    it('publishes an auth refusal when the session has lapsed', async () => {
+      const fetchMock = vi.fn(async (url: string) => {
+        expect(url).toBe('/api/auth/status');
+        return new Response(JSON.stringify({ authenticated: false }));
+      });
+      vi.stubGlobal('fetch', fetchMock);
+      const refusals: string[] = [];
+      const unsubscribe = onAuthRefusal((refusal) => refusals.push(refusal));
+
+      subscribeToRun('run-123', { onLog: vi.fn(), onStatus: vi.fn(), onError: vi.fn() });
+      errorListener()?.(new Event('error'));
+      await vi.waitFor(() => expect(refusals).toEqual(['unauthenticated']));
+
+      // The probe is the public status route, and it is asked exactly once.
+      expect(fetchMock.mock.calls.map((call) => call[0])).toEqual(['/api/auth/status']);
+      unsubscribe();
+    });
+
+    it('says nothing when the operator is still signed in', async () => {
+      const refusals: string[] = [];
+      const unsubscribe = onAuthRefusal((refusal) => refusals.push(refusal));
+
+      subscribeToRun('run-123', { onLog: vi.fn(), onStatus: vi.fn(), onError: vi.fn() });
+      errorListener()?.(new Event('error'));
+      await vi.waitFor(() => expect(fetch).toHaveBeenCalled());
+
+      // A live session with a broken stream is a stream problem. Demoting the
+      // shell here would throw the operator out of a session that works.
+      expect(refusals).toEqual([]);
+      unsubscribe();
+    });
+
+    it('does not probe once a status frame has arrived', async () => {
+      const fetchMock = vi.fn(async (_url: string) => new Response(JSON.stringify({ authenticated: false })));
+      vi.stubGlobal('fetch', fetchMock);
+
+      subscribeToRun('run-123', { onLog: vi.fn(), onStatus: vi.fn(), onError: vi.fn() });
+      statusListener()?.({ data: JSON.stringify({ id: 'run-123', status: 'running' }) } as MessageEvent<string>);
+      // A mid-stream drop is an ordinary reconnect, and each retry fires another
+      // error event: probing on every one would be a request loop of its own.
+      errorListener()?.(new Event('error'));
+      errorListener()?.(new Event('error'));
+
+      expect(fetchMock).not.toHaveBeenCalled();
+    });
   });
 
   it('returns an unsubscribe function that closes the EventSource', () => {

--- a/apps/eval-ops/tests/site.test.ts
+++ b/apps/eval-ops/tests/site.test.ts
@@ -1,0 +1,75 @@
+// @vitest-environment node
+// This suite is the Bun server's own routing, not a browser: happy-dom replaces
+// `Response`, and its version cannot read a `Bun.file` body (it stringifies it to
+// "[object Blob]"), which would make the static-file assertions test the DOM stub
+// rather than the server.
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { mkdtemp, mkdir, rm, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+
+import { createSiteFetch } from '../site';
+
+/**
+ * The single-process entrypoint's forwarding rule.
+ *
+ * This is the seam that decides, per request, whether the ops API answers or the
+ * built SPA does — and it shipped forwarding only `/api/`. `/callback` is not
+ * under `/api/`, and cannot be: the sign-in bridge's own validator accepts that
+ * pathname and no other. So the bridge redirected the operator's browser, with a
+ * freshly minted API key in the query string, to a path this server answered with
+ * `index.html`. The key was never exchanged and never invalidated, and it stayed
+ * in the URL bar, in browser history, and in the `Referer` of the SPA's own asset
+ * requests, for a sign-in that could never complete.
+ */
+
+let dist: string;
+/** Every request the stub API was handed, in order. */
+let forwarded: string[];
+
+/** Stands in for the ops handler: records the path and answers recognisably. */
+const api = async (request: Request): Promise<Response> => {
+  forwarded.push(new URL(request.url).pathname);
+  return new Response('from the ops api', { status: 200 });
+};
+
+beforeEach(async () => {
+  dist = await mkdtemp(path.join(tmpdir(), 'eval-ops-site-'));
+  await writeFile(path.join(dist, 'index.html'), '<!doctype html><title>spa</title>');
+  await mkdir(path.join(dist, 'assets'));
+  await writeFile(path.join(dist, 'assets', 'app.js'), 'console.log("spa")');
+  forwarded = [];
+});
+
+afterEach(async () => {
+  await rm(dist, { recursive: true, force: true });
+});
+
+const fetchSite = (pathname: string) =>
+  createSiteFetch({ api, distDir: dist })(new Request(`http://127.0.0.1:4321${pathname}`));
+
+describe('the single-process entrypoint', () => {
+  it('forwards the sign-in callback to the ops API, not to the SPA', async () => {
+    const response = await fetchSite('/callback?state=abc&api_key=radioactive');
+
+    expect(forwarded).toEqual(['/callback']);
+    expect(await response.text()).toBe('from the ops api');
+  });
+
+  it('forwards every /api path to the ops API', async () => {
+    for (const pathname of ['/api', '/api/auth/status', '/api/runs', '/api/runs/some-id/stream']) {
+      expect(await (await fetchSite(pathname)).text()).toBe('from the ops api');
+    }
+
+    expect(forwarded).toEqual(['/api', '/api/auth/status', '/api/runs', '/api/runs/some-id/stream']);
+  });
+
+  it('serves the SPA for everything the API does not own', async () => {
+    expect(await (await fetchSite('/')).text()).toContain('<title>spa</title>');
+    expect(await (await fetchSite('/assets/app.js')).text()).toBe('console.log("spa")');
+    // A client-side route has no file of its own: the fallback is what makes a
+    // hard refresh on /launch work.
+    expect(await (await fetchSite('/launch')).text()).toContain('<title>spa</title>');
+    expect(forwarded).toEqual([]);
+  });
+});

--- a/apps/eval-ops/tests/smoke.test.tsx
+++ b/apps/eval-ops/tests/smoke.test.tsx
@@ -10,6 +10,11 @@ beforeEach(() => {
   vi.stubGlobal(
     'fetch',
     vi.fn(async (url: string) => {
+      // The shell gates its children on this answer, so the dashboard only mounts
+      // when the operator is signed in.
+      if (String(url).endsWith('/api/auth/status')) {
+        return new Response(JSON.stringify({ authenticated: true, email: 'ops@index.network', name: 'Ops' }));
+      }
       if (String(url).endsWith('/api/harnesses')) {
         return new Response(JSON.stringify({ harnesses: [] }));
       }

--- a/apps/eval-ops/tests/smoke.test.tsx
+++ b/apps/eval-ops/tests/smoke.test.tsx
@@ -43,7 +43,7 @@ describe('App', () => {
     expect(screen.getByText(/index eval ops/i)).toBeInTheDocument();
   });
 
-  it('links to every route an operator needs', () => {
+  it('links to every route an operator needs', async () => {
     render(<App />);
     const expected: ReadonlyArray<[string, string]> = [
       ['overview', '/'],
@@ -51,8 +51,10 @@ describe('App', () => {
       ['compare', '/compare'],
       ['profiles', '/profiles'],
     ];
+    // The nav mounts with the dashboard, once the stubbed status answer arrives:
+    // a link to a route the operator cannot open yet is not an offer worth making.
     for (const [name, href] of expected) {
-      expect(screen.getByRole('link', { name })).toHaveAttribute('href', href);
+      expect(await screen.findByRole('link', { name })).toHaveAttribute('href', href);
     }
   });
 });

--- a/bun.lock
+++ b/bun.lock
@@ -110,7 +110,7 @@
     },
     "packages/protocol": {
       "name": "@indexnetwork/protocol",
-      "version": "8.3.0",
+      "version": "8.4.0",
       "dependencies": {
         "@langchain/core": "1.1.48",
         "@langchain/langgraph": "1.3.2",

--- a/docs/guides/development-reference.md
+++ b/docs/guides/development-reference.md
@@ -126,10 +126,15 @@ bun run dev:eval-ops                        # UI on 127.0.0.1:5174 (from repo ro
 bun run build:eval-ops                      # Build the UI
 ```
 
-Both bind loopback and there is no authentication: this is an operator-trust
-decision about local processes. State-changing requests must be same-origin and
-carry a JSON content type, and every request must be addressed to a loopback
-host, so another site the operator has open cannot drive or read it. The app is
+Both bind loopback, and every route but the two that make signing in possible
+requires a session belonging to a verified `@index.network` Index account
+(sign-in reuses the CLI browser-auth bridge). That is defence in depth, not
+permission to expose it: state-changing requests must be same-origin and carry a
+JSON content type, and every request must be addressed to a loopback host, so
+another site the operator has open cannot drive or read it — those guards, not
+the authentication, are what keep the site local. `WEB_APP_URL` and `API_URL`
+are one pair (mint and verify); the ops server refuses to start on a mismatched
+or half-configured pair. The app is
 deliberately excluded from the root `build` script and from Railway. CI gates it
 through the `eval-ops` job in `.github/workflows/lint.yml` (typecheck, test,
 lint) — the root `build` does not cover it.

--- a/docs/guides/getting-started.md
+++ b/docs/guides/getting-started.md
@@ -377,10 +377,14 @@ bun run dev:eval-ops
 that file's `DATABASE_URL` as the fixture target.
 
 Only the four scorecard harnesses (`matching`, `profile`, `premise`, `opportunity`) are
-supported. It **binds loopback and has no authentication** — any local process can drive
-it, and it can launch runs that spend real money and flush the test database. Do not change
-`EVAL_OPS_BIND` until authentication exists. The app is deliberately excluded from the
-production build and from Railway.
+supported. It **binds loopback and requires a verified `@index.network` Index account** —
+signing in opens the same browser-auth bridge the CLI uses, and every route but the two
+that make signing in possible needs that session. The authentication is defence in depth,
+not permission to expose the site: the loopback bind, the `Host` check and the `Origin`
+allowlist are what keep it local, so do not change `EVAL_OPS_BIND`. `WEB_APP_URL` and
+`API_URL` must name the same environment — the first mints the sign-in key and the second
+verifies it, and the server refuses to start on a mismatched pair. The app is deliberately
+excluded from the production build and from Railway.
 
 See [`packages/protocol/eval/ops/README.md`](../../packages/protocol/eval/ops/README.md)
 for the security model and [`apps/eval-ops/README.md`](../../apps/eval-ops/README.md) for

--- a/packages/protocol/eval/README.md
+++ b/packages/protocol/eval/README.md
@@ -107,7 +107,10 @@ it is forced to `--no-save` (so it can never become `--rolling-baseline` fuel in
 `eval/<harness>/runs/` for everyone else) and is never diffed against the committed
 baseline.
 
-The API binds loopback and **has no authentication**. See
+The API binds loopback **and** requires a verified `@index.network` Index identity on every
+route but the two that make signing in possible — defence in depth, not a licence to expose
+it: the loopback bind, the `Host` check and the `Origin` allowlist are what keep it local,
+and it is still not safe to expose. See
 [`eval/ops/README.md`](./ops/README.md) for the full security model, the profile contract,
 the exit-code→status map, the comparability refusal, and the fixture guard.
 

--- a/packages/protocol/eval/ops/README.md
+++ b/packages/protocol/eval/ops/README.md
@@ -6,9 +6,11 @@ artifacts, and drives a guarded test-database fixture reset.
 
 This directory is the whole server. The browser app is a thin client over the JSON + SSE
 API in [`ops.server.ts`](./ops.server.ts); every decision that matters — what may run,
-under which configuration, against which database — is made here. **There is no
-authentication**: any process on this machine can spend real tokens and flush the test
-database (see [§ There is no authentication](#there-is-no-authentication) below).
+under which configuration, against which database — is made here, including **who is
+allowed to ask**: every route but two requires a session belonging to a verified
+`@index.network` Index account. That is defence in depth on top of the loopback guards,
+not a replacement for them — the site is still loopback-only and still not safe to expose
+(see [§ Who may use this server](#who-may-use-this-server) below).
 
 Everything in this directory is provider-free and covered by `bun run eval:verify`
 (`suite: ops`).
@@ -285,8 +287,15 @@ perform the `.env.test` cross-check that `resolveResetTarget` does, so an operat
 
 `createOpsHandler(context)` returns a plain `(Request) => Promise<Response>`.
 
+Every route below requires a session except the two marked **public**; `GET /callback` is
+handled ahead of the gate because it is the request that establishes one.
+
 | Method | Route | Purpose |
 | :----- | :---- | :------ |
+| `GET` | `/api/auth/status` | **public.** `{ authenticated: false }` or `{ authenticated: true, email, name }`. |
+| `POST` | `/api/auth/login` | **public.** `{ url }` — the sign-in bridge link, carrying a one-time state. |
+| `GET` | `/callback` | **public, pre-gate.** The bridge lands here: validates the state, resolves the identity, applies the domain policy, then redirects to the UI or renders a refusal page. |
+| `POST` | `/api/auth/logout` | Clears the session and expires the cookie. |
 | `GET` | `/api/harnesses` | `HARNESS_REGISTRY` values. |
 | `GET` | `/api/profiles` | Committed profiles. |
 | `GET` | `/api/artifacts` | `{ refs, issues }` — the artifact index, with unreadable files surfaced rather than dropped. |
@@ -325,17 +334,47 @@ perform the `.env.test` cross-check that `resolveResetTarget` does, so an operat
   `scrubCredentials`.
 - Artifact ids are decoded and rejected if they normalise outside `eval/`.
 
-### There is no authentication
+### Who may use this server
 
-Any process on this machine can drive this server: launch runs that spend real money and
-flush the test database. That is an explicit operator-trust decision about **local**
-processes.
+Four independent guards stand in front of every request, and they **compose** rather than
+substitute for one another: the loopback bind, the `Host` check, the `Origin` allowlist,
+and identity. Removing any one of them is not offset by the others.
 
-`ops.serve.ts` binds `127.0.0.1` unless `EVAL_OPS_BIND` is set. **`EVAL_OPS_BIND` is the
-hook where authentication must land before any non-local deployment — it must not be
-changed until that exists.** Note that setting it alone is no longer sufficient anyway:
-the loopback `Origin` allowlist fails closed, so a browser on another host would have every
-write refused.
+**Identity.** Every route except `GET /api/auth/status` and `POST /api/auth/login`
+(`PUBLIC_ROUTES` in `ops.server.ts`) requires a session, and a session exists only for an
+Index account whose email is **verified** and whose domain is exactly `index.network`.
+The gate sits ahead of dispatch, so a route added later is gated by default and an unknown
+path is refused with 401 rather than a 404 that would confirm what exists. The policy is
+re-evaluated on **every** request, so narrowing it refuses live sessions too; 401 ("nobody
+is signed in") and 403 ("signed in, not permitted") are deliberately distinguishable.
+
+There is no cookie to forward — the ops UI is on `127.0.0.1` and the API on
+`localhost:3001`, and a Better Auth session cookie is host-scoped — so sign-in reuses the
+CLI browser-auth bridge: `POST /api/auth/login` mints a one-time state and returns
+`<WEB_APP_URL>/cli-auth?callback=http://127.0.0.1:<port>/callback&version=2&state=…`, the
+bridge mints a revocable API key against the operator's existing browser session, and
+`GET /callback` consumes the state, exchanges the key for an identity, applies the domain
+policy and **discards the key**. The key is never stored in a session, never logged, never
+returned to the browser and never rendered.
+
+`WEB_APP_URL` and `API_URL` are one pair: the first mints the key, the second verifies it.
+A key minted by one deployment is meaningless to another, so the server **refuses to
+start** on a half-configured or mismatched pair rather than failing every sign-in later
+with an unhelpful "No Index account could be resolved".
+
+**It is still not safe to expose.** What keeps this site local is the guards, not the
+authentication. `ops.serve.ts` binds `127.0.0.1` unless `EVAL_OPS_BIND` is set: **do not
+change it.** Setting it alone would not help anyway — the loopback `Origin` allowlist and
+the `Host` check both fail closed, so a browser on another host would have every write
+refused and every read refused with it.
+
+**The session cookie is visible to every port on `127.0.0.1`.** Cookies are not
+port-scoped, so any *other* local HTTP service the operator's browser visits on loopback
+receives `eval_ops_session` too. `HttpOnly` keeps it out of JavaScript's reach and the
+`Host` guard means a foreign host cannot replay it against this server, so the practical
+exposure is low — but it is a real property of running several services on loopback, and
+it is one more reason the ops session is worth no more than the local trust boundary it
+sits inside.
 
 ## Running it
 

--- a/packages/protocol/eval/ops/ops.auth.ts
+++ b/packages/protocol/eval/ops/ops.auth.ts
@@ -1,0 +1,382 @@
+/**
+ * Identity for the eval ops site: who is at the browser, and may they be here.
+ *
+ * The ops server is loopback-only and stays that way — the bind address, the
+ * `Host` check and the `Origin` allowlist in ops.server.ts are what keep it off
+ * the network. This module is defence in depth on top of them, not a
+ * replacement: it answers "which Index account is driving this", so a machine
+ * shared with anyone, or a process running as another user, still cannot spend
+ * tokens or flush a database through it.
+ *
+ * There is no cookie to forward. The ops UI runs on 127.0.0.1 and the API on
+ * localhost:3001, and a Better Auth session cookie is host-scoped, so the ops
+ * server cannot read it. The repository already solves exactly this for the CLI:
+ * open `<WEB_APP_URL>/cli-auth` against the browser's existing session, let it
+ * mint a revocable API key, and have it redirect that key to a loopback
+ * callback. This module reuses that bridge — see `buildBridgeUrl`.
+ *
+ * Everything here is injectable and free of I/O except `ApiIdentityResolver`,
+ * which is the one seam that talks to the API. Nothing here reads the
+ * environment, opens a socket by default, or logs.
+ *
+ * The credential is radioactive: it is a broad API key for a real account. It is
+ * accepted, exchanged for an identity, and dropped. It is never stored in a
+ * session, never returned to the browser and never put in a message.
+ */
+import { randomBytes, timingSafeEqual } from "node:crypto";
+
+import { z } from "zod";
+
+/**
+ * The one domain whose members may use the eval ops site.
+ *
+ * Compared with `===` against the part after the last `@`, lowercased. Not a
+ * suffix test: `a@index.network.evil.com` and `a@sub.index.network` are other
+ * people's domains and both must be refused.
+ */
+export const ALLOWED_EMAIL_DOMAIN = "index.network";
+
+/**
+ * How many `@` an address this server will admit may contain.
+ *
+ * Do not "simplify" this away. An address with two `@` is one we do not
+ * understand. RFC 5321 permits a quoted local part containing `@`, so
+ * `a@evil.com?x=@index.network` has a last-`@` domain of exactly index.network
+ * and the domain rule alone would admit it — but neither Google OAuth nor the
+ * better-auth magic link ever mints such an address, so the only realistic way
+ * one reaches `users.email` is something having gone wrong upstream. This gate
+ * protects a tool that can flush a database and spend tokens, so refusing an
+ * address we cannot unambiguously parse beats picking either interpretation.
+ */
+const MAX_EMAIL_AT_SIGNS = 1;
+
+/**
+ * The one-time state accepted by the bridge page.
+ *
+ * Pinned to `CLI_STATE_PATTERN` in apps/web/src/lib/cli-auth.ts: a state outside
+ * it makes `parseCliAuthRequest` reject the whole request, so minting one would
+ * produce a sign-in link that silently never works. tests/auth.spec.ts checks a
+ * minted state against that file's own parser.
+ */
+const BRIDGE_STATE_PATTERN = /^[A-Za-z0-9_-]{32,128}$/;
+
+/** How long a minted sign-in state stays usable. One browser round-trip, no more. */
+export const STATE_TTL_MS = 5 * 60_000;
+
+/** An identity as resolved from the API, reduced to what the policy needs. */
+export interface ResolvedIdentity {
+  email: string | null;
+  emailVerified: boolean;
+  name: string;
+}
+
+/** What the ops server may show and remember about a permitted user. */
+export interface AllowedIdentity {
+  email: string;
+  name: string;
+}
+
+/**
+ * The verdict of the domain policy. The refusal carries a reason so the callback
+ * page can say why; the reason names the address, never the credential.
+ */
+export type IdentityVerdict =
+  | { allowed: true; identity: AllowedIdentity }
+  | { allowed: false; reason: string };
+
+/**
+ * Decides whether a resolved identity may use the ops site. Pure, and the only
+ * place that decision is made.
+ *
+ * Allowed only when the address is verified *and* its domain is exactly
+ * {@link ALLOWED_EMAIL_DOMAIN}. "Exactly" means the substring after the **last**
+ * `@`, lowercased, compared with `===`. The last `@` matters: `"a@index.network"@evil.com`
+ * is an address at evil.com, and a check anchored anywhere else reads it as ours.
+ *
+ * Everything unrecognised fails closed: no identity, no address, a non-string
+ * address, an address with no domain part, an address we cannot parse
+ * unambiguously (see {@link MAX_EMAIL_AT_SIGNS}).
+ *
+ * The order of the refusals is deliberate. The domain comparison runs first, so
+ * an address at someone else's domain is refused on the plainest possible
+ * ground. The ambiguity guard exists only to stop an address from being
+ * *admitted*, so it sits on the path to admission, after the domain has already
+ * been found to match.
+ */
+export function assessIdentity(identity: ResolvedIdentity | null | undefined): IdentityVerdict {
+  if (identity === null || identity === undefined) {
+    return { allowed: false, reason: "No Index account could be resolved for this sign-in." };
+  }
+
+  const email = typeof identity.email === "string" ? identity.email : "";
+  const domain = emailDomain(email);
+  if (domain === null) {
+    return { allowed: false, reason: "This Index account has no usable email address." };
+  }
+  if (domain !== ALLOWED_EMAIL_DOMAIN) {
+    return { allowed: false, reason: `${email} is not an @${ALLOWED_EMAIL_DOMAIN} address.` };
+  }
+  if (countAtSigns(email) > MAX_EMAIL_AT_SIGNS) {
+    return { allowed: false, reason: `${email} cannot be read as one unambiguous address.` };
+  }
+  if (identity.emailVerified !== true) {
+    return { allowed: false, reason: `${email} is not verified.` };
+  }
+  return { allowed: true, identity: { email, name: identity.name } };
+}
+
+/**
+ * The domain of an address: everything after the last `@`, lowercased.
+ * Null when there is no `@`, nothing before it, or nothing after it.
+ */
+function emailDomain(email: string): string | null {
+  const at = email.lastIndexOf("@");
+  if (at <= 0 || at === email.length - 1) return null;
+  return email.slice(at + 1).toLowerCase();
+}
+
+/** How many `@` the address contains. */
+function countAtSigns(email: string): number {
+  let count = 0;
+  for (const character of email) {
+    if (character === "@") count += 1;
+  }
+  return count;
+}
+
+/**
+ * The sign-in states this server has handed out and not yet seen come back.
+ *
+ * Each state binds one browser round-trip to this exact process. A callback
+ * carrying a state this server never minted is not a login this server started,
+ * and is refused before the credential in it is looked at at all.
+ *
+ * In memory on purpose: the ops server is a single local process, and a state
+ * that outlived it would be a state nobody is waiting for.
+ */
+export class OneTimeStateStore {
+  /** state -> the instant it stops being usable. */
+  private readonly pending = new Map<string, number>();
+  private readonly ttlMs: number;
+  private readonly now: () => number;
+
+  constructor(options: { ttlMs?: number; now?: () => number } = {}) {
+    this.ttlMs = options.ttlMs ?? STATE_TTL_MS;
+    this.now = options.now ?? Date.now;
+  }
+
+  /** Mints a state for one sign-in. 256 bits, URL-safe, accepted by the bridge page. */
+  mint(): string {
+    const now = this.now();
+    this.prune(now);
+    const state = randomBytes(32).toString("base64url");
+    this.pending.set(state, now + this.ttlMs);
+    return state;
+  }
+
+  /**
+   * Accepts a returning state exactly once.
+   *
+   * Consuming *is* the validation: a match is removed before this returns, so a
+   * replayed callback — a refresh, a second tab, a copied URL — fails. Expired
+   * states are dropped first, so age is enforced on the same path.
+   *
+   * The comparison is constant-time against every outstanding state, so a caller
+   * cannot learn a state prefix by timing guesses.
+   */
+  consume(candidate: string | null | undefined): boolean {
+    const now = this.now();
+    this.prune(now);
+    const matched = matchConstantTime(this.pending.keys(), candidate);
+    if (matched === null) return false;
+    this.pending.delete(matched);
+    return true;
+  }
+
+  private prune(now: number): void {
+    for (const [state, expiresAt] of this.pending) {
+      if (expiresAt <= now) this.pending.delete(state);
+    }
+  }
+}
+
+/** Everything `buildBridgeUrl` needs; all of it comes from this server, none from a request. */
+export interface BridgeUrlOptions {
+  /** Base URL of the web app that serves /cli-auth. */
+  webAppUrl: string;
+  /** Port this server's `/callback` route is listening on. */
+  callbackPort: number;
+  /** A state from {@link OneTimeStateStore.mint}. */
+  state: string;
+}
+
+/**
+ * Builds the sign-in link: `<WEB_APP_URL>/cli-auth?callback=...&version=2&state=...`.
+ *
+ * The callback must be `http://127.0.0.1:<port>/callback` and nothing else.
+ * `validateCliCallbackUrl` in apps/web/src/lib/cli-auth.ts requires the `http:`
+ * scheme, a loopback host, that exact pathname, and no credentials, query string
+ * or fragment — so the callback is assembled here rather than taken from a
+ * caller, and only the port varies.
+ *
+ * A bad port or a malformed state throws instead of producing a link that would
+ * be rejected on arrival, where the operator would see nothing but a blank
+ * bridge page.
+ */
+export function buildBridgeUrl(options: BridgeUrlOptions): string {
+  const { callbackPort, state } = options;
+  if (!Number.isInteger(callbackPort) || callbackPort < 1 || callbackPort > 65535) {
+    return raise(`Refusing to build a sign-in URL for callback port ${callbackPort}: the bridge accepts an integer port in 1..65535.`);
+  }
+  if (!BRIDGE_STATE_PATTERN.test(state)) {
+    return raise("Refusing to build a sign-in URL: the one-time state is not in the form the bridge accepts.");
+  }
+
+  const url = new URL(`${options.webAppUrl.replace(/\/$/, "")}/cli-auth`);
+  url.searchParams.set("callback", `http://127.0.0.1:${callbackPort}/callback`);
+  url.searchParams.set("version", "2");
+  url.searchParams.set("state", state);
+  return url.toString();
+}
+
+/**
+ * Exchanges a credential for the identity behind it.
+ *
+ * A seam, so the tests never need an API, a database or a socket: the ops server
+ * injects {@link ApiIdentityResolver} and a spec injects a stub.
+ */
+export interface IdentityResolver {
+  /**
+   * @param apiKey - The credential the bridge delivered. Never stored, never logged.
+   * @returns The identity, or null when the credential is not accepted or the
+   *          reply is not the shape this server understands.
+   */
+  resolve(apiKey: string): Promise<ResolvedIdentity | null>;
+}
+
+/**
+ * The `/api/auth/me` reply, narrowed to the fields the policy reads.
+ *
+ * Shaped from services/api/src/controllers/auth.controller.ts: `me` returns
+ * `{ user, features }` where `user` is the full `users` row (so `emailVerified`
+ * is present and boolean) plus socials and notification preferences. Unknown
+ * keys are ignored rather than rejected — this server has no business failing
+ * because the API grew a field.
+ */
+const MeResponseSchema = z.object({
+  user: z.object({
+    email: z.string().nullish(),
+    emailVerified: z.boolean().nullish(),
+    name: z.string().nullish(),
+  }),
+});
+
+/** Wiring for {@link ApiIdentityResolver}. */
+export interface ApiIdentityResolverOptions {
+  /** Base URL of the API, e.g. http://localhost:3001. */
+  apiUrl: string;
+  /** Injectable for tests; defaults to the global fetch. */
+  fetch?: typeof fetch;
+}
+
+/**
+ * Resolves an identity through the API's own `/api/auth/me`.
+ *
+ * The credential travels in the `x-api-key` header, which is what `AuthGuard`
+ * reads for a key; putting it in the URL would leak it into every access log on
+ * the way. A refusal or an unrecognised body resolves to null, so the caller
+ * refuses the sign-in rather than inventing an identity. Transport failures
+ * reject: "the API is down" is not "you are not allowed in".
+ */
+export class ApiIdentityResolver implements IdentityResolver {
+  private readonly apiUrl: string;
+  private readonly fetchImpl: typeof fetch;
+
+  constructor(options: ApiIdentityResolverOptions) {
+    this.apiUrl = options.apiUrl.replace(/\/$/, "");
+    this.fetchImpl = options.fetch ?? fetch;
+  }
+
+  async resolve(apiKey: string): Promise<ResolvedIdentity | null> {
+    const response = await this.fetchImpl(`${this.apiUrl}/api/auth/me`, {
+      method: "GET",
+      headers: { "x-api-key": apiKey, accept: "application/json" },
+    });
+    if (!response.ok) return null;
+
+    let body: unknown;
+    try {
+      body = await response.json();
+    } catch {
+      return null;
+    }
+    const parsed = MeResponseSchema.safeParse(body);
+    if (!parsed.success) return null;
+
+    const { email, emailVerified, name } = parsed.data.user;
+    return {
+      email: email ?? null,
+      // Absent is not verified: the policy must never read a missing flag as a yes.
+      emailVerified: emailVerified === true,
+      name: name ?? "",
+    };
+  }
+}
+
+/**
+ * The browser sessions this server has established.
+ *
+ * In memory, for the same reason as the state store: one local process, and
+ * nothing here is worth persisting past its lifetime. A session holds the
+ * identity and nothing else — in particular not the API key, which is discarded
+ * the moment it has been exchanged, so no serialisation of a session can ever
+ * carry a credential back to the browser.
+ */
+export class OpsSessionStore {
+  private readonly sessions = new Map<string, AllowedIdentity>();
+
+  /** Establishes a session for a permitted identity. Returns its 256-bit value. */
+  establish(identity: AllowedIdentity): string {
+    const value = randomBytes(32).toString("base64url");
+    this.sessions.set(value, { email: identity.email, name: identity.name });
+    return value;
+  }
+
+  /** The identity behind a session value, or null. Constant-time, like state. */
+  lookup(value: string | null | undefined): AllowedIdentity | null {
+    const matched = matchConstantTime(this.sessions.keys(), value);
+    return matched === null ? null : { ...this.sessions.get(matched) as AllowedIdentity };
+  }
+
+  /** Ends a session. False when there was nothing to end. */
+  clear(value: string | null | undefined): boolean {
+    const matched = matchConstantTime(this.sessions.keys(), value);
+    if (matched === null) return false;
+    this.sessions.delete(matched);
+    return true;
+  }
+}
+
+/**
+ * Finds `candidate` among `known` without leaking where it stopped matching.
+ *
+ * `timingSafeEqual` throws on a length mismatch, so unequal lengths are skipped
+ * — a length is not a secret here, since every value this compares is minted at
+ * one fixed size. Every same-length entry is compared, with no early exit.
+ */
+function matchConstantTime(known: Iterable<string>, candidate: string | null | undefined): string | null {
+  if (typeof candidate !== "string" || candidate.length === 0) return null;
+  const probe = Buffer.from(candidate, "utf8");
+  let matched: string | null = null;
+  for (const value of known) {
+    const expected = Buffer.from(value, "utf8");
+    if (expected.length !== probe.length) continue;
+    if (timingSafeEqual(expected, probe)) matched = value;
+  }
+  return matched;
+}
+
+/** Throws from an expression position, so a guard can stay a single statement. */
+function raise(message: string): never {
+  throw new Error(message);
+}

--- a/packages/protocol/eval/ops/ops.auth.ts
+++ b/packages/protocol/eval/ops/ops.auth.ts
@@ -51,6 +51,19 @@ export const ALLOWED_EMAIL_DOMAIN = "index.network";
 const MAX_EMAIL_AT_SIGNS = 1;
 
 /**
+ * The only characters a domain we will compare may contain (letters, digits,
+ * hyphen, dot). Anything else is an address we cannot read unambiguously —
+ * same doctrine as {@link MAX_EMAIL_AT_SIGNS}. In particular this stops
+ * `toLowerCase()`, which is a *Unicode* operation, folding U+212A KELVIN SIGN
+ * into ASCII `k`: without this guard `a@index.networ\u212A` lowercases to
+ * `index.network` and a domain that is not ours passes the load-bearing rule.
+ * U+212A is the only non-ASCII code point in the whole Unicode range whose
+ * `toLowerCase()` yields an ASCII character appearing in `index.network`, but
+ * the guard is written as an allowlist so the next such folding cannot appear.
+ */
+const DOMAIN_CHARACTERS = /^[A-Za-z0-9.-]+$/;
+
+/**
  * The one-time state accepted by the bridge page.
  *
  * Pinned to `CLI_STATE_PATTERN` in apps/web/src/lib/cli-auth.ts: a state outside
@@ -62,6 +75,28 @@ const BRIDGE_STATE_PATTERN = /^[A-Za-z0-9_-]{32,128}$/;
 
 /** How long a minted sign-in state stays usable. One browser round-trip, no more. */
 export const STATE_TTL_MS = 5 * 60_000;
+
+/**
+ * How many sign-in states may be outstanding at once.
+ *
+ * `POST /api/auth/login` is public, and this module's own threat model names a
+ * process running as another user on the same machine. Without a cap that
+ * process can mint states faster than the TTL retires them, and every one of
+ * them makes `prune()` and the constant-time scan in `consume()` slower for the
+ * real operator's callback.
+ *
+ * The cap **evicts the oldest** rather than refusing to mint. Refusing would
+ * hand the attacker a deterministic lockout — {@link MAX_PENDING_STATES}
+ * requests and the operator cannot start a sign-in at all for the whole TTL.
+ * Evicting keeps the operator's newest attempt alive and the store bounded; the
+ * attacker can still evict a state the operator has already been handed, but
+ * that costs a full cap's worth of requests inside one round-trip and only ever
+ * fails a sign-in closed, which the operator retries.
+ *
+ * One human at one browser needs one. Sixty-four is slack for retries and
+ * abandoned tabs, not a queue depth to tune.
+ */
+export const MAX_PENDING_STATES = 64;
 
 /** An identity as resolved from the API, reduced to what the policy needs. */
 export interface ResolvedIdentity {
@@ -78,7 +113,12 @@ export interface AllowedIdentity {
 
 /**
  * The verdict of the domain policy. The refusal carries a reason so the callback
- * page can say why; the reason names the address, never the credential.
+ * page can say why.
+ *
+ * A reason names the address and never the credential — but the address is
+ * user-controlled text, so a reason is **not** safe to render verbatim. It must
+ * be escaped before it reaches the callback refusal page, which is served under
+ * the operator's own loopback origin. Task A2 owns that escaping.
  */
 export type IdentityVerdict =
   | { allowed: true; identity: AllowedIdentity }
@@ -95,7 +135,7 @@ export type IdentityVerdict =
  *
  * Everything unrecognised fails closed: no identity, no address, a non-string
  * address, an address with no domain part, an address we cannot parse
- * unambiguously (see {@link MAX_EMAIL_AT_SIGNS}).
+ * unambiguously (see {@link MAX_EMAIL_AT_SIGNS} and {@link DOMAIN_CHARACTERS}).
  *
  * The order of the refusals is deliberate. The domain comparison runs first, so
  * an address at someone else's domain is refused on the plainest possible
@@ -108,7 +148,9 @@ export function assessIdentity(identity: ResolvedIdentity | null | undefined): I
     return { allowed: false, reason: "No Index account could be resolved for this sign-in." };
   }
 
-  const email = typeof identity.email === "string" ? identity.email : "";
+  // Trimmed before anything reads it: surrounding whitespace is not part of the
+  // address, and an untrimmed one would be stored and echoed back into the UI.
+  const email = typeof identity.email === "string" ? identity.email.trim() : "";
   const domain = emailDomain(email);
   if (domain === null) {
     return { allowed: false, reason: "This Index account has no usable email address." };
@@ -122,17 +164,23 @@ export function assessIdentity(identity: ResolvedIdentity | null | undefined): I
   if (identity.emailVerified !== true) {
     return { allowed: false, reason: `${email} is not verified.` };
   }
-  return { allowed: true, identity: { email, name: identity.name } };
+  // `name` is coerced rather than trusted: ResolvedIdentity is the contract for
+  // any injected resolver, and A2 serialises this identity toward the browser.
+  return { allowed: true, identity: { email, name: typeof identity.name === "string" ? identity.name : "" } };
 }
 
 /**
  * The domain of an address: everything after the last `@`, lowercased.
- * Null when there is no `@`, nothing before it, or nothing after it.
+ * Null when there is no `@`, nothing before it, nothing after it, or the domain
+ * contains a character outside {@link DOMAIN_CHARACTERS}.
  */
 function emailDomain(email: string): string | null {
   const at = email.lastIndexOf("@");
   if (at <= 0 || at === email.length - 1) return null;
-  return email.slice(at + 1).toLowerCase();
+  const domain = email.slice(at + 1);
+  // Checked before lowercasing, because lowercasing is what does the damage.
+  if (!DOMAIN_CHARACTERS.test(domain)) return null;
+  return domain.toLowerCase();
 }
 
 /** How many `@` the address contains. */
@@ -158,10 +206,12 @@ export class OneTimeStateStore {
   /** state -> the instant it stops being usable. */
   private readonly pending = new Map<string, number>();
   private readonly ttlMs: number;
+  private readonly maxPending: number;
   private readonly now: () => number;
 
-  constructor(options: { ttlMs?: number; now?: () => number } = {}) {
+  constructor(options: { ttlMs?: number; maxPending?: number; now?: () => number } = {}) {
     this.ttlMs = options.ttlMs ?? STATE_TTL_MS;
+    this.maxPending = Math.max(1, options.maxPending ?? MAX_PENDING_STATES);
     this.now = options.now ?? Date.now;
   }
 
@@ -169,6 +219,14 @@ export class OneTimeStateStore {
   mint(): string {
     const now = this.now();
     this.prune(now);
+    // Every state carries the same TTL, so insertion order is expiry order and
+    // the first key of the Map is the oldest. See MAX_PENDING_STATES for why
+    // this evicts rather than refuses.
+    while (this.pending.size >= this.maxPending) {
+      const oldest = this.pending.keys().next();
+      if (oldest.done === true) break;
+      this.pending.delete(oldest.value);
+    }
     const state = randomBytes(32).toString("base64url");
     this.pending.set(state, now + this.ttlMs);
     return state;
@@ -219,9 +277,12 @@ export interface BridgeUrlOptions {
  * or fragment — so the callback is assembled here rather than taken from a
  * caller, and only the port varies.
  *
- * A bad port or a malformed state throws instead of producing a link that would
- * be rejected on arrival, where the operator would see nothing but a blank
- * bridge page.
+ * A bad port, a malformed state or a web app base that does not yield exactly
+ * `<origin>/cli-auth` throws instead of producing a link that would be rejected
+ * on arrival, where the operator would see nothing but a blank bridge page. A
+ * base carrying its own path or query would silently move the bridge page
+ * somewhere it is not served from, so the assembled URL is checked rather than
+ * assumed.
  */
 export function buildBridgeUrl(options: BridgeUrlOptions): string {
   const { callbackPort, state } = options;
@@ -232,7 +293,19 @@ export function buildBridgeUrl(options: BridgeUrlOptions): string {
     return raise("Refusing to build a sign-in URL: the one-time state is not in the form the bridge accepts.");
   }
 
-  const url = new URL(`${options.webAppUrl.replace(/\/$/, "")}/cli-auth`);
+  let url: URL;
+  try {
+    url = new URL(`${options.webAppUrl.replace(/\/$/, "")}/cli-auth`);
+  } catch {
+    return raise(`Refusing to build a sign-in URL: ${options.webAppUrl} is not a usable web app URL.`);
+  }
+  if (url.protocol !== "http:" && url.protocol !== "https:") {
+    return raise(`Refusing to build a sign-in URL: the web app URL ${options.webAppUrl} is not http(s).`);
+  }
+  if (url.pathname !== "/cli-auth" || url.search !== "" || url.hash !== "") {
+    return raise(`Refusing to build a sign-in URL: the web app URL ${options.webAppUrl} does not resolve to /cli-auth.`);
+  }
+
   url.searchParams.set("callback", `http://127.0.0.1:${callbackPort}/callback`);
   url.searchParams.set("version", "2");
   url.searchParams.set("state", state);

--- a/packages/protocol/eval/ops/ops.paths.ts
+++ b/packages/protocol/eval/ops/ops.paths.ts
@@ -1,0 +1,49 @@
+/**
+ * Which request paths the ops HTTP handler owns.
+ *
+ * `createOpsHandler` is mounted two ways: standalone (ops.serve.ts, API only)
+ * and behind a static file server that also serves the built SPA
+ * (apps/eval-ops/server.ts). The second one has to decide, per request, whether
+ * to forward to the handler or to answer with a file — and a bare
+ * `pathname.startsWith("/api/")` gets that wrong, because the handler also owns
+ * {@link OPS_CALLBACK_PATH}. That is not a cosmetic miss: the sign-in bridge
+ * redirects the operator's browser to `/callback` carrying a freshly minted API
+ * key, so answering it with `index.html` leaves a real credential sitting in the
+ * URL bar and in browser history for a sign-in that can never complete.
+ *
+ * The rule therefore lives here, in one zero-dependency module both sides
+ * import, rather than being restated as a prefix test at each mount point. The
+ * callback path cannot be under `/api/`: `validateCliCallbackUrl` in
+ * apps/web/src/lib/cli-auth.ts requires the pathname to be exactly `/callback`.
+ *
+ * A test in eval/ops/tests/server.spec.ts asserts that every route in the
+ * server's own hand-maintained inventory is owned here, so a route added to
+ * ops.server.ts outside `/api/` fails there rather than silently falling through
+ * to the SPA.
+ */
+
+/** Every route the JSON API serves lives under this prefix. */
+export const OPS_API_PREFIX = "/api/";
+
+/**
+ * Where the CLI-auth bridge delivers the credential. Exactly `/callback`, and
+ * deliberately not under {@link OPS_API_PREFIX} — the bridge's own validator
+ * accepts no other pathname.
+ */
+export const OPS_CALLBACK_PATH = "/callback";
+
+/**
+ * True when the ops handler — not the static file server in front of it — must
+ * answer this path.
+ *
+ * `/api` with no trailing slash is included: the handler answers it (gated, then
+ * 404), and forwarding it keeps "the API owns /api" true without a special case
+ * at every mount point.
+ */
+export function isOpsServerPath(pathname: string): boolean {
+  return (
+    pathname === OPS_CALLBACK_PATH
+    || pathname === OPS_API_PREFIX.slice(0, -1)
+    || pathname.startsWith(OPS_API_PREFIX)
+  );
+}

--- a/packages/protocol/eval/ops/ops.serve.ts
+++ b/packages/protocol/eval/ops/ops.serve.ts
@@ -2,9 +2,19 @@
 /**
  * Standalone entrypoint for the eval ops API.
  *
- * Binds loopback unless EVAL_OPS_BIND is set explicitly. That variable is the
- * hook where authentication must land before any non-local deployment: this
- * server has none, and everything it exposes can spend money and flush a database.
+ * Binds loopback unless EVAL_OPS_BIND is set explicitly, and every request must
+ * also carry a session belonging to a verified @index.network Index account (see
+ * ops.auth.ts). Authentication is defence in depth on top of the loopback
+ * guards, not a replacement for them: it says *who* is driving a tool that can
+ * spend money and flush a database, while the bind address, the `Host` check and
+ * the `Origin` allowlist are what keep the site off the network. Do not set
+ * EVAL_OPS_BIND to a non-loopback address — the guards would refuse the traffic
+ * anyway, and this site has never been reviewed for exposure beyond loopback.
+ *
+ * EVAL_OPS_PORT is read here for the bind and again in `createDefaultOpsContext`
+ * for the bridge callback URL. They must agree, or the sign-in bridge delivers
+ * the credential to a port nothing is listening on; a test in
+ * tests/server.spec.ts pins that they read the same variable and default.
  */
 import path from "node:path";
 

--- a/packages/protocol/eval/ops/ops.server.ts
+++ b/packages/protocol/eval/ops/ops.server.ts
@@ -33,6 +33,7 @@ import { ApiIdentityResolver, assessIdentity, buildBridgeUrl, OneTimeStateStore,
 import { compareArtifacts } from "./ops.compare.js";
 import { LocalProcessRunExecutor, tailLog, type ExecutionStep, type RunExecutor } from "./ops.executor.js";
 import { assessFixtureTarget, BunSqlFixtureInspector, buildResetPipeline, MAX_PERSONAS, redactDatabaseUrl, scrubCredentials, SEED_STEP_CWD, type FixtureInspector, type FixtureTarget } from "./ops.fixture.js";
+import { OPS_CALLBACK_PATH } from "./ops.paths.js";
 import { loadProfiles, resolveProfile } from "./ops.profiles.js";
 import { HARNESS_REGISTRY } from "./ops.registry.js";
 import { RunQueue } from "./ops.queue.js";
@@ -68,6 +69,16 @@ export interface OpsAuthContext {
   webAppUrl: string;
   /** The port this server's /callback is reachable on. */
   callbackPort: number;
+  /**
+   * Where a completed sign-in sends the browser.
+   *
+   * Configuration, never a request parameter, so this cannot become an open
+   * redirect. It is not always `/`: in the documented two-process dev flow the
+   * callback is answered by this API on :4321, which serves no UI at all, so a
+   * bare `/` lands the operator on `{"error":"Unknown route: GET /"}`. See
+   * `resolveUiUrl`.
+   */
+  uiUrl: string;
 }
 
 /** Origins a browser may legitimately be running the ops UI on: loopback only. */
@@ -139,7 +150,7 @@ export function createOpsHandler(context: OpsContext): (request: Request) => Pro
     try {
       // Ahead of the gate: this is the request that establishes a session, so it
       // cannot require one. It is still behind both loopback guards above.
-      if (url.pathname === "/callback" && request.method === "GET") {
+      if (url.pathname === OPS_CALLBACK_PATH && request.method === "GET") {
         return await completeSignIn(context, url);
       }
 
@@ -187,8 +198,11 @@ function authRefusal(context: OpsContext, request: Request, url: URL): Response 
   if (identity === null) {
     return json({ error: "Sign in with your Index account to use the eval ops site.", authenticated: false }, 401);
   }
-  // Re-checked on every request rather than trusted from sign-in time: the policy
-  // is the authority, and a session established before it is not a licence.
+  // The *domain* rule is re-checked on every request rather than trusted from
+  // sign-in time, so narrowing the allowed domain refuses live sessions too.
+  // Verification is not re-checked: a session only exists past a verified check
+  // at /callback, and the credential that could re-ask the API was discarded
+  // there. `emailVerified: true` below states that, rather than proving it.
   const verdict = assessIdentity({ email: identity.email, emailVerified: true, name: identity.name });
   if (!verdict.allowed) {
     return json({ error: verdict.reason, authenticated: true, permitted: false }, 403);
@@ -247,7 +261,7 @@ async function completeSignIn(context: OpsContext, url: URL): Promise<Response> 
   return new Response(null, {
     status: 302,
     headers: {
-      Location: "/",
+      Location: auth.uiUrl,
       "Set-Cookie": `${SESSION_COOKIE}=${session}; ${SESSION_COOKIE_ATTRIBUTES}`,
     },
   });
@@ -881,20 +895,141 @@ async function readEnvValue(file: string, key: string): Promise<string | null> {
 // Default wiring
 // ---------------------------------------------------------------------------
 
-/** Where the API that resolves an identity lives, when the environment does not say. */
+/**
+ * Where the API that resolves an identity lives, when the environment does not say.
+ *
+ * Paired with {@link DEFAULT_WEB_APP_URL} on purpose: see {@link resolveIdentityEndpoints}.
+ */
 const DEFAULT_API_URL = "http://localhost:3001";
-/** Where the web app serving the /cli-auth bridge lives, when the environment does not say. */
-const DEFAULT_WEB_APP_URL = "https://index.network";
+/**
+ * Where the web app serving the /cli-auth bridge lives, when the environment does not say.
+ *
+ * The local web dev server, matching {@link DEFAULT_API_URL}'s local API. It was
+ * `https://index.network`, which paired a *production* bridge with a *local*
+ * resolver: the bridge minted a production API key and the local API could not
+ * verify it, so sign-in refused with "No Index account could be resolved" and
+ * nothing said why. Both defaults now name the same environment.
+ */
+const DEFAULT_WEB_APP_URL = "http://localhost:3000";
 /** The port this server listens on, when the environment does not say. Mirrors ops.serve.ts. */
 const DEFAULT_PORT = 4321;
+/**
+ * Where a completed sign-in sends the browser, when the environment does not say.
+ *
+ * The Vite dev server from the documented two-process flow, which is the UI in
+ * that mode — this API serves no UI. The single-process entrypoint
+ * (apps/eval-ops/server.ts) serves both from one origin and passes `uiUrl: "/"`.
+ */
+const DEFAULT_UI_URL = "http://127.0.0.1:5174";
+
+/** Hosts a sign-in may return the browser to, and the only ones this server may name. */
+const LOOPBACK_UI_HOSTNAMES = new Set(["127.0.0.1", "localhost", "::1"]);
+
+/**
+ * Reads an environment variable, treating an empty or whitespace-only value as unset.
+ *
+ * `WEB_APP_URL=` in a dotenv file is an operator saying nothing, not an operator
+ * naming the empty origin, and `??` alone would take it literally.
+ */
+function readEnv(env: Record<string, string | undefined>, key: string): string | undefined {
+  const value = env[key];
+  if (value === undefined) return undefined;
+  const trimmed = value.trim();
+  return trimmed === "" ? undefined : trimmed;
+}
+
+/**
+ * The bridge and the resolver, checked to be the same environment before the server starts.
+ *
+ * These two are one pair: `WEB_APP_URL` mints the API key and `API_URL` verifies
+ * it. A key minted by one deployment is meaningless to another, so a mismatched
+ * pair does not fail at startup — it fails at the end of a browser round-trip,
+ * as "No Index account could be resolved for this sign-in", which reads like a
+ * permissions problem and is not one. Failing loudly here costs the operator one
+ * clear message instead of a debugging session.
+ *
+ * Two ways a pair is refused:
+ *  - exactly one of the two is set. The other silently keeps its default, which
+ *    is how the production-bridge/local-resolver trap was reachable at all.
+ *  - one names a loopback host and the other does not, so they cannot be the
+ *    same deployment.
+ *
+ * Exported for tests: it is pure, so the pairing rule needs no server, socket or
+ * environment mutation to pin.
+ */
+export function resolveIdentityEndpoints(env: Record<string, string | undefined>): { webAppUrl: string; apiUrl: string } {
+  const webAppUrl = readEnv(env, "WEB_APP_URL");
+  const apiUrl = readEnv(env, "API_URL");
+
+  if (webAppUrl === undefined && apiUrl === undefined) {
+    return { webAppUrl: DEFAULT_WEB_APP_URL, apiUrl: DEFAULT_API_URL };
+  }
+  if (webAppUrl === undefined || apiUrl === undefined) {
+    const named = webAppUrl === undefined ? "API_URL" : "WEB_APP_URL";
+    const missing = webAppUrl === undefined ? "WEB_APP_URL" : "API_URL";
+    throw new Error(
+      `Refusing to start: ${named} is set but ${missing} is not. The eval ops sign-in mints an API key at `
+      + `WEB_APP_URL and verifies it at API_URL, so a key minted by one deployment is not verifiable by `
+      + `another. Set both to the same environment, or neither (which defaults to ${DEFAULT_WEB_APP_URL} `
+      + `and ${DEFAULT_API_URL}).`,
+    );
+  }
+  if (isLoopbackUrl(webAppUrl, "WEB_APP_URL") !== isLoopbackUrl(apiUrl, "API_URL")) {
+    throw new Error(
+      `Refusing to start: WEB_APP_URL (${webAppUrl}) and API_URL (${apiUrl}) are not the same environment — one is `
+      + `local and the other is not. The eval ops sign-in mints an API key at WEB_APP_URL and verifies it at `
+      + `API_URL, so a mismatched pair refuses every sign-in with "No Index account could be resolved".`,
+    );
+  }
+  return { webAppUrl, apiUrl };
+}
+
+/** True when a configured URL names a loopback host. Throws on a URL that is not one. */
+function isLoopbackUrl(value: string, name: string): boolean {
+  let parsed: URL;
+  try {
+    parsed = new URL(value);
+  } catch {
+    throw new Error(`Refusing to start: ${name} (${value}) is not a usable URL.`);
+  }
+  return LOOPBACK_UI_HOSTNAMES.has(parsed.hostname.replace(/^\[|\]$/g, ""));
+}
+
+/**
+ * Where a completed sign-in returns the browser.
+ *
+ * `EVAL_OPS_UI_URL` overrides, then the embedder's own answer (the single-process
+ * entrypoint serves the UI itself and says `/`), then {@link DEFAULT_UI_URL}.
+ *
+ * Restricted to a same-origin path or a loopback origin. This value is never
+ * taken from a request, so it is not an open-redirect sink today; the check is
+ * here so it cannot become one by configuration, and because a sign-in that
+ * hands the browser to a non-local origin is a mistake worth refusing loudly.
+ */
+function resolveUiUrl(env: Record<string, string | undefined>, fallback: string | undefined): string {
+  const value = readEnv(env, "EVAL_OPS_UI_URL") ?? fallback ?? DEFAULT_UI_URL;
+  if (value.startsWith("/") && !value.startsWith("//")) return value;
+  if (!isLoopbackUrl(value, "EVAL_OPS_UI_URL")) {
+    throw new Error(
+      `Refusing to start: EVAL_OPS_UI_URL (${value}) is not a loopback origin or a same-origin path. `
+      + `The eval ops site is loopback-only, so a sign-in must not hand the browser anywhere else.`,
+    );
+  }
+  return value;
+}
 
 /** Builds the context the standalone server runs on: everything rooted at the repository. */
-export async function createDefaultOpsContext(options: { repoRoot: string }): Promise<OpsContext> {
+export async function createDefaultOpsContext(options: { repoRoot: string; uiUrl?: string }): Promise<OpsContext> {
   const protocolDir = path.join(options.repoRoot, "packages/protocol");
   const evalDir = path.join(protocolDir, "eval");
   const store = new FsRunStore({ evalDir });
   const executor = new LocalProcessRunExecutor({ store, cwd: protocolDir });
   const databaseUrl = process.env.DATABASE_URL;
+
+  // Ahead of any I/O: a misconfigured identity pair must stop the server, not
+  // surface as a refused sign-in five minutes later.
+  const endpoints = resolveIdentityEndpoints(process.env);
+  const uiUrl = resolveUiUrl(process.env, options.uiUrl);
 
   // Reported, not fatal: fixture control is only one page, and the reset route
   // fails closed on the same divergence. A silent mismatch is what must not happen.
@@ -930,8 +1065,9 @@ export async function createDefaultOpsContext(options: { repoRoot: string }): Pr
       // The bridge mints a real API key against the operator's own browser
       // session, so this resolver is the only part of the server that talks to
       // the API at all.
-      identities: new ApiIdentityResolver({ apiUrl: process.env.API_URL ?? DEFAULT_API_URL }),
-      webAppUrl: process.env.WEB_APP_URL ?? DEFAULT_WEB_APP_URL,
+      identities: new ApiIdentityResolver({ apiUrl: endpoints.apiUrl }),
+      webAppUrl: endpoints.webAppUrl,
+      uiUrl,
       // Must match the port Bun.serve actually binds, or the bridge would send the
       // credential to a port nothing is listening on. ops.serve.ts reads the same
       // variable and the same default.

--- a/packages/protocol/eval/ops/ops.server.ts
+++ b/packages/protocol/eval/ops/ops.server.ts
@@ -278,14 +278,24 @@ function refusalPage(reason: string, status: number): Response {
   });
 }
 
-/** Escapes the five characters that can break out of HTML text or an attribute. */
+/** The five characters that can break out of HTML text or an attribute value. */
+const HTML_ESCAPES: Readonly<Record<string, string>> = Object.freeze({
+  "&": "&amp;",
+  "<": "&lt;",
+  ">": "&gt;",
+  '"': "&quot;",
+  "'": "&#39;",
+});
+
+/**
+ * Escapes the five characters that can break out of HTML text or an attribute.
+ *
+ * A single regex pass rather than chained `replaceAll`: this suite's tsconfig
+ * targets below ES2021, where `replaceAll` does not exist, and chained replaces
+ * would also rewrite the ampersands the earlier steps introduced.
+ */
 function escapeHtml(value: string): string {
-  return value
-    .replaceAll("&", "&amp;")
-    .replaceAll("<", "&lt;")
-    .replaceAll(">", "&gt;")
-    .replaceAll('"', "&quot;")
-    .replaceAll("'", "&#39;");
+  return value.replace(/[&<>"']/g, (character) => HTML_ESCAPES[character]);
 }
 
 /** Reads one cookie out of the request's Cookie header. */

--- a/packages/protocol/eval/ops/ops.server.ts
+++ b/packages/protocol/eval/ops/ops.server.ts
@@ -6,14 +6,22 @@
  * and a request carrying any of those fails validation instead of being ignored.
  * Nothing that leaves here contains a credential.
  *
- * There is no authentication: any process on this machine may drive this server.
- * That is an operator-trust decision about LOCAL processes, and it is not the same
- * thing as being drivable by any web page the operator happens to have open, so
- * state-changing requests are refused unless they are same-origin (see
- * `crossOriginRefusal`) and carry a JSON content type. Every request, read
- * included, must also arrive addressed to a loopback host (see
- * `foreignHostRefusal`), which is what keeps a rebound DNS name from reading
- * artifacts, run records, logs and fixture metadata.
+ * Four independent guards stand in front of every request, and they compose
+ * rather than substitute for one another:
+ *
+ *  1. `foreignHostRefusal` — every request, read included, must be addressed to a
+ *     loopback host. This is what stops a rebound DNS name reading artifacts,
+ *     run records, logs and fixture metadata.
+ *  2. `crossOriginRefusal` — a state-changing request must be same-origin, so a
+ *     page the operator happens to have open cannot drive a run or a flush.
+ *  3. A JSON content type on writes, which `no-cors` cannot produce.
+ *  4. `authRefusal` — the caller must hold a session belonging to a verified
+ *     member of the allowed domain (see ops.auth.ts).
+ *
+ * Authentication is the newest of the four and the weakest place to lean: it is
+ * defence in depth on top of the loopback guards, not a licence to relax them.
+ * A signed-in browser is still refused a cross-origin write, and a foreign Host
+ * is still refused before the session is even looked at.
  */
 import path from "node:path";
 
@@ -21,6 +29,7 @@ import { z } from "zod";
 
 import { renderRun, RunSpecSchema } from "./ops.argv.js";
 import { decodeArtifactId, FsArtifactSource, type ArtifactSource } from "./ops.artifacts.js";
+import { ApiIdentityResolver, assessIdentity, buildBridgeUrl, OneTimeStateStore, OpsSessionStore, type AllowedIdentity, type IdentityResolver } from "./ops.auth.js";
 import { compareArtifacts } from "./ops.compare.js";
 import { LocalProcessRunExecutor, tailLog, type ExecutionStep, type RunExecutor } from "./ops.executor.js";
 import { assessFixtureTarget, BunSqlFixtureInspector, buildResetPipeline, MAX_PERSONAS, redactDatabaseUrl, scrubCredentials, SEED_STEP_CWD, type FixtureInspector, type FixtureTarget } from "./ops.fixture.js";
@@ -46,10 +55,58 @@ export interface OpsContext {
   databaseUrl: string | undefined;
   /** Read-only live counts. Absent when no database client is configured. */
   inspector?: FixtureInspector;
+  /** Identity. Absent only in tests that predate the gate; see `authRefusal`. */
+  auth?: OpsAuthContext;
+}
+
+/** Everything the auth gate needs. All of it is injectable, so tests need no API. */
+export interface OpsAuthContext {
+  states: OneTimeStateStore;
+  sessions: OpsSessionStore;
+  identities: IdentityResolver;
+  /** Base URL of the web app serving /cli-auth. */
+  webAppUrl: string;
+  /** The port this server's /callback is reachable on. */
+  callbackPort: number;
 }
 
 /** Origins a browser may legitimately be running the ops UI on: loopback only. */
 const LOOPBACK_HOSTNAMES = new Set(["127.0.0.1", "localhost", "[::1]"]);
+
+/**
+ * The only routes reachable without a session, and the reason each one must be.
+ *
+ * This is an allowlist because the gate is default-deny: `authRefusal` refuses
+ * everything not named here, including unknown paths, so a route added to
+ * `route()` without a thought about access is gated rather than exposed. Adding
+ * an entry here is the deliberate act of publishing something.
+ *
+ *  - `GET /api/auth/status` — the UI asks "am I signed in?" before it has a
+ *    session; gating it would make the question unanswerable.
+ *  - `POST /api/auth/login` — mints the sign-in link, so requiring a session to
+ *    call it would be circular.
+ *
+ * `/callback` is deliberately absent: it is not under /api/ and is handled ahead
+ * of the gate, because it is the request that *establishes* a session.
+ */
+export const PUBLIC_ROUTES: ReadonlyArray<{ method: string; path: string }> = Object.freeze([
+  Object.freeze({ method: "GET", path: "/api/auth/status" }),
+  Object.freeze({ method: "POST", path: "/api/auth/login" }),
+]);
+
+/** Name of the ops session cookie. */
+const SESSION_COOKIE = "eval_ops_session";
+
+/**
+ * The session cookie's attributes.
+ *
+ * `Secure` is deliberately absent. The ops site is served over plain http on
+ * loopback, and a Secure cookie would be dropped by the browser — sign-in would
+ * appear to succeed and then silently never take effect. `SameSite=Lax` keeps the
+ * cookie off cross-site writes, which is the same boundary `crossOriginRefusal`
+ * enforces server-side.
+ */
+const SESSION_COOKIE_ATTRIBUTES = "HttpOnly; SameSite=Lax; Path=/";
 
 /** Fetch metadata values that mean "this was not initiated by another site". */
 const SAME_ORIGIN_FETCH_SITES = new Set(["same-origin", "none"]);
@@ -80,6 +137,18 @@ export function createOpsHandler(context: OpsContext): (request: Request) => Pro
     const refusal = crossOriginRefusal(request);
     if (refusal !== null) return refusal;
     try {
+      // Ahead of the gate: this is the request that establishes a session, so it
+      // cannot require one. It is still behind both loopback guards above.
+      if (url.pathname === "/callback" && request.method === "GET") {
+        return await completeSignIn(context, url);
+      }
+
+      // Default-deny. Everything from here on either sits on PUBLIC_ROUTES or
+      // carries a session, including unknown paths — so a route added below
+      // without a decision about access is gated, not published.
+      const denied = authRefusal(context, request, url);
+      if (denied !== null) return denied;
+
       const response = await route(context, state, request, url);
       return response ?? json({ error: `Unknown route: ${request.method} ${url.pathname}` }, 404);
     } catch (error) {
@@ -87,6 +156,149 @@ export function createOpsHandler(context: OpsContext): (request: Request) => Pro
       return json({ error: scrubCredentials(messageOf(error)) }, 500);
     }
   };
+}
+
+// ---------------------------------------------------------------------------
+// Authentication
+// ---------------------------------------------------------------------------
+
+/**
+ * Refuses a request that carries no session, unless its route is public.
+ *
+ * 401 and 403 are kept distinct because the UI must tell two different stories:
+ * 401 means "nobody is signed in, offer the sign-in button", while 403 means "an
+ * Index account is signed in but it is not permitted here", which no amount of
+ * retrying fixes. Collapsing them would leave an outsider clicking sign-in forever.
+ *
+ * Returns null when the request may proceed.
+ */
+function authRefusal(context: OpsContext, request: Request, url: URL): Response | null {
+  const auth = context.auth;
+  // A context with no auth wiring is a programming error, not an open door: the
+  // server refuses everything rather than serving unauthenticated.
+  if (auth === undefined) {
+    return json({ error: "This server has no identity configured, so nothing can be authorised." }, 500);
+  }
+  if (PUBLIC_ROUTES.some((entry) => entry.method === request.method && entry.path === url.pathname)) {
+    return null;
+  }
+
+  const identity = auth.sessions.lookup(readCookie(request, SESSION_COOKIE));
+  if (identity === null) {
+    return json({ error: "Sign in with your Index account to use the eval ops site.", authenticated: false }, 401);
+  }
+  // Re-checked on every request rather than trusted from sign-in time: the policy
+  // is the authority, and a session established before it is not a licence.
+  const verdict = assessIdentity({ email: identity.email, emailVerified: true, name: identity.name });
+  if (!verdict.allowed) {
+    return json({ error: verdict.reason, authenticated: true, permitted: false }, 403);
+  }
+  return null;
+}
+
+/** The signed-in identity, or null. Only meaningful after `authRefusal` has passed. */
+function sessionIdentity(context: OpsContext, request: Request): AllowedIdentity | null {
+  return context.auth?.sessions.lookup(readCookie(request, SESSION_COOKIE)) ?? null;
+}
+
+/**
+ * Completes the bridge round-trip: state in, session out.
+ *
+ * The order is deliberate and every step fails closed. The state is consumed
+ * first, so a callback this server did not start is refused before the credential
+ * in it is read at all. The credential is then exchanged for an identity and
+ * dropped — it is a broad API key for a real account, and it is never stored in a
+ * session, logged, or written into a page.
+ */
+async function completeSignIn(context: OpsContext, url: URL): Promise<Response> {
+  const auth = context.auth;
+  if (auth === undefined) return refusalPage("This server has no identity configured.", 500);
+
+  // Consuming is the validation: unknown, expired and replayed states all fail here.
+  if (!auth.states.consume(url.searchParams.get("state"))) {
+    return refusalPage(
+      "This sign-in link is no longer valid. It may have already been used, or it may have expired. Start the sign-in again from the eval ops site.",
+      403,
+    );
+  }
+
+  // The bridge sends the key as `api_key` (v2) or `session_token` (the v1 name,
+  // which is also an API-key secret rather than a browser token).
+  const credential = url.searchParams.get("api_key") ?? url.searchParams.get("session_token");
+  if (credential === null || credential === "") {
+    return refusalPage("The sign-in did not deliver a credential. Start the sign-in again from the eval ops site.", 403);
+  }
+
+  let resolved;
+  try {
+    resolved = await auth.identities.resolve(credential);
+  } catch (error) {
+    // "The API is down" is not "you are not allowed in", and must not read as it.
+    return refusalPage(
+      `The Index API could not be reached to verify this sign-in: ${scrubCredentials(messageOf(error))}`,
+      502,
+    );
+  }
+
+  const verdict = assessIdentity(resolved);
+  if (!verdict.allowed) return refusalPage(verdict.reason, 403);
+
+  const session = auth.sessions.establish(verdict.identity);
+  return new Response(null, {
+    status: 302,
+    headers: {
+      Location: "/",
+      "Set-Cookie": `${SESSION_COOKIE}=${session}; ${SESSION_COOKIE_ATTRIBUTES}`,
+    },
+  });
+}
+
+/**
+ * The page a refused sign-in lands on.
+ *
+ * The reason interpolates the address the API returned, which is user-controlled
+ * text arriving through a redirect and rendered under the operator's own loopback
+ * origin — an injection sink unless it is escaped. `escapeHtml` is applied to the
+ * reason and nothing else is interpolated, so the page has no other sink.
+ */
+function refusalPage(reason: string, status: number): Response {
+  const body = `<!doctype html>
+<html lang="en">
+<head><meta charset="utf-8"><title>Sign-in refused</title></head>
+<body style="font-family: ui-monospace, monospace; background: #0b0d0e; color: #c8ccc8; padding: 2rem;">
+<h1 style="color: #ff6b64;">Sign-in refused</h1>
+<p>${escapeHtml(reason)}</p>
+<p><a href="/" style="color: #56c8d8;">Return to the eval ops site</a></p>
+</body>
+</html>
+`;
+  return new Response(body, {
+    status,
+    headers: { "Content-Type": "text/html; charset=utf-8" },
+  });
+}
+
+/** Escapes the five characters that can break out of HTML text or an attribute. */
+function escapeHtml(value: string): string {
+  return value
+    .replaceAll("&", "&amp;")
+    .replaceAll("<", "&lt;")
+    .replaceAll(">", "&gt;")
+    .replaceAll('"', "&quot;")
+    .replaceAll("'", "&#39;");
+}
+
+/** Reads one cookie out of the request's Cookie header. */
+function readCookie(request: Request, name: string): string | null {
+  const header = request.headers.get("cookie");
+  if (header === null) return null;
+  for (const part of header.split(";")) {
+    const separator = part.indexOf("=");
+    if (separator === -1) continue;
+    if (part.slice(0, separator).trim() !== name) continue;
+    return part.slice(separator + 1).trim();
+  }
+  return null;
 }
 
 /**
@@ -181,6 +393,7 @@ async function route(context: OpsContext, state: ServerState, request: Request, 
   const [, resource, ...rest] = segments;
 
   if (request.method === "GET") {
+    if (resource === "auth" && rest.length === 1 && rest[0] === "status") return authStatus(context, request);
     if (resource === "harnesses" && rest.length === 0) return json({ harnesses: Object.values(HARNESS_REGISTRY) });
     if (resource === "profiles" && rest.length === 0) return json({ profiles: await loadProfiles(context.profilesDir) });
     if (resource === "artifacts" && rest.length === 0) return json(await context.artifacts.list());
@@ -195,12 +408,50 @@ async function route(context: OpsContext, state: ServerState, request: Request, 
   }
 
   if (request.method === "POST") {
+    if (resource === "auth" && rest.length === 1 && rest[0] === "login") return beginSignIn(context);
+    if (resource === "auth" && rest.length === 1 && rest[0] === "logout") return endSession(context, request);
     if (resource === "runs" && rest.length === 0) return await launchRun(context, state, request);
     if (resource === "runs" && rest.length === 2 && rest[1] === "cancel") return await cancelRun(context, rest[0]);
     if (resource === "fixture" && rest.length === 1 && rest[0] === "reset") return await resetFixture(context, state, request);
   }
 
   return null;
+}
+
+/** Who is signed in, if anyone. The one route the UI may ask before it has a session. */
+function authStatus(context: OpsContext, request: Request): Response {
+  const identity = sessionIdentity(context, request);
+  if (identity === null) return json({ authenticated: false });
+  return json({ authenticated: true, email: identity.email, name: identity.name });
+}
+
+/**
+ * Starts a sign-in: mints a one-time state and returns the bridge link.
+ *
+ * Everything in the link comes from this server's own configuration; nothing in
+ * it is taken from the request, so a caller cannot steer the callback elsewhere.
+ */
+function beginSignIn(context: OpsContext): Response {
+  const auth = context.auth;
+  if (auth === undefined) return json({ error: "This server has no identity configured." }, 500);
+  const url = buildBridgeUrl({
+    webAppUrl: auth.webAppUrl,
+    callbackPort: auth.callbackPort,
+    state: auth.states.mint(),
+  });
+  return json({ url });
+}
+
+/** Ends the session and expires the cookie, so the browser stops presenting it. */
+function endSession(context: OpsContext, request: Request): Response {
+  context.auth?.sessions.clear(readCookie(request, SESSION_COOKIE));
+  return new Response(JSON.stringify({ authenticated: false }), {
+    status: 200,
+    headers: {
+      "Content-Type": "application/json",
+      "Set-Cookie": `${SESSION_COOKIE}=; ${SESSION_COOKIE_ATTRIBUTES}; Max-Age=0`,
+    },
+  });
 }
 
 // ---------------------------------------------------------------------------
@@ -620,6 +871,13 @@ async function readEnvValue(file: string, key: string): Promise<string | null> {
 // Default wiring
 // ---------------------------------------------------------------------------
 
+/** Where the API that resolves an identity lives, when the environment does not say. */
+const DEFAULT_API_URL = "http://localhost:3001";
+/** Where the web app serving the /cli-auth bridge lives, when the environment does not say. */
+const DEFAULT_WEB_APP_URL = "https://index.network";
+/** The port this server listens on, when the environment does not say. Mirrors ops.serve.ts. */
+const DEFAULT_PORT = 4321;
+
 /** Builds the context the standalone server runs on: everything rooted at the repository. */
 export async function createDefaultOpsContext(options: { repoRoot: string }): Promise<OpsContext> {
   const protocolDir = path.join(options.repoRoot, "packages/protocol");
@@ -656,6 +914,19 @@ export async function createDefaultOpsContext(options: { repoRoot: string }): Pr
     queue: new RunQueue({ executor, store }),
     databaseUrl,
     inspector: new BunSqlFixtureInspector(),
+    auth: {
+      states: new OneTimeStateStore(),
+      sessions: new OpsSessionStore(),
+      // The bridge mints a real API key against the operator's own browser
+      // session, so this resolver is the only part of the server that talks to
+      // the API at all.
+      identities: new ApiIdentityResolver({ apiUrl: process.env.API_URL ?? DEFAULT_API_URL }),
+      webAppUrl: process.env.WEB_APP_URL ?? DEFAULT_WEB_APP_URL,
+      // Must match the port Bun.serve actually binds, or the bridge would send the
+      // credential to a port nothing is listening on. ops.serve.ts reads the same
+      // variable and the same default.
+      callbackPort: Number(process.env.EVAL_OPS_PORT ?? DEFAULT_PORT),
+    },
   };
 }
 

--- a/packages/protocol/eval/ops/tests/auth.spec.ts
+++ b/packages/protocol/eval/ops/tests/auth.spec.ts
@@ -1,0 +1,325 @@
+import { describe, expect, it, beforeAll } from "bun:test";
+import path from "node:path";
+
+import { ALLOWED_EMAIL_DOMAIN, ApiIdentityResolver, assessIdentity, buildBridgeUrl, OneTimeStateStore, OpsSessionStore, type ResolvedIdentity } from "../ops.auth.js";
+
+/**
+ * The bridge page's own validator, loaded from the file that actually runs in
+ * the browser app. This is a pin, not a copy: a URL this suite calls valid is
+ * checked by `apps/web/src/lib/cli-auth.ts` itself, so a future tightening of
+ * that validator fails here instead of silently breaking ops sign-in.
+ *
+ * It is imported through a computed specifier because the eval TypeScript
+ * project is rooted at packages/protocol and cannot name a file outside it.
+ * cli-auth.ts has no imports of its own, so loading it standalone is safe.
+ */
+const CLI_AUTH_PATH = path.join(import.meta.dir, "../../../../../apps/web/src/lib/cli-auth.ts");
+
+interface CliAuthModule {
+  validateCliCallbackUrl(value: string | null): string | null;
+  parseCliAuthRequest(params: URLSearchParams): { protocolVersion: 1; callback: string } | { protocolVersion: 2; callback: string; state: string } | null;
+}
+
+let cliAuth: CliAuthModule;
+
+beforeAll(async () => {
+  cliAuth = (await import(CLI_AUTH_PATH)) as CliAuthModule;
+});
+
+function identity(overrides: Partial<ResolvedIdentity> = {}): ResolvedIdentity {
+  return { email: "a@index.network", emailVerified: true, name: "Ada", ...overrides };
+}
+
+// ---------------------------------------------------------------------------
+// Domain policy
+// ---------------------------------------------------------------------------
+
+describe("assessIdentity", () => {
+  it("allows a verified address on the exact allowed domain", () => {
+    const verdict = assessIdentity(identity());
+    expect(verdict.allowed).toBe(true);
+    if (!verdict.allowed) throw new Error("unreachable");
+    expect(verdict.identity).toEqual({ email: "a@index.network", name: "Ada" });
+  });
+
+  it("allows regardless of case", () => {
+    expect(assessIdentity(identity({ email: "A@INDEX.NETWORK" })).allowed).toBe(true);
+  });
+
+  it("refuses an unverified address on the allowed domain", () => {
+    const verdict = assessIdentity(identity({ emailVerified: false }));
+    expect(verdict.allowed).toBe(false);
+    if (verdict.allowed) throw new Error("unreachable");
+    expect(verdict.reason).toContain("not verified");
+  });
+
+  // The classic hole: a suffix test on the domain would allow this.
+  it("refuses a domain that only starts with the allowed domain", () => {
+    expect(assessIdentity(identity({ email: "a@index.network.evil.com" })).allowed).toBe(false);
+  });
+
+  it("refuses a subdomain of the allowed domain", () => {
+    expect(assessIdentity(identity({ email: "a@sub.index.network" })).allowed).toBe(false);
+  });
+
+  // Refused by the last-@ rule: the domain here is evil.com, whatever the local part says.
+  it("refuses an address whose allowed domain is not after the last @", () => {
+    const verdict = assessIdentity(identity({ email: '"a@index.network"@evil.com' }));
+    expect(verdict.allowed).toBe(false);
+    if (verdict.allowed) throw new Error("unreachable");
+    expect(verdict.reason).toContain(`not an @${ALLOWED_EMAIL_DOMAIN} address`);
+  });
+
+  // Refused by the multi-@ rule: the last-@ domain IS index.network, so only the
+  // ambiguity guard stops this one. A different branch from the case above.
+  it("refuses an address it cannot read unambiguously", () => {
+    const verdict = assessIdentity(identity({ email: "a@evil.com?x=@index.network" }));
+    expect(verdict.allowed).toBe(false);
+    if (verdict.allowed) throw new Error("unreachable");
+    expect(verdict.reason).toContain("unambiguous");
+  });
+
+  // Guards the guard: the multi-@ rule must not become "refuse everything".
+  it("still admits an ordinary single-@ address", () => {
+    for (const email of ["a@index.network", "first.last+tag@index.network"]) {
+      expect({ email, allowed: assessIdentity(identity({ email })).allowed }).toEqual({ email, allowed: true });
+    }
+  });
+
+  it("refuses a missing, empty or domain-less address", () => {
+    for (const email of [null, undefined, "", "   ", "a", "@index.network", "a@"]) {
+      const verdict = assessIdentity(identity({ email: email as string | null }));
+      expect({ email, allowed: verdict.allowed }).toEqual({ email, allowed: false });
+    }
+  });
+
+  it("refuses a missing identity", () => {
+    expect(assessIdentity(null).allowed).toBe(false);
+  });
+
+  it("states the allowed domain once, as a constant", () => {
+    expect(ALLOWED_EMAIL_DOMAIN).toBe("index.network");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// One-time state
+// ---------------------------------------------------------------------------
+
+describe("OneTimeStateStore", () => {
+  it("mints a state the bridge's own validator accepts", () => {
+    const state = new OneTimeStateStore().mint();
+    expect(state).toMatch(/^[A-Za-z0-9_-]{32,128}$/);
+  });
+
+  it("mints a distinct state every time", () => {
+    const store = new OneTimeStateStore();
+    const minted = new Set([store.mint(), store.mint(), store.mint()]);
+    expect(minted.size).toBe(3);
+  });
+
+  it("accepts a state once and refuses the replay", () => {
+    const store = new OneTimeStateStore();
+    const state = store.mint();
+    expect(store.consume(state)).toBe(true);
+    expect(store.consume(state)).toBe(false);
+  });
+
+  it("refuses a state that has expired", () => {
+    let now = 1_000;
+    const store = new OneTimeStateStore({ ttlMs: 100, now: () => now });
+    const state = store.mint();
+    now += 101;
+    expect(store.consume(state)).toBe(false);
+  });
+
+  it("still accepts a state inside its window", () => {
+    let now = 1_000;
+    const store = new OneTimeStateStore({ ttlMs: 100, now: () => now });
+    const state = store.mint();
+    now += 99;
+    expect(store.consume(state)).toBe(true);
+  });
+
+  it("refuses an unknown, empty or absent state without throwing", () => {
+    const store = new OneTimeStateStore();
+    const state = store.mint();
+    expect(store.consume("not-the-state")).toBe(false);
+    expect(store.consume(`${state}x`)).toBe(false);
+    expect(store.consume("")).toBe(false);
+    expect(store.consume(null)).toBe(false);
+    // None of the above may have consumed the real one.
+    expect(store.consume(state)).toBe(true);
+  });
+
+  it("keeps concurrent states independent", () => {
+    const store = new OneTimeStateStore();
+    const first = store.mint();
+    const second = store.mint();
+    expect(store.consume(second)).toBe(true);
+    expect(store.consume(first)).toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Bridge URL
+// ---------------------------------------------------------------------------
+
+describe("buildBridgeUrl", () => {
+  const state = "s".repeat(43);
+
+  it("builds the exact URL the bridge page expects", () => {
+    const url = buildBridgeUrl({ webAppUrl: "http://localhost:3000", callbackPort: 4321, state });
+    expect(url).toBe(`http://localhost:3000/cli-auth?callback=http%3A%2F%2F127.0.0.1%3A4321%2Fcallback&version=2&state=${state}`);
+  });
+
+  it("produces a request the real bridge validator parses as protocol v2", () => {
+    const url = new URL(buildBridgeUrl({ webAppUrl: "https://index.network", callbackPort: 5174, state }));
+    expect(url.pathname).toBe("/cli-auth");
+    const request = cliAuth.parseCliAuthRequest(url.searchParams);
+    expect(request).toEqual({ protocolVersion: 2, callback: "http://127.0.0.1:5174/callback", state });
+  });
+
+  it("produces a callback the real bridge validator accepts", () => {
+    const url = new URL(buildBridgeUrl({ webAppUrl: "https://index.network", callbackPort: 65535, state }));
+    expect(cliAuth.validateCliCallbackUrl(url.searchParams.get("callback"))).toBe("http://127.0.0.1:65535/callback");
+  });
+
+  it("tolerates a trailing slash on the web app URL", () => {
+    const url = buildBridgeUrl({ webAppUrl: "http://localhost:3000/", callbackPort: 4321, state });
+    expect(new URL(url).pathname).toBe("/cli-auth");
+  });
+
+  it("refuses a port the bridge validator would reject", () => {
+    for (const callbackPort of [0, -1, 65536, 1.5, Number.NaN]) {
+      expect(() => buildBridgeUrl({ webAppUrl: "http://localhost:3000", callbackPort, state })).toThrow(/port/i);
+    }
+  });
+
+  it("refuses a state the bridge validator would reject", () => {
+    for (const bad of ["", "short", "has spaces in it and is long enough!!!!!!!", "x".repeat(129)]) {
+      expect(() => buildBridgeUrl({ webAppUrl: "http://localhost:3000", callbackPort: 4321, state: bad })).toThrow(/state/i);
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Identity resolution
+// ---------------------------------------------------------------------------
+
+interface FetchCall {
+  url: string;
+  init: RequestInit | undefined;
+}
+
+/** Answers with a canned response and records the call. No socket is opened. */
+function stubFetch(responder: (url: string) => Response): { fetch: typeof fetch; calls: FetchCall[] } {
+  const calls: FetchCall[] = [];
+  const impl = async (input: string | URL | Request, init?: RequestInit): Promise<Response> => {
+    const url = typeof input === "string" ? input : input instanceof URL ? input.toString() : input.url;
+    calls.push({ url, init });
+    return responder(url);
+  };
+  return { fetch: impl as unknown as typeof fetch, calls };
+}
+
+/** The shape `/api/auth/me` actually returns (services/api/src/controllers/auth.controller.ts). */
+function meResponse(user: Record<string, unknown>): Response {
+  return Response.json({
+    user: { id: "u1", key: null, avatar: null, socials: [], notificationPreferences: {}, ...user },
+    features: { negotiatorChat: false, signalAgent: false, agentSurface: false, agentActions: false, fastSignalIntake: false },
+  });
+}
+
+describe("ApiIdentityResolver", () => {
+  it("sends the credential as x-api-key and never in the URL", async () => {
+    const stub = stubFetch(() => meResponse({ email: "a@index.network", emailVerified: true, name: "Ada" }));
+    const resolver = new ApiIdentityResolver({ apiUrl: "http://localhost:3001/", fetch: stub.fetch });
+    await resolver.resolve("secret-key");
+
+    expect(stub.calls).toHaveLength(1);
+    expect(stub.calls[0].url).toBe("http://localhost:3001/api/auth/me");
+    expect(stub.calls[0].url).not.toContain("secret-key");
+    expect(new Headers(stub.calls[0].init?.headers).get("x-api-key")).toBe("secret-key");
+  });
+
+  it("maps the real response body to a resolved identity", async () => {
+    const stub = stubFetch(() => meResponse({ email: "a@index.network", emailVerified: true, name: "Ada" }));
+    const resolver = new ApiIdentityResolver({ apiUrl: "http://localhost:3001", fetch: stub.fetch });
+    expect(await resolver.resolve("secret-key")).toEqual({ email: "a@index.network", emailVerified: true, name: "Ada" });
+  });
+
+  it("reports an unverified user as unverified rather than dropping the field", async () => {
+    const stub = stubFetch(() => meResponse({ email: "a@index.network", emailVerified: false, name: "Ada" }));
+    const resolver = new ApiIdentityResolver({ apiUrl: "http://localhost:3001", fetch: stub.fetch });
+    expect(await resolver.resolve("secret-key")).toEqual({ email: "a@index.network", emailVerified: false, name: "Ada" });
+  });
+
+  it("resolves nothing when the credential is refused", async () => {
+    const stub = stubFetch(() => Response.json({ error: "Access token or API key required" }, { status: 401 }));
+    const resolver = new ApiIdentityResolver({ apiUrl: "http://localhost:3001", fetch: stub.fetch });
+    expect(await resolver.resolve("secret-key")).toBeNull();
+  });
+
+  it("resolves nothing when the body is not the documented shape", async () => {
+    for (const body of [{}, { user: null }, { user: { email: 42 } }, "not json at all"]) {
+      const stub = stubFetch(() => (typeof body === "string" ? new Response(body) : Response.json(body)));
+      const resolver = new ApiIdentityResolver({ apiUrl: "http://localhost:3001", fetch: stub.fetch });
+      expect(await resolver.resolve("secret-key")).toBeNull();
+    }
+  });
+
+  it("fails closed when the verified flag is missing", async () => {
+    const stub = stubFetch(() => meResponse({ email: "a@index.network", name: "Ada" }));
+    const resolver = new ApiIdentityResolver({ apiUrl: "http://localhost:3001", fetch: stub.fetch });
+    const resolved = await resolver.resolve("secret-key");
+    expect(resolved).toEqual({ email: "a@index.network", emailVerified: false, name: "Ada" });
+    expect(assessIdentity(resolved).allowed).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Ops session
+// ---------------------------------------------------------------------------
+
+describe("OpsSessionStore", () => {
+  const allowed = { email: "a@index.network", name: "Ada" };
+
+  it("mints an unguessable, URL-safe session value", () => {
+    const store = new OpsSessionStore();
+    const token = store.establish(allowed);
+    expect(token).toMatch(/^[A-Za-z0-9_-]{32,}$/);
+    expect(store.establish(allowed)).not.toBe(token);
+  });
+
+  it("looks a session up by its value", () => {
+    const store = new OpsSessionStore();
+    const token = store.establish(allowed);
+    expect(store.lookup(token)).toEqual(allowed);
+  });
+
+  it("stores nothing beyond the identity, so no credential can reach the browser", () => {
+    const store = new OpsSessionStore();
+    const session = store.lookup(store.establish(allowed));
+    expect(Object.keys(session ?? {}).sort()).toEqual(["email", "name"]);
+    expect(JSON.stringify(session)).not.toContain("key");
+  });
+
+  it("returns nothing for an unknown, empty or absent value", () => {
+    const store = new OpsSessionStore();
+    store.establish(allowed);
+    expect(store.lookup("nope")).toBeNull();
+    expect(store.lookup("")).toBeNull();
+    expect(store.lookup(null)).toBeNull();
+  });
+
+  it("clears one session without disturbing another", () => {
+    const store = new OpsSessionStore();
+    const first = store.establish(allowed);
+    const second = store.establish({ email: "b@index.network", name: "Bob" });
+    expect(store.clear(first)).toBe(true);
+    expect(store.lookup(first)).toBeNull();
+    expect(store.lookup(second)).toEqual({ email: "b@index.network", name: "Bob" });
+    expect(store.clear(first)).toBe(false);
+  });
+});

--- a/packages/protocol/eval/ops/tests/auth.spec.ts
+++ b/packages/protocol/eval/ops/tests/auth.spec.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it, beforeAll } from "bun:test";
 import path from "node:path";
 
-import { ALLOWED_EMAIL_DOMAIN, ApiIdentityResolver, assessIdentity, buildBridgeUrl, OneTimeStateStore, OpsSessionStore, type ResolvedIdentity } from "../ops.auth.js";
+import { ALLOWED_EMAIL_DOMAIN, ApiIdentityResolver, assessIdentity, buildBridgeUrl, MAX_PENDING_STATES, OneTimeStateStore, OpsSessionStore, type ResolvedIdentity } from "../ops.auth.js";
 
 /**
  * The bridge page's own validator, loaded from the file that actually runs in
@@ -16,6 +16,7 @@ import { ALLOWED_EMAIL_DOMAIN, ApiIdentityResolver, assessIdentity, buildBridgeU
 const CLI_AUTH_PATH = path.join(import.meta.dir, "../../../../../apps/web/src/lib/cli-auth.ts");
 
 interface CliAuthModule {
+  validateCliAuthState(value: string | null): string | null;
   validateCliCallbackUrl(value: string | null): string | null;
   parseCliAuthRequest(params: URLSearchParams): { protocolVersion: 1; callback: string } | { protocolVersion: 2; callback: string; state: string } | null;
 }
@@ -60,6 +61,38 @@ describe("assessIdentity", () => {
 
   it("refuses a subdomain of the allowed domain", () => {
     expect(assessIdentity(identity({ email: "a@sub.index.network" })).allowed).toBe(false);
+  });
+
+  // The Unicode hole. `toLowerCase()` is a *Unicode* operation, so without the
+  // DOMAIN_CHARACTERS guard U+212A KELVIN SIGN folds to ASCII `k` and
+  // `index.networ<KELVIN>` — a domain that is not ours — passes the rule. The
+  // code points are written as escapes on purpose: spelled literally they look
+  // like typos and someone will "fix" them.
+  it("refuses a domain that only lowercases into the allowed domain", () => {
+    for (const email of [
+      "a@index.networ\u212A", // U+212A KELVIN SIGN -> toLowerCase() gives ASCII "k"
+      "a@\uFF49ndex.network", // U+FF49 FULLWIDTH LATIN SMALL LETTER I
+      "a@index\u3002network", // U+3002 IDEOGRAPHIC FULL STOP
+    ]) {
+      const verdict = assessIdentity(identity({ email }));
+      expect({ email: JSON.stringify(email), allowed: verdict.allowed }).toEqual({ email: JSON.stringify(email), allowed: false });
+    }
+  });
+
+  it("trims the address rather than storing and echoing the whitespace", () => {
+    const verdict = assessIdentity(identity({ email: "  a@index.network " }));
+    expect(verdict.allowed).toBe(true);
+    if (!verdict.allowed) throw new Error("unreachable");
+    expect(verdict.identity.email).toBe("a@index.network");
+  });
+
+  // ResolvedIdentity is the contract for any injected resolver, and A2
+  // serialises the allowed identity toward the browser.
+  it("coerces a non-string name to a string", () => {
+    const verdict = assessIdentity(identity({ name: undefined as unknown as string }));
+    expect(verdict.allowed).toBe(true);
+    if (!verdict.allowed) throw new Error("unreachable");
+    expect(verdict.identity.name).toBe("");
   });
 
   // Refused by the last-@ rule: the domain here is evil.com, whatever the local part says.
@@ -107,9 +140,11 @@ describe("assessIdentity", () => {
 // ---------------------------------------------------------------------------
 
 describe("OneTimeStateStore", () => {
+  // Asserted through the bridge's own validator, not a copy of its pattern: a
+  // hand-written regex here would still pass if the bridge tightened its own.
   it("mints a state the bridge's own validator accepts", () => {
     const state = new OneTimeStateStore().mint();
-    expect(state).toMatch(/^[A-Za-z0-9_-]{32,128}$/);
+    expect(cliAuth.validateCliAuthState(state)).toBe(state);
   });
 
   it("mints a distinct state every time", () => {
@@ -152,6 +187,25 @@ describe("OneTimeStateStore", () => {
     expect(store.consume(state)).toBe(true);
   });
 
+  // POST /api/auth/login is public and a process running as another user on the
+  // same machine can hammer it; unbounded pending states would slow every
+  // consume() the real operator makes. The newest mint always survives.
+  it("caps the outstanding states, evicting the oldest", () => {
+    const store = new OneTimeStateStore({ maxPending: 4 });
+    const states = [store.mint(), store.mint(), store.mint(), store.mint()];
+    const newest = store.mint();
+    expect(store.consume(states[0])).toBe(false);
+    expect(store.consume(newest)).toBe(true);
+    expect(store.consume(states[3])).toBe(true);
+  });
+
+  it("caps at MAX_PENDING_STATES by default", () => {
+    const store = new OneTimeStateStore();
+    const first = store.mint();
+    for (let i = 0; i < MAX_PENDING_STATES; i += 1) store.mint();
+    expect(store.consume(first)).toBe(false);
+  });
+
   it("keeps concurrent states independent", () => {
     const store = new OneTimeStateStore();
     const first = store.mint();
@@ -166,7 +220,11 @@ describe("OneTimeStateStore", () => {
 // ---------------------------------------------------------------------------
 
 describe("buildBridgeUrl", () => {
-  const state = "s".repeat(43);
+  // A genuinely minted state, not a synthetic "sss…": a placeholder satisfies
+  // almost any tightening of the bridge's pattern, so it would not catch the
+  // one regression this pin exists for — the bridge rejecting base64url's
+  // `-` and `_`.
+  const state = new OneTimeStateStore().mint();
 
   it("builds the exact URL the bridge page expects", () => {
     const url = buildBridgeUrl({ webAppUrl: "http://localhost:3000", callbackPort: 4321, state });
@@ -199,6 +257,21 @@ describe("buildBridgeUrl", () => {
   it("refuses a state the bridge validator would reject", () => {
     for (const bad of ["", "short", "has spaces in it and is long enough!!!!!!!", "x".repeat(129)]) {
       expect(() => buildBridgeUrl({ webAppUrl: "http://localhost:3000", callbackPort: 4321, state: bad })).toThrow(/state/i);
+      expect(cliAuth.validateCliAuthState(bad)).toBeNull();
+    }
+  });
+
+  // A base with its own path or query silently yields a URL whose pathname is
+  // not /cli-auth, and garbage would throw a raw TypeError from the URL parser.
+  it("refuses a web app URL that does not resolve to /cli-auth", () => {
+    for (const webAppUrl of ["", "not a url", "http://localhost:3000/app", "http://localhost:3000?next=/x", "http://localhost:3000#frag"]) {
+      expect(() => buildBridgeUrl({ webAppUrl, callbackPort: 4321, state })).toThrow(/sign-in URL/i);
+    }
+  });
+
+  it("refuses a web app URL that is not http(s)", () => {
+    for (const webAppUrl of ["file:///tmp", "javascript:alert(1)//", "ftp://example.com"]) {
+      expect(() => buildBridgeUrl({ webAppUrl, callbackPort: 4321, state })).toThrow(/sign-in URL/i);
     }
   });
 });

--- a/packages/protocol/eval/ops/tests/server.spec.ts
+++ b/packages/protocol/eval/ops/tests/server.spec.ts
@@ -7,8 +7,9 @@ import { FsArtifactSource } from "../ops.artifacts.js";
 import { OneTimeStateStore, OpsSessionStore, type IdentityResolver, type ResolvedIdentity } from "../ops.auth.js";
 import type { ExecutionStep, RunExecutor } from "../ops.executor.js";
 import { SEED_STEP_CWD, type FixtureCounts, type FixtureInspector } from "../ops.fixture.js";
+import { isOpsServerPath, OPS_CALLBACK_PATH } from "../ops.paths.js";
 import { RunQueue } from "../ops.queue.js";
-import { createDefaultOpsContext, createOpsHandler, PUBLIC_ROUTES, type OpsContext } from "../ops.server.js";
+import { createDefaultOpsContext, createOpsHandler, PUBLIC_ROUTES, resolveIdentityEndpoints, type OpsContext } from "../ops.server.js";
 import { FsRunStore, type RunStore } from "../ops.store.js";
 import type { RunRecord } from "../ops.types.js";
 
@@ -110,6 +111,7 @@ async function build(overrides: Partial<OpsContext> = {}): Promise<void> {
       identities,
       webAppUrl: "https://index.network",
       callbackPort: 4321,
+      uiUrl: "http://127.0.0.1:5174",
     },
     ...overrides,
   };
@@ -795,6 +797,34 @@ describe("authentication", () => {
       ]);
     });
 
+    it("claims every route it serves, so an embedder cannot answer one itself", () => {
+      // apps/eval-ops/server.ts mounts this handler behind a static file server and
+      // has to decide, per request, which one answers. It used to ask
+      // `startsWith("/api/")`, which is false for /callback — so the SPA answered
+      // the sign-in bridge with index.html and left the minted API key in the
+      // browser's history for a sign-in that could never complete. The forwarding
+      // rule is now isOpsServerPath, and this pins it against the inventory above:
+      // a route added outside /api/ fails here rather than falling through.
+      for (const route of API_ROUTES) {
+        expect(isOpsServerPath(route.path.split("?")[0])).toBe(true);
+      }
+      expect(isOpsServerPath(OPS_CALLBACK_PATH)).toBe(true);
+      // And it claims nothing the SPA owns.
+      for (const spa of ["/", "/index.html", "/assets/app.js", "/launch", "/r/some-id"]) {
+        expect(isOpsServerPath(spa)).toBe(false);
+      }
+    });
+
+    it("answers /callback at the one path the bridge accepts", async () => {
+      // validateCliCallbackUrl in apps/web/src/lib/cli-auth.ts requires exactly
+      // this pathname, so the constant the forwarding rule shares is the same one
+      // the handler dispatches on.
+      const state = states.mint();
+      const response = await handler(new Request(`http://localhost${OPS_CALLBACK_PATH}?state=${state}&api_key=k`));
+
+      expect(response.status).toBe(302);
+    });
+
     it("gates the unknown-route 404 as well, so probing needs a session", async () => {
       // A 404 that answers anonymously would still confirm which routes exist.
       expect((await anonymous("GET", "/api/nope")).status).toBe(401);
@@ -839,13 +869,15 @@ describe("authentication", () => {
   describe("GET /callback", () => {
     const callback = (query: string) => handler(new Request(`http://localhost/callback?${query}`));
 
-    it("establishes a session and redirects to the app", async () => {
+    it("establishes a session and redirects to the configured UI", async () => {
       const state = states.mint();
 
       const response = await callback(`state=${state}&api_key=k`);
 
       expect(response.status).toBe(302);
-      expect(response.headers.get("location")).toBe("/");
+      // Not a bare "/": in the documented two-process flow this API serves no UI,
+      // so "/" is its own 404 and the operator has to navigate back by hand.
+      expect(response.headers.get("location")).toBe("http://127.0.0.1:5174");
       const cookie = response.headers.get("set-cookie") ?? "";
       expect(cookie).toMatch(/HttpOnly/i);
       expect(cookie).toMatch(/SameSite=Lax/i);
@@ -1020,12 +1052,67 @@ describe("authentication", () => {
   });
 });
 
+describe("resolveIdentityEndpoints", () => {
+  // The bridge mints the API key and the resolver verifies it, so the two are one
+  // pair. A mismatched pair does not fail at startup: it fails at the end of a
+  // browser round-trip as "No Index account could be resolved for this sign-in",
+  // which reads like a permissions problem and is not one. Pure, so this needs no
+  // server, socket or environment mutation.
+  it("defaults both endpoints to the same environment", () => {
+    const resolved = resolveIdentityEndpoints({});
+
+    // Both local. The old defaults paired a production bridge with a local API.
+    expect(resolved).toEqual({ webAppUrl: "http://localhost:3000", apiUrl: "http://localhost:3001" });
+  });
+
+  it("refuses a half-configured pair rather than silently defaulting the other half", () => {
+    // This is exactly how the production-bridge/local-resolver trap was reachable.
+    expect(() => resolveIdentityEndpoints({ WEB_APP_URL: "https://index.network" })).toThrow(/API_URL/);
+    expect(() => resolveIdentityEndpoints({ API_URL: "https://protocol.dev.index.network" })).toThrow(/WEB_APP_URL/);
+  });
+
+  it("refuses a local bridge with a remote resolver, and the reverse", () => {
+    expect(() =>
+      resolveIdentityEndpoints({ WEB_APP_URL: "https://index.network", API_URL: "http://localhost:3001" }),
+    ).toThrow(/not the same environment/);
+    expect(() =>
+      resolveIdentityEndpoints({ WEB_APP_URL: "http://localhost:3000", API_URL: "https://protocol.dev.index.network" }),
+    ).toThrow(/not the same environment/);
+  });
+
+  it("accepts a coherent pair, local or remote", () => {
+    expect(resolveIdentityEndpoints({ WEB_APP_URL: "http://localhost:3000", API_URL: "http://127.0.0.1:3001" }))
+      .toEqual({ webAppUrl: "http://localhost:3000", apiUrl: "http://127.0.0.1:3001" });
+    // The pair .env.test sets, which is what `eval:web` actually runs with.
+    expect(resolveIdentityEndpoints({ WEB_APP_URL: "https://dev.index.network", API_URL: "https://protocol.dev.index.network" }))
+      .toEqual({ webAppUrl: "https://dev.index.network", apiUrl: "https://protocol.dev.index.network" });
+  });
+
+  it("reads an empty value as unset, not as an empty origin", () => {
+    expect(resolveIdentityEndpoints({ WEB_APP_URL: "  ", API_URL: "" })).toEqual({
+      webAppUrl: "http://localhost:3000",
+      apiUrl: "http://localhost:3001",
+    });
+  });
+
+  it("refuses a value that is not a URL at all", () => {
+    expect(() => resolveIdentityEndpoints({ WEB_APP_URL: "index.network", API_URL: "http://localhost:3001" }))
+      .toThrow(/not a usable URL/);
+  });
+});
+
 describe("createDefaultOpsContext", () => {
-  const ENV_KEYS = ["API_URL", "WEB_APP_URL", "EVAL_OPS_PORT"] as const;
+  const ENV_KEYS = ["API_URL", "WEB_APP_URL", "EVAL_OPS_PORT", "EVAL_OPS_UI_URL"] as const;
   const original: Record<string, string | undefined> = {};
 
   beforeEach(() => {
-    for (const key of ENV_KEYS) original[key] = process.env[key];
+    // Saved and then cleared: these tests assert what the *defaults* wire, so an
+    // ambient API_URL or WEB_APP_URL in the shell that runs them would otherwise
+    // decide the answer — and a half-set ambient pair now refuses to start.
+    for (const key of ENV_KEYS) {
+      original[key] = process.env[key];
+      delete process.env[key];
+    }
   });
 
   afterEach(() => {
@@ -1040,7 +1127,9 @@ describe("createDefaultOpsContext", () => {
     // it. If they ever disagree the bridge delivers the credential to a port
     // nothing is listening on, and sign-in fails with no visible cause.
     process.env.EVAL_OPS_PORT = "4399";
+    // Set as a pair: a half-configured environment now refuses to start.
     process.env.WEB_APP_URL = "https://index.network";
+    process.env.API_URL = "https://protocol.index.network";
 
     const built = await createDefaultOpsContext({ repoRoot: root });
     const response = await createOpsHandler(built)(
@@ -1062,5 +1151,42 @@ describe("createDefaultOpsContext", () => {
     // An anonymous read is refused by the context the real entrypoint uses.
     const response = await createOpsHandler(built)(new Request("http://localhost/api/runs"));
     expect(response.status).toBe(401);
+  });
+
+  it("sends a completed sign-in to the UI, not to a route this server does not serve", async () => {
+    // The standalone API serves no UI: a bare "/" here is its own 404.
+    const built = await createDefaultOpsContext({ repoRoot: root });
+
+    expect(built.auth?.uiUrl).toBe("http://127.0.0.1:5174");
+  });
+
+  it("lets an embedder that serves the UI itself say so", async () => {
+    // apps/eval-ops/server.ts serves the SPA on the same origin as the API.
+    const built = await createDefaultOpsContext({ repoRoot: root, uiUrl: "/" });
+
+    expect(built.auth?.uiUrl).toBe("/");
+  });
+
+  it("lets the environment override the redirect target", async () => {
+    process.env.EVAL_OPS_UI_URL = "http://127.0.0.1:6000";
+
+    const built = await createDefaultOpsContext({ repoRoot: root, uiUrl: "/" });
+
+    expect(built.auth?.uiUrl).toBe("http://127.0.0.1:6000");
+  });
+
+  it("refuses to send a completed sign-in off loopback", async () => {
+    // Configuration, never a request parameter — but a sign-in that hands the
+    // browser to another origin is a mistake worth refusing loudly.
+    process.env.EVAL_OPS_UI_URL = "https://evil.example";
+
+    await expect(createDefaultOpsContext({ repoRoot: root })).rejects.toThrow(/loopback/);
+  });
+
+  it("refuses to start on a half-configured identity pair", async () => {
+    process.env.WEB_APP_URL = "https://index.network";
+    delete process.env.API_URL;
+
+    await expect(createDefaultOpsContext({ repoRoot: root })).rejects.toThrow(/API_URL/);
   });
 });

--- a/packages/protocol/eval/ops/tests/server.spec.ts
+++ b/packages/protocol/eval/ops/tests/server.spec.ts
@@ -920,6 +920,19 @@ describe("authentication", () => {
       expect(text).toContain("&lt;img");
     });
 
+    it("escapes each character once, without re-escaping its own ampersands", async () => {
+      // A chained replace that escaped < before & would turn < into &amp;lt;,
+      // rendering the escape itself. One pass cannot get the order wrong. The
+      // address is the only interpolated value, so this is the whole sink.
+      identities.identity = { email: `a&b<c>"d'e@evil.example`, emailVerified: true, name: "x" };
+      const state = states.mint();
+
+      const text = await (await callback(`state=${state}&api_key=k`)).text();
+
+      expect(text).toContain("a&amp;b&lt;c&gt;&quot;d&#39;e@evil.example");
+      expect(text).not.toContain("&amp;lt;");
+    });
+
     it("answers 502 when the identity service cannot be reached", async () => {
       // "The API is down" is not "you are not allowed in", and must not read as it.
       identities.failure = new Error("connect ECONNREFUSED 127.0.0.1:3001");

--- a/packages/protocol/eval/ops/tests/server.spec.ts
+++ b/packages/protocol/eval/ops/tests/server.spec.ts
@@ -4,10 +4,11 @@ import { tmpdir } from "node:os";
 import path from "node:path";
 
 import { FsArtifactSource } from "../ops.artifacts.js";
+import { OneTimeStateStore, OpsSessionStore, type IdentityResolver, type ResolvedIdentity } from "../ops.auth.js";
 import type { ExecutionStep, RunExecutor } from "../ops.executor.js";
 import { SEED_STEP_CWD, type FixtureCounts, type FixtureInspector } from "../ops.fixture.js";
 import { RunQueue } from "../ops.queue.js";
-import { createOpsHandler, type OpsContext } from "../ops.server.js";
+import { createDefaultOpsContext, createOpsHandler, PUBLIC_ROUTES, type OpsContext } from "../ops.server.js";
 import { FsRunStore, type RunStore } from "../ops.store.js";
 import type { RunRecord } from "../ops.types.js";
 
@@ -50,11 +51,30 @@ const COUNTS: FixtureCounts = {
   tables: { users: 2, intents: 5, opportunities: 7 },
 };
 
+/** Hands back whatever identity a test set, without an API, a socket or a key. */
+class StubIdentityResolver implements IdentityResolver {
+  /** Credentials this resolver was handed, so a test can prove one was discarded. */
+  readonly seen: string[] = [];
+  identity: ResolvedIdentity | null = { email: "operator@index.network", emailVerified: true, name: "Operator" };
+  failure: Error | null = null;
+
+  async resolve(apiKey: string): Promise<ResolvedIdentity | null> {
+    this.seen.push(apiKey);
+    if (this.failure !== null) throw this.failure;
+    return this.identity;
+  }
+}
+
 let root: string;
 let store: FsRunStore;
 let executor: FakeExecutor;
 let context: OpsContext;
 let handler: (request: Request) => Promise<Response>;
+let states: OneTimeStateStore;
+let sessions: OpsSessionStore;
+let identities: StubIdentityResolver;
+/** A `Cookie` header for a signed-in operator, refreshed by `signIn()`. */
+let sessionCookie: Record<string, string>;
 
 async function build(overrides: Partial<OpsContext> = {}): Promise<void> {
   const evalDir = path.join(root, "eval");
@@ -70,6 +90,9 @@ async function build(overrides: Partial<OpsContext> = {}): Promise<void> {
   );
   store = new FsRunStore({ evalDir });
   executor = new FakeExecutor(store);
+  states = new OneTimeStateStore();
+  sessions = new OpsSessionStore();
+  identities = new StubIdentityResolver();
   context = {
     evalDir,
     protocolDir: root,
@@ -81,9 +104,39 @@ async function build(overrides: Partial<OpsContext> = {}): Promise<void> {
     queue: new RunQueue({ executor, store }),
     databaseUrl: DATABASE_URL,
     inspector: { count: async () => COUNTS },
+    auth: {
+      states,
+      sessions,
+      identities,
+      webAppUrl: "https://index.network",
+      callbackPort: 4321,
+    },
     ...overrides,
   };
   handler = createOpsHandler(context);
+  sessionCookie = {};
+  await signIn();
+}
+
+/**
+ * Drives a full bridge round-trip and leaves `sessionCookie` holding the session.
+ *
+ * Called by `build()` rather than only once, because a test that rebuilds the
+ * context gets fresh stores — a cookie minted against the old ones would no
+ * longer resolve, and every assertion after it would fail on a 401 instead of
+ * the behaviour it meant to check.
+ */
+async function signIn(): Promise<void> {
+  const state = states.mint();
+  const response = await handler(
+    new Request(`http://localhost/callback?state=${state}&api_key=test-credential`),
+  );
+  const cookie = response.headers.get("set-cookie");
+  if (cookie === null) throw new Error(`sign-in did not set a session cookie (status ${response.status})`);
+  sessionCookie = { Cookie: cookie.split(";")[0] };
+  // The sign-in above exchanged one credential; a test asserting "the credential
+  // was never looked at" must not see this one.
+  identities.seen.length = 0;
 }
 
 beforeEach(async () => {
@@ -95,12 +148,17 @@ afterEach(async () => {
   await rm(root, { recursive: true, force: true });
 });
 
-const get = (url: string) => handler(new Request(`http://localhost${url}`));
+// Every existing test drives the server as a signed-in operator: authentication
+// is a new gate in front of behaviour those tests already pinned, so they carry
+// the session and keep asserting the behaviour rather than the gate. The gate
+// itself is pinned by `describe("authentication")` below.
+const get = (url: string, headers: Record<string, string> = {}) =>
+  handler(new Request(`http://localhost${url}`, { headers: { ...sessionCookie, ...headers } }));
 const post = (url: string, body: unknown, headers: Record<string, string> = {}) =>
   handler(
     new Request(`http://localhost${url}`, {
       method: "POST",
-      headers: { "Content-Type": "application/json", ...headers },
+      headers: { "Content-Type": "application/json", ...sessionCookie, ...headers },
       body: JSON.stringify(body),
     }),
   );
@@ -250,7 +308,7 @@ describe("POST /api/runs", () => {
     const response = await handler(
       new Request("http://localhost/api/runs", {
         method: "POST",
-        headers: { "Content-Type": "application/json" },
+        headers: { "Content-Type": "application/json", ...sessionCookie },
         body: "not json",
       }),
     );
@@ -344,7 +402,7 @@ describe("cross-origin requests", () => {
     const response = await handler(
       new Request("http://localhost/api/runs", {
         method: "POST",
-        headers: { "Content-Type": "text/plain;charset=UTF-8" },
+        headers: { "Content-Type": "text/plain;charset=UTF-8", ...sessionCookie },
         body: JSON.stringify(RUN_BODY),
       }),
     );
@@ -356,7 +414,7 @@ describe("cross-origin requests", () => {
 
   it("leaves reads reachable: a GET is not a state change", async () => {
     const response = await handler(
-      new Request("http://localhost/api/harnesses", { headers: { Origin: "https://evil.example" } }),
+      new Request("http://localhost/api/harnesses", { headers: { Origin: "https://evil.example", ...sessionCookie } }),
     );
     // Nothing here mutates, and without a CORS header the body stays unreadable
     // — provided the request actually reached this server as a loopback host,
@@ -372,8 +430,10 @@ describe("Host header guard", () => {
   // CORS header is needed to read the reply. Only the Host header still names the
   // attacker's domain, so it is the one value worth checking — and unlike the
   // Origin guard it must apply to reads, which are what rebinding exists to steal.
+  // Carries the session so the acceptance cases below reach the route rather than
+  // the auth gate; the refusal cases are unaffected, since Host is checked first.
   const withHost = (host: string, path = "/api/harnesses") =>
-    handler(new Request(`http://localhost${path}`, { headers: { Host: host } }));
+    handler(new Request(`http://localhost${path}`, { headers: { Host: host, ...sessionCookie } }));
 
   it("refuses a GET whose Host names a foreign domain", async () => {
     const response = await withHost("evil.example.com");
@@ -399,7 +459,7 @@ describe("Host header guard", () => {
   it("accepts a request with no Host header", async () => {
     // curl over an explicit socket, and any hop that drops it. A request with no
     // Host was not steered here by a resolved name, so rebinding does not apply.
-    const response = await handler(new Request("http://localhost/api/harnesses"));
+    const response = await handler(new Request("http://localhost/api/harnesses", { headers: { ...sessionCookie } }));
 
     expect(response.status).toBe(200);
   });
@@ -665,5 +725,329 @@ describe("POST /api/fixture/reset", () => {
     expect((await response.json()).error).toMatch(/reset/i);
     release();
     await Bun.sleep(10);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Authentication
+// ---------------------------------------------------------------------------
+
+/**
+ * Every `/api/*` route this server answers, as (method, path) pairs.
+ *
+ * Hand-maintained on purpose: the point of the inventory test below is that
+ * adding a route to ops.server.ts without deciding whether it is public fails
+ * here, and a list derived from the router itself could not detect that.
+ */
+const API_ROUTES: ReadonlyArray<{ method: "GET" | "POST"; path: string }> = [
+  { method: "GET", path: "/api/auth/status" },
+  { method: "POST", path: "/api/auth/login" },
+  { method: "POST", path: "/api/auth/logout" },
+  { method: "GET", path: "/api/harnesses" },
+  { method: "GET", path: "/api/profiles" },
+  { method: "GET", path: "/api/artifacts" },
+  { method: "GET", path: "/api/artifacts/some-id" },
+  { method: "GET", path: "/api/compare?reference=a&subject=b" },
+  { method: "GET", path: "/api/runs" },
+  { method: "GET", path: "/api/runs/some-id/stream" },
+  { method: "GET", path: "/api/fixture" },
+  { method: "POST", path: "/api/runs" },
+  { method: "POST", path: "/api/runs/some-id/cancel" },
+  { method: "POST", path: "/api/fixture/reset" },
+];
+
+describe("authentication", () => {
+  /** Sends a request with no session at all. */
+  const anonymous = (method: "GET" | "POST", url: string) =>
+    handler(
+      new Request(`http://localhost${url}`, {
+        method,
+        headers: method === "POST" ? { "Content-Type": "application/json" } : {},
+        body: method === "POST" ? "{}" : undefined,
+      }),
+    );
+
+  describe("the gate covers every route", () => {
+    // The whole failure mode of this task is a route that forgets the gate. This
+    // enumerates the server's surface and asserts each entry is either on the
+    // public allowlist or refuses an anonymous caller — so a new route added
+    // without a decision about access fails here rather than shipping unguarded.
+    for (const route of API_ROUTES) {
+      const isPublic = PUBLIC_ROUTES.some(
+        (entry) => entry.method === route.method && route.path.split("?")[0] === entry.path,
+      );
+
+      it(`${route.method} ${route.path} is ${isPublic ? "public by decision" : "session-gated"}`, async () => {
+        const response = await anonymous(route.method, route.path);
+
+        if (isPublic) {
+          expect(response.status).not.toBe(401);
+        } else {
+          expect(response.status).toBe(401);
+        }
+      });
+    }
+
+    it("pins the public allowlist, so widening it is a deliberate edit", () => {
+      expect([...PUBLIC_ROUTES].map((entry) => `${entry.method} ${entry.path}`).sort()).toEqual([
+        "GET /api/auth/status",
+        "POST /api/auth/login",
+      ]);
+    });
+
+    it("gates the unknown-route 404 as well, so probing needs a session", async () => {
+      // A 404 that answers anonymously would still confirm which routes exist.
+      expect((await anonymous("GET", "/api/nope")).status).toBe(401);
+      expect((await get("/api/nope")).status).toBe(404);
+    });
+  });
+
+  describe("GET /api/auth/status", () => {
+    it("reports an anonymous caller without a session", async () => {
+      const response = await anonymous("GET", "/api/auth/status");
+
+      expect(response.status).toBe(200);
+      expect(await response.json()).toEqual({ authenticated: false });
+    });
+
+    it("reports the signed-in identity", async () => {
+      const body = await (await get("/api/auth/status")).json();
+
+      expect(body).toEqual({ authenticated: true, email: "operator@index.network", name: "Operator" });
+    });
+  });
+
+  describe("POST /api/auth/login", () => {
+    it("returns a bridge URL carrying a fresh one-time state", async () => {
+      const body = await (await anonymous("POST", "/api/auth/login")).json();
+      const url = new URL(body.url);
+
+      expect(url.origin + url.pathname).toBe("https://index.network/cli-auth");
+      expect(url.searchParams.get("callback")).toBe("http://127.0.0.1:4321/callback");
+      expect(url.searchParams.get("version")).toBe("2");
+      expect(url.searchParams.get("state")).toMatch(/^[A-Za-z0-9_-]{32,128}$/);
+    });
+
+    it("mints a distinct state per call", async () => {
+      const first = new URL((await (await anonymous("POST", "/api/auth/login")).json()).url);
+      const second = new URL((await (await anonymous("POST", "/api/auth/login")).json()).url);
+
+      expect(first.searchParams.get("state")).not.toBe(second.searchParams.get("state"));
+    });
+  });
+
+  describe("GET /callback", () => {
+    const callback = (query: string) => handler(new Request(`http://localhost/callback?${query}`));
+
+    it("establishes a session and redirects to the app", async () => {
+      const state = states.mint();
+
+      const response = await callback(`state=${state}&api_key=k`);
+
+      expect(response.status).toBe(302);
+      expect(response.headers.get("location")).toBe("/");
+      const cookie = response.headers.get("set-cookie") ?? "";
+      expect(cookie).toMatch(/HttpOnly/i);
+      expect(cookie).toMatch(/SameSite=Lax/i);
+      expect(cookie).toMatch(/Path=\//);
+      // Loopback is plain http: a Secure cookie would be dropped by the browser
+      // and sign-in would fail silently.
+      expect(cookie).not.toMatch(/Secure/i);
+    });
+
+    it("refuses a state this server never minted", async () => {
+      const response = await callback("state=not-a-real-state&api_key=k");
+
+      expect(response.status).toBe(403);
+      // The credential must not even be looked at once the state fails.
+      expect(identities.seen).toHaveLength(0);
+      expect(response.headers.get("set-cookie")).toBeNull();
+    });
+
+    it("refuses a replayed state, so a copied callback URL cannot sign in twice", async () => {
+      const state = states.mint();
+      expect((await callback(`state=${state}&api_key=k`)).status).toBe(302);
+
+      const replay = await callback(`state=${state}&api_key=k`);
+
+      expect(replay.status).toBe(403);
+      expect(replay.headers.get("set-cookie")).toBeNull();
+    });
+
+    it("refuses a callback with no credential", async () => {
+      const state = states.mint();
+
+      const response = await callback(`state=${state}`);
+
+      expect(response.status).toBe(403);
+      expect(identities.seen).toHaveLength(0);
+    });
+
+    it("refuses an identity outside the allowed domain and discards the credential", async () => {
+      identities.identity = { email: "someone@evil.example", emailVerified: true, name: "Outsider" };
+      const state = states.mint();
+
+      const response = await callback(`state=${state}&api_key=radioactive`);
+      const text = await response.text();
+
+      expect(response.status).toBe(403);
+      expect(response.headers.get("set-cookie")).toBeNull();
+      // Exchanged once, then dropped: never echoed to the browser.
+      expect(identities.seen).toEqual(["radioactive"]);
+      expect(text).not.toContain("radioactive");
+    });
+
+    it("refuses an unverified address", async () => {
+      identities.identity = { email: "operator@index.network", emailVerified: false, name: "Operator" };
+      const state = states.mint();
+
+      expect((await callback(`state=${state}&api_key=k`)).status).toBe(403);
+    });
+
+    it("escapes the refusal reason rather than rendering the address as markup", async () => {
+      // The address is user-controlled and the reason interpolates it verbatim,
+      // so the callback page is an injection sink unless it escapes.
+      identities.identity = {
+        email: "<img src=x onerror=alert(1)>@evil.example",
+        emailVerified: true,
+        name: "x",
+      };
+      const state = states.mint();
+
+      const text = await (await callback(`state=${state}&api_key=k`)).text();
+
+      expect(text).not.toContain("<img src=x");
+      expect(text).toContain("&lt;img");
+    });
+
+    it("answers 502 when the identity service cannot be reached", async () => {
+      // "The API is down" is not "you are not allowed in", and must not read as it.
+      identities.failure = new Error("connect ECONNREFUSED 127.0.0.1:3001");
+      const state = states.mint();
+
+      const response = await callback(`state=${state}&api_key=k`);
+
+      expect(response.status).toBe(502);
+      expect(response.headers.get("set-cookie")).toBeNull();
+    });
+
+    it("refuses a callback addressed to a foreign host", async () => {
+      // The bridge redirect lands in a browser, so the rebinding guard must cover
+      // this route too — it is not under /api/.
+      const state = states.mint();
+
+      const response = await handler(
+        new Request(`http://localhost/callback?state=${state}&api_key=k`, {
+          headers: { Host: "evil.example.com" },
+        }),
+      );
+
+      expect(response.status).toBe(403);
+      expect(identities.seen).toHaveLength(0);
+    });
+  });
+
+  describe("POST /api/auth/logout", () => {
+    it("clears the session and requires one to call", async () => {
+      expect((await anonymous("POST", "/api/auth/logout")).status).toBe(401);
+
+      const response = await post("/api/auth/logout", {});
+
+      expect(response.status).toBe(200);
+      expect((await (await get("/api/auth/status")).json()).authenticated).toBe(false);
+      // The gate closes again immediately.
+      expect((await get("/api/runs")).status).toBe(401);
+    });
+  });
+
+  describe("401 and 403 are distinguishable", () => {
+    it("answers 401 with no session and 403 for a session the policy later refuses", async () => {
+      expect((await anonymous("GET", "/api/runs")).status).toBe(401);
+
+      // A session established for an identity the policy no longer admits: the
+      // UI must be able to tell "sign in" from "your account is not permitted".
+      const stale = sessions.establish({ email: "someone@evil.example", name: "Outsider" });
+      const response = await handler(
+        new Request("http://localhost/api/runs", { headers: { Cookie: `eval_ops_session=${stale}` } }),
+      );
+
+      expect(response.status).toBe(403);
+    });
+  });
+
+  describe("the existing loopback guards still apply", () => {
+    it("refuses a foreign Host before it considers the session", async () => {
+      const response = await handler(
+        new Request("http://localhost/api/runs", { headers: { Host: "evil.example.com", ...sessionCookie } }),
+      );
+
+      expect(response.status).toBe(403);
+      expect((await response.json()).error).toMatch(/evil\.example\.com/);
+    });
+
+    it("refuses a cross-origin write from a signed-in browser", async () => {
+      // A session does not license a drive-by: both guards still have to pass.
+      const response = await post("/api/runs", RUN_BODY, { Origin: "https://evil.example" });
+
+      expect(response.status).toBe(403);
+      expect((await store.list()).records).toHaveLength(0);
+    });
+
+    it("still requires a JSON content type on a signed-in write", async () => {
+      const response = await handler(
+        new Request("http://localhost/api/runs", {
+          method: "POST",
+          headers: { "Content-Type": "text/plain;charset=UTF-8", ...sessionCookie },
+          body: JSON.stringify(RUN_BODY),
+        }),
+      );
+
+      expect(response.status).toBe(415);
+    });
+  });
+});
+
+describe("createDefaultOpsContext", () => {
+  const ENV_KEYS = ["API_URL", "WEB_APP_URL", "EVAL_OPS_PORT"] as const;
+  const original: Record<string, string | undefined> = {};
+
+  beforeEach(() => {
+    for (const key of ENV_KEYS) original[key] = process.env[key];
+  });
+
+  afterEach(() => {
+    for (const key of ENV_KEYS) {
+      if (original[key] === undefined) delete process.env[key];
+      else process.env[key] = original[key];
+    }
+  });
+
+  it("builds a callback on the port the server actually binds", async () => {
+    // ops.serve.ts binds EVAL_OPS_PORT and this builds the bridge callback from
+    // it. If they ever disagree the bridge delivers the credential to a port
+    // nothing is listening on, and sign-in fails with no visible cause.
+    process.env.EVAL_OPS_PORT = "4399";
+    process.env.WEB_APP_URL = "https://index.network";
+
+    const built = await createDefaultOpsContext({ repoRoot: root });
+    const response = await createOpsHandler(built)(
+      new Request("http://localhost/api/auth/login", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: "{}",
+      }),
+    );
+    const url = new URL((await response.json()).url);
+
+    expect(url.searchParams.get("callback")).toBe("http://127.0.0.1:4399/callback");
+  });
+
+  it("wires identity, so the default server is never unauthenticated", async () => {
+    const built = await createDefaultOpsContext({ repoRoot: root });
+
+    expect(built.auth).toBeDefined();
+    // An anonymous read is refused by the context the real entrypoint uses.
+    const response = await createOpsHandler(built)(new Request("http://localhost/api/runs"));
+    expect(response.status).toBe(401);
   });
 });

--- a/packages/protocol/package.json
+++ b/packages/protocol/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@indexnetwork/protocol",
-  "version": "8.3.0",
+  "version": "8.4.0",
   "type": "module",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",


### PR DESCRIPTION
Restricts the eval ops site to users with a **verified `@index.network` Index identity**.

Stacked on #1315 — review that first; this PR targets `feat/eval-ops-website`, so its diff is only the auth work.

## Decisions

- **Reuse the existing better-auth identity** in `services/api`. No new credential store, no shared secret.
- **The site stays loopback-only.** All three existing guards (127.0.0.1 bind, `Host` check, `Origin` allowlist) are untouched and still run first. Auth is **defence in depth, not permission to expose**. `apps/eval-ops` remains excluded from the production build and Railway.

## Why the CLI bridge rather than a cookie

The ops site runs on `127.0.0.1:4321`/`:5174`; the API runs on `localhost:3001`. A better-auth session cookie is host-scoped, so the ops server cannot read it — "just forward the cookie" does not work here.

This repository already solves exactly this for a local tool needing an Index identity: the CLI browser-auth bridge. `index login` opens `/cli-auth` against the user's existing browser session, which mints a **revocable API key** and redirects it to a loopback callback. Reusing that is what "reuse better-auth" means in practice, and it is the established pattern rather than a new invention.

## Flow

1. Unauthenticated browser → sign-in screen.
2. `POST /api/auth/login` mints a one-time, expiring state and returns the bridge URL.
3. User signs in through the existing Index flow (Google OAuth / magic link).
4. The bridge mints an API key and redirects to `GET /callback`.
5. The server consumes the state **before** reading the credential, resolves the identity via `GET /api/auth/me`, and applies the domain policy.
6. Allowed → session established. Refused → credential discarded immediately.

## The domain policy

Allowed only when `emailVerified === true` **and** the domain is exactly `index.network` — the substring after the **last** `@`, lowercased, compared with `===`.

Two non-obvious rules, both found during review and both load-bearing:

- **Multi-`@` addresses are refused outright.** The last-`@` rule alone allows `a@evil.com?x=@index.network`. Neither Google OAuth nor magic link ever mints a quoted local part, so such a string means something went wrong upstream; refusing an address we cannot unambiguously parse beats picking an interpretation.
- **The domain must be LDH characters before comparison.** `String.prototype.toLowerCase()` is a *Unicode* operation: U+212A KELVIN SIGN lowercases to ASCII `k`, so `a@index.networ\u212A` folded to `index.network` and was **allowed**. A reviewer brute-forced all 1,112,064 code points to confirm U+212A was the only such character, and the fix is an allowlist rather than a point fix — the guard's complete preimage of the target is now provably the ASCII case-variants and nothing else.

Refused and tested: unverified email, `a@index.network.evil.com`, `a@sub.index.network`, homoglyphs, fullwidth, ideographic full stop, NUL/ZWSP, trailing dot, missing/empty/non-string email, `emailVerified` truthy-but-not-`true`.

## Enforcement

**Default-deny.** The gate runs *before* dispatch, so a route added later is gated unless deliberately added to a frozen, exported, test-pinned `PUBLIC_ROUTES` (exactly two entries: `GET /api/auth/status` and `POST /api/auth/login`). Unknown paths are gated too, so the 404 cannot be used to enumerate routes without a session.

`401` (no session) and `403` (session whose identity the policy refuses) are distinguished by a body discriminator, and the UI presents them differently — a 403 user is told the site is restricted to `@index.network`, never offered a sign-in loop.

The policy is re-evaluated on **every** request, so a session established earlier is not a licence.

## Safety properties

- The API key is never logged, never returned to the browser, never rendered, never stored in a session, and is discarded the moment the policy refuses. The state is consumed *before* the credential is read, so a forged callback never touches a key.
- The refusal page escapes the reason in a **single pass** — the reason interpolates a user-controlled email, on a page served under the operator's own loopback origin.
- Session cookie is `HttpOnly; SameSite=Lax; Path=/` and deliberately **not** `Secure` — loopback is plain http, so `Secure` would silently break sign-in.
- One-time state: single use (validation consumes), 5-minute TTL, constant-time comparison, capped at 64 pending.
- `sessions.establish()` has exactly one production call site, immediately behind `verdict.allowed === true`.

## Verification

| Gate | Result |
| :-- | :-- |
| `bun run eval:verify` | 13 suites, provider-free |
| `bun test eval/ops/tests/` | 253 pass |
| `apps/eval-ops` `bun run test` | 95 pass |
| `apps/eval-ops` `bun run typecheck` | clean |
| root `bun run lint` | 0 errors |

Tests are provider-free, database-free and network-free — the identity resolver is injected.

## Notable defects found by review

- `SignIn`/`NotPermitted` shipped **unmounted** — imported only by their own test file, with the shell rendering `<Outlet />` unconditionally, so an unauthenticated operator saw the whole dashboard with every route 401-erroring behind it. The unit tests passed because they rendered the components directly. Now gated, with an integration test whose strongest assertion is that *no non-auth fetch is ever issued* while signed out.
- `/callback` is not under `/api/`, and the single-process entrypoint forwarded only `/api/*` — so sign-in could never complete there, and the bridge-minted API key was left in the URL bar and browser history for a credential never exchanged. The forwarding rule now lives with the API as `isOpsServerPath`, so it cannot drift again.
- Default endpoints were an incoherent pair (production bridge, local resolver), which would have minted a production key for a local API to reject with an unhelpful message. The server now refuses to start on a mismatched pair.

## Known follow-ups (non-blocking)

- `isOpsServerPath` misses leading-double-slash forms (`//api/runs`). Fails **closed** — answered by the static file server, no API action executes, not browser-reachable.
- The pairing check is loopback-vs-remote, so it cannot see a dev-bridge/prod-resolver mismatch between two remotes.
- The refusal page's "return" link still points at `/`, which 404s in the two-process dev flow (failure path only).
- Sessions have no TTL or idle expiry; they live until the process exits.
- The bridge round-trip has not been exercised end-to-end (needs the web app and API running). First real sign-in is the true integration test.
