### PR TITLE
feat(eval-ops): simplify launch to the variables that change results

### DIFF
--- a/apps/eval-ops/package.json
+++ b/apps/eval-ops/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@indexnetwork/eval-ops",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "private": true,
   "scripts": {
     "dev": "vite --host 127.0.0.1 --port 5174",

--- a/apps/eval-ops/src/api/client.ts
+++ b/apps/eval-ops/src/api/client.ts
@@ -50,16 +50,18 @@ import type { ConfigProfile } from '../../../../packages/protocol/eval/ops/ops.p
 export type {
   AgentMeta,
   EnvFlagMeta,
+  FlagMeta,
   ModelMeta,
 } from '../../../../packages/protocol/eval/ops/ops.metadata';
 
-import type { AgentMeta, EnvFlagMeta, ModelMeta } from '../../../../packages/protocol/eval/ops/ops.metadata';
+import type { AgentMeta, EnvFlagMeta, FlagMeta, ModelMeta } from '../../../../packages/protocol/eval/ops/ops.metadata';
 
 /** Exactly what GET /api/configs/metadata serves. */
 export interface ConfigMetadata {
   env: readonly EnvFlagMeta[];
   models: readonly ModelMeta[];
   harnessAgents: Record<OpsHarness, readonly AgentMeta[]>;
+  flags: readonly FlagMeta[];
 }
 
 import type { HarnessDescriptor, IndexIssue, IndexResult, OpsHarness, RunRecord, RunSpec, RunStatus } from '../../../../packages/protocol/eval/ops/ops.types';

--- a/apps/eval-ops/src/routes/Launch.tsx
+++ b/apps/eval-ops/src/routes/Launch.tsx
@@ -2,88 +2,45 @@ import { useEffect, useState } from 'react';
 import { Link, useNavigate, useSearchParams } from 'react-router';
 
 import { Frame } from '../components/Frame';
-import { GuidedEnvEditor, envRowsToOverrides, type EnvOverrideRow } from '../components/GuidedEnvEditor';
 import { ModelOverrideEditor } from '../components/ModelOverrideEditor';
-import { api, type AgentMeta, type ConfigMetadata, type ConfigProfile, type EnvFlagMeta, type EvalRunSpec, type HarnessDescriptor, type HarnessFlag, type ModelMeta, type ProfileDescriptor, type RunFlags } from '../api/client';
+import { api, type AgentMeta, type ConfigMetadata, type ConfigProfile, type EvalRunSpec, type FlagMeta, type HarnessDescriptor, type HarnessFlag, type ModelMeta, type ProfileDescriptor, type RunFlags } from '../api/client';
 
-/** One side's ad-hoc overrides: model choices plus guided env-flag rows. */
-interface SideOverrides {
-  models: Record<string, string>;
-  envRows: EnvOverrideRow[];
-  /** GuidedEnvEditor's verdict on envRows; empty rows are valid. */
-  envValid: boolean;
-}
+/**
+ * Flags that decide WHICH cases run. Two runs that disagree here are not
+ * comparable at all (the comparison refuses on a selection mismatch), so the
+ * A/B form shares one control for these between both sides.
+ */
+const SELECTION_FLAGS = ['runs', 'case', 'rule', 'tier'] as const;
 
-const EMPTY_SIDE: SideOverrides = { models: {}, envRows: [], envValid: true };
+/** A/B side ids. "reference" runs first, "candidate" second. */
+type Side = 'reference' | 'candidate';
 
 interface LaunchState {
   harnesses: HarnessDescriptor[];
   profiles: ProfileDescriptor[];
-  /** Saved (DB) configs, listed after the shipped repo profiles. */
   savedConfigs: ConfigProfile[];
-  /** Guided-editing metadata; null when the endpoint cannot be reached. */
+  /** Flag/agent/model copy; null when the endpoint cannot be reached. */
   metadata: ConfigMetadata | null;
   selectedHarness: HarnessDescriptor | null;
-  selectedProfile: string;
-  /** A/B mode: each side picks its own profile and carries its own overrides. */
   ab: boolean;
-  referenceProfile: string;
-  candidateProfile: string;
-  referenceOverrides: SideOverrides;
-  candidateOverrides: SideOverrides;
-  flags: RunFlags;
+  /** Per side: the named config it runs under ("default" = ad-hoc overrides allowed). */
+  profile: Record<Side, string>;
+  /** Per side: model overrides, only expressible on top of "default". */
+  models: Record<Side, Record<string, string>>;
+  /** Per side: flags that change how a run is scored. */
+  scoring: Record<Side, RunFlags>;
+  /** Shared by both sides: what gets tested. */
+  selection: RunFlags;
   awaitingConfirmation: boolean;
-  /** The "save as config…" inline form. */
   savingConfig: boolean;
   configName: string;
   configDescription: string;
   saveError: string | null;
-  /** A failure loading the registry or the profiles: nothing can be launched. */
   error: string | null;
-  /** A rejected launch. Rendered inline so the entered flags survive. */
   launchError: string | null;
 }
 
-/**
- * Plain-English presentation for the runner knobs, keyed by flag name. Every
- * explanation is grounded in the harness/runner code — see the eval shared
- * runner, baseline comparison, and matching harness sources. Unknown flags
- * fall back to their CLI spelling with no explanation.
- */
-const FLAG_COPY: Readonly<Record<string, { label: string; help: string }>> = {
-  runs: {
-    label: 'Runs per case',
-    help: 'How many times every case is executed; 3 lets flaky behavior show up.',
-  },
-  case: {
-    label: 'Case filter',
-    help: 'Only run cases whose id contains this text.',
-  },
-  rule: {
-    label: 'Rule filter',
-    help: 'Only run cases whose scoring rule contains this text.',
-  },
-  tier: {
-    label: 'Tier filter',
-    help: 'Only run cases from this corpus tier.',
-  },
-  alpha: {
-    label: 'Significance level',
-    help: 'How strict the regression test against the baseline is — smaller is stricter (default 0.05).',
-  },
-  attemptTimeoutMs: {
-    label: 'Attempt timeout (ms)',
-    help: 'Cancel a single model attempt after this many milliseconds.',
-  },
-  noJudge: {
-    label: 'Skip the judge model',
-    help: 'Every judgment auto-passes — fast and free, but scores say nothing about judgment quality.',
-  },
-  strictEvidence: {
-    label: 'Strict evidence',
-    help: 'Fail the run when any requested case run is incomplete, instead of recording partial evidence.',
-  },
-};
+const EMPTY_FLAGS: RunFlags = {};
 
 export function Launch() {
   const navigate = useNavigate();
@@ -94,14 +51,11 @@ export function Launch() {
     savedConfigs: [],
     metadata: null,
     selectedHarness: null,
-    // The configs page links here as /launch?profile=<name>.
-    selectedProfile: searchParams.get('profile') ?? 'default',
     ab: false,
-    referenceProfile: 'default',
-    candidateProfile: 'default',
-    referenceOverrides: EMPTY_SIDE,
-    candidateOverrides: EMPTY_SIDE,
-    flags: {},
+    profile: { reference: 'default', candidate: 'default' },
+    models: { reference: {}, candidate: {} },
+    scoring: { reference: EMPTY_FLAGS, candidate: EMPTY_FLAGS },
+    selection: EMPTY_FLAGS,
     awaitingConfirmation: false,
     savingConfig: false,
     configName: '',
@@ -113,39 +67,35 @@ export function Launch() {
 
   useEffect(() => {
     let mounted = true;
+    const requested = searchParams.get('harness');
 
     Promise.all([api.harnesses(), api.profiles()])
       .then(([harnesses, profiles]) => {
-        if (mounted) {
-          const firstHarness = harnesses.harnesses[0] ?? null;
-          setState((prev) => ({
-            ...prev,
-            harnesses: harnesses.harnesses,
-            profiles: profiles.profiles,
-            selectedHarness: firstHarness,
-          }));
-        }
+        if (!mounted) return;
+        const selected =
+          harnesses.harnesses.find((h) => h.harness === requested) ?? harnesses.harnesses[0] ?? null;
+        setState((prev) => ({
+          ...prev,
+          harnesses: harnesses.harnesses,
+          profiles: profiles.profiles,
+          selectedHarness: selected,
+        }));
       })
       .catch((error) => {
-        if (mounted) {
-          setState((prev) => ({
-            ...prev,
-            error: error instanceof Error ? error.message : String(error),
-          }));
-        }
+        if (!mounted) return;
+        setState((prev) => ({
+          ...prev,
+          error: error instanceof Error ? error.message : String(error),
+        }));
       });
 
-    // Saved configs enhance the form but must never break it: failures are swallowed.
+    // Saved configs and copy metadata enhance the form but must never break it.
     api
       .configs()
       .then((result) => {
-        if (!mounted) return;
-        const saved = result.saved ?? [];
-        setState((prev) => ({ ...prev, savedConfigs: saved }));
+        if (mounted) setState((prev) => ({ ...prev, savedConfigs: result.saved ?? [] }));
       })
       .catch(() => {});
-    // Guided-editing metadata (flag descriptions, agent roles, model blurbs).
-    // Without it the guided sections hide; the plain form keeps working.
     api
       .configMetadata()
       .then((result) => {
@@ -154,6 +104,7 @@ export function Launch() {
           env: result.env ?? [],
           models: result.models ?? [],
           harnessAgents: result.harnessAgents ?? {},
+          flags: result.flags ?? [],
         };
         setState((prev) => ({ ...prev, metadata }));
       })
@@ -162,178 +113,166 @@ export function Launch() {
     return () => {
       mounted = false;
     };
-  }, []);
+  }, [searchParams]);
 
   const handleHarnessChange = (harness: string) => {
     const descriptor = state.harnesses.find((h) => h.harness === harness) ?? null;
     setState((prev) => ({
       ...prev,
       selectedHarness: descriptor,
-      flags: {},
-      // Overrides name agents; a different harness exercises different agents.
-      referenceOverrides: EMPTY_SIDE,
-      candidateOverrides: EMPTY_SIDE,
+      // Model overrides name agents, and flags are per harness: both reset.
+      models: { reference: {}, candidate: {} },
+      scoring: { reference: EMPTY_FLAGS, candidate: EMPTY_FLAGS },
+      selection: EMPTY_FLAGS,
       awaitingConfirmation: false,
       launchError: null,
     }));
   };
 
-  const handleProfileChange = (profile: string) => {
+  /** Assigns one flag while preserving RunFlags' key/value type relation. */
+  const withFlag = (
+    flags: RunFlags,
+    name: HarnessFlag['name'],
+    value: string | number | boolean | undefined,
+  ): RunFlags => {
+    const next: RunFlags = { ...flags };
+    if (value === undefined) {
+      delete next[name];
+      return next;
+    }
+    switch (name) {
+      case 'runs':
+        next.runs = value as number;
+        break;
+      case 'tier':
+        next.tier = value as number;
+        break;
+      case 'alpha':
+        next.alpha = value as number;
+        break;
+      case 'attemptTimeoutMs':
+        next.attemptTimeoutMs = value as number;
+        break;
+      case 'case':
+        next.case = value as string;
+        break;
+      case 'rule':
+        next.rule = value as string;
+        break;
+      case 'noJudge':
+        next.noJudge = value as boolean;
+        break;
+      case 'strictEvidence':
+        next.strictEvidence = value as boolean;
+        break;
+    }
+    return next;
+  };
+
+  const handleSelectionChange = (
+    name: HarnessFlag['name'],
+    value: string | number | boolean | undefined,
+  ) => {
     setState((prev) => ({
       ...prev,
-      selectedProfile: profile,
+      selection: withFlag(prev.selection, name, value),
       awaitingConfirmation: false,
       launchError: null,
     }));
   };
 
-  const handleFlagChange = (name: HarnessFlag['name'], value: string | number | boolean | undefined) => {
-    setState((prev) => {
-      const flags: RunFlags = { ...prev.flags };
-      if (value === undefined) {
-        delete flags[name];
-      } else {
-        // Discriminated assignment preserves the key/value type relation that a
-        // computed-key Object.assign would defeat.
-        switch (name) {
-          case 'runs':
-            flags.runs = value as number;
-            break;
-          case 'tier':
-            flags.tier = value as number;
-            break;
-          case 'alpha':
-            flags.alpha = value as number;
-            break;
-          case 'attemptTimeoutMs':
-            flags.attemptTimeoutMs = value as number;
-            break;
-          case 'case':
-            flags.case = value as string;
-            break;
-          case 'rule':
-            flags.rule = value as string;
-            break;
-          case 'noJudge':
-            flags.noJudge = value as boolean;
-            break;
-          case 'strictEvidence':
-            flags.strictEvidence = value as boolean;
-            break;
-        }
-      }
-      return { ...prev, flags, awaitingConfirmation: false, launchError: null };
-    });
+  const handleScoringChange = (
+    side: Side,
+    name: HarnessFlag['name'],
+    value: string | number | boolean | undefined,
+  ) => {
+    setState((prev) => ({
+      ...prev,
+      scoring: { ...prev.scoring, [side]: withFlag(prev.scoring[side], name, value) },
+      awaitingConfirmation: false,
+      launchError: null,
+    }));
   };
 
-  const isFullCorpus = (): boolean => {
-    const selectionFlags = ['case', 'rule', 'tier'] as const;
-    return !selectionFlags.some((name) => state.flags[name] !== undefined);
-  };
+  const isFullCorpus = (): boolean =>
+    !(['case', 'rule', 'tier'] as const).some((name) => state.selection[name] !== undefined);
 
   /**
-   * A selection value beginning with "-" would arrive at the harness's parser
-   * looking like a flag. The server rejects it (SelectionValueSchema); the form
-   * says so and refuses to submit rather than silently discarding the keystroke.
+   * A selection value beginning with "-" would reach the harness parser looking
+   * like a flag. The server rejects it; the form says so rather than silently
+   * discarding the keystroke.
    */
-  const invalidSelectionFlags = (Object.entries(state.flags) as [string, unknown][])
+  const invalidSelectionFlags = (Object.entries(state.selection) as [string, unknown][])
     .filter(([, value]) => typeof value === 'string' && value.startsWith('-'))
     .map(([name]) => state.selectedHarness?.flags.find((flag) => flag.name === name)?.cli ?? `--${name}`);
 
-  /**
-   * Overrides are only expressible on top of the default configuration — the
-   * server refuses a named profile combined with overrides, so the form never
-   * offers the combination.
-   */
-  const buildSpec = (profile: string, side: SideOverrides): EvalRunSpec => {
-    const env = envRowsToOverrides(side.envRows);
-    const hasModels = Object.keys(side.models).length > 0;
-    const hasEnv = Object.keys(env).length > 0;
+  const buildSpec = (side: Side): EvalRunSpec => {
+    const profile = state.profile[side];
+    const models = state.models[side];
     return {
       kind: 'eval',
       harness: state.selectedHarness!.harness,
       profile,
-      flags: state.flags,
-      ...(profile === 'default' && (hasModels || hasEnv)
-        ? { overrides: { models: side.models, env } }
+      flags: { ...state.selection, ...state.scoring[side] },
+      ...(profile === 'default' && Object.keys(models).length > 0
+        ? { overrides: { models, env: {} } }
         : {}),
     };
   };
 
   const handleRun = () => {
-    if (launchBlocked) return;
+    if (launchBlocked || state.selectedHarness === null) return;
 
     if (isFullCorpus() && !state.awaitingConfirmation) {
       setState((prev) => ({ ...prev, awaitingConfirmation: true }));
       return;
     }
 
-    if (state.selectedHarness === null) {
-      setState((prev) => ({ ...prev, error: 'No harness selected' }));
-      return;
-    }
+    const fail = (error: unknown) =>
+      setState((prev) => ({
+        ...prev,
+        launchError: error instanceof Error ? error.message : String(error),
+        awaitingConfirmation: false,
+      }));
 
     if (state.ab) {
-      // Reference first, candidate second: they serialise through the run
-      // queue, which keeps the comparison fair on one machine.
-      const referenceSpec = buildSpec(state.referenceProfile, state.referenceOverrides);
-      const candidateSpec = buildSpec(state.candidateProfile, state.candidateOverrides);
+      // Reference first, candidate second: they serialise through the run queue,
+      // which keeps the comparison fair on one machine.
+      const referenceSpec = buildSpec('reference');
+      const candidateSpec = buildSpec('candidate');
       api
         .launch(referenceSpec)
-        .then((reference) =>
-          api.launch(candidateSpec).then((candidate) => ({ reference, candidate })),
-        )
+        .then((reference) => api.launch(candidateSpec).then((candidate) => ({ reference, candidate })))
         .then(({ reference, candidate }) => {
           navigate(`/compare?referenceRun=${reference.id}&subjectRun=${candidate.id}`);
         })
-        .catch((error) => {
-          setState((prev) => ({
-            ...prev,
-            launchError: error instanceof Error ? error.message : String(error),
-            awaitingConfirmation: false,
-          }));
-        });
+        .catch(fail);
       return;
     }
 
-    const spec = buildSpec(state.selectedProfile, state.referenceOverrides);
-
     api
-      .launch(spec)
-      .then((record) => {
-        navigate(`/r/${record.id}`);
-      })
-      .catch((error) => {
-        // The form stays mounted: every entered flag survives a rejected launch.
-        setState((prev) => ({
-          ...prev,
-          launchError: error instanceof Error ? error.message : String(error),
-          awaitingConfirmation: false,
-        }));
-      });
+      .launch(buildSpec('reference'))
+      .then((record) => navigate(`/r/${record.id}`))
+      .catch(fail);
   };
 
   const handleSaveConfig = () => {
     const name = state.configName.trim();
     const description = state.configDescription.trim();
-    const env = envRowsToOverrides(state.referenceOverrides.envRows);
-    const hasValues = Object.keys(state.referenceOverrides.models).length > 0 || Object.keys(env).length > 0;
-    if (name === '' || description === '' || !hasValues) return;
-    const profile: ConfigProfile = { name, description, models: state.referenceOverrides.models, env };
+    const models = state.models.reference;
+    if (name === '' || description === '' || Object.keys(models).length === 0) return;
     api
-      .createConfig(profile)
+      .createConfig({ name, description, models, env: {} })
       .then((created) => {
         setState((prev) => ({
           ...prev,
           savedConfigs: [...prev.savedConfigs, created],
-          selectedProfile: created.name,
+          profile: { ...prev.profile, reference: created.name },
+          models: { ...prev.models, reference: {} },
           savingConfig: false,
           configName: '',
           configDescription: '',
           saveError: null,
-          // The overrides now live in the saved config; the editors reset.
-          referenceOverrides: EMPTY_SIDE,
-          candidateOverrides: EMPTY_SIDE,
         }));
       })
       .catch((error) => {
@@ -342,10 +281,6 @@ export function Launch() {
           saveError: error instanceof Error ? error.message : String(error),
         }));
       });
-  };
-
-  const handleCancelConfirmation = () => {
-    setState((prev) => ({ ...prev, awaitingConfirmation: false }));
   };
 
   if (state.error !== null) {
@@ -368,363 +303,276 @@ export function Launch() {
     );
   }
 
-  const isExperimental = state.selectedProfile !== 'default';
-  const overridesAllowed = state.selectedProfile === 'default';
-  const fullCorpus = isFullCorpus();
-  const runs = state.flags.runs ?? state.selectedHarness?.defaultRuns ?? 0;
-  // The same first factor renderRun uses: a narrowed selection runs exactly one case.
-  const cases = state.selectedHarness === null ? 0 : fullCorpus ? state.selectedHarness.caseCount : 1;
-  const workload = cases * runs * (state.ab ? 2 : 1);
-
-  // Guided-editing inputs derived from the metadata (empty when unavailable).
   const harnessId = state.selectedHarness?.harness ?? null;
   const agents: readonly AgentMeta[] =
     harnessId === null ? [] : (state.metadata?.harnessAgents[harnessId] ?? []);
   const guidedModels: readonly ModelMeta[] = state.metadata?.models ?? [];
-  const envFlags: readonly EnvFlagMeta[] = state.metadata?.env ?? [];
-  // The default option in each model dropdown names what the default profile assigns.
+  const flagMeta: readonly FlagMeta[] = state.metadata?.flags ?? [];
   const profileDefaults = state.profiles.find((p) => p.name === 'default')?.models ?? {};
 
-  // Only visible env editors participate in validity; hidden ones cannot block.
-  const envValidity = (profile: string, side: SideOverrides): boolean =>
-    profile === 'default' && envFlags.length > 0 ? side.envValid : true;
-  const envInputValid = state.ab
-    ? envValidity(state.referenceProfile, state.referenceOverrides) &&
-      envValidity(state.candidateProfile, state.candidateOverrides)
-    : envValidity(state.selectedProfile, state.referenceOverrides);
+  const harnessFlags = state.selectedHarness?.flags ?? [];
+  const metaFor = (name: string): FlagMeta | undefined => flagMeta.find((f) => f.name === name);
+  const selectionFlags = harnessFlags.filter((flag) =>
+    (SELECTION_FLAGS as readonly string[]).includes(flag.name),
+  );
+  const scoringFlags = harnessFlags.filter(
+    (flag) => !(SELECTION_FLAGS as readonly string[]).includes(flag.name),
+  );
 
-  const launchBlocked = invalidSelectionFlags.length > 0 || !envInputValid;
-  // Saving carries the same env overrides a run would, so an invalid value must
-  // block the save too — otherwise POST /api/configs 400s on a value the editor
-  // has already flagged inline.
+  const fullCorpus = isFullCorpus();
+  const runs = state.selection.runs ?? state.selectedHarness?.defaultRuns ?? 0;
+  const cases = state.selectedHarness === null ? 0 : fullCorpus ? state.selectedHarness.caseCount : 1;
+  const workload = cases * runs * (state.ab ? 2 : 1);
+
+  // Scoring differences are legitimate to compare but change what a verdict
+  // means, so the form says so instead of presenting the diff as like-for-like.
+  const scoringDiffers =
+    state.ab && JSON.stringify(state.scoring.reference) !== JSON.stringify(state.scoring.candidate);
+
+  const launchBlocked = invalidSelectionFlags.length > 0;
   const saveConfigBlocked =
-    state.configName.trim() === '' || state.configDescription.trim() === '' || !envInputValid;
-  const singleEnv = envRowsToOverrides(state.referenceOverrides.envRows);
+    state.configName.trim() === '' ||
+    state.configDescription.trim() === '' ||
+    Object.keys(state.models.reference).length === 0;
   const showSaveConfig =
-    overridesAllowed &&
-    (Object.keys(state.referenceOverrides.models).length > 0 || Object.keys(singleEnv).length > 0);
+    !state.ab &&
+    state.profile.reference === 'default' &&
+    Object.keys(state.models.reference).length > 0;
 
   const sideProps = {
     agents,
     guidedModels,
     profileDefaults,
-    envFlags,
+    scoringFlags,
+    metaFor,
     profiles: state.profiles,
     savedConfigs: state.savedConfigs,
   };
 
   return (
     <div className="p-4">
-      <Frame label={state.ab ? 'launch a/b run' : 'launch run'}>
+      <Frame label={state.ab ? 'launch a/b' : 'launch'}>
         <div className="space-y-4">
-          <div>
-            <label htmlFor="harness" className="block mb-1">
-              Harness
-            </label>
-            <select
-              id="harness"
-              className="w-full bg-term-bg border border-term-rule px-[1ch] py-[0.5lh]"
-              value={state.selectedHarness?.harness ?? ''}
-              onChange={(e) => handleHarnessChange(e.target.value)}
-            >
-              {state.harnesses.map((h) => (
-                <option key={h.harness} value={h.harness}>
-                  {h.harness}
-                </option>
-              ))}
-            </select>
-            {state.selectedHarness !== null && (
-              <p className="text-term-dim mt-1">
-                {state.selectedHarness.question} {state.selectedHarness.detail}
-              </p>
-            )}
-          </div>
-
-          <div>
-            <label className="flex items-center gap-2">
+          <div className="flex items-baseline justify-between gap-4">
+            <div className="flex items-baseline gap-2">
+              <select
+                aria-label="Harness"
+                className="bg-term-bg border border-term-rule px-[1ch] py-[0.5lh]"
+                value={state.selectedHarness?.harness ?? ''}
+                onChange={(e) => handleHarnessChange(e.target.value)}
+              >
+                {state.harnesses.map((h) => (
+                  <option key={h.harness} value={h.harness}>
+                    {h.harness}
+                  </option>
+                ))}
+              </select>
+              {state.selectedHarness !== null && (
+                <span className="text-term-dim">
+                  {state.selectedHarness.caseCount} cases · {state.selectedHarness.question}
+                </span>
+              )}
+            </div>
+            <label className="flex items-center gap-2 shrink-0">
               <input
                 type="checkbox"
                 checked={state.ab}
-                onChange={(e) => {
-                  const ab = e.target.checked;
+                onChange={(e) =>
                   setState((prev) => ({
                     ...prev,
-                    ab,
-                    // The single-mode profile is the reference side's starting point.
-                    referenceProfile: ab ? prev.selectedProfile : prev.referenceProfile,
+                    ab: e.target.checked,
                     awaitingConfirmation: false,
                     launchError: null,
-                  }));
-                }}
+                  }))
+                }
               />
-              <span>A/B — compare two configurations</span>
+              <span>A/B</span>
             </label>
-            {state.ab && (
-              <p className="text-term-dim mt-1">
-                Two runs back to back — reference first, then candidate — with the comparison shown
-                when both end.
-              </p>
-            )}
           </div>
 
-          {!state.ab && (
-            <div className="space-y-3">
-              <h3 className="text-term-cyan">What controls this run</h3>
-              <div>
-                <label htmlFor="profile" className="block mb-1">
-                  Configuration profile
-                </label>
-                <select
-                  id="profile"
-                  className="w-full bg-term-bg border border-term-rule px-[1ch] py-[0.5lh]"
-                  value={state.selectedProfile}
-                  onChange={(e) => handleProfileChange(e.target.value)}
-                >
-                  {state.profiles.map((p) => (
-                    <option key={p.name} value={p.name}>
-                      {p.name} — {p.description}
-                    </option>
-                  ))}
-                  {state.savedConfigs.map((p) => (
-                    <option key={p.name} value={p.name}>
-                      {p.name} (saved) — {p.description}
-                    </option>
-                  ))}
-                </select>
-                <p className="text-term-dim mt-1">The named configuration this run executes under.</p>
-                {isExperimental && (
-                  <p className="mt-2 text-term-yellow">
-                    Experimental — forced to --no-save and never diffed against the committed baseline.
-                  </p>
-                )}
-              </div>
-
-              {overridesAllowed && agents.length > 0 && (
-                <ModelOverrideEditor
-                  agents={agents}
-                  models={guidedModels}
-                  profileDefaults={profileDefaults}
-                  value={state.referenceOverrides.models}
-                  onChange={(models) =>
-                    setState((prev) => ({
-                      ...prev,
-                      referenceOverrides: { ...prev.referenceOverrides, models },
-                    }))
-                  }
-                />
-              )}
-              {!overridesAllowed && (
-                <p className="text-term-dim">
-                  Overrides apply on top of the default configuration. To tweak a saved config,{' '}
-                  <Link to="/profiles" className="text-term-cyan underline">
-                    edit it on the configs page
-                  </Link>
-                  .
-                </p>
-              )}
-
-              {showSaveConfig && !state.savingConfig && (
-                <button
-                  type="button"
-                  className="px-[2ch] py-[0.5lh] border border-term-rule text-term-dim"
-                  onClick={() => setState((prev) => ({ ...prev, savingConfig: true, saveError: null }))}
-                >
-                  save as config…
-                </button>
-              )}
-              {state.savingConfig && (
-                <div className="space-y-2 border border-term-rule p-2">
-                  <div>
-                    <label htmlFor="config-name" className="block mb-1 text-term-dim">
-                      config name
-                    </label>
-                    <input
-                      id="config-name"
-                      type="text"
-                      placeholder="kebab-case-name"
-                      className="w-full bg-term-bg border border-term-rule px-[1ch] py-[0.5lh]"
-                      value={state.configName}
-                      onChange={(e) => setState((prev) => ({ ...prev, configName: e.target.value }))}
-                    />
-                  </div>
-                  <div>
-                    <label htmlFor="config-description" className="block mb-1 text-term-dim">
-                      config description
-                    </label>
-                    <input
-                      id="config-description"
-                      type="text"
-                      placeholder="what this config is for"
-                      className="w-full bg-term-bg border border-term-rule px-[1ch] py-[0.5lh]"
-                      value={state.configDescription}
-                      onChange={(e) =>
-                        setState((prev) => ({ ...prev, configDescription: e.target.value }))
-                      }
-                    />
-                  </div>
-                  {state.saveError !== null && (
-                    <p role="alert" className="text-term-red">
-                      {state.saveError}
-                    </p>
-                  )}
-                  <div className="flex gap-2">
-                    <button
-                      type="button"
-                      className="px-[2ch] py-[0.5lh] bg-term-cyan text-term-bg font-bold disabled:opacity-50"
-                      disabled={saveConfigBlocked}
-                      onClick={handleSaveConfig}
-                    >
-                      Save config
-                    </button>
-                    <button
-                      type="button"
-                      className="px-[2ch] py-[0.5lh] border border-term-rule"
-                      onClick={() =>
-                        setState((prev) => ({ ...prev, savingConfig: false, saveError: null }))
-                      }
-                    >
-                      Cancel
-                    </button>
-                  </div>
-                </div>
-              )}
-            </div>
-          )}
-
-          {state.ab && (
-            <div className="space-y-4">
-              <AbSide
+          {state.ab ? (
+            <div className="grid grid-cols-2 gap-4">
+              <ConfigColumn
                 side="reference"
-                profile={state.referenceProfile}
-                overrides={state.referenceOverrides}
+                heading="A · reference"
+                profile={state.profile.reference}
+                models={state.models.reference}
+                scoring={state.scoring.reference}
                 {...sideProps}
                 onProfileChange={(profile) =>
                   setState((prev) => ({
                     ...prev,
-                    referenceProfile: profile,
-                    awaitingConfirmation: false,
+                    profile: { ...prev.profile, reference: profile },
                     launchError: null,
                   }))
                 }
-                onOverridesChange={(next) =>
-                  setState((prev) => ({ ...prev, referenceOverrides: next }))
+                onModelsChange={(models) =>
+                  setState((prev) => ({ ...prev, models: { ...prev.models, reference: models } }))
                 }
+                onScoringChange={(name, value) => handleScoringChange('reference', name, value)}
               />
-              <AbSide
+              <ConfigColumn
                 side="candidate"
-                profile={state.candidateProfile}
-                overrides={state.candidateOverrides}
+                heading="B · candidate"
+                profile={state.profile.candidate}
+                models={state.models.candidate}
+                scoring={state.scoring.candidate}
                 {...sideProps}
                 onProfileChange={(profile) =>
                   setState((prev) => ({
                     ...prev,
-                    candidateProfile: profile,
-                    awaitingConfirmation: false,
+                    profile: { ...prev.profile, candidate: profile },
                     launchError: null,
                   }))
                 }
-                onOverridesChange={(next) =>
-                  setState((prev) => ({ ...prev, candidateOverrides: next }))
+                onModelsChange={(models) =>
+                  setState((prev) => ({ ...prev, models: { ...prev.models, candidate: models } }))
                 }
+                onScoringChange={(name, value) => handleScoringChange('candidate', name, value)}
               />
             </div>
+          ) : (
+            <ConfigColumn
+              side="reference"
+              heading={null}
+              profile={state.profile.reference}
+              models={state.models.reference}
+              scoring={state.scoring.reference}
+              {...sideProps}
+              onProfileChange={(profile) =>
+                setState((prev) => ({
+                  ...prev,
+                  profile: { ...prev.profile, reference: profile },
+                  launchError: null,
+                }))
+              }
+              onModelsChange={(models) =>
+                setState((prev) => ({ ...prev, models: { ...prev.models, reference: models } }))
+              }
+              onScoringChange={(name, value) => handleScoringChange('reference', name, value)}
+            />
           )}
 
-          {state.selectedHarness !== null && (
-            <details>
-              <summary className="cursor-pointer text-term-cyan">Advanced options</summary>
-              <div className="mt-2 space-y-3">
-                {state.selectedHarness.flags.map((flag) => (
-                  <FlagInput
+          {scoringDiffers && (
+            <p className="text-term-yellow">
+              The two sides score differently, so their results are not like-for-like.
+            </p>
+          )}
+
+          {selectionFlags.length > 0 && (
+            <div className="border-t border-term-rule pt-3">
+              <p className="text-term-dim mb-2">
+                What gets tested{state.ab ? ' — shared by both sides' : ''}
+              </p>
+              <div className="grid grid-cols-2 gap-x-4 gap-y-2 md:grid-cols-4">
+                {selectionFlags.map((flag) => (
+                  <FlagField
                     key={flag.name}
                     flag={flag}
-                    value={state.flags[flag.name]}
-                    onChange={(value) => handleFlagChange(flag.name, value)}
+                    meta={metaFor(flag.name)}
+                    value={state.selection[flag.name]}
+                    onChange={(value) => handleSelectionChange(flag.name, value)}
                   />
                 ))}
               </div>
-            </details>
+            </div>
           )}
 
-          {!state.ab && overridesAllowed && envFlags.length > 0 && (
-            <details>
-              <summary className="cursor-pointer text-term-cyan">
-                Advanced: live-pipeline flags
-              </summary>
-              <div className="mt-2 space-y-3">
-                <p className="text-term-dim">
-                  These flags tune the live discovery and negotiation services. This scorecard
-                  harness does not read them — they are recorded with the run for staging work.
+          {showSaveConfig && !state.savingConfig && (
+            <button
+              type="button"
+              className="px-[2ch] py-[0.5lh] border border-term-rule text-term-dim"
+              onClick={() => setState((prev) => ({ ...prev, savingConfig: true, saveError: null }))}
+            >
+              save as config…
+            </button>
+          )}
+          {state.savingConfig && (
+            <div className="space-y-2 border border-term-rule p-2">
+              <input
+                aria-label="config name"
+                type="text"
+                placeholder="kebab-case-name"
+                className="w-full bg-term-bg border border-term-rule px-[1ch] py-[0.5lh]"
+                value={state.configName}
+                onChange={(e) => setState((prev) => ({ ...prev, configName: e.target.value }))}
+              />
+              <input
+                aria-label="config description"
+                type="text"
+                placeholder="what this config is for"
+                className="w-full bg-term-bg border border-term-rule px-[1ch] py-[0.5lh]"
+                value={state.configDescription}
+                onChange={(e) => setState((prev) => ({ ...prev, configDescription: e.target.value }))}
+              />
+              {state.saveError !== null && (
+                <p role="alert" className="text-term-red">
+                  {state.saveError}
                 </p>
-                <GuidedEnvEditor
-                  flags={envFlags}
-                  rows={state.referenceOverrides.envRows}
-                  onChange={(envRows, envValid) =>
-                    setState((prev) => ({
-                      ...prev,
-                      referenceOverrides: { ...prev.referenceOverrides, envRows, envValid },
-                    }))
-                  }
-                />
+              )}
+              <div className="flex gap-2">
+                <button
+                  type="button"
+                  className="px-[2ch] py-[0.5lh] bg-term-cyan text-term-bg font-bold disabled:opacity-50"
+                  disabled={saveConfigBlocked}
+                  onClick={handleSaveConfig}
+                >
+                  Save config
+                </button>
+                <button
+                  type="button"
+                  className="px-[2ch] py-[0.5lh] border border-term-rule"
+                  onClick={() => setState((prev) => ({ ...prev, savingConfig: false, saveError: null }))}
+                >
+                  Cancel
+                </button>
               </div>
-            </details>
+            </div>
           )}
 
-          <div className="border-t border-term-rule pt-4 mt-4">
-            <p className="mb-2">
-              <span className="text-term-dim">Workload: </span>
-              {cases} {cases === 1 ? 'case' : 'cases'}
-              {fullCorpus ? '' : ' (filtered)'} × {runs} runs{state.ab ? ' × 2 sides' : ''} = {workload}
-            </p>
-
-            {invalidSelectionFlags.length > 0 && (
-              <p className="mb-2 text-term-red">
-                Fix {invalidSelectionFlags.join(', ')} before running.
+          <div className="border-t border-term-rule pt-3 flex items-center justify-between gap-4">
+            <div>
+              <p>
+                <span className="text-term-dim">Workload: </span>
+                {cases} {cases === 1 ? 'case' : 'cases'}
+                {fullCorpus ? '' : ' (filtered)'} × {runs} runs{state.ab ? ' × 2 sides' : ''} ={' '}
+                {workload}
               </p>
-            )}
-
-            {!envInputValid && (
-              <p className="mb-2 text-term-red">
-                Finish or fix the flag override above to launch.
-              </p>
-            )}
-
-            {state.launchError !== null && (
-              <p role="alert" className="mb-2 text-term-red">
-                Launch refused: {state.launchError}
-              </p>
-            )}
-
-            {state.awaitingConfirmation ? (
-              <div className="space-y-2">
+              {invalidSelectionFlags.length > 0 && (
+                <p className="text-term-red">Fix {invalidSelectionFlags.join(', ')} before running.</p>
+              )}
+              {state.launchError !== null && (
+                <p role="alert" className="text-term-red">
+                  Launch refused: {state.launchError}
+                </p>
+              )}
+              {state.awaitingConfirmation && (
                 <p className="text-term-yellow">
                   Confirm full-corpus run: {workload} model invocations
                 </p>
-                <div className="flex gap-2">
-                  <button
-                    onClick={handleRun}
-                    disabled={launchBlocked}
-                    className="px-[2ch] py-[0.5lh] bg-term-green text-term-bg font-bold disabled:opacity-50"
-                  >
-                    Confirm and Run
-                  </button>
-                  <button
-                    onClick={handleCancelConfirmation}
-                    className="px-[2ch] py-[0.5lh] border border-term-rule"
-                  >
-                    Cancel
-                  </button>
-                </div>
-              </div>
-            ) : (
+              )}
+            </div>
+            <div className="flex gap-2 shrink-0">
+              {state.awaitingConfirmation && (
+                <button
+                  onClick={() => setState((prev) => ({ ...prev, awaitingConfirmation: false }))}
+                  className="px-[2ch] py-[0.5lh] border border-term-rule"
+                >
+                  Cancel
+                </button>
+              )}
               <button
                 onClick={handleRun}
                 disabled={launchBlocked}
-                className="px-[2ch] py-[0.5lh] bg-term-cyan text-term-bg font-bold disabled:opacity-50"
+                className={`px-[2ch] py-[0.5lh] font-bold disabled:opacity-50 ${
+                  state.awaitingConfirmation
+                    ? 'bg-term-green text-term-bg'
+                    : 'bg-term-cyan text-term-bg'
+                }`}
               >
-                Run
+                {state.awaitingConfirmation ? 'Confirm and Run' : state.ab ? 'Run A/B' : 'Run'}
               </button>
-            )}
+            </div>
           </div>
         </div>
       </Frame>
@@ -733,191 +581,170 @@ export function Launch() {
 }
 
 /**
- * One side of an A/B launch: its own profile select (repo profiles, then saved
- * configs), its own model editor, and its own live-pipeline env disclosure.
- * Overrides are only expressible on top of the default configuration — the
- * server refuses a named profile combined with overrides — so a named profile
- * replaces the editors with the configs-page pointer.
+ * One configuration: the named config it runs under, the model each agent uses,
+ * and the flags that change how the run is scored. In A/B two of these sit side
+ * by side and only their differences matter.
  */
-function AbSide({
-  side,
-  profile,
-  overrides,
-  agents,
-  guidedModels,
-  profileDefaults,
-  envFlags,
-  profiles,
-  savedConfigs,
-  onProfileChange,
-  onOverridesChange,
-}: {
-  side: 'reference' | 'candidate';
+function ConfigColumn(props: {
+  side: Side;
+  /** Column title in A/B; null in single mode, where there is nothing to name. */
+  heading: string | null;
   profile: string;
-  overrides: SideOverrides;
+  models: Record<string, string>;
+  scoring: RunFlags;
   agents: readonly AgentMeta[];
   guidedModels: readonly ModelMeta[];
   profileDefaults: Record<string, string>;
-  envFlags: readonly EnvFlagMeta[];
-  profiles: ProfileDescriptor[];
-  savedConfigs: ConfigProfile[];
+  scoringFlags: readonly HarnessFlag[];
+  metaFor: (name: string) => FlagMeta | undefined;
+  profiles: readonly ProfileDescriptor[];
+  savedConfigs: readonly ConfigProfile[];
   onProfileChange: (profile: string) => void;
-  onOverridesChange: (next: SideOverrides) => void;
+  onModelsChange: (models: Record<string, string>) => void;
+  onScoringChange: (name: HarnessFlag['name'], value: string | number | boolean | undefined) => void;
 }) {
+  const {
+    side,
+    heading,
+    profile,
+    models,
+    scoring,
+    agents,
+    guidedModels,
+    profileDefaults,
+    scoringFlags,
+    metaFor,
+    profiles,
+    savedConfigs,
+    onProfileChange,
+    onModelsChange,
+    onScoringChange,
+  } = props;
+  const overridesAllowed = profile === 'default';
+  // The config picker only earns its space once there is something to pick.
+  const showProfilePicker = savedConfigs.length > 0 || profiles.length > 1;
+
   return (
-    <fieldset aria-label={side} className="border border-term-rule p-2 space-y-3">
-      <legend className="px-[1ch] text-term-dim">{side}</legend>
-      <div>
-        <label htmlFor={`${side}-profile`} className="block mb-1">
-          profile
-        </label>
-        <select
-          id={`${side}-profile`}
-          className="w-full bg-term-bg border border-term-rule px-[1ch] py-[0.5lh]"
-          value={profile}
-          onChange={(e) => onProfileChange(e.target.value)}
-        >
-          {profiles.map((p) => (
-            <option key={p.name} value={p.name}>
-              {p.name} — {p.description}
-            </option>
-          ))}
-          {savedConfigs.map((p) => (
-            <option key={p.name} value={p.name}>
-              {p.name} (saved) — {p.description}
-            </option>
-          ))}
-        </select>
-      </div>
-      {profile !== 'default' && (
-        <p className="text-term-yellow">
-          Experimental — forced to --no-save and never diffed against the committed baseline.
-        </p>
+    <div className={heading === null ? 'space-y-3' : 'border border-term-rule p-3 space-y-3'}>
+      {heading !== null && <p className="text-term-cyan">{heading}</p>}
+
+      {showProfilePicker && (
+        <div>
+          <label htmlFor={`${side}-profile`} className="block mb-1 text-term-dim">
+            Config
+          </label>
+          <select
+            id={`${side}-profile`}
+            className="w-full bg-term-bg border border-term-rule px-[1ch] py-[0.5lh]"
+            value={profile}
+            onChange={(e) => onProfileChange(e.target.value)}
+          >
+            {profiles.map((p) => (
+              <option key={p.name} value={p.name}>
+                {p.name}
+              </option>
+            ))}
+            {savedConfigs.map((p) => (
+              <option key={p.name} value={p.name}>
+                {p.name} (saved)
+              </option>
+            ))}
+          </select>
+        </div>
       )}
-      {profile === 'default' ? (
-        <>
-          {agents.length > 0 && (
-            <ModelOverrideEditor
-              agents={agents}
-              models={guidedModels}
-              profileDefaults={profileDefaults}
-              value={overrides.models}
-              onChange={(models) => onOverridesChange({ ...overrides, models })}
-            />
-          )}
-          {envFlags.length > 0 && (
-            <details>
-              <summary className="cursor-pointer text-term-cyan">
-                Advanced: live-pipeline flags
-              </summary>
-              <div className="mt-2 space-y-3">
-                <p className="text-term-dim">
-                  These flags tune the live discovery and negotiation services. This scorecard
-                  harness does not read them — they are recorded with the run for staging work.
-                </p>
-                <GuidedEnvEditor
-                  flags={envFlags}
-                  rows={overrides.envRows}
-                  onChange={(envRows, envValid) => onOverridesChange({ ...overrides, envRows, envValid })}
-                />
-              </div>
-            </details>
-          )}
-        </>
-      ) : (
+
+      {overridesAllowed && agents.length > 0 && (
+        <ModelOverrideEditor
+          agents={agents}
+          models={guidedModels}
+          profileDefaults={profileDefaults}
+          value={models}
+          onChange={onModelsChange}
+        />
+      )}
+      {!overridesAllowed && (
         <p className="text-term-dim">
-          Overrides apply on top of the default configuration. To tweak a saved config,{' '}
+          Runs as saved.{' '}
           <Link to="/profiles" className="text-term-cyan underline">
-            edit it on the configs page
+            Edit this config
           </Link>
           .
         </p>
       )}
-    </fieldset>
+
+      {scoringFlags.length > 0 && (
+        <div className="grid grid-cols-2 gap-x-4 gap-y-2">
+          {scoringFlags.map((flag) => (
+            <FlagField
+              key={flag.name}
+              flag={flag}
+              meta={metaFor(flag.name)}
+              value={scoring[flag.name]}
+              idPrefix={side}
+              onChange={(value) => onScoringChange(flag.name, value)}
+            />
+          ))}
+        </div>
+      )}
+    </div>
   );
 }
 
-function FlagInput({
-  flag,
-  value,
-  onChange,
-}: {
+/**
+ * One flag control: plain-English label, the harness's own bounds, and the
+ * default named in the placeholder so an untouched field reads as "unset"
+ * rather than empty. The description is a title tooltip — visible on demand,
+ * never crowding the grid.
+ */
+function FlagField(props: {
   flag: HarnessFlag;
+  meta: FlagMeta | undefined;
   value: string | number | boolean | undefined;
+  idPrefix?: string;
   onChange: (value: string | number | boolean | undefined) => void;
 }) {
-  const copy = FLAG_COPY[flag.name];
-  const label = copy?.label ?? flag.cli;
+  const { flag, meta, value, idPrefix, onChange } = props;
+  const id = `${idPrefix ?? 'flag'}-${flag.name}`;
+  const label = meta?.label ?? flag.cli;
+  const title = meta?.description;
 
   if (flag.kind === 'boolean') {
     return (
-      <div>
-        <label className="flex items-center gap-2">
-          <input
-            type="checkbox"
-            checked={Boolean(value)}
-            onChange={(e) => onChange(e.target.checked || undefined)}
-          />
-          <span>{label}</span>
-        </label>
-        {copy !== undefined && <p className="mt-1 text-term-dim">{copy.help}</p>}
-      </div>
-    );
-  }
-
-  if (flag.kind === 'number') {
-    return (
-      <div>
-        <label htmlFor={flag.name} className="block mb-1">
-          {label}
-        </label>
+      <label className="flex items-center gap-2" title={title}>
         <input
-          type="number"
-          id={flag.name}
-          className="w-full bg-term-bg border border-term-rule px-[1ch] py-[0.5lh]"
-          value={typeof value === 'number' ? value : ''}
-          onChange={(e) => {
-            const num = e.target.value === '' ? undefined : Number(e.target.value);
-            onChange(num);
-          }}
-          min={flag.min}
-          max={flag.max}
-          step={flag.step}
+          id={id}
+          type="checkbox"
+          checked={value === true}
+          onChange={(e) => onChange(e.target.checked ? true : undefined)}
         />
-        {copy !== undefined && (
-          <p className="mt-1 text-term-dim">
-            {copy.help} <span className="text-term-dim">({flag.cli})</span>
-          </p>
-        )}
-      </div>
+        <span>{label}</span>
+      </label>
     );
   }
 
-  // string kind
-  const invalid = typeof value === 'string' && value.startsWith('-');
   return (
-    <div>
-      <label htmlFor={flag.name} className="block mb-1">
+    <div title={title}>
+      <label htmlFor={id} className="block text-term-dim">
         {label}
       </label>
       <input
-        type="text"
-        id={flag.name}
+        id={id}
+        type={flag.kind === 'number' ? 'number' : 'text'}
+        min={flag.min}
+        max={flag.max}
+        step={flag.step}
+        placeholder={meta?.defaultLabel ?? ''}
         className="w-full bg-term-bg border border-term-rule px-[1ch] py-[0.5lh]"
-        value={typeof value === 'string' ? value : ''}
-        aria-invalid={invalid}
-        onChange={(e) => onChange(e.target.value === '' ? undefined : e.target.value)}
+        value={value === undefined ? '' : String(value)}
+        onChange={(e) => {
+          const raw = e.target.value;
+          if (raw === '') {
+            onChange(undefined);
+            return;
+          }
+          onChange(flag.kind === 'number' ? Number(raw) : raw);
+        }}
       />
-      {copy !== undefined && (
-        <p className="mt-1 text-term-dim">
-          {copy.help} <span className="text-term-dim">({flag.cli})</span>
-        </p>
-      )}
-      {invalid && (
-        <p className="mt-1 text-term-red text-sm">
-          {flag.cli} values may not begin with &apos;-&apos;
-        </p>
-      )}
     </div>
   );
 }

--- a/apps/eval-ops/src/routes/Profiles.tsx
+++ b/apps/eval-ops/src/routes/Profiles.tsx
@@ -84,6 +84,7 @@ export function Profiles() {
           env: result.env ?? [],
           models: result.models ?? [],
           harnessAgents: result.harnessAgents ?? {},
+          flags: result.flags ?? [],
         };
         setState((prev) => ({
           ...prev,

--- a/apps/eval-ops/tests/launch.test.tsx
+++ b/apps/eval-ops/tests/launch.test.tsx
@@ -1,7 +1,7 @@
 import { describe, expect, it, vi, beforeEach, afterEach } from 'vitest';
 import { render, screen, cleanup, within } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
-import { BrowserRouter, MemoryRouter } from 'react-router';
+import { BrowserRouter } from 'react-router';
 
 import { Launch } from '../src/routes/Launch';
 
@@ -35,8 +35,6 @@ const HARNESSES = {
   ],
 };
 
-const CONFIG_MODELS = { models: ['google/gemini-2.5-flash', 'anthropic/claude-sonnet-4'] };
-
 const METADATA = {
   env: [
     {
@@ -46,13 +44,6 @@ const METADATA = {
       kind: 'enum',
       values: ['off', 'on'],
       defaultDescription: 'off',
-    },
-    {
-      key: 'NEGOTIATION_MAX_TURNS_CHAT',
-      label: 'Chat turn cap',
-      description: 'Maximum negotiation turns in chat mode.',
-      kind: 'integer',
-      defaultDescription: 'server default',
     },
   ],
   models: [
@@ -68,11 +59,17 @@ const METADATA = {
       { id: 'premiseAnalyzer', label: 'Premise analyzer', role: 'Scores each candidate premise.' },
     ],
   },
+  flags: [
+    { name: 'runs', label: 'Runs per case', description: 'How many times every case is executed.', scope: 'selection', defaultLabel: '3' },
+    { name: 'case', label: 'Case', description: 'Run only cases whose id contains this text.', scope: 'selection', defaultLabel: 'all cases' },
+    { name: 'tier', label: 'Tier', description: 'Run only one difficulty tier.', scope: 'selection', defaultLabel: 'all tiers' },
+    { name: 'noJudge', label: 'LLM judge', description: 'The judge runs reasoning checks.', scope: 'scoring', defaultLabel: 'on' },
+  ],
 };
 
 const PROFILES = {
   profiles: [
-    { name: 'default', description: 'no overrides', models: {}, env: {} },
+    { name: 'default', description: 'no overrides', models: { opportunityEvaluator: 'google/gemini-2.5-flash' }, env: {} },
     {
       name: 'claude-evaluator',
       description: 'claude',
@@ -82,7 +79,6 @@ const PROFILES = {
   ],
 };
 
-let launched: unknown = null;
 let postedRuns: unknown[] = [];
 let postedConfigs: unknown[] = [];
 let runCounter = 0;
@@ -91,7 +87,6 @@ const stubFetch = ({ withMetadata = true }: { withMetadata?: boolean } = {}) =>
   vi.fn(async (url: string, init?: RequestInit) => {
     if (String(url).endsWith('/api/harnesses')) return new Response(JSON.stringify(HARNESSES));
     if (String(url).endsWith('/api/profiles')) return new Response(JSON.stringify(PROFILES));
-    if (String(url).endsWith('/api/configs/models')) return new Response(JSON.stringify(CONFIG_MODELS));
     if (String(url).endsWith('/api/configs/metadata')) {
       return withMetadata ? new Response(JSON.stringify(METADATA)) : new Response(JSON.stringify({}));
     }
@@ -104,7 +99,6 @@ const stubFetch = ({ withMetadata = true }: { withMetadata?: boolean } = {}) =>
     }
     if (String(url).endsWith('/api/runs') && init?.method === 'POST') {
       const body = JSON.parse(String(init.body));
-      launched = body;
       postedRuns.push(body);
       runCounter += 1;
       return new Response(JSON.stringify({ id: `run-${runCounter}` }), { status: 202 });
@@ -113,7 +107,6 @@ const stubFetch = ({ withMetadata = true }: { withMetadata?: boolean } = {}) =>
   });
 
 beforeEach(() => {
-  launched = null;
   postedRuns = [];
   postedConfigs = [];
   runCounter = 0;
@@ -125,451 +118,268 @@ afterEach(() => {
   vi.unstubAllGlobals();
 });
 
-const renderLaunch = () => render(
-  <BrowserRouter>
-    <Launch />
-  </BrowserRouter>,
-);
+const renderLaunch = () =>
+  render(
+    <BrowserRouter>
+      <Launch />
+    </BrowserRouter>,
+  );
 
-/** The runner knobs live behind a collapsed disclosure; jsdom lets us open it directly. */
-const openAdvancedOptions = () => {
-  const summary = screen.getByText(/advanced options/i);
-  const details = summary.closest('details');
-  expect(details).not.toBeNull();
-  details!.open = true;
-  return details!;
-};
-
-const openEnvFlags = (scope: HTMLElement | typeof screen = screen) => {
-  const queries = 'getByText' in scope ? (scope as typeof screen) : within(scope as HTMLElement);
-  const summary = queries.getByText(/live-pipeline flags/i);
-  const details = summary.closest('details');
-  expect(details).not.toBeNull();
-  details!.open = true;
-  return details!;
+/** Full-corpus runs ask for confirmation first; this completes that handshake. */
+const runAndConfirm = async (user: ReturnType<typeof userEvent.setup>, label: RegExp) => {
+  await user.click(await screen.findByRole('button', { name: label }));
+  await user.click(await screen.findByRole('button', { name: /confirm and run/i }));
 };
 
 describe('Launch', () => {
+  it('shows the harness it will run and its agents, with nothing collapsed', async () => {
+    renderLaunch();
+
+    // The model that decides this harness's results is on screen immediately.
+    expect(await screen.findByLabelText(/evaluator/i)).toBeTruthy();
+    expect(screen.getByText(/decides accept or reject/i)).toBeTruthy();
+    // No disclosure widgets at all: the page is flat.
+    expect(document.querySelectorAll('details')).toHaveLength(0);
+  });
+
+  it('shows only the agents the selected harness exercises', async () => {
+    const user = userEvent.setup();
+    renderLaunch();
+
+    expect(await screen.findByLabelText(/evaluator/i)).toBeTruthy();
+    expect(screen.queryByLabelText(/premise decomposer/i)).toBeNull();
+
+    await user.selectOptions(screen.getByLabelText('Harness'), 'premise');
+
+    expect(await screen.findByLabelText(/premise decomposer/i)).toBeTruthy();
+    expect(screen.getByLabelText(/premise analyzer/i)).toBeTruthy();
+    expect(screen.queryByLabelText(/^evaluator$/i)).toBeNull();
+  });
+
+  it('shows what gets tested directly, without an advanced disclosure', async () => {
+    renderLaunch();
+
+    expect(await screen.findByLabelText('Runs per case')).toBeTruthy();
+    expect(screen.getByLabelText('Case')).toBeTruthy();
+    expect(screen.getByLabelText('Tier')).toBeTruthy();
+    expect(screen.getByText(/what gets tested/i)).toBeTruthy();
+  });
+
+  it('never offers live-pipeline env flags: they do not affect these harnesses', async () => {
+    renderLaunch();
+    await screen.findByLabelText(/evaluator/i);
+
+    expect(screen.queryByText(/live-pipeline/i)).toBeNull();
+    expect(screen.queryByText(/POOL_QUESTIONS_MODE/)).toBeNull();
+    expect(screen.queryByText(/pool questions/i)).toBeNull();
+  });
+
   it('offers only the flags the selected harness supports', async () => {
+    const user = userEvent.setup();
     renderLaunch();
-    await screen.findByLabelText(/harness/i);
-    openAdvancedOptions();
-    await userEvent.selectOptions(screen.getByLabelText(/harness/i), 'premise');
-    expect(screen.queryByLabelText(/tier filter/i)).toBeNull();
+
+    expect(await screen.findByLabelText('Tier')).toBeTruthy();
+
+    await user.selectOptions(screen.getByLabelText('Harness'), 'premise');
+
+    // premise declares runs only: tier and the judge toggle must disappear.
+    expect(await screen.findByLabelText('Runs per case')).toBeTruthy();
+    expect(screen.queryByLabelText('Tier')).toBeNull();
+    expect(screen.queryByLabelText(/llm judge/i)).toBeNull();
   });
 
-  it('shows the computed workload before launching', async () => {
+  it('launches with the selected model override and the shared selection flags', async () => {
+    const user = userEvent.setup();
     renderLaunch();
-    await screen.findByLabelText(/harness/i);
-    expect(await screen.findByText(/40 cases × 3 runs = 120/)).toBeInTheDocument();
+
+    await user.selectOptions(await screen.findByLabelText(/evaluator/i), 'anthropic/claude-sonnet-4');
+    await user.clear(screen.getByLabelText('Runs per case'));
+    await user.type(screen.getByLabelText('Runs per case'), '5');
+    await runAndConfirm(user, /^run$/i);
+
+    expect(postedRuns).toHaveLength(1);
+    expect(postedRuns[0]).toEqual({
+      kind: 'eval',
+      harness: 'matching',
+      profile: 'default',
+      flags: { runs: 5 },
+      overrides: { models: { opportunityEvaluator: 'anthropic/claude-sonnet-4' }, env: {} },
+    });
   });
 
-  it('requires confirmation for a full-corpus run', async () => {
+  it('puts the two A/B configurations side by side and shares what gets tested', async () => {
+    const user = userEvent.setup();
     renderLaunch();
-    await screen.findByLabelText(/harness/i);
-    await userEvent.click(screen.getByRole('button', { name: /run/i }));
-    expect(await screen.findByRole('button', { name: /confirm/i })).toBeInTheDocument();
-    expect(launched).toBeNull();
+
+    await user.click(await screen.findByRole('checkbox', { name: 'A/B' }));
+
+    const headingA = await screen.findByText(/A · reference/);
+    const headingB = screen.getByText(/B · candidate/);
+    // Side by side, not stacked: both columns are cells of one 2-column grid.
+    const grid = headingA.parentElement!.parentElement!;
+    expect(grid.className).toMatch(/grid-cols-2/);
+    expect(grid).toBe(headingB.parentElement!.parentElement!);
+    // One shared selection control, not one per side.
+    expect(screen.getAllByLabelText('Runs per case')).toHaveLength(1);
+    expect(screen.getByText(/shared by both sides/i)).toBeTruthy();
+    // Each side carries its own model choice.
+    expect(screen.getAllByLabelText(/evaluator/i)).toHaveLength(2);
   });
 
-  it('posts only harness, profile and flags — never env or argv', async () => {
+  it('launches both A/B sides with shared selection and per-side models', async () => {
+    const user = userEvent.setup();
     renderLaunch();
-    await screen.findByLabelText(/harness/i);
-    await userEvent.click(screen.getByRole('button', { name: /run/i }));
-    await userEvent.click(await screen.findByRole('button', { name: /confirm/i }));
 
-    expect(Object.keys(launched as object).sort()).toEqual(['flags', 'harness', 'kind', 'profile']);
+    await user.click(await screen.findByRole('checkbox', { name: 'A/B' }));
+    const evaluators = await screen.findAllByLabelText(/evaluator/i);
+    await user.selectOptions(evaluators[1]!, 'anthropic/claude-sonnet-4');
+    await user.clear(screen.getByLabelText('Runs per case'));
+    await user.type(screen.getByLabelText('Runs per case'), '2');
+    await runAndConfirm(user, /run a\/b/i);
+
+    expect(postedRuns).toHaveLength(2);
+    expect(postedRuns[0]).toEqual({
+      kind: 'eval',
+      harness: 'matching',
+      profile: 'default',
+      flags: { runs: 2 },
+    });
+    expect(postedRuns[1]).toEqual({
+      kind: 'eval',
+      harness: 'matching',
+      profile: 'default',
+      flags: { runs: 2 },
+      overrides: { models: { opportunityEvaluator: 'anthropic/claude-sonnet-4' }, env: {} },
+    });
   });
 
-  it('shows the narrowed workload when a selection flag filters the corpus', async () => {
+  it('says so when the two sides score differently, because the results are not like-for-like', async () => {
+    const user = userEvent.setup();
     renderLaunch();
-    await screen.findByLabelText(/harness/i);
-    openAdvancedOptions();
-    await userEvent.type(screen.getByLabelText(/tier filter/i), '2');
-    expect(await screen.findByText(/1 case \(filtered\) × 3 runs = 3/)).toBeInTheDocument();
+
+    await user.click(await screen.findByRole('checkbox', { name: 'A/B' }));
+    const judges = await screen.findAllByLabelText(/llm judge/i);
+    expect(judges).toHaveLength(2);
+    expect(screen.queryByText(/not like-for-like/i)).toBeNull();
+
+    await user.click(judges[1]!);
+
+    expect(screen.getByText(/not like-for-like/i)).toBeTruthy();
+  });
+
+  it('counts both sides in the workload', async () => {
+    const user = userEvent.setup();
+    renderLaunch();
+
+    expect(await screen.findByText(/40 cases × 3 runs = 120/)).toBeTruthy();
+
+    await user.click(screen.getByRole('checkbox', { name: 'A/B' }));
+
+    expect(screen.getByText(/40 cases × 3 runs × 2 sides = 240/)).toBeTruthy();
   });
 
   it('explains a selection value beginning with "-" and refuses to launch it', async () => {
+    const user = userEvent.setup();
     renderLaunch();
-    await screen.findByLabelText(/harness/i);
-    openAdvancedOptions();
-    await userEvent.type(screen.getByLabelText(/case filter/i), '-foo');
 
-    expect(screen.getByLabelText(/case filter/i)).toHaveValue('-foo');
-    expect(await screen.findByText(/--case values may not begin with/i)).toBeInTheDocument();
-    expect(screen.getByRole('button', { name: 'Run' })).toBeDisabled();
+    await user.type(await screen.findByLabelText('Case'), '--force');
+
+    expect(screen.getByText(/fix --case before running/i)).toBeTruthy();
+    expect(screen.getByRole('button', { name: /^run$/i })).toBeDisabled();
   });
 
-  it('keeps the entered flags and explains a refused launch inline', async () => {
+  it('keeps the entered values and explains a refused launch inline', async () => {
     vi.stubGlobal(
       'fetch',
       vi.fn(async (url: string, init?: RequestInit) => {
         if (String(url).endsWith('/api/harnesses')) return new Response(JSON.stringify(HARNESSES));
         if (String(url).endsWith('/api/profiles')) return new Response(JSON.stringify(PROFILES));
-        if (String(url).endsWith('/api/runs') && init?.method === 'POST') {
-          return new Response(JSON.stringify({ error: 'flags.tier: too big' }), { status: 400 });
-        }
-        return new Response(JSON.stringify({}));
-      }),
-    );
-
-    renderLaunch();
-    await screen.findByLabelText(/harness/i);
-    openAdvancedOptions();
-    await userEvent.type(screen.getByLabelText(/tier filter/i), '2');
-    await userEvent.click(screen.getByRole('button', { name: 'Run' }));
-
-    expect(await screen.findByRole('alert')).toHaveTextContent(/flags\.tier: too big/);
-    expect(screen.getByLabelText(/tier filter/i)).toHaveValue(2);
-  });
-
-  it('warns that a non-default profile produces an experimental run', async () => {
-    renderLaunch();
-    await screen.findByLabelText(/profile/i);
-    await userEvent.selectOptions(screen.getByLabelText(/profile/i), 'claude-evaluator');
-    expect(await screen.findByText(/experimental/i)).toBeInTheDocument();
-  });
-
-  it('scopes model overrides to the agents the harness exercises', async () => {
-    renderLaunch();
-    await screen.findByLabelText(/harness/i);
-    // matching exercises only the evaluator — no premise agents on offer.
-    expect(await screen.findByLabelText('model for Evaluator')).toBeInTheDocument();
-    expect(screen.queryByLabelText('model for Premise decomposer')).toBeNull();
-
-    await userEvent.selectOptions(screen.getByLabelText(/harness/i), 'premise');
-    expect(await screen.findByLabelText('model for Premise decomposer')).toBeInTheDocument();
-    expect(screen.getByLabelText('model for Premise analyzer')).toBeInTheDocument();
-    expect(screen.queryByLabelText('model for Evaluator')).toBeNull();
-  });
-
-  it('keeps the runner knobs behind advanced options, explained in plain English', async () => {
-    renderLaunch();
-    await screen.findByLabelText(/harness/i);
-    const details = screen.getByText(/advanced options/i).closest('details');
-    expect(details).not.toBeNull();
-    expect(details).not.toHaveAttribute('open');
-
-    openAdvancedOptions();
-    expect(
-      await screen.findByText(/How many times every case is executed; 3 lets flaky behavior show up/i),
-    ).toBeInTheDocument();
-  });
-
-  it('renders Advanced options before the live-pipeline flags disclosure (spec order)', async () => {
-    renderLaunch();
-    await screen.findByLabelText(/harness/i);
-    const advanced = screen.getByText(/^advanced options$/i);
-    const envFlags = screen.getByText(/advanced: live-pipeline flags/i);
-    expect(
-      advanced.compareDocumentPosition(envFlags) & Node.DOCUMENT_POSITION_FOLLOWING,
-    ).toBeTruthy();
-  });
-
-  it('keeps live-pipeline flags behind a disclosure with the honesty note', async () => {
-    renderLaunch();
-    await screen.findByLabelText(/harness/i);
-    const details = screen.getByText(/live-pipeline flags/i).closest('details');
-    expect(details).not.toBeNull();
-    expect(details).not.toHaveAttribute('open');
-
-    openEnvFlags();
-    expect(
-      await screen.findByText(/This scorecard harness does not read them/i),
-    ).toBeInTheDocument();
-  });
-
-  it('hides the guided sections when configuration metadata is unavailable', async () => {
-    vi.stubGlobal('fetch', stubFetch({ withMetadata: false }));
-    renderLaunch();
-    await screen.findByLabelText(/harness/i);
-    // No guided model rows, no env-flag disclosure — but the form still launches.
-    expect(screen.queryByLabelText('model for Evaluator')).toBeNull();
-    expect(screen.queryByText(/live-pipeline flags/i)).toBeNull();
-    await userEvent.click(screen.getByRole('button', { name: /run/i }));
-    expect(await screen.findByRole('button', { name: /confirm/i })).toBeInTheDocument();
-  });
-
-  it('blocks launch while an env override is invalid', async () => {
-    renderLaunch();
-    await screen.findByLabelText(/harness/i);
-    openEnvFlags();
-    await userEvent.click(screen.getByRole('button', { name: /add flag override/i }));
-    await userEvent.selectOptions(screen.getByLabelText('flag 1'), 'NEGOTIATION_MAX_TURNS_CHAT');
-    await userEvent.type(screen.getByLabelText('value 1'), 'lots');
-
-    expect(await screen.findByText(/must be an integer/i)).toBeInTheDocument();
-    expect(screen.getByRole('button', { name: 'Run' })).toBeDisabled();
-    // The disclosure may be collapsed — a page-level hint must say why launch is blocked.
-    expect(screen.getByText(/finish or fix the flag override above to launch/i)).toBeInTheDocument();
-
-    await userEvent.clear(screen.getByLabelText('value 1'));
-    await userEvent.type(screen.getByLabelText('value 1'), '4');
-    expect(screen.getByRole('button', { name: 'Run' })).toBeEnabled();
-    expect(screen.queryByText(/finish or fix the flag override above to launch/i)).toBeNull();
-  });
-
-  it('shows the same blocking hint for a merely incomplete override row', async () => {
-    renderLaunch();
-    await screen.findByLabelText(/harness/i);
-    openEnvFlags();
-    // A fresh row is incomplete, not invalid: no inline issue, but launch is blocked.
-    await userEvent.click(screen.getByRole('button', { name: /add flag override/i }));
-
-    expect(screen.getByRole('button', { name: 'Run' })).toBeDisabled();
-    expect(screen.getByText(/finish or fix the flag override above to launch/i)).toBeInTheDocument();
-  });
-
-  it('submits ad-hoc model and env overrides with profile default', async () => {
-    renderLaunch();
-    await screen.findByLabelText(/harness/i);
-    await userEvent.selectOptions(
-      await screen.findByLabelText('model for Evaluator'),
-      'anthropic/claude-sonnet-4',
-    );
-    openEnvFlags();
-    await userEvent.click(screen.getByRole('button', { name: /add flag override/i }));
-    await userEvent.selectOptions(screen.getByLabelText('flag 1'), 'POOL_QUESTIONS_MODE');
-    await userEvent.selectOptions(screen.getByLabelText('value 1'), 'on');
-
-    // Narrow the corpus so no full-corpus confirmation stands in the way.
-    openAdvancedOptions();
-    await userEvent.type(screen.getByLabelText(/tier filter/i), '2');
-    await userEvent.click(screen.getByRole('button', { name: 'Run' }));
-
-    await vi.waitFor(() => expect(postedRuns).toHaveLength(1));
-    const spec = postedRuns[0] as {
-      profile: string;
-      overrides?: { models: Record<string, string>; env: Record<string, string> };
-    };
-    expect(spec.profile).toBe('default');
-    expect(spec.overrides?.models).toEqual({ opportunityEvaluator: 'anthropic/claude-sonnet-4' });
-    expect(spec.overrides?.env).toEqual({ POOL_QUESTIONS_MODE: 'on' });
-  });
-
-  it('omits the overrides key entirely when nothing is overridden', async () => {
-    renderLaunch();
-    await screen.findByLabelText(/harness/i);
-    openAdvancedOptions();
-    await userEvent.type(screen.getByLabelText(/tier filter/i), '2');
-    await userEvent.click(screen.getByRole('button', { name: 'Run' }));
-
-    await vi.waitFor(() => expect(postedRuns).toHaveLength(1));
-    expect(Object.keys(postedRuns[0] as object).sort()).toEqual(['flags', 'harness', 'kind', 'profile']);
-  });
-
-  it('saves the current overrides as a named config', async () => {
-    renderLaunch();
-    await screen.findByLabelText(/harness/i);
-    await userEvent.selectOptions(
-      await screen.findByLabelText('model for Evaluator'),
-      'anthropic/claude-sonnet-4',
-    );
-    await userEvent.click(screen.getByRole('button', { name: /save as config/i }));
-    await userEvent.type(screen.getByLabelText(/config name/i), 'sonnet-evaluator');
-    await userEvent.type(screen.getByLabelText(/config description/i), 'evaluator on sonnet');
-    await userEvent.click(screen.getByRole('button', { name: 'Save config' }));
-
-    await vi.waitFor(() => expect(postedConfigs).toHaveLength(1));
-    expect(postedConfigs[0]).toEqual({
-      name: 'sonnet-evaluator',
-      description: 'evaluator on sonnet',
-      models: { opportunityEvaluator: 'anthropic/claude-sonnet-4' },
-      env: {},
-    });
-    // The form switches to the freshly saved config.
-    await vi.waitFor(() =>
-      expect(screen.getByLabelText<HTMLSelectElement>(/profile/i).value).toBe('sonnet-evaluator'),
-    );
-  });
-
-  it('blocks “save as config” while an env override is invalid, like it blocks launch', async () => {
-    // Save posted the same invalid env Run refuses, so the server 400'd on a
-    // value the UI had already flagged inline.
-    renderLaunch();
-    await screen.findByLabelText(/harness/i);
-    openEnvFlags();
-    await userEvent.click(screen.getByRole('button', { name: /add flag override/i }));
-    await userEvent.selectOptions(screen.getByLabelText('flag 1'), 'NEGOTIATION_MAX_TURNS_CHAT');
-    await userEvent.type(screen.getByLabelText('value 1'), 'lots');
-
-    await userEvent.click(screen.getByRole('button', { name: /save as config/i }));
-    await userEvent.type(screen.getByLabelText(/config name/i), 'bad-flag');
-    await userEvent.type(screen.getByLabelText(/config description/i), 'invalid value');
-
-    expect(screen.getByRole('button', { name: 'Save config' })).toBeDisabled();
-    expect(postedConfigs).toHaveLength(0);
-
-    await userEvent.clear(screen.getByLabelText('value 1'));
-    await userEvent.type(screen.getByLabelText('value 1'), '4');
-    expect(screen.getByRole('button', { name: 'Save config' })).toBeEnabled();
-  });
-
-  it('A/B mode fires two launches and navigates to the pair URL', async () => {
-    renderLaunch();
-    await screen.findByLabelText(/harness/i);
-    await userEvent.click(screen.getByLabelText(/a\/b/i));
-    const candidate = await screen.findByRole('group', { name: 'candidate' });
-    await userEvent.selectOptions(
-      within(candidate).getByLabelText('model for Evaluator'),
-      'anthropic/claude-sonnet-4',
-    );
-    openAdvancedOptions();
-    await userEvent.type(screen.getByLabelText(/tier filter/i), '2');
-    await userEvent.click(screen.getByRole('button', { name: 'Run' }));
-
-    await vi.waitFor(() => expect(postedRuns).toHaveLength(2));
-    const reference = postedRuns[0] as { overrides?: unknown };
-    const candidateSpec = postedRuns[1] as { overrides?: { models: Record<string, string> } };
-    expect('overrides' in reference).toBe(false);
-    expect(candidateSpec.overrides?.models).toEqual({ opportunityEvaluator: 'anthropic/claude-sonnet-4' });
-    await vi.waitFor(() =>
-      expect(window.location.search).toBe('?referenceRun=run-1&subjectRun=run-2'),
-    );
-  });
-
-  it('A/B mode lets each side pick its own profile independently', async () => {
-    vi.stubGlobal(
-      'fetch',
-      vi.fn(async (url: string, init?: RequestInit) => {
-        if (String(url).endsWith('/api/harnesses')) return new Response(JSON.stringify(HARNESSES));
-        if (String(url).endsWith('/api/profiles')) return new Response(JSON.stringify(PROFILES));
-        if (String(url).endsWith('/api/configs/models')) return new Response(JSON.stringify(CONFIG_MODELS));
         if (String(url).endsWith('/api/configs/metadata')) return new Response(JSON.stringify(METADATA));
-        if (String(url).endsWith('/api/configs')) {
-          return new Response(
-            JSON.stringify({
-              repo: PROFILES.profiles,
-              saved: [
-                {
-                  name: 'sonnet-evaluator',
-                  description: 'evaluator on sonnet',
-                  models: { opportunityEvaluator: 'anthropic/claude-sonnet-4' },
-                  env: {},
-                },
-              ],
-            }),
-          );
-        }
+        if (String(url).endsWith('/api/configs')) return new Response(JSON.stringify({ repo: PROFILES.profiles, saved: [] }));
         if (String(url).endsWith('/api/runs') && init?.method === 'POST') {
-          postedRuns.push(JSON.parse(String(init.body)));
-          runCounter += 1;
-          return new Response(JSON.stringify({ id: `run-${runCounter}` }), { status: 202 });
+          return new Response(JSON.stringify({ error: 'queue is full' }), { status: 429 });
         }
         return new Response(JSON.stringify({}));
       }),
     );
-
+    const user = userEvent.setup();
     renderLaunch();
-    await screen.findByLabelText(/harness/i);
-    await userEvent.click(screen.getByLabelText(/a\/b/i));
 
-    const reference = await screen.findByRole('group', { name: 'reference' });
-    const candidate = screen.getByRole('group', { name: 'candidate' });
-    await userEvent.selectOptions(within(reference).getByLabelText('profile'), 'claude-evaluator');
-    await userEvent.selectOptions(within(candidate).getByLabelText('profile'), 'sonnet-evaluator');
+    await user.clear(await screen.findByLabelText('Runs per case'));
+    await user.type(screen.getByLabelText('Runs per case'), '7');
+    await runAndConfirm(user, /^run$/i);
 
-    // A named profile leaves no model editor on that side.
-    expect(within(reference).queryByLabelText('model for Evaluator')).toBeNull();
-    expect(within(reference).getByText(/edit it on the configs page/i)).toBeInTheDocument();
-    expect(within(candidate).queryByLabelText('model for Evaluator')).toBeNull();
-
-    openAdvancedOptions();
-    await userEvent.type(screen.getByLabelText(/tier filter/i), '2');
-    await userEvent.click(screen.getByRole('button', { name: 'Run' }));
-
-    await vi.waitFor(() => expect(postedRuns).toHaveLength(2));
-    expect((postedRuns[0] as { profile: string }).profile).toBe('claude-evaluator');
-    expect((postedRuns[1] as { profile: string }).profile).toBe('sonnet-evaluator');
-    for (const spec of postedRuns as { overrides?: unknown }[]) {
-      expect('overrides' in spec).toBe(false);
-    }
-    // Shared flags still apply to both sides.
-    for (const spec of postedRuns as { flags: { tier?: number } }[]) {
-      expect(spec.flags.tier).toBe(2);
-    }
+    expect(await screen.findByRole('alert')).toHaveTextContent(/launch refused/i);
+    expect(screen.getByLabelText('Runs per case')).toHaveValue(7);
   });
 
-  it('A/B posts overrides only on the side whose profile is default', async () => {
+  it('hides model overrides for a saved config and points at the configs page', async () => {
+    const user = userEvent.setup();
     renderLaunch();
-    await screen.findByLabelText(/harness/i);
-    await userEvent.click(screen.getByLabelText(/a\/b/i));
 
-    const reference = await screen.findByRole('group', { name: 'reference' });
-    const candidate = screen.getByRole('group', { name: 'candidate' });
-    await userEvent.selectOptions(within(reference).getByLabelText('profile'), 'claude-evaluator');
-    await userEvent.selectOptions(
-      within(candidate).getByLabelText('model for Evaluator'),
-      'anthropic/claude-sonnet-4',
-    );
+    await user.selectOptions(await screen.findByLabelText('Config'), 'claude-evaluator');
 
-    openAdvancedOptions();
-    await userEvent.type(screen.getByLabelText(/tier filter/i), '2');
-    await userEvent.click(screen.getByRole('button', { name: 'Run' }));
-
-    await vi.waitFor(() => expect(postedRuns).toHaveLength(2));
-    const referenceSpec = postedRuns[0] as { profile: string; overrides?: unknown };
-    const candidateSpec = postedRuns[1] as { profile: string; overrides?: { models: Record<string, string> } };
-    expect(referenceSpec.profile).toBe('claude-evaluator');
-    expect('overrides' in referenceSpec).toBe(false);
-    expect(candidateSpec.profile).toBe('default');
-    expect(candidateSpec.overrides?.models).toEqual({ opportunityEvaluator: 'anthropic/claude-sonnet-4' });
+    expect(screen.queryByLabelText(/evaluator model/i)).toBeNull();
+    expect(screen.getByRole('link', { name: /edit this config/i })).toBeTruthy();
   });
 
-  it('A/B mode defaults both sides to the same profile and shares flags', async () => {
+  it('saves the chosen models as a named config', async () => {
+    const user = userEvent.setup();
     renderLaunch();
-    await screen.findByLabelText(/harness/i);
-    await userEvent.click(screen.getByLabelText(/a\/b/i));
-    openAdvancedOptions();
-    await userEvent.type(screen.getByLabelText(/tier filter/i), '2');
-    await userEvent.click(screen.getByRole('button', { name: 'Run' }));
 
-    await vi.waitFor(() => expect(postedRuns).toHaveLength(2));
-    for (const spec of postedRuns as { profile: string; flags: { tier?: number } }[]) {
-      expect(spec.profile).toBe('default');
-      expect(spec.flags.tier).toBe(2);
-    }
+    await user.selectOptions(await screen.findByLabelText(/evaluator/i), 'anthropic/claude-sonnet-4');
+    await user.click(screen.getByRole('button', { name: /save as config/i }));
+    await user.type(screen.getByLabelText('config name'), 'claude-eval');
+    await user.type(screen.getByLabelText('config description'), 'evaluator on claude');
+    await user.click(screen.getByRole('button', { name: /^save config$/i }));
+
+    expect(postedConfigs).toEqual([
+      {
+        name: 'claude-eval',
+        description: 'evaluator on claude',
+        models: { opportunityEvaluator: 'anthropic/claude-sonnet-4' },
+        env: {},
+      },
+    ]);
   });
 
-  it('A/B gives each side its own env-flag disclosure', async () => {
+  it('still launches when the metadata endpoint is unreachable', async () => {
+    vi.stubGlobal('fetch', stubFetch({ withMetadata: false }));
+    const user = userEvent.setup();
     renderLaunch();
-    await screen.findByLabelText(/harness/i);
-    await userEvent.click(screen.getByLabelText(/a\/b/i));
-    const candidate = await screen.findByRole('group', { name: 'candidate' });
 
-    openEnvFlags(candidate);
-    await userEvent.click(within(candidate).getByRole('button', { name: /add flag override/i }));
-    await userEvent.selectOptions(within(candidate).getByLabelText('flag 1'), 'POOL_QUESTIONS_MODE');
-    await userEvent.selectOptions(within(candidate).getByLabelText('value 1'), 'on');
+    // Falls back to the CLI spelling rather than rendering an empty form.
+    const runs = await screen.findByLabelText('--runs');
+    await user.clear(runs);
+    await user.type(runs, '1');
+    await runAndConfirm(user, /^run$/i);
 
-    openAdvancedOptions();
-    await userEvent.type(screen.getByLabelText(/tier filter/i), '2');
-    await userEvent.click(screen.getByRole('button', { name: 'Run' }));
-
-    await vi.waitFor(() => expect(postedRuns).toHaveLength(2));
-    const referenceSpec = postedRuns[0] as { overrides?: { env?: Record<string, string> } };
-    const candidateSpec = postedRuns[1] as { overrides?: { env?: Record<string, string> } };
-    expect('overrides' in referenceSpec).toBe(false);
-    expect(candidateSpec.overrides?.env).toEqual({ POOL_QUESTIONS_MODE: 'on' });
+    expect(postedRuns).toEqual([
+      { kind: 'eval', harness: 'matching', profile: 'default', flags: { runs: 1 } },
+    ]);
   });
 
-  it('disables overrides when a named profile is selected and points to configs', async () => {
+  it('narrows the workload when a selection flag filters the corpus', async () => {
+    const user = userEvent.setup();
     renderLaunch();
-    await screen.findByLabelText(/profile/i);
-    await userEvent.selectOptions(screen.getByLabelText(/profile/i), 'claude-evaluator');
 
-    expect(screen.queryByLabelText('model for Evaluator')).toBeNull();
-    expect(screen.queryByText(/live-pipeline flags/i)).toBeNull();
-    expect(await screen.findByText(/edit it on the configs page/i)).toBeInTheDocument();
+    await user.type(await screen.findByLabelText('Case'), 'is_a_identity');
+
+    expect(screen.getByText(/1 case \(filtered\) × 3 runs = 3/)).toBeTruthy();
   });
 
-  it('preselects the profile named by the ?profile= search param', async () => {
-    render(
-      <MemoryRouter initialEntries={['/launch?profile=claude-evaluator']}>
-        <Launch />
-      </MemoryRouter>,
-    );
-    await screen.findByLabelText(/harness/i);
-    expect(screen.getByLabelText(/profile/i)).toHaveValue('claude-evaluator');
+  it('scopes A/B scoring controls to their own side', async () => {
+    const user = userEvent.setup();
+    renderLaunch();
+
+    await user.click(await screen.findByRole('checkbox', { name: 'A/B' }));
+    const columns = screen.getAllByText(/· (reference|candidate)/).map((el) => el.parentElement!);
+    const judgeA = within(columns[0]!).getByLabelText(/llm judge/i);
+    const judgeB = within(columns[1]!).getByLabelText(/llm judge/i);
+
+    await user.click(judgeA);
+
+    expect(judgeA).toBeChecked();
+    expect(judgeB).not.toBeChecked();
   });
 });

--- a/bun.lock
+++ b/bun.lock
@@ -19,7 +19,7 @@
     },
     "apps/eval-ops": {
       "name": "@indexnetwork/eval-ops",
-      "version": "0.3.0",
+      "version": "0.4.0",
       "dependencies": {
         "react": "^19.0.0",
         "react-dom": "^19.0.0",
@@ -110,7 +110,7 @@
     },
     "packages/protocol": {
       "name": "@indexnetwork/protocol",
-      "version": "8.9.0",
+      "version": "8.10.0",
       "dependencies": {
         "@langchain/core": "1.1.48",
         "@langchain/langgraph": "1.3.2",

--- a/packages/protocol/eval/ops/ops.metadata.ts
+++ b/packages/protocol/eval/ops/ops.metadata.ts
@@ -265,3 +265,92 @@ export const MODEL_METADATA: readonly ModelMeta[] = Object.freeze([
     blurb: "OpenAI's small GPT-4.1 variant.",
   },
 ]);
+
+/**
+ * A harness flag's presentation and — crucially — whether it may differ between
+ * the two sides of an A/B run.
+ *
+ * `selection` flags decide WHICH cases run. If the two sides disagree, the runs
+ * are not comparable at all (compareArtifacts refuses on a selection mismatch),
+ * so the UI shares one control between both sides.
+ *
+ * `scoring` flags decide HOW a run is scored. They may legitimately differ —
+ * that is a comparison worth making — but the UI must say so, because a verdict
+ * produced under different scoring rules is not a like-for-like result.
+ */
+export interface FlagMeta {
+  /** HarnessFlag.name in ops.registry.ts. */
+  name: string;
+  label: string;
+  /** What changing it does, grounded in the harness CLI help. */
+  description: string;
+  scope: "selection" | "scoring";
+  /** Shown as the control's default/placeholder. */
+  defaultLabel: string;
+}
+
+/**
+ * Copy for every flag the registry can expose. Grounded in the harness usage
+ * banner (eval/matching/matching.eval.ts:40-61) and the argv handling beside it.
+ * Drift-guarded by test against HARNESS_REGISTRY.
+ */
+export const FLAG_METADATA: readonly FlagMeta[] = Object.freeze([
+  {
+    name: "runs",
+    label: "Runs per case",
+    description: "How many times every case is executed. More runs expose flaky cases that pass only sometimes.",
+    scope: "selection",
+    defaultLabel: "3",
+  },
+  {
+    name: "case",
+    label: "Case",
+    description: "Run only cases whose id contains this text — the fastest way to reproduce one failure.",
+    scope: "selection",
+    defaultLabel: "all cases",
+  },
+  {
+    name: "rule",
+    label: "Rule",
+    description: "Run only the cases belonging to one rule (for example is_a_identity).",
+    scope: "selection",
+    defaultLabel: "all rules",
+  },
+  {
+    name: "tier",
+    label: "Tier",
+    description: "Run only one difficulty tier (1-4). Higher tiers hold the harder, more adversarial cases.",
+    scope: "selection",
+    defaultLabel: "all tiers",
+  },
+  {
+    name: "noJudge",
+    label: "LLM judge",
+    description:
+      "The judge runs the reasoning checks that cannot be asserted mechanically. Turning it off is free and fast, but scores then reflect deterministic assertions only.",
+    scope: "scoring",
+    defaultLabel: "on",
+  },
+  {
+    name: "alpha",
+    label: "Regression threshold",
+    description:
+      "Significance level for calling a change a regression. Lower is stricter — fewer changes are reported as real.",
+    scope: "scoring",
+    defaultLabel: "0.05",
+  },
+  {
+    name: "strictEvidence",
+    label: "Strict evidence",
+    description: "Fail the run when any requested case-run did not complete, instead of scoring what did finish.",
+    scope: "scoring",
+    defaultLabel: "off",
+  },
+  {
+    name: "attemptTimeoutMs",
+    label: "Attempt timeout",
+    description: "How long a single attempt may take before it is abandoned and retried.",
+    scope: "scoring",
+    defaultLabel: "harness default",
+  },
+]);

--- a/packages/protocol/eval/ops/ops.profiles.ts
+++ b/packages/protocol/eval/ops/ops.profiles.ts
@@ -16,8 +16,8 @@ import { PROFILE_ENV_ALLOWLIST } from "./ops.allowlist.js";
 
 // Guided-editing metadata is likewise dependency-free (ops.metadata.ts) so the
 // browser app imports it directly; re-exported here for server-side consumers.
-export { ENV_FLAG_METADATA, HARNESS_AGENT_METADATA, MODEL_METADATA } from "./ops.metadata.js";
-export type { AgentMeta, EnvFlagMeta, ModelMeta } from "./ops.metadata.js";
+export { ENV_FLAG_METADATA, FLAG_METADATA, HARNESS_AGENT_METADATA, MODEL_METADATA } from "./ops.metadata.js";
+export type { AgentMeta, EnvFlagMeta, FlagMeta, ModelMeta } from "./ops.metadata.js";
 import { ENV_FLAG_METADATA } from "./ops.metadata.js";
 
 export const ConfigProfileSchema = z

--- a/packages/protocol/eval/ops/ops.server.ts
+++ b/packages/protocol/eval/ops/ops.server.ts
@@ -37,7 +37,7 @@ import { BunSqlConfigStore, ConfigConflictError, InMemoryConfigStore, type Confi
 import { LocalProcessRunExecutor, tailLog, type ExecutionStep, type RunExecutor } from "./ops.executor.js";
 import { assessFixtureTarget, BunSqlFixtureInspector, buildResetPipeline, MAX_PERSONAS, redactDatabaseUrl, scrubCredentials, SEED_STEP_CWD, type FixtureInspector, type FixtureTarget } from "./ops.fixture.js";
 import { OPS_CALLBACK_PATH } from "./ops.paths.js";
-import { ALLOWED_CONFIG_MODELS, ConfigProfileSchema, DEFAULT_PROFILE_NAME, ENV_FLAG_METADATA, HARNESS_AGENT_METADATA, MODEL_METADATA, loadProfiles, resolveAdHoc, resolveProfile, validateConfigOverrides, type ConfigProfile, type ResolvedProfile } from "./ops.profiles.js";
+import { ALLOWED_CONFIG_MODELS, ConfigProfileSchema, DEFAULT_PROFILE_NAME, ENV_FLAG_METADATA, FLAG_METADATA, HARNESS_AGENT_METADATA, MODEL_METADATA, loadProfiles, resolveAdHoc, resolveProfile, validateConfigOverrides, type ConfigProfile, type ResolvedProfile } from "./ops.profiles.js";
 import { HARNESS_REGISTRY } from "./ops.registry.js";
 import { RunQueue } from "./ops.queue.js";
 import { FsRunStore, isTerminalStatus, type RunStore } from "./ops.store.js";
@@ -880,7 +880,8 @@ const ConfigPatchSchema = z
 
 /** Static, dependency-free description of everything the guided editors may offer. */
 function configMetadata(): Response {
-  const response = json({ env: ENV_FLAG_METADATA, models: MODEL_METADATA, harnessAgents: HARNESS_AGENT_METADATA });
+  const response = json({ env: ENV_FLAG_METADATA, models: MODEL_METADATA, harnessAgents: HARNESS_AGENT_METADATA, flags: FLAG_METADATA
+    });
   response.headers.set("Cache-Control", "no-store");
   return response;
 }

--- a/packages/protocol/eval/ops/tests/metadata.spec.ts
+++ b/packages/protocol/eval/ops/tests/metadata.spec.ts
@@ -5,7 +5,7 @@ import path from "node:path";
 import { PROFILE_ENV_ALLOWLIST } from "../ops.allowlist.js";
 import { ALLOWED_CONFIG_MODELS } from "../ops.profiles.js";
 import { HARNESS_REGISTRY, OPS_HARNESSES } from "../ops.registry.js";
-import { ENV_FLAG_METADATA, HARNESS_AGENT_METADATA, MODEL_METADATA, type EnvFlagMeta } from "../ops.metadata.js";
+import { FLAG_METADATA, ENV_FLAG_METADATA, HARNESS_AGENT_METADATA, MODEL_METADATA, type EnvFlagMeta } from "../ops.metadata.js";
 
 describe("ENV_FLAG_METADATA", () => {
   it("covers exactly the allowlisted keys, once each, in allowlist order", () => {
@@ -109,6 +109,35 @@ describe("ENV_FLAG_METADATA", () => {
     // Guard the guard: if the regexes stop matching, this test must not silently
     // pass having pinned nothing.
     expect(pinnedFromSchema).toBe(PROFILE_ENV_ALLOWLIST.length - Object.keys(USE_SITE_ONLY_FLAGS).length);
+  });
+});
+
+describe("FLAG_METADATA", () => {
+  it("covers exactly the flags the registry can expose, with no extras", () => {
+    const registryFlags = new Set(
+      Object.values(HARNESS_REGISTRY).flatMap((descriptor) => descriptor.flags.map((flag) => flag.name)),
+    );
+    const documented = new Set(FLAG_METADATA.map((flag) => flag.name));
+    expect([...documented].sort()).toEqual([...registryFlags].sort());
+  });
+
+  it("classifies every flag that decides which cases run as selection", () => {
+    // A selection difference makes two runs incomparable (compareArtifacts
+    // refuses), so these must never become per-side controls in the A/B form.
+    for (const name of ["runs", "case", "rule", "tier"]) {
+      expect(FLAG_METADATA.find((flag) => flag.name === name)?.scope, `${name} scope`).toBe("selection");
+    }
+    for (const name of ["noJudge", "alpha", "strictEvidence", "attemptTimeoutMs"]) {
+      expect(FLAG_METADATA.find((flag) => flag.name === name)?.scope, `${name} scope`).toBe("scoring");
+    }
+  });
+
+  it("gives every flag non-empty copy", () => {
+    for (const flag of FLAG_METADATA) {
+      expect(flag.label.length, `${flag.name} label`).toBeGreaterThan(0);
+      expect(flag.description.length, `${flag.name} description`).toBeGreaterThan(20);
+      expect(flag.defaultLabel.length, `${flag.name} defaultLabel`).toBeGreaterThan(0);
+    }
   });
 });
 

--- a/packages/protocol/package.json
+++ b/packages/protocol/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@indexnetwork/protocol",
-  "version": "8.9.0",
+  "version": "8.10.0",
   "type": "module",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",


### PR DESCRIPTION
## Launch, simplified to the variables that change results

The previous form spoke in disclosures: two collapsed "Advanced" sections, an env-flag editor for flags no scorecard harness reads, and the harness's own flags buried. What actually moves a result was the hardest thing to reach. This makes the page flat.

### On screen, directly

- **The model each agent will use** — matching shows the Evaluator, premise shows decomposer + analyzer.
- **That harness's scoring flags** — LLM judge, regression threshold, strict evidence, attempt timeout — read from `HARNESS_REGISTRY`, so the form cannot drift from what the CLI accepts.
- **What gets tested** — runs, case, rule, tier — in one shared row.

Zero `<details>` elements remain on the page. `Launch.tsx` goes 923 → 750 lines; the branch is net −241.

### A/B is actually side by side

Two columns holding only what differs, with the shared selection row beneath them:

```
┌─ A · reference ─────────┐  ┌─ B · candidate ─────────┐
│ Config    [ default ▾ ] │  │ Config    [ default ▾ ] │
│ Evaluator [ gemini ▾  ] │  │ Evaluator [ sonnet ▾  ] │
│ ☐ LLM judge  alpha[   ] │  │ ☐ LLM judge  alpha[   ] │
└─────────────────────────┘  └─────────────────────────┘
What gets tested — shared by both sides
Runs [3]  Case [all]  Tier [all]
```

The split is not cosmetic, it is a correctness rule:

- **Selection flags cannot differ per side.** A selection mismatch makes two runs incomparable — `compareArtifacts` refuses on it — so the form shares one control. Pinned by test (`FLAG_METADATA` scope classification) and by a mutation check: moving `runs` out of the shared set fails two tests.
- **Scoring flags may differ**, because that is a comparison worth making — but the form says *"The two sides score differently, so their results are not like-for-like"* rather than presenting the diff as apples-to-apples.

### Env flags left the launch page

They tune the live discovery/negotiation services, which these four harnesses never invoke. Keeping them behind an honesty note was still noise on a form about these harnesses. They remain fully editable on the Configs page, where staging-study profiles are authored.

### Evidence

- 160 app tests (vitest), 389 ops tests, `eval:verify` 13/13, `tsc --noEmit` both packages, `vite build`, eslint clean, `bun install --frozen-lockfile` clean.
- Non-tautology proven by mutation: stacking the A/B columns fails the side-by-side test; un-sharing `runs` fails two tests. File restored and md5-verified after each.
- `FLAG_METADATA` is drift-guarded against `HARNESS_REGISTRY` (every registry flag documented, no extras) with selection/scoring scope pinned per flag.
- Metadata-unreachable path still launches, falling back to CLI flag spellings.

Versions: protocol 8.9.0 → 8.10.0 (dev's 8.9.0 was taken by #1325), eval-ops 0.3.0 → 0.4.0, `bun.lock` synced.
