### PR TITLE
feat(eval-ops): deploy to Railway dev, run view, config management + A/B runs

### DIFF
--- a/apps/eval-ops/package.json
+++ b/apps/eval-ops/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@indexnetwork/eval-ops",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "private": true,
   "scripts": {
     "dev": "vite --host 127.0.0.1 --port 5174",

--- a/apps/eval-ops/railway.toml
+++ b/apps/eval-ops/railway.toml
@@ -1,0 +1,19 @@
+# Railway eval ops service configuration.
+#
+# This file exists because the root railway.toml is the API's config, and a
+# service without its own config inherits it — including
+# `preDeployCommand = "cd services/api && bun run db:migrate"`. That ran
+# drizzle-kit against this service on every deploy and failed only because no
+# DATABASE_URL was set. A migration is not this service's job.
+#
+# There is deliberately no healthcheckPath: every route on the ops server is
+# behind the Host allowlist, so a probe arriving with an internal hostname is
+# refused with 403 and would fail an otherwise healthy container.
+[build]
+watchPatterns = ["/apps/eval-ops/**", "/packages/protocol/eval/ops/**", "/bun.lock", "/package.json", "/apps/eval-ops/railway.toml"]
+buildCommand = "bun run build:package:protocol && cd apps/eval-ops && bun run build"
+
+[deploy]
+startCommand = "cd apps/eval-ops && bun server.ts"
+restartPolicyType = "ON_FAILURE"
+restartPolicyMaxRetries = 10

--- a/apps/eval-ops/server.ts
+++ b/apps/eval-ops/server.ts
@@ -33,6 +33,13 @@ const api = createOpsHandler(await createDefaultOpsContext({ repoRoot, uiUrl: '/
 const server = Bun.serve({
   hostname: resolveBindHostname(process.env),
   port,
+  // The run-log SSE stream is quiet between log writes and sends its own comment
+  // heartbeat every HEARTBEAT_MS (15s, ops.server.ts). Bun's default request idle
+  // timeout is 10s, so without this a run that produces no output for ten seconds
+  // — which is every run while a model is thinking — has its stream closed before
+  // the first heartbeat can hold it open. Matches ops.serve.ts, which is the same
+  // handler and needs the same allowance.
+  idleTimeout: 255,
   fetch: createSiteFetch({ api, distDir: path.join(import.meta.dir, 'dist') }),
 });
 

--- a/apps/eval-ops/server.ts
+++ b/apps/eval-ops/server.ts
@@ -9,17 +9,33 @@
  * the browser to `/`; the two-process dev flow serves the UI elsewhere, which is
  * why the target is configuration rather than a constant. `createSiteFetch` owns
  * the forwarding rule, so `/callback` cannot be answered with index.html.
+ *
+ * This is the entrypoint a platform starts, so it honours the `PORT` that
+ * platform injects — unlike the local API entrypoint (ops.serve.ts), which is
+ * started with `.env.test` loaded and would otherwise take the API service's
+ * `PORT=3001`. The port is resolved once and handed to both `Bun.serve` and
+ * `createDefaultOpsContext`, because the bridge callback URL must name the port
+ * this process actually bound.
+ *
+ * Reaching it from a browser needs more than a wider bind: EVAL_OPS_PUBLIC_ORIGIN
+ * must also name the deployed origin, or the Host and Origin allowlists refuse
+ * every request.
  */
 import path from 'node:path';
 
-import { createDefaultOpsContext, createOpsHandler } from '../../packages/protocol/eval/ops/ops.server.js';
+import { createDefaultOpsContext, createOpsHandler, resolveBindHostname, resolveBindPort } from '../../packages/protocol/eval/ops/ops.server.js';
 import { createSiteFetch } from './site';
 
 const repoRoot = path.resolve(import.meta.dir, '../..');
-const api = createOpsHandler(await createDefaultOpsContext({ repoRoot, uiUrl: '/' }));
+const port = resolveBindPort({ env: process.env, honourPlatformPort: true });
+const api = createOpsHandler(await createDefaultOpsContext({ repoRoot, uiUrl: '/', port }));
 
-Bun.serve({
-  hostname: process.env.EVAL_OPS_BIND ?? '127.0.0.1',
-  port: Number(process.env.EVAL_OPS_PORT ?? 4321),
+const server = Bun.serve({
+  hostname: resolveBindHostname(process.env),
+  port,
   fetch: createSiteFetch({ api, distDir: path.join(import.meta.dir, 'dist') }),
 });
+
+console.log(
+  `[eval-ops] listening on http://${server.hostname}:${server.port} (single-process site; honours the platform's PORT)`,
+);

--- a/apps/eval-ops/server.ts
+++ b/apps/eval-ops/server.ts
@@ -23,12 +23,14 @@
  */
 import path from 'node:path';
 
-import { createDefaultOpsContext, createOpsHandler, resolveBindHostname, resolveBindPort } from '../../packages/protocol/eval/ops/ops.server.js';
+import { createDefaultOpsContext, createOpsHandler, ensureConfigStorage, resolveBindHostname, resolveBindPort } from '../../packages/protocol/eval/ops/ops.server.js';
 import { createSiteFetch } from './site';
 
 const repoRoot = path.resolve(import.meta.dir, '../..');
 const port = resolveBindPort({ env: process.env, honourPlatformPort: true });
-const api = createOpsHandler(await createDefaultOpsContext({ repoRoot, uiUrl: '/', port }));
+const context = await createDefaultOpsContext({ repoRoot, uiUrl: '/', port });
+await ensureConfigStorage(context);
+const api = createOpsHandler(context);
 
 const server = Bun.serve({
   hostname: resolveBindHostname(process.env),

--- a/apps/eval-ops/src/api/client.ts
+++ b/apps/eval-ops/src/api/client.ts
@@ -32,6 +32,15 @@ export type {
   RunStepRecord,
 } from '../../../../packages/protocol/eval/ops/ops.types';
 
+/**
+ * The saved-config shape, re-exported from the ops core for the same reason as
+ * the wire types above: one definition, compiler-enforced. `import type` is
+ * erased, so the zod schema it is inferred from never enters the bundle.
+ */
+export type { ConfigProfile } from '../../../../packages/protocol/eval/ops/ops.profiles';
+
+import type { ConfigProfile } from '../../../../packages/protocol/eval/ops/ops.profiles';
+
 import type { HarnessDescriptor, IndexIssue, IndexResult, OpsHarness, RunRecord, RunSpec, RunStatus } from '../../../../packages/protocol/eval/ops/ops.types';
 
 export interface RunsResult {
@@ -167,6 +176,24 @@ export type CompareResult =
       aggregate: { reference: number; subject: number; delta: number };
     };
 
+/** One side of a run-vs-run comparison, labelled from its run record. */
+export interface RunSide {
+  id: string;
+  profile: string;
+  profileFingerprint: string;
+  /** False when the run finished with incomplete execution evidence. */
+  complete: boolean | null;
+}
+
+/**
+ * What GET /api/compare?referenceRun=…&subjectRun=… serves: the same outcome
+ * as artifact compare, plus the two runs' labels. `runs` is optional so a
+ * CompareResult from artifact mode can be widened without a type lie.
+ */
+export type RunCompareResult = CompareResult & {
+  runs?: { reference: RunSide; subject: RunSide };
+};
+
 /**
  * The two ways the server can tell this app that its session does not admit it.
  *
@@ -225,6 +252,8 @@ async function fetchJson<T>(url: string, init?: RequestInit): Promise<T> {
     if (refusal !== null) notifyAuthRefusal(refusal);
     throw new Error(body.error ?? `HTTP ${response.status}`);
   }
+  // A 204 (the config DELETE) has no body to parse; response.json() would throw.
+  if (response.status === 204) return undefined as T;
   return response.json();
 }
 
@@ -235,6 +264,20 @@ async function postJson<T>(url: string, body: unknown): Promise<T> {
     headers: { 'Content-Type': 'application/json' },
     body: JSON.stringify(body),
   });
+}
+
+/** PATCH helper; the JSON content type is the same anti-CSRF barrier as POST. */
+async function patchJson<T>(url: string, body: unknown): Promise<T> {
+  return fetchJson<T>(url, {
+    method: 'PATCH',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(body),
+  });
+}
+
+/** DELETE helper. The server answers 204 with no body. */
+async function deleteJson(url: string): Promise<void> {
+  await fetchJson<unknown>(url, { method: 'DELETE' });
 }
 
 /**
@@ -297,6 +340,29 @@ export const api = {
     return fetchJson('/api/profiles');
   },
 
+  async configs(): Promise<{ repo: ConfigProfile[]; saved: ConfigProfile[] }> {
+    return fetchJson('/api/configs');
+  },
+
+  async configModels(): Promise<{ models: string[] }> {
+    return fetchJson('/api/configs/models');
+  },
+
+  async createConfig(profile: ConfigProfile): Promise<ConfigProfile> {
+    return postJson('/api/configs', profile);
+  },
+
+  async updateConfig(
+    name: string,
+    patch: Partial<Omit<ConfigProfile, 'name'>>,
+  ): Promise<ConfigProfile> {
+    return patchJson(`/api/configs/${encodeURIComponent(name)}`, patch);
+  },
+
+  async deleteConfig(name: string): Promise<void> {
+    await deleteJson(`/api/configs/${encodeURIComponent(name)}`);
+  },
+
   async artifacts(): Promise<IndexResult> {
     return fetchJson('/api/artifacts');
   },
@@ -331,6 +397,12 @@ export const api = {
   async compare(reference: string, subject: string): Promise<CompareResult> {
     return fetchJson(
       `/api/compare?reference=${encodeURIComponent(reference)}&subject=${encodeURIComponent(subject)}`,
+    );
+  },
+
+  async compareRuns(referenceRun: string, subjectRun: string): Promise<RunCompareResult> {
+    return fetchJson(
+      `/api/compare?referenceRun=${encodeURIComponent(referenceRun)}&subjectRun=${encodeURIComponent(subjectRun)}`,
     );
   },
 };

--- a/apps/eval-ops/src/api/client.ts
+++ b/apps/eval-ops/src/api/client.ts
@@ -237,13 +237,52 @@ async function postJson<T>(url: string, body: unknown): Promise<T> {
   });
 }
 
+/**
+ * How this server expects a browser to prove who it is, as `POST /api/auth/login`
+ * reports it.
+ *
+ * A discriminated union because the two postures are genuinely different
+ * exchanges, not one exchange with optional fields:
+ *
+ *  - `bridge` — the local posture. Navigate to `url`: `<WEB_APP_URL>/cli-auth`
+ *    mints a revocable API key against the operator's existing Index session and
+ *    redirects it to the ops server's loopback `/callback`.
+ *  - `token` — the deployed posture. The bridge cannot complete off loopback
+ *    (`validateCliCallbackUrl` in apps/web accepts only `http:` on 127.0.0.1),
+ *    so fetch a better-auth JWT from `${apiUrl}/api/auth/token` with the
+ *    browser's own API cookie and post it to `POST /api/auth/session`, which
+ *    resolves it server-side. `webAppUrl` is where the operator signs in to Index
+ *    when the API says it has no session for them.
+ *
+ * The server sends exactly these fields. It is not a route that reports server
+ * configuration in general, and it must not become one.
+ */
+export type SignInStart =
+  | { kind: 'bridge'; url: string }
+  | { kind: 'token'; apiUrl: string; webAppUrl: string };
+
 export const api = {
   async authStatus(): Promise<{ authenticated: boolean; email?: string; name?: string }> {
     return fetchJson('/api/auth/status');
   },
 
-  async login(): Promise<{ url: string }> {
+  async login(): Promise<SignInStart> {
     return postJson('/api/auth/login', {});
+  },
+
+  /**
+   * Submits a better-auth token and, if the server resolves it to a permitted
+   * identity, receives the ops session cookie.
+   *
+   * The token is a bearer credential and this is its only use: it is passed in,
+   * sent once, and never stored, rendered or logged. The server answers 401 when
+   * the API rejects the token and 403 with `permitted: false` when the identity
+   * behind it is not admitted — `fetchJson` publishes both through
+   * `onAuthRefusal`, so the shell reacts the same way it does to any other
+   * refusal.
+   */
+  async submitToken(token: string): Promise<{ authenticated: boolean; email?: string; name?: string }> {
+    return postJson('/api/auth/session', { token });
   },
 
   async logout(): Promise<void> {

--- a/apps/eval-ops/src/components/CompareDiff.tsx
+++ b/apps/eval-ops/src/components/CompareDiff.tsx
@@ -1,0 +1,133 @@
+import { Frame } from './Frame';
+import type { CompareResult } from '../api/client';
+
+/**
+ * The diff half of a comparison: the refusal with its findings, or the
+ * aggregate delta with regressions and improvements. Rendering is shared by
+ * the artifact compare page and the run pair page — the two modes differ in
+ * how the pair is chosen, not in how the outcome reads.
+ */
+export function CompareDiff({ result }: { result: CompareResult }) {
+  if (!result.comparable) {
+    return (
+      <Frame label="These artifacts cannot be compared">
+        <p className="mb-[1lh]">
+          Comparison requires identical harness, corpus fingerprint, configuration fingerprint, and case selection.
+        </p>
+        <div className="space-y-[0.5lh]">
+          {result.findings.map((finding, idx) => (
+            <div key={idx} className="font-mono">
+              <span className="text-term-cyan">{finding.dimension}</span>
+              <span className="text-term-dim"> · reference: </span>
+              <span className="text-term-fg">{finding.reference}</span>
+              <span className="text-term-dim"> · subject: </span>
+              <span className="text-term-fg">{finding.subject}</span>
+            </div>
+          ))}
+        </div>
+      </Frame>
+    );
+  }
+
+  return (
+    <>
+      <Frame label="Aggregate">
+        <div className="flex gap-[4ch] font-mono">
+          <div>
+            <span className="text-term-dim">Reference: </span>
+            <span className="text-term-fg">{(result.aggregate.reference * 100).toFixed(2)}%</span>
+          </div>
+          <div>
+            <span className="text-term-dim">Subject: </span>
+            <span className="text-term-fg">{(result.aggregate.subject * 100).toFixed(2)}%</span>
+          </div>
+          <div>
+            <span className="text-term-dim">Δ: </span>
+            <span
+              className={
+                result.aggregate.delta > 0
+                  ? 'text-term-green'
+                  : result.aggregate.delta < 0
+                    ? 'text-term-red'
+                    : 'text-term-dim'
+              }
+            >
+              {result.aggregate.delta > 0 ? '+' : ''}
+              {(result.aggregate.delta * 100).toFixed(2)}%
+            </span>
+          </div>
+        </div>
+      </Frame>
+
+      {result.regressions.regressions.length > 0 && (
+        <Frame label="Regressions (subject worse)">
+          <table className="w-full font-mono">
+            <thead>
+              <tr className="text-term-dim border-b border-term-rule">
+                <th className="text-left py-[0.5lh]">ID</th>
+                <th className="text-left py-[0.5lh]">Type</th>
+                <th className="text-right py-[0.5lh]">Before</th>
+                <th className="text-right py-[0.5lh]">After</th>
+                <th className="text-right py-[0.5lh]">p-value</th>
+              </tr>
+            </thead>
+            <tbody>
+              {result.regressions.regressions.map((reg, idx) => (
+                <tr key={idx} className="border-b border-term-rule">
+                  <td className="py-[0.5lh]">{reg.id}</td>
+                  <td className="py-[0.5lh] text-term-dim">{reg.kind}</td>
+                  <td className="text-right py-[0.5lh]">{(reg.before * 100).toFixed(1)}%</td>
+                  <td className="text-right py-[0.5lh] text-term-red">{(reg.after * 100).toFixed(1)}%</td>
+                  <td className="text-right py-[0.5lh] text-term-dim">{reg.pValue.toFixed(4)}</td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </Frame>
+      )}
+
+      {result.improvements.regressions.length > 0 && (
+        <Frame label="Improvements (subject better)">
+          <table className="w-full font-mono">
+            <thead>
+              <tr className="text-term-dim border-b border-term-rule">
+                <th className="text-left py-[0.5lh]">ID</th>
+                <th className="text-left py-[0.5lh]">Type</th>
+                <th className="text-right py-[0.5lh]">Before</th>
+                <th className="text-right py-[0.5lh]">After</th>
+                <th className="text-right py-[0.5lh]">p-value</th>
+              </tr>
+            </thead>
+            <tbody>
+              {result.improvements.regressions.map((reg, idx) => (
+                <tr key={idx} className="border-b border-term-rule">
+                  <td className="py-[0.5lh]">{reg.id}</td>
+                  <td className="py-[0.5lh] text-term-dim">{reg.kind}</td>
+                  <td className="text-right py-[0.5lh]">{(reg.before * 100).toFixed(1)}%</td>
+                  <td className="text-right py-[0.5lh] text-term-green">{(reg.after * 100).toFixed(1)}%</td>
+                  <td className="text-right py-[0.5lh] text-term-dim">{reg.pValue.toFixed(4)}</td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </Frame>
+      )}
+
+      {result.regressions.regressions.length === 0 &&
+        result.improvements.regressions.length === 0 && (
+          <Frame label="No Significant Differences">
+            <p className="text-term-dim">
+              No statistically significant regressions or improvements detected between these artifacts.
+            </p>
+          </Frame>
+        )}
+
+      <Frame label="Statistical Note">
+        <p className="text-term-dim text-sm">
+          Significance uses the same one-sided beta-binomial posterior-predictive test as the CLI, evaluated in
+          both directions. It is not a symmetric two-sided test.
+        </p>
+      </Frame>
+    </>
+  );
+}

--- a/apps/eval-ops/src/components/OverridesEditor.tsx
+++ b/apps/eval-ops/src/components/OverridesEditor.tsx
@@ -1,0 +1,151 @@
+import { useId } from 'react';
+
+export interface Overrides {
+  models: Record<string, string>;
+  env: Record<string, string>;
+}
+
+export const EMPTY_OVERRIDES: Overrides = { models: {}, env: {} };
+
+export function hasOverrides(value: Overrides): boolean {
+  return Object.keys(value.models).length > 0 || Object.keys(value.env).length > 0;
+}
+
+/**
+ * Strips env rows whose value is still blank (a row the user added but never
+ * filled in). The record itself is never mutated; submit and save-as-config
+ * both go through this so an empty row can never reach the server.
+ */
+export function cleanOverrides(value: Overrides): Overrides {
+  return {
+    models: { ...value.models },
+    env: Object.fromEntries(
+      Object.entries(value.env).filter(([, envValue]) => envValue.trim() !== ''),
+    ),
+  };
+}
+
+interface OverridesEditorProps {
+  /** Model-overridable agents the selected harness exercises. */
+  agents: readonly string[];
+  /** The curated, server-enforced model list. */
+  models: readonly string[];
+  /** The env keys a profile may set (PROFILE_ENV_ALLOWLIST). */
+  envKeys: readonly string[];
+  value: Overrides;
+  onChange: (next: Overrides) => void;
+}
+
+/**
+ * Edits one side's ad-hoc overrides: a model dropdown per agent the harness
+ * exercises, plus env key/value rows. Pure controlled inputs — the parent owns
+ * the value. Mouse-first like the rest of the site: no keyboard handlers.
+ */
+export function OverridesEditor({ agents, models, envKeys, value, onChange }: OverridesEditorProps) {
+  const prefix = useId();
+
+  const setModel = (agent: string, model: string) => {
+    const nextModels = { ...value.models };
+    if (model === '') {
+      delete nextModels[agent];
+    } else {
+      nextModels[agent] = model;
+    }
+    onChange({ ...value, models: nextModels });
+  };
+
+  const setEnvKey = (oldKey: string, newKey: string) => {
+    // Keyed by position: renaming a key keeps the row's value and row order.
+    const entries = Object.entries(value.env).map(([key, envValue]) =>
+      key === oldKey ? [newKey, envValue] as [string, string] : [key, envValue] as [string, string],
+    );
+    onChange({ ...value, env: Object.fromEntries(entries) });
+  };
+
+  const setEnvValue = (key: string, envValue: string) => {
+    onChange({ ...value, env: { ...value.env, [key]: envValue } });
+  };
+
+  const removeEnv = (key: string) => {
+    const nextEnv = { ...value.env };
+    delete nextEnv[key];
+    onChange({ ...value, env: nextEnv });
+  };
+
+  const addEnv = () => {
+    const unused = envKeys.find((key) => !(key in value.env));
+    if (unused === undefined) return;
+    onChange({ ...value, env: { ...value.env, [unused]: '' } });
+  };
+
+  return (
+    <div className="space-y-3">
+      {agents.map((agent) => (
+        <div key={agent}>
+          <label htmlFor={`${prefix}-model-${agent}`} className="block mb-1 text-term-dim">
+            {agent}
+          </label>
+          <select
+            id={`${prefix}-model-${agent}`}
+            className="w-full bg-term-bg border border-term-rule px-[1ch] py-[0.5lh]"
+            value={value.models[agent] ?? ''}
+            onChange={(e) => setModel(agent, e.target.value)}
+          >
+            <option value="">default</option>
+            {models.map((model) => (
+              <option key={model} value={model}>
+                {model}
+              </option>
+            ))}
+          </select>
+        </div>
+      ))}
+
+      {Object.entries(value.env).map(([key, envValue]) => (
+        <div key={key} className="flex items-center gap-2">
+          <select
+            aria-label={`env key ${key}`}
+            className="bg-term-bg border border-term-rule px-[1ch] py-[0.5lh]"
+            value={key}
+            onChange={(e) => setEnvKey(key, e.target.value)}
+          >
+            <option value={key}>{key}</option>
+            {envKeys
+              .filter((candidate) => candidate !== key && !(candidate in value.env))
+              .map((candidate) => (
+                <option key={candidate} value={candidate}>
+                  {candidate}
+                </option>
+              ))}
+          </select>
+          <input
+            type="text"
+            aria-label={`env value ${key}`}
+            placeholder="value"
+            className="flex-1 bg-term-bg border border-term-rule px-[1ch] py-[0.5lh]"
+            value={envValue}
+            onChange={(e) => setEnvValue(key, e.target.value)}
+          />
+          <button
+            type="button"
+            aria-label={`remove ${key}`}
+            className="px-[1ch] py-[0.5lh] border border-term-rule text-term-dim"
+            onClick={() => removeEnv(key)}
+          >
+            ✕
+          </button>
+        </div>
+      ))}
+
+      {envKeys.some((key) => !(key in value.env)) && (
+        <button
+          type="button"
+          className="px-[2ch] py-[0.5lh] border border-term-rule text-term-dim"
+          onClick={addEnv}
+        >
+          add env override
+        </button>
+      )}
+    </div>
+  );
+}

--- a/apps/eval-ops/src/components/RunProgress.tsx
+++ b/apps/eval-ops/src/components/RunProgress.tsx
@@ -1,0 +1,118 @@
+import { useEffect, useState } from 'react';
+
+import type { CaseProgress, RunProgress } from '../../../../packages/protocol/eval/ops/ops.progress';
+
+export interface RunProgressViewProps {
+  progress: RunProgress;
+  /** Epoch ms when each case was first seen, for live durations. */
+  caseStartedAt: ReadonlyMap<string, number>;
+  /** Run start, epoch ms; drives the elapsed readout. */
+  runStartedAt: number | null;
+  /** True while the run is live; freezes timers otherwise. */
+  live: boolean;
+}
+
+/**
+ * The followable face of a run: where it is, what each case did, and which one
+ * is working right now. The raw harness output stays available behind a toggle
+ * in the parent — this view replaces it as the primary readout.
+ */
+export function RunProgressView({ progress, caseStartedAt, runStartedAt, live }: RunProgressViewProps) {
+  // One ticker for both the elapsed readout and the in-flight case timer.
+  const [now, setNow] = useState(() => Date.now());
+  useEffect(() => {
+    if (!live) return;
+    const id = setInterval(() => setNow(Date.now()), 1000);
+    return () => clearInterval(id);
+  }, [live]);
+
+  const total = progress.totalCases;
+  const done = progress.completed;
+  const fraction = total !== null && total > 0 ? done / total : 0;
+  const filled = Math.round(fraction * 20);
+  const bar = '█'.repeat(filled) + '░'.repeat(20 - filled);
+
+  return (
+    <div className="space-y-2">
+      <div className="flex items-center gap-4 flex-wrap">
+        <span className="text-term-green font-mono">{bar}</span>
+        <span>
+          {total !== null ? `${done}/${total} cases` : `${done} cases`}
+        </span>
+        <span className="text-term-dim">
+          {progress.passed} passed
+          {progress.failed > 0 && <span className="text-term-red"> · {progress.failed} failed</span>}
+        </span>
+        {runStartedAt !== null && (
+          <span className="text-term-dim ml-auto">{formatClock(Math.max(0, now - runStartedAt))}</span>
+        )}
+      </div>
+
+      {progress.current !== null && (
+        <div className="text-term-cyan">
+          ● running {progress.current.id}
+          <span className="text-term-dim ml-4">
+            {formatClock(Math.max(0, now - (caseStartedAt.get(progress.current.id) ?? now)))}
+          </span>
+        </div>
+      )}
+
+      <div className="space-y-1">
+        {progress.cases.filter((c) => c.done).map((c) => (
+          <CaseRow key={c.id} c={c} durationMs={durationOf(c, caseStartedAt, live)} />
+        ))}
+      </div>
+    </div>
+  );
+}
+
+function durationOf(
+  c: CaseProgress,
+  caseStartedAt: ReadonlyMap<string, number>,
+  live: boolean,
+): number | null {
+  // Durations exist only for cases this session watched finish; replayed logs
+  // carry no timing, so their rows show '—' rather than a fabricated number.
+  if (!live) return null;
+  const started = caseStartedAt.get(c.id);
+  const finished = caseStartedAt.get(`${c.id}::done`);
+  if (started === undefined || finished === undefined) return null;
+  return finished - started;
+}
+
+function CaseRow({ c, durationMs }: { c: CaseProgress; durationMs: number | null }) {
+  const unknown = c.passes === null || c.runs === null;
+  const passed = !unknown && c.passes === c.runs;
+  const partial = !unknown && !passed && (c.passes as number) > 0;
+  const icon = unknown ? '?' : passed ? '✓' : partial ? '◐' : '✗';
+  const colour = unknown
+    ? 'text-term-dim'
+    : passed
+      ? 'text-term-green'
+      : partial || c.flaky
+        ? 'text-term-yellow'
+        : 'text-term-red';
+  const verdict = unknown
+    ? 'unknown'
+    : passed
+      ? 'passed'
+      : `${c.passes}/${c.runs} passed${c.flaky ? ' (flaky)' : ''}`;
+
+  return (
+    <div className="flex gap-4 font-mono text-sm">
+      <span className={colour}>{icon}</span>
+      <span className="flex-1">{c.id}</span>
+      <span className={colour}>{verdict}</span>
+      <span className="text-term-dim w-12 text-right">
+        {durationMs !== null ? formatClock(durationMs) : '—'}
+      </span>
+    </div>
+  );
+}
+
+function formatClock(ms: number): string {
+  const seconds = Math.floor(ms / 1000);
+  const minutes = Math.floor(seconds / 60);
+  if (minutes > 0) return `${minutes}m ${String(seconds % 60).padStart(2, '0')}s`;
+  return `0:${String(seconds).padStart(2, '0')}`;
+}

--- a/apps/eval-ops/src/components/Shell.tsx
+++ b/apps/eval-ops/src/components/Shell.tsx
@@ -9,7 +9,7 @@ const LINKS: ReadonlyArray<{ to: string; label: string }> = [
   { to: '/', label: 'overview' },
   { to: '/launch', label: 'launch' },
   { to: '/compare', label: 'compare' },
-  { to: '/profiles', label: 'profiles' },
+  { to: '/profiles', label: 'configs' },
   { to: '/fixture', label: 'fixture' },
 ];
 

--- a/apps/eval-ops/src/hooks/useRunProgress.ts
+++ b/apps/eval-ops/src/hooks/useRunProgress.ts
@@ -1,0 +1,86 @@
+import { useEffect, useRef, useState } from 'react';
+
+import { HarnessProgressParser, type RunProgress } from '../../../../packages/protocol/eval/ops/ops.progress';
+import { isTerminalStatus, subscribeToRun, type RunRecord } from '../api/client';
+
+export interface RunProgressState {
+  run: RunRecord | null;
+  progress: RunProgress | null;
+  /** First-seen and completion timestamps per case id, for live durations. */
+  caseTimes: ReadonlyMap<string, number>;
+  /** Set when the stream fails before any status frame arrives. */
+  streamError: string | null;
+}
+
+/**
+ * Subscribes to one run's stream and keeps the structured progress view fed:
+ * status frames update the record, log chunks advance the parser, and case
+ * timestamps give RunProgressView its durations. The pair page runs two of
+ * these side by side; the single-run page keeps its own richer wiring (it
+ * also fetches artifacts, comparisons and handles cancel).
+ *
+ * On a mid-stream reconnect the server replays the log from byte 0, so the
+ * parser and timestamps reset — otherwise every case would render twice.
+ */
+export function useRunProgress(runId: string): RunProgressState {
+  const [run, setRun] = useState<RunRecord | null>(null);
+  const [progress, setProgress] = useState<RunProgress | null>(null);
+  const [streamError, setStreamError] = useState<string | null>(null);
+  const parserRef = useRef(new HarnessProgressParser());
+  const caseTimesRef = useRef(new Map<string, number>());
+
+  useEffect(() => {
+    let mounted = true;
+    let sawStatus = false;
+    let closed = false;
+
+    const unsubscribe = subscribeToRun(runId, {
+      onLog: (chunk: string) => {
+        if (!mounted) return;
+        parserRef.current.push(chunk);
+        const snapshot = parserRef.current.snapshot();
+        const times = caseTimesRef.current;
+        const nowMs = Date.now();
+        for (const c of snapshot.cases) {
+          if (!times.has(c.id)) times.set(c.id, nowMs);
+          if (c.done && !times.has(`${c.id}::done`)) times.set(`${c.id}::done`, nowMs);
+        }
+        setProgress(snapshot);
+      },
+      onStatus: (record: RunRecord) => {
+        if (!mounted) return;
+        sawStatus = true;
+        setRun(record);
+        setStreamError(null);
+
+        // The server closes the stream once a run is terminal; a browser
+        // EventSource would reconnect forever, replaying the log each time.
+        if (isTerminalStatus(record.status)) {
+          closed = true;
+          unsubscribe();
+        }
+      },
+      onError: () => {
+        if (!mounted || closed) return;
+
+        if (!sawStatus) {
+          closed = true;
+          unsubscribe();
+          setStreamError(`No run with id "${runId}" is available to stream.`);
+          return;
+        }
+
+        parserRef.current = new HarnessProgressParser();
+        caseTimesRef.current.clear();
+        setProgress(null);
+      },
+    });
+
+    return () => {
+      mounted = false;
+      unsubscribe();
+    };
+  }, [runId]);
+
+  return { run, progress, caseTimes: caseTimesRef.current, streamError };
+}

--- a/apps/eval-ops/src/routes/Compare.tsx
+++ b/apps/eval-ops/src/routes/Compare.tsx
@@ -1,8 +1,33 @@
-import { useEffect, useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import { useSearchParams } from 'react-router';
 
 import { Frame } from '../components/Frame';
-import { api, type CompareResult, type ArtifactRef } from '../api/client';
+import { CompareDiff } from '../components/CompareDiff';
+import { RunProgressView } from '../components/RunProgress';
+import { useRunProgress, type RunProgressState } from '../hooks/useRunProgress';
+import { api, isTerminalStatus, type CompareResult, type RunCompareResult, type ArtifactRef } from '../api/client';
+
+export function Compare() {
+  const [searchParams] = useSearchParams();
+  // The URL is the only home of the selection, so back/forward moves the
+  // selects (or the pair) and the comparison together.
+  const referenceRun = searchParams.get('referenceRun');
+  const subjectRun = searchParams.get('subjectRun');
+
+  // Pair mode: two runs, launched together, compared the moment both end.
+  // Keyed by the pair so navigating to a different pair resets all state.
+  if (referenceRun !== null && subjectRun !== null) {
+    return (
+      <PairCompare
+        key={`${referenceRun}/${subjectRun}`}
+        referenceRunId={referenceRun}
+        subjectRunId={subjectRun}
+      />
+    );
+  }
+
+  return <ArtifactCompare />;
+}
 
 interface CompareState {
   artifacts: ArtifactRef[];
@@ -11,10 +36,8 @@ interface CompareState {
   error: string | null;
 }
 
-export function Compare() {
+function ArtifactCompare() {
   const [searchParams, setSearchParams] = useSearchParams();
-  // The URL is the only home of the selection, so back/forward moves the selects
-  // and the comparison together instead of leaving them disagreeing with the URL.
   const referenceId = searchParams.get('reference');
   const subjectId = searchParams.get('subject');
   const [state, setState] = useState<CompareState>({
@@ -174,125 +197,124 @@ export function Compare() {
         </Frame>
       )}
 
-      {state.result && !state.result.comparable && (
-        <Frame label="These artifacts cannot be compared">
-          <p className="mb-[1lh]">
-            Comparison requires identical harness, corpus fingerprint, configuration fingerprint, and case selection.
-          </p>
-          <div className="space-y-[0.5lh]">
-            {state.result.findings.map((finding, idx) => (
-              <div key={idx} className="font-mono">
-                <span className="text-term-cyan">{finding.dimension}</span>
-                <span className="text-term-dim"> · reference: </span>
-                <span className="text-term-fg">{finding.reference}</span>
-                <span className="text-term-dim"> · subject: </span>
-                <span className="text-term-fg">{finding.subject}</span>
-              </div>
-            ))}
-          </div>
+      {state.result && <CompareDiff result={state.result} />}
+    </div>
+  );
+}
+
+/**
+ * The A/B payoff loop: both runs' progress side by side (stacked), and the
+ * moment the second run goes terminal the run-vs-run diff loads itself.
+ * The URL carries the pair, so the page is shareable and back/forward-safe.
+ */
+function PairCompare({ referenceRunId, subjectRunId }: { referenceRunId: string; subjectRunId: string }) {
+  const reference = useRunProgress(referenceRunId);
+  const subject = useRunProgress(subjectRunId);
+  const [result, setResult] = useState<RunCompareResult | null>(null);
+  const [compareError, setCompareError] = useState<string | null>(null);
+  const fetchedRef = useRef(false);
+
+  const referenceDone = reference.run !== null && isTerminalStatus(reference.run.status);
+  const subjectDone = subject.run !== null && isTerminalStatus(subject.run.status);
+
+  useEffect(() => {
+    if (!referenceDone || !subjectDone || fetchedRef.current) return;
+    fetchedRef.current = true;
+    let mounted = true;
+    api
+      .compareRuns(referenceRunId, subjectRunId)
+      .then((outcome) => {
+        if (mounted) setResult(outcome);
+      })
+      .catch((error) => {
+        if (mounted) {
+          setCompareError(error instanceof Error ? error.message : String(error));
+        }
+      });
+    return () => {
+      mounted = false;
+    };
+  }, [referenceDone, subjectDone, referenceRunId, subjectRunId]);
+
+  const bothDone = referenceDone && subjectDone;
+
+  return (
+    <div className="flex flex-col gap-[2lh] p-[2ch]">
+      <h1 className="text-term-cyan text-[2em]">A/B Comparison</h1>
+
+      <PairPanel side="reference" state={reference} />
+      <PairPanel side="candidate" state={subject} />
+
+      {!bothDone && (
+        <p className="text-term-dim">comparison appears when both runs finish</p>
+      )}
+
+      {compareError !== null && (
+        <Frame label="Error">
+          <pre className="text-term-red">{compareError}</pre>
         </Frame>
       )}
 
-      {state.result && state.result.comparable && (
+      {result !== null && (
         <>
-          <Frame label="Aggregate">
-            <div className="flex gap-[4ch] font-mono">
-              <div>
-                <span className="text-term-dim">Reference: </span>
-                <span className="text-term-fg">{(state.result.aggregate.reference * 100).toFixed(2)}%</span>
+          {result.runs !== undefined && (
+            <Frame label="runs compared">
+              <div className="space-y-[0.5lh] font-mono">
+                <SideHeader side="reference" label={result.runs.reference} />
+                <SideHeader side="candidate" label={result.runs.subject} />
               </div>
-              <div>
-                <span className="text-term-dim">Subject: </span>
-                <span className="text-term-fg">{(state.result.aggregate.subject * 100).toFixed(2)}%</span>
-              </div>
-              <div>
-                <span className="text-term-dim">Δ: </span>
-                <span
-                  className={
-                    state.result.aggregate.delta > 0
-                      ? 'text-term-green'
-                      : state.result.aggregate.delta < 0
-                        ? 'text-term-red'
-                        : 'text-term-dim'
-                  }
-                >
-                  {state.result.aggregate.delta > 0 ? '+' : ''}
-                  {(state.result.aggregate.delta * 100).toFixed(2)}%
-                </span>
-              </div>
-            </div>
-          </Frame>
-
-          {state.result.regressions.regressions.length > 0 && (
-            <Frame label="Regressions (subject worse)">
-              <table className="w-full font-mono">
-                <thead>
-                  <tr className="text-term-dim border-b border-term-rule">
-                    <th className="text-left py-[0.5lh]">ID</th>
-                    <th className="text-left py-[0.5lh]">Type</th>
-                    <th className="text-right py-[0.5lh]">Before</th>
-                    <th className="text-right py-[0.5lh]">After</th>
-                    <th className="text-right py-[0.5lh]">p-value</th>
-                  </tr>
-                </thead>
-                <tbody>
-                  {state.result.regressions.regressions.map((reg, idx) => (
-                    <tr key={idx} className="border-b border-term-rule">
-                      <td className="py-[0.5lh]">{reg.id}</td>
-                      <td className="py-[0.5lh] text-term-dim">{reg.kind}</td>
-                      <td className="text-right py-[0.5lh]">{(reg.before * 100).toFixed(1)}%</td>
-                      <td className="text-right py-[0.5lh] text-term-red">{(reg.after * 100).toFixed(1)}%</td>
-                      <td className="text-right py-[0.5lh] text-term-dim">{reg.pValue.toFixed(4)}</td>
-                    </tr>
-                  ))}
-                </tbody>
-              </table>
             </Frame>
           )}
-
-          {state.result.improvements.regressions.length > 0 && (
-            <Frame label="Improvements (subject better)">
-              <table className="w-full font-mono">
-                <thead>
-                  <tr className="text-term-dim border-b border-term-rule">
-                    <th className="text-left py-[0.5lh]">ID</th>
-                    <th className="text-left py-[0.5lh]">Type</th>
-                    <th className="text-right py-[0.5lh]">Before</th>
-                    <th className="text-right py-[0.5lh]">After</th>
-                    <th className="text-right py-[0.5lh]">p-value</th>
-                  </tr>
-                </thead>
-                <tbody>
-                  {state.result.improvements.regressions.map((reg, idx) => (
-                    <tr key={idx} className="border-b border-term-rule">
-                      <td className="py-[0.5lh]">{reg.id}</td>
-                      <td className="py-[0.5lh] text-term-dim">{reg.kind}</td>
-                      <td className="text-right py-[0.5lh]">{(reg.before * 100).toFixed(1)}%</td>
-                      <td className="text-right py-[0.5lh] text-term-green">{(reg.after * 100).toFixed(1)}%</td>
-                      <td className="text-right py-[0.5lh] text-term-dim">{reg.pValue.toFixed(4)}</td>
-                    </tr>
-                  ))}
-                </tbody>
-              </table>
-            </Frame>
-          )}
-
-          {state.result.regressions.regressions.length === 0 &&
-            state.result.improvements.regressions.length === 0 && (
-              <Frame label="No Significant Differences">
-                <p className="text-term-dim">
-                  No statistically significant regressions or improvements detected between these artifacts.
-                </p>
-              </Frame>
-            )}
-
-          <Frame label="Statistical Note">
-            <p className="text-term-dim text-sm">
-              Significance uses the same one-sided beta-binomial posterior-predictive test as the CLI, evaluated in
-              both directions. It is not a symmetric two-sided test.
-            </p>
-          </Frame>
+          <CompareDiff result={result} />
         </>
+      )}
+    </div>
+  );
+}
+
+function PairPanel({ side, state }: { side: 'reference' | 'candidate'; state: RunProgressState }) {
+  const profile =
+    state.run !== null && state.run.spec.kind === 'eval' ? state.run.spec.profile : null;
+  const live =
+    state.run !== null && (state.run.status === 'running' || state.run.status === 'queued');
+
+  return (
+    <Frame label={profile !== null ? `${side} · ${profile}` : side}>
+      {state.streamError !== null && <p className="text-term-red">{state.streamError}</p>}
+      {state.streamError === null && state.run === null && (
+        <p className="text-term-dim">Loading…</p>
+      )}
+      {state.streamError === null && state.run !== null && state.progress !== null && state.progress.totalCases !== null && (
+        <RunProgressView
+          progress={state.progress}
+          caseStartedAt={state.caseTimes}
+          runStartedAt={state.run.startedAt !== null ? new Date(state.run.startedAt).getTime() : null}
+          live={live}
+        />
+      )}
+      {state.streamError === null && state.run !== null && (state.progress === null || state.progress.totalCases === null) && (
+        <p className="text-term-dim">waiting for harness output…</p>
+      )}
+    </Frame>
+  );
+}
+
+function SideHeader({
+  side,
+  label,
+}: {
+  side: 'reference' | 'candidate';
+  label: { profile: string; profileFingerprint: string; complete: boolean | null };
+}) {
+  return (
+    <div>
+      <span className="text-term-cyan">{side}</span>
+      <span className="text-term-dim"> · </span>
+      <span className="text-term-fg">{label.profile}</span>
+      <span className="text-term-dim"> · config </span>
+      <span className="text-term-fg">{label.profileFingerprint.slice(0, 12)}</span>
+      {label.complete === false && (
+        <span className="text-term-yellow"> · incomplete evidence — interpret with care</span>
       )}
     </div>
   );

--- a/apps/eval-ops/src/routes/Harness.tsx
+++ b/apps/eval-ops/src/routes/Harness.tsx
@@ -2,11 +2,12 @@ import { useEffect, useState } from 'react';
 import { Link, useParams } from 'react-router';
 
 import { Frame } from '../components/Frame';
-import { api, type ArtifactRef, type IndexIssue } from '../api/client';
+import { api, type ArtifactRef, type HarnessDescriptor, type IndexIssue } from '../api/client';
 
 interface HarnessState {
   artifacts: ArtifactRef[];
   issues: IndexIssue[];
+  descriptor: HarnessDescriptor | null;
   error: string | null;
 }
 
@@ -15,6 +16,7 @@ export function Harness() {
   const [state, setState] = useState<HarnessState>({
     artifacts: [],
     issues: [],
+    descriptor: null,
     error: null,
   });
 
@@ -27,24 +29,38 @@ export function Harness() {
         if (mounted) {
           const filtered = result.refs.filter((a) => a.harness === harness);
           filtered.sort((a, b) => b.createdAt.localeCompare(a.createdAt));
-          setState({
+          setState((prev) => ({
+            ...prev,
             artifacts: filtered,
             issues: result.issues.filter((issue) =>
               issue.path.startsWith(`${harness}/`),
             ),
             error: null,
-          });
+          }));
         }
       })
       .catch((error) => {
         if (mounted) {
-          setState({
+          setState((prev) => ({
+            ...prev,
             artifacts: [],
             issues: [],
             error: error instanceof Error ? error.message : String(error),
-          });
+          }));
         }
       });
+
+    // The description is a courtesy line; a failure here must not take the
+    // artifact list down with it, so it is fetched and settled separately.
+    api
+      .harnesses()
+      .then((result) => {
+        if (!mounted) return;
+        const descriptor =
+          (result.harnesses ?? []).find((h) => h.harness === harness) ?? null;
+        setState((prev) => ({ ...prev, descriptor }));
+      })
+      .catch(() => {});
 
     return () => {
       mounted = false;
@@ -69,6 +85,12 @@ export function Harness() {
         </Link>
         <h1 className="text-xl">{harness}</h1>
       </div>
+
+      {state.descriptor !== null && (
+        <p className="text-term-dim -mt-2">
+          {state.descriptor.question} {state.descriptor.detail}
+        </p>
+      )}
 
       <Frame label="artifacts">
         <ArtifactList artifacts={state.artifacts} />

--- a/apps/eval-ops/src/routes/Launch.tsx
+++ b/apps/eval-ops/src/routes/Launch.tsx
@@ -15,8 +15,10 @@ interface LaunchState {
   models: string[];
   selectedHarness: HarnessDescriptor | null;
   selectedProfile: string;
-  /** A/B mode: reference and candidate each carry their own overrides. */
+  /** A/B mode: each side picks its own profile and carries its own overrides. */
   ab: boolean;
+  referenceProfile: string;
+  candidateProfile: string;
   referenceOverrides: Overrides;
   candidateOverrides: Overrides;
   flags: RunFlags;
@@ -44,6 +46,8 @@ export function Launch() {
     // The configs page links here as /launch?profile=<name>.
     selectedProfile: searchParams.get('profile') ?? 'default',
     ab: false,
+    referenceProfile: 'default',
+    candidateProfile: 'default',
     referenceOverrides: EMPTY_OVERRIDES,
     candidateOverrides: EMPTY_OVERRIDES,
     flags: {},
@@ -185,14 +189,14 @@ export function Launch() {
    * server refuses a named profile combined with overrides, so the form never
    * offers the combination.
    */
-  const buildSpec = (overrides: Overrides): EvalRunSpec => {
+  const buildSpec = (profile: string, overrides: Overrides): EvalRunSpec => {
     const cleaned = cleanOverrides(overrides);
     return {
       kind: 'eval',
       harness: state.selectedHarness!.harness,
-      profile: state.selectedProfile,
+      profile,
       flags: state.flags,
-      ...(state.selectedProfile === 'default' && hasOverrides(cleaned) ? { overrides: cleaned } : {}),
+      ...(profile === 'default' && hasOverrides(cleaned) ? { overrides: cleaned } : {}),
     };
   };
 
@@ -212,8 +216,8 @@ export function Launch() {
     if (state.ab) {
       // Reference first, candidate second: they serialise through the run
       // queue, which keeps the comparison fair on one machine.
-      const referenceSpec = buildSpec(state.referenceOverrides);
-      const candidateSpec = buildSpec(state.candidateOverrides);
+      const referenceSpec = buildSpec(state.referenceProfile, state.referenceOverrides);
+      const candidateSpec = buildSpec(state.candidateProfile, state.candidateOverrides);
       api
         .launch(referenceSpec)
         .then((reference) =>
@@ -232,7 +236,7 @@ export function Launch() {
       return;
     }
 
-    const spec = buildSpec(state.referenceOverrides);
+    const spec = buildSpec(state.selectedProfile, state.referenceOverrides);
 
     api
       .launch(spec)
@@ -344,6 +348,7 @@ export function Launch() {
             )}
           </div>
 
+          {!state.ab && (
           <div>
             <label htmlFor="profile" className="block mb-1">
               Configuration Profile
@@ -371,20 +376,24 @@ export function Launch() {
               </p>
             )}
           </div>
+          )}
 
           <div>
             <label className="flex items-center gap-2">
               <input
                 type="checkbox"
                 checked={state.ab}
-                onChange={(e) =>
+                onChange={(e) => {
+                  const ab = e.target.checked;
                   setState((prev) => ({
                     ...prev,
-                    ab: e.target.checked,
+                    ab,
+                    // The single-mode profile is the reference side's starting point.
+                    referenceProfile: ab ? prev.selectedProfile : prev.referenceProfile,
                     awaitingConfirmation: false,
                     launchError: null,
-                  }))
-                }
+                  }));
+                }}
               />
               <span>A/B — compare two configurations</span>
             </label>
@@ -396,6 +405,50 @@ export function Launch() {
             )}
           </div>
 
+          {state.ab && (
+            <div className="space-y-4">
+              <AbSide
+                side="reference"
+                profile={state.referenceProfile}
+                overrides={state.referenceOverrides}
+                profiles={state.profiles}
+                savedConfigs={state.savedConfigs}
+                editorProps={editorProps}
+                onProfileChange={(profile) =>
+                  setState((prev) => ({
+                    ...prev,
+                    referenceProfile: profile,
+                    awaitingConfirmation: false,
+                    launchError: null,
+                  }))
+                }
+                onOverridesChange={(next) =>
+                  setState((prev) => ({ ...prev, referenceOverrides: next }))
+                }
+              />
+              <AbSide
+                side="candidate"
+                profile={state.candidateProfile}
+                overrides={state.candidateOverrides}
+                profiles={state.profiles}
+                savedConfigs={state.savedConfigs}
+                editorProps={editorProps}
+                onProfileChange={(profile) =>
+                  setState((prev) => ({
+                    ...prev,
+                    candidateProfile: profile,
+                    awaitingConfirmation: false,
+                    launchError: null,
+                  }))
+                }
+                onOverridesChange={(next) =>
+                  setState((prev) => ({ ...prev, candidateOverrides: next }))
+                }
+              />
+            </div>
+          )}
+
+          {!state.ab && (
           <details>
             <summary className="cursor-pointer text-term-cyan">overrides (this run only)</summary>
             <div className="mt-2 space-y-3">
@@ -504,6 +557,7 @@ export function Launch() {
               )}
             </div>
           </details>
+          )}
 
           {state.selectedHarness !== null && (
             <div className="space-y-3">
@@ -572,6 +626,77 @@ export function Launch() {
         </div>
       </Frame>
     </div>
+  );
+}
+
+/**
+ * One side of an A/B launch: its own profile select (repo profiles, then saved
+ * configs) and its own overrides editor. Overrides are only expressible on top
+ * of the default configuration — the server refuses a named profile combined
+ * with overrides — so the editor is replaced by the configs-page pointer when
+ * this side runs a named profile.
+ */
+function AbSide({
+  side,
+  profile,
+  overrides,
+  profiles,
+  savedConfigs,
+  editorProps,
+  onProfileChange,
+  onOverridesChange,
+}: {
+  side: 'reference' | 'candidate';
+  profile: string;
+  overrides: Overrides;
+  profiles: ProfileDescriptor[];
+  savedConfigs: ConfigProfile[];
+  editorProps: { agents: readonly string[]; models: readonly string[]; envKeys: readonly string[] };
+  onProfileChange: (profile: string) => void;
+  onOverridesChange: (next: Overrides) => void;
+}) {
+  return (
+    <fieldset aria-label={side} className="border border-term-rule p-2 space-y-3">
+      <legend className="px-[1ch] text-term-dim">{side}</legend>
+      <div>
+        <label htmlFor={`${side}-profile`} className="block mb-1">
+          profile
+        </label>
+        <select
+          id={`${side}-profile`}
+          className="w-full bg-term-bg border border-term-rule px-[1ch] py-[0.5lh]"
+          value={profile}
+          onChange={(e) => onProfileChange(e.target.value)}
+        >
+          {profiles.map((p) => (
+            <option key={p.name} value={p.name}>
+              {p.name} — {p.description}
+            </option>
+          ))}
+          {savedConfigs.map((p) => (
+            <option key={p.name} value={p.name}>
+              {p.name} (saved) — {p.description}
+            </option>
+          ))}
+        </select>
+      </div>
+      {profile !== 'default' && (
+        <p className="text-term-yellow">
+          Experimental — forced to --no-save and never diffed against the committed baseline.
+        </p>
+      )}
+      {profile === 'default' ? (
+        <OverridesEditor {...editorProps} value={overrides} onChange={onOverridesChange} />
+      ) : (
+        <p className="text-term-dim">
+          Overrides apply on top of the default configuration. To tweak a saved config,{' '}
+          <Link to="/profiles" className="text-term-cyan underline">
+            edit it on the configs page
+          </Link>
+          .
+        </p>
+      )}
+    </fieldset>
   );
 }
 

--- a/apps/eval-ops/src/routes/Launch.tsx
+++ b/apps/eval-ops/src/routes/Launch.tsx
@@ -1,16 +1,31 @@
 import { useEffect, useState } from 'react';
-import { useNavigate } from 'react-router';
+import { Link, useNavigate } from 'react-router';
 
 import { Frame } from '../components/Frame';
-import { api, type EvalRunSpec, type HarnessDescriptor, type HarnessFlag, type ProfileDescriptor, type RunFlags } from '../api/client';
+import { cleanOverrides, EMPTY_OVERRIDES, hasOverrides, OverridesEditor, type Overrides } from '../components/OverridesEditor';
+import { PROFILE_ENV_ALLOWLIST } from '../../../../packages/protocol/eval/ops/ops.allowlist';
+import { api, type ConfigProfile, type EvalRunSpec, type HarnessDescriptor, type HarnessFlag, type ProfileDescriptor, type RunFlags } from '../api/client';
 
 interface LaunchState {
   harnesses: HarnessDescriptor[];
   profiles: ProfileDescriptor[];
+  /** Saved (DB) configs, listed after the shipped repo profiles. */
+  savedConfigs: ConfigProfile[];
+  /** The curated model list for the override dropdowns. */
+  models: string[];
   selectedHarness: HarnessDescriptor | null;
   selectedProfile: string;
+  /** A/B mode: reference and candidate each carry their own overrides. */
+  ab: boolean;
+  referenceOverrides: Overrides;
+  candidateOverrides: Overrides;
   flags: RunFlags;
   awaitingConfirmation: boolean;
+  /** The "save as config…" inline form. */
+  savingConfig: boolean;
+  configName: string;
+  configDescription: string;
+  saveError: string | null;
   /** A failure loading the registry or the profiles: nothing can be launched. */
   error: string | null;
   /** A rejected launch. Rendered inline so the entered flags survive. */
@@ -22,10 +37,19 @@ export function Launch() {
   const [state, setState] = useState<LaunchState>({
     harnesses: [],
     profiles: [],
+    savedConfigs: [],
+    models: [],
     selectedHarness: null,
     selectedProfile: 'default',
+    ab: false,
+    referenceOverrides: EMPTY_OVERRIDES,
+    candidateOverrides: EMPTY_OVERRIDES,
     flags: {},
     awaitingConfirmation: false,
+    savingConfig: false,
+    configName: '',
+    configDescription: '',
+    saveError: null,
     error: null,
     launchError: null,
   });
@@ -54,6 +78,25 @@ export function Launch() {
         }
       });
 
+    // Saved configs and the curated model list enhance the form but must never
+    // break it: both settle independently and failures are swallowed.
+    api
+      .configs()
+      .then((result) => {
+        if (!mounted) return;
+        const saved = result.saved ?? [];
+        setState((prev) => ({ ...prev, savedConfigs: saved }));
+      })
+      .catch(() => {});
+    api
+      .configModels()
+      .then((result) => {
+        if (!mounted) return;
+        const models = result.models ?? [];
+        setState((prev) => ({ ...prev, models }));
+      })
+      .catch(() => {});
+
     return () => {
       mounted = false;
     };
@@ -65,6 +108,9 @@ export function Launch() {
       ...prev,
       selectedHarness: descriptor,
       flags: {},
+      // Overrides name agents; a different harness exercises different agents.
+      referenceOverrides: EMPTY_OVERRIDES,
+      candidateOverrides: EMPTY_OVERRIDES,
       awaitingConfirmation: false,
       launchError: null,
     }));
@@ -132,6 +178,22 @@ export function Launch() {
     .filter(([, value]) => typeof value === 'string' && value.startsWith('-'))
     .map(([name]) => state.selectedHarness?.flags.find((flag) => flag.name === name)?.cli ?? `--${name}`);
 
+  /**
+   * Overrides are only expressible on top of the default configuration — the
+   * server refuses a named profile combined with overrides, so the form never
+   * offers the combination.
+   */
+  const buildSpec = (overrides: Overrides): EvalRunSpec => {
+    const cleaned = cleanOverrides(overrides);
+    return {
+      kind: 'eval',
+      harness: state.selectedHarness!.harness,
+      profile: state.selectedProfile,
+      flags: state.flags,
+      ...(state.selectedProfile === 'default' && hasOverrides(cleaned) ? { overrides: cleaned } : {}),
+    };
+  };
+
   const handleRun = () => {
     if (invalidSelectionFlags.length > 0) return;
 
@@ -145,12 +207,30 @@ export function Launch() {
       return;
     }
 
-    const spec: EvalRunSpec = {
-      kind: 'eval',
-      harness: state.selectedHarness.harness,
-      profile: state.selectedProfile,
-      flags: state.flags,
-    };
+    if (state.ab) {
+      // Reference first, candidate second: they serialise through the run
+      // queue, which keeps the comparison fair on one machine.
+      const referenceSpec = buildSpec(state.referenceOverrides);
+      const candidateSpec = buildSpec(state.candidateOverrides);
+      api
+        .launch(referenceSpec)
+        .then((reference) =>
+          api.launch(candidateSpec).then((candidate) => ({ reference, candidate })),
+        )
+        .then(({ reference, candidate }) => {
+          navigate(`/compare?referenceRun=${reference.id}&subjectRun=${candidate.id}`);
+        })
+        .catch((error) => {
+          setState((prev) => ({
+            ...prev,
+            launchError: error instanceof Error ? error.message : String(error),
+            awaitingConfirmation: false,
+          }));
+        });
+      return;
+    }
+
+    const spec = buildSpec(state.referenceOverrides);
 
     api
       .launch(spec)
@@ -163,6 +243,36 @@ export function Launch() {
           ...prev,
           launchError: error instanceof Error ? error.message : String(error),
           awaitingConfirmation: false,
+        }));
+      });
+  };
+
+  const handleSaveConfig = () => {
+    const cleaned = cleanOverrides(state.referenceOverrides);
+    const name = state.configName.trim();
+    const description = state.configDescription.trim();
+    if (name === '' || description === '' || !hasOverrides(cleaned)) return;
+    const profile: ConfigProfile = { name, description, models: cleaned.models, env: cleaned.env };
+    api
+      .createConfig(profile)
+      .then((created) => {
+        setState((prev) => ({
+          ...prev,
+          savedConfigs: [...prev.savedConfigs, created],
+          selectedProfile: created.name,
+          savingConfig: false,
+          configName: '',
+          configDescription: '',
+          saveError: null,
+          // The overrides now live in the saved config; the editors reset.
+          referenceOverrides: EMPTY_OVERRIDES,
+          candidateOverrides: EMPTY_OVERRIDES,
+        }));
+      })
+      .catch((error) => {
+        setState((prev) => ({
+          ...prev,
+          saveError: error instanceof Error ? error.message : String(error),
         }));
       });
   };
@@ -192,16 +302,22 @@ export function Launch() {
   }
 
   const isExperimental = state.selectedProfile !== 'default';
+  const overridesAllowed = state.selectedProfile === 'default';
   const fullCorpus = isFullCorpus();
   const runs = state.flags.runs ?? state.selectedHarness?.defaultRuns ?? 0;
   // The same first factor renderRun uses: a narrowed selection runs exactly one case.
   const cases = state.selectedHarness === null ? 0 : fullCorpus ? state.selectedHarness.caseCount : 1;
-  const workload = cases * runs;
+  const workload = cases * runs * (state.ab ? 2 : 1);
   const launchBlocked = invalidSelectionFlags.length > 0;
+  const agents = state.selectedHarness?.agents ?? [];
+  const showSaveConfig =
+    overridesAllowed && hasOverrides(cleanOverrides(state.referenceOverrides));
+
+  const editorProps = { agents, models: state.models, envKeys: PROFILE_ENV_ALLOWLIST };
 
   return (
     <div className="p-4">
-      <Frame label="launch run">
+      <Frame label={state.ab ? 'launch a/b run' : 'launch run'}>
         <div className="space-y-4">
           <div>
             <label htmlFor="harness" className="block mb-1">
@@ -241,6 +357,11 @@ export function Launch() {
                   {p.name} — {p.description}
                 </option>
               ))}
+              {state.savedConfigs.map((p) => (
+                <option key={p.name} value={p.name}>
+                  {p.name} (saved) — {p.description}
+                </option>
+              ))}
             </select>
             {isExperimental && (
               <p className="mt-2 text-term-yellow">
@@ -248,6 +369,139 @@ export function Launch() {
               </p>
             )}
           </div>
+
+          <div>
+            <label className="flex items-center gap-2">
+              <input
+                type="checkbox"
+                checked={state.ab}
+                onChange={(e) =>
+                  setState((prev) => ({
+                    ...prev,
+                    ab: e.target.checked,
+                    awaitingConfirmation: false,
+                    launchError: null,
+                  }))
+                }
+              />
+              <span>A/B — compare two configurations</span>
+            </label>
+            {state.ab && (
+              <p className="text-term-dim mt-1">
+                Two runs back to back — reference first, then candidate — with the comparison shown
+                when both end.
+              </p>
+            )}
+          </div>
+
+          <details>
+            <summary className="cursor-pointer text-term-cyan">overrides (this run only)</summary>
+            <div className="mt-2 space-y-3">
+              {!overridesAllowed && (
+                <p className="text-term-dim">
+                  Overrides apply on top of the default configuration. To tweak a saved config,{' '}
+                  <Link to="/profiles" className="text-term-cyan underline">
+                    edit it on the configs page
+                  </Link>
+                  .
+                </p>
+              )}
+              {overridesAllowed && state.ab && (
+                <div className="space-y-4">
+                  <fieldset aria-label="reference" className="border border-term-rule p-2">
+                    <legend className="px-[1ch] text-term-dim">reference</legend>
+                    <OverridesEditor
+                      {...editorProps}
+                      value={state.referenceOverrides}
+                      onChange={(next) => setState((prev) => ({ ...prev, referenceOverrides: next }))}
+                    />
+                  </fieldset>
+                  <fieldset aria-label="candidate" className="border border-term-rule p-2">
+                    <legend className="px-[1ch] text-term-dim">candidate</legend>
+                    <OverridesEditor
+                      {...editorProps}
+                      value={state.candidateOverrides}
+                      onChange={(next) => setState((prev) => ({ ...prev, candidateOverrides: next }))}
+                    />
+                  </fieldset>
+                </div>
+              )}
+              {overridesAllowed && !state.ab && (
+                <>
+                  <OverridesEditor
+                    {...editorProps}
+                    value={state.referenceOverrides}
+                    onChange={(next) => setState((prev) => ({ ...prev, referenceOverrides: next }))}
+                  />
+                  {showSaveConfig && !state.savingConfig && (
+                    <button
+                      type="button"
+                      className="px-[2ch] py-[0.5lh] border border-term-rule text-term-dim"
+                      onClick={() => setState((prev) => ({ ...prev, savingConfig: true, saveError: null }))}
+                    >
+                      save as config…
+                    </button>
+                  )}
+                  {state.savingConfig && (
+                    <div className="space-y-2 border border-term-rule p-2">
+                      <div>
+                        <label htmlFor="config-name" className="block mb-1 text-term-dim">
+                          config name
+                        </label>
+                        <input
+                          id="config-name"
+                          type="text"
+                          placeholder="kebab-case-name"
+                          className="w-full bg-term-bg border border-term-rule px-[1ch] py-[0.5lh]"
+                          value={state.configName}
+                          onChange={(e) => setState((prev) => ({ ...prev, configName: e.target.value }))}
+                        />
+                      </div>
+                      <div>
+                        <label htmlFor="config-description" className="block mb-1 text-term-dim">
+                          config description
+                        </label>
+                        <input
+                          id="config-description"
+                          type="text"
+                          placeholder="what this config is for"
+                          className="w-full bg-term-bg border border-term-rule px-[1ch] py-[0.5lh]"
+                          value={state.configDescription}
+                          onChange={(e) =>
+                            setState((prev) => ({ ...prev, configDescription: e.target.value }))
+                          }
+                        />
+                      </div>
+                      {state.saveError !== null && (
+                        <p role="alert" className="text-term-red">
+                          {state.saveError}
+                        </p>
+                      )}
+                      <div className="flex gap-2">
+                        <button
+                          type="button"
+                          className="px-[2ch] py-[0.5lh] bg-term-cyan text-term-bg font-bold disabled:opacity-50"
+                          disabled={state.configName.trim() === '' || state.configDescription.trim() === ''}
+                          onClick={handleSaveConfig}
+                        >
+                          Save config
+                        </button>
+                        <button
+                          type="button"
+                          className="px-[2ch] py-[0.5lh] border border-term-rule"
+                          onClick={() =>
+                            setState((prev) => ({ ...prev, savingConfig: false, saveError: null }))
+                          }
+                        >
+                          Cancel
+                        </button>
+                      </div>
+                    </div>
+                  )}
+                </>
+              )}
+            </div>
+          </details>
 
           {state.selectedHarness !== null && (
             <div className="space-y-3">
@@ -267,7 +521,7 @@ export function Launch() {
             <p className="mb-2">
               <span className="text-term-dim">Workload: </span>
               {cases} {cases === 1 ? 'case' : 'cases'}
-              {fullCorpus ? '' : ' (filtered)'} × {runs} runs = {workload}
+              {fullCorpus ? '' : ' (filtered)'} × {runs} runs{state.ab ? ' × 2 sides' : ''} = {workload}
             </p>
 
             {launchBlocked && (

--- a/apps/eval-ops/src/routes/Launch.tsx
+++ b/apps/eval-ops/src/routes/Launch.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useState } from 'react';
-import { Link, useNavigate } from 'react-router';
+import { Link, useNavigate, useSearchParams } from 'react-router';
 
 import { Frame } from '../components/Frame';
 import { cleanOverrides, EMPTY_OVERRIDES, hasOverrides, OverridesEditor, type Overrides } from '../components/OverridesEditor';
@@ -34,13 +34,15 @@ interface LaunchState {
 
 export function Launch() {
   const navigate = useNavigate();
+  const [searchParams] = useSearchParams();
   const [state, setState] = useState<LaunchState>({
     harnesses: [],
     profiles: [],
     savedConfigs: [],
     models: [],
     selectedHarness: null,
-    selectedProfile: 'default',
+    // The configs page links here as /launch?profile=<name>.
+    selectedProfile: searchParams.get('profile') ?? 'default',
     ab: false,
     referenceOverrides: EMPTY_OVERRIDES,
     candidateOverrides: EMPTY_OVERRIDES,

--- a/apps/eval-ops/src/routes/Launch.tsx
+++ b/apps/eval-ops/src/routes/Launch.tsx
@@ -219,6 +219,11 @@ export function Launch() {
                 </option>
               ))}
             </select>
+            {state.selectedHarness !== null && (
+              <p className="text-term-dim mt-1">
+                {state.selectedHarness.question} {state.selectedHarness.detail}
+              </p>
+            )}
           </div>
 
           <div>

--- a/apps/eval-ops/src/routes/Overview.tsx
+++ b/apps/eval-ops/src/routes/Overview.tsx
@@ -117,31 +117,34 @@ function HarnessHealth({
           .sort((a, b) => b.createdAt.localeCompare(a.createdAt))[0];
 
         return (
-          <div key={harness.harness} className="flex gap-4">
-            <Link
-              to={`/h/${harness.harness}`}
-              className="text-term-blue hover:underline w-24"
-            >
-              {harness.harness}
-            </Link>
-            <span className="text-term-dim w-20">baseline:</span>
-            <span className="w-16">
-              {baseline
-                ? `${(baseline.aggregatePassRate * 100).toFixed(1)}%`
-                : '—'}
-            </span>
-            <span className="text-term-dim w-20">latest:</span>
-            <span className="w-16">
-              {latestRun
-                ? `${(latestRun.aggregatePassRate * 100).toFixed(1)}%`
-                : '—'}
-            </span>
-            {baseline && latestRun && (
-              <Delta
-                baseline={baseline.aggregatePassRate}
-                current={latestRun.aggregatePassRate}
-              />
-            )}
+          <div key={harness.harness}>
+            <div className="flex gap-4">
+              <Link
+                to={`/h/${harness.harness}`}
+                className="text-term-blue hover:underline w-24"
+              >
+                {harness.harness}
+              </Link>
+              <span className="text-term-dim w-20">baseline:</span>
+              <span className="w-16">
+                {baseline
+                  ? `${(baseline.aggregatePassRate * 100).toFixed(1)}%`
+                  : '—'}
+              </span>
+              <span className="text-term-dim w-20">latest:</span>
+              <span className="w-16">
+                {latestRun
+                  ? `${(latestRun.aggregatePassRate * 100).toFixed(1)}%`
+                  : '—'}
+              </span>
+              {baseline && latestRun && (
+                <Delta
+                  baseline={baseline.aggregatePassRate}
+                  current={latestRun.aggregatePassRate}
+                />
+              )}
+            </div>
+            <p className="text-term-dim ml-28 -mt-1">{harness.question}</p>
           </div>
         );
       })}

--- a/apps/eval-ops/src/routes/Profiles.tsx
+++ b/apps/eval-ops/src/routes/Profiles.tsx
@@ -3,47 +3,156 @@ import { Link } from 'react-router';
 
 import { Frame } from '../components/Frame';
 import { StatusChip } from '../components/StatusChip';
-import { api, type ProfileDescriptor, type RunRecord } from '../api/client';
+import { cleanOverrides, OverridesEditor, type Overrides } from '../components/OverridesEditor';
+import { PROFILE_ENV_ALLOWLIST } from '../../../../packages/protocol/eval/ops/ops.allowlist';
+import { api, type ConfigProfile, type RunRecord } from '../api/client';
 
 interface ProfilesState {
-  profiles: ProfileDescriptor[];
+  /** Shipped repo profiles: committed, code-reviewed, read-only here. */
+  repo: ConfigProfile[];
+  /** Saved configs: created in the browser, stored in the eval-ops database. */
+  saved: ConfigProfile[];
   runs: RunRecord[];
+  /**
+   * Union of every harness's overridable agents. A saved config is
+   * harness-agnostic — it can be selected for any harness — so the edit
+   * editor offers every agent any harness exercises, not one harness's set.
+   */
+  agents: string[];
+  /** The curated model list for the edit editor's dropdowns. */
+  models: string[];
+  loaded: boolean;
+  /** Name of the config currently being edited, or null. */
+  editing: string | null;
+  editDescription: string;
+  editOverrides: Overrides;
+  editError: string | null;
+  /** Name of the config awaiting delete confirmation, or null. */
+  confirmingDelete: string | null;
+  deleteError: string | null;
   error: string | null;
 }
 
 export function Profiles() {
   const [state, setState] = useState<ProfilesState>({
-    profiles: [],
+    repo: [],
+    saved: [],
     runs: [],
+    agents: [],
+    models: [],
+    loaded: false,
+    editing: null,
+    editDescription: '',
+    editOverrides: { models: {}, env: {} },
+    editError: null,
+    confirmingDelete: null,
+    deleteError: null,
     error: null,
   });
 
   useEffect(() => {
     let mounted = true;
 
-    Promise.all([api.profiles(), api.runs()])
-      .then(([profiles, runs]) => {
-        if (mounted) {
-          setState({
-            profiles: profiles.profiles,
-            runs: runs.runs,
-            error: null,
-          });
-        }
+    Promise.all([api.configs(), api.runs()])
+      .then(([configs, runs]) => {
+        if (!mounted) return;
+        // Tests stub fetch naïvely: never trust the payload's shape, and never
+        // compute derived values inside a setState updater.
+        const repo = configs.repo ?? [];
+        const saved = configs.saved ?? [];
+        const runList = runs.runs ?? [];
+        setState((prev) => ({ ...prev, repo, saved, runs: runList, loaded: true, error: null }));
       })
       .catch((error) => {
-        if (mounted) {
-          setState((prev) => ({
-            ...prev,
-            error: error instanceof Error ? error.message : String(error),
-          }));
-        }
+        if (!mounted) return;
+        setState((prev) => ({
+          ...prev,
+          loaded: true,
+          error: error instanceof Error ? error.message : String(error),
+        }));
       });
+
+    // Agents and curated models only enhance the edit form; a failure here must
+    // not take the page down, so both settle independently.
+    api
+      .harnesses()
+      .then((result) => {
+        if (!mounted) return;
+        const agents = [
+          ...new Set((result.harnesses ?? []).flatMap((h) => h.agents ?? [])),
+        ].sort();
+        setState((prev) => ({ ...prev, agents }));
+      })
+      .catch(() => {});
+    api
+      .configModels()
+      .then((result) => {
+        if (!mounted) return;
+        const models = result.models ?? [];
+        setState((prev) => ({ ...prev, models }));
+      })
+      .catch(() => {});
 
     return () => {
       mounted = false;
     };
   }, []);
+
+  const runsFor = (name: string): RunRecord[] =>
+    state.runs.filter((r) => r.spec.kind === 'eval' && r.spec.profile === name);
+
+  const startEdit = (config: ConfigProfile) => {
+    setState((prev) => ({
+      ...prev,
+      editing: config.name,
+      editDescription: config.description,
+      editOverrides: { models: { ...config.models }, env: { ...config.env } },
+      editError: null,
+      confirmingDelete: null,
+      deleteError: null,
+    }));
+  };
+
+  const handleSaveEdit = (name: string) => {
+    const description = state.editDescription.trim();
+    if (description === '') return;
+    const cleaned = cleanOverrides(state.editOverrides);
+    api
+      .updateConfig(name, { description, models: cleaned.models, env: cleaned.env })
+      .then((updated) => {
+        setState((prev) => ({
+          ...prev,
+          saved: prev.saved.map((config) => (config.name === name ? updated : config)),
+          editing: null,
+          editError: null,
+        }));
+      })
+      .catch((error) => {
+        setState((prev) => ({
+          ...prev,
+          editError: error instanceof Error ? error.message : String(error),
+        }));
+      });
+  };
+
+  const handleDelete = (name: string) => {
+    api
+      .deleteConfig(name)
+      .then(() => {
+        setState((prev) => ({
+          ...prev,
+          saved: prev.saved.filter((config) => config.name !== name),
+          confirmingDelete: null,
+          deleteError: null,
+        }));
+      })
+      .catch((error) => {
+        setState((prev) => ({
+          ...prev,
+          deleteError: error instanceof Error ? error.message : String(error),
+        }));
+      });
+  };
 
   if (state.error !== null) {
     return (
@@ -55,105 +164,262 @@ export function Profiles() {
     );
   }
 
-  if (state.profiles.length === 0) {
+  if (!state.loaded) {
     return (
       <div className="p-4">
-        <Frame label="profiles">
+        <Frame label="configs">
           <p className="text-term-dim">Loading...</p>
         </Frame>
       </div>
     );
   }
 
+  // When the harness list has not arrived, the edit editor still shows the
+  // agents the config already overrides rather than hiding them.
+  const editAgents =
+    state.agents.length > 0 ? state.agents : Object.keys(state.editOverrides.models);
+
   return (
     <div className="p-4 space-y-4">
-      <Frame label="configuration profiles">
+      <Frame label="configs">
         <div className="mb-4">
           <p className="text-term-dim mb-2">
-            Profiles are committed files in{' '}
-            <code className="text-term-cyan">packages/protocol/eval/ops/profiles/</code>.
+            A configuration is a set of model and environment overrides a run launches under.
           </p>
           <p className="text-term-dim">
-            They are edited in the repository, not in the browser, so every configuration change is
-            code-reviewed and versioned alongside the harnesses themselves. This prevents
-            accidentally comparing runs made under different model or environment settings.
+            <span className="text-term-fg">Saved configs</span> are created and edited here and
+            stored in the eval-ops database. <span className="text-term-fg">Shipped profiles</span>{' '}
+            are committed in{' '}
+            <code className="text-term-cyan">packages/protocol/eval/ops/profiles/</code> — edited in
+            the repository, not the browser, so the baseline configuration stays code-reviewed.
           </p>
         </div>
 
-        <div className="space-y-6">
-          {state.profiles.map((profile) => {
-            const profileRuns = state.runs.filter(
-              (r) => r.spec.kind === 'eval' && r.spec.profile === profile.name,
-            );
-
-            return (
-              <div key={profile.name} className="border-t border-term-rule pt-4 first:border-0 first:pt-0">
-                <h3 className="text-term-cyan text-lg mb-2">{profile.name}</h3>
-                <p className="text-term-dim mb-3">{profile.description}</p>
-
-                <div className="grid grid-cols-[auto_1fr] gap-x-4 gap-y-2 text-sm mb-3">
-                  <span className="text-term-dim">Model overrides:</span>
-                  <span>
-                    {Object.keys(profile.models).length === 0 ? (
-                      <span className="text-term-dim">none</span>
-                    ) : (
-                      <ul className="space-y-1">
-                        {Object.entries(profile.models).map(([agent, model]) => (
-                          <li key={agent}>
-                            <code className="text-term-green">{agent}</code> →{' '}
-                            <code className="text-term-white">{model}</code>
-                          </li>
-                        ))}
-                      </ul>
-                    )}
-                  </span>
-
-                  <span className="text-term-dim">Environment overrides:</span>
-                  <span>
-                    {Object.keys(profile.env).length === 0 ? (
-                      <span className="text-term-dim">none</span>
-                    ) : (
-                      <ul className="space-y-1">
-                        {Object.entries(profile.env).map(([key, value]) => (
-                          <li key={key}>
-                            <code className="text-term-green">{key}</code> ={' '}
-                            <code className="text-term-white">{value}</code>
-                          </li>
-                        ))}
-                      </ul>
-                    )}
-                  </span>
-
-                  <span className="text-term-dim">Runs:</span>
-                  <span>
-                    {profileRuns.length === 0 ? (
-                      <span className="text-term-dim">none</span>
-                    ) : (
-                      <div className="space-y-1">
-                        {profileRuns.slice(0, 5).map((run) => (
-                          <div key={run.id}>
-                            <Link to={`/r/${run.id}`} className="text-term-cyan hover:underline">
-                              {run.id}
-                            </Link>{' '}
-                            — <StatusChip status={run.status} /> —{' '}
-                            {run.spec.kind === 'eval' && run.spec.harness} —{' '}
-                            {new Date(run.createdAt).toLocaleString()}
-                          </div>
-                        ))}
-                        {profileRuns.length > 5 && (
-                          <p className="text-term-dim text-xs">
-                            +{profileRuns.length - 5} more
-                          </p>
-                        )}
-                      </div>
-                    )}
-                  </span>
+        <h2 className="text-term-cyan mb-3">saved configs</h2>
+        {state.saved.length === 0 ? (
+          <p className="text-term-dim mb-6">
+            None yet — set overrides on the{' '}
+            <Link to="/launch" className="text-term-cyan hover:underline">
+              launch page
+            </Link>{' '}
+            and choose “save as config…”.
+          </p>
+        ) : (
+          <div className="space-y-6 mb-6">
+            {state.saved.map((config) => (
+              <section
+                key={config.name}
+                aria-label={`config ${config.name}`}
+                className="border-t border-term-rule pt-4 first:border-0 first:pt-0"
+              >
+                <div className="flex items-baseline gap-3 mb-2">
+                  <h3 className="text-term-cyan text-lg">{config.name}</h3>
+                  <Link
+                    to={`/launch?profile=${config.name}`}
+                    className="text-term-cyan hover:underline text-sm"
+                  >
+                    launch →
+                  </Link>
+                  {state.editing !== config.name && state.confirmingDelete !== config.name && (
+                    <>
+                      <button
+                        type="button"
+                        className="text-term-dim hover:underline text-sm"
+                        onClick={() => startEdit(config)}
+                      >
+                        edit
+                      </button>
+                      <button
+                        type="button"
+                        className="text-term-red hover:underline text-sm"
+                        onClick={() =>
+                          setState((prev) => ({
+                            ...prev,
+                            confirmingDelete: config.name,
+                            deleteError: null,
+                            editing: null,
+                          }))
+                        }
+                      >
+                        delete
+                      </button>
+                    </>
+                  )}
                 </div>
+
+                {state.confirmingDelete === config.name && (
+                  <div className="mb-3">
+                    <p className="text-term-yellow mb-2">delete {config.name}?</p>
+                    <div className="flex gap-2">
+                      <button
+                        type="button"
+                        className="px-[2ch] py-[0.5lh] bg-term-red text-term-bg font-bold"
+                        onClick={() => handleDelete(config.name)}
+                      >
+                        yes
+                      </button>
+                      <button
+                        type="button"
+                        className="px-[2ch] py-[0.5lh] border border-term-rule"
+                        onClick={() =>
+                          setState((prev) => ({ ...prev, confirmingDelete: null, deleteError: null }))
+                        }
+                      >
+                        no
+                      </button>
+                    </div>
+                    {state.deleteError !== null && (
+                      <p role="alert" className="mt-2 text-term-red">
+                        {state.deleteError}
+                      </p>
+                    )}
+                  </div>
+                )}
+
+                {state.editing === config.name ? (
+                  <div className="space-y-3 border border-term-rule p-2 mb-3">
+                    <div>
+                      <label htmlFor="edit-description" className="block mb-1 text-term-dim">
+                        description
+                      </label>
+                      <input
+                        id="edit-description"
+                        type="text"
+                        className="w-full bg-term-bg border border-term-rule px-[1ch] py-[0.5lh]"
+                        value={state.editDescription}
+                        onChange={(e) =>
+                          setState((prev) => ({ ...prev, editDescription: e.target.value }))
+                        }
+                      />
+                    </div>
+                    <OverridesEditor
+                      agents={editAgents}
+                      models={state.models}
+                      envKeys={PROFILE_ENV_ALLOWLIST}
+                      value={state.editOverrides}
+                      onChange={(next) => setState((prev) => ({ ...prev, editOverrides: next }))}
+                    />
+                    {state.editError !== null && (
+                      <p role="alert" className="text-term-red">
+                        {state.editError}
+                      </p>
+                    )}
+                    <div className="flex gap-2">
+                      <button
+                        type="button"
+                        className="px-[2ch] py-[0.5lh] bg-term-cyan text-term-bg font-bold disabled:opacity-50"
+                        disabled={state.editDescription.trim() === ''}
+                        onClick={() => handleSaveEdit(config.name)}
+                      >
+                        save changes
+                      </button>
+                      <button
+                        type="button"
+                        className="px-[2ch] py-[0.5lh] border border-term-rule"
+                        onClick={() =>
+                          setState((prev) => ({ ...prev, editing: null, editError: null }))
+                        }
+                      >
+                        cancel
+                      </button>
+                    </div>
+                  </div>
+                ) : (
+                  <ConfigDetail config={config} runs={runsFor(config.name)} />
+                )}
+              </section>
+            ))}
+          </div>
+        )}
+
+        <h2 className="text-term-cyan mb-3">shipped profiles</h2>
+        <div className="space-y-6">
+          {state.repo.map((profile) => (
+            <section
+              key={profile.name}
+              aria-label={`config ${profile.name}`}
+              className="border-t border-term-rule pt-4 first:border-0 first:pt-0 text-term-dim"
+            >
+              <div className="flex items-baseline gap-3 mb-2">
+                <h3 className="text-term-cyan text-lg">{profile.name}</h3>
+                <span className="text-term-dim text-sm">shipped</span>
+                <Link
+                  to={`/launch?profile=${profile.name}`}
+                  className="text-term-cyan hover:underline text-sm"
+                >
+                  launch →
+                </Link>
               </div>
-            );
-          })}
+              <ConfigDetail config={profile} runs={runsFor(profile.name)} />
+            </section>
+          ))}
         </div>
       </Frame>
     </div>
+  );
+}
+
+/** The read-only display of one configuration: description, overrides, runs. */
+function ConfigDetail({ config, runs }: { config: ConfigProfile; runs: RunRecord[] }) {
+  return (
+    <>
+      <p className="text-term-dim mb-3">{config.description}</p>
+      <div className="grid grid-cols-[auto_1fr] gap-x-4 gap-y-2 text-sm mb-3">
+        <span className="text-term-dim">Model overrides:</span>
+        <span>
+          {Object.keys(config.models).length === 0 ? (
+            <span className="text-term-dim">none</span>
+          ) : (
+            <ul className="space-y-1">
+              {Object.entries(config.models).map(([agent, model]) => (
+                <li key={agent}>
+                  <code className="text-term-green">{agent}</code> →{' '}
+                  <code className="text-term-white">{model}</code>
+                </li>
+              ))}
+            </ul>
+          )}
+        </span>
+
+        <span className="text-term-dim">Environment overrides:</span>
+        <span>
+          {Object.keys(config.env).length === 0 ? (
+            <span className="text-term-dim">none</span>
+          ) : (
+            <ul className="space-y-1">
+              {Object.entries(config.env).map(([key, value]) => (
+                <li key={key}>
+                  <code className="text-term-green">{key}</code> ={' '}
+                  <code className="text-term-white">{value}</code>
+                </li>
+              ))}
+            </ul>
+          )}
+        </span>
+
+        <span className="text-term-dim">Runs:</span>
+        <span>
+          {runs.length === 0 ? (
+            <span className="text-term-dim">none</span>
+          ) : (
+            <div className="space-y-1">
+              {runs.slice(0, 5).map((run) => (
+                <div key={run.id}>
+                  <Link to={`/r/${run.id}`} className="text-term-cyan hover:underline">
+                    {run.id}
+                  </Link>{' '}
+                  — <StatusChip status={run.status} /> —{' '}
+                  {run.spec.kind === 'eval' && run.spec.harness} —{' '}
+                  {new Date(run.createdAt).toLocaleString()}
+                </div>
+              ))}
+              {runs.length > 5 && (
+                <p className="text-term-dim text-xs">+{runs.length - 5} more</p>
+              )}
+            </div>
+          )}
+        </span>
+      </div>
+    </>
   );
 }

--- a/apps/eval-ops/src/routes/Run.tsx
+++ b/apps/eval-ops/src/routes/Run.tsx
@@ -252,6 +252,7 @@ function RunDetail({ runId }: { runId: string }) {
     run.spec.kind === 'eval'
       ? state.harnesses.find((h) => h.harness === (run.spec as { harness: string }).harness)?.question ?? null
       : null;
+  const overridesSummary = run.spec.kind === 'eval' ? summarizeRunEnv(run.env) : null;
 
   return (
     <div className="p-4 space-y-4">
@@ -283,6 +284,12 @@ function RunDetail({ runId }: { runId: string }) {
                 <span className="text-term-dim w-24">profile:</span>
                 <span>{run.spec.profile}</span>
               </div>
+              {overridesSummary !== null && (
+                <div className="flex gap-4">
+                  <span className="text-term-dim w-24">overrides:</span>
+                  <span className="text-term-dim">{overridesSummary}</span>
+                </div>
+              )}
             </>
           ) : (
             <div className="flex gap-4">
@@ -479,6 +486,41 @@ function RunDetail({ runId }: { runId: string }) {
       )}
     </div>
   );
+}
+
+/**
+ * renderRun's internal pins are bookkeeping for the spawn, not operator
+ * signal, so they never appear in the summary.
+ */
+const INTERNAL_ENV_PINS: ReadonlySet<string> = new Set(['OPENROUTER_FALLBACK_MODEL']);
+
+/**
+ * Renders a run's injected env as a one-line overrides summary: `agent → model`
+ * pairs from EVAL_MODEL_OVERRIDES, then the remaining KEY=value entries sorted
+ * by key. Returns null when there is nothing to show — a default run's env is
+ * empty. Never throws: a hand-written or corrupt record must not break the run
+ * page.
+ */
+function summarizeRunEnv(env: Record<string, string>): string | null {
+  const parts: string[] = [];
+  const rawOverrides = env.EVAL_MODEL_OVERRIDES;
+  if (rawOverrides !== undefined) {
+    try {
+      const parsed: unknown = JSON.parse(rawOverrides);
+      if (parsed !== null && typeof parsed === 'object' && !Array.isArray(parsed)) {
+        for (const [agent, model] of Object.entries(parsed as Record<string, unknown>)) {
+          parts.push(`${agent} → ${String(model)}`);
+        }
+      }
+    } catch {
+      parts.push('EVAL_MODEL_OVERRIDES (unparseable)');
+    }
+  }
+  for (const key of Object.keys(env).sort()) {
+    if (key === 'EVAL_MODEL_OVERRIDES' || INTERNAL_ENV_PINS.has(key)) continue;
+    parts.push(`${key}=${env[key]}`);
+  }
+  return parts.length === 0 ? null : parts.join(', ');
 }
 
 function Delta({ value }: { value: number }) {

--- a/apps/eval-ops/src/routes/Run.tsx
+++ b/apps/eval-ops/src/routes/Run.tsx
@@ -1,15 +1,19 @@
-import { useEffect, useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import { Link, useParams } from 'react-router';
 
 import { Frame } from '../components/Frame';
 import { StatusChip } from '../components/StatusChip';
 import { LogView } from '../components/LogView';
 import { CaseTable } from '../components/CaseTable';
-import { api, encodeArtifactId, isTerminalStatus, subscribeToRun, type Artifact, type CompareResult, type RunRecord } from '../api/client';
+import { RunProgressView } from '../components/RunProgress';
+import { HarnessProgressParser, type RunProgress } from '../../../../packages/protocol/eval/ops/ops.progress';
+import { api, encodeArtifactId, isTerminalStatus, subscribeToRun, type Artifact, type CompareResult, type HarnessDescriptor, type RunRecord } from '../api/client';
 
 interface RunState {
   run: RunRecord | null;
   log: string;
+  progress: RunProgress | null;
+  harnesses: HarnessDescriptor[];
   artifact: Artifact | null;
   baseline: Artifact | null;
   comparison: CompareResult | null;
@@ -39,6 +43,8 @@ function RunDetail({ runId }: { runId: string }) {
   const [state, setState] = useState<RunState>({
     run: null,
     log: '',
+    progress: null,
+    harnesses: [],
     artifact: null,
     baseline: null,
     comparison: null,
@@ -47,6 +53,10 @@ function RunDetail({ runId }: { runId: string }) {
     streamError: null,
   });
   const [cancelling, setCancelling] = useState(false);
+  const [showRawLog, setShowRawLog] = useState(false);
+  const parserRef = useRef(new HarnessProgressParser());
+  /** First-seen and completion timestamps per case id, for live durations. */
+  const caseTimesRef = useRef(new Map<string, number>());
 
   useEffect(() => {
     let logAccumulator = '';
@@ -54,11 +64,24 @@ function RunDetail({ runId }: { runId: string }) {
     let sawStatus = false;
     let closed = false;
 
+    const feedProgress = (chunk: string) => {
+      parserRef.current.push(chunk);
+      const snapshot = parserRef.current.snapshot();
+      const times = caseTimesRef.current;
+      const nowMs = Date.now();
+      for (const c of snapshot.cases) {
+        if (!times.has(c.id)) times.set(c.id, nowMs);
+        if (c.done && !times.has(`${c.id}::done`)) times.set(`${c.id}::done`, nowMs);
+      }
+      return snapshot;
+    };
+
     const unsubscribe = subscribeToRun(runId, {
       onLog: (chunk: string) => {
         if (!mounted) return;
         logAccumulator += chunk;
-        setState((prev) => ({ ...prev, log: logAccumulator }));
+        const progress = feedProgress(chunk);
+        setState((prev) => ({ ...prev, log: logAccumulator, progress }));
       },
       onStatus: (record: RunRecord) => {
         if (!mounted) return;
@@ -98,11 +121,22 @@ function RunDetail({ runId }: { runId: string }) {
         }
 
         // Mid-stream failure: EventSource reconnects and the server replays from
-        // byte 0, so reset the accumulator to avoid rendering the log twice.
+        // byte 0, so reset the accumulator AND the parser to avoid rendering
+        // the log twice or counting every case a second time.
         logAccumulator = '';
-        setState((prev) => ({ ...prev, log: '' }));
+        parserRef.current = new HarnessProgressParser();
+        caseTimesRef.current.clear();
+        setState((prev) => ({ ...prev, log: '', progress: null }));
       },
     });
+
+    // The harness's own description of what this run answers, shown next to
+    // its name. A courtesy line: never let it break the run page.
+    void api.harnesses().then((result) => {
+      if (!mounted) return;
+      const harnesses = result.harnesses ?? [];
+      setState((prev) => ({ ...prev, harnesses }));
+    }).catch(() => {});
 
     async function fetchArtifactAndComparison(record: RunRecord) {
       const { artifactPath, spec } = record;
@@ -214,6 +248,10 @@ function RunDetail({ runId }: { runId: string }) {
 
   const run = state.run;
   const isRunning = run.status === 'running' || run.status === 'queued';
+  const harnessQuestion =
+    run.spec.kind === 'eval'
+      ? state.harnesses.find((h) => h.harness === (run.spec as { harness: string }).harness)?.question ?? null
+      : null;
 
   return (
     <div className="p-4 space-y-4">
@@ -237,6 +275,9 @@ function RunDetail({ runId }: { runId: string }) {
                 <Link to={`/h/${run.spec.harness}`} className="text-term-blue hover:underline">
                   {run.spec.harness}
                 </Link>
+                {harnessQuestion !== null && (
+                  <span className="text-term-dim">{harnessQuestion}</span>
+                )}
               </div>
               <div className="flex gap-4">
                 <span className="text-term-dim w-24">profile:</span>
@@ -409,9 +450,33 @@ function RunDetail({ runId }: { runId: string }) {
         </Frame>
       )}
 
-      <Frame label="log">
-        <LogView text={state.log} />
-      </Frame>
+      {state.progress !== null && state.progress.totalCases !== null ? (
+        <Frame label="progress">
+          <RunProgressView
+            progress={state.progress}
+            caseStartedAt={caseTimesRef.current}
+            runStartedAt={run.startedAt !== null ? new Date(run.startedAt).getTime() : null}
+            live={isRunning}
+          />
+          <div className="mt-2">
+            <button
+              onClick={() => setShowRawLog((v) => !v)}
+              className="text-term-blue hover:underline"
+            >
+              {showRawLog ? 'hide raw output' : 'show raw output'}
+            </button>
+          </div>
+          {showRawLog && (
+            <div className="mt-2 border-t border-term-rule pt-2">
+              <LogView text={state.log} />
+            </div>
+          )}
+        </Frame>
+      ) : (
+        <Frame label="log">
+          <LogView text={state.log} />
+        </Frame>
+      )}
     </div>
   );
 }

--- a/apps/eval-ops/src/routes/SignIn.tsx
+++ b/apps/eval-ops/src/routes/SignIn.tsx
@@ -1,25 +1,88 @@
 import { useState } from 'react';
 import { Frame } from '../components/Frame';
-import { api } from '../api/client';
+import { api, type SignInStart } from '../api/client';
+
+/** The deployed variant of {@link SignInStart}, once the union has been narrowed. */
+type TokenStart = Extract<SignInStart, { kind: 'token' }>;
 
 /**
  * Sign-in screen shown when the operator has no ops session.
  *
- * The server redirects unauthenticated requests to the Index web app's /cli-auth
- * bridge, which mints a revocable API key from the user's existing browser session
- * and redirects back to /callback where the ops server establishes its own session.
+ * The server decides which of two exchanges it runs and says so in the reply to
+ * `POST /api/auth/login`; this screen never guesses.
+ *
+ *  - Locally the server returns a bridge URL. The Index web app's /cli-auth page
+ *    mints a revocable API key from the operator's existing browser session and
+ *    redirects back to /callback, where the ops server establishes its session.
+ *  - On a deployed host the bridge cannot complete — `validateCliCallbackUrl` in
+ *    apps/web accepts only `http:` on loopback, deliberately — so the server
+ *    returns the API and web app origins instead. This screen fetches a
+ *    better-auth JWT from the API with the browser's own session cookie
+ *    (cross-site works because that cookie is `SameSite=None; Secure`) and posts
+ *    it to the ops server, which resolves it against `/api/auth/me` and applies
+ *    the same domain policy. The browser supplies a token, never an identity.
+ *
+ * The token is a bearer credential. It exists in a local const for the length of
+ * one exchange: it never reaches React state, the DOM, the URL or a log.
  */
 export function SignIn() {
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
+  /**
+   * Set when the API says this browser has no Index session.
+   *
+   * The operator has been sent to the web app in a *new tab*, so this one keeps
+   * its place: navigating away would sign them in with no way back, which is the
+   * same dead end as a sign-in that redirects to a page this site does not serve.
+   * Holding the start here is what lets "continue" retry the identical exchange.
+   */
+  const [awaitingIndex, setAwaitingIndex] = useState<TokenStart | null>(null);
 
-  const handleSignIn = async () => {
+  /** Fetches a token, submits it, and reloads into the signed-in dashboard. */
+  const exchangeToken = async (start: TokenStart): Promise<void> => {
+    const response = await fetch(`${start.apiUrl}/api/auth/token`, {
+      // The browser's own Index session is the whole credential here.
+      credentials: 'include',
+      headers: { Accept: 'application/json' },
+    });
+
+    if (response.status === 401) {
+      // No Index session in this browser. Sign in over there, come back here.
+      // Re-opened on every attempt, including "continue" pressed too early: a
+      // click that appeared to do nothing would read as a broken button.
+      window.open(start.webAppUrl, '_blank', 'noopener,noreferrer');
+      setAwaitingIndex(start);
+      setLoading(false);
+      return;
+    }
+    if (!response.ok) {
+      throw new Error(`Index could not issue a session token (HTTP ${response.status}).`);
+    }
+
+    const body: unknown = await response.json();
+    const token = (body as { token?: unknown }).token;
+    if (typeof token !== 'string' || token === '') {
+      throw new Error('Index did not return a session token.');
+    }
+
+    // Resolved server-side; the reply carries the identity and never the token.
+    await api.submitToken(token);
+    // The shell asks who is signed in on mount, so a reload is the whole handoff.
+    window.location.reload();
+  };
+
+  const handleSignIn = async (): Promise<void> => {
     setLoading(true);
     setError(null);
     try {
-      const data = await api.login();
-      // Navigate to the bridge URL
-      window.location.href = data.url;
+      // Asked once. A retry reuses the answer rather than minting a bridge state
+      // nobody will ever return.
+      const started = awaitingIndex ?? (await api.login());
+      if (started.kind === 'bridge') {
+        window.location.href = started.url;
+        return;
+      }
+      await exchangeToken(started);
     } catch (err) {
       setError(err instanceof Error ? err.message : 'Sign-in failed');
       setLoading(false);
@@ -35,15 +98,18 @@ export function SignIn() {
         <Frame label="sign in">
           <div className="flex flex-col gap-4 py-4">
             <p className="text-term-fg">
-              Sign in with your Index account to access the eval ops dashboard.
+              {awaitingIndex === null
+                ? 'Sign in with your Index account to access the eval ops dashboard.'
+                : 'Sign in to Index in the tab that just opened, then continue here.'}
             </p>
             <button
               onClick={handleSignIn}
               disabled={loading}
               className="px-4 py-2 bg-term-panel border border-term-rule text-term-cyan hover:bg-term-rule disabled:opacity-50 disabled:cursor-not-allowed"
-              aria-label="Sign in with Index"
+              aria-label={awaitingIndex === null ? 'Sign in with Index' : 'Continue'}
             >
-              {loading ? 'Redirecting...' : 'Sign in with Index'}
+              {/* Not "Redirecting...": the deployed exchange never leaves this page. */}
+              {loading ? 'Signing in...' : awaitingIndex === null ? 'Sign in with Index' : 'Continue'}
             </button>
             {error && (
               <p className="text-term-red text-sm">{error}</p>

--- a/apps/eval-ops/tests/auth.test.tsx
+++ b/apps/eval-ops/tests/auth.test.tsx
@@ -19,10 +19,12 @@ import { Shell } from '../src/components/Shell';
 let realLocation: PropertyDescriptor | undefined;
 
 /** Replaces `window.location` with a recording stub, remembering the real one. */
-function stubLocation(): void {
+function stubLocation(): { reload: ReturnType<typeof vi.fn> } {
   realLocation = Object.getOwnPropertyDescriptor(window, 'location');
   delete (window as unknown as { location?: unknown }).location;
-  (window as unknown as { location: { href: string } }).location = { href: '' };
+  const reload = vi.fn();
+  (window as unknown as { location: { href: string; reload: () => void } }).location = { href: '', reload };
+  return { reload };
 }
 
 afterEach(() => {
@@ -50,7 +52,7 @@ describe('SignIn', () => {
     const user = userEvent.setup();
     const mockFetch = vi.fn(async (url: string, init?: RequestInit) => {
       if (String(url).endsWith('/api/auth/login') && init?.method === 'POST') {
-        return new Response(JSON.stringify({ url: 'https://index.network/cli-auth?callback=http://127.0.0.1:4321/callback&version=2&state=abc' }));
+        return new Response(JSON.stringify({ kind: 'bridge', url: 'https://index.network/cli-auth?callback=http://127.0.0.1:4321/callback&version=2&state=abc' }));
       }
       return new Response('{}');
     });
@@ -79,6 +81,24 @@ describe('SignIn', () => {
     });
   });
 
+  it('never navigates to a bridge URL when the server does not offer one', async () => {
+    // The discriminator is what stops the deployed posture being read as a bridge
+    // with a missing field, which would navigate to `undefined`.
+    const user = userEvent.setup();
+    vi.stubGlobal('fetch', vi.fn(async () => new Response(JSON.stringify(TOKEN_START))));
+    vi.stubGlobal('open', vi.fn());
+    stubLocation();
+
+    render(
+      <BrowserRouter>
+        <SignIn />
+      </BrowserRouter>
+    );
+    await user.click(screen.getByRole('button', { name: /sign in/i }));
+
+    await waitFor(() => expect(window.location.href).toBe(''));
+  });
+
   it('never renders server-supplied strings as HTML', () => {
     globalThis.fetch = vi.fn() as unknown as typeof fetch;
     const { container } = render(
@@ -89,6 +109,173 @@ describe('SignIn', () => {
 
     // React escapes by default, so any attempt to render HTML would appear as text
     expect(container.innerHTML).not.toContain('dangerouslySetInnerHTML');
+  });
+});
+
+/**
+ * The deployed sign-in.
+ *
+ * The bridge cannot complete off loopback, so the server answers `POST
+ * /api/auth/login` with `kind: "token"` and this screen fetches a better-auth JWT
+ * from the API against the browser's own session, then posts it to the ops
+ * server, which resolves it server-side. The token is a bearer credential: it
+ * lives in a local const for the length of one exchange and never reaches React
+ * state, the DOM, the URL or a log.
+ */
+const TOKEN_START = {
+  kind: 'token',
+  apiUrl: 'https://protocol.dev.index.network',
+  webAppUrl: 'https://index.network',
+} as const;
+
+const JWT = 'eyJhbGciOiJFZERTQSJ9.eyJpZCI6InUxIn0.c2lnbmF0dXJl';
+
+describe('SignIn on a deployed host', () => {
+  /**
+   * Answers the three requests the deployed flow makes.
+   *
+   * @param hasIndexSession - whether `${apiUrl}/api/auth/token` finds a session.
+   */
+  function stubDeployedFetch(hasIndexSession: boolean) {
+    return vi.fn(async (url: string | URL, init?: RequestInit) => {
+      const href = String(url);
+      if (href.endsWith('/api/auth/login')) return new Response(JSON.stringify(TOKEN_START));
+      if (href === `${TOKEN_START.apiUrl}/api/auth/token`) {
+        return hasIndexSession
+          ? new Response(JSON.stringify({ token: JWT }))
+          : new Response(JSON.stringify({ message: 'Unauthorized', code: 'UNAUTHORIZED' }), { status: 401 });
+      }
+      if (href.endsWith('/api/auth/session') && init?.method === 'POST') {
+        return new Response(JSON.stringify({ authenticated: true, email: 'a@index.network', name: 'Ada' }));
+      }
+      return new Response('{}');
+    });
+  }
+
+  it('exchanges the API token for an ops session and reloads', async () => {
+    const user = userEvent.setup();
+    const mockFetch = stubDeployedFetch(true);
+    vi.stubGlobal('fetch', mockFetch);
+    const { reload } = stubLocation();
+
+    render(
+      <BrowserRouter>
+        <SignIn />
+      </BrowserRouter>
+    );
+    await user.click(screen.getByRole('button', { name: /sign in/i }));
+
+    await waitFor(() => expect(reload).toHaveBeenCalled());
+
+    // The token is fetched with the browser's own API cookie, which is the only
+    // reason this works cross-site (the API sets SameSite=None; Secure).
+    expect(mockFetch).toHaveBeenCalledWith(
+      `${TOKEN_START.apiUrl}/api/auth/token`,
+      expect.objectContaining({ credentials: 'include' })
+    );
+    // And it is handed to the ops server, which resolves it — the browser never
+    // asserts an identity.
+    expect(mockFetch).toHaveBeenCalledWith(
+      '/api/auth/session',
+      expect.objectContaining({ method: 'POST', body: JSON.stringify({ token: JWT }) })
+    );
+  });
+
+  it('keeps the token out of the page, the URL and the session it establishes', async () => {
+    const user = userEvent.setup();
+    vi.stubGlobal('fetch', stubDeployedFetch(true));
+    stubLocation();
+
+    const { container } = render(
+      <BrowserRouter>
+        <SignIn />
+      </BrowserRouter>
+    );
+    await user.click(screen.getByRole('button', { name: /sign in/i }));
+
+    await waitFor(() => expect(window.location.href).toBe(''));
+    expect(container.innerHTML).not.toContain(JWT);
+    expect(document.body.innerHTML).not.toContain(JWT);
+  });
+
+  it('sends the operator to Index to sign in, in a tab that leaves this one in place', async () => {
+    // The dead end to avoid: navigating away means the operator signs in and has
+    // no way back. This tab keeps its place and offers to continue.
+    const user = userEvent.setup();
+    vi.stubGlobal('fetch', stubDeployedFetch(false));
+    const open = vi.fn();
+    vi.stubGlobal('open', open);
+    stubLocation();
+
+    render(
+      <BrowserRouter>
+        <SignIn />
+      </BrowserRouter>
+    );
+    await user.click(screen.getByRole('button', { name: /sign in with index/i }));
+
+    await waitFor(() => expect(open).toHaveBeenCalledWith(TOKEN_START.webAppUrl, '_blank', 'noopener,noreferrer'));
+    expect(window.location.href).toBe('');
+    expect(await screen.findByRole('button', { name: /continue/i })).toBeInTheDocument();
+  });
+
+  it('completes once the operator has signed in to Index in the other tab', async () => {
+    const user = userEvent.setup();
+    let hasIndexSession = false;
+    const mockFetch = vi.fn(async (url: string | URL, init?: RequestInit) => {
+      const href = String(url);
+      if (href.endsWith('/api/auth/login')) return new Response(JSON.stringify(TOKEN_START));
+      if (href === `${TOKEN_START.apiUrl}/api/auth/token`) {
+        return hasIndexSession
+          ? new Response(JSON.stringify({ token: JWT }))
+          : new Response('{}', { status: 401 });
+      }
+      if (href.endsWith('/api/auth/session') && init?.method === 'POST') return new Response('{}');
+      return new Response('{}');
+    });
+    vi.stubGlobal('fetch', mockFetch);
+    vi.stubGlobal('open', vi.fn());
+    const { reload } = stubLocation();
+
+    render(
+      <BrowserRouter>
+        <SignIn />
+      </BrowserRouter>
+    );
+    await user.click(screen.getByRole('button', { name: /sign in with index/i }));
+    const continueButton = await screen.findByRole('button', { name: /continue/i });
+
+    hasIndexSession = true;
+    await user.click(continueButton);
+
+    await waitFor(() => expect(reload).toHaveBeenCalled());
+  });
+
+  it('reports a refused sign-in instead of reloading into the same prompt', async () => {
+    const user = userEvent.setup();
+    vi.stubGlobal('fetch', vi.fn(async (url: string | URL, init?: RequestInit) => {
+      const href = String(url);
+      if (href.endsWith('/api/auth/login')) return new Response(JSON.stringify(TOKEN_START));
+      if (href === `${TOKEN_START.apiUrl}/api/auth/token`) return new Response(JSON.stringify({ token: JWT }));
+      if (href.endsWith('/api/auth/session') && init?.method === 'POST') {
+        return new Response(
+          JSON.stringify({ error: 'someone@evil.example is not an @index.network address.', authenticated: true, permitted: false }),
+          { status: 403 }
+        );
+      }
+      return new Response('{}');
+    }));
+    const { reload } = stubLocation();
+
+    render(
+      <BrowserRouter>
+        <SignIn />
+      </BrowserRouter>
+    );
+    await user.click(screen.getByRole('button', { name: /sign in with index/i }));
+
+    expect(await screen.findByText(/not an @index\.network address/i)).toBeInTheDocument();
+    expect(reload).not.toHaveBeenCalled();
   });
 });
 

--- a/apps/eval-ops/tests/client.test.ts
+++ b/apps/eval-ops/tests/client.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it, vi, beforeEach, afterEach } from 'vitest';
-import { onAuthRefusal, subscribeToRun, encodeArtifactId } from '../src/api/client';
+import { api, onAuthRefusal, subscribeToRun, encodeArtifactId } from '../src/api/client';
 
 describe('subscribeToRun', () => {
   let mockSource: {
@@ -197,6 +197,129 @@ describe('subscribeToRun', () => {
 
     unsubscribe();
     expect(mockSource.close).toHaveBeenCalledOnce();
+  });
+});
+
+describe('config and run-comparison client methods', () => {
+  const calls: { url: string; init?: RequestInit }[] = [];
+
+  function stubFetch(respond: (url: string) => Response) {
+    calls.length = 0;
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async (url: string, init?: RequestInit) => {
+        calls.push({ url, init });
+        return respond(url);
+      }),
+    );
+  }
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  const profile = {
+    name: 'sonnet-evaluator',
+    description: 'evaluator on sonnet',
+    models: { opportunityEvaluator: 'anthropic/claude-sonnet-4' },
+    env: {},
+  };
+
+  it('configs() fetches GET /api/configs', async () => {
+    const body = { repo: [], saved: [profile] };
+    stubFetch(() => new Response(JSON.stringify(body)));
+
+    const result = await api.configs();
+
+    expect(result).toEqual(body);
+    expect(calls).toEqual([{ url: '/api/configs', init: undefined }]);
+  });
+
+  it('configModels() fetches GET /api/configs/models', async () => {
+    stubFetch(() => new Response(JSON.stringify({ models: ['google/gemini-2.5-flash'] })));
+
+    const result = await api.configModels();
+
+    expect(result).toEqual({ models: ['google/gemini-2.5-flash'] });
+    expect(calls.map((c) => c.url)).toEqual(['/api/configs/models']);
+  });
+
+  it('createConfig() POSTs the profile as JSON with the anti-CSRF content type', async () => {
+    stubFetch(() => new Response(JSON.stringify(profile), { status: 201 }));
+
+    const result = await api.createConfig(profile);
+
+    expect(result).toEqual(profile);
+    expect(calls).toHaveLength(1);
+    expect(calls[0].url).toBe('/api/configs');
+    expect(calls[0].init?.method).toBe('POST');
+    expect((calls[0].init?.headers as Record<string, string>)['Content-Type']).toBe('application/json');
+    expect(JSON.parse(calls[0].init?.body as string)).toEqual(profile);
+  });
+
+  it('updateConfig() PATCHes the named config with the patch body', async () => {
+    const patch = { description: 'better description' };
+    stubFetch(() => new Response(JSON.stringify({ ...profile, ...patch })));
+
+    const result = await api.updateConfig('sonnet-evaluator', patch);
+
+    expect(result.description).toBe('better description');
+    expect(calls).toHaveLength(1);
+    expect(calls[0].url).toBe('/api/configs/sonnet-evaluator');
+    expect(calls[0].init?.method).toBe('PATCH');
+    expect((calls[0].init?.headers as Record<string, string>)['Content-Type']).toBe('application/json');
+    expect(JSON.parse(calls[0].init?.body as string)).toEqual(patch);
+  });
+
+  it('deleteConfig() DELETEs the named config and tolerates the 204 empty body', async () => {
+    stubFetch(() => new Response(null, { status: 204 }));
+
+    await expect(api.deleteConfig('sonnet-evaluator')).resolves.toBeUndefined();
+
+    expect(calls).toHaveLength(1);
+    expect(calls[0].url).toBe('/api/configs/sonnet-evaluator');
+    expect(calls[0].init?.method).toBe('DELETE');
+  });
+
+  it('compareRuns() builds the run-mode compare URL', async () => {
+    const outcome = { comparable: false, findings: [] };
+    stubFetch(() => new Response(JSON.stringify(outcome)));
+
+    const result = await api.compareRuns('run-a', 'run-b');
+
+    expect(result).toEqual(outcome);
+    expect(calls.map((c) => c.url)).toEqual(['/api/compare?referenceRun=run-a&subjectRun=run-b']);
+  });
+
+  it('launch() posts a spec carrying ad-hoc overrides verbatim', async () => {
+    const record = { id: 'run-1', status: 'queued' };
+    stubFetch(() => new Response(JSON.stringify(record), { status: 202 }));
+
+    await api.launch({
+      kind: 'eval',
+      harness: 'matching',
+      profile: 'default',
+      overrides: { models: { opportunityEvaluator: 'anthropic/claude-sonnet-4' }, env: {} },
+      flags: { runs: 1 },
+    });
+
+    const posted = JSON.parse(calls[0].init?.body as string);
+    expect(posted.overrides).toEqual({
+      models: { opportunityEvaluator: 'anthropic/claude-sonnet-4' },
+      env: {},
+    });
+  });
+
+  it('surfaces the server error field on a refused create', async () => {
+    stubFetch(() =>
+      new Response(JSON.stringify({ error: 'A config named "sonnet-evaluator" already exists' }), {
+        status: 409,
+      }),
+    );
+
+    await expect(api.createConfig(profile)).rejects.toThrow(
+      'A config named "sonnet-evaluator" already exists',
+    );
   });
 });
 

--- a/apps/eval-ops/tests/compare.test.tsx
+++ b/apps/eval-ops/tests/compare.test.tsx
@@ -4,6 +4,124 @@ import userEvent from '@testing-library/user-event';
 import { createMemoryRouter, MemoryRouter, RouterProvider } from 'react-router';
 
 import { Compare } from '../src/routes/Compare';
+import type { RunRecord } from '../src/api/client';
+
+/** One MockEventSource per stream URL, so a pair page's two subscriptions are
+ * addressable independently by run id. */
+class MockEventSource {
+  static instances = new Map<string, MockEventSource>();
+
+  closed = false;
+
+  private listeners = new Map<string, Set<(event: MessageEvent | Event) => void>>();
+
+  constructor(public readonly url: string) {
+    MockEventSource.instances.set(url, this);
+  }
+
+  addEventListener(event: string, handler: (event: MessageEvent | Event) => void) {
+    if (!this.listeners.has(event)) this.listeners.set(event, new Set());
+    this.listeners.get(event)!.add(handler);
+  }
+
+  close() {
+    this.closed = true;
+  }
+
+  _emit(event: string, data: unknown) {
+    const handlers = this.listeners.get(event);
+    if (handlers) {
+      const messageEvent = new MessageEvent(event, { data: JSON.stringify(data) });
+      handlers.forEach((handler) => handler(messageEvent));
+    }
+  }
+
+  static forRun(runId: string): MockEventSource {
+    const instance = MockEventSource.instances.get(`/api/runs/${runId}/stream`);
+    if (!instance) throw new Error(`No EventSource opened for run ${runId}`);
+    return instance;
+  }
+}
+
+const RUN_A: RunRecord = {
+  id: 'run-a',
+  status: 'running',
+  spec: { kind: 'eval', harness: 'matching', profile: 'default', flags: { runs: 1 } },
+  argv: ['bun', 'run', 'eval:matching'],
+  env: {},
+  profileFingerprint: 'fp-a',
+  experimental: false,
+  workload: 2,
+  exitCode: null,
+  artifactPath: null,
+  createdAt: '2026-07-30T10:00:00.000Z',
+  startedAt: '2026-07-30T10:00:01.000Z',
+  endedAt: null,
+  pid: 111,
+};
+
+const RUN_B: RunRecord = {
+  ...RUN_A,
+  id: 'run-b',
+  spec: { kind: 'eval', harness: 'matching', profile: 'sonnet-evaluator', flags: { runs: 1 } },
+  profileFingerprint: 'fp-b',
+  experimental: true,
+};
+
+const TERMINAL_A: RunRecord = {
+  ...RUN_A,
+  status: 'passed',
+  endedAt: '2026-07-30T10:05:00.000Z',
+  exitCode: 0,
+};
+
+const TERMINAL_B: RunRecord = {
+  ...RUN_B,
+  status: 'passed',
+  endedAt: '2026-07-30T10:06:00.000Z',
+  exitCode: 0,
+};
+
+const EMPTY_DIFF = {
+  regressions: [],
+  skippedCaseIds: [],
+  addedCaseIds: [],
+  removedCaseIds: [],
+  unscoredCaseIds: [],
+};
+
+const PAIR_RESULT = {
+  comparable: true,
+  aggregate: { reference: 0.9, subject: 0.95, delta: 0.05 },
+  regressions: {
+    ...EMPTY_DIFF,
+    regressions: [{ id: 'case-reg', kind: 'case', before: 1, after: 0.5, pValue: 0.01 }],
+  },
+  improvements: EMPTY_DIFF,
+  runs: {
+    reference: { id: 'run-a', profile: 'default', profileFingerprint: 'aaaabbbbccccdddd', complete: true },
+    subject: { id: 'run-b', profile: 'sonnet-evaluator', profileFingerprint: 'eeeeffff00001111', complete: false },
+  },
+};
+
+function stubPair(compare: unknown) {
+  MockEventSource.instances.clear();
+  const fetchMock = vi.fn(async (url: string) => {
+    if (String(url).includes('/api/compare')) return new Response(JSON.stringify(compare));
+    return new Response(JSON.stringify({ error: 'not found' }), { status: 404 });
+  });
+  vi.stubGlobal('fetch', fetchMock);
+  vi.stubGlobal('EventSource', MockEventSource);
+  return fetchMock;
+}
+
+function renderPair() {
+  render(
+    <MemoryRouter initialEntries={['/?referenceRun=run-a&subjectRun=run-b']}>
+      <Compare />
+    </MemoryRouter>,
+  );
+}
 
 const REFS = {
   refs: [
@@ -146,5 +264,87 @@ describe('Compare', () => {
       expect(params.get('reference')).toBe('c');
       expect(params.get('subject')).toBeNull();
     });
+  });
+});
+
+describe('Compare pair mode', () => {
+  it("shows both runs' progress while either is active", async () => {
+    const fetchMock = stubPair({ comparable: false, findings: [] });
+    renderPair();
+
+    act(() => {
+      MockEventSource.forRun('run-a')._emit('status', RUN_A);
+      MockEventSource.forRun('run-b')._emit('status', RUN_B);
+    });
+
+    expect(await screen.findByText(/reference · default/)).toBeInTheDocument();
+    expect(screen.getByText(/candidate · sonnet-evaluator/)).toBeInTheDocument();
+
+    act(() => {
+      MockEventSource.forRun('run-a')._emit(
+        'log',
+        'Running 2 case(s) \u00d7 1 run(s) against google/gemini-2.5-flash\u2026\n',
+      );
+    });
+
+    expect(await screen.findByText('0/2 cases')).toBeInTheDocument();
+    // While either run is active the page says so instead of showing a stale diff.
+    expect(screen.getByText('comparison appears when both runs finish')).toBeInTheDocument();
+    expect(
+      fetchMock.mock.calls.map(([url]) => String(url)).filter((url) => url.includes('/api/compare')),
+    ).toEqual([]);
+  });
+
+  it('flips to the diff view when both runs are terminal', async () => {
+    const fetchMock = stubPair(PAIR_RESULT);
+    renderPair();
+
+    act(() => {
+      MockEventSource.forRun('run-a')._emit('status', TERMINAL_A);
+      MockEventSource.forRun('run-b')._emit('status', TERMINAL_B);
+    });
+
+    // The diff renders, each side labelled with its profile and fingerprint prefix.
+    expect(await screen.findByText(/case-reg/)).toBeInTheDocument();
+    expect(await screen.findByText(/aaaabbbbcccc(?!d)/)).toBeInTheDocument();
+    expect(screen.getByText(/eeeeffff0000(?!1)/)).toBeInTheDocument();
+
+    const compareUrls = fetchMock.mock.calls
+      .map(([url]) => String(url))
+      .filter((url) => url.includes('/api/compare'));
+    expect(compareUrls).toHaveLength(1);
+    expect(compareUrls[0]).toContain('referenceRun=run-a');
+    expect(compareUrls[0]).toContain('subjectRun=run-b');
+
+    // Both streams were closed once their runs went terminal.
+    expect(MockEventSource.forRun('run-a').closed).toBe(true);
+    expect(MockEventSource.forRun('run-b').closed).toBe(true);
+  });
+
+  it('renders the incomplete-evidence caveat when a side is incomplete', async () => {
+    stubPair(PAIR_RESULT);
+    renderPair();
+
+    act(() => {
+      MockEventSource.forRun('run-a')._emit('status', TERMINAL_A);
+      MockEventSource.forRun('run-b')._emit('status', TERMINAL_B);
+    });
+
+    expect(await screen.findByText(/incomplete evidence/)).toBeInTheDocument();
+  });
+
+  it('keeps artifact compare working when no run params are present', async () => {
+    stub({
+      comparable: false,
+      findings: [{ dimension: 'corpusFingerprint', reference: 'aaa', subject: 'bbb' }],
+    });
+    render(
+      <MemoryRouter initialEntries={['/?reference=a&subject=b']}>
+        <Compare />
+      </MemoryRouter>,
+    );
+
+    expect(await screen.findByText(/cannot be compared/i)).toBeInTheDocument();
+    expect(screen.queryByText('comparison appears when both runs finish')).toBeNull();
   });
 });

--- a/apps/eval-ops/tests/launch.test.tsx
+++ b/apps/eval-ops/tests/launch.test.tsx
@@ -1,5 +1,5 @@
 import { describe, expect, it, vi, beforeEach, afterEach } from 'vitest';
-import { render, screen, cleanup } from '@testing-library/react';
+import { render, screen, cleanup, within } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { BrowserRouter } from 'react-router';
 
@@ -12,6 +12,9 @@ const HARNESSES = {
       script: 'eval:matching',
       caseCount: 40,
       defaultRuns: 3,
+      question: 'Should these two people be connected at all?',
+      detail: 'Evaluates candidates.',
+      agents: ['opportunityEvaluator'],
       flags: [
         { name: 'runs', cli: '--runs', kind: 'number', min: 1, max: 25, step: 1 },
         { name: 'case', cli: '--case', kind: 'string' },
@@ -24,10 +27,15 @@ const HARNESSES = {
       script: 'eval:premise',
       caseCount: 12,
       defaultRuns: 3,
+      question: 'Did we break an intent into correct atomic premises?',
+      detail: 'Decomposes and classifies.',
+      agents: ['premiseDecomposer', 'premiseAnalyzer'],
       flags: [{ name: 'runs', cli: '--runs', kind: 'number' }],
     },
   ],
 };
+
+const CONFIG_MODELS = { models: ['google/gemini-2.5-flash', 'anthropic/claude-sonnet-4'] };
 
 const PROFILES = {
   profiles: [
@@ -42,17 +50,34 @@ const PROFILES = {
 };
 
 let launched: unknown = null;
+let postedRuns: unknown[] = [];
+let postedConfigs: unknown[] = [];
+let runCounter = 0;
 
 beforeEach(() => {
   launched = null;
+  postedRuns = [];
+  postedConfigs = [];
+  runCounter = 0;
   vi.stubGlobal(
     'fetch',
     vi.fn(async (url: string, init?: RequestInit) => {
       if (String(url).endsWith('/api/harnesses')) return new Response(JSON.stringify(HARNESSES));
       if (String(url).endsWith('/api/profiles')) return new Response(JSON.stringify(PROFILES));
+      if (String(url).endsWith('/api/configs/models')) return new Response(JSON.stringify(CONFIG_MODELS));
+      if (String(url).endsWith('/api/configs') && init?.method === 'POST') {
+        postedConfigs.push(JSON.parse(String(init.body)));
+        return new Response(JSON.stringify(JSON.parse(String(init.body))), { status: 201 });
+      }
+      if (String(url).endsWith('/api/configs')) {
+        return new Response(JSON.stringify({ repo: PROFILES.profiles, saved: [] }));
+      }
       if (String(url).endsWith('/api/runs') && init?.method === 'POST') {
-        launched = JSON.parse(String(init.body));
-        return new Response(JSON.stringify({ id: 'run-1' }), { status: 202 });
+        const body = JSON.parse(String(init.body));
+        launched = body;
+        postedRuns.push(body);
+        runCounter += 1;
+        return new Response(JSON.stringify({ id: `run-${runCounter}` }), { status: 202 });
       }
       return new Response(JSON.stringify({}));
     }),
@@ -145,5 +170,106 @@ describe('Launch', () => {
     await screen.findByLabelText(/profile/i);
     await userEvent.selectOptions(screen.getByLabelText(/profile/i), 'claude-evaluator');
     expect(await screen.findByText(/experimental/i)).toBeInTheDocument();
+  });
+
+  it('submits ad-hoc overrides with profile default', async () => {
+    renderLaunch();
+    await screen.findByLabelText(/harness/i);
+    await userEvent.click(screen.getByText('overrides (this run only)'));
+    await userEvent.selectOptions(
+      await screen.findByLabelText('opportunityEvaluator'),
+      'anthropic/claude-sonnet-4',
+    );
+    // Narrow the corpus so no full-corpus confirmation stands in the way.
+    await userEvent.type(screen.getByLabelText('--tier'), '2');
+    await userEvent.click(screen.getByRole('button', { name: 'Run' }));
+
+    await vi.waitFor(() => expect(postedRuns).toHaveLength(1));
+    const spec = postedRuns[0] as { profile: string; overrides?: { models: Record<string, string> } };
+    expect(spec.profile).toBe('default');
+    expect(spec.overrides?.models).toEqual({ opportunityEvaluator: 'anthropic/claude-sonnet-4' });
+  });
+
+  it('omits the overrides key entirely when nothing is overridden', async () => {
+    renderLaunch();
+    await screen.findByLabelText(/harness/i);
+    await userEvent.type(screen.getByLabelText('--tier'), '2');
+    await userEvent.click(screen.getByRole('button', { name: 'Run' }));
+
+    await vi.waitFor(() => expect(postedRuns).toHaveLength(1));
+    expect(Object.keys(postedRuns[0] as object).sort()).toEqual(['flags', 'harness', 'kind', 'profile']);
+  });
+
+  it('saves the current overrides as a named config', async () => {
+    renderLaunch();
+    await screen.findByLabelText(/harness/i);
+    await userEvent.click(screen.getByText('overrides (this run only)'));
+    await userEvent.selectOptions(
+      await screen.findByLabelText('opportunityEvaluator'),
+      'anthropic/claude-sonnet-4',
+    );
+    await userEvent.click(screen.getByRole('button', { name: /save as config/i }));
+    await userEvent.type(screen.getByLabelText(/config name/i), 'sonnet-evaluator');
+    await userEvent.type(screen.getByLabelText(/config description/i), 'evaluator on sonnet');
+    await userEvent.click(screen.getByRole('button', { name: 'Save config' }));
+
+    await vi.waitFor(() => expect(postedConfigs).toHaveLength(1));
+    expect(postedConfigs[0]).toEqual({
+      name: 'sonnet-evaluator',
+      description: 'evaluator on sonnet',
+      models: { opportunityEvaluator: 'anthropic/claude-sonnet-4' },
+      env: {},
+    });
+    // The form switches to the freshly saved config.
+    await vi.waitFor(() =>
+      expect(screen.getByLabelText<HTMLSelectElement>(/profile/i).value).toBe('sonnet-evaluator'),
+    );
+  });
+
+  it('A/B mode fires two launches and navigates to the pair URL', async () => {
+    renderLaunch();
+    await screen.findByLabelText(/harness/i);
+    await userEvent.click(screen.getByLabelText(/a\/b/i));
+    await userEvent.click(screen.getByText('overrides (this run only)'));
+    const candidate = await screen.findByRole('group', { name: 'candidate' });
+    await userEvent.selectOptions(
+      within(candidate).getByLabelText('opportunityEvaluator'),
+      'anthropic/claude-sonnet-4',
+    );
+    await userEvent.type(screen.getByLabelText('--tier'), '2');
+    await userEvent.click(screen.getByRole('button', { name: 'Run' }));
+
+    await vi.waitFor(() => expect(postedRuns).toHaveLength(2));
+    const reference = postedRuns[0] as { overrides?: unknown };
+    const candidateSpec = postedRuns[1] as { overrides?: { models: Record<string, string> } };
+    expect('overrides' in reference).toBe(false);
+    expect(candidateSpec.overrides?.models).toEqual({ opportunityEvaluator: 'anthropic/claude-sonnet-4' });
+    await vi.waitFor(() =>
+      expect(window.location.search).toBe('?referenceRun=run-1&subjectRun=run-2'),
+    );
+  });
+
+  it('A/B mode defaults both sides to the same profile and shares flags', async () => {
+    renderLaunch();
+    await screen.findByLabelText(/harness/i);
+    await userEvent.click(screen.getByLabelText(/a\/b/i));
+    await userEvent.type(screen.getByLabelText('--tier'), '2');
+    await userEvent.click(screen.getByRole('button', { name: 'Run' }));
+
+    await vi.waitFor(() => expect(postedRuns).toHaveLength(2));
+    for (const spec of postedRuns as { profile: string; flags: { tier?: number } }[]) {
+      expect(spec.profile).toBe('default');
+      expect(spec.flags.tier).toBe(2);
+    }
+  });
+
+  it('disables overrides when a named profile is selected and points to configs', async () => {
+    renderLaunch();
+    await screen.findByLabelText(/profile/i);
+    await userEvent.selectOptions(screen.getByLabelText(/profile/i), 'claude-evaluator');
+    await userEvent.click(screen.getByText('overrides (this run only)'));
+
+    expect(screen.queryByLabelText('opportunityEvaluator')).toBeNull();
+    expect(await screen.findByText(/edit it on the configs page/i)).toBeInTheDocument();
   });
 });

--- a/apps/eval-ops/tests/launch.test.tsx
+++ b/apps/eval-ops/tests/launch.test.tsx
@@ -230,7 +230,6 @@ describe('Launch', () => {
     renderLaunch();
     await screen.findByLabelText(/harness/i);
     await userEvent.click(screen.getByLabelText(/a\/b/i));
-    await userEvent.click(screen.getByText('overrides (this run only)'));
     const candidate = await screen.findByRole('group', { name: 'candidate' });
     await userEvent.selectOptions(
       within(candidate).getByLabelText('opportunityEvaluator'),
@@ -247,6 +246,91 @@ describe('Launch', () => {
     await vi.waitFor(() =>
       expect(window.location.search).toBe('?referenceRun=run-1&subjectRun=run-2'),
     );
+  });
+
+  it('A/B mode lets each side pick its own profile independently', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async (url: string, init?: RequestInit) => {
+        if (String(url).endsWith('/api/harnesses')) return new Response(JSON.stringify(HARNESSES));
+        if (String(url).endsWith('/api/profiles')) return new Response(JSON.stringify(PROFILES));
+        if (String(url).endsWith('/api/configs/models')) return new Response(JSON.stringify(CONFIG_MODELS));
+        if (String(url).endsWith('/api/configs')) {
+          return new Response(
+            JSON.stringify({
+              repo: PROFILES.profiles,
+              saved: [
+                {
+                  name: 'sonnet-evaluator',
+                  description: 'evaluator on sonnet',
+                  models: { opportunityEvaluator: 'anthropic/claude-sonnet-4' },
+                  env: {},
+                },
+              ],
+            }),
+          );
+        }
+        if (String(url).endsWith('/api/runs') && init?.method === 'POST') {
+          postedRuns.push(JSON.parse(String(init.body)));
+          runCounter += 1;
+          return new Response(JSON.stringify({ id: `run-${runCounter}` }), { status: 202 });
+        }
+        return new Response(JSON.stringify({}));
+      }),
+    );
+
+    renderLaunch();
+    await screen.findByLabelText(/harness/i);
+    await userEvent.click(screen.getByLabelText(/a\/b/i));
+
+    const reference = await screen.findByRole('group', { name: 'reference' });
+    const candidate = screen.getByRole('group', { name: 'candidate' });
+    await userEvent.selectOptions(within(reference).getByLabelText('profile'), 'claude-evaluator');
+    await userEvent.selectOptions(within(candidate).getByLabelText('profile'), 'sonnet-evaluator');
+
+    // A named profile leaves no overrides editor on that side.
+    expect(within(reference).queryByLabelText('opportunityEvaluator')).toBeNull();
+    expect(within(reference).getByText(/edit it on the configs page/i)).toBeInTheDocument();
+    expect(within(candidate).queryByLabelText('opportunityEvaluator')).toBeNull();
+
+    await userEvent.type(screen.getByLabelText('--tier'), '2');
+    await userEvent.click(screen.getByRole('button', { name: 'Run' }));
+
+    await vi.waitFor(() => expect(postedRuns).toHaveLength(2));
+    expect((postedRuns[0] as { profile: string }).profile).toBe('claude-evaluator');
+    expect((postedRuns[1] as { profile: string }).profile).toBe('sonnet-evaluator');
+    for (const spec of postedRuns as { overrides?: unknown }[]) {
+      expect('overrides' in spec).toBe(false);
+    }
+    // Shared flags still apply to both sides.
+    for (const spec of postedRuns as { flags: { tier?: number } }[]) {
+      expect(spec.flags.tier).toBe(2);
+    }
+  });
+
+  it('A/B posts overrides only on the side whose profile is default', async () => {
+    renderLaunch();
+    await screen.findByLabelText(/harness/i);
+    await userEvent.click(screen.getByLabelText(/a\/b/i));
+
+    const reference = await screen.findByRole('group', { name: 'reference' });
+    const candidate = screen.getByRole('group', { name: 'candidate' });
+    await userEvent.selectOptions(within(reference).getByLabelText('profile'), 'claude-evaluator');
+    await userEvent.selectOptions(
+      within(candidate).getByLabelText('opportunityEvaluator'),
+      'anthropic/claude-sonnet-4',
+    );
+
+    await userEvent.type(screen.getByLabelText('--tier'), '2');
+    await userEvent.click(screen.getByRole('button', { name: 'Run' }));
+
+    await vi.waitFor(() => expect(postedRuns).toHaveLength(2));
+    const referenceSpec = postedRuns[0] as { profile: string; overrides?: unknown };
+    const candidateSpec = postedRuns[1] as { profile: string; overrides?: { models: Record<string, string> } };
+    expect(referenceSpec.profile).toBe('claude-evaluator');
+    expect('overrides' in referenceSpec).toBe(false);
+    expect(candidateSpec.profile).toBe('default');
+    expect(candidateSpec.overrides?.models).toEqual({ opportunityEvaluator: 'anthropic/claude-sonnet-4' });
   });
 
   it('A/B mode defaults both sides to the same profile and shares flags', async () => {

--- a/apps/eval-ops/tests/launch.test.tsx
+++ b/apps/eval-ops/tests/launch.test.tsx
@@ -1,7 +1,7 @@
 import { describe, expect, it, vi, beforeEach, afterEach } from 'vitest';
 import { render, screen, cleanup, within } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
-import { BrowserRouter } from 'react-router';
+import { BrowserRouter, MemoryRouter } from 'react-router';
 
 import { Launch } from '../src/routes/Launch';
 
@@ -271,5 +271,14 @@ describe('Launch', () => {
 
     expect(screen.queryByLabelText('opportunityEvaluator')).toBeNull();
     expect(await screen.findByText(/edit it on the configs page/i)).toBeInTheDocument();
+  });
+  it('preselects the profile named by the ?profile= search param', async () => {
+    render(
+      <MemoryRouter initialEntries={['/launch?profile=claude-evaluator']}>
+        <Launch />
+      </MemoryRouter>,
+    );
+    await screen.findByLabelText(/harness/i);
+    expect(screen.getByLabelText(/profile/i)).toHaveValue('claude-evaluator');
   });
 });

--- a/apps/eval-ops/tests/profiles.test.tsx
+++ b/apps/eval-ops/tests/profiles.test.tsx
@@ -1,0 +1,164 @@
+import { describe, expect, it, vi, beforeEach, afterEach } from 'vitest';
+import { render, screen, cleanup, within, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { BrowserRouter } from 'react-router';
+
+import { Profiles } from '../src/routes/Profiles';
+
+const HARNESSES = {
+  harnesses: [
+    {
+      harness: 'matching',
+      script: 'eval:matching',
+      caseCount: 40,
+      defaultRuns: 3,
+      question: 'Should these two people be connected at all?',
+      detail: 'Evaluates candidates.',
+      agents: ['opportunityEvaluator'],
+      flags: [],
+    },
+    {
+      harness: 'premise',
+      script: 'eval:premise',
+      caseCount: 12,
+      defaultRuns: 3,
+      question: 'Did we break an intent into correct atomic premises?',
+      detail: 'Decomposes and classifies.',
+      agents: ['premiseDecomposer', 'premiseAnalyzer'],
+      flags: [],
+    },
+  ],
+};
+
+const CONFIG_MODELS = { models: ['google/gemini-2.5-flash', 'anthropic/claude-sonnet-4'] };
+
+const REPO = [
+  { name: 'default', description: 'no overrides', models: {}, env: {} },
+  {
+    name: 'claude-evaluator',
+    description: 'claude, shipped',
+    models: { opportunityEvaluator: 'anthropic/claude-sonnet-4' },
+    env: {},
+  },
+];
+
+const SAVED = [
+  {
+    name: 'my-config',
+    description: 'mine',
+    models: { opportunityEvaluator: 'anthropic/claude-sonnet-4' },
+    env: {},
+  },
+];
+
+let patched: { name: string; body: unknown } | null;
+let deleted: string[];
+let savedConfigs: typeof SAVED;
+
+beforeEach(() => {
+  patched = null;
+  deleted = [];
+  savedConfigs = SAVED.map((config) => ({ ...config }));
+  vi.stubGlobal(
+    'fetch',
+    vi.fn(async (url: string, init?: RequestInit) => {
+      const href = String(url);
+      if (href.endsWith('/api/harnesses')) return new Response(JSON.stringify(HARNESSES));
+      if (href.endsWith('/api/configs/models')) return new Response(JSON.stringify(CONFIG_MODELS));
+      if (href.includes('/api/configs/') && init?.method === 'PATCH') {
+        const name = decodeURIComponent(href.split('/api/configs/')[1]);
+        patched = { name, body: JSON.parse(String(init.body)) };
+        return new Response(
+          JSON.stringify({ name, ...(patched.body as object) }),
+        );
+      }
+      if (href.includes('/api/configs/') && init?.method === 'DELETE') {
+        deleted.push(decodeURIComponent(href.split('/api/configs/')[1]));
+        return new Response(null, { status: 204 });
+      }
+      if (href.endsWith('/api/configs')) {
+        return new Response(JSON.stringify({ repo: REPO, saved: savedConfigs }));
+      }
+      if (href.endsWith('/api/runs')) {
+        return new Response(JSON.stringify({ runs: [], issues: [] }));
+      }
+      return new Response(JSON.stringify({}));
+    }),
+  );
+});
+
+afterEach(() => {
+  cleanup();
+  vi.unstubAllGlobals();
+});
+
+const renderProfiles = () =>
+  render(
+    <BrowserRouter>
+      <Profiles />
+    </BrowserRouter>,
+  );
+
+describe('Profiles (configs page)', () => {
+  it('lists shipped profiles read-only and saved configs with edit/delete', async () => {
+    renderProfiles();
+
+    const shipped = await screen.findByRole('region', { name: 'config default' });
+    expect(within(shipped).getByText('shipped')).toBeInTheDocument();
+    expect(within(shipped).queryByRole('button', { name: 'edit' })).toBeNull();
+    expect(within(shipped).queryByRole('button', { name: 'delete' })).toBeNull();
+
+    const saved = screen.getByRole('region', { name: 'config my-config' });
+    expect(within(saved).getByRole('button', { name: 'edit' })).toBeInTheDocument();
+    expect(within(saved).getByRole('button', { name: 'delete' })).toBeInTheDocument();
+  });
+
+  it('deletes a saved config after confirmation', async () => {
+    renderProfiles();
+    const saved = await screen.findByRole('region', { name: 'config my-config' });
+
+    await userEvent.click(within(saved).getByRole('button', { name: 'delete' }));
+    // Nothing leaves until the operator confirms.
+    expect(deleted).toEqual([]);
+    expect(await within(saved).findByText('delete my-config?')).toBeInTheDocument();
+
+    await userEvent.click(within(saved).getByRole('button', { name: 'yes' }));
+
+    await waitFor(() => expect(deleted).toEqual(['my-config']));
+    await waitFor(() =>
+      expect(screen.queryByRole('region', { name: 'config my-config' })).toBeNull(),
+    );
+  });
+
+  it("edits a saved config's models through the overrides editor", async () => {
+    renderProfiles();
+    const saved = await screen.findByRole('region', { name: 'config my-config' });
+
+    await userEvent.click(within(saved).getByRole('button', { name: 'edit' }));
+    await userEvent.selectOptions(
+      within(saved).getByLabelText('opportunityEvaluator'),
+      'google/gemini-2.5-flash',
+    );
+    await userEvent.click(within(saved).getByRole('button', { name: 'save changes' }));
+
+    await waitFor(() => expect(patched).not.toBeNull());
+    expect(patched!.name).toBe('my-config');
+    expect(patched!.body).toEqual({
+      description: 'mine',
+      models: { opportunityEvaluator: 'google/gemini-2.5-flash' },
+      env: {},
+    });
+  });
+
+  it('links every config to a prefilled launch', async () => {
+    renderProfiles();
+
+    for (const name of ['default', 'claude-evaluator', 'my-config']) {
+      const region = await screen.findByRole('region', { name: `config ${name}` });
+      expect(within(region).getByRole('link', { name: 'launch →' })).toHaveAttribute(
+        'href',
+        `/launch?profile=${name}`,
+      );
+    }
+  });
+});

--- a/apps/eval-ops/tests/run.test.tsx
+++ b/apps/eval-ops/tests/run.test.tsx
@@ -1,5 +1,5 @@
 import { describe, expect, it, vi, beforeEach, afterEach } from 'vitest';
-import { render, screen, cleanup } from '@testing-library/react';
+import { render, screen, cleanup, fireEvent } from '@testing-library/react';
 import { createMemoryRouter, RouterProvider } from 'react-router';
 
 import { Run } from '../src/routes/Run';
@@ -21,6 +21,8 @@ const RUN: RunRecord = {
   endedAt: null,
   pid: 12345,
 };
+
+const HEADER = 'Running 2 case(s) × 1 run(s) against google/gemini-2.5-flash…\n';
 
 class MockEventSource {
   /**
@@ -222,5 +224,38 @@ describe('Run', () => {
 
     expect(await screen.findByText(/No run with id/)).toBeInTheDocument();
     expect(screen.queryByText(/Loading/)).toBeNull();
+  });
+  it('renders structured progress from real harness output, raw log behind a toggle', async () => {
+    renderRun(RUN);
+    await screen.findByText(/run-1/);
+
+    // The real format: case start, a multi-line debug dump on the same logical
+    // line, and the score alone on its own line afterwards.
+    mockEventSource._emit('log', HEADER);
+    mockEventSource._emit('log', '  is_a/identity-basic … [OpportunityEvaluator:invokeEntityBundle] Done {\n  total: 1,\n}\n');
+    mockEventSource._emit('log', '1/1\n');
+    mockEventSource._emit('log', '  location/known-mismatch … [OpportunityEvaluator:invokeEntityBundle] Done {\n');
+
+    // The progress frame leads: position, tally, the finished row, and the
+    // in-flight case called out instead of a silent ellipsis.
+    expect(await screen.findByText('1/2 cases')).toBeInTheDocument();
+    expect(screen.getByText(/● running location\/known-mismatch/)).toBeInTheDocument();
+    expect(screen.getByText('✓')).toBeInTheDocument();
+    expect(screen.getByText('passed')).toBeInTheDocument();
+
+    // The raw debug dump is one click away, not the primary view.
+    expect(screen.queryByText(/total: 1,/)).toBeNull();
+    fireEvent.click(screen.getByText('show raw output'));
+    expect(await screen.findByText(/total: 1,/)).toBeInTheDocument();
+  });
+
+  it('keeps the plain log frame for output that is not a harness run', async () => {
+    renderRun(RUN);
+    await screen.findByText(/run-1/);
+
+    mockEventSource._emit('log', 'Usage: eval:matching [flags]\n');
+
+    expect(await screen.findByText(/Usage: eval:matching/)).toBeInTheDocument();
+    expect(screen.queryByText('show raw output')).toBeNull();
   });
 });

--- a/apps/eval-ops/tests/run.test.tsx
+++ b/apps/eval-ops/tests/run.test.tsx
@@ -258,4 +258,35 @@ describe('Run', () => {
     expect(await screen.findByText(/Usage: eval:matching/)).toBeInTheDocument();
     expect(screen.queryByText('show raw output')).toBeNull();
   });
+
+  it('summarises the resolved overrides in the header', async () => {
+    const overridden: RunRecord = {
+      ...RUN,
+      env: {
+        EVAL_MODEL_OVERRIDES: JSON.stringify({ opportunityEvaluator: 'anthropic/claude-sonnet-4' }),
+        RUN_OPPORTUNITY_EVAL_IN_PARALLEL: 'true',
+        OPENROUTER_FALLBACK_MODEL: 'none',
+      },
+    };
+    renderRun(overridden);
+    expect(
+      await screen.findByText(/opportunityEvaluator → anthropic\/claude-sonnet-4/),
+    ).toBeInTheDocument();
+    expect(screen.getByText(/RUN_OPPORTUNITY_EVAL_IN_PARALLEL=true/)).toBeInTheDocument();
+    // renderRun's internal pin is bookkeeping, not operator signal.
+    expect(screen.queryByText(/OPENROUTER_FALLBACK_MODEL/)).toBeNull();
+  });
+
+  it('renders no overrides summary for a default run', async () => {
+    renderRun(RUN);
+    await screen.findByText(/run-1/);
+    expect(screen.queryByText(/overrides:/)).toBeNull();
+  });
+
+  it('survives a malformed EVAL_MODEL_OVERRIDES value', async () => {
+    const corrupt: RunRecord = { ...RUN, env: { EVAL_MODEL_OVERRIDES: '{not json' } };
+    renderRun(corrupt);
+    expect(await screen.findByText(/run-1/)).toBeInTheDocument();
+    expect(screen.getByText(/EVAL_MODEL_OVERRIDES \(unparseable\)/)).toBeInTheDocument();
+  });
 });

--- a/apps/eval-ops/tests/smoke.test.tsx
+++ b/apps/eval-ops/tests/smoke.test.tsx
@@ -49,7 +49,7 @@ describe('App', () => {
       ['overview', '/'],
       ['launch', '/launch'],
       ['compare', '/compare'],
-      ['profiles', '/profiles'],
+      ['configs', '/profiles'],
     ];
     // The nav mounts with the dashboard, once the stubbed status answer arrives:
     // a link to a route the operator cannot open yet is not an offer worth making.

--- a/bun.lock
+++ b/bun.lock
@@ -110,7 +110,7 @@
     },
     "packages/protocol": {
       "name": "@indexnetwork/protocol",
-      "version": "8.4.0",
+      "version": "8.5.0",
       "dependencies": {
         "@langchain/core": "1.1.48",
         "@langchain/langgraph": "1.3.2",

--- a/bun.lock
+++ b/bun.lock
@@ -19,7 +19,7 @@
     },
     "apps/eval-ops": {
       "name": "@indexnetwork/eval-ops",
-      "version": "0.1.0",
+      "version": "0.2.0",
       "dependencies": {
         "react": "^19.0.0",
         "react-dom": "^19.0.0",
@@ -110,7 +110,7 @@
     },
     "packages/protocol": {
       "name": "@indexnetwork/protocol",
-      "version": "8.5.0",
+      "version": "8.6.0",
       "dependencies": {
         "@langchain/core": "1.1.48",
         "@langchain/langgraph": "1.3.2",

--- a/docs/superpowers/plans/2026-08-01-eval-ops-config-management.md
+++ b/docs/superpowers/plans/2026-08-01-eval-ops-config-management.md
@@ -1,0 +1,1019 @@
+# Eval Ops Configuration Management Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Let operators launch eval runs under different configurations — ad-hoc or named, created in the browser — and automatically compare two runs when both finish.
+
+**Architecture:** UI configs are the existing profile concept stored in a Neon table instead of repo JSON, validated by the existing profile schema plus a new curated model allowlist. Ad-hoc launch overrides resolve through the same profile path so fingerprints match named configs. Run-vs-run comparison reads each run's captured `report.json` (written for every run, even `--no-save`) and diffs them with the existing `compareArtifacts`, with config mismatch explicitly allowed because config is the variable under test.
+
+**Tech Stack:** Bun, zod, Bun.SQL (postgres), React + vitest (apps/eval-ops), plain-TypeScript ops package (packages/protocol/eval/ops, `bun test`).
+
+**Spec:** `docs/superpowers/specs/2026-08-01-eval-ops-config-management-design.md` (same worktree).
+
+## Global Constraints
+
+- Worktree: `/home/yanek/Projects/index/.worktrees/feat-eval-ops-deploy`, branch `feat/eval-ops-deploy`. Never edit the canonical root.
+- Ops package tests: `cd packages/protocol && bun test eval/ops/tests/`. App tests: `cd apps/eval-ops && bun run test` (**vitest** — `bun test` is the wrong runner here and produces spurious failures).
+- Typecheck: `bunx tsc --noEmit` in each touched package.
+- `docs/superpowers/` is gitignored: `git add -f` for spec/plan files (precedent exists in history).
+- Client-originated config must validate through the SAME zod + allowlist path everywhere (save, edit, launch). No parallel validation.
+- Any run with overrides is experimental → `--no-save` forced. Baselines must not be polluted through the UI.
+- `compareArtifacts` config-mismatch refusal stays ON for artifact compare; only run-vs-run compare relaxes it.
+- SemVer bump + regenerated `bun.lock` for every touched package, per repo convention, in the final task.
+
+## File Structure
+
+- `packages/protocol/eval/ops/ops.profiles.ts` (modify) — curated model allowlist, `validateConfigOverrides`, `resolveAdHoc`.
+- `packages/protocol/eval/ops/ops.registry.ts` (modify) — `agents` on each harness descriptor.
+- `packages/protocol/eval/ops/ops.types.ts` (modify) — `HarnessDescriptor.agents`, `EvalRunSpec.overrides`.
+- `packages/protocol/eval/ops/ops.configs.ts` (create) — config store: interface, in-memory, Bun.SQL impl, DDL.
+- `packages/protocol/eval/ops/ops.argv.ts` (modify) — `RunSpecSchema.overrides`.
+- `packages/protocol/eval/ops/ops.compare.ts` (modify) — `allowConfigMismatch` option.
+- `packages/protocol/eval/ops/ops.server.ts` (modify) — config routes, launch resolution, run-vs-run compare, boot DDL.
+- `apps/eval-ops/src/api/client.ts` (modify) — config + compareRuns methods, types.
+- `apps/eval-ops/src/components/OverridesEditor.tsx` (create) — shared override editing widget.
+- `apps/eval-ops/src/routes/Launch.tsx` (modify) — overrides section, A/B mode.
+- `apps/eval-ops/src/routes/Profiles.tsx` (modify) — becomes the Configs page (repo + saved, CRUD, launch).
+- `apps/eval-ops/src/routes/Compare.tsx` (modify) — pair mode: dual progress → auto diff.
+- Tests: `packages/protocol/eval/ops/tests/{profiles,configs,server,compare}.spec.ts`, `apps/eval-ops/tests/{launch,profiles,compare}.test.tsx`.
+
+---
+
+### Task 1: Curated model allowlist, agent map, override validation
+
+**Files:**
+- Modify: `packages/protocol/eval/ops/ops.profiles.ts`
+- Modify: `packages/protocol/eval/ops/ops.registry.ts` (descriptor entries)
+- Modify: `packages/protocol/eval/ops/ops.types.ts` (`HarnessDescriptor`)
+- Test: `packages/protocol/eval/ops/tests/profiles.spec.ts`
+
+**Interfaces:**
+- Produces:
+  - `export const ALLOWED_CONFIG_MODELS: readonly string[]`
+  - `export function validateConfigOverrides(overrides: { models: Record<string, string>; env: Record<string, string> }): string[]` — returns issue messages, empty when valid.
+  - `export function resolveAdHoc(overrides: { models: Record<string, string>; env: Record<string, string> }): ResolvedProfile` — synthetic profile named `default`, `experimental: true`, fingerprint identical to a named profile with the same payload.
+  - `HarnessDescriptor.agents: readonly string[]`
+- Consumes: existing `PROFILE_ENV_ALLOWLIST`, `ConfigProfileSchema`, `resolveProfile`, `ResolvedProfile` from `ops.profiles.ts`.
+
+- [ ] **Step 1: Write the failing tests**
+
+Add to `packages/protocol/eval/ops/tests/profiles.spec.ts`:
+
+```ts
+import { ALLOWED_CONFIG_MODELS, resolveAdHoc, validateConfigOverrides } from "../ops.profiles.js";
+import { HARNESS_REGISTRY } from "../ops.registry.js";
+
+describe("validateConfigOverrides", () => {
+  it("accepts a valid override set", () => {
+    expect(validateConfigOverrides({
+      models: { opportunityEvaluator: ALLOWED_CONFIG_MODELS[0] },
+      env: { RUN_OPPORTUNITY_EVAL_IN_PARALLEL: "true" },
+    })).toEqual([]);
+  });
+
+  it("rejects a model outside the curated allowlist and names it", () => {
+    const issues = validateConfigOverrides({
+      models: { opportunityEvaluator: "anthropic/claude-opus-4.8" },
+      env: {},
+    });
+    expect(issues.some((i) => i.includes("claude-opus-4.8"))).toBe(true);
+  });
+
+  it("rejects an agent key no scorecard harness exercises", () => {
+    const issues = validateConfigOverrides({ models: { negotiator: ALLOWED_CONFIG_MODELS[0] }, env: {} });
+    expect(issues.some((i) => i.includes("negotiator"))).toBe(true);
+  });
+
+  it("rejects an env key outside PROFILE_ENV_ALLOWLIST", () => {
+    const issues = validateConfigOverrides({ models: {}, env: { OPENROUTER_API_KEY: "x" } });
+    expect(issues.some((i) => i.includes("OPENROUTER_API_KEY"))).toBe(true);
+  });
+});
+
+describe("resolveAdHoc", () => {
+  it("fingerprints identically to a named profile with the same payload", () => {
+    const overrides = { models: { opportunityEvaluator: "anthropic/claude-sonnet-4" }, env: {} };
+    const adHoc = resolveAdHoc(overrides);
+    const named = resolveProfile({ name: "candidate", description: "x", ...overrides });
+    expect(adHoc.fingerprint).toBe(named.fingerprint);
+    expect(adHoc.experimental).toBe(true);
+    expect(adHoc.profile.name).toBe("default");
+    expect(adHoc.env.EVAL_MODEL_OVERRIDES).toBe(JSON.stringify(overrides.models));
+  });
+});
+
+describe("HARNESS_REGISTRY agents", () => {
+  it("maps each harness to the agents it exercises", () => {
+    expect(HARNESS_REGISTRY.matching.agents).toEqual(["opportunityEvaluator"]);
+    expect(HARNESS_REGISTRY.opportunity.agents).toEqual(["opportunityPresenter"]);
+    expect(HARNESS_REGISTRY.profile.agents).toEqual(["profileGenerator"]);
+    expect(HARNESS_REGISTRY.premise.agents).toEqual(["premiseDecomposer", "premiseAnalyzer"]);
+  });
+});
+```
+
+(`resolveProfile` is already imported in the existing test file; add it if not.)
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `cd packages/protocol && bun test eval/ops/tests/profiles.spec.ts`
+Expected: FAIL — `ALLOWED_CONFIG_MODELS`/`validateConfigOverrides`/`resolveAdHoc` not exported; `agents` missing on descriptors.
+
+- [ ] **Step 3: Implement**
+
+In `ops.types.ts`, add to `HarnessDescriptor`:
+
+```ts
+  /** Model-overridable agents this harness exercises, in pipeline order. */
+  agents: readonly string[];
+```
+
+In `ops.registry.ts`, add to each descriptor: matching → `agents: ["opportunityEvaluator"]`, opportunity → `agents: ["opportunityPresenter"]`, profile → `agents: ["profileGenerator"]`, premise → `agents: ["premiseDecomposer", "premiseAnalyzer"]`. (Grounded in source: matching constructs `OpportunityEvaluator`; opportunity `OpportunityPresenter`; profile's `EnrichmentGenerator` calls `createStructuredModel("profileGenerator", …)`; premise constructs `PremiseDecomposer` + `PremiseAnalyzer`.)
+
+In `ops.profiles.ts`, append:
+
+```ts
+/**
+ * The only models a client may select. Live spend on a shared URL with no
+ * actor attribution yet: free-text slugs stay out until attribution exists.
+ * Repo profiles are code-reviewed and exempt.
+ */
+export const ALLOWED_CONFIG_MODELS = [
+  "google/gemini-2.5-flash",
+  "google/gemini-2.5-flash-lite",
+  "google/gemini-3-pro-preview",
+  "anthropic/claude-sonnet-4",
+  "anthropic/claude-haiku-4.5",
+  "openai/gpt-4.1-mini",
+] as const;
+
+/** Agent keys any scorecard harness can actually exercise (from the registry). */
+function overridableAgents(): ReadonlySet<string> {
+  return new Set(Object.values(HARNESS_REGISTRY).flatMap((d) => d.agents));
+}
+
+/**
+ * Validates client-originated overrides. Returns human-readable issues;
+ * empty means valid. Used by the config routes and the launch path — never
+ * by the repo profile loader, whose files are code-reviewed.
+ */
+export function validateConfigOverrides(overrides: {
+  models: Record<string, string>;
+  env: Record<string, string>;
+}): string[] {
+  const issues: string[] = [];
+  const agents = overridableAgents();
+  for (const [agent, model] of Object.entries(overrides.models)) {
+    if (!agents.has(agent)) {
+      issues.push(`Unknown agent "${agent}". Overridable agents: ${[...agents].sort().join(", ")}`);
+    } else if (!(ALLOWED_CONFIG_MODELS as readonly string[]).includes(model)) {
+      issues.push(`Model "${model}" is not selectable. Allowed: ${ALLOWED_CONFIG_MODELS.join(", ")}`);
+    }
+  }
+  for (const key of Object.keys(overrides.env)) {
+    if (!PROFILE_ENV_ALLOWLIST.includes(key)) {
+      issues.push(`env key ${key} is not in PROFILE_ENV_ALLOWLIST`);
+    }
+  }
+  return issues;
+}
+
+/**
+ * Resolves ad-hoc launch overrides through the same path as a named profile,
+ * so fingerprints match a saved config with the same payload. The synthetic
+ * profile is named "default" (renderRun asserts the resolved name matches the
+ * requested one) but is always experimental: ad-hoc runs never save.
+ */
+export function resolveAdHoc(overrides: {
+  models: Record<string, string>;
+  env: Record<string, string>;
+}): ResolvedProfile {
+  const resolved = resolveProfile({ name: DEFAULT_PROFILE_NAME, description: "ad-hoc overrides", ...overrides });
+  return { ...resolved, experimental: true };
+}
+```
+
+Import `HARNESS_REGISTRY` from `./ops.registry.js` in `ops.profiles.ts` (check for an import cycle first: `ops.registry.ts` must not import `ops.profiles.ts` — it currently does not).
+
+Wait — `resolveProfile` rejects a `default` profile with overrides? No: the *loader* (`loadProfiles`) rejects default-with-overrides; `resolveProfile` itself does not. Confirm while implementing; if it does, inline the fingerprint/env construction instead of calling `resolveProfile`.
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `cd packages/protocol && bun test eval/ops/tests/profiles.spec.ts`
+Expected: PASS. Also `bun test eval/ops/tests/` (registry shape change ripples) and `bunx tsc --noEmit`.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/protocol/eval/ops/ops.profiles.ts packages/protocol/eval/ops/ops.registry.ts packages/protocol/eval/ops/ops.types.ts packages/protocol/eval/ops/tests/profiles.spec.ts
+git commit -m "feat(eval-ops): curated model allowlist, harness agent map, override validation"
+```
+
+---
+
+### Task 2: Config store (DB-backed, with in-memory fake)
+
+**Files:**
+- Create: `packages/protocol/eval/ops/ops.configs.ts`
+- Test: `packages/protocol/eval/ops/tests/configs.spec.ts`
+
+**Interfaces:**
+- Consumes: `ConfigProfile`, `ConfigProfileSchema`, `validateConfigOverrides` (Task 1).
+- Produces:
+  - `export interface ConfigStore { list(): Promise<ConfigProfile[]>; get(name: string): Promise<ConfigProfile | null>; create(profile: ConfigProfile): Promise<void>; update(name: string, patch: { description?: string; models?: Record<string, string>; env?: Record<string, string> }): Promise<ConfigProfile | null>; remove(name: string): Promise<boolean>; }`
+  - `export class InMemoryConfigStore implements ConfigStore`
+  - `export class BunSqlConfigStore implements ConfigStore` — `constructor(databaseUrl: string)`; `async ensureTable(): Promise<void>` runs idempotent DDL.
+  - `export const CONFIG_TABLE_DDL: string`
+  - `export class ConfigConflictError extends Error` (name already exists)
+
+- [ ] **Step 1: Write the failing tests**
+
+`packages/protocol/eval/ops/tests/configs.spec.ts`:
+
+```ts
+import { describe, expect, it } from "bun:test";
+import { InMemoryConfigStore, ConfigConflictError, CONFIG_TABLE_DDL } from "../ops.configs.js";
+
+const candidate = {
+  name: "sonnet-evaluator",
+  description: "evaluator on sonnet",
+  models: { opportunityEvaluator: "anthropic/claude-sonnet-4" },
+  env: {},
+};
+
+describe("InMemoryConfigStore", () => {
+  it("creates, lists, gets, updates and removes configs", async () => {
+    const store = new InMemoryConfigStore();
+    await store.create(candidate);
+    expect(await store.get("sonnet-evaluator")).toEqual(candidate);
+    expect((await store.list()).map((c) => c.name)).toEqual(["sonnet-evaluator"]);
+
+    const updated = await store.update("sonnet-evaluator", { description: "better description" });
+    expect(updated?.description).toBe("better description");
+    expect(updated?.models).toEqual(candidate.models);
+
+    expect(await store.remove("sonnet-evaluator")).toBe(true);
+    expect(await store.get("sonnet-evaluator")).toBeNull();
+    expect(await store.remove("sonnet-evaluator")).toBe(false);
+  });
+
+  it("rejects a duplicate name with ConfigConflictError", async () => {
+    const store = new InMemoryConfigStore();
+    await store.create(candidate);
+    await expect(store.create(candidate)).rejects.toBeInstanceOf(ConfigConflictError);
+  });
+
+  it("returns null when updating an unknown name", async () => {
+    expect(await new InMemoryConfigStore().update("nope", { description: "x" })).toBeNull();
+  });
+});
+
+describe("CONFIG_TABLE_DDL", () => {
+  it("is idempotent", () => {
+    expect(CONFIG_TABLE_DDL).toContain("CREATE TABLE IF NOT EXISTS eval_ops_configs");
+  });
+});
+```
+
+- [ ] **Step 2: Run to verify fail** — `cd packages/protocol && bun test eval/ops/tests/configs.spec.ts` → module not found.
+
+- [ ] **Step 3: Implement `ops.configs.ts`**
+
+```ts
+import { SQL } from "bun";
+import { ConfigProfileSchema, type ConfigProfile } from "./ops.profiles.js";
+
+export class ConfigConflictError extends Error {
+  constructor(name: string) {
+    super(`A config named "${name}" already exists`);
+    this.name = "ConfigConflictError";
+  }
+}
+
+export const CONFIG_TABLE_DDL = `
+  CREATE TABLE IF NOT EXISTS eval_ops_configs (
+    name        text PRIMARY KEY,
+    description text NOT NULL,
+    models      jsonb NOT NULL DEFAULT '{}',
+    env         jsonb NOT NULL DEFAULT '{}',
+    created_at  timestamptz NOT NULL DEFAULT now(),
+    updated_at  timestamptz NOT NULL DEFAULT now()
+  )`;
+
+export interface ConfigStore {
+  list(): Promise<ConfigProfile[]>;
+  get(name: string): Promise<ConfigProfile | null>;
+  create(profile: ConfigProfile): Promise<void>;
+  update(name: string, patch: { description?: string; models?: Record<string, string>; env?: Record<string, string> }): Promise<ConfigProfile | null>;
+  remove(name: string): Promise<boolean>;
+}
+
+export class InMemoryConfigStore implements ConfigStore {
+  private readonly configs = new Map<string, ConfigProfile>();
+  async list(): Promise<ConfigProfile[]> {
+    return [...this.configs.values()].sort((a, b) => a.name.localeCompare(b.name));
+  }
+  async get(name: string): Promise<ConfigProfile | null> {
+    return this.configs.get(name) ?? null;
+  }
+  async create(profile: ConfigProfile): Promise<void> {
+    if (this.configs.has(profile.name)) throw new ConfigConflictError(profile.name);
+    this.configs.set(profile.name, profile);
+  }
+  async update(name: string, patch: { description?: string; models?: Record<string, string>; env?: Record<string, string> }): Promise<ConfigProfile | null> {
+    const existing = this.configs.get(name);
+    if (existing === undefined) return null;
+    const updated: ConfigProfile = {
+      name,
+      description: patch.description ?? existing.description,
+      models: patch.models ?? existing.models,
+      env: patch.env ?? existing.env,
+    };
+    this.configs.set(name, updated);
+    return updated;
+  }
+  async remove(name: string): Promise<boolean> {
+    return this.configs.delete(name);
+  }
+}
+
+/**
+ * Config persistence in the same Neon database the fixture control plane uses.
+ * The table is eval-ops app state, not fixture corpus: db:flush truncates a
+ * hard-coded list of api-owned tables, so a fixture reset never touches it.
+ */
+export class BunSqlConfigStore implements ConfigStore {
+  private readonly sql: SQL;
+  constructor(databaseUrl: string) {
+    this.sql = new SQL(databaseUrl);
+  }
+  async ensureTable(): Promise<void> {
+    await this.sql.unsafe(CONFIG_TABLE_DDL);
+  }
+  async list(): Promise<ConfigProfile[]> {
+    const rows = await this.sql`SELECT name, description, models, env FROM eval_ops_configs ORDER BY name`;
+    return rows.map((row) => ConfigProfileSchema.parse(row));
+  }
+  async get(name: string): Promise<ConfigProfile | null> {
+    const rows = await this.sql`SELECT name, description, models, env FROM eval_ops_configs WHERE name = ${name}`;
+    return rows.length === 0 ? null : ConfigProfileSchema.parse(rows[0]);
+  }
+  async create(profile: ConfigProfile): Promise<void> {
+    try {
+      await this.sql`INSERT INTO eval_ops_configs (name, description, models, env)
+        VALUES (${profile.name}, ${profile.description}, ${JSON.stringify(profile.models)}, ${JSON.stringify(profile.env)})`;
+    } catch (error) {
+      if (error instanceof Error && error.message.includes("duplicate key")) throw new ConfigConflictError(profile.name);
+      throw error;
+    }
+  }
+  async update(name: string, patch: { description?: string; models?: Record<string, string>; env?: Record<string, string> }): Promise<ConfigProfile | null> {
+    const existing = await this.get(name);
+    if (existing === null) return null;
+    const updated: ConfigProfile = {
+      name,
+      description: patch.description ?? existing.description,
+      models: patch.models ?? existing.models,
+      env: patch.env ?? existing.env,
+    };
+    await this.sql`UPDATE eval_ops_configs
+      SET description = ${updated.description}, models = ${JSON.stringify(updated.models)},
+          env = ${JSON.stringify(updated.env)}, updated_at = now()
+      WHERE name = ${name}`;
+    return updated;
+  }
+  async remove(name: string): Promise<boolean> {
+    const rows = await this.sql`DELETE FROM eval_ops_configs WHERE name = ${name} RETURNING name`;
+    return rows.length > 0;
+  }
+}
+```
+
+Note for implementer: `ConfigProfileSchema` is not currently exported from `ops.profiles.ts` — export it. The SQL jsonb columns: Bun.SQL serialises bound JS objects for jsonb; if binding plain objects fails, bind `JSON.stringify(...)` with `::jsonb` casts — verify against the real driver behaviour used in `ops.fixture.ts` (`BunSqlFixtureInspector`).
+
+- [ ] **Step 4: Run to verify pass** — `bun test eval/ops/tests/configs.spec.ts` and full `bun test eval/ops/tests/`, `bunx tsc --noEmit`.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/protocol/eval/ops/ops.configs.ts packages/protocol/eval/ops/ops.profiles.ts packages/protocol/eval/ops/tests/configs.spec.ts
+git commit -m "feat(eval-ops): config store with in-memory and Bun.SQL implementations"
+```
+
+---
+
+### Task 3: Config routes + boot DDL in the ops server
+
+**Files:**
+- Modify: `packages/protocol/eval/ops/ops.server.ts`
+- Test: `packages/protocol/eval/ops/tests/server.spec.ts`
+
+**Interfaces:**
+- Consumes: `ConfigStore`, `BunSqlConfigStore`, `InMemoryConfigStore`, `ConfigConflictError`, `validateConfigOverrides`, `ALLOWED_CONFIG_MODELS`, `ConfigProfileSchema`.
+- Produces (HTTP, under the existing auth gate):
+  - `GET /api/configs` → `{ repo: ConfigProfile[], saved: ConfigProfile[] }`
+  - `GET /api/configs/models` → `{ models: string[] }`
+  - `POST /api/configs` body `ConfigProfile` → 201 created config; 400 with issue list; 409 on name collision (repo profile OR saved config)
+  - `PATCH /api/configs/:name` body `{ description?, models?, env? }` → updated config; 404 unknown; 400 invalid; 409 if `:name` is a repo profile
+  - `DELETE /api/configs/:name` → 204; 404 unknown; 409 if repo profile
+
+- [ ] **Step 1: Write the failing tests**
+
+Follow the existing `server.spec.ts` harness (it builds the server with an in-memory run store; extend that context with an `InMemoryConfigStore`). Tests:
+
+```ts
+describe("config routes", () => {
+  it("lists repo profiles and saved configs in one response", async () => {
+    // seed InMemoryConfigStore with one config; GET /api/configs
+    // expect body.repo to equal the committed profiles and body.saved the seeded one
+  });
+
+  it("creates a config and rejects a name colliding with a repo profile", async () => {
+    // POST valid config → 201
+    // POST { name: "default", ... } → 409 (repo profile name)
+    // POST same name twice → 409
+  });
+
+  it("rejects models outside the curated list with a 400 naming the model", async () => {
+    // POST { models: { opportunityEvaluator: "x/y" } } → 400, body contains "x/y"
+  });
+
+  it("rejects env keys outside the allowlist", async () => {
+    // POST { env: { OPENROUTER_API_KEY: "x" } } → 400
+  });
+
+  it("updates and deletes a saved config, 404s unknown names, 409s repo profile names", async () => {
+    // PATCH saved → 200; PATCH "default" → 409; PATCH "ghost" → 404
+    // DELETE saved → 204; DELETE "default" → 409; DELETE "ghost" → 404
+  });
+
+  it("serves the curated model list", async () => {
+    // GET /api/configs/models → 200, body.models includes "google/gemini-2.5-flash"
+  });
+});
+```
+
+- [ ] **Step 2: Run to verify fail** — routes 404.
+
+- [ ] **Step 3: Implement**
+
+In `ops.server.ts`:
+
+1. `OpsContext` gains `configs: ConfigStore`. In the production context factory (where `profilesDir` etc. are assembled), build `BunSqlConfigStore` from `process.env.DATABASE_URL` when set, else `InMemoryConfigStore` (and log loudly that configs will not persist). Await `ensureTable()` at boot when the store is `BunSqlConfigStore`; on DDL failure, throw — the server must refuse to start (fail closed per spec).
+2. Route registrations inside `route()`:
+
+```ts
+if (request.method === "GET") {
+  // ...
+  if (resource === "configs" && rest.length === 0) return await listConfigs(context);
+  if (resource === "configs" && rest.length === 1 && rest[0] === "models") return json({ models: [...ALLOWED_CONFIG_MODELS] });
+}
+if (request.method === "POST") {
+  // ...
+  if (resource === "configs" && rest.length === 0) return await createConfig(context, request);
+}
+if (request.method === "PATCH") {
+  if (resource === "configs" && rest.length === 1) return await updateConfig(context, rest[0], request);
+}
+if (request.method === "DELETE") {
+  if (resource === "configs" && rest.length === 1) return await deleteConfig(context, rest[0]);
+}
+```
+
+(Check how `route()` is dispatched for non-GET/POST methods today — if the router only branches on GET/POST, add PATCH/DELETE branches.)
+
+3. Handlers (new, near `compare()`):
+
+```ts
+async function listConfigs(context: OpsContext): Promise<Response> {
+  return json({ repo: await loadProfiles(context.profilesDir), saved: await context.configs.list() });
+}
+
+async function createConfig(context: OpsContext, request: Request): Promise<Response> {
+  const body = await readJson(request);
+  if (!body.ok) return json({ error: body.error }, body.status);
+  const parsed = ConfigProfileSchema.safeParse(body.value);
+  if (!parsed.success) return json({ error: describeIssues(parsed.error) }, 400);
+  const issues = validateConfigOverrides(parsed.data);
+  if (issues.length > 0) return json({ error: issues.join("; ") }, 400);
+  if (parsed.data.name === DEFAULT_PROFILE_NAME) {
+    return json({ error: `"${DEFAULT_PROFILE_NAME}" names the shipped default profile` }, 409);
+  }
+  const repoNames = new Set((await loadProfiles(context.profilesDir)).map((p) => p.name));
+  if (repoNames.has(parsed.data.name)) {
+    return json({ error: `"${parsed.data.name}" names a shipped repo profile` }, 409);
+  }
+  try {
+    await context.configs.create(parsed.data);
+  } catch (error) {
+    if (error instanceof ConfigConflictError) return json({ error: error.message }, 409);
+    throw error;
+  }
+  return json(parsed.data, 201);
+}
+```
+
+`updateConfig`/`deleteConfig` follow the same pattern: repo-name check → 409; store miss → 404; patch re-validated through `ConfigProfileSchema.partial()` minus `name` (name is immutable) plus `validateConfigOverrides` on the merged result.
+
+- [ ] **Step 4: Run to verify pass** — `bun test eval/ops/tests/server.spec.ts`, full ops suite, typecheck.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/protocol/eval/ops/ops.server.ts packages/protocol/eval/ops/tests/server.spec.ts
+git commit -m "feat(eval-ops): config CRUD routes with repo-profile collision guards"
+```
+
+---
+
+### Task 4: Ad-hoc overrides at launch + DB configs in profile resolution
+
+**Files:**
+- Modify: `packages/protocol/eval/ops/ops.argv.ts` (`RunSpecSchema`)
+- Modify: `packages/protocol/eval/ops/ops.types.ts` (`EvalRunSpec`)
+- Modify: `packages/protocol/eval/ops/ops.server.ts` (`launchRun`)
+- Test: `packages/protocol/eval/ops/tests/server.spec.ts` (launch section)
+
+**Interfaces:**
+- Consumes: `validateConfigOverrides`, `resolveAdHoc` (Task 1), `ConfigStore` (Task 2/3).
+- Produces: `EvalRunSpec.overrides?: { models: Record<string, string>; env: Record<string, string> }`. Launch accepts either a named profile (repo or DB) or `profile: "default"` + `overrides`; both present (named profile + overrides) → 400.
+
+- [ ] **Step 1: Write the failing tests**
+
+```ts
+describe("launch with overrides", () => {
+  it("launches an ad-hoc run as experimental with the overrides env injected", async () => {
+    // POST /api/runs { kind: "eval", harness: "matching", profile: "default",
+    //   flags: { runs: 1 }, overrides: { models: { opportunityEvaluator: "anthropic/claude-sonnet-4" }, env: {} } }
+    // → 202; record.experimental === true;
+    // record.env.EVAL_MODEL_OVERRIDES contains claude-sonnet-4;
+    // record.argv contains --no-save
+  });
+
+  it("fingerprints an ad-hoc run identically to a saved config with the same payload", async () => {
+    // create config "candidate" with payload P via POST /api/configs
+    // launch profile "candidate"; launch ad-hoc with P
+    // → both records share profileFingerprint; both experimental
+  });
+
+  it("rejects a named profile combined with overrides", async () => {
+    // POST { profile: "default" /* or any */, overrides, and profile != "default" } → 400
+    // also: schema rejects overrides key on a non-default profile at parse time
+  });
+
+  it("rejects override models outside the curated list at launch", async () => {
+    // → 400 naming the model
+  });
+
+  it("resolves a saved DB config exactly like a repo profile", async () => {
+    // seed config store; POST /api/runs with profile = saved name → 202,
+    // env injected, experimental true, --no-save in argv
+  });
+});
+```
+
+- [ ] **Step 2: Run to verify fail** — schema rejects `overrides` (strict) / unknown profile.
+
+- [ ] **Step 3: Implement**
+
+1. `ops.types.ts`:
+
+```ts
+export interface EvalRunSpec {
+  kind: "eval";
+  harness: OpsHarness;
+  /** Name of a committed or saved profile. "default" + overrides = ad-hoc. */
+  profile: string;
+  /** Ad-hoc overrides; only valid with profile "default". Never credentials. */
+  overrides?: { models: Record<string, string>; env: Record<string, string> };
+  flags: RunFlags;
+}
+```
+
+2. `ops.argv.ts` `RunSpecSchema`: add
+
+```ts
+      overrides: z
+        .object({ models: z.record(z.string().min(1)), env: z.record(z.string()) })
+        .strict()
+        .optional(),
+```
+
+and extend `superRefine`: when `spec.overrides !== undefined && spec.profile !== "default"`, add an issue at `["overrides"]`: "ad-hoc overrides require profile \"default\"; launch a named config and tweak it from the Configs page instead".
+
+3. `ops.server.ts` `launchRun`, replace the profile lookup block:
+
+```ts
+    let resolved: ResolvedProfile;
+    if (parsed.data.overrides !== undefined) {
+      const issues = validateConfigOverrides(parsed.data.overrides);
+      if (issues.length > 0) return json({ error: issues.join("; ") }, 400);
+      resolved = resolveAdHoc(parsed.data.overrides);
+    } else {
+      // Profiles resolve from both sources: shipped repo files and saved configs.
+      const repoProfiles = await loadProfiles(context.profilesDir);
+      const profile =
+        repoProfiles.find((candidate) => candidate.name === parsed.data.profile)
+        ?? await context.configs.get(parsed.data.profile)
+        ?? undefined;
+      if (profile === undefined) return json({ error: `Unknown profile "${parsed.data.profile}"` }, 400);
+      resolved = resolveProfile(profile);
+    }
+```
+
+Nothing else in `launchRun` changes: `renderRun` already forces `--no-save` for experimental runs and pins `OPENROUTER_FALLBACK_MODEL=none` for model overrides.
+
+- [ ] **Step 4: Run to verify pass** — server spec, full ops suite, typecheck.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/protocol/eval/ops/ops.argv.ts packages/protocol/eval/ops/ops.types.ts packages/protocol/eval/ops/ops.server.ts packages/protocol/eval/ops/tests/server.spec.ts
+git commit -m "feat(eval-ops): ad-hoc launch overrides and DB-config profile resolution"
+```
+
+---
+
+### Task 5: Run-vs-run comparison endpoint
+
+**Files:**
+- Modify: `packages/protocol/eval/ops/ops.compare.ts`
+- Modify: `packages/protocol/eval/ops/ops.server.ts` (`compare()`)
+- Test: `packages/protocol/eval/ops/tests/compare.spec.ts` (create or extend)
+
+**Interfaces:**
+- Consumes: `context.store.get(id)`, `context.store.reportPath(id)`, `readEvalArtifact` from `../shared/index.js` (already used by `ops.artifacts.ts` via `parseEvalArtifact`; use `parseEvalArtifact(json, { expectedType: EVAL_RUN_REPORT_ARTIFACT_TYPE })`), `getExecutionEvidence` from `../shared/index.js`.
+- Produces:
+  - `compareArtifacts(reference, subject, alpha?, opts?: { allowConfigMismatch?: boolean })`
+  - `GET /api/compare?referenceRun=<id>&subjectRun=<id>` → `CompareOutcome & { runs: { reference: RunSide; subject: RunSide } }` where `RunSide = { id: string; profile: string; profileFingerprint: string; complete: boolean | null }`.
+
+- [ ] **Step 1: Write the failing tests**
+
+```ts
+describe("compareArtifacts allowConfigMismatch", () => {
+  it("still refuses artifact compare when configs differ (default)", () => {
+    // two envelopes differing only in configFingerprint → comparable: false
+  });
+  it("compares across configs when allowConfigMismatch is set", () => {
+    // same pair with opts → comparable: true, regressions/improvements present
+  });
+});
+
+describe("run-vs-run compare route", () => {
+  it("diffs two run reports and labels each side", async () => {
+    // seed store with two runs whose report.json files exist (fixtures under
+    // a temp .ops-runs dir — follow how server.spec.ts seeds run records)
+    // GET /api/compare?referenceRun=a&subjectRun=b
+    // → 200; body.runs.reference.id === "a"; comparable true; evidence complete flags present
+  });
+  it("422s naming the side whose report is missing", async () => {
+    // subject run without report.json → 422, message contains the subject run id
+  });
+  it("404s an unknown run id", async () => { /* ... */ });
+  it("400s when run params and artifact params are mixed", async () => { /* ... */ });
+});
+```
+
+Envelope fixtures: build minimal v2 envelopes via `buildEvalArtifact(EVAL_RUN_REPORT_ARTIFACT_TYPE, scorecard, meta)` from `../shared/index.js` — copy the scorecard/meta shape from an existing compare or artifact test.
+
+- [ ] **Step 2: Run to verify fail** — `allowConfigMismatch` not accepted; route 400s on run params.
+
+- [ ] **Step 3: Implement**
+
+1. `ops.compare.ts`: extend the signature and gate the config finding:
+
+```ts
+export function compareArtifacts(
+  reference: EvalArtifactEnvelope,
+  subject: EvalArtifactEnvelope,
+  alpha = 0.05,
+  opts: { allowConfigMismatch?: boolean } = {},
+): CompareOutcome {
+  // ...
+  if (!opts.allowConfigMismatch && reference.configFingerprint !== subject.configFingerprint) {
+    findings.push({ dimension: "configFingerprint", /* ... */ });
+  }
+```
+
+(When the mismatch is allowed it is the variable under test, not a finding.)
+
+2. `ops.server.ts` `compare()`:
+
+```ts
+async function compare(context: OpsContext, url: URL): Promise<Response> {
+  const referenceId = url.searchParams.get("reference");
+  const subjectId = url.searchParams.get("subject");
+  const referenceRun = url.searchParams.get("referenceRun");
+  const subjectRun = url.searchParams.get("subjectRun");
+  const artifactMode = referenceId !== null || subjectId !== null;
+  const runMode = referenceRun !== null || subjectRun !== null;
+  if (artifactMode === runMode) {
+    return json({ error: "compare requires either reference+subject artifact ids or referenceRun+subjectRun run ids" }, 400);
+  }
+  if (runMode) {
+    if (referenceRun === null || subjectRun === null) {
+      return json({ error: "compare requires both referenceRun and subjectRun" }, 400);
+    }
+    return await compareRuns(context, referenceRun, subjectRun);
+  }
+  // … existing artifact path unchanged …
+}
+
+async function compareRuns(context: OpsContext, referenceRunId: string, subjectRunId: string): Promise<Response> {
+  const sides: { id: string; record: RunRecord; envelope: EvalArtifactEnvelope }[] = [];
+  for (const id of [referenceRunId, subjectRunId]) {
+    const record = await context.store.get(id);
+    if (record === null) return json({ error: `Unknown run id: ${id}` }, 404);
+    const reportPath = context.store.reportPath(record.id);
+    if (!(await Bun.file(reportPath).exists())) {
+      return json({ error: `Run ${id} has no report to compare (it may have died before writing one)` }, 422);
+    }
+    const envelope = parseEvalArtifact(await Bun.file(reportPath).json(), { expectedType: EVAL_RUN_REPORT_ARTIFACT_TYPE });
+    sides.push({ id, record, envelope });
+  }
+  const [reference, subject] = sides;
+  const outcome = compareArtifacts(reference.envelope, subject.envelope, 0.05, { allowConfigMismatch: true });
+  const side = ({ id, record, envelope }: (typeof sides)[number]) => ({
+    id,
+    profile: record.spec.kind === "eval" ? record.spec.profile : "default",
+    profileFingerprint: record.profileFingerprint,
+    complete: getExecutionEvidence(envelope)?.complete ?? null,
+  });
+  return json({ ...outcome, runs: { reference: side(reference), subject: side(subject) } });
+}
+```
+
+Check `getExecutionEvidence`'s evidence shape for the exact `complete` field name (`EvalExecutionEvidence` from `eval/shared/runner.ts` — the artifact test at `artifact.ts:68` shows `complete: z.boolean()` inside the evidence schema).
+
+- [ ] **Step 4: Run to verify pass** — compare spec, full ops suite, typecheck.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/protocol/eval/ops/ops.compare.ts packages/protocol/eval/ops/ops.server.ts packages/protocol/eval/ops/tests/compare.spec.ts
+git commit -m "feat(eval-ops): run-vs-run comparison across configs"
+```
+
+---
+
+### Task 6: App client methods and types
+
+**Files:**
+- Modify: `apps/eval-ops/src/api/client.ts`
+- Test: `apps/eval-ops/tests/client.test.ts`
+
+**Interfaces:**
+- Consumes: Task 3 routes, Task 5 route.
+- Produces:
+  - `export interface ConfigProfile { name: string; description: string; models: Record<string, string>; env: Record<string, string> }`
+  - `api.configs(): Promise<{ repo: ConfigProfile[]; saved: ConfigProfile[] }>`
+  - `api.createConfig(profile: ConfigProfile): Promise<ConfigProfile>`
+  - `api.updateConfig(name: string, patch: Partial<Omit<ConfigProfile, "name">>): Promise<ConfigProfile>`
+  - `api.deleteConfig(name: string): Promise<void>`
+  - `api.configModels(): Promise<{ models: string[] }>`
+  - `api.compareRuns(referenceRun: string, subjectRun: string): Promise<RunCompareResult>`
+  - `export type RunCompareResult = CompareResult & { runs?: { reference: RunSide; subject: RunSide } }`, `RunSide = { id: string; profile: string; profileFingerprint: string; complete: boolean | null }`
+  - `RunSpec` (client copy) gains `overrides?: { models: Record<string, string>; env: Record<string, string> }`
+
+- [ ] **Step 1: Failing tests** in `client.test.ts`: stub `fetch` per-URL and assert each method hits the right route with the right method/body (`PATCH`/`DELETE` verbs included), and that `compareRuns` builds `/api/compare?referenceRun=a&subjectRun=b`.
+
+- [ ] **Step 2: Run to verify fail.**
+
+- [ ] **Step 3: Implement** — mirror existing `api` methods; add `patchJson`/`deleteJson` helpers next to `postJson`:
+
+```ts
+async function patchJson<T>(url: string, body: unknown): Promise<T> {
+  return fetchJson<T>(url, { method: "PATCH", headers: { "content-type": "application/json" }, body: JSON.stringify(body) });
+}
+async function deleteJson(url: string): Promise<void> {
+  await fetchJson<unknown>(url, { method: "DELETE" });
+}
+```
+
+(Match the exact existing `postJson` error/refusal handling — copy its shape, do not improvise a second style.)
+
+- [ ] **Step 4: Run to verify pass** — `cd apps/eval-ops && bun run test` and `bunx tsc --noEmit`.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/eval-ops/src/api/client.ts apps/eval-ops/tests/client.test.ts
+git commit -m "feat(eval-ops): client methods for configs and run comparison"
+```
+
+---
+
+### Task 7: OverridesEditor component + Launch page (ad-hoc + save-as-config + A/B)
+
+**Files:**
+- Create: `apps/eval-ops/src/components/OverridesEditor.tsx`
+- Modify: `apps/eval-ops/src/routes/Launch.tsx`
+- Test: `apps/eval-ops/tests/launch.test.tsx`
+
+**Interfaces:**
+- Consumes: `api.configs`, `api.configModels`, `api.createConfig`, `api.launch`, `HarnessDescriptor.agents` (already served by `/api/harnesses`).
+- Produces:
+  - `<OverridesEditor agents: readonly string[]; models: readonly string[]; value: Overrides; onChange: (next: Overrides) => void />` where `Overrides = { models: Record<string, string>; env: Record<string, string> }`. Per-agent dropdown ("default" + curated models) and env key/value rows (key dropdown from a server-agnostic list passed via prop `envKeys: readonly string[]`, value text input, remove button; "add env override" button).
+  - Launch submits `overrides` only when at least one model or env value is set.
+
+- [ ] **Step 1: Failing tests** (`launch.test.tsx`, extend existing):
+
+```tsx
+it("submits ad-hoc overrides with profile default", async () => {
+  // render Launch, open "overrides (this run only)", pick a model for the
+  // harness's agent, submit → the posted spec has profile "default" and
+  // overrides.models[agent] === chosen model
+});
+
+it("saves the current overrides as a named config", async () => {
+  // set an override, click "save as config…", enter name+description,
+  // confirm → POST /api/configs fired with the overrides payload
+});
+
+it("A/B mode fires two launches and navigates to the pair URL", async () => {
+  // toggle A/B, give the candidate side an override, submit →
+  // two POST /api/runs (reference first), navigate to
+  // /compare?referenceRun=<first>&subjectRun=<second>
+});
+
+it("A/B mode defaults both sides to the same profile and shares flags", async () => {
+  // flags (runs=1) appear in both posted specs
+});
+```
+
+The existing launch tests stub `fetch` naïvely — follow the `run.test.tsx`/`Harness` lesson: compute derived data BEFORE setState, and keep extra fetches (`api.configs`, `api.configModels`) non-blocking with `.catch(() => {})` so a naïve stub can never crash the form.
+
+- [ ] **Step 2: Run to verify fail.**
+
+- [ ] **Step 3: Implement**
+
+`OverridesEditor.tsx`:
+
+```tsx
+export interface Overrides {
+  models: Record<string, string>;
+  env: Record<string, string>;
+}
+
+export const EMPTY_OVERRIDES: Overrides = { models: {}, env: {} };
+
+export function hasOverrides(value: Overrides): boolean {
+  return Object.keys(value.models).length > 0 || Object.keys(value.env).length > 0;
+}
+```
+
+Render: for each agent in `agents`, a row `<span className="text-term-dim">{agent}</span>` + `<select>` with options `default` (empty string) and each curated model; onChange writes/deletes `value.models[agent]`. Env section: rows of `<select>` of unused `envKeys` + `<input>` value + `✕`; an "add env override" button appending a row with the first unused key. All plain controlled inputs — the site is mouse-first, no keyboard handlers.
+
+`Launch.tsx` changes:
+1. State gains `configs: { repo: ConfigProfile[]; saved: ConfigProfile[] }`, `models: string[]`, `ab: boolean`, `referenceOverrides: Overrides`, `candidateOverrides: Overrides`. Fetch configs/models on mount, non-blocking.
+2. The profile `<select>` lists repo profiles then saved configs (labelled `(saved)`).
+3. "overrides (this run only)" `<details>` section renders `<OverridesEditor>` for the harness's `agents`. In A/B mode the section becomes two columns labelled `reference` and `candidate`, each with its own editor.
+4. Submit: build spec(s). Single mode: `overrides: hasOverrides(ref) ? ref : undefined`. A/B mode: two specs — reference `{ profile, overrides: hasOverrides(ref) ? ref : undefined }`, candidate likewise — POST sequentially (`await api.launch(a)` then `await api.launch(b)`), then `navigate(`/compare?referenceRun=${a.id}&subjectRun=${b.id}`)`. Single mode navigates to `/r/:id` as today. When a named profile other than `default` is chosen, overrides are not submitted (server rejects the combination); the UI disables the overrides section unless `profile === "default"` and points to the Configs page for tweaking saved configs.
+5. "save as config…" (visible when `hasOverrides`): inline name + description inputs; POST; on success refresh `configs.saved` and switch the profile select to the new name.
+
+- [ ] **Step 4: Run to verify pass** — `bun run test`, `bunx tsc --noEmit`.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/eval-ops/src/components/OverridesEditor.tsx apps/eval-ops/src/routes/Launch.tsx apps/eval-ops/tests/launch.test.tsx
+git commit -m "feat(eval-ops): launch overrides, save-as-config, A/B launch mode"
+```
+
+---
+
+### Task 8: Profiles page becomes the Configs page
+
+**Files:**
+- Modify: `apps/eval-ops/src/routes/Profiles.tsx`
+- Test: `apps/eval-ops/tests/profiles.test.tsx`
+
+**Interfaces:**
+- Consumes: `api.configs`, `api.updateConfig`, `api.deleteConfig`, `OverridesEditor` (Task 7).
+- Produces: route `/profiles` (path unchanged) listing both sources; nav label updated to `configs`.
+
+- [ ] **Step 1: Failing tests**
+
+```tsx
+it("lists shipped profiles read-only and saved configs with edit/delete", async () => {
+  // shipped rows render dimmed with a "shipped" label and no delete button;
+  // saved rows show edit + delete
+});
+
+it("deletes a saved config after confirmation", async () => { /* DELETE fired, row gone */ });
+
+it("edits a saved config's models through the overrides editor", async () => { /* PATCH fired with merged payload */ });
+
+it("links every config to a prefilled launch", async () => {
+  // each row's "launch →" links to /launch?profile=<name>
+});
+```
+
+(Launch reads `?profile=` to preselect — add that one-liner to Launch.tsx in this task.)
+
+- [ ] **Step 2: Run to verify fail.**
+
+- [ ] **Step 3: Implement** — extend the existing Profiles page: fetch `api.configs()`; render `repo` entries dimmed with `shipped`, `saved` entries with edit (inline expansion with `OverridesEditor` + description input + save), delete (confirm inline: "delete? yes / no"), and `launch →`. Update the page heading to "configs" and the nav label where navigation is defined (find the nav component — likely `App.tsx` or a header component; the Overview nav pills list `harnesses profiles compare fixture launch`).
+
+- [ ] **Step 4: Run to verify pass.**
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/eval-ops/src/routes/Profiles.tsx apps/eval-ops/src/routes/Launch.tsx apps/eval-ops/tests/profiles.test.tsx
+git commit -m "feat(eval-ops): configs page managing saved configs alongside shipped profiles"
+```
+
+---
+
+### Task 9: Pair page — dual progress, automatic diff
+
+**Files:**
+- Modify: `apps/eval-ops/src/routes/Compare.tsx`
+- Create: `apps/eval-ops/src/components/CompareDiff.tsx` (extract the existing diff rendering from Compare.tsx unchanged in behaviour)
+- Test: `apps/eval-ops/tests/compare.test.tsx`
+
+**Interfaces:**
+- Consumes: `subscribeToRun`, `RunProgressView` + `HarnessProgressParser` (existing run page machinery), `api.compareRuns`, `CompareDiff`.
+- Produces: `/compare?referenceRun=A&subjectRun=B` pair mode. Artifact mode (`reference`/`subject`) unchanged.
+
+- [ ] **Step 1: Failing tests**
+
+```tsx
+it("shows both runs' progress while either is active", async () => {
+  // referenceRun/subjectRun params; emit status+log frames for both
+  // → two progress frames with each side's profile label
+});
+
+it("flips to the diff view when both runs are terminal", async () => {
+  // both runs terminal → api.compareRuns fetched; regressions render;
+  // each side header shows profile + config fingerprint prefix
+});
+
+it("renders the incomplete-evidence caveat when a side is incomplete", async () => {
+  // compare result with runs.subject.complete === false → caveat text
+});
+
+it("keeps artifact compare working unchanged", async () => {
+  // reference/subject params → existing behaviour (existing tests must pass)
+});
+```
+
+Reuse the `MockEventSource` pattern from `run.test.tsx` — two subscriptions means the mock must hand out one instance per URL; extend the stub to a tiny factory keyed by run id.
+
+- [ ] **Step 2: Run to verify fail.**
+
+- [ ] **Step 3: Implement**
+
+1. Extract the diff rendering (the `result.comparable ? … : … findings …` JSX) from `Compare.tsx` into `components/CompareDiff.tsx` as `<CompareDiff result={CompareOutcome} />`; Compare's artifact mode renders it. No behaviour change; existing tests pin this.
+2. Pair mode in `Compare.tsx`: when `referenceRun`/`subjectRun` params are present, subscribe to both runs (two `subscribeToRun` calls, each feeding its own parser + timestamps, exactly like `Run.tsx`). Layout: two stacked panels headed `reference · <profile>` / `candidate · <profile>` (subject is the candidate), each with `RunProgressView`. A `useEffect` on both statuses: when `isTerminalStatus` for both, call `api.compareRuns(referenceRun, subjectRun)` and render `<CompareDiff>` plus side headers (`profile`, `profileFingerprint.slice(0, 12)`, and when `complete === false` a yellow `incomplete evidence — interpret with care` line).
+3. While waiting, a dim line `comparison appears when both runs finish`.
+
+- [ ] **Step 4: Run to verify pass** — full app suite + typecheck.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/eval-ops/src/routes/Compare.tsx apps/eval-ops/src/components/CompareDiff.tsx apps/eval-ops/tests/compare.test.tsx
+git commit -m "feat(eval-ops): pair page flips from dual progress to automatic diff"
+```
+
+---
+
+### Task 10: Version bumps, lockfile, deploy verification
+
+**Files:**
+- Modify: `packages/protocol/package.json`, `apps/eval-ops/package.json`, `bun.lock`
+
+- [ ] **Step 1: SemVer bump** both touched packages (minor — new features), regenerate `bun.lock` from the repo root (`bun install`), commit.
+
+- [ ] **Step 2: Full targeted validation**
+
+```bash
+cd packages/protocol && bunx tsc --noEmit && bun test eval/ops/tests/
+cd ../../apps/eval-ops && bunx tsc --noEmit && bun run test
+```
+
+- [ ] **Step 3: Push and watch the deploy**
+
+```bash
+git push origin feat/eval-ops-deploy
+```
+
+Then verify the deployed service: boot log clean (DDL ran), `GET /api/configs` responds after sign-in, and the launch page shows the overrides section. Record evidence in PR #1318.
+
+- [ ] **Step 4: Commit + push**
+
+```bash
+git commit -m "chore: bump protocol and eval-ops versions"
+git push origin feat/eval-ops-deploy
+```
+
+---
+
+## Self-Review Notes
+
+- Spec coverage: model allowlist (T1), storage + reset survival (T2, T3 boot DDL; flush-list exclusion verified in spec), CRUD routes (T3), ad-hoc launch + fingerprint parity + xor rule (T4), run-vs-run compare + completeness + 422 (T5), UI surfaces (T7/T8/T9), curated dropdown (T1/T7), testing (per-task + T10). A/B toggle + pair page + auto-diff (T7/T9, spec addendum).
+- `resolveAdHoc` relies on `resolveProfile` accepting a `default`-named profile with overrides — flagged in Task 1 Step 3 to verify; fallback given.
+- PATCH/DELETE routing: Task 3 flags checking the dispatcher; the router currently branches only on GET/POST.
+- Type consistency: `Overrides`, `ConfigProfile`, `RunSide`, `RunCompareResult`, `validateConfigOverrides`, `resolveAdHoc`, `ConfigStore` names used consistently across tasks.

--- a/docs/superpowers/specs/2026-08-01-eval-ops-config-management-design.md
+++ b/docs/superpowers/specs/2026-08-01-eval-ops-config-management-design.md
@@ -22,6 +22,7 @@ comparing outcomes.
 | Storage for UI-created configs | Neon DB table; repo profiles stay as shipped read-only defaults |
 | Model freedom | Curated server-side allowlist only (live spend on a shared URL; no actor attribution yet) |
 | Knobs beyond models | Env toggles from the existing `PROFILE_ENV_ALLOWLIST` only. Judge model and runs/seed stay per-run launch fields, not config fields |
+| Payoff loop | A/B launch: two runs under different configurations, comparison shown automatically when both end (addendum below) |
 
 ## Design
 
@@ -150,6 +151,47 @@ each harness exercises — next to the `question`/`detail` added in the run-view
 work. This drives the launch form's filtered dropdowns and keeps the mapping
 in one reviewed place.
 
+## A/B runs with automatic comparison (addendum)
+
+The payoff loop the whole feature exists for: launch two runs under different
+configurations, watch both, and see the diff the moment the second one ends.
+
+Enabler (verified in source): the executor passes `--report <runDir>/report.json`
+to every harness child, and `--no-save` suppresses only the rolling-baseline
+write. **Every run — saved or experimental — captures a full report at
+`.ops-runs/<id>/report.json`.** Two experimental runs can therefore be diffed
+directly; baselines and saved artifacts are never touched.
+
+**Server — compare runs, not just artifacts.** `GET /api/compare` gains
+`referenceRun`/`subjectRun` parameters alongside the existing artifact-id
+ones. Both runs' `report.json` files are read through the run store and fed
+to the same `compareArtifacts`/`diffBaseline` path — same one-sided
+beta-binomial statistics, same incompatibility reporting (different harness,
+corpus-fingerprint mismatch). A run that died before writing a report yields
+422 naming which side. An incomplete run (exit 2/3) still has a report and
+still compares; the response carries the evidence-completeness state so the
+UI shows the caveat rather than hiding it.
+
+**Launch — A/B mode.** A toggle on the launch page, "A/B — compare two
+configurations", splits the config section into **reference** and
+**candidate** columns. Harness and run flags (runs, seed) stay shared; each
+side independently picks default / a named config / ad-hoc overrides. Submit
+fires two launches back-to-back — they serialize through the existing run
+queue, which is also the fair way to compare on one machine — and navigates
+to the pair page.
+
+**Pair page — progress now, diff when done.** The existing `/compare` route,
+extended: with run ids it shows both runs' progress views (the RunProgress
+component) stacked, each headed by its side's resolved-config summary. When
+both runs reach a terminal state it automatically fetches the run-vs-run
+comparison and renders the existing diff view (regressions/improvements per
+case) with the incomplete-evidence caveat when applicable. No new entity or
+table: **the URL is the pair** — shareable, back/forward-safe.
+
+Reference vs candidate semantics follow the existing compare view:
+regressions are cases where the candidate is worse than the reference,
+improvements the reverse.
+
 ## Error handling
 
 - Invalid config payloads: 400 with the zod issue list, rendered verbatim in
@@ -172,11 +214,18 @@ Ops package (`bun test`):
   present is rejected; DB config resolves identically to a repo profile.
 - Boot DDL idempotency (boot twice, no error).
 - Fixture reset preserves `eval_ops_configs`.
+- Run-vs-run compare: diffs two run reports; 422 when either side lacks a
+  report; incompatibility (harness/fingerprint) reported; incomplete-evidence
+  state present in the response.
 
 App (`vitest`):
 - Configs page: lists both sources, edit/delete flows, launch prefill.
 - Launch page: overrides section validates client-side, save-as-config flow,
   named-config prefill and tweak.
+- A/B launch: toggle reveals reference/candidate columns, submit fires two
+  launches and navigates to the pair URL.
+- Pair page: shows both progress views while active; flips to the diff view
+  when both runs are terminal; incomplete-evidence caveat renders.
 
 Targeted validation policy per the development reference: affected suites
 plus typecheck; no full-suite run. Database-backed tests only under the

--- a/docs/superpowers/specs/2026-08-01-eval-ops-config-management-design.md
+++ b/docs/superpowers/specs/2026-08-01-eval-ops-config-management-design.md
@@ -1,0 +1,191 @@
+# Eval Ops Configuration Management — Design
+
+Date: 2026-08-01
+Status: approved (design review with maintainer)
+Branch: `feat/eval-ops-deploy` (the branch the live `eval.dev.index.network` service deploys)
+
+## Problem
+
+Eval configuration today is a git round-trip. Config profiles are JSON files
+in `packages/protocol/eval/ops/profiles/`, baked into the container image at
+build time. Comparing "what if the evaluator were claude-sonnet-4 instead of
+gemini-2.5-flash" means: hand-write JSON, commit, push, wait for a Railway
+rebuild, launch, compare. That friction suppresses exactly the behaviour the
+site exists for — running harnesses under different configurations and
+comparing outcomes.
+
+## Decisions (maintainer, 2026-08-01)
+
+| Question | Decision |
+| --- | --- |
+| Core loop | Both ad-hoc overrides at launch **and** named saved configs; ad-hoc is primary |
+| Storage for UI-created configs | Neon DB table; repo profiles stay as shipped read-only defaults |
+| Model freedom | Curated server-side allowlist only (live spend on a shared URL; no actor attribution yet) |
+| Knobs beyond models | Env toggles from the existing `PROFILE_ENV_ALLOWLIST` only. Judge model and runs/seed stay per-run launch fields, not config fields |
+
+## Design
+
+### One concept, two sources
+
+A "config" is exactly the existing profile shape — `{name, description,
+models: {agent → modelId}, env: {VAR → value}}` — validated by the existing
+`ConfigProfileSchema`, resolved by the existing `resolveProfile`, fingerprinted
+by the existing sha256-of-sorted-overrides, and forced `--no-save` when
+experimental. UI configs differ from repo profiles in storage only: a
+database row instead of a JSON file.
+
+At launch, repo profiles and DB configs merge into one list keyed by name.
+`RunSpec` already carries `profile` and `profileFingerprint`, so every run
+record and artifact shows which config produced it, and the existing compare
+view works across configs unchanged.
+
+Non-goal: editing or deleting repo profiles from the UI. They are shipped,
+code-reviewed defaults and remain read-only.
+
+### Storage
+
+One table in the Neon branch the eval-ops service already uses:
+
+```sql
+CREATE TABLE IF NOT EXISTS eval_ops_configs (
+  name        text PRIMARY KEY,
+  description text NOT NULL,
+  models      jsonb NOT NULL DEFAULT '{}',
+  env         jsonb NOT NULL DEFAULT '{}',
+  created_at  timestamptz NOT NULL DEFAULT now(),
+  updated_at  timestamptz NOT NULL DEFAULT now()
+);
+```
+
+- Created by idempotent DDL at eval-ops server boot (the ops server is plain
+  Bun with no drizzle setup; a migration framework for one table is
+  unjustified weight). Boot DDL runs before the first request is served.
+- The fixture reset's truncate list **excludes** `eval_ops_configs`; a test
+  asserts configs survive a reset. The table is eval-ops app state, not
+  fixture corpus.
+- Name uniqueness spans both sources: creating a DB config whose name
+  collides with a repo profile is rejected (409).
+
+### Validation and spend safety
+
+All client-originated configuration — config save/edit and ad-hoc launch
+overrides — flows through one validation path in `ops.profiles.ts`:
+
+1. `ConfigProfileSchema` (zod strict): kebab-case name, non-empty description,
+   record shapes.
+2. `PROFILE_ENV_ALLOWLIST` for every env key (existing).
+3. **New** `ALLOWED_CONFIG_MODELS`: a curated list of OpenRouter model ids
+   (initial: `google/gemini-2.5-flash`, `google/gemini-2.5-flash-lite`,
+   `anthropic/claude-sonnet-4`, `anthropic/claude-haiku-4.5`,
+   `openai/gpt-4.1-mini`, `google/gemini-3-pro-preview`). Every value in
+   `models` must be on this list. Enforced on client-originated input only;
+   repo profiles are trusted because they are code-reviewed.
+4. Model keys (agents) must be known agent ids — the same check
+   `readModelOverrides` performs; the error names the valid agents.
+
+Any run whose effective configuration differs from `default` is experimental:
+`--no-save` is forced, exactly as for experimental repo profiles today, so
+baselines cannot be polluted through the UI.
+
+### Ad-hoc overrides at launch
+
+`RunSpec` gains an optional field:
+
+```ts
+overrides?: { models: Record<string, string>; env: Record<string, string> }
+```
+
+- `profile: "default"` **xor** `overrides` present: an anonymous one-off
+  config. The executor builds child env through the same
+  `resolveProfile`-shaped path and computes the fingerprint over the same
+  `{models, env}` payload, so an ad-hoc run and a named config with identical
+  overrides fingerprint identically — comparable in the diff view.
+- `profile: <named>` with `overrides` absent: current behaviour, where
+  `<named>` may now be a DB config as well as a repo profile.
+- Both present is rejected (400) — "config, tweaked once" is expressed by
+  launching the named config from the Configs page and editing the prefilled
+  overrides section before submitting, which submits ad-hoc overrides.
+
+### UI surfaces
+
+**Launch page** (primary): a collapsed "overrides (this run only)" section.
+
+- Per-agent model dropdowns, filtered to the agents the selected harness
+  exercises (matching → `opportunityEvaluator`; opportunity →
+  `opportunityPresenter`; profile → `profileGenerator`; premise →
+  `premiseDecomposer`, `premiseAnalyzer`). Each dropdown offers the curated
+  model list plus "default (gemini-2.5-flash)". The harness→agents map lives
+  in the registry next to the new descriptions.
+- Env-toggle rows: dropdown of allowlisted keys + value input + remove
+  button; "add override" appends a row.
+- "save as config…" button: prompts for name + description, POSTs the
+  current overrides, and on success switches the form to that named config.
+
+**Configs page** (new route, header link next to Fixtures): a table listing
+repo profiles (dimmed, labelled "shipped", read-only) and DB configs
+(edit/delete with confirm, "launch →" linking to a prefilled launch form).
+Editor reuses the same override widgets as the launch page.
+
+**Run page**: the header gains a resolved-overrides summary line (e.g.
+`opportunityEvaluator → anthropic/claude-sonnet-4, RUN_OPPORTUNITY_EVAL_IN_PARALLEL=true`)
+so two runs' difference is visible without opening the compare view.
+
+### Server routes
+
+Under the existing auth gate:
+
+- `GET    /api/configs` → `{ repo: ConfigProfile[], saved: ConfigProfile[] }`
+- `POST   /api/configs` → create; 400 invalid, 409 name collision
+- `PATCH  /api/configs/:name` → edit description/models/env
+- `DELETE /api/configs/:name` → delete
+- `GET    /api/configs/models` → `{ models: string[] }` (the curated list, for dropdowns)
+
+The existing `GET /api/profiles` keeps working unchanged; the launch path
+(`POST /api/runs`) merges both sources when resolving `spec.profile`.
+
+### Harness/agents registry addition
+
+`HarnessDescriptor` gains `agents: string[]` — the model-overridable agents
+each harness exercises — next to the `question`/`detail` added in the run-view
+work. This drives the launch form's filtered dropdowns and keeps the mapping
+in one reviewed place.
+
+## Error handling
+
+- Invalid config payloads: 400 with the zod issue list, rendered verbatim in
+  the UI (consistent with existing launch errors).
+- Unknown model id or agent key: 400 naming the valid values.
+- Name collision with a repo profile or existing DB config: 409.
+- Boot DDL failure: server refuses to start (fail closed — the site is
+  useless without its config store, and a silent fallback to repo-only would
+  look like lost configs).
+- DB unreachable on config routes: 503 with an explicit message; launches of
+  repo profiles continue to work.
+
+## Testing
+
+Ops package (`bun test`):
+- Config CRUD: create/validate/persist/edit/delete; name-collision 409s;
+  model-allowlist and agent-key rejections; env-allowlist rejections.
+- Launch: ad-hoc overrides fingerprint identically to a named config with the
+  same payload; overrides force `--no-save`; `profile`+`overrides` both
+  present is rejected; DB config resolves identically to a repo profile.
+- Boot DDL idempotency (boot twice, no error).
+- Fixture reset preserves `eval_ops_configs`.
+
+App (`vitest`):
+- Configs page: lists both sources, edit/delete flows, launch prefill.
+- Launch page: overrides section validates client-side, save-as-config flow,
+  named-config prefill and tweak.
+
+Targeted validation policy per the development reference: affected suites
+plus typecheck; no full-suite run. Database-backed tests only under the
+existing `TEST_DATABASE_SAFE=1` guard.
+
+## Explicitly out of scope
+
+- Judge model and runs/seed in configs (remain per-run launch fields).
+- Free-text OpenRouter slugs (requires actor attribution + rate limiting first).
+- Editing shipped repo profiles from the UI.
+- Per-user config ownership (any signed-in user sees and edits all configs —
+  matches the current shared-URL posture; revisit with actor attribution).

--- a/packages/protocol/eval/ops/README.md
+++ b/packages/protocol/eval/ops/README.md
@@ -431,3 +431,25 @@ sign-in bridge's callback URL is built from. See
 cd packages/protocol && bun run eval:verify   # includes `suite: ops` (typecheck + tests)
 cd packages/protocol && bun test eval/ops/tests
 ```
+
+## Deploying this service
+
+The ops server has its own Railway config at `apps/eval-ops/railway.toml`, and the
+service must be pointed at that path.
+
+This is not optional tidiness. A Railway service with no config of its own inherits
+the repository-root `railway.toml`, which is the **API's** configuration — including:
+
+```toml
+preDeployCommand = "cd services/api && bun run db:migrate"
+healthcheckPath  = "/health"
+```
+
+Inheriting that made the eval ops service run `drizzle-kit migrate` on every deploy.
+It failed only because the service had no `DATABASE_URL`; had one been configured it
+would have migrated that database from this service. The dev environment's
+`DATABASE_URL` names `protocol_prod`.
+
+The config also deliberately sets **no** `healthcheckPath`. Every route here sits
+behind the `Host` allowlist, so a probe arriving with an internal hostname is refused
+with 403 and would fail an otherwise healthy container.

--- a/packages/protocol/eval/ops/README.md
+++ b/packages/protocol/eval/ops/README.md
@@ -287,14 +287,15 @@ perform the `.env.test` cross-check that `resolveResetTarget` does, so an operat
 
 `createOpsHandler(context)` returns a plain `(Request) => Promise<Response>`.
 
-Every route below requires a session except the two marked **public**; `GET /callback` is
+Every route below requires a session except the three marked **public**; `GET /callback` is
 handled ahead of the gate because it is the request that establishes one.
 
 | Method | Route | Purpose |
 | :----- | :---- | :------ |
 | `GET` | `/api/auth/status` | **public.** `{ authenticated: false }` or `{ authenticated: true, email, name }`. |
-| `POST` | `/api/auth/login` | **public.** `{ url }` — the sign-in bridge link, carrying a one-time state. |
-| `GET` | `/callback` | **public, pre-gate.** The bridge lands here: validates the state, resolves the identity, applies the domain policy, then redirects to the UI or renders a refusal page. |
+| `POST` | `/api/auth/login` | **public.** Which sign-in this server runs: `{ kind: "bridge", url }` locally, or `{ kind: "token", apiUrl, webAppUrl }` when deployed. |
+| `POST` | `/api/auth/session` | **public.** Deployed only. `{ token }` → resolved server-side, domain policy applied, session cookie set. 403 in the local posture. |
+| `GET` | `/callback` | **public, pre-gate.** The bridge lands here: validates the state, resolves the identity, applies the domain policy, then redirects to the UI or renders a refusal page. 403 in the deployed posture, which mints no states. |
 | `POST` | `/api/auth/logout` | Clears the session and expires the cookie. |
 | `GET` | `/api/harnesses` | `HARNESS_REGISTRY` values. |
 | `GET` | `/api/profiles` | Committed profiles. |
@@ -340,27 +341,49 @@ Four independent guards stand in front of every request, and they **compose** ra
 substitute for one another: the loopback bind, the `Host` check, the `Origin` allowlist,
 and identity. Removing any one of them is not offset by the others.
 
-**Identity.** Every route except `GET /api/auth/status` and `POST /api/auth/login`
-(`PUBLIC_ROUTES` in `ops.server.ts`) requires a session, and a session exists only for an
+**Identity.** Every route except `GET /api/auth/status`, `POST /api/auth/login` and
+`POST /api/auth/session` (`PUBLIC_ROUTES` in `ops.server.ts`) requires a session — the
+exemptions are the routes that *obtain* a session, which cannot require one — and a
+session exists only for an
 Index account whose email is **verified** and whose domain is exactly `index.network`.
 The gate sits ahead of dispatch, so a route added later is gated by default and an unknown
 path is refused with 401 rather than a 404 that would confirm what exists. The policy is
 re-evaluated on **every** request, so narrowing it refuses live sessions too; 401 ("nobody
 is signed in") and 403 ("signed in, not permitted") are deliberately distinguishable.
 
-There is no cookie to forward — the ops UI is on `127.0.0.1` and the API on
-`localhost:3001`, and a Better Auth session cookie is host-scoped — so sign-in reuses the
-CLI browser-auth bridge: `POST /api/auth/login` mints a one-time state and returns
+There is no cookie to forward in either posture — a Better Auth session cookie is
+host-scoped — so there are two exchanges, chosen by `resolveSignInMode(env)`:
+`EVAL_OPS_PUBLIC_ORIGIN` unset means **bridge**, set means **token**. That is the same
+variable that extends the allowlists, and it is exactly the circumstance in which the
+bridge cannot complete. Both exchanges end with *this server* resolving a credential
+against the API; nothing is ever client-asserted.
+
+**Bridge (local).** `POST /api/auth/login` mints a one-time state and returns
 `<WEB_APP_URL>/cli-auth?callback=http://127.0.0.1:<port>/callback&version=2&state=…`, the
 bridge mints a revocable API key against the operator's existing browser session, and
 `GET /callback` consumes the state, exchanges the key for an identity, applies the domain
-policy and **discards the key**. The key is never stored in a session, never logged, never
-returned to the browser and never rendered.
+policy and **discards the key**.
 
-`WEB_APP_URL` and `API_URL` are one pair: the first mints the key, the second verifies it.
-A key minted by one deployment is meaningless to another, so the server **refuses to
-start** on a half-configured or mismatched pair rather than failing every sign-in later
-with an unhelpful "No Index account could be resolved".
+**Token (deployed).** The bridge is unusable off loopback: `validateCliCallbackUrl` in
+`apps/web/src/lib/cli-auth.ts` accepts only `http:` on `127.0.0.1`/`[::1]`, deliberately,
+so that broad API credentials are never redirected to a caller-controlled origin — and
+that rule is shared with the released CLI, so it is not changed. Instead the browser
+fetches a Better Auth JWT from `${API_URL}/api/auth/token` with `credentials: "include"`
+(cross-site works because the API's cookie is `SameSite=None; Secure`) and posts it to
+`POST /api/auth/session`. `JwtIdentityResolver` presents it to `${API_URL}/api/auth/me` as
+`Authorization: Bearer …`, where the API verifies the signature against its own JWKS. The
+`/api/auth/me` hop is **required, not an optimisation**: the `jwt` plugin's `definePayload`
+returns `{ id, email, name }` and no `emailVerified`, and the policy demands verification,
+so it can never be inferred from possession of a token.
+
+In both cases the credential is exchanged once and dropped. It is never stored in a
+session, never logged, never returned to the browser and never rendered.
+
+`WEB_APP_URL` and `API_URL` are one pair: the first is where the operator's session lives,
+the second is what verifies the credential minted from it. A credential minted by one
+deployment is meaningless to another, so the server **refuses to start** on a
+half-configured or mismatched pair rather than failing every sign-in later with an
+unhelpful "No Index account could be resolved".
 
 **What keeps this site local is the guards, not the authentication.** Both entrypoints bind
 `127.0.0.1` unless `EVAL_OPS_BIND` is set, and setting it alone changes nothing reachable:

--- a/packages/protocol/eval/ops/README.md
+++ b/packages/protocol/eval/ops/README.md
@@ -362,11 +362,21 @@ A key minted by one deployment is meaningless to another, so the server **refuse
 start** on a half-configured or mismatched pair rather than failing every sign-in later
 with an unhelpful "No Index account could be resolved".
 
-**It is still not safe to expose.** What keeps this site local is the guards, not the
-authentication. `ops.serve.ts` binds `127.0.0.1` unless `EVAL_OPS_BIND` is set: **do not
-change it.** Setting it alone would not help anyway — the loopback `Origin` allowlist and
-the `Host` check both fail closed, so a browser on another host would have every write
-refused and every read refused with it.
+**What keeps this site local is the guards, not the authentication.** Both entrypoints bind
+`127.0.0.1` unless `EVAL_OPS_BIND` is set, and setting it alone changes nothing reachable:
+the `Host` and `Origin` allowlists still fail closed, so a browser on another host has
+every write refused and every read refused with it.
+
+Those allowlists are extended — by exactly one entry — only when `EVAL_OPS_PUBLIC_ORIGIN`
+names the deployed origin, e.g. `https://eval.index.network`. Unset means loopback only,
+which is the local posture and the default. The value is validated at startup as one
+absolute `https:` origin with no path, query, fragment or credentials, and the server
+**refuses to start** on anything else rather than falling back to something permissive.
+There is no wildcard and no flag that switches a guard off: a subdomain of the configured
+origin, the same name over `http:`, and every other host are all still refused. Exposing
+the site therefore takes three deliberate acts (bind, public origin, a route to the port),
+and leaves the `@index.network` identity gate as the only thing in front of a tool that
+spends tokens and can flush a database.
 
 **The session cookie is visible to every port on `127.0.0.1`.** Cookies are not
 port-scoped, so any *other* local HTTP service the operator's browser visits on loopback
@@ -384,7 +394,12 @@ bun run dev:eval-ops                        # UI on 127.0.0.1:5174 (from the rep
 ```
 
 `eval:web` runs with `--env-file=../../.env.test`, so the fixture target is the test
-database. `EVAL_OPS_PORT` changes the port. See
+database. `EVAL_OPS_PORT` changes the port. That file also sets `PORT=3001` for the API
+service, which is why `ops.serve.ts` ignores `PORT` — honouring it would move the ops API
+onto the API's port. The deployed single-process entrypoint
+(`apps/eval-ops/server.ts`) is the one a platform starts, and it *does* honour the `PORT`
+that platform injects; both resolve it through `resolveBindPort`, which is also what the
+sign-in bridge's callback URL is built from. See
 [`apps/eval-ops/README.md`](../../../../apps/eval-ops/README.md) for the browser app.
 
 ## Tests

--- a/packages/protocol/eval/ops/ops.allowlist.ts
+++ b/packages/protocol/eval/ops/ops.allowlist.ts
@@ -1,0 +1,29 @@
+/**
+ * Environment variables a profile or ad-hoc override is permitted to set.
+ * Everything here is a protocol feature flag read live from process.env.
+ * Credentials, connection strings and NODE_ENV are deliberately absent: an
+ * override must never be able to repoint a run at another database or
+ * provider account.
+ *
+ * Lives in its own module (not ops.profiles.ts) so the browser app can import
+ * it: ops.profiles.ts pulls in node:fs and node:crypto, which the Vite bundle
+ * cannot. This module must stay dependency-free.
+ */
+export const PROFILE_ENV_ALLOWLIST: readonly string[] = Object.freeze([
+  "DISCOVERY_ALLOWED_TYPES",
+  "DISCOVERY_PROFILE_SOURCE",
+  "DISCOVERY_CONTEXT_TO_INTENT",
+  "DISCOVERY_REJECTION_COOLDOWN_DAYS",
+  "DISCOVERY_SOURCE_PREMISE_LIMIT",
+  "RUN_OPPORTUNITY_EVAL_IN_PARALLEL",
+  "INTRODUCER_DISCOVERY_ENABLED",
+  "NEGOTIATION_INCLUDE_OTHER_INTENTS",
+  "NEGOTIATION_MAX_TURNS_CHAT",
+  "NEGOTIATION_MAX_TURNS_AMBIENT",
+  "NEGOTIATION_EVIDENCE_QUESTIONS_MODE",
+  "OUTCOME_QUESTIONS_MODE",
+  "POOL_QUESTIONS_MINING",
+  "POOL_QUESTIONS_MODE",
+  "POOL_QUESTIONS_PUSH",
+  "POOL_QUESTIONS_RANKING",
+]);

--- a/packages/protocol/eval/ops/ops.argv.ts
+++ b/packages/protocol/eval/ops/ops.argv.ts
@@ -40,6 +40,10 @@ export const RunSpecSchema = z
     kind: z.literal("eval"),
     harness: z.enum(OPS_HARNESSES as unknown as [string, ...string[]]),
     profile: z.string().regex(/^[a-z0-9]+(?:-[a-z0-9]+)*$/),
+    overrides: z
+      .object({ models: z.record(z.string().min(1)), env: z.record(z.string()) })
+      .strict()
+      .optional(),
     flags: RunFlagsSchema,
   })
   .strict()
@@ -53,6 +57,15 @@ export const RunSpecSchema = z
           message: `The ${spec.harness} harness does not accept --${name}`,
         });
       }
+    }
+    // Ad-hoc overrides ARE the profile: combining them with a named profile
+    // would make the run's provenance ambiguous, so the pair is inexpressible.
+    if (spec.overrides !== undefined && spec.profile !== "default") {
+      context.addIssue({
+        code: z.ZodIssueCode.custom,
+        path: ["overrides"],
+        message: 'ad-hoc overrides require profile "default"; launch a named config and tweak it from the Configs page instead',
+      });
     }
   }) as unknown as z.ZodType<EvalRunSpec>;
 

--- a/packages/protocol/eval/ops/ops.auth.ts
+++ b/packages/protocol/eval/ops/ops.auth.ts
@@ -1,27 +1,37 @@
 /**
  * Identity for the eval ops site: who is at the browser, and may they be here.
  *
- * The ops server is loopback-only and stays that way — the bind address, the
- * `Host` check and the `Origin` allowlist in ops.server.ts are what keep it off
- * the network. This module is defence in depth on top of them, not a
- * replacement: it answers "which Index account is driving this", so a machine
- * shared with anyone, or a process running as another user, still cannot spend
- * tokens or flush a database through it.
+ * Locally the ops server is loopback-only, and the bind address, the `Host`
+ * check and the `Origin` allowlist in ops.server.ts are what keep it off the
+ * network. Deployed, `EVAL_OPS_PUBLIC_ORIGIN` extends those allowlists to one
+ * configured origin and this module becomes the *only* thing between the
+ * internet and a tool that can spend tokens and flush a database. It answers
+ * "which Index account is driving this", and the answer must be earned on every
+ * sign-in.
  *
- * There is no cookie to forward. The ops UI runs on 127.0.0.1 and the API on
- * localhost:3001, and a Better Auth session cookie is host-scoped, so the ops
- * server cannot read it. The repository already solves exactly this for the CLI:
- * open `<WEB_APP_URL>/cli-auth` against the browser's existing session, let it
- * mint a revocable API key, and have it redirect that key to a loopback
- * callback. This module reuses that bridge — see `buildBridgeUrl`.
+ * There is no cookie to forward, in either posture: a Better Auth session cookie
+ * is host-scoped (`advanced.defaultCookieAttributes` sets `sameSite: "none"`,
+ * `secure: true`, with no `crossSubDomainCookies`), so the ops server cannot read
+ * it. Two exchanges therefore exist, one per posture, and both end with this
+ * server resolving a credential rather than believing a claim:
  *
- * Everything here is injectable and free of I/O except `ApiIdentityResolver`,
- * which is the one seam that talks to the API. Nothing here reads the
- * environment, opens a socket by default, or logs.
+ *  - **Local** — the CLI bridge the repository already had. Open
+ *    `<WEB_APP_URL>/cli-auth` against the browser's existing session, let it mint
+ *    a revocable API key, and have it redirect that key to a loopback callback.
+ *    See `buildBridgeUrl` and `ApiIdentityResolver`.
+ *  - **Deployed** — a better-auth JWT. The bridge cannot be used off loopback:
+ *    `validateCliCallbackUrl` in apps/web accepts only `http:` on 127.0.0.1/[::1],
+ *    deliberately, and that rule is shared with the released CLI. See
+ *    `JwtIdentityResolver`.
  *
- * The credential is radioactive: it is a broad API key for a real account. It is
- * accepted, exchanged for an identity, and dropped. It is never stored in a
- * session, never returned to the browser and never put in a message.
+ * Everything here is injectable and free of I/O except the two resolvers, which
+ * are the one seam that talks to the API. Nothing here reads the environment,
+ * opens a socket by default, or logs.
+ *
+ * The credential is radioactive in both postures — a broad API key for a real
+ * account, or a bearer token that is one. It is accepted, exchanged for an
+ * identity, and dropped. It is never stored in a session, never returned to the
+ * browser and never put in a message.
  */
 import { randomBytes, timingSafeEqual } from "node:crypto";
 
@@ -316,15 +326,20 @@ export function buildBridgeUrl(options: BridgeUrlOptions): string {
  * Exchanges a credential for the identity behind it.
  *
  * A seam, so the tests never need an API, a database or a socket: the ops server
- * injects {@link ApiIdentityResolver} and a spec injects a stub.
+ * injects {@link ApiIdentityResolver} or {@link JwtIdentityResolver}, and a spec
+ * injects a stub. Which one the server injects is decided by configuration — see
+ * `resolveSignInMode` in ops.server.ts — and both answer the same question, so
+ * every caller past this point is posture-blind.
  */
 export interface IdentityResolver {
   /**
-   * @param apiKey - The credential the bridge delivered. Never stored, never logged.
+   * @param credential - The credential the sign-in delivered: an API key from the
+   *          local bridge, or a better-auth JWT from the deployed browser. Never
+   *          stored, never logged.
    * @returns The identity, or null when the credential is not accepted or the
    *          reply is not the shape this server understands.
    */
-  resolve(apiKey: string): Promise<ResolvedIdentity | null>;
+  resolve(credential: string): Promise<ResolvedIdentity | null>;
 }
 
 /**
@@ -375,25 +390,103 @@ export class ApiIdentityResolver implements IdentityResolver {
       method: "GET",
       headers: { "x-api-key": apiKey, accept: "application/json" },
     });
-    if (!response.ok) return null;
-
-    let body: unknown;
-    try {
-      body = await response.json();
-    } catch {
-      return null;
-    }
-    const parsed = MeResponseSchema.safeParse(body);
-    if (!parsed.success) return null;
-
-    const { email, emailVerified, name } = parsed.data.user;
-    return {
-      email: email ?? null,
-      // Absent is not verified: the policy must never read a missing flag as a yes.
-      emailVerified: emailVerified === true,
-      name: name ?? "",
-    };
+    return readMeResponse(response);
   }
+}
+
+/**
+ * A compact JWS: three base64url segments separated by dots, and nothing else.
+ *
+ * Load-bearing twice over. It fails closed on anything that cannot be a
+ * better-auth token, so a junk submission costs no request. And the token
+ * arrives in a browser POST body on its way into an `Authorization` header, so
+ * this is also what guarantees no whitespace, CR/LF or control character ever
+ * reaches that header.
+ */
+const COMPACT_JWS_PATTERN = /^[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+$/;
+
+/** Wiring for {@link JwtIdentityResolver}. */
+export interface JwtIdentityResolverOptions {
+  /** Base URL of the API, e.g. https://protocol.dev.index.network. */
+  apiUrl: string;
+  /** Injectable for tests; defaults to the global fetch. */
+  fetch?: typeof fetch;
+}
+
+/**
+ * Resolves an identity from a better-auth JWT, server-side.
+ *
+ * This is the deployed posture's resolver. The local bridge cannot be used off
+ * loopback: `validateCliCallbackUrl` in apps/web/src/lib/cli-auth.ts accepts only
+ * `http:` on 127.0.0.1/[::1], deliberately, so that a broad API credential is
+ * never redirected to a caller-controlled origin — and that rule is shared with
+ * the released CLI. A shared parent-domain cookie is unavailable too: the
+ * better-auth cookie is host-only (`advanced.defaultCookieAttributes` sets
+ * `sameSite: "none"`, `secure: true`, with no `crossSubDomainCookies`).
+ *
+ * So the browser fetches a JWT from `${API_URL}/api/auth/token` against its own
+ * API session and posts it here, and **this server resolves it** by presenting it
+ * to `${API_URL}/api/auth/me`. The API's own `AuthGuard` verifies the signature
+ * against its JWKS with issuer and audience checks, so a user coming back proves
+ * the token is genuine. Nothing is client-asserted: the browser supplies a token,
+ * never an identity.
+ *
+ * The `/api/auth/me` hop is required, not an optimisation. The `jwt` plugin's
+ * `definePayload` returns `{ id, email, name }` and no `emailVerified`, and
+ * {@link assessIdentity} demands verification — so verification can never be
+ * inferred from possession of a token, only read from the user record.
+ *
+ * Like {@link ApiIdentityResolver}: a refusal or an unrecognised body resolves to
+ * null, and a transport failure rejects, because "the API is down" is not "you are
+ * not allowed in".
+ */
+export class JwtIdentityResolver implements IdentityResolver {
+  private readonly apiUrl: string;
+  private readonly fetchImpl: typeof fetch;
+
+  constructor(options: JwtIdentityResolverOptions) {
+    this.apiUrl = options.apiUrl.replace(/\/$/, "");
+    this.fetchImpl = options.fetch ?? fetch;
+  }
+
+  async resolve(token: string): Promise<ResolvedIdentity | null> {
+    if (typeof token !== "string" || !COMPACT_JWS_PATTERN.test(token)) return null;
+    const response = await this.fetchImpl(`${this.apiUrl}/api/auth/me`, {
+      method: "GET",
+      // The bearer header, not x-api-key: AuthGuard reads the two on different
+      // paths, and only the bearer path verifies a JWT.
+      headers: { authorization: `Bearer ${token}`, accept: "application/json" },
+    });
+    return readMeResponse(response);
+  }
+}
+
+/**
+ * Reads `/api/auth/me` into a {@link ResolvedIdentity}, or null.
+ *
+ * Shared by both resolvers so the two postures cannot disagree about what the
+ * API said — in particular about a missing `emailVerified`, which must read as
+ * "not verified" and never as "absent, so ignore it".
+ */
+async function readMeResponse(response: Response): Promise<ResolvedIdentity | null> {
+  if (!response.ok) return null;
+
+  let body: unknown;
+  try {
+    body = await response.json();
+  } catch {
+    return null;
+  }
+  const parsed = MeResponseSchema.safeParse(body);
+  if (!parsed.success) return null;
+
+  const { email, emailVerified, name } = parsed.data.user;
+  return {
+    email: email ?? null,
+    // Absent is not verified: the policy must never read a missing flag as a yes.
+    emailVerified: emailVerified === true,
+    name: name ?? "",
+  };
 }
 
 /**

--- a/packages/protocol/eval/ops/ops.compare.ts
+++ b/packages/protocol/eval/ops/ops.compare.ts
@@ -31,11 +31,19 @@ const selectionKey = (envelope: EvalArtifactEnvelope): string =>
  * directions are evaluated: `regressions` asks "is the subject worse?" and
  * `improvements` asks the reverse. This is not a symmetric two-sided test and
  * must not be presented as one.
+ *
+ * `opts.allowConfigMismatch` drops the config-fingerprint refusal for
+ * run-vs-run A/B comparison, where the configuration difference is the
+ * variable under test rather than evidence of an invalid comparison. Every
+ * other dimension still refuses. Artifact compare keeps the refusal: a
+ * committed baseline under a non-default config is a governance smell, not an
+ * experiment.
  */
 export function compareArtifacts(
   reference: EvalArtifactEnvelope,
   subject: EvalArtifactEnvelope,
   alpha = 0.05,
+  opts: { allowConfigMismatch?: boolean } = {},
 ): CompareOutcome {
   const findings: ComparabilityFinding[] = [];
   if (reference.harness !== subject.harness) {
@@ -48,7 +56,7 @@ export function compareArtifacts(
       subject: subject.corpusFingerprint,
     });
   }
-  if (reference.configFingerprint !== subject.configFingerprint) {
+  if (!opts.allowConfigMismatch && reference.configFingerprint !== subject.configFingerprint) {
     findings.push({
       dimension: "configFingerprint",
       reference: reference.configFingerprint,

--- a/packages/protocol/eval/ops/ops.configs.ts
+++ b/packages/protocol/eval/ops/ops.configs.ts
@@ -72,11 +72,42 @@ export class InMemoryConfigStore implements ConfigStore {
   }
 }
 
+/**
+ * Raw row shape as the driver returns it. Verified on Bun v1.3.14: Bun.SQL
+ * decodes jsonb columns to STRINGS, not objects — so `models`/`env` arrive as
+ * JSON text and must be parsed before schema validation.
+ */
 interface ConfigRow {
   name: string;
   description: string;
-  models: Record<string, string>;
-  env: Record<string, string>;
+  models: Record<string, string> | string;
+  env: Record<string, string> | string;
+}
+
+/** Parses one jsonb field, tolerating drivers that decode to objects instead. */
+function parseJsonbField(value: Record<string, string> | string, field: string, name: string): Record<string, string> {
+  if (typeof value !== "string") return value;
+  try {
+    return JSON.parse(value) as Record<string, string>;
+  } catch (error) {
+    throw new Error(
+      `Config "${name}" has corrupt JSON in ${field}: ${error instanceof Error ? error.message : String(error)}`,
+      { cause: error },
+    );
+  }
+}
+
+/**
+ * Normalises a raw driver row into a validated ConfigProfile. The unit under
+ * test for the row-mapping behaviour — kept pure so it needs no database.
+ */
+export function configFromRow(row: ConfigRow): ConfigProfile {
+  return ConfigProfileSchema.parse({
+    name: row.name,
+    description: row.description,
+    models: parseJsonbField(row.models, "models", row.name),
+    env: parseJsonbField(row.env, "env", row.name),
+  });
 }
 
 /**
@@ -100,12 +131,12 @@ export class BunSqlConfigStore implements ConfigStore {
 
   async list(): Promise<ConfigProfile[]> {
     const rows = (await this.sql`SELECT name, description, models, env FROM eval_ops_configs ORDER BY name`) as ConfigRow[];
-    return rows.map((row) => ConfigProfileSchema.parse(row));
+    return rows.map(configFromRow);
   }
 
   async get(name: string): Promise<ConfigProfile | null> {
     const rows = (await this.sql`SELECT name, description, models, env FROM eval_ops_configs WHERE name = ${name}`) as ConfigRow[];
-    return rows.length === 0 ? null : ConfigProfileSchema.parse(rows[0]);
+    return rows.length === 0 ? null : configFromRow(rows[0]);
   }
 
   async create(profile: ConfigProfile): Promise<void> {

--- a/packages/protocol/eval/ops/ops.configs.ts
+++ b/packages/protocol/eval/ops/ops.configs.ts
@@ -1,0 +1,144 @@
+import { SQL } from "bun";
+
+import { ConfigProfileSchema, type ConfigProfile } from "./ops.profiles.js";
+
+export class ConfigConflictError extends Error {
+  constructor(name: string) {
+    super(`A config named "${name}" already exists`);
+    this.name = "ConfigConflictError";
+  }
+}
+
+/**
+ * eval-ops app state, not fixture corpus. db:flush truncates a hard-coded
+ * list of api-owned tables, so a fixture reset never touches this table, and
+ * IF NOT EXISTS makes boot-time application idempotent.
+ */
+export const CONFIG_TABLE_DDL = `
+  CREATE TABLE IF NOT EXISTS eval_ops_configs (
+    name        text PRIMARY KEY,
+    description text NOT NULL,
+    models      jsonb NOT NULL DEFAULT '{}',
+    env         jsonb NOT NULL DEFAULT '{}',
+    created_at  timestamptz NOT NULL DEFAULT now(),
+    updated_at  timestamptz NOT NULL DEFAULT now()
+  )`;
+
+export interface ConfigStore {
+  list(): Promise<ConfigProfile[]>;
+  get(name: string): Promise<ConfigProfile | null>;
+  create(profile: ConfigProfile): Promise<void>;
+  update(
+    name: string,
+    patch: { description?: string; models?: Record<string, string>; env?: Record<string, string> },
+  ): Promise<ConfigProfile | null>;
+  remove(name: string): Promise<boolean>;
+}
+
+export class InMemoryConfigStore implements ConfigStore {
+  private readonly configs = new Map<string, ConfigProfile>();
+
+  async list(): Promise<ConfigProfile[]> {
+    return [...this.configs.values()].sort((a, b) => a.name.localeCompare(b.name));
+  }
+
+  async get(name: string): Promise<ConfigProfile | null> {
+    return this.configs.get(name) ?? null;
+  }
+
+  async create(profile: ConfigProfile): Promise<void> {
+    if (this.configs.has(profile.name)) throw new ConfigConflictError(profile.name);
+    this.configs.set(profile.name, profile);
+  }
+
+  async update(
+    name: string,
+    patch: { description?: string; models?: Record<string, string>; env?: Record<string, string> },
+  ): Promise<ConfigProfile | null> {
+    const existing = this.configs.get(name);
+    if (existing === undefined) return null;
+    const updated: ConfigProfile = {
+      name,
+      description: patch.description ?? existing.description,
+      models: patch.models ?? existing.models,
+      env: patch.env ?? existing.env,
+    };
+    this.configs.set(name, updated);
+    return updated;
+  }
+
+  async remove(name: string): Promise<boolean> {
+    return this.configs.delete(name);
+  }
+}
+
+interface ConfigRow {
+  name: string;
+  description: string;
+  models: Record<string, string>;
+  env: Record<string, string>;
+}
+
+/**
+ * Config persistence in the same Neon database the fixture control plane
+ * uses. The connection is long-lived (unlike BunSqlFixtureInspector, which
+ * connects per probe): the store sits on the server context for the process
+ * lifetime. jsonb values are bound as JSON strings with explicit casts —
+ * Bun.SQL leaves parameter typing to Postgres, and the cast makes the target
+ * type unambiguous regardless of inference.
+ */
+export class BunSqlConfigStore implements ConfigStore {
+  private readonly sql: SQL;
+
+  constructor(databaseUrl: string) {
+    this.sql = new SQL(databaseUrl, { max: 2 });
+  }
+
+  async ensureTable(): Promise<void> {
+    await this.sql.unsafe(CONFIG_TABLE_DDL);
+  }
+
+  async list(): Promise<ConfigProfile[]> {
+    const rows = (await this.sql`SELECT name, description, models, env FROM eval_ops_configs ORDER BY name`) as ConfigRow[];
+    return rows.map((row) => ConfigProfileSchema.parse(row));
+  }
+
+  async get(name: string): Promise<ConfigProfile | null> {
+    const rows = (await this.sql`SELECT name, description, models, env FROM eval_ops_configs WHERE name = ${name}`) as ConfigRow[];
+    return rows.length === 0 ? null : ConfigProfileSchema.parse(rows[0]);
+  }
+
+  async create(profile: ConfigProfile): Promise<void> {
+    try {
+      await this.sql`INSERT INTO eval_ops_configs (name, description, models, env)
+        VALUES (${profile.name}, ${profile.description}, ${JSON.stringify(profile.models)}::jsonb, ${JSON.stringify(profile.env)}::jsonb)`;
+    } catch (error) {
+      if (error instanceof Error && error.message.includes("duplicate key")) throw new ConfigConflictError(profile.name);
+      throw error;
+    }
+  }
+
+  async update(
+    name: string,
+    patch: { description?: string; models?: Record<string, string>; env?: Record<string, string> },
+  ): Promise<ConfigProfile | null> {
+    const existing = await this.get(name);
+    if (existing === null) return null;
+    const updated: ConfigProfile = {
+      name,
+      description: patch.description ?? existing.description,
+      models: patch.models ?? existing.models,
+      env: patch.env ?? existing.env,
+    };
+    await this.sql`UPDATE eval_ops_configs
+      SET description = ${updated.description}, models = ${JSON.stringify(updated.models)}::jsonb,
+          env = ${JSON.stringify(updated.env)}::jsonb, updated_at = now()
+      WHERE name = ${name}`;
+    return updated;
+  }
+
+  async remove(name: string): Promise<boolean> {
+    const rows = await this.sql`DELETE FROM eval_ops_configs WHERE name = ${name} RETURNING name`;
+    return rows.length > 0;
+  }
+}

--- a/packages/protocol/eval/ops/ops.profiles.ts
+++ b/packages/protocol/eval/ops/ops.profiles.ts
@@ -8,30 +8,11 @@ import { HARNESS_REGISTRY } from "./ops.registry.js";
 
 export const DEFAULT_PROFILE_NAME = "default";
 
-/**
- * Environment variables a profile is permitted to set. Everything here is a
- * protocol feature flag read live from process.env. Credentials, connection
- * strings and NODE_ENV are deliberately absent: a profile must never be able to
- * repoint a run at another database or provider account.
- */
-export const PROFILE_ENV_ALLOWLIST: readonly string[] = Object.freeze([
-  "DISCOVERY_ALLOWED_TYPES",
-  "DISCOVERY_PROFILE_SOURCE",
-  "DISCOVERY_CONTEXT_TO_INTENT",
-  "DISCOVERY_REJECTION_COOLDOWN_DAYS",
-  "DISCOVERY_SOURCE_PREMISE_LIMIT",
-  "RUN_OPPORTUNITY_EVAL_IN_PARALLEL",
-  "INTRODUCER_DISCOVERY_ENABLED",
-  "NEGOTIATION_INCLUDE_OTHER_INTENTS",
-  "NEGOTIATION_MAX_TURNS_CHAT",
-  "NEGOTIATION_MAX_TURNS_AMBIENT",
-  "NEGOTIATION_EVIDENCE_QUESTIONS_MODE",
-  "OUTCOME_QUESTIONS_MODE",
-  "POOL_QUESTIONS_MINING",
-  "POOL_QUESTIONS_MODE",
-  "POOL_QUESTIONS_PUSH",
-  "POOL_QUESTIONS_RANKING",
-]);
+// The allowlist lives in ops.allowlist.ts (dependency-free) so the browser app
+// can import it without dragging node:fs/crypto into the Vite bundle. Re-exported
+// here so existing server-side imports keep working.
+export { PROFILE_ENV_ALLOWLIST } from "./ops.allowlist.js";
+import { PROFILE_ENV_ALLOWLIST } from "./ops.allowlist.js";
 
 export const ConfigProfileSchema = z
   .object({

--- a/packages/protocol/eval/ops/ops.profiles.ts
+++ b/packages/protocol/eval/ops/ops.profiles.ts
@@ -4,6 +4,8 @@ import path from "node:path";
 
 import { z } from "zod";
 
+import { HARNESS_REGISTRY } from "./ops.registry.js";
+
 export const DEFAULT_PROFILE_NAME = "default";
 
 /**
@@ -94,4 +96,63 @@ export function resolveProfile(profile: ConfigProfile): ResolvedProfile {
 
 function sortedRecord(record: Record<string, string>): Record<string, string> {
   return Object.fromEntries(Object.entries(record).sort(([a], [b]) => a.localeCompare(b)));
+}
+
+/**
+ * The only models a client may select. Live spend on a shared URL with no
+ * actor attribution yet: free-text slugs stay out until attribution exists.
+ * Repo profiles are code-reviewed and exempt.
+ */
+export const ALLOWED_CONFIG_MODELS = [
+  "google/gemini-2.5-flash",
+  "google/gemini-2.5-flash-lite",
+  "google/gemini-3-pro-preview",
+  "anthropic/claude-sonnet-4",
+  "anthropic/claude-haiku-4.5",
+  "openai/gpt-4.1-mini",
+] as const;
+
+/** Agent keys any scorecard harness can actually exercise (from the registry). */
+function overridableAgents(): ReadonlySet<string> {
+  return new Set(Object.values(HARNESS_REGISTRY).flatMap((d) => d.agents));
+}
+
+/**
+ * Validates client-originated overrides. Returns human-readable issues;
+ * empty means valid. Used by the config routes and the launch path — never
+ * by the repo profile loader, whose files are code-reviewed.
+ */
+export function validateConfigOverrides(overrides: {
+  models: Record<string, string>;
+  env: Record<string, string>;
+}): string[] {
+  const issues: string[] = [];
+  const agents = overridableAgents();
+  for (const [agent, model] of Object.entries(overrides.models)) {
+    if (!agents.has(agent)) {
+      issues.push(`Unknown agent "${agent}". Overridable agents: ${[...agents].sort().join(", ")}`);
+    } else if (!(ALLOWED_CONFIG_MODELS as readonly string[]).includes(model)) {
+      issues.push(`Model "${model}" is not selectable. Allowed: ${ALLOWED_CONFIG_MODELS.join(", ")}`);
+    }
+  }
+  for (const key of Object.keys(overrides.env)) {
+    if (!PROFILE_ENV_ALLOWLIST.includes(key)) {
+      issues.push(`env key ${key} is not in PROFILE_ENV_ALLOWLIST`);
+    }
+  }
+  return issues;
+}
+
+/**
+ * Resolves ad-hoc launch overrides through the same path as a named profile,
+ * so fingerprints match a saved config with the same payload. The synthetic
+ * profile is named "default" (renderRun asserts the resolved name matches the
+ * requested one) but is always experimental: ad-hoc runs never save.
+ */
+export function resolveAdHoc(overrides: {
+  models: Record<string, string>;
+  env: Record<string, string>;
+}): ResolvedProfile {
+  const resolved = resolveProfile({ name: DEFAULT_PROFILE_NAME, description: "ad-hoc overrides", ...overrides });
+  return { ...resolved, experimental: true };
 }

--- a/packages/protocol/eval/ops/ops.profiles.ts
+++ b/packages/protocol/eval/ops/ops.profiles.ts
@@ -33,7 +33,7 @@ export const PROFILE_ENV_ALLOWLIST: readonly string[] = Object.freeze([
   "POOL_QUESTIONS_RANKING",
 ]);
 
-const ConfigProfileSchema = z
+export const ConfigProfileSchema = z
   .object({
     name: z.string().regex(/^[a-z0-9]+(?:-[a-z0-9]+)*$/, "profile names are lowercase kebab-case"),
     description: z.string().min(1),

--- a/packages/protocol/eval/ops/ops.progress.ts
+++ b/packages/protocol/eval/ops/ops.progress.ts
@@ -1,0 +1,158 @@
+/**
+ * Turns a harness's console output into structured run progress.
+ *
+ * A real harness log is not the clean idiom the usage text suggests. Cases are
+ * announced with process.stdout.write, then the evaluator's unconditional
+ * verbose logger dumps multi-line objects, and the score lands later:
+ *
+ *   Running 40 case(s) × 3 run(s) against google/gemini-2.5-flash…
+ *     is_a/identity-basic … [OpportunityEvaluator:invokeEntityBundle] Done {
+ *       total: 1,
+ *       …20 more lines of debug…
+ *     }
+ *   3/3                                  ← completion, alone on its own line
+ *     location/known-mismatch … [debug…  ← next case starts
+ *
+ * So: a case STARTS on a line beginning "  <id> … " (anything may follow on
+ * that line) and is COMPLETED by a line that is exactly "N/M" or "N/M (flaky)".
+ * A new start with no completion seen closes the previous case as unknown.
+ * This module is pure — no Bun or DOM APIs — so the web client imports it
+ * directly and parses live chunks and replayed logs with the same code.
+ * Harnesses are untouched: CLI and CI output do not change.
+ */
+
+export interface CaseProgress {
+  id: string;
+  /** null when the completion line was never seen (in flight, or missed). */
+  passes: number | null;
+  runs: number | null;
+  flaky: boolean;
+  done: boolean;
+}
+
+export interface RunProgress {
+  /** From the "Running N case(s)…" header; null until it arrives. */
+  totalCases: number | null;
+  runsPerCase: number | null;
+  model: string | null;
+  /** Cases seen so far, in order; the last entry may be in flight. */
+  cases: CaseProgress[];
+  completed: number;
+  /** Completed cases where passes === runs. */
+  passed: number;
+  /** Completed cases where passes !== runs (flaky or failing). */
+  failed: number;
+  current: CaseProgress | null;
+}
+
+// "Running 40 case(s) × 3 run(s) against anthropic/claude-x (judge off)…"
+const HEADER_RE = /^Running (\d+) case\(s\) × (\d+) run\(s\) against (.+?)(?: \(judge off\))?…/;
+// "  is_a/identity-basic … 1/1" — start and completion on one line (quiet output).
+const CASE_INLINE_RE = /^ {2}(\S+) …\s+(\d+)\/(\d+)( \(flaky\))?\s*$/;
+// "  is_a/identity-basic … " possibly followed by debug noise on the same line.
+const CASE_START_RE = /^ {2}(\S+) …/;
+// "3/3" or "1/3 (flaky)" — the completion, alone on its own line.
+const CASE_DONE_RE = /^(\d+)\/(\d+)( \(flaky\))?$/;
+
+// CSI sequences (colour, cursor movement) the harness or its dependencies may emit.
+// eslint-disable-next-line no-control-regex -- matching ESC is the point
+const ANSI_RE = /\u001b\[[0-9;?]*[ -/]*[@-~]/g;
+
+function emptyProgress(): RunProgress {
+  return {
+    totalCases: null,
+    runsPerCase: null,
+    model: null,
+    cases: [],
+    completed: 0,
+    passed: 0,
+    failed: 0,
+    current: null,
+  };
+}
+
+/** A start line while another case is open means its completion was missed. */
+function closeOpenAsUnknown(progress: RunProgress): void {
+  const last = progress.cases[progress.cases.length - 1];
+  if (last !== undefined && !last.done) last.done = true;
+}
+
+function applyLine(progress: RunProgress, line: string): void {
+  const header = HEADER_RE.exec(line);
+  if (header) {
+    progress.totalCases = Number(header[1]);
+    progress.runsPerCase = Number(header[2]);
+    progress.model = header[3];
+    return;
+  }
+  const inline = CASE_INLINE_RE.exec(line);
+  if (inline) {
+    closeOpenAsUnknown(progress);
+    progress.cases.push({
+      id: inline[1],
+      passes: Number(inline[2]),
+      runs: Number(inline[3]),
+      flaky: inline[4] !== undefined,
+      done: true,
+    });
+    return;
+  }
+  const start = CASE_START_RE.exec(line);
+  if (start) {
+    closeOpenAsUnknown(progress);
+    progress.cases.push({ id: start[1], passes: null, runs: null, flaky: false, done: false });
+    return;
+  }
+  const done = CASE_DONE_RE.exec(line);
+  if (done) {
+    const last = progress.cases[progress.cases.length - 1];
+    if (last !== undefined && !last.done) {
+      last.passes = Number(done[1]);
+      last.runs = Number(done[2]);
+      last.flaky = done[3] !== undefined;
+      last.done = true;
+    }
+    return;
+  }
+  // Anything else — debug dumps, retry notices, scorecard output — is not progress.
+}
+
+function recompute(progress: RunProgress): void {
+  progress.completed = progress.cases.filter((c) => c.done).length;
+  progress.passed = progress.cases.filter((c) => c.done && c.passes !== null && c.passes === c.runs).length;
+  progress.failed = progress.cases.filter((c) => c.done && c.passes !== null && c.passes !== c.runs).length;
+  const last = progress.cases[progress.cases.length - 1];
+  progress.current = last !== undefined && !last.done ? last : null;
+}
+
+/**
+ * Incremental parser for a live stream. Chunks may split lines anywhere;
+ * state lives across push() calls, so a case stays "in flight" while the
+ * evaluator's debug output scrolls past.
+ */
+export class HarnessProgressParser {
+  private buffer = "";
+  private readonly progress = emptyProgress();
+
+  push(chunk: string): void {
+    this.buffer += chunk.replace(ANSI_RE, "");
+    let newline = this.buffer.indexOf("\n");
+    while (newline !== -1) {
+      applyLine(this.progress, this.buffer.slice(0, newline).replace(/\r$/, ""));
+      this.buffer = this.buffer.slice(newline + 1);
+      newline = this.buffer.indexOf("\n");
+    }
+    recompute(this.progress);
+  }
+
+  snapshot(): RunProgress {
+    return { ...this.progress, cases: this.progress.cases.map((c) => ({ ...c })) };
+  }
+}
+
+/** Parses a complete log in one shot — replayed runs, finished runs, tests. */
+export function parseHarnessProgress(text: string): RunProgress {
+  const parser = new HarnessProgressParser();
+  parser.push(text);
+  return parser.snapshot();
+}

--- a/packages/protocol/eval/ops/ops.registry.ts
+++ b/packages/protocol/eval/ops/ops.registry.ts
@@ -20,6 +20,7 @@ function descriptor(
   caseCount: number,
   question: string,
   detail: string,
+  agents: readonly string[],
   extra: readonly HarnessFlag[] = [],
 ): HarnessDescriptor {
   return Object.freeze({
@@ -30,6 +31,7 @@ function descriptor(
     caseCount,
     question,
     detail,
+    agents: Object.freeze(agents),
   });
 }
 
@@ -45,6 +47,7 @@ export const HARNESS_REGISTRY: Readonly<Record<OpsHarness, HarnessDescriptor>> =
     40,
     "Should these two people be connected at all?",
     "Scores the match decision: relevance, identity rules, and penalties such as a known location mismatch.",
+    ["opportunityEvaluator"],
     [TIER_FLAG],
   ),
   profile: descriptor(
@@ -52,17 +55,20 @@ export const HARNESS_REGISTRY: Readonly<Record<OpsHarness, HarnessDescriptor>> =
     8,
     "Did we build the right profile from what the user told us?",
     "Scores profile generation: extraction coverage, correct apply, and privacy boundaries.",
+    ["profileGenerator"],
   ),
   premise: descriptor(
     "premise",
     10,
     "Did we break an intent into correct atomic premises?",
     "Scores the premise pipeline: decomposition atomicity and speech-act analysis.",
+    ["premiseDecomposer", "premiseAnalyzer"],
   ),
   opportunity: descriptor(
     "opportunity",
     8,
     "Is the card text about a match any good?",
     "Scores the write-up shown to users: grounding, framing, tone, and no leaked evaluator reasoning.",
+    ["opportunityPresenter"],
   ),
 });

--- a/packages/protocol/eval/ops/ops.registry.ts
+++ b/packages/protocol/eval/ops/ops.registry.ts
@@ -15,13 +15,21 @@ const COMMON_FLAGS: readonly HarnessFlag[] = Object.freeze([
 
 const TIER_FLAG: HarnessFlag = { name: "tier", cli: "--tier", kind: "number", min: 1, max: 4, step: 1 };
 
-function descriptor(harness: OpsHarness, caseCount: number, extra: readonly HarnessFlag[] = []): HarnessDescriptor {
+function descriptor(
+  harness: OpsHarness,
+  caseCount: number,
+  question: string,
+  detail: string,
+  extra: readonly HarnessFlag[] = [],
+): HarnessDescriptor {
   return Object.freeze({
     harness,
     script: `eval:${harness}`,
     flags: Object.freeze([...COMMON_FLAGS, ...extra]),
     defaultRuns: 3,
     caseCount,
+    question,
+    detail,
   });
 }
 
@@ -32,8 +40,29 @@ function descriptor(harness: OpsHarness, caseCount: number, extra: readonly Harn
  * that is not here cannot be produced by any RunSpec.
  */
 export const HARNESS_REGISTRY: Readonly<Record<OpsHarness, HarnessDescriptor>> = Object.freeze({
-  matching: descriptor("matching", 40, [TIER_FLAG]),
-  profile: descriptor("profile", 8),
-  premise: descriptor("premise", 10),
-  opportunity: descriptor("opportunity", 8),
+  matching: descriptor(
+    "matching",
+    40,
+    "Should these two people be connected at all?",
+    "Scores the match decision: relevance, identity rules, and penalties such as a known location mismatch.",
+    [TIER_FLAG],
+  ),
+  profile: descriptor(
+    "profile",
+    8,
+    "Did we build the right profile from what the user told us?",
+    "Scores profile generation: extraction coverage, correct apply, and privacy boundaries.",
+  ),
+  premise: descriptor(
+    "premise",
+    10,
+    "Did we break an intent into correct atomic premises?",
+    "Scores the premise pipeline: decomposition atomicity and speech-act analysis.",
+  ),
+  opportunity: descriptor(
+    "opportunity",
+    8,
+    "Is the card text about a match any good?",
+    "Scores the write-up shown to users: grounding, framing, tone, and no leaked evaluator reasoning.",
+  ),
 });

--- a/packages/protocol/eval/ops/ops.serve.ts
+++ b/packages/protocol/eval/ops/ops.serve.ts
@@ -24,11 +24,12 @@
  */
 import path from "node:path";
 
-import { createDefaultOpsContext, createOpsHandler, resolveBindHostname, resolveBindPort } from "./ops.server.js";
+import { createDefaultOpsContext, createOpsHandler, ensureConfigStorage, resolveBindHostname, resolveBindPort } from "./ops.server.js";
 
 const repoRoot = path.resolve(import.meta.dir, "../../../..");
 const port = resolveBindPort({ env: process.env, honourPlatformPort: false });
 const context = await createDefaultOpsContext({ repoRoot, port });
+await ensureConfigStorage(context);
 
 const server = Bun.serve({
   hostname: resolveBindHostname(process.env),

--- a/packages/protocol/eval/ops/ops.serve.ts
+++ b/packages/protocol/eval/ops/ops.serve.ts
@@ -11,25 +11,36 @@
  * EVAL_OPS_BIND to a non-loopback address — the guards would refuse the traffic
  * anyway, and this site has never been reviewed for exposure beyond loopback.
  *
- * EVAL_OPS_PORT is read here for the bind and again in `createDefaultOpsContext`
- * for the bridge callback URL. They must agree, or the sign-in bridge delivers
- * the credential to a port nothing is listening on; a test in
- * tests/server.spec.ts pins that they read the same variable and default.
+ * The port is resolved once, here, and handed to both `Bun.serve` and
+ * `createDefaultOpsContext` — the bridge callback URL must name the port this
+ * process actually bound, and two independent reads of the environment are how
+ * those drift.
+ *
+ * This is the *local* entrypoint, so it does not honour the platform's `PORT`:
+ * `bun run eval:web` starts it with `--env-file=../../.env.test`, and that file
+ * sets `PORT=3001` for the API service. `EVAL_OPS_PORT` changes the port here.
+ * The deployed single-process entrypoint (apps/eval-ops/server.ts) is the one
+ * the platform starts, and it does honour `PORT`.
  */
 import path from "node:path";
 
-import { createDefaultOpsContext, createOpsHandler } from "./ops.server.js";
+import { createDefaultOpsContext, createOpsHandler, resolveBindHostname, resolveBindPort } from "./ops.server.js";
 
 const repoRoot = path.resolve(import.meta.dir, "../../../..");
-const context = await createDefaultOpsContext({ repoRoot });
+const port = resolveBindPort({ env: process.env, honourPlatformPort: false });
+const context = await createDefaultOpsContext({ repoRoot, port });
 
 const server = Bun.serve({
-  hostname: process.env.EVAL_OPS_BIND ?? "127.0.0.1",
-  port: Number(process.env.EVAL_OPS_PORT ?? 4321),
+  hostname: resolveBindHostname(process.env),
+  port,
   // SSE streams are quiet between log writes; the stream sends its own heartbeat,
   // and this raises Bun's 10s request idle timeout out of the way of it.
   idleTimeout: 255,
   fetch: createOpsHandler(context),
 });
 
-console.log(`[eval-ops] listening on http://${server.hostname}:${server.port}`);
+// Names the posture as well as the address: a `PORT` in the environment is
+// deliberately ignored here, and silence about that would read as a bug.
+console.log(
+  `[eval-ops] listening on http://${server.hostname}:${server.port} (local API; PORT is ignored, EVAL_OPS_PORT sets this)`,
+);

--- a/packages/protocol/eval/ops/ops.server.ts
+++ b/packages/protocol/eval/ops/ops.server.ts
@@ -41,7 +41,8 @@ import { ALLOWED_CONFIG_MODELS, ConfigProfileSchema, DEFAULT_PROFILE_NAME, loadP
 import { HARNESS_REGISTRY } from "./ops.registry.js";
 import { RunQueue } from "./ops.queue.js";
 import { FsRunStore, isTerminalStatus, type RunStore } from "./ops.store.js";
-import type { RunStatus, RunStepRecord } from "./ops.types.js";
+import type { RunRecord, RunStatus, RunStepRecord } from "./ops.types.js";
+import { EVAL_RUN_REPORT_ARTIFACT_TYPE, parseEvalArtifact, type EvalArtifactEnvelope } from "../shared/index.js";
 
 export interface OpsContext {
   /** Absolute path to packages/protocol/eval. */
@@ -781,6 +782,22 @@ async function readArtifact(context: OpsContext, id: string): Promise<Response> 
 async function compare(context: OpsContext, url: URL): Promise<Response> {
   const referenceId = url.searchParams.get("reference");
   const subjectId = url.searchParams.get("subject");
+  const referenceRun = url.searchParams.get("referenceRun");
+  const subjectRun = url.searchParams.get("subjectRun");
+  const artifactMode = referenceId !== null || subjectId !== null;
+  const runMode = referenceRun !== null || subjectRun !== null;
+  if (artifactMode === runMode) {
+    return json(
+      { error: "compare requires either reference+subject artifact ids or referenceRun+subjectRun run ids" },
+      400,
+    );
+  }
+  if (runMode) {
+    if (referenceRun === null || subjectRun === null) {
+      return json({ error: "compare requires both referenceRun and subjectRun" }, 400);
+    }
+    return await compareRuns(context, referenceRun, subjectRun);
+  }
   if (referenceId === null || subjectId === null) {
     return json({ error: "compare requires both a reference and a subject artifact id" }, 400);
   }
@@ -801,6 +818,47 @@ async function compare(context: OpsContext, url: URL): Promise<Response> {
     const status = (error as { code?: string }).code === "ENOENT" ? 404 : 422;
     return json({ error: scrubCredentials(`Artifacts could not be compared: ${messageOf(error)}`) }, status);
   }
+}
+
+/**
+ * Diffs two runs by their captured reports. Every run — saved or --no-save —
+ * leaves a run-report envelope at its report path, so experimental A/B runs
+ * compare without ever touching the artifact store. The config difference is
+ * the variable under test, so the config-fingerprint refusal is dropped;
+ * harness, corpus and selection still refuse. Each side is labelled from its
+ * run record so the UI can head the diff with what actually ran.
+ */
+async function compareRuns(context: OpsContext, referenceRunId: string, subjectRunId: string): Promise<Response> {
+  const sides: { id: string; record: RunRecord; envelope: EvalArtifactEnvelope }[] = [];
+  for (const id of [referenceRunId, subjectRunId]) {
+    const record = await context.store.get(id);
+    if (record === null) return json({ error: `Unknown run id: ${id}` }, 404);
+    const reportPath = context.store.reportPath(record.id);
+    if (!(await Bun.file(reportPath).exists())) {
+      return json({ error: `Run ${id} has no report to compare (it may have died before writing one)` }, 422);
+    }
+    let envelope: EvalArtifactEnvelope;
+    try {
+      envelope = parseEvalArtifact(await Bun.file(reportPath).json(), { expectedType: EVAL_RUN_REPORT_ARTIFACT_TYPE });
+    } catch (error) {
+      return json({ error: scrubCredentials(`Run ${id} report could not be read: ${messageOf(error)}`) }, 422);
+    }
+    sides.push({ id, record, envelope });
+  }
+  const [reference, subject] = sides;
+  const outcome = compareArtifacts(reference.envelope, subject.envelope, 0.05, { allowConfigMismatch: true });
+  const side = ({ id, record, envelope }: (typeof sides)[number]) => {
+    // v1 envelopes predate the completeness flag; null says "unknown" rather
+    // than guessing, matching how the artifact index treats them.
+    const completeness = envelope.completeness as { complete?: boolean };
+    return {
+      id,
+      profile: record.spec.kind === "eval" ? record.spec.profile : "default",
+      profileFingerprint: record.profileFingerprint,
+      complete: typeof completeness.complete === "boolean" ? completeness.complete : null,
+    };
+  };
+  return json({ ...outcome, runs: { reference: side(reference), subject: side(subject) } });
 }
 
 // ---------------------------------------------------------------------------

--- a/packages/protocol/eval/ops/ops.server.ts
+++ b/packages/protocol/eval/ops/ops.server.ts
@@ -37,7 +37,7 @@ import { BunSqlConfigStore, ConfigConflictError, InMemoryConfigStore, type Confi
 import { LocalProcessRunExecutor, tailLog, type ExecutionStep, type RunExecutor } from "./ops.executor.js";
 import { assessFixtureTarget, BunSqlFixtureInspector, buildResetPipeline, MAX_PERSONAS, redactDatabaseUrl, scrubCredentials, SEED_STEP_CWD, type FixtureInspector, type FixtureTarget } from "./ops.fixture.js";
 import { OPS_CALLBACK_PATH } from "./ops.paths.js";
-import { ALLOWED_CONFIG_MODELS, ConfigProfileSchema, DEFAULT_PROFILE_NAME, loadProfiles, resolveProfile, validateConfigOverrides, type ConfigProfile } from "./ops.profiles.js";
+import { ALLOWED_CONFIG_MODELS, ConfigProfileSchema, DEFAULT_PROFILE_NAME, loadProfiles, resolveAdHoc, resolveProfile, validateConfigOverrides, type ConfigProfile, type ResolvedProfile } from "./ops.profiles.js";
 import { HARNESS_REGISTRY } from "./ops.registry.js";
 import { RunQueue } from "./ops.queue.js";
 import { FsRunStore, isTerminalStatus, type RunStore } from "./ops.store.js";
@@ -894,12 +894,24 @@ async function launchRun(context: OpsContext, state: ServerState, request: Reque
   const parsed = RunSpecSchema.safeParse(body.value);
   if (!parsed.success) return json({ error: describeIssues(parsed.error) }, 400);
 
-  // The profile is looked up by name among committed files. The client cannot
-  // supply overrides, only choose from what is in the repository.
-  const profiles = await loadProfiles(context.profilesDir);
-  const profile = profiles.find((candidate) => candidate.name === parsed.data.profile);
-  if (profile === undefined) return json({ error: `Unknown profile "${parsed.data.profile}"` }, 400);
-  const resolved = resolveProfile(profile);
+  // Two ways to configure a run: ad-hoc overrides (the schema has already
+  // confined them to profile "default"), or a named profile resolved from
+  // both sources — shipped repo files and saved configs. Raw model/env keys
+  // never arrive outside the validated overrides object.
+  let resolved: ResolvedProfile;
+  if (parsed.data.overrides !== undefined) {
+    const issues = validateConfigOverrides(parsed.data.overrides);
+    if (issues.length > 0) return json({ error: issues.join("; ") }, 400);
+    resolved = resolveAdHoc(parsed.data.overrides);
+  } else {
+    const repoProfiles = await loadProfiles(context.profilesDir);
+    const profile =
+      repoProfiles.find((candidate) => candidate.name === parsed.data.profile)
+      ?? await context.configs.get(parsed.data.profile)
+      ?? undefined;
+    if (profile === undefined) return json({ error: `Unknown profile "${parsed.data.profile}"` }, 400);
+    resolved = resolveProfile(profile);
+  }
 
   // Two phases: the report path contains the run id, and the id is minted by the
   // store, so the record is created first and then completed with its argv.

--- a/packages/protocol/eval/ops/ops.server.ts
+++ b/packages/protocol/eval/ops/ops.server.ts
@@ -33,10 +33,11 @@ import { renderRun, RunSpecSchema } from "./ops.argv.js";
 import { decodeArtifactId, FsArtifactSource, type ArtifactSource } from "./ops.artifacts.js";
 import { ApiIdentityResolver, assessIdentity, buildBridgeUrl, JwtIdentityResolver, OneTimeStateStore, OpsSessionStore, type AllowedIdentity, type IdentityResolver } from "./ops.auth.js";
 import { compareArtifacts } from "./ops.compare.js";
+import { BunSqlConfigStore, ConfigConflictError, InMemoryConfigStore, type ConfigStore } from "./ops.configs.js";
 import { LocalProcessRunExecutor, tailLog, type ExecutionStep, type RunExecutor } from "./ops.executor.js";
 import { assessFixtureTarget, BunSqlFixtureInspector, buildResetPipeline, MAX_PERSONAS, redactDatabaseUrl, scrubCredentials, SEED_STEP_CWD, type FixtureInspector, type FixtureTarget } from "./ops.fixture.js";
 import { OPS_CALLBACK_PATH } from "./ops.paths.js";
-import { loadProfiles, resolveProfile } from "./ops.profiles.js";
+import { ALLOWED_CONFIG_MODELS, ConfigProfileSchema, DEFAULT_PROFILE_NAME, loadProfiles, resolveProfile, validateConfigOverrides, type ConfigProfile } from "./ops.profiles.js";
 import { HARNESS_REGISTRY } from "./ops.registry.js";
 import { RunQueue } from "./ops.queue.js";
 import { FsRunStore, isTerminalStatus, type RunStore } from "./ops.store.js";
@@ -54,6 +55,8 @@ export interface OpsContext {
   executor: RunExecutor;
   queue: RunQueue;
   profilesDir: string;
+  /** Saved (DB-backed) eval configs; the writable counterpart of the shipped profiles. */
+  configs: ConfigStore;
   /** Resolved from the server's own .env.test. Never from a request, never sent to a client. */
   databaseUrl: string | undefined;
   /** Read-only live counts. Absent when no database client is configured. */
@@ -583,6 +586,8 @@ async function route(context: OpsContext, state: ServerState, request: Request, 
     if (resource === "auth" && rest.length === 1 && rest[0] === "status") return authStatus(context, request);
     if (resource === "harnesses" && rest.length === 0) return json({ harnesses: Object.values(HARNESS_REGISTRY) });
     if (resource === "profiles" && rest.length === 0) return json({ profiles: await loadProfiles(context.profilesDir) });
+    if (resource === "configs" && rest.length === 0) return await listConfigs(context);
+    if (resource === "configs" && rest.length === 1 && rest[0] === "models") return json({ models: [...ALLOWED_CONFIG_MODELS] });
     if (resource === "artifacts" && rest.length === 0) return json(await context.artifacts.list());
     if (resource === "artifacts" && rest.length === 1) return await readArtifact(context, rest[0]);
     if (resource === "compare" && rest.length === 0) return await compare(context, url);
@@ -601,6 +606,15 @@ async function route(context: OpsContext, state: ServerState, request: Request, 
     if (resource === "runs" && rest.length === 0) return await launchRun(context, state, request);
     if (resource === "runs" && rest.length === 2 && rest[1] === "cancel") return await cancelRun(context, rest[0]);
     if (resource === "fixture" && rest.length === 1 && rest[0] === "reset") return await resetFixture(context, state, request);
+    if (resource === "configs" && rest.length === 0) return await createConfig(context, request);
+  }
+
+  if (request.method === "PATCH") {
+    if (resource === "configs" && rest.length === 1) return await updateConfig(context, rest[0], request);
+  }
+
+  if (request.method === "DELETE") {
+    if (resource === "configs" && rest.length === 1) return await deleteConfig(context, rest[0]);
   }
 
   return null;
@@ -787,6 +801,81 @@ async function compare(context: OpsContext, url: URL): Promise<Response> {
     const status = (error as { code?: string }).code === "ENOENT" ? 404 : 422;
     return json({ error: scrubCredentials(`Artifacts could not be compared: ${messageOf(error)}`) }, status);
   }
+}
+
+// ---------------------------------------------------------------------------
+// Configs
+// ---------------------------------------------------------------------------
+
+/**
+ * What a config edit may change. Names are immutable — a rename is delete +
+ * create — so `name` is absent here and `.strict()` refuses it if supplied.
+ */
+const ConfigPatchSchema = z
+  .object({
+    description: z.string().min(1).optional(),
+    models: z.record(z.string().min(1)).optional(),
+    env: z.record(z.string()).optional(),
+  })
+  .strict();
+
+async function listConfigs(context: OpsContext): Promise<Response> {
+  return json({ repo: await loadProfiles(context.profilesDir), saved: await context.configs.list() });
+}
+
+/** The shipped profiles are read-only through the API: edited in git, reviewed in a PR. */
+async function repoProfileNameConflict(context: OpsContext, name: string): Promise<Response | null> {
+  if (name === DEFAULT_PROFILE_NAME) {
+    return json({ error: `"${DEFAULT_PROFILE_NAME}" names the shipped default profile` }, 409);
+  }
+  const repoNames = new Set((await loadProfiles(context.profilesDir)).map((profile) => profile.name));
+  if (repoNames.has(name)) return json({ error: `"${name}" names a shipped repo profile` }, 409);
+  return null;
+}
+
+async function createConfig(context: OpsContext, request: Request): Promise<Response> {
+  const body = await readJson(request);
+  if (!body.ok) return json({ error: body.error }, body.status);
+  const parsed = ConfigProfileSchema.safeParse(body.value);
+  if (!parsed.success) return json({ error: describeIssues(parsed.error) }, 400);
+  const issues = validateConfigOverrides(parsed.data);
+  if (issues.length > 0) return json({ error: issues.join("; ") }, 400);
+  const conflict = await repoProfileNameConflict(context, parsed.data.name);
+  if (conflict !== null) return conflict;
+  try {
+    await context.configs.create(parsed.data);
+  } catch (error) {
+    if (error instanceof ConfigConflictError) return json({ error: error.message }, 409);
+    throw error;
+  }
+  return json(parsed.data, 201);
+}
+
+async function updateConfig(context: OpsContext, name: string, request: Request): Promise<Response> {
+  const conflict = await repoProfileNameConflict(context, name);
+  if (conflict !== null) return conflict;
+  const body = await readJson(request);
+  if (!body.ok) return json({ error: body.error }, body.status);
+  const parsed = ConfigPatchSchema.safeParse(body.value);
+  if (!parsed.success) return json({ error: describeIssues(parsed.error) }, 400);
+  const existing = await context.configs.get(name);
+  if (existing === null) return json({ error: `Unknown config "${name}"` }, 404);
+  const merged: Pick<ConfigProfile, "models" | "env"> = {
+    models: parsed.data.models ?? existing.models,
+    env: parsed.data.env ?? existing.env,
+  };
+  const issues = validateConfigOverrides(merged);
+  if (issues.length > 0) return json({ error: issues.join("; ") }, 400);
+  const updated = await context.configs.update(name, parsed.data);
+  if (updated === null) return json({ error: `Unknown config "${name}"` }, 404);
+  return json(updated);
+}
+
+async function deleteConfig(context: OpsContext, name: string): Promise<Response> {
+  const conflict = await repoProfileNameConflict(context, name);
+  if (conflict !== null) return conflict;
+  if (!(await context.configs.remove(name))) return json({ error: `Unknown config "${name}"` }, 404);
+  return new Response(null, { status: 204 });
 }
 
 // ---------------------------------------------------------------------------
@@ -1460,6 +1549,18 @@ export async function createDefaultOpsContext(options: {
     console.log(`[eval-ops] marked ${interrupted.length} orphaned run(s) as interrupted`);
   }
 
+  // Saved configs live in the same database fixture control uses. Constructing
+  // the store is lazy (Bun.SQL connects on first query), so tests can build
+  // this context without a socket; the table itself is created at boot by
+  // `ensureConfigStorage`, which only the real entrypoints call.
+  let configs: ConfigStore;
+  if (databaseUrl !== undefined) {
+    configs = new BunSqlConfigStore(databaseUrl);
+  } else {
+    console.warn("[eval-ops] DATABASE_URL is not set; saved configs live in memory and WILL NOT PERSIST across restarts.");
+    configs = new InMemoryConfigStore();
+  }
+
   return {
     evalDir,
     protocolDir,
@@ -1469,6 +1570,7 @@ export async function createDefaultOpsContext(options: {
     store,
     executor,
     queue: new RunQueue({ executor, store }),
+    configs,
     databaseUrl,
     inspector: new BunSqlFixtureInspector(),
     publicOrigin,
@@ -1509,6 +1611,21 @@ export async function createDefaultOpsContext(options: {
 // ---------------------------------------------------------------------------
 // Helpers
 // ---------------------------------------------------------------------------
+
+/**
+ * Boot-time config storage setup, called by the real entrypoints only.
+ *
+ * Idempotent DDL against the database `DATABASE_URL` names; a failure throws
+ * and refuses the boot, because a server that starts without its config table
+ * would look like it silently lost every saved config. An in-memory store
+ * (local runs without a database) has nothing to ensure.
+ */
+export async function ensureConfigStorage(context: OpsContext): Promise<void> {
+  if (context.configs instanceof BunSqlConfigStore) {
+    await context.configs.ensureTable();
+    console.log("[eval-ops] eval_ops_configs table is present");
+  }
+}
 
 function json(body: unknown, status = 200): Response {
   return new Response(JSON.stringify(body), {

--- a/packages/protocol/eval/ops/ops.server.ts
+++ b/packages/protocol/eval/ops/ops.server.ts
@@ -31,7 +31,7 @@ import { z } from "zod";
 
 import { renderRun, RunSpecSchema } from "./ops.argv.js";
 import { decodeArtifactId, FsArtifactSource, type ArtifactSource } from "./ops.artifacts.js";
-import { ApiIdentityResolver, assessIdentity, buildBridgeUrl, OneTimeStateStore, OpsSessionStore, type AllowedIdentity, type IdentityResolver } from "./ops.auth.js";
+import { ApiIdentityResolver, assessIdentity, buildBridgeUrl, JwtIdentityResolver, OneTimeStateStore, OpsSessionStore, type AllowedIdentity, type IdentityResolver } from "./ops.auth.js";
 import { compareArtifacts } from "./ops.compare.js";
 import { LocalProcessRunExecutor, tailLog, type ExecutionStep, type RunExecutor } from "./ops.executor.js";
 import { assessFixtureTarget, BunSqlFixtureInspector, buildResetPipeline, MAX_PERSONAS, redactDatabaseUrl, scrubCredentials, SEED_STEP_CWD, type FixtureInspector, type FixtureTarget } from "./ops.fixture.js";
@@ -73,13 +73,18 @@ export interface OpsContext {
 
 /** Everything the auth gate needs. All of it is injectable, so tests need no API. */
 export interface OpsAuthContext {
-  states: OneTimeStateStore;
   sessions: OpsSessionStore;
+  /**
+   * The one seam that turns a credential into an identity.
+   *
+   * Which implementation is here is decided together with {@link signIn}, by
+   * {@link resolveSignInMode}: the bridge mints API keys and the token exchange
+   * carries JWTs, and a resolver paired with the wrong door refuses every
+   * sign-in.
+   */
   identities: IdentityResolver;
-  /** Base URL of the web app serving /cli-auth. */
-  webAppUrl: string;
-  /** The port this server's /callback is reachable on. */
-  callbackPort: number;
+  /** How a browser is expected to prove who it is. */
+  signIn: SignInPosture;
   /**
    * Where a completed sign-in sends the browser.
    *
@@ -91,6 +96,43 @@ export interface OpsAuthContext {
    */
   uiUrl: string;
 }
+
+/**
+ * The two doors a browser can sign in through, and everything each one needs.
+ *
+ * A discriminated union rather than a bag of optional fields, because the two
+ * are genuinely different exchanges and only one of them can be open at a time.
+ * The bridge holds the one-time state store; the token exchange does not have
+ * one at all, so a deployed server cannot answer a bridge callback even by
+ * accident.
+ *
+ *  - `bridge` is the local posture, unchanged: `<WEB_APP_URL>/cli-auth` mints a
+ *    revocable API key against the operator's existing browser session and
+ *    redirects it to `http://127.0.0.1:<port>/callback`.
+ *  - `token` is the deployed posture. The bridge is unusable there —
+ *    `validateCliCallbackUrl` in apps/web/src/lib/cli-auth.ts accepts only
+ *    `http:` on loopback, deliberately, and that rule is shared with the released
+ *    CLI — so the browser fetches a better-auth JWT from `${apiUrl}/api/auth/token`
+ *    against its own API session and posts it to `POST /api/auth/session`, which
+ *    resolves it server-side.
+ */
+export type SignInPosture =
+  | {
+      kind: "bridge";
+      /** One-time states, so a callback this server did not start is refused. */
+      states: OneTimeStateStore;
+      /** Base URL of the web app serving /cli-auth. */
+      webAppUrl: string;
+      /** The port this server's /callback is reachable on. */
+      callbackPort: number;
+    }
+  | {
+      kind: "token";
+      /** Base URL of the API that issues and verifies the token. */
+      apiUrl: string;
+      /** Where the operator signs in to Index when the API says it has no session. */
+      webAppUrl: string;
+    };
 
 /** Origins a browser may legitimately be running the ops UI on, before deployment. */
 const LOOPBACK_HOSTNAMES = new Set(["127.0.0.1", "localhost", "[::1]"]);
@@ -121,6 +163,12 @@ export interface PublicOrigin {
  *    session; gating it would make the question unanswerable.
  *  - `POST /api/auth/login` — mints the sign-in link, so requiring a session to
  *    call it would be circular.
+ *  - `POST /api/auth/session` — the deployed posture's equivalent of `/callback`:
+ *    it is the request that *establishes* a session by submitting a better-auth
+ *    token, so it cannot require one. The same circularity, and the same
+ *    deliberate exemption. It is not a hole in the gate: the Host, Origin and
+ *    JSON content-type guards all still run in front of it, and it grants nothing
+ *    except a session for an identity `assessIdentity` admits.
  *
  * `/callback` is deliberately absent: it is not under /api/ and is handled ahead
  * of the gate, because it is the request that *establishes* a session.
@@ -128,6 +176,7 @@ export interface PublicOrigin {
 export const PUBLIC_ROUTES: ReadonlyArray<{ method: string; path: string }> = Object.freeze([
   Object.freeze({ method: "GET", path: "/api/auth/status" }),
   Object.freeze({ method: "POST", path: "/api/auth/login" }),
+  Object.freeze({ method: "POST", path: "/api/auth/session" }),
 ]);
 
 /** Name of the ops session cookie. */
@@ -257,8 +306,9 @@ function authRefusal(context: OpsContext, request: Request, url: URL): Response 
   // The *domain* rule is re-checked on every request rather than trusted from
   // sign-in time, so narrowing the allowed domain refuses live sessions too.
   // Verification is not re-checked: a session only exists past a verified check
-  // at /callback, and the credential that could re-ask the API was discarded
-  // there. `emailVerified: true` below states that, rather than proving it.
+  // at the sign-in that established it (/callback, or POST /api/auth/session),
+  // and the credential that could re-ask the API was discarded there.
+  // `emailVerified: true` below states that, rather than proving it.
   const verdict = assessIdentity({ email: identity.email, emailVerified: true, name: identity.name });
   if (!verdict.allowed) {
     return json({ error: verdict.reason, authenticated: true, permitted: false }, 403);
@@ -283,9 +333,20 @@ function sessionIdentity(context: OpsContext, request: Request): AllowedIdentity
 async function completeSignIn(context: OpsContext, request: Request, url: URL): Promise<Response> {
   const auth = context.auth;
   if (auth === undefined) return refusalPage("This server has no identity configured.", 500);
+  // A deployed server mints no states, so it can validate no callback. Refusing
+  // is the only honest answer: the bridge could not have sent this browser here
+  // (its own validator accepts loopback callbacks only), so anything arriving is
+  // hand-made.
+  if (auth.signIn.kind !== "bridge") {
+    return refusalPage(
+      "This server does not sign in through the local bridge. Start the sign-in again from the eval ops site.",
+      403,
+    );
+  }
+  const { states } = auth.signIn;
 
   // Consuming is the validation: unknown, expired and replayed states all fail here.
-  if (!auth.states.consume(url.searchParams.get("state"))) {
+  if (!states.consume(url.searchParams.get("state"))) {
     return refusalPage(
       "This sign-in link is no longer valid. It may have already been used, or it may have expired. Start the sign-in again from the eval ops site.",
       403,
@@ -535,6 +596,7 @@ async function route(context: OpsContext, state: ServerState, request: Request, 
 
   if (request.method === "POST") {
     if (resource === "auth" && rest.length === 1 && rest[0] === "login") return beginSignIn(context);
+    if (resource === "auth" && rest.length === 1 && rest[0] === "session") return await establishTokenSession(context, request, url);
     if (resource === "auth" && rest.length === 1 && rest[0] === "logout") return endSession(context, request, url);
     if (resource === "runs" && rest.length === 0) return await launchRun(context, state, request);
     if (resource === "runs" && rest.length === 2 && rest[1] === "cancel") return await cancelRun(context, rest[0]);
@@ -552,20 +614,122 @@ function authStatus(context: OpsContext, request: Request): Response {
 }
 
 /**
- * Starts a sign-in: mints a one-time state and returns the bridge link.
+ * Starts a sign-in, and says which of the two exchanges this server runs.
  *
- * Everything in the link comes from this server's own configuration; nothing in
- * it is taken from the request, so a caller cannot steer the callback elsewhere.
+ * A discriminated reply, not an optional field: the two postures return
+ * genuinely different things, and a `url` that is sometimes absent would leave
+ * the browser guessing.
+ *
+ *  - `bridge` — the local posture. Everything in the link comes from this
+ *    server's own configuration; nothing in it is taken from the request, so a
+ *    caller cannot steer the callback elsewhere.
+ *  - `token` — the deployed posture. Names the API to fetch a better-auth token
+ *    from and the web app to sign in at, and *nothing else*. Both are public DNS
+ *    names the browser already talks to, one of them being where its own session
+ *    cookie lives. This is deliberately not a route that reports server
+ *    configuration in general.
  */
 function beginSignIn(context: OpsContext): Response {
   const auth = context.auth;
   if (auth === undefined) return json({ error: "This server has no identity configured." }, 500);
+  const posture = auth.signIn;
+  if (posture.kind === "token") {
+    return json({ kind: "token", apiUrl: posture.apiUrl, webAppUrl: posture.webAppUrl });
+  }
   const url = buildBridgeUrl({
-    webAppUrl: auth.webAppUrl,
-    callbackPort: auth.callbackPort,
-    state: auth.states.mint(),
+    webAppUrl: posture.webAppUrl,
+    callbackPort: posture.callbackPort,
+    state: posture.states.mint(),
   });
-  return json({ url });
+  return json({ kind: "bridge", url });
+}
+
+/** The one field `POST /api/auth/session` accepts. Strict: no client-asserted identity. */
+const TokenSubmissionSchema = z.object({ token: z.string().min(1) }).strict();
+
+/**
+ * Completes the deployed sign-in: a better-auth token in, a session cookie out.
+ *
+ * The browser obtained the token from `${API_URL}/api/auth/token` against its
+ * own API session — that works cross-site because the API's cookie is
+ * `SameSite=None; Secure` — and posts it here. **This server resolves it**, by
+ * presenting it to `${API_URL}/api/auth/me`, where the API verifies the
+ * signature against its own JWKS. Nothing in the request is believed: the body
+ * carries a credential, never an identity, and the schema is `.strict()` so a
+ * body that tries to carry one is refused rather than ignored.
+ *
+ * The `/api/auth/me` hop is required rather than an optimisation. The `jwt`
+ * plugin's `definePayload` returns `{ id, email, name }` and no `emailVerified`,
+ * and {@link assessIdentity} demands verification — so a verified address can
+ * only ever be read from the user record, never inferred from possession of a
+ * token.
+ *
+ * The token is a bearer credential and is treated as one: it is exchanged once
+ * and dropped. It is never stored in a session, never logged, and never written
+ * into a response — including the 502 below, whose message is scrubbed of it in
+ * case a transport error quoted the request it failed to make.
+ *
+ * 401 and 403 stay distinct here for the same reason as in {@link authRefusal}:
+ * "the API does not accept this token" is a sign-in the operator can retry, and
+ * "this account is not permitted" is not.
+ */
+async function establishTokenSession(context: OpsContext, request: Request, url: URL): Promise<Response> {
+  const auth = context.auth;
+  if (auth === undefined) return json({ error: "This server has no identity configured." }, 500);
+  if (auth.signIn.kind !== "token") {
+    return json(
+      { error: "This server signs in through the local bridge; start the sign-in at POST /api/auth/login." },
+      403,
+    );
+  }
+
+  const body = await readJson(request);
+  if (!body.ok) return json({ error: body.error }, body.status);
+  const parsed = TokenSubmissionSchema.safeParse(body.value);
+  if (!parsed.success) return json({ error: describeIssues(parsed.error) }, 400);
+  const token = parsed.data.token;
+
+  let resolved;
+  try {
+    resolved = await auth.identities.resolve(token);
+  } catch (error) {
+    // "The API is down" is not "you are not allowed in", and must not read as it.
+    return json(
+      { error: `The Index API could not be reached to verify this sign-in: ${redact(scrubCredentials(messageOf(error)), token)}` },
+      502,
+    );
+  }
+
+  if (resolved === null) {
+    return json(
+      { error: "The Index API did not accept this sign-in. Sign in to Index again and retry.", authenticated: false },
+      401,
+    );
+  }
+
+  const verdict = assessIdentity(resolved);
+  if (!verdict.allowed) return json({ error: verdict.reason, authenticated: true, permitted: false }, 403);
+
+  const session = auth.sessions.establish(verdict.identity);
+  return new Response(JSON.stringify({ authenticated: true, email: verdict.identity.email, name: verdict.identity.name }), {
+    status: 200,
+    headers: {
+      "Content-Type": "application/json",
+      "Set-Cookie": `${SESSION_COOKIE}=${session}; ${sessionCookieAttributes(isSecureRequest(context, request, url))}`,
+    },
+  });
+}
+
+/**
+ * Removes a credential from a message that may have quoted it.
+ *
+ * `scrubCredentials` knows about connection strings, not bearer tokens, and the
+ * message here comes from whatever threw inside `fetch`. This is belt-and-braces
+ * on top of never interpolating the token ourselves: the one thing that must not
+ * happen is the credential travelling back to the browser in an error.
+ */
+function redact(message: string, credential: string): string {
+  return credential === "" ? message : message.split(credential).join("[redacted]");
 }
 
 /** Ends the session and expires the cookie, so the browser stops presenting it. */
@@ -1228,6 +1392,30 @@ export function resolvePublicOrigin(env: Record<string, string | undefined>): Pu
   return { origin: parsed.origin, host: parsed.host };
 }
 
+/**
+ * Which of the two sign-in exchanges this server runs.
+ *
+ * One rule, exported and pure, so the choice is a thing a test can state rather
+ * than a guess buried in the wiring. The condition is `EVAL_OPS_PUBLIC_ORIGIN`,
+ * because that variable *is* the deployed posture — it is what extends the Host
+ * and Origin allowlists past loopback — and it is exactly the circumstance in
+ * which the bridge cannot work: `validateCliCallbackUrl` accepts only `http:` on
+ * 127.0.0.1/[::1], so a browser on a deployed origin can never be redirected
+ * back with a credential.
+ *
+ * Nothing else decides it. A wider `EVAL_OPS_BIND` or a platform `PORT` does not
+ * make the callback unreachable, and inferring the posture from either would
+ * change how sign-in works on a developer's machine.
+ *
+ * A malformed value throws here exactly as it does in the guards, rather than
+ * falling back to the bridge — that fallback would be a deployed server
+ * advertising a loopback callback, which is the failure this posture exists to
+ * remove.
+ */
+export function resolveSignInMode(env: Record<string, string | undefined>): "bridge" | "token" {
+  return resolvePublicOrigin(env) === undefined ? "bridge" : "token";
+}
+
 /** Builds the context the standalone server runs on: everything rooted at the repository. */
 export async function createDefaultOpsContext(options: {
   repoRoot: string;
@@ -1253,6 +1441,7 @@ export async function createDefaultOpsContext(options: {
   const endpoints = resolveIdentityEndpoints(process.env);
   const uiUrl = resolveUiUrl(process.env, options.uiUrl);
   const publicOrigin = resolvePublicOrigin(process.env);
+  const signInMode = resolveSignInMode(process.env);
 
   // Reported, not fatal: fixture control is only one page, and the reset route
   // fails closed on the same divergence. A silent mismatch is what must not happen.
@@ -1283,20 +1472,37 @@ export async function createDefaultOpsContext(options: {
     databaseUrl,
     inspector: new BunSqlFixtureInspector(),
     publicOrigin,
-    auth: {
-      states: new OneTimeStateStore(),
-      sessions: new OpsSessionStore(),
-      // The bridge mints a real API key against the operator's own browser
-      // session, so this resolver is the only part of the server that talks to
-      // the API at all.
-      identities: new ApiIdentityResolver({ apiUrl: endpoints.apiUrl }),
-      webAppUrl: endpoints.webAppUrl,
-      uiUrl,
-      // The port the entrypoint bound, handed to Bun.serve and to this from one
-      // resolution — or the bridge would send the credential to a port nothing is
-      // listening on.
-      callbackPort: options.port,
-    },
+    // One decision picks both the door and the resolver behind it, in a single
+    // expression, because they are the same decision: the bridge delivers an API
+    // key and the token exchange delivers a JWT, and a resolver paired with the
+    // wrong door refuses every sign-in with a message about permissions.
+    auth: signInMode === "token"
+      ? {
+          sessions: new OpsSessionStore(),
+          // Resolved server-side against the API's own /api/auth/me, which is
+          // where a verified address can be read at all — the token does not
+          // carry one.
+          identities: new JwtIdentityResolver({ apiUrl: endpoints.apiUrl }),
+          uiUrl,
+          signIn: { kind: "token", apiUrl: endpoints.apiUrl, webAppUrl: endpoints.webAppUrl },
+        }
+      : {
+          sessions: new OpsSessionStore(),
+          // The bridge mints a real API key against the operator's own browser
+          // session, so this resolver is the only part of the server that talks to
+          // the API at all.
+          identities: new ApiIdentityResolver({ apiUrl: endpoints.apiUrl }),
+          uiUrl,
+          signIn: {
+            kind: "bridge",
+            states: new OneTimeStateStore(),
+            webAppUrl: endpoints.webAppUrl,
+            // The port the entrypoint bound, handed to Bun.serve and to this from
+            // one resolution — or the bridge would send the credential to a port
+            // nothing is listening on.
+            callbackPort: options.port,
+          },
+        },
   };
 }
 

--- a/packages/protocol/eval/ops/ops.server.ts
+++ b/packages/protocol/eval/ops/ops.server.ts
@@ -10,10 +10,12 @@
  * rather than substitute for one another:
  *
  *  1. `foreignHostRefusal` — every request, read included, must be addressed to a
- *     loopback host. This is what stops a rebound DNS name reading artifacts,
+ *     loopback host, or to the one origin `EVAL_OPS_PUBLIC_ORIGIN` names when the
+ *     server is deployed. This is what stops a rebound DNS name reading artifacts,
  *     run records, logs and fixture metadata.
- *  2. `crossOriginRefusal` — a state-changing request must be same-origin, so a
- *     page the operator happens to have open cannot drive a run or a flush.
+ *  2. `crossOriginRefusal` — a state-changing request must come from an allowed
+ *     origin, so a page the operator happens to have open cannot drive a run or a
+ *     flush.
  *  3. A JSON content type on writes, which `no-cors` cannot produce.
  *  4. `authRefusal` — the caller must hold a session belonging to a verified
  *     member of the allowed domain (see ops.auth.ts).
@@ -56,6 +58,15 @@ export interface OpsContext {
   databaseUrl: string | undefined;
   /** Read-only live counts. Absent when no database client is configured. */
   inspector?: FixtureInspector;
+  /**
+   * The one non-loopback origin this server also answers on, when it is deployed.
+   *
+   * Absent means loopback only, which is the local posture and the default. It is
+   * never a wildcard and never a way to switch a guard off: see
+   * {@link resolvePublicOrigin}, which validates it and refuses to start on
+   * anything else.
+   */
+  publicOrigin?: PublicOrigin;
   /** Identity. Absent only in tests that predate the gate; see `authRefusal`. */
   auth?: OpsAuthContext;
 }
@@ -81,8 +92,22 @@ export interface OpsAuthContext {
   uiUrl: string;
 }
 
-/** Origins a browser may legitimately be running the ops UI on: loopback only. */
+/** Origins a browser may legitimately be running the ops UI on, before deployment. */
 const LOOPBACK_HOSTNAMES = new Set(["127.0.0.1", "localhost", "[::1]"]);
+
+/**
+ * The single deployed origin the guards below also accept.
+ *
+ * Both fields are derived from one validated value, so the `Host` check and the
+ * `Origin` check cannot drift apart: `origin` is what an `Origin` header must
+ * equal, `host` is what a `Host` header must equal (including a non-default port).
+ */
+export interface PublicOrigin {
+  /** The normalised origin, e.g. `https://eval.index.network`. Never a wildcard. */
+  origin: string;
+  /** Its host, including a non-default port. */
+  host: string;
+}
 
 /**
  * The only routes reachable without a session, and the reason each one must be.
@@ -109,15 +134,46 @@ export const PUBLIC_ROUTES: ReadonlyArray<{ method: string; path: string }> = Ob
 const SESSION_COOKIE = "eval_ops_session";
 
 /**
- * The session cookie's attributes.
+ * The session cookie's attributes, minus `Secure`.
  *
- * `Secure` is deliberately absent. The ops site is served over plain http on
- * loopback, and a Secure cookie would be dropped by the browser — sign-in would
- * appear to succeed and then silently never take effect. `SameSite=Lax` keeps the
- * cookie off cross-site writes, which is the same boundary `crossOriginRefusal`
- * enforces server-side.
+ * `SameSite=Lax` keeps the cookie off cross-site writes, which is the same
+ * boundary `crossOriginRefusal` enforces server-side.
  */
 const SESSION_COOKIE_ATTRIBUTES = "HttpOnly; SameSite=Lax; Path=/";
+
+/**
+ * The cookie's attributes for one request.
+ *
+ * `Secure` follows the request rather than a hand-set flag, because both mistakes
+ * are silent. On loopback the site is plain http, and a Secure cookie would be
+ * dropped by the browser: sign-in would appear to succeed and never take effect.
+ * Over HTTPS an insecure session cookie is a real exposure, and nothing in the
+ * browser would say so.
+ */
+function sessionCookieAttributes(secure: boolean): string {
+  return secure ? `${SESSION_COOKIE_ATTRIBUTES}; Secure` : SESSION_COOKIE_ATTRIBUTES;
+}
+
+/**
+ * True when the browser reached this server over HTTPS.
+ *
+ * Two signals, both of them things this server can vouch for. The request URL's
+ * own scheme is one. The other is the configured public origin: it is validated
+ * to be `https:` and nothing else, so a request addressed to that host was served
+ * over HTTPS even though a TLS-terminating proxy — Railway's edge, for one —
+ * forwards it onward as plain http.
+ *
+ * `X-Forwarded-Proto` is deliberately not consulted. It is a header any client
+ * can set, including a page on the operator's own machine, and trusting it would
+ * let that page get the loopback session cookie dropped.
+ */
+function isSecureRequest(context: OpsContext, request: Request, url: URL): boolean {
+  if (url.protocol === "https:") return true;
+  const publicOrigin = context.publicOrigin;
+  if (publicOrigin === undefined) return false;
+  const host = request.headers.get("host");
+  return host !== null && host.trim().toLowerCase() === publicOrigin.host;
+}
 
 /** Fetch metadata values that mean "this was not initiated by another site". */
 const SAME_ORIGIN_FETCH_SITES = new Set(["same-origin", "none"]);
@@ -143,15 +199,15 @@ export function createOpsHandler(context: OpsContext): (request: Request) => Pro
   const state: ServerState = { resetInFlight: false };
   return async (request: Request): Promise<Response> => {
     const url = new URL(request.url);
-    const rebinding = foreignHostRefusal(request);
+    const rebinding = foreignHostRefusal(context, request);
     if (rebinding !== null) return rebinding;
-    const refusal = crossOriginRefusal(request);
+    const refusal = crossOriginRefusal(context, request);
     if (refusal !== null) return refusal;
     try {
       // Ahead of the gate: this is the request that establishes a session, so it
-      // cannot require one. It is still behind both loopback guards above.
+      // cannot require one. It is still behind both host/origin guards above.
       if (url.pathname === OPS_CALLBACK_PATH && request.method === "GET") {
-        return await completeSignIn(context, url);
+        return await completeSignIn(context, request, url);
       }
 
       // Default-deny. Everything from here on either sits on PUBLIC_ROUTES or
@@ -224,7 +280,7 @@ function sessionIdentity(context: OpsContext, request: Request): AllowedIdentity
  * dropped — it is a broad API key for a real account, and it is never stored in a
  * session, logged, or written into a page.
  */
-async function completeSignIn(context: OpsContext, url: URL): Promise<Response> {
+async function completeSignIn(context: OpsContext, request: Request, url: URL): Promise<Response> {
   const auth = context.auth;
   if (auth === undefined) return refusalPage("This server has no identity configured.", 500);
 
@@ -262,7 +318,7 @@ async function completeSignIn(context: OpsContext, url: URL): Promise<Response> 
     status: 302,
     headers: {
       Location: auth.uiUrl,
-      "Set-Cookie": `${SESSION_COOKIE}=${session}; ${SESSION_COOKIE_ATTRIBUTES}`,
+      "Set-Cookie": `${SESSION_COOKIE}=${session}; ${sessionCookieAttributes(isSecureRequest(context, request, url))}`,
     },
   });
 }
@@ -340,6 +396,9 @@ function readCookie(request: Request, name: string): string | null {
  *    on 127.0.0.1:5174 and proxies /api here; the proxy forwards the browser's
  *    own `Origin: http://127.0.0.1:5174` verbatim, and a direct visit to this
  *    server sends `Origin: http://127.0.0.1:4321`. Both are loopback.
+ *  - the one origin `EVAL_OPS_PUBLIC_ORIGIN` names, when the server is deployed.
+ *    Exactly that origin: a different scheme, a different port and a subdomain of
+ *    it are all different origins and all refused.
  *  - no `Origin` at all: curl, and any proxy hop that drops it. A request with no
  *    `Origin` was not initiated by a page, so it is not the drive-by this closes.
  *  - `Sec-Fetch-Site: same-origin` or `none`, which say the same thing.
@@ -348,12 +407,19 @@ function readCookie(request: Request, name: string): string | null {
  * frame or a file:// page sends — and, when no `Origin` is present, a
  * `Sec-Fetch-Site` that names another site.
  */
-function crossOriginRefusal(request: Request): Response | null {
+function crossOriginRefusal(context: OpsContext, request: Request): Response | null {
   if (request.method === "GET" || request.method === "HEAD") return null;
   const origin = request.headers.get("origin");
   if (origin !== null) {
-    if (isLoopbackOrigin(origin)) return null;
-    return json({ error: `Refusing a ${request.method} from origin ${origin}: this server only accepts local requests.` }, 403);
+    if (isAllowedOrigin(origin, context.publicOrigin)) return null;
+    return json(
+      {
+        error:
+          `Refusing a ${request.method} from origin ${origin}: this server only accepts requests from `
+          + `${describeAllowedOrigins(context.publicOrigin)}.`,
+      },
+      403,
+    );
   }
   const site = request.headers.get("sec-fetch-site");
   if (site !== null && !SAME_ORIGIN_FETCH_SITES.has(site.toLowerCase())) {
@@ -379,15 +445,26 @@ function crossOriginRefusal(request: Request): Response | null {
  *
  * A request with no `Host` is accepted: it was not steered here by a resolved
  * name, so rebinding does not apply.
+ *
+ * A deployed server also answers on the one host `EVAL_OPS_PUBLIC_ORIGIN` names.
+ * That is a second entry in the allowlist, not a hole in it: every other host,
+ * including a subdomain of the configured one, is still refused.
  */
-function foreignHostRefusal(request: Request): Response | null {
+function foreignHostRefusal(context: OpsContext, request: Request): Response | null {
   const host = request.headers.get("host");
   if (host === null) return null;
-  if (isLoopbackHost(host)) return null;
+  if (isAllowedHost(host, context.publicOrigin)) return null;
   return json(
-    { error: `Refusing a request for host ${host}: this server only answers on loopback (${[...LOOPBACK_HOSTNAMES].join(", ")}).` },
+    { error: `Refusing a request for host ${host}: this server only answers on ${describeAllowedHosts(context.publicOrigin)}.` },
     403,
   );
+}
+
+/** Loopback, plus the configured public host when there is one. */
+function isAllowedHost(host: string, publicOrigin: PublicOrigin | undefined): boolean {
+  const value = host.trim().toLowerCase();
+  if (publicOrigin !== undefined && value === publicOrigin.host) return true;
+  return isLoopbackHost(value);
 }
 
 /** Strips an optional port and compares against the loopback allowlist. */
@@ -396,6 +473,21 @@ function isLoopbackHost(host: string): boolean {
   // Bracketed IPv6 keeps its brackets, which is how LOOPBACK_HOSTNAMES stores ::1.
   const hostname = value.startsWith("[") ? value.slice(0, value.indexOf("]") + 1) : value.split(":")[0];
   return LOOPBACK_HOSTNAMES.has(hostname);
+}
+
+/** Loopback at any port, plus the configured public origin exactly. */
+function isAllowedOrigin(origin: string, publicOrigin: PublicOrigin | undefined): boolean {
+  if (isLoopbackOrigin(origin)) return true;
+  if (publicOrigin === undefined) return false;
+  let parsed: URL;
+  try {
+    parsed = new URL(origin);
+  } catch {
+    return false;
+  }
+  // URL.origin normalises scheme and host case and drops a default port, so this
+  // is an origin comparison rather than a string comparison of two spellings.
+  return parsed.origin === publicOrigin.origin;
 }
 
 function isLoopbackOrigin(origin: string): boolean {
@@ -408,6 +500,16 @@ function isLoopbackOrigin(origin: string): boolean {
   }
   if (parsed.protocol !== "http:" && parsed.protocol !== "https:") return false;
   return LOOPBACK_HOSTNAMES.has(parsed.hostname);
+}
+
+/** The refusal message names what is allowed, so a misrouted deploy says what to fix. */
+function describeAllowedHosts(publicOrigin: PublicOrigin | undefined): string {
+  const loopback = `loopback (${[...LOOPBACK_HOSTNAMES].join(", ")})`;
+  return publicOrigin === undefined ? loopback : `${loopback} and ${publicOrigin.host}`;
+}
+
+function describeAllowedOrigins(publicOrigin: PublicOrigin | undefined): string {
+  return publicOrigin === undefined ? "loopback origins" : `loopback origins and ${publicOrigin.origin}`;
 }
 
 /** Returns null when nothing matched, so the caller can answer 404 in one place. */
@@ -433,7 +535,7 @@ async function route(context: OpsContext, state: ServerState, request: Request, 
 
   if (request.method === "POST") {
     if (resource === "auth" && rest.length === 1 && rest[0] === "login") return beginSignIn(context);
-    if (resource === "auth" && rest.length === 1 && rest[0] === "logout") return endSession(context, request);
+    if (resource === "auth" && rest.length === 1 && rest[0] === "logout") return endSession(context, request, url);
     if (resource === "runs" && rest.length === 0) return await launchRun(context, state, request);
     if (resource === "runs" && rest.length === 2 && rest[1] === "cancel") return await cancelRun(context, rest[0]);
     if (resource === "fixture" && rest.length === 1 && rest[0] === "reset") return await resetFixture(context, state, request);
@@ -467,13 +569,15 @@ function beginSignIn(context: OpsContext): Response {
 }
 
 /** Ends the session and expires the cookie, so the browser stops presenting it. */
-function endSession(context: OpsContext, request: Request): Response {
+function endSession(context: OpsContext, request: Request, url: URL): Response {
   context.auth?.sessions.clear(readCookie(request, SESSION_COOKIE));
   return new Response(JSON.stringify({ authenticated: false }), {
     status: 200,
     headers: {
       "Content-Type": "application/json",
-      "Set-Cookie": `${SESSION_COOKIE}=; ${SESSION_COOKIE_ATTRIBUTES}; Max-Age=0`,
+      // Expired with the attributes it was set with, so the browser overwrites the
+      // cookie it holds rather than being handed a second, differently scoped one.
+      "Set-Cookie": `${SESSION_COOKIE}=; ${sessionCookieAttributes(isSecureRequest(context, request, url))}; Max-Age=0`,
     },
   });
 }
@@ -911,8 +1015,10 @@ const DEFAULT_API_URL = "http://localhost:3001";
  * nothing said why. Both defaults now name the same environment.
  */
 const DEFAULT_WEB_APP_URL = "http://localhost:3000";
-/** The port this server listens on, when the environment does not say. Mirrors ops.serve.ts. */
+/** The port this server listens on, when the environment does not say. */
 const DEFAULT_PORT = 4321;
+/** The address this server binds, when the environment does not say. Loopback, deliberately. */
+const DEFAULT_BIND = "127.0.0.1";
 /**
  * Where a completed sign-in sends the browser, when the environment does not say.
  *
@@ -1018,18 +1124,135 @@ function resolveUiUrl(env: Record<string, string | undefined>, fallback: string 
   return value;
 }
 
+/**
+ * The port an entrypoint binds, and the bridge callback must therefore advertise.
+ *
+ * `EVAL_OPS_PORT` always wins: it names *this* server and nothing else. What it
+ * falls back to depends on which entrypoint is asking, which is why the posture
+ * is a parameter rather than an ambient guess:
+ *
+ *  - `apps/eval-ops/server.ts` is the deployed single-process site. The platform
+ *    (Railway) chooses the port and injects `PORT`; ignoring it would leave the
+ *    service listening where nothing routes, and its health check failing.
+ *  - `ops.serve.ts` is the local dev API, started by `bun run eval:web` with
+ *    `--env-file=../../.env.test` — and that file sets `PORT=3001` for the *API
+ *    service*. Honouring `PORT` there would silently move the ops API onto the
+ *    API's port and break the documented two-process flow on every machine.
+ *
+ * Do not collapse the two call sites back into one unconditional rule. That
+ * `PORT=3001` line is the reason this parameter exists.
+ */
+export interface BindPortOptions {
+  env: Record<string, string | undefined>;
+  /** True only for the entrypoint the platform starts and injects `PORT` into. */
+  honourPlatformPort: boolean;
+}
+
+export function resolveBindPort(options: BindPortOptions): number {
+  const explicit = readEnv(options.env, "EVAL_OPS_PORT");
+  if (explicit !== undefined) return parsePort(explicit, "EVAL_OPS_PORT");
+  if (options.honourPlatformPort) {
+    const platform = readEnv(options.env, "PORT");
+    if (platform !== undefined) return parsePort(platform, "PORT");
+  }
+  return DEFAULT_PORT;
+}
+
+/** Refuses a port that is not one, rather than letting Number() bind something arbitrary. */
+function parsePort(value: string, name: string): number {
+  const port = Number(value);
+  if (!Number.isInteger(port) || port < 1 || port > 65535) {
+    throw new Error(
+      `Refusing to start: ${name} (${value}) is not a usable TCP port. Set it to an integer between 1 and `
+      + `65535, or leave it unset to use ${DEFAULT_PORT}.`,
+    );
+  }
+  return port;
+}
+
+/**
+ * The address an entrypoint binds. Loopback unless `EVAL_OPS_BIND` says otherwise.
+ *
+ * Widening the bind stays one deliberate, explicit act, and it is not implied by
+ * anything else: a deployed port does not move it, and it is not what makes the
+ * site reachable — the `Host` and `Origin` allowlists still have to name the
+ * origin as well (see {@link resolvePublicOrigin}).
+ */
+export function resolveBindHostname(env: Record<string, string | undefined>): string {
+  return readEnv(env, "EVAL_OPS_BIND") ?? DEFAULT_BIND;
+}
+
+/** Hostnames a public origin may name: letters, digits and hyphens, dot-separated. */
+const PUBLIC_HOSTNAME_PATTERN = /^[a-z0-9]([a-z0-9-]*[a-z0-9])?(\.[a-z0-9]([a-z0-9-]*[a-z0-9])?)*$/;
+
+/**
+ * The one deployed origin the `Host` and `Origin` allowlists are extended to.
+ *
+ * Unset means loopback only — the local posture, unchanged. There is deliberately
+ * no wildcard and no way to switch a guard off: the value is one absolute origin
+ * or the server does not start.
+ *
+ * Validated rather than trusted, because every way of getting this wrong is
+ * silent at startup and expensive later. `http:` would let a session cookie ride
+ * a plaintext hop and would also make {@link isSecureRequest} wrong. A path,
+ * query or fragment means the operator supplied a URL where an origin was asked
+ * for, and the string comparison against a browser's `Origin` header would then
+ * never match — every request 403ing with no stated cause. A hostname outside
+ * LDH is either a wildcard attempt or a typo.
+ */
+export function resolvePublicOrigin(env: Record<string, string | undefined>): PublicOrigin | undefined {
+  const value = readEnv(env, "EVAL_OPS_PUBLIC_ORIGIN");
+  if (value === undefined) return undefined;
+
+  const refuse = (reason: string): never => {
+    throw new Error(
+      `Refusing to start: EVAL_OPS_PUBLIC_ORIGIN (${value}) ${reason}. It must be exactly one absolute https `
+      + `origin with no path, query or fragment, such as https://eval.index.network — or be unset, which keeps `
+      + `this server loopback-only.`,
+    );
+  };
+
+  let parsed: URL;
+  try {
+    parsed = new URL(value);
+  } catch {
+    return refuse("is not a usable URL");
+  }
+  if (parsed.protocol !== "https:") return refuse(`names ${parsed.protocol.replace(":", "")}, not https`);
+  if (parsed.username !== "" || parsed.password !== "") return refuse("carries credentials");
+  if (parsed.search !== "") return refuse("carries a query string");
+  if (parsed.hash !== "") return refuse("carries a fragment");
+  if (parsed.pathname !== "" && parsed.pathname !== "/") return refuse(`names a path (${parsed.pathname})`);
+  if (!PUBLIC_HOSTNAME_PATTERN.test(parsed.hostname)) return refuse(`does not name a usable host (${parsed.hostname})`);
+
+  return { origin: parsed.origin, host: parsed.host };
+}
+
 /** Builds the context the standalone server runs on: everything rooted at the repository. */
-export async function createDefaultOpsContext(options: { repoRoot: string; uiUrl?: string }): Promise<OpsContext> {
+export async function createDefaultOpsContext(options: {
+  repoRoot: string;
+  uiUrl?: string;
+  /**
+   * The port the entrypoint bound, from {@link resolveBindPort}.
+   *
+   * Passed in rather than re-read here: the bridge callback must name the port
+   * the server is actually listening on, and two independent reads of the
+   * environment are how those drift.
+   */
+  port: number;
+}): Promise<OpsContext> {
   const protocolDir = path.join(options.repoRoot, "packages/protocol");
   const evalDir = path.join(protocolDir, "eval");
   const store = new FsRunStore({ evalDir });
   const executor = new LocalProcessRunExecutor({ store, cwd: protocolDir });
   const databaseUrl = process.env.DATABASE_URL;
 
-  // Ahead of any I/O: a misconfigured identity pair must stop the server, not
-  // surface as a refused sign-in five minutes later.
+  // Ahead of any I/O: a misconfigured identity pair, or a malformed public
+  // origin, must stop the server rather than surface as a refused sign-in or a
+  // site that 403s every request five minutes later.
   const endpoints = resolveIdentityEndpoints(process.env);
   const uiUrl = resolveUiUrl(process.env, options.uiUrl);
+  const publicOrigin = resolvePublicOrigin(process.env);
 
   // Reported, not fatal: fixture control is only one page, and the reset route
   // fails closed on the same divergence. A silent mismatch is what must not happen.
@@ -1059,6 +1282,7 @@ export async function createDefaultOpsContext(options: { repoRoot: string; uiUrl
     queue: new RunQueue({ executor, store }),
     databaseUrl,
     inspector: new BunSqlFixtureInspector(),
+    publicOrigin,
     auth: {
       states: new OneTimeStateStore(),
       sessions: new OpsSessionStore(),
@@ -1068,10 +1292,10 @@ export async function createDefaultOpsContext(options: { repoRoot: string; uiUrl
       identities: new ApiIdentityResolver({ apiUrl: endpoints.apiUrl }),
       webAppUrl: endpoints.webAppUrl,
       uiUrl,
-      // Must match the port Bun.serve actually binds, or the bridge would send the
-      // credential to a port nothing is listening on. ops.serve.ts reads the same
-      // variable and the same default.
-      callbackPort: Number(process.env.EVAL_OPS_PORT ?? DEFAULT_PORT),
+      // The port the entrypoint bound, handed to Bun.serve and to this from one
+      // resolution — or the bridge would send the credential to a port nothing is
+      // listening on.
+      callbackPort: options.port,
     },
   };
 }

--- a/packages/protocol/eval/ops/ops.types.ts
+++ b/packages/protocol/eval/ops/ops.types.ts
@@ -43,6 +43,8 @@ export interface HarnessDescriptor {
   question: string;
   /** One sentence on what is actually scored, shown under `question` for context. */
   detail: string;
+  /** Model-overridable agents this harness exercises, in pipeline order. */
+  agents: readonly string[];
 }
 
 export interface ArtifactRef {

--- a/packages/protocol/eval/ops/ops.types.ts
+++ b/packages/protocol/eval/ops/ops.types.ts
@@ -95,8 +95,10 @@ export interface RunFlags {
 export interface EvalRunSpec {
   kind: "eval";
   harness: OpsHarness;
-  /** Name of a committed profile. Never a set of raw overrides. */
+  /** Name of a committed or saved profile. "default" + overrides = ad-hoc. */
   profile: string;
+  /** Ad-hoc overrides; only valid with profile "default". Never credentials. */
+  overrides?: { models: Record<string, string>; env: Record<string, string> };
   flags: RunFlags;
 }
 

--- a/packages/protocol/eval/ops/ops.types.ts
+++ b/packages/protocol/eval/ops/ops.types.ts
@@ -35,6 +35,14 @@ export interface HarnessDescriptor {
   defaultRuns: number;
   /** Corpus size, used to show workload (cases x runs) before launching. */
   caseCount: number;
+  /**
+   * The question this harness answers, phrased for a reader who did not write it.
+   * Shown wherever the site names the harness, so the four names are never the
+   * only explanation on the page.
+   */
+  question: string;
+  /** One sentence on what is actually scored, shown under `question` for context. */
+  detail: string;
 }
 
 export interface ArtifactRef {

--- a/packages/protocol/eval/ops/tests/auth.spec.ts
+++ b/packages/protocol/eval/ops/tests/auth.spec.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it, beforeAll } from "bun:test";
 import path from "node:path";
 
-import { ALLOWED_EMAIL_DOMAIN, ApiIdentityResolver, assessIdentity, buildBridgeUrl, MAX_PENDING_STATES, OneTimeStateStore, OpsSessionStore, type ResolvedIdentity } from "../ops.auth.js";
+import { ALLOWED_EMAIL_DOMAIN, ApiIdentityResolver, assessIdentity, buildBridgeUrl, JwtIdentityResolver, MAX_PENDING_STATES, OneTimeStateStore, OpsSessionStore, type ResolvedIdentity } from "../ops.auth.js";
 
 /**
  * The bridge page's own validator, loaded from the file that actually runs in
@@ -348,6 +348,110 @@ describe("ApiIdentityResolver", () => {
     const resolved = await resolver.resolve("secret-key");
     expect(resolved).toEqual({ email: "a@index.network", emailVerified: false, name: "Ada" });
     expect(assessIdentity(resolved).allowed).toBe(false);
+  });
+});
+
+/**
+ * A syntactically plausible compact JWS. The signature is never checked here —
+ * the API checks it — but the *shape* is, so the value has to be a real one.
+ */
+const JWT = "eyJhbGciOiJFZERTQSJ9.eyJpZCI6InUxIn0.c2lnbmF0dXJl";
+
+describe("JwtIdentityResolver", () => {
+  it("presents the token as a bearer credential and never in the URL", async () => {
+    const stub = stubFetch(() => meResponse({ email: "a@index.network", emailVerified: true, name: "Ada" }));
+    const resolver = new JwtIdentityResolver({ apiUrl: "https://protocol.dev.index.network/", fetch: stub.fetch });
+
+    await resolver.resolve(JWT);
+
+    expect(stub.calls).toHaveLength(1);
+    expect(stub.calls[0].url).toBe("https://protocol.dev.index.network/api/auth/me");
+    expect(stub.calls[0].url).not.toContain(JWT);
+    expect(new Headers(stub.calls[0].init?.headers).get("authorization")).toBe(`Bearer ${JWT}`);
+    // Not an API key: the API's AuthGuard reads the two headers on different paths.
+    expect(new Headers(stub.calls[0].init?.headers).get("x-api-key")).toBeNull();
+  });
+
+  it("maps the real response body to a resolved identity", async () => {
+    const stub = stubFetch(() => meResponse({ email: "a@index.network", emailVerified: true, name: "Ada" }));
+    const resolver = new JwtIdentityResolver({ apiUrl: "https://protocol.dev.index.network", fetch: stub.fetch });
+
+    expect(await resolver.resolve(JWT)).toEqual({ email: "a@index.network", emailVerified: true, name: "Ada" });
+  });
+
+  /**
+   * The reason the `/api/auth/me` hop exists at all. The `jwt` plugin's
+   * `definePayload` in services/api/src/lib/betterauth/betterauth.ts returns
+   * `{ id, email, name }` and no `emailVerified`, so possession of a genuine
+   * token says nothing about verification — and `assessIdentity` demands it.
+   */
+  it("reports an unverified user as unverified rather than dropping the field", async () => {
+    const stub = stubFetch(() => meResponse({ email: "a@index.network", emailVerified: false, name: "Ada" }));
+    const resolver = new JwtIdentityResolver({ apiUrl: "https://protocol.dev.index.network", fetch: stub.fetch });
+
+    const resolved = await resolver.resolve(JWT);
+    expect(resolved).toEqual({ email: "a@index.network", emailVerified: false, name: "Ada" });
+    expect(assessIdentity(resolved).allowed).toBe(false);
+  });
+
+  it("fails closed when the verified flag is missing", async () => {
+    const stub = stubFetch(() => meResponse({ email: "a@index.network", name: "Ada" }));
+    const resolver = new JwtIdentityResolver({ apiUrl: "https://protocol.dev.index.network", fetch: stub.fetch });
+
+    const resolved = await resolver.resolve(JWT);
+    expect(resolved).toEqual({ email: "a@index.network", emailVerified: false, name: "Ada" });
+    expect(assessIdentity(resolved).allowed).toBe(false);
+  });
+
+  it("resolves nothing when the API refuses the token", async () => {
+    // What the live API answers a token it cannot verify:
+    // {"error":"Invalid or expired access token"} with status 401.
+    const stub = stubFetch(() => Response.json({ error: "Invalid or expired access token" }, { status: 401 }));
+    const resolver = new JwtIdentityResolver({ apiUrl: "https://protocol.dev.index.network", fetch: stub.fetch });
+
+    expect(await resolver.resolve(JWT)).toBeNull();
+  });
+
+  it("resolves nothing when the body is not the documented shape", async () => {
+    for (const body of [{}, { user: null }, { user: { email: 42 } }, "not json at all"]) {
+      const stub = stubFetch(() => (typeof body === "string" ? new Response(body) : Response.json(body)));
+      const resolver = new JwtIdentityResolver({ apiUrl: "https://protocol.dev.index.network", fetch: stub.fetch });
+      expect(await resolver.resolve(JWT)).toBeNull();
+    }
+  });
+
+  /**
+   * The token arrives from a browser POST body, so it is caller-controlled text
+   * on its way into an HTTP header. Anything that is not a compact JWS is refused
+   * before a request is made: it cannot be a better-auth token, and a value
+   * carrying CR/LF would otherwise be handed to `fetch` as a header value.
+   */
+  it("refuses anything that is not a compact JWS, without contacting the API", async () => {
+    for (const candidate of [
+      "",
+      "   ",
+      "not-a-jwt",
+      "only.two",
+      "a.b.c.d",
+      "a.b.c extra",
+      "a.b.c\r\nX-Injected: 1",
+      `${JWT} `,
+    ]) {
+      const stub = stubFetch(() => meResponse({ email: "a@index.network", emailVerified: true, name: "Ada" }));
+      const resolver = new JwtIdentityResolver({ apiUrl: "https://protocol.dev.index.network", fetch: stub.fetch });
+
+      expect({ candidate, resolved: await resolver.resolve(candidate) }).toEqual({ candidate, resolved: null });
+      expect({ candidate, calls: stub.calls.length }).toEqual({ candidate, calls: 0 });
+    }
+  });
+
+  it("lets a transport failure reject, because a dead API is not a refusal", async () => {
+    const failing = (async () => {
+      throw new Error("connect ECONNREFUSED");
+    }) as unknown as typeof fetch;
+    const resolver = new JwtIdentityResolver({ apiUrl: "https://protocol.dev.index.network", fetch: failing });
+
+    await expect(resolver.resolve(JWT)).rejects.toThrow(/ECONNREFUSED/);
   });
 });
 

--- a/packages/protocol/eval/ops/tests/compare.spec.ts
+++ b/packages/protocol/eval/ops/tests/compare.spec.ts
@@ -61,6 +61,42 @@ describe("compareArtifacts", () => {
     expect(outcome.aggregate.delta).toBeLessThan(0);
   });
 
+  it("still refuses across differing scoring configuration by default", () => {
+    const outcome = compareArtifacts(
+      envelope({ config: "config-a", passes: 10, runs: 10 }),
+      envelope({ config: "config-b", passes: 10, runs: 10 }),
+      0.05,
+    );
+
+    expect(outcome.comparable).toBe(false);
+  });
+
+  it("compares across configs when allowConfigMismatch is set: the config is the variable under test", () => {
+    const outcome = compareArtifacts(
+      envelope({ config: "config-a", passes: 20, runs: 20 }),
+      envelope({ config: "config-b", passes: 2, runs: 20 }),
+      0.05,
+      { allowConfigMismatch: true },
+    );
+
+    if (!outcome.comparable) throw new Error("expected a comparable outcome");
+    expect(outcome.regressions.regressions.map((r) => r.id)).toContain("a/b");
+    expect(outcome.aggregate.delta).toBeLessThan(0);
+  });
+
+  it("keeps every other refusal when allowConfigMismatch is set", () => {
+    const outcome = compareArtifacts(
+      envelope({ corpus: "corpus-a", config: "config-a", passes: 10, runs: 10 }),
+      envelope({ corpus: "corpus-b", config: "config-b", passes: 10, runs: 10 }),
+      0.05,
+      { allowConfigMismatch: true },
+    );
+
+    expect(outcome.comparable).toBe(false);
+    if (outcome.comparable) throw new Error("unreachable");
+    expect(outcome.findings.map((f) => f.dimension)).toEqual(["corpusFingerprint"]);
+  });
+
   it("reports an improvement by evaluating the reversed direction", () => {
     const outcome = compareArtifacts(
       envelope({ passes: 2, runs: 20 }),

--- a/packages/protocol/eval/ops/tests/configs.spec.ts
+++ b/packages/protocol/eval/ops/tests/configs.spec.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "bun:test";
 
-import { CONFIG_TABLE_DDL, ConfigConflictError, InMemoryConfigStore } from "../ops.configs.js";
+import { CONFIG_TABLE_DDL, ConfigConflictError, InMemoryConfigStore, configFromRow } from "../ops.configs.js";
 
 const candidate = {
   name: "sonnet-evaluator",
@@ -39,5 +39,49 @@ describe("InMemoryConfigStore", () => {
 describe("CONFIG_TABLE_DDL", () => {
   it("is idempotent", () => {
     expect(CONFIG_TABLE_DDL).toContain("CREATE TABLE IF NOT EXISTS eval_ops_configs");
+  });
+});
+
+describe("configFromRow", () => {
+  it("parses string-typed jsonb fields (verified Bun v1.3.14 driver behaviour)", () => {
+    const profile = configFromRow({
+      name: "sonnet-evaluator",
+      description: "evaluator on sonnet",
+      models: JSON.stringify({ opportunityEvaluator: "anthropic/claude-sonnet-4" }),
+      env: JSON.stringify({ RUN_OPPORTUNITY_EVAL_IN_PARALLEL: "true" }),
+    });
+    expect(profile).toEqual({
+      name: "sonnet-evaluator",
+      description: "evaluator on sonnet",
+      models: { opportunityEvaluator: "anthropic/claude-sonnet-4" },
+      env: { RUN_OPPORTUNITY_EVAL_IN_PARALLEL: "true" },
+    });
+  });
+
+  it("passes object-typed fields through unchanged", () => {
+    const profile = configFromRow(candidate);
+    expect(profile).toEqual(candidate);
+  });
+
+  it("surfaces corrupt JSON as a clear error naming the config and field", () => {
+    expect(() =>
+      configFromRow({
+        name: "broken",
+        description: "x",
+        models: "{not json",
+        env: {},
+      }),
+    ).toThrow(/Config "broken" has corrupt JSON in models/);
+  });
+
+  it("still rejects schema violations (schema not relaxed)", () => {
+    expect(() =>
+      configFromRow({
+        name: "Not Kebab Case",
+        description: "x",
+        models: {},
+        env: {},
+      }),
+    ).toThrow();
   });
 });

--- a/packages/protocol/eval/ops/tests/configs.spec.ts
+++ b/packages/protocol/eval/ops/tests/configs.spec.ts
@@ -1,0 +1,43 @@
+import { describe, expect, it } from "bun:test";
+
+import { CONFIG_TABLE_DDL, ConfigConflictError, InMemoryConfigStore } from "../ops.configs.js";
+
+const candidate = {
+  name: "sonnet-evaluator",
+  description: "evaluator on sonnet",
+  models: { opportunityEvaluator: "anthropic/claude-sonnet-4" },
+  env: {},
+};
+
+describe("InMemoryConfigStore", () => {
+  it("creates, lists, gets, updates and removes configs", async () => {
+    const store = new InMemoryConfigStore();
+    await store.create(candidate);
+    expect(await store.get("sonnet-evaluator")).toEqual(candidate);
+    expect((await store.list()).map((c) => c.name)).toEqual(["sonnet-evaluator"]);
+
+    const updated = await store.update("sonnet-evaluator", { description: "better description" });
+    expect(updated?.description).toBe("better description");
+    expect(updated?.models).toEqual(candidate.models);
+
+    expect(await store.remove("sonnet-evaluator")).toBe(true);
+    expect(await store.get("sonnet-evaluator")).toBeNull();
+    expect(await store.remove("sonnet-evaluator")).toBe(false);
+  });
+
+  it("rejects a duplicate name with ConfigConflictError", async () => {
+    const store = new InMemoryConfigStore();
+    await store.create(candidate);
+    await expect(store.create(candidate)).rejects.toBeInstanceOf(ConfigConflictError);
+  });
+
+  it("returns null when updating an unknown name", async () => {
+    expect(await new InMemoryConfigStore().update("nope", { description: "x" })).toBeNull();
+  });
+});
+
+describe("CONFIG_TABLE_DDL", () => {
+  it("is idempotent", () => {
+    expect(CONFIG_TABLE_DDL).toContain("CREATE TABLE IF NOT EXISTS eval_ops_configs");
+  });
+});

--- a/packages/protocol/eval/ops/tests/profiles.spec.ts
+++ b/packages/protocol/eval/ops/tests/profiles.spec.ts
@@ -3,7 +3,8 @@ import { mkdtemp, writeFile, rm } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import path from "node:path";
 
-import { DEFAULT_PROFILE_NAME, loadProfiles, resolveProfile } from "../ops.profiles.js";
+import { ALLOWED_CONFIG_MODELS, DEFAULT_PROFILE_NAME, loadProfiles, resolveAdHoc, resolveProfile, validateConfigOverrides } from "../ops.profiles.js";
+import { HARNESS_REGISTRY } from "../ops.registry.js";
 
 let dir: string;
 
@@ -94,5 +95,53 @@ describe("resolveProfile", () => {
 
     expect(a.fingerprint).toBe(b.fingerprint);
     expect(a.fingerprint).not.toBe(c.fingerprint);
+  });
+});
+
+describe("validateConfigOverrides", () => {
+  it("accepts a valid override set", () => {
+    expect(validateConfigOverrides({
+      models: { opportunityEvaluator: ALLOWED_CONFIG_MODELS[0] },
+      env: { RUN_OPPORTUNITY_EVAL_IN_PARALLEL: "true" },
+    })).toEqual([]);
+  });
+
+  it("rejects a model outside the curated allowlist and names it", () => {
+    const issues = validateConfigOverrides({
+      models: { opportunityEvaluator: "anthropic/claude-opus-4.8" },
+      env: {},
+    });
+    expect(issues.some((i) => i.includes("claude-opus-4.8"))).toBe(true);
+  });
+
+  it("rejects an agent key no scorecard harness exercises", () => {
+    const issues = validateConfigOverrides({ models: { negotiator: ALLOWED_CONFIG_MODELS[0] }, env: {} });
+    expect(issues.some((i) => i.includes("negotiator"))).toBe(true);
+  });
+
+  it("rejects an env key outside PROFILE_ENV_ALLOWLIST", () => {
+    const issues = validateConfigOverrides({ models: {}, env: { OPENROUTER_API_KEY: "x" } });
+    expect(issues.some((i) => i.includes("OPENROUTER_API_KEY"))).toBe(true);
+  });
+});
+
+describe("resolveAdHoc", () => {
+  it("fingerprints identically to a named profile with the same payload", () => {
+    const overrides = { models: { opportunityEvaluator: "anthropic/claude-sonnet-4" }, env: {} };
+    const adHoc = resolveAdHoc(overrides);
+    const named = resolveProfile({ name: "candidate", description: "x", ...overrides });
+    expect(adHoc.fingerprint).toBe(named.fingerprint);
+    expect(adHoc.experimental).toBe(true);
+    expect(adHoc.profile.name).toBe("default");
+    expect(adHoc.env.EVAL_MODEL_OVERRIDES).toBe(JSON.stringify(overrides.models));
+  });
+});
+
+describe("HARNESS_REGISTRY agents", () => {
+  it("maps each harness to the agents it exercises", () => {
+    expect(HARNESS_REGISTRY.matching.agents).toEqual(["opportunityEvaluator"]);
+    expect(HARNESS_REGISTRY.opportunity.agents).toEqual(["opportunityPresenter"]);
+    expect(HARNESS_REGISTRY.profile.agents).toEqual(["profileGenerator"]);
+    expect(HARNESS_REGISTRY.premise.agents).toEqual(["premiseDecomposer", "premiseAnalyzer"]);
   });
 });

--- a/packages/protocol/eval/ops/tests/progress.spec.ts
+++ b/packages/protocol/eval/ops/tests/progress.spec.ts
@@ -1,0 +1,133 @@
+import { describe, expect, test } from "bun:test";
+
+import { HarnessProgressParser, parseHarnessProgress } from "../ops.progress.js";
+
+const HEADER = "Running 3 case(s) × 1 run(s) against anthropic/claude-test…\n";
+const DEBUG_BLOCK =
+  "[OpportunityEvaluator:invokeEntityBundle] Done {\n" +
+  "  total: 1,\n" +
+  "  afterClaimGuard: 0,\n" +
+  "  accepted: 0,\n" +
+  "}\n";
+
+describe("parseHarnessProgress", () => {
+  test("parses the real format: start line, debug dump, completion on its own line", () => {
+    const log =
+      HEADER +
+      `  is_a/identity-basic … ${DEBUG_BLOCK}` +
+      "1/1\n" +
+      `  is_a/identity-negated … ${DEBUG_BLOCK}` +
+      "0/1 (flaky)\n" +
+      `  location/remote-vs-onsite … ${DEBUG_BLOCK}` +
+      "1/1\n" +
+      "\nScorecard: 66.7%\n";
+    const p = parseHarnessProgress(log);
+    expect(p.totalCases).toBe(3);
+    expect(p.runsPerCase).toBe(1);
+    expect(p.model).toBe("anthropic/claude-test");
+    expect(p.completed).toBe(3);
+    expect(p.passed).toBe(2);
+    expect(p.failed).toBe(1);
+    expect(p.current).toBeNull();
+    expect(p.cases.map((c) => c.id)).toEqual([
+      "is_a/identity-basic",
+      "is_a/identity-negated",
+      "location/remote-vs-onsite",
+    ]);
+    expect(p.cases[1].flaky).toBe(true);
+  });
+
+  test("quiet output: start and completion on one line", () => {
+    const p = parseHarnessProgress(HEADER + "  is_a/identity-basic … 1/1\n  a/two … 0/1 (flaky)\n");
+    expect(p.completed).toBe(2);
+    expect(p.passed).toBe(1);
+    expect(p.failed).toBe(1);
+  });
+
+  test("a case stays in flight while debug output scrolls past", () => {
+    const log = HEADER + "  is_a/identity-basic … 1/1\n" + `  location/known-mismatch … ${DEBUG_BLOCK}`;
+    const p = parseHarnessProgress(log);
+    expect(p.completed).toBe(1);
+    expect(p.current?.id).toBe("location/known-mismatch");
+    expect(p.cases).toHaveLength(2);
+  });
+
+  test("a new case start closes the previous case as unknown", () => {
+    const log = HEADER + "  a/one … debug without completion\n" + "  a/two … 1/1\n";
+    const p = parseHarnessProgress(log);
+    expect(p.cases).toHaveLength(2);
+    expect(p.cases[0]).toMatchObject({ id: "a/one", done: true, passes: null, runs: null });
+    expect(p.cases[1]).toMatchObject({ id: "a/two", done: true, passes: 1, runs: 1 });
+    // Unknown completions count as neither passed nor failed.
+    expect(p.passed).toBe(1);
+    expect(p.failed).toBe(0);
+    expect(p.completed).toBe(2);
+  });
+
+  test("retry notices do not complete a case, despite containing attempt N/M", () => {
+    const log =
+      HEADER +
+      `  a/one … ${DEBUG_BLOCK}` +
+      "[matching eval] call failed (run 1, attempt 1/3); retrying in 1000ms: evaluator-incomplete\n" +
+      "[matching eval] call failed (run 1, attempt 2/3); retrying in 2000ms: evaluator-incomplete\n" +
+      "2/3\n";
+    const p = parseHarnessProgress(log);
+    expect(p.cases).toHaveLength(1);
+    expect(p.cases[0]).toMatchObject({ passes: 2, runs: 3, done: true });
+  });
+
+  test("returns nulls for output that is not a harness run", () => {
+    const p = parseHarnessProgress("Usage: eval:matching [flags]\n--runs <n>\n");
+    expect(p.totalCases).toBeNull();
+    expect(p.cases).toHaveLength(0);
+  });
+
+  test("strips ANSI colour before parsing", () => {
+    const esc = "\u001b";
+    const log = HEADER + `  ${esc}[32mis_a/identity-basic${esc}[0m … 1/1\n`;
+    const p = parseHarnessProgress(log);
+    expect(p.completed).toBe(1);
+    expect(p.cases[0].id).toBe("is_a/identity-basic");
+  });
+
+  test("handles judge-off header variant", () => {
+    const p = parseHarnessProgress(
+      "Running 8 case(s) × 3 run(s) against openai/gpt-test (judge off)…\n",
+    );
+    expect(p.totalCases).toBe(8);
+    expect(p.runsPerCase).toBe(3);
+    expect(p.model).toBe("openai/gpt-test");
+  });
+});
+
+describe("HarnessProgressParser (incremental)", () => {
+  test("a completion line split across chunks still parses", () => {
+    const parser = new HarnessProgressParser();
+    parser.push(HEADER);
+    parser.push("  a/one … debug\n");
+    expect(parser.snapshot().current?.id).toBe("a/one");
+    parser.push("1/");
+    expect(parser.snapshot().current?.id).toBe("a/one");
+    parser.push("1\n");
+    const p = parser.snapshot();
+    expect(p.completed).toBe(1);
+    expect(p.current).toBeNull();
+    expect(p.cases[0].passes).toBe(1);
+  });
+
+  test("snapshot is a copy; mutation does not corrupt the parser", () => {
+    const parser = new HarnessProgressParser();
+    parser.push(HEADER + "  a/one … 1/1\n");
+    parser.snapshot().cases.pop();
+    expect(parser.snapshot().cases).toHaveLength(1);
+  });
+
+  test("a case completed after the snapshot mutates the parser, not the snapshot", () => {
+    const parser = new HarnessProgressParser();
+    parser.push(HEADER + "  a/one … debug\n");
+    const before = parser.snapshot();
+    parser.push("0/1\n");
+    expect(before.cases[0].done).toBe(false);
+    expect(parser.snapshot().cases[0].done).toBe(true);
+  });
+});

--- a/packages/protocol/eval/ops/tests/server.spec.ts
+++ b/packages/protocol/eval/ops/tests/server.spec.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it, beforeEach, afterEach } from "bun:test";
-import { mkdtemp, mkdir, writeFile, rm } from "node:fs/promises";
+import { mkdtemp, mkdir, readFile, writeFile, rm } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import path from "node:path";
 
@@ -9,7 +9,7 @@ import type { ExecutionStep, RunExecutor } from "../ops.executor.js";
 import { SEED_STEP_CWD, type FixtureCounts, type FixtureInspector } from "../ops.fixture.js";
 import { isOpsServerPath, OPS_CALLBACK_PATH } from "../ops.paths.js";
 import { RunQueue } from "../ops.queue.js";
-import { createDefaultOpsContext, createOpsHandler, PUBLIC_ROUTES, resolveIdentityEndpoints, type OpsContext } from "../ops.server.js";
+import { createDefaultOpsContext, createOpsHandler, PUBLIC_ROUTES, resolveBindHostname, resolveBindPort, resolveIdentityEndpoints, resolvePublicOrigin, type OpsContext } from "../ops.server.js";
 import { FsRunStore, type RunStore } from "../ops.store.js";
 import type { RunRecord } from "../ops.types.js";
 
@@ -478,6 +478,169 @@ describe("Host header guard", () => {
     expect(response.status).toBe(403);
     await context.queue.drain();
     expect(executor.starts).toHaveLength(0);
+  });
+});
+
+describe("the configured public origin", () => {
+  // Deploying the site puts it on a real domain, where the loopback allowlists
+  // above would refuse every request. They are therefore extended to exactly one
+  // configured origin — never a wildcard, never a way to switch a guard off —
+  // and an unset variable still means "loopback only", which is the whole of the
+  // local posture. Every acceptance below is paired with a refusal, so a guard
+  // that stopped checking would fail here rather than pass vacuously.
+  const PUBLIC_ORIGIN = resolvePublicOrigin({ EVAL_OPS_PUBLIC_ORIGIN: "https://eval.index.network" });
+
+  const deployed = (path: string, headers: Record<string, string> = {}) =>
+    handler(new Request(`https://eval.index.network${path}`, { headers: { Host: "eval.index.network", ...sessionCookie, ...headers } }));
+
+  const deployedPost = (path: string, headers: Record<string, string> = {}) =>
+    handler(
+      new Request(`https://eval.index.network${path}`, {
+        method: "POST",
+        headers: {
+          Host: "eval.index.network",
+          "Content-Type": "application/json",
+          Origin: "https://eval.index.network",
+          ...sessionCookie,
+          ...headers,
+        },
+        body: JSON.stringify(RUN_BODY),
+      }),
+    );
+
+  describe("with no public origin configured", () => {
+    it("still refuses the deployed host and origin, so the default is loopback-only", async () => {
+      expect(context.publicOrigin).toBeUndefined();
+
+      expect((await deployed("/api/harnesses")).status).toBe(403);
+      expect((await deployedPost("/api/runs")).status).toBe(403);
+      await context.queue.drain();
+      expect(executor.starts).toHaveLength(0);
+    });
+  });
+
+  describe("with a public origin configured", () => {
+    beforeEach(async () => {
+      await build({ publicOrigin: PUBLIC_ORIGIN });
+    });
+
+    it("answers a read addressed to the configured host", async () => {
+      const response = await deployed("/api/harnesses");
+
+      expect(response.status).toBe(200);
+    });
+
+    it("accepts a write from the configured origin", async () => {
+      const response = await deployedPost("/api/runs");
+
+      expect(response.status).toBe(202);
+      await context.queue.drain();
+    });
+
+    it("still refuses every other host — the allowlist is one entry, not a wildcard", async () => {
+      for (const host of ["evil.example.com", "eval.index.network.evil.com", "sub.eval.index.network", "index.network"]) {
+        const response = await handler(
+          new Request("https://eval.index.network/api/harnesses", { headers: { Host: host, ...sessionCookie } }),
+        );
+        expect(response.status).toBe(403);
+      }
+    });
+
+    it("still refuses every other origin on a write", async () => {
+      for (const origin of [
+        "https://evil.example",
+        "https://eval.index.network.evil.com",
+        "https://sub.eval.index.network",
+        // The same name over plain http is a different origin, and not this one.
+        "http://eval.index.network",
+        "null",
+      ]) {
+        const response = await deployedPost("/api/runs", { Origin: origin });
+        expect(response.status).toBe(403);
+      }
+      await context.queue.drain();
+      expect(executor.starts).toHaveLength(0);
+    });
+
+    it("leaves loopback exactly as it was, so local development is unchanged", async () => {
+      for (const host of ["127.0.0.1:4321", "localhost", "[::1]:4321"]) {
+        expect((await get("/api/harnesses", { Host: host })).status).toBe(200);
+      }
+      expect((await post("/api/runs", RUN_BODY, { Origin: "http://127.0.0.1:5174" })).status).toBe(202);
+      await context.queue.drain();
+    });
+  });
+});
+
+describe("the session cookie's Secure attribute", () => {
+  // Loopback is plain http, so a Secure cookie is dropped by the browser and
+  // sign-in fails silently; over HTTPS an insecure session cookie is a real
+  // exposure. The attribute therefore follows the request, not a hand-set flag.
+  const PUBLIC_ORIGIN = resolvePublicOrigin({ EVAL_OPS_PUBLIC_ORIGIN: "https://eval.index.network" });
+
+  const signInAt = (url: string, headers: Record<string, string> = {}) =>
+    handler(new Request(`${url}/callback?state=${states.mint()}&api_key=k`, { headers }));
+
+  it("omits Secure on loopback, where a Secure cookie would never be sent", async () => {
+    const response = await signInAt("http://localhost");
+
+    expect(response.status).toBe(302);
+    expect(response.headers.get("set-cookie") ?? "").not.toMatch(/Secure/i);
+  });
+
+  it("sets Secure on a sign-in served over HTTPS", async () => {
+    await build({ publicOrigin: PUBLIC_ORIGIN });
+
+    const response = await signInAt("https://eval.index.network", { Host: "eval.index.network" });
+
+    expect(response.status).toBe(302);
+    expect(response.headers.get("set-cookie") ?? "").toMatch(/;\s*Secure/i);
+  });
+
+  it("sets Secure behind a TLS-terminating proxy, which forwards plain http", async () => {
+    // Railway terminates TLS at its edge and speaks http to the container, so the
+    // request URL says http even though the browser is on https. The configured
+    // public origin is validated to be https, so a request addressed to it was
+    // served over https — that, not a spoofable x-forwarded-proto, is the signal.
+    await build({ publicOrigin: PUBLIC_ORIGIN });
+
+    const response = await signInAt("http://eval.index.network", { Host: "eval.index.network" });
+
+    expect(response.status).toBe(302);
+    expect(response.headers.get("set-cookie") ?? "").toMatch(/;\s*Secure/i);
+  });
+
+  it("does not trust x-forwarded-proto on a loopback request", async () => {
+    // Any local page can send this header; it must not be able to make the
+    // operator's own sign-in fail by getting the cookie dropped.
+    const response = await signInAt("http://localhost", { "X-Forwarded-Proto": "https" });
+
+    expect(response.status).toBe(302);
+    expect(response.headers.get("set-cookie") ?? "").not.toMatch(/Secure/i);
+  });
+
+  it("expires the cookie with the same attributes it was set with", async () => {
+    await build({ publicOrigin: PUBLIC_ORIGIN });
+
+    const loopback = await post("/api/auth/logout", {});
+    expect(loopback.headers.get("set-cookie") ?? "").not.toMatch(/Secure/i);
+
+    await build({ publicOrigin: PUBLIC_ORIGIN });
+    const deployed = await handler(
+      new Request("https://eval.index.network/api/auth/logout", {
+        method: "POST",
+        headers: {
+          Host: "eval.index.network",
+          "Content-Type": "application/json",
+          Origin: "https://eval.index.network",
+          ...sessionCookie,
+        },
+        body: "{}",
+      }),
+    );
+    expect(deployed.status).toBe(200);
+    expect(deployed.headers.get("set-cookie") ?? "").toMatch(/;\s*Secure/i);
+    expect(deployed.headers.get("set-cookie") ?? "").toMatch(/Max-Age=0/);
   });
 });
 
@@ -1101,8 +1264,124 @@ describe("resolveIdentityEndpoints", () => {
   });
 });
 
+describe("resolveBindPort", () => {
+  // Two entrypoints, two postures, one rule. ops.serve.ts is the local dev API,
+  // started by `bun run eval:web` with --env-file=../../.env.test — and that file
+  // sets PORT=3001 for the *API service*. Honouring PORT there would silently move
+  // the ops API onto the API's port and break the documented two-process flow for
+  // every developer. apps/eval-ops/server.ts is what the platform starts, and the
+  // platform injects PORT.
+  it("defaults to 4321 in both postures", () => {
+    expect(resolveBindPort({ env: {}, honourPlatformPort: false })).toBe(4321);
+    expect(resolveBindPort({ env: {}, honourPlatformPort: true })).toBe(4321);
+  });
+
+  it("honours the platform's PORT in the deployed posture", () => {
+    expect(resolveBindPort({ env: { PORT: "8080" }, honourPlatformPort: true })).toBe(8080);
+  });
+
+  it("ignores PORT in the local posture, because .env.test sets it to the API's port", () => {
+    expect(resolveBindPort({ env: { PORT: "3001" }, honourPlatformPort: false })).toBe(4321);
+  });
+
+  it("lets EVAL_OPS_PORT win over the platform's PORT", () => {
+    expect(resolveBindPort({ env: { PORT: "8080", EVAL_OPS_PORT: "4399" }, honourPlatformPort: true })).toBe(4399);
+    expect(resolveBindPort({ env: { EVAL_OPS_PORT: "4399" }, honourPlatformPort: false })).toBe(4399);
+  });
+
+  it("reads an empty value as unset", () => {
+    expect(resolveBindPort({ env: { PORT: "", EVAL_OPS_PORT: "  " }, honourPlatformPort: true })).toBe(4321);
+  });
+
+  it("refuses a value that is not a usable TCP port, rather than binding something arbitrary", () => {
+    expect(() => resolveBindPort({ env: { EVAL_OPS_PORT: "http" }, honourPlatformPort: false })).toThrow(/EVAL_OPS_PORT/);
+    expect(() => resolveBindPort({ env: { EVAL_OPS_PORT: "4321.5" }, honourPlatformPort: false })).toThrow(/usable TCP port/);
+    expect(() => resolveBindPort({ env: { PORT: "70000" }, honourPlatformPort: true })).toThrow(/PORT/);
+    expect(() => resolveBindPort({ env: { PORT: "0" }, honourPlatformPort: true })).toThrow(/usable TCP port/);
+  });
+});
+
+describe("resolveBindHostname", () => {
+  it("binds loopback unless the environment deliberately says otherwise", () => {
+    expect(resolveBindHostname({})).toBe("127.0.0.1");
+    // A platform PORT does not imply a wider bind: widening stays one explicit act.
+    expect(resolveBindHostname({ PORT: "8080" })).toBe("127.0.0.1");
+    expect(resolveBindHostname({ EVAL_OPS_BIND: "  " })).toBe("127.0.0.1");
+  });
+
+  it("binds exactly what EVAL_OPS_BIND names", () => {
+    expect(resolveBindHostname({ EVAL_OPS_BIND: "0.0.0.0" })).toBe("0.0.0.0");
+  });
+});
+
+describe("resolvePublicOrigin", () => {
+  it("means loopback-only when it is unset", () => {
+    expect(resolvePublicOrigin({})).toBeUndefined();
+    expect(resolvePublicOrigin({ EVAL_OPS_PUBLIC_ORIGIN: "  " })).toBeUndefined();
+  });
+
+  it("accepts one absolute https origin and normalises it", () => {
+    expect(resolvePublicOrigin({ EVAL_OPS_PUBLIC_ORIGIN: "https://eval.index.network" }))
+      .toEqual({ origin: "https://eval.index.network", host: "eval.index.network" });
+    // A trailing slash names no path, and the host is compared case-insensitively.
+    expect(resolvePublicOrigin({ EVAL_OPS_PUBLIC_ORIGIN: "https://EVAL.index.network/" }))
+      .toEqual({ origin: "https://eval.index.network", host: "eval.index.network" });
+    // A non-default port is part of the host a Host header must equal.
+    expect(resolvePublicOrigin({ EVAL_OPS_PUBLIC_ORIGIN: "https://eval.index.network:8443" }))
+      .toEqual({ origin: "https://eval.index.network:8443", host: "eval.index.network:8443" });
+  });
+
+  it("refuses anything that is not exactly one https origin, loudly", () => {
+    const refused: Array<[string, RegExp]> = [
+      ["eval.index.network", /not a usable URL/],
+      ["http://eval.index.network", /https/],
+      ["https://*.index.network", /host/i],
+      ["https://*", /host/i],
+      ["*", /not a usable URL/],
+      ["https://eval.index.network/ops", /path/i],
+      ["https://eval.index.network/?a=b", /query/i],
+      ["https://eval.index.network/#f", /fragment/i],
+      ["https://user:pass@eval.index.network", /credential/i],
+      ["https://a.example https://b.example", /./],
+    ];
+    for (const [value, message] of refused) {
+      expect(() => resolvePublicOrigin({ EVAL_OPS_PUBLIC_ORIGIN: value })).toThrow(message);
+    }
+  });
+
+  it("names the variable in every refusal, so a bad deploy says what to fix", () => {
+    expect(() => resolvePublicOrigin({ EVAL_OPS_PUBLIC_ORIGIN: "http://eval.index.network" }))
+      .toThrow(/EVAL_OPS_PUBLIC_ORIGIN/);
+  });
+});
+
+describe("the entrypoints resolve one port and use it twice", () => {
+  // The bridge callback URL must name the port the server actually bound. It used
+  // to be re-read from the environment inside createDefaultOpsContext, which is
+  // exactly how an advertised callback drifts from the real listener; the port is
+  // now resolved once per entrypoint and passed to both. This pins that shape,
+  // and the posture each entrypoint declares.
+  const ENTRYPOINTS: Array<{ file: string; honoursPlatformPort: boolean }> = [
+    { file: path.join(import.meta.dir, "../ops.serve.ts"), honoursPlatformPort: false },
+    { file: path.join(import.meta.dir, "../../../../../apps/eval-ops/server.ts"), honoursPlatformPort: true },
+  ];
+
+  for (const entrypoint of ENTRYPOINTS) {
+    it(`${path.basename(path.dirname(entrypoint.file))}/${path.basename(entrypoint.file)} resolves the port once and declares its posture`, async () => {
+      const source = await readFile(entrypoint.file, "utf8");
+
+      expect(source.match(/resolveBindPort\(/g)).toHaveLength(1);
+      expect(source).toContain(`honourPlatformPort: ${entrypoint.honoursPlatformPort}`);
+      // The same resolved value reaches the listener and the bridge callback.
+      expect(source).toMatch(/createDefaultOpsContext\(\{[^}]*\bport\b[^}]*\}\)/);
+      expect(source).toMatch(/Bun\.serve\(\{[^{]*\bport,/);
+      expect(source).toMatch(/hostname: resolveBindHostname\(/);
+    });
+  }
+});
+
 describe("createDefaultOpsContext", () => {
-  const ENV_KEYS = ["API_URL", "WEB_APP_URL", "EVAL_OPS_PORT", "EVAL_OPS_UI_URL"] as const;
+  const ENV_KEYS = ["API_URL", "WEB_APP_URL", "PORT", "EVAL_OPS_PORT", "EVAL_OPS_UI_URL", "EVAL_OPS_PUBLIC_ORIGIN"] as const;
   const original: Record<string, string | undefined> = {};
 
   beforeEach(() => {
@@ -1122,16 +1401,19 @@ describe("createDefaultOpsContext", () => {
     }
   });
 
-  it("builds a callback on the port the server actually binds", async () => {
-    // ops.serve.ts binds EVAL_OPS_PORT and this builds the bridge callback from
-    // it. If they ever disagree the bridge delivers the credential to a port
-    // nothing is listening on, and sign-in fails with no visible cause.
+  it("advertises the bridge callback on the port it was told the server bound", async () => {
+    // The port is resolved once by the entrypoint and passed in, rather than
+    // re-read from the environment here. If the two ever disagree the bridge
+    // delivers the credential to a port nothing is listening on, and sign-in
+    // fails with no visible cause — so this drives the same resolution the local
+    // entrypoint performs and asserts the advertised callback matches it.
     process.env.EVAL_OPS_PORT = "4399";
     // Set as a pair: a half-configured environment now refuses to start.
     process.env.WEB_APP_URL = "https://index.network";
     process.env.API_URL = "https://protocol.index.network";
+    const port = resolveBindPort({ env: process.env, honourPlatformPort: false });
 
-    const built = await createDefaultOpsContext({ repoRoot: root });
+    const built = await createDefaultOpsContext({ repoRoot: root, port });
     const response = await createOpsHandler(built)(
       new Request("http://localhost/api/auth/login", {
         method: "POST",
@@ -1141,11 +1423,21 @@ describe("createDefaultOpsContext", () => {
     );
     const url = new URL((await response.json()).url);
 
-    expect(url.searchParams.get("callback")).toBe("http://127.0.0.1:4399/callback");
+    expect(port).toBe(4399);
+    expect(url.searchParams.get("callback")).toBe(`http://127.0.0.1:${port}/callback`);
+  });
+
+  it("advertises the platform's port when the deployed entrypoint resolves one", async () => {
+    process.env.PORT = "8080";
+    const port = resolveBindPort({ env: process.env, honourPlatformPort: true });
+
+    const built = await createDefaultOpsContext({ repoRoot: root, uiUrl: "/", port });
+
+    expect(built.auth?.callbackPort).toBe(8080);
   });
 
   it("wires identity, so the default server is never unauthenticated", async () => {
-    const built = await createDefaultOpsContext({ repoRoot: root });
+    const built = await createDefaultOpsContext({ repoRoot: root, port: 4321 });
 
     expect(built.auth).toBeDefined();
     // An anonymous read is refused by the context the real entrypoint uses.
@@ -1155,14 +1447,14 @@ describe("createDefaultOpsContext", () => {
 
   it("sends a completed sign-in to the UI, not to a route this server does not serve", async () => {
     // The standalone API serves no UI: a bare "/" here is its own 404.
-    const built = await createDefaultOpsContext({ repoRoot: root });
+    const built = await createDefaultOpsContext({ repoRoot: root, port: 4321 });
 
     expect(built.auth?.uiUrl).toBe("http://127.0.0.1:5174");
   });
 
   it("lets an embedder that serves the UI itself say so", async () => {
     // apps/eval-ops/server.ts serves the SPA on the same origin as the API.
-    const built = await createDefaultOpsContext({ repoRoot: root, uiUrl: "/" });
+    const built = await createDefaultOpsContext({ repoRoot: root, uiUrl: "/", port: 4321 });
 
     expect(built.auth?.uiUrl).toBe("/");
   });
@@ -1170,7 +1462,7 @@ describe("createDefaultOpsContext", () => {
   it("lets the environment override the redirect target", async () => {
     process.env.EVAL_OPS_UI_URL = "http://127.0.0.1:6000";
 
-    const built = await createDefaultOpsContext({ repoRoot: root, uiUrl: "/" });
+    const built = await createDefaultOpsContext({ repoRoot: root, uiUrl: "/", port: 4321 });
 
     expect(built.auth?.uiUrl).toBe("http://127.0.0.1:6000");
   });
@@ -1180,13 +1472,39 @@ describe("createDefaultOpsContext", () => {
     // browser to another origin is a mistake worth refusing loudly.
     process.env.EVAL_OPS_UI_URL = "https://evil.example";
 
-    await expect(createDefaultOpsContext({ repoRoot: root })).rejects.toThrow(/loopback/);
+    await expect(createDefaultOpsContext({ repoRoot: root, port: 4321 })).rejects.toThrow(/loopback/);
   });
 
   it("refuses to start on a half-configured identity pair", async () => {
     process.env.WEB_APP_URL = "https://index.network";
     delete process.env.API_URL;
 
-    await expect(createDefaultOpsContext({ repoRoot: root })).rejects.toThrow(/API_URL/);
+    await expect(createDefaultOpsContext({ repoRoot: root, port: 4321 })).rejects.toThrow(/API_URL/);
+  });
+
+  it("stays loopback-only when no public origin is configured", async () => {
+    const built = await createDefaultOpsContext({ repoRoot: root, port: 4321 });
+
+    expect(built.publicOrigin).toBeUndefined();
+  });
+
+  it("carries the configured public origin into the guards", async () => {
+    process.env.EVAL_OPS_PUBLIC_ORIGIN = "https://eval.index.network";
+
+    const built = await createDefaultOpsContext({ repoRoot: root, uiUrl: "/", port: 4321 });
+
+    expect(built.publicOrigin).toEqual({ origin: "https://eval.index.network", host: "eval.index.network" });
+  });
+
+  it("refuses to start on a malformed public origin rather than falling back to permissive", async () => {
+    process.env.EVAL_OPS_PUBLIC_ORIGIN = "https://eval.index.network/ops?x=1";
+
+    await expect(createDefaultOpsContext({ repoRoot: root, port: 4321 })).rejects.toThrow(/EVAL_OPS_PUBLIC_ORIGIN/);
+  });
+
+  it("refuses a wildcard public origin outright", async () => {
+    process.env.EVAL_OPS_PUBLIC_ORIGIN = "*";
+
+    await expect(createDefaultOpsContext({ repoRoot: root, port: 4321 })).rejects.toThrow(/EVAL_OPS_PUBLIC_ORIGIN/);
   });
 });

--- a/packages/protocol/eval/ops/tests/server.spec.ts
+++ b/packages/protocol/eval/ops/tests/server.spec.ts
@@ -13,6 +13,8 @@ import { RunQueue } from "../ops.queue.js";
 import { createDefaultOpsContext, createOpsHandler, PUBLIC_ROUTES, resolveBindHostname, resolveBindPort, resolveIdentityEndpoints, resolvePublicOrigin, resolveSignInMode, type OpsAuthContext, type OpsContext } from "../ops.server.js";
 import { FsRunStore, type RunStore } from "../ops.store.js";
 import type { RunRecord } from "../ops.types.js";
+import { EVAL_RUN_REPORT_ARTIFACT_TYPE, buildEvalArtifact, buildScorecard } from "../../shared/index.js";
+import { makeSuccessfulExecution, makeTestMeta } from "../../shared/tests/artifact.fixtures.js";
 
 const DATABASE_URL = "postgres://u:p@host/neondb";
 
@@ -796,6 +798,132 @@ describe("GET /api/compare", () => {
     const response = await get("/api/compare?reference=abc");
     expect(response.status).toBe(400);
     expect((await response.json()).error).toMatch(/reference/i);
+  });
+
+  describe("run-vs-run", () => {
+    const caseResult = (caseId: string, passes: number, runs: number) => ({
+      caseId,
+      rule: "r",
+      runs,
+      passes,
+      passRate: passes / runs,
+      flaky: passes > 0 && passes < runs,
+      scoredRunIds: Array.from({ length: runs }, (_, i) => `${encodeURIComponent(caseId)}::run:${i + 1}`),
+    });
+
+    /** A valid v2 run report on disk for a fresh run record. */
+    async function seedRunWithReport(options: {
+      profile: string;
+      profileFingerprint: string;
+      configFingerprint: string;
+      passes: number;
+    }): Promise<RunRecord> {
+      const created = await store.create({
+        spec: { kind: "eval", harness: "matching", profile: options.profile, flags: { runs: 20 } },
+        argv: ["bun", "run", "eval:matching"],
+        env: {},
+        profileFingerprint: options.profileFingerprint,
+        experimental: true,
+        workload: 20,
+      });
+      const scorecard = buildScorecard([caseResult("a/b", options.passes, 20)], {
+        model: "test/model",
+        runs: 20,
+      });
+      const envelope = buildEvalArtifact(
+        EVAL_RUN_REPORT_ARTIFACT_TYPE,
+        scorecard,
+        makeTestMeta({
+          harness: "matching",
+          runs: 20,
+          configFingerprint: options.configFingerprint,
+          execution: makeSuccessfulExecution(["a/b"], 20),
+        }),
+      );
+      await Bun.write(store.reportPath(created.id), JSON.stringify(envelope));
+      await store.update(created.id, { status: "passed", exitCode: 0, endedAt: new Date().toISOString() });
+      return created;
+    }
+
+    it("diffs two run reports across configs and labels each side", async () => {
+      const reference = await seedRunWithReport({
+        profile: "default",
+        profileFingerprint: "fp-reference",
+        configFingerprint: "a".repeat(64),
+        passes: 20,
+      });
+      const subject = await seedRunWithReport({
+        profile: "sonnet-evaluator",
+        profileFingerprint: "fp-subject",
+        configFingerprint: "c".repeat(64),
+        passes: 2,
+      });
+
+      const response = await get(`/api/compare?referenceRun=${reference.id}&subjectRun=${subject.id}`);
+
+      expect(response.status).toBe(200);
+      const body = await response.json();
+      expect(body.comparable).toBe(true);
+      expect(body.aggregate.delta).toBeLessThan(0);
+      expect(body.runs.reference).toEqual({
+        id: reference.id,
+        profile: "default",
+        profileFingerprint: "fp-reference",
+        complete: true,
+      });
+      expect(body.runs.subject).toEqual({
+        id: subject.id,
+        profile: "sonnet-evaluator",
+        profileFingerprint: "fp-subject",
+        complete: true,
+      });
+    });
+
+    it("422s naming the side whose report is missing", async () => {
+      const reference = await seedRunWithReport({
+        profile: "default",
+        profileFingerprint: "fp-reference",
+        configFingerprint: "a".repeat(64),
+        passes: 20,
+      });
+      const subject = await store.create({
+        spec: { kind: "eval", harness: "matching", profile: "default", flags: {} },
+        argv: ["bun", "run", "eval:matching"],
+        env: {},
+        profileFingerprint: "fp-subject",
+        experimental: true,
+        workload: 20,
+      });
+
+      const response = await get(`/api/compare?referenceRun=${reference.id}&subjectRun=${subject.id}`);
+
+      expect(response.status).toBe(422);
+      expect((await response.json()).error).toContain(subject.id);
+    });
+
+    it("404s an unknown run id", async () => {
+      const reference = await seedRunWithReport({
+        profile: "default",
+        profileFingerprint: "fp-reference",
+        configFingerprint: "a".repeat(64),
+        passes: 20,
+      });
+
+      const response = await get(`/api/compare?referenceRun=${reference.id}&subjectRun=nope`);
+
+      expect(response.status).toBe(404);
+      expect((await response.json()).error).toContain("nope");
+    });
+
+    it("400s when run params and artifact params are mixed", async () => {
+      const response = await get("/api/compare?reference=a&subjectRun=b");
+      expect(response.status).toBe(400);
+    });
+
+    it("400s when only one run param is given", async () => {
+      const response = await get("/api/compare?referenceRun=a");
+      expect(response.status).toBe(400);
+    });
   });
 });
 

--- a/packages/protocol/eval/ops/tests/server.spec.ts
+++ b/packages/protocol/eval/ops/tests/server.spec.ts
@@ -1673,6 +1673,11 @@ describe("the entrypoints resolve one port and use it twice", () => {
       expect(source).toMatch(/createDefaultOpsContext\(\{[^}]*\bport\b[^}]*\}\)/);
       expect(source).toMatch(/Bun\.serve\(\{[^{]*\bport,/);
       expect(source).toMatch(/hostname: resolveBindHostname\(/);
+      // Both entrypoints mount the same SSE stream, whose heartbeat is 15s. Bun's
+      // default request idle timeout is 10s, so an entrypoint that omits this
+      // closes a quiet run-log stream before the first heartbeat can hold it
+      // open — which the deployed entrypoint did.
+      expect(source).toMatch(/idleTimeout: 255/);
     });
   }
 });

--- a/packages/protocol/eval/ops/tests/server.spec.ts
+++ b/packages/protocol/eval/ops/tests/server.spec.ts
@@ -4,12 +4,12 @@ import { tmpdir } from "node:os";
 import path from "node:path";
 
 import { FsArtifactSource } from "../ops.artifacts.js";
-import { OneTimeStateStore, OpsSessionStore, type IdentityResolver, type ResolvedIdentity } from "../ops.auth.js";
+import { ApiIdentityResolver, JwtIdentityResolver, OneTimeStateStore, OpsSessionStore, type IdentityResolver, type ResolvedIdentity } from "../ops.auth.js";
 import type { ExecutionStep, RunExecutor } from "../ops.executor.js";
 import { SEED_STEP_CWD, type FixtureCounts, type FixtureInspector } from "../ops.fixture.js";
 import { isOpsServerPath, OPS_CALLBACK_PATH } from "../ops.paths.js";
 import { RunQueue } from "../ops.queue.js";
-import { createDefaultOpsContext, createOpsHandler, PUBLIC_ROUTES, resolveBindHostname, resolveBindPort, resolveIdentityEndpoints, resolvePublicOrigin, type OpsContext } from "../ops.server.js";
+import { createDefaultOpsContext, createOpsHandler, PUBLIC_ROUTES, resolveBindHostname, resolveBindPort, resolveIdentityEndpoints, resolvePublicOrigin, resolveSignInMode, type OpsAuthContext, type OpsContext } from "../ops.server.js";
 import { FsRunStore, type RunStore } from "../ops.store.js";
 import type { RunRecord } from "../ops.types.js";
 
@@ -59,12 +59,21 @@ class StubIdentityResolver implements IdentityResolver {
   identity: ResolvedIdentity | null = { email: "operator@index.network", emailVerified: true, name: "Operator" };
   failure: Error | null = null;
 
-  async resolve(apiKey: string): Promise<ResolvedIdentity | null> {
-    this.seen.push(apiKey);
+  async resolve(credential: string): Promise<ResolvedIdentity | null> {
+    this.seen.push(credential);
     if (this.failure !== null) throw this.failure;
     return this.identity;
   }
 }
+
+/**
+ * A syntactically plausible better-auth JWT for the deployed sign-in tests.
+ *
+ * The stub resolver never inspects it; it exists so a test can assert the exact
+ * string the browser submitted was handed to the resolver once and then never
+ * appears anywhere else.
+ */
+const JWT = "eyJhbGciOiJFZERTQSJ9.eyJpZCI6InUxIn0.c2lnbmF0dXJl";
 
 let root: string;
 let store: FsRunStore;
@@ -77,7 +86,7 @@ let identities: StubIdentityResolver;
 /** A `Cookie` header for a signed-in operator, refreshed by `signIn()`. */
 let sessionCookie: Record<string, string>;
 
-async function build(overrides: Partial<OpsContext> = {}): Promise<void> {
+async function build(overrides: Partial<OpsContext> = {}, auth: Partial<OpsAuthContext> = {}): Promise<void> {
   const evalDir = path.join(root, "eval");
   const profilesDir = path.join(evalDir, "ops/profiles");
   await mkdir(profilesDir, { recursive: true });
@@ -106,18 +115,20 @@ async function build(overrides: Partial<OpsContext> = {}): Promise<void> {
     databaseUrl: DATABASE_URL,
     inspector: { count: async () => COUNTS },
     auth: {
-      states,
       sessions,
       identities,
-      webAppUrl: "https://index.network",
-      callbackPort: 4321,
       uiUrl: "http://127.0.0.1:5174",
+      signIn: { kind: "bridge", states, webAppUrl: "https://index.network", callbackPort: 4321 },
+      ...auth,
     },
     ...overrides,
   };
   handler = createOpsHandler(context);
   sessionCookie = {};
-  await signIn();
+  // Signed in through whichever door this posture actually opens: the tests past
+  // this point assert behaviour behind the gate, not the gate itself.
+  if (context.auth?.signIn.kind === "token") await signInWithToken();
+  else await signIn();
 }
 
 /**
@@ -138,6 +149,21 @@ async function signIn(): Promise<void> {
   sessionCookie = { Cookie: cookie.split(";")[0] };
   // The sign-in above exchanged one credential; a test asserting "the credential
   // was never looked at" must not see this one.
+  identities.seen.length = 0;
+}
+
+/** The deployed equivalent: submit a token, receive the same session cookie. */
+async function signInWithToken(): Promise<void> {
+  const response = await handler(
+    new Request("http://localhost/api/auth/session", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ token: JWT }),
+    }),
+  );
+  const cookie = response.headers.get("set-cookie");
+  if (cookie === null) throw new Error(`sign-in did not set a session cookie (status ${response.status})`);
+  sessionCookie = { Cookie: cookie.split(";")[0] };
   identities.seen.length = 0;
 }
 
@@ -907,6 +933,7 @@ describe("POST /api/fixture/reset", () => {
 const API_ROUTES: ReadonlyArray<{ method: "GET" | "POST"; path: string }> = [
   { method: "GET", path: "/api/auth/status" },
   { method: "POST", path: "/api/auth/login" },
+  { method: "POST", path: "/api/auth/session" },
   { method: "POST", path: "/api/auth/logout" },
   { method: "GET", path: "/api/harnesses" },
   { method: "GET", path: "/api/profiles" },
@@ -957,6 +984,7 @@ describe("authentication", () => {
       expect([...PUBLIC_ROUTES].map((entry) => `${entry.method} ${entry.path}`).sort()).toEqual([
         "GET /api/auth/status",
         "POST /api/auth/login",
+        "POST /api/auth/session",
       ]);
     });
 
@@ -1015,6 +1043,9 @@ describe("authentication", () => {
       const body = await (await anonymous("POST", "/api/auth/login")).json();
       const url = new URL(body.url);
 
+      // The discriminator is what keeps the two postures from being told apart by
+      // guessing which optional field is present.
+      expect(body.kind).toBe("bridge");
       expect(url.origin + url.pathname).toBe("https://index.network/cli-auth");
       expect(url.searchParams.get("callback")).toBe("http://127.0.0.1:4321/callback");
       expect(url.searchParams.get("version")).toBe("2");
@@ -1026,6 +1057,23 @@ describe("authentication", () => {
       const second = new URL((await (await anonymous("POST", "/api/auth/login")).json()).url);
 
       expect(first.searchParams.get("state")).not.toBe(second.searchParams.get("state"));
+    });
+
+    it("names no API or web app URL in the local posture, so nothing new is disclosed", async () => {
+      const body = await (await anonymous("POST", "/api/auth/login")).json();
+
+      expect(Object.keys(body).sort()).toEqual(["kind", "url"]);
+    });
+  });
+
+  describe("POST /api/auth/session in the local posture", () => {
+    it("refuses outright, so a token cannot be submitted to a bridge server", async () => {
+      const response = await anonymous("POST", "/api/auth/session");
+
+      expect(response.status).toBe(403);
+      expect((await response.json()).error).toMatch(/bridge/i);
+      expect(response.headers.get("set-cookie")).toBeNull();
+      expect(identities.seen).toHaveLength(0);
     });
   });
 
@@ -1212,6 +1260,255 @@ describe("authentication", () => {
 
       expect(response.status).toBe(415);
     });
+  });
+});
+
+/**
+ * The deployed sign-in: a better-auth JWT, resolved server-side.
+ *
+ * On a real host the bridge is unusable — `validateCliCallbackUrl` in
+ * apps/web/src/lib/cli-auth.ts accepts only `http:` on loopback, by design, and
+ * that rule is shared with the released CLI. So the browser fetches a token from
+ * the API against its own session and posts it here; this server presents it to
+ * `/api/auth/me` and applies the *same* `assessIdentity` policy to what comes
+ * back. Nothing is client-asserted: the browser supplies a token, never an
+ * identity.
+ */
+describe("deployed sign-in with a better-auth token", () => {
+  const TOKEN_POSTURE = {
+    kind: "token",
+    apiUrl: "https://protocol.dev.index.network",
+    webAppUrl: "https://index.network",
+  } as const;
+  const PUBLIC_ORIGIN = resolvePublicOrigin({ EVAL_OPS_PUBLIC_ORIGIN: "https://eval.index.network" });
+
+  beforeEach(async () => {
+    await build({ publicOrigin: PUBLIC_ORIGIN }, { signIn: TOKEN_POSTURE });
+  });
+
+  /** Submits a token exactly as the browser does, with no session of its own. */
+  const submit = (body: unknown, headers: Record<string, string> = {}) =>
+    handler(
+      new Request("http://localhost/api/auth/session", {
+        method: "POST",
+        headers: { "Content-Type": "application/json", ...headers },
+        body: JSON.stringify(body),
+      }),
+    );
+
+  describe("POST /api/auth/login", () => {
+    it("tells the browser where to get a token and where to sign in", async () => {
+      const response = await handler(
+        new Request("http://localhost/api/auth/login", {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: "{}",
+        }),
+      );
+      const body = await response.json();
+
+      expect(body.kind).toBe("token");
+      // Exactly two fields, both of them public DNS names the browser already
+      // talks to. This is not a "dump the server's configuration" route.
+      expect(Object.keys(body).sort()).toEqual(["apiUrl", "kind", "webAppUrl"]);
+      expect(body.apiUrl).toBe("https://protocol.dev.index.network");
+      expect(body.webAppUrl).toBe("https://index.network");
+      // No loopback bridge callback: it could never complete from here.
+      expect(JSON.stringify(body)).not.toContain("/cli-auth");
+      expect(JSON.stringify(body)).not.toContain("127.0.0.1");
+    });
+  });
+
+  describe("POST /api/auth/session", () => {
+    it("establishes a session for a token that resolves to an allowed identity", async () => {
+      const response = await submit({ token: JWT });
+
+      expect(response.status).toBe(200);
+      expect(await response.json()).toEqual({ authenticated: true, email: "operator@index.network", name: "Operator" });
+      // Resolved server-side, exactly once.
+      expect(identities.seen).toEqual([JWT]);
+
+      const cookie = response.headers.get("set-cookie") ?? "";
+      expect(cookie).toMatch(/^eval_ops_session=/);
+      expect(cookie).toMatch(/HttpOnly/i);
+      expect(cookie).toMatch(/SameSite=Lax/i);
+      // And the session it establishes actually opens the gate.
+      const gated = await handler(
+        new Request("http://localhost/api/runs", { headers: { Cookie: cookie.split(";")[0] } }),
+      );
+      expect(gated.status).toBe(200);
+    });
+
+    it("never returns, stores or echoes the token", async () => {
+      const response = await submit({ token: JWT });
+      const cookie = response.headers.get("set-cookie") ?? "";
+
+      expect(await response.text()).not.toContain(JWT);
+      expect(cookie).not.toContain(JWT);
+      // The session holds an identity and nothing else, so no later response can
+      // carry the credential back out.
+      const status = await handler(
+        new Request("http://localhost/api/auth/status", { headers: { Cookie: cookie.split(";")[0] } }),
+      );
+      expect(await status.text()).not.toContain(JWT);
+    });
+
+    it("refuses an identity outside the allowed domain and discards the credential", async () => {
+      identities.identity = { email: "someone@evil.example", emailVerified: true, name: "Outsider" };
+
+      const response = await submit({ token: JWT });
+      const text = await response.text();
+
+      expect(response.status).toBe(403);
+      // The UI has to tell "sign in" from "your account is not permitted".
+      expect(JSON.parse(text)).toMatchObject({ authenticated: true, permitted: false });
+      expect(response.headers.get("set-cookie")).toBeNull();
+      // Exchanged once, then dropped: never echoed to the browser.
+      expect(identities.seen).toEqual([JWT]);
+      expect(text).not.toContain(JWT);
+    });
+
+    it("refuses an unverified address, which is the whole reason for the /me hop", async () => {
+      // The jwt plugin's definePayload returns { id, email, name } and no
+      // emailVerified, so verification can only come from the user record.
+      identities.identity = { email: "operator@index.network", emailVerified: false, name: "Operator" };
+
+      const response = await submit({ token: JWT });
+
+      expect(response.status).toBe(403);
+      expect((await response.json()).error).toMatch(/not verified/i);
+      expect(response.headers.get("set-cookie")).toBeNull();
+    });
+
+    it("answers 401 for a token the API rejects, so the UI offers sign-in again", async () => {
+      identities.identity = null;
+
+      const response = await submit({ token: JWT });
+
+      expect(response.status).toBe(401);
+      expect(await response.json()).toMatchObject({ authenticated: false });
+      expect(response.headers.get("set-cookie")).toBeNull();
+    });
+
+    it("answers 502 when the API cannot be reached, without echoing the token", async () => {
+      // "The API is down" is not "you are not allowed in" — and a transport error
+      // that happened to quote the request must still not carry the credential out.
+      identities.failure = new Error(`fetch failed for Bearer ${JWT}`);
+
+      const response = await submit({ token: JWT });
+      const text = await response.text();
+
+      expect(response.status).toBe(502);
+      expect(text).not.toContain(JWT);
+      expect(response.headers.get("set-cookie")).toBeNull();
+    });
+
+    it("refuses a body that is not exactly one token", async () => {
+      for (const body of [{}, { token: "" }, { token: 42 }, { token: JWT, email: "a@index.network" }]) {
+        const response = await submit(body);
+        expect({ body, status: response.status }).toEqual({ body, status: 400 });
+      }
+      // In particular the browser cannot assert who it is.
+      expect(identities.seen).toHaveLength(0);
+    });
+
+    it("is gated exactly like every other write", async () => {
+      // Content type: `no-cors` cannot produce application/json.
+      const untyped = await handler(
+        new Request("http://localhost/api/auth/session", {
+          method: "POST",
+          headers: { "Content-Type": "text/plain;charset=UTF-8" },
+          body: JSON.stringify({ token: JWT }),
+        }),
+      );
+      expect(untyped.status).toBe(415);
+
+      // Origin: a page on another origin cannot drive a sign-in here.
+      const foreignOrigin = await submit({ token: JWT }, { Origin: "https://evil.example" });
+      expect(foreignOrigin.status).toBe(403);
+
+      // Host: the rebinding guard runs first, on this route too.
+      const foreignHost = await submit({ token: JWT }, { Host: "evil.example.com" });
+      expect(foreignHost.status).toBe(403);
+
+      // None of the three ever looked at the credential.
+      expect(identities.seen).toHaveLength(0);
+    });
+
+    it("sets a Secure cookie when the browser reached the deployed origin", async () => {
+      const response = await handler(
+        new Request("https://eval.index.network/api/auth/session", {
+          method: "POST",
+          headers: {
+            Host: "eval.index.network",
+            Origin: "https://eval.index.network",
+            "Content-Type": "application/json",
+          },
+          body: JSON.stringify({ token: JWT }),
+        }),
+      );
+
+      expect(response.status).toBe(200);
+      expect(response.headers.get("set-cookie") ?? "").toMatch(/Secure/i);
+    });
+  });
+
+  describe("GET /callback", () => {
+    it("refuses the bridge callback on the posture, not on a state it happens not to hold", async () => {
+      // A deployed server mints no states at all, so the refusal has to come from
+      // "this server does not run that exchange" rather than from an empty store
+      // — which would look identical today and stop being a refusal the moment
+      // anything else minted one.
+      const response = await handler(new Request("http://localhost/callback?state=anything&api_key=k"));
+      const text = await response.text();
+
+      expect(response.status).toBe(403);
+      expect(text).toMatch(/does not sign in through the local bridge/i);
+      expect(response.headers.get("set-cookie")).toBeNull();
+      expect(identities.seen).toHaveLength(0);
+    });
+  });
+
+  describe("401 and 403 stay distinguishable", () => {
+    it("answers 401 with no session and 403 for a session the policy refuses", async () => {
+      const anonymous = await handler(new Request("http://localhost/api/runs"));
+      expect(anonymous.status).toBe(401);
+
+      const stale = sessions.establish({ email: "someone@evil.example", name: "Outsider" });
+      const refused = await handler(
+        new Request("http://localhost/api/runs", { headers: { Cookie: `eval_ops_session=${stale}` } }),
+      );
+      expect(refused.status).toBe(403);
+    });
+  });
+});
+
+describe("resolveSignInMode", () => {
+  // The deployed posture is already named by EVAL_OPS_PUBLIC_ORIGIN, and it is
+  // exactly the condition under which the loopback bridge cannot complete. One
+  // rule, exported and pure, rather than an implicit guess inside the wiring.
+  it("chooses the local bridge when no public origin is configured", () => {
+    expect(resolveSignInMode({})).toBe("bridge");
+    expect(resolveSignInMode({ EVAL_OPS_PUBLIC_ORIGIN: "" })).toBe("bridge");
+    expect(resolveSignInMode({ EVAL_OPS_PUBLIC_ORIGIN: "   " })).toBe("bridge");
+  });
+
+  it("chooses the token exchange once the server answers on a deployed origin", () => {
+    expect(resolveSignInMode({ EVAL_OPS_PUBLIC_ORIGIN: "https://eval.index.network" })).toBe("token");
+  });
+
+  it("refuses a malformed public origin rather than quietly falling back to the bridge", () => {
+    // Falling back would produce a deployed server advertising a loopback
+    // callback — the exact failure this posture exists to remove.
+    expect(() => resolveSignInMode({ EVAL_OPS_PUBLIC_ORIGIN: "http://eval.index.network" })).toThrow(
+      /EVAL_OPS_PUBLIC_ORIGIN/,
+    );
+  });
+
+  it("is not decided by a wider bind or a platform port", () => {
+    // Neither of those makes the bridge callback unreachable; only a deployed
+    // origin does.
+    expect(resolveSignInMode({ EVAL_OPS_BIND: "0.0.0.0", PORT: "8080" })).toBe("bridge");
   });
 });
 
@@ -1433,7 +1730,31 @@ describe("createDefaultOpsContext", () => {
 
     const built = await createDefaultOpsContext({ repoRoot: root, uiUrl: "/", port });
 
-    expect(built.auth?.callbackPort).toBe(8080);
+    expect(built.auth?.signIn).toMatchObject({ kind: "bridge", callbackPort: 8080 });
+  });
+
+  it("wires the bridge and its API-key resolver when no public origin is configured", async () => {
+    const built = await createDefaultOpsContext({ repoRoot: root, port: 4321 });
+
+    // The resolver and the posture are chosen together, by one decision: a bridge
+    // that minted API keys for a JWT resolver would refuse every sign-in.
+    expect(built.auth?.signIn.kind).toBe("bridge");
+    expect(built.auth?.identities).toBeInstanceOf(ApiIdentityResolver);
+  });
+
+  it("wires the token exchange and its JWT resolver once a public origin is configured", async () => {
+    process.env.EVAL_OPS_PUBLIC_ORIGIN = "https://eval.index.network";
+    process.env.WEB_APP_URL = "https://index.network";
+    process.env.API_URL = "https://protocol.dev.index.network";
+
+    const built = await createDefaultOpsContext({ repoRoot: root, uiUrl: "/", port: 4321 });
+
+    expect(built.auth?.signIn).toEqual({
+      kind: "token",
+      apiUrl: "https://protocol.dev.index.network",
+      webAppUrl: "https://index.network",
+    });
+    expect(built.auth?.identities).toBeInstanceOf(JwtIdentityResolver);
   });
 
   it("wires identity, so the default server is never unauthenticated", async () => {

--- a/packages/protocol/eval/ops/tests/server.spec.ts
+++ b/packages/protocol/eval/ops/tests/server.spec.ts
@@ -5,6 +5,7 @@ import path from "node:path";
 
 import { FsArtifactSource } from "../ops.artifacts.js";
 import { ApiIdentityResolver, JwtIdentityResolver, OneTimeStateStore, OpsSessionStore, type IdentityResolver, type ResolvedIdentity } from "../ops.auth.js";
+import { InMemoryConfigStore } from "../ops.configs.js";
 import type { ExecutionStep, RunExecutor } from "../ops.executor.js";
 import { SEED_STEP_CWD, type FixtureCounts, type FixtureInspector } from "../ops.fixture.js";
 import { isOpsServerPath, OPS_CALLBACK_PATH } from "../ops.paths.js";
@@ -78,6 +79,7 @@ const JWT = "eyJhbGciOiJFZERTQSJ9.eyJpZCI6InUxIn0.c2lnbmF0dXJl";
 let root: string;
 let store: FsRunStore;
 let executor: FakeExecutor;
+let configs: InMemoryConfigStore;
 let context: OpsContext;
 let handler: (request: Request) => Promise<Response>;
 let states: OneTimeStateStore;
@@ -100,6 +102,7 @@ async function build(overrides: Partial<OpsContext> = {}, auth: Partial<OpsAuthC
   );
   store = new FsRunStore({ evalDir });
   executor = new FakeExecutor(store);
+  configs = new InMemoryConfigStore();
   states = new OneTimeStateStore();
   sessions = new OpsSessionStore();
   identities = new StubIdentityResolver();
@@ -112,6 +115,7 @@ async function build(overrides: Partial<OpsContext> = {}, auth: Partial<OpsAuthC
     store,
     executor,
     queue: new RunQueue({ executor, store }),
+    configs,
     databaseUrl: DATABASE_URL,
     inspector: { count: async () => COUNTS },
     auth: {
@@ -190,6 +194,16 @@ const post = (url: string, body: unknown, headers: Record<string, string> = {}) 
       body: JSON.stringify(body),
     }),
   );
+const patch = (url: string, body: unknown, headers: Record<string, string> = {}) =>
+  handler(
+    new Request(`http://localhost${url}`, {
+      method: "PATCH",
+      headers: { "Content-Type": "application/json", ...sessionCookie, ...headers },
+      body: JSON.stringify(body),
+    }),
+  );
+const del = (url: string, headers: Record<string, string> = {}) =>
+  handler(new Request(`http://localhost${url}`, { method: "DELETE", headers: { ...sessionCookie, ...headers } }));
 
 const RUN_BODY = { kind: "eval", harness: "matching", profile: "default", flags: {} };
 
@@ -689,6 +703,90 @@ describe("GET /api/compare", () => {
     const response = await get("/api/compare?reference=abc");
     expect(response.status).toBe(400);
     expect((await response.json()).error).toMatch(/reference/i);
+  });
+});
+
+describe("config routes", () => {
+  const SONNET_CONFIG = {
+    name: "sonnet-evaluator",
+    description: "evaluator on sonnet",
+    models: { opportunityEvaluator: "anthropic/claude-sonnet-4" },
+    env: {},
+  };
+
+  it("lists repo profiles and saved configs in one response", async () => {
+    await configs.create(SONNET_CONFIG);
+    const response = await get("/api/configs");
+    expect(response.status).toBe(200);
+    const body = await response.json();
+    expect(body.repo.map((p: { name: string }) => p.name)).toEqual(["claude-evaluator", "default"]);
+    expect(body.saved).toEqual([SONNET_CONFIG]);
+  });
+
+  it("creates a config and rejects names colliding with a repo profile or a saved config", async () => {
+    const created = await post("/api/configs", SONNET_CONFIG);
+    expect(created.status).toBe(201);
+    expect(await created.json()).toEqual(SONNET_CONFIG);
+
+    const duplicate = await post("/api/configs", SONNET_CONFIG);
+    expect(duplicate.status).toBe(409);
+
+    for (const name of ["default", "claude-evaluator"]) {
+      const collision = await post("/api/configs", { ...SONNET_CONFIG, name });
+      expect(collision.status).toBe(409);
+      expect((await collision.json()).error).toContain(name);
+    }
+  });
+
+  it("rejects models outside the curated list with a 400 naming the model", async () => {
+    const response = await post("/api/configs", { ...SONNET_CONFIG, models: { opportunityEvaluator: "x/y" } });
+    expect(response.status).toBe(400);
+    expect((await response.json()).error).toContain("x/y");
+  });
+
+  it("rejects env keys outside the allowlist", async () => {
+    const response = await post("/api/configs", { ...SONNET_CONFIG, env: { OPENROUTER_API_KEY: "x" } });
+    expect(response.status).toBe(400);
+    expect((await response.json()).error).toContain("OPENROUTER_API_KEY");
+  });
+
+  it("updates and deletes a saved config, 404s unknown names, 409s repo profile names", async () => {
+    await configs.create(SONNET_CONFIG);
+
+    const updated = await patch("/api/configs/sonnet-evaluator", { description: "better description" });
+    expect(updated.status).toBe(200);
+    const updatedBody = await updated.json();
+    expect(updatedBody.description).toBe("better description");
+    expect(updatedBody.models).toEqual(SONNET_CONFIG.models);
+    expect(await configs.get("sonnet-evaluator")).toEqual(updatedBody);
+
+    const patchedRepo = await patch("/api/configs/default", { description: "x" });
+    expect(patchedRepo.status).toBe(409);
+    const patchedGhost = await patch("/api/configs/ghost", { description: "x" });
+    expect(patchedGhost.status).toBe(404);
+
+    const deletedRepo = await del("/api/configs/default");
+    expect(deletedRepo.status).toBe(409);
+    const deletedGhost = await del("/api/configs/ghost");
+    expect(deletedGhost.status).toBe(404);
+
+    const deleted = await del("/api/configs/sonnet-evaluator");
+    expect(deleted.status).toBe(204);
+    expect(await configs.get("sonnet-evaluator")).toBeNull();
+  });
+
+  it("rejects an override patch that would make a saved config invalid", async () => {
+    await configs.create(SONNET_CONFIG);
+    const response = await patch("/api/configs/sonnet-evaluator", { models: { opportunityEvaluator: "x/y" } });
+    expect(response.status).toBe(400);
+    expect((await response.json()).error).toContain("x/y");
+    expect((await configs.get("sonnet-evaluator"))?.models).toEqual(SONNET_CONFIG.models);
+  });
+
+  it("serves the curated model list", async () => {
+    const response = await get("/api/configs/models");
+    expect(response.status).toBe(200);
+    expect((await response.json()).models).toContain("google/gemini-2.5-flash");
   });
 });
 

--- a/packages/protocol/eval/ops/tests/server.spec.ts
+++ b/packages/protocol/eval/ops/tests/server.spec.ts
@@ -381,6 +381,99 @@ describe("POST /api/runs", () => {
   });
 });
 
+describe("launch with overrides", () => {
+  const PAYLOAD = { models: { opportunityEvaluator: "anthropic/claude-sonnet-4" }, env: {} };
+
+  it("launches an ad-hoc run as experimental with the overrides env injected", async () => {
+    const response = await post("/api/runs", {
+      kind: "eval",
+      harness: "matching",
+      profile: "default",
+      flags: { runs: 1 },
+      overrides: PAYLOAD,
+    });
+
+    expect(response.status).toBe(202);
+    const record = (await response.json()) as RunRecord;
+    expect(record.experimental).toBe(true);
+    expect(record.env.EVAL_MODEL_OVERRIDES).toBe(JSON.stringify(PAYLOAD.models));
+    expect(record.argv).toContain("--no-save");
+    await context.queue.drain();
+  });
+
+  it("fingerprints an ad-hoc run identically to a saved config with the same payload", async () => {
+    const created = await post("/api/configs", { name: "candidate", description: "c", ...PAYLOAD });
+    expect(created.status).toBe(201);
+
+    const named = (await (await post("/api/runs", {
+      kind: "eval",
+      harness: "matching",
+      profile: "candidate",
+      flags: { runs: 1 },
+    })).json()) as RunRecord;
+    const adHoc = (await (await post("/api/runs", {
+      kind: "eval",
+      harness: "matching",
+      profile: "default",
+      flags: { runs: 1 },
+      overrides: PAYLOAD,
+    })).json()) as RunRecord;
+
+    expect(named.profileFingerprint).toBe(adHoc.profileFingerprint);
+    expect(named.experimental).toBe(true);
+    expect(adHoc.experimental).toBe(true);
+    await context.queue.drain();
+  });
+
+  it("rejects a named profile combined with overrides", async () => {
+    const response = await post("/api/runs", {
+      kind: "eval",
+      harness: "matching",
+      profile: "claude-evaluator",
+      flags: {},
+      overrides: PAYLOAD,
+    });
+
+    expect(response.status).toBe(400);
+    expect((await response.json()).error).toMatch(/overrides/);
+    await context.queue.drain();
+    expect(executor.starts).toHaveLength(0);
+  });
+
+  it("rejects override models outside the curated list at launch", async () => {
+    const response = await post("/api/runs", {
+      kind: "eval",
+      harness: "matching",
+      profile: "default",
+      flags: {},
+      overrides: { models: { opportunityEvaluator: "anthropic/claude-opus-9" }, env: {} },
+    });
+
+    expect(response.status).toBe(400);
+    expect((await response.json()).error).toMatch(/claude-opus-9/);
+    await context.queue.drain();
+    expect(executor.starts).toHaveLength(0);
+  });
+
+  it("resolves a saved DB config exactly like a repo profile", async () => {
+    await configs.create({ name: "sonnet-evaluator", description: "d", ...PAYLOAD });
+
+    const response = await post("/api/runs", {
+      kind: "eval",
+      harness: "matching",
+      profile: "sonnet-evaluator",
+      flags: { runs: 1 },
+    });
+
+    expect(response.status).toBe(202);
+    const record = (await response.json()) as RunRecord;
+    expect(record.experimental).toBe(true);
+    expect(record.env.EVAL_MODEL_OVERRIDES).toBe(JSON.stringify(PAYLOAD.models));
+    expect(record.argv).toContain("--no-save");
+    await context.queue.drain();
+  });
+});
+
 describe("cross-origin requests", () => {
   // A page on any origin the operator has open can POST here with mode:"no-cors";
   // it cannot read the reply, but the run it launches spends real tokens.

--- a/packages/protocol/package.json
+++ b/packages/protocol/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@indexnetwork/protocol",
-  "version": "8.5.0",
+  "version": "8.6.0",
   "type": "module",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",

--- a/packages/protocol/package.json
+++ b/packages/protocol/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@indexnetwork/protocol",
-  "version": "8.4.0",
+  "version": "8.5.0",
   "type": "module",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",


### PR DESCRIPTION
Makes the eval ops site deployable to a real URL, and adds sign-in for a deployed host. Builds on #1315 and #1316.

## Why this reverses an earlier decision

The site shipped loopback-only on purpose: a `127.0.0.1` bind plus `Host` and `Origin` allowlists were what made a database-flush button acceptable — it was unreachable from anywhere but the operator's machine. The repository owner asked for it on `eval.dev.index.network` with full parity, so this removes that control deliberately and narrowly.

## D1 — deployability

- Railway's injected `PORT` is honoured **only on the deployed entrypoint**. `.env.test` sets `PORT=3001` for the API and `eval:web` loads it, so an unconditional rule would have moved the local ops API onto 3001 and broken the documented two-process flow. One shared `resolveBindPort({ env, honourPlatformPort })` with the posture named at each call site.
- The bound port is now **passed into** `createDefaultOpsContext` rather than re-read from the environment, so the advertised sign-in callback cannot drift from the actually-bound port.
- `EVAL_OPS_BIND` still defaults to `127.0.0.1`.
- `Host` and `Origin` allowlists extend to **one** configured origin (`EVAL_OPS_PUBLIC_ORIGIN`), validated as an absolute `https:` origin with no path/query/fragment, failing loudly at startup. Never wildcarded, never disabled; unset still means loopback-only.
- The session cookie sets `Secure` when the request is genuinely HTTPS, and still omits it on loopback http. `X-Forwarded-Proto` is deliberately not consulted.

An independent escape hunt against the allowlists — case, ports, trailing dots, subdomains, suffixes, `null`, multi-valued headers, percent-encoding, wildcard-shaped config — found no way in from a host or origin that is neither loopback nor the configured one.

## D2 — sign-in on a deployed host

The CLI bridge cannot be used over HTTPS: `validateCliCallbackUrl` accepts only `http:` on loopback, deliberately, and it is shared with the released CLI — **unchanged here**. A shared parent-domain cookie is also unavailable, because the Better Auth cookie is host-only.

So the deployed path uses a Better Auth **JWT resolved server-side**:

1. The browser fetches a JWT from `${API_URL}/api/auth/token` with `credentials: "include"` (works cross-site because that cookie is `SameSite=None; Secure`).
2. It posts the token to the ops server.
3. **The ops server** calls `${API_URL}/api/auth/me` with `Authorization: Bearer`.
4. The existing `assessIdentity` policy runs unchanged — verified email, exact `index.network` domain, single `@`, LDH characters.

The `/api/auth/me` hop is required rather than optional: the JWT's `definePayload` omits `emailVerified`, which the policy demands, so possession of a token never implies verification. Nothing about the identity comes from the client — the request body is `.strict()` with exactly one field.

Implemented as a second `IdentityResolver` behind the existing seam, selected by explicit configuration. The local bridge path is unchanged and pinned by tests. The login response is a discriminated union (`kind: "bridge" | "token"`), and `PUBLIC_ROUTES` grew by exactly one entry — you cannot require a session in order to obtain one — with that reason recorded in code.

Also raises the deployed entrypoint's `idleTimeout` above the 15s SSE heartbeat; Bun's 10s default would have closed a quiet run-log stream.

## Tests

312 protocol ops tests, 101 app tests, `eval:verify` 13 suites, typecheck clean, lint 0 errors. 16 mutants, each failing the test that must catch it.

## Deployment posture

The Railway `eval-ops` service in `dev` is configured but **not** given `DATABASE_URL` or `OPENROUTER_API_KEY`, so on arrival the fixture reset refuses and runs cannot launch. Enabling either is a separate, deliberate act.

Note that even with a database configured, the dev environment's `DATABASE_URL` names `protocol_prod`, which `assessFixtureTarget` refuses by name — the reset can only ever act against a database someone deliberately points it at.

## Known gaps (not blocking a dev deployment)

- **Sessions are in-memory**: a redeploy signs everyone out, and more than one replica breaks sign-in outright.
- **No actor attribution**: run records and fixture resets do not record who performed them. That mattered less on loopback, where "who" was obvious; on a shared URL it does not.
- The sign-in round-trip has not been exercised end-to-end against a live API.


---

## Follow-on: followable run view + harness descriptions (deployed)

- `HARNESS_REGISTRY` gains `question`/`detail` per harness, grounded in the code each harness exercises (matching→`OpportunityEvaluator`, opportunity→`OpportunityPresenter`, profile→`profileGenerator`/`EnrichmentGenerator`, premise→`PremiseDecomposer`+`PremiseAnalyzer`); shown on overview, launch, harness, and run pages.
- `ops.progress.ts`: dependency-free incremental parser for the real harness output format (case start, multi-line debug dump, score on its own line), shared unchanged with the web client. Cross-validated against a real deployed run log: 40/40 cases, tallies matching the harness scorecard exactly.
- Run page leads with a progress bar, pass/fail tally, per-case rows, in-flight case with live timer; raw output behind a toggle.

## Follow-on: configuration management + A/B runs (this push)

Spec: `docs/superpowers/specs/2026-08-01-eval-ops-config-management-design.md`; plan: `docs/superpowers/plans/2026-08-01-eval-ops-config-management.md`.

**One concept, two sources.** UI-created configs are the existing profile shape stored in a Neon table (`eval_ops_configs`, boot DDL, fail-closed) instead of repo JSON; repo profiles stay shipped and read-only. Name uniqueness spans both sources (409).

- **Validation**: every client-originated payload flows through the same `ConfigProfileSchema` + `PROFILE_ENV_ALLOWLIST` + new curated `ALLOWED_CONFIG_MODELS` (6 models). Repo profiles are exempt (code-reviewed).
- **Ad-hoc overrides at launch**: `RunSpec.overrides`, valid only with `profile: "default"`; resolves through the same profile path so fingerprints match a named config with the same payload (pinned by test). Any run with overrides is experimental → `--no-save`; baselines cannot be polluted through the UI.
- **Configs page** (`/profiles`, heading "configs"): shipped vs saved, create/edit/delete with confirm, launch → prefilled.
- **A/B mode**: launch page toggle gives each side its own profile + overrides; fires two runs (reference first, serialized through the queue) and navigates to the pair URL.
- **Pair page** (`/compare?referenceRun=A&subjectRun=B`): dual progress views; when both runs end it automatically renders the existing statistical diff. Run-vs-run compare reads each run's captured `report.json` (written even for `--no-save` runs) and relaxes only the `configFingerprint` refusal — config is the variable under test; harness/corpus/selection refusals stay. Per-side completeness is surfaced with an "incomplete evidence" caveat.

### Evidence

- 357 protocol ops tests, 131 app (vitest) tests, both typechecks clean, `bun run build` clean.
- Live SQL verification against the Neon fixture branch: boot DDL + create/get/update/remove round-trip, duplicate create → `ConfigConflictError` (caught a real bug unit tests couldn't: Bun.SQL returns jsonb as strings; fixed in `cc49f374c`).
- Executed subagent-driven: per-task spec+quality reviews, whole-branch final review, one fix wave (per-side A/B profiles; run-page overrides summary), scoped re-reviews. Ledger: `.superpowers/sdd/2026-08-01-eval-ops-config-management/progress.md` (in-branch history; workspace removed after merge).

### Known minors (deferred, non-blocking)

- DB-unreachable on config routes surfaces as 500, not the spec's 503 (repo-profile launches unaffected).
- `Run.tsx` keeps its own subscription wiring rather than the new `useRunProgress` hook (drift risk accepted; reconnect semantics live in both).
- CompareDiff's refusal copy says "artifacts" in run mode (verbatim extraction of the artifact-mode component).
- `updateConfig` is read-then-write (fine for a single-operator ops tool).
- Deferred test-coverage notes in the ledger (env-row editing, corrupt-report 422 branch, xor matcher strictness).
