### PR TITLE
docs: record AASA rollout procedure

### DIFF
--- a/docs/superpowers/plans/2026-08-04-dev-aasa-configuration.md
+++ b/docs/superpowers/plans/2026-08-04-dev-aasa-configuration.md
@@ -1,0 +1,109 @@
+# Dev AASA configuration Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Enable the correct Apple App Site Association app ID on the Railway dev frontend and prove it is publicly valid.
+
+**Architecture:** This is an infrastructure-only change: Railway provides `APPLE_TEAM_ID` to the existing `apps/web/server.ts` AASA route. The variable update restarts the dev frontend; external HTTP verification and startup logs provide the acceptance evidence.
+
+**Tech Stack:** Railway frontend service, Railway MCP, HTTPS, `curl`, `jq`.
+
+## Global Constraints
+
+- Change only Railway project `Index` (`5a1f986c-e0fb-4e5f-a78b-0c58ed1b0e10`), service `frontend` (`aa371189-1215-490d-a363-baf45e8128d8`), environment `dev` (`455d1280-79d1-4a8d-b2ff-0f4bbecdc9ca`).
+- Set `APPLE_TEAM_ID` to exactly `LMQ3XNXLAD`.
+- Do not mutate Railway `main`; its deployed revision lacks the AASA route, so production requires the later web release.
+- A valid dev response must be HTTP 200, unredirected JSON whose sole app ID is `LMQ3XNXLAD.network.index.system6`.
+- If deployment or validation fails, stop before any production action and inspect frontend logs.
+
+---
+
+### Task 1: Configure the dev frontend
+
+**Files:**
+- Modify: Railway dev `frontend` service variables (no repository file changes)
+
+**Interfaces:**
+- Consumes: Railway IDs and `APPLE_TEAM_ID` value from Global Constraints.
+- Produces: A variable-triggered frontend deployment containing `APPLE_TEAM_ID=LMQ3XNXLAD`.
+
+- [ ] **Step 1: Confirm the target service's current variables**
+
+Call `railway_list_variables` with:
+
+```json
+{
+  "project_id": "5a1f986c-e0fb-4e5f-a78b-0c58ed1b0e10",
+  "environment_id": "455d1280-79d1-4a8d-b2ff-0f4bbecdc9ca",
+  "service_id": "aa371189-1215-490d-a363-baf45e8128d8"
+}
+```
+
+Expected: `RAILWAY_ENVIRONMENT_NAME=dev` and `RAILWAY_SERVICE_NAME=frontend`.
+
+- [ ] **Step 2: Set the sole required variable**
+
+Call `railway_set_variables` with:
+
+```json
+{
+  "project_id": "5a1f986c-e0fb-4e5f-a78b-0c58ed1b0e10",
+  "environment_id": "455d1280-79d1-4a8d-b2ff-0f4bbecdc9ca",
+  "service_id": "aa371189-1215-490d-a363-baf45e8128d8",
+  "variables": {"APPLE_TEAM_ID": "LMQ3XNXLAD"}
+}
+```
+
+Expected: Railway accepts the update and starts a frontend deployment.
+
+- [ ] **Step 3: Verify the exact value is present**
+
+Repeat the `railway_list_variables` call from Step 1.
+
+Expected: `APPLE_TEAM_ID=LMQ3XNXLAD` is returned with the dev frontend variables.
+
+### Task 2: Verify the public AASA endpoint
+
+**Files:**
+- Modify: none
+
+**Interfaces:**
+- Consumes: successful dev frontend deployment from Task 1.
+- Produces: evidence that Apple can retrieve the intended AASA document.
+
+- [ ] **Step 1: Wait for the latest deployment to succeed**
+
+Call `railway_list_deployments` with:
+
+```json
+{
+  "project_id": "5a1f986c-e0fb-4e5f-a78b-0c58ed1b0e10",
+  "environment_id": "455d1280-79d1-4a8d-b2ff-0f4bbecdc9ca",
+  "service_id": "aa371189-1215-490d-a363-baf45e8128d8",
+  "limit": 1
+}
+```
+
+Expected: the newest deployment status is `SUCCESS`. If it is `FAILED` or `CRASHED`, retrieve frontend deploy logs and stop.
+
+- [ ] **Step 2: Assert the public AASA transport and payload**
+
+Run:
+
+```bash
+curl -sS -D /tmp/dev-aasa.headers https://dev.index.network/.well-known/apple-app-site-association -o /tmp/dev-aasa.json
+awk 'NR == 1 || tolower($0) ~ /^content-type:/' /tmp/dev-aasa.headers
+jq -e '.applinks.details[0].appIDs == ["LMQ3XNXLAD.network.index.system6"]' /tmp/dev-aasa.json
+```
+
+Expected: `HTTP/2 200`, `Content-Type: application/json`, and `true`. The command does not follow redirects, so a 3xx response fails validation.
+
+- [ ] **Step 3: Confirm the startup warning is absent**
+
+Call `railway_get_logs` for the same dev frontend service and deployment, requesting deployment logs.
+
+Expected: no log line contains `APPLE_TEAM_ID is not set`; any present log confirms the released AASA behavior is not active and blocks promotion.
+
+- [ ] **Step 4: Record production follow-up**
+
+Keep Railway `main` unchanged until the production web release carries the AASA route. At that release, repeat Tasks 1–3 against environment `main` (`14d759e9-ce00-4c26-855c-9a0a7f15bc65`) and `https://index.network` before signing/notarization handoff testing.

--- a/docs/superpowers/plans/2026-08-04-dev-aasa-configuration.md
+++ b/docs/superpowers/plans/2026-08-04-dev-aasa-configuration.md
@@ -92,11 +92,16 @@ Run:
 
 ```bash
 curl -sS -D /tmp/dev-aasa.headers https://dev.index.network/.well-known/apple-app-site-association -o /tmp/dev-aasa.json
-awk 'NR == 1 || tolower($0) ~ /^content-type:/' /tmp/dev-aasa.headers
+status=$(awk 'NR == 1 { print $2; exit }' /tmp/dev-aasa.headers)
+content_type=$(awk 'BEGIN { IGNORECASE=1 } /^content-type:/ { print tolower($0); exit }' /tmp/dev-aasa.headers)
+location=$(awk 'BEGIN { IGNORECASE=1 } /^location:/ { print; exit }' /tmp/dev-aasa.headers)
+test "$status" = 200
+printf '%s\n' "$content_type" | grep -Eq '^content-type:[[:space:]]*application/json([;[:space:]]|$)'
+test -z "$location"
 jq -e '.applinks.details[0].appIDs == ["LMQ3XNXLAD.network.index.system6"]' /tmp/dev-aasa.json
 ```
 
-Expected: `HTTP/2 200`, `Content-Type: application/json`, and `true`. The command does not follow redirects, so a 3xx response fails validation.
+Expected: `HTTP/2 200`, `Content-Type: application/json`, no `Location` header, and `true`. The explicit assertions fail on a redirect, a non-200 response, or a non-JSON content type.
 
 - [ ] **Step 3: Confirm the startup warning is absent**
 

--- a/docs/superpowers/specs/2026-08-04-aasa-rollout-design.md
+++ b/docs/superpowers/specs/2026-08-04-aasa-rollout-design.md
@@ -8,7 +8,7 @@ Enable Apple universal links for the macOS bundle `network.index.system6` withou
 
 - `apps/web/server.ts` renders `/.well-known/apple-app-site-association` from `APPLE_TEAM_ID`; when absent it serves `TEAMIDPLACEHOLDER.network.index.system6`.
 - The approved Apple Developer Team ID is `LMQ3XNXLAD`.
-- Railway `dev` frontend already serves the AASA route but currently contains the placeholder.
+- Railway `dev` frontend serves the AASA route with `LMQ3XNXLAD.network.index.system6` after the completed dev configuration rollout.
 - Railway `main` frontend serves `index.network` but currently deploys a pre-deep-link revision, so its AASA route returns HTTP 404.
 
 ## Rollout

--- a/docs/superpowers/specs/2026-08-04-aasa-rollout-design.md
+++ b/docs/superpowers/specs/2026-08-04-aasa-rollout-design.md
@@ -1,0 +1,33 @@
+# AASA universal-link rollout design
+
+## Purpose
+
+Enable Apple universal links for the macOS bundle `network.index.system6` without exposing a malformed association file or changing API routing before the web fallback is deployed.
+
+## Current state
+
+- `apps/web/server.ts` renders `/.well-known/apple-app-site-association` from `APPLE_TEAM_ID`; when absent it serves `TEAMIDPLACEHOLDER.network.index.system6`.
+- The approved Apple Developer Team ID is `LMQ3XNXLAD`.
+- Railway `dev` frontend already serves the AASA route but currently contains the placeholder.
+- Railway `main` frontend serves `index.network` but currently deploys a pre-deep-link revision, so its AASA route returns HTTP 404.
+
+## Rollout
+
+1. Set `APPLE_TEAM_ID=LMQ3XNXLAD` only on Railway's `frontend` service in the `dev` environment.
+2. Wait for the variable-triggered deployment to reach a terminal successful state.
+3. Verify `https://dev.index.network/.well-known/apple-app-site-association` from outside Railway:
+   - HTTP 200;
+   - no redirect;
+   - `Content-Type: application/json`;
+   - JSON `applinks.details[0].appIDs` exactly equals `["LMQ3XNXLAD.network.index.system6"]`.
+4. Check the dev frontend logs to confirm the missing-`APPLE_TEAM_ID` startup warning is absent.
+5. Do not configure or claim production universal-link readiness until a release deploys the web AASA route to Railway `main`. The web deployment must precede any API deployment that removes the legacy `/c/:code/go` behavior.
+6. During that production web release, set the same variable on Railway `main` frontend and repeat the public AASA verification at `https://index.network/.well-known/apple-app-site-association`.
+
+## Error handling and rollback
+
+If the dev deployment fails, inspect its Railway logs and do not continue to production. If the AASA response is malformed, redirected, or contains another app ID, correct the dev configuration and re-verify before any production action. Removing the variable restores the existing placeholder behavior but does not repair an unrelated failed deployment; use it only to undo an incorrect value.
+
+## Validation
+
+This is an infrastructure-only change. Validation is the external AASA response, Railway deployment status, and frontend startup logs; source tests are unaffected.


### PR DESCRIPTION
## Summary
- document the approved dev-first AASA / Apple Team ID rollout
- record production release gating and post-release task ordering

## Verification
- Railway dev frontend deployment `a0b3d41b-b2a4-49a7-a405-f330c279bd73`: `SUCCESS`
- `https://dev.index.network/.well-known/apple-app-site-association`: HTTP 200, `application/json`, no redirect, app ID `LMQ3XNXLAD.network.index.system6`

Refs IND-615; production remains intentionally unchanged until the web release deploys the AASA route.