### PR TITLE
fix(mac): preserve deep links after initial load failure

### DIFF
--- a/apps/mac/IndexApp/Resources/index.html
+++ b/apps/mac/IndexApp/Resources/index.html
@@ -34453,6 +34453,7 @@ function isIndexDeepLink(rawUrl, options = {}) {
  */
 function claimedPath(rawUrl, options) {
   if (typeof rawUrl !== 'string') return null;
+  const opts = options || {};
   const raw = rawUrl.trim();
   if (!raw) return null;
 
@@ -34477,8 +34478,8 @@ function claimedPath(rawUrl, options) {
     return null;
   }
 
-  const hosts = Array.isArray(options.hosts) && options.hosts.length
-    ? options.hosts
+  const hosts = Array.isArray(opts.hosts) && opts.hosts.length
+    ? opts.hosts
     : DEFAULT_HOSTS;
   const hostname = url.hostname.toLowerCase();
   const allowed = hosts.some(

--- a/apps/mac/IndexApp/Sources/main.swift
+++ b/apps/mac/IndexApp/Sources/main.swift
@@ -532,6 +532,9 @@ final class AppDelegate: NSObject, NSApplicationDelegate, WKNavigationDelegate, 
     /// the oldest entries are dropped first, the user's latest click survives.
     private let maxPendingDeepLinks = 8
     private var webViewReady = false
+    /// A failed initial navigation has no document to receive queued events.
+    /// Once a page has finished, a later failed reload can safely use it.
+    private var hasLoadedDocument = false
 
     /// Smallest window the web layout renders correctly at. See the note where
     /// it's applied, the screens clip below roughly 860x600. The width is held
@@ -706,12 +709,11 @@ final class AppDelegate: NSObject, NSApplicationDelegate, WKNavigationDelegate, 
     }
 
     /// didStartProvisionalNavigation clears `webViewReady` so links are not
-    /// dispatched into a document about to be replaced. If that navigation then
-    /// fails, nothing else would ever restore readiness and every later link
-    /// would queue forever, so restore it against whatever document is still
-    /// loaded and flush what is queued.
+    /// dispatched into a document about to be replaced. A failed reload can
+    /// restore readiness against the previously loaded document; the initial
+    /// load cannot, because flushing into about:blank silently loses events.
     private func deepLinkNavigationFailed() {
-        guard webView != nil else { return }
+        guard webView != nil, hasLoadedDocument else { return }
         webViewReady = true
         flushPendingDeepLinks()
     }
@@ -769,6 +771,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate, WKNavigationDelegate, 
     }
 
     func webView(_ webView: WKWebView, didFinish navigation: WKNavigation!) {
+        hasLoadedDocument = true
         webViewReady = true
         flushPendingDeepLinks()
     }

--- a/apps/mac/api/deeplink.mjs
+++ b/apps/mac/api/deeplink.mjs
@@ -76,6 +76,7 @@ export function isIndexDeepLink(rawUrl, options = {}) {
  */
 function claimedPath(rawUrl, options) {
   if (typeof rawUrl !== 'string') return null;
+  const opts = options || {};
   const raw = rawUrl.trim();
   if (!raw) return null;
 
@@ -100,8 +101,8 @@ function claimedPath(rawUrl, options) {
     return null;
   }
 
-  const hosts = Array.isArray(options.hosts) && options.hosts.length
-    ? options.hosts
+  const hosts = Array.isArray(opts.hosts) && opts.hosts.length
+    ? opts.hosts
     : DEFAULT_HOSTS;
   const hostname = url.hostname.toLowerCase();
   const allowed = hosts.some(

--- a/apps/mac/api/deeplink.spec.mjs
+++ b/apps/mac/api/deeplink.spec.mjs
@@ -104,7 +104,10 @@ describe('mac deep-link routing contract', () => {
     expect(isIndexDeepLink(null)).toBe(false);
   });
 
-  it('never throws on malformed or non-string input', () => {
+  it('never throws on malformed input or null options', () => {
+    expect(parseDeepLink(`https://index.network/o/${OPPORTUNITY_ID}`, null))
+      .toEqual({ route: 'card', id: OPPORTUNITY_ID });
+    expect(isIndexDeepLink(`https://index.network/o/${OPPORTUNITY_ID}`, null)).toBe(true);
     expect(parseDeepLink('')).toBeNull();
     expect(parseDeepLink('   ')).toBeNull();
     expect(parseDeepLink('not a url')).toBeNull();


### PR DESCRIPTION
## Summary
- retain queued deep links when the first WKWebView navigation fails, then flush after a successful document load
- keep failed-reload recovery for an already loaded document
- make the deep-link parser total for explicit `null` options and regenerate the bundled client

## Verification
- `bun test apps/mac/api/` — 14 passing
- `cd apps/mac/IndexApp && python3 assemble.py`
- `git diff --check`

## Notes
- macOS compilation is covered by the existing macOS CI workflow; this Linux environment does not include `swiftc`.