### PR TITLE
fix(eval-ops): allow reset without deployed env file

### DIFF
--- a/docs/superpowers/plans/2026-08-02-eval-ops-reset-env-file.md
+++ b/docs/superpowers/plans/2026-08-02-eval-ops-reset-env-file.md
@@ -1,0 +1,207 @@
+# Eval Ops Reset Environment File Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Let the deployed eval-ops reset use its validated injected `DATABASE_URL` when `.env.test` is absent, without weakening local env-file mismatch protections.
+
+**Architecture:** Keep `assessFixtureTarget` as the first, credential-free database safety guard. Change the env-file read to distinguish an absent file from a present file with no `DATABASE_URL`, then make `resolveResetTarget` accept only the absent-file case. When `.env.test` exists, its non-empty URL must still exactly match the injected URL before the flush/migrate/seed pipeline is launched. Update the startup warning to use the same distinction.
+
+**Tech Stack:** Bun, TypeScript, `bun:test`, `Bun.file`, provider-free eval-ops tests.
+
+## Global Constraints
+
+- Never allow production database names (`*_prod` / `*_production`) or redirect-capable connection-string query parameters.
+- Keep the reset target derived from server environment, never from request payloads.
+- Preserve exact URL equality when `.env.test` exists.
+- Preserve `NODE_ENV=test`, `TEST_DATABASE_SAFE=1`, and injected `DATABASE_URL` for reset subprocesses.
+- Do not add a Railway pre-deploy migration or provision a secret `.env.test` file.
+- Keep credential redaction in all operator-facing messages.
+- Work only in `/home/yanek/Projects/index/.worktrees/fix-eval-ops-env-file-reset`; leave canonical `dev` untouched.
+
+---
+
+### Task 1: Add an env-file presence regression test
+
+**Files:**
+- Modify: `packages/protocol/eval/ops/tests/server.spec.ts` in the existing `POST /api/fixture/reset` test section
+- Test: `packages/protocol/eval/ops/tests/server.spec.ts`
+
+**Interfaces:**
+- Consumes: the current reset preflight behavior in `packages/protocol/eval/ops/ops.server.ts`.
+- Produces: failing examples that define the required absent/present `.env.test` contract for the implementation.
+
+- [ ] **Step 1: Locate the existing server reset tests and add four focused cases**
+
+Use the existing test helper/style rather than constructing unrelated infrastructure. Export one pure test seam from `ops.server.ts` with this exact shape:
+
+```ts
+export interface ResetEnvFileState {
+  exists: boolean;
+  databaseUrl: string | null;
+}
+
+export function validateResetEnvFile(
+  injectedDatabaseUrl: string,
+  envFile: ResetEnvFileState,
+): { ok: true; databaseUrl: string } | { ok: false; reason: string };
+```
+
+The cases must assert:
+
+```ts
+expect(validateResetEnvFile("postgres://u:p@host/neondb", {
+  exists: false,
+  databaseUrl: null,
+})).toEqual({ ok: true, databaseUrl: "postgres://u:p@host/neondb" });
+
+expect(validateResetEnvFile("postgres://u:p@host/neondb", {
+  exists: true,
+  databaseUrl: null,
+})).toMatchObject({ ok: false });
+
+expect(validateResetEnvFile("postgres://u:p@host/neondb", {
+  exists: true,
+  databaseUrl: "postgres://u:p@host/otherdb",
+})).toMatchObject({ ok: false });
+
+expect(validateResetEnvFile("postgres://u:p@host/neondb", {
+  exists: true,
+  databaseUrl: "postgres://u:p@host/neondb",
+})).toEqual({ ok: true, databaseUrl: "postgres://u:p@host/neondb" });
+```
+
+Also assert refusal messages remain credential-free for the mismatch case.
+
+- [ ] **Step 2: Run the focused test to verify it fails for the missing behavior**
+
+Run from the worktree:
+
+```bash
+bun test packages/protocol/eval/ops/tests/server.spec.ts
+```
+
+Expected: FAIL because the exported seam does not yet exist, or because the absent-file case is currently rejected. Do not proceed until the failure demonstrates the intended behavior gap rather than a path/import typo.
+
+- [ ] **Step 3: Commit the red test**
+
+```bash
+git add packages/protocol/eval/ops/tests/server.spec.ts
+git commit -m "test(eval-ops): cover deployed reset env file absence"
+```
+
+---
+
+### Task 2: Implement the minimal absent-file-safe preflight
+
+**Files:**
+- Modify: `packages/protocol/eval/ops/ops.server.ts:1270-1315,1600-1613`
+- Test: `packages/protocol/eval/ops/tests/server.spec.ts`
+
+**Interfaces:**
+- Consumes: `validateResetEnvFile` tests from Task 1 and the existing `assessFixtureTarget`/`redactDatabaseUrl` guards.
+- Produces: `validateResetEnvFile`, the presence-aware `readEnvValue`, and reset behavior that accepts an absent `.env.test` only.
+
+- [ ] **Step 1: Make the env-file reader distinguish absence from a missing key**
+
+Replace the current `readEnvValue(file, key): Promise<string | null>` contract with:
+
+```ts
+interface EnvFileValue {
+  exists: boolean;
+  value: string | null;
+}
+
+async function readEnvValue(file: string, key: string): Promise<EnvFileValue>;
+```
+
+Return `{ exists: false, value: null }` when `Bun.file(file).exists()` is false. For an existing file, preserve the current dotenv parsing rules and return `{ exists: true, value }`, where `value` remains `null` when the key is absent or blank. Do not log or include raw values in errors.
+
+- [ ] **Step 2: Add the pure reset env-file validator**
+
+Implement the exact interface from Task 1:
+
+```ts
+export function validateResetEnvFile(
+  injectedDatabaseUrl: string,
+  envFile: ResetEnvFileState,
+): { ok: true; databaseUrl: string } | { ok: false; reason: string } {
+  const databaseUrl = injectedDatabaseUrl.trim();
+  if (!envFile.exists) return { ok: true, databaseUrl };
+  if (envFile.databaseUrl === null) {
+    return { ok: false, reason: "DATABASE_URL is not set in .env.test; fixture control is unavailable." };
+  }
+  if (envFile.databaseUrl !== databaseUrl) {
+    return {
+      ok: false,
+      reason:
+        `this server's DATABASE_URL is ${redactDatabaseUrl(databaseUrl)}, but .env.test names `
+        + `${redactDatabaseUrl(envFile.databaseUrl)}. The migrate step reads that file directly, so the two must agree.`,
+    };
+  }
+  return { ok: true, databaseUrl };
+}
+```
+
+Keep `resolveResetTarget` responsible for the existing `assessFixtureTarget` status/error response. It should call `readEnvValue`, pass `{ exists, databaseUrl: value }` to the pure validator, return status `409` with the existing user-facing wording for failures, and return the injected validated URL when the file is absent. Continue returning `target` from `assessFixtureTarget`; do not move production-name or query-parameter checks into the new helper.
+
+- [ ] **Step 3: Update startup mismatch warning to check only existing files**
+
+At `createDefaultOpsContext`, change the warning condition from `declared !== null` to `declared.exists && declared.value !== null`, then redact `declared.value`. A missing deployment `.env.test` must not produce a false mismatch warning, while an existing divergent file must still warn.
+
+- [ ] **Step 4: Run the focused tests and typecheck**
+
+Run:
+
+```bash
+bun test packages/protocol/eval/ops/tests/server.spec.ts
+bun run --cwd apps/eval-ops typecheck
+```
+
+Expected: all server tests pass, including the four env-file cases, and TypeScript reports no errors.
+
+- [ ] **Step 5: Commit the implementation**
+
+```bash
+git add packages/protocol/eval/ops/ops.server.ts packages/protocol/eval/ops/tests/server.spec.ts
+git commit -m "fix(eval-ops): allow reset with deployed database env"
+```
+
+---
+
+### Task 3: Run the affected validation and inspect the final diff
+
+**Files:**
+- Modify: none beyond Tasks 1–2.
+
+**Interfaces:**
+- Consumes: the committed implementation and its regression tests.
+- Produces: verified evidence that deployed reset behavior is fixed without changing Railway service configuration.
+
+- [ ] **Step 1: Run the complete provider-free eval-ops test suite**
+
+```bash
+bun test packages/protocol/eval/ops/tests
+```
+
+Expected: PASS with no failures.
+
+- [ ] **Step 2: Run repository-targeted static checks**
+
+```bash
+bun run --cwd apps/eval-ops lint
+bun run --cwd apps/eval-ops typecheck
+bun run test:scripts
+```
+
+Expected: all commands exit successfully. If a check fails, keep the task open and fix only regressions caused by this change.
+
+- [ ] **Step 3: Verify source and worktree invariants**
+
+```bash
+git diff origin/dev...HEAD --check
+git diff origin/dev...HEAD --stat
+git status --short --branch
+cd /home/yanek/Projects/index && git status --short --branch && git branch --show-current
+```
+
+Expected: the fix worktree contains only the approved spec, plan, implementation, and tests; the canonical root remains clean on `dev`.

--- a/docs/superpowers/specs/2026-08-02-eval-ops-reset-env-file-design.md
+++ b/docs/superpowers/specs/2026-08-02-eval-ops-reset-env-file-design.md
@@ -1,0 +1,33 @@
+# Eval Ops Reset Environment File Design
+
+## Problem
+
+The deployed `eval-ops` Railway service receives a validated `DATABASE_URL`, but the repository-root `.env.test` is gitignored and is not present in the `/app` image. The reset endpoint currently refuses before launching its migrate step whenever that file does not define `DATABASE_URL`:
+
+> Refusing to reset: /app/.env.test does not set DATABASE_URL, so the migrate step would target an unknown database.
+
+This makes deployed fixture reset permanently unavailable even though the child process already receives the same validated URL through its environment. The Railway service config correctly has no pre-deploy migration; this is an eval-ops reset preflight issue.
+
+## Decision
+
+Allow the injected `DATABASE_URL` when `.env.test` is absent. Preserve strict local safety when the file exists:
+
+1. Run the existing `assessFixtureTarget` validation first. Production database names, redirecting query parameters, malformed URLs, and missing injected URLs remain refused.
+2. If `.env.test` does not exist, accept the validated injected URL. `drizzle.config.ts` already leaves the process-provided URL in place when no env file is available, and the reset child also receives `NODE_ENV=test` and `TEST_DATABASE_SAFE=1`.
+3. If `.env.test` exists, require a non-empty `DATABASE_URL` and require exact equality with the validated injected URL. This prevents a local or partially mounted deployment from flushing one target while migrating another.
+4. Keep all existing credential redaction and fail-closed validation behavior.
+
+## Implementation shape
+
+Add a small environment-file inspection result that distinguishes “file absent” from “file present but key missing.” Use it in `resolveResetTarget` rather than treating both states as `DATABASE_URL` missing. Keep the existing `readEnvValue` parsing semantics, including last assignment wins, comments, blank values, and quoted values.
+
+## Testing
+
+Add focused provider-free tests for the preflight helper:
+
+- absent `.env.test` accepts a safe injected disposable URL;
+- present `.env.test` without `DATABASE_URL` refuses;
+- present `.env.test` with a different URL refuses;
+- present `.env.test` with the same URL accepts.
+
+Run the eval-ops ops test suite and TypeScript checks. Confirm the canonical root remains on `dev` and all changes are isolated to the fix worktree.

--- a/packages/protocol/eval/ops/ops.server.ts
+++ b/packages/protocol/eval/ops/ops.server.ts
@@ -1264,38 +1264,25 @@ export interface ResetEnvFileState {
   databaseUrl: string | null;
 }
 
-/**
- * Validates the relationship between the server-injected target and .env.test.
- *
- * The deployed preflight currently requires the file to be present because the
- * migrate step reads it directly; the absent-file acceptance is intentionally
- * pinned by the regression test before that behavior is changed.
- */
+/** Validates the relationship between the server-injected target and .env.test. */
 export function validateResetEnvFile(
   injectedDatabaseUrl: string,
   envFile: ResetEnvFileState,
 ): { ok: true; databaseUrl: string } | { ok: false; reason: string } {
-  if (!envFile.exists) {
-    return {
-      ok: false,
-      reason: "Refusing to reset: .env.test is absent, so the migrate step would target an unknown database.",
-    };
-  }
+  const databaseUrl = injectedDatabaseUrl.trim();
+  if (!envFile.exists) return { ok: true, databaseUrl };
   if (envFile.databaseUrl === null) {
-    return {
-      ok: false,
-      reason: "Refusing to reset: .env.test does not set DATABASE_URL, so the migrate step would target an unknown database.",
-    };
+    return { ok: false, reason: "DATABASE_URL is not set in .env.test; fixture control is unavailable." };
   }
-  if (envFile.databaseUrl !== injectedDatabaseUrl.trim()) {
+  if (envFile.databaseUrl !== databaseUrl) {
     return {
       ok: false,
       reason:
-        `Refusing to reset: .env.test names ${redactDatabaseUrl(envFile.databaseUrl)}, but this server validated `
-        + `${redactDatabaseUrl(injectedDatabaseUrl)}. The migrate step reads that file directly, so the two must agree.`,
+        `this server's DATABASE_URL is ${redactDatabaseUrl(databaseUrl)}, but .env.test names `
+        + `${redactDatabaseUrl(envFile.databaseUrl)}. The migrate step reads that file directly, so the two must agree.`,
     };
   }
