### PR TITLE
fix(api): grant CORS only to configured trusted origins

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -79,7 +79,11 @@ CONNECT_JWT_SECRET=              # Secret for signing connect redirect JWTs (48h
 # GOOGLE_CLIENT_ID=
 # GOOGLE_CLIENT_SECRET=
 
-# Comma-separated list of trusted origins for CORS
+# Comma-separated list of browser origins allowed to make credentialed requests
+# (CORS) and trusted by Better Auth. This list is the only source of that trust:
+# the API never trusts a caller's own Origin header. Entries are compared exactly
+# (scheme + host + port); anything that is not a valid http(s) origin is skipped
+# with a warning and never widens the set.
 # TRUSTED_ORIGINS=http://localhost:3000
 
 

--- a/bun.lock
+++ b/bun.lock
@@ -126,7 +126,7 @@
     },
     "services/api": {
       "name": "@indexnetwork/api",
-      "version": "0.70.0",
+      "version": "0.70.1",
       "dependencies": {
         "@aws-sdk/client-s3": "^3.939.0",
         "@aws-sdk/s3-request-presigner": "^3.983.0",

--- a/docs/guides/getting-started.md
+++ b/docs/guides/getting-started.md
@@ -486,7 +486,9 @@ The app's origin is not in the allowed list. Set `TRUSTED_ORIGINS` in the root `
 TRUSTED_ORIGINS=http://localhost:3000
 ```
 
-Restart the API service after changing this value.
+Restart the API service after changing this value. The origin must be listed
+exactly (scheme, host and port) — an unlisted browser origin receives no CORS
+grant at all, which also surfaces as a CORS error in the browser console.
 
 ### pgvector extension missing
 

--- a/services/api/package.json
+++ b/services/api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@indexnetwork/api",
-  "version": "0.70.0",
+  "version": "0.70.1",
   "license": "MIT",
   "private": true,
   "scripts": {

--- a/services/api/src/lib/cors.ts
+++ b/services/api/src/lib/cors.ts
@@ -1,3 +1,94 @@
+/**
+ * CORS policy for the API.
+ *
+ * One rule, one source: a browser origin is granted access only when it appears
+ * in `TRUSTED_ORIGINS`. The request's own `Origin` is never evidence of anything
+ * — reflecting it (as this module used to) with
+ * `Access-Control-Allow-Credentials: true` let any website read a signed-in
+ * user's `set-auth-jwt` from `/api/auth/token`, because the session cookie is
+ * `SameSite=None`.
+ *
+ * `getCorsHeaders` and `getTrustedOrigins` both read the same parsed set, so the
+ * CORS layer cannot grant an origin that Better Auth would not also trust.
+ *
+ * Callers that send no `Origin` (CLI, MCP clients, Telegram webhooks) are
+ * untouched: they get the base headers and no grant, exactly as before.
+ */
+import { log } from './log';
+
+const logger = log.lib.from('cors');
+
+/**
+ * Serialize an origin to `scheme://host[:port]`, or null if it is not one.
+ *
+ * `URL.origin` is the comparison key on both sides of the check, which makes the
+ * match exact rather than textual: a default port is dropped (`https://x:443` ===
+ * `https://x`), a trailing slash or path is discarded, and userinfo cannot smuggle
+ * a hostname (`https://index.network@evil.example` → `https://evil.example`).
+ *
+ * Non-HTTP(S) schemes are refused because `URL.origin` serializes them to the
+ * opaque `"null"`, which would make every one of them compare equal to every
+ * other and to a sandboxed browser context. `"null"` itself never parses, so an
+ * opaque origin can neither be sent nor configured into the trusted set.
+ */
+function normalizeOrigin(value: string): string | null {
+  const trimmed = value.trim();
+  if (!trimmed) return null;
+  let url: URL;
+  try {
+    url = new URL(trimmed);
+  } catch {
+    return null;
+  }
+  if (url.protocol !== 'http:' && url.protocol !== 'https:') return null;
+  if (!url.hostname) return null;
+  return url.origin;
+}
+
+/**
+ * Parsed `TRUSTED_ORIGINS`, cached against the raw value it was parsed from.
+ *
+ * Keyed by the raw string rather than parsed once at import so a changed
+ * environment is picked up (tests do this) while a request still costs one map
+ * lookup instead of a parse.
+ */
+let cache: { raw: string; origins: ReadonlySet<string> } | null = null;
+
+/**
+ * The configured trusted origins.
+ *
+ * A malformed entry is skipped and named in a warning, not fatal. Failing the
+ * boot would let one typo in one entry take the whole API down, and silently
+ * dropping it is how a trusted set quietly shrinks to nothing with no signal;
+ * the warning is emitted once per distinct `TRUSTED_ORIGINS` value, so it lands
+ * at startup on the first request rather than on every request. Skipping can
+ * only ever shrink the set — it never widens it.
+ */
+function trustedOrigins(): ReadonlySet<string> {
+  const raw = process.env.TRUSTED_ORIGINS ?? '';
+  if (cache && cache.raw === raw) return cache.origins;
+
+  const origins = new Set<string>();
+  const rejected: string[] = [];
+  for (const entry of raw.split(',')) {
+    const trimmed = entry.trim();
+    if (!trimmed) continue;
+    const normalized = normalizeOrigin(trimmed);
+    if (normalized === null) {
+      rejected.push(trimmed);
+      continue;
+    }
+    origins.add(normalized);
+  }
+
+  if (rejected.length > 0) {
+    logger.warn('Ignoring malformed TRUSTED_ORIGINS entries', { rejected, trusted: [...origins] });
+  }
+
+  cache = { raw, origins };
+  return origins;
+}
+
 export function getCorsHeaders(req: Request): Record<string, string> {
   const headers: Record<string, string> = {
     'Access-Control-Allow-Methods': 'GET, POST, PUT, PATCH, DELETE, OPTIONS',
@@ -7,28 +98,25 @@ export function getCorsHeaders(req: Request): Record<string, string> {
   };
 
   const origin = req.headers.get('Origin');
-  if (origin) {
-    headers['Access-Control-Allow-Origin'] = origin;
+  const normalized = origin ? normalizeOrigin(origin) : null;
+  // The normalized form is echoed, never the caller's raw string, so nothing
+  // from the request reaches a response header.
+  if (normalized !== null && trustedOrigins().has(normalized)) {
+    headers['Access-Control-Allow-Origin'] = normalized;
     headers['Access-Control-Allow-Credentials'] = 'true';
   }
 
   return headers;
 }
 
-/** Trusted origins for Better Auth from TRUSTED_ORIGINS env var plus request Origin. */
-export async function getTrustedOrigins(request?: Request): Promise<string[]> {
-  const origins = new Set<string>();
-
-  const envOrigins = process.env.TRUSTED_ORIGINS;
-  if (envOrigins) {
-    for (const o of envOrigins.split(',')) {
-      const trimmed = o.trim();
-      if (trimmed) origins.add(trimmed);
-    }
-  }
-
-  const reqOrigin = request?.headers?.get?.('Origin');
-  if (reqOrigin) origins.add(reqOrigin);
-
-  return [...origins];
+/**
+ * Trusted origins for Better Auth, from `TRUSTED_ORIGINS` only.
+ *
+ * The `request` parameter is part of Better Auth's `trustedOrigins` callback
+ * signature and is deliberately unused: adding the caller's own `Origin` here
+ * (as this used to) made Better Auth's trusted-origin check accept whatever the
+ * caller claimed to be.
+ */
+export async function getTrustedOrigins(_request?: Request): Promise<string[]> {
+  return [...trustedOrigins()];
 }

--- a/services/api/src/lib/tests/cors.spec.ts
+++ b/services/api/src/lib/tests/cors.spec.ts
@@ -1,0 +1,219 @@
+/**
+ * CORS origin policy.
+ *
+ * These tests exist because the API used to reflect *any* `Origin` back with
+ * `Access-Control-Allow-Credentials: true`, which let any website read a
+ * logged-in user's auth token (`/api/auth/token`, exposed via
+ * `Access-Control-Expose-Headers: set-auth-jwt`, with a `SameSite=None` session
+ * cookie). The grant must now come from configuration only.
+ */
+import { afterEach, beforeEach, describe, expect, test } from 'bun:test';
+
+import { getCorsHeaders, getTrustedOrigins } from '../cors';
+
+const PROD_LIKE = 'https://index.network';
+const DEV_LIKE = 'https://dev.index.network';
+const LOCAL_LIKE = 'http://localhost:3000';
+
+let savedTrustedOrigins: string | undefined;
+
+/** Build a request the way Bun.serve hands one to `getCorsHeaders`. */
+function request(origin?: string | null, method = 'GET'): Request {
+  const headers = new Headers();
+  if (origin !== undefined && origin !== null) headers.set('Origin', origin);
+  return new Request('https://protocol.index.network/api/auth/token', { method, headers });
+}
+
+/** The headers every response gets regardless of origin (no grant in here). */
+const BASE_HEADER_KEYS = [
+  'Access-Control-Allow-Methods',
+  'Access-Control-Allow-Headers',
+  'Access-Control-Expose-Headers',
+  'Access-Control-Max-Age',
+];
+
+beforeEach(() => {
+  savedTrustedOrigins = process.env.TRUSTED_ORIGINS;
+  process.env.TRUSTED_ORIGINS = `${PROD_LIKE},${LOCAL_LIKE}`;
+});
+
+afterEach(() => {
+  if (savedTrustedOrigins === undefined) delete process.env.TRUSTED_ORIGINS;
+  else process.env.TRUSTED_ORIGINS = savedTrustedOrigins;
+});
+
+describe('getCorsHeaders — grants', () => {
+  test('grants a configured origin, with credentials', () => {
+    const headers = getCorsHeaders(request(PROD_LIKE));
+    expect(headers['Access-Control-Allow-Origin']).toBe(PROD_LIKE);
+    expect(headers['Access-Control-Allow-Credentials']).toBe('true');
+  });
+
+  test('grants the local web dev origin from .env.development', () => {
+    process.env.TRUSTED_ORIGINS = `${DEV_LIKE},${LOCAL_LIKE}`;
+    const headers = getCorsHeaders(request(LOCAL_LIKE));
+    expect(headers['Access-Control-Allow-Origin']).toBe(LOCAL_LIKE);
+    expect(headers['Access-Control-Allow-Credentials']).toBe('true');
+  });
+
+  test('a configured entry written with a trailing slash still grants the browser origin', () => {
+    process.env.TRUSTED_ORIGINS = 'https://index.network/';
+    const headers = getCorsHeaders(request(PROD_LIKE));
+    expect(headers['Access-Control-Allow-Origin']).toBe(PROD_LIKE);
+  });
+
+  test('a default port on either side compares equal', () => {
+    process.env.TRUSTED_ORIGINS = 'https://index.network:443';
+    expect(getCorsHeaders(request(PROD_LIKE))['Access-Control-Allow-Origin']).toBe(PROD_LIKE);
+  });
+
+  test('picks up a changed TRUSTED_ORIGINS without a restart of the module', () => {
+    expect(getCorsHeaders(request(DEV_LIKE))['Access-Control-Allow-Origin']).toBeUndefined();
+    process.env.TRUSTED_ORIGINS = DEV_LIKE;
+    expect(getCorsHeaders(request(DEV_LIKE))['Access-Control-Allow-Origin']).toBe(DEV_LIKE);
+  });
+});
+
+describe('getCorsHeaders — refusals', () => {
+  test('an untrusted origin gets no CORS grant at all', () => {
+    const headers = getCorsHeaders(request('https://evil.example'));
+    expect(headers['Access-Control-Allow-Origin']).toBeUndefined();
+    expect(headers['Access-Control-Allow-Credentials']).toBeUndefined();
+  });
+
+  test('never echoes an untrusted origin into any header value', () => {
+    const headers = getCorsHeaders(request('https://evil.example'));
+    expect(Object.values(headers).join('|')).not.toContain('evil.example');
+  });
+
+  test.each([
+    ['suffix impostor', 'https://index.network.evil.com'],
+    ['subdomain impostor', 'https://evil.index.network'],
+    ['prefix impostor', 'https://index.networkevil.com'],
+    ['scheme mismatch', 'http://index.network'],
+    ['explicit non-default port', 'https://index.network:8443'],
+    ['userinfo smuggling', 'https://index.network@evil.example'],
+    ['path suffix', 'https://evil.example/https://index.network'],
+  ])('refuses a near-match: %s', (_label, origin) => {
+    const headers = getCorsHeaders(request(origin));
+    expect(headers['Access-Control-Allow-Origin']).toBeUndefined();
+    expect(headers['Access-Control-Allow-Credentials']).toBeUndefined();
+  });
+
+  test('refuses the opaque origin `null`', () => {
+    // `Origin: null` is presented by sandboxed iframes, data: URLs and some
+    // cross-origin redirects. It is unauthenticatable, so a grant to `null` is
+    // a grant to everyone. This must stay refused even if a client asks for it.
+    const headers = getCorsHeaders(request('null'));
+    expect(headers['Access-Control-Allow-Origin']).toBeUndefined();
+    expect(headers['Access-Control-Allow-Credentials']).toBeUndefined();
+  });
+
+  test('refuses a literal `null` entry in TRUSTED_ORIGINS too', () => {
+    process.env.TRUSTED_ORIGINS = `null,${PROD_LIKE}`;
+    expect(getCorsHeaders(request('null'))['Access-Control-Allow-Origin']).toBeUndefined();
+    expect(getCorsHeaders(request(PROD_LIKE))['Access-Control-Allow-Origin']).toBe(PROD_LIKE);
+  });
+
+  test('refuses a wildcard origin and does not honour `*` as configuration', () => {
+    process.env.TRUSTED_ORIGINS = `*,${PROD_LIKE}`;
+    expect(getCorsHeaders(request('https://evil.example'))['Access-Control-Allow-Origin']).toBeUndefined();
+    expect(getCorsHeaders(request('*'))['Access-Control-Allow-Origin']).toBeUndefined();
+    expect(getCorsHeaders(request(PROD_LIKE))['Access-Control-Allow-Origin']).toBe(PROD_LIKE);
+  });
+
+  test('grants nothing when TRUSTED_ORIGINS is unset or empty', () => {
+    delete process.env.TRUSTED_ORIGINS;
+    expect(getCorsHeaders(request(PROD_LIKE))['Access-Control-Allow-Origin']).toBeUndefined();
+    process.env.TRUSTED_ORIGINS = '   ,,  ';
+    expect(getCorsHeaders(request(PROD_LIKE))['Access-Control-Allow-Origin']).toBeUndefined();
+  });
+
+  test('a malformed entry does not widen the set', () => {
+    process.env.TRUSTED_ORIGINS = `not a url, ://broken , ${PROD_LIKE}`;
+    expect(getCorsHeaders(request('https://evil.example'))['Access-Control-Allow-Origin']).toBeUndefined();
+    expect(getCorsHeaders(request('not a url'))['Access-Control-Allow-Origin']).toBeUndefined();
+    expect(getCorsHeaders(request(PROD_LIKE))['Access-Control-Allow-Origin']).toBe(PROD_LIKE);
+  });
+});
+
+describe('getCorsHeaders — non-browser callers are unaffected', () => {
+  test('a request with no Origin gets exactly the base headers (CLI, MCP, Telegram)', () => {
+    const headers = getCorsHeaders(request());
+    expect(Object.keys(headers).sort()).toEqual([...BASE_HEADER_KEYS].sort());
+    expect(headers['Access-Control-Allow-Methods']).toBe('GET, POST, PUT, PATCH, DELETE, OPTIONS');
+    expect(headers['Access-Control-Allow-Headers']).toBe(
+      'Content-Type, Authorization, X-Requested-With, Accept, x-api-key'
+    );
+    expect(headers['Access-Control-Expose-Headers']).toBe('X-Session-Id, X-Chat-Persona, set-auth-jwt');
+    expect(headers['Access-Control-Max-Age']).toBe('86400');
+  });
+
+  test('an empty Origin header is treated as no origin', () => {
+    const headers = getCorsHeaders(request(''));
+    expect(headers['Access-Control-Allow-Origin']).toBeUndefined();
+    expect(headers['Access-Control-Allow-Credentials']).toBeUndefined();
+  });
+
+  test('the base headers are identical for trusted, untrusted and origin-less requests', () => {
+    const pick = (h: Record<string, string>) =>
+      Object.fromEntries(BASE_HEADER_KEYS.map((k) => [k, h[k]]));
+    const none = pick(getCorsHeaders(request()));
+    expect(pick(getCorsHeaders(request(PROD_LIKE)))).toEqual(none);
+    expect(pick(getCorsHeaders(request('https://evil.example')))).toEqual(none);
+  });
+});
+
+describe('getCorsHeaders — preflight (OPTIONS, main.ts:640)', () => {
+  test('a preflight from a trusted origin is granted and keeps the preflight headers', () => {
+    const headers = getCorsHeaders(request(PROD_LIKE, 'OPTIONS'));
+    expect(headers['Access-Control-Allow-Origin']).toBe(PROD_LIKE);
+    expect(headers['Access-Control-Allow-Credentials']).toBe('true');
+    expect(headers['Access-Control-Allow-Methods']).toContain('OPTIONS');
+    expect(headers['Access-Control-Max-Age']).toBe('86400');
+  });
+
+  test('a preflight from an untrusted origin is not granted', () => {
+    const headers = getCorsHeaders(request('https://evil.example', 'OPTIONS'));
+    expect(headers['Access-Control-Allow-Origin']).toBeUndefined();
+    expect(headers['Access-Control-Allow-Credentials']).toBeUndefined();
+  });
+});
+
+describe('getTrustedOrigins', () => {
+  test('does not echo the caller back as trusted', async () => {
+    const origins = await getTrustedOrigins(request('https://evil.example'));
+    expect(origins).not.toContain('https://evil.example');
+    expect(origins).toEqual([PROD_LIKE, LOCAL_LIKE]);
+  });
+
+  test('is identical with and without a request', async () => {
+    const withRequest = await getTrustedOrigins(request('https://evil.example'));
+    const withoutRequest = await getTrustedOrigins();
+    expect(withRequest).toEqual(withoutRequest);
+  });
+
+  test('normalises and de-duplicates configured entries', async () => {
+    process.env.TRUSTED_ORIGINS = `${PROD_LIKE}/, https://index.network:443 ,${PROD_LIKE}`;
+    expect(await getTrustedOrigins()).toEqual([PROD_LIKE]);
+  });
+
+  test('skips malformed entries instead of widening the set', async () => {
+    process.env.TRUSTED_ORIGINS = `not a url,*,ftp://index.network,${PROD_LIKE}`;
+    expect(await getTrustedOrigins()).toEqual([PROD_LIKE]);
+  });
+
+  test('is empty when TRUSTED_ORIGINS is unset', async () => {
+    delete process.env.TRUSTED_ORIGINS;
+    expect(await getTrustedOrigins(request(PROD_LIKE))).toEqual([]);
+  });
+
+  test('agrees with getCorsHeaders: anything CORS grants, Better Auth also trusts', async () => {
+    process.env.TRUSTED_ORIGINS = `${PROD_LIKE}/,${DEV_LIKE},${LOCAL_LIKE},garbage`;
+    const trusted = await getTrustedOrigins();
+    for (const candidate of [PROD_LIKE, DEV_LIKE, LOCAL_LIKE, 'https://evil.example', 'null', 'garbage']) {
+      const granted = getCorsHeaders(request(candidate))['Access-Control-Allow-Origin'] !== undefined;
+      expect(granted).toBe(trusted.includes(candidate));
+    }
+  });
+});


### PR DESCRIPTION
## Bug Fixes

Restricts CORS grants to configured trusted origins. Previously the API reflected **any** `Origin` back with `Access-Control-Allow-Credentials: true`, and `getTrustedOrigins` added the caller's own origin to Better Auth's trusted set.

### Why this matters

Confirmed live against **both** dev and production before the fix:

```
$ curl -i -H 'Origin: https://evil.example' https://protocol.index.network/api/auth/token
access-control-allow-origin: https://evil.example
access-control-allow-credentials: true
```

Combined with the session cookie being `SameSite=None; Secure` and `set-auth-jwt` sitting in `Access-Control-Expose-Headers`, any website a logged-in Index user visited could run `fetch('/api/auth/token', { credentials: 'include' })`, read the JWT, and replay it as `Authorization: Bearer` as that user. `getTrustedOrigins` echoing the caller meant Better Auth's own origin check did not constrain it either.

This was exploitable on production independent of any other change.

### The fix

- `getCorsHeaders` emits `Access-Control-Allow-Origin` / `-Credentials` **only** when the request `Origin` is in the configured set. An untrusted origin gets no grant at all.
- `getTrustedOrigins` no longer adds the caller's `Origin`; the set is configuration-only.
- Both derive from **one** parse and one normalizer, so a request CORS grants is always one Better Auth also trusts — the equivalence is structural, not two similar implementations.
- Comparison is exact scheme + host + port via `URL.origin`. Non-`http(s)` schemes are refused, because `URL.origin` serializes `file:`/`data:`/custom schemes to the literal `"null"`, which would otherwise all compare equal to each other and to a sandboxed browser context.
- `Origin: null` is refused and pinned by a test. It is presented by sandboxed iframes, `data:` URLs and cross-origin redirects, so it is unauthenticatable — granting it would reintroduce the same hole in a different shape.
- Malformed `TRUSTED_ORIGINS` entries are skipped and warned once, not fatal. A typo should not take the API down, and skipping can only ever shrink the set.

Requests with **no** `Origin` — the CLI, MCP clients, Telegram webhooks — are byte-identical to before.

## Tests

New `services/api/src/lib/tests/cors.spec.ts` — 30 tests, none existed previously: trusted grant, untrusted no-grant, no-`Origin` unchanged (exact key set and values), suffix / subdomain / prefix / scheme / port / userinfo near-matches refused, `Origin: null` refused, preflight both directions, `getTrustedOrigins` no longer echoing, and equivalence between the two functions.

Non-vacuity measured, not asserted: reverting the `getCorsHeaders` change fails 17 tests, reverting the `getTrustedOrigins` change fails 3.

## ⚠️ Pre-deploy gate

`TRUSTED_ORIGINS` is now load-bearing where it previously was not — the caller-echo used to mask a missing or wrong value. If a deployed environment omits the web app's origin, the failure is **not** just a CORS error: cookie-bearing Better Auth POSTs return `403 INVALID_ORIGIN` and sign-in calls carrying an absolute `callbackURL` return `403 INVALID_CALLBACK_URL`. That is the whole login flow.

Verified against the live Railway config:

| Environment | Frontend origins | `TRUSTED_ORIGINS` | |
| :-- | :-- | :-- | :-- |
| **main** | `https://index.network` | `https://index.network` | complete |
| **dev** | `https://dev.index.network`, `https://frontend-dev-0569.up.railway.app` | `https://dev.index.network` | **missing the Railway-generated URL** |

**Production is fully covered.** On dev, anyone using the Railway-generated frontend URL will lose auth after this deploys — it works today only because of the behaviour being removed. Either add that origin to dev's `TRUSTED_ORIGINS` before merging, or accept it as unused.

Rollback trigger: `403 INVALID_ORIGIN` or `403 INVALID_CALLBACK_URL` on sign-in after deploy.

## Known residual risk

The shipped macOS WKWebView (`apps/mac/IndexApp`) loads from `file://`, so its `Origin` is `null` and it is not in `TRUSTED_ORIGINS`. It should be unaffected: it sets `allowUniversalAccessFromFileURLs = true`, which bypasses CORS in WebKit, and it authenticates with `x-api-key` rather than the session cookie, so it never needed a credentialed grant — and `x-api-key` remains in `Access-Control-Allow-Headers` for all callers. This could not be verified without macOS/WebKit. Since this branch targets `dev`, smoke-test `/chat/stream` and `/conversations/stream` against `protocol.dev.index.network` before the change reaches production.

## Follow-ups (not blocking)

- `/api/auth/mcp/register` still carries Better Auth's upstream `Access-Control-Allow-Origin: *`. It carries no credentials, so it is not the vulnerability, and the wildcard is deliberate upstream for dynamic client registration.
- No `Vary: Origin`. Pre-existing; the failure mode behind a shared cache is a blocked request, not a leak, because `ACAO` must now equal the requester's origin.
- `chat.controller.ts` parses `TRUSTED_ORIGINS` separately with `includes` for the SSE origin check. Config-only and exact, but it should adopt the shared normalizer so the two cannot diverge on a trailing slash.
- The malformed-config warning is lazy; an API seeing only server-side traffic would never emit it.
