### PR TITLE
fix(eval): anonymize corpus source id, repair scout case, refresh baseline

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -110,7 +110,7 @@
     },
     "packages/protocol": {
       "name": "@indexnetwork/protocol",
-      "version": "8.6.0",
+      "version": "8.6.1",
       "dependencies": {
         "@langchain/core": "1.1.48",
         "@langchain/langgraph": "1.3.2",

--- a/packages/protocol/eval/matching/baselines/matching.baseline.json
+++ b/packages/protocol/eval/matching/baselines/matching.baseline.json
@@ -1,98 +1,2634 @@
 {
   "artifactType": "index-eval/baseline",
-  "schemaVersion": 1,
   "harness": "matching",
   "harnessVersion": "1",
-  "source": "legacy-migration",
-  "createdAt": "2026-05-29T18:05:23.210Z",
-  "startedAt": "2026-05-29T18:05:23.210Z",
-  "completedAt": "2026-05-29T18:05:23.210Z",
+  "createdAt": "2026-08-02T10:47:37.542Z",
+  "startedAt": "2026-08-02T10:43:50.660Z",
+  "completedAt": "2026-08-02T10:47:37.524Z",
   "models": [
     "google/gemini-2.5-flash"
   ],
-  "runs": 7,
+  "runs": 3,
   "selection": {
     "fullCorpus": true,
     "filters": {}
   },
-  "corpusFingerprint": "unavailable-legacy-migration",
-  "configFingerprint": "unavailable-legacy-migration",
+  "corpusFingerprint": "0d2f5289ca69beb4b510def23823212066e04ca04ef49e28d776c82e86a77a7d",
+  "configFingerprint": "d9b0b433eb47d15daaf8a70d35a8f47b3817cb3a5fe0001cfe7f2866bbb15573",
   "git": {
-    "revision": "unknown",
-    "dirty": null
+    "revision": "84f2764c569aa50fa358fb811a4befa9354274c9",
+    "dirty": false
   },
+  "schemaVersion": 2,
+  "source": "run",
   "completeness": {
     "caseCount": 40,
     "ruleCount": 10,
-    "totalRuns": 280,
-    "totalPasses": 277,
-    "flakyCaseCount": 3
+    "totalRuns": 120,
+    "totalPasses": 108,
+    "flakyCaseCount": 3,
+    "requestedRuns": 120,
+    "completedRuns": 120,
+    "failedRuns": 0,
+    "recoveredRuns": 0,
+    "totalAttempts": 120,
+    "complete": true
+  },
+  "execution": {
+    "policy": "strict",
+    "runs": [
+      {
+        "runId": "is_a_identity%2Fsamurai-vs-character-designer::run:1",
+        "caseId": "is_a_identity/samurai-vs-character-designer",
+        "runIndex": 0,
+        "outcome": "success",
+        "recovered": false,
+        "attempts": [
+          {
+            "attemptId": "is_a_identity%2Fsamurai-vs-character-designer::run:1::attempt:1",
+            "runId": "is_a_identity%2Fsamurai-vs-character-designer::run:1",
+            "runIndex": 0,
+            "attemptNumber": 1,
+            "startedAt": "2026-08-02T10:43:50.662Z",
+            "completedAt": "2026-08-02T10:43:52.160Z",
+            "durationMs": 1498,
+            "outcome": "success",
+            "retryable": false,
+            "backoffMs": 0
+          }
+        ]
+      },
+      {
+        "runId": "is_a_identity%2Fsamurai-vs-character-designer::run:2",
+        "caseId": "is_a_identity/samurai-vs-character-designer",
+        "runIndex": 1,
+        "outcome": "success",
+        "recovered": false,
+        "attempts": [
+          {
+            "attemptId": "is_a_identity%2Fsamurai-vs-character-designer::run:2::attempt:1",
+            "runId": "is_a_identity%2Fsamurai-vs-character-designer::run:2",
+            "runIndex": 1,
+            "attemptNumber": 1,
+            "startedAt": "2026-08-02T10:43:52.160Z",
+            "completedAt": "2026-08-02T10:43:53.720Z",
+            "durationMs": 1560,
+            "outcome": "success",
+            "retryable": false,
+            "backoffMs": 0
+          }
+        ]
+      },
+      {
+        "runId": "is_a_identity%2Fsamurai-vs-character-designer::run:3",
+        "caseId": "is_a_identity/samurai-vs-character-designer",
+        "runIndex": 2,
+        "outcome": "success",
+        "recovered": false,
+        "attempts": [
+          {
+            "attemptId": "is_a_identity%2Fsamurai-vs-character-designer::run:3::attempt:1",
+            "runId": "is_a_identity%2Fsamurai-vs-character-designer::run:3",
+            "runIndex": 2,
+            "attemptNumber": 1,
+            "startedAt": "2026-08-02T10:43:53.720Z",
+            "completedAt": "2026-08-02T10:43:55.046Z",
+            "durationMs": 1326,
+            "outcome": "success",
+            "retryable": false,
+            "backoffMs": 0
+          }
+        ]
+      },
+      {
+        "runId": "is_a_identity%2Finvestor-vs-funded-engineer::run:1",
+        "caseId": "is_a_identity/investor-vs-funded-engineer",
+        "runIndex": 0,
+        "outcome": "success",
+        "recovered": false,
+        "attempts": [
+          {
+            "attemptId": "is_a_identity%2Finvestor-vs-funded-engineer::run:1::attempt:1",
+            "runId": "is_a_identity%2Finvestor-vs-funded-engineer::run:1",
+            "runIndex": 0,
+            "attemptNumber": 1,
+            "startedAt": "2026-08-02T10:43:55.047Z",
+            "completedAt": "2026-08-02T10:43:56.452Z",
+            "durationMs": 1405,
+            "outcome": "success",
+            "retryable": false,
+            "backoffMs": 0
+          }
+        ]
+      },
+      {
+        "runId": "is_a_identity%2Finvestor-vs-funded-engineer::run:2",
+        "caseId": "is_a_identity/investor-vs-funded-engineer",
+        "runIndex": 1,
+        "outcome": "success",
+        "recovered": false,
+        "attempts": [
+          {
+            "attemptId": "is_a_identity%2Finvestor-vs-funded-engineer::run:2::attempt:1",
+            "runId": "is_a_identity%2Finvestor-vs-funded-engineer::run:2",
+            "runIndex": 1,
+            "attemptNumber": 1,
+            "startedAt": "2026-08-02T10:43:56.452Z",
+            "completedAt": "2026-08-02T10:43:57.623Z",
+            "durationMs": 1171,
+            "outcome": "success",
+            "retryable": false,
+            "backoffMs": 0
+          }
+        ]
+      },
+      {
+        "runId": "is_a_identity%2Finvestor-vs-funded-engineer::run:3",
+        "caseId": "is_a_identity/investor-vs-funded-engineer",
+        "runIndex": 2,
+        "outcome": "success",
+        "recovered": false,
+        "attempts": [
+          {
+            "attemptId": "is_a_identity%2Finvestor-vs-funded-engineer::run:3::attempt:1",
+            "runId": "is_a_identity%2Finvestor-vs-funded-engineer::run:3",
+            "runIndex": 2,
+            "attemptNumber": 1,
+            "startedAt": "2026-08-02T10:43:57.623Z",
+            "completedAt": "2026-08-02T10:43:58.842Z",
+            "durationMs": 1219,
+            "outcome": "success",
+            "retryable": false,
+            "backoffMs": 0
+          }
+        ]
+      },
+      {
+        "runId": "is_a_identity%2Finvestor-vs-real-investor::run:1",
+        "caseId": "is_a_identity/investor-vs-real-investor",
+        "runIndex": 0,
+        "outcome": "success",
+        "recovered": false,
+        "attempts": [
+          {
+            "attemptId": "is_a_identity%2Finvestor-vs-real-investor::run:1::attempt:1",
+            "runId": "is_a_identity%2Finvestor-vs-real-investor::run:1",
+            "runIndex": 0,
+            "attemptNumber": 1,
+            "startedAt": "2026-08-02T10:43:58.842Z",
+            "completedAt": "2026-08-02T10:44:00.348Z",
+            "durationMs": 1506,
+            "outcome": "success",
+            "retryable": false,
+            "backoffMs": 0
+          }
+        ]
+      },
+      {
+        "runId": "is_a_identity%2Finvestor-vs-real-investor::run:2",
+        "caseId": "is_a_identity/investor-vs-real-investor",
+        "runIndex": 1,
+        "outcome": "success",
+        "recovered": false,
+        "attempts": [
+          {
+            "attemptId": "is_a_identity%2Finvestor-vs-real-investor::run:2::attempt:1",
+            "runId": "is_a_identity%2Finvestor-vs-real-investor::run:2",
+            "runIndex": 1,
+            "attemptNumber": 1,
+            "startedAt": "2026-08-02T10:44:00.348Z",
+            "completedAt": "2026-08-02T10:44:01.790Z",
+            "durationMs": 1442,
+            "outcome": "success",
+            "retryable": false,
+            "backoffMs": 0
+          }
+        ]
+      },
+      {
+        "runId": "is_a_identity%2Finvestor-vs-real-investor::run:3",
+        "caseId": "is_a_identity/investor-vs-real-investor",
+        "runIndex": 2,
+        "outcome": "success",
+        "recovered": false,
+        "attempts": [
+          {
+            "attemptId": "is_a_identity%2Finvestor-vs-real-investor::run:3::attempt:1",
+            "runId": "is_a_identity%2Finvestor-vs-real-investor::run:3",
+            "runIndex": 2,
+            "attemptNumber": 1,
+            "startedAt": "2026-08-02T10:44:01.790Z",
+            "completedAt": "2026-08-02T10:44:03.312Z",
+            "durationMs": 1522,
+            "outcome": "success",
+            "retryable": false,
+            "backoffMs": 0
+          }
+        ]
+      },
+      {
+        "runId": "query_primary%2Fbackground-intent-does-not-rescue::run:1",
+        "caseId": "query_primary/background-intent-does-not-rescue",
+        "runIndex": 0,
+        "outcome": "success",
+        "recovered": false,
+        "attempts": [
+          {
+            "attemptId": "query_primary%2Fbackground-intent-does-not-rescue::run:1::attempt:1",
+            "runId": "query_primary%2Fbackground-intent-does-not-rescue::run:1",
+            "runIndex": 0,
+            "attemptNumber": 1,
+            "startedAt": "2026-08-02T10:44:03.312Z",
+            "completedAt": "2026-08-02T10:44:04.636Z",
+            "durationMs": 1324,
+            "outcome": "success",
+            "retryable": false,
+            "backoffMs": 0
+          }
+        ]
+      },
+      {
+        "runId": "query_primary%2Fbackground-intent-does-not-rescue::run:2",
+        "caseId": "query_primary/background-intent-does-not-rescue",
+        "runIndex": 1,
+        "outcome": "success",
+        "recovered": false,
+        "attempts": [
+          {
+            "attemptId": "query_primary%2Fbackground-intent-does-not-rescue::run:2::attempt:1",
+            "runId": "query_primary%2Fbackground-intent-does-not-rescue::run:2",
+            "runIndex": 1,
+            "attemptNumber": 1,
+            "startedAt": "2026-08-02T10:44:04.636Z",
+            "completedAt": "2026-08-02T10:44:05.788Z",
+            "durationMs": 1152,
+            "outcome": "success",
+            "retryable": false,
+            "backoffMs": 0
+          }
+        ]
+      },
+      {
+        "runId": "query_primary%2Fbackground-intent-does-not-rescue::run:3",
+        "caseId": "query_primary/background-intent-does-not-rescue",
+        "runIndex": 2,
+        "outcome": "success",
+        "recovered": false,
+        "attempts": [
+          {
+            "attemptId": "query_primary%2Fbackground-intent-does-not-rescue::run:3::attempt:1",
+            "runId": "query_primary%2Fbackground-intent-does-not-rescue::run:3",
+            "runIndex": 2,
+            "attemptNumber": 1,
+            "startedAt": "2026-08-02T10:44:05.788Z",
+            "completedAt": "2026-08-02T10:44:06.971Z",
+            "durationMs": 1183,
+            "outcome": "success",
+            "retryable": false,
+            "backoffMs": 0
+          }
+        ]
+      },
+      {
+        "runId": "query_primary%2Fspecific-art-query-accepts-illustrator::run:1",
+        "caseId": "query_primary/specific-art-query-accepts-illustrator",
+        "runIndex": 0,
+        "outcome": "success",
+        "recovered": false,
+        "attempts": [
+          {
+            "attemptId": "query_primary%2Fspecific-art-query-accepts-illustrator::run:1::attempt:1",
+            "runId": "query_primary%2Fspecific-art-query-accepts-illustrator::run:1",
+            "runIndex": 0,
+            "attemptNumber": 1,
+            "startedAt": "2026-08-02T10:44:07.936Z",
+            "completedAt": "2026-08-02T10:44:09.447Z",
+            "durationMs": 1511,
+            "outcome": "success",
+            "retryable": false,
+            "backoffMs": 0
+          }
+        ]
+      },
+      {
+        "runId": "query_primary%2Fspecific-art-query-accepts-illustrator::run:2",
+        "caseId": "query_primary/specific-art-query-accepts-illustrator",
+        "runIndex": 1,
+        "outcome": "success",
+        "recovered": false,
+        "attempts": [
+          {
+            "attemptId": "query_primary%2Fspecific-art-query-accepts-illustrator::run:2::attempt:1",
+            "runId": "query_primary%2Fspecific-art-query-accepts-illustrator::run:2",
+            "runIndex": 1,
+            "attemptNumber": 1,
+            "startedAt": "2026-08-02T10:44:09.447Z",
+            "completedAt": "2026-08-02T10:44:11.244Z",
+            "durationMs": 1797,
+            "outcome": "success",
+            "retryable": false,
+            "backoffMs": 0
+          }
+        ]
+      },
+      {
+        "runId": "query_primary%2Fspecific-art-query-accepts-illustrator::run:3",
+        "caseId": "query_primary/specific-art-query-accepts-illustrator",
+        "runIndex": 2,
+        "outcome": "success",
+        "recovered": false,
+        "attempts": [
+          {
+            "attemptId": "query_primary%2Fspecific-art-query-accepts-illustrator::run:3::attempt:1",
+            "runId": "query_primary%2Fspecific-art-query-accepts-illustrator::run:3",
+            "runIndex": 2,
+            "attemptNumber": 1,
+            "startedAt": "2026-08-02T10:44:11.244Z",
+            "completedAt": "2026-08-02T10:44:12.888Z",
+            "durationMs": 1644,
+            "outcome": "success",
+            "retryable": false,
+            "backoffMs": 0
+          }
+        ]
+      },
+      {
+        "runId": "query_primary%2Finvestors-query-rejects-funded-founder::run:1",
+        "caseId": "query_primary/investors-query-rejects-funded-founder",
+        "runIndex": 0,
+        "outcome": "success",
+        "recovered": false,
+        "attempts": [
+          {
+            "attemptId": "query_primary%2Finvestors-query-rejects-funded-founder::run:1::attempt:1",
+            "runId": "query_primary%2Finvestors-query-rejects-funded-founder::run:1",
+            "runIndex": 0,
+            "attemptNumber": 1,
+            "startedAt": "2026-08-02T10:44:12.888Z",
+            "completedAt": "2026-08-02T10:44:14.175Z",
+            "durationMs": 1287,
+            "outcome": "success",
+            "retryable": false,
+            "backoffMs": 0
+          }
+        ]
+      },
+      {
+        "runId": "query_primary%2Finvestors-query-rejects-funded-founder::run:2",
+        "caseId": "query_primary/investors-query-rejects-funded-founder",
+        "runIndex": 1,
+        "outcome": "success",
+        "recovered": false,
+        "attempts": [
+          {
+            "attemptId": "query_primary%2Finvestors-query-rejects-funded-founder::run:2::attempt:1",
+            "runId": "query_primary%2Finvestors-query-rejects-funded-founder::run:2",
+            "runIndex": 1,
+            "attemptNumber": 1,
+            "startedAt": "2026-08-02T10:44:14.175Z",
+            "completedAt": "2026-08-02T10:44:15.338Z",
+            "durationMs": 1163,
+            "outcome": "success",
+            "retryable": false,
+            "backoffMs": 0
+          }
+        ]
+      },
+      {
+        "runId": "query_primary%2Finvestors-query-rejects-funded-founder::run:3",
+        "caseId": "query_primary/investors-query-rejects-funded-founder",
+        "runIndex": 2,
+        "outcome": "success",
+        "recovered": false,
+        "attempts": [
+          {
+            "attemptId": "query_primary%2Finvestors-query-rejects-funded-founder::run:3::attempt:1",
+            "runId": "query_primary%2Finvestors-query-rejects-funded-founder::run:3",
+            "runIndex": 2,
+            "attemptNumber": 1,
+            "startedAt": "2026-08-02T10:44:15.338Z",
+            "completedAt": "2026-08-02T10:44:16.577Z",
+            "durationMs": 1239,
+            "outcome": "success",
+            "retryable": false,
+            "backoffMs": 0
+          }
+        ]
+      },
+      {
+        "runId": "query_primary%2Ffounders-raising-seed-accepts-founder::run:1",
+        "caseId": "query_primary/founders-raising-seed-accepts-founder",
+        "runIndex": 0,
+        "outcome": "success",
+        "recovered": false,
+        "attempts": [
+          {
+            "attemptId": "query_primary%2Ffounders-raising-seed-accepts-founder::run:1::attempt:1",
+            "runId": "query_primary%2Ffounders-raising-seed-accepts-founder::run:1",
+            "runIndex": 0,
+            "attemptNumber": 1,
+            "startedAt": "2026-08-02T10:44:16.577Z",
+            "completedAt": "2026-08-02T10:44:17.734Z",
+            "durationMs": 1157,
+            "outcome": "success",
+            "retryable": false,
+            "backoffMs": 0
+          }
+        ]
+      },
+      {
+        "runId": "query_primary%2Ffounders-raising-seed-accepts-founder::run:2",
+        "caseId": "query_primary/founders-raising-seed-accepts-founder",
+        "runIndex": 1,
+        "outcome": "success",
+        "recovered": false,
+        "attempts": [
+          {
+            "attemptId": "query_primary%2Ffounders-raising-seed-accepts-founder::run:2::attempt:1",
+            "runId": "query_primary%2Ffounders-raising-seed-accepts-founder::run:2",
+            "runIndex": 1,
+            "attemptNumber": 1,
+            "startedAt": "2026-08-02T10:44:17.734Z",
+            "completedAt": "2026-08-02T10:44:19.021Z",
+            "durationMs": 1287,
+            "outcome": "success",
+            "retryable": false,
+            "backoffMs": 0
+          }
+        ]
+      },
+      {
+        "runId": "query_primary%2Ffounders-raising-seed-accepts-founder::run:3",
+        "caseId": "query_primary/founders-raising-seed-accepts-founder",
+        "runIndex": 2,
+        "outcome": "success",
+        "recovered": false,
+        "attempts": [
+          {
+            "attemptId": "query_primary%2Ffounders-raising-seed-accepts-founder::run:3::attempt:1",
+            "runId": "query_primary%2Ffounders-raising-seed-accepts-founder::run:3",
+            "runIndex": 2,
+            "attemptNumber": 1,
+            "startedAt": "2026-08-02T10:44:19.021Z",
+            "completedAt": "2026-08-02T10:44:20.486Z",
+            "durationMs": 1465,
+            "outcome": "success",
+            "retryable": false,
+            "backoffMs": 0
+          }
+        ]
+      },
+      {
+        "runId": "query_primary%2Flocation-query-rejects-wrong-city::run:1",
+        "caseId": "query_primary/location-query-rejects-wrong-city",
+        "runIndex": 0,
+        "outcome": "success",
+        "recovered": false,
+        "attempts": [
+          {
+            "attemptId": "query_primary%2Flocation-query-rejects-wrong-city::run:1::attempt:1",
+            "runId": "query_primary%2Flocation-query-rejects-wrong-city::run:1",
+            "runIndex": 0,
+            "attemptNumber": 1,
+            "startedAt": "2026-08-02T10:44:20.486Z",
+            "completedAt": "2026-08-02T10:44:21.671Z",
+            "durationMs": 1185,
+            "outcome": "success",
+            "retryable": false,
+            "backoffMs": 0
+          }
+        ]
+      },
+      {
+        "runId": "query_primary%2Flocation-query-rejects-wrong-city::run:2",
+        "caseId": "query_primary/location-query-rejects-wrong-city",
+        "runIndex": 1,
+        "outcome": "success",
+        "recovered": false,
+        "attempts": [
+          {
+            "attemptId": "query_primary%2Flocation-query-rejects-wrong-city::run:2::attempt:1",
+            "runId": "query_primary%2Flocation-query-rejects-wrong-city::run:2",
+            "runIndex": 1,
+            "attemptNumber": 1,
+            "startedAt": "2026-08-02T10:44:21.672Z",
+            "completedAt": "2026-08-02T10:44:22.827Z",
+            "durationMs": 1155,
+            "outcome": "success",
+            "retryable": false,
+            "backoffMs": 0
+          }
+        ]
+      },
+      {
+        "runId": "query_primary%2Flocation-query-rejects-wrong-city::run:3",
+        "caseId": "query_primary/location-query-rejects-wrong-city",
+        "runIndex": 2,
+        "outcome": "success",
+        "recovered": false,
+        "attempts": [
+          {
+            "attemptId": "query_primary%2Flocation-query-rejects-wrong-city::run:3::attempt:1",
+            "runId": "query_primary%2Flocation-query-rejects-wrong-city::run:3",
+            "runIndex": 2,
+            "attemptNumber": 1,
+            "startedAt": "2026-08-02T10:44:22.827Z",
+            "completedAt": "2026-08-02T10:44:24.021Z",
+            "durationMs": 1194,
+            "outcome": "success",
+            "retryable": false,
+            "backoffMs": 0
+          }
+        ]
+      },
+      {
+        "runId": "query_primary%2Fvague-query-can-use-background-intent::run:1",
+        "caseId": "query_primary/vague-query-can-use-background-intent",
+        "runIndex": 0,
+        "outcome": "success",
+        "recovered": false,
+        "attempts": [
+          {
+            "attemptId": "query_primary%2Fvague-query-can-use-background-intent::run:1::attempt:1",
+            "runId": "query_primary%2Fvague-query-can-use-background-intent::run:1",
+            "runIndex": 0,
+            "attemptNumber": 1,
+            "startedAt": "2026-08-02T10:44:24.021Z",
+            "completedAt": "2026-08-02T10:44:25.637Z",
+            "durationMs": 1616,
+            "outcome": "success",
+            "retryable": false,
+            "backoffMs": 0
+          }
+        ]
+      },
+      {
+        "runId": "query_primary%2Fvague-query-can-use-background-intent::run:2",
+        "caseId": "query_primary/vague-query-can-use-background-intent",
+        "runIndex": 1,
+        "outcome": "success",
+        "recovered": false,
+        "attempts": [
+          {
+            "attemptId": "query_primary%2Fvague-query-can-use-background-intent::run:2::attempt:1",
+            "runId": "query_primary%2Fvague-query-can-use-background-intent::run:2",
+            "runIndex": 1,
+            "attemptNumber": 1,
+            "startedAt": "2026-08-02T10:44:25.637Z",
+            "completedAt": "2026-08-02T10:44:27.312Z",
+            "durationMs": 1675,
+            "outcome": "success",
+            "retryable": false,
+            "backoffMs": 0
+          }
+        ]
+      },
+      {
+        "runId": "query_primary%2Fvague-query-can-use-background-intent::run:3",
+        "caseId": "query_primary/vague-query-can-use-background-intent",
+        "runIndex": 2,
+        "outcome": "success",
+        "recovered": false,
+        "attempts": [
+          {
+            "attemptId": "query_primary%2Fvague-query-can-use-background-intent::run:3::attempt:1",
+            "runId": "query_primary%2Fvague-query-can-use-background-intent::run:3",
+            "runIndex": 2,
+            "attemptNumber": 1,
+            "startedAt": "2026-08-02T10:44:27.312Z",
+            "completedAt": "2026-08-02T10:44:29.199Z",
+            "durationMs": 1887,
+            "outcome": "success",
+            "retryable": false,
+            "backoffMs": 0
+          }
+        ]
+      },
+      {
+        "runId": "query_primary%2Fscouts-query-rejects-scouted-athlete::run:1",
+        "caseId": "query_primary/scouts-query-rejects-scouted-athlete",
+        "runIndex": 0,
+        "outcome": "success",
+        "recovered": false,
+        "attempts": [
+          {
+            "attemptId": "query_primary%2Fscouts-query-rejects-scouted-athlete::run:1::attempt:1",
+            "runId": "query_primary%2Fscouts-query-rejects-scouted-athlete::run:1",
+            "runIndex": 0,
+            "attemptNumber": 1,
+            "startedAt": "2026-08-02T10:44:29.200Z",
+            "completedAt": "2026-08-02T10:44:30.296Z",
+            "durationMs": 1096,
+            "outcome": "success",
+            "retryable": false,
+            "backoffMs": 0
+          }
+        ]
+      },
+      {
+        "runId": "query_primary%2Fscouts-query-rejects-scouted-athlete::run:2",
+        "caseId": "query_primary/scouts-query-rejects-scouted-athlete",
+        "runIndex": 1,
+        "outcome": "success",
+        "recovered": false,
+        "attempts": [
+          {
+            "attemptId": "query_primary%2Fscouts-query-rejects-scouted-athlete::run:2::attempt:1",
+            "runId": "query_primary%2Fscouts-query-rejects-scouted-athlete::run:2",
+            "runIndex": 1,
+            "attemptNumber": 1,
+            "startedAt": "2026-08-02T10:44:30.296Z",
+            "completedAt": "2026-08-02T10:44:31.958Z",
+            "durationMs": 1662,
+            "outcome": "success",
+            "retryable": false,
+            "backoffMs": 0
+          }
+        ]
+      },
+      {
+        "runId": "query_primary%2Fscouts-query-rejects-scouted-athlete::run:3",
+        "caseId": "query_primary/scouts-query-rejects-scouted-athlete",
+        "runIndex": 2,
+        "outcome": "success",
+        "recovered": false,
+        "attempts": [
+          {
+            "attemptId": "query_primary%2Fscouts-query-rejects-scouted-athlete::run:3::attempt:1",
+            "runId": "query_primary%2Fscouts-query-rejects-scouted-athlete::run:3",
+            "runIndex": 2,
+            "attemptNumber": 1,
+            "startedAt": "2026-08-02T10:44:31.958Z",
+            "completedAt": "2026-08-02T10:44:33.412Z",
+            "durationMs": 1454,
+            "outcome": "success",
+            "retryable": false,
+            "backoffMs": 0
+          }
+        ]
+      },
+      {
+        "runId": "complementary_role%2Fvc-for-cofounder-intent::run:1",
+        "caseId": "complementary_role/vc-for-cofounder-intent",
+        "runIndex": 0,
+        "outcome": "success",
+        "recovered": false,
+        "attempts": [
+          {
+            "attemptId": "complementary_role%2Fvc-for-cofounder-intent::run:1::attempt:1",
+            "runId": "complementary_role%2Fvc-for-cofounder-intent::run:1",
+            "runIndex": 0,
+            "attemptNumber": 1,
+            "startedAt": "2026-08-02T10:44:33.412Z",
+            "completedAt": "2026-08-02T10:44:34.555Z",
+            "durationMs": 1143,
+            "outcome": "success",
+            "retryable": false,
+            "backoffMs": 0
+          }
+        ]
+      },
+      {
+        "runId": "complementary_role%2Fvc-for-cofounder-intent::run:2",
+        "caseId": "complementary_role/vc-for-cofounder-intent",
+        "runIndex": 1,
+        "outcome": "success",
+        "recovered": false,
+        "attempts": [
+          {
+            "attemptId": "complementary_role%2Fvc-for-cofounder-intent::run:2::attempt:1",
+            "runId": "complementary_role%2Fvc-for-cofounder-intent::run:2",
+            "runIndex": 1,
+            "attemptNumber": 1,
+            "startedAt": "2026-08-02T10:44:34.556Z",
+            "completedAt": "2026-08-02T10:44:35.814Z",
+            "durationMs": 1258,
+            "outcome": "success",
+            "retryable": false,
+            "backoffMs": 0
+          }
+        ]
+      },
+      {
+        "runId": "complementary_role%2Fvc-for-cofounder-intent::run:3",
+        "caseId": "complementary_role/vc-for-cofounder-intent",
+        "runIndex": 2,
+        "outcome": "success",
+        "recovered": false,
+        "attempts": [
+          {
+            "attemptId": "complementary_role%2Fvc-for-cofounder-intent::run:3::attempt:1",
+            "runId": "complementary_role%2Fvc-for-cofounder-intent::run:3",
+            "runIndex": 2,
+            "attemptNumber": 1,
+            "startedAt": "2026-08-02T10:44:35.814Z",
+            "completedAt": "2026-08-02T10:44:37.329Z",
+            "durationMs": 1515,
+            "outcome": "success",
+            "retryable": false,
+            "backoffMs": 0
+          }
+        ]
+      },
+      {
+        "runId": "complementary_role%2Fengineer-for-cofounder-intent::run:1",
+        "caseId": "complementary_role/engineer-for-cofounder-intent",
+        "runIndex": 0,
+        "outcome": "success",
+        "recovered": false,
+        "attempts": [
+          {
+            "attemptId": "complementary_role%2Fengineer-for-cofounder-intent::run:1::attempt:1",
+            "runId": "complementary_role%2Fengineer-for-cofounder-intent::run:1",
+            "runIndex": 0,
+            "attemptNumber": 1,
+            "startedAt": "2026-08-02T10:44:37.331Z",
+            "completedAt": "2026-08-02T10:44:39.040Z",
+            "durationMs": 1709,
+            "outcome": "success",
+            "retryable": false,
+            "backoffMs": 0
+          }
+        ]
+      },
+      {
+        "runId": "complementary_role%2Fengineer-for-cofounder-intent::run:2",
+        "caseId": "complementary_role/engineer-for-cofounder-intent",
+        "runIndex": 1,
+        "outcome": "success",
+        "recovered": false,
+        "attempts": [
+          {
+            "attemptId": "complementary_role%2Fengineer-for-cofounder-intent::run:2::attempt:1",
+            "runId": "complementary_role%2Fengineer-for-cofounder-intent::run:2",
+            "runIndex": 1,
+            "attemptNumber": 1,
+            "startedAt": "2026-08-02T10:44:39.040Z",
+            "completedAt": "2026-08-02T10:44:41.850Z",
+            "durationMs": 2810,
+            "outcome": "success",
+            "retryable": false,
+            "backoffMs": 0
+          }
+        ]
+      },
+      {
+        "runId": "complementary_role%2Fengineer-for-cofounder-intent::run:3",
+        "caseId": "complementary_role/engineer-for-cofounder-intent",
+        "runIndex": 2,
+        "outcome": "success",
+        "recovered": false,
+        "attempts": [
+          {
+            "attemptId": "complementary_role%2Fengineer-for-cofounder-intent::run:3::attempt:1",
+            "runId": "complementary_role%2Fengineer-for-cofounder-intent::run:3",
+            "runIndex": 2,
+            "attemptNumber": 1,
+            "startedAt": "2026-08-02T10:44:41.850Z",
+            "completedAt": "2026-08-02T10:44:43.632Z",
+            "durationMs": 1782,
+            "outcome": "success",
+            "retryable": false,
+            "backoffMs": 0
+          }
+        ]
+      },
+      {
+        "runId": "same_side%2Fboth-seeking-investors::run:1",
+        "caseId": "same_side/both-seeking-investors",
+        "runIndex": 0,
+        "outcome": "success",
+        "recovered": false,
+        "attempts": [
+          {
+            "attemptId": "same_side%2Fboth-seeking-investors::run:1::attempt:1",
+            "runId": "same_side%2Fboth-seeking-investors::run:1",
+            "runIndex": 0,
+            "attemptNumber": 1,
+            "startedAt": "2026-08-02T10:44:43.632Z",
+            "completedAt": "2026-08-02T10:44:44.573Z",
+            "durationMs": 941,
+            "outcome": "success",
+            "retryable": false,
+            "backoffMs": 0
+          }
+        ]
+      },
+      {
+        "runId": "same_side%2Fboth-seeking-investors::run:2",
+        "caseId": "same_side/both-seeking-investors",
+        "runIndex": 1,
+        "outcome": "success",
+        "recovered": false,
+        "attempts": [
+          {
+            "attemptId": "same_side%2Fboth-seeking-investors::run:2::attempt:1",
+            "runId": "same_side%2Fboth-seeking-investors::run:2",
+            "runIndex": 1,
+            "attemptNumber": 1,
+            "startedAt": "2026-08-02T10:44:44.573Z",
+            "completedAt": "2026-08-02T10:44:45.533Z",
+            "durationMs": 960,
+            "outcome": "success",
+            "retryable": false,
+            "backoffMs": 0
+          }
+        ]
+      },
+      {
+        "runId": "same_side%2Fboth-seeking-investors::run:3",
+        "caseId": "same_side/both-seeking-investors",
+        "runIndex": 2,
+        "outcome": "success",
+        "recovered": false,
+        "attempts": [
+          {
+            "attemptId": "same_side%2Fboth-seeking-investors::run:3::attempt:1",
+            "runId": "same_side%2Fboth-seeking-investors::run:3",
+            "runIndex": 2,
+            "attemptNumber": 1,
+            "startedAt": "2026-08-02T10:44:45.533Z",
+            "completedAt": "2026-08-02T10:44:47.041Z",
+            "durationMs": 1508,
+            "outcome": "success",
+            "retryable": false,
+            "backoffMs": 0
+          }
+        ]
+      },
+      {
+        "runId": "already_known%2Fsame-company-cofounders::run:1",
+        "caseId": "already_known/same-company-cofounders",
+        "runIndex": 0,
+        "outcome": "success",
+        "recovered": false,
+        "attempts": [
+          {
+            "attemptId": "already_known%2Fsame-company-cofounders::run:1::attempt:1",
+            "runId": "already_known%2Fsame-company-cofounders::run:1",
+            "runIndex": 0,
+            "attemptNumber": 1,
+            "startedAt": "2026-08-02T10:44:47.041Z",
+            "completedAt": "2026-08-02T10:44:47.765Z",
+            "durationMs": 724,
+            "outcome": "success",
+            "retryable": false,
+            "backoffMs": 0
+          }
+        ]
+      },
+      {
+        "runId": "already_known%2Fsame-company-cofounders::run:2",
+        "caseId": "already_known/same-company-cofounders",
+        "runIndex": 1,
+        "outcome": "success",
+        "recovered": false,
+        "attempts": [
+          {
+            "attemptId": "already_known%2Fsame-company-cofounders::run:2::attempt:1",
+            "runId": "already_known%2Fsame-company-cofounders::run:2",
+            "runIndex": 1,
+            "attemptNumber": 1,
+            "startedAt": "2026-08-02T10:44:47.765Z",
+            "completedAt": "2026-08-02T10:44:48.715Z",
+            "durationMs": 950,
+            "outcome": "success",
+            "retryable": false,
+            "backoffMs": 0
+          }
+        ]
+      },
+      {
+        "runId": "already_known%2Fsame-company-cofounders::run:3",
+        "caseId": "already_known/same-company-cofounders",
+        "runIndex": 2,
+        "outcome": "success",
+        "recovered": false,
+        "attempts": [
+          {
+            "attemptId": "already_known%2Fsame-company-cofounders::run:3::attempt:1",
+            "runId": "already_known%2Fsame-company-cofounders::run:3",
+            "runIndex": 2,
+            "attemptNumber": 1,
+            "startedAt": "2026-08-02T10:44:48.715Z",
+            "completedAt": "2026-08-02T10:44:49.451Z",
+            "durationMs": 736,
+            "outcome": "success",
+            "retryable": false,
+            "backoffMs": 0
+          }
+        ]
+      },
+      {
+        "runId": "location%2Fknown-mismatch-penalized::run:1",
+        "caseId": "location/known-mismatch-penalized",
+        "runIndex": 0,
+        "outcome": "success",
+        "recovered": false,
+        "attempts": [
+          {
+            "attemptId": "location%2Fknown-mismatch-penalized::run:1::attempt:1",
+            "runId": "location%2Fknown-mismatch-penalized::run:1",
+            "runIndex": 0,
+            "attemptNumber": 1,
+            "startedAt": "2026-08-02T10:44:49.451Z",
+            "completedAt": "2026-08-02T10:44:50.639Z",
+            "durationMs": 1188,
+            "outcome": "success",
+            "retryable": false,
+            "backoffMs": 0
+          }
+        ]
+      },
+      {
+        "runId": "location%2Fknown-mismatch-penalized::run:2",
+        "caseId": "location/known-mismatch-penalized",
+        "runIndex": 1,
+        "outcome": "success",
+        "recovered": false,
+        "attempts": [
+          {
+            "attemptId": "location%2Fknown-mismatch-penalized::run:2::attempt:1",
+            "runId": "location%2Fknown-mismatch-penalized::run:2",
+            "runIndex": 1,
+            "attemptNumber": 1,
+            "startedAt": "2026-08-02T10:44:50.639Z",
+            "completedAt": "2026-08-02T10:44:52.903Z",
+            "durationMs": 2264,
+            "outcome": "success",
+            "retryable": false,
+            "backoffMs": 0
+          }
+        ]
+      },
+      {
+        "runId": "location%2Fknown-mismatch-penalized::run:3",
+        "caseId": "location/known-mismatch-penalized",
+        "runIndex": 2,
+        "outcome": "success",
+        "recovered": false,
+        "attempts": [
+          {
+            "attemptId": "location%2Fknown-mismatch-penalized::run:3::attempt:1",
+            "runId": "location%2Fknown-mismatch-penalized::run:3",
+            "runIndex": 2,
+            "attemptNumber": 1,
+            "startedAt": "2026-08-02T10:44:52.903Z",
+            "completedAt": "2026-08-02T10:44:54.338Z",
+            "durationMs": 1435,
+            "outcome": "success",
+            "retryable": false,
+            "backoffMs": 0
+          }
+        ]
+      },
+      {
+        "runId": "location%2Funknown-not-penalized::run:1",
+        "caseId": "location/unknown-not-penalized",
+        "runIndex": 0,
+        "outcome": "success",
+        "recovered": false,
+        "attempts": [
+          {
+            "attemptId": "location%2Funknown-not-penalized::run:1::attempt:1",
+            "runId": "location%2Funknown-not-penalized::run:1",
+            "runIndex": 0,
+            "attemptNumber": 1,
+            "startedAt": "2026-08-02T10:44:54.338Z",
+            "completedAt": "2026-08-02T10:44:55.876Z",
+            "durationMs": 1538,
+            "outcome": "success",
+            "retryable": false,
+            "backoffMs": 0
+          }
+        ]
+      },
+      {
+        "runId": "location%2Funknown-not-penalized::run:2",
+        "caseId": "location/unknown-not-penalized",
+        "runIndex": 1,
+        "outcome": "success",
+        "recovered": false,
+        "attempts": [
+          {
+            "attemptId": "location%2Funknown-not-penalized::run:2::attempt:1",
+            "runId": "location%2Funknown-not-penalized::run:2",
+            "runIndex": 1,
+            "attemptNumber": 1,
+            "startedAt": "2026-08-02T10:44:55.876Z",
+            "completedAt": "2026-08-02T10:44:57.798Z",
+            "durationMs": 1922,
+            "outcome": "success",
+            "retryable": false,
+            "backoffMs": 0
+          }
+        ]
+      },
+      {
+        "runId": "location%2Funknown-not-penalized::run:3",
+        "caseId": "location/unknown-not-penalized",
+        "runIndex": 2,
+        "outcome": "success",
+        "recovered": false,
+        "attempts": [
+          {
+            "attemptId": "location%2Funknown-not-penalized::run:3::attempt:1",
+            "runId": "location%2Funknown-not-penalized::run:3",
+            "runIndex": 2,
+            "attemptNumber": 1,
+            "startedAt": "2026-08-02T10:44:57.798Z",
+            "completedAt": "2026-08-02T10:44:59.443Z",
+            "durationMs": 1645,
+            "outcome": "success",
+            "retryable": false,
+            "backoffMs": 0
+          }
+        ]
+      },
+      {
+        "runId": "valency_role%2Fseeker-gets-patient-provider-gets-agent::run:1",
+        "caseId": "valency_role/seeker-gets-patient-provider-gets-agent",
+        "runIndex": 0,
+        "outcome": "success",
+        "recovered": false,
+        "attempts": [
+          {
+            "attemptId": "valency_role%2Fseeker-gets-patient-provider-gets-agent::run:1::attempt:1",
+            "runId": "valency_role%2Fseeker-gets-patient-provider-gets-agent::run:1",
+            "runIndex": 0,
+            "attemptNumber": 1,
+            "startedAt": "2026-08-02T10:44:59.443Z",
+            "completedAt": "2026-08-02T10:45:01.561Z",
+            "durationMs": 2118,
+            "outcome": "success",
+            "retryable": false,
+            "backoffMs": 0
+          }
+        ]
+      },
+      {
+        "runId": "valency_role%2Fseeker-gets-patient-provider-gets-agent::run:2",
+        "caseId": "valency_role/seeker-gets-patient-provider-gets-agent",
+        "runIndex": 1,
+        "outcome": "success",
+        "recovered": false,
+        "attempts": [
+          {
+            "attemptId": "valency_role%2Fseeker-gets-patient-provider-gets-agent::run:2::attempt:1",
+            "runId": "valency_role%2Fseeker-gets-patient-provider-gets-agent::run:2",
+            "runIndex": 1,
+            "attemptNumber": 1,
+            "startedAt": "2026-08-02T10:45:01.561Z",
+            "completedAt": "2026-08-02T10:45:03.212Z",
+            "durationMs": 1651,
+            "outcome": "success",
+            "retryable": false,
+            "backoffMs": 0
+          }
+        ]
+      },
+      {
+        "runId": "valency_role%2Fseeker-gets-patient-provider-gets-agent::run:3",
+        "caseId": "valency_role/seeker-gets-patient-provider-gets-agent",
+        "runIndex": 2,
+        "outcome": "success",
+        "recovered": false,
+        "attempts": [
+          {
+            "attemptId": "valency_role%2Fseeker-gets-patient-provider-gets-agent::run:3::attempt:1",
+            "runId": "valency_role%2Fseeker-gets-patient-provider-gets-agent::run:3",
+            "runIndex": 2,
+            "attemptNumber": 1,
+            "startedAt": "2026-08-02T10:45:03.212Z",
+            "completedAt": "2026-08-02T10:45:04.732Z",
+            "durationMs": 1520,
+            "outcome": "success",
+            "retryable": false,
+            "backoffMs": 0
+          }
+        ]
+      },
+      {
+        "runId": "score_calibration%2Fmust-meet-primary-role::run:1",
+        "caseId": "score_calibration/must-meet-primary-role",
+        "runIndex": 0,
+        "outcome": "success",
+        "recovered": false,
+        "attempts": [
+          {
+            "attemptId": "score_calibration%2Fmust-meet-primary-role::run:1::attempt:1",
+            "runId": "score_calibration%2Fmust-meet-primary-role::run:1",
+            "runIndex": 0,
+            "attemptNumber": 1,
+            "startedAt": "2026-08-02T10:45:04.733Z",
+            "completedAt": "2026-08-02T10:45:05.971Z",
+            "durationMs": 1238,
+            "outcome": "success",
+            "retryable": false,
+            "backoffMs": 0
+          }
+        ]
+      },
+      {
+        "runId": "score_calibration%2Fmust-meet-primary-role::run:2",
+        "caseId": "score_calibration/must-meet-primary-role",
+        "runIndex": 1,
+        "outcome": "success",
+        "recovered": false,
+        "attempts": [
+          {
+            "attemptId": "score_calibration%2Fmust-meet-primary-role::run:2::attempt:1",
+            "runId": "score_calibration%2Fmust-meet-primary-role::run:2",
+            "runIndex": 1,
+            "attemptNumber": 1,
+            "startedAt": "2026-08-02T10:45:05.971Z",
+            "completedAt": "2026-08-02T10:45:07.253Z",
+            "durationMs": 1282,
+            "outcome": "success",
+            "retryable": false,
+            "backoffMs": 0
+          }
+        ]
+      },
+      {
+        "runId": "score_calibration%2Fmust-meet-primary-role::run:3",
+        "caseId": "score_calibration/must-meet-primary-role",
+        "runIndex": 2,
+        "outcome": "success",
+        "recovered": false,
+        "attempts": [
+          {
+            "attemptId": "score_calibration%2Fmust-meet-primary-role::run:3::attempt:1",
+            "runId": "score_calibration%2Fmust-meet-primary-role::run:3",
+            "runIndex": 2,
+            "attemptNumber": 1,
+            "startedAt": "2026-08-02T10:45:07.253Z",
+            "completedAt": "2026-08-02T10:45:09.094Z",
+            "durationMs": 1841,
+            "outcome": "success",
+            "retryable": false,
+            "backoffMs": 0
+          }
+        ]
+      },
+      {
+        "runId": "event_network%2Fco-membership-is-not-attendance::run:1",
+        "caseId": "event_network/co-membership-is-not-attendance",
+        "runIndex": 0,
+        "outcome": "success",
+        "recovered": false,
+        "attempts": [
+          {
+            "attemptId": "event_network%2Fco-membership-is-not-attendance::run:1::attempt:1",
+            "runId": "event_network%2Fco-membership-is-not-attendance::run:1",
+            "runIndex": 0,
+            "attemptNumber": 1,
+            "startedAt": "2026-08-02T10:45:09.094Z",
+            "completedAt": "2026-08-02T10:45:10.507Z",
+            "durationMs": 1413,
+            "outcome": "success",
+            "retryable": false,
+            "backoffMs": 0
+          }
+        ]
+      },
+      {
+        "runId": "event_network%2Fco-membership-is-not-attendance::run:2",
+        "caseId": "event_network/co-membership-is-not-attendance",
+        "runIndex": 1,
+        "outcome": "success",
+        "recovered": false,
+        "attempts": [
+          {
+            "attemptId": "event_network%2Fco-membership-is-not-attendance::run:2::attempt:1",
+            "runId": "event_network%2Fco-membership-is-not-attendance::run:2",
+            "runIndex": 1,
+            "attemptNumber": 1,
+            "startedAt": "2026-08-02T10:45:10.507Z",
+            "completedAt": "2026-08-02T10:45:12.316Z",
+            "durationMs": 1809,
+            "outcome": "success",
+            "retryable": false,
+            "backoffMs": 0
+          }
+        ]
+      },
+      {
+        "runId": "event_network%2Fco-membership-is-not-attendance::run:3",
+        "caseId": "event_network/co-membership-is-not-attendance",
+        "runIndex": 2,
+        "outcome": "success",
+        "recovered": false,
+        "attempts": [
+          {
+            "attemptId": "event_network%2Fco-membership-is-not-attendance::run:3::attempt:1",
+            "runId": "event_network%2Fco-membership-is-not-attendance::run:3",
+            "runIndex": 2,
+            "attemptNumber": 1,
+            "startedAt": "2026-08-02T10:45:12.316Z",
+            "completedAt": "2026-08-02T10:45:14.822Z",
+            "durationMs": 2506,
+            "outcome": "success",
+            "retryable": false,
+            "backoffMs": 0
+          }
+        ]
+      },
+      {
+        "runId": "score_calibration%2Ftier2-cofounder-pool::run:1",
+        "caseId": "score_calibration/tier2-cofounder-pool",
+        "runIndex": 0,
+        "outcome": "success",
+        "recovered": false,
+        "attempts": [
+          {
+            "attemptId": "score_calibration%2Ftier2-cofounder-pool::run:1::attempt:1",
+            "runId": "score_calibration%2Ftier2-cofounder-pool::run:1",
+            "runIndex": 0,
+            "attemptNumber": 1,
+            "startedAt": "2026-08-02T10:45:14.823Z",
+            "completedAt": "2026-08-02T10:45:17.247Z",
+            "durationMs": 2424,
+            "outcome": "success",
+            "retryable": false,
+            "backoffMs": 0
+          }
+        ]
+      },
+      {
+        "runId": "score_calibration%2Ftier2-cofounder-pool::run:2",
+        "caseId": "score_calibration/tier2-cofounder-pool",
+        "runIndex": 1,
+        "outcome": "success",
+        "recovered": false,
+        "attempts": [
+          {
+            "attemptId": "score_calibration%2Ftier2-cofounder-pool::run:2::attempt:1",
+            "runId": "score_calibration%2Ftier2-cofounder-pool::run:2",
+            "runIndex": 1,
+            "attemptNumber": 1,
+            "startedAt": "2026-08-02T10:45:17.247Z",
+            "completedAt": "2026-08-02T10:45:20.512Z",
+            "durationMs": 3265,
+            "outcome": "success",
+            "retryable": false,
+            "backoffMs": 0
+          }
+        ]
+      },
+      {
+        "runId": "score_calibration%2Ftier2-cofounder-pool::run:3",
+        "caseId": "score_calibration/tier2-cofounder-pool",
+        "runIndex": 2,
+        "outcome": "success",
+        "recovered": false,
+        "attempts": [
+          {
+            "attemptId": "score_calibration%2Ftier2-cofounder-pool::run:3::attempt:1",
+            "runId": "score_calibration%2Ftier2-cofounder-pool::run:3",
+            "runIndex": 2,
+            "attemptNumber": 1,
+            "startedAt": "2026-08-02T10:45:20.512Z",
+            "completedAt": "2026-08-02T10:45:23.785Z",
+            "durationMs": 3273,
+            "outcome": "success",
+            "retryable": false,
+            "backoffMs": 0
+          }
+        ]
+      },
+      {
+        "runId": "cross_domain%2Fanimation-query-vs-geo-protocols-premise::run:1",
+        "caseId": "cross_domain/animation-query-vs-geo-protocols-premise",
+        "runIndex": 0,
+        "outcome": "success",
+        "recovered": false,
+        "attempts": [
+          {
+            "attemptId": "cross_domain%2Fanimation-query-vs-geo-protocols-premise::run:1::attempt:1",
+            "runId": "cross_domain%2Fanimation-query-vs-geo-protocols-premise::run:1",
+            "runIndex": 0,
+            "attemptNumber": 1,
+            "startedAt": "2026-08-02T10:45:23.785Z",
+            "completedAt": "2026-08-02T10:45:24.995Z",
+            "durationMs": 1210,
+            "outcome": "success",
+            "retryable": false,
+            "backoffMs": 0
+          }
+        ]
+      },
+      {
+        "runId": "cross_domain%2Fanimation-query-vs-geo-protocols-premise::run:2",
+        "caseId": "cross_domain/animation-query-vs-geo-protocols-premise",
+        "runIndex": 1,
+        "outcome": "success",
+        "recovered": false,
+        "attempts": [
+          {
+            "attemptId": "cross_domain%2Fanimation-query-vs-geo-protocols-premise::run:2::attempt:1",
+            "runId": "cross_domain%2Fanimation-query-vs-geo-protocols-premise::run:2",
+            "runIndex": 1,
+            "attemptNumber": 1,
+            "startedAt": "2026-08-02T10:45:24.995Z",
+            "completedAt": "2026-08-02T10:45:25.915Z",
+            "durationMs": 920,
+            "outcome": "success",
+            "retryable": false,
+            "backoffMs": 0
+          }
+        ]
+      },
+      {
+        "runId": "cross_domain%2Fanimation-query-vs-geo-protocols-premise::run:3",
+        "caseId": "cross_domain/animation-query-vs-geo-protocols-premise",
+        "runIndex": 2,
+        "outcome": "success",
+        "recovered": false,
+        "attempts": [
+          {
+            "attemptId": "cross_domain%2Fanimation-query-vs-geo-protocols-premise::run:3::attempt:1",
+            "runId": "cross_domain%2Fanimation-query-vs-geo-protocols-premise::run:3",
+            "runIndex": 2,
+            "attemptNumber": 1,
+            "startedAt": "2026-08-02T10:45:25.915Z",
+            "completedAt": "2026-08-02T10:45:27.043Z",
+            "durationMs": 1128,
+            "outcome": "success",
+            "retryable": false,
+            "backoffMs": 0
+          }
+        ]
+      },
+      {
+        "runId": "historical%2Fbuilder-and-operator::run:1",
+        "caseId": "historical/builder-and-operator",
+        "runIndex": 0,
+        "outcome": "success",
+        "recovered": false,
+        "attempts": [
+          {
+            "attemptId": "historical%2Fbuilder-and-operator::run:1::attempt:1",
+            "runId": "historical%2Fbuilder-and-operator::run:1",
+            "runIndex": 0,
+            "attemptNumber": 1,
+            "startedAt": "2026-08-02T10:45:27.929Z",
+            "completedAt": "2026-08-02T10:45:30.279Z",
+            "durationMs": 2350,
+            "outcome": "success",
+            "retryable": false,
+            "backoffMs": 0
+          }
+        ]
+      },
+      {
+        "runId": "historical%2Fbuilder-and-operator::run:2",
+        "caseId": "historical/builder-and-operator",
+        "runIndex": 1,
+        "outcome": "success",
+        "recovered": false,
+        "attempts": [
+          {
+            "attemptId": "historical%2Fbuilder-and-operator::run:2::attempt:1",
+            "runId": "historical%2Fbuilder-and-operator::run:2",
+            "runIndex": 1,
+            "attemptNumber": 1,
+            "startedAt": "2026-08-02T10:45:30.279Z",
+            "completedAt": "2026-08-02T10:45:33.578Z",
+            "durationMs": 3299,
+            "outcome": "success",
+            "retryable": false,
+            "backoffMs": 0
+          }
+        ]
+      },
+      {
+        "runId": "historical%2Fbuilder-and-operator::run:3",
+        "caseId": "historical/builder-and-operator",
+        "runIndex": 2,
+        "outcome": "success",
+        "recovered": false,
+        "attempts": [
+          {
+            "attemptId": "historical%2Fbuilder-and-operator::run:3::attempt:1",
+            "runId": "historical%2Fbuilder-and-operator::run:3",
+            "runIndex": 2,
+            "attemptNumber": 1,
+            "startedAt": "2026-08-02T10:45:33.578Z",
+            "completedAt": "2026-08-02T10:45:37.008Z",
+            "durationMs": 3430,
+            "outcome": "success",
+            "retryable": false,
+            "backoffMs": 0
+          }
+        ]
+      },
+      {
+        "runId": "historical%2Fco-researchers-structure::run:1",
+        "caseId": "historical/co-researchers-structure",
+        "runIndex": 0,
+        "outcome": "success",
+        "recovered": false,
+        "attempts": [
+          {
+            "attemptId": "historical%2Fco-researchers-structure::run:1::attempt:1",
+            "runId": "historical%2Fco-researchers-structure::run:1",
+            "runIndex": 0,
+            "attemptNumber": 1,
+            "startedAt": "2026-08-02T10:45:37.008Z",
+            "completedAt": "2026-08-02T10:45:40.144Z",
+            "durationMs": 3136,
+            "outcome": "success",
+            "retryable": false,
+            "backoffMs": 0
+          }
+        ]
+      },
+      {
+        "runId": "historical%2Fco-researchers-structure::run:2",
+        "caseId": "historical/co-researchers-structure",
+        "runIndex": 1,
+        "outcome": "success",
+        "recovered": false,
+        "attempts": [
+          {
+            "attemptId": "historical%2Fco-researchers-structure::run:2::attempt:1",
+            "runId": "historical%2Fco-researchers-structure::run:2",
+            "runIndex": 1,
+            "attemptNumber": 1,
+            "startedAt": "2026-08-02T10:45:40.144Z",
+            "completedAt": "2026-08-02T10:45:43.626Z",
+            "durationMs": 3482,
+            "outcome": "success",
+            "retryable": false,
+            "backoffMs": 0
+          }
+        ]
+      },
+      {
+        "runId": "historical%2Fco-researchers-structure::run:3",
+        "caseId": "historical/co-researchers-structure",
+        "runIndex": 2,
+        "outcome": "success",
+        "recovered": false,
+        "attempts": [
+          {
+            "attemptId": "historical%2Fco-researchers-structure::run:3::attempt:1",
+            "runId": "historical%2Fco-researchers-structure::run:3",
+            "runIndex": 2,
+            "attemptNumber": 1,
+            "startedAt": "2026-08-02T10:45:43.626Z",
+            "completedAt": "2026-08-02T10:45:47.127Z",
+            "durationMs": 3501,
+            "outcome": "success",
+            "retryable": false,
+            "backoffMs": 0
+          }
+        ]
+      },
+      {
+        "runId": "historical%2Fsongwriting-duo::run:1",
+        "caseId": "historical/songwriting-duo",
+        "runIndex": 0,
+        "outcome": "success",
+        "recovered": false,
+        "attempts": [
+          {
+            "attemptId": "historical%2Fsongwriting-duo::run:1::attempt:1",
+            "runId": "historical%2Fsongwriting-duo::run:1",
+            "runIndex": 0,
+            "attemptNumber": 1,
+            "startedAt": "2026-08-02T10:45:47.127Z",
+            "completedAt": "2026-08-02T10:45:50.670Z",
+            "durationMs": 3543,
+            "outcome": "success",
+            "retryable": false,
+            "backoffMs": 0
+          }
+        ]
+      },
+      {
+        "runId": "historical%2Fsongwriting-duo::run:2",
+        "caseId": "historical/songwriting-duo",
+        "runIndex": 1,
+        "outcome": "success",
+        "recovered": false,
+        "attempts": [
+          {
+            "attemptId": "historical%2Fsongwriting-duo::run:2::attempt:1",
+            "runId": "historical%2Fsongwriting-duo::run:2",
+            "runIndex": 1,
+            "attemptNumber": 1,
+            "startedAt": "2026-08-02T10:45:50.670Z",
+            "completedAt": "2026-08-02T10:45:54.392Z",
+            "durationMs": 3722,
+            "outcome": "success",
+            "retryable": false,
+            "backoffMs": 0
+          }
+        ]
+      },
+      {
+        "runId": "historical%2Fsongwriting-duo::run:3",
+        "caseId": "historical/songwriting-duo",
+        "runIndex": 2,
+        "outcome": "success",
+        "recovered": false,
+        "attempts": [
+          {
+            "attemptId": "historical%2Fsongwriting-duo::run:3::attempt:1",
+            "runId": "historical%2Fsongwriting-duo::run:3",
+            "runIndex": 2,
+            "attemptNumber": 1,
+            "startedAt": "2026-08-02T10:45:54.392Z",
+            "completedAt": "2026-08-02T10:45:57.750Z",
+            "durationMs": 3358,
+            "outcome": "success",
+            "retryable": false,
+            "backoffMs": 0
+          }
+        ]
+      },
+      {
+        "runId": "historical%2Ffirst-check-investor::run:1",
+        "caseId": "historical/first-check-investor",
+        "runIndex": 0,
+        "outcome": "success",
+        "recovered": false,
+        "attempts": [
+          {
+            "attemptId": "historical%2Ffirst-check-investor::run:1::attempt:1",
+            "runId": "historical%2Ffirst-check-investor::run:1",
+            "runIndex": 0,
+            "attemptNumber": 1,
+            "startedAt": "2026-08-02T10:45:57.750Z",
+            "completedAt": "2026-08-02T10:46:00.400Z",
+            "durationMs": 2650,
+            "outcome": "success",
+            "retryable": false,
+            "backoffMs": 0
+          }
+        ]
+      },
+      {
+        "runId": "historical%2Ffirst-check-investor::run:2",
+        "caseId": "historical/first-check-investor",
+        "runIndex": 1,
+        "outcome": "success",
+        "recovered": false,
+        "attempts": [
+          {
+            "attemptId": "historical%2Ffirst-check-investor::run:2::attempt:1",
+            "runId": "historical%2Ffirst-check-investor::run:2",
+            "runIndex": 1,
+            "attemptNumber": 1,
+            "startedAt": "2026-08-02T10:46:00.400Z",
+            "completedAt": "2026-08-02T10:46:03.800Z",
+            "durationMs": 3400,
+            "outcome": "success",
+            "retryable": false,
+            "backoffMs": 0
+          }
+        ]
+      },
+      {
+        "runId": "historical%2Ffirst-check-investor::run:3",
+        "caseId": "historical/first-check-investor",
+        "runIndex": 2,
+        "outcome": "success",
+        "recovered": false,
+        "attempts": [
+          {
+            "attemptId": "historical%2Ffirst-check-investor::run:3::attempt:1",
+            "runId": "historical%2Ffirst-check-investor::run:3",
+            "runIndex": 2,
+            "attemptNumber": 1,
+            "startedAt": "2026-08-02T10:46:03.800Z",
+            "completedAt": "2026-08-02T10:46:07.399Z",
+            "durationMs": 3599,
+            "outcome": "success",
+            "retryable": false,
+            "backoffMs": 0
+          }
+        ]
+      },
+      {
+        "runId": "historical%2Fdomain-expert-and-ml::run:1",
+        "caseId": "historical/domain-expert-and-ml",
+        "runIndex": 0,
+        "outcome": "success",
+        "recovered": false,
+        "attempts": [
+          {
+            "attemptId": "historical%2Fdomain-expert-and-ml::run:1::attempt:1",
+            "runId": "historical%2Fdomain-expert-and-ml::run:1",
+            "runIndex": 0,
+            "attemptNumber": 1,
+            "startedAt": "2026-08-02T10:46:07.399Z",
+            "completedAt": "2026-08-02T10:46:10.820Z",
+            "durationMs": 3421,
+            "outcome": "success",
+            "retryable": false,
+            "backoffMs": 0
+          }
+        ]
+      },
+      {
+        "runId": "historical%2Fdomain-expert-and-ml::run:2",
+        "caseId": "historical/domain-expert-and-ml",
+        "runIndex": 1,
+        "outcome": "success",
+        "recovered": false,
+        "attempts": [
+          {
+            "attemptId": "historical%2Fdomain-expert-and-ml::run:2::attempt:1",
+            "runId": "historical%2Fdomain-expert-and-ml::run:2",
+            "runIndex": 1,
+            "attemptNumber": 1,
+            "startedAt": "2026-08-02T10:46:10.820Z",
+            "completedAt": "2026-08-02T10:46:14.250Z",
+            "durationMs": 3430,
+            "outcome": "success",
+            "retryable": false,
+            "backoffMs": 0
+          }
+        ]
+      },
+      {
+        "runId": "historical%2Fdomain-expert-and-ml::run:3",
+        "caseId": "historical/domain-expert-and-ml",
+        "runIndex": 2,
+        "outcome": "success",
+        "recovered": false,
+        "attempts": [
+          {
+            "attemptId": "historical%2Fdomain-expert-and-ml::run:3::attempt:1",
+            "runId": "historical%2Fdomain-expert-and-ml::run:3",
+            "runIndex": 2,
+            "attemptNumber": 1,
+            "startedAt": "2026-08-02T10:46:14.250Z",
+            "completedAt": "2026-08-02T10:46:17.446Z",
+            "durationMs": 3196,
+            "outcome": "success",
+            "retryable": false,
+            "backoffMs": 0
+          }
+        ]
+      },
+      {
+        "runId": "is_a_identity%2Fstartup-funder-vs-funded-bootstrapper::run:1",
+        "caseId": "is_a_identity/startup-funder-vs-funded-bootstrapper",
+        "runIndex": 0,
+        "outcome": "success",
+        "recovered": false,
+        "attempts": [
+          {
+            "attemptId": "is_a_identity%2Fstartup-funder-vs-funded-bootstrapper::run:1::attempt:1",
+            "runId": "is_a_identity%2Fstartup-funder-vs-funded-bootstrapper::run:1",
+            "runIndex": 0,
+            "attemptNumber": 1,
+            "startedAt": "2026-08-02T10:46:17.447Z",
+            "completedAt": "2026-08-02T10:46:18.880Z",
+            "durationMs": 1433,
+            "outcome": "success",
+            "retryable": false,
+            "backoffMs": 0
+          }
+        ]
+      },
+      {
+        "runId": "is_a_identity%2Fstartup-funder-vs-funded-bootstrapper::run:2",
+        "caseId": "is_a_identity/startup-funder-vs-funded-bootstrapper",
+        "runIndex": 1,
+        "outcome": "success",
+        "recovered": false,
+        "attempts": [
+          {
+            "attemptId": "is_a_identity%2Fstartup-funder-vs-funded-bootstrapper::run:2::attempt:1",
+            "runId": "is_a_identity%2Fstartup-funder-vs-funded-bootstrapper::run:2",
+            "runIndex": 1,
+            "attemptNumber": 1,
+            "startedAt": "2026-08-02T10:46:18.880Z",
+            "completedAt": "2026-08-02T10:46:20.302Z",
+            "durationMs": 1422,
+            "outcome": "success",
+            "retryable": false,
+            "backoffMs": 0
+          }
+        ]
+      },
+      {
+        "runId": "is_a_identity%2Fstartup-funder-vs-funded-bootstrapper::run:3",
+        "caseId": "is_a_identity/startup-funder-vs-funded-bootstrapper",
+        "runIndex": 2,
+        "outcome": "success",
+        "recovered": false,
+        "attempts": [
+          {
+            "attemptId": "is_a_identity%2Fstartup-funder-vs-funded-bootstrapper::run:3::attempt:1",
+            "runId": "is_a_identity%2Fstartup-funder-vs-funded-bootstrapper::run:3",
+            "runIndex": 2,
+            "attemptNumber": 1,
+            "startedAt": "2026-08-02T10:46:20.302Z",
+            "completedAt": "2026-08-02T10:46:21.510Z",
+            "durationMs": 1208,
+            "outcome": "success",
+            "retryable": false,
+            "backoffMs": 0
+          }
+        ]
+      },
+      {
+        "runId": "is_a_identity%2Fart-director-vs-illustrator::run:1",
+        "caseId": "is_a_identity/art-director-vs-illustrator",
+        "runIndex": 0,
+        "outcome": "success",
+        "recovered": false,
+        "attempts": [
+          {
+            "attemptId": "is_a_identity%2Fart-director-vs-illustrator::run:1::attempt:1",
+            "runId": "is_a_identity%2Fart-director-vs-illustrator::run:1",
+            "runIndex": 0,
+            "attemptNumber": 1,
+            "startedAt": "2026-08-02T10:46:21.510Z",
+            "completedAt": "2026-08-02T10:46:22.860Z",
+            "durationMs": 1350,
+            "outcome": "success",
+            "retryable": false,
+            "backoffMs": 0
+          }
+        ]
+      },
+      {
+        "runId": "is_a_identity%2Fart-director-vs-illustrator::run:2",
+        "caseId": "is_a_identity/art-director-vs-illustrator",
+        "runIndex": 1,
+        "outcome": "success",
+        "recovered": false,
+        "attempts": [
+          {
+            "attemptId": "is_a_identity%2Fart-director-vs-illustrator::run:2::attempt:1",
+            "runId": "is_a_identity%2Fart-director-vs-illustrator::run:2",
+            "runIndex": 1,
+            "attemptNumber": 1,
+            "startedAt": "2026-08-02T10:46:22.860Z",
+            "completedAt": "2026-08-02T10:46:24.168Z",
+            "durationMs": 1308,
+            "outcome": "success",
+            "retryable": false,
+            "backoffMs": 0
+          }
+        ]
+      },
+      {
+        "runId": "is_a_identity%2Fart-director-vs-illustrator::run:3",
+        "caseId": "is_a_identity/art-director-vs-illustrator",
+        "runIndex": 2,
+        "outcome": "success",
+        "recovered": false,
+        "attempts": [
+          {
+            "attemptId": "is_a_identity%2Fart-director-vs-illustrator::run:3::attempt:1",
+            "runId": "is_a_identity%2Fart-director-vs-illustrator::run:3",
+            "runIndex": 2,
+            "attemptNumber": 1,
+            "startedAt": "2026-08-02T10:46:24.168Z",
+            "completedAt": "2026-08-02T10:46:25.933Z",
+            "durationMs": 1765,
+            "outcome": "success",
+            "retryable": false,
+            "backoffMs": 0
+          }
+        ]
+      },
+      {
+        "runId": "is_a_identity%2Fscout-vs-scouted-athlete::run:1",
+        "caseId": "is_a_identity/scout-vs-scouted-athlete",
+        "runIndex": 0,
+        "outcome": "success",
+        "recovered": false,
+        "attempts": [
+          {
+            "attemptId": "is_a_identity%2Fscout-vs-scouted-athlete::run:1::attempt:1",
+            "runId": "is_a_identity%2Fscout-vs-scouted-athlete::run:1",
+            "runIndex": 0,
+            "attemptNumber": 1,
+            "startedAt": "2026-08-02T10:46:25.933Z",
+            "completedAt": "2026-08-02T10:46:27.844Z",
+            "durationMs": 1911,
+            "outcome": "success",
+            "retryable": false,
+            "backoffMs": 0
+          }
+        ]
+      },
+      {
+        "runId": "is_a_identity%2Fscout-vs-scouted-athlete::run:2",
+        "caseId": "is_a_identity/scout-vs-scouted-athlete",
+        "runIndex": 1,
+        "outcome": "success",
+        "recovered": false,
+        "attempts": [
+          {
+            "attemptId": "is_a_identity%2Fscout-vs-scouted-athlete::run:2::attempt:1",
+            "runId": "is_a_identity%2Fscout-vs-scouted-athlete::run:2",
+            "runIndex": 1,
+            "attemptNumber": 1,
+            "startedAt": "2026-08-02T10:46:27.844Z",
+            "completedAt": "2026-08-02T10:46:29.765Z",
+            "durationMs": 1921,
+            "outcome": "success",
+            "retryable": false,
+            "backoffMs": 0
+          }
+        ]
+      },
+      {
+        "runId": "is_a_identity%2Fscout-vs-scouted-athlete::run:3",
+        "caseId": "is_a_identity/scout-vs-scouted-athlete",
+        "runIndex": 2,
+        "outcome": "success",
+        "recovered": false,
+        "attempts": [
+          {
+            "attemptId": "is_a_identity%2Fscout-vs-scouted-athlete::run:3::attempt:1",
+            "runId": "is_a_identity%2Fscout-vs-scouted-athlete::run:3",
+            "runIndex": 2,
+            "attemptNumber": 1,
+            "startedAt": "2026-08-02T10:46:29.765Z",
+            "completedAt": "2026-08-02T10:46:32.349Z",
+            "durationMs": 2584,
+            "outcome": "success",
+            "retryable": false,
+            "backoffMs": 0
+          }
+        ]
+      },
+      {
+        "runId": "is_a_identity%2Finvestor-vs-grant-recipient::run:1",
+        "caseId": "is_a_identity/investor-vs-grant-recipient",
+        "runIndex": 0,
+        "outcome": "success",
+        "recovered": false,
+        "attempts": [
+          {
+            "attemptId": "is_a_identity%2Finvestor-vs-grant-recipient::run:1::attempt:1",
+            "runId": "is_a_identity%2Finvestor-vs-grant-recipient::run:1",
+            "runIndex": 0,
+            "attemptNumber": 1,
+            "startedAt": "2026-08-02T10:46:32.349Z",
+            "completedAt": "2026-08-02T10:46:33.509Z",
+            "durationMs": 1160,
+            "outcome": "success",
+            "retryable": false,
+            "backoffMs": 0
+          }
+        ]
+      },
+      {
+        "runId": "is_a_identity%2Finvestor-vs-grant-recipient::run:2",
+        "caseId": "is_a_identity/investor-vs-grant-recipient",
+        "runIndex": 1,
+        "outcome": "success",
+        "recovered": false,
+        "attempts": [
+          {
+            "attemptId": "is_a_identity%2Finvestor-vs-grant-recipient::run:2::attempt:1",
+            "runId": "is_a_identity%2Finvestor-vs-grant-recipient::run:2",
+            "runIndex": 1,
+            "attemptNumber": 1,
+            "startedAt": "2026-08-02T10:46:33.509Z",
+            "completedAt": "2026-08-02T10:46:34.772Z",
+            "durationMs": 1263,
+            "outcome": "success",
+            "retryable": false,
+            "backoffMs": 0
+          }
+        ]
+      },
+      {
+        "runId": "is_a_identity%2Finvestor-vs-grant-recipient::run:3",
+        "caseId": "is_a_identity/investor-vs-grant-recipient",
+        "runIndex": 2,
+        "outcome": "success",
+        "recovered": false,
+        "attempts": [
+          {
+            "attemptId": "is_a_identity%2Finvestor-vs-grant-recipient::run:3::attempt:1",
+            "runId": "is_a_identity%2Finvestor-vs-grant-recipient::run:3",
+            "runIndex": 2,
+            "attemptNumber": 1,
+            "startedAt": "2026-08-02T10:46:34.772Z",
+            "completedAt": "2026-08-02T10:46:36.165Z",
+            "durationMs": 1393,
+            "outcome": "success",
+            "retryable": false,
+            "backoffMs": 0
+          }
+        ]
+      },
+      {
+        "runId": "complementary_role%2Fdesign-cofounder-for-tech-founder::run:1",
+        "caseId": "complementary_role/design-cofounder-for-tech-founder",
+        "runIndex": 0,
+        "outcome": "success",
+        "recovered": false,
+        "attempts": [
+          {
+            "attemptId": "complementary_role%2Fdesign-cofounder-for-tech-founder::run:1::attempt:1",
+            "runId": "complementary_role%2Fdesign-cofounder-for-tech-founder::run:1",
+            "runIndex": 0,
+            "attemptNumber": 1,
+            "startedAt": "2026-08-02T10:46:36.165Z",
+            "completedAt": "2026-08-02T10:46:38.499Z",
+            "durationMs": 2334,
+            "outcome": "success",
+            "retryable": false,
+            "backoffMs": 0
+          }
+        ]
+      },
+      {
+        "runId": "complementary_role%2Fdesign-cofounder-for-tech-founder::run:2",
+        "caseId": "complementary_role/design-cofounder-for-tech-founder",
+        "runIndex": 1,
+        "outcome": "success",
+        "recovered": false,
+        "attempts": [
+          {
+            "attemptId": "complementary_role%2Fdesign-cofounder-for-tech-founder::run:2::attempt:1",
+            "runId": "complementary_role%2Fdesign-cofounder-for-tech-founder::run:2",
+            "runIndex": 1,
+            "attemptNumber": 1,
+            "startedAt": "2026-08-02T10:46:38.499Z",
+            "completedAt": "2026-08-02T10:46:46.978Z",
+            "durationMs": 8479,
+            "outcome": "success",
+            "retryable": false,
+            "backoffMs": 0
+          }
+        ]
+      },
+      {
+        "runId": "complementary_role%2Fdesign-cofounder-for-tech-founder::run:3",
+        "caseId": "complementary_role/design-cofounder-for-tech-founder",
+        "runIndex": 2,
+        "outcome": "success",
+        "recovered": false,
+        "attempts": [
+          {
+            "attemptId": "complementary_role%2Fdesign-cofounder-for-tech-founder::run:3::attempt:1",
+            "runId": "complementary_role%2Fdesign-cofounder-for-tech-founder::run:3",
+            "runIndex": 2,
+            "attemptNumber": 1,
+            "startedAt": "2026-08-02T10:46:46.979Z",
+            "completedAt": "2026-08-02T10:46:52.745Z",
+            "durationMs": 5766,
+            "outcome": "success",
+            "retryable": false,
+            "backoffMs": 0
+          }
+        ]
+      },
+      {
+        "runId": "complementary_role%2Fmarketing-cofounder-for-ai-engineer::run:1",
+        "caseId": "complementary_role/marketing-cofounder-for-ai-engineer",
+        "runIndex": 0,
+        "outcome": "success",
+        "recovered": false,
+        "attempts": [
+          {
+            "attemptId": "complementary_role%2Fmarketing-cofounder-for-ai-engineer::run:1::attempt:1",
+            "runId": "complementary_role%2Fmarketing-cofounder-for-ai-engineer::run:1",
+            "runIndex": 0,
+            "attemptNumber": 1,
+            "startedAt": "2026-08-02T10:46:52.745Z",
+            "completedAt": "2026-08-02T10:46:54.206Z",
+            "durationMs": 1461,
+            "outcome": "success",
+            "retryable": false,
+            "backoffMs": 0
+          }
+        ]
+      },
+      {
+        "runId": "complementary_role%2Fmarketing-cofounder-for-ai-engineer::run:2",
+        "caseId": "complementary_role/marketing-cofounder-for-ai-engineer",
+        "runIndex": 1,
+        "outcome": "success",
+        "recovered": false,
+        "attempts": [
+          {
+            "attemptId": "complementary_role%2Fmarketing-cofounder-for-ai-engineer::run:2::attempt:1",
+            "runId": "complementary_role%2Fmarketing-cofounder-for-ai-engineer::run:2",
+            "runIndex": 1,
+            "attemptNumber": 1,
+            "startedAt": "2026-08-02T10:46:54.206Z",
+            "completedAt": "2026-08-02T10:46:55.984Z",
+            "durationMs": 1778,
+            "outcome": "success",
+            "retryable": false,
+            "backoffMs": 0
+          }
+        ]
+      },
+      {
+        "runId": "complementary_role%2Fmarketing-cofounder-for-ai-engineer::run:3",
+        "caseId": "complementary_role/marketing-cofounder-for-ai-engineer",
+        "runIndex": 2,
+        "outcome": "success",
+        "recovered": false,
+        "attempts": [
+          {
+            "attemptId": "complementary_role%2Fmarketing-cofounder-for-ai-engineer::run:3::attempt:1",
+            "runId": "complementary_role%2Fmarketing-cofounder-for-ai-engineer::run:3",
+            "runIndex": 2,
+            "attemptNumber": 1,
+            "startedAt": "2026-08-02T10:46:55.984Z",
+            "completedAt": "2026-08-02T10:46:57.663Z",
+            "durationMs": 1679,
+            "outcome": "success",
+            "retryable": false,
+            "backoffMs": 0
+          }
+        ]
+      },
+      {
+        "runId": "same_side%2Fboth-seeking-cofounders::run:1",
+        "caseId": "same_side/both-seeking-cofounders",
+        "runIndex": 0,
+        "outcome": "success",
+        "recovered": false,
+        "attempts": [
+          {
+            "attemptId": "same_side%2Fboth-seeking-cofounders::run:1::attempt:1",
+            "runId": "same_side%2Fboth-seeking-cofounders::run:1",
+            "runIndex": 0,
+            "attemptNumber": 1,
+            "startedAt": "2026-08-02T10:46:57.663Z",
+            "completedAt": "2026-08-02T10:46:58.761Z",
+            "durationMs": 1098,
+            "outcome": "success",
+            "retryable": false,
+            "backoffMs": 0
+          }
+        ]
+      },
+      {
+        "runId": "same_side%2Fboth-seeking-cofounders::run:2",
+        "caseId": "same_side/both-seeking-cofounders",
+        "runIndex": 1,
+        "outcome": "success",
+        "recovered": false,
+        "attempts": [
+          {
+            "attemptId": "same_side%2Fboth-seeking-cofounders::run:2::attempt:1",
+            "runId": "same_side%2Fboth-seeking-cofounders::run:2",
+            "runIndex": 1,
+            "attemptNumber": 1,
+            "startedAt": "2026-08-02T10:46:58.761Z",
+            "completedAt": "2026-08-02T10:46:59.843Z",
+            "durationMs": 1082,
+            "outcome": "success",
+            "retryable": false,
+            "backoffMs": 0
+          }
+        ]
+      },
+      {
+        "runId": "same_side%2Fboth-seeking-cofounders::run:3",
+        "caseId": "same_side/both-seeking-cofounders",
+        "runIndex": 2,
+        "outcome": "success",
+        "recovered": false,
+        "attempts": [
+          {
+            "attemptId": "same_side%2Fboth-seeking-cofounders::run:3::attempt:1",
+            "runId": "same_side%2Fboth-seeking-cofounders::run:3",
+            "runIndex": 2,
+            "attemptNumber": 1,
+            "startedAt": "2026-08-02T10:46:59.843Z",
+            "completedAt": "2026-08-02T10:47:01.003Z",
+            "durationMs": 1160,
+            "outcome": "success",
+            "retryable": false,
+            "backoffMs": 0
+          }
+        ]
+      },
+      {
+        "runId": "same_side%2Fboth-hiring-engineers::run:1",
+        "caseId": "same_side/both-hiring-engineers",
+        "runIndex": 0,
+        "outcome": "success",
+        "recovered": false,
+        "attempts": [
+          {
+            "attemptId": "same_side%2Fboth-hiring-engineers::run:1::attempt:1",
+            "runId": "same_side%2Fboth-hiring-engineers::run:1",
+            "runIndex": 0,
+            "attemptNumber": 1,
+            "startedAt": "2026-08-02T10:47:01.003Z",
+            "completedAt": "2026-08-02T10:47:02.361Z",
+            "durationMs": 1358,
+            "outcome": "success",
+            "retryable": false,
+            "backoffMs": 0
+          }
+        ]
+      },
+      {
+        "runId": "same_side%2Fboth-hiring-engineers::run:2",
+        "caseId": "same_side/both-hiring-engineers",
+        "runIndex": 1,
+        "outcome": "success",
+        "recovered": false,
+        "attempts": [
+          {
+            "attemptId": "same_side%2Fboth-hiring-engineers::run:2::attempt:1",
+            "runId": "same_side%2Fboth-hiring-engineers::run:2",
+            "runIndex": 1,
+            "attemptNumber": 1,
+            "startedAt": "2026-08-02T10:47:02.361Z",
+            "completedAt": "2026-08-02T10:47:03.400Z",
+            "durationMs": 1039,
+            "outcome": "success",
+            "retryable": false,
+            "backoffMs": 0
+          }
+        ]
+      },
+      {
+        "runId": "same_side%2Fboth-hiring-engineers::run:3",
+        "caseId": "same_side/both-hiring-engineers",
+        "runIndex": 2,
+        "outcome": "success",
+        "recovered": false,
+        "attempts": [
+          {
+            "attemptId": "same_side%2Fboth-hiring-engineers::run:3::attempt:1",
+            "runId": "same_side%2Fboth-hiring-engineers::run:3",
+            "runIndex": 2,
+            "attemptNumber": 1,
+            "startedAt": "2026-08-02T10:47:03.400Z",
+            "completedAt": "2026-08-02T10:47:04.531Z",
+            "durationMs": 1131,
+            "outcome": "success",
+            "retryable": false,
+            "backoffMs": 0
+          }
+        ]
+      },
+      {
+        "runId": "location%2Fberlin-mismatch-vs-london-query::run:1",
+        "caseId": "location/berlin-mismatch-vs-london-query",
+        "runIndex": 0,
+        "outcome": "success",
+        "recovered": false,
+        "attempts": [
+          {
+            "attemptId": "location%2Fberlin-mismatch-vs-london-query::run:1::attempt:1",
+            "runId": "location%2Fberlin-mismatch-vs-london-query::run:1",
+            "runIndex": 0,
+            "attemptNumber": 1,
+            "startedAt": "2026-08-02T10:47:04.531Z",
+            "completedAt": "2026-08-02T10:47:05.490Z",
+            "durationMs": 959,
+            "outcome": "success",
+            "retryable": false,
+            "backoffMs": 0
+          }
+        ]
+      },
+      {
+        "runId": "location%2Fberlin-mismatch-vs-london-query::run:2",
+        "caseId": "location/berlin-mismatch-vs-london-query",
+        "runIndex": 1,
+        "outcome": "success",
+        "recovered": false,
+        "attempts": [
+          {
+            "attemptId": "location%2Fberlin-mismatch-vs-london-query::run:2::attempt:1",
+            "runId": "location%2Fberlin-mismatch-vs-london-query::run:2",
+            "runIndex": 1,
+            "attemptNumber": 1,
+            "startedAt": "2026-08-02T10:47:05.490Z",
+            "completedAt": "2026-08-02T10:47:06.531Z",
+            "durationMs": 1041,
+            "outcome": "success",
+            "retryable": false,
+            "backoffMs": 0
+          }
+        ]
+      },
+      {
+        "runId": "location%2Fberlin-mismatch-vs-london-query::run:3",
+        "caseId": "location/berlin-mismatch-vs-london-query",
+        "runIndex": 2,
+        "outcome": "success",
+        "recovered": false,
+        "attempts": [
+          {
+            "attemptId": "location%2Fberlin-mismatch-vs-london-query::run:3::attempt:1",
+            "runId": "location%2Fberlin-mismatch-vs-london-query::run:3",
+            "runIndex": 2,
+            "attemptNumber": 1,
+            "startedAt": "2026-08-02T10:47:06.531Z",
+            "completedAt": "2026-08-02T10:47:07.730Z",
+            "durationMs": 1199,
+            "outcome": "success",
+            "retryable": false,
+            "backoffMs": 0
+          }
+        ]
+      },
+      {
+        "runId": "location%2Funknown-city-not-penalized-variant::run:1",
+        "caseId": "location/unknown-city-not-penalized-variant",
+        "runIndex": 0,
+        "outcome": "success",
+        "recovered": false,
+        "attempts": [
+          {
+            "attemptId": "location%2Funknown-city-not-penalized-variant::run:1::attempt:1",
+            "runId": "location%2Funknown-city-not-penalized-variant::run:1",
+            "runIndex": 0,
+            "attemptNumber": 1,
+            "startedAt": "2026-08-02T10:47:07.730Z",
+            "completedAt": "2026-08-02T10:47:08.786Z",
+            "durationMs": 1056,
+            "outcome": "success",
+            "retryable": false,
+            "backoffMs": 0
+          }
+        ]
+      },
+      {
+        "runId": "location%2Funknown-city-not-penalized-variant::run:2",
+        "caseId": "location/unknown-city-not-penalized-variant",
+        "runIndex": 1,
+        "outcome": "success",
+        "recovered": false,
+        "attempts": [
+          {
+            "attemptId": "location%2Funknown-city-not-penalized-variant::run:2::attempt:1",
+            "runId": "location%2Funknown-city-not-penalized-variant::run:2",
+            "runIndex": 1,
+            "attemptNumber": 1,
+            "startedAt": "2026-08-02T10:47:08.786Z",
+            "completedAt": "2026-08-02T10:47:10.272Z",
+            "durationMs": 1486,
+            "outcome": "success",
+            "retryable": false,
+            "backoffMs": 0
+          }
+        ]
+      },
+      {
+        "runId": "location%2Funknown-city-not-penalized-variant::run:3",
+        "caseId": "location/unknown-city-not-penalized-variant",
+        "runIndex": 2,
+        "outcome": "success",
+        "recovered": false,
+        "attempts": [
+          {
+            "attemptId": "location%2Funknown-city-not-penalized-variant::run:3::attempt:1",
+            "runId": "location%2Funknown-city-not-penalized-variant::run:3",
+            "runIndex": 2,
+            "attemptNumber": 1,
+            "startedAt": "2026-08-02T10:47:10.272Z",
+            "completedAt": "2026-08-02T10:47:11.543Z",
+            "durationMs": 1271,
+            "outcome": "success",
+            "retryable": false,
+            "backoffMs": 0
+          }
+        ]
+      },
+      {
+        "runId": "valency_role%2Fseeker-needs-design-provider-offers-design::run:1",
+        "caseId": "valency_role/seeker-needs-design-provider-offers-design",
+        "runIndex": 0,
+        "outcome": "success",
+        "recovered": false,
+        "attempts": [
+          {
+            "attemptId": "valency_role%2Fseeker-needs-design-provider-offers-design::run:1::attempt:1",
+            "runId": "valency_role%2Fseeker-needs-design-provider-offers-design::run:1",
+            "runIndex": 0,
+            "attemptNumber": 1,
+            "startedAt": "2026-08-02T10:47:11.543Z",
+            "completedAt": "2026-08-02T10:47:12.801Z",
+            "durationMs": 1258,
+            "outcome": "success",
+            "retryable": false,
+            "backoffMs": 0
+          }
+        ]
+      },
+      {
+        "runId": "valency_role%2Fseeker-needs-design-provider-offers-design::run:2",
+        "caseId": "valency_role/seeker-needs-design-provider-offers-design",
+        "runIndex": 1,
+        "outcome": "success",
+        "recovered": false,
+        "attempts": [
+          {
+            "attemptId": "valency_role%2Fseeker-needs-design-provider-offers-design::run:2::attempt:1",
+            "runId": "valency_role%2Fseeker-needs-design-provider-offers-design::run:2",
+            "runIndex": 1,
+            "attemptNumber": 1,
+            "startedAt": "2026-08-02T10:47:12.801Z",
+            "completedAt": "2026-08-02T10:47:14.602Z",
+            "durationMs": 1801,
+            "outcome": "success",
+            "retryable": false,
+            "backoffMs": 0
+          }
+        ]
+      },
+      {
+        "runId": "valency_role%2Fseeker-needs-design-provider-offers-design::run:3",
+        "caseId": "valency_role/seeker-needs-design-provider-offers-design",
+        "runIndex": 2,
+        "outcome": "success",
+        "recovered": false,
+        "attempts": [
+          {
+            "attemptId": "valency_role%2Fseeker-needs-design-provider-offers-design::run:3::attempt:1",
+            "runId": "valency_role%2Fseeker-needs-design-provider-offers-design::run:3",
+            "runIndex": 2,
+            "attemptNumber": 1,
+            "startedAt": "2026-08-02T10:47:14.602Z",
+            "completedAt": "2026-08-02T10:47:16.389Z",
+            "durationMs": 1787,
+            "outcome": "success",
+            "retryable": false,
+            "backoffMs": 0
+          }
+        ]
+      },
+      {
+        "runId": "valency_role%2Fseeker-offers-capacity-provider-needs-capacity::run:1",
+        "caseId": "valency_role/seeker-offers-capacity-provider-needs-capacity",
+        "runIndex": 0,
+        "outcome": "success",
+        "recovered": false,
+        "attempts": [
+          {
+            "attemptId": "valency_role%2Fseeker-offers-capacity-provider-needs-capacity::run:1::attempt:1",
+            "runId": "valency_role%2Fseeker-offers-capacity-provider-needs-capacity::run:1",
+            "runIndex": 0,
+            "attemptNumber": 1,
+            "startedAt": "2026-08-02T10:47:16.389Z",
+            "completedAt": "2026-08-02T10:47:18.862Z",
+            "durationMs": 2473,
+            "outcome": "success",
+            "retryable": false,
+            "backoffMs": 0
+          }
+        ]
+      },
+      {
+        "runId": "valency_role%2Fseeker-offers-capacity-provider-needs-capacity::run:2",
+        "caseId": "valency_role/seeker-offers-capacity-provider-needs-capacity",
+        "runIndex": 1,
+        "outcome": "success",
+        "recovered": false,
+        "attempts": [
+          {
+            "attemptId": "valency_role%2Fseeker-offers-capacity-provider-needs-capacity::run:2::attempt:1",
+            "runId": "valency_role%2Fseeker-offers-capacity-provider-needs-capacity::run:2",
+            "runIndex": 1,
+            "attemptNumber": 1,
+            "startedAt": "2026-08-02T10:47:18.862Z",
+            "completedAt": "2026-08-02T10:47:20.534Z",
+            "durationMs": 1672,
+            "outcome": "success",
+            "retryable": false,
+            "backoffMs": 0
+          }
+        ]
+      },
+      {
+        "runId": "valency_role%2Fseeker-offers-capacity-provider-needs-capacity::run:3",
+        "caseId": "valency_role/seeker-offers-capacity-provider-needs-capacity",
+        "runIndex": 2,
+        "outcome": "success",
+        "recovered": false,
+        "attempts": [
+          {
+            "attemptId": "valency_role%2Fseeker-offers-capacity-provider-needs-capacity::run:3::attempt:1",
+            "runId": "valency_role%2Fseeker-offers-capacity-provider-needs-capacity::run:3",
+            "runIndex": 2,
+            "attemptNumber": 1,
+            "startedAt": "2026-08-02T10:47:20.534Z",
+            "completedAt": "2026-08-02T10:47:21.980Z",
+            "durationMs": 1446,
+            "outcome": "success",
+            "retryable": false,
+            "backoffMs": 0
+          }
+        ]
+      },
+      {
+        "runId": "score_calibration%2Fmust-meet-sales-cofounder::run:1",
+        "caseId": "score_calibration/must-meet-sales-cofounder",
+        "runIndex": 0,
+        "outcome": "success",
+        "recovered": false,
+        "attempts": [
+          {
+            "attemptId": "score_calibration%2Fmust-meet-sales-cofounder::run:1::attempt:1",
+            "runId": "score_calibration%2Fmust-meet-sales-cofounder::run:1",
+            "runIndex": 0,
+            "attemptNumber": 1,
+            "startedAt": "2026-08-02T10:47:21.980Z",
+            "completedAt": "2026-08-02T10:47:24.050Z",
+            "durationMs": 2070,
+            "outcome": "success",
+            "retryable": false,
+            "backoffMs": 0
+          }
+        ]
+      },
+      {
+        "runId": "score_calibration%2Fmust-meet-sales-cofounder::run:2",
+        "caseId": "score_calibration/must-meet-sales-cofounder",
+        "runIndex": 1,
+        "outcome": "success",
+        "recovered": false,
+        "attempts": [
+          {
+            "attemptId": "score_calibration%2Fmust-meet-sales-cofounder::run:2::attempt:1",
+            "runId": "score_calibration%2Fmust-meet-sales-cofounder::run:2",
+            "runIndex": 1,
+            "attemptNumber": 1,
+            "startedAt": "2026-08-02T10:47:24.050Z",
+            "completedAt": "2026-08-02T10:47:25.764Z",
+            "durationMs": 1714,
+            "outcome": "success",
+            "retryable": false,
+            "backoffMs": 0
+          }
+        ]
+      },
+      {
+        "runId": "score_calibration%2Fmust-meet-sales-cofounder::run:3",
+        "caseId": "score_calibration/must-meet-sales-cofounder",
+        "runIndex": 2,
+        "outcome": "success",
+        "recovered": false,
+        "attempts": [
+          {
+            "attemptId": "score_calibration%2Fmust-meet-sales-cofounder::run:3::attempt:1",
+            "runId": "score_calibration%2Fmust-meet-sales-cofounder::run:3",
+            "runIndex": 2,
+            "attemptNumber": 1,
+            "startedAt": "2026-08-02T10:47:25.764Z",
+            "completedAt": "2026-08-02T10:47:27.645Z",
+            "durationMs": 1881,
+            "outcome": "success",
+            "retryable": false,
+            "backoffMs": 0
+          }
+        ]
+      },
+      {
+        "runId": "score_calibration%2Ftier2-researcher-pool-variant::run:1",
+        "caseId": "score_calibration/tier2-researcher-pool-variant",
+        "runIndex": 0,
+        "outcome": "success",
+        "recovered": false,
+        "attempts": [
+          {
+            "attemptId": "score_calibration%2Ftier2-researcher-pool-variant::run:1::attempt:1",
+            "runId": "score_calibration%2Ftier2-researcher-pool-variant::run:1",
+            "runIndex": 0,
+            "attemptNumber": 1,
+            "startedAt": "2026-08-02T10:47:27.645Z",
+            "completedAt": "2026-08-02T10:47:30.304Z",
+            "durationMs": 2659,
+            "outcome": "success",
+            "retryable": false,
+            "backoffMs": 0
+          }
+        ]
+      },
+      {
+        "runId": "score_calibration%2Ftier2-researcher-pool-variant::run:2",
+        "caseId": "score_calibration/tier2-researcher-pool-variant",
+        "runIndex": 1,
+        "outcome": "success",
+        "recovered": false,
+        "attempts": [
+          {
+            "attemptId": "score_calibration%2Ftier2-researcher-pool-variant::run:2::attempt:1",
+            "runId": "score_calibration%2Ftier2-researcher-pool-variant::run:2",
+            "runIndex": 1,
+            "attemptNumber": 1,
+            "startedAt": "2026-08-02T10:47:30.304Z",
+            "completedAt": "2026-08-02T10:47:34.143Z",
+            "durationMs": 3839,
+            "outcome": "success",
+            "retryable": false,
+            "backoffMs": 0
+          }
+        ]
+      },
+      {
+        "runId": "score_calibration%2Ftier2-researcher-pool-variant::run:3",
+        "caseId": "score_calibration/tier2-researcher-pool-variant",
+        "runIndex": 2,
+        "outcome": "success",
+        "recovered": false,
+        "attempts": [
+          {
+            "attemptId": "score_calibration%2Ftier2-researcher-pool-variant::run:3::attempt:1",
+            "runId": "score_calibration%2Ftier2-researcher-pool-variant::run:3",
+            "runIndex": 2,
+            "attemptNumber": 1,
+            "startedAt": "2026-08-02T10:47:34.143Z",
+            "completedAt": "2026-08-02T10:47:37.523Z",
+            "durationMs": 3380,
+            "outcome": "success",
+            "retryable": false,
+            "backoffMs": 0
+          }
+        ]
+      }
+    ]
   },
   "payload": {
-    "generatedAt": "2026-05-29T18:05:23.210Z",
+    "generatedAt": "2026-08-02T10:47:37.524Z",
     "model": "google/gemini-2.5-flash",
-    "runs": 7,
-    "aggregatePassRate": 0.9892857142857142,
+    "runs": 3,
+    "aggregatePassRate": 0.9,
     "rules": [
       {
         "rule": "is_a_identity",
         "caseCount": 7,
-        "passRate": 1.0
+        "passRate": 1
       },
       {
         "rule": "query_primary",
         "caseCount": 8,
-        "passRate": 0.9821428571428571
+        "passRate": 0.875
       },
       {
         "rule": "complementary_role",
         "caseCount": 4,
-        "passRate": 0.9642857142857143
+        "passRate": 0.6666666666666666
       },
       {
         "rule": "same_side",
         "caseCount": 3,
-        "passRate": 1.0
+        "passRate": 1
       },
       {
         "rule": "already_known",
         "caseCount": 1,
-        "passRate": 1.0
+        "passRate": 1
       },
       {
         "rule": "location",
         "caseCount": 4,
-        "passRate": 1.0
+        "passRate": 0.75
       },
       {
         "rule": "valency_role",
         "caseCount": 3,
-        "passRate": 1.0
+        "passRate": 1
       },
       {
         "rule": "score_calibration",
         "caseCount": 4,
-        "passRate": 1.0
+        "passRate": 1
       },
       {
         "rule": "event_network",
         "caseCount": 1,
-        "passRate": 1.0
+        "passRate": 1
       },
       {
         "rule": "historical",
         "caseCount": 5,
-        "passRate": 0.9714285714285714
+        "passRate": 0.8666666666666666
       }
     ],
     "cases": [
       {
         "caseId": "is_a_identity/samurai-vs-character-designer",
         "rule": "is_a_identity",
-        "runs": 7,
-        "passes": 7,
+        "runs": 3,
+        "passes": 3,
         "passRate": 1,
         "flaky": false,
+        "scoredRunIds": [
+          "is_a_identity%2Fsamurai-vs-character-designer::run:1",
+          "is_a_identity%2Fsamurai-vs-character-designer::run:2",
+          "is_a_identity%2Fsamurai-vs-character-designer::run:3"
+        ],
         "runResults": [
           {
             "passed": true,
@@ -109,7 +2645,9 @@
                 "passed": true,
                 "detail": "expected score in [0,29], got 0"
               }
-            ]
+            ],
+            "runId": "is_a_identity%2Fsamurai-vs-character-designer::run:1",
+            "runIndex": 0
           },
           {
             "passed": true,
@@ -126,7 +2664,9 @@
                 "passed": true,
                 "detail": "expected score in [0,29], got 0"
               }
-            ]
+            ],
+            "runId": "is_a_identity%2Fsamurai-vs-character-designer::run:2",
+            "runIndex": 1
           },
           {
             "passed": true,
@@ -143,85 +2683,24 @@
                 "passed": true,
                 "detail": "expected score in [0,29], got 0"
               }
-            ]
-          },
-          {
-            "passed": true,
-            "assertions": [
-              {
-                "kind": "match",
-                "candidateId": "c-yuki",
-                "passed": true,
-                "detail": "expected match=false, got surfaced=false (score 0, threshold 30)"
-              },
-              {
-                "kind": "band",
-                "candidateId": "c-yuki",
-                "passed": true,
-                "detail": "expected score in [0,29], got 0"
-              }
-            ]
-          },
-          {
-            "passed": true,
-            "assertions": [
-              {
-                "kind": "match",
-                "candidateId": "c-yuki",
-                "passed": true,
-                "detail": "expected match=false, got surfaced=false (score 0, threshold 30)"
-              },
-              {
-                "kind": "band",
-                "candidateId": "c-yuki",
-                "passed": true,
-                "detail": "expected score in [0,29], got 0"
-              }
-            ]
-          },
-          {
-            "passed": true,
-            "assertions": [
-              {
-                "kind": "match",
-                "candidateId": "c-yuki",
-                "passed": true,
-                "detail": "expected match=false, got surfaced=false (score 0, threshold 30)"
-              },
-              {
-                "kind": "band",
-                "candidateId": "c-yuki",
-                "passed": true,
-                "detail": "expected score in [0,29], got 0"
-              }
-            ]
-          },
-          {
-            "passed": true,
-            "assertions": [
-              {
-                "kind": "match",
-                "candidateId": "c-yuki",
-                "passed": true,
-                "detail": "expected match=false, got surfaced=false (score 0, threshold 30)"
-              },
-              {
-                "kind": "band",
-                "candidateId": "c-yuki",
-                "passed": true,
-                "detail": "expected score in [0,29], got 0"
-              }
-            ]
+            ],
+            "runId": "is_a_identity%2Fsamurai-vs-character-designer::run:3",
+            "runIndex": 2
           }
         ]
       },
       {
         "caseId": "is_a_identity/investor-vs-funded-engineer",
         "rule": "is_a_identity",
-        "runs": 7,
-        "passes": 7,
+        "runs": 3,
+        "passes": 3,
         "passRate": 1,
         "flaky": false,
+        "scoredRunIds": [
+          "is_a_identity%2Finvestor-vs-funded-engineer::run:1",
+          "is_a_identity%2Finvestor-vs-funded-engineer::run:2",
+          "is_a_identity%2Finvestor-vs-funded-engineer::run:3"
+        ],
         "runResults": [
           {
             "passed": true,
@@ -238,7 +2717,9 @@
                 "passed": true,
                 "detail": "expected score in [0,29], got 0"
               }
-            ]
+            ],
+            "runId": "is_a_identity%2Finvestor-vs-funded-engineer::run:1",
+            "runIndex": 0
           },
           {
             "passed": true,
@@ -255,7 +2736,9 @@
                 "passed": true,
                 "detail": "expected score in [0,29], got 0"
               }
-            ]
+            ],
+            "runId": "is_a_identity%2Finvestor-vs-funded-engineer::run:2",
+            "runIndex": 1
           },
           {
             "passed": true,
@@ -272,85 +2755,24 @@
                 "passed": true,
                 "detail": "expected score in [0,29], got 0"
               }
-            ]
-          },
-          {
-            "passed": true,
-            "assertions": [
-              {
-                "kind": "match",
-                "candidateId": "c-sam",
-                "passed": true,
-                "detail": "expected match=false, got surfaced=false (score 0, threshold 30)"
-              },
-              {
-                "kind": "band",
-                "candidateId": "c-sam",
-                "passed": true,
-                "detail": "expected score in [0,29], got 0"
-              }
-            ]
-          },
-          {
-            "passed": true,
-            "assertions": [
-              {
-                "kind": "match",
-                "candidateId": "c-sam",
-                "passed": true,
-                "detail": "expected match=false, got surfaced=false (score 0, threshold 30)"
-              },
-              {
-                "kind": "band",
-                "candidateId": "c-sam",
-                "passed": true,
-                "detail": "expected score in [0,29], got 0"
-              }
-            ]
-          },
-          {
-            "passed": true,
-            "assertions": [
-              {
-                "kind": "match",
-                "candidateId": "c-sam",
-                "passed": true,
-                "detail": "expected match=false, got surfaced=false (score 0, threshold 30)"
-              },
-              {
-                "kind": "band",
-                "candidateId": "c-sam",
-                "passed": true,
-                "detail": "expected score in [0,29], got 0"
-              }
-            ]
-          },
-          {
-            "passed": true,
-            "assertions": [
-              {
-                "kind": "match",
-                "candidateId": "c-sam",
-                "passed": true,
-                "detail": "expected match=false, got surfaced=false (score 0, threshold 30)"
-              },
-              {
-                "kind": "band",
-                "candidateId": "c-sam",
-                "passed": true,
-                "detail": "expected score in [0,29], got 0"
-              }
-            ]
+            ],
+            "runId": "is_a_identity%2Finvestor-vs-funded-engineer::run:3",
+            "runIndex": 2
           }
         ]
       },
       {
         "caseId": "is_a_identity/investor-vs-real-investor",
         "rule": "is_a_identity",
-        "runs": 7,
-        "passes": 7,
+        "runs": 3,
+        "passes": 3,
         "passRate": 1,
         "flaky": false,
+        "scoredRunIds": [
+          "is_a_identity%2Finvestor-vs-real-investor::run:1",
+          "is_a_identity%2Finvestor-vs-real-investor::run:2",
+          "is_a_identity%2Finvestor-vs-real-investor::run:3"
+        ],
         "runResults": [
           {
             "passed": true,
@@ -367,7 +2789,9 @@
                 "passed": true,
                 "detail": "expected score in [70,100], got 95"
               }
-            ]
+            ],
+            "runId": "is_a_identity%2Finvestor-vs-real-investor::run:1",
+            "runIndex": 0
           },
           {
             "passed": true,
@@ -384,7 +2808,9 @@
                 "passed": true,
                 "detail": "expected score in [70,100], got 95"
               }
-            ]
+            ],
+            "runId": "is_a_identity%2Finvestor-vs-real-investor::run:2",
+            "runIndex": 1
           },
           {
             "passed": true,
@@ -401,85 +2827,24 @@
                 "passed": true,
                 "detail": "expected score in [70,100], got 95"
               }
-            ]
-          },
-          {
-            "passed": true,
-            "assertions": [
-              {
-                "kind": "match",
-                "candidateId": "c-sarah",
-                "passed": true,
-                "detail": "expected match=true, got surfaced=true (score 95, threshold 30)"
-              },
-              {
-                "kind": "band",
-                "candidateId": "c-sarah",
-                "passed": true,
-                "detail": "expected score in [70,100], got 95"
-              }
-            ]
-          },
-          {
-            "passed": true,
-            "assertions": [
-              {
-                "kind": "match",
-                "candidateId": "c-sarah",
-                "passed": true,
-                "detail": "expected match=true, got surfaced=true (score 95, threshold 30)"
-              },
-              {
-                "kind": "band",
-                "candidateId": "c-sarah",
-                "passed": true,
-                "detail": "expected score in [70,100], got 95"
-              }
-            ]
-          },
-          {
-            "passed": true,
-            "assertions": [
-              {
-                "kind": "match",
-                "candidateId": "c-sarah",
-                "passed": true,
-                "detail": "expected match=true, got surfaced=true (score 95, threshold 30)"
-              },
-              {
-                "kind": "band",
-                "candidateId": "c-sarah",
-                "passed": true,
-                "detail": "expected score in [70,100], got 95"
-              }
-            ]
-          },
-          {
-            "passed": true,
-            "assertions": [
-              {
-                "kind": "match",
-                "candidateId": "c-sarah",
-                "passed": true,
-                "detail": "expected match=true, got surfaced=true (score 95, threshold 30)"
-              },
-              {
-                "kind": "band",
-                "candidateId": "c-sarah",
-                "passed": true,
-                "detail": "expected score in [70,100], got 95"
-              }
-            ]
+            ],
+            "runId": "is_a_identity%2Finvestor-vs-real-investor::run:3",
+            "runIndex": 2
           }
         ]
       },
       {
         "caseId": "query_primary/background-intent-does-not-rescue",
         "rule": "query_primary",
-        "runs": 7,
-        "passes": 7,
+        "runs": 3,
+        "passes": 3,
         "passRate": 1,
         "flaky": false,
+        "scoredRunIds": [
+          "query_primary%2Fbackground-intent-does-not-rescue::run:1",
+          "query_primary%2Fbackground-intent-does-not-rescue::run:2",
+          "query_primary%2Fbackground-intent-does-not-rescue::run:3"
+        ],
         "runResults": [
           {
             "passed": true,
@@ -502,7 +2867,9 @@
                 "passed": true,
                 "detail": "judge passed"
               }
-            ]
+            ],
+            "runId": "query_primary%2Fbackground-intent-does-not-rescue::run:1",
+            "runIndex": 0
           },
           {
             "passed": true,
@@ -525,7 +2892,9 @@
                 "passed": true,
                 "detail": "judge passed"
               }
-            ]
+            ],
+            "runId": "query_primary%2Fbackground-intent-does-not-rescue::run:2",
+            "runIndex": 1
           },
           {
             "passed": true,
@@ -548,109 +2917,24 @@
                 "passed": true,
                 "detail": "judge passed"
               }
-            ]
-          },
-          {
-            "passed": true,
-            "assertions": [
-              {
-                "kind": "match",
-                "candidateId": "c-yuki",
-                "passed": true,
-                "detail": "expected match=false, got surfaced=false (score 0, threshold 30)"
-              },
-              {
-                "kind": "band",
-                "candidateId": "c-yuki",
-                "passed": true,
-                "detail": "expected score in [0,29], got 0"
-              },
-              {
-                "kind": "reasoning",
-                "candidateId": "c-yuki",
-                "passed": true,
-                "detail": "judge passed"
-              }
-            ]
-          },
-          {
-            "passed": true,
-            "assertions": [
-              {
-                "kind": "match",
-                "candidateId": "c-yuki",
-                "passed": true,
-                "detail": "expected match=false, got surfaced=false (score 0, threshold 30)"
-              },
-              {
-                "kind": "band",
-                "candidateId": "c-yuki",
-                "passed": true,
-                "detail": "expected score in [0,29], got 0"
-              },
-              {
-                "kind": "reasoning",
-                "candidateId": "c-yuki",
-                "passed": true,
-                "detail": "judge passed"
-              }
-            ]
-          },
-          {
-            "passed": true,
-            "assertions": [
-              {
-                "kind": "match",
-                "candidateId": "c-yuki",
-                "passed": true,
-                "detail": "expected match=false, got surfaced=false (score 0, threshold 30)"
-              },
-              {
-                "kind": "band",
-                "candidateId": "c-yuki",
-                "passed": true,
-                "detail": "expected score in [0,29], got 0"
-              },
-              {
-                "kind": "reasoning",
-                "candidateId": "c-yuki",
-                "passed": true,
-                "detail": "judge passed"
-              }
-            ]
-          },
-          {
-            "passed": true,
-            "assertions": [
-              {
-                "kind": "match",
-                "candidateId": "c-yuki",
-                "passed": true,
-                "detail": "expected match=false, got surfaced=false (score 0, threshold 30)"
-              },
-              {
-                "kind": "band",
-                "candidateId": "c-yuki",
-                "passed": true,
-                "detail": "expected score in [0,29], got 0"
-              },
-              {
-                "kind": "reasoning",
-                "candidateId": "c-yuki",
-                "passed": true,
-                "detail": "judge passed"
-              }
-            ]
+            ],
+            "runId": "query_primary%2Fbackground-intent-does-not-rescue::run:3",
+            "runIndex": 2
           }
         ]
       },
       {
         "caseId": "query_primary/specific-art-query-accepts-illustrator",
         "rule": "query_primary",
-        "runs": 7,
-        "passes": 6,
-        "passRate": 0.8571428571428571,
-        "flaky": true,
+        "runs": 3,
+        "passes": 3,
+        "passRate": 1,
+        "flaky": false,
+        "scoredRunIds": [
+          "query_primary%2Fspecific-art-query-accepts-illustrator::run:1",
+          "query_primary%2Fspecific-art-query-accepts-illustrator::run:2",
+          "query_primary%2Fspecific-art-query-accepts-illustrator::run:3"
+        ],
         "runResults": [
           {
             "passed": true,
@@ -673,30 +2957,9 @@
                 "passed": true,
                 "detail": "expected role=agent, got agent"
               }
-            ]
-          },
-          {
-            "passed": true,
-            "assertions": [
-              {
-                "kind": "match",
-                "candidateId": "c-yuki",
-                "passed": true,
-                "detail": "expected match=true, got surfaced=true (score 98, threshold 30)"
-              },
-              {
-                "kind": "band",
-                "candidateId": "c-yuki",
-                "passed": true,
-                "detail": "expected score in [70,100], got 98"
-              },
-              {
-                "kind": "role",
-                "candidateId": "c-yuki",
-                "passed": true,
-                "detail": "expected role=agent, got agent"
-              }
-            ]
+            ],
+            "runId": "query_primary%2Fspecific-art-query-accepts-illustrator::run:1",
+            "runIndex": 0
           },
           {
             "passed": true,
@@ -719,7 +2982,9 @@
                 "passed": true,
                 "detail": "expected role=agent, got agent"
               }
-            ]
+            ],
+            "runId": "query_primary%2Fspecific-art-query-accepts-illustrator::run:2",
+            "runIndex": 1
           },
           {
             "passed": true,
@@ -742,86 +3007,24 @@
                 "passed": true,
                 "detail": "expected role=agent, got agent"
               }
-            ]
-          },
-          {
-            "passed": true,
-            "assertions": [
-              {
-                "kind": "match",
-                "candidateId": "c-yuki",
-                "passed": true,
-                "detail": "expected match=true, got surfaced=true (score 95, threshold 30)"
-              },
-              {
-                "kind": "band",
-                "candidateId": "c-yuki",
-                "passed": true,
-                "detail": "expected score in [70,100], got 95"
-              },
-              {
-                "kind": "role",
-                "candidateId": "c-yuki",
-                "passed": true,
-                "detail": "expected role=agent, got agent"
-              }
-            ]
-          },
-          {
-            "passed": true,
-            "assertions": [
-              {
-                "kind": "match",
-                "candidateId": "c-yuki",
-                "passed": true,
-                "detail": "expected match=true, got surfaced=true (score 95, threshold 30)"
-              },
-              {
-                "kind": "band",
-                "candidateId": "c-yuki",
-                "passed": true,
-                "detail": "expected score in [70,100], got 95"
-              },
-              {
-                "kind": "role",
-                "candidateId": "c-yuki",
-                "passed": true,
-                "detail": "expected role=agent, got agent"
-              }
-            ]
-          },
-          {
-            "passed": false,
-            "assertions": [
-              {
-                "kind": "match",
-                "candidateId": "c-yuki",
-                "passed": true,
-                "detail": "expected match=true, got surfaced=true (score 95, threshold 30)"
-              },
-              {
-                "kind": "band",
-                "candidateId": "c-yuki",
-                "passed": true,
-                "detail": "expected score in [70,100], got 95"
-              },
-              {
-                "kind": "role",
-                "candidateId": "c-yuki",
-                "passed": false,
-                "detail": "expected role=agent, got peer"
-              }
-            ]
+            ],
+            "runId": "query_primary%2Fspecific-art-query-accepts-illustrator::run:3",
+            "runIndex": 2
           }
         ]
       },
       {
         "caseId": "query_primary/investors-query-rejects-funded-founder",
         "rule": "query_primary",
-        "runs": 7,
-        "passes": 7,
+        "runs": 3,
+        "passes": 3,
         "passRate": 1,
         "flaky": false,
+        "scoredRunIds": [
+          "query_primary%2Finvestors-query-rejects-funded-founder::run:1",
+          "query_primary%2Finvestors-query-rejects-funded-founder::run:2",
+          "query_primary%2Finvestors-query-rejects-funded-founder::run:3"
+        ],
         "runResults": [
           {
             "passed": true,
@@ -838,7 +3041,9 @@
                 "passed": true,
                 "detail": "expected score in [0,29], got 0"
               }
-            ]
+            ],
+            "runId": "query_primary%2Finvestors-query-rejects-funded-founder::run:1",
+            "runIndex": 0
           },
           {
             "passed": true,
@@ -855,7 +3060,9 @@
                 "passed": true,
                 "detail": "expected score in [0,29], got 0"
               }
-            ]
+            ],
+            "runId": "query_primary%2Finvestors-query-rejects-funded-founder::run:2",
+            "runIndex": 1
           },
           {
             "passed": true,
@@ -872,214 +3079,96 @@
                 "passed": true,
                 "detail": "expected score in [0,29], got 0"
               }
