### PR TITLE
fix(opportunity): keep intent-scoped radar linked after network reassignment

### DIFF
--- a/services/api/src/adapters/opportunity.database.adapter.ts
+++ b/services/api/src/adapters/opportunity.database.adapter.ts
@@ -729,31 +729,25 @@ export class OpportunityDatabaseAdapter {
     userId: string,
     options?: { status?: string; statuses?: string[]; networkId?: string; scopeType?: 'intent'; scopeId?: string; role?: string; limit?: number; offset?: number; conversationId?: string }
   ): Promise<OpportunityRow[]> {
-    let intentScopeNetworkIds: string[] | null = null;
+    let intentScopeValid = false;
     if (options?.scopeType === 'intent' && options.scopeId) {
-      const scopeRows = await db
-        .select({ networkId: schema.intentNetworks.networkId })
+      // Scope validity is ownership, not current network assignment: an
+      // intent's assigned networks can change after discovery, and gating the
+      // scoped read on the *current* assignment orphaned every opportunity
+      // anchored on a since-removed network — while countsByIntent (linkage
+      // only) still counted them, so badges said N and the intent radar said 0.
+      // The scoped view must be a pure narrowing of the unscoped view:
+      // unscoped visibility ∩ intent linkage (+ the live-anchor guard below).
+      const owned = await db
+        .select({ id: schema.intents.id })
         .from(schema.intents)
-        .innerJoin(
-          schema.intentNetworks,
-          eq(schema.intentNetworks.intentId, schema.intents.id),
-        )
-        .innerJoin(
-          schema.networkMembers,
-          and(
-            eq(schema.networkMembers.userId, userId),
-            eq(schema.networkMembers.networkId, schema.intentNetworks.networkId),
-          ),
-        )
-        .innerJoin(schema.networks, eq(schema.networks.id, schema.intentNetworks.networkId))
         .where(and(
           eq(schema.intents.id, options.scopeId),
           eq(schema.intents.userId, userId),
-          isNull(schema.networkMembers.deletedAt),
-          isNull(schema.networks.deletedAt),
-        ));
-      intentScopeNetworkIds = [...new Set(scopeRows.map((row) => row.networkId))].sort();
-      if (intentScopeNetworkIds.length === 0) return [];
+        ))
+        .limit(1);
+      if (owned.length === 0) return [];
+      intentScopeValid = true;
     }
 
     // Role-based visibility: who can see depends on actor role and status (and whether introducer exists)