-  return { ok: true, databaseUrl: envFile.databaseUrl };
+  return { ok: true, databaseUrl };
 }
 
 type ResetTarget =
@@ -1305,13 +1292,12 @@ type ResetTarget =
 /**
  * Resolves the one database a reset may touch.
  *
- * The guard decides whether the target is disposable at all. The second check is
- * load-bearing, not documentation: every reset runs `db:migrate:test`, whose
- * drizzle.config.ts loads the repository-root .env.test with `override: true` and
- * therefore ignores the DATABASE_URL injected into the child. Flush and seed use
- * the injected URL. The two are the same database only while this server's
- * DATABASE_URL is still the one .env.test names, so a divergence fails the reset
- * closed instead of migrating a database the operator never confirmed.
+ * The guard decides whether the target is disposable at all. When .env.test
+ * exists, the second check is load-bearing: `db:migrate:test` reads that file
+ * directly, while flush and seed use the injected URL. A divergent existing file
+ * therefore fails the reset closed instead of migrating a database the operator
+ * never confirmed. If the file is absent, every subprocess receives the validated
+ * server URL through its environment.
  */
 async function resolveResetTarget(context: OpsContext): Promise<ResetTarget> {
   const databaseUrl = context.databaseUrl ?? "";
@@ -1319,9 +1305,10 @@ async function resolveResetTarget(context: OpsContext): Promise<ResetTarget> {
   if (!guard.allowed) return { ok: false, reason: guard.reason, status: 403 };
 
   const envFile = path.join(context.repoRoot, ".env.test");
+  const declared = await readEnvValue(envFile, "DATABASE_URL");
   const envFileState: ResetEnvFileState = {
-    exists: await Bun.file(envFile).exists(),
-    databaseUrl: await readEnvValue(envFile, "DATABASE_URL"),
+    exists: declared.exists,
+    databaseUrl: declared.value,
   };
   const envValidation = validateResetEnvFile(databaseUrl, envFileState);
   if (!envValidation.ok) return { ok: false, reason: envValidation.reason, status: 409 };
@@ -1329,9 +1316,14 @@ async function resolveResetTarget(context: OpsContext): Promise<ResetTarget> {
 }
 
 /** Reads one key out of a dotenv file. Last assignment wins, as dotenv does. */
-async function readEnvValue(file: string, key: string): Promise<string | null> {
+interface EnvFileValue {
+  exists: boolean;
+  value: string | null;
+}
+
+async function readEnvValue(file: string, key: string): Promise<EnvFileValue> {
   const handle = Bun.file(file);
-  if (!(await handle.exists())) return null;
+  if (!(await handle.exists())) return { exists: false, value: null };
   const pattern = new RegExp(`^(?:export\\s+)?${key}\\s*=\\s*(.*)$`);
   let found: string | null = null;
   for (const raw of (await handle.text()).split(/\r?\n/)) {
@@ -1341,9 +1333,10 @@ async function readEnvValue(file: string, key: string): Promise<string | null> {
     if (match === null) continue;
     const value = match[1].trim();
     const quoted = value.length >= 2 && ((value.startsWith('"') && value.endsWith('"')) || (value.startsWith("'") && value.endsWith("'")));
-    found = quoted ? value.slice(1, -1) : value;
+    const parsed = quoted ? value.slice(1, -1) : value;
+    found = parsed === "" ? null : parsed;
   }
-  return found;
+  return { exists: true, value: found };
 }
 
 // ---------------------------------------------------------------------------
@@ -1633,10 +1626,10 @@ export async function createDefaultOpsContext(options: {
   // Reported, not fatal: fixture control is only one page, and the reset route
   // fails closed on the same divergence. A silent mismatch is what must not happen.
   const declared = await readEnvValue(path.join(options.repoRoot, ".env.test"), "DATABASE_URL");
-  if (databaseUrl !== undefined && declared !== null && declared !== databaseUrl.trim()) {
+  if (databaseUrl !== undefined && declared.exists && declared.value !== null && declared.value !== databaseUrl.trim()) {
     console.warn(
       `[eval-ops] DATABASE_URL (${redactDatabaseUrl(databaseUrl)}) differs from the one in .env.test `
-      + `(${redactDatabaseUrl(declared)}); fixture reset will refuse until they agree.`,
+      + `(${redactDatabaseUrl(declared.value)}); fixture reset will refuse until they agree.`,
     );
   }
 

--- a/packages/protocol/eval/ops/ops.server.ts
+++ b/packages/protocol/eval/ops/ops.server.ts
@@ -1259,6 +1259,45 @@ async function prepareAndLaunchReset(context: OpsContext, state: ServerState, re
   return json(record, 202);
 }
 
+export interface ResetEnvFileState {
+  exists: boolean;
+  databaseUrl: string | null;
+}
+
+/**
+ * Validates the relationship between the server-injected target and .env.test.
+ *
+ * The deployed preflight currently requires the file to be present because the
+ * migrate step reads it directly; the absent-file acceptance is intentionally
+ * pinned by the regression test before that behavior is changed.
+ */
+export function validateResetEnvFile(
+  injectedDatabaseUrl: string,
+  envFile: ResetEnvFileState,
+): { ok: true; databaseUrl: string } | { ok: false; reason: string } {
+  if (!envFile.exists) {
+    return {
+      ok: false,
+      reason: "Refusing to reset: .env.test is absent, so the migrate step would target an unknown database.",
+    };
+  }
+  if (envFile.databaseUrl === null) {
+    return {
+      ok: false,
+      reason: "Refusing to reset: .env.test does not set DATABASE_URL, so the migrate step would target an unknown database.",
+    };
+  }
+  if (envFile.databaseUrl !== injectedDatabaseUrl.trim()) {
+    return {
+      ok: false,
+      reason:
+        `Refusing to reset: .env.test names ${redactDatabaseUrl(envFile.databaseUrl)}, but this server validated `
+        + `${redactDatabaseUrl(injectedDatabaseUrl)}. The migrate step reads that file directly, so the two must agree.`,
+    };
+  }
+  return { ok: true, databaseUrl: envFile.databaseUrl };
+}
+
 type ResetTarget =
   | { ok: true; target: FixtureTarget; databaseUrl: string }
   | { ok: false; reason: string; status: number };
@@ -1280,24 +1319,13 @@ async function resolveResetTarget(context: OpsContext): Promise<ResetTarget> {
   if (!guard.allowed) return { ok: false, reason: guard.reason, status: 403 };
 
   const envFile = path.join(context.repoRoot, ".env.test");
-  const declared = await readEnvValue(envFile, "DATABASE_URL");
-  if (declared === null) {
-    return {
-      ok: false,
-      reason: `Refusing to reset: ${envFile} does not set DATABASE_URL, so the migrate step would target an unknown database.`,
-      status: 409,
-    };
-  }
-  if (declared !== databaseUrl.trim()) {
-    return {
-      ok: false,
-      reason:
-        `Refusing to reset: this server validated ${guard.target.redactedUrl}, but ${envFile} now names `
-        + `${redactDatabaseUrl(declared)}. The migrate step reads that file directly, so the two must agree.`,
-      status: 409,
-    };
-  }
-  return { ok: true, target: guard.target, databaseUrl: declared };
+  const envFileState: ResetEnvFileState = {
+    exists: await Bun.file(envFile).exists(),
+    databaseUrl: await readEnvValue(envFile, "DATABASE_URL"),
+  };
+  const envValidation = validateResetEnvFile(databaseUrl, envFileState);
+  if (!envValidation.ok) return { ok: false, reason: envValidation.reason, status: 409 };
+  return { ok: true, target: guard.target, databaseUrl: envValidation.databaseUrl };
 }
 
 /** Reads one key out of a dotenv file. Last assignment wins, as dotenv does. */

--- a/packages/protocol/eval/ops/tests/server.spec.ts
+++ b/packages/protocol/eval/ops/tests/server.spec.ts
@@ -10,7 +10,7 @@ import type { ExecutionStep, RunExecutor } from "../ops.executor.js";
 import { SEED_STEP_CWD, type FixtureCounts, type FixtureInspector } from "../ops.fixture.js";
 import { isOpsServerPath, OPS_CALLBACK_PATH } from "../ops.paths.js";
 import { RunQueue } from "../ops.queue.js";
-import { createDefaultOpsContext, createOpsHandler, PUBLIC_ROUTES, resolveBindHostname, resolveBindPort, resolveIdentityEndpoints, resolvePublicOrigin, resolveSignInMode, type OpsAuthContext, type OpsContext } from "../ops.server.js";
+import { createDefaultOpsContext, createOpsHandler, PUBLIC_ROUTES, resolveBindHostname, resolveBindPort, resolveIdentityEndpoints, resolvePublicOrigin, resolveSignInMode, validateResetEnvFile, type OpsAuthContext, type OpsContext } from "../ops.server.js";
 import { FsRunStore, type RunStore } from "../ops.store.js";
 import type { RunRecord } from "../ops.types.js";
 import { EVAL_RUN_REPORT_ARTIFACT_TYPE, buildEvalArtifact, buildScorecard } from "../../shared/index.js";
@@ -1106,6 +1106,36 @@ describe("GET /api/fixture", () => {
 
 describe("POST /api/fixture/reset", () => {
   const writeEnvTest = (url: string) => writeFile(path.join(root, ".env.test"), `# comment\nDATABASE_URL=${url}\n`);
+
+  it("accepts an absent .env.test when the server already has the injected target", () => {
+    expect(validateResetEnvFile("postgres://u:p@host/neondb", {
+      exists: false,
+      databaseUrl: null,
+    })).toEqual({ ok: true, databaseUrl: "postgres://u:p@host/neondb" });
+  });
+
+  it("refuses an existing .env.test without DATABASE_URL", () => {
+    expect(validateResetEnvFile("postgres://u:p@host/neondb", {
+      exists: true,
+      databaseUrl: null,
+    })).toMatchObject({ ok: false });
+  });
+
+  it("refuses an existing .env.test naming a different database without credentials", () => {
+    const result = validateResetEnvFile("postgres://u:p@host/neondb", {
+      exists: true,
+      databaseUrl: "postgres://u:p@host/otherdb",
+    });
+    expect(result).toMatchObject({ ok: false });
+    if (!result.ok) expect(result.reason).not.toContain(":p@");
+  });
+
+  it("accepts an existing .env.test naming the injected target exactly", () => {
+    expect(validateResetEnvFile("postgres://u:p@host/neondb", {
+      exists: true,
+      databaseUrl: "postgres://u:p@host/neondb",
+    })).toEqual({ ok: true, databaseUrl: "postgres://u:p@host/neondb" });
+  });
 
   it("runs the guarded pipeline with the environment this layer injects", async () => {
     await writeEnvTest(DATABASE_URL);

--- a/packages/protocol/eval/ops/tests/server.spec.ts
+++ b/packages/protocol/eval/ops/tests/server.spec.ts
@@ -1182,11 +1182,17 @@ describe("POST /api/fixture/reset", () => {
     expect(executor.starts).toHaveLength(0);
   });
 
-  it("refuses when .env.test is missing", async () => {
+  it("accepts when .env.test is missing because the server injects the validated target", async () => {
     const response = await post("/api/fixture/reset", { confirmDatabaseName: "neondb", personas: 1 });
 
-    expect(response.status).toBe(409);
-    expect(executor.starts).toHaveLength(0);
+    expect(response.status).toBe(202);
+    const call = executor.starts[0];
+    expect(call.steps?.map((step) => step.label)).toEqual(["flush", "migrate", "seed"]);
+    for (const step of call.steps ?? []) {
+      expect(step.env.DATABASE_URL).toBe(DATABASE_URL);
+      expect(step.env.NODE_ENV).toBe("test");
+      expect(step.env.TEST_DATABASE_SAFE).toBe("1");
+    }
   });
 
   it("refuses a mistyped confirmation", async () => {


### PR DESCRIPTION
## Summary

- Fixes deployed eval-ops fixture reset failures when `/app/.env.test` is absent.
- Accepts Railway's validated injected `DATABASE_URL` only when the env file is absent.
- Preserves strict exact-match and credential-redacted safety checks when `.env.test` exists.
- Adds regression coverage for absent, missing, mismatched, and matching env-file states.

## Root cause

Railway does not ship the gitignored `.env.test` into `/app`, but the reset preflight required that file before launching the migration subprocess. The migration already receives the validated server URL through its environment.

## Verification

- `bun test packages/protocol/eval/ops/tests` — 361 passed, 0 failed
- `bun run --cwd apps/eval-ops lint` — passed, 0 errors; 6 pre-existing unrelated UI warnings
- `bun run --cwd apps/eval-ops typecheck` — passed
- `bun run test:scripts` — 50 passed, 0 failed
- Canonical worktree remains clean on `dev`

## Notes

No Railway configuration or database was mutated. Deferred non-blocking follow-ups: direct tests for blank dotenv assignments/startup warning behavior.