-            ]
-          },
-          {
-            "passed": true,
-            "assertions": [
-              {
-                "kind": "match",
-                "candidateId": "c-sam",
-                "passed": true,
-                "detail": "expected match=false, got surfaced=false (score 0, threshold 30)"
-              },
-              {
-                "kind": "band",
-                "candidateId": "c-sam",
-                "passed": true,
-                "detail": "expected score in [0,29], got 0"
-              }
-            ]
-          },
-          {
-            "passed": true,
-            "assertions": [
-              {
-                "kind": "match",
-                "candidateId": "c-sam",
-                "passed": true,
-                "detail": "expected match=false, got surfaced=false (score 0, threshold 30)"
-              },
-              {
-                "kind": "band",
-                "candidateId": "c-sam",
-                "passed": true,
-                "detail": "expected score in [0,29], got 0"
-              }
-            ]
-          },
-          {
-            "passed": true,
-            "assertions": [
-              {
-                "kind": "match",
-                "candidateId": "c-sam",
-                "passed": true,
-                "detail": "expected match=false, got surfaced=false (score 0, threshold 30)"
-              },
-              {
-                "kind": "band",
-                "candidateId": "c-sam",
-                "passed": true,
-                "detail": "expected score in [0,29], got 0"
-              }
-            ]
-          },
-          {
-            "passed": true,
-            "assertions": [
-              {
-                "kind": "match",
-                "candidateId": "c-sam",
-                "passed": true,
-                "detail": "expected match=false, got surfaced=false (score 0, threshold 30)"
-              },
-              {
-                "kind": "band",
-                "candidateId": "c-sam",
-                "passed": true,
-                "detail": "expected score in [0,29], got 0"
-              }
-            ]
+            ],
+            "runId": "query_primary%2Finvestors-query-rejects-funded-founder::run:3",
+            "runIndex": 2
           }
         ]
       },
       {
         "caseId": "query_primary/founders-raising-seed-accepts-founder",
         "rule": "query_primary",
-        "runs": 7,
-        "passes": 7,
-        "passRate": 1,
+        "runs": 3,
+        "passes": 0,
+        "passRate": 0,
         "flaky": false,
+        "scoredRunIds": [
+          "query_primary%2Ffounders-raising-seed-accepts-founder::run:1",
+          "query_primary%2Ffounders-raising-seed-accepts-founder::run:2",
+          "query_primary%2Ffounders-raising-seed-accepts-founder::run:3"
+        ],
         "runResults": [
           {
-            "passed": true,
+            "passed": false,
             "assertions": [
               {
                 "kind": "match",
                 "candidateId": "c-sam",
-                "passed": true,
-                "detail": "expected match=true, got surfaced=true (score 95, threshold 30)"
+                "passed": false,
+                "detail": "expected match=true, got surfaced=false (score 0, threshold 30)"
               },
               {
                 "kind": "band",
                 "candidateId": "c-sam",
-                "passed": true,
-                "detail": "expected score in [70,100], got 95"
+                "passed": false,
+                "detail": "expected score in [70,100], got 0"
               }
-            ]
+            ],
+            "runId": "query_primary%2Ffounders-raising-seed-accepts-founder::run:1",
+            "runIndex": 0
           },
           {
-            "passed": true,
+            "passed": false,
             "assertions": [
               {
                 "kind": "match",
                 "candidateId": "c-sam",
-                "passed": true,
-                "detail": "expected match=true, got surfaced=true (score 95, threshold 30)"
+                "passed": false,
+                "detail": "expected match=true, got surfaced=false (score 0, threshold 30)"
               },
               {
                 "kind": "band",
                 "candidateId": "c-sam",
-                "passed": true,
-                "detail": "expected score in [70,100], got 95"
+                "passed": false,
+                "detail": "expected score in [70,100], got 0"
               }
-            ]
+            ],
+            "runId": "query_primary%2Ffounders-raising-seed-accepts-founder::run:2",
+            "runIndex": 1
           },
           {
-            "passed": true,
+            "passed": false,
             "assertions": [
               {
                 "kind": "match",
                 "candidateId": "c-sam",
-                "passed": true,
-                "detail": "expected match=true, got surfaced=true (score 95, threshold 30)"
+                "passed": false,
+                "detail": "expected match=true, got surfaced=false (score 0, threshold 30)"
               },
               {
                 "kind": "band",
                 "candidateId": "c-sam",
-                "passed": true,
-                "detail": "expected score in [70,100], got 95"
+                "passed": false,
+                "detail": "expected score in [70,100], got 0"
               }
-            ]
-          },
-          {
-            "passed": true,
-            "assertions": [
-              {
-                "kind": "match",
-                "candidateId": "c-sam",
-                "passed": true,
-                "detail": "expected match=true, got surfaced=true (score 95, threshold 30)"
-              },
-              {
-                "kind": "band",
-                "candidateId": "c-sam",
-                "passed": true,
-                "detail": "expected score in [70,100], got 95"
-              }
-            ]
-          },
-          {
-            "passed": true,
-            "assertions": [
-              {
-                "kind": "match",
-                "candidateId": "c-sam",
-                "passed": true,
-                "detail": "expected match=true, got surfaced=true (score 95, threshold 30)"
-              },
-              {
-                "kind": "band",
-                "candidateId": "c-sam",
-                "passed": true,
-                "detail": "expected score in [70,100], got 95"
-              }
-            ]
-          },
-          {
-            "passed": true,
-            "assertions": [
-              {
-                "kind": "match",
-                "candidateId": "c-sam",
-                "passed": true,
-                "detail": "expected match=true, got surfaced=true (score 95, threshold 30)"
-              },
-              {
-                "kind": "band",
-                "candidateId": "c-sam",
-                "passed": true,
-                "detail": "expected score in [70,100], got 95"
-              }
-            ]
-          },
-          {
-            "passed": true,
-            "assertions": [
-              {
-                "kind": "match",
-                "candidateId": "c-sam",
-                "passed": true,
-                "detail": "expected match=true, got surfaced=true (score 95, threshold 30)"
-              },
-              {
-                "kind": "band",
-                "candidateId": "c-sam",
-                "passed": true,
-                "detail": "expected score in [70,100], got 95"
-              }
-            ]
+            ],
+            "runId": "query_primary%2Ffounders-raising-seed-accepts-founder::run:3",
+            "runIndex": 2
           }
         ]
       },
       {
         "caseId": "query_primary/location-query-rejects-wrong-city",
         "rule": "query_primary",
-        "runs": 7,
-        "passes": 7,
+        "runs": 3,
+        "passes": 3,
         "passRate": 1,
         "flaky": false,
+        "scoredRunIds": [
+          "query_primary%2Flocation-query-rejects-wrong-city::run:1",
+          "query_primary%2Flocation-query-rejects-wrong-city::run:2",
+          "query_primary%2Flocation-query-rejects-wrong-city::run:3"
+        ],
         "runResults": [
           {
             "passed": true,
@@ -1096,7 +3185,9 @@
                 "passed": true,
                 "detail": "expected score in [0,29], got 0"
               }
-            ]
+            ],
+            "runId": "query_primary%2Flocation-query-rejects-wrong-city::run:1",
+            "runIndex": 0
           },
           {
             "passed": true,
@@ -1113,7 +3204,9 @@
                 "passed": true,
                 "detail": "expected score in [0,29], got 0"
               }
-            ]
+            ],
+            "runId": "query_primary%2Flocation-query-rejects-wrong-city::run:2",
+            "runIndex": 1
           },
           {
             "passed": true,
@@ -1130,85 +3223,24 @@
                 "passed": true,
                 "detail": "expected score in [0,29], got 0"
               }
-            ]
-          },
-          {
-            "passed": true,
-            "assertions": [
-              {
-                "kind": "match",
-                "candidateId": "c-berlin-unreal",
-                "passed": true,
-                "detail": "expected match=false, got surfaced=false (score 0, threshold 30)"
-              },
-              {
-                "kind": "band",
-                "candidateId": "c-berlin-unreal",
-                "passed": true,
-                "detail": "expected score in [0,29], got 0"
-              }
-            ]
-          },
-          {
-            "passed": true,
-            "assertions": [
-              {
-                "kind": "match",
-                "candidateId": "c-berlin-unreal",
-                "passed": true,
-                "detail": "expected match=false, got surfaced=false (score 0, threshold 30)"
-              },
-              {
-                "kind": "band",
-                "candidateId": "c-berlin-unreal",
-                "passed": true,
-                "detail": "expected score in [0,29], got 0"
-              }
-            ]
-          },
-          {
-            "passed": true,
-            "assertions": [
-              {
-                "kind": "match",
-                "candidateId": "c-berlin-unreal",
-                "passed": true,
-                "detail": "expected match=false, got surfaced=false (score 0, threshold 30)"
-              },
-              {
-                "kind": "band",
-                "candidateId": "c-berlin-unreal",
-                "passed": true,
-                "detail": "expected score in [0,29], got 0"
-              }
-            ]
-          },
-          {
-            "passed": true,
-            "assertions": [
-              {
-                "kind": "match",
-                "candidateId": "c-berlin-unreal",
-                "passed": true,
-                "detail": "expected match=false, got surfaced=false (score 0, threshold 30)"
-              },
-              {
-                "kind": "band",
-                "candidateId": "c-berlin-unreal",
-                "passed": true,
-                "detail": "expected score in [0,29], got 0"
-              }
-            ]
+            ],
+            "runId": "query_primary%2Flocation-query-rejects-wrong-city::run:3",
+            "runIndex": 2
           }
         ]
       },
       {
         "caseId": "query_primary/vague-query-can-use-background-intent",
         "rule": "query_primary",
-        "runs": 7,
-        "passes": 7,
+        "runs": 3,
+        "passes": 3,
         "passRate": 1,
         "flaky": false,
+        "scoredRunIds": [
+          "query_primary%2Fvague-query-can-use-background-intent::run:1",
+          "query_primary%2Fvague-query-can-use-background-intent::run:2",
+          "query_primary%2Fvague-query-can-use-background-intent::run:3"
+        ],
         "runResults": [
           {
             "passed": true,
@@ -1225,7 +3257,9 @@
                 "passed": true,
                 "detail": "expected score in [70,100], got 95"
               }
-            ]
+            ],
+            "runId": "query_primary%2Fvague-query-can-use-background-intent::run:1",
+            "runIndex": 0
           },
           {
             "passed": true,
@@ -1242,24 +3276,9 @@
                 "passed": true,
                 "detail": "expected score in [70,100], got 95"
               }
-            ]
-          },
-          {
-            "passed": true,
-            "assertions": [
-              {
-                "kind": "match",
-                "candidateId": "c-yuki",
-                "passed": true,
-                "detail": "expected match=true, got surfaced=true (score 85, threshold 30)"
-              },
-              {
-                "kind": "band",
-                "candidateId": "c-yuki",
-                "passed": true,
-                "detail": "expected score in [70,100], got 85"
-              }
-            ]
+            ],
+            "runId": "query_primary%2Fvague-query-can-use-background-intent::run:2",
+            "runIndex": 1
           },
           {
             "passed": true,
@@ -1276,68 +3295,24 @@
                 "passed": true,
                 "detail": "expected score in [70,100], got 95"
               }
-            ]
-          },
-          {
-            "passed": true,
-            "assertions": [
-              {
-                "kind": "match",
-                "candidateId": "c-yuki",
-                "passed": true,
-                "detail": "expected match=true, got surfaced=true (score 90, threshold 30)"
-              },
-              {
-                "kind": "band",
-                "candidateId": "c-yuki",
-                "passed": true,
-                "detail": "expected score in [70,100], got 90"
-              }
-            ]
-          },
-          {
-            "passed": true,
-            "assertions": [
-              {
-                "kind": "match",
-                "candidateId": "c-yuki",
-                "passed": true,
-                "detail": "expected match=true, got surfaced=true (score 95, threshold 30)"
-              },
-              {
-                "kind": "band",
-                "candidateId": "c-yuki",
-                "passed": true,
-                "detail": "expected score in [70,100], got 95"
-              }
-            ]
-          },
-          {
-            "passed": true,
-            "assertions": [
-              {
-                "kind": "match",
-                "candidateId": "c-yuki",
-                "passed": true,
-                "detail": "expected match=true, got surfaced=true (score 90, threshold 30)"
-              },
-              {
-                "kind": "band",
-                "candidateId": "c-yuki",
-                "passed": true,
-                "detail": "expected score in [70,100], got 90"
-              }
-            ]
+            ],
+            "runId": "query_primary%2Fvague-query-can-use-background-intent::run:3",
+            "runIndex": 2
           }
         ]
       },
       {
         "caseId": "query_primary/scouts-query-rejects-scouted-athlete",
         "rule": "query_primary",
-        "runs": 7,
-        "passes": 7,
+        "runs": 3,
+        "passes": 3,
         "passRate": 1,
         "flaky": false,
+        "scoredRunIds": [
+          "query_primary%2Fscouts-query-rejects-scouted-athlete::run:1",
+          "query_primary%2Fscouts-query-rejects-scouted-athlete::run:2",
+          "query_primary%2Fscouts-query-rejects-scouted-athlete::run:3"
+        ],
         "runResults": [
           {
             "passed": true,
@@ -1354,7 +3329,9 @@
                 "passed": true,
                 "detail": "expected score in [0,29], got 0"
               }
-            ]
+            ],
+            "runId": "query_primary%2Fscouts-query-rejects-scouted-athlete::run:1",
+            "runIndex": 0
           },
           {
             "passed": true,
@@ -1371,7 +3348,9 @@
                 "passed": true,
                 "detail": "expected score in [0,29], got 0"
               }
-            ]
+            ],
+            "runId": "query_primary%2Fscouts-query-rejects-scouted-athlete::run:2",
+            "runIndex": 1
           },
           {
             "passed": true,
@@ -1388,85 +3367,24 @@
                 "passed": true,
                 "detail": "expected score in [0,29], got 0"
               }
-            ]
-          },
-          {
-            "passed": true,
-            "assertions": [
-              {
-                "kind": "match",
-                "candidateId": "c-athlete",
-                "passed": true,
-                "detail": "expected match=false, got surfaced=false (score 0, threshold 30)"
-              },
-              {
-                "kind": "band",
-                "candidateId": "c-athlete",
-                "passed": true,
-                "detail": "expected score in [0,29], got 0"
-              }
-            ]
-          },
-          {
-            "passed": true,
-            "assertions": [
-              {
-                "kind": "match",
-                "candidateId": "c-athlete",
-                "passed": true,
-                "detail": "expected match=false, got surfaced=false (score 0, threshold 30)"
-              },
-              {
-                "kind": "band",
-                "candidateId": "c-athlete",
-                "passed": true,
-                "detail": "expected score in [0,29], got 0"
-              }
-            ]
-          },
-          {
-            "passed": true,
-            "assertions": [
-              {
-                "kind": "match",
-                "candidateId": "c-athlete",
-                "passed": true,
-                "detail": "expected match=false, got surfaced=false (score 0, threshold 30)"
-              },
-              {
-                "kind": "band",
-                "candidateId": "c-athlete",
-                "passed": true,
-                "detail": "expected score in [0,29], got 0"
-              }
-            ]
-          },
-          {
-            "passed": true,
-            "assertions": [
-              {
-                "kind": "match",
-                "candidateId": "c-athlete",
-                "passed": true,
-                "detail": "expected match=false, got surfaced=false (score 0, threshold 30)"
-              },
-              {
-                "kind": "band",
-                "candidateId": "c-athlete",
-                "passed": true,
-                "detail": "expected score in [0,29], got 0"
-              }
-            ]
+            ],
+            "runId": "query_primary%2Fscouts-query-rejects-scouted-athlete::run:3",
+            "runIndex": 2
           }
         ]
       },
       {
         "caseId": "complementary_role/vc-for-cofounder-intent",
         "rule": "complementary_role",
-        "runs": 7,
-        "passes": 7,
+        "runs": 3,
+        "passes": 3,
         "passRate": 1,
         "flaky": false,
+        "scoredRunIds": [
+          "complementary_role%2Fvc-for-cofounder-intent::run:1",
+          "complementary_role%2Fvc-for-cofounder-intent::run:2",
+          "complementary_role%2Fvc-for-cofounder-intent::run:3"
+        ],
         "runResults": [
           {
             "passed": true,
@@ -1483,7 +3401,9 @@
                 "passed": true,
                 "detail": "expected score in [0,29], got 0"
               }
-            ]
+            ],
+            "runId": "complementary_role%2Fvc-for-cofounder-intent::run:1",
+            "runIndex": 0
           },
           {
             "passed": true,
@@ -1500,7 +3420,9 @@
                 "passed": true,
                 "detail": "expected score in [0,29], got 0"
               }
-            ]
+            ],
+            "runId": "complementary_role%2Fvc-for-cofounder-intent::run:2",
+            "runIndex": 1
           },
           {
             "passed": true,
@@ -1517,85 +3439,24 @@
                 "passed": true,
                 "detail": "expected score in [0,29], got 0"
               }
-            ]
-          },
-          {
-            "passed": true,
-            "assertions": [
-              {
-                "kind": "match",
-                "candidateId": "p-vc",
-                "passed": true,
-                "detail": "expected match=false, got surfaced=false (score 0, threshold 30)"
-              },
-              {
-                "kind": "band",
-                "candidateId": "p-vc",
-                "passed": true,
-                "detail": "expected score in [0,29], got 0"
-              }
-            ]
-          },
-          {
-            "passed": true,
-            "assertions": [
-              {
-                "kind": "match",
-                "candidateId": "p-vc",
-                "passed": true,
-                "detail": "expected match=false, got surfaced=false (score 0, threshold 30)"
-              },
-              {
-                "kind": "band",
-                "candidateId": "p-vc",
-                "passed": true,
-                "detail": "expected score in [0,29], got 0"
-              }
-            ]
-          },
-          {
-            "passed": true,
-            "assertions": [
-              {
-                "kind": "match",
-                "candidateId": "p-vc",
-                "passed": true,
-                "detail": "expected match=false, got surfaced=false (score 0, threshold 30)"
-              },
-              {
-                "kind": "band",
-                "candidateId": "p-vc",
-                "passed": true,
-                "detail": "expected score in [0,29], got 0"
-              }
-            ]
-          },
-          {
-            "passed": true,
-            "assertions": [
-              {
-                "kind": "match",
-                "candidateId": "p-vc",
-                "passed": true,
-                "detail": "expected match=false, got surfaced=false (score 0, threshold 30)"
-              },
-              {
-                "kind": "band",
-                "candidateId": "p-vc",
-                "passed": true,
-                "detail": "expected score in [0,29], got 0"
-              }
-            ]
+            ],
+            "runId": "complementary_role%2Fvc-for-cofounder-intent::run:3",
+            "runIndex": 2
           }
         ]
       },
       {
         "caseId": "complementary_role/engineer-for-cofounder-intent",
         "rule": "complementary_role",
-        "runs": 7,
-        "passes": 7,
+        "runs": 3,
+        "passes": 3,
         "passRate": 1,
         "flaky": false,
+        "scoredRunIds": [
+          "complementary_role%2Fengineer-for-cofounder-intent::run:1",
+          "complementary_role%2Fengineer-for-cofounder-intent::run:2",
+          "complementary_role%2Fengineer-for-cofounder-intent::run:3"
+        ],
         "runResults": [
           {
             "passed": true,
@@ -1604,13 +3465,13 @@
                 "kind": "match",
                 "candidateId": "p-tech-cofounder",
                 "passed": true,
-                "detail": "expected match=true, got surfaced=true (score 98, threshold 30)"
+                "detail": "expected match=true, got surfaced=true (score 95, threshold 30)"
               },
               {
                 "kind": "band",
                 "candidateId": "p-tech-cofounder",
                 "passed": true,
-                "detail": "expected score in [70,100], got 98"
+                "detail": "expected score in [70,100], got 95"
               },
               {
                 "kind": "role",
@@ -1618,7 +3479,9 @@
                 "passed": true,
                 "detail": "expected role=agent, got agent"
               }
-            ]
+            ],
+            "runId": "complementary_role%2Fengineer-for-cofounder-intent::run:1",
+            "runIndex": 0
           },
           {
             "passed": true,
@@ -1627,13 +3490,13 @@
                 "kind": "match",
                 "candidateId": "p-tech-cofounder",
                 "passed": true,
-                "detail": "expected match=true, got surfaced=true (score 98, threshold 30)"
+                "detail": "expected match=true, got surfaced=true (score 95, threshold 30)"
               },
               {
                 "kind": "band",
                 "candidateId": "p-tech-cofounder",
                 "passed": true,
-                "detail": "expected score in [70,100], got 98"
+                "detail": "expected score in [70,100], got 95"
               },
               {
                 "kind": "role",
@@ -1641,7 +3504,9 @@
                 "passed": true,
                 "detail": "expected role=agent, got agent"
               }
-            ]
+            ],
+            "runId": "complementary_role%2Fengineer-for-cofounder-intent::run:2",
+            "runIndex": 1
           },
           {
             "passed": true,
@@ -1650,13 +3515,13 @@
                 "kind": "match",
                 "candidateId": "p-tech-cofounder",
                 "passed": true,
-                "detail": "expected match=true, got surfaced=true (score 98, threshold 30)"
+                "detail": "expected match=true, got surfaced=true (score 95, threshold 30)"
               },
               {
                 "kind": "band",
                 "candidateId": "p-tech-cofounder",
                 "passed": true,
-                "detail": "expected score in [70,100], got 98"
+                "detail": "expected score in [70,100], got 95"
               },
               {
                 "kind": "role",
@@ -1664,109 +3529,24 @@
                 "passed": true,
                 "detail": "expected role=agent, got agent"
               }
-            ]
-          },
-          {
-            "passed": true,
-            "assertions": [
-              {
-                "kind": "match",
-                "candidateId": "p-tech-cofounder",
-                "passed": true,
-                "detail": "expected match=true, got surfaced=true (score 98, threshold 30)"
-              },
-              {
-                "kind": "band",
-                "candidateId": "p-tech-cofounder",
-                "passed": true,
-                "detail": "expected score in [70,100], got 98"
-              },
-              {
-                "kind": "role",
-                "candidateId": "p-tech-cofounder",
-                "passed": true,
-                "detail": "expected role=agent, got agent"
-              }
-            ]
-          },
-          {
-            "passed": true,
-            "assertions": [
-              {
-                "kind": "match",
-                "candidateId": "p-tech-cofounder",
-                "passed": true,
-                "detail": "expected match=true, got surfaced=true (score 98, threshold 30)"
-              },
-              {
-                "kind": "band",
-                "candidateId": "p-tech-cofounder",
-                "passed": true,
-                "detail": "expected score in [70,100], got 98"
-              },
-              {
-                "kind": "role",
-                "candidateId": "p-tech-cofounder",
-                "passed": true,
-                "detail": "expected role=agent, got agent"
-              }
-            ]
-          },
-          {
-            "passed": true,
-            "assertions": [
-              {
-                "kind": "match",
-                "candidateId": "p-tech-cofounder",
-                "passed": true,
-                "detail": "expected match=true, got surfaced=true (score 98, threshold 30)"
-              },
-              {
-                "kind": "band",
-                "candidateId": "p-tech-cofounder",
-                "passed": true,
-                "detail": "expected score in [70,100], got 98"
-              },
-              {
-                "kind": "role",
-                "candidateId": "p-tech-cofounder",
-                "passed": true,
-                "detail": "expected role=agent, got agent"
-              }
-            ]
-          },
-          {
-            "passed": true,
-            "assertions": [
-              {
-                "kind": "match",
-                "candidateId": "p-tech-cofounder",
-                "passed": true,
-                "detail": "expected match=true, got surfaced=true (score 98, threshold 30)"
-              },
-              {
-                "kind": "band",
-                "candidateId": "p-tech-cofounder",
-                "passed": true,
-                "detail": "expected score in [70,100], got 98"
-              },
-              {
-                "kind": "role",
-                "candidateId": "p-tech-cofounder",
-                "passed": true,
-                "detail": "expected role=agent, got agent"
-              }
-            ]
+            ],
+            "runId": "complementary_role%2Fengineer-for-cofounder-intent::run:3",
+            "runIndex": 2
           }
         ]
       },
       {
         "caseId": "same_side/both-seeking-investors",
         "rule": "same_side",
-        "runs": 7,
-        "passes": 7,
+        "runs": 3,
+        "passes": 3,
         "passRate": 1,
         "flaky": false,
+        "scoredRunIds": [
+          "same_side%2Fboth-seeking-investors::run:1",
+          "same_side%2Fboth-seeking-investors::run:2",
+          "same_side%2Fboth-seeking-investors::run:3"
+        ],
         "runResults": [
           {
             "passed": true,
@@ -1783,7 +3563,9 @@
                 "passed": true,
                 "detail": "expected score in [0,29], got 0"
               }
-            ]
+            ],
+            "runId": "same_side%2Fboth-seeking-investors::run:1",
+            "runIndex": 0
           },
           {
             "passed": true,
@@ -1800,7 +3582,9 @@
                 "passed": true,
                 "detail": "expected score in [0,29], got 0"
               }
-            ]
+            ],
+            "runId": "same_side%2Fboth-seeking-investors::run:2",
+            "runIndex": 1
           },
           {
             "passed": true,
@@ -1817,85 +3601,24 @@
                 "passed": true,
                 "detail": "expected score in [0,29], got 0"
               }
-            ]
-          },
-          {
-            "passed": true,
-            "assertions": [
-              {
-                "kind": "match",
-                "candidateId": "c-raising",
-                "passed": true,
-                "detail": "expected match=false, got surfaced=false (score 0, threshold 30)"
-              },
-              {
-                "kind": "band",
-                "candidateId": "c-raising",
-                "passed": true,
-                "detail": "expected score in [0,29], got 0"
-              }
-            ]
-          },
-          {
-            "passed": true,
-            "assertions": [
-              {
-                "kind": "match",
-                "candidateId": "c-raising",
-                "passed": true,
-                "detail": "expected match=false, got surfaced=false (score 0, threshold 30)"
-              },
-              {
-                "kind": "band",
-                "candidateId": "c-raising",
-                "passed": true,
-                "detail": "expected score in [0,29], got 0"
-              }
-            ]
-          },
-          {
-            "passed": true,
-            "assertions": [
-              {
-                "kind": "match",
-                "candidateId": "c-raising",
-                "passed": true,
-                "detail": "expected match=false, got surfaced=false (score 0, threshold 30)"
-              },
-              {
-                "kind": "band",
-                "candidateId": "c-raising",
-                "passed": true,
-                "detail": "expected score in [0,29], got 0"
-              }
-            ]
-          },
-          {
-            "passed": true,
-            "assertions": [
-              {
-                "kind": "match",
-                "candidateId": "c-raising",
-                "passed": true,
-                "detail": "expected match=false, got surfaced=false (score 0, threshold 30)"
-              },
-              {
-                "kind": "band",
-                "candidateId": "c-raising",
-                "passed": true,
-                "detail": "expected score in [0,29], got 0"
-              }
-            ]
+            ],
+            "runId": "same_side%2Fboth-seeking-investors::run:3",
+            "runIndex": 2
           }
         ]
       },
       {
         "caseId": "already_known/same-company-cofounders",
         "rule": "already_known",
-        "runs": 7,
-        "passes": 7,
+        "runs": 3,
+        "passes": 3,
         "passRate": 1,
         "flaky": false,
+        "scoredRunIds": [
+          "already_known%2Fsame-company-cofounders::run:1",
+          "already_known%2Fsame-company-cofounders::run:2",
+          "already_known%2Fsame-company-cofounders::run:3"
+        ],
         "runResults": [
           {
             "passed": true,
@@ -1912,7 +3635,9 @@
                 "passed": true,
                 "detail": "expected score in [0,29], got 0"
               }
-            ]
+            ],
+            "runId": "already_known%2Fsame-company-cofounders::run:1",
+            "runIndex": 0
           },
           {
             "passed": true,
@@ -1929,7 +3654,9 @@
                 "passed": true,
                 "detail": "expected score in [0,29], got 0"
               }
-            ]
+            ],
+            "runId": "already_known%2Fsame-company-cofounders::run:2",
+            "runIndex": 1
           },
           {
             "passed": true,
@@ -1946,85 +3673,24 @@
                 "passed": true,
                 "detail": "expected score in [0,29], got 0"
               }
-            ]
-          },
-          {
-            "passed": true,
-            "assertions": [
-              {
-                "kind": "match",
-                "candidateId": "c-acme",
-                "passed": true,
-                "detail": "expected match=false, got surfaced=false (score 0, threshold 30)"
-              },
-              {
-                "kind": "band",
-                "candidateId": "c-acme",
-                "passed": true,
-                "detail": "expected score in [0,29], got 0"
-              }
-            ]
-          },
-          {
-            "passed": true,
-            "assertions": [
-              {
-                "kind": "match",
-                "candidateId": "c-acme",
-                "passed": true,
-                "detail": "expected match=false, got surfaced=false (score 0, threshold 30)"
-              },
-              {
-                "kind": "band",
-                "candidateId": "c-acme",
-                "passed": true,
-                "detail": "expected score in [0,29], got 0"
-              }
-            ]
-          },
-          {
-            "passed": true,
-            "assertions": [
-              {
-                "kind": "match",
-                "candidateId": "c-acme",
-                "passed": true,
-                "detail": "expected match=false, got surfaced=false (score 0, threshold 30)"
-              },
-              {
-                "kind": "band",
-                "candidateId": "c-acme",
-                "passed": true,
-                "detail": "expected score in [0,29], got 0"
-              }
-            ]
-          },
-          {
-            "passed": true,
-            "assertions": [
-              {
-                "kind": "match",
-                "candidateId": "c-acme",
-                "passed": true,
-                "detail": "expected match=false, got surfaced=false (score 0, threshold 30)"
-              },
-              {
-                "kind": "band",
-                "candidateId": "c-acme",
-                "passed": true,
-                "detail": "expected score in [0,29], got 0"
-              }
-            ]
+            ],
+            "runId": "already_known%2Fsame-company-cofounders::run:3",
+            "runIndex": 2
           }
         ]
       },
       {
         "caseId": "location/known-mismatch-penalized",
         "rule": "location",
-        "runs": 7,
-        "passes": 7,
+        "runs": 3,
+        "passes": 3,
         "passRate": 1,
         "flaky": false,
+        "scoredRunIds": [
+          "location%2Fknown-mismatch-penalized::run:1",
+          "location%2Fknown-mismatch-penalized::run:2",
+          "location%2Fknown-mismatch-penalized::run:3"
+        ],
         "runResults": [
           {
             "passed": true,
@@ -2041,7 +3707,9 @@
                 "passed": true,
                 "detail": "expected score in [0,29], got 0"
               }
-            ]
+            ],
+            "runId": "location%2Fknown-mismatch-penalized::run:1",
+            "runIndex": 0
           },
           {
             "passed": true,
@@ -2058,7 +3726,9 @@
                 "passed": true,
                 "detail": "expected score in [0,29], got 0"
               }
-            ]
+            ],
+            "runId": "location%2Fknown-mismatch-penalized::run:2",
+            "runIndex": 1
           },
           {
             "passed": true,
@@ -2075,85 +3745,24 @@
                 "passed": true,
                 "detail": "expected score in [0,29], got 0"
               }
-            ]
-          },
-          {
-            "passed": true,
-            "assertions": [
-              {
-                "kind": "match",
-                "candidateId": "c-ny",
-                "passed": true,
-                "detail": "expected match=false, got surfaced=false (score 0, threshold 30)"
-              },
-              {
-                "kind": "band",
-                "candidateId": "c-ny",
-                "passed": true,
-                "detail": "expected score in [0,29], got 0"
-              }
-            ]
-          },
-          {
-            "passed": true,
-            "assertions": [
-              {
-                "kind": "match",
-                "candidateId": "c-ny",
-                "passed": true,
-                "detail": "expected match=false, got surfaced=false (score 0, threshold 30)"
-              },
-              {
-                "kind": "band",
-                "candidateId": "c-ny",
-                "passed": true,
-                "detail": "expected score in [0,29], got 0"
-              }
-            ]
-          },
-          {
-            "passed": true,
-            "assertions": [
-              {
-                "kind": "match",
-                "candidateId": "c-ny",
-                "passed": true,
-                "detail": "expected match=false, got surfaced=false (score 0, threshold 30)"
-              },
-              {
-                "kind": "band",
-                "candidateId": "c-ny",
-                "passed": true,
-                "detail": "expected score in [0,29], got 0"
-              }
-            ]
-          },
-          {
-            "passed": true,
-            "assertions": [
-              {
-                "kind": "match",
-                "candidateId": "c-ny",
-                "passed": true,
-                "detail": "expected match=false, got surfaced=false (score 0, threshold 30)"
-              },
-              {
-                "kind": "band",
-                "candidateId": "c-ny",
-                "passed": true,
-                "detail": "expected score in [0,29], got 0"
-              }
-            ]
+            ],
+            "runId": "location%2Fknown-mismatch-penalized::run:3",
+            "runIndex": 2
           }
         ]
       },
       {
         "caseId": "location/unknown-not-penalized",
         "rule": "location",
-        "runs": 7,
-        "passes": 7,
+        "runs": 3,
+        "passes": 3,
         "passRate": 1,
         "flaky": false,
+        "scoredRunIds": [
+          "location%2Funknown-not-penalized::run:1",
+          "location%2Funknown-not-penalized::run:2",
+          "location%2Funknown-not-penalized::run:3"
+        ],
         "runResults": [
           {
             "passed": true,
@@ -2162,15 +3771,17 @@
                 "kind": "match",
                 "candidateId": "c-unknown",
                 "passed": true,
-                "detail": "expected match=true, got surfaced=true (score 80, threshold 30)"
+                "detail": "expected match=true, got surfaced=true (score 75, threshold 30)"
               },
               {
                 "kind": "band",
                 "candidateId": "c-unknown",
                 "passed": true,
-                "detail": "expected score in [60,100], got 80"
+                "detail": "expected score in [60,100], got 75"
               }
-            ]
+            ],
+            "runId": "location%2Funknown-not-penalized::run:1",
+            "runIndex": 0
           },
           {
             "passed": true,
@@ -2187,7 +3798,9 @@
                 "passed": true,
                 "detail": "expected score in [60,100], got 85"
               }
-            ]
+            ],
+            "runId": "location%2Funknown-not-penalized::run:2",
+            "runIndex": 1
           },
           {
             "passed": true,
@@ -2196,93 +3809,32 @@
                 "kind": "match",
                 "candidateId": "c-unknown",
                 "passed": true,
-                "detail": "expected match=true, got surfaced=true (score 80, threshold 30)"
+                "detail": "expected match=true, got surfaced=true (score 75, threshold 30)"
               },
               {
                 "kind": "band",
                 "candidateId": "c-unknown",
                 "passed": true,
-                "detail": "expected score in [60,100], got 80"
+                "detail": "expected score in [60,100], got 75"
               }
-            ]
-          },
-          {
-            "passed": true,
-            "assertions": [
-              {
-                "kind": "match",
-                "candidateId": "c-unknown",
-                "passed": true,
-                "detail": "expected match=true, got surfaced=true (score 85, threshold 30)"
-              },
-              {
-                "kind": "band",
-                "candidateId": "c-unknown",
-                "passed": true,
-                "detail": "expected score in [60,100], got 85"
-              }
-            ]
-          },
-          {
-            "passed": true,
-            "assertions": [
-              {
-                "kind": "match",
-                "candidateId": "c-unknown",
-                "passed": true,
-                "detail": "expected match=true, got surfaced=true (score 85, threshold 30)"
-              },
-              {
-                "kind": "band",
-                "candidateId": "c-unknown",
-                "passed": true,
-                "detail": "expected score in [60,100], got 85"
-              }
-            ]
-          },
-          {
-            "passed": true,
-            "assertions": [
-              {
-                "kind": "match",
-                "candidateId": "c-unknown",
-                "passed": true,
-                "detail": "expected match=true, got surfaced=true (score 80, threshold 30)"
-              },
-              {
-                "kind": "band",
-                "candidateId": "c-unknown",
-                "passed": true,
-                "detail": "expected score in [60,100], got 80"
-              }
-            ]
-          },
-          {
-            "passed": true,
-            "assertions": [
-              {
-                "kind": "match",
-                "candidateId": "c-unknown",
-                "passed": true,
-                "detail": "expected match=true, got surfaced=true (score 80, threshold 30)"
-              },
-              {
-                "kind": "band",
-                "candidateId": "c-unknown",
-                "passed": true,
-                "detail": "expected score in [60,100], got 80"
-              }
-            ]
+            ],
+            "runId": "location%2Funknown-not-penalized::run:3",
+            "runIndex": 2
           }
         ]
       },
       {
         "caseId": "valency_role/seeker-gets-patient-provider-gets-agent",
         "rule": "valency_role",
-        "runs": 7,
-        "passes": 7,
+        "runs": 3,
+        "passes": 3,
         "passRate": 1,
         "flaky": false,
+        "scoredRunIds": [
+          "valency_role%2Fseeker-gets-patient-provider-gets-agent::run:1",
+          "valency_role%2Fseeker-gets-patient-provider-gets-agent::run:2",
+          "valency_role%2Fseeker-gets-patient-provider-gets-agent::run:3"
+        ],
         "runResults": [
           {
             "passed": true,
@@ -2291,13 +3843,13 @@
                 "kind": "match",
                 "candidateId": "c-ml",
                 "passed": true,
-                "detail": "expected match=true, got surfaced=true (score 98, threshold 30)"
+                "detail": "expected match=true, got surfaced=true (score 95, threshold 30)"
               },
               {
                 "kind": "band",
                 "candidateId": "c-ml",
                 "passed": true,
-                "detail": "expected score in [70,100], got 98"
+                "detail": "expected score in [70,100], got 95"
               },
               {
                 "kind": "role",
@@ -2305,7 +3857,9 @@
                 "passed": true,
                 "detail": "expected role=agent, got agent"
               }
-            ]
+            ],
+            "runId": "valency_role%2Fseeker-gets-patient-provider-gets-agent::run:1",
+            "runIndex": 0
           },
           {
             "passed": true,
@@ -2314,13 +3868,13 @@
                 "kind": "match",
                 "candidateId": "c-ml",
                 "passed": true,
-                "detail": "expected match=true, got surfaced=true (score 98, threshold 30)"
+                "detail": "expected match=true, got surfaced=true (score 95, threshold 30)"
               },
               {
                 "kind": "band",
                 "candidateId": "c-ml",
                 "passed": true,
-                "detail": "expected score in [70,100], got 98"
+                "detail": "expected score in [70,100], got 95"
               },
               {
                 "kind": "role",
@@ -2328,7 +3882,9 @@
                 "passed": true,
                 "detail": "expected role=agent, got agent"
               }
-            ]
+            ],
+            "runId": "valency_role%2Fseeker-gets-patient-provider-gets-agent::run:2",
+            "runIndex": 1
           },
           {
             "passed": true,
@@ -2337,13 +3893,13 @@
                 "kind": "match",
                 "candidateId": "c-ml",
                 "passed": true,
-                "detail": "expected match=true, got surfaced=true (score 98, threshold 30)"
+                "detail": "expected match=true, got surfaced=true (score 95, threshold 30)"
               },
               {
                 "kind": "band",
                 "candidateId": "c-ml",
                 "passed": true,
-                "detail": "expected score in [70,100], got 98"
+                "detail": "expected score in [70,100], got 95"
               },
               {
                 "kind": "role",
@@ -2351,109 +3907,24 @@
                 "passed": true,
                 "detail": "expected role=agent, got agent"
               }
-            ]
-          },
-          {
-            "passed": true,
-            "assertions": [
-              {
-                "kind": "match",
-                "candidateId": "c-ml",
-                "passed": true,
-                "detail": "expected match=true, got surfaced=true (score 98, threshold 30)"
-              },
-              {
-                "kind": "band",
-                "candidateId": "c-ml",
-                "passed": true,
-                "detail": "expected score in [70,100], got 98"
-              },
-              {
-                "kind": "role",
-                "candidateId": "c-ml",
-                "passed": true,
-                "detail": "expected role=agent, got agent"
-              }
-            ]
-          },
-          {
-            "passed": true,
-            "assertions": [
-              {
-                "kind": "match",
-                "candidateId": "c-ml",
-                "passed": true,
-                "detail": "expected match=true, got surfaced=true (score 98, threshold 30)"
-              },
-              {
-                "kind": "band",
-                "candidateId": "c-ml",
-                "passed": true,
-                "detail": "expected score in [70,100], got 98"
-              },
-              {
-                "kind": "role",
-                "candidateId": "c-ml",
-                "passed": true,
-                "detail": "expected role=agent, got agent"
-              }
-            ]
-          },
-          {
-            "passed": true,
-            "assertions": [
-              {
-                "kind": "match",
-                "candidateId": "c-ml",
-                "passed": true,
-                "detail": "expected match=true, got surfaced=true (score 98, threshold 30)"
-              },
-              {
-                "kind": "band",
-                "candidateId": "c-ml",
-                "passed": true,
-                "detail": "expected score in [70,100], got 98"
-              },
-              {
-                "kind": "role",
-                "candidateId": "c-ml",
-                "passed": true,
-                "detail": "expected role=agent, got agent"
-              }
-            ]
-          },
-          {
-            "passed": true,
-            "assertions": [
-              {
-                "kind": "match",
-                "candidateId": "c-ml",
-                "passed": true,
-                "detail": "expected match=true, got surfaced=true (score 98, threshold 30)"
-              },
-              {
-                "kind": "band",
-                "candidateId": "c-ml",
-                "passed": true,
-                "detail": "expected score in [70,100], got 98"
-              },
-              {
-                "kind": "role",
-                "candidateId": "c-ml",
-                "passed": true,
-                "detail": "expected role=agent, got agent"
-              }
-            ]
+            ],
+            "runId": "valency_role%2Fseeker-gets-patient-provider-gets-agent::run:3",
+            "runIndex": 2
           }
         ]
       },
       {
         "caseId": "score_calibration/must-meet-primary-role",
         "rule": "score_calibration",
-        "runs": 7,
-        "passes": 7,
+        "runs": 3,
+        "passes": 3,
         "passRate": 1,
         "flaky": false,
+        "scoredRunIds": [
+          "score_calibration%2Fmust-meet-primary-role::run:1",
+          "score_calibration%2Fmust-meet-primary-role::run:2",
+          "score_calibration%2Fmust-meet-primary-role::run:3"
+        ],
         "runResults": [
           {
             "passed": true,
@@ -2462,66 +3933,17 @@
                 "kind": "match",
                 "candidateId": "c-aiml",
                 "passed": true,
-                "detail": "expected match=true, got surfaced=true (score 98, threshold 30)"
+                "detail": "expected match=true, got surfaced=true (score 95, threshold 30)"
               },
               {
                 "kind": "band",
                 "candidateId": "c-aiml",
                 "passed": true,
-                "detail": "expected score in [85,100], got 98"
+                "detail": "expected score in [85,100], got 95"
               }
-            ]
-          },
-          {
-            "passed": true,
-            "assertions": [
-              {
-                "kind": "match",
-                "candidateId": "c-aiml",
-                "passed": true,
-                "detail": "expected match=true, got surfaced=true (score 98, threshold 30)"
-              },
-              {
-                "kind": "band",
-                "candidateId": "c-aiml",
-                "passed": true,
-                "detail": "expected score in [85,100], got 98"
-              }
-            ]
-          },
-          {
-            "passed": true,
-            "assertions": [
-              {
-                "kind": "match",
-                "candidateId": "c-aiml",
-                "passed": true,
-                "detail": "expected match=true, got surfaced=true (score 98, threshold 30)"
-              },
-              {
-                "kind": "band",
-                "candidateId": "c-aiml",
-                "passed": true,
-                "detail": "expected score in [85,100], got 98"
-              }
-            ]
-          },
-          {
-            "passed": true,
-            "assertions": [
-              {
-                "kind": "match",
-                "candidateId": "c-aiml",
-                "passed": true,
-                "detail": "expected match=true, got surfaced=true (score 98, threshold 30)"
-              },
-              {
-                "kind": "band",
-                "candidateId": "c-aiml",
-                "passed": true,
-                "detail": "expected score in [85,100], got 98"
-              }
-            ]
+            ],
+            "runId": "score_calibration%2Fmust-meet-primary-role::run:1",
+            "runIndex": 0
           },
           {
             "passed": true,
@@ -2538,7 +3960,9 @@
                 "passed": true,
                 "detail": "expected score in [85,100], got 95"
               }
-            ]
+            ],
+            "runId": "score_calibration%2Fmust-meet-primary-role::run:2",
+            "runIndex": 1
           },
           {
             "passed": true,
@@ -2547,42 +3971,32 @@
                 "kind": "match",
                 "candidateId": "c-aiml",
                 "passed": true,
-                "detail": "expected match=true, got surfaced=true (score 98, threshold 30)"
+                "detail": "expected match=true, got surfaced=true (score 95, threshold 30)"
               },
               {
                 "kind": "band",
                 "candidateId": "c-aiml",
                 "passed": true,
-                "detail": "expected score in [85,100], got 98"
+                "detail": "expected score in [85,100], got 95"
               }
-            ]
-          },
-          {
-            "passed": true,
-            "assertions": [
-              {
-                "kind": "match",
-                "candidateId": "c-aiml",
-                "passed": true,
-                "detail": "expected match=true, got surfaced=true (score 98, threshold 30)"
-              },
-              {
-                "kind": "band",
-                "candidateId": "c-aiml",
-                "passed": true,
-                "detail": "expected score in [85,100], got 98"
-              }
-            ]
+            ],
+            "runId": "score_calibration%2Fmust-meet-primary-role::run:3",
+            "runIndex": 2
           }
         ]
       },
       {
-        "caseId": "event_network/co-attendance-theme-lift",
+        "caseId": "event_network/co-membership-is-not-attendance",
         "rule": "event_network",
-        "runs": 7,
-        "passes": 7,
+        "runs": 3,
+        "passes": 3,
         "passRate": 1,
         "flaky": false,
+        "scoredRunIds": [
+          "event_network%2Fco-membership-is-not-attendance::run:1",
+          "event_network%2Fco-membership-is-not-attendance::run:2",
+          "event_network%2Fco-membership-is-not-attendance::run:3"
+        ],
         "runResults": [
           {
             "passed": true,
@@ -2591,21 +4005,17 @@
                 "kind": "match",
                 "candidateId": "c-attendee",
                 "passed": true,
-                "detail": "expected match=true, got surfaced=true (score 95, threshold 30)"
+                "detail": "expected match=false, got surfaced=false (score 0, threshold 30)"
               },
               {
                 "kind": "band",
                 "candidateId": "c-attendee",
                 "passed": true,
-                "detail": "expected score in [70,100], got 95"
-              },
-              {
-                "kind": "role",
-                "candidateId": "c-attendee",
-                "passed": true,
-                "detail": "expected role=peer, got peer"
+                "detail": "expected score in [0,29], got 0"
               }
-            ]
+            ],
+            "runId": "event_network%2Fco-membership-is-not-attendance::run:1",
+            "runIndex": 0
           },
           {
             "passed": true,
@@ -2614,21 +4024,17 @@
                 "kind": "match",
                 "candidateId": "c-attendee",
                 "passed": true,
-                "detail": "expected match=true, got surfaced=true (score 95, threshold 30)"
+                "detail": "expected match=false, got surfaced=false (score 0, threshold 30)"
               },
               {
                 "kind": "band",
                 "candidateId": "c-attendee",
                 "passed": true,
-                "detail": "expected score in [70,100], got 95"
-              },
-              {
-                "kind": "role",
-                "candidateId": "c-attendee",
-                "passed": true,
-                "detail": "expected role=peer, got peer"
+                "detail": "expected score in [0,29], got 0"
               }
-            ]
+            ],
+            "runId": "event_network%2Fco-membership-is-not-attendance::run:2",
+            "runIndex": 1
           },
           {
             "passed": true,
@@ -2637,123 +4043,32 @@
                 "kind": "match",
                 "candidateId": "c-attendee",
                 "passed": true,
-                "detail": "expected match=true, got surfaced=true (score 98, threshold 30)"
+                "detail": "expected match=false, got surfaced=false (score 0, threshold 30)"
               },
               {
                 "kind": "band",
                 "candidateId": "c-attendee",
                 "passed": true,
-                "detail": "expected score in [70,100], got 98"
-              },
-              {
-                "kind": "role",
-                "candidateId": "c-attendee",
-                "passed": true,
-                "detail": "expected role=peer, got peer"
+                "detail": "expected score in [0,29], got 0"
               }
-            ]
-          },
-          {
-            "passed": true,
-            "assertions": [
-              {
-                "kind": "match",
-                "candidateId": "c-attendee",
-                "passed": true,
-                "detail": "expected match=true, got surfaced=true (score 98, threshold 30)"
-              },
-              {
-                "kind": "band",
-                "candidateId": "c-attendee",
-                "passed": true,
-                "detail": "expected score in [70,100], got 98"
-              },
-              {
-                "kind": "role",
-                "candidateId": "c-attendee",
-                "passed": true,
-                "detail": "expected role=peer, got peer"
-              }
-            ]
-          },
-          {
-            "passed": true,
-            "assertions": [
-              {
-                "kind": "match",
-                "candidateId": "c-attendee",
-                "passed": true,
-                "detail": "expected match=true, got surfaced=true (score 95, threshold 30)"
-              },
-              {
-                "kind": "band",
-                "candidateId": "c-attendee",
-                "passed": true,
-                "detail": "expected score in [70,100], got 95"
-              },
-              {
-                "kind": "role",
-                "candidateId": "c-attendee",
-                "passed": true,
-                "detail": "expected role=peer, got peer"
-              }
-            ]
-          },
-          {
-            "passed": true,
-            "assertions": [
-              {
-                "kind": "match",
-                "candidateId": "c-attendee",
-                "passed": true,
-                "detail": "expected match=true, got surfaced=true (score 98, threshold 30)"
-              },
-              {
-                "kind": "band",
-                "candidateId": "c-attendee",
-                "passed": true,
-                "detail": "expected score in [70,100], got 98"
-              },
-              {
-                "kind": "role",
-                "candidateId": "c-attendee",
-                "passed": true,
-                "detail": "expected role=peer, got peer"
-              }
-            ]
-          },
-          {
-            "passed": true,
-            "assertions": [
-              {
-                "kind": "match",
-                "candidateId": "c-attendee",
-                "passed": true,
-                "detail": "expected match=true, got surfaced=true (score 95, threshold 30)"
-              },
-              {
-                "kind": "band",
-                "candidateId": "c-attendee",
-                "passed": true,
-                "detail": "expected score in [70,100], got 95"
-              },
-              {
-                "kind": "role",
-                "candidateId": "c-attendee",
-                "passed": true,
-                "detail": "expected role=peer, got peer"
-              }
-            ]
+            ],
+            "runId": "event_network%2Fco-membership-is-not-attendance::run:3",
+            "runIndex": 2
           }
         ]
       },
       {
         "caseId": "score_calibration/tier2-cofounder-pool",
         "rule": "score_calibration",
-        "runs": 7,
-        "passes": 7,
+        "runs": 3,
+        "passes": 3,
         "passRate": 1,
         "flaky": false,
+        "scoredRunIds": [
+          "score_calibration%2Ftier2-cofounder-pool::run:1",
+          "score_calibration%2Ftier2-cofounder-pool::run:2",
+          "score_calibration%2Ftier2-cofounder-pool::run:3"
+        ],
         "runResults": [
           {
             "passed": true,
@@ -2762,13 +4077,13 @@
                 "kind": "match",
                 "candidateId": "p-tech-cofounder",
                 "passed": true,
-                "detail": "expected match=true, got surfaced=true (score 98, threshold 30)"
+                "detail": "expected match=true, got surfaced=true (score 95, threshold 30)"
               },
               {
                 "kind": "band",
                 "candidateId": "p-tech-cofounder",
                 "passed": true,
-                "detail": "expected score in [70,100], got 98"
+                "detail": "expected score in [70,100], got 95"
               },
               {
                 "kind": "match",
@@ -2794,7 +4109,9 @@
                 "passed": true,
                 "detail": "expected score in [0,29], got 0"
               }
-            ]
+            ],
+            "runId": "score_calibration%2Ftier2-cofounder-pool::run:1",
+            "runIndex": 0
           },
           {
             "passed": true,
@@ -2803,13 +4120,13 @@
                 "kind": "match",
                 "candidateId": "p-tech-cofounder",
                 "passed": true,
-                "detail": "expected match=true, got surfaced=true (score 98, threshold 30)"
+                "detail": "expected match=true, got surfaced=true (score 95, threshold 30)"
               },
               {
                 "kind": "band",
                 "candidateId": "p-tech-cofounder",
                 "passed": true,
-                "detail": "expected score in [70,100], got 98"
+                "detail": "expected score in [70,100], got 95"
               },
               {
                 "kind": "match",
@@ -2835,7 +4152,9 @@
                 "passed": true,
                 "detail": "expected score in [0,29], got 0"
               }
-            ]
+            ],
+            "runId": "score_calibration%2Ftier2-cofounder-pool::run:2",
+            "runIndex": 1
           },
           {
             "passed": true,
@@ -2844,13 +4163,13 @@
                 "kind": "match",
                 "candidateId": "p-tech-cofounder",
                 "passed": true,
-                "detail": "expected match=true, got surfaced=true (score 98, threshold 30)"
+                "detail": "expected match=true, got surfaced=true (score 95, threshold 30)"
               },
               {
                 "kind": "band",
                 "candidateId": "p-tech-cofounder",
                 "passed": true,
-                "detail": "expected score in [70,100], got 98"
+                "detail": "expected score in [70,100], got 95"
               },
               {
                 "kind": "match",
@@ -2876,181 +4195,114 @@
                 "passed": true,
                 "detail": "expected score in [0,29], got 0"
               }
-            ]
+            ],
+            "runId": "score_calibration%2Ftier2-cofounder-pool::run:3",
+            "runIndex": 2
+          }
+        ]
+      },
+      {
+        "caseId": "cross_domain/animation-query-vs-geo-protocols-premise",
+        "rule": "query_primary",
+        "runs": 3,
+        "passes": 3,
+        "passRate": 1,
+        "flaky": false,
+        "scoredRunIds": [
+          "cross_domain%2Fanimation-query-vs-geo-protocols-premise::run:1",
+          "cross_domain%2Fanimation-query-vs-geo-protocols-premise::run:2",
+          "cross_domain%2Fanimation-query-vs-geo-protocols-premise::run:3"
+        ],
+        "runResults": [
+          {
+            "passed": true,
+            "assertions": [
+              {
+                "kind": "match",
+                "candidateId": "c-logistics",
+                "passed": true,
+                "detail": "expected match=false, got surfaced=false (score 0, threshold 30)"
+              },
+              {
+                "kind": "band",
+                "candidateId": "c-logistics",
+                "passed": true,
+                "detail": "expected score in [0,29], got 0"
+              },
+              {
+                "kind": "reasoning",
+                "candidateId": "c-logistics",
+                "passed": true,
+                "detail": "judge passed"
+              }
+            ],
+            "runId": "cross_domain%2Fanimation-query-vs-geo-protocols-premise::run:1",
+            "runIndex": 0
           },
           {
             "passed": true,
             "assertions": [
               {
                 "kind": "match",
-                "candidateId": "p-tech-cofounder",
-                "passed": true,
-                "detail": "expected match=true, got surfaced=true (score 98, threshold 30)"
-              },
-              {
-                "kind": "band",
-                "candidateId": "p-tech-cofounder",
-                "passed": true,
-                "detail": "expected score in [70,100], got 98"
-              },
-              {
-                "kind": "match",
-                "candidateId": "p-vc",
+                "candidateId": "c-logistics",
                 "passed": true,
                 "detail": "expected match=false, got surfaced=false (score 0, threshold 30)"
               },
               {
                 "kind": "band",
-                "candidateId": "p-vc",
+                "candidateId": "c-logistics",
                 "passed": true,
                 "detail": "expected score in [0,29], got 0"
               },
               {
-                "kind": "match",
-                "candidateId": "p-designer",
+                "kind": "reasoning",
+                "candidateId": "c-logistics",
                 "passed": true,
-                "detail": "expected match=false, got surfaced=false (score 0, threshold 30)"
-              },
-              {
-                "kind": "band",
-                "candidateId": "p-designer",
-                "passed": true,
-                "detail": "expected score in [0,29], got 0"
+                "detail": "judge passed"
               }
-            ]
+            ],
+            "runId": "cross_domain%2Fanimation-query-vs-geo-protocols-premise::run:2",
+            "runIndex": 1
           },
           {
             "passed": true,
             "assertions": [
               {
                 "kind": "match",
-                "candidateId": "p-tech-cofounder",
-                "passed": true,
-                "detail": "expected match=true, got surfaced=true (score 98, threshold 30)"
-              },
-              {
-                "kind": "band",
-                "candidateId": "p-tech-cofounder",
-                "passed": true,
-                "detail": "expected score in [70,100], got 98"
-              },
-              {
-                "kind": "match",
-                "candidateId": "p-vc",
+                "candidateId": "c-logistics",
                 "passed": true,
                 "detail": "expected match=false, got surfaced=false (score 0, threshold 30)"
               },
               {
                 "kind": "band",
-                "candidateId": "p-vc",
+                "candidateId": "c-logistics",
                 "passed": true,
                 "detail": "expected score in [0,29], got 0"
               },
               {
-                "kind": "match",
-                "candidateId": "p-designer",
+                "kind": "reasoning",
+                "candidateId": "c-logistics",
                 "passed": true,
-                "detail": "expected match=false, got surfaced=false (score 0, threshold 30)"
-              },
-              {
-                "kind": "band",
-                "candidateId": "p-designer",
-                "passed": true,
-                "detail": "expected score in [0,29], got 0"
+                "detail": "judge passed"
               }
-            ]
-          },
-          {
-            "passed": true,
-            "assertions": [
-              {
-                "kind": "match",
-                "candidateId": "p-tech-cofounder",
-                "passed": true,
-                "detail": "expected match=true, got surfaced=true (score 98, threshold 30)"
-              },
-              {
-                "kind": "band",
-                "candidateId": "p-tech-cofounder",
-                "passed": true,
-                "detail": "expected score in [70,100], got 98"
-              },
-              {
-                "kind": "match",
-                "candidateId": "p-vc",
-                "passed": true,
-                "detail": "expected match=false, got surfaced=false (score 0, threshold 30)"
-              },
-              {
-                "kind": "band",
-                "candidateId": "p-vc",
-                "passed": true,
-                "detail": "expected score in [0,29], got 0"
-              },
-              {
-                "kind": "match",
-                "candidateId": "p-designer",
-                "passed": true,
-                "detail": "expected match=false, got surfaced=false (score 0, threshold 30)"
-              },
-              {
-                "kind": "band",
-                "candidateId": "p-designer",
-                "passed": true,
-                "detail": "expected score in [0,29], got 0"
-              }
-            ]
-          },
-          {
-            "passed": true,
-            "assertions": [
-              {
-                "kind": "match",
-                "candidateId": "p-tech-cofounder",
-                "passed": true,
-                "detail": "expected match=true, got surfaced=true (score 98, threshold 30)"
-              },
-              {
-                "kind": "band",
-                "candidateId": "p-tech-cofounder",
-                "passed": true,
-                "detail": "expected score in [70,100], got 98"
-              },
-              {
-                "kind": "match",
-                "candidateId": "p-vc",
-                "passed": true,
-                "detail": "expected match=false, got surfaced=false (score 0, threshold 30)"
-              },
-              {
-                "kind": "band",
-                "candidateId": "p-vc",
-                "passed": true,
-                "detail": "expected score in [0,29], got 0"
-              },
-              {
-                "kind": "match",
-                "candidateId": "p-designer",
-                "passed": true,
-                "detail": "expected match=false, got surfaced=false (score 0, threshold 30)"
-              },
-              {
-                "kind": "band",
-                "candidateId": "p-designer",
-                "passed": true,
-                "detail": "expected score in [0,29], got 0"
-              }
-            ]
+            ],
+            "runId": "cross_domain%2Fanimation-query-vs-geo-protocols-premise::run:3",
+            "runIndex": 2
           }
         ]
       },
       {
         "caseId": "historical/builder-and-operator",
         "rule": "historical",
-        "runs": 7,
-        "passes": 7,
+        "runs": 3,
+        "passes": 3,
         "passRate": 1,
         "flaky": false,
+        "scoredRunIds": [
+          "historical%2Fbuilder-and-operator::run:1",
+          "historical%2Fbuilder-and-operator::run:2",
+          "historical%2Fbuilder-and-operator::run:3"
+        ],
         "runResults": [
           {
             "passed": true,
@@ -3109,7 +4361,9 @@
                 "passed": true,
                 "detail": "expected score in [0,29], got 0"
               }
-            ]
+            ],
+            "runId": "historical%2Fbuilder-and-operator::run:1",
+            "runIndex": 0
           },
           {
             "passed": true,
@@ -3168,7 +4422,9 @@
                 "passed": true,
                 "detail": "expected score in [0,29], got 0"
               }
-            ]
+            ],
+            "runId": "historical%2Fbuilder-and-operator::run:2",
+            "runIndex": 1
           },
           {
             "passed": true,
@@ -3227,253 +4483,24 @@
                 "passed": true,
                 "detail": "expected score in [0,29], got 0"
               }
-            ]
-          },
-          {
-            "passed": true,
-            "assertions": [
-              {
-                "kind": "match",
-                "candidateId": "h1-b",
-                "passed": true,
-                "detail": "expected match=true, got surfaced=true (score 98, threshold 30)"
-              },
-              {
-                "kind": "band",
-                "candidateId": "h1-b",
-                "passed": true,
-                "detail": "expected score in [60,100], got 98"
-              },
-              {
-                "kind": "role",
-                "candidateId": "h1-b",
-                "passed": true,
-                "detail": "expected role=agent, got agent"
-              },
-              {
-                "kind": "match",
-                "candidateId": "h1-c",
-                "passed": true,
-                "detail": "expected match=false, got surfaced=false (score 0, threshold 30)"
-              },
-              {
-                "kind": "band",
-                "candidateId": "h1-c",
-                "passed": true,
-                "detail": "expected score in [0,29], got 0"
-              },
-              {
-                "kind": "match",
-                "candidateId": "h1-d",
-                "passed": true,
-                "detail": "expected match=false, got surfaced=false (score 0, threshold 30)"
-              },
-              {
-                "kind": "band",
-                "candidateId": "h1-d",
-                "passed": true,
-                "detail": "expected score in [0,29], got 0"
-              },
-              {
-                "kind": "match",
-                "candidateId": "h1-e",
-                "passed": true,
-                "detail": "expected match=false, got surfaced=false (score 0, threshold 30)"
-              },
-              {
-                "kind": "band",
-                "candidateId": "h1-e",
-                "passed": true,
-                "detail": "expected score in [0,29], got 0"
-              }
-            ]
-          },
-          {
-            "passed": true,
-            "assertions": [
-              {
-                "kind": "match",
-                "candidateId": "h1-b",
-                "passed": true,
-                "detail": "expected match=true, got surfaced=true (score 95, threshold 30)"
-              },
-              {
-                "kind": "band",
-                "candidateId": "h1-b",
-                "passed": true,
-                "detail": "expected score in [60,100], got 95"
-              },
-              {
-                "kind": "role",
-                "candidateId": "h1-b",
-                "passed": true,
-                "detail": "expected role=agent, got agent"
-              },
-              {
-                "kind": "match",
-                "candidateId": "h1-c",
-                "passed": true,
-                "detail": "expected match=false, got surfaced=false (score 0, threshold 30)"
-              },
-              {
-                "kind": "band",
-                "candidateId": "h1-c",
-                "passed": true,
-                "detail": "expected score in [0,29], got 0"
-              },
-              {
-                "kind": "match",
-                "candidateId": "h1-d",
-                "passed": true,
-                "detail": "expected match=false, got surfaced=false (score 0, threshold 30)"
-              },
-              {
-                "kind": "band",
-                "candidateId": "h1-d",
-                "passed": true,
-                "detail": "expected score in [0,29], got 0"
-              },
-              {
-                "kind": "match",
-                "candidateId": "h1-e",
-                "passed": true,
-                "detail": "expected match=false, got surfaced=false (score 0, threshold 30)"
-              },
-              {
-                "kind": "band",
-                "candidateId": "h1-e",
-                "passed": true,
-                "detail": "expected score in [0,29], got 0"
-              }
-            ]
-          },
-          {
-            "passed": true,
-            "assertions": [
-              {
-                "kind": "match",
-                "candidateId": "h1-b",
-                "passed": true,
-                "detail": "expected match=true, got surfaced=true (score 95, threshold 30)"
-              },
-              {
-                "kind": "band",
-                "candidateId": "h1-b",
-                "passed": true,
-                "detail": "expected score in [60,100], got 95"
-              },
-              {
-                "kind": "role",
-                "candidateId": "h1-b",
-                "passed": true,
-                "detail": "expected role=agent, got agent"
-              },
-              {
-                "kind": "match",
-                "candidateId": "h1-c",
-                "passed": true,
-                "detail": "expected match=false, got surfaced=false (score 0, threshold 30)"
-              },
-              {
-                "kind": "band",
-                "candidateId": "h1-c",
-                "passed": true,
-                "detail": "expected score in [0,29], got 0"
-              },
-              {
-                "kind": "match",
-                "candidateId": "h1-d",
-                "passed": true,
-                "detail": "expected match=false, got surfaced=false (score 0, threshold 30)"
-              },
-              {
-                "kind": "band",
-                "candidateId": "h1-d",
-                "passed": true,
-                "detail": "expected score in [0,29], got 0"
-              },
-              {
-                "kind": "match",
-                "candidateId": "h1-e",
-                "passed": true,
-                "detail": "expected match=false, got surfaced=false (score 0, threshold 30)"
-              },
-              {
-                "kind": "band",
-                "candidateId": "h1-e",
-                "passed": true,
-                "detail": "expected score in [0,29], got 0"
-              }
-            ]
-          },
-          {
-            "passed": true,
-            "assertions": [
-              {
-                "kind": "match",
-                "candidateId": "h1-b",
-                "passed": true,
-                "detail": "expected match=true, got surfaced=true (score 95, threshold 30)"
-              },
-              {
-                "kind": "band",
-                "candidateId": "h1-b",
-                "passed": true,
-                "detail": "expected score in [60,100], got 95"
-              },
-              {
-                "kind": "role",
-                "candidateId": "h1-b",
-                "passed": true,
-                "detail": "expected role=agent, got agent"
-              },
-              {
-                "kind": "match",
-                "candidateId": "h1-c",
-                "passed": true,
-                "detail": "expected match=false, got surfaced=false (score 0, threshold 30)"
-              },
-              {
-                "kind": "band",
-                "candidateId": "h1-c",
-                "passed": true,
-                "detail": "expected score in [0,29], got 0"
-              },
-              {
-                "kind": "match",
-                "candidateId": "h1-d",
-                "passed": true,
-                "detail": "expected match=false, got surfaced=false (score 0, threshold 30)"
-              },
-              {
-                "kind": "band",
-                "candidateId": "h1-d",
-                "passed": true,
-                "detail": "expected score in [0,29], got 0"
-              },
-              {
-                "kind": "match",
-                "candidateId": "h1-e",
-                "passed": true,
-                "detail": "expected match=false, got surfaced=false (score 0, threshold 30)"
-              },
-              {
-                "kind": "band",
-                "candidateId": "h1-e",
-                "passed": true,
-                "detail": "expected score in [0,29], got 0"
-              }
-            ]
+            ],
+            "runId": "historical%2Fbuilder-and-operator::run:3",
+            "runIndex": 2
           }
         ]
       },
       {
         "caseId": "historical/co-researchers-structure",
         "rule": "historical",
-        "runs": 7,
-        "passes": 6,
-        "passRate": 0.8571428571428571,
-        "flaky": true,
+        "runs": 3,
+        "passes": 3,
+        "passRate": 1,
+        "flaky": false,
+        "scoredRunIds": [
+          "historical%2Fco-researchers-structure::run:1",
+          "historical%2Fco-researchers-structure::run:2",
+          "historical%2Fco-researchers-structure::run:3"
+        ],
         "runResults": [
           {
             "passed": true,
@@ -3482,13 +4509,13 @@
                 "kind": "match",
                 "candidateId": "h2-b",
                 "passed": true,
-                "detail": "expected match=true, got surfaced=true (score 98, threshold 30)"
+                "detail": "expected match=true, got surfaced=true (score 95, threshold 30)"
               },
               {
                 "kind": "band",
                 "candidateId": "h2-b",
                 "passed": true,
-                "detail": "expected score in [60,100], got 98"
+                "detail": "expected score in [60,100], got 95"
               },
               {
                 "kind": "match",
@@ -3526,7 +4553,9 @@
                 "passed": true,
                 "detail": "expected score in [0,29], got 0"
               }
-            ]
+            ],
+            "runId": "historical%2Fco-researchers-structure::run:1",
+            "runIndex": 0
           },
           {
             "passed": true,
@@ -3535,13 +4564,13 @@
                 "kind": "match",
                 "candidateId": "h2-b",
                 "passed": true,
-                "detail": "expected match=true, got surfaced=true (score 98, threshold 30)"
+                "detail": "expected match=true, got surfaced=true (score 95, threshold 30)"
               },
               {
                 "kind": "band",
                 "candidateId": "h2-b",
                 "passed": true,
-                "detail": "expected score in [60,100], got 98"
+                "detail": "expected score in [60,100], got 95"
               },
               {
                 "kind": "match",
@@ -3579,7 +4608,9 @@
                 "passed": true,
                 "detail": "expected score in [0,29], got 0"
               }
-            ]
+            ],
+            "runId": "historical%2Fco-researchers-structure::run:2",
+            "runIndex": 1
           },
           {
             "passed": true,
@@ -3588,13 +4619,13 @@
                 "kind": "match",
                 "candidateId": "h2-b",
                 "passed": true,
-                "detail": "expected match=true, got surfaced=true (score 98, threshold 30)"
+                "detail": "expected match=true, got surfaced=true (score 95, threshold 30)"
               },
               {
                 "kind": "band",
                 "candidateId": "h2-b",
                 "passed": true,
-                "detail": "expected score in [60,100], got 98"
+                "detail": "expected score in [60,100], got 95"
               },
               {
                 "kind": "match",
@@ -3632,229 +4663,24 @@
                 "passed": true,
                 "detail": "expected score in [0,29], got 0"
               }
-            ]
-          },
-          {
-            "passed": false,
-            "assertions": [
-              {
-                "kind": "match",
-                "candidateId": "h2-b",
-                "passed": true,
-                "detail": "expected match=true, got surfaced=true (score 98, threshold 30)"
-              },
-              {
-                "kind": "band",
-                "candidateId": "h2-b",
-                "passed": true,
-                "detail": "expected score in [60,100], got 98"
-              },
-              {
-                "kind": "match",
-                "candidateId": "h2-c",
-                "passed": false,
-                "detail": "expected match=false, got surfaced=true (score 65, threshold 30)"
-              },
-              {
-                "kind": "band",
-                "candidateId": "h2-c",
-                "passed": false,
-                "detail": "expected score in [0,29], got 65"
-              },
-              {
-                "kind": "match",
-                "candidateId": "h2-d",
-                "passed": true,
-                "detail": "expected match=false, got surfaced=false (score 0, threshold 30)"
-              },
-              {
-                "kind": "band",
-                "candidateId": "h2-d",
-                "passed": true,
-                "detail": "expected score in [0,29], got 0"
-              },
-              {
-                "kind": "match",
-                "candidateId": "h2-e",
-                "passed": true,
-                "detail": "expected match=false, got surfaced=false (score 0, threshold 30)"
-              },
-              {
-                "kind": "band",
-                "candidateId": "h2-e",
-                "passed": true,
-                "detail": "expected score in [0,29], got 0"
-              }
-            ]
-          },
-          {
-            "passed": true,
-            "assertions": [
-              {
-                "kind": "match",
-                "candidateId": "h2-b",
-                "passed": true,
-                "detail": "expected match=true, got surfaced=true (score 98, threshold 30)"
-              },
-              {
-                "kind": "band",
-                "candidateId": "h2-b",
-                "passed": true,
-                "detail": "expected score in [60,100], got 98"
-              },
-              {
-                "kind": "match",
-                "candidateId": "h2-c",
-                "passed": true,
-                "detail": "expected match=false, got surfaced=false (score 0, threshold 30)"
-              },
-              {
-                "kind": "band",
-                "candidateId": "h2-c",
-                "passed": true,
-                "detail": "expected score in [0,29], got 0"
-              },
-              {
-                "kind": "match",
-                "candidateId": "h2-d",
-                "passed": true,
-                "detail": "expected match=false, got surfaced=false (score 0, threshold 30)"
-              },
-              {
-                "kind": "band",
-                "candidateId": "h2-d",
-                "passed": true,
-                "detail": "expected score in [0,29], got 0"
-              },
-              {
-                "kind": "match",
-                "candidateId": "h2-e",
-                "passed": true,
-                "detail": "expected match=false, got surfaced=false (score 0, threshold 30)"
-              },
-              {
-                "kind": "band",
-                "candidateId": "h2-e",
-                "passed": true,
-                "detail": "expected score in [0,29], got 0"
-              }
-            ]
-          },
-          {
-            "passed": true,
-            "assertions": [
-              {
-                "kind": "match",
-                "candidateId": "h2-b",
-                "passed": true,
-                "detail": "expected match=true, got surfaced=true (score 98, threshold 30)"
-              },
-              {
-                "kind": "band",
-                "candidateId": "h2-b",
-                "passed": true,
-                "detail": "expected score in [60,100], got 98"
-              },
-              {
-                "kind": "match",
-                "candidateId": "h2-c",
-                "passed": true,
-                "detail": "expected match=false, got surfaced=false (score 0, threshold 30)"
-              },
-              {
-                "kind": "band",
-                "candidateId": "h2-c",
-                "passed": true,
-                "detail": "expected score in [0,29], got 0"
-              },
-              {
-                "kind": "match",
-                "candidateId": "h2-d",
-                "passed": true,
-                "detail": "expected match=false, got surfaced=false (score 0, threshold 30)"
-              },
-              {
-                "kind": "band",
-                "candidateId": "h2-d",
-                "passed": true,
-                "detail": "expected score in [0,29], got 0"
-              },
-              {
-                "kind": "match",
-                "candidateId": "h2-e",
-                "passed": true,
-                "detail": "expected match=false, got surfaced=false (score 0, threshold 30)"
-              },
-              {
-                "kind": "band",
-                "candidateId": "h2-e",
-                "passed": true,
-                "detail": "expected score in [0,29], got 0"
-              }
-            ]
-          },
-          {
-            "passed": true,
-            "assertions": [
-              {
-                "kind": "match",
-                "candidateId": "h2-b",
-                "passed": true,
-                "detail": "expected match=true, got surfaced=true (score 98, threshold 30)"
-              },
-              {
-                "kind": "band",
-                "candidateId": "h2-b",
-                "passed": true,
-                "detail": "expected score in [60,100], got 98"
-              },
-              {
-                "kind": "match",
-                "candidateId": "h2-c",
-                "passed": true,
-                "detail": "expected match=false, got surfaced=false (score 0, threshold 30)"
-              },
-              {
-                "kind": "band",
-                "candidateId": "h2-c",
-                "passed": true,
-                "detail": "expected score in [0,29], got 0"
-              },
-              {
-                "kind": "match",
-                "candidateId": "h2-d",
-                "passed": true,
-                "detail": "expected match=false, got surfaced=false (score 0, threshold 30)"
-              },
-              {
-                "kind": "band",
-                "candidateId": "h2-d",
-                "passed": true,
-                "detail": "expected score in [0,29], got 0"
-              },
-              {
-                "kind": "match",
-                "candidateId": "h2-e",
-                "passed": true,
-                "detail": "expected match=false, got surfaced=false (score 0, threshold 30)"
-              },
-              {
-                "kind": "band",
-                "candidateId": "h2-e",
-                "passed": true,
-                "detail": "expected score in [0,29], got 0"
-              }
-            ]
+            ],
+            "runId": "historical%2Fco-researchers-structure::run:3",
+            "runIndex": 2
           }
         ]
       },
       {
         "caseId": "historical/songwriting-duo",
         "rule": "historical",
-        "runs": 7,
-        "passes": 7,
-        "passRate": 1,
-        "flaky": false,
+        "runs": 3,
+        "passes": 2,
+        "passRate": 0.6666666666666666,
+        "flaky": true,
+        "scoredRunIds": [
+          "historical%2Fsongwriting-duo::run:1",
+          "historical%2Fsongwriting-duo::run:2",
+          "historical%2Fsongwriting-duo::run:3"
+        ],
         "runResults": [
           {
             "passed": true,
@@ -3863,13 +4689,13 @@
                 "kind": "match",
                 "candidateId": "h3-b",
                 "passed": true,
-                "detail": "expected match=true, got surfaced=true (score 98, threshold 30)"
+                "detail": "expected match=true, got surfaced=true (score 95, threshold 30)"
               },
               {
                 "kind": "band",
                 "candidateId": "h3-b",
                 "passed": true,
-                "detail": "expected score in [60,100], got 98"
+                "detail": "expected score in [60,100], got 95"
               },
               {
                 "kind": "match",
@@ -3907,7 +4733,9 @@
                 "passed": true,
                 "detail": "expected score in [0,29], got 0"
               }
-            ]
+            ],
+            "runId": "historical%2Fsongwriting-duo::run:1",
+            "runIndex": 0
           },
           {
             "passed": true,
@@ -3960,22 +4788,24 @@
                 "passed": true,
                 "detail": "expected score in [0,29], got 0"
               }
-            ]
+            ],
+            "runId": "historical%2Fsongwriting-duo::run:2",
+            "runIndex": 1
           },
           {
-            "passed": true,
+            "passed": false,
             "assertions": [
               {
                 "kind": "match",
                 "candidateId": "h3-b",
-                "passed": true,
-                "detail": "expected match=true, got surfaced=true (score 98, threshold 30)"
+                "passed": false,
+                "detail": "expected match=true, got surfaced=false (score 0, threshold 30)"
               },
               {
                 "kind": "band",
                 "candidateId": "h3-b",
-                "passed": true,
-                "detail": "expected score in [60,100], got 98"
+                "passed": false,
+                "detail": "expected score in [60,100], got 0"
               },
               {
                 "kind": "match",
@@ -4013,250 +4843,39 @@
                 "passed": true,
                 "detail": "expected score in [0,29], got 0"
               }
-            ]
-          },
-          {
-            "passed": true,
-            "assertions": [
-              {
-                "kind": "match",
-                "candidateId": "h3-b",
-                "passed": true,
-                "detail": "expected match=true, got surfaced=true (score 98, threshold 30)"
-              },
-              {
-                "kind": "band",
-                "candidateId": "h3-b",
-                "passed": true,
-                "detail": "expected score in [60,100], got 98"
-              },
-              {
-                "kind": "match",
-                "candidateId": "h3-c",
-                "passed": true,
-                "detail": "expected match=false, got surfaced=false (score 0, threshold 30)"
-              },
-              {
-                "kind": "band",
-                "candidateId": "h3-c",
-                "passed": true,
-                "detail": "expected score in [0,29], got 0"
-              },
-              {
-                "kind": "match",
-                "candidateId": "h3-d",
-                "passed": true,
-                "detail": "expected match=false, got surfaced=false (score 0, threshold 30)"
-              },
-              {
-                "kind": "band",
-                "candidateId": "h3-d",
-                "passed": true,
-                "detail": "expected score in [0,29], got 0"
-              },
-              {
-                "kind": "match",
-                "candidateId": "h3-e",
-                "passed": true,
-                "detail": "expected match=false, got surfaced=false (score 0, threshold 30)"
-              },
-              {
-                "kind": "band",
-                "candidateId": "h3-e",
-                "passed": true,
-                "detail": "expected score in [0,29], got 0"
-              }
-            ]
-          },
-          {
-            "passed": true,
-            "assertions": [
-              {
-                "kind": "match",
-                "candidateId": "h3-b",
-                "passed": true,
-                "detail": "expected match=true, got surfaced=true (score 98, threshold 30)"
-              },
-              {
-                "kind": "band",
-                "candidateId": "h3-b",
-                "passed": true,
-                "detail": "expected score in [60,100], got 98"
-              },
-              {
-                "kind": "match",
-                "candidateId": "h3-c",
-                "passed": true,
-                "detail": "expected match=false, got surfaced=false (score 0, threshold 30)"
-              },
-              {
-                "kind": "band",
-                "candidateId": "h3-c",
-                "passed": true,
-                "detail": "expected score in [0,29], got 0"
-              },
-              {
-                "kind": "match",
-                "candidateId": "h3-d",
-                "passed": true,
-                "detail": "expected match=false, got surfaced=false (score 0, threshold 30)"
-              },
-              {
-                "kind": "band",
-                "candidateId": "h3-d",
-                "passed": true,
-                "detail": "expected score in [0,29], got 0"
-              },
-              {
-                "kind": "match",
-                "candidateId": "h3-e",
-                "passed": true,
-                "detail": "expected match=false, got surfaced=false (score 0, threshold 30)"
-              },
-              {
-                "kind": "band",
-                "candidateId": "h3-e",
-                "passed": true,
-                "detail": "expected score in [0,29], got 0"
-              }
-            ]
-          },
-          {
-            "passed": true,
-            "assertions": [
-              {
-                "kind": "match",
-                "candidateId": "h3-b",
-                "passed": true,
-                "detail": "expected match=true, got surfaced=true (score 95, threshold 30)"
-              },
-              {
-                "kind": "band",
-                "candidateId": "h3-b",
-                "passed": true,
-                "detail": "expected score in [60,100], got 95"
-              },
-              {
-                "kind": "match",
-                "candidateId": "h3-c",
-                "passed": true,
-                "detail": "expected match=false, got surfaced=false (score 0, threshold 30)"
-              },
-              {
-                "kind": "band",
-                "candidateId": "h3-c",
-                "passed": true,
-                "detail": "expected score in [0,29], got 0"
-              },
-              {
-                "kind": "match",
-                "candidateId": "h3-d",
-                "passed": true,
-                "detail": "expected match=false, got surfaced=false (score 0, threshold 30)"
-              },
-              {
-                "kind": "band",
-                "candidateId": "h3-d",
-                "passed": true,
-                "detail": "expected score in [0,29], got 0"
-              },
-              {
-                "kind": "match",
-                "candidateId": "h3-e",
-                "passed": true,
-                "detail": "expected match=false, got surfaced=false (score 0, threshold 30)"
-              },
-              {
-                "kind": "band",
-                "candidateId": "h3-e",
-                "passed": true,
-                "detail": "expected score in [0,29], got 0"
-              }
-            ]
-          },
-          {
-            "passed": true,
-            "assertions": [
-              {
-                "kind": "match",
-                "candidateId": "h3-b",
-                "passed": true,
-                "detail": "expected match=true, got surfaced=true (score 98, threshold 30)"
-              },
-              {
-                "kind": "band",
-                "candidateId": "h3-b",
-                "passed": true,
-                "detail": "expected score in [60,100], got 98"
-              },
-              {
-                "kind": "match",
-                "candidateId": "h3-c",
-                "passed": true,
-                "detail": "expected match=false, got surfaced=false (score 0, threshold 30)"
-              },
-              {
-                "kind": "band",
-                "candidateId": "h3-c",
-                "passed": true,
-                "detail": "expected score in [0,29], got 0"
-              },
-              {
-                "kind": "match",
-                "candidateId": "h3-d",
-                "passed": true,
-                "detail": "expected match=false, got surfaced=false (score 0, threshold 30)"
-              },
-              {
-                "kind": "band",
-                "candidateId": "h3-d",
-                "passed": true,
-                "detail": "expected score in [0,29], got 0"
-              },
-              {
-                "kind": "match",
-                "candidateId": "h3-e",
-                "passed": true,
-                "detail": "expected match=false, got surfaced=false (score 0, threshold 30)"
-              },
-              {
-                "kind": "band",
-                "candidateId": "h3-e",
-                "passed": true,
-                "detail": "expected score in [0,29], got 0"
-              }
-            ]
+            ],
+            "runId": "historical%2Fsongwriting-duo::run:3",
+            "runIndex": 2
           }
         ]
       },
       {
         "caseId": "historical/first-check-investor",
         "rule": "historical",
-        "runs": 7,
-        "passes": 7,
-        "passRate": 1,
-        "flaky": false,
+        "runs": 3,
+        "passes": 2,
+        "passRate": 0.6666666666666666,
+        "flaky": true,
+        "scoredRunIds": [
+          "historical%2Ffirst-check-investor::run:1",
+          "historical%2Ffirst-check-investor::run:2",
+          "historical%2Ffirst-check-investor::run:3"
+        ],
         "runResults": [
           {
-            "passed": true,
+            "passed": false,
             "assertions": [
               {
                 "kind": "match",
                 "candidateId": "h4-b",
-                "passed": true,
-                "detail": "expected match=true, got surfaced=true (score 98, threshold 30)"
+                "passed": false,
+                "detail": "expected match=true, got surfaced=false (score 0, threshold 30)"
               },
               {
                 "kind": "band",
                 "candidateId": "h4-b",
-                "passed": true,
-                "detail": "expected score in [60,100], got 98"
-              },
-              {
-                "kind": "role",
-                "candidateId": "h4-b",
-                "passed": true,
-                "detail": "expected role=agent, got agent"
+                "passed": false,
+                "detail": "expected score in [60,100], got 0"
               },
               {
                 "kind": "match",
@@ -4294,7 +4913,9 @@
                 "passed": true,
                 "detail": "expected score in [0,29], got 0"
               }
-            ]
+            ],
+            "runId": "historical%2Ffirst-check-investor::run:1",
+            "runIndex": 0
           },
           {
             "passed": true,
@@ -4303,13 +4924,13 @@
                 "kind": "match",
                 "candidateId": "h4-b",
                 "passed": true,
-                "detail": "expected match=true, got surfaced=true (score 98, threshold 30)"
+                "detail": "expected match=true, got surfaced=true (score 95, threshold 30)"
               },
               {
                 "kind": "band",
                 "candidateId": "h4-b",
                 "passed": true,
-                "detail": "expected score in [60,100], got 98"
+                "detail": "expected score in [60,100], got 95"
               },
               {
                 "kind": "role",
@@ -4353,7 +4974,9 @@
                 "passed": true,
                 "detail": "expected score in [0,29], got 0"
               }
-            ]
+            ],
+            "runId": "historical%2Ffirst-check-investor::run:2",
+            "runIndex": 1
           },
           {
             "passed": true,
@@ -4362,13 +4985,13 @@
                 "kind": "match",
                 "candidateId": "h4-b",
                 "passed": true,
-                "detail": "expected match=true, got surfaced=true (score 98, threshold 30)"
+                "detail": "expected match=true, got surfaced=true (score 95, threshold 30)"
               },
               {
                 "kind": "band",
                 "candidateId": "h4-b",
                 "passed": true,
-                "detail": "expected score in [60,100], got 98"
+                "detail": "expected score in [60,100], got 95"
               },
               {
                 "kind": "role",
@@ -4412,253 +5035,24 @@
                 "passed": true,
                 "detail": "expected score in [0,29], got 0"
               }
-            ]
-          },
-          {
-            "passed": true,
-            "assertions": [
-              {
-                "kind": "match",
-                "candidateId": "h4-b",
-                "passed": true,
-                "detail": "expected match=true, got surfaced=true (score 98, threshold 30)"
-              },
-              {
-                "kind": "band",
-                "candidateId": "h4-b",
-                "passed": true,
-                "detail": "expected score in [60,100], got 98"
-              },
-              {
-                "kind": "role",
-                "candidateId": "h4-b",
-                "passed": true,
-                "detail": "expected role=agent, got agent"
-              },
-              {
-                "kind": "match",
-                "candidateId": "h4-c",
-                "passed": true,
-                "detail": "expected match=false, got surfaced=false (score 0, threshold 30)"
-              },
-              {
-                "kind": "band",
-                "candidateId": "h4-c",
-                "passed": true,
-                "detail": "expected score in [0,29], got 0"
-              },
-              {
-                "kind": "match",
-                "candidateId": "h4-d",
-                "passed": true,
-                "detail": "expected match=false, got surfaced=false (score 0, threshold 30)"
-              },
-              {
-                "kind": "band",
-                "candidateId": "h4-d",
-                "passed": true,
-                "detail": "expected score in [0,29], got 0"
-              },
-              {
-                "kind": "match",
-                "candidateId": "h4-e",
-                "passed": true,
-                "detail": "expected match=false, got surfaced=false (score 0, threshold 30)"
-              },
-              {
-                "kind": "band",
-                "candidateId": "h4-e",
-                "passed": true,
-                "detail": "expected score in [0,29], got 0"
-              }
-            ]
-          },
-          {
-            "passed": true,
-            "assertions": [
-              {
-                "kind": "match",
-                "candidateId": "h4-b",
-                "passed": true,
-                "detail": "expected match=true, got surfaced=true (score 98, threshold 30)"
-              },
-              {
-                "kind": "band",
-                "candidateId": "h4-b",
-                "passed": true,
-                "detail": "expected score in [60,100], got 98"
-              },
-              {
-                "kind": "role",
-                "candidateId": "h4-b",
-                "passed": true,
-                "detail": "expected role=agent, got agent"
-              },
-              {
-                "kind": "match",
-                "candidateId": "h4-c",
-                "passed": true,
-                "detail": "expected match=false, got surfaced=false (score 0, threshold 30)"
-              },
-              {
-                "kind": "band",
-                "candidateId": "h4-c",
-                "passed": true,
-                "detail": "expected score in [0,29], got 0"
-              },
-              {
-                "kind": "match",
-                "candidateId": "h4-d",
-                "passed": true,
-                "detail": "expected match=false, got surfaced=false (score 0, threshold 30)"
-              },
-              {
-                "kind": "band",
-                "candidateId": "h4-d",
-                "passed": true,
-                "detail": "expected score in [0,29], got 0"
-              },
-              {
-                "kind": "match",
-                "candidateId": "h4-e",
-                "passed": true,
-                "detail": "expected match=false, got surfaced=false (score 0, threshold 30)"
-              },
-              {
-                "kind": "band",
-                "candidateId": "h4-e",
-                "passed": true,
-                "detail": "expected score in [0,29], got 0"
-              }
-            ]
-          },
-          {
-            "passed": true,
-            "assertions": [
-              {
-                "kind": "match",
-                "candidateId": "h4-b",
-                "passed": true,
-                "detail": "expected match=true, got surfaced=true (score 98, threshold 30)"
-              },
-              {
-                "kind": "band",
-                "candidateId": "h4-b",
-                "passed": true,
-                "detail": "expected score in [60,100], got 98"
-              },
-              {
-                "kind": "role",
-                "candidateId": "h4-b",
-                "passed": true,
-                "detail": "expected role=agent, got agent"
-              },
-              {
-                "kind": "match",
-                "candidateId": "h4-c",
-                "passed": true,
-                "detail": "expected match=false, got surfaced=false (score 0, threshold 30)"
-              },
-              {
-                "kind": "band",
-                "candidateId": "h4-c",
-                "passed": true,
-                "detail": "expected score in [0,29], got 0"
-              },
-              {
-                "kind": "match",
-                "candidateId": "h4-d",
-                "passed": true,
-                "detail": "expected match=false, got surfaced=false (score 0, threshold 30)"
-              },
-              {
-                "kind": "band",
-                "candidateId": "h4-d",
-                "passed": true,
-                "detail": "expected score in [0,29], got 0"
-              },
-              {
-                "kind": "match",
-                "candidateId": "h4-e",
-                "passed": true,
-                "detail": "expected match=false, got surfaced=false (score 0, threshold 30)"
-              },
-              {
-                "kind": "band",
-                "candidateId": "h4-e",
-                "passed": true,
-                "detail": "expected score in [0,29], got 0"
-              }
-            ]
-          },
-          {
-            "passed": true,
-            "assertions": [
-              {
-                "kind": "match",
-                "candidateId": "h4-b",
-                "passed": true,
-                "detail": "expected match=true, got surfaced=true (score 98, threshold 30)"
-              },
-              {
-                "kind": "band",
-                "candidateId": "h4-b",
-                "passed": true,
-                "detail": "expected score in [60,100], got 98"
-              },
-              {
-                "kind": "role",
-                "candidateId": "h4-b",
-                "passed": true,
-                "detail": "expected role=agent, got agent"
-              },
-              {
-                "kind": "match",
-                "candidateId": "h4-c",
-                "passed": true,
-                "detail": "expected match=false, got surfaced=false (score 0, threshold 30)"
-              },
-              {
-                "kind": "band",
-                "candidateId": "h4-c",
-                "passed": true,
-                "detail": "expected score in [0,29], got 0"
-              },
-              {
-                "kind": "match",
-                "candidateId": "h4-d",
-                "passed": true,
-                "detail": "expected match=false, got surfaced=false (score 0, threshold 30)"
-              },
-              {
-                "kind": "band",
-                "candidateId": "h4-d",
-                "passed": true,
-                "detail": "expected score in [0,29], got 0"
-              },
-              {
-                "kind": "match",
-                "candidateId": "h4-e",
-                "passed": true,
-                "detail": "expected match=false, got surfaced=false (score 0, threshold 30)"
-              },
-              {
-                "kind": "band",
-                "candidateId": "h4-e",
-                "passed": true,
-                "detail": "expected score in [0,29], got 0"
-              }
-            ]
+            ],
+            "runId": "historical%2Ffirst-check-investor::run:3",
+            "runIndex": 2
           }
         ]
       },
       {
         "caseId": "historical/domain-expert-and-ml",
         "rule": "historical",
-        "runs": 7,
-        "passes": 7,
+        "runs": 3,
+        "passes": 3,
         "passRate": 1,
         "flaky": false,
+        "scoredRunIds": [
+          "historical%2Fdomain-expert-and-ml::run:1",
+          "historical%2Fdomain-expert-and-ml::run:2",
+          "historical%2Fdomain-expert-and-ml::run:3"
+        ],
         "runResults": [
           {
             "passed": true,
@@ -4667,13 +5061,13 @@
                 "kind": "match",
                 "candidateId": "h5-b",
                 "passed": true,
-                "detail": "expected match=true, got surfaced=true (score 98, threshold 30)"
+                "detail": "expected match=true, got surfaced=true (score 95, threshold 30)"
               },
               {
                 "kind": "band",
                 "candidateId": "h5-b",
                 "passed": true,
-                "detail": "expected score in [60,100], got 98"
+                "detail": "expected score in [60,100], got 95"
               },
               {
                 "kind": "match",
@@ -4711,113 +5105,9 @@
                 "passed": true,
                 "detail": "expected score in [0,29], got 0"
               }
-            ]
-          },
-          {
-            "passed": true,
-            "assertions": [
-              {
-                "kind": "match",
-                "candidateId": "h5-b",
-                "passed": true,
-                "detail": "expected match=true, got surfaced=true (score 98, threshold 30)"
-              },
-              {
-                "kind": "band",
-                "candidateId": "h5-b",
-                "passed": true,
-                "detail": "expected score in [60,100], got 98"
-              },
-              {
-                "kind": "match",
-                "candidateId": "h5-c",
-                "passed": true,
-                "detail": "expected match=false, got surfaced=false (score 0, threshold 30)"
-              },
-              {
-                "kind": "band",
-                "candidateId": "h5-c",
-                "passed": true,
-                "detail": "expected score in [0,29], got 0"
-              },
-              {
-                "kind": "match",
-                "candidateId": "h5-d",
-                "passed": true,
-                "detail": "expected match=false, got surfaced=false (score 0, threshold 30)"
-              },
-              {
-                "kind": "band",
-                "candidateId": "h5-d",
-                "passed": true,
-                "detail": "expected score in [0,29], got 0"
-              },
-              {
-                "kind": "match",
-                "candidateId": "h5-e",
-                "passed": true,
-                "detail": "expected match=false, got surfaced=false (score 0, threshold 30)"
-              },
-              {
-                "kind": "band",
-                "candidateId": "h5-e",
-                "passed": true,
-                "detail": "expected score in [0,29], got 0"
-              }
-            ]
-          },
-          {
-            "passed": true,
-            "assertions": [
-              {
-                "kind": "match",
-                "candidateId": "h5-b",
-                "passed": true,
-                "detail": "expected match=true, got surfaced=true (score 98, threshold 30)"
-              },
-              {
-                "kind": "band",
-                "candidateId": "h5-b",
-                "passed": true,
-                "detail": "expected score in [60,100], got 98"
-              },
-              {
-                "kind": "match",
-                "candidateId": "h5-c",
-                "passed": true,
-                "detail": "expected match=false, got surfaced=false (score 0, threshold 30)"
-              },
-              {
-                "kind": "band",
-                "candidateId": "h5-c",
-                "passed": true,
-                "detail": "expected score in [0,29], got 0"
-              },
-              {
-                "kind": "match",
-                "candidateId": "h5-d",
-                "passed": true,
-                "detail": "expected match=false, got surfaced=false (score 0, threshold 30)"
-              },
-              {
-                "kind": "band",
-                "candidateId": "h5-d",
-                "passed": true,
-                "detail": "expected score in [0,29], got 0"
-              },
-              {
-                "kind": "match",
-                "candidateId": "h5-e",
-                "passed": true,
-                "detail": "expected match=false, got surfaced=false (score 0, threshold 30)"
-              },
-              {
-                "kind": "band",
-                "candidateId": "h5-e",
-                "passed": true,
-                "detail": "expected score in [0,29], got 0"
-              }
-            ]
+            ],
+            "runId": "historical%2Fdomain-expert-and-ml::run:1",
+            "runIndex": 0
           },
           {
             "passed": true,
@@ -4870,113 +5160,9 @@
                 "passed": true,
                 "detail": "expected score in [0,29], got 0"
               }
-            ]
-          },
-          {
-            "passed": true,
-            "assertions": [
-              {
-                "kind": "match",
-                "candidateId": "h5-b",
-                "passed": true,
-                "detail": "expected match=true, got surfaced=true (score 98, threshold 30)"
-              },
-              {
-                "kind": "band",
-                "candidateId": "h5-b",
-                "passed": true,
-                "detail": "expected score in [60,100], got 98"
-              },
-              {
-                "kind": "match",
-                "candidateId": "h5-c",
-                "passed": true,
-                "detail": "expected match=false, got surfaced=false (score 0, threshold 30)"
-              },
-              {
-                "kind": "band",
-                "candidateId": "h5-c",
-                "passed": true,
-                "detail": "expected score in [0,29], got 0"
-              },
-              {
-                "kind": "match",
-                "candidateId": "h5-d",
-                "passed": true,
-                "detail": "expected match=false, got surfaced=false (score 0, threshold 30)"
-              },
-              {
-                "kind": "band",
-                "candidateId": "h5-d",
-                "passed": true,
-                "detail": "expected score in [0,29], got 0"
-              },
-              {
-                "kind": "match",
-                "candidateId": "h5-e",
-                "passed": true,
-                "detail": "expected match=false, got surfaced=false (score 0, threshold 30)"
-              },
-              {
-                "kind": "band",
-                "candidateId": "h5-e",
-                "passed": true,
-                "detail": "expected score in [0,29], got 0"
-              }
-            ]
-          },
-          {
-            "passed": true,
-            "assertions": [
-              {
-                "kind": "match",
-                "candidateId": "h5-b",
-                "passed": true,
-                "detail": "expected match=true, got surfaced=true (score 98, threshold 30)"
-              },
-              {
-                "kind": "band",
-                "candidateId": "h5-b",
-                "passed": true,
-                "detail": "expected score in [60,100], got 98"
-              },
-              {
-                "kind": "match",
-                "candidateId": "h5-c",
-                "passed": true,
-                "detail": "expected match=false, got surfaced=false (score 0, threshold 30)"
-              },
-              {
-                "kind": "band",
-                "candidateId": "h5-c",
-                "passed": true,
-                "detail": "expected score in [0,29], got 0"
-              },
-              {
-                "kind": "match",
-                "candidateId": "h5-d",
-                "passed": true,
-                "detail": "expected match=false, got surfaced=false (score 0, threshold 30)"
-              },
-              {
-                "kind": "band",
-                "candidateId": "h5-d",
-                "passed": true,
-                "detail": "expected score in [0,29], got 0"
-              },
-              {
-                "kind": "match",
-                "candidateId": "h5-e",
-                "passed": true,
-                "detail": "expected match=false, got surfaced=false (score 0, threshold 30)"
-              },
-              {
-                "kind": "band",
-                "candidateId": "h5-e",
-                "passed": true,
-                "detail": "expected score in [0,29], got 0"
-              }
-            ]
+            ],
+            "runId": "historical%2Fdomain-expert-and-ml::run:2",
+            "runIndex": 1
           },
           {
             "passed": true,
@@ -5029,17 +5215,24 @@
                 "passed": true,
                 "detail": "expected score in [0,29], got 0"
               }
-            ]
+            ],
+            "runId": "historical%2Fdomain-expert-and-ml::run:3",
+            "runIndex": 2
           }
         ]
       },
       {
         "caseId": "is_a_identity/startup-funder-vs-funded-bootstrapper",
         "rule": "is_a_identity",
-        "runs": 7,
-        "passes": 7,
+        "runs": 3,
+        "passes": 3,
         "passRate": 1,
         "flaky": false,
+        "scoredRunIds": [
+          "is_a_identity%2Fstartup-funder-vs-funded-bootstrapper::run:1",
+          "is_a_identity%2Fstartup-funder-vs-funded-bootstrapper::run:2",
+          "is_a_identity%2Fstartup-funder-vs-funded-bootstrapper::run:3"
+        ],
         "runResults": [
           {
             "passed": true,
@@ -5056,7 +5249,9 @@
                 "passed": true,
                 "detail": "expected score in [0,29], got 0"
               }
-            ]
+            ],
+            "runId": "is_a_identity%2Fstartup-funder-vs-funded-bootstrapper::run:1",
+            "runIndex": 0
           },
           {
             "passed": true,
@@ -5073,7 +5268,9 @@
                 "passed": true,
                 "detail": "expected score in [0,29], got 0"
               }
-            ]
+            ],
+            "runId": "is_a_identity%2Fstartup-funder-vs-funded-bootstrapper::run:2",
+            "runIndex": 1
           },
           {
             "passed": true,
@@ -5090,85 +5287,24 @@
                 "passed": true,
                 "detail": "expected score in [0,29], got 0"
               }
-            ]
-          },
-          {
-            "passed": true,
-            "assertions": [
-              {
-                "kind": "match",
-                "candidateId": "c-bootstrap",
-                "passed": true,
-                "detail": "expected match=false, got surfaced=false (score 0, threshold 30)"
-              },
-              {
-                "kind": "band",
-                "candidateId": "c-bootstrap",
-                "passed": true,
-                "detail": "expected score in [0,29], got 0"
-              }
-            ]
-          },
-          {
-            "passed": true,
-            "assertions": [
-              {
-                "kind": "match",
-                "candidateId": "c-bootstrap",
-                "passed": true,
-                "detail": "expected match=false, got surfaced=false (score 0, threshold 30)"
-              },
-              {
-                "kind": "band",
-                "candidateId": "c-bootstrap",
-                "passed": true,
-                "detail": "expected score in [0,29], got 0"
-              }
-            ]
-          },
-          {
-            "passed": true,
-            "assertions": [
-              {
-                "kind": "match",
-                "candidateId": "c-bootstrap",
-                "passed": true,
-                "detail": "expected match=false, got surfaced=false (score 0, threshold 30)"
-              },
-              {
-                "kind": "band",
-                "candidateId": "c-bootstrap",
-                "passed": true,
-                "detail": "expected score in [0,29], got 0"
-              }
-            ]
-          },
-          {
-            "passed": true,
-            "assertions": [
-              {
-                "kind": "match",
-                "candidateId": "c-bootstrap",
-                "passed": true,
-                "detail": "expected match=false, got surfaced=false (score 0, threshold 30)"
-              },
-              {
-                "kind": "band",
-                "candidateId": "c-bootstrap",
-                "passed": true,
-                "detail": "expected score in [0,29], got 0"
-              }
-            ]
+            ],
+            "runId": "is_a_identity%2Fstartup-funder-vs-funded-bootstrapper::run:3",
+            "runIndex": 2
           }
         ]
       },
       {
         "caseId": "is_a_identity/art-director-vs-illustrator",
         "rule": "is_a_identity",
-        "runs": 7,
-        "passes": 7,
+        "runs": 3,
+        "passes": 3,
         "passRate": 1,
         "flaky": false,
+        "scoredRunIds": [
+          "is_a_identity%2Fart-director-vs-illustrator::run:1",
+          "is_a_identity%2Fart-director-vs-illustrator::run:2",
+          "is_a_identity%2Fart-director-vs-illustrator::run:3"
+        ],
         "runResults": [
           {
             "passed": true,
@@ -5185,7 +5321,9 @@
                 "passed": true,
                 "detail": "expected score in [0,29], got 0"
               }
-            ]
+            ],
+            "runId": "is_a_identity%2Fart-director-vs-illustrator::run:1",
+            "runIndex": 0
           },
           {
             "passed": true,
@@ -5202,7 +5340,9 @@
                 "passed": true,
                 "detail": "expected score in [0,29], got 0"
               }
-            ]
+            ],
+            "runId": "is_a_identity%2Fart-director-vs-illustrator::run:2",
+            "runIndex": 1
           },
           {
             "passed": true,
@@ -5219,85 +5359,24 @@
                 "passed": true,
                 "detail": "expected score in [0,29], got 0"
               }
-            ]
-          },
-          {
-            "passed": true,
-            "assertions": [
-              {
-                "kind": "match",
-                "candidateId": "c-lucia",
-                "passed": true,
-                "detail": "expected match=false, got surfaced=false (score 0, threshold 30)"
-              },
-              {
-                "kind": "band",
-                "candidateId": "c-lucia",
-                "passed": true,
-                "detail": "expected score in [0,29], got 0"
-              }
-            ]
-          },
-          {
-            "passed": true,
-            "assertions": [
-              {
-                "kind": "match",
-                "candidateId": "c-lucia",
-                "passed": true,
-                "detail": "expected match=false, got surfaced=false (score 0, threshold 30)"
-              },
-              {
-                "kind": "band",
-                "candidateId": "c-lucia",
-                "passed": true,
-                "detail": "expected score in [0,29], got 0"
-              }
-            ]
-          },
-          {
-            "passed": true,
-            "assertions": [
-              {
-                "kind": "match",
-                "candidateId": "c-lucia",
-                "passed": true,
-                "detail": "expected match=false, got surfaced=false (score 0, threshold 30)"
-              },
-              {
-                "kind": "band",
-                "candidateId": "c-lucia",
-                "passed": true,
-                "detail": "expected score in [0,29], got 0"
-              }
-            ]
-          },
-          {
-            "passed": true,
-            "assertions": [
-              {
-                "kind": "match",
-                "candidateId": "c-lucia",
-                "passed": true,
-                "detail": "expected match=false, got surfaced=false (score 0, threshold 30)"
-              },
-              {
-                "kind": "band",
-                "candidateId": "c-lucia",
-                "passed": true,
-                "detail": "expected score in [0,29], got 0"
-              }
-            ]
+            ],
+            "runId": "is_a_identity%2Fart-director-vs-illustrator::run:3",
+            "runIndex": 2
           }
         ]
       },
       {
         "caseId": "is_a_identity/scout-vs-scouted-athlete",
         "rule": "is_a_identity",
-        "runs": 7,
-        "passes": 7,
+        "runs": 3,
+        "passes": 3,
         "passRate": 1,
         "flaky": false,
+        "scoredRunIds": [
+          "is_a_identity%2Fscout-vs-scouted-athlete::run:1",
+          "is_a_identity%2Fscout-vs-scouted-athlete::run:2",
+          "is_a_identity%2Fscout-vs-scouted-athlete::run:3"
+        ],
         "runResults": [
           {
             "passed": true,
@@ -5306,13 +5385,13 @@
                 "kind": "match",
                 "candidateId": "c-scout",
                 "passed": true,
-                "detail": "expected match=true, got surfaced=true (score 92, threshold 30)"
+                "detail": "expected match=true, got surfaced=true (score 95, threshold 30)"
               },
               {
                 "kind": "band",
                 "candidateId": "c-scout",
                 "passed": true,
-                "detail": "expected score in [70,100], got 92"
+                "detail": "expected score in [70,100], got 95"
               },
               {
                 "kind": "match",
@@ -5326,36 +5405,9 @@
                 "passed": true,
                 "detail": "expected score in [0,29], got 0"
               }
-            ]
-          },
-          {
-            "passed": true,
-            "assertions": [
-              {
-                "kind": "match",
-                "candidateId": "c-scout",
-                "passed": true,
-                "detail": "expected match=true, got surfaced=true (score 85, threshold 30)"
-              },
-              {
-                "kind": "band",
-                "candidateId": "c-scout",
-                "passed": true,
-                "detail": "expected score in [70,100], got 85"
-              },
-              {
-                "kind": "match",
-                "candidateId": "c-athlete",
-                "passed": true,
-                "detail": "expected match=false, got surfaced=false (score 0, threshold 30)"
-              },
-              {
-                "kind": "band",
-                "candidateId": "c-athlete",
-                "passed": true,
-                "detail": "expected score in [0,29], got 0"
-              }
-            ]
+            ],
+            "runId": "is_a_identity%2Fscout-vs-scouted-athlete::run:1",
+            "runIndex": 0
           },
           {
             "passed": true,
@@ -5384,7 +5436,9 @@
                 "passed": true,
                 "detail": "expected score in [0,29], got 0"
               }
-            ]
+            ],
+            "runId": "is_a_identity%2Fscout-vs-scouted-athlete::run:2",
+            "runIndex": 1
           },
           {
             "passed": true,
@@ -5413,104 +5467,24 @@
                 "passed": true,
                 "detail": "expected score in [0,29], got 0"
               }
-            ]
-          },
-          {
-            "passed": true,
-            "assertions": [
-              {
-                "kind": "match",
-                "candidateId": "c-scout",
-                "passed": true,
-                "detail": "expected match=true, got surfaced=true (score 95, threshold 30)"
-              },
-              {
-                "kind": "band",
-                "candidateId": "c-scout",
-                "passed": true,
-                "detail": "expected score in [70,100], got 95"
-              },
-              {
-                "kind": "match",
-                "candidateId": "c-athlete",
-                "passed": true,
-                "detail": "expected match=false, got surfaced=false (score 0, threshold 30)"
-              },
-              {
-                "kind": "band",
-                "candidateId": "c-athlete",
-                "passed": true,
-                "detail": "expected score in [0,29], got 0"
-              }
-            ]
-          },
-          {
-            "passed": true,
-            "assertions": [
-              {
-                "kind": "match",
-                "candidateId": "c-scout",
-                "passed": true,
-                "detail": "expected match=true, got surfaced=true (score 95, threshold 30)"
-              },
-              {
-                "kind": "band",
-                "candidateId": "c-scout",
-                "passed": true,
-                "detail": "expected score in [70,100], got 95"
-              },
-              {
-                "kind": "match",
-                "candidateId": "c-athlete",
-                "passed": true,
-                "detail": "expected match=false, got surfaced=false (score 0, threshold 30)"
-              },
-              {
-                "kind": "band",
-                "candidateId": "c-athlete",
-                "passed": true,
-                "detail": "expected score in [0,29], got 0"
-              }
-            ]
-          },
-          {
-            "passed": true,
-            "assertions": [
-              {
-                "kind": "match",
-                "candidateId": "c-scout",
-                "passed": true,
-                "detail": "expected match=true, got surfaced=true (score 95, threshold 30)"
-              },
-              {
-                "kind": "band",
-                "candidateId": "c-scout",
-                "passed": true,
-                "detail": "expected score in [70,100], got 95"
-              },
-              {
-                "kind": "match",
-                "candidateId": "c-athlete",
-                "passed": true,
-                "detail": "expected match=false, got surfaced=false (score 0, threshold 30)"
-              },
-              {
-                "kind": "band",
-                "candidateId": "c-athlete",
-                "passed": true,
-                "detail": "expected score in [0,29], got 0"
-              }
-            ]
+            ],
+            "runId": "is_a_identity%2Fscout-vs-scouted-athlete::run:3",
+            "runIndex": 2
           }
         ]
       },
       {
         "caseId": "is_a_identity/investor-vs-grant-recipient",
         "rule": "is_a_identity",
-        "runs": 7,
-        "passes": 7,
+        "runs": 3,
+        "passes": 3,
         "passRate": 1,
         "flaky": false,
+        "scoredRunIds": [
+          "is_a_identity%2Finvestor-vs-grant-recipient::run:1",
+          "is_a_identity%2Finvestor-vs-grant-recipient::run:2",
+          "is_a_identity%2Finvestor-vs-grant-recipient::run:3"
+        ],
         "runResults": [
           {
             "passed": true,
@@ -5527,7 +5501,9 @@
                 "passed": true,
                 "detail": "expected score in [0,29], got 0"
               }
-            ]
+            ],
+            "runId": "is_a_identity%2Finvestor-vs-grant-recipient::run:1",
+            "runIndex": 0
           },
           {
             "passed": true,
@@ -5544,7 +5520,9 @@
                 "passed": true,
                 "detail": "expected score in [0,29], got 0"
               }
-            ]
+            ],
+            "runId": "is_a_identity%2Finvestor-vs-grant-recipient::run:2",
+            "runIndex": 1
           },
           {
             "passed": true,
@@ -5561,85 +5539,24 @@
                 "passed": true,
                 "detail": "expected score in [0,29], got 0"
               }
-            ]
-          },
-          {
-            "passed": true,
-            "assertions": [
-              {
-                "kind": "match",
-                "candidateId": "c-grant",
-                "passed": true,
-                "detail": "expected match=false, got surfaced=false (score 0, threshold 30)"
-              },
-              {
-                "kind": "band",
-                "candidateId": "c-grant",
-                "passed": true,
-                "detail": "expected score in [0,29], got 0"
-              }
-            ]
-          },
-          {
-            "passed": true,
-            "assertions": [
-              {
-                "kind": "match",
-                "candidateId": "c-grant",
-                "passed": true,
-                "detail": "expected match=false, got surfaced=false (score 0, threshold 30)"
-              },
-              {
-                "kind": "band",
-                "candidateId": "c-grant",
-                "passed": true,
-                "detail": "expected score in [0,29], got 0"
-              }
-            ]
-          },
-          {
-            "passed": true,
-            "assertions": [
-              {
-                "kind": "match",
-                "candidateId": "c-grant",
-                "passed": true,
-                "detail": "expected match=false, got surfaced=false (score 0, threshold 30)"
-              },
-              {
-                "kind": "band",
-                "candidateId": "c-grant",
-                "passed": true,
-                "detail": "expected score in [0,29], got 0"
-              }
-            ]
-          },
-          {
-            "passed": true,
-            "assertions": [
-              {
-                "kind": "match",
-                "candidateId": "c-grant",
-                "passed": true,
-                "detail": "expected match=false, got surfaced=false (score 0, threshold 30)"
-              },
-              {
-                "kind": "band",
-                "candidateId": "c-grant",
-                "passed": true,
-                "detail": "expected score in [0,29], got 0"
-              }
-            ]
+            ],
+            "runId": "is_a_identity%2Finvestor-vs-grant-recipient::run:3",
+            "runIndex": 2
           }
         ]
       },
       {
         "caseId": "complementary_role/design-cofounder-for-tech-founder",
         "rule": "complementary_role",
-        "runs": 7,
-        "passes": 6,
-        "passRate": 0.8571428571428571,
+        "runs": 3,
+        "passes": 2,
+        "passRate": 0.6666666666666666,
         "flaky": true,
+        "scoredRunIds": [
+          "complementary_role%2Fdesign-cofounder-for-tech-founder::run:1",
+          "complementary_role%2Fdesign-cofounder-for-tech-founder::run:2",
+          "complementary_role%2Fdesign-cofounder-for-tech-founder::run:3"
+        ],
         "runResults": [
           {
             "passed": true,
@@ -5674,42 +5591,9 @@
                 "passed": true,
                 "detail": "expected role=agent, got agent"
               }
-            ]
-          },
-          {
-            "passed": true,
-            "assertions": [
-              {
-                "kind": "match",
-                "candidateId": "p-vc",
-                "passed": true,
-                "detail": "expected match=false, got surfaced=false (score 0, threshold 30)"
-              },
-              {
-                "kind": "band",
-                "candidateId": "p-vc",
-                "passed": true,
-                "detail": "expected score in [0,29], got 0"
-              },
-              {
-                "kind": "match",
-                "candidateId": "p-designer-alt",
-                "passed": true,
-                "detail": "expected match=true, got surfaced=true (score 92, threshold 30)"
-              },
-              {
-                "kind": "band",
-                "candidateId": "p-designer-alt",
-                "passed": true,
-                "detail": "expected score in [70,100], got 92"
-              },
-              {
-                "kind": "role",
-                "candidateId": "p-designer-alt",
-                "passed": true,
-                "detail": "expected role=agent, got agent"
-              }
-            ]
+            ],
+            "runId": "complementary_role%2Fdesign-cofounder-for-tech-founder::run:1",
+            "runIndex": 0
           },
           {
             "passed": true,
@@ -5744,77 +5628,9 @@
                 "passed": true,
                 "detail": "expected role=agent, got agent"
               }
-            ]
-          },
-          {
-            "passed": true,
-            "assertions": [
-              {
-                "kind": "match",
-                "candidateId": "p-vc",
-                "passed": true,
-                "detail": "expected match=false, got surfaced=false (score 0, threshold 30)"
-              },
-              {
-                "kind": "band",
-                "candidateId": "p-vc",
-                "passed": true,
-                "detail": "expected score in [0,29], got 0"
-              },
-              {
-                "kind": "match",
-                "candidateId": "p-designer-alt",
-                "passed": true,
-                "detail": "expected match=true, got surfaced=true (score 95, threshold 30)"
-              },
-              {
-                "kind": "band",
-                "candidateId": "p-designer-alt",
-                "passed": true,
-                "detail": "expected score in [70,100], got 95"
-              },
-              {
-                "kind": "role",
-                "candidateId": "p-designer-alt",
-                "passed": true,
-                "detail": "expected role=agent, got agent"
-              }
-            ]
-          },
-          {
-            "passed": true,
-            "assertions": [
-              {
-                "kind": "match",
-                "candidateId": "p-vc",
-                "passed": true,
-                "detail": "expected match=false, got surfaced=false (score 0, threshold 30)"
-              },
-              {
-                "kind": "band",
-                "candidateId": "p-vc",
-                "passed": true,
-                "detail": "expected score in [0,29], got 0"
-              },
-              {
-                "kind": "match",
-                "candidateId": "p-designer-alt",
-                "passed": true,
-                "detail": "expected match=true, got surfaced=true (score 95, threshold 30)"
-              },
-              {
-                "kind": "band",
-                "candidateId": "p-designer-alt",
-                "passed": true,
-                "detail": "expected score in [70,100], got 95"
-              },
-              {
-                "kind": "role",
-                "candidateId": "p-designer-alt",
-                "passed": true,
-                "detail": "expected role=agent, got agent"
-              }
-            ]
+            ],
+            "runId": "complementary_role%2Fdesign-cofounder-for-tech-founder::run:2",
+            "runIndex": 1
           },
           {
             "passed": false,
@@ -5834,88 +5650,48 @@
               {
                 "kind": "match",
                 "candidateId": "p-designer-alt",
-                "passed": true,
-                "detail": "expected match=true, got surfaced=true (score 95, threshold 30)"
+                "passed": false,
+                "detail": "expected match=true, got surfaced=false (score 0, threshold 30)"
               },
               {
                 "kind": "band",
-                "candidateId": "p-designer-alt",
-                "passed": true,
-                "detail": "expected score in [70,100], got 95"
-              },
-              {
-                "kind": "role",
                 "candidateId": "p-designer-alt",
                 "passed": false,
-                "detail": "expected role=agent, got peer"
+                "detail": "expected score in [70,100], got 0"
               }
-            ]
-          },
-          {
-            "passed": true,
-            "assertions": [
-              {
-                "kind": "match",
-                "candidateId": "p-vc",
-                "passed": true,
-                "detail": "expected match=false, got surfaced=false (score 0, threshold 30)"
-              },
-              {
-                "kind": "band",
-                "candidateId": "p-vc",
-                "passed": true,
-                "detail": "expected score in [0,29], got 0"
-              },
-              {
-                "kind": "match",
-                "candidateId": "p-designer-alt",
-                "passed": true,
-                "detail": "expected match=true, got surfaced=true (score 95, threshold 30)"
-              },
-              {
-                "kind": "band",
-                "candidateId": "p-designer-alt",
-                "passed": true,
-                "detail": "expected score in [70,100], got 95"
-              },
-              {
-                "kind": "role",
-                "candidateId": "p-designer-alt",
-                "passed": true,
-                "detail": "expected role=agent, got agent"
-              }
-            ]
+            ],
+            "runId": "complementary_role%2Fdesign-cofounder-for-tech-founder::run:3",
+            "runIndex": 2
           }
         ]
       },
       {
         "caseId": "complementary_role/marketing-cofounder-for-ai-engineer",
         "rule": "complementary_role",
-        "runs": 7,
-        "passes": 7,
-        "passRate": 1,
+        "runs": 3,
+        "passes": 0,
+        "passRate": 0,
         "flaky": false,
+        "scoredRunIds": [
+          "complementary_role%2Fmarketing-cofounder-for-ai-engineer::run:1",
+          "complementary_role%2Fmarketing-cofounder-for-ai-engineer::run:2",
+          "complementary_role%2Fmarketing-cofounder-for-ai-engineer::run:3"
+        ],
         "runResults": [
           {
-            "passed": true,
+            "passed": false,
             "assertions": [
               {
                 "kind": "match",
                 "candidateId": "p-operator",
-                "passed": true,
-                "detail": "expected match=true, got surfaced=true (score 95, threshold 30)"
+                "passed": false,
+                "detail": "expected match=true, got surfaced=false (score 0, threshold 30)"
               },
               {
                 "kind": "band",
                 "candidateId": "p-operator",
-                "passed": true,
-                "detail": "expected score in [70,100], got 95"
-              },
-              {
-                "kind": "role",
-                "candidateId": "p-operator",
-                "passed": true,
-                "detail": "expected role=agent, got agent"
+                "passed": false,
+                "detail": "expected score in [70,100], got 0"
               },
               {
                 "kind": "match",
@@ -5929,28 +5705,24 @@
                 "passed": true,
                 "detail": "expected score in [0,29], got 0"
               }
-            ]
+            ],
+            "runId": "complementary_role%2Fmarketing-cofounder-for-ai-engineer::run:1",
+            "runIndex": 0
           },
           {
-            "passed": true,
+            "passed": false,
             "assertions": [
               {
                 "kind": "match",
                 "candidateId": "p-operator",
-                "passed": true,
-                "detail": "expected match=true, got surfaced=true (score 88, threshold 30)"
+                "passed": false,
+                "detail": "expected match=true, got surfaced=false (score 0, threshold 30)"
               },
               {
                 "kind": "band",
                 "candidateId": "p-operator",
-                "passed": true,
-                "detail": "expected score in [70,100], got 88"
-              },
-              {
-                "kind": "role",
-                "candidateId": "p-operator",
-                "passed": true,
-                "detail": "expected role=agent, got agent"
+                "passed": false,
+                "detail": "expected score in [70,100], got 0"
               },
               {
                 "kind": "match",
@@ -5964,28 +5736,24 @@
                 "passed": true,
                 "detail": "expected score in [0,29], got 0"
               }
-            ]
+            ],
+            "runId": "complementary_role%2Fmarketing-cofounder-for-ai-engineer::run:2",
+            "runIndex": 1
           },
           {
-            "passed": true,
+            "passed": false,
             "assertions": [
               {
                 "kind": "match",
                 "candidateId": "p-operator",
-                "passed": true,
-                "detail": "expected match=true, got surfaced=true (score 85, threshold 30)"
+                "passed": false,
+                "detail": "expected match=true, got surfaced=false (score 0, threshold 30)"
               },
               {
                 "kind": "band",
                 "candidateId": "p-operator",
-                "passed": true,
-                "detail": "expected score in [70,100], got 85"
-              },
-              {
-                "kind": "role",
-                "candidateId": "p-operator",
-                "passed": true,
-                "detail": "expected role=agent, got agent"
+                "passed": false,
+                "detail": "expected score in [70,100], got 0"
               },
               {
                 "kind": "match",
@@ -5999,157 +5767,24 @@
                 "passed": true,
                 "detail": "expected score in [0,29], got 0"
               }
-            ]
-          },
-          {
-            "passed": true,
-            "assertions": [
-              {
-                "kind": "match",
-                "candidateId": "p-operator",
-                "passed": true,
-                "detail": "expected match=true, got surfaced=true (score 90, threshold 30)"
-              },
-              {
-                "kind": "band",
-                "candidateId": "p-operator",
-                "passed": true,
-                "detail": "expected score in [70,100], got 90"
-              },
-              {
-                "kind": "role",
-                "candidateId": "p-operator",
-                "passed": true,
-                "detail": "expected role=agent, got agent"
-              },
-              {
-                "kind": "match",
-                "candidateId": "p-tech-alt",
-                "passed": true,
-                "detail": "expected match=false, got surfaced=false (score 0, threshold 30)"
-              },
-              {
-                "kind": "band",
-                "candidateId": "p-tech-alt",
-                "passed": true,
-                "detail": "expected score in [0,29], got 0"
-              }
-            ]
-          },
-          {
-            "passed": true,
-            "assertions": [
-              {
-                "kind": "match",
-                "candidateId": "p-operator",
-                "passed": true,
-                "detail": "expected match=true, got surfaced=true (score 95, threshold 30)"
-              },
-              {
-                "kind": "band",
-                "candidateId": "p-operator",
-                "passed": true,
-                "detail": "expected score in [70,100], got 95"
-              },
-              {
-                "kind": "role",
-                "candidateId": "p-operator",
-                "passed": true,
-                "detail": "expected role=agent, got agent"
-              },
-              {
-                "kind": "match",
-                "candidateId": "p-tech-alt",
-                "passed": true,
-                "detail": "expected match=false, got surfaced=false (score 0, threshold 30)"
-              },
-              {
-                "kind": "band",
-                "candidateId": "p-tech-alt",
-                "passed": true,
-                "detail": "expected score in [0,29], got 0"
-              }
-            ]
-          },
-          {
-            "passed": true,
-            "assertions": [
-              {
-                "kind": "match",
-                "candidateId": "p-operator",
-                "passed": true,
-                "detail": "expected match=true, got surfaced=true (score 95, threshold 30)"
-              },
-              {
-                "kind": "band",
-                "candidateId": "p-operator",
-                "passed": true,
-                "detail": "expected score in [70,100], got 95"
-              },
-              {
-                "kind": "role",
-                "candidateId": "p-operator",
-                "passed": true,
-                "detail": "expected role=agent, got agent"
-              },
-              {
-                "kind": "match",
-                "candidateId": "p-tech-alt",
-                "passed": true,
-                "detail": "expected match=false, got surfaced=false (score 0, threshold 30)"
-              },
-              {
-                "kind": "band",
-                "candidateId": "p-tech-alt",
-                "passed": true,
-                "detail": "expected score in [0,29], got 0"
-              }
-            ]
-          },
-          {
-            "passed": true,
-            "assertions": [
-              {
-                "kind": "match",
-                "candidateId": "p-operator",
-                "passed": true,
-                "detail": "expected match=true, got surfaced=true (score 95, threshold 30)"
-              },
-              {
-                "kind": "band",
-                "candidateId": "p-operator",
-                "passed": true,
-                "detail": "expected score in [70,100], got 95"
-              },
-              {
-                "kind": "role",
-                "candidateId": "p-operator",
-                "passed": true,
-                "detail": "expected role=agent, got agent"
-              },
-              {
-                "kind": "match",
-                "candidateId": "p-tech-alt",
-                "passed": true,
-                "detail": "expected match=false, got surfaced=false (score 0, threshold 30)"
-              },
-              {
-                "kind": "band",
-                "candidateId": "p-tech-alt",
-                "passed": true,
-                "detail": "expected score in [0,29], got 0"
-              }
-            ]
+            ],
+            "runId": "complementary_role%2Fmarketing-cofounder-for-ai-engineer::run:3",
+            "runIndex": 2
           }
         ]
       },
       {
         "caseId": "same_side/both-seeking-cofounders",
         "rule": "same_side",
-        "runs": 7,
-        "passes": 7,
+        "runs": 3,
+        "passes": 3,
         "passRate": 1,
         "flaky": false,
+        "scoredRunIds": [
+          "same_side%2Fboth-seeking-cofounders::run:1",
+          "same_side%2Fboth-seeking-cofounders::run:2",
+          "same_side%2Fboth-seeking-cofounders::run:3"
+        ],
         "runResults": [
           {
             "passed": true,
@@ -6166,7 +5801,9 @@
                 "passed": true,
                 "detail": "expected score in [0,29], got 0"
               }
-            ]
+            ],
+            "runId": "same_side%2Fboth-seeking-cofounders::run:1",
+            "runIndex": 0
           },
           {
             "passed": true,
@@ -6183,7 +5820,9 @@
                 "passed": true,
                 "detail": "expected score in [0,29], got 0"
               }
-            ]
+            ],
+            "runId": "same_side%2Fboth-seeking-cofounders::run:2",
+            "runIndex": 1
           },
           {
             "passed": true,
@@ -6200,85 +5839,24 @@
                 "passed": true,
                 "detail": "expected score in [0,29], got 0"
               }
-            ]
-          },
-          {
-            "passed": true,
-            "assertions": [
-              {
-                "kind": "match",
-                "candidateId": "c-seek-cof",
-                "passed": true,
-                "detail": "expected match=false, got surfaced=false (score 0, threshold 30)"
-              },
-              {
-                "kind": "band",
-                "candidateId": "c-seek-cof",
-                "passed": true,
-                "detail": "expected score in [0,29], got 0"
-              }
-            ]
-          },
-          {
-            "passed": true,
-            "assertions": [
-              {
-                "kind": "match",
-                "candidateId": "c-seek-cof",
-                "passed": true,
-                "detail": "expected match=false, got surfaced=false (score 0, threshold 30)"
-              },
-              {
-                "kind": "band",
-                "candidateId": "c-seek-cof",
-                "passed": true,
-                "detail": "expected score in [0,29], got 0"
-              }
-            ]
-          },
-          {
-            "passed": true,
-            "assertions": [
-              {
-                "kind": "match",
-                "candidateId": "c-seek-cof",
-                "passed": true,
-                "detail": "expected match=false, got surfaced=false (score 0, threshold 30)"
-              },
-              {
-                "kind": "band",
-                "candidateId": "c-seek-cof",
-                "passed": true,
-                "detail": "expected score in [0,29], got 0"
-              }
-            ]
-          },
-          {
-            "passed": true,
-            "assertions": [
-              {
-                "kind": "match",
-                "candidateId": "c-seek-cof",
-                "passed": true,
-                "detail": "expected match=false, got surfaced=false (score 0, threshold 30)"
-              },
-              {
-                "kind": "band",
-                "candidateId": "c-seek-cof",
-                "passed": true,
-                "detail": "expected score in [0,29], got 0"
-              }
-            ]
+            ],
+            "runId": "same_side%2Fboth-seeking-cofounders::run:3",
+            "runIndex": 2
           }
         ]
       },
       {
         "caseId": "same_side/both-hiring-engineers",
         "rule": "same_side",
-        "runs": 7,
-        "passes": 7,
+        "runs": 3,
+        "passes": 3,
         "passRate": 1,
         "flaky": false,
+        "scoredRunIds": [
+          "same_side%2Fboth-hiring-engineers::run:1",
+          "same_side%2Fboth-hiring-engineers::run:2",
+          "same_side%2Fboth-hiring-engineers::run:3"
+        ],
         "runResults": [
           {
             "passed": true,
@@ -6295,7 +5873,9 @@
                 "passed": true,
                 "detail": "expected score in [0,29], got 0"
               }
-            ]
+            ],
+            "runId": "same_side%2Fboth-hiring-engineers::run:1",
+            "runIndex": 0
           },
           {
             "passed": true,
@@ -6312,7 +5892,9 @@
                 "passed": true,
                 "detail": "expected score in [0,29], got 0"
               }
-            ]
+            ],
+            "runId": "same_side%2Fboth-hiring-engineers::run:2",
+            "runIndex": 1
           },
           {
             "passed": true,
@@ -6329,85 +5911,24 @@
                 "passed": true,
                 "detail": "expected score in [0,29], got 0"
               }
-            ]
-          },
-          {
-            "passed": true,
-            "assertions": [
-              {
-                "kind": "match",
-                "candidateId": "c-recruiting",
-                "passed": true,
-                "detail": "expected match=false, got surfaced=false (score 0, threshold 30)"
-              },
-              {
-                "kind": "band",
-                "candidateId": "c-recruiting",
-                "passed": true,
-                "detail": "expected score in [0,29], got 0"
-              }
-            ]
-          },
-          {
-            "passed": true,
-            "assertions": [
-              {
-                "kind": "match",
-                "candidateId": "c-recruiting",
-                "passed": true,
-                "detail": "expected match=false, got surfaced=false (score 0, threshold 30)"
-              },
-              {
-                "kind": "band",
-                "candidateId": "c-recruiting",
-                "passed": true,
-                "detail": "expected score in [0,29], got 0"
-              }
-            ]
-          },
-          {
-            "passed": true,
-            "assertions": [
-              {
-                "kind": "match",
-                "candidateId": "c-recruiting",
-                "passed": true,
-                "detail": "expected match=false, got surfaced=false (score 0, threshold 30)"
-              },
-              {
-                "kind": "band",
-                "candidateId": "c-recruiting",
-                "passed": true,
-                "detail": "expected score in [0,29], got 0"
-              }
-            ]
-          },
-          {
-            "passed": true,
-            "assertions": [
-              {
-                "kind": "match",
-                "candidateId": "c-recruiting",
-                "passed": true,
-                "detail": "expected match=false, got surfaced=false (score 0, threshold 30)"
-              },
-              {
-                "kind": "band",
-                "candidateId": "c-recruiting",
-                "passed": true,
-                "detail": "expected score in [0,29], got 0"
-              }
-            ]
+            ],
+            "runId": "same_side%2Fboth-hiring-engineers::run:3",
+            "runIndex": 2
           }
         ]
       },
       {
         "caseId": "location/berlin-mismatch-vs-london-query",
         "rule": "location",
-        "runs": 7,
-        "passes": 7,
+        "runs": 3,
+        "passes": 3,
         "passRate": 1,
         "flaky": false,
+        "scoredRunIds": [
+          "location%2Fberlin-mismatch-vs-london-query::run:1",
+          "location%2Fberlin-mismatch-vs-london-query::run:2",
+          "location%2Fberlin-mismatch-vs-london-query::run:3"
+        ],
         "runResults": [
           {
             "passed": true,
@@ -6424,7 +5945,9 @@
                 "passed": true,
                 "detail": "expected score in [0,29], got 0"
               }
-            ]
+            ],
+            "runId": "location%2Fberlin-mismatch-vs-london-query::run:1",
+            "runIndex": 0
           },
           {
             "passed": true,
@@ -6441,7 +5964,9 @@
                 "passed": true,
                 "detail": "expected score in [0,29], got 0"
               }
-            ]
+            ],
+            "runId": "location%2Fberlin-mismatch-vs-london-query::run:2",
+            "runIndex": 1
           },
           {
             "passed": true,
@@ -6458,214 +5983,96 @@
                 "passed": true,
                 "detail": "expected score in [0,29], got 0"
               }
-            ]
-          },
-          {
-            "passed": true,
-            "assertions": [
-              {
-                "kind": "match",
-                "candidateId": "c-berlin",
-                "passed": true,
-                "detail": "expected match=false, got surfaced=false (score 0, threshold 30)"
-              },
-              {
-                "kind": "band",
-                "candidateId": "c-berlin",
-                "passed": true,
-                "detail": "expected score in [0,29], got 0"
-              }
-            ]
-          },
-          {
-            "passed": true,
-            "assertions": [
-              {
-                "kind": "match",
-                "candidateId": "c-berlin",
-                "passed": true,
-                "detail": "expected match=false, got surfaced=false (score 0, threshold 30)"
-              },
-              {
-                "kind": "band",
-                "candidateId": "c-berlin",
-                "passed": true,
-                "detail": "expected score in [0,29], got 0"
-              }
-            ]
-          },
-          {
-            "passed": true,
-            "assertions": [
-              {
-                "kind": "match",
-                "candidateId": "c-berlin",
-                "passed": true,
-                "detail": "expected match=false, got surfaced=false (score 0, threshold 30)"
-              },
-              {
-                "kind": "band",
-                "candidateId": "c-berlin",
-                "passed": true,
-                "detail": "expected score in [0,29], got 0"
-              }
-            ]
-          },
-          {
-            "passed": true,
-            "assertions": [
-              {
-                "kind": "match",
-                "candidateId": "c-berlin",
-                "passed": true,
-                "detail": "expected match=false, got surfaced=false (score 0, threshold 30)"
-              },
-              {
-                "kind": "band",
-                "candidateId": "c-berlin",
-                "passed": true,
-                "detail": "expected score in [0,29], got 0"
-              }
-            ]
+            ],
+            "runId": "location%2Fberlin-mismatch-vs-london-query::run:3",
+            "runIndex": 2
           }
         ]
       },
       {
         "caseId": "location/unknown-city-not-penalized-variant",
         "rule": "location",
-        "runs": 7,
-        "passes": 7,
-        "passRate": 1,
+        "runs": 3,
+        "passes": 0,
+        "passRate": 0,
         "flaky": false,
+        "scoredRunIds": [
+          "location%2Funknown-city-not-penalized-variant::run:1",
+          "location%2Funknown-city-not-penalized-variant::run:2",
+          "location%2Funknown-city-not-penalized-variant::run:3"
+        ],
         "runResults": [
           {
-            "passed": true,
+            "passed": false,
             "assertions": [
               {
                 "kind": "match",
                 "candidateId": "c-empty-loc",
-                "passed": true,
-                "detail": "expected match=true, got surfaced=true (score 85, threshold 30)"
+                "passed": false,
+                "detail": "expected match=true, got surfaced=false (score 0, threshold 30)"
               },
               {
                 "kind": "band",
                 "candidateId": "c-empty-loc",
-                "passed": true,
-                "detail": "expected score in [60,100], got 85"
+                "passed": false,
+                "detail": "expected score in [60,100], got 0"
               }
-            ]
+            ],
+            "runId": "location%2Funknown-city-not-penalized-variant::run:1",
+            "runIndex": 0
           },
           {
-            "passed": true,
+            "passed": false,
             "assertions": [
               {
                 "kind": "match",
                 "candidateId": "c-empty-loc",
-                "passed": true,
-                "detail": "expected match=true, got surfaced=true (score 85, threshold 30)"
+                "passed": false,
+                "detail": "expected match=true, got surfaced=false (score 0, threshold 30)"
               },
               {
                 "kind": "band",
                 "candidateId": "c-empty-loc",
-                "passed": true,
-                "detail": "expected score in [60,100], got 85"
+                "passed": false,
+                "detail": "expected score in [60,100], got 0"
               }
-            ]
+            ],
+            "runId": "location%2Funknown-city-not-penalized-variant::run:2",
+            "runIndex": 1
           },
           {
-            "passed": true,
+            "passed": false,
             "assertions": [
               {
                 "kind": "match",
                 "candidateId": "c-empty-loc",
-                "passed": true,
-                "detail": "expected match=true, got surfaced=true (score 85, threshold 30)"
+                "passed": false,
+                "detail": "expected match=true, got surfaced=false (score 0, threshold 30)"
               },
               {
                 "kind": "band",
                 "candidateId": "c-empty-loc",
-                "passed": true,
-                "detail": "expected score in [60,100], got 85"
+                "passed": false,
+                "detail": "expected score in [60,100], got 0"
               }
-            ]
-          },
-          {
-            "passed": true,
-            "assertions": [
-              {
-                "kind": "match",
-                "candidateId": "c-empty-loc",
-                "passed": true,
-                "detail": "expected match=true, got surfaced=true (score 85, threshold 30)"
-              },
-              {
-                "kind": "band",
-                "candidateId": "c-empty-loc",
-                "passed": true,
-                "detail": "expected score in [60,100], got 85"
-              }
-            ]
-          },
-          {
-            "passed": true,
-            "assertions": [
-              {
-                "kind": "match",
-                "candidateId": "c-empty-loc",
-                "passed": true,
-                "detail": "expected match=true, got surfaced=true (score 85, threshold 30)"
-              },
-              {
-                "kind": "band",
-                "candidateId": "c-empty-loc",
-                "passed": true,
-                "detail": "expected score in [60,100], got 85"
-              }
-            ]
-          },
-          {
-            "passed": true,
-            "assertions": [
-              {
-                "kind": "match",
-                "candidateId": "c-empty-loc",
-                "passed": true,
-                "detail": "expected match=true, got surfaced=true (score 85, threshold 30)"
-              },
-              {
-                "kind": "band",
-                "candidateId": "c-empty-loc",
-                "passed": true,
-                "detail": "expected score in [60,100], got 85"
-              }
-            ]
-          },
-          {
-            "passed": true,
-            "assertions": [
-              {
-                "kind": "match",
-                "candidateId": "c-empty-loc",
-                "passed": true,
-                "detail": "expected match=true, got surfaced=true (score 85, threshold 30)"
-              },
-              {
-                "kind": "band",
-                "candidateId": "c-empty-loc",
-                "passed": true,
-                "detail": "expected score in [60,100], got 85"
-              }
-            ]
+            ],
+            "runId": "location%2Funknown-city-not-penalized-variant::run:3",
+            "runIndex": 2
           }
         ]
       },
       {
         "caseId": "valency_role/seeker-needs-design-provider-offers-design",
         "rule": "valency_role",
-        "runs": 7,
-        "passes": 7,
+        "runs": 3,
+        "passes": 3,
         "passRate": 1,
         "flaky": false,
+        "scoredRunIds": [
+          "valency_role%2Fseeker-needs-design-provider-offers-design::run:1",
+          "valency_role%2Fseeker-needs-design-provider-offers-design::run:2",
+          "valency_role%2Fseeker-needs-design-provider-offers-design::run:3"
+        ],
         "runResults": [
           {
             "passed": true,
@@ -6674,13 +6081,13 @@
                 "kind": "match",
                 "candidateId": "c-designer-alt",
                 "passed": true,
-                "detail": "expected match=true, got surfaced=true (score 98, threshold 30)"
+                "detail": "expected match=true, got surfaced=true (score 95, threshold 30)"
               },
               {
                 "kind": "band",
                 "candidateId": "c-designer-alt",
                 "passed": true,
-                "detail": "expected score in [70,100], got 98"
+                "detail": "expected score in [70,100], got 95"
               },
               {
                 "kind": "role",
@@ -6688,7 +6095,9 @@
                 "passed": true,
                 "detail": "expected role=agent, got agent"
               }
-            ]
+            ],
+            "runId": "valency_role%2Fseeker-needs-design-provider-offers-design::run:1",
+            "runIndex": 0
           },
           {
             "passed": true,
@@ -6697,13 +6106,13 @@
                 "kind": "match",
                 "candidateId": "c-designer-alt",
                 "passed": true,
-                "detail": "expected match=true, got surfaced=true (score 98, threshold 30)"
+                "detail": "expected match=true, got surfaced=true (score 95, threshold 30)"
               },
               {
                 "kind": "band",
                 "candidateId": "c-designer-alt",
                 "passed": true,
-                "detail": "expected score in [70,100], got 98"
+                "detail": "expected score in [70,100], got 95"
               },
               {
                 "kind": "role",
@@ -6711,7 +6120,9 @@
                 "passed": true,
                 "detail": "expected role=agent, got agent"
               }
-            ]
+            ],
+            "runId": "valency_role%2Fseeker-needs-design-provider-offers-design::run:2",
+            "runIndex": 1
           },
           {
             "passed": true,
@@ -6720,13 +6131,13 @@
                 "kind": "match",
                 "candidateId": "c-designer-alt",
                 "passed": true,
-                "detail": "expected match=true, got surfaced=true (score 98, threshold 30)"
+                "detail": "expected match=true, got surfaced=true (score 95, threshold 30)"
               },
               {
                 "kind": "band",
                 "candidateId": "c-designer-alt",
                 "passed": true,
-                "detail": "expected score in [70,100], got 98"
+                "detail": "expected score in [70,100], got 95"
               },
               {
                 "kind": "role",
@@ -6734,109 +6145,24 @@
                 "passed": true,
                 "detail": "expected role=agent, got agent"
               }
-            ]
-          },
-          {
-            "passed": true,
-            "assertions": [
-              {
-                "kind": "match",
-                "candidateId": "c-designer-alt",
-                "passed": true,
-                "detail": "expected match=true, got surfaced=true (score 98, threshold 30)"
-              },
-              {
-                "kind": "band",
-                "candidateId": "c-designer-alt",
-                "passed": true,
-                "detail": "expected score in [70,100], got 98"
-              },
-              {
-                "kind": "role",
-                "candidateId": "c-designer-alt",
-                "passed": true,
-                "detail": "expected role=agent, got agent"
-              }
-            ]
-          },
-          {
-            "passed": true,
-            "assertions": [
-              {
-                "kind": "match",
-                "candidateId": "c-designer-alt",
-                "passed": true,
-                "detail": "expected match=true, got surfaced=true (score 98, threshold 30)"
-              },
-              {
-                "kind": "band",
-                "candidateId": "c-designer-alt",
-                "passed": true,
-                "detail": "expected score in [70,100], got 98"
-              },
-              {
-                "kind": "role",
-                "candidateId": "c-designer-alt",
-                "passed": true,
-                "detail": "expected role=agent, got agent"
-              }
-            ]
-          },
-          {
-            "passed": true,
-            "assertions": [
-              {
-                "kind": "match",
-                "candidateId": "c-designer-alt",
-                "passed": true,
-                "detail": "expected match=true, got surfaced=true (score 98, threshold 30)"
-              },
-              {
-                "kind": "band",
-                "candidateId": "c-designer-alt",
-                "passed": true,
-                "detail": "expected score in [70,100], got 98"
-              },
-              {
-                "kind": "role",
-                "candidateId": "c-designer-alt",
-                "passed": true,
-                "detail": "expected role=agent, got agent"
-              }
-            ]
-          },
-          {
-            "passed": true,
-            "assertions": [
-              {
-                "kind": "match",
-                "candidateId": "c-designer-alt",
-                "passed": true,
-                "detail": "expected match=true, got surfaced=true (score 98, threshold 30)"
-              },
-              {
-                "kind": "band",
-                "candidateId": "c-designer-alt",
-                "passed": true,
-                "detail": "expected score in [70,100], got 98"
-              },
-              {
-                "kind": "role",
-                "candidateId": "c-designer-alt",
-                "passed": true,
-                "detail": "expected role=agent, got agent"
-              }
-            ]
+            ],
+            "runId": "valency_role%2Fseeker-needs-design-provider-offers-design::run:3",
+            "runIndex": 2
           }
         ]
       },
       {
         "caseId": "valency_role/seeker-offers-capacity-provider-needs-capacity",
         "rule": "valency_role",
-        "runs": 7,
-        "passes": 7,
+        "runs": 3,
+        "passes": 3,
         "passRate": 1,
         "flaky": false,
+        "scoredRunIds": [
+          "valency_role%2Fseeker-offers-capacity-provider-needs-capacity::run:1",
+          "valency_role%2Fseeker-offers-capacity-provider-needs-capacity::run:2",
+          "valency_role%2Fseeker-offers-capacity-provider-needs-capacity::run:3"
+        ],
         "runResults": [
           {
             "passed": true,
@@ -6845,13 +6171,13 @@
                 "kind": "match",
                 "candidateId": "c-needs-gpu",
                 "passed": true,
-                "detail": "expected match=true, got surfaced=true (score 98, threshold 30)"
+                "detail": "expected match=true, got surfaced=true (score 95, threshold 30)"
               },
               {
                 "kind": "band",
                 "candidateId": "c-needs-gpu",
                 "passed": true,
-                "detail": "expected score in [70,100], got 98"
+                "detail": "expected score in [70,100], got 95"
               },
               {
                 "kind": "role",
@@ -6859,7 +6185,9 @@
                 "passed": true,
                 "detail": "expected role=patient, got patient"
               }
-            ]
+            ],
+            "runId": "valency_role%2Fseeker-offers-capacity-provider-needs-capacity::run:1",
+            "runIndex": 0
           },
           {
             "passed": true,
@@ -6868,13 +6196,13 @@
                 "kind": "match",
                 "candidateId": "c-needs-gpu",
                 "passed": true,
-                "detail": "expected match=true, got surfaced=true (score 98, threshold 30)"
+                "detail": "expected match=true, got surfaced=true (score 95, threshold 30)"
               },
               {
                 "kind": "band",
                 "candidateId": "c-needs-gpu",
                 "passed": true,
-                "detail": "expected score in [70,100], got 98"
+                "detail": "expected score in [70,100], got 95"
               },
               {
                 "kind": "role",
@@ -6882,7 +6210,9 @@
                 "passed": true,
                 "detail": "expected role=patient, got patient"
               }
-            ]
+            ],
+            "runId": "valency_role%2Fseeker-offers-capacity-provider-needs-capacity::run:2",
+            "runIndex": 1
           },
           {
             "passed": true,
@@ -6891,13 +6221,13 @@
                 "kind": "match",
                 "candidateId": "c-needs-gpu",
                 "passed": true,
-                "detail": "expected match=true, got surfaced=true (score 98, threshold 30)"
+                "detail": "expected match=true, got surfaced=true (score 95, threshold 30)"
               },
               {
                 "kind": "band",
                 "candidateId": "c-needs-gpu",
                 "passed": true,
-                "detail": "expected score in [70,100], got 98"
+                "detail": "expected score in [70,100], got 95"
               },
               {
                 "kind": "role",
@@ -6905,109 +6235,24 @@
                 "passed": true,
                 "detail": "expected role=patient, got patient"
               }
-            ]
-          },
-          {
-            "passed": true,
-            "assertions": [
-              {
-                "kind": "match",
-                "candidateId": "c-needs-gpu",
-                "passed": true,
-                "detail": "expected match=true, got surfaced=true (score 98, threshold 30)"
-              },
-              {
-                "kind": "band",
-                "candidateId": "c-needs-gpu",
-                "passed": true,
-                "detail": "expected score in [70,100], got 98"
-              },
-              {
-                "kind": "role",
-                "candidateId": "c-needs-gpu",
-                "passed": true,
-                "detail": "expected role=patient, got patient"
-              }
-            ]
-          },
-          {
-            "passed": true,
-            "assertions": [
-              {
-                "kind": "match",
-                "candidateId": "c-needs-gpu",
-                "passed": true,
-                "detail": "expected match=true, got surfaced=true (score 98, threshold 30)"
-              },
-              {
-                "kind": "band",
-                "candidateId": "c-needs-gpu",
-                "passed": true,
-                "detail": "expected score in [70,100], got 98"
-              },
-              {
-                "kind": "role",
-                "candidateId": "c-needs-gpu",
-                "passed": true,
-                "detail": "expected role=patient, got patient"
-              }
-            ]
-          },
-          {
-            "passed": true,
-            "assertions": [
-              {
-                "kind": "match",
-                "candidateId": "c-needs-gpu",
-                "passed": true,
-                "detail": "expected match=true, got surfaced=true (score 98, threshold 30)"
-              },
-              {
-                "kind": "band",
-                "candidateId": "c-needs-gpu",
-                "passed": true,
-                "detail": "expected score in [70,100], got 98"
-              },
-              {
-                "kind": "role",
-                "candidateId": "c-needs-gpu",
-                "passed": true,
-                "detail": "expected role=patient, got patient"
-              }
-            ]
-          },
-          {
-            "passed": true,
-            "assertions": [
-              {
-                "kind": "match",
-                "candidateId": "c-needs-gpu",
-                "passed": true,
-                "detail": "expected match=true, got surfaced=true (score 98, threshold 30)"
-              },
-              {
-                "kind": "band",
-                "candidateId": "c-needs-gpu",
-                "passed": true,
-                "detail": "expected score in [70,100], got 98"
-              },
-              {
-                "kind": "role",
-                "candidateId": "c-needs-gpu",
-                "passed": true,
-                "detail": "expected role=patient, got patient"
-              }
-            ]
+            ],
+            "runId": "valency_role%2Fseeker-offers-capacity-provider-needs-capacity::run:3",
+            "runIndex": 2
           }
         ]
       },
       {
         "caseId": "score_calibration/must-meet-sales-cofounder",
         "rule": "score_calibration",
-        "runs": 7,
-        "passes": 7,
+        "runs": 3,
+        "passes": 3,
         "passRate": 1,
         "flaky": false,
+        "scoredRunIds": [
+          "score_calibration%2Fmust-meet-sales-cofounder::run:1",
+          "score_calibration%2Fmust-meet-sales-cofounder::run:2",
+          "score_calibration%2Fmust-meet-sales-cofounder::run:3"
+        ],
         "runResults": [
           {
             "passed": true,
@@ -7016,49 +6261,17 @@
                 "kind": "match",
                 "candidateId": "c-sales-cof",
                 "passed": true,
-                "detail": "expected match=true, got surfaced=true (score 98, threshold 30)"
+                "detail": "expected match=true, got surfaced=true (score 95, threshold 30)"
               },
               {
                 "kind": "band",
                 "candidateId": "c-sales-cof",
                 "passed": true,
-                "detail": "expected score in [85,100], got 98"
+                "detail": "expected score in [85,100], got 95"
               }
-            ]
-          },
-          {
-            "passed": true,
-            "assertions": [
-              {
-                "kind": "match",
-                "candidateId": "c-sales-cof",
-                "passed": true,
-                "detail": "expected match=true, got surfaced=true (score 98, threshold 30)"
-              },
-              {
-                "kind": "band",
-                "candidateId": "c-sales-cof",
-                "passed": true,
-                "detail": "expected score in [85,100], got 98"
-              }
-            ]
-          },
-          {
-            "passed": true,
-            "assertions": [
-              {
-                "kind": "match",
-                "candidateId": "c-sales-cof",
-                "passed": true,
-                "detail": "expected match=true, got surfaced=true (score 98, threshold 30)"
-              },
-              {
-                "kind": "band",
-                "candidateId": "c-sales-cof",
-                "passed": true,
-                "detail": "expected score in [85,100], got 98"
-              }
-            ]
+            ],
+            "runId": "score_calibration%2Fmust-meet-sales-cofounder::run:1",
+            "runIndex": 0
           },
           {
             "passed": true,
@@ -7075,7 +6288,9 @@
                 "passed": true,
                 "detail": "expected score in [85,100], got 95"
               }
-            ]
+            ],
+            "runId": "score_calibration%2Fmust-meet-sales-cofounder::run:2",
+            "runIndex": 1
           },
           {
             "passed": true,
@@ -7084,59 +6299,32 @@
                 "kind": "match",
                 "candidateId": "c-sales-cof",
                 "passed": true,
-                "detail": "expected match=true, got surfaced=true (score 98, threshold 30)"
+                "detail": "expected match=true, got surfaced=true (score 95, threshold 30)"
               },
               {
                 "kind": "band",
                 "candidateId": "c-sales-cof",
                 "passed": true,
-                "detail": "expected score in [85,100], got 98"
+                "detail": "expected score in [85,100], got 95"
               }
-            ]
-          },
-          {
-            "passed": true,
-            "assertions": [
-              {
-                "kind": "match",
-                "candidateId": "c-sales-cof",
-                "passed": true,
-                "detail": "expected match=true, got surfaced=true (score 98, threshold 30)"
-              },
-              {
-                "kind": "band",
-                "candidateId": "c-sales-cof",
-                "passed": true,
-                "detail": "expected score in [85,100], got 98"
-              }
-            ]
-          },
-          {
-            "passed": true,
-            "assertions": [
-              {
-                "kind": "match",
-                "candidateId": "c-sales-cof",
-                "passed": true,
-                "detail": "expected match=true, got surfaced=true (score 93, threshold 30)"
-              },
-              {
-                "kind": "band",
-                "candidateId": "c-sales-cof",
-                "passed": true,
-                "detail": "expected score in [85,100], got 93"
-              }
-            ]
+            ],
+            "runId": "score_calibration%2Fmust-meet-sales-cofounder::run:3",
+            "runIndex": 2
           }
         ]
       },
       {
         "caseId": "score_calibration/tier2-researcher-pool-variant",
         "rule": "score_calibration",
-        "runs": 7,
-        "passes": 7,
+        "runs": 3,
+        "passes": 3,
         "passRate": 1,
         "flaky": false,
+        "scoredRunIds": [
+          "score_calibration%2Ftier2-researcher-pool-variant::run:1",
+          "score_calibration%2Ftier2-researcher-pool-variant::run:2",
+          "score_calibration%2Ftier2-researcher-pool-variant::run:3"
+        ],
         "runResults": [
           {
             "passed": true,
@@ -7145,13 +6333,13 @@
                 "kind": "match",
                 "candidateId": "p-tech-cofounder",
                 "passed": true,
-                "detail": "expected match=true, got surfaced=true (score 85, threshold 30)"
+                "detail": "expected match=true, got surfaced=true (score 95, threshold 30)"
               },
               {
                 "kind": "band",
                 "candidateId": "p-tech-cofounder",
                 "passed": true,
-                "detail": "expected score in [70,100], got 85"
+                "detail": "expected score in [70,100], got 95"
               },
               {
                 "kind": "match",
@@ -7177,130 +6365,9 @@
                 "passed": true,
                 "detail": "expected score in [0,29], got 0"
               }
-            ]
-          },
-          {
-            "passed": true,
-            "assertions": [
-              {
-                "kind": "match",
-                "candidateId": "p-tech-cofounder",
-                "passed": true,
-                "detail": "expected match=true, got surfaced=true (score 98, threshold 30)"
-              },
-              {
-                "kind": "band",
-                "candidateId": "p-tech-cofounder",
-                "passed": true,
-                "detail": "expected score in [70,100], got 98"
-              },
-              {
-                "kind": "match",
-                "candidateId": "p-researcher",
-                "passed": true,
-                "detail": "expected match=false, got surfaced=false (score 0, threshold 30)"
-              },
-              {
-                "kind": "band",
-                "candidateId": "p-researcher",
-                "passed": true,
-                "detail": "expected score in [0,29], got 0"
-              },
-              {
-                "kind": "match",
-                "candidateId": "p-operator",
-                "passed": true,
-                "detail": "expected match=false, got surfaced=false (score 0, threshold 30)"
-              },
-              {
-                "kind": "band",
-                "candidateId": "p-operator",
-                "passed": true,
-                "detail": "expected score in [0,29], got 0"
-              }
-            ]
-          },
-          {
-            "passed": true,
-            "assertions": [
-              {
-                "kind": "match",
-                "candidateId": "p-tech-cofounder",
-                "passed": true,
-                "detail": "expected match=true, got surfaced=true (score 98, threshold 30)"
-              },
-              {
-                "kind": "band",
-                "candidateId": "p-tech-cofounder",
-                "passed": true,
-                "detail": "expected score in [70,100], got 98"
-              },
-              {
-                "kind": "match",
-                "candidateId": "p-researcher",
-                "passed": true,
-                "detail": "expected match=false, got surfaced=false (score 0, threshold 30)"
-              },
-              {
-                "kind": "band",
-                "candidateId": "p-researcher",
-                "passed": true,
-                "detail": "expected score in [0,29], got 0"
-              },
-              {
-                "kind": "match",
-                "candidateId": "p-operator",
-                "passed": true,
-                "detail": "expected match=false, got surfaced=false (score 0, threshold 30)"
-              },
-              {
-                "kind": "band",
-                "candidateId": "p-operator",
-                "passed": true,
-                "detail": "expected score in [0,29], got 0"
-              }
-            ]
-          },
-          {
-            "passed": true,
-            "assertions": [
-              {
-                "kind": "match",
-                "candidateId": "p-tech-cofounder",
-                "passed": true,
-                "detail": "expected match=true, got surfaced=true (score 98, threshold 30)"
-              },
-              {
-                "kind": "band",
-                "candidateId": "p-tech-cofounder",
-                "passed": true,
-                "detail": "expected score in [70,100], got 98"
-              },
-              {
-                "kind": "match",
-                "candidateId": "p-researcher",
-                "passed": true,
-                "detail": "expected match=false, got surfaced=false (score 0, threshold 30)"
-              },
-              {
-                "kind": "band",
-                "candidateId": "p-researcher",
-                "passed": true,
-                "detail": "expected score in [0,29], got 0"
-              },
-              {
-                "kind": "match",
-                "candidateId": "p-operator",
-                "passed": true,
-                "detail": "expected match=false, got surfaced=false (score 0, threshold 30)"
-              },
-              {
-                "kind": "band",
-                "candidateId": "p-operator",
-                "passed": true,
-                "detail": "expected score in [0,29], got 0"
-              }
-            ]
+            ],
+            "runId": "score_calibration%2Ftier2-researcher-pool-variant::run:1",
+            "runIndex": 0
           },
           {
             "passed": true,
@@ -7341,7 +6408,9 @@
                 "passed": true,
                 "detail": "expected score in [0,29], got 0"
               }
-            ]
+            ],
+            "runId": "score_calibration%2Ftier2-researcher-pool-variant::run:2",
+            "runIndex": 1
           },
           {
             "passed": true,
@@ -7382,219 +6451,9 @@
                 "passed": true,
                 "detail": "expected score in [0,29], got 0"
               }
-            ]
-          },
-          {
-            "passed": true,
-            "assertions": [
-              {
-                "kind": "match",
-                "candidateId": "p-tech-cofounder",
-                "passed": true,
-                "detail": "expected match=true, got surfaced=true (score 95, threshold 30)"
-              },
-              {
-                "kind": "band",
-                "candidateId": "p-tech-cofounder",
-                "passed": true,
-                "detail": "expected score in [70,100], got 95"
-              },
-              {
-                "kind": "match",
-                "candidateId": "p-researcher",
-                "passed": true,
-                "detail": "expected match=false, got surfaced=false (score 0, threshold 30)"
-              },
-              {
-                "kind": "band",
-                "candidateId": "p-researcher",
-                "passed": true,
-                "detail": "expected score in [0,29], got 0"
-              },
-              {
-                "kind": "match",
-                "candidateId": "p-operator",
-                "passed": true,
-                "detail": "expected match=false, got surfaced=false (score 0, threshold 30)"
-              },
-              {
-                "kind": "band",
-                "candidateId": "p-operator",
-                "passed": true,
-                "detail": "expected score in [0,29], got 0"
-              }
-            ]
-          }
-        ]
-      },
-      {
-        "caseId": "cross_domain/animation-query-vs-geo-protocols-premise",
-        "rule": "query_primary",
-        "runs": 7,
-        "passes": 7,
-        "passRate": 1.0,
-        "flaky": false,
-        "runResults": [
-          {
-            "passed": true,
-            "assertions": [
-              {
-                "kind": "match",
-                "candidateId": "c-logistics",
-                "passed": true,
-                "detail": "expected match=false, got surfaced=false (score 0, threshold 30)"
-              },
-              {
-                "kind": "band",
-                "candidateId": "c-logistics",
-                "passed": true,
-                "detail": "expected score in [0,29], got 0"
-              },
-              {
-                "kind": "reasoning",
-                "candidateId": "c-logistics",
-                "passed": true,
-                "detail": "judge passed"
-              }
-            ]
-          },
-          {
-            "passed": true,
-            "assertions": [
-              {
-                "kind": "match",
-                "candidateId": "c-logistics",
-                "passed": true,
-                "detail": "expected match=false, got surfaced=false (score 0, threshold 30)"
-              },
-              {
-                "kind": "band",
-                "candidateId": "c-logistics",
-                "passed": true,
-                "detail": "expected score in [0,29], got 0"
-              },
-              {
-                "kind": "reasoning",
-                "candidateId": "c-logistics",
-                "passed": true,
-                "detail": "judge passed"
-              }
-            ]
-          },
-          {
-            "passed": true,
-            "assertions": [
-              {
-                "kind": "match",
-                "candidateId": "c-logistics",
-                "passed": true,
-                "detail": "expected match=false, got surfaced=false (score 0, threshold 30)"
-              },
-              {
-                "kind": "band",
-                "candidateId": "c-logistics",
-                "passed": true,
-                "detail": "expected score in [0,29], got 0"
-              },
-              {
-                "kind": "reasoning",
-                "candidateId": "c-logistics",
-                "passed": true,
-                "detail": "judge passed"
-              }
-            ]
-          },
-          {
-            "passed": true,
-            "assertions": [
-              {
-                "kind": "match",
-                "candidateId": "c-logistics",
-                "passed": true,
-                "detail": "expected match=false, got surfaced=false (score 0, threshold 30)"
-              },
-              {
-                "kind": "band",
-                "candidateId": "c-logistics",
-                "passed": true,
-                "detail": "expected score in [0,29], got 0"
-              },
-              {
-                "kind": "reasoning",
-                "candidateId": "c-logistics",
-                "passed": true,
-                "detail": "judge passed"
-              }
-            ]
-          },
-          {
-            "passed": true,
-            "assertions": [
-              {
-                "kind": "match",
-                "candidateId": "c-logistics",
-                "passed": true,
-                "detail": "expected match=false, got surfaced=false (score 0, threshold 30)"
-              },
-              {
-                "kind": "band",
-                "candidateId": "c-logistics",
-                "passed": true,
-                "detail": "expected score in [0,29], got 0"
-              },
-              {
-                "kind": "reasoning",
-                "candidateId": "c-logistics",
-                "passed": true,
-                "detail": "judge passed"
-              }
-            ]
-          },
-          {
-            "passed": true,
-            "assertions": [
-              {
-                "kind": "match",
-                "candidateId": "c-logistics",
-                "passed": true,
-                "detail": "expected match=false, got surfaced=false (score 0, threshold 30)"
-              },
-              {
-                "kind": "band",
-                "candidateId": "c-logistics",
-                "passed": true,
-                "detail": "expected score in [0,29], got 0"
-              },
-              {
-                "kind": "reasoning",
-                "candidateId": "c-logistics",
-                "passed": true,
-                "detail": "judge passed"
-              }
-            ]
-          },
-          {
-            "passed": true,
-            "assertions": [
-              {
-                "kind": "match",
-                "candidateId": "c-logistics",
-                "passed": true,
-                "detail": "expected match=false, got surfaced=false (score 0, threshold 30)"
-              },
-              {
-                "kind": "band",
-                "candidateId": "c-logistics",
-                "passed": true,
-                "detail": "expected score in [0,29], got 0"
-              },
-              {
-                "kind": "reasoning",
-                "candidateId": "c-logistics",
-                "passed": true,
-                "detail": "judge passed"
-              }
-            ]
+            ],
+            "runId": "score_calibration%2Ftier2-researcher-pool-variant::run:3",
+            "runIndex": 2
           }
         ]
       }

--- a/packages/protocol/eval/matching/baselines/matching.baseline.update.json
+++ b/packages/protocol/eval/matching/baselines/matching.baseline.update.json
@@ -1,0 +1,135 @@
+{
+  "artifactType": "index-eval/baseline-update-summary",
+  "schemaVersion": 1,
+  "harness": "matching",
+  "harnessVersion": "1",
+  "createdAt": "2026-08-02T10:47:37.524Z",
+  "reason": "corpus anonymization rename (src-yanki -> src-creative-tech) plus scout-vs-scouted-athlete discovererId repair; full-corpus refresh with complete evidence",
+  "git": {
+    "revision": "84f2764c569aa50fa358fb811a4befa9354274c9",
+    "dirty": false
+  },
+  "previous": {
+    "schemaVersion": 1,
+    "source": "legacy-migration",
+    "models": [
+      "google/gemini-2.5-flash"
+    ],
+    "runs": 7,
+    "generatedAt": "2026-05-29T18:05:23.210Z",
+    "corpusFingerprint": "unavailable-legacy-migration",
+    "configFingerprint": "unavailable-legacy-migration",
+    "git": {
+      "revision": "unknown",
+      "dirty": null
+    },
+    "caseCount": 40,
+    "ruleCount": 10,
+    "aggregatePassRate": 0.9892857142857142
+  },
+  "next": {
+    "schemaVersion": 2,
+    "source": "run",
+    "models": [
+      "google/gemini-2.5-flash"
+    ],
+    "runs": 3,
+    "generatedAt": "2026-08-02T10:47:37.524Z",
+    "corpusFingerprint": "0d2f5289ca69beb4b510def23823212066e04ca04ef49e28d776c82e86a77a7d",
+    "configFingerprint": "d9b0b433eb47d15daaf8a70d35a8f47b3817cb3a5fe0001cfe7f2866bbb15573",
+    "git": {
+      "revision": "84f2764c569aa50fa358fb811a4befa9354274c9",
+      "dirty": false
+    },
+    "caseCount": 40,
+    "ruleCount": 10,
+    "aggregatePassRate": 0.9
+  },
+  "comparability": {
+    "status": "unprovable",
+    "mismatches": [],
+    "unprovable": [
+      {
+        "dimension": "corpus",
+        "baseline": "unavailable-legacy-migration",
+        "current": "0d2f5289ca69beb4b510def23823212066e04ca04ef49e28d776c82e86a77a7d",
+        "message": "baseline corpus fingerprint is unavailable (legacy migration); corpus identity cannot be proven"
+      },
+      {
+        "dimension": "config",
+        "baseline": "unavailable-legacy-migration",
+        "current": "d9b0b433eb47d15daaf8a70d35a8f47b3817cb3a5fe0001cfe7f2866bbb15573",
+        "message": "baseline scoring-config fingerprint is unavailable (legacy migration); scoring-config identity cannot be proven"
+      },
+      {
+        "dimension": "run-protocol",
+        "baseline": "schema v1 (legacy-migration)",
+        "current": "schema v2 (run)",
+        "message": "schema-v1 baseline carries no execution evidence; run protocol and completeness cannot be proven"
+      }
+    ]
+  },
+  "caseChanges": {
+    "added": [
+      "event_network/co-membership-is-not-attendance"
+    ],
+    "removed": [
+      "event_network/co-attendance-theme-lift"
+    ],
+    "retainedCount": 39
+  },
+  "ruleChanges": {
+    "added": [],
+    "removed": []
+  },
+  "aggregatePassRate": {
+    "previous": 0.9892857142857142,
+    "next": 0.9,
+    "delta": -0.08928571428571419
+  },
+  "regressions": [
+    {
+      "id": "query_primary/founders-raising-seed-accepts-founder",
+      "kind": "case",
+      "before": 1,
+      "after": 0,
+      "pValue": 0.006060606060606057
+    },
+    {
+      "id": "complementary_role/marketing-cofounder-for-ai-engineer",
+      "kind": "case",
+      "before": 1,
+      "after": 0,
+      "pValue": 0.006060606060606057
+    },
+    {
+      "id": "location/unknown-city-not-penalized-variant",
+      "kind": "case",
+      "before": 1,
+      "after": 0,
+      "pValue": 0.006060606060606057
+    },
+    {
+      "id": "complementary_role",
+      "kind": "rule",
+      "before": 0.9642857142857143,
+      "after": 0.6666666666666666,
+      "pValue": 0.02021222367820607
+    },
+    {
+      "id": "location",
+      "kind": "rule",
+      "before": 1,
+      "after": 0.75,
+      "pValue": 0.020637898686679455
+    }
+  ],
+  "execution": {
+    "requestedRuns": 120,
+    "completedRuns": 120,
+    "failedRuns": 0,
+    "recoveredRuns": 0,
+    "totalAttempts": 120,
+    "complete": true
+  }
+}

--- a/packages/protocol/eval/matching/matching.cases-tier4.ts
+++ b/packages/protocol/eval/matching/matching.cases-tier4.ts
@@ -23,7 +23,7 @@ const NETWORK = "idx-commons";
 
 /** Creative-tech discoverer (mirrors the original identity cases). */
 const creativeTechSource: EvaluatorEntity = {
-  userId: "src-yanki",
+  userId: "src-creative-tech",
   profile: {
     name: "(source user)",
     bio: "Professional with a focus on creative technology and game development.",
@@ -51,7 +51,7 @@ const _isA_1: MatchingCase = {
     domains: ["funding", "technology"],
   description: "'startup funders' identity query must reject a bootstrapper who self-funded (bootstrapping ≠ funding others). Minimal-pair variant of investor-vs-funded-engineer.",
   input: {
-    discovererId: "src-yanki",
+    discovererId: "src-creative-tech",
     entities: [
       creativeTechSource,
       {
@@ -83,7 +83,7 @@ const _isA_2: MatchingCase = {
   domains: ["arts"],
   description: "'art director' identity query must reject a solo illustrator with no visual-direction ownership. Minimal-pair of samurai-vs-character-designer.",
   input: {
-    discovererId: "src-yanki",
+    discovererId: "src-creative-tech",
     entities: [
       creativeTechSource,
       {
@@ -114,7 +114,7 @@ const _isA_3: MatchingCase = {
     domains: ["sports"],
   description: "'scouts' identity query must accept a talent scout and reject a recently-signed athlete (being signed ≠ scouting).",
   input: {
-    discovererId: "src-yanki",
+    discovererId: "src-creative-tech",
     entities: [
       {
         userId: "src-scout",
@@ -171,7 +171,7 @@ const _isA_4: MatchingCase = {
     domains: ["funding", "research"],
   description: "'investors' identity query must reject an academic who received a research grant (receiving a grant ≠ investing). Minimal-pair variant.",
   input: {
-    discovererId: "src-yanki",
+    discovererId: "src-creative-tech",
     entities: [
       creativeTechSource,
       {
@@ -381,7 +381,7 @@ const _loc_1: MatchingCase = {
     domains: ["location", "technology"],
   description: "Query asks for London; a Berlin candidate with strong fit is penalized (≤40). Synonym of known-mismatch-penalized.",
   input: {
-    discovererId: "src-yanki",
+    discovererId: "src-creative-tech",
     entities: [
       creativeTechSource,
       {
@@ -412,7 +412,7 @@ const _loc_2: MatchingCase = {
   domains: ["location", "technology"],
   description: "Query asks for Tokyo technical artists; a candidate with empty location must not be penalized. Synonym of unknown-not-penalized.",
   input: {
-    discovererId: "src-yanki",
+    discovererId: "src-creative-tech",
     entities: [
       creativeTechSource,
       {

--- a/packages/protocol/eval/matching/matching.cases-tier4.ts
+++ b/packages/protocol/eval/matching/matching.cases-tier4.ts
@@ -114,7 +114,10 @@ const _isA_3: MatchingCase = {
     domains: ["sports"],
   description: "'scouts' identity query must accept a talent scout and reject a recently-signed athlete (being signed ≠ scouting).",
   input: {
-    discovererId: "src-creative-tech",
+    // The discoverer is the bespoke scouting-org entity below: discovererId must
+    // name an entity in this list, or every entity becomes a candidate and the
+    // evaluator's complete-batch contract can never be satisfied.
+    discovererId: "src-scout",
     entities: [
       {
         userId: "src-scout",

--- a/packages/protocol/eval/matching/matching.cases.ts
+++ b/packages/protocol/eval/matching/matching.cases.ts
@@ -8,7 +8,7 @@ const NETWORK = "idx-commons";
 
 // Shared source used by the ported identity cases (mirrors evaluator-identity-query.spec.ts).
 const creativeTechSource: EvaluatorEntity = {
-  userId: "src-yanki",
+  userId: "src-creative-tech",
   profile: {
     name: "(source user)",
     bio: "Professional with a focus on creative technology and game development.",
@@ -32,7 +32,7 @@ export const CASES: MatchingCase[] = [
     domains: ["arts"],
     description: "'samurai' identity query must reject a character-design artist (subject-matter ≠ identity).",
     input: {
-      discovererId: "src-yanki",
+      discovererId: "src-creative-tech",
       entities: [
         creativeTechSource,
         {
@@ -60,7 +60,7 @@ export const CASES: MatchingCase[] = [
     domains: ["funding", "technology"],
     description: "'investors' identity query must reject an engineer who raised funding (raising ≠ investing).",
     input: {
-      discovererId: "src-yanki",
+      discovererId: "src-creative-tech",
       entities: [
         creativeTechSource,
         {
@@ -89,7 +89,7 @@ export const CASES: MatchingCase[] = [
     domains: ["funding", "technology"],
     description: "'investors' identity query must accept an actual angel investor.",
     input: {
-      discovererId: "src-yanki",
+      discovererId: "src-creative-tech",
       entities: [
         creativeTechSource,
         {
@@ -118,7 +118,7 @@ export const CASES: MatchingCase[] = [
     domains: ["arts"],
     description: "Explicit 'samurai' query must override the source's 'visual artists' background intent.",
     input: {
-      discovererId: "src-yanki",
+      discovererId: "src-creative-tech",
       entities: [
         creativeTechSource,
         {
@@ -154,7 +154,7 @@ export const CASES: MatchingCase[] = [
     domains: ["arts"],
     description: "Minimal pair: when the explicit query asks for a samurai character illustrator, the same visual artist should be accepted.",
     input: {
-      discovererId: "src-yanki",
+      discovererId: "src-creative-tech",
       entities: [
         creativeTechSource,
         {
@@ -183,7 +183,7 @@ export const CASES: MatchingCase[] = [
     domains: ["funding", "technology"],
     description: "Explicit 'investors' query must reject a founder/engineer who has raised money but does not invest.",
     input: {
-      discovererId: "src-yanki",
+      discovererId: "src-creative-tech",
       entities: [
         creativeTechSource,
         {
@@ -212,7 +212,7 @@ export const CASES: MatchingCase[] = [
     domains: ["funding", "technology"],
     description: "Minimal pair: when the explicit query asks for founders raising seed, the funded founder should be accepted.",
     input: {
-      discovererId: "src-yanki",
+      discovererId: "src-creative-tech",
       entities: [
         creativeTechSource,
         {
@@ -241,7 +241,7 @@ export const CASES: MatchingCase[] = [
     domains: ["location", "technology"],
     description: "Explicit London query must reject a Berlin candidate even when their technical profile matches the background intent.",
     input: {
-      discovererId: "src-yanki",
+      discovererId: "src-creative-tech",
       entities: [
         creativeTechSource,
         {
@@ -269,7 +269,7 @@ export const CASES: MatchingCase[] = [
     domains: ["arts"],
     description: "When the explicit query is vague, the source's background visual-artist intent may fill in the blanks.",
     input: {
-      discovererId: "src-yanki",
+      discovererId: "src-creative-tech",
       entities: [
         creativeTechSource,
         {
@@ -432,7 +432,7 @@ export const CASES: MatchingCase[] = [
     domains: ["location", "technology"],
     description: "Query asks for SF; a New York candidate with otherwise strong fit is penalized (≤40).",
     input: {
-      discovererId: "src-yanki",
+      discovererId: "src-creative-tech",
       entities: [
         creativeTechSource,
         {
@@ -460,7 +460,7 @@ export const CASES: MatchingCase[] = [
     domains: ["location", "technology"],
     description: "Minimal pair: same candidate with UNKNOWN location must not be penalized for location.",
     input: {
-      discovererId: "src-yanki",
+      discovererId: "src-creative-tech",
       entities: [
         creativeTechSource,
         {

--- a/packages/protocol/eval/matching/tests/matching.cases.spec.ts
+++ b/packages/protocol/eval/matching/tests/matching.cases.spec.ts
@@ -25,6 +25,19 @@ describe("matching corpus", () => {
     }
   });
 
+  it("every discovererId names exactly one entity in its case", () => {
+    // The evaluator's candidates are `entities where userId !== discovererId`.
+    // A discovererId that names no entity silently promotes the source to a
+    // candidate, and the model can never return the expected batch: the run
+    // fails every attempt with evaluator-incomplete. This fails statically
+    // here instead of after a live model call. (scout-vs-scouted-athlete
+    // shipped exactly this way and failed 6/6 attempts across environments.)
+    for (const c of CASES) {
+      const matches = c.input.entities.filter((e) => e.userId === c.input.discovererId);
+      expect(matches.length).toBe(1);
+    }
+  });
+
   it("every case has at least one explicit domain category", () => {
     const allowed = new Set<Domain>(["technology", "research", "arts", "funding", "location", "community", "sports"]);
     for (const c of CASES) {

--- a/packages/protocol/eval/matching/tests/matching.cases.spec.ts
+++ b/packages/protocol/eval/matching/tests/matching.cases.spec.ts
@@ -76,9 +76,10 @@ describe("matching corpus", () => {
     // Cases added to the corpus but not yet captured by a live `--update-baseline`
     // run. Every entry here must still be missing from the baseline (stale entries
     // fail below) — remove ids from this set when the baseline is next refreshed.
-    const BASELINE_PENDING_CASE_IDS = new Set<string>([
-      "event_network/co-membership-is-not-attendance", // added in #1144 without a baseline run
-    ]);
+    // Empty: the 2026-08-02 refresh captured every corpus case, including
+    // event_network/co-membership-is-not-attendance (added in #1144 without a
+    // baseline run). Add ids here only when a case lands before its baseline run.
+    const BASELINE_PENDING_CASE_IDS = new Set<string>([]);
 
     const envelope = (await Bun.file(new URL("../baselines/matching.baseline.json", import.meta.url)).json()) as { payload: Scorecard };
     const baselineIds = new Set(envelope.payload.cases.map((c) => c.caseId));

--- a/packages/protocol/eval/shared/tests/governance.spec.ts
+++ b/packages/protocol/eval/shared/tests/governance.spec.ts
@@ -537,7 +537,7 @@ describe("scoring-config fingerprint", () => {
 });
 
 describe("committed schema-v1 baselines", () => {
-  const committed: Array<[string]> = [["matching"], ["opportunity"], ["premise"], ["profile"]];
+  const committed: Array<[string]> = [["opportunity"], ["premise"], ["profile"]];
 
   it.each(committed)("eval/%s committed baseline stays readable and is unprovable, never incompatible, for a same-model run", async (harness) => {
     const path = new URL(`../../${harness}/${harness}.eval.ts`, import.meta.url).pathname
@@ -558,6 +558,42 @@ describe("committed schema-v1 baselines", () => {
     const result = assessBaselineComparability(subject, envelope!);
     expect(result.status).toBe("unprovable");
     expect(result.mismatches).toHaveLength(0);
+  });
+
+  // The matching baseline was refreshed on 2026-08-02 as a v2 run artifact:
+  // provenance questions a v1 baseline could only shrug at are now answered.
+  it("eval/matching committed v2 baseline makes provenance provable in both directions", async () => {
+    const path = new URL("../../matching/matching.eval.ts", import.meta.url).pathname
+      .replace("matching.eval.ts", "baselines/matching.baseline.json");
+    const { readBaselineArtifact } = await import("../baseline.js");
+    const envelope = await readBaselineArtifact(path, { harness: "matching" });
+    expect(envelope).not.toBeNull();
+    expect(envelope!.schemaVersion).toBe(2);
+
+    const base = {
+      harness: "matching",
+      harnessVersion: envelope!.harnessVersion,
+      models: [...envelope!.models],
+      selection: { fullCorpus: true, filters: {} },
+      complete: true,
+    };
+
+    // A run from the same corpus and scoring config is provably comparable.
+    const same = assessBaselineComparability(
+      { ...base, corpusFingerprint: envelope!.corpusFingerprint, configFingerprint: envelope!.configFingerprint },
+      envelope!,
+    );
+    expect(same.status).toBe("comparable");
+
+    // A run from a different corpus/config is a named mismatch, never unprovable.
+    const drifted = assessBaselineComparability(
+      { ...base, corpusFingerprint: TEST_FINGERPRINT, configFingerprint: TEST_FINGERPRINT },
+      envelope!,
+    );
+    expect(drifted.status).toBe("incompatible");
+    expect(drifted.mismatches.map((m) => m.dimension)).toEqual(
+      expect.arrayContaining(["corpus", "config"]),
+    );
   });
 });
 

--- a/packages/protocol/eval/shared/tests/migration.spec.ts
+++ b/packages/protocol/eval/shared/tests/migration.spec.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it } from "bun:test";
 import path from "node:path";
 
-import { EVAL_BASELINE_ARTIFACT_TYPE, EVAL_LEGACY_UNAVAILABLE } from "../artifact.js";
+import { EVAL_BASELINE_ARTIFACT_TYPE, EVAL_LEGACY_UNAVAILABLE, isEvalArtifactV2 } from "../artifact.js";
 import { readEvalArtifact } from "../artifact.io.js";
 
 /**
@@ -12,7 +12,7 @@ import { readEvalArtifact } from "../artifact.io.js";
  * diff), and provenance that could not be reconstructed carries explicit
  * sentinels instead of fabricated values.
  */
-const COMMITTED_BASELINES = ["matching", "premise", "profile", "opportunity"] as const;
+const COMMITTED_BASELINES = ["premise", "profile", "opportunity"] as const;
 
 describe("committed baselines are versioned artifacts", () => {
   for (const harness of COMMITTED_BASELINES) {
@@ -31,4 +31,24 @@ describe("committed baselines are versioned artifacts", () => {
       expect(envelope!.completeness.totalPasses).toBeLessThanOrEqual(envelope!.completeness.totalRuns);
     });
   }
+
+  // The matching baseline was refreshed on 2026-08-02 with a live full-corpus
+  // run: it is the first committed v2 baseline, with real fingerprints and
+  // complete execution evidence rather than legacy sentinels.
+  it("matching baseline validates as a v2 baseline envelope", async () => {
+    const baselinePath = path.resolve(import.meta.dir, "../../matching/baselines/matching.baseline.json");
+    const envelope = await readEvalArtifact(baselinePath, {
+      expectedType: EVAL_BASELINE_ARTIFACT_TYPE,
+      expectedHarness: "matching",
+    });
+    expect(envelope).not.toBeNull();
+    expect(envelope!.schemaVersion).toBe(2);
+    expect(envelope!.source).toBe("run");
+    expect(envelope!.corpusFingerprint).not.toBe(EVAL_LEGACY_UNAVAILABLE);
+    expect(envelope!.selection).toEqual({ fullCorpus: true, filters: {} });
+    expect(envelope!.completeness.caseCount).toBe(envelope!.payload.cases.length);
+    expect(envelope!.completeness.totalPasses).toBeLessThanOrEqual(envelope!.completeness.totalRuns);
+    if (!isEvalArtifactV2(envelope!)) throw new Error("matching baseline must be a v2 envelope");
+    expect(envelope.completeness.complete).toBe(true);
+  });
 });

--- a/packages/protocol/eval/viewer/tests/viewer.adapters.spec.ts
+++ b/packages/protocol/eval/viewer/tests/viewer.adapters.spec.ts
@@ -133,10 +133,16 @@ describe("explicit viewer adapters", () => {
       const document = adaptViewerArtifact(artifact, { source: SOURCE });
       const html = renderViewerHtml(document);
 
-      expect(document.adapterId).toBe(`shared-${harness}-baseline-v1`);
+      const isV2 = harness === "matching"; // refreshed 2026-08-02: first committed v2 baseline
+      expect(document.adapterId).toBe(`shared-${harness}-baseline-${isV2 ? "v2" : "v1"}`);
       expect(document.items).toHaveLength(expectedCases);
-      expect(document.telemetryNotice).toContain("attempt telemetry was not recorded");
-      expect(document.items.every((item) => !item.executionAvailable && item.executionRuns.length === 0)).toBe(true);
+      if (isV2) {
+        expect(document.telemetryNotice).toContain("execution attempts are shown");
+        expect(document.items.every((item) => item.executionAvailable && item.executionRuns.length > 0)).toBe(true);
+      } else {
+        expect(document.telemetryNotice).toContain("attempt telemetry was not recorded");
+        expect(document.items.every((item) => !item.executionAvailable && item.executionRuns.length === 0)).toBe(true);
+      }
       expect(JSON.stringify(document)).not.toContain(SENSITIVE_SENTINEL);
       expect(html).not.toContain(SENSITIVE_SENTINEL);
       expect(html).not.toContain('"detail":');
@@ -303,7 +309,10 @@ describe("explicit viewer adapters", () => {
 
 describe("baseline comparison", () => {
   it("computes improved, regressed, new, missing, and unchanged deltas without mutation", async () => {
-    const baselineArtifact = asRawArtifact(await readCommittedBaseline("matching"));
+    // premise's committed baseline is still v1: the pass-count mutations below
+    // stay internally consistent, unlike a v2 artifact whose execution evidence
+    // cross-checks every case's passes/passRate/flaky.
+    const baselineArtifact = asRawArtifact(await readCommittedBaseline("premise"));
     const currentArtifact = structuredClone(baselineArtifact);
     currentArtifact.artifactType = "index-eval/run-report";
     currentArtifact.corpusFingerprint = "c".repeat(64);
@@ -342,9 +351,14 @@ describe("baseline comparison", () => {
     expect(compared.items.some((item) => item.delta?.state === "unchanged")).toBe(true);
   });
 
-  it("allows a complete v2 report to compare with a committed v1 baseline", async () => {
-    const current = adaptViewerArtifact(makeCompleteV2RunReport(), { source: SOURCE });
-    const baseline = adaptViewerArtifact(await readCommittedBaseline("matching"), { source: BASELINE_SOURCE });
+  it("allows a complete v2 report to compare with a committed v2 baseline of the same corpus", async () => {
+    // The committed matching baseline is v2 with a real corpus fingerprint, so
+    // the current report must present the same corpus to be comparable.
+    const baselineArtifact = asRawArtifact(await readCommittedBaseline("matching"));
+    const currentArtifact = structuredClone(makeCompleteV2RunReport());
+    currentArtifact.corpusFingerprint = String(baselineArtifact.corpusFingerprint);
+    const current = adaptViewerArtifact(currentArtifact, { source: SOURCE });
+    const baseline = adaptViewerArtifact(baselineArtifact, { source: BASELINE_SOURCE });
     const compared = applyViewerBaseline(current, baseline);
     expect(compared.kind).toBe("shared-scorecard-v2");
     expect(compared.baseline).toBeDefined();

--- a/packages/protocol/eval/viewer/tests/viewer.io.spec.ts
+++ b/packages/protocol/eval/viewer/tests/viewer.io.spec.ts
@@ -78,7 +78,12 @@ describe("read-only provider-free viewer generation", () => {
       expect(digest(after)).toBe(digest(before));
       expect(after.equals(before)).toBe(true);
       for (const construct of NETWORK_CONSTRUCTS) expect(firstHtml).not.toMatch(construct);
-      expect(firstHtml).toContain("Execution retry/attempt telemetry was not recorded");
+      if (harness === "matching") {
+        // Refreshed 2026-08-02: first committed v2 baseline — telemetry is shown.
+        expect(firstHtml).toContain("execution attempts are shown");
+      } else {
+        expect(firstHtml).toContain("Execution retry/attempt telemetry was not recorded");
+      }
     }
     await rm(dir, { recursive: true, force: true });
   });
@@ -93,7 +98,9 @@ describe("read-only provider-free viewer generation", () => {
     );
     const run = JSON.parse(sourceBaseline.toString("utf8")) as Record<string, unknown>;
     run.artifactType = "index-eval/run-report";
-    run.corpusFingerprint = "c".repeat(64);
+    // The committed baseline is v2 with a real corpus fingerprint: same-corpus
+    // comparison requires presenting that fingerprint, not a placeholder.
+    run.corpusFingerprint = (JSON.parse(sourceBaseline.toString("utf8")) as { corpusFingerprint: string }).corpusFingerprint;
     await writeFile(baselinePath, sourceBaseline);
     await writeFile(runPath, JSON.stringify(run, null, 2) + "\n");
     const baselineBefore = await readFile(baselinePath);
@@ -109,7 +116,7 @@ describe("read-only provider-free viewer generation", () => {
     expect((await readFile(runPath)).equals(runBefore)).toBe(true);
     const html = await readFile(outputPath, "utf8");
     expect(html).toContain("Baseline comparison");
-    expect(html).toContain("legacy-baseline-unverified");
+    expect(html).toContain("known-corpus-match");
     expect(html).toContain("Descriptive only");
     await rm(dir, { recursive: true, force: true });
   });

--- a/packages/protocol/package.json
+++ b/packages/protocol/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@indexnetwork/protocol",
-  "version": "8.6.0",
+  "version": "8.6.1",
   "type": "module",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",


### PR DESCRIPTION
## What

Two corpus repairs in the matching eval, plus the baseline refresh they were blocking.

1. **Anonymize a real-person identifier.** `src-yanki` — a real person's handle — appeared 19× across `matching.cases.ts` / `matching.cases-tier4.ts` as discoverer/entity ids, ported verbatim from an old unit spec into the committed corpus. The historical corpus is properly anonymized (`h1-a`…); these two files were the only exception. Renamed to `src-creative-tech`. Ids are opaque to the model; payloads were already generic.

2. **Repair `is_a_identity/scout-vs-scouted-athlete`.** Its `discovererId` never matched any entity's `userId`, so every entity became a candidate and the model could never satisfy the complete-batch contract: `evaluator-incomplete` on every attempt, in every environment (6/6 observed: deployed run + local refresh). A raw-output probe showed the model returning two perfectly correct verdicts every time — the case was malformed since it shipped; the evaluator correctly refused to guess. Fixed `discovererId` to name its bespoke source entity (`src-scout`); the case now runs 3/3 live at 100%.

3. **New provider-free corpus invariant** in `eval:verify`: every `discovererId` must name exactly one entity in its case. Verified RED (broken id fails the spec) and GREEN (fixed corpus, 40/40 cases satisfy it). This class now dies in CI instead of after a live model call.

4. **Baseline refresh** (governed, `--reason`, `--force`): 120/120 requested runs completed, 0 failed. The 5 reported regressions are against the previous schema-v1 baseline (comparability unprovable) and are staleness, not PR damage: `marketing-cofounder-for-ai-engineer` references no renamed id, and `founders-raising-seed-accepts-founder` fails identically (0%) on unrenamed dev. Pre-existing eval-health signal (90% aggregate, 6 flaky cases) worth a separate look — out of scope here.

## Evidence

- `eval:verify` 13/13 suites green; `bunx tsc --noEmit` clean.
- Live: scout case 3/3 at 100% after the fix; probe captured the model's raw (correct) output before it.
- Baseline refresh log: complete evidence, `120 for 120 requested run(s)`.

Version: protocol 8.6.0 → 8.6.1 (bun.lock synced).

## Follow-up: provider-free suites realigned with the first committed v2 baseline

The refresh upgraded matching's committed baseline from v1 legacy-migration to a v2 run artifact — the first committed v2 baseline. Suites that pinned v1-only properties now assert the v2 reality: matching validates as v2 with real fingerprints and complete evidence; provenance is provable in both directions (comparable for same corpus/config, named mismatches for drift); viewer adapters/compare assert v2 telemetry and `known-corpus-match`. `eval:verify` 13/13 green after the realignment (CI caught the drift before this commit; local re-run confirms).