@@ -817,10 +811,10 @@ export class OpportunityDatabaseAdapter {
         )
       )`);
     }
-    if (options?.scopeType === 'intent' && options.scopeId && intentScopeNetworkIds) {
-      // Selected-intent Radar keeps the historical linkage predicate, but the
-      // selected intent must be viewer-owned and its scope is authoritative:
-      // assigned networks intersect live viewer memberships and live networks.
+    if (options?.scopeType === 'intent' && options.scopeId && intentScopeValid) {
+      // Selected-intent Radar: the historical linkage predicate. From-intent
+      // discovery records `detection.triggeredBy`; older or manually linked
+      // rows are selected via the viewer's own actor `intent` stamp.
       conditions.push(sql`(
         ${opportunities.detection}->>'triggeredBy' = ${options.scopeId}
         OR EXISTS (
@@ -830,10 +824,12 @@ export class OpportunityDatabaseAdapter {
         )
       )`);
       // Participant-safe rather than row-strict: every distinct actor user must
-      // have at least one actor anchor inside the intent's valid scope, and that
-      // exact user/network pair must still be active. This blocks candidate
-      // membership leaks while tolerating harmless duplicate actor stamps for
-      // the same participant on another network.
+      // still hold a live membership on at least one network they are anchored
+      // on in this opportunity. This blocks removed-candidate membership leaks
+      // while tolerating harmless duplicate actor stamps for the same
+      // participant on another network. Anchors are the discovery-time
+      // networks stamped on the row — deliberately not the intent's *current*
+      // network assignment, which can change after discovery.
       conditions.push(sql`NOT EXISTS (
         SELECT 1 FROM jsonb_array_elements(${opportunities.actors}) AS participant
         WHERE NOT EXISTS (
@@ -843,14 +839,7 @@ export class OpportunityDatabaseAdapter {
             ON nm.user_id = anchor->>'userId'
            AND nm.network_id = anchor->>'networkId'
           JOIN ${schema.networks} n ON n.id = nm.network_id
-          JOIN ${schema.intentNetworks} scoped_intent_network
-            ON scoped_intent_network.network_id = anchor->>'networkId'
-           AND scoped_intent_network.intent_id = ${options.scopeId}
-          JOIN ${schema.intents} scoped_intent
-            ON scoped_intent.id = scoped_intent_network.intent_id
-           AND scoped_intent.user_id = ${userId}
           WHERE anchor->>'userId' = participant->>'userId'
-            AND anchor->>'networkId' = ANY(ARRAY[${sql.join(intentScopeNetworkIds.map((id) => sql`${id}`), sql`, `)}]::text[])
             AND nm.deleted_at IS NULL
             AND n.deleted_at IS NULL
         )

--- a/services/api/src/adapters/tests/network-discovery-isolation.adapter.spec.ts
+++ b/services/api/src/adapters/tests/network-discovery-isolation.adapter.spec.ts
@@ -2,7 +2,7 @@ import { config } from 'dotenv';
 config({ path: '.env.test', override: true });
 
 import { afterAll, beforeAll, describe, expect, it } from 'bun:test';
-import { inArray } from 'drizzle-orm/sql';
+import { and, eq, inArray } from 'drizzle-orm/sql';
 import { v4 as uuidv4 } from 'uuid';
 
 import db from '../../lib/drizzle/drizzle';
@@ -488,10 +488,17 @@ describe('network discovery adapter isolation', () => {
 
     const good = await makeOpportunity(ids.activeCandidate, 'good');
     const leaked = await makeOpportunity(ids.removedCandidate, 'removed');
-    // Anchored on a live network with live memberships that is not in the
-    // intent's current network assignment: discovery-time anchors stay valid
-    // after reassignment, so this must remain visible in the scoped radar.
+    // Model a real reassignment: discovery occurs while this network belongs
+    // to the intent, then the assignment is removed before the Radar read.
+    await db.insert(intentNetworks).values({
+      intentId: ids.selectedIntent,
+      networkId: ids.reassignedNetwork,
+    });
     const offAssignment = await makeOpportunity(ids.activeCandidate, 'off-assignment', ids.reassignedNetwork);
+    await db.delete(intentNetworks).where(and(
+      eq(intentNetworks.intentId, ids.selectedIntent),
+      eq(intentNetworks.networkId, ids.reassignedNetwork),
+    ));
     createdOpportunityIds.push(good.id, leaked.id, offAssignment.id);
 
     const radar = await opportunity.getOpportunitiesForUser(ids.viewer, {

--- a/services/api/src/adapters/tests/network-discovery-isolation.adapter.spec.ts
+++ b/services/api/src/adapters/tests/network-discovery-isolation.adapter.spec.ts
@@ -25,6 +25,9 @@ const ids = {
   removedCandidate: uuidv4(),
   deletedNetworkCandidate: uuidv4(),
   activeNetwork: uuidv4(),
+  // Live network with live memberships that is NOT assigned to selectedIntent:
+  // simulates an intent whose network assignment changed after discovery.
+  reassignedNetwork: uuidv4(),
   deletedNetwork: uuidv4(),
   selectedIntent: uuidv4(),
   otherViewerIntent: uuidv4(),
@@ -56,10 +59,13 @@ beforeAll(async () => {
   ]);
   await db.insert(networks).values([
     { id: ids.activeNetwork, title: `${TEST_PREFIX}active` },
+    { id: ids.reassignedNetwork, title: `${TEST_PREFIX}reassigned` },
     { id: ids.deletedNetwork, title: `${TEST_PREFIX}deleted`, deletedAt: new Date() },
   ]);
   await db.insert(networkMembers).values([
     { networkId: ids.activeNetwork, userId: ids.viewer, permissions: ['owner'] },
+    { networkId: ids.reassignedNetwork, userId: ids.viewer, permissions: ['member'] },
+    { networkId: ids.reassignedNetwork, userId: ids.activeCandidate, permissions: ['member'] },
     // Contact is intentionally valid: discovery eligibility is permission-agnostic.
     { networkId: ids.activeNetwork, userId: ids.activeCandidate, permissions: ['contact'] },
     { networkId: ids.activeNetwork, userId: ids.removedCandidate, permissions: ['member'], deletedAt: new Date() },
@@ -178,8 +184,8 @@ afterAll(async () => {
     ids.removedIntent,
     ids.deletedNetworkIntent,
   ]));
-  await db.delete(networkMembers).where(inArray(networkMembers.networkId, [ids.activeNetwork, ids.deletedNetwork]));
-  await db.delete(networks).where(inArray(networks.id, [ids.activeNetwork, ids.deletedNetwork]));
+  await db.delete(networkMembers).where(inArray(networkMembers.networkId, [ids.activeNetwork, ids.reassignedNetwork, ids.deletedNetwork]));
+  await db.delete(networks).where(inArray(networks.id, [ids.activeNetwork, ids.reassignedNetwork, ids.deletedNetwork]));
   await db.delete(users).where(inArray(users.id, [
     ids.viewer,
     ids.activeCandidate,
@@ -458,7 +464,7 @@ describe('network discovery adapter isolation', () => {
   }, 20_000);
 
   it('keeps paused owned-intent Radar history while blocking inactive participants and foreign scopes', async () => {
-    const makeOpportunity = async (candidateUserId: string, suffix: string) => opportunity.createOpportunity({
+    const makeOpportunity = async (candidateUserId: string, suffix: string, networkId = ids.activeNetwork) => opportunity.createOpportunity({
       detection: {
         source: 'opportunity_graph',
         createdBy: 'agent-opportunity-finder',
@@ -466,8 +472,8 @@ describe('network discovery adapter isolation', () => {
         timestamp: new Date().toISOString(),
       },
       actors: [
-        { userId: ids.viewer, networkId: ids.activeNetwork, role: 'peer', intent: ids.selectedIntent },
-        { userId: candidateUserId, networkId: ids.activeNetwork, role: 'peer' },
+        { userId: ids.viewer, networkId, role: 'peer', intent: ids.selectedIntent },
+        { userId: candidateUserId, networkId, role: 'peer' },
       ],
       interpretation: {
         category: 'collaboration',
@@ -475,14 +481,18 @@ describe('network discovery adapter isolation', () => {
         confidence: 0.9,
         signals: [],
       },
-      context: { networkId: ids.activeNetwork },
+      context: { networkId },
       confidence: '0.9',
       status: 'pending',
     });
 
     const good = await makeOpportunity(ids.activeCandidate, 'good');
     const leaked = await makeOpportunity(ids.removedCandidate, 'removed');
-    createdOpportunityIds.push(good.id, leaked.id);
+    // Anchored on a live network with live memberships that is not in the
+    // intent's current network assignment: discovery-time anchors stay valid
+    // after reassignment, so this must remain visible in the scoped radar.
+    const offAssignment = await makeOpportunity(ids.activeCandidate, 'off-assignment', ids.reassignedNetwork);
+    createdOpportunityIds.push(good.id, leaked.id, offAssignment.id);
 
     const radar = await opportunity.getOpportunitiesForUser(ids.viewer, {
       scopeType: 'intent',
@@ -491,6 +501,7 @@ describe('network discovery adapter isolation', () => {
     });
     expect(radar.some((row) => row.id === good.id)).toBe(true);
     expect(radar.some((row) => row.id === leaked.id)).toBe(false);
+    expect(radar.some((row) => row.id === offAssignment.id)).toBe(true);
 
     const foreign = await opportunity.getOpportunitiesForUser(ids.activeCandidate, {
       scopeType: 'intent',


### PR DESCRIPTION
## Summary
- The intent-scoped opportunity read (`getOpportunitiesForUser` with `scopeType: 'intent'`) gated rows on the intent's **current** network assignment. When an intent's networks get reassigned after discovery (observed today on dev: an intent dropped Edge City, where all of its live opportunities are anchored), every existing opportunity vanished from the intent Radar — while `countsByIntent` (linkage-only) still counted them, so the badge said 9 and the radar said 0. Hermes, reading the unscoped list, still showed all of them.
- Scope validity is now intent **ownership** (viewer owns the intent), and the participant-safety guard requires each participant to hold a **live membership on a network they are anchored on in the opportunity** (discovery-time anchor) instead of a network in the current assignment. The scoped view becomes a pure narrowing of the unscoped view: visibility ∩ intent linkage ∩ live anchors.
- Both protections pinned by the #1144 isolation spec still hold: removed-member candidates stay hidden, and a non-owner scoping someone else's intent gets `[]`.

## Test plan
- [x] `network-discovery-isolation.adapter.spec.ts` extended with the regression case: an opportunity anchored on a live network **not** in the intent's current assignment must remain visible in the scoped radar (plus existing removed-member and foreign-scope expectations unchanged). All 7 tests pass against the disposable test DB (`TEST_DATABASE_SAFE=1`).
- [x] `tsc --noEmit`: same 30 pre-existing errors with and without this change (stale `packages/protocol/dist`, unrelated files); no new errors.
- [x] Verified the failing case live on dev: `GET /opportunities/radar?scopeType=intent&scopeId=…` returns `items: 0` for an intent whose `waitingOpportunityCount` is 9; all 9 rows carry live shared-network anchors and pass the new predicate.