### PR TITLE
feat(eval): compare two discovery env configurations head to head (IND-627)

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -135,6 +135,43 @@ jobs:
             src/queues/tests/timeout.queue.spec.ts \
             src/queues/tests/claim-timeout.queue.spec.ts
 
+  eval-cli-tests:
+    # The services/api eval CLI specs, which ran local-only until now. They are
+    # drift guards, and a drift guard nobody runs guards nothing: the discovery
+    # A/B set derives the nine offerable flags from the discovery graph's own
+    # import closure and fails when that set moves, refuses an asymmetric or
+    # identical configuration pair, and proves every artifact case row carries
+    # the configuration it was produced under.
+    #
+    # Separate from the `test` job above because these are not dist-free: the
+    # A/B artifact and child specs import `discovery-ab.main.ts`, which imports
+    # `@indexnetwork/protocol` (that is, `packages/protocol/dist`, gitignored).
+    # Hence the explicit build step. No secrets and no database: every spec here
+    # fakes the control plane, the graph and the judge, and provider
+    # credentials are stripped so a spec that reached for a live model fails.
+    runs-on: blacksmith-4vcpu-ubuntu-2404
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: "1.3.14"
+          no-cache: true
+
+      - name: Install dependencies
+        run: |
+          bun pm cache rm || true
+          bun install --frozen-lockfile
+
+      - name: Build packages/protocol
+        run: cd packages/protocol && bun run build
+
+      - name: Run the eval CLI specs (discovery A/B and env matrix)
+        run: |
+          unset OPENROUTER_API_KEY OPENAI_API_KEY
+          cd services/api
+          bun test src/cli/tests/
+
   protocol-source-tests:
     # Per-file processes prevent Bun mock.module state from leaking between
     # source specs. The runner also strips provider credentials and reports

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -90,6 +90,15 @@ jobs:
       - name: Type check API
         run: cd services/api && bun run build
 
+      # `bun run build` compiles services/api/tsconfig.json, which excludes
+      # `src/**/*.spec.ts`, so no spec is type-checked by the step above. That
+      # matters for the discovery A/B CLI specs, where one assertion *is* a type
+      # assertion: `discovery-ab.neon.spec.ts` proves `resetAbBranch` refuses an
+      # unattested manifest with a `@ts-expect-error`, and a directive nobody
+      # compiles proves nothing. See services/api/tsconfig.spec.json.
+      - name: Type check the discovery A/B CLI specs
+        run: cd services/api && bun run typecheck:cli-specs
+
   test:
     # Runs the hermetic pinning/characterization specs that mock all external
     # systems (Redis/LLM/DB), so they need no services, secrets, or built

--- a/.gitignore
+++ b/.gitignore
@@ -58,6 +58,10 @@ packages/protocol/eval/opportunity/runs/
 packages/protocol/eval/canary/runs/
 packages/protocol/eval/discovery-retrieval/runs/
 services/api/eval/discovery-env-matrix/runs/
+# The A/B runs directory itself is tracked (via .gitkeep) so the harness has
+# somewhere to write on a fresh clone; only its artifacts are ignored.
+services/api/eval/discovery-ab/runs/*
+!services/api/eval/discovery-ab/runs/.gitkeep
 packages/protocol/eval/.ops-runs/
 
 # superpowers brainstorm mockups

--- a/bun.lock
+++ b/bun.lock
@@ -110,7 +110,7 @@
     },
     "packages/protocol": {
       "name": "@indexnetwork/protocol",
-      "version": "8.10.0",
+      "version": "8.11.0",
       "dependencies": {
         "@langchain/core": "1.1.48",
         "@langchain/langgraph": "1.3.2",
@@ -126,7 +126,7 @@
     },
     "services/api": {
       "name": "@indexnetwork/api",
-      "version": "0.72.0",
+      "version": "0.73.0",
       "dependencies": {
         "@aws-sdk/client-s3": "^3.939.0",
         "@aws-sdk/s3-request-presigner": "^3.983.0",

--- a/docs/guides/development-reference.md
+++ b/docs/guides/development-reference.md
@@ -31,6 +31,10 @@ bun test --watch                            # Run tests in watch mode
 
 # Code quality
 bun run lint                                # Run ESLint
+bun run typecheck:cli-specs                 # Type-check the discovery A/B CLI specs (see tsconfig.spec.json)
+
+# Evals (gated, mutating, cost tokens — see ### Discovery A/B Eval)
+bun run eval:discovery-ab -- --help         # Discovery A/B: contract and exit codes, no credentials needed
 
 # Maintenance/CLI tools
 bun run maintenance:backfill-premises       # Backfill: enqueue enrichment for users in a network
@@ -111,6 +115,203 @@ bun run eval:matching -- --runs 3           # Run a harness (costs tokens)
 
 Harness exit codes: `0` pass, `1` regression, `2` execution error, `3`
 insufficient evidence.
+
+### Discovery A/B Eval
+
+Lives in `services/api` (not `packages/protocol`) because it drives the real
+discovery graph against real Neon databases.
+
+```bash
+cd services/api
+bun run eval:discovery-ab -- --help          # The whole contract, no credentials needed
+bun run eval:discovery-ab -- \
+  --a DISCOVERY_ALLOWED_TYPES=intent \
+  --b DISCOVERY_ALLOWED_TYPES=intent,profile  # A default run (costs tokens and ~13 minutes)
+```
+
+**What it compares.** Two operator-chosen environment configurations over the
+same cases. Selection (`--case`, `--runs`) is shared; configuration is not. Each
+side runs in its own child process — `withDiscoveryEnvironment` mutates the real
+`process.env`, so two configurations in one process would read each other's
+flags — and each child is composed against its own Neon branch (`eval-ab-a`,
+`eval-ab-b`), which the parent resets from the protected `eval-discovery-base`
+branch before it spawns anything. Both resets must succeed first: a
+half-isolated comparison is not a comparison. The command never creates or
+deletes Neon branches.
+
+**The gate.** Every A/B process, parent included, refuses to start without all
+four of these, and refuses before it imports anything that can compose a
+database:
+
+| Variable | Why |
+| --- | --- |
+| `DISCOVERY_AB_CONFIRM=1` | Explicit consent to a mutating, paid run. |
+| `TEST_DATABASE_SAFE=1` | The disposable-database marker; the graph writes opportunities and negotiation tasks. |
+| `NEON_API_KEY` | Required up front, because every process attests its targets against the control plane before it loads the graph. |
+| `DISCOVERY_AB_TARGETS` | The manifest below, attested against the Neon control plane on every invocation. |
+
+```json
+{
+  "projectId": "...",
+  "baseBranchId": "br-...",
+  "targets": [
+    { "sideId": "a", "branchId": "br-...", "endpointId": "ep-...", "databaseUrl": "postgres://...neon.tech/protocol_eval" },
+    { "sideId": "b", "branchId": "br-...", "endpointId": "ep-...", "databaseUrl": "postgres://...neon.tech/protocol_eval" }
+  ]
+}
+```
+
+Attestation checks each side is the exactly-named designated branch, is not
+primary, is parented on a base branch named `eval-discovery-base`, and has an
+endpoint whose host matches its `databaseUrl`. A failed attestation prints one
+fixed message and never the control plane's own — control-plane responses and
+`DATABASE_URL`s carry credentials — so do not expect the specific mismatch to be
+named.
+
+**The nine flags it can offer.** `AB_FLAGS` in
+`services/api/src/cli/discovery-ab.flags.ts`, asserted by
+`discovery-ab.flags.spec.ts` against a fresh scan of the discovery graph's own
+import closure rather than hand-maintained:
+
+```
+DISCOVERY_ALLOWED_TYPES            DISCOVERY_CONTEXT_TO_INTENT
+DISCOVERY_PROFILE_SOURCE           DISCOVERY_REJECTION_COOLDOWN_DAYS
+DISCOVERY_SOURCE_PREMISE_LIMIT     NEGOTIATION_INCLUDE_OTHER_INTENTS
+NEGOTIATION_MAX_TURNS_AMBIENT      NEGOTIATION_MAX_TURNS_CHAT
+RUN_OPPORTUNITY_EVAL_IN_PARALLEL
+```
+
+**The seven it cannot.** `PROFILE_ENV_ALLOWLIST`
+(`packages/protocol/eval/ops/ops.allowlist.ts`) has sixteen entries. The other
+seven are **not reachable from the discovery graph**, so this harness refuses
+them by name rather than pretending to test them:
+
+```
+POOL_QUESTIONS_MODE       POOL_QUESTIONS_PUSH      POOL_QUESTIONS_RANKING
+POOL_QUESTIONS_MINING     OUTCOME_QUESTIONS_MODE   INTRODUCER_DISCOVERY_ENABLED
+NEGOTIATION_EVIDENCE_QUESTIONS_MODE
+```
+
+"Not reachable from the discovery graph" is the whole claim, and it is not the
+same as "untestable". For most of them the behaviour lives in
+`packages/protocol` and only the scheduling is in the API queues; they need a
+different harness, not no harness. Deciding where that home is, is tracked as
+**IND-630**. Do not assume the A/B editor covers all sixteen.
+
+**Both sides must declare the same key set.** Explicit value versus explicit
+value. `buildAbPlan` refuses an asymmetric pair, because an omitted key does not
+mean "neutral" — it means the graph's own default, and that default can coincide
+with the other side's explicit value. `{}` against
+`{ DISCOVERY_ALLOWED_TYPES: 'intent,profile' }` is the worst case: the default
+*is* `intent,profile`
+(`packages/protocol/src/opportunity/discovery.env.ts`), so both sides behave
+identically, the run measures nothing but noise, and the artifact attributes
+that noise to the flag. Identical configurations are refused for the same
+reason.
+
+**A value-level trap the symmetry check cannot catch.**
+`DISCOVERY_CONTEXT_TO_INTENT` only changes behaviour when
+`DISCOVERY_PROFILE_SOURCE` is `user_context`
+(`opportunity.graph.ts:388` and `:1202-1204`; the same lines also require
+`profile` to be in `DISCOVERY_ALLOWED_TYPES`). Comparing it alone, under the
+default `premise` profile source, measures noise on both sides. The harness will
+accept that run — it is a legal, symmetric, differing pair — so this one is on
+the operator.
+
+**Cost.** The corpus is five cases (`HISTORICAL_MATRIX_CASES`), so a default run
+is 5 cases × 3 repetitions × 2 sides = **30 graph invocations**: 15 slots per
+side, run sequentially within a side, with the two sides running concurrently.
+At the ~52s per invocation recorded in `discovery-ab.contract.ts` that is
+roughly **13 minutes** of wall clock, plus one judge call per scored slot.
+`--runs` defaults to 3 (one observation cannot separate a difference from noise)
+and is capped at 10, which is 100 invocations.
+
+**Exit codes**, for the parent invocation an operator runs:
+
+| Code | Conclude |
+| --- | --- |
+| `0` | Both sides completed and the artifact holds the comparison. Read it. |
+| `2` | Refused before anything happened — gate, arguments, manifest or attestation. No branch was reset, no side spawned, nothing spent. Fix what the message names and re-run; you lost seconds. |
+| `3` | The run happened and was paid for and the artifact on disk is real, but a side did not score every slot, so there is **no verdict**. Do not read one side's numbers as a comparison. |
+| `4` | Failed after the branches began being reset and/or a side was spawned. The branches were mutated and a live run may already be spent; re-running costs that again. The message, not the code, says what was overwritten and whether an artifact or any child artifacts survived. |
+
+The distinction that matters is `2` versus `4`: both are failures, but one costs
+nothing and the other costs a live run.
+
+**There is no baseline, and there will not be one.** Arbitrary operator-chosen
+configurations have no committed baseline, so the pair *is* the result. The
+harness reads, writes and compares no baseline and emits no regression verdict.
+
+**`configs`/`configDiff` are deliberately not in the artifact.** The shared
+envelope and scorecard payload schemas are both zod `.strict()`
+(`packages/protocol/eval/shared/artifact.ts`), so a run-level configuration
+rollup has no legal home in them, and widening a contract shared by every
+harness and every committed baseline for a convenience copy is a bad trade.
+Nothing is lost: every case row carries `configDeltas` naming that side's
+complete configuration (the case schema is the sanctioned `.passthrough()`
+extension point), `assertAbConfigProvenance` refuses to write an artifact where
+that is missing or wrong, and the diff is printed to the console at the end of
+every run. The run-level pair is a rollup of the rows, derivable by grouping
+them by rule.
+
+Artifacts land in `services/api/eval/discovery-ab/runs/<timestamp>.json`
+(gitignored). `payload.rules` are the two sides (`a`, `b`); case ids are
+`<caseId>/<side>/r<repetition>`.
+
+#### Operator runbook: first-time setup and smoke
+
+These steps need `NEON_API_KEY` and Neon project access, so they are an operator
+procedure, not something CI or a local checkout can do. Run them in order.
+
+1. **Create and seed the protected base (IND-626).** `eval-discovery-base` must
+   exist in the Neon project with an endpoint on database `protocol_eval`, and
+   must carry the seeded historical fixture corpus. Seed and verify it with the
+   existing protected-base command, whose own gate is
+   `DISCOVERY_ENV_MATRIX_BASE_CONFIRM=1`, `TEST_DATABASE_SAFE=1`,
+   `DISCOVERY_ENV_MATRIX_BASE_BRANCH=eval-discovery-base` and a `DATABASE_URL`
+   matching the attested base target:
+
+   ```bash
+   cd services/api
+   bun run eval:discovery-env-matrix-base           # seed
+   bun run eval:discovery-env-matrix-base:verify    # metadata + fixture-structure reads only
+   ```
+
+   Nothing below works until this branch exists and verifies: every A/B run
+   attests that its base branch is named `eval-discovery-base`, and every A/B
+   child re-verifies the base metadata and fixture integrity on its own branch
+   before it spends anything.
+
+2. **Branch `eval-ab-a` and `eval-ab-b` from it.** Both must be children of
+   `eval-discovery-base`, non-primary, named exactly that, and each must have its
+   own endpoint on database `protocol_eval`. Create them in the Neon console or
+   via the API, then record the project id, the base branch id, and each side's
+   branch id, endpoint id and `DATABASE_URL` in the manifest above. Attestation
+   fails on any of those being wrong, and the failure is deliberately
+   non-specific.
+
+3. **Smoke it: one case, one repetition.**
+
+   ```bash
+   cd services/api
+   DISCOVERY_AB_CONFIRM=1 TEST_DATABASE_SAFE=1 \
+   NEON_API_KEY=<key> DISCOVERY_AB_TARGETS='<manifest>' \
+     bun run eval:discovery-ab -- \
+       --case historical/builder-and-operator --runs 1 \
+       --a DISCOVERY_ALLOWED_TYPES=intent \
+       --b DISCOVERY_ALLOWED_TYPES=intent,profile
+   ```
+
+   That is 2 graph invocations (1 case × 1 repetition × 2 sides) plus 2 judge
+   calls — a couple of minutes, not forty. Expect exit `0`, a reset line per
+   side, the printed configuration diff, and one artifact in
+   `eval/discovery-ab/runs/`. In the artifact, check:
+   `harness === "discovery-ab"`; `completeness.complete === true`;
+   `payload.rules` is exactly the two sides `a` and `b`; and both case rows
+   (`historical/builder-and-operator/a/r1` and `.../b/r1`) carry a `configDeltas`
+   naming that side's configuration. If `completeness.complete` is `false` the
+   exit code is `3` and the run supports no comparison, however good the numbers
+   look.
 
 ### Eval Ops Site
 

--- a/docs/guides/development-reference.md
+++ b/docs/guides/development-reference.md
@@ -298,16 +298,20 @@ steps in order.
    `DISCOVERY_ENV_MATRIX_BASE_CONFIRM=1`, `TEST_DATABASE_SAFE=1`,
    `DISCOVERY_ENV_MATRIX_BASE_BRANCH=eval-discovery-base` and a `DATABASE_URL`
    matching the attested base target. That command attests its target the same
-   way the matrix does, so it also needs `NEON_API_KEY` and the matrix manifest
-   `DISCOVERY_ENV_MATRIX_CHILDREN` (a different manifest from
-   `DISCOVERY_AB_TARGETS`); it refuses without them:
+   way the matrix does, so it also needs `NEON_API_KEY` and a
+   `DISCOVERY_ENV_MATRIX_CHILDREN` manifest (a different manifest from
+   `DISCOVERY_AB_TARGETS`); it refuses without them. That manifest must be
+   base-only: the base command parses it with no expected child keys
+   (`discovery-env-matrix-base.ts:74`), so `children` has to be `[]` — pasting
+   the matrix's own five-child manifest is refused with `Manifest must contain
+   exactly the expected children`:
 
    ```bash
    cd services/api
    export DISCOVERY_ENV_MATRIX_BASE_CONFIRM=1 TEST_DATABASE_SAFE=1
    export DISCOVERY_ENV_MATRIX_BASE_BRANCH=eval-discovery-base
    export NEON_API_KEY=<key>
-   export DISCOVERY_ENV_MATRIX_CHILDREN='<matrix manifest>'
+   export DISCOVERY_ENV_MATRIX_CHILDREN='{"version":1,"base":{"projectId":"...","branchId":"br-...","endpointId":"ep-...","databaseName":"protocol_eval","databaseUrl":"postgres://...neon.tech/protocol_eval"},"children":[]}'
    export DATABASE_URL='<the attested base target databaseUrl>'
    bun run eval:discovery-env-matrix-base           # seed
    bun run eval:discovery-env-matrix-base:verify    # metadata + fixture-structure reads only

--- a/docs/guides/development-reference.md
+++ b/docs/guides/development-reference.md
@@ -124,9 +124,14 @@ discovery graph against real Neon databases.
 ```bash
 cd services/api
 bun run eval:discovery-ab -- --help          # The whole contract, no credentials needed
-bun run eval:discovery-ab -- \
-  --a DISCOVERY_ALLOWED_TYPES=intent \
-  --b DISCOVERY_ALLOWED_TYPES=intent,profile  # A default run (costs tokens and ~13 minutes)
+
+# A default run (costs tokens and ~13 minutes). Every A/B invocation but --help
+# needs all four gate variables; see **The gate** below.
+DISCOVERY_AB_CONFIRM=1 TEST_DATABASE_SAFE=1 \
+NEON_API_KEY=<key> DISCOVERY_AB_TARGETS='<manifest>' \
+  bun run eval:discovery-ab -- \
+    --a DISCOVERY_ALLOWED_TYPES=intent \
+    --b DISCOVERY_ALLOWED_TYPES=intent,profile
 ```
 
 **What it compares.** Two operator-chosen environment configurations over the
@@ -218,6 +223,14 @@ default `premise` profile source, measures noise on both sides. The harness will
 accept that run — it is a legal, symmetric, differing pair — so this one is on
 the operator.
 
+**A/B does not enforce per-row evidence gating**, so a passing A/B slot is not
+evidence that the configuration's evidence restriction held: every slot is
+scored against all three evidence kinds (`AB_ALLOWED_EVIDENCE` in
+`discovery-ab.main.ts`). That is deliberate — which evidence a given arbitrary
+configuration should be allowed to cite is the fixed matrix's question, not
+this harness's. Every other deterministic assertion still applies, including
+the non-empty evidence check.
+
 **Cost.** The corpus is five cases (`HISTORICAL_MATRIX_CASES`), so a default run
 is 5 cases × 3 repetitions × 2 sides = **30 graph invocations**: 15 slots per
 side, run sequentially within a side, with the two sides running concurrently.
@@ -248,11 +261,14 @@ envelope and scorecard payload schemas are both zod `.strict()`
 rollup has no legal home in them, and widening a contract shared by every
 harness and every committed baseline for a convenience copy is a bad trade.
 Nothing is lost: every case row carries `configDeltas` naming that side's
-complete configuration (the case schema is the sanctioned `.passthrough()`
+specified overrides (the case schema is the sanctioned `.passthrough()`
 extension point), `assertAbConfigProvenance` refuses to write an artifact where
 that is missing or wrong, and the diff is printed to the console at the end of
 every run. The run-level pair is a rollup of the rows, derivable by grouping
-them by rule.
+them by rule. Only the keys the operator passed on `--a`/`--b` are recorded:
+any other flag value that comes from the env file the command loads (for
+example `RUN_OPPORTUNITY_EVAL_IN_PARALLEL` in `.env.test`) is inherited
+identically by both sides and is not recorded per case.
 
 Artifacts land in `services/api/eval/discovery-ab/runs/<timestamp>.json`
 (gitignored). `payload.rules` are the two sides (`a`, `b`); case ids are
@@ -260,19 +276,39 @@ Artifacts land in `services/api/eval/discovery-ab/runs/<timestamp>.json`
 
 #### Operator runbook: first-time setup and smoke
 
-These steps need `NEON_API_KEY` and Neon project access, so they are an operator
-procedure, not something CI or a local checkout can do. Run them in order.
+Every step but the first needs `NEON_API_KEY` and Neon project access, so this
+is an operator procedure, not something CI or a local checkout can do. Run the
+steps in order.
 
-1. **Create and seed the protected base (IND-626).** `eval-discovery-base` must
+1. **Build `packages/protocol` first.** The A/B parent statically imports
+   `@indexnetwork/protocol`, which resolves to `packages/protocol/dist` — a
+   gitignored build output that a fresh checkout does not have. The parent dies
+   inside that import, and the failure message is deliberately generic, so a
+   missing build is not named as the cause:
+
+   ```bash
+   cd services/api
+   bun run --cwd ../../packages/protocol build
+   ```
+
+2. **Create and seed the protected base (IND-626).** `eval-discovery-base` must
    exist in the Neon project with an endpoint on database `protocol_eval`, and
    must carry the seeded historical fixture corpus. Seed and verify it with the
    existing protected-base command, whose own gate is
    `DISCOVERY_ENV_MATRIX_BASE_CONFIRM=1`, `TEST_DATABASE_SAFE=1`,
    `DISCOVERY_ENV_MATRIX_BASE_BRANCH=eval-discovery-base` and a `DATABASE_URL`
-   matching the attested base target:
+   matching the attested base target. That command attests its target the same
+   way the matrix does, so it also needs `NEON_API_KEY` and the matrix manifest
+   `DISCOVERY_ENV_MATRIX_CHILDREN` (a different manifest from
+   `DISCOVERY_AB_TARGETS`); it refuses without them:
 
    ```bash
    cd services/api
+   export DISCOVERY_ENV_MATRIX_BASE_CONFIRM=1 TEST_DATABASE_SAFE=1
+   export DISCOVERY_ENV_MATRIX_BASE_BRANCH=eval-discovery-base
+   export NEON_API_KEY=<key>
+   export DISCOVERY_ENV_MATRIX_CHILDREN='<matrix manifest>'
+   export DATABASE_URL='<the attested base target databaseUrl>'
    bun run eval:discovery-env-matrix-base           # seed
    bun run eval:discovery-env-matrix-base:verify    # metadata + fixture-structure reads only
    ```
@@ -282,7 +318,7 @@ procedure, not something CI or a local checkout can do. Run them in order.
    child re-verifies the base metadata and fixture integrity on its own branch
    before it spends anything.
 
-2. **Branch `eval-ab-a` and `eval-ab-b` from it.** Both must be children of
+3. **Branch `eval-ab-a` and `eval-ab-b` from it.** Both must be children of
    `eval-discovery-base`, non-primary, named exactly that, and each must have its
    own endpoint on database `protocol_eval`. Create them in the Neon console or
    via the API, then record the project id, the base branch id, and each side's
@@ -290,7 +326,7 @@ procedure, not something CI or a local checkout can do. Run them in order.
    fails on any of those being wrong, and the failure is deliberately
    non-specific.
 
-3. **Smoke it: one case, one repetition.**
+4. **Smoke it: one case, one repetition.**
 
    ```bash
    cd services/api

--- a/docs/superpowers/plans/2026-08-04-discovery-env-ab-engine.md
+++ b/docs/superpowers/plans/2026-08-04-discovery-env-ab-engine.md
@@ -1,0 +1,1051 @@
+# Discovery env A/B engine — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Run the real discovery graph twice — once per operator-chosen environment configuration — over a shared case selection, and emit one artifact holding both sides.
+
+**Architecture:** Generalize the existing `discovery-env-matrix` machinery from five hard-coded rows to two operator-chosen env configs. A dependency-free bootstrap attests the Neon targets *before* any runtime import, resets both side branches from the protected base, then spawns one child process per side (the API composes its database singleton once per process, so a side's `DATABASE_URL` must be fixed for that process's lifetime). Each child runs its slots under its own env config; the parent aggregates both sides into one artifact with no baseline comparison.
+
+**Tech Stack:** Bun, TypeScript, Drizzle, Neon control plane (REST), `@indexnetwork/protocol` graph + eval policy modules.
+
+**Spec:** `docs/superpowers/specs/2026-08-04-discovery-env-ab-engine-design.md`
+**Linear:** IND-627 (engine), IND-626 (base fixture, Task 1), IND-630 (the seven unreachable flags)
+
+## Global Constraints
+
+- **Only nine flags may be offered:** `DISCOVERY_ALLOWED_TYPES`, `DISCOVERY_PROFILE_SOURCE`, `DISCOVERY_CONTEXT_TO_INTENT`, `DISCOVERY_SOURCE_PREMISE_LIMIT`, `DISCOVERY_REJECTION_COOLDOWN_DAYS`, `RUN_OPPORTUNITY_EVAL_IN_PARALLEL`, `NEGOTIATION_MAX_TURNS_CHAT`, `NEGOTIATION_MAX_TURNS_AMBIENT`, `NEGOTIATION_INCLUDE_OTHER_INTENTS`. Derived by test, never hand-copied (Task 2).
+- **No baseline.** This harness never reads, writes or compares a baseline file. The pair is the result.
+- **Errors are sanitized** before reaching logs or artifacts — provider and database errors can carry credentials and response bodies. Reuse `sanitizeMatrixError` / `MatrixExecutionError` classification.
+- **Selection is shared, configuration is per side.** Cases and repetitions are one control for both sides.
+- **Identical configs are refused** before any spend.
+- **Never target `production` (`br-fragrant-brook-ahexgsek`) or `dev`.** Attestation must make them unreachable by construction.
+- **Test command:** `cd services/api && bun test src/cli/tests/<file>.spec.ts` for a single file. Full suite: `bun run test` (runs `NODE_ENV=test API_TEST_REQUIRE_DATABASE=1 bun test`).
+- **Lint:** `cd services/api && bun run lint`.
+- All new files live in `services/api/src/cli/`, tests in `services/api/src/cli/tests/`, following the existing `discovery-env-matrix.*` naming.
+
+---
+
+## File Structure
+
+| File | Responsibility |
+|---|---|
+| `src/cli/discovery-ab.flags.ts` | The nine offerable flags + value-kind validation. Pure. |
+| `src/cli/tests/discovery-ab.flags.spec.ts` | Derives the reachable flag set from the graph source and asserts it equals the offered set. |
+| `src/cli/discovery-env-matrix.runtime.ts` *(modify)* | `withMatrixEnvironment` generalized to an arbitrary allowlisted env map. |
+| `src/cli/discovery-ab.plan.ts` | `(cases, reps, configA, configB) → slots`; refuses identical configs; shares selection. Pure. |
+| `src/cli/tests/discovery-ab.plan.spec.ts` | Plan-builder tests. |
+| `src/cli/discovery-ab.neon.ts` | A/B target attestation + the single mutating reset call. |
+| `src/cli/tests/discovery-ab.neon.spec.ts` | Attestation and reset tests against a fake control plane. |
+| `src/cli/discovery-ab.main.ts` | Parent: gate → reset → spawn two children → aggregate → artifact. Child: run assigned slots. |
+| `src/cli/discovery-ab.ts` | Dependency-free attesting bootstrap (mirrors `discovery-env-matrix.ts`). |
+| `src/cli/tests/discovery-ab.artifact.spec.ts` | Artifact shape: two rules, per-side configs, diff, no baseline. |
+| `services/api/package.json` *(modify)* | `eval:discovery-ab` script. |
+
+---
+
+### Task 1: Recreate and seed the protected base fixture (IND-626)
+
+This is operational, not code: `eval-discovery-base` does not exist in Neon project `shiny-cloud-34341469`, so every later task has nothing to branch from. Seeding embeds every fixture intent and builds HyDE documents with vectors — this is why the design clones a pre-embedded base instead of re-seeding per run.
+
+**Files:**
+- No source changes. Uses existing `src/cli/discovery-env-matrix-base.main.ts`.
+
+**Interfaces:**
+- Consumes: nothing.
+- Produces: a Neon branch named exactly `eval-discovery-base` on project `shiny-cloud-34341469`, database `protocol_eval`, holding the `historical-matrix-v1` corpus; its `branchId`, `endpointId` and `databaseUrl` for later tasks.
+
+- [ ] **Step 1: Confirm the base is really absent**
+
+```bash
+# Expect: no branch named eval-discovery-base
+curl -s -H "Authorization: Bearer $NEON_API_KEY" \
+  https://console.neon.tech/api/v2/projects/shiny-cloud-34341469/branches \
+  | grep -o '"name":"[^"]*"' | sort -u
+```
+
+- [ ] **Step 2: Read the base lifecycle command's contract before running it**
+
+Read `src/cli/discovery-env-matrix-base.main.ts` — specifically `runBaseCommand`, `seedProtectedBase`, `verifyProtectedBase`, `verifyBaseFixtureIntegrity`. Note the required env: `NEON_API_KEY`, a confirm variable, and a `DATABASE_URL` pointing at the new branch. Do not guess the flags; `main(args)` parses them.
+
+- [ ] **Step 3: Create the branch and seed it**
+
+Create branch `eval-discovery-base` from `production` (schema source), then run the seed. The seed embeds intents and builds HyDE documents, so it needs provider credentials and takes several minutes.
+
+```bash
+cd services/api
+bun run eval:discovery-env-matrix-base   # exact flags per Step 2
+```
+
+- [ ] **Step 4: Verify integrity**
+
+```bash
+cd services/api
+bun run eval:discovery-env-matrix-base:verify
+```
+
+Expected: passes, reporting a `fixtureFingerprint` and `fixtureCorpusVersion` of `historical-matrix-v1`. It must refuse if any fixture intent is unembedded — if it does, the seed did not complete; do not proceed.
+
+- [ ] **Step 5: Mark the branch protected in Neon and record its identifiers**
+
+Set branch protection so no run can write to it. Record `branchId`, `endpointId` and the `protocol_eval` `databaseUrl` in the Linear issue IND-626, and note them for Task 6.
+
+- [ ] **Step 6: Commit**
+
+No code changed. Post the fingerprints and branch identifiers as a comment on IND-626 and close it.
+
+---
+
+### Task 2: The nine offerable flags, derived rather than copied
+
+The entire project exists because sixteen flags were editable while zero harnesses read them. A hand-maintained list would reintroduce exactly that drift, so the test recomputes the reachable set from the graph source.
+
+**Files:**
+- Create: `services/api/src/cli/discovery-ab.flags.ts`
+- Test: `services/api/src/cli/tests/discovery-ab.flags.spec.ts`
+
+**Interfaces:**
+- Consumes: nothing.
+- Produces:
+  - `AB_FLAGS: readonly string[]` — the nine keys, sorted.
+  - `type AbEnvConfig = Readonly<Record<string, string>>`
+  - `assertAbEnvConfig(config: AbEnvConfig): void` — throws when a key is outside `AB_FLAGS` or a value is empty/whitespace.
+  - `reachableEnvKeys(entryFile: string, candidateKeys: readonly string[]): Set<string>` — transitive-import-closure scan, used by the test.
+
+- [ ] **Step 1: Write the failing test**
+
+```ts
+// services/api/src/cli/tests/discovery-ab.flags.spec.ts
+import { describe, expect, it } from 'bun:test';
+import path from 'node:path';
+
+import { AB_FLAGS, assertAbEnvConfig, reachableEnvKeys } from '../discovery-ab.flags';
+
+const PROFILE_ENV_ALLOWLIST = [
+  'DISCOVERY_ALLOWED_TYPES', 'DISCOVERY_CONTEXT_TO_INTENT', 'DISCOVERY_PROFILE_SOURCE',
+  'DISCOVERY_REJECTION_COOLDOWN_DAYS', 'DISCOVERY_SOURCE_PREMISE_LIMIT', 'INTRODUCER_DISCOVERY_ENABLED',
+  'NEGOTIATION_EVIDENCE_QUESTIONS_MODE', 'NEGOTIATION_INCLUDE_OTHER_INTENTS', 'NEGOTIATION_MAX_TURNS_AMBIENT',
+  'NEGOTIATION_MAX_TURNS_CHAT', 'OUTCOME_QUESTIONS_MODE', 'POOL_QUESTIONS_MINING', 'POOL_QUESTIONS_MODE',
+  'POOL_QUESTIONS_PUSH', 'POOL_QUESTIONS_RANKING', 'RUN_OPPORTUNITY_EVAL_IN_PARALLEL',
+];
+
+const GRAPH_ENTRY = path.resolve(
+  import.meta.dir, '../../../../../packages/protocol/src/opportunity/application/opportunity.graph.ts',
+);
+
+describe('AB_FLAGS', () => {
+  it('is exactly the set of allowlisted keys the discovery graph can reach', () => {
+    const reachable = reachableEnvKeys(GRAPH_ENTRY, PROFILE_ENV_ALLOWLIST);
+    expect([...reachable].sort()).toEqual([...AB_FLAGS].sort());
+  });
+
+  it('offers nine flags and excludes every queue-only key', () => {
+    expect(AB_FLAGS).toHaveLength(9);
+    for (const key of ['POOL_QUESTIONS_MODE', 'POOL_QUESTIONS_PUSH', 'POOL_QUESTIONS_RANKING',
+      'POOL_QUESTIONS_MINING', 'OUTCOME_QUESTIONS_MODE', 'NEGOTIATION_EVIDENCE_QUESTIONS_MODE',
+      'INTRODUCER_DISCOVERY_ENABLED']) {
+      expect(AB_FLAGS).not.toContain(key);
+    }
+  });
+});
+
+describe('assertAbEnvConfig', () => {
+  it('accepts a config drawn from the offered flags', () => {
+    expect(() => assertAbEnvConfig({ DISCOVERY_ALLOWED_TYPES: 'intent' })).not.toThrow();
+  });
+
+  it('refuses a key the graph cannot reach, naming it', () => {
+    expect(() => assertAbEnvConfig({ POOL_QUESTIONS_MODE: 'on' })).toThrow(/POOL_QUESTIONS_MODE/);
+  });
+
+  it('refuses an empty value, because unset and empty are not the same thing', () => {
+    expect(() => assertAbEnvConfig({ DISCOVERY_ALLOWED_TYPES: '   ' })).toThrow(/DISCOVERY_ALLOWED_TYPES/);
+  });
+});
+```
+
+- [ ] **Step 2: Run it to make sure it fails**
+
+Run: `cd services/api && bun test src/cli/tests/discovery-ab.flags.spec.ts`
+Expected: FAIL — cannot resolve `../discovery-ab.flags`.
+
+- [ ] **Step 3: Implement**
+
+```ts
+// services/api/src/cli/discovery-ab.flags.ts
+/**
+ * The only environment flags this harness may offer: those the discovery graph
+ * actually reads. The list is asserted against a fresh scan of the graph's
+ * import closure (discovery-ab.flags.spec.ts) rather than trusted, because a
+ * hand-maintained copy is exactly how sixteen editable flags came to move
+ * nothing at all.
+ */
+import { existsSync, readFileSync } from 'node:fs';
+import path from 'node:path';
+
+export const AB_FLAGS: readonly string[] = [
+  'DISCOVERY_ALLOWED_TYPES',
+  'DISCOVERY_CONTEXT_TO_INTENT',
+  'DISCOVERY_PROFILE_SOURCE',
+  'DISCOVERY_REJECTION_COOLDOWN_DAYS',
+  'DISCOVERY_SOURCE_PREMISE_LIMIT',
+  'NEGOTIATION_INCLUDE_OTHER_INTENTS',
+  'NEGOTIATION_MAX_TURNS_AMBIENT',
+  'NEGOTIATION_MAX_TURNS_CHAT',
+  'RUN_OPPORTUNITY_EVAL_IN_PARALLEL',
+];
+
+export type AbEnvConfig = Readonly<Record<string, string>>;
+
+/** Resolves a relative TypeScript import specifier the way Bun does for these modules. */
+function resolveSpecifier(fromFile: string, specifier: string): string | null {
+  if (!specifier.startsWith('.')) return null;
+  const base = path.resolve(path.dirname(fromFile), specifier).replace(/\.js$/, '.ts');
+  for (const candidate of [base, `${base}.ts`, path.join(base, 'index.ts')]) {
+    if (candidate.endsWith('.ts') && existsSync(candidate)) return candidate;
+  }
+  return null;
+}
+
+/** Every candidate key mentioned anywhere in the entry file's transitive import closure. */
+export function reachableEnvKeys(entryFile: string, candidateKeys: readonly string[]): Set<string> {
+  const seen = new Set<string>();
+  const found = new Set<string>();
+  const stack = [path.resolve(entryFile)];
+  while (stack.length > 0) {
+    const file = stack.pop()!;
+    if (seen.has(file) || !existsSync(file)) continue;
+    seen.add(file);
+    const source = readFileSync(file, 'utf8');
+    for (const key of candidateKeys) if (source.includes(key)) found.add(key);
+    for (const match of source.matchAll(/(?:from|import)\s*\(?\s*["']([^"']+)["']/g)) {
+      const resolved = resolveSpecifier(file, match[1]!);
+      if (resolved !== null) stack.push(resolved);
+    }
+  }
+  return found;
+}
+
+/** Throws when a config names a flag this harness cannot honestly exercise. */
+export function assertAbEnvConfig(config: AbEnvConfig): void {
+  for (const [key, value] of Object.entries(config)) {
+    if (!AB_FLAGS.includes(key)) {
+      throw new Error(`${key} is not readable by the discovery graph; this harness cannot test it`);
+    }
+    if (value.trim() === '') {
+      throw new Error(`${key} has an empty value; unset it instead of blanking it`);
+    }
+  }
+}
+```
+
+- [ ] **Step 4: Run the tests and make sure they pass**
+
+Run: `cd services/api && bun test src/cli/tests/discovery-ab.flags.spec.ts`
+Expected: PASS, 5 tests.
+
+- [ ] **Step 5: Prove the derivation test is not tautological**
+
+Temporarily add `'POOL_QUESTIONS_MODE',` to `AB_FLAGS`, re-run, and confirm the first test FAILS. Remove it and confirm PASS again. A test that cannot fail is not evidence.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add services/api/src/cli/discovery-ab.flags.ts services/api/src/cli/tests/discovery-ab.flags.spec.ts
+git commit -m "feat(eval): derive the env flags a discovery A/B run may offer
+
+The nine keys are asserted against a fresh scan of opportunity.graph.ts's
+import closure rather than trusted as a list, because a hand-maintained copy
+is exactly how sixteen editable flags came to move nothing at all."
+```
+
+---
+
+### Task 3: Generalize environment application to an arbitrary config
+
+`withMatrixEnvironment` hard-codes two keys. A/B needs any of the nine, and must restore precisely — including deleting keys that were previously unset, or a run leaks configuration into the process that outlives it.
+
+**Files:**
+- Modify: `services/api/src/cli/discovery-env-matrix.runtime.ts:67-80`
+- Test: `services/api/src/cli/tests/discovery-ab.env.spec.ts` (create)
+
+**Interfaces:**
+- Consumes: `AbEnvConfig`, `assertAbEnvConfig` (Task 2).
+- Produces: `withDiscoveryEnvironment<T>(config: AbEnvConfig, run: () => Promise<T>): Promise<T>` exported from `discovery-env-matrix.runtime.ts`. The existing `withMatrixEnvironment(row, run)` keeps its signature and delegates, so the matrix harness is untouched.
+
+- [ ] **Step 1: Write the failing test**
+
+```ts
+// services/api/src/cli/tests/discovery-ab.env.spec.ts
+import { describe, expect, it } from 'bun:test';
+
+import { withDiscoveryEnvironment, withMatrixEnvironment } from '../discovery-env-matrix.runtime';
+
+describe('withDiscoveryEnvironment', () => {
+  it('applies every configured key for the duration of the run', async () => {
+    delete process.env.DISCOVERY_ALLOWED_TYPES;
+    process.env.DISCOVERY_SOURCE_PREMISE_LIMIT = '40';
+    const seen = await withDiscoveryEnvironment(
+      { DISCOVERY_ALLOWED_TYPES: 'intent', DISCOVERY_SOURCE_PREMISE_LIMIT: '5' },
+      async () => ({
+        allowed: process.env.DISCOVERY_ALLOWED_TYPES,
+        limit: process.env.DISCOVERY_SOURCE_PREMISE_LIMIT,
+      }),
+    );
+    expect(seen).toEqual({ allowed: 'intent', limit: '5' });
+  });
+
+  it('deletes keys that were unset before, rather than leaving them behind', async () => {
+    delete process.env.DISCOVERY_ALLOWED_TYPES;
+    await withDiscoveryEnvironment({ DISCOVERY_ALLOWED_TYPES: 'intent' }, async () => undefined);
+    expect('DISCOVERY_ALLOWED_TYPES' in process.env).toBe(false);
+  });
+
+  it('restores the previous value of keys that were set before', async () => {
+    process.env.DISCOVERY_SOURCE_PREMISE_LIMIT = '40';
+    await withDiscoveryEnvironment({ DISCOVERY_SOURCE_PREMISE_LIMIT: '5' }, async () => undefined);
+    expect(process.env.DISCOVERY_SOURCE_PREMISE_LIMIT).toBe('40');
+    delete process.env.DISCOVERY_SOURCE_PREMISE_LIMIT;
+  });
+
+  it('restores even when the run throws', async () => {
+    process.env.DISCOVERY_SOURCE_PREMISE_LIMIT = '40';
+    await expect(withDiscoveryEnvironment(
+      { DISCOVERY_SOURCE_PREMISE_LIMIT: '5' },
+      async () => { throw new Error('graph failed'); },
+    )).rejects.toThrow('graph failed');
+    expect(process.env.DISCOVERY_SOURCE_PREMISE_LIMIT).toBe('40');
+    delete process.env.DISCOVERY_SOURCE_PREMISE_LIMIT;
+  });
+
+  it('refuses a key the graph cannot reach', async () => {
+    await expect(withDiscoveryEnvironment(
+      { POOL_QUESTIONS_MODE: 'on' }, async () => undefined,
+    )).rejects.toThrow(/POOL_QUESTIONS_MODE/);
+  });
+});
+
+describe('withMatrixEnvironment', () => {
+  it('still applies the two matrix keys unchanged', async () => {
+    const seen = await withMatrixEnvironment(
+      { id: 'intent-only', allowedTypes: 'intent', profileSource: 'premise' },
+      async () => ({
+        allowed: process.env.DISCOVERY_ALLOWED_TYPES,
+        source: process.env.DISCOVERY_PROFILE_SOURCE,
+      }),
+    );
+    expect(seen).toEqual({ allowed: 'intent', source: 'premise' });
+  });
+});
+```
+
+- [ ] **Step 2: Run it to make sure it fails**
+
+Run: `cd services/api && bun test src/cli/tests/discovery-ab.env.spec.ts`
+Expected: FAIL — `withDiscoveryEnvironment` is not exported.
+
+- [ ] **Step 3: Implement**
+
+Replace the body of `withMatrixEnvironment` in `discovery-env-matrix.runtime.ts` with a delegation, and add the general function:
+
+```ts
+/**
+ * Applies an environment configuration for exactly one run and restores the
+ * previous state, including deleting keys that were previously unset. Values
+ * are applied to `process.env` because the graph reads them there at call
+ * time; the child process running this is single-purpose, so no other work is
+ * observing these keys.
+ */
+export async function withDiscoveryEnvironment<T>(config: AbEnvConfig, run: () => Promise<T>): Promise<T> {
+  assertAbEnvConfig(config);
+  const previous = new Map<string, string | undefined>();
+  for (const [key, value] of Object.entries(config)) {
+    previous.set(key, process.env[key]);
+    process.env[key] = value;
+  }
+  try {
+    return await run();
+  } finally {
+    for (const [key, value] of previous) {
+      if (value === undefined) delete process.env[key];
+      else process.env[key] = value;
+    }
+  }
+}
+
+export async function withMatrixEnvironment<T>(row: MatrixRowEnvironment, run: () => Promise<T>): Promise<T> {
+  return withDiscoveryEnvironment(
+    { DISCOVERY_ALLOWED_TYPES: row.allowedTypes, DISCOVERY_PROFILE_SOURCE: row.profileSource },
+    run,
+  );
+}
+```
+
+Add the import: `import { assertAbEnvConfig, type AbEnvConfig } from './discovery-ab.flags';`
+
+- [ ] **Step 4: Run the tests and make sure they pass**
+
+Run: `cd services/api && bun test src/cli/tests/discovery-ab.env.spec.ts src/cli/tests/discovery-env-matrix.spec.ts`
+Expected: PASS. The existing matrix spec must stay green — that is the proof the delegation preserved behavior.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add services/api/src/cli/discovery-env-matrix.runtime.ts services/api/src/cli/tests/discovery-ab.env.spec.ts
+git commit -m "feat(eval): apply an arbitrary discovery env config for one run
+
+withMatrixEnvironment hard-coded two keys. A/B needs any of the nine, and
+must restore precisely - including deleting keys that were unset before, or
+a run leaks configuration into the process that outlives it. The matrix
+entry point keeps its signature and delegates."
+```
+
+---
+
+### Task 4: Plan builder — shared selection, per-side configuration
+
+**Files:**
+- Create: `services/api/src/cli/discovery-ab.plan.ts`
+- Test: `services/api/src/cli/tests/discovery-ab.plan.spec.ts`
+
+**Interfaces:**
+- Consumes: `AbEnvConfig`, `assertAbEnvConfig` (Task 2); `HistoricalMatrixFixture` from `./discovery-env-matrix.shared`.
+- Produces:
+  - `type AbSideId = 'a' | 'b'`
+  - `interface AbSide { id: AbSideId; config: AbEnvConfig }`
+  - `interface AbSlot { matrixCase: HistoricalMatrixFixture; side: AbSide; repetition: number }`
+  - `buildAbPlan(cases: readonly HistoricalMatrixFixture[], sides: readonly [AbSide, AbSide], repetitions: number): AbSlot[]`
+  - `configDiff(a: AbEnvConfig, b: AbEnvConfig): Array<{ key: string; a: string | null; b: string | null }>`
+
+- [ ] **Step 1: Write the failing test**
+
+```ts
+// services/api/src/cli/tests/discovery-ab.plan.spec.ts
+import { describe, expect, it } from 'bun:test';
+
+import { buildAbPlan, configDiff, type AbSide } from '../discovery-ab.plan';
+import type { HistoricalMatrixFixture } from '../discovery-env-matrix.shared';
+
+const testCase = (id: string): HistoricalMatrixFixture => ({
+  id, description: id, networkContext: 'ctx', sourceUserId: 'u1', expectedUserId: 'u2',
+  excludedUserIds: [], participants: [],
+});
+
+const sideA: AbSide = { id: 'a', config: { DISCOVERY_ALLOWED_TYPES: 'intent' } };
+const sideB: AbSide = { id: 'b', config: { DISCOVERY_ALLOWED_TYPES: 'intent,profile' } };
+
+describe('buildAbPlan', () => {
+  it('produces cases x repetitions x two sides', () => {
+    const plan = buildAbPlan([testCase('c1'), testCase('c2')], [sideA, sideB], 3);
+    expect(plan).toHaveLength(12);
+    expect(plan.filter((slot) => slot.side.id === 'a')).toHaveLength(6);
+    expect(plan.filter((slot) => slot.side.id === 'b')).toHaveLength(6);
+  });
+
+  it('gives both sides identical case and repetition coverage', () => {
+    const plan = buildAbPlan([testCase('c1'), testCase('c2')], [sideA, sideB], 2);
+    const coverage = (side: string) => plan
+      .filter((slot) => slot.side.id === side)
+      .map((slot) => `${slot.matrixCase.id}/r${slot.repetition}`)
+      .sort();
+    expect(coverage('a')).toEqual(coverage('b'));
+  });
+
+  it('refuses identical configurations, which would spend a run measuring noise', () => {
+    expect(() => buildAbPlan([testCase('c1')], [sideA, { id: 'b', config: sideA.config }], 1))
+      .toThrow(/identical/i);
+  });
+
+  it('refuses a flag the graph cannot reach', () => {
+    expect(() => buildAbPlan([testCase('c1')], [sideA, { id: 'b', config: { POOL_QUESTIONS_MODE: 'on' } }], 1))
+      .toThrow(/POOL_QUESTIONS_MODE/);
+  });
+
+  it('refuses a non-positive repetition count', () => {
+    expect(() => buildAbPlan([testCase('c1')], [sideA, sideB], 0)).toThrow(/repetition/i);
+  });
+
+  it('refuses an empty case selection', () => {
+    expect(() => buildAbPlan([], [sideA, sideB], 1)).toThrow(/case/i);
+  });
+});
+
+describe('configDiff', () => {
+  it('reports differing, added and removed keys with null for absent', () => {
+    expect(configDiff(
+      { DISCOVERY_ALLOWED_TYPES: 'intent', DISCOVERY_SOURCE_PREMISE_LIMIT: '40' },
+      { DISCOVERY_ALLOWED_TYPES: 'profile', NEGOTIATION_MAX_TURNS_CHAT: '6' },
+    )).toEqual([
+      { key: 'DISCOVERY_ALLOWED_TYPES', a: 'intent', b: 'profile' },
+      { key: 'DISCOVERY_SOURCE_PREMISE_LIMIT', a: '40', b: null },
+      { key: 'NEGOTIATION_MAX_TURNS_CHAT', a: null, b: '6' },
+    ]);
+  });
+
+  it('omits keys the two sides agree on, because they explain no difference', () => {
+    expect(configDiff(
+      { DISCOVERY_ALLOWED_TYPES: 'intent' },
+      { DISCOVERY_ALLOWED_TYPES: 'intent', NEGOTIATION_MAX_TURNS_CHAT: '6' },
+    )).toEqual([{ key: 'NEGOTIATION_MAX_TURNS_CHAT', a: null, b: '6' }]);
+  });
+});
+```
+
+- [ ] **Step 2: Run it to make sure it fails**
+
+Run: `cd services/api && bun test src/cli/tests/discovery-ab.plan.spec.ts`
+Expected: FAIL — cannot resolve `../discovery-ab.plan`.
+
+- [ ] **Step 3: Implement**
+
+```ts
+// services/api/src/cli/discovery-ab.plan.ts
+/**
+ * Turns a selection and two configurations into slots.
+ *
+ * Selection is shared: two sides that ran different cases or different
+ * repetition counts are not comparable, so it is one input, not two.
+ */
+import { assertAbEnvConfig, type AbEnvConfig } from './discovery-ab.flags';
+import type { HistoricalMatrixFixture } from './discovery-env-matrix.shared';
+
+export type AbSideId = 'a' | 'b';
+export interface AbSide { id: AbSideId; config: AbEnvConfig }
+export interface AbSlot { matrixCase: HistoricalMatrixFixture; side: AbSide; repetition: number }
+
+/** Keys where the two sides disagree. Agreed keys explain no difference and are omitted. */
+export function configDiff(a: AbEnvConfig, b: AbEnvConfig): Array<{ key: string; a: string | null; b: string | null }> {
+  return [...new Set([...Object.keys(a), ...Object.keys(b)])]
+    .sort()
+    .filter((key) => a[key] !== b[key])
+    .map((key) => ({ key, a: a[key] ?? null, b: b[key] ?? null }));
+}
+
+export function buildAbPlan(
+  cases: readonly HistoricalMatrixFixture[],
+  sides: readonly [AbSide, AbSide],
+  repetitions: number,
+): AbSlot[] {
+  if (cases.length === 0) throw new Error('A discovery A/B run requires at least one case');
+  if (!Number.isInteger(repetitions) || repetitions < 1) {
+    throw new Error(`A discovery A/B run requires a positive repetition count (received ${repetitions})`);
+  }
+  for (const side of sides) assertAbEnvConfig(side.config);
+  const differences = configDiff(sides[0].config, sides[1].config);
+  if (differences.length === 0) {
+    throw new Error('Both sides have identical configurations; the run would measure noise, not a difference');
+  }
+  const slots: AbSlot[] = [];
+  for (const matrixCase of cases) {
+    for (let repetition = 0; repetition < repetitions; repetition += 1) {
+      for (const side of sides) slots.push({ matrixCase, side, repetition });
+    }
+  }
+  return slots;
+}
+```
+
+- [ ] **Step 4: Run the tests and make sure they pass**
+
+Run: `cd services/api && bun test src/cli/tests/discovery-ab.plan.spec.ts`
+Expected: PASS, 8 tests.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add services/api/src/cli/discovery-ab.plan.ts services/api/src/cli/tests/discovery-ab.plan.spec.ts
+git commit -m "feat(eval): plan discovery A/B slots with shared selection
+
+Selection is one input rather than two: sides that ran different cases are
+not comparable. Identical configurations are refused outright - that run
+would spend ninety graph invocations to measure noise."
+```
+
+---
+
+### Task 5: A/B target attestation and the one mutating Neon call
+
+`discovery-env-matrix.neon.ts` exposes a deliberately read-only control plane. Reset needs one write. It is added narrowly — refusing any branch that is not a designated A/B branch — rather than by opening the client to general writes.
+
+**Files:**
+- Create: `services/api/src/cli/discovery-ab.neon.ts`
+- Test: `services/api/src/cli/tests/discovery-ab.neon.spec.ts`
+
+**Interfaces:**
+- Consumes: `NeonControlPlane`, `NeonBranch`, `NeonEndpoint` from `./discovery-env-matrix.neon`.
+- Produces:
+  - `AB_BRANCH_NAMES: { a: 'eval-ab-a'; b: 'eval-ab-b' }`
+  - `interface AbTarget { sideId: 'a' | 'b'; branchId: string; endpointId: string; databaseUrl: string }`
+  - `interface AbManifest { projectId: string; baseBranchId: string; targets: readonly [AbTarget, AbTarget] }`
+  - `parseAbManifest(raw: string | undefined): AbManifest`
+  - `attestAbTargets(input: { manifest: AbManifest; controlPlane: NeonControlPlane }): Promise<AbManifest>`
+  - `resetAbBranch(input: { manifest: AbManifest; branchId: string; apiKey: string; fetchImpl?: typeof fetch }): Promise<void>`
+
+**Deliberate deviation from `attestMatrixTargets`:** matrix children must carry a future `expiresAt`, because they are ephemeral. The A/B branches are durable by design, so expiry is not required; the safety property is preserved differently — they are reset from base before every run, so they never accumulate state worth protecting. Every other check (non-primary, parent is the attested base, endpoint host matches the URL) is kept, and the name check is *stricter*: an exact match rather than a prefix.
+
+- [ ] **Step 1: Write the failing test**
+
+```ts
+// services/api/src/cli/tests/discovery-ab.neon.spec.ts
+import { describe, expect, it } from 'bun:test';
+
+import { attestAbTargets, parseAbManifest, resetAbBranch, type AbManifest } from '../discovery-ab.neon';
+import type { NeonControlPlane } from '../discovery-env-matrix.neon';
+
+const manifest: AbManifest = {
+  projectId: 'proj-1',
+  baseBranchId: 'br-base',
+  targets: [
+    { sideId: 'a', branchId: 'br-a', endpointId: 'ep-a', databaseUrl: 'postgresql://u:p@ep-a.neon.tech/protocol_eval' },
+    { sideId: 'b', branchId: 'br-b', endpointId: 'ep-b', databaseUrl: 'postgresql://u:p@ep-b.neon.tech/protocol_eval' },
+  ],
+};
+
+const controlPlane = (overrides: Record<string, Partial<{ name: string; parentId: string | null; primary: boolean }>> = {}): NeonControlPlane => ({
+  getBranch: async (_projectId, branchId) => ({
+    id: branchId,
+    name: { 'br-base': 'eval-discovery-base', 'br-a': 'eval-ab-a', 'br-b': 'eval-ab-b' }[branchId] ?? 'unknown',
+    parentId: branchId === 'br-base' ? null : 'br-base',
+    expiresAt: null,
+    primary: false,
+    ...overrides[branchId],
+  }),
+  listEndpoints: async (_projectId, branchId) => [
+    { id: `ep-${branchId.slice(3)}`, branchId, host: `ep-${branchId.slice(3)}.neon.tech` },
+  ],
+});
+
+describe('attestAbTargets', () => {
+  it('accepts two A/B branches parented on the attested base', async () => {
+    await expect(attestAbTargets({ manifest, controlPlane: controlPlane() })).resolves.toBeDefined();
+  });
+
+  it('refuses a branch whose name is not a designated A/B branch', async () => {
+    await expect(attestAbTargets({ manifest, controlPlane: controlPlane({ 'br-a': { name: 'dev' } }) }))
+      .rejects.toThrow(/identity is invalid/);
+  });
+
+  it('refuses a branch that is not parented on the base', async () => {
+    await expect(attestAbTargets({ manifest, controlPlane: controlPlane({ 'br-b': { parentId: 'br-production' } }) }))
+      .rejects.toThrow(/identity is invalid/);
+  });
+
+  it('refuses the primary branch outright', async () => {
+    await expect(attestAbTargets({ manifest, controlPlane: controlPlane({ 'br-a': { primary: true } }) }))
+      .rejects.toThrow(/identity is invalid/);
+  });
+
+  it('refuses a base branch that is not the protected fixture base', async () => {
+    await expect(attestAbTargets({ manifest, controlPlane: controlPlane({ 'br-base': { name: 'production' } }) }))
+      .rejects.toThrow(/base branch identity is invalid/);
+  });
+});
+
+describe('resetAbBranch', () => {
+  it('refuses to reset a branch that is not in the attested manifest', async () => {
+    await expect(resetAbBranch({ manifest, branchId: 'br-production', apiKey: 'k' }))
+      .rejects.toThrow(/not a designated/i);
+  });
+
+  it('posts a reset for an attested A/B branch', async () => {
+    const calls: string[] = [];
+    await resetAbBranch({
+      manifest, branchId: 'br-a', apiKey: 'k',
+      fetchImpl: (async (url: string, init?: RequestInit) => {
+        calls.push(`${init?.method ?? 'GET'} ${url}`);
+        return new Response('{}', { status: 200 });
+      }) as unknown as typeof fetch,
+    });
+    expect(calls).toEqual(['POST https://console.neon.tech/api/v2/projects/proj-1/branches/br-a/reset_to_parent']);
+  });
+
+  it('raises a sanitized error when the control plane refuses', async () => {
+    await expect(resetAbBranch({
+      manifest, branchId: 'br-a', apiKey: 'k',
+      fetchImpl: (async () => new Response('{"message":"token sk-secret invalid"}', { status: 401 })) as unknown as typeof fetch,
+    })).rejects.toThrow(/Neon control-plane reset failed/);
+  });
+
+  it('never puts the response body in the error, because it can carry credentials', async () => {
+    const error = await resetAbBranch({
+      manifest, branchId: 'br-a', apiKey: 'k',
+      fetchImpl: (async () => new Response('{"message":"token sk-secret invalid"}', { status: 401 })) as unknown as typeof fetch,
+    }).catch((caught: Error) => caught);
+    expect((error as Error).message).not.toContain('sk-secret');
+  });
+});
+
+describe('parseAbManifest', () => {
+  it('refuses a manifest that does not name exactly two sides', () => {
+    expect(() => parseAbManifest(JSON.stringify({ projectId: 'p', baseBranchId: 'b', targets: [] })))
+      .toThrow(/exactly two/i);
+  });
+
+  it('refuses a missing manifest', () => {
+    expect(() => parseAbManifest(undefined)).toThrow(/manifest/i);
+  });
+});
+```
+
+- [ ] **Step 2: Run it to make sure it fails**
+
+Run: `cd services/api && bun test src/cli/tests/discovery-ab.neon.spec.ts`
+Expected: FAIL — cannot resolve `../discovery-ab.neon`.
+
+- [ ] **Step 3: Implement**
+
+```ts
+// services/api/src/cli/discovery-ab.neon.ts
+/**
+ * Attestation and reset for the two durable A/B branches.
+ *
+ * discovery-env-matrix.neon.ts is deliberately read-only. Reset is the one
+ * write this harness needs, so it lives here, refuses any branch outside the
+ * attested manifest, and never surfaces a response body: control-plane
+ * responses can carry credentials.
+ */
+import type { NeonControlPlane } from './discovery-env-matrix.neon';
+
+const BASE_NAME = 'eval-discovery-base';
+export const AB_BRANCH_NAMES = { a: 'eval-ab-a', b: 'eval-ab-b' } as const;
+
+export interface AbTarget { sideId: 'a' | 'b'; branchId: string; endpointId: string; databaseUrl: string }
+export interface AbManifest { projectId: string; baseBranchId: string; targets: readonly [AbTarget, AbTarget] }
+
+function isEndpointHost(urlHost: string, endpointHost: string): boolean {
+  return urlHost === endpointHost || urlHost === endpointHost.replace(/^ep-/, '');
+}
+
+export function parseAbManifest(raw: string | undefined): AbManifest {
+  if (raw === undefined || raw.trim() === '') throw new Error('Discovery A/B manifest is required');
+  const parsed = JSON.parse(raw) as AbManifest;
+  if (!Array.isArray(parsed.targets) || parsed.targets.length !== 2) {
+    throw new Error('Discovery A/B manifest must name exactly two sides');
+  }
+  if (typeof parsed.projectId !== 'string' || typeof parsed.baseBranchId !== 'string') {
+    throw new Error('Discovery A/B manifest is missing projectId or baseBranchId');
+  }
+  return parsed;
+}
+
+/**
+ * Verifies both sides are the designated A/B branches, parented on the
+ * protected base. Unlike matrix children these are durable, so no expiry is
+ * required; they are reset from base before every run and never accumulate
+ * state. The name check is exact rather than a prefix.
+ */
+export async function attestAbTargets(input: { manifest: AbManifest; controlPlane: NeonControlPlane }): Promise<AbManifest> {
+  const { manifest, controlPlane } = input;
+  const base = await controlPlane.getBranch(manifest.projectId, manifest.baseBranchId);
+  if (base.id !== manifest.baseBranchId || base.name !== BASE_NAME || base.primary) {
+    throw new Error('Neon control-plane base branch identity is invalid');
+  }
+  for (const target of manifest.targets) {
+    const branch = await controlPlane.getBranch(manifest.projectId, target.branchId);
+    if (branch.id !== target.branchId || branch.name !== AB_BRANCH_NAMES[target.sideId]
+      || branch.parentId !== base.id || branch.primary) {
+      throw new Error(`Neon control-plane side ${target.sideId} identity is invalid`);
+    }
+    const endpoints = await controlPlane.listEndpoints(manifest.projectId, target.branchId);
+    const endpoint = endpoints.find((candidate) => candidate.id === target.endpointId);
+    if (!endpoint || endpoint.branchId !== target.branchId
+      || !isEndpointHost(new URL(target.databaseUrl).hostname, endpoint.host)) {
+      throw new Error(`Neon control-plane side ${target.sideId} endpoint host does not match DATABASE_URL`);
+    }
+  }
+  return manifest;
+}
+
+/** Resets one attested A/B branch from its parent. The only mutating call this harness makes. */
+export async function resetAbBranch(input: {
+  manifest: AbManifest; branchId: string; apiKey: string; fetchImpl?: typeof fetch;
+}): Promise<void> {
+  const { manifest, branchId, apiKey } = input;
+  if (!manifest.targets.some((target) => target.branchId === branchId)) {
+    throw new Error(`${branchId} is not a designated A/B branch; refusing to reset it`);
+  }
+  const send = input.fetchImpl ?? fetch;
+  const response = await send(
+    `https://console.neon.tech/api/v2/projects/${encodeURIComponent(manifest.projectId)}/branches/${encodeURIComponent(branchId)}/reset_to_parent`,
+    { method: 'POST', headers: { authorization: `Bearer ${apiKey}`, accept: 'application/json' } },
+  );
+  // The body may echo credentials; only the status is safe to report.
+  if (!response.ok) throw new Error(`Neon control-plane reset failed with status ${response.status}`);
+}
+```
+
+- [ ] **Step 4: Run the tests and make sure they pass**
+
+Run: `cd services/api && bun test src/cli/tests/discovery-ab.neon.spec.ts`
+Expected: PASS, 10 tests.
+
+- [ ] **Step 5: Verify the reset endpoint against Neon's current API**
+
+Confirm `POST /projects/{project_id}/branches/{branch_id}/reset_to_parent` is the current reset operation (Neon has renamed restore/reset operations before). If it differs, update the path and the test together; do not leave the test asserting a path the API no longer has.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add services/api/src/cli/discovery-ab.neon.ts services/api/src/cli/tests/discovery-ab.neon.spec.ts
+git commit -m "feat(eval): attest and reset the two durable A/B branches
+
+The matrix control plane is deliberately read-only. Reset is the single
+write this harness needs, so it refuses any branch outside the attested
+manifest and reports only a status - control-plane bodies can carry
+credentials. Matrix children must expire because they are ephemeral; these
+are durable and reset before every run instead, so the name check is exact
+rather than a prefix."
+```
+
+---
+
+### Task 6: Child runner — one side, one branch, one configuration
+
+**Files:**
+- Create: `services/api/src/cli/discovery-ab.main.ts` (child half; the parent half is Task 7)
+- Test: covered by Task 7's artifact spec plus the live smoke in Task 8. The graph invocation itself is not unit-testable without a database, which is why the seam below is the tested part.
+
+**Interfaces:**
+- Consumes: `buildAbPlan`, `AbSlot` (Task 4); `withDiscoveryEnvironment` (Task 3); from `./discovery-env-matrix.main`: `composeCaseRuntime`, `collectCandidates`, `projectFinalCandidates`, `collectEvaluatorTraces`, `runMatrixBoundary`, `sanitizeMatrixError`, `resolveFixtureTriggerIntent`, `databaseCase`; from the protocol eval bundle: `HISTORICAL_MATRIX_CASES`, `scoreMatrixSlot`, `buildExecutionEvidence`, `executeRuns`.
+- Produces: `runAbChild(sideId: 'a' | 'b', slots: readonly AbSlot[], outputPath: string): Promise<void>` — writes `{ slots, execution }` JSON, the same shape the matrix child writes.
+
+- [ ] **Step 1: Read the matrix child implementation end to end**
+
+Read `runChild` in `src/cli/discovery-env-matrix.main.ts` (roughly lines 770–870). The A/B child differs in exactly two ways: `invokeMatrixDiscoveryGraph(..., slot.row, ...)` becomes a `withDiscoveryEnvironment(side.config, ...)` wrapper, and `rowId` becomes the side id. Everything else — boundary classification, candidate collection, evaluator projection, judge wiring, the failed-slot fallback — is reused unchanged.
+
+- [ ] **Step 2: Implement the child**
+
+```ts
+/** Invokes the graph for one slot under that side's configuration. */
+async function invokeAbDiscoveryGraph<T>(
+  graph: { invoke(input: { userId: string; networkId: string; triggerIntentId: string; options: { minScore: number } }, config?: { signal?: AbortSignal }): Promise<T> },
+  runtime: { sourceUserId: string; networkId: string; triggerIntentId: string },
+  config: AbEnvConfig,
+  signal?: AbortSignal,
+): Promise<T> {
+  return withDiscoveryEnvironment(config, () => graph.invoke({
+    userId: runtime.sourceUserId,
+    networkId: runtime.networkId,
+    triggerIntentId: runtime.triggerIntentId,
+    options: { minScore: 50 },
+  }, signal ? { signal } : undefined));
+}
+```
+
+Then mirror `runChild`, passing to `scoreMatrixSlot`:
+- `rowId: slot.side.id`
+- `configDeltas: Object.entries(slot.side.config).map(([key, after]) => ({ key, before: null, after }))` — `scoreMatrixSlot` already accepts `configDeltas`, so each side's exact configuration is recorded per slot with no schema change.
+- `caseId: `${slot.matrixCase.id}/${slot.side.id}/r${slot.repetition + 1}``
+
+Keep `ATTEMPT_TIMEOUT_MS`, the `executeRuns` retry wrapper and the failed-slot fallback identical to the matrix child; a slot that exhausts attempts must still produce a scored, failed slot so completeness accounting stays honest.
+
+- [ ] **Step 3: Typecheck**
+
+Run: `cd services/api && bunx tsc --noEmit`
+Expected: no errors.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add services/api/src/cli/discovery-ab.main.ts
+git commit -m "feat(eval): run one A/B side against one branch under one config
+
+Mirrors the matrix child: same boundary classification, candidate collection,
+evaluator projection, judge wiring and failed-slot fallback. Only two things
+differ - the graph runs inside that side's env config, and the slot's rowId
+is the side. Each slot records its side's exact configuration through the
+configDeltas field scoreMatrixSlot already accepts."
+```
+
+---
+
+### Task 7: Parent — gate, reset, spawn, aggregate, artifact
+
+**Files:**
+- Modify: `services/api/src/cli/discovery-ab.main.ts` (add the parent half)
+- Create: `services/api/src/cli/discovery-ab.ts` (dependency-free attesting bootstrap)
+- Test: `services/api/src/cli/tests/discovery-ab.artifact.spec.ts`
+
+**Interfaces:**
+- Consumes: everything from Tasks 2–6.
+- Produces:
+  - `buildAbArtifactMeta(input: { sides: readonly [AbSide, AbSide]; cases: readonly HistoricalMatrixFixture[]; repetitions: number; startedAt: string; git: unknown }): Record<string, unknown>` — exported for the test.
+  - `main(args?: readonly string[]): Promise<void>`
+  - Artifact written to `services/api/eval/discovery-ab/runs/<timestamp>.json`.
+
+- [ ] **Step 1: Write the failing artifact test**
+
+```ts
+// services/api/src/cli/tests/discovery-ab.artifact.spec.ts
+import { describe, expect, it } from 'bun:test';
+
+import { buildAbArtifactMeta } from '../discovery-ab.main';
+import type { AbSide } from '../discovery-ab.plan';
+import type { HistoricalMatrixFixture } from '../discovery-env-matrix.shared';
+
+const cases: HistoricalMatrixFixture[] = [{
+  id: 'c1', description: 'c1', networkContext: 'ctx', sourceUserId: 'u1',
+  expectedUserId: 'u2', excludedUserIds: [], participants: [],
+}];
+const sides: [AbSide, AbSide] = [
+  { id: 'a', config: { DISCOVERY_ALLOWED_TYPES: 'intent' } },
+  { id: 'b', config: { DISCOVERY_ALLOWED_TYPES: 'intent,profile', DISCOVERY_SOURCE_PREMISE_LIMIT: '5' } },
+];
+
+describe('buildAbArtifactMeta', () => {
+  const meta = buildAbArtifactMeta({
+    sides, cases, repetitions: 3, startedAt: '2026-08-04T00:00:00.000Z',
+    git: { revision: 'abc123', dirty: false },
+  });
+
+  it('names the harness and does not claim a baseline', () => {
+    expect(meta.harness).toBe('discovery-ab');
+    expect(meta).not.toHaveProperty('baselinePath');
+    expect(meta.selection).toMatchObject({ fullCorpus: true });
+  });
+
+  it('records each side\'s exact configuration', () => {
+    expect(meta.configs).toMatchObject({
+      a: { DISCOVERY_ALLOWED_TYPES: 'intent' },
+      b: { DISCOVERY_ALLOWED_TYPES: 'intent,profile', DISCOVERY_SOURCE_PREMISE_LIMIT: '5' },
+    });
+  });
+
+  it('records the diff, so the artifact says what produced any difference', () => {
+    expect(meta.configDiff).toEqual([
+      { key: 'DISCOVERY_ALLOWED_TYPES', a: 'intent', b: 'intent,profile' },
+      { key: 'DISCOVERY_SOURCE_PREMISE_LIMIT', a: null, b: '5' },
+    ]);
+  });
+
+  it('fingerprints the corpus and the scoring configuration', () => {
+    expect(typeof meta.corpusFingerprint).toBe('string');
+    expect(typeof meta.configFingerprint).toBe('string');
+  });
+
+  it('gives different configurations different scoring fingerprints', () => {
+    const other = buildAbArtifactMeta({
+      sides: [sides[0], { id: 'b', config: { DISCOVERY_ALLOWED_TYPES: 'profile' } }],
+      cases, repetitions: 3, startedAt: '2026-08-04T00:00:00.000Z',
+      git: { revision: 'abc123', dirty: false },
+    });
+    expect(other.configFingerprint).not.toBe(meta.configFingerprint);
+  });
+});
+```
+
+- [ ] **Step 2: Run it to make sure it fails**
+
+Run: `cd services/api && bun test src/cli/tests/discovery-ab.artifact.spec.ts`
+Expected: FAIL — `buildAbArtifactMeta` is not exported.
+
+- [ ] **Step 3: Implement the parent**
+
+Mirror `runParent` in `discovery-env-matrix.main.ts` with these differences:
+
+1. **Gate first.** Refuse unless `DISCOVERY_AB_CONFIRM === '1'`. Then `parseAbManifest(process.env.DISCOVERY_AB_TARGETS)` and `attestAbTargets` — before any runtime import, exactly as the matrix bootstrap does.
+2. **Reset both branches** via `resetAbBranch` for each target. If either reset fails, abort before spawning anything: a half-isolated comparison is not a comparison.
+3. **Spawn two children**, one per side, each with `DATABASE_URL` set to that side's attested URL and `--side a|b --child-output <path>`. Reuse `runBoundedChildTasks` with concurrency 2 and the existing SIGTERM/SIGKILL escalation.
+4. **Aggregate** both children's slots with `buildScorecard(slots, { model: process.env.CHAT_MODEL ?? 'configured runtime models', runs: 1 })`; `payload.rules` will hold the two side ids because `rowId` is the side.
+5. **Meta** via `buildAbArtifactMeta`, including `configs`, `configDiff`, `corpusFingerprint: fingerprintEvalCorpus(cases)` and `configFingerprint: buildEvalScoringConfigFingerprint({ sides: sides.map((side) => side.config), repetitions, judge: true })`.
+6. **No baseline.** Do not call `compareAgainstGovernedBaseline`, `performGovernedBaselineUpdate` or `writeBaseline`. Write the run artifact to `RUNS_DIR` after `assertEvalWritePlan({ inputs: [], outputs: [runPath], force })`.
+7. **Incomplete runs report no verdict.** If either side has any failed slot, set `completeness.complete = false` and exit non-zero with a message naming the failed side.
+
+Then create the bootstrap `src/cli/discovery-ab.ts` mirroring `discovery-env-matrix.ts`: parse args, attest via `attestAbTargets` + `createNeonControlPlane(process.env.NEON_API_KEY ?? '')`, set `DATABASE_URL` for a child invocation, and only then `await (await import('./discovery-ab.main')).main()`. Nothing that touches the database may be imported before attestation succeeds.
+
+- [ ] **Step 4: Run the tests and make sure they pass**
+
+Run: `cd services/api && bun test src/cli/tests/discovery-ab.artifact.spec.ts`
+Expected: PASS, 5 tests.
+
+- [ ] **Step 5: Prove the no-baseline claim holds**
+
+Run: `cd services/api && grep -n "Baseline\|baseline" src/cli/discovery-ab.main.ts`
+Expected: no call to `compareAgainstGovernedBaseline`, `performGovernedBaselineUpdate`, `writeBaseline`, or any `BASELINE_PATH` constant. If any appears, remove it — the spec forbids a baseline for this harness.
+
+- [ ] **Step 6: Typecheck, lint and commit**
+
+```bash
+cd services/api && bunx tsc --noEmit && bun run lint
+git add services/api/src/cli/discovery-ab.main.ts services/api/src/cli/discovery-ab.ts services/api/src/cli/tests/discovery-ab.artifact.spec.ts
+git commit -m "feat(eval): compare two discovery configurations in one artifact
+
+Gate, attest, reset both branches, run one child per side, aggregate into a
+single artifact whose two rules are the two sides. No baseline: arbitrary
+configurations have none, so the pair is the result. A failed side reports
+no verdict rather than half a comparison."
+```
+
+---
+
+### Task 8: Wire the command, document it, and smoke it live
+
+**Files:**
+- Modify: `services/api/package.json` (scripts)
+- Create: `services/api/eval/discovery-ab/runs/.gitkeep`
+- Modify: `docs/guides/development-reference.md` (command reference)
+
+**Interfaces:**
+- Consumes: everything above.
+- Produces: `bun run eval:discovery-ab` in `services/api`.
+
+- [ ] **Step 1: Add the script**
+
+```json
+"eval:discovery-ab": "bun --env-file=../../.env.test ./src/cli/discovery-ab.ts"
+```
+
+Match the existing `eval:discovery-env-matrix` entry's env-file convention exactly.
+
+- [ ] **Step 2: Verify the command refuses without its gate**
+
+```bash
+cd services/api && bun run eval:discovery-ab
+```
+Expected: refuses, naming the missing confirm variable. It must not reach a database.
+
+- [ ] **Step 3: Verify it refuses a non-A/B target**
+
+Set `DISCOVERY_AB_CONFIRM=1` and a manifest whose side `a` points at the `dev` branch id.
+Expected: `Neon control-plane side a identity is invalid`. Nothing is reset, nothing spawns.
+
+- [ ] **Step 4: Create the two A/B branches**
+
+Branch `eval-ab-a` and `eval-ab-b` from `eval-discovery-base` (Task 1), each with an endpoint on database `protocol_eval`. Record branch and endpoint ids in the manifest.
+
+- [ ] **Step 5: Live smoke — one case, one repetition**
+
+```bash
+cd services/api
+DISCOVERY_AB_CONFIRM=1 DISCOVERY_AB_TARGETS='<manifest>' \
+  bun run eval:discovery-ab -- --case <first case id> --runs 1 \
+  --a DISCOVERY_ALLOWED_TYPES=intent \
+  --b DISCOVERY_ALLOWED_TYPES=intent,profile
+```
+
+Expected: 4 graph invocations (1 case × 1 rep × 2 sides, plus judge), ~2 minutes, one artifact under `eval/discovery-ab/runs/`. Inspect it: two rules, both configs recorded, diff present, `completeness.complete === true`.
+
+- [ ] **Step 6: Document the command**
+
+Add to `docs/guides/development-reference.md` beside the existing matrix entry: what it compares, the required gate and manifest, the nine offerable flags, and the cost of a default run (15 cases × 3 reps × 2 sides ≈ 90 invocations, ~40 min). State plainly that the other seven allowlisted flags are not readable by this harness and link IND-630.
+
+- [ ] **Step 7: Full suite, then commit**
+
+```bash
+cd services/api && bun run test && bun run lint && bunx tsc --noEmit
+git add services/api/package.json services/api/eval/discovery-ab docs/guides/development-reference.md
+git commit -m "feat(eval): ship the discovery A/B command with a live smoke
+
+Documents what it compares, what it costs, and - as plainly - the seven
+allowlisted flags it cannot read, so the next reader does not assume the
+editor covers all sixteen."
+```
+
+---
+
+## Self-Review
+
+**Spec coverage.** §4 nine flags → Task 2. §5 architecture (bootstrap, reset, per-side process, aggregate) → Tasks 5–7. §5 clone-not-reseed → Task 1. §6 shared selection and identical-config refusal → Task 4. §7 scoring and artifact (`rules` = sides, `configs` block) → Tasks 6–7. §8 three safety gates → Task 7 step 3 (confirm), Task 5 (branch allowlist), Task 7 step 3 (reset before). §9 failure modes → Task 7 steps 3 and 5, Task 6 step 2 (failed-slot fallback). §10 testing → Tasks 2–5, 7, and the live smoke in Task 8. §11 sequencing → Task 1 first, branches created in Task 8 step 4. Appendix A → Task 8 step 6.
+
+**Placeholder scan.** `<manifest>` and `<first case id>` in Task 8 are operator inputs that only exist after Task 8 step 4; every code step contains real code. Task 1 step 3 defers exact flags to the command's own parser rather than guessing them — deliberate, and the step says how to find them.
+
+**Type consistency.** `AbEnvConfig`, `AbSide`, `AbSideId`, `AbSlot`, `AbTarget`, `AbManifest` are defined once (Tasks 2, 4, 5) and used with those names throughout. `withDiscoveryEnvironment` keeps one signature across Tasks 3 and 6. `rowId` carries the side id into `scoreMatrixSlot` in Task 6, which is what makes `payload.rules` the two sides in Task 7.

--- a/docs/superpowers/plans/2026-08-04-discovery-env-ab-engine.md
+++ b/docs/superpowers/plans/2026-08-04-discovery-env-ab-engine.md
@@ -1022,11 +1022,11 @@ DISCOVERY_AB_CONFIRM=1 DISCOVERY_AB_TARGETS='<manifest>' \
   --b DISCOVERY_ALLOWED_TYPES=intent,profile
 ```
 
-Expected: 4 graph invocations (1 case × 1 rep × 2 sides, plus judge), ~2 minutes, one artifact under `eval/discovery-ab/runs/`. Inspect it: two rules, both configs recorded, diff present, `completeness.complete === true`.
+Expected: 2 graph invocations (1 case × 1 rep × 2 sides) plus judge calls, ~2 minutes, one artifact under `eval/discovery-ab/runs/`. Inspect it: two rules, both configs recorded, diff present, `completeness.complete === true`.
 
 - [ ] **Step 6: Document the command**
 
-Add to `docs/guides/development-reference.md` beside the existing matrix entry: what it compares, the required gate and manifest, the nine offerable flags, and the cost of a default run (15 cases × 3 reps × 2 sides ≈ 90 invocations, ~40 min). State plainly that the other seven allowlisted flags are not readable by this harness and link IND-630.
+Add to `docs/guides/development-reference.md` beside the existing matrix entry: what it compares, the required gate and manifest, the nine offerable flags, and the cost of a default run (5 cases × 3 reps × 2 sides = 30 invocations, ~13 min). State plainly that the other seven allowlisted flags are not readable by this harness and link IND-630.
 
 - [ ] **Step 7: Full suite, then commit**
 

--- a/docs/superpowers/plans/2026-08-04-discovery-env-ab-engine.md
+++ b/docs/superpowers/plans/2026-08-04-discovery-env-ab-engine.md
@@ -37,8 +37,11 @@
 | `src/cli/discovery-ab.neon.ts` | A/B target attestation + the single mutating reset call. |
 | `src/cli/tests/discovery-ab.neon.spec.ts` | Attestation and reset tests against a fake control plane. |
 | `src/cli/discovery-ab.main.ts` | Parent: gate → reset → spawn two children → aggregate → artifact. Child: run assigned slots. |
+| `src/cli/discovery-ab.contract.ts` | Operator contract: help text, exit codes, and the classification that picks between them. Dependency-free, so `--help` needs no credentials. |
+| `src/cli/discovery-ab.gate.ts` | The four-variable gate and `AbGateError`, read before anything that can compose a database. |
 | `src/cli/discovery-ab.ts` | Dependency-free attesting bootstrap (mirrors `discovery-env-matrix.ts`). |
 | `src/cli/tests/discovery-ab.artifact.spec.ts` | Artifact shape: two rules, per-side configs, diff, no baseline. |
+| `src/cli/tests/discovery-ab.{contract,gate,child,parent,env}.spec.ts` | Contract and exit-code classification, gate refusals, the child's slot execution, the parent's supervision and outcome, and env application/restoration. |
 | `services/api/package.json` *(modify)* | `eval:discovery-ab` script. |
 
 ---

--- a/docs/superpowers/specs/2026-08-04-discovery-env-ab-engine-design.md
+++ b/docs/superpowers/specs/2026-08-04-discovery-env-ab-engine-design.md
@@ -97,12 +97,14 @@ One process per side is not stylistic: the API composes its database singleton o
 | Unit | Responsibility | Depends on |
 |---|---|---|
 | `discovery-ab.plan.ts` | Turn (cases, reps, two configs) into slots; validate configs against the nine-flag set | nothing (pure) |
-| `discovery-ab.env.ts` | Apply a config around one graph invocation, restore prior values in `finally` | nothing (pure) |
-| `discovery-ab.branches.ts` | Resolve the two side URLs, assert they are designated A/B branches, reset both from base | Neon control plane |
+| `discovery-env-matrix.runtime.ts` *(shipped there, not in a new module)* | Apply a config around one graph invocation, restore prior values in `finally` | nothing (pure) |
+| `discovery-ab.neon.ts` *(shipped there, not in a new module)* | Resolve the two side URLs, assert they are designated A/B branches, reset both from base | Neon control plane |
+| `discovery-ab.contract.ts` | The operator contract: help text, exit codes, and the classification that picks between them | nothing (dependency-free) |
+| `discovery-ab.gate.ts` | The four-variable gate, read before anything that can compose a database | nothing (pure) |
 | `discovery-ab.ts` (child) | Run assigned slots against one branch under one config | graph, policy |
 | `discovery-ab.main.ts` (parent) | Gate, reset, spawn, aggregate, write artifact | all of the above |
 
-`discovery-ab.env.ts` generalizes today's `withMatrixEnvironment`, which hard-codes two keys and restores them in a `finally`. The generalized version takes a `Record<string, string>`, applies only allowlisted keys, and restores every key it touched — including deleting keys that were previously unset.
+Env application shipped as `withDiscoveryEnvironment` in `discovery-env-matrix.runtime.ts` rather than a new `discovery-ab.env.ts`, because it generalizes today's `withMatrixEnvironment`, which lives there and hard-codes two keys and restores them in a `finally`. The generalized version takes a `Record<string, string>`, applies only allowlisted keys, and restores every key it touched — including deleting keys that were previously unset. Branch handling shipped in `discovery-ab.neon.ts` (attestation and the single mutating reset together) rather than a separate `discovery-ab.branches.ts`.
 
 **Why clone rather than re-seed.** Seeding the corpus is not a pure SQL insert: `seedProtectedBase` embeds every fixture intent and builds HyDE documents with vectors, and `verifyBaseFixtureIntegrity` refuses a base whose intents are unembedded or whose vectors are malformed. Re-seeding per run would mean re-embedding per run — provider spend and non-determinism on every comparison. Cloning a pre-embedded protected base gives an identical, already-embedded corpus in seconds, which is why the existing matrix works this way.
 

--- a/docs/superpowers/specs/2026-08-04-discovery-env-ab-engine-design.md
+++ b/docs/superpowers/specs/2026-08-04-discovery-env-ab-engine-design.md
@@ -46,7 +46,7 @@ Three gaps: it varies 2 of the 16 flags in 5 combinations chosen at authoring ti
 **Non-goals.**
 
 - **No baseline.** Arbitrary env configurations have no committed baseline and never will; the pair is the result. This harness is comparison-native, not regression-gated.
-- **No queue-worker flags.** Seven of the sixteen (`POOL_QUESTIONS_MODE`, `POOL_QUESTIONS_PUSH`, `POOL_QUESTIONS_RANKING`, `POOL_QUESTIONS_MINING`, `OUTCOME_QUESTIONS_MODE`, `NEGOTIATION_EVIDENCE_QUESTIONS_MODE`, `INTRODUCER_DISCOVERY_ENABLED`) are read by API queue workers. A graph harness cannot exercise them, so it must not offer them.
+- **No flags outside the graph's reach.** Seven of the sixteen (`POOL_QUESTIONS_MODE`, `POOL_QUESTIONS_PUSH`, `POOL_QUESTIONS_RANKING`, `POOL_QUESTIONS_MINING`, `OUTCOME_QUESTIONS_MODE`, `NEGOTIATION_EVIDENCE_QUESTIONS_MODE`, `INTRODUCER_DISCOVERY_ENABLED`) gate subsystems the discovery graph never invokes, so this harness cannot exercise them and must not offer them. That is **not** the same as saying they are untestable — see appendix A and IND-630.
 - **No eval-ops UI.** That is IND-628, specced once this engine has produced a real artifact.
 - **No model overrides.** The graph composes its own agents; model selection stays as configured. Adding it later is additive.
 
@@ -172,3 +172,27 @@ Live validation is one 1-case × 1-repetition smoke per side (~2 minutes, 4 invo
 ## 12. Open question deferred on purpose
 
 What the comparison should *show* an operator — rank of the expected user, surfaced/excluded counts, judge verdicts, or a blend — is not settled here. The artifact records all of it; choosing the headline number is IND-628's job, made with a real artifact in hand rather than an imagined one.
+
+## Appendix A — the other seven flags (IND-630)
+
+Shipping this engine fixes 9 of 16 and would leave 7 in exactly the state that caused this project: configurable, unmeasured, easy to believe in. They are recorded here so the omission stays visible and gets a decision.
+
+Calling them "API-side flags" would be wrong, and the distinction decides the work. For nearly all of them the **behavior lives in `packages/protocol`**; the API queue only decides *when* to run it. The entire API-side contribution for two of them is `services/api/src/queues/pool/mining.shared.ts:93`:
+
+```ts
+return poolQuestionsMiningMode() === 'shadow' || poolQuestionsMode() === 'on';
+```
+
+…where the miner, the shadow runner and the selection logic are all imported from `@indexnetwork/protocol`. The accurate statement is **"not reachable from the discovery graph"**, not "not reachable at all".
+
+| Flag | Protocol reader (behavior) | API reader (orchestration) | Testable without the API? |
+|---|---|---|---|
+| `POOL_QUESTIONS_PUSH` | `discriminator.env.ts` | — | **Yes** — protocol only |
+| `INTRODUCER_DISCOVERY_ENABLED` | `opportunity.introducer-feature.ts`, facade, `maintenance.graph.ts` | — | **Yes** — protocol only |
+| `POOL_QUESTIONS_MINING` | `discriminator.env.ts`, miner/shadow runner | `queues/pool/mining.shared.ts` | Likely — mining behavior is protocol |
+| `POOL_QUESTIONS_MODE` | `discriminator.env.ts` | `mining.shared.ts`, `visitmining.queue.ts` | Partly — selection is protocol, enqueue is API |
+| `POOL_QUESTIONS_RANKING` | `discriminator.env.ts`, `radar.graph.ts` | `opportunity.database.adapter.ts`, `answer.shared.ts` | Partly — ranking is protocol, ordering is in the adapter |
+| `OUTCOME_QUESTIONS_MODE` | `outcome.env.ts`, `outcome.shadow.ts`, `outcome.hypotheses.ts` | `outcome-feedback.recorder.ts`, schema | Partly |
+| `NEGOTIATION_EVIDENCE_QUESTIONS_MODE` | `negotiation-evidence.env.ts` | `negotiation-evidence.shadow.ts` | Partly |
+
+Two of these need no database, no branches and no live spend — a protocol-level harness would cover them far more cheaply than this engine covers its nine. That is the likely first move, but the decision per flag belongs to IND-630, not to this spec.

--- a/docs/superpowers/specs/2026-08-04-discovery-env-ab-engine-design.md
+++ b/docs/superpowers/specs/2026-08-04-discovery-env-ab-engine-design.md
@@ -1,0 +1,174 @@
+# Discovery env A/B engine — design
+
+**Linear:** [IND-627](https://linear.app/indexnetwork/issue/IND-627) (engine), [IND-626](https://linear.app/indexnetwork/issue/IND-626) (base fixture), [IND-628](https://linear.app/indexnetwork/issue/IND-628) (eval-ops UI, later)
+**Date:** 2026-08-04
+**Status:** proposed
+
+## 1. Problem
+
+Operators want to test discovery strategies against each other: run the pipeline one way, run it another way, see which produces better matches. The eval-ops site appears to offer this — saved configs carry environment overrides drawn from `PROFILE_ENV_ALLOWLIST` — but the feature is inert.
+
+No eval harness reads any of those keys. Traced mechanically over the full transitive import closure of every harness entry point:
+
+| Harness | Files in closure | Of the 16 env flags, read |
+|---|---|---|
+| matching | 44 | 0 |
+| premise | 30 | 0 |
+| profile | 30 | 0 |
+| opportunity | 127 | 0 executed (`negotiation.graph.ts` appears in the closure but the harness never invokes it) |
+| canary | 52 | 0 |
+| clarification | 15 | 0 |
+| discovery-retrieval | 63 | 0 |
+| hyde | 47 | 0 |
+| stance | 26 | 0 |
+
+The flags are read by `services/api/src/startup.env.ts` and by `src/opportunity/application/opportunity.graph.ts` — the running product. The four scorecard harnesses invoke agents directly (`OpportunityEvaluator`, `OpportunityPresenter`, `EnrichmentGenerator`, `PremiseDecomposer`/`PremiseAnalyzer`) and never enter the graph.
+
+So `DISCOVERY_SOURCE_PREMISE_LIMIT=5` and `=50` produce byte-identical behavior on every harness the site can run. An A/B over env values today would render two identical columns and call it a comparison.
+
+**To compare strategies, something has to run the code that reads them.**
+
+## 2. What already exists
+
+`discovery-env-matrix` does exactly that, for a fixed set of strategies:
+
+- **Cases and scoring** in `packages/protocol/eval/discovery-env-matrix/` — `HISTORICAL_MATRIX_CASES` (15 seeded networks), `historical-matrix.policy.ts` (deterministic assertions plus a relationship judge), a reporter.
+- **Runner** in `services/api/src/cli/discovery-env-matrix*.ts` — composes the real `OpportunityGraphFactory` against a Neon child branch, one child process per branch, and aggregates slots into a governed artifact.
+- **Five hard-coded rows** varying `DISCOVERY_ALLOWED_TYPES` × `DISCOVERY_PROFILE_SOURCE`: `intent-only`, `profile-premise`, `profile-context`, `both-premise`, `both-context`.
+- **Proven**: a committed baseline from 2026-07-30 records 15 cases × 5 rows × 3 repetitions = 75 slots, aggregate pass rate 93.3%, wall clock 14 minutes across 15 parallel children. Per-slot duration ~52s.
+
+Three gaps: it varies 2 of the 16 flags in 5 combinations chosen at authoring time; it is invisible from eval-ops; and its base branch `eval-discovery-base` no longer exists in the Neon project (confirmed 2026-08-04 — only `production`, `dev`, `local-dev`, `eval-ops-fixtures*` and dated backups remain).
+
+## 3. Goal and non-goals
+
+**Goal.** A `discovery-ab` harness that runs the real discovery graph twice — once per operator-chosen environment configuration — over a shared case selection, and emits one artifact holding both sides.
+
+**Non-goals.**
+
+- **No baseline.** Arbitrary env configurations have no committed baseline and never will; the pair is the result. This harness is comparison-native, not regression-gated.
+- **No queue-worker flags.** Seven of the sixteen (`POOL_QUESTIONS_MODE`, `POOL_QUESTIONS_PUSH`, `POOL_QUESTIONS_RANKING`, `POOL_QUESTIONS_MINING`, `OUTCOME_QUESTIONS_MODE`, `NEGOTIATION_EVIDENCE_QUESTIONS_MODE`, `INTRODUCER_DISCOVERY_ENABLED`) are read by API queue workers. A graph harness cannot exercise them, so it must not offer them.
+- **No eval-ops UI.** That is IND-628, specced once this engine has produced a real artifact.
+- **No model overrides.** The graph composes its own agents; model selection stays as configured. Adding it later is additive.
+
+## 4. The nine offerable flags
+
+Only flags reachable from `opportunity.graph.ts` may appear. Traced from the graph as entry point (140 files):
+
+| Flag | Read by | Kind |
+|---|---|---|
+| `DISCOVERY_ALLOWED_TYPES` | `opportunity.graph.ts`, `discovery.env.ts` | string list |
+| `DISCOVERY_PROFILE_SOURCE` | `opportunity.graph.ts`, `discovery.env.ts` | string |
+| `DISCOVERY_CONTEXT_TO_INTENT` | `opportunity.graph.ts` | `0`/`1` |
+| `DISCOVERY_SOURCE_PREMISE_LIMIT` | `opportunity.graph.ts` | integer ≥ 0 |
+| `DISCOVERY_REJECTION_COOLDOWN_DAYS` | `opportunity.graph.ts` | positive float |
+| `RUN_OPPORTUNITY_EVAL_IN_PARALLEL` | `opportunity.graph.ts` | `true`/`false` |
+| `NEGOTIATION_MAX_TURNS_CHAT` | `opportunity.graph.ts` | integer |
+| `NEGOTIATION_MAX_TURNS_AMBIENT` | `opportunity.graph.ts`, `negotiation.graph.ts` | integer |
+| `NEGOTIATION_INCLUDE_OTHER_INTENTS` | `opportunity.existing-negotiation.ts` | `true`/`false` |
+
+This list is derived, not copied: a test recomputes the reachable set and fails when the graph starts or stops reading a flag, so the harness cannot silently drift into offering a dead lever — the exact failure this whole project exists to correct.
+
+## 5. Architecture
+
+Invoked as `eval:discovery-ab` from `services/api`.
+
+```
+discovery-ab.main.ts  (parent, no database of its own)
+  │
+  ├─ safety gate: confirm variable set; both side URLs resolve to designated
+  │               A/B branches; refuse anything else
+  ├─ reset eval-ab-a from base ─┐  Neon reset-from-parent, awaited
+  ├─ reset eval-ab-b from base ─┘
+  │
+  ├─ spawn child A: DATABASE_URL=<eval-ab-a>, env config A ─┐
+  ├─ spawn child B: DATABASE_URL=<eval-ab-b>, env config B ─┘  concurrently
+  │     each child, for each case × repetition:
+  │       withDiscoveryEnvironment(config, () => graph.invoke({...}))
+  │       collect candidates, project evaluator outcomes
+  │     child writes slots as JSON to a temp path
+  │
+  └─ parent: aggregate slots → scorecard (rule = side) → one artifact
+```
+
+One process per side is not stylistic: the API composes its database singleton once per process, so a side's `DATABASE_URL` must be fixed for that process's lifetime. This mirrors the existing matrix runner, which spawns one child per branch for the same reason.
+
+**Components and boundaries.**
+
+| Unit | Responsibility | Depends on |
+|---|---|---|
+| `discovery-ab.plan.ts` | Turn (cases, reps, two configs) into slots; validate configs against the nine-flag set | nothing (pure) |
+| `discovery-ab.env.ts` | Apply a config around one graph invocation, restore prior values in `finally` | nothing (pure) |
+| `discovery-ab.branches.ts` | Resolve the two side URLs, assert they are designated A/B branches, reset both from base | Neon control plane |
+| `discovery-ab.ts` (child) | Run assigned slots against one branch under one config | graph, policy |
+| `discovery-ab.main.ts` (parent) | Gate, reset, spawn, aggregate, write artifact | all of the above |
+
+`discovery-ab.env.ts` generalizes today's `withMatrixEnvironment`, which hard-codes two keys and restores them in a `finally`. The generalized version takes a `Record<string, string>`, applies only allowlisted keys, and restores every key it touched — including deleting keys that were previously unset.
+
+**Why clone rather than re-seed.** Seeding the corpus is not a pure SQL insert: `seedProtectedBase` embeds every fixture intent and builds HyDE documents with vectors, and `verifyBaseFixtureIntegrity` refuses a base whose intents are unembedded or whose vectors are malformed. Re-seeding per run would mean re-embedding per run — provider spend and non-determinism on every comparison. Cloning a pre-embedded protected base gives an identical, already-embedded corpus in seconds, which is why the existing matrix works this way.
+
+**One new mutating capability.** `discovery-env-matrix.neon.ts` exposes a deliberately read-only control plane: a GET-only request helper behind `getBranch` and `listEndpoints`. Reset needs one write. It is added as a single narrowly-scoped call that refuses any branch whose name is not an A/B branch, rather than by opening the client up to general writes. `NEON_API_KEY` is required; the eval database is `protocol_eval`.
+
+## 6. Selection is shared; configuration is not
+
+| Scope | Values | Behavior |
+|---|---|---|
+| **Selection** | cases, repetitions | Shared by both sides. Two sides that ran different cases are not comparable, so this is one control, not two. |
+| **Configuration** | the nine env flags | Per side. This is the thing being compared. |
+
+Defaults: all 15 cases, 3 repetitions per side — 90 graph invocations, ~40 minutes at the observed ~52s per invocation. `--runs 1` is the quick look (30 invocations, ~13 minutes) and cannot mark anything flaky, since one observation per case cannot separate a difference from noise.
+
+If the two configurations are identical the run is refused: it would spend ~90 graph invocations to measure noise. The refusal names the flags that would have to differ.
+
+## 7. Scoring and artifact
+
+Scoring is reused unchanged from `historical-matrix.policy.ts` — deterministic assertions (expected user surfaced, excluded users absent, fixture ownership) plus the relationship judge over final evaluator outcomes, with raw retrieval retained for diagnostics only. Reusing it means A/B numbers are directly readable next to the existing matrix baseline.
+
+The artifact keeps the established envelope (`artifactType`, `harness`, `harnessVersion`, `corpusFingerprint`, `configFingerprint`, `git`, `completeness`, `execution`, `payload`) so existing viewer tooling can read it. Two departures, both deliberate:
+
+- `payload.rules` holds exactly two entries, the two sides, rather than five fixed strategy rows.
+- A new `payload.configs` block records each side's exact env map and the diff between them. Without it the artifact would show that A beat B while omitting what A and B were.
+
+Per case the artifact records passes/runs per side and a flaky marker, so a 3/3 vs 1/3 difference is distinguishable from 2/3 vs 3/3 noise. That distinction is the reason repetitions default to 3.
+
+## 8. Safety
+
+The graph writes opportunities and negotiation tasks. Three gates, in order:
+
+1. **Confirm variable.** Absent it, the command refuses, mirroring `DISCOVERY_ENV_MATRIX_CONFIRM=1`.
+2. **Branch allowlist.** Each side's URL must resolve to its designated A/B branch, and the reset call refuses any branch outside that set. `production` (`br-fragrant-brook-ahexgsek`) and `dev` are unreachable by construction, not by care — a reset pointed at either is refused by the same check that authorizes the A/B branches.
+3. **Reset before, not after.** Both branches are reset from base *before* a run. A crashed run leaves dirty branches, which the next run cleans; the alternative leaves a window where a dirty branch looks clean.
+
+Provider and database errors are sanitized before they reach logs or artifacts, following the existing `MatrixExecutionError` classification — these errors can carry credentials and response bodies.
+
+## 9. Failure modes
+
+| Failure | Behavior |
+|---|---|
+| Reset fails for either branch | Refuse to start. No half-isolated comparison. |
+| One side fails mid-run | Artifact marks the run incomplete and reports no verdict. A comparison with one side missing is not a comparison. |
+| A slot exhausts its attempts | Recorded as a failed slot; the side continues. `completeness.complete` becomes false. |
+| Both configs identical | Refused before any spend (§6). |
+| Child process hangs | Existing bounded child supervision terminates it (SIGTERM, then SIGKILL after a grace window). |
+
+## 10. Testing
+
+Provider-free, following the repo's targeted-validation policy:
+
+- **Plan builder** — slot count equals cases × reps × 2; both sides receive identical selection; identical configs are refused.
+- **Env application** — only allowlisted keys applied; previously-unset keys deleted afterwards, not left behind; prior values restored on throw.
+- **Nine-flag derivation** — recompute the reachable flag set from the graph and assert it equals the offered set (§4).
+- **Safety gate** — a non-designated URL is refused; a missing confirm variable is refused; production and dev URLs are refused explicitly.
+- **Artifact shape** — two rules, per-side config recorded, diff correct, no baseline comparison attempted.
+
+Live validation is one 1-case × 1-repetition smoke per side (~2 minutes, 4 invocations) before any full run.
+
+## 11. Sequencing
+
+1. **P1 (IND-626)** — recreate and seed `eval-discovery-base` (including intent embeddings and HyDE documents), verify fingerprints, mark protected. Prerequisite; no design decisions remain.
+2. **Create the two A/B branches** from the verified base.
+3. **P2 (IND-627)** — this design, built and smoke-tested from the CLI.
+4. **P3 (IND-628)** — eval-ops integration, specced against a real artifact.
+
+## 12. Open question deferred on purpose
+
+What the comparison should *show* an operator — rank of the expected user, surfaced/excluded counts, judge verdicts, or a blend — is not settled here. The artifact records all of it; choosing the headline number is IND-628's job, made with a real artifact in hand rather than an imagined one.

--- a/docs/superpowers/specs/2026-08-04-discovery-env-ab-engine-design.md
+++ b/docs/superpowers/specs/2026-08-04-discovery-env-ab-engine-design.md
@@ -32,10 +32,10 @@ So `DISCOVERY_SOURCE_PREMISE_LIMIT=5` and `=50` produce byte-identical behavior 
 
 `discovery-env-matrix` does exactly that, for a fixed set of strategies:
 
-- **Cases and scoring** in `packages/protocol/eval/discovery-env-matrix/` — `HISTORICAL_MATRIX_CASES` (15 seeded networks), `historical-matrix.policy.ts` (deterministic assertions plus a relationship judge), a reporter.
+- **Cases and scoring** in `packages/protocol/eval/discovery-env-matrix/` — `HISTORICAL_MATRIX_CASES` (5 seeded networks), `historical-matrix.policy.ts` (deterministic assertions plus a relationship judge), a reporter.
 - **Runner** in `services/api/src/cli/discovery-env-matrix*.ts` — composes the real `OpportunityGraphFactory` against a Neon child branch, one child process per branch, and aggregates slots into a governed artifact.
 - **Five hard-coded rows** varying `DISCOVERY_ALLOWED_TYPES` × `DISCOVERY_PROFILE_SOURCE`: `intent-only`, `profile-premise`, `profile-context`, `both-premise`, `both-context`.
-- **Proven**: a committed baseline from 2026-07-30 records 15 cases × 5 rows × 3 repetitions = 75 slots, aggregate pass rate 93.3%, wall clock 14 minutes across 15 parallel children. Per-slot duration ~52s.
+- **Proven**: a committed baseline from 2026-07-30 records 5 cases × 5 rows × 3 repetitions = 75 slots, aggregate pass rate 93.3%, wall clock 14 minutes across 15 parallel children. Per-slot duration ~52s.
 
 Three gaps: it varies 2 of the 16 flags in 5 combinations chosen at authoring time; it is invisible from eval-ops; and its base branch `eval-discovery-base` no longer exists in the Neon project (confirmed 2026-08-04 — only `production`, `dev`, `local-dev`, `eval-ops-fixtures*` and dated backups remain).
 
@@ -115,9 +115,9 @@ One process per side is not stylistic: the API composes its database singleton o
 | **Selection** | cases, repetitions | Shared by both sides. Two sides that ran different cases are not comparable, so this is one control, not two. |
 | **Configuration** | the nine env flags | Per side. This is the thing being compared. |
 
-Defaults: all 15 cases, 3 repetitions per side — 90 graph invocations, ~40 minutes at the observed ~52s per invocation. `--runs 1` is the quick look (30 invocations, ~13 minutes) and cannot mark anything flaky, since one observation per case cannot separate a difference from noise.
+Defaults: all 5 cases, 3 repetitions per side — 30 graph invocations, ~13 minutes with the two sides running in parallel at the observed ~52s per invocation. `--runs 1` is the quick look (10 invocations, ~4 minutes) and cannot mark anything flaky, since one observation per case cannot separate a difference from noise.
 
-If the two configurations are identical the run is refused: it would spend ~90 graph invocations to measure noise. The refusal names the flags that would have to differ.
+If the two configurations are identical the run is refused: it would spend a full run of graph invocations to measure noise. The refusal names the flags that would have to differ.
 
 ## 7. Scoring and artifact
 
@@ -126,7 +126,7 @@ Scoring is reused unchanged from `historical-matrix.policy.ts` — deterministic
 The artifact keeps the established envelope (`artifactType`, `harness`, `harnessVersion`, `corpusFingerprint`, `configFingerprint`, `git`, `completeness`, `execution`, `payload`) so existing viewer tooling can read it. Two departures, both deliberate:
 
 - `payload.rules` holds exactly two entries, the two sides, rather than five fixed strategy rows.
-- A new `payload.configs` block records each side's exact env map and the diff between them. Without it the artifact would show that A beat B while omitting what A and B were.
+- ~~A new `payload.configs` block records each side's exact env map and the diff between them.~~ **Amended during implementation.** `EvalScorecardPayloadV2Schema` and the envelope are both zod `.strict()`, and `buildEvalArtifact` copies only named meta fields — so a top-level rollup either gets silently dropped on write or makes the file unreadable to `parseEvalArtifact`. Widening a governed schema shared by every harness and every committed baseline, for a rollup that is derivable, was the wrong trade. The requirement's intent is met instead through the sanctioned extension point: `caseResultSchema` is `.passthrough()`, and every case row carries that side's complete configuration as `configDeltas`. The artifact still cannot show that A beat B while omitting what A and B were — the answer is per case rather than rolled up, and the diff is printed to the console at the end of a run. An explicit, tested projection (`toGovernedRunMeta`) makes the omission deliberate rather than accidental.
 
 Per case the artifact records passes/runs per side and a flaky marker, so a 3/3 vs 1/3 difference is distinguishable from 2/3 vs 3/3 noise. That distinction is the reason repetitions default to 3.
 
@@ -160,7 +160,7 @@ Provider-free, following the repo's targeted-validation policy:
 - **Safety gate** — a non-designated URL is refused; a missing confirm variable is refused; production and dev URLs are refused explicitly.
 - **Artifact shape** — two rules, per-side config recorded, diff correct, no baseline comparison attempted.
 
-Live validation is one 1-case × 1-repetition smoke per side (~2 minutes, 4 invocations) before any full run.
+Live validation is one 1-case × 1-repetition smoke per side (~2 minutes, 2 graph invocations plus judge calls) before any full run.
 
 ## 11. Sequencing
 

--- a/packages/protocol/eval/discovery-env-matrix/historical-matrix.policy.ts
+++ b/packages/protocol/eval/discovery-env-matrix/historical-matrix.policy.ts
@@ -13,6 +13,15 @@ export type MatrixRow = typeof MATRIX_ROWS[number];
 export type MatrixRowId = MatrixRow["id"];
 export type MatrixEvidenceType = MatrixRow["allowedEvidence"][number];
 
+/**
+ * The identifier of the arm a slot belongs to. The fixed matrix names one of
+ * `MATRIX_ROWS`; other harnesses that reuse this scoring policy (the discovery
+ * A/B harness names its two sides) supply their own arm identifier and must
+ * then supply `allowedEvidence` explicitly, because no `MATRIX_ROWS` entry
+ * describes their arm.
+ */
+export type MatrixSlotRowId = MatrixRowId | (string & Record<never, never>);
+
 export interface MatrixCandidateEvidenceIds {
   /** Concrete graph evidence IDs retained for run-artifact inspection. */
   candidateIntentId?: string;
@@ -72,7 +81,7 @@ export interface MatrixAssertion {
 /** The exhaustive, model-safe data available to the relationship judge. */
 export interface MatrixJudgeInput {
   sourceText: string;
-  rowId: MatrixRowId;
+  rowId: MatrixSlotRowId;
   candidateIds: string[];
   evidenceTypes: MatrixEvidenceType[];
   caseDescription: string;
@@ -93,8 +102,14 @@ export interface MatrixConfigDelta {
 
 export interface ScoreMatrixSlotInput {
   matrixCase: HistoricalMatrixCase;
-  rowId: MatrixRowId;
+  rowId: MatrixSlotRowId;
   repetition: number;
+  /**
+   * Evidence types this arm may cite. Omit it for the fixed matrix: the row's
+   * own `allowedEvidence` is then the only source, so an unknown matrix row
+   * still throws rather than being scored against a guess.
+   */
+  allowedEvidence?: readonly MatrixEvidenceType[];
   /** Evaluator-approved, graph-ranked candidates used by every policy assertion and judge. */
   candidates: readonly MatrixCandidate[];
   /** Raw retrieval diagnostics retained in run artifacts but never scored or judged. */
@@ -109,7 +124,7 @@ export interface ScoreMatrixSlotInput {
 
 /** Complete, raw run evidence for one case/row/repetition slot. */
 export interface MatrixSlotResult extends CaseResultLike {
-  rowId: MatrixRowId;
+  rowId: MatrixSlotRowId;
   repetition: number;
   passed: boolean;
   targetRank: number | null;
@@ -256,20 +271,27 @@ export function evaluateControlCalibratedGate(
   };
 }
 
-function rowFor(rowId: MatrixRowId): MatrixRow {
+function rowFor(rowId: MatrixSlotRowId): MatrixRow {
   const row = MATRIX_ROWS.find((candidate) => candidate.id === rowId);
   if (!row) throw new Error(`Unknown discovery environment matrix row: ${rowId}`);
   return row;
 }
 
-/** Checks that a returned candidate only cites evidence allowed by this row. */
+/**
+ * Checks that a returned candidate only cites evidence this arm may cite.
+ *
+ * The fixed matrix passes no `allowed` set, so `rowFor` remains the sole source
+ * of a matrix row's permitted evidence and an unknown row id still throws. A
+ * caller scoring an arm that is not a matrix row must state the permitted set
+ * itself rather than have one inferred for it.
+ */
 export function assertAllowedEvidence(
-  rowId: MatrixRowId,
+  rowId: MatrixSlotRowId,
   evidenceTypes: readonly MatrixEvidenceType[],
+  allowed?: readonly MatrixEvidenceType[],
 ): { passed: true } | { passed: false; detail: string } {
-  const row = rowFor(rowId);
+  const allowedEvidence: readonly MatrixEvidenceType[] = allowed ?? rowFor(rowId).allowedEvidence;
   if (evidenceTypes.length === 0) return { passed: false, detail: "missing_evidence" };
-  const allowedEvidence: readonly MatrixEvidenceType[] = row.allowedEvidence;
   const unexpected = evidenceTypes.filter((evidenceType) => !allowedEvidence.includes(evidenceType));
   return unexpected.length === 0
     ? { passed: true }
@@ -307,7 +329,7 @@ function deterministicAssertions(input: ScoreMatrixSlotInput): {
   const excludedCandidate = candidateIds.find((candidateId) => input.matrixCase.excludedUserIds.includes(candidateId));
   const evidenceTypes = [...new Set(input.candidates.flatMap((candidate) => candidate.evidenceTypes))];
   const evidenceFailure = input.candidates
-    .map((candidate) => ({ id: candidate.id, result: assertAllowedEvidence(input.rowId, candidate.evidenceTypes) }))
+    .map((candidate) => ({ id: candidate.id, result: assertAllowedEvidence(input.rowId, candidate.evidenceTypes, input.allowedEvidence) }))
     .find(({ result }) => !result.passed);
 
   return {

--- a/packages/protocol/eval/discovery-env-matrix/tests/historical-matrix.policy.spec.ts
+++ b/packages/protocol/eval/discovery-env-matrix/tests/historical-matrix.policy.spec.ts
@@ -64,6 +64,45 @@ describe("historical discovery environment matrix policy", () => {
     });
   });
 
+  it("scores an arm that is not a matrix row when it states its own allowed evidence", async () => {
+    // Regression: scoring a slot whose rowId is a comparison-arm id (the
+    // discovery A/B harness names its sides "a" and "b") threw
+    // "Unknown discovery environment matrix row: a" for every slot that
+    // returned a candidate, because the allowed-evidence assertion resolved the
+    // row. An arm that supplies its own permitted set must score instead.
+    const matrixCase = HISTORICAL_MATRIX_CASES[0]!;
+    const result = await scoreMatrixSlot({
+      matrixCase,
+      rowId: "a",
+      repetition: 0,
+      completed: true,
+      allowedEvidence: ["intent", "premise", "user_context"],
+      candidates: [{ id: matrixCase.expectedUserId, finalRank: 1, evidenceTypes: ["user_context"], evidenceIds: {} }],
+      judge: async () => ({ passed: true }),
+    });
+
+    expect(result.rowId).toBe("a");
+    expect(result.rule).toBe("a");
+    expect(result.passed).toBe(true);
+    expect(result.assertions.find((assertion) => assertion.kind === "allowed_evidence")).toMatchObject({ passed: true });
+    // The non-empty evidence check still applies to such an arm.
+    expect(assertAllowedEvidence("a", [], ["intent", "premise", "user_context"])).toMatchObject({ passed: false, detail: "missing_evidence" });
+    // And a stated set is still enforced.
+    expect(assertAllowedEvidence("a", ["premise"], ["intent"])).toMatchObject({ passed: false });
+  });
+
+  it("still refuses an unknown row when no allowed evidence is stated", async () => {
+    const matrixCase = HISTORICAL_MATRIX_CASES[0]!;
+    expect(() => assertAllowedEvidence("made-up", ["intent"])).toThrow("Unknown discovery environment matrix row: made-up");
+    await expect(scoreMatrixSlot({
+      matrixCase,
+      rowId: "made-up",
+      repetition: 0,
+      completed: true,
+      candidates: [{ id: matrixCase.expectedUserId, finalRank: 1, evidenceTypes: ["intent"], evidenceIds: {} }],
+    })).rejects.toThrow("Unknown discovery environment matrix row: made-up");
+  });
+
   it("scores only final evaluator candidates when raw retrieval contains an excluded candidate", async () => {
     const matrixCase = HISTORICAL_MATRIX_CASES[0]!;
     const judgeInputs: string[][] = [];

--- a/packages/protocol/package.json
+++ b/packages/protocol/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@indexnetwork/protocol",
-  "version": "8.10.0",
+  "version": "8.11.0",
   "type": "module",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",

--- a/services/api/package.json
+++ b/services/api/package.json
@@ -8,6 +8,7 @@
     "build": "bun run --cwd ../../packages/protocol build && tsc",
     "start": "bun --preload ./dist/instrument.js dist/main.js",
     "lint": "eslint src/",
+    "typecheck:cli-specs": "tsc -p tsconfig.spec.json",
     "test:isolated": "NODE_ENV=test bash scripts/test-isolated.sh",
     "test:all": "NODE_ENV=test API_TEST_REQUIRE_DATABASE=1 bun test",
     "db:generate": "drizzle-kit generate",
@@ -37,6 +38,7 @@
     "eval:discovery-env-matrix-base": "bun ./src/cli/discovery-env-matrix-base.ts",
     "eval:discovery-env-matrix-base:verify": "bun ./src/cli/discovery-env-matrix-base.ts --verify",
     "eval:discovery-env-matrix": "bun --env-file=../../.env.test ./src/cli/discovery-env-matrix.ts",
+    "eval:discovery-ab": "bun --env-file=../../.env.test ./src/cli/discovery-ab.ts",
     "test": "NODE_ENV=test bash scripts/test-safe.sh",
     "test:raw": "NODE_ENV=test bun test"
   },

--- a/services/api/package.json
+++ b/services/api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@indexnetwork/api",
-  "version": "0.72.0",
+  "version": "0.73.0",
   "license": "MIT",
   "private": true,
   "scripts": {

--- a/services/api/src/cli/discovery-ab.contract.ts
+++ b/services/api/src/cli/discovery-ab.contract.ts
@@ -1,0 +1,186 @@
+/**
+ * The discovery A/B harness's operator-facing contract: what the command
+ * promises, and what each of its exit codes means.
+ *
+ * It lives in its own dependency-free module for two reasons, both of them
+ * about what an operator can find out and when.
+ *
+ * 1. **`--help` must be readable without credentials.** The bootstrap refuses
+ *    to run without an attested manifest, a Neon key and two confirm variables
+ *    — which is exactly what the help text exists to explain. A help text that
+ *    could only be printed by someone who already had all of it would be
+ *    useless. So the contract lives above the gate, in a module that imports
+ *    nothing that can compose a database: the bootstrap prints it before it
+ *    reads a single environment variable, and its "attest before importing the
+ *    runtime" ordering is untouched.
+ * 2. **The exit codes must be visible in one place.** The bootstrap decides the
+ *    process exit code and cannot import `discovery-ab.main.ts` (that module
+ *    reaches `@indexnetwork/protocol` on its first import), so the codes and
+ *    the classification that picks between them have to live somewhere both
+ *    halves can reach.
+ *
+ * The codes below describe a *parent* invocation, which is the one an operator
+ * runs. A `--side` child's exit code is consumed by the parent's supervision,
+ * which then reports the run-level code for the whole comparison.
+ */
+import { AB_BRANCH_NAMES } from './discovery-ab.neon';
+import { AbGateError } from './discovery-ab.gate';
+
+/** The protected branch both A/B branches are reset from before every run. */
+export const AB_BASE_BRANCH = 'eval-discovery-base';
+/** Three repetitions per side; one observation per case cannot separate a difference from noise. */
+export const AB_DEFAULT_REPETITIONS = 3;
+/**
+ * A ceiling on `--runs`, because a mistyped one costs real money and hours: at
+ * the observed ~52s per invocation, ten repetitions over the full corpus is
+ * already 300 graph invocations. Nothing above this is a considered choice.
+ */
+export const AB_MAX_REPETITIONS = 10;
+
+// ── Exit codes ──────────────────────────────────────────────────────────────
+// Four codes, and the operator conclusion each one licenses. The distinction
+// that matters most is between 2 and 4: both are failures, but one costs
+// nothing and the other costs a live run.
+
+/** 0 — both sides completed and the artifact holds the comparison. */
+export const AB_EXIT_COMPARISON = 0;
+/**
+ * 2 — refused before anything happened: the gate, the arguments, the manifest
+ * or the attestation. No branch was reset, no child was spawned, no provider
+ * call was made. Conclude: fix what the message names and re-run; you have lost
+ * nothing but the seconds it took to refuse.
+ */
+export const AB_EXIT_PREFLIGHT_REFUSED = 2;
+/**
+ * 3 — the run finished and the artifact was written, but at least one side did
+ * not score every slot it was planned, so there is **no verdict**. Matches
+ * `EVAL_EXIT_INSUFFICIENT_EVIDENCE` in the shared eval CLI; restated rather
+ * than imported because this package reaches the eval bundle only through the
+ * dynamic `loadMatrixEval` seam. Conclude: the run happened and was paid for,
+ * the artifact on disk is real, and it does not support a comparison.
+ */
+export const AB_EXIT_INSUFFICIENT_EVIDENCE = 3;
+/**
+ * 4 — failed *after* the branches were reset and/or a side was spawned, and no
+ * artifact exists. Conclude: this run mutated the A/B branches and may have
+ * spent a live run (provider calls, graph writes, wall-clock hours) and nothing
+ * of it survives. Re-running costs that again. This is the code that keeps a
+ * forty-minute loss from looking like a refusal.
+ */
+export const AB_EXIT_SPENT_WITHOUT_ARTIFACT = 4;
+
+/**
+ * How far a parent run got before it failed. `null` — the third case — is
+ * pre-flight, and is deliberately not a member: it is the absence of any
+ * mutation, not a stage of one.
+ */
+export type AbRunStage = 'reset' | 'spawned';
+
+const AB_SPENT_MESSAGES: Record<AbRunStage, string> = {
+  reset: `Discovery A/B failed after resetting the A/B branches (${AB_BRANCH_NAMES.a}, ${AB_BRANCH_NAMES.b}) `
+    + `from ${AB_BASE_BRANCH} and before spawning any side: both branches were overwritten, no run was spent, `
+    + 'and no artifact was written.',
+  spawned: 'Discovery A/B failed after spawning a side: both A/B branches were reset and a live run was started, '
+    + 'so provider spend and wall-clock time are gone. No artifact was written and there is no verdict — '
+    + 'nothing of this run survives, and re-running costs the same again.',
+};
+
+/**
+ * A failure that happened after this run began mutating or spending.
+ *
+ * Its message is authored here from the stage alone and never from the
+ * underlying error, which may carry a `DATABASE_URL` password or a
+ * control-plane response body. The original is kept as `cause` for anyone
+ * holding the error rather than printing it.
+ */
+export class AbSpentRunError extends Error {
+  readonly stage: AbRunStage;
+
+  constructor(stage: AbRunStage, options?: ErrorOptions) {
+    super(AB_SPENT_MESSAGES[stage], options);
+    this.name = 'AbSpentRunError';
+    this.stage = stage;
+  }
+}
+
+/**
+ * Classifies a parent failure by how far the run got, so the two halves of the
+ * old catch-all can be told apart.
+ *
+ * A pre-flight failure is returned untouched: its own message (a gate refusal,
+ * a bad argument, an unparseable manifest) is what the operator needs, and it
+ * costs nothing. Anything after the first reset is rewritten into an
+ * `AbSpentRunError`, because the one thing the operator cannot work out from a
+ * generic failure is whether they just paid for it.
+ */
+export function classifyAbParentFailure(stage: AbRunStage | null, error: unknown): unknown {
+  return stage === null ? error : new AbSpentRunError(stage, { cause: error });
+}
+
+export interface AbFailureReport { exitCode: number; message: string }
+
+/**
+ * What to print and what to exit with, for any failure reaching the bootstrap.
+ *
+ * Only messages authored in this codebase are printed. Gate refusals name
+ * environment variables; spend reports name stages. Everything else prints a
+ * fixed line, because provider, database and control-plane errors can carry
+ * credentials and response bodies.
+ */
+export function describeAbFailure(error: unknown): AbFailureReport {
+  if (error instanceof AbSpentRunError) {
+    return { exitCode: AB_EXIT_SPENT_WITHOUT_ARTIFACT, message: error.message };
+  }
+  if (error instanceof AbGateError) {
+    return { exitCode: AB_EXIT_PREFLIGHT_REFUSED, message: error.message };
+  }
+  return {
+    exitCode: AB_EXIT_PREFLIGHT_REFUSED,
+    message: 'Discovery A/B command failed before anything was reset or spawned: '
+      + 'no branch was mutated and no run was spent.',
+  };
+}
+
+/**
+ * The full contract, printable with no environment, no credentials and no
+ * manifest — see this module's header for why that is the whole point.
+ */
+export function abUsage(): string {
+  const manifest = '{"projectId":"...","baseBranchId":"br-...","targets":[{"sideId":"a","branchId":"br-...","endpointId":"ep-...","databaseUrl":"postgres://...neon.tech/protocol_eval"}, ...]}';
+  return [
+    'Discovery A/B eval',
+    '',
+    'Runs the real discovery graph twice - once per operator-chosen environment',
+    'configuration - over the same cases, and emits one artifact holding both sides.',
+    'It never reads, writes or compares a baseline: arbitrary configurations have',
+    'none, so the pair is the result.',
+    '',
+    'Required operator attestation:',
+    '  DISCOVERY_AB_CONFIRM=1',
+    '  TEST_DATABASE_SAFE=1',
+    '  NEON_API_KEY=<neon api key>',
+    `  DISCOVERY_AB_TARGETS='${manifest}'`,
+    '',
+    'This command never creates or deletes Neon branches. It resets both attested',
+    `A/B branches (${AB_BRANCH_NAMES.a}, ${AB_BRANCH_NAMES.b}) from ${AB_BASE_BRANCH} before it spawns anything.`,
+    '',
+    'Selection is shared by both sides; configuration is not:',
+    '  --case <id>       Restrict to one case. Repeatable. Default: the full corpus.',
+    `  --runs <n>        Repetitions per side (default ${AB_DEFAULT_REPETITIONS}, maximum ${AB_MAX_REPETITIONS}).`,
+    '  --a KEY=VALUE     A flag for side a. Repeatable.',
+    '  --b KEY=VALUE     A flag for side b. Repeatable.',
+    '  --force           Consent to replacing an existing run artifact.',
+    '',
+    'Both sides must state the same keys with differing values; identical or',
+    'asymmetric configurations are refused before any spend.',
+    '',
+    'Exit codes:',
+    `  ${AB_EXIT_COMPARISON}   Both sides completed; the artifact holds the comparison.`,
+    `  ${AB_EXIT_PREFLIGHT_REFUSED}   Refused before anything ran (gate, arguments, manifest, attestation).`,
+    '      Nothing was reset, nothing was spawned, nothing was spent.',
+    `  ${AB_EXIT_INSUFFICIENT_EVIDENCE}   The artifact was written but a side did not score every slot, so there is no`,
+    '      verdict. The run was spent and the artifact on disk is real.',
+    `  ${AB_EXIT_SPENT_WITHOUT_ARTIFACT}   Failed after the branches were reset and/or a side was spawned, and no artifact`,
+    '      was written. The branches were mutated and a live run may have been spent.',
+  ].join('\n');
+}

--- a/services/api/src/cli/discovery-ab.contract.ts
+++ b/services/api/src/cli/discovery-ab.contract.ts
@@ -45,10 +45,16 @@ export const AB_MAX_REPETITIONS = 10;
 /** 0 — both sides completed and the artifact holds the comparison. */
 export const AB_EXIT_COMPARISON = 0;
 /**
- * 2 — refused before anything happened: the gate, the arguments, the manifest
- * or the attestation. No branch was reset, no child was spawned, no provider
- * call was made. Conclude: fix what the message names and re-run; you have lost
- * nothing but the seconds it took to refuse.
+ * 2 — for a *parent* run: refused before anything happened — the gate, the
+ * arguments, the manifest or the attestation. No branch was reset, no child was
+ * spawned, no provider call was made. Conclude: fix what the message names and
+ * re-run; you have lost nothing but the seconds it took to refuse.
+ *
+ * A `--side` child also exits 2 for failures that are *not* pre-flight, because
+ * a child cannot know what the run as a whole cost — it did not reset the
+ * branches and did not start the other side. That is why a child's message
+ * makes no cost claim and why its exit code is consumed by the parent's
+ * supervision rather than read by an operator.
  */
 export const AB_EXIT_PREFLIGHT_REFUSED = 2;
 /**
@@ -61,45 +67,91 @@ export const AB_EXIT_PREFLIGHT_REFUSED = 2;
  */
 export const AB_EXIT_INSUFFICIENT_EVIDENCE = 3;
 /**
- * 4 — failed *after* the branches were reset and/or a side was spawned, and no
- * artifact exists. Conclude: this run mutated the A/B branches and may have
- * spent a live run (provider calls, graph writes, wall-clock hours) and nothing
- * of it survives. Re-running costs that again. This is the code that keeps a
- * forty-minute loss from looking like a refusal.
+ * 4 — failed *after* the branches began being reset and/or a side was spawned.
+ * Conclude: this run mutated the A/B branches and may have spent a live run
+ * (provider calls, graph writes, wall-clock hours). Usually nothing of it
+ * survives and re-running costs that again; the one exception is a failure that
+ * lands *after* the run report was saved, whose message names the artifact on
+ * disk. The code stays 4 there because the run did not complete — what the
+ * message says, not the code, is what tells an operator whether anything
+ * survived. This is the code that keeps a forty-minute loss from looking like a
+ * refusal.
  */
 export const AB_EXIT_SPENT_WITHOUT_ARTIFACT = 4;
 
 /**
- * How far a parent run got before it failed. `null` — the third case — is
+ * How far a parent run got before it failed. `null` — the fifth case — is
  * pre-flight, and is deliberately not a member: it is the absence of any
  * mutation, not a stage of one.
+ *
+ * `'resetting'` and `'reset'` are separate stages because the difference
+ * between them is a claim the operator cannot check: inside the loop, one
+ * branch may have been overwritten and the other never touched, and a refused
+ * restore is the most likely post-attestation failure there is. Only the
+ * completed loop licenses "both branches were overwritten".
  */
-export type AbRunStage = 'reset' | 'spawned';
+export type AbRunStage = 'resetting' | 'reset' | 'spawned' | 'written';
 
-const AB_SPENT_MESSAGES: Record<AbRunStage, string> = {
-  reset: `Discovery A/B failed after resetting the A/B branches (${AB_BRANCH_NAMES.a}, ${AB_BRANCH_NAMES.b}) `
-    + `from ${AB_BASE_BRANCH} and before spawning any side: both branches were overwritten, no run was spent, `
-    + 'and no artifact was written.',
-  spawned: 'Discovery A/B failed after spawning a side: both A/B branches were reset and a live run was started, '
-    + 'so provider spend and wall-clock time are gone. No artifact was written and there is no verdict — '
-    + 'nothing of this run survives, and re-running costs the same again.',
-};
+/**
+ * What a failure at each stage may truthfully assert.
+ *
+ * Every clause here has to hold in *every* situation that can reach it. Where
+ * the stage cannot distinguish two situations — a restore that failed on side a
+ * versus one that failed on side b — the message hedges rather than reporting
+ * the common case as fact.
+ */
+function abSpentMessage(stage: AbRunStage, artifactPath?: string): string {
+  switch (stage) {
+    case 'resetting':
+      return `Discovery A/B failed while resetting the A/B branches (${AB_BRANCH_NAMES.a}, ${AB_BRANCH_NAMES.b}) `
+        + `from ${AB_BASE_BRANCH}: one or both branches may have been overwritten — the reset was still in `
+        + 'progress, so this run cannot say which. No side was spawned, no run was spent, and no artifact was '
+        + 'written. Treat both branches as dirty; the next run resets them again.';
+    case 'reset':
+      return `Discovery A/B failed after resetting the A/B branches (${AB_BRANCH_NAMES.a}, ${AB_BRANCH_NAMES.b}) `
+        + `from ${AB_BASE_BRANCH} and before spawning any side: both branches were overwritten, no run was spent, `
+        + 'and no artifact was written.';
+    case 'spawned':
+      // "may already be gone", not "are gone": the stage is set the moment a
+      // side process exists, and a side that died at its own gate spent
+      // nothing. What it did spend is bounded only by how far it got, which
+      // this process cannot see.
+      return 'Discovery A/B failed after spawning a side: both A/B branches were reset and at least one side '
+        + 'process was started, so provider spend and wall-clock time may already be gone. No artifact was '
+        + 'written and there is no verdict — nothing of this run survives, and re-running pays for the whole '
+        + 'comparison again.';
+    case 'written':
+      return 'Discovery A/B failed after the run artifact was written'
+        + `${artifactPath === undefined ? '' : ` (${artifactPath})`}: both A/B branches were reset and a live run `
+        + 'was spent, and the failure came after the artifact was saved. The artifact on disk is real — read it '
+        + 'before re-running, which costs the same again.';
+  }
+}
+
+/** What a spend report knows beyond the stage. */
+export interface AbSpentRunDetail {
+  /** The run report's path, known only once it has been written. */
+  artifactPath?: string;
+}
 
 /**
  * A failure that happened after this run began mutating or spending.
  *
- * Its message is authored here from the stage alone and never from the
- * underlying error, which may carry a `DATABASE_URL` password or a
- * control-plane response body. The original is kept as `cause` for anyone
- * holding the error rather than printing it.
+ * Its message is authored here from the stage (and, at `'written'`, the path
+ * this harness itself chose) and never from the underlying error, which may
+ * carry a `DATABASE_URL` password or a control-plane response body. The
+ * original is kept as `cause` for anyone holding the error rather than printing
+ * it.
  */
 export class AbSpentRunError extends Error {
   readonly stage: AbRunStage;
+  readonly artifactPath?: string;
 
-  constructor(stage: AbRunStage, options?: ErrorOptions) {
-    super(AB_SPENT_MESSAGES[stage], options);
+  constructor(stage: AbRunStage, options?: ErrorOptions & AbSpentRunDetail) {
+    super(abSpentMessage(stage, options?.artifactPath), options);
     this.name = 'AbSpentRunError';
     this.stage = stage;
+    if (options?.artifactPath !== undefined) this.artifactPath = options.artifactPath;
   }
 }
 
@@ -113,11 +165,17 @@ export class AbSpentRunError extends Error {
  * `AbSpentRunError`, because the one thing the operator cannot work out from a
  * generic failure is whether they just paid for it.
  */
-export function classifyAbParentFailure(stage: AbRunStage | null, error: unknown): unknown {
-  return stage === null ? error : new AbSpentRunError(stage, { cause: error });
+export function classifyAbParentFailure(stage: AbRunStage | null, error: unknown, detail?: AbSpentRunDetail): unknown {
+  return stage === null ? error : new AbSpentRunError(stage, { cause: error, ...detail });
 }
 
 export interface AbFailureReport { exitCode: number; message: string }
+
+/**
+ * Which invocation is reporting. A parent owns the run-level cost report; a
+ * child owns nothing but its own outcome.
+ */
+export type AbInvocationRole = 'parent' | 'child';
 
 /**
  * What to print and what to exit with, for any failure reaching the bootstrap.
@@ -126,8 +184,17 @@ export interface AbFailureReport { exitCode: number; message: string }
  * environment variables; spend reports name stages. Everything else prints a
  * fixed line, because provider, database and control-plane errors can carry
  * credentials and response bodies.
+ *
+ * The fixed line depends on who is printing it. In a parent, an unclassified
+ * failure really did escape before the first reset — `withAbSpendAccounting`
+ * wraps everything after it — so "nothing was mutated or spent" is true. In a
+ * `--side` child it is not: a child runs the graph, writes to its branch and
+ * pays providers, and any failure after that (the child-artifact write, closing
+ * its resources, assembling its evidence) reaches this same fallback. So a
+ * child says only that it failed, and leaves every cost claim to the parent,
+ * which is the process that knows.
  */
-export function describeAbFailure(error: unknown): AbFailureReport {
+export function describeAbFailure(error: unknown, role: AbInvocationRole = 'parent'): AbFailureReport {
   if (error instanceof AbSpentRunError) {
     return { exitCode: AB_EXIT_SPENT_WITHOUT_ARTIFACT, message: error.message };
   }
@@ -136,9 +203,39 @@ export function describeAbFailure(error: unknown): AbFailureReport {
   }
   return {
     exitCode: AB_EXIT_PREFLIGHT_REFUSED,
-    message: 'Discovery A/B command failed before anything was reset or spawned: '
-      + 'no branch was mutated and no run was spent.',
+    message: role === 'child'
+      ? 'Discovery A/B side process failed. A child makes no claim about what this run cost: whether the '
+        + 'branches were reset, a side was spawned or a live run was spent is reported by the parent '
+        + "invocation, and the parent's exit code is the one to act on."
+      : 'Discovery A/B command failed before anything was reset or spawned: '
+        + 'no branch was mutated and no run was spent.',
   };
+}
+
+/**
+ * The refusal printed when the two targets cannot be attested, authored for
+ * whichever invocation is refusing.
+ *
+ * The same attestation runs in the parent and in every child, and the two are
+ * at different points in the run. "Nothing was reset and nothing was spawned"
+ * is true of a parent refusing before its first reset; a child attests *after*
+ * the parent has already reset both branches and spawned it, so the same
+ * sentence printed from a child is simply false. A child speaks only for
+ * itself.
+ *
+ * The underlying control-plane error is never included: it reaches the caller
+ * through `response.json()`, whose parse failures can quote response text. It
+ * is kept as `cause` for anyone holding the error rather than printing it.
+ */
+export function abAttestationRefusal(role: AbInvocationRole, options?: ErrorOptions): AbGateError {
+  return new AbGateError(
+    'Refusing to run: DISCOVERY_AB_TARGETS was not attested as the two designated A/B branches '
+    + `(${AB_BRANCH_NAMES.a}, ${AB_BRANCH_NAMES.b}) parented on ${AB_BASE_BRANCH}. `
+    + (role === 'child'
+      ? 'This side did not run; what the run reset or spawned is reported by the parent invocation.'
+      : 'Nothing was reset and nothing was spawned.'),
+    options,
+  );
 }
 
 /**
@@ -174,13 +271,15 @@ export function abUsage(): string {
     'Both sides must state the same keys with differing values; identical or',
     'asymmetric configurations are refused before any spend.',
     '',
-    'Exit codes:',
+    'Exit codes, for the parent invocation an operator runs (a --side child\'s code',
+    "is consumed by the parent's supervision, which reports the run-level code):",
     `  ${AB_EXIT_COMPARISON}   Both sides completed; the artifact holds the comparison.`,
     `  ${AB_EXIT_PREFLIGHT_REFUSED}   Refused before anything ran (gate, arguments, manifest, attestation).`,
     '      Nothing was reset, nothing was spawned, nothing was spent.',
     `  ${AB_EXIT_INSUFFICIENT_EVIDENCE}   The artifact was written but a side did not score every slot, so there is no`,
     '      verdict. The run was spent and the artifact on disk is real.',
-    `  ${AB_EXIT_SPENT_WITHOUT_ARTIFACT}   Failed after the branches were reset and/or a side was spawned, and no artifact`,
-    '      was written. The branches were mutated and a live run may have been spent.',
+    `  ${AB_EXIT_SPENT_WITHOUT_ARTIFACT}   Failed after the branches began being reset and/or a side was spawned. The`,
+    '      branches were mutated and a live run may have been spent; the message says what',
+    '      was overwritten and whether an artifact survived.',
   ].join('\n');
 }

--- a/services/api/src/cli/discovery-ab.contract.ts
+++ b/services/api/src/cli/discovery-ab.contract.ts
@@ -32,8 +32,9 @@ export const AB_BASE_BRANCH = 'eval-discovery-base';
 export const AB_DEFAULT_REPETITIONS = 3;
 /**
  * A ceiling on `--runs`, because a mistyped one costs real money and hours: at
- * the observed ~52s per invocation, ten repetitions over the full corpus is
- * already 300 graph invocations. Nothing above this is a considered choice.
+ * the observed ~52s per invocation, ten repetitions over the full five-case
+ * corpus is already 100 graph invocations (5 cases x 10 repetitions x 2 sides).
+ * Nothing above this is a considered choice.
  */
 export const AB_MAX_REPETITIONS = 10;
 

--- a/services/api/src/cli/discovery-ab.contract.ts
+++ b/services/api/src/cli/discovery-ab.contract.ts
@@ -69,11 +69,11 @@ export const AB_EXIT_INSUFFICIENT_EVIDENCE = 3;
 /**
  * 4 — failed *after* the branches began being reset and/or a side was spawned.
  * Conclude: this run mutated the A/B branches and may have spent a live run
- * (provider calls, graph writes, wall-clock hours). Usually nothing of it
- * survives and re-running costs that again; the one exception is a failure that
- * lands *after* the run report was saved, whose message names the artifact on
- * disk. The code stays 4 there because the run did not complete — what the
- * message says, not the code, is what tells an operator whether anything
+ * (provider calls, graph writes, wall-clock hours). Re-running costs that again,
+ * and what (if anything) survived is named by the message: the run report, when
+ * the failure landed *after* it was saved, or the child artifacts a failed run
+ * kept. The code stays 4 in both cases because the run did not complete — what
+ * the message says, not the code, is what tells an operator whether anything
  * survived. This is the code that keeps a forty-minute loss from looking like a
  * refusal.
  */
@@ -116,15 +116,26 @@ function abSpentMessage(stage: AbRunStage, artifactPath?: string): string {
       // side process exists, and a side that died at its own gate spent
       // nothing. What it did spend is bounded only by how far it got, which
       // this process cannot see.
+      //
+      // And it cannot say nothing survived. One side can finish and write its
+      // child artifact while the other times out, and
+      // `finalizeAbChildArtifacts` — which runs in the parent's `finally`,
+      // before this message is printed — keeps that directory and names what is
+      // in it precisely so the scored slots can be read. What is certainly lost
+      // is the run report and the verdict, so that is what this says.
       return 'Discovery A/B failed after spawning a side: both A/B branches were reset and at least one side '
-        + 'process was started, so provider spend and wall-clock time may already be gone. No artifact was '
-        + 'written and there is no verdict — nothing of this run survives, and re-running pays for the whole '
-        + 'comparison again.';
+        + 'process was started, so provider spend and wall-clock time may already be gone. No run report was '
+        + 'written and there is no verdict — any child artifact this run kept is named above — and re-running '
+        + 'pays for the whole comparison again.';
     case 'written':
+      // "may have been spent", like every other stage: a child writes its output
+      // and exits 0 even when every one of its slots failed, so both sides can
+      // complete with nothing scored. Attempts were certainly made; a paid run
+      // is not something this stage can assert.
       return 'Discovery A/B failed after the run artifact was written'
         + `${artifactPath === undefined ? '' : ` (${artifactPath})`}: both A/B branches were reset and a live run `
-        + 'was spent, and the failure came after the artifact was saved. The artifact on disk is real — read it '
-        + 'before re-running, which costs the same again.';
+        + 'may have been spent, and the failure came after the artifact was saved. The artifact on disk is real — '
+        + 'read it before re-running, which costs the same again.';
   }
 }
 

--- a/services/api/src/cli/discovery-ab.flags.ts
+++ b/services/api/src/cli/discovery-ab.flags.ts
@@ -8,7 +8,7 @@
 import { existsSync, readFileSync } from 'node:fs';
 import path from 'node:path';
 
-export const AB_FLAGS: readonly string[] = [
+export const AB_FLAGS: readonly string[] = Object.freeze([
   'DISCOVERY_ALLOWED_TYPES',
   'DISCOVERY_CONTEXT_TO_INTENT',
   'DISCOVERY_PROFILE_SOURCE',
@@ -18,7 +18,7 @@ export const AB_FLAGS: readonly string[] = [
   'NEGOTIATION_MAX_TURNS_AMBIENT',
   'NEGOTIATION_MAX_TURNS_CHAT',
   'RUN_OPPORTUNITY_EVAL_IN_PARALLEL',
-];
+]);
 
 export type AbEnvConfig = Readonly<Record<string, string>>;
 
@@ -32,8 +32,60 @@ function resolveSpecifier(fromFile: string, specifier: string): string | null {
   return null;
 }
 
-/** Every candidate key mentioned anywhere in the entry file's transitive import closure. */
+/**
+ * Removes comments so a commented-out read cannot pass for a live one. Quotes
+ * and template literals are honoured; regular-expression literals are not
+ * parsed, which at worst hides a real read behind a `//` inside a regex and so
+ * fails the derivation test loudly rather than passing it silently.
+ */
+function stripComments(source: string): string {
+  let out = '';
+  let i = 0;
+  while (i < source.length) {
+    const ch = source[i]!;
+    if (ch === '/' && source[i + 1] === '/') {
+      while (i < source.length && source[i] !== '\n') i += 1;
+      continue;
+    }
+    if (ch === '/' && source[i + 1] === '*') {
+      i += 2;
+      while (i < source.length && !(source[i] === '*' && source[i + 1] === '/')) i += 1;
+      i += 2;
+      continue;
+    }
+    out += ch;
+    i += 1;
+    if (ch !== '"' && ch !== "'" && ch !== '`') continue;
+    while (i < source.length) {
+      const inner = source[i]!;
+      out += inner;
+      i += 1;
+      if (inner === '\\' && i < source.length) {
+        out += source[i];
+        i += 1;
+        continue;
+      }
+      if (inner === ch) break;
+    }
+  }
+  return out;
+}
+
+/**
+ * Matches an actual read of `key` from the environment — `process.env.KEY`,
+ * `process.env['KEY']` or `process.env["KEY"]` — and nothing else. A plain
+ * substring match would count a comment or a log message as a read (the graph
+ * names several of these flags in both), so deleting the last real read would
+ * leave the flag in `AB_FLAGS` as fiction with every test still green.
+ */
+function envReadPattern(key: string): RegExp {
+  const escaped = key.replace(/[^A-Za-z0-9_]/g, '\\$&');
+  return new RegExp(`process\\.env(?:\\.${escaped}\\b|\\[\\s*(['"\`])${escaped}\\1\\s*\\])`);
+}
+
+/** Every candidate key actually read from `process.env` somewhere in the entry file's transitive import closure. */
 export function reachableEnvKeys(entryFile: string, candidateKeys: readonly string[]): Set<string> {
+  const patterns = candidateKeys.map((key) => [key, envReadPattern(key)] as const);
   const seen = new Set<string>();
   const found = new Set<string>();
   const stack = [path.resolve(entryFile)];
@@ -41,8 +93,8 @@ export function reachableEnvKeys(entryFile: string, candidateKeys: readonly stri
     const file = stack.pop()!;
     if (seen.has(file) || !existsSync(file)) continue;
     seen.add(file);
-    const source = readFileSync(file, 'utf8');
-    for (const key of candidateKeys) if (source.includes(key)) found.add(key);
+    const source = stripComments(readFileSync(file, 'utf8'));
+    for (const [key, pattern] of patterns) if (pattern.test(source)) found.add(key);
     for (const match of source.matchAll(/(?:from|import)\s*\(?\s*["']([^"']+)["']/g)) {
       const resolved = resolveSpecifier(file, match[1]!);
       if (resolved !== null) stack.push(resolved);

--- a/services/api/src/cli/discovery-ab.flags.ts
+++ b/services/api/src/cli/discovery-ab.flags.ts
@@ -33,59 +33,68 @@ function resolveSpecifier(fromFile: string, specifier: string): string | null {
 }
 
 /**
- * Removes comments so a commented-out read cannot pass for a live one. Quotes
- * and template literals are honoured; regular-expression literals are not
- * parsed, which at worst hides a real read behind a `//` inside a regex and so
- * fails the derivation test loudly rather than passing it silently.
+ * Drops comments (and type-only imports) by running the file through Bun's own
+ * TypeScript parser, so a commented-out read cannot pass for a live one.
+ *
+ * A hand-rolled stripper was tried first and was unsound: it tracked string
+ * state character by character and desynced on the `'` inside the regex literal
+ * at `opportunity.presentation.ts:160`, leaving hundreds of lines in four
+ * closure files un-stripped. The dangerous direction there is *silent* — a
+ * commented-out `process.env.SOME_FLAG` on an un-stripped line counts as a real
+ * read and the derivation test stays green on fiction. Only a real parser gets
+ * regex literals, nested quotes and template substitutions right.
+ *
+ * Falls back to the raw source if the transform throws, so an unparseable file
+ * still contributes its reads and imports rather than vanishing from the scan.
+ *
+ * One quirk to know: the transpiler constant-folds `process.env.NODE_ENV`, so
+ * that one key would never be seen as a read. It is not in the profile
+ * allowlist, so nothing here depends on it — but do not add it.
  */
-function stripComments(source: string): string {
-  let out = '';
-  let i = 0;
-  while (i < source.length) {
-    const ch = source[i]!;
-    if (ch === '/' && source[i + 1] === '/') {
-      while (i < source.length && source[i] !== '\n') i += 1;
-      continue;
-    }
-    if (ch === '/' && source[i + 1] === '*') {
-      i += 2;
-      while (i < source.length && !(source[i] === '*' && source[i + 1] === '/')) i += 1;
-      i += 2;
-      continue;
-    }
-    out += ch;
-    i += 1;
-    if (ch !== '"' && ch !== "'" && ch !== '`') continue;
-    while (i < source.length) {
-      const inner = source[i]!;
-      out += inner;
-      i += 1;
-      if (inner === '\\' && i < source.length) {
-        out += source[i];
-        i += 1;
-        continue;
-      }
-      if (inner === ch) break;
-    }
+function parseAwayComments(transpiler: Bun.Transpiler, source: string): string {
+  try {
+    return transpiler.transformSync(source);
+  } catch {
+    return source;
   }
-  return out;
 }
 
 /**
- * Matches an actual read of `key` from the environment — `process.env.KEY`,
- * `process.env['KEY']` or `process.env["KEY"]` — and nothing else. A plain
- * substring match would count a comment or a log message as a read (the graph
- * names several of these flags in both), so deleting the last real read would
- * leave the flag in `AB_FLAGS` as fiction with every test still green.
+ * Matches an actual read of `key` from the environment. Recognised forms are
+ * exactly: `process.env.KEY`, `process.env?.KEY`, `process.env['KEY']`,
+ * `process.env["KEY"]`, `` process.env[`KEY`] `` and their `process.env?.[...]`
+ * variants. Nothing else counts — a plain substring match would treat a comment
+ * or a log message as a read (the graph names several of these flags in both),
+ * so deleting the last real read would leave the flag in `AB_FLAGS` as fiction
+ * with every test still green.
+ *
+ * Deliberately *not* recognised, because they need real data-flow analysis:
+ * destructuring (`const { KEY } = process.env`) and computed access through a
+ * variable (`process.env[name]`). Both fail in the loud direction — the key
+ * drops out of the derived set and the derivation test breaks — so a future
+ * read written that way announces itself instead of passing silently.
  */
 function envReadPattern(key: string): RegExp {
   const escaped = key.replace(/[^A-Za-z0-9_]/g, '\\$&');
-  return new RegExp(`process\\.env(?:\\.${escaped}\\b|\\[\\s*(['"\`])${escaped}\\1\\s*\\])`);
+  return new RegExp(
+    `process\\.env(?:\\??\\.${escaped}\\b|(?:\\?\\.)?\\[\\s*(['"\`])${escaped}\\1\\s*\\])`,
+  );
 }
 
-/** Every candidate key actually read from `process.env` somewhere in the entry file's transitive import closure. */
+/**
+ * Every candidate key actually read from `process.env` somewhere in the entry
+ * file's transitive import closure.
+ *
+ * The closure is walked over transpiled output, so type-only imports are gone:
+ * a module reached only for its types cannot execute and cannot read anything,
+ * which is why it is right to drop it. The same erasure also drops a value
+ * import whose bindings go unused, so a read living in a side-effect-only
+ * position of such a module would be missed — loudly, by shrinking the derived
+ * set, never by inflating it.
+ */
 export function reachableEnvKeys(entryFile: string, candidateKeys: readonly string[]): Set<string> {
   const patterns = candidateKeys.map((key) => [key, envReadPattern(key)] as const);
+  const transpiler = new Bun.Transpiler({ loader: 'ts' });
   const seen = new Set<string>();
   const found = new Set<string>();
   const stack = [path.resolve(entryFile)];
@@ -93,7 +102,7 @@ export function reachableEnvKeys(entryFile: string, candidateKeys: readonly stri
     const file = stack.pop()!;
     if (seen.has(file) || !existsSync(file)) continue;
     seen.add(file);
-    const source = stripComments(readFileSync(file, 'utf8'));
+    const source = parseAwayComments(transpiler, readFileSync(file, 'utf8'));
     for (const [key, pattern] of patterns) if (pattern.test(source)) found.add(key);
     for (const match of source.matchAll(/(?:from|import)\s*\(?\s*["']([^"']+)["']/g)) {
       const resolved = resolveSpecifier(file, match[1]!);

--- a/services/api/src/cli/discovery-ab.flags.ts
+++ b/services/api/src/cli/discovery-ab.flags.ts
@@ -85,12 +85,24 @@ function envReadPattern(key: string): RegExp {
  * Every candidate key actually read from `process.env` somewhere in the entry
  * file's transitive import closure.
  *
- * The closure is walked over transpiled output, so type-only imports are gone:
- * a module reached only for its types cannot execute and cannot read anything,
- * which is why it is right to drop it. The same erasure also drops a value
- * import whose bindings go unused, so a read living in a side-effect-only
- * position of such a module would be missed — loudly, by shrinking the derived
- * set, never by inflating it.
+ * The closure is walked over transpiled output, and the only edges that erasure
+ * removes are `import type`, `export type` and inline `import('...').T` — all
+ * 154 elided edges in today's closure were of exactly that shape, and value
+ * imports (including unused bindings and bare `import './x.js'`) survive
+ * verbatim. That is precisely what the runtime erases too, so a module reached
+ * only through a type-only import genuinely never loads and genuinely never
+ * reads anything.
+ *
+ * So the failure direction is under-offering, never fiction: if a listed flag's
+ * read becomes unreachable the derived set shrinks and the derivation test
+ * fails loudly (verified by retyping the `discovery.env.js` import as
+ * `import type` — two flags dropped, suite red).
+ *
+ * Two narrow holes remain, both with zero occurrences in the closure today:
+ * Bun preserves legal comments — a `//!` or `/*!` banner survives and would
+ * match the read pattern, though an `@license` block comment is stripped — and
+ * a string or template literal spelling out `process.env.SOME_KEY` counts as a
+ * read.
  */
 export function reachableEnvKeys(entryFile: string, candidateKeys: readonly string[]): Set<string> {
   const patterns = candidateKeys.map((key) => [key, envReadPattern(key)] as const);

--- a/services/api/src/cli/discovery-ab.flags.ts
+++ b/services/api/src/cli/discovery-ab.flags.ts
@@ -1,0 +1,64 @@
+/**
+ * The only environment flags this harness may offer: those the discovery graph
+ * actually reads. The list is asserted against a fresh scan of the graph's
+ * import closure (discovery-ab.flags.spec.ts) rather than trusted, because a
+ * hand-maintained copy is exactly how sixteen editable flags came to move
+ * nothing at all.
+ */
+import { existsSync, readFileSync } from 'node:fs';
+import path from 'node:path';
+
+export const AB_FLAGS: readonly string[] = [
+  'DISCOVERY_ALLOWED_TYPES',
+  'DISCOVERY_CONTEXT_TO_INTENT',
+  'DISCOVERY_PROFILE_SOURCE',
+  'DISCOVERY_REJECTION_COOLDOWN_DAYS',
+  'DISCOVERY_SOURCE_PREMISE_LIMIT',
+  'NEGOTIATION_INCLUDE_OTHER_INTENTS',
+  'NEGOTIATION_MAX_TURNS_AMBIENT',
+  'NEGOTIATION_MAX_TURNS_CHAT',
+  'RUN_OPPORTUNITY_EVAL_IN_PARALLEL',
+];
+
+export type AbEnvConfig = Readonly<Record<string, string>>;
+
+/** Resolves a relative TypeScript import specifier the way Bun does for these modules. */
+function resolveSpecifier(fromFile: string, specifier: string): string | null {
+  if (!specifier.startsWith('.')) return null;
+  const base = path.resolve(path.dirname(fromFile), specifier).replace(/\.js$/, '.ts');
+  for (const candidate of [base, `${base}.ts`, path.join(base, 'index.ts')]) {
+    if (candidate.endsWith('.ts') && existsSync(candidate)) return candidate;
+  }
+  return null;
+}
+
+/** Every candidate key mentioned anywhere in the entry file's transitive import closure. */
+export function reachableEnvKeys(entryFile: string, candidateKeys: readonly string[]): Set<string> {
+  const seen = new Set<string>();
+  const found = new Set<string>();
+  const stack = [path.resolve(entryFile)];
+  while (stack.length > 0) {
+    const file = stack.pop()!;
+    if (seen.has(file) || !existsSync(file)) continue;
+    seen.add(file);
+    const source = readFileSync(file, 'utf8');
+    for (const key of candidateKeys) if (source.includes(key)) found.add(key);
+    for (const match of source.matchAll(/(?:from|import)\s*\(?\s*["']([^"']+)["']/g)) {
+      const resolved = resolveSpecifier(file, match[1]!);
+      if (resolved !== null) stack.push(resolved);
+    }
+  }
+  return found;
+}
+
+/** Throws when a config names a flag this harness cannot honestly exercise. */
+export function assertAbEnvConfig(config: AbEnvConfig): void {
+  for (const [key, value] of Object.entries(config)) {
+    if (!AB_FLAGS.includes(key)) {
+      throw new Error(`${key} is not readable by the discovery graph; this harness cannot test it`);
+    }
+    if (value.trim() === '') {
+      throw new Error(`${key} has an empty value; unset it instead of blanking it`);
+    }
+  }
+}

--- a/services/api/src/cli/discovery-ab.gate.ts
+++ b/services/api/src/cli/discovery-ab.gate.ts
@@ -1,0 +1,109 @@
+/**
+ * The discovery A/B harness's fail-closed environment gate.
+ *
+ * It is the A/B counterpart of `assertMatrixEnvironment`, and it checks the
+ * same five things: an explicit confirm variable, the disposable-database
+ * marker, a Neon host, exactly the `protocol_eval` database, and the branch the
+ * process is actually pointed at. The graph writes opportunities and
+ * negotiation tasks, so nothing here is advisory.
+ *
+ * It lives in its own dependency-free module rather than in
+ * `discovery-ab.main.ts` because the bootstrap must refuse an unconfirmed run
+ * *before* importing anything that could compose a database singleton, and
+ * `discovery-ab.main.ts` reaches `@indexnetwork/protocol` through its very
+ * first import. A gate you can only reach after loading the graph is not a
+ * gate.
+ *
+ * Errors never echo `DATABASE_URL`, which carries a password; only the hostname
+ * and the offending field name are reported, exactly as the matrix gate does.
+ */
+import { AB_BRANCH_NAMES } from './discovery-ab.neon';
+
+import type { AbSideId } from './discovery-ab.plan';
+
+/**
+ * A refusal the operator is meant to read.
+ *
+ * The bootstrap prints a deliberately generic message for every other failure,
+ * because provider and control-plane errors can carry credentials. Gate
+ * refusals are authored here in full and name only environment variable names,
+ * so they are safe to print and useless unless printed: "set
+ * DISCOVERY_AB_CONFIRM=1" is the whole point of the gate.
+ */
+export class AbGateError extends Error {
+  constructor(message: string, options?: ErrorOptions) {
+    super(message, options);
+    this.name = 'AbGateError';
+  }
+}
+
+/** The branch label the bootstrap derives from the attested manifest for a child. */
+export const AB_SIDE_BRANCH_ENV = 'DISCOVERY_AB_SIDE_BRANCH';
+
+export interface AbSideEnvironment {
+  databaseUrl: URL;
+  branch: string;
+}
+
+/**
+ * The operator attestation every A/B process requires, parent included.
+ *
+ * The parent composes no database of its own, but it resets two branches and
+ * spawns two processes that do, so it is gated by the same variables rather
+ * than by the children it starts. `NEON_API_KEY` is required here rather than
+ * where it is used because every A/B process attests its targets before
+ * importing anything that touches a database, and a missing key would
+ * otherwise surface as an attestation refusal that says nothing about the key.
+ */
+export function assertAbConfirmation(env: NodeJS.ProcessEnv): void {
+  if (env.DISCOVERY_AB_CONFIRM !== '1') {
+    throw new AbGateError('Refusing to mutate: set DISCOVERY_AB_CONFIRM=1');
+  }
+  if (env.TEST_DATABASE_SAFE !== '1') {
+    throw new AbGateError('Refusing to mutate: set TEST_DATABASE_SAFE=1 only for a disposable evaluation branch');
+  }
+  if ((env.NEON_API_KEY ?? '') === '') {
+    throw new AbGateError('Refusing to run: NEON_API_KEY is required to attest both A/B branches before anything runs');
+  }
+  // Presence only. What a manifest must contain is `parseAbManifest`'s contract,
+  // and restating any of it here would be a second copy to drift from.
+  if ((env.DISCOVERY_AB_TARGETS ?? '').trim() === '') {
+    throw new AbGateError('Refusing to run: DISCOVERY_AB_TARGETS must declare the two designated A/B branches');
+  }
+}
+
+/**
+ * Everything above, plus proof that this process is pointed at its own side's
+ * designated A/B branch.
+ *
+ * The branch label is compared against `AB_BRANCH_NAMES[sideId]` exactly, so a
+ * child that was handed side b's URL under side a's flag is refused before it
+ * composes a database singleton — the artifact would otherwise attribute side
+ * b's branch to side a's configuration.
+ */
+export function assertAbSideEnvironment(env: NodeJS.ProcessEnv, sideId: AbSideId): AbSideEnvironment {
+  assertAbConfirmation(env);
+  let databaseUrl: URL;
+  try {
+    databaseUrl = new URL(env.DATABASE_URL ?? '');
+  } catch {
+    throw new AbGateError('Refusing to mutate: DATABASE_URL must be a valid Neon protocol_eval URL');
+  }
+  if (databaseUrl.protocol !== 'postgres:' && databaseUrl.protocol !== 'postgresql:') {
+    throw new AbGateError('Refusing to mutate: DATABASE_URL must use postgres');
+  }
+  if (!databaseUrl.hostname.endsWith('.neon.tech')) {
+    throw new AbGateError(`Refusing non-Neon DATABASE_URL host: ${databaseUrl.hostname}`);
+  }
+  if (databaseUrl.pathname !== '/protocol_eval') {
+    throw new AbGateError(`Refusing to mutate: DATABASE_URL path must be exactly /protocol_eval (received ${databaseUrl.pathname || '/'})`);
+  }
+  if (databaseUrl.port && databaseUrl.port !== '5432') {
+    throw new AbGateError(`Refusing to mutate: DATABASE_URL port must be exactly 5432 (received ${databaseUrl.port})`);
+  }
+  const branch = env[AB_SIDE_BRANCH_ENV] ?? '';
+  if (branch !== AB_BRANCH_NAMES[sideId]) {
+    throw new AbGateError(`Refusing to mutate: ${AB_SIDE_BRANCH_ENV} must be exactly ${AB_BRANCH_NAMES[sideId]} for side ${sideId}`);
+  }
+  return { databaseUrl, branch };
+}

--- a/services/api/src/cli/discovery-ab.main.ts
+++ b/services/api/src/cli/discovery-ab.main.ts
@@ -16,7 +16,7 @@
  * one configuration, so no cross-configuration overlap is possible here.
  */
 import { expectedBaseMetadata, verifyBaseFixtureIntegrity, verifyProtectedBase } from './discovery-env-matrix-base.main';
-import { ATTEMPT_TIMEOUT_MS, MatrixExecutionError, buildMatrixArtifactEvidence, closeChildResources, collectCandidates, collectEvaluatorTraces, composeCaseRuntime, createChildDependencies, databaseCase, loadJudge, loadMatrixEval, projectFinalCandidates, resolveFixtureTriggerIntent, runMatrixBoundary, runWithChildCleanup, sanitizeMatrixError, type MatrixExecutionEvidence, type MatrixGraphRuntimeInput, type MatrixSlotResult } from './discovery-env-matrix.main';
+import { ATTEMPT_TIMEOUT_MS, MatrixExecutionError, buildMatrixArtifactEvidence, closeChildResources, collectCandidates, collectEvaluatorTraces, composeCaseRuntime, createChildDependencies, databaseCase, loadJudge, loadMatrixEval, projectFinalCandidates, resolveFixtureTriggerIntent, runMatrixBoundary, runWithChildCleanup, sanitizeMatrixError, type MatrixCandidate, type MatrixEvaluatorTrace, type MatrixExecutionEvidence, type MatrixGraphRuntimeInput, type MatrixRetrievalCandidate, type MatrixSlotResult } from './discovery-env-matrix.main';
 import { withDiscoveryEnvironment } from './discovery-env-matrix.runtime';
 import { baseSeedPayload, type HistoricalMatrixFixture } from './discovery-env-matrix.shared';
 
@@ -48,6 +48,27 @@ export type AbConfigDelta = { key: string; before: null; after: string };
 export type AbChildOutput = { slots: MatrixSlotResult[]; execution: MatrixExecutionEvidence };
 export interface AbSideSelection { side: AbSide; slots: AbSlot[] }
 
+/** What one attempt produced, or the empty outcome of a slot that exhausted its attempts. */
+export interface AbSlotOutcome {
+  candidates: readonly MatrixCandidate[];
+  rawCandidates?: readonly MatrixRetrievalCandidate[];
+  evaluatorTraces?: readonly MatrixEvaluatorTrace[];
+  completed: boolean;
+}
+
+/**
+ * The `scoreMatrixSlot` input for one A/B slot, minus the judge callback, plus
+ * the `caseId` the child writes over the scored slot afterwards.
+ */
+export interface AbSlotScoreInput extends AbSlotOutcome {
+  caseId: string;
+  matrixCase: HistoricalMatrixFixture;
+  rowId: AbSideId;
+  repetition: number;
+  allowedEvidence: typeof AB_ALLOWED_EVIDENCE;
+  configDeltas: AbConfigDelta[];
+}
+
 /**
  * Repetition is 0-based in the plan and 1-based in the id, matching the matrix
  * harness exactly so the two harnesses' artifacts read the same way.
@@ -66,6 +87,33 @@ export function abSlotCaseId(slot: AbSlot): string {
  */
 export function abConfigDeltas(config: AbEnvConfig): AbConfigDelta[] {
   return Object.keys(config).sort().map((key) => ({ key, before: null, after: config[key]! }));
+}
+
+/**
+ * Builds everything `scoreMatrixSlot` is given for one A/B slot except the judge
+ * callback, so the scored path and the failed-slot fallback cannot drift apart.
+ *
+ * The three A/B-specific fields live here and nowhere else: `rowId` is the side
+ * (not a matrix row), `allowedEvidence` is `AB_ALLOWED_EVIDENCE` — without it
+ * `scoreMatrixSlot` resolves the row through `rowFor` and throws
+ * `Unknown discovery environment matrix row: a` for every candidate-bearing
+ * slot — and `configDeltas` records the side's configuration on the artifact,
+ * including on a failed slot. `caseId` is returned alongside because the child
+ * writes it over the scored slot; `scoreMatrixSlot` itself is not given it.
+ */
+export function buildAbSlotScoreInput(slot: AbSlot, outcome: AbSlotOutcome): AbSlotScoreInput {
+  return {
+    caseId: abSlotCaseId(slot),
+    matrixCase: databaseCase(slot.matrixCase),
+    rowId: slot.side.id,
+    repetition: slot.repetition,
+    candidates: outcome.candidates,
+    ...(outcome.rawCandidates ? { rawCandidates: outcome.rawCandidates } : {}),
+    ...(outcome.evaluatorTraces ? { evaluatorTraces: outcome.evaluatorTraces } : {}),
+    completed: outcome.completed,
+    allowedEvidence: AB_ALLOWED_EVIDENCE,
+    configDeltas: abConfigDeltas(slot.side.config),
+  };
 }
 
 /** Canonical, order-independent identity of a configuration, for comparison only. */
@@ -148,7 +196,6 @@ async function runAbSide(
   const { HISTORICAL_MATRIX_CASES, scoreMatrixSlot, buildExecutionEvidence, executeRuns } = await loadMatrixEval();
   const assertLLM = await loadJudge();
   const { side, slots } = selection;
-  const configDeltas = abConfigDeltas(side.config);
   await verifyAbBranchBase(HISTORICAL_MATRIX_CASES as HistoricalMatrixFixture[]);
 
   const batch = await executeRuns(async ({ runIndex, signal }: { runIndex: number; signal: AbortSignal }) => runMatrixBoundary('matrix_runtime_failure', async () => {
@@ -170,16 +217,9 @@ async function runAbSide(
     const rawCandidates = collectCandidates(graphResult, new Set(matrixCase.participants.map((participant) => participant.id)));
     const candidates = projectFinalCandidates(graphResult, rawCandidates, fixtureCase.sourceUserId, AB_MIN_SCORE);
     const evaluatorTraces = collectEvaluatorTraces(graphResult, rawCandidates, candidates);
+    const { caseId, ...scoreInput } = buildAbSlotScoreInput(slot, { candidates, rawCandidates, evaluatorTraces, completed: true });
     const scored = await runMatrixBoundary('matrix_scoring_failure', async () => scoreMatrixSlot({
-      matrixCase,
-      rowId: side.id,
-      repetition: slot.repetition,
-      candidates,
-      rawCandidates,
-      evaluatorTraces,
-      completed: true,
-      allowedEvidence: AB_ALLOWED_EVIDENCE,
-      configDeltas,
+      ...scoreInput,
       judge: async (input: { candidateIds: string[]; evidenceTypes: string[]; caseDescription: string; rowId: string; sourceText: string; expectedUserId: string; excludedUserIds: string[] }) => {
         try {
           await runMatrixBoundary('matrix_judge_failure', async () => assertLLM({ candidateIds: input.candidateIds, evidenceTypes: input.evidenceTypes }, [
@@ -198,7 +238,7 @@ async function runAbSide(
         }
       },
     }));
-    return { ...scored, caseId: abSlotCaseId(slot) };
+    return { ...scored, caseId };
   }), slots.length, {
     caseId: `${HARNESS}/${side.id}`,
     policy: 'strict',
@@ -208,17 +248,10 @@ async function runAbSide(
 
   // A slot that exhausted its attempts still produces a scored, failed slot, so
   // completeness accounting stays honest rather than silently losing the slot.
-  const scoredSlots: MatrixSlotResult[] = await Promise.all((batch as { runs: Array<{ output?: MatrixSlotResult }> }).runs.map(async (run, index: number) => run.output ?? {
-    ...(await scoreMatrixSlot({
-      matrixCase: databaseCase(slots[index]!.matrixCase),
-      rowId: side.id,
-      repetition: slots[index]!.repetition,
-      candidates: [],
-      completed: false,
-      allowedEvidence: AB_ALLOWED_EVIDENCE,
-      configDeltas,
-    })),
-    caseId: abSlotCaseId(slots[index]!),
+  const scoredSlots: MatrixSlotResult[] = await Promise.all((batch as { runs: Array<{ output?: MatrixSlotResult }> }).runs.map(async (run, index: number) => {
+    if (run.output) return run.output;
+    const { caseId, ...scoreInput } = buildAbSlotScoreInput(slots[index]!, { candidates: [], completed: false });
+    return { ...(await scoreMatrixSlot(scoreInput)), caseId };
   }));
   return buildMatrixArtifactEvidence(
     scoredSlots,

--- a/services/api/src/cli/discovery-ab.main.ts
+++ b/services/api/src/cli/discovery-ab.main.ts
@@ -22,14 +22,15 @@
  * one configuration, so no cross-configuration overlap is possible here.
  */
 import path from 'node:path';
-import { mkdtemp } from 'node:fs/promises';
+import { mkdtemp, readdir, rm } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 
+import { AB_BASE_BRANCH, AB_DEFAULT_REPETITIONS, AB_EXIT_COMPARISON, AB_EXIT_INSUFFICIENT_EVIDENCE, AB_MAX_REPETITIONS, abUsage, classifyAbParentFailure, type AbRunStage } from './discovery-ab.contract';
 import { AB_SIDE_BRANCH_ENV, AbGateError, assertAbConfirmation, assertAbSideEnvironment } from './discovery-ab.gate';
 import { AB_BRANCH_NAMES, attestAbTargets, parseAbManifest, resetAbBranch, type AbTarget } from './discovery-ab.neon';
 import { buildAbPlan, configDiff } from './discovery-ab.plan';
 import { expectedBaseMetadata, verifyBaseFixtureIntegrity, verifyProtectedBase } from './discovery-env-matrix-base.main';
-import { ATTEMPT_TIMEOUT_MS, MatrixExecutionError, awaitMatrixChildProcess, buildMatrixArtifactEvidence, closeChildResources, collectCandidates, collectEvaluatorTraces, composeCaseRuntime, createChildDependencies, databaseCase, finalizeMatrixChildArtifacts, loadJudge, loadMatrixEval, projectFinalCandidates, resolveFixtureTriggerIntent, runBoundedChildTasks, runMatrixBoundary, runWithChildCleanup, sanitizeMatrixError, type MatrixCandidate, type MatrixEvaluatorTrace, type MatrixExecutionEvidence, type MatrixGraphRuntimeInput, type MatrixRetrievalCandidate, type MatrixSlotResult } from './discovery-env-matrix.main';
+import { ATTEMPT_TIMEOUT_MS, MatrixExecutionError, awaitMatrixChildProcess, buildMatrixArtifactEvidence, closeChildResources, collectCandidates, collectEvaluatorTraces, composeCaseRuntime, createChildDependencies, databaseCase, loadJudge, loadMatrixEval, projectFinalCandidates, resolveFixtureTriggerIntent, runBoundedChildTasks, runMatrixBoundary, runWithChildCleanup, sanitizeMatrixError, type MatrixCandidate, type MatrixEvaluatorTrace, type MatrixExecutionEvidence, type MatrixGraphRuntimeInput, type MatrixRetrievalCandidate, type MatrixSlotResult } from './discovery-env-matrix.main';
 import { createNeonControlPlane } from './discovery-env-matrix.neon';
 import { withDiscoveryEnvironment } from './discovery-env-matrix.runtime';
 import { baseSeedPayload, type HistoricalMatrixFixture } from './discovery-env-matrix.shared';
@@ -40,7 +41,6 @@ import type { AbSide, AbSideId, AbSlot } from './discovery-ab.plan';
 const HARNESS = 'discovery-ab';
 const HARNESS_VERSION = '1';
 const RUNS_DIR = path.resolve(import.meta.dir, '../../eval/discovery-ab/runs');
-const AB_BASE_BRANCH = 'eval-discovery-base';
 /** Identical to the matrix child's graph invocation, and to its policy projection. */
 const AB_MIN_SCORE = 50;
 
@@ -294,14 +294,14 @@ export async function runAbChild(sideId: AbSideId, slots: readonly AbSlot[], out
 // ── Parent half ─────────────────────────────────────────────────────────────
 // Gate, attest, reset both branches, spawn one child per side, aggregate.
 
-/** Three repetitions per side; one observation per case cannot separate a difference from noise. */
-export const AB_DEFAULT_REPETITIONS = 3;
 /**
- * A ceiling on `--runs`, because a mistyped one costs real money and hours: at
- * the observed ~52s per invocation, ten repetitions over the full corpus is
- * already 300 graph invocations. Nothing above this is a considered choice.
+ * The operator-facing contract — the repetition bounds and the exit codes —
+ * lives in `discovery-ab.contract.ts`, so the bootstrap can print and act on it
+ * without importing anything that composes a database. These three are
+ * re-exported because they are read as properties of the parent run.
  */
-export const AB_MAX_REPETITIONS = 10;
+export { AB_DEFAULT_REPETITIONS, AB_EXIT_INSUFFICIENT_EVIDENCE, AB_MAX_REPETITIONS };
+
 /** `executeRuns` gives each slot three attempts, each bounded by ATTEMPT_TIMEOUT_MS. */
 const AB_ATTEMPTS_PER_SLOT = 3;
 /** The 1s + 2s retry backoff `executeRuns` inserts between those attempts. */
@@ -312,12 +312,6 @@ const AB_CHILD_STARTUP_HEADROOM_MS = 5 * 60_000;
 const AB_CHILD_CONCURRENCY = 2;
 /** How long a sibling gets to honour SIGTERM before it is killed, matching the matrix. */
 const AB_CHILD_TERMINATION_GRACE_MS = 5_000;
-/**
- * Insufficient evidence, matching `EVAL_EXIT_INSUFFICIENT_EVIDENCE` in the
- * shared eval CLI. It is restated rather than imported because this package
- * reaches the eval bundle only through the dynamic `loadMatrixEval` seam.
- */
-export const AB_EXIT_INSUFFICIENT_EVIDENCE = 3;
 
 /**
  * The watchdog for one side, derived from what that side may legitimately take
@@ -675,7 +669,7 @@ export function resolveAbRunOutcome(input: {
     sides,
     incompleteSides,
     verdict,
-    exitCode: 0,
+    exitCode: AB_EXIT_COMPARISON,
     summary: `Discovery A/B result: ${verdict.map((entry) => `side ${entry.sideId} ${entry.passes}/${entry.runs} (${(entry.passRate * 100).toFixed(1)}%)`).join('  vs  ')}`,
   };
 }
@@ -692,35 +686,64 @@ function abChildDescriptor(target: AbTarget): { childKey: string; branch: string
 
 type AbChildProcess = { exited: Promise<number>; kill(signal?: NodeJS.Signals): void };
 
-function usage(): string {
-  const manifest = '{"projectId":"...","baseBranchId":"br-...","targets":[{"sideId":"a","branchId":"br-...","endpointId":"ep-...","databaseUrl":"postgres://...neon.tech/protocol_eval"}, ...]}';
-  return [
-    'Discovery A/B eval',
-    '',
-    'Runs the real discovery graph twice - once per operator-chosen environment',
-    'configuration - over the same cases, and emits one artifact holding both sides.',
-    'It never reads, writes or compares a baseline: arbitrary configurations have',
-    'none, so the pair is the result.',
-    '',
-    'Required operator attestation:',
-    '  DISCOVERY_AB_CONFIRM=1',
-    '  TEST_DATABASE_SAFE=1',
-    '  NEON_API_KEY=<neon api key>',
-    `  DISCOVERY_AB_TARGETS='${manifest}'`,
-    '',
-    'This command never creates or deletes Neon branches. It resets both attested',
-    `A/B branches (${AB_BRANCH_NAMES.a}, ${AB_BRANCH_NAMES.b}) from ${AB_BASE_BRANCH} before it spawns anything.`,
-    '',
-    'Selection is shared by both sides; configuration is not:',
-    '  --case <id>       Restrict to one case. Repeatable. Default: the full corpus.',
-    `  --runs <n>        Repetitions per side (default ${AB_DEFAULT_REPETITIONS}, maximum ${AB_MAX_REPETITIONS}).`,
-    '  --a KEY=VALUE     A flag for side a. Repeatable.',
-    '  --b KEY=VALUE     A flag for side b. Repeatable.',
-    '  --force           Consent to replacing an existing run artifact.',
-    '',
-    'Both sides must state the same keys with differing values; identical or',
-    'asymmetric configurations are refused before any spend.',
-  ].join('\n');
+/**
+ * Cleans up, or reports honestly what was kept.
+ *
+ * The matrix's `finalizeMatrixChildArtifacts` is not reused because its warning
+ * says "Discovery environment matrix retained child artifacts", which names the
+ * wrong harness during an A/B run, and because it promises artifacts that are
+ * often not there: the failure that retains this directory is usually a dead or
+ * timed-out child, which wrote nothing at all. An operator who goes looking for
+ * the retained evidence of a forty-minute loss and finds an empty directory has
+ * been misled twice. So the directory is read, and the warning says what is
+ * actually in it.
+ */
+export async function finalizeAbChildArtifacts(
+  temporaryDirectory: string,
+  completedSuccessfully: boolean,
+  fs: { readdir: typeof readdir; rm: typeof rm } = { readdir, rm },
+  logger: Pick<Console, 'warn'> = console,
+): Promise<void> {
+  if (completedSuccessfully) {
+    await fs.rm(temporaryDirectory, { recursive: true, force: true });
+    return;
+  }
+  const retained = await fs.readdir(temporaryDirectory).catch(() => [] as string[]);
+  if (retained.length === 0) {
+    await fs.rm(temporaryDirectory, { recursive: true, force: true });
+    logger.warn('Discovery A/B kept no child artifacts: neither side wrote one before the run failed');
+    return;
+  }
+  logger.warn(
+    `Discovery A/B retained ${retained.length} child artifact(s) from a failed run in ${temporaryDirectory}: `
+    + `${[...retained].sort().join(', ')}`,
+  );
+}
+
+/**
+ * How far this run has got. It is recorded as the run advances rather than
+ * inferred afterwards, because the one thing a failure cannot tell you about
+ * itself is whether the money was already spent.
+ */
+export interface AbRunProgress { stage: AbRunStage | null }
+
+/**
+ * Runs something that may reset branches and spend money, and turns any failure
+ * into a report of what it cost.
+ *
+ * Everything the operator can act on hangs off this distinction. A failure
+ * before the first reset is a refusal: its own message says what to fix and it
+ * cost nothing. A failure after it is a loss, and the operator has to be told
+ * so rather than left to work out whether "Discovery A/B command failed" meant
+ * a typo or forty minutes and two overwritten branches.
+ */
+export async function withAbSpendAccounting(run: (progress: AbRunProgress) => Promise<void>): Promise<void> {
+  const progress: AbRunProgress = { stage: null };
+  try {
+    await run(progress);
+  } catch (error) {
+    throw classifyAbParentFailure(progress.stage, error);
+  }
 }
 
 /**
@@ -735,7 +758,7 @@ function usage(): string {
  * than by the order two files happen to run in. Six control-plane GETs is a
  * cheap price for that.
  */
-async function runAbParent(args: readonly string[]): Promise<void> {
+async function runAbComparison(args: readonly string[], progress: AbRunProgress): Promise<void> {
   assertAbConfirmation(process.env);
   const apiKey = process.env.NEON_API_KEY ?? '';
   const manifest = parseAbManifest(process.env.DISCOVERY_AB_TARGETS);
@@ -760,6 +783,9 @@ async function runAbParent(args: readonly string[]): Promise<void> {
   // run cleans, where resetting afterwards leaves a window in which a dirty
   // branch looks clean. Both must succeed before anything is spawned - a
   // half-isolated comparison is not a comparison.
+  // Everything from here on can fail with the branches already overwritten,
+  // which is a different thing to report than a refusal.
+  progress.stage = 'reset';
   for (const target of attested.targets) {
     await resetAbBranch({ manifest: attested, branchId: target.branchId, apiKey });
     console.log(`Discovery A/B reset side ${target.sideId} (${AB_BRANCH_NAMES[target.sideId]}) from ${AB_BASE_BRANCH}`);
@@ -799,6 +825,9 @@ async function runAbParent(args: readonly string[]): Promise<void> {
           stdout: 'inherit', stderr: 'inherit',
         });
         activeChildren.add(proc);
+        // A live run now exists: from here a failure costs provider spend and
+        // hours, not just the two resets.
+        progress.stage = 'spawned';
         console.log(`Discovery A/B side ${target.sideId} started against ${AB_BRANCH_NAMES[target.sideId]} (${slotsPerSide} slot(s))`);
         try {
           // Shared supervision: the same watchdog, SIGTERM/SIGKILL escalation
@@ -843,10 +872,15 @@ async function runAbParent(args: readonly string[]): Promise<void> {
     const outcome = resolveAbRunOutcome({ slots, sides: selection.sides, expectedSlotsPerSide: slotsPerSide });
     console.log(outcome.summary);
     process.exitCode = outcome.exitCode;
-    completedSuccessfully = outcome.exitCode === 0;
+    completedSuccessfully = outcome.exitCode === AB_EXIT_COMPARISON;
   } finally {
-    await finalizeMatrixChildArtifacts(temporaryDirectory, completedSuccessfully);
+    await finalizeAbChildArtifacts(temporaryDirectory, completedSuccessfully);
   }
+}
+
+/** The comparison, with every failure after the first reset reported as what it cost. */
+async function runAbParent(args: readonly string[]): Promise<void> {
+  await withAbSpendAccounting(async (progress) => runAbComparison(args, progress));
 }
 
 /**
@@ -857,7 +891,7 @@ async function runAbParent(args: readonly string[]): Promise<void> {
  * Neon host, exactly `protocol_eval`, and the branch label for its own side.
  */
 export async function main(args: readonly string[] = process.argv.slice(2)): Promise<void> {
-  if (args.includes('--help') || args.includes('-h')) return void console.log(usage());
+  if (args.includes('--help') || args.includes('-h')) return void console.log(abUsage());
   if (!args.includes('--side')) return void await runAbParent(args);
 
   const { sideId, outputPath } = parseAbChildArgs(args);

--- a/services/api/src/cli/discovery-ab.main.ts
+++ b/services/api/src/cli/discovery-ab.main.ts
@@ -1,0 +1,242 @@
+/**
+ * Child half of the discovery A/B harness: one side, one branch, one
+ * configuration.
+ *
+ * This is the matrix child (`runChild` in `discovery-env-matrix.main.ts`) with
+ * exactly two differences, and nothing else redesigned: the graph runs inside
+ * that side's environment configuration instead of a fixed matrix row, and the
+ * slot's `rowId` is the side id rather than a matrix row id. Boundary
+ * classification, candidate collection, evaluator projection, judge wiring, the
+ * `executeRuns` retry wrapper and the failed-slot fallback are reused verbatim.
+ *
+ * One process handles exactly one side, because `withDiscoveryEnvironment`
+ * mutates the real `process.env`: two configurations applied concurrently in
+ * one process would read each other's flags. `executeRuns` runs its slots
+ * sequentially, and `selectAbSideSlots` refuses a batch that carries more than
+ * one configuration, so no cross-configuration overlap is possible here.
+ */
+import { expectedBaseMetadata, verifyBaseFixtureIntegrity, verifyProtectedBase } from './discovery-env-matrix-base.main';
+import { ATTEMPT_TIMEOUT_MS, MatrixExecutionError, buildMatrixArtifactEvidence, closeChildResources, collectCandidates, collectEvaluatorTraces, composeCaseRuntime, createChildDependencies, databaseCase, loadJudge, loadMatrixEval, projectFinalCandidates, resolveFixtureTriggerIntent, runMatrixBoundary, runWithChildCleanup, sanitizeMatrixError, type MatrixExecutionEvidence, type MatrixGraphRuntimeInput, type MatrixSlotResult } from './discovery-env-matrix.main';
+import { withDiscoveryEnvironment } from './discovery-env-matrix.runtime';
+import { baseSeedPayload, type HistoricalMatrixFixture } from './discovery-env-matrix.shared';
+
+import type { AbEnvConfig } from './discovery-ab.flags';
+import type { AbSide, AbSideId, AbSlot } from './discovery-ab.plan';
+
+const HARNESS = 'discovery-ab';
+/** Identical to the matrix child's graph invocation, and to its policy projection. */
+const AB_MIN_SCORE = 50;
+
+/**
+ * The evidence types an A/B slot may cite: all of them.
+ *
+ * This is deliberately a relaxation, and it is not a hidden one. The matrix's
+ * `allowed_evidence` assertion asks "did the graph respect *this row's* evidence
+ * restriction", which is well defined only because the five `MATRIX_ROWS` were
+ * authored together with their `allowedEvidence`. The A/B harness compares two
+ * arbitrary operator-chosen configurations, for which no such authored mapping
+ * exists; inferring one from the config would fail a 40-minute live run on our
+ * guess rather than on the graph's behaviour. So A/B does **not** enforce
+ * per-row evidence gating — do not read a passing A/B slot as evidence that a
+ * configuration's evidence restriction held. Every other deterministic
+ * assertion still applies, including the non-empty evidence check this set
+ * preserves (a candidate citing no evidence still fails `missing_evidence`).
+ */
+export const AB_ALLOWED_EVIDENCE = ['intent', 'premise', 'user_context'] as const;
+
+export type AbConfigDelta = { key: string; before: null; after: string };
+export type AbChildOutput = { slots: MatrixSlotResult[]; execution: MatrixExecutionEvidence };
+export interface AbSideSelection { side: AbSide; slots: AbSlot[] }
+
+/**
+ * Repetition is 0-based in the plan and 1-based in the id, matching the matrix
+ * harness exactly so the two harnesses' artifacts read the same way.
+ */
+export function abSlotCaseId(slot: AbSlot): string {
+  return `${slot.matrixCase.id}/${slot.side.id}/r${slot.repetition + 1}`;
+}
+
+/**
+ * Records the side's exact configuration on every slot through the
+ * `configDeltas` field `scoreMatrixSlot` already accepts, so each side's
+ * configuration reaches the artifact with no schema change. `before` is `null`
+ * because the child applies the configuration around the graph call rather than
+ * changing an established value. Keys are sorted so two runs of the same
+ * configuration produce identical artifacts regardless of flag order.
+ */
+export function abConfigDeltas(config: AbEnvConfig): AbConfigDelta[] {
+  return Object.keys(config).sort().map((key) => ({ key, before: null, after: config[key]! }));
+}
+
+/** Canonical, order-independent identity of a configuration, for comparison only. */
+function configIdentity(config: AbEnvConfig): string {
+  return JSON.stringify(abConfigDeltas(config).map((delta) => [delta.key, delta.after]));
+}
+
+/**
+ * Narrows a plan to the slots this child owns and proves it owns exactly one
+ * configuration.
+ *
+ * The single-configuration check is a safety property, not a formality: this
+ * process applies its side's configuration to the real `process.env`, so a
+ * batch carrying two configurations under one side id would run some slots
+ * under a configuration the artifact does not attribute to them.
+ */
+export function selectAbSideSlots(sideId: AbSideId, slots: readonly AbSlot[]): AbSideSelection {
+  const owned = slots.filter((slot) => slot.side.id === sideId);
+  if (owned.length === 0) {
+    throw new Error(`Discovery A/B child ${sideId} owns no slots`);
+  }
+  const side = owned[0]!.side;
+  const identity = configIdentity(side.config);
+  const conflicting = owned.find((slot) => configIdentity(slot.side.config) !== identity);
+  if (conflicting) {
+    throw new Error(
+      `Discovery A/B child ${sideId} was given more than one configuration; one process applies exactly `
+      + `one configuration to process.env, so its slots would not all run under the configuration recorded for them`,
+    );
+  }
+  return { side, slots: owned };
+}
+
+/** Parses the child invocation contract: `--side a|b --child-output <path>`. */
+export function parseAbChildArgs(args: readonly string[]): { sideId: AbSideId; outputPath: string } {
+  const valueOf = (flag: string): string | undefined => {
+    const index = args.indexOf(flag);
+    return index === -1 ? undefined : args[index + 1];
+  };
+  const side = valueOf('--side');
+  if (side !== 'a' && side !== 'b') {
+    throw new Error(`--side must be exactly a or b (received ${side ?? 'nothing'})`);
+  }
+  const outputPath = valueOf('--child-output');
+  if (outputPath === undefined || outputPath.trim() === '' || outputPath.startsWith('--')) {
+    throw new Error('--child-output <path> is required for a discovery A/B child invocation');
+  }
+  return { sideId: side, outputPath };
+}
+
+/** Invokes the graph for one slot under that side's configuration. */
+export async function invokeAbDiscoveryGraph<T>(
+  graph: { invoke(input: { userId: string; networkId: string; triggerIntentId: string; options: { minScore: number } }, config?: { signal?: AbortSignal }): Promise<T> },
+  runtime: MatrixGraphRuntimeInput,
+  config: AbEnvConfig,
+  signal?: AbortSignal,
+): Promise<T> {
+  return withDiscoveryEnvironment(config, () => graph.invoke({
+    userId: runtime.sourceUserId,
+    networkId: runtime.networkId,
+    triggerIntentId: runtime.triggerIntentId,
+    options: { minScore: AB_MIN_SCORE },
+  }, signal ? { signal } : undefined));
+}
+
+/** Proves this branch still carries the protected base before any graph spend. */
+async function verifyAbBranchBase(cases: readonly HistoricalMatrixFixture[]): Promise<void> {
+  const expected = await expectedBaseMetadata(cases);
+  const childDb = (await import('../lib/drizzle/drizzle')).default;
+  const childSchema = await import('../schemas/database.schema');
+  await verifyProtectedBase(childDb, childSchema, expected);
+  await verifyBaseFixtureIntegrity(childDb, childSchema, baseSeedPayload(cases));
+}
+
+/** Runs every slot of one side sequentially against this process's single branch. */
+async function runAbSide(
+  selection: AbSideSelection,
+  deps: Awaited<ReturnType<typeof createChildDependencies>>,
+): Promise<AbChildOutput> {
+  const { HISTORICAL_MATRIX_CASES, scoreMatrixSlot, buildExecutionEvidence, executeRuns } = await loadMatrixEval();
+  const assertLLM = await loadJudge();
+  const { side, slots } = selection;
+  const configDeltas = abConfigDeltas(side.config);
+  await verifyAbBranchBase(HISTORICAL_MATRIX_CASES as HistoricalMatrixFixture[]);
+
+  const batch = await executeRuns(async ({ runIndex, signal }: { runIndex: number; signal: AbortSignal }) => runMatrixBoundary('matrix_runtime_failure', async () => {
+    const slot = slots[runIndex]!;
+    const matrixCase = databaseCase(slot.matrixCase);
+    const fixturePayload = baseSeedPayload([slot.matrixCase]);
+    const fixtureCase = fixturePayload.cases[0];
+    const network = fixturePayload.networks[0];
+    if (!network || !fixtureCase) throw new MatrixExecutionError('matrix_runtime_failure');
+    const triggerIntentId = resolveFixtureTriggerIntent(fixturePayload, fixtureCase.sourceUserId, network.id);
+    const composed = await composeCaseRuntime(deps, matrixCase, network, triggerIntentId);
+    const graphResult = await runMatrixBoundary('matrix_graph_failure', async () => invokeAbDiscoveryGraph(
+      deps.opportunityGraph as never,
+      composed,
+      side.config,
+      signal,
+    )) as Record<string, unknown>;
+    if (graphResult.error) throw new MatrixExecutionError('matrix_graph_failure');
+    const rawCandidates = collectCandidates(graphResult, new Set(matrixCase.participants.map((participant) => participant.id)));
+    const candidates = projectFinalCandidates(graphResult, rawCandidates, fixtureCase.sourceUserId, AB_MIN_SCORE);
+    const evaluatorTraces = collectEvaluatorTraces(graphResult, rawCandidates, candidates);
+    const scored = await runMatrixBoundary('matrix_scoring_failure', async () => scoreMatrixSlot({
+      matrixCase,
+      rowId: side.id,
+      repetition: slot.repetition,
+      candidates,
+      rawCandidates,
+      evaluatorTraces,
+      completed: true,
+      allowedEvidence: AB_ALLOWED_EVIDENCE,
+      configDeltas,
+      judge: async (input: { candidateIds: string[]; evidenceTypes: string[]; caseDescription: string; rowId: string; sourceText: string; expectedUserId: string; excludedUserIds: string[] }) => {
+        try {
+          await runMatrixBoundary('matrix_judge_failure', async () => assertLLM({ candidateIds: input.candidateIds, evidenceTypes: input.evidenceTypes }, [
+            'Assess this discovery A/B result.',
+            `Case: ${input.caseDescription}`,
+            `Side: ${input.rowId}`,
+            `Source text: ${input.sourceText}`,
+            `Expected target: ${input.expectedUserId}`,
+            `Excluded targets: ${input.excludedUserIds.join(', ') || 'none'}`,
+            `Returned candidates: ${input.candidateIds.join(', ') || 'none'}`,
+            `Evidence types: ${input.evidenceTypes.join(', ') || 'none'}`,
+          ].join('\n')));
+          return { passed: true };
+        } catch (error) {
+          return { passed: false, detail: sanitizeMatrixError(error) };
+        }
+      },
+    }));
+    return { ...scored, caseId: abSlotCaseId(slot) };
+  }), slots.length, {
+    caseId: `${HARNESS}/${side.id}`,
+    policy: 'strict',
+    attemptTimeoutMs: ATTEMPT_TIMEOUT_MS,
+    label: HARNESS,
+  });
+
+  // A slot that exhausted its attempts still produces a scored, failed slot, so
+  // completeness accounting stays honest rather than silently losing the slot.
+  const scoredSlots: MatrixSlotResult[] = await Promise.all((batch as { runs: Array<{ output?: MatrixSlotResult }> }).runs.map(async (run, index: number) => run.output ?? {
+    ...(await scoreMatrixSlot({
+      matrixCase: databaseCase(slots[index]!.matrixCase),
+      rowId: side.id,
+      repetition: slots[index]!.repetition,
+      candidates: [],
+      completed: false,
+      allowedEvidence: AB_ALLOWED_EVIDENCE,
+      configDeltas,
+    })),
+    caseId: abSlotCaseId(slots[index]!),
+  }));
+  return buildMatrixArtifactEvidence(
+    scoredSlots,
+    buildExecutionEvidence([batch]) as MatrixExecutionEvidence,
+  );
+}
+
+/**
+ * Runs one side's slots against the branch this process is composed against and
+ * writes `{ slots, execution }` — the same artifact shape the matrix child
+ * writes, so the parent aggregates both harnesses' children identically.
+ */
+export async function runAbChild(sideId: AbSideId, slots: readonly AbSlot[], outputPath: string): Promise<void> {
+  const selection = selectAbSideSlots(sideId, slots);
+  await runWithChildCleanup(async () => {
+    const deps = await createChildDependencies();
+    const output = await runAbSide(selection, deps);
+    await Bun.write(outputPath, JSON.stringify(output));
+    console.log(`Discovery A/B child artifact written: side=${sideId} path=${outputPath}`);
+  }, closeChildResources);
+}

--- a/services/api/src/cli/discovery-ab.main.ts
+++ b/services/api/src/cli/discovery-ab.main.ts
@@ -724,8 +724,17 @@ export async function finalizeAbChildArtifacts(
  * How far this run has got. It is recorded as the run advances rather than
  * inferred afterwards, because the one thing a failure cannot tell you about
  * itself is whether the money was already spent.
+ *
+ * Each stage is set at the moment its claim becomes true and not before: the
+ * message authored from it is read by an operator deciding whether they just
+ * lost forty minutes, so a stage that runs slightly ahead of the run is a
+ * message that asserts something that did not happen.
  */
-export interface AbRunProgress { stage: AbRunStage | null }
+export interface AbRunProgress {
+  stage: AbRunStage | null;
+  /** Set with the `'written'` stage, so the failure report can name the artifact. */
+  artifactPath?: string;
+}
 
 /**
  * Runs something that may reset branches and spend money, and turns any failure
@@ -742,7 +751,7 @@ export async function withAbSpendAccounting(run: (progress: AbRunProgress) => Pr
   try {
     await run(progress);
   } catch (error) {
-    throw classifyAbParentFailure(progress.stage, error);
+    throw classifyAbParentFailure(progress.stage, error, { artifactPath: progress.artifactPath });
   }
 }
 
@@ -783,13 +792,16 @@ async function runAbComparison(args: readonly string[], progress: AbRunProgress)
   // run cleans, where resetting afterwards leaves a window in which a dirty
   // branch looks clean. Both must succeed before anything is spawned - a
   // half-isolated comparison is not a comparison.
-  // Everything from here on can fail with the branches already overwritten,
-  // which is a different thing to report than a refusal.
-  progress.stage = 'reset';
+  // Everything from here on can fail with a branch already overwritten, which is
+  // a different thing to report than a refusal. Inside the loop only "one or
+  // both" is true - a restore refused on side a overwrites nothing at all - so
+  // 'reset', which claims both, is not set until the loop has finished.
+  progress.stage = 'resetting';
   for (const target of attested.targets) {
     await resetAbBranch({ manifest: attested, branchId: target.branchId, apiKey });
     console.log(`Discovery A/B reset side ${target.sideId} (${AB_BRANCH_NAMES[target.sideId]}) from ${AB_BASE_BRANCH}`);
   }
+  progress.stage = 'reset';
 
   const startedAt = new Date().toISOString();
   const temporaryDirectory = await mkdtemp(path.join(tmpdir(), 'discovery-ab-'));
@@ -865,6 +877,11 @@ async function runAbComparison(args: readonly string[], progress: AbRunProgress)
       meta: toGovernedRunMeta(meta, { completedAt: new Date().toISOString(), execution }),
       force: selection.force,
     });
+    // The artifact exists from here: a failure below (console formatting, or the
+    // finally's temp-directory cleanup) must not tell an operator that nothing
+    // of this run survived when the run report is on disk.
+    progress.artifactPath = runPath;
+    progress.stage = 'written';
 
     console.log(formatConsole(scorecard, [], [], { title: 'Discovery A/B scorecard', execution }));
     console.log(formatAbConfigDiff(meta));

--- a/services/api/src/cli/discovery-ab.main.ts
+++ b/services/api/src/cli/discovery-ab.main.ts
@@ -1,6 +1,12 @@
 /**
- * Child half of the discovery A/B harness: one side, one branch, one
- * configuration.
+ * The discovery A/B harness: two operator-chosen environment configurations,
+ * the same cases, one child process per side, one artifact holding both.
+ *
+ * The parent gates, attests, resets both branches, spawns the two children and
+ * aggregates them. The child half below it runs one side.
+ *
+ * ── Child half ──────────────────────────────────────────────────────────────
+ * One side, one branch, one configuration.
  *
  * This is the matrix child (`runChild` in `discovery-env-matrix.main.ts`) with
  * exactly two differences, and nothing else redesigned: the graph runs inside
@@ -15,8 +21,16 @@
  * sequentially, and `selectAbSideSlots` refuses a batch that carries more than
  * one configuration, so no cross-configuration overlap is possible here.
  */
+import path from 'node:path';
+import { mkdtemp } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+
+import { AB_SIDE_BRANCH_ENV, AbGateError, assertAbConfirmation, assertAbSideEnvironment } from './discovery-ab.gate';
+import { AB_BRANCH_NAMES, attestAbTargets, parseAbManifest, resetAbBranch, type AbTarget } from './discovery-ab.neon';
+import { buildAbPlan, configDiff } from './discovery-ab.plan';
 import { expectedBaseMetadata, verifyBaseFixtureIntegrity, verifyProtectedBase } from './discovery-env-matrix-base.main';
-import { ATTEMPT_TIMEOUT_MS, MatrixExecutionError, buildMatrixArtifactEvidence, closeChildResources, collectCandidates, collectEvaluatorTraces, composeCaseRuntime, createChildDependencies, databaseCase, loadJudge, loadMatrixEval, projectFinalCandidates, resolveFixtureTriggerIntent, runMatrixBoundary, runWithChildCleanup, sanitizeMatrixError, type MatrixCandidate, type MatrixEvaluatorTrace, type MatrixExecutionEvidence, type MatrixGraphRuntimeInput, type MatrixRetrievalCandidate, type MatrixSlotResult } from './discovery-env-matrix.main';
+import { ATTEMPT_TIMEOUT_MS, MatrixExecutionError, awaitMatrixChildProcess, buildMatrixArtifactEvidence, closeChildResources, collectCandidates, collectEvaluatorTraces, composeCaseRuntime, createChildDependencies, databaseCase, finalizeMatrixChildArtifacts, loadJudge, loadMatrixEval, projectFinalCandidates, resolveFixtureTriggerIntent, runBoundedChildTasks, runMatrixBoundary, runWithChildCleanup, sanitizeMatrixError, type MatrixCandidate, type MatrixEvaluatorTrace, type MatrixExecutionEvidence, type MatrixGraphRuntimeInput, type MatrixRetrievalCandidate, type MatrixSlotResult } from './discovery-env-matrix.main';
+import { createNeonControlPlane } from './discovery-env-matrix.neon';
 import { withDiscoveryEnvironment } from './discovery-env-matrix.runtime';
 import { baseSeedPayload, type HistoricalMatrixFixture } from './discovery-env-matrix.shared';
 
@@ -24,6 +38,9 @@ import type { AbEnvConfig } from './discovery-ab.flags';
 import type { AbSide, AbSideId, AbSlot } from './discovery-ab.plan';
 
 const HARNESS = 'discovery-ab';
+const HARNESS_VERSION = '1';
+const RUNS_DIR = path.resolve(import.meta.dir, '../../eval/discovery-ab/runs');
+const AB_BASE_BRANCH = 'eval-discovery-base';
 /** Identical to the matrix child's graph invocation, and to its policy projection. */
 const AB_MIN_SCORE = 50;
 
@@ -272,4 +289,586 @@ export async function runAbChild(sideId: AbSideId, slots: readonly AbSlot[], out
     await Bun.write(outputPath, JSON.stringify(output));
     console.log(`Discovery A/B child artifact written: side=${sideId} path=${outputPath}`);
   }, closeChildResources);
+}
+
+// ── Parent half ─────────────────────────────────────────────────────────────
+// Gate, attest, reset both branches, spawn one child per side, aggregate.
+
+/** Three repetitions per side; one observation per case cannot separate a difference from noise. */
+export const AB_DEFAULT_REPETITIONS = 3;
+/**
+ * A ceiling on `--runs`, because a mistyped one costs real money and hours: at
+ * the observed ~52s per invocation, ten repetitions over the full corpus is
+ * already 300 graph invocations. Nothing above this is a considered choice.
+ */
+export const AB_MAX_REPETITIONS = 10;
+/** `executeRuns` gives each slot three attempts, each bounded by ATTEMPT_TIMEOUT_MS. */
+const AB_ATTEMPTS_PER_SLOT = 3;
+/** The 1s + 2s retry backoff `executeRuns` inserts between those attempts. */
+const AB_SLOT_BACKOFF_MS = 3_000;
+/** Bounded headroom for child startup, base verification and cleanup. */
+const AB_CHILD_STARTUP_HEADROOM_MS = 5 * 60_000;
+/** Two sides, two isolated branches, two processes: they never wait on each other. */
+const AB_CHILD_CONCURRENCY = 2;
+/** How long a sibling gets to honour SIGTERM before it is killed, matching the matrix. */
+const AB_CHILD_TERMINATION_GRACE_MS = 5_000;
+/**
+ * Insufficient evidence, matching `EVAL_EXIT_INSUFFICIENT_EVIDENCE` in the
+ * shared eval CLI. It is restated rather than imported because this package
+ * reaches the eval bundle only through the dynamic `loadMatrixEval` seam.
+ */
+export const AB_EXIT_INSUFFICIENT_EVIDENCE = 3;
+
+/**
+ * The watchdog for one side, derived from what that side may legitimately take
+ * rather than from a fixed number: a side owns every case × repetition slot, and
+ * `executeRuns` runs them sequentially.
+ */
+export function abChildTimeoutMs(slotsPerSide: number): number {
+  if (!Number.isInteger(slotsPerSide) || slotsPerSide < 1) {
+    throw new Error(`A discovery A/B side must own at least one slot (received ${slotsPerSide})`);
+  }
+  return slotsPerSide * (AB_ATTEMPTS_PER_SLOT * ATTEMPT_TIMEOUT_MS + AB_SLOT_BACKOFF_MS) + AB_CHILD_STARTUP_HEADROOM_MS;
+}
+
+/** What the operator asked for: shared selection, per-side configuration. */
+export interface AbRunSelection {
+  /** Empty means the full corpus. */
+  caseIds: string[];
+  repetitions: number;
+  sides: [AbSide, AbSide];
+  force: boolean;
+}
+
+const AB_ENV_ASSIGNMENT = /^([A-Za-z_][A-Za-z0-9_]*)=(.*)$/;
+
+/** Every value given to a repeatable flag, refusing a flag left without one. */
+function collectFlagValues(args: readonly string[], flag: string): string[] {
+  const values: string[] = [];
+  for (const [index, value] of args.entries()) {
+    if (value !== flag) continue;
+    const next = args[index + 1];
+    if (next === undefined || next.startsWith('--')) throw new Error(`${flag} requires a value`);
+    values.push(next);
+  }
+  return values;
+}
+
+/**
+ * One side's configuration, built through a Map so a key like `__proto__`
+ * cannot reach an object prototype. Which keys are legal is not decided here:
+ * `buildAbPlan` asserts them against `AB_FLAGS`, and duplicating that list at
+ * the CLI is exactly the drift this harness exists to prevent.
+ */
+function parseAbSideConfig(args: readonly string[], flag: string, sideId: AbSideId): AbEnvConfig {
+  const config = new Map<string, string>();
+  for (const assignment of collectFlagValues(args, flag)) {
+    const match = AB_ENV_ASSIGNMENT.exec(assignment);
+    if (!match) throw new Error(`${flag} expects KEY=VALUE (received ${assignment})`);
+    const [, key, value] = match as unknown as [string, string, string];
+    if (config.has(key)) throw new Error(`${flag} sets ${key} twice; a side has exactly one value per flag`);
+    config.set(key, value);
+  }
+  if (config.size === 0) {
+    throw new Error(`Side ${sideId} has no configuration; pass at least one ${flag} KEY=VALUE`);
+  }
+  return Object.fromEntries(config);
+}
+
+/** Parses the operator's run contract: `--case <id>* --runs <n> --a K=V* --b K=V* [--force]`. */
+export function parseAbRunArgs(args: readonly string[]): AbRunSelection {
+  const caseIds = collectFlagValues(args, '--case');
+  if (new Set(caseIds).size !== caseIds.length) throw new Error('--case names the same case twice');
+  const runs = collectFlagValues(args, '--runs');
+  if (runs.length > 1) throw new Error('--runs may be given at most once; both sides share one repetition count');
+  const raw = runs[0];
+  if (raw !== undefined && !/^[1-9]\d*$/.test(raw)) {
+    throw new Error(`--runs must be a positive integer (received ${raw})`);
+  }
+  const repetitions = raw === undefined ? AB_DEFAULT_REPETITIONS : Number(raw);
+  if (repetitions > AB_MAX_REPETITIONS) {
+    throw new Error(`--runs must not exceed ${AB_MAX_REPETITIONS}; ${repetitions} repetitions is hours of live graph invocations`);
+  }
+  return {
+    caseIds,
+    repetitions,
+    sides: [
+      { id: 'a', config: parseAbSideConfig(args, '--a', 'a') },
+      { id: 'b', config: parseAbSideConfig(args, '--b', 'b') },
+    ],
+    force: args.includes('--force'),
+  };
+}
+
+/**
+ * Re-serializes the selection for the child invocation.
+ *
+ * The children are handed this rather than the parent's own argv so both sides
+ * plan from one normalized input: `buildAbPlan` is pure, so identical arguments
+ * produce identical plans, and a side cannot silently run a different
+ * selection. `--force` is deliberately not forwarded — only the parent writes
+ * the artifact.
+ */
+export function formatAbRunArgs(selection: AbRunSelection): string[] {
+  return [
+    ...selection.caseIds.flatMap((caseId) => ['--case', caseId]),
+    '--runs', String(selection.repetitions),
+    ...abConfigDeltas(selection.sides[0].config).flatMap((delta) => ['--a', `${delta.key}=${delta.after}`]),
+    ...abConfigDeltas(selection.sides[1].config).flatMap((delta) => ['--b', `${delta.key}=${delta.after}`]),
+  ];
+}
+
+/** Resolves the shared case selection, in the order the operator named it. */
+export function resolveAbCases(
+  cases: readonly HistoricalMatrixFixture[],
+  caseIds: readonly string[],
+): HistoricalMatrixFixture[] {
+  if (caseIds.length === 0) return [...cases];
+  return caseIds.map((caseId) => {
+    const matrixCase = cases.find((candidate) => candidate.id === caseId);
+    if (!matrixCase) throw new Error(`Unknown discovery A/B case: ${caseId}`);
+    return matrixCase;
+  });
+}
+
+/** The artifact's selection filters; an empty set is what makes a run full-corpus. */
+export function abSelectionFilters(caseIds: readonly string[]): Record<string, string> {
+  return caseIds.length === 0 ? {} : { case: [...caseIds].join(',') };
+}
+
+export interface AbArtifactMetaInput {
+  sides: readonly [AbSide, AbSide];
+  cases: readonly HistoricalMatrixFixture[];
+  repetitions: number;
+  startedAt: string;
+  git: unknown;
+  /** Absent or empty means the run covered the full corpus. */
+  filters?: Readonly<Record<string, string>>;
+}
+
+/**
+ * The run's own description of itself: what was compared, over what corpus,
+ * under what scoring configuration.
+ *
+ * Deliberately no `baselinePath` and no comparison of any kind. Two arbitrary
+ * operator-chosen configurations have no committed baseline and never will, so
+ * the pair is the result; a harness that quietly grew one would be claiming a
+ * regression verdict it has no evidence for.
+ *
+ * Asynchronous because the corpus and scoring fingerprints are the shared eval
+ * library's, and this package can only reach that library through the dynamic
+ * `loadMatrixEval` seam — a static cross-package import would violate the API
+ * package's `rootDir`. Recomputing either fingerprint here instead would be a
+ * second implementation of a value whose entire purpose is to match.
+ */
+export async function buildAbArtifactMeta(input: AbArtifactMetaInput): Promise<Record<string, unknown>> {
+  const { fingerprintEvalCorpus, buildEvalScoringConfigFingerprint, resolveEvalJudgeModelId } = await loadMatrixEval();
+  const filters = { ...(input.filters ?? {}) };
+  return {
+    harness: HARNESS,
+    harnessVersion: HARNESS_VERSION,
+    // De-duplicated because the envelope refuses repeated model IDs, and the
+    // runtime and judge models are configured independently.
+    models: [...new Set([process.env.CHAT_MODEL ?? 'configured runtime models', resolveEvalJudgeModelId() as string])],
+    runs: 1,
+    selection: { fullCorpus: Object.keys(filters).length === 0, filters },
+    configs: { a: { ...input.sides[0].config }, b: { ...input.sides[1].config } },
+    configDiff: configDiff(input.sides[0].config, input.sides[1].config),
+    corpusFingerprint: fingerprintEvalCorpus(input.cases) as string,
+    // The two configurations and the repetition count go through
+    // `scorerConfig`, which is the only field `buildEvalScoringConfigFingerprint`
+    // actually hashes beyond the judge toggle and judge model; passing them as
+    // top-level options (as the matrix harness does) drops them silently and
+    // would give every pair of configurations the same fingerprint.
+    configFingerprint: buildEvalScoringConfigFingerprint({
+      judge: true,
+      scorerConfig: {
+        sides: input.sides.map((side) => ({ ...side.config })),
+        repetitions: input.repetitions,
+      },
+    }) as string,
+    git: input.git,
+    startedAt: input.startedAt,
+  };
+}
+
+/**
+ * The subset of the A/B meta the governed envelope accepts.
+ *
+ * Structural mirror of the shared library's `EvalRunMeta`, restated for the
+ * same reason `buildAbArtifactMeta` is asynchronous: the eval bundle is only
+ * reachable through a dynamic import, so its types cannot be imported here.
+ */
+export interface AbGovernedRunMeta {
+  harness: string;
+  harnessVersion: string;
+  models: string[];
+  runs: number;
+  selection: { fullCorpus: boolean; filters: Record<string, string> };
+  corpusFingerprint: string;
+  configFingerprint: string;
+  git: unknown;
+  startedAt: string;
+  completedAt: string;
+  execution: MatrixExecutionEvidence;
+}
+
+function metaString(meta: Record<string, unknown>, key: string): string {
+  const value = meta[key];
+  if (typeof value !== 'string' || value === '') throw new Error(`Discovery A/B meta ${key} must be a non-empty string`);
+  return value;
+}
+
+/**
+ * Projects the A/B meta onto what the governed artifact envelope will accept.
+ *
+ * `configs` and `configDiff` are intentionally **not** written to the artifact.
+ * The shared envelope and scorecard payload schemas are both `.strict()`
+ * (`packages/protocol/eval/shared/artifact.ts`), so a run-level configuration
+ * block has no legal home in them, and widening a contract shared by every
+ * harness and every committed baseline to carry a convenience copy is a bad
+ * trade.
+ *
+ * Nothing is lost. Each case row carries `configDeltas` naming that side's
+ * complete configuration — the case schema is the sanctioned `.passthrough()`
+ * extension point — so the artifact can always answer "what was A and what was
+ * B"; the run-level pair is a rollup of those rows, derivable by grouping them
+ * by rule. `assertAbConfigProvenance` is what keeps that derivation true, and
+ * the diff is printed to the console so an operator never has to derive it by
+ * hand.
+ */
+export function toGovernedRunMeta(
+  meta: Record<string, unknown>,
+  input: { completedAt: string; execution: MatrixExecutionEvidence },
+): AbGovernedRunMeta {
+  const selection = meta.selection;
+  if (!selection || typeof selection !== 'object' || typeof (selection as { fullCorpus?: unknown }).fullCorpus !== 'boolean') {
+    throw new Error('Discovery A/B meta selection must record fullCorpus and its filters');
+  }
+  const models = meta.models;
+  if (!Array.isArray(models) || models.length === 0 || models.some((model) => typeof model !== 'string')) {
+    throw new Error('Discovery A/B meta models must be a non-empty list of model IDs');
+  }
+  if (typeof meta.runs !== 'number') throw new Error('Discovery A/B meta runs must be a number');
+  return {
+    harness: metaString(meta, 'harness'),
+    harnessVersion: metaString(meta, 'harnessVersion'),
+    models: models as string[],
+    runs: meta.runs,
+    selection: selection as AbGovernedRunMeta['selection'],
+    corpusFingerprint: metaString(meta, 'corpusFingerprint'),
+    configFingerprint: metaString(meta, 'configFingerprint'),
+    git: meta.git,
+    startedAt: metaString(meta, 'startedAt'),
+    completedAt: input.completedAt,
+    execution: input.execution,
+  };
+}
+
+/** Renders the two configurations and their difference for the console. */
+export function formatAbConfigDiff(meta: Record<string, unknown>): string {
+  const diff = meta.configDiff;
+  if (!Array.isArray(diff) || diff.length === 0) return 'Discovery A/B compared two configurations with no recorded difference';
+  const rows = diff.map((entry) => {
+    const { key, a, b } = entry as { key: string; a: string | null; b: string | null };
+    return `  ${key}: a=${a ?? 'unset'}  b=${b ?? 'unset'}`;
+  });
+  return ['Discovery A/B configuration difference:', ...rows].join('\n');
+}
+
+/**
+ * Proves every aggregated slot still names its side's complete configuration.
+ *
+ * This is load-bearing rather than defensive. Per-case `configDeltas` is the
+ * only on-disk record of what each side was (see `toGovernedRunMeta`), so if
+ * the child ever stops attaching it — or attaches the wrong side's — the
+ * artifact would report that A beat B while omitting what A and B were, and
+ * nothing else would notice. The parent refuses to write that artifact.
+ */
+export function assertAbConfigProvenance(
+  slots: readonly MatrixSlotResult[],
+  sides: readonly [AbSide, AbSide],
+): void {
+  const expected = new Map(sides.map((side) => [side.id as string, JSON.stringify(abConfigDeltas(side.config))]));
+  for (const slot of slots) {
+    const wanted = expected.get(slot.rowId);
+    if (wanted === undefined) {
+      throw new Error(`Discovery A/B slot ${slot.caseId} names side ${slot.rowId}, which this run did not compare`);
+    }
+    if (JSON.stringify(slot.configDeltas ?? null) !== wanted) {
+      throw new Error(
+        `Discovery A/B slot ${slot.caseId} does not record side ${slot.rowId}'s configuration; `
+        + 'the artifact would report a comparison without saying what was compared',
+      );
+    }
+  }
+}
+
+export interface AbSideCompleteness {
+  sideId: AbSideId;
+  expected: number;
+  produced: number;
+  scored: number;
+  failed: number;
+  passes: number;
+  complete: boolean;
+}
+
+export interface AbRunOutcome {
+  sides: AbSideCompleteness[];
+  incompleteSides: AbSideId[];
+  /** Null whenever either side is incomplete: half a comparison is not a comparison. */
+  verdict: Array<{ sideId: AbSideId; passes: number; runs: number; passRate: number }> | null;
+  exitCode: number;
+  summary: string;
+}
+
+/**
+ * Decides whether this run produced a comparison at all.
+ *
+ * A side is complete only when it returned every slot it was planned and every
+ * one of them was scored; a slot that exhausted its attempts comes back with
+ * `runs: 0` and is a failure, not a zero. If either side is incomplete the run
+ * reports **no verdict** and exits non-zero, naming the side — reporting one
+ * side's numbers as though they were a comparison is the specific dishonesty
+ * this harness has to avoid.
+ */
+export function resolveAbRunOutcome(input: {
+  slots: readonly MatrixSlotResult[];
+  sides: readonly [AbSide, AbSide];
+  expectedSlotsPerSide: number;
+}): AbRunOutcome {
+  const sides = input.sides.map((side): AbSideCompleteness => {
+    const owned = input.slots.filter((slot) => slot.rowId === side.id);
+    const scored = owned.filter((slot) => slot.runs > 0);
+    return {
+      sideId: side.id,
+      expected: input.expectedSlotsPerSide,
+      produced: owned.length,
+      scored: scored.length,
+      failed: owned.length - scored.length,
+      passes: scored.reduce((total, slot) => total + slot.passes, 0),
+      complete: owned.length === input.expectedSlotsPerSide && scored.length === owned.length,
+    };
+  });
+  const incompleteSides = sides.filter((side) => !side.complete).map((side) => side.sideId);
+  if (incompleteSides.length > 0) {
+    const detail = sides
+      .filter((side) => !side.complete)
+      .map((side) => `side ${side.sideId} scored ${side.scored}/${side.expected} slot(s), ${side.failed} failed`)
+      .join('; ');
+    return {
+      sides,
+      incompleteSides,
+      verdict: null,
+      exitCode: AB_EXIT_INSUFFICIENT_EVIDENCE,
+      summary: `Discovery A/B reports no verdict: ${detail}. A comparison with one side missing is not a comparison.`,
+    };
+  }
+  const verdict = sides.map((side) => ({
+    sideId: side.sideId,
+    passes: side.passes,
+    runs: side.scored,
+    passRate: side.scored === 0 ? 0 : side.passes / side.scored,
+  }));
+  return {
+    sides,
+    incompleteSides,
+    verdict,
+    exitCode: 0,
+    summary: `Discovery A/B result: ${verdict.map((entry) => `side ${entry.sideId} ${entry.passes}/${entry.runs} (${(entry.passRate * 100).toFixed(1)}%)`).join('  vs  ')}`,
+  };
+}
+
+/** A side's child, described in the shape the shared child supervision reports on. */
+function abChildDescriptor(target: AbTarget): { childKey: string; branch: string; databaseUrl: string; baseBranch: string } {
+  return {
+    childKey: `${HARNESS}/${target.sideId}`,
+    branch: AB_BRANCH_NAMES[target.sideId],
+    databaseUrl: target.databaseUrl,
+    baseBranch: AB_BASE_BRANCH,
+  };
+}
+
+type AbChildProcess = { exited: Promise<number>; kill(signal?: NodeJS.Signals): void };
+
+function usage(): string {
+  const manifest = '{"projectId":"...","baseBranchId":"br-...","targets":[{"sideId":"a","branchId":"br-...","endpointId":"ep-...","databaseUrl":"postgres://...neon.tech/protocol_eval"}, ...]}';
+  return [
+    'Discovery A/B eval',
+    '',
+    'Runs the real discovery graph twice - once per operator-chosen environment',
+    'configuration - over the same cases, and emits one artifact holding both sides.',
+    'It never reads, writes or compares a baseline: arbitrary configurations have',
+    'none, so the pair is the result.',
+    '',
+    'Required operator attestation:',
+    '  DISCOVERY_AB_CONFIRM=1',
+    '  TEST_DATABASE_SAFE=1',
+    '  NEON_API_KEY=<neon api key>',
+    `  DISCOVERY_AB_TARGETS='${manifest}'`,
+    '',
+    'This command never creates or deletes Neon branches. It resets both attested',
+    `A/B branches (${AB_BRANCH_NAMES.a}, ${AB_BRANCH_NAMES.b}) from ${AB_BASE_BRANCH} before it spawns anything.`,
+    '',
+    'Selection is shared by both sides; configuration is not:',
+    '  --case <id>       Restrict to one case. Repeatable. Default: the full corpus.',
+    `  --runs <n>        Repetitions per side (default ${AB_DEFAULT_REPETITIONS}, maximum ${AB_MAX_REPETITIONS}).`,
+    '  --a KEY=VALUE     A flag for side a. Repeatable.',
+    '  --b KEY=VALUE     A flag for side b. Repeatable.',
+    '  --force           Consent to replacing an existing run artifact.',
+    '',
+    'Both sides must state the same keys with differing values; identical or',
+    'asymmetric configurations are refused before any spend.',
+  ].join('\n');
+}
+
+/**
+ * Gate, attest, reset both branches, run one child per side, aggregate.
+ *
+ * The bootstrap has already attested these targets before importing this
+ * module - that is what keeps the graph and its database singleton unreachable
+ * until the branches are proven. This attests them a second time because
+ * `resetAbBranch` accepts only the branded `AttestedAbManifest` that
+ * `attestAbTargets` produces, and a brand cannot cross a process boundary: the
+ * ordering "reset only what you attested" is enforced by the type system rather
+ * than by the order two files happen to run in. Six control-plane GETs is a
+ * cheap price for that.
+ */
+async function runAbParent(args: readonly string[]): Promise<void> {
+  assertAbConfirmation(process.env);
+  const apiKey = process.env.NEON_API_KEY ?? '';
+  const manifest = parseAbManifest(process.env.DISCOVERY_AB_TARGETS);
+  const attested = await attestAbTargets({ manifest, controlPlane: createNeonControlPlane(apiKey) });
+  const selection = parseAbRunArgs(args);
+  const {
+    HISTORICAL_MATRIX_CASES, assertEvalWritePlan, readEvalGitProvenance,
+    buildScorecard, writeRunReport, formatConsole,
+  } = await loadMatrixEval();
+  const cases = resolveAbCases(HISTORICAL_MATRIX_CASES as HistoricalMatrixFixture[], selection.caseIds);
+  // Refuses identical, asymmetric and unreachable-flag configurations here,
+  // before a single branch is reset or a single graph call is paid for.
+  const plan = buildAbPlan(cases, selection.sides, selection.repetitions);
+  const slotsPerSide = plan.filter((slot) => slot.side.id === 'a').length;
+
+  const stamp = new Date().toISOString().replace(/[:.]/g, '-');
+  const runPath = path.resolve(RUNS_DIR, `${stamp}.json`);
+  // No inputs: this harness reads no baseline, so nothing it writes can clobber one.
+  await assertEvalWritePlan({ inputs: [], outputs: [runPath], force: selection.force });
+
+  // Reset before, not after: a crashed run leaves dirty branches that the next
+  // run cleans, where resetting afterwards leaves a window in which a dirty
+  // branch looks clean. Both must succeed before anything is spawned - a
+  // half-isolated comparison is not a comparison.
+  for (const target of attested.targets) {
+    await resetAbBranch({ manifest: attested, branchId: target.branchId, apiKey });
+    console.log(`Discovery A/B reset side ${target.sideId} (${AB_BRANCH_NAMES[target.sideId]}) from ${AB_BASE_BRANCH}`);
+  }
+
+  const startedAt = new Date().toISOString();
+  const temporaryDirectory = await mkdtemp(path.join(tmpdir(), 'discovery-ab-'));
+  let completedSuccessfully = false;
+  try {
+    const activeChildren = new Set<AbChildProcess>();
+    const outputs: AbChildOutput[] = await runBoundedChildTasks({
+      items: attested.targets,
+      concurrency: AB_CHILD_CONCURRENCY,
+      onFailure: () => {
+        for (const active of activeChildren) active.kill('SIGTERM');
+        const escalation = setTimeout(() => {
+          for (const active of activeChildren) active.kill('SIGKILL');
+        }, AB_CHILD_TERMINATION_GRACE_MS);
+        escalation.unref?.();
+      },
+      task: async (target) => {
+        const outputPath = path.join(temporaryDirectory, `${target.sideId}.json`);
+        const proc = Bun.spawn({
+          cmd: [
+            process.execPath, new URL('./discovery-ab.ts', import.meta.url).pathname,
+            '--side', target.sideId, '--child-output', outputPath,
+            ...formatAbRunArgs(selection),
+          ],
+          // One process per side, with that side's DATABASE_URL fixed for its
+          // lifetime: withDiscoveryEnvironment mutates the real process.env, so
+          // two configurations in one process would read each other's flags.
+          env: {
+            ...process.env,
+            DATABASE_URL: target.databaseUrl,
+            [AB_SIDE_BRANCH_ENV]: AB_BRANCH_NAMES[target.sideId],
+          },
+          stdout: 'inherit', stderr: 'inherit',
+        });
+        activeChildren.add(proc);
+        console.log(`Discovery A/B side ${target.sideId} started against ${AB_BRANCH_NAMES[target.sideId]} (${slotsPerSide} slot(s))`);
+        try {
+          // Shared supervision: the same watchdog, SIGTERM/SIGKILL escalation
+          // and artifact-availability reporting the matrix children get. Its
+          // log lines say "matrix" because the code is shared, not because a
+          // matrix run is happening.
+          await awaitMatrixChildProcess({
+            child: abChildDescriptor(target),
+            outputPath,
+            timeoutMs: abChildTimeoutMs(slotsPerSide),
+            process: proc,
+          });
+        } finally {
+          activeChildren.delete(proc);
+        }
+        return await Bun.file(outputPath).json() as AbChildOutput;
+      },
+    });
+
+    const slots = outputs.flatMap((output) => output.slots);
+    const execution: MatrixExecutionEvidence = { policy: 'strict', runs: outputs.flatMap((output) => output.execution.runs) };
+    assertAbConfigProvenance(slots, selection.sides);
+    // rowId is the side, and scoreMatrixSlot copies it to rule, so the
+    // scorecard's two rules are the two sides.
+    const scorecard = buildScorecard(slots, { model: process.env.CHAT_MODEL ?? 'configured runtime models', runs: 1 });
+    const meta = await buildAbArtifactMeta({
+      sides: selection.sides,
+      cases,
+      repetitions: selection.repetitions,
+      startedAt,
+      git: readEvalGitProvenance(import.meta.dir),
+      filters: abSelectionFilters(selection.caseIds),
+    });
+    await writeRunReport(runPath, scorecard, {
+      meta: toGovernedRunMeta(meta, { completedAt: new Date().toISOString(), execution }),
+      force: selection.force,
+    });
+
+    console.log(formatConsole(scorecard, [], [], { title: 'Discovery A/B scorecard', execution }));
+    console.log(formatAbConfigDiff(meta));
+    console.log(`Discovery A/B artifact written: ${runPath}`);
+    const outcome = resolveAbRunOutcome({ slots, sides: selection.sides, expectedSlotsPerSide: slotsPerSide });
+    console.log(outcome.summary);
+    process.exitCode = outcome.exitCode;
+    completedSuccessfully = outcome.exitCode === 0;
+  } finally {
+    await finalizeMatrixChildArtifacts(temporaryDirectory, completedSuccessfully);
+  }
+}
+
+/**
+ * The one entry point, parent and child.
+ *
+ * A `--side` argument makes this a child invocation, and a child never gets
+ * past `assertAbSideEnvironment`: confirm variable, disposable-database marker,
+ * Neon host, exactly `protocol_eval`, and the branch label for its own side.
+ */
+export async function main(args: readonly string[] = process.argv.slice(2)): Promise<void> {
+  if (args.includes('--help') || args.includes('-h')) return void console.log(usage());
+  if (!args.includes('--side')) return void await runAbParent(args);
+
+  const { sideId, outputPath } = parseAbChildArgs(args);
+  const environment = assertAbSideEnvironment(process.env, sideId);
+  const manifest = parseAbManifest(process.env.DISCOVERY_AB_TARGETS);
+  const target = manifest.targets.find((candidate) => candidate.sideId === sideId);
+  if (!target || new URL(target.databaseUrl).toString() !== environment.databaseUrl.toString()) {
+    throw new AbGateError(`Refusing to mutate: side ${sideId} is not composed against the database its manifest entry declares`);
+  }
+  const selection = parseAbRunArgs(args);
+  const { HISTORICAL_MATRIX_CASES } = await loadMatrixEval();
+  const cases = resolveAbCases(HISTORICAL_MATRIX_CASES as HistoricalMatrixFixture[], selection.caseIds);
+  await runAbChild(sideId, buildAbPlan(cases, selection.sides, selection.repetitions), outputPath);
 }

--- a/services/api/src/cli/discovery-ab.neon.ts
+++ b/services/api/src/cli/discovery-ab.neon.ts
@@ -172,8 +172,20 @@ export async function attestAbTargets(input: { manifest: AbManifest; controlPlan
 /** Neon's `OperationStatus` enum. Anything else is treated as unrecognized. */
 const OPERATION_STATUSES = ['scheduling', 'running', 'finished', 'failed', 'error', 'cancelling', 'cancelled', 'skipped'] as const;
 type OperationStatus = (typeof OPERATION_STATUSES)[number];
-/** States that may still become `finished`; every other state is terminal. */
+/** States that may still become terminal; every other state is terminal. */
 const PENDING_STATUSES: ReadonlySet<OperationStatus> = new Set<OperationStatus>(['scheduling', 'running', 'cancelling']);
+/**
+ * Terminal states that mean the step did not fail.
+ *
+ * `skipped` is here because restore replies with the whole operation chain, not
+ * just the restore: Neon schedules compute suspend/start alongside it and
+ * reports `skipped` for a step it did not need to perform (a compute that was
+ * already suspended, say). That is a successful reset, so treating it as fatal
+ * would abort a run whose branches were in fact reset correctly — and print a
+ * warning saying the branches may have been overwritten and it cannot say
+ * which, which would be false. `failed`, `error` and `cancelled` stay fatal.
+ */
+const SUCCESS_STATUSES: ReadonlySet<OperationStatus> = new Set<OperationStatus>(['finished', 'skipped']);
 
 function isOperationStatus(value: unknown): value is OperationStatus {
   return typeof value === 'string' && (OPERATION_STATUSES as readonly string[]).includes(value);
@@ -189,8 +201,9 @@ async function readJson(response: Response, context: string): Promise<unknown> {
 }
 
 /**
- * Restore replies with `BranchOperations`; the operation ids are the only thing
- * taken from the body, and they are never echoed anywhere.
+ * Restore replies with `BranchOperations` — the restore plus whatever compute
+ * operations Neon schedules alongside it — and the operation ids are the only
+ * thing taken from the body, and they are never echoed anywhere.
  */
 function readOperationIds(body: unknown): string[] {
   const root = asRecord(body, 'Neon control-plane restore response is not an object');
@@ -238,7 +251,7 @@ async function awaitOperations(input: {
   for (const operationId of input.operationIds) {
     for (;;) {
       const status = await readOperationStatus({ projectId: input.projectId, operationId, apiKey: input.apiKey, send: input.send });
-      if (status === 'finished') break;
+      if (SUCCESS_STATUSES.has(status)) break;
       if (!PENDING_STATUSES.has(status)) throw new Error(`Neon control-plane reset operation ended with status ${status}`);
       if (Date.now() >= deadline) {
         throw new Error(`Neon control-plane reset did not finish within ${input.pollTimeoutMs}ms`);
@@ -259,7 +272,8 @@ async function awaitOperations(input: {
  *
  * The manifest must be an `AttestedAbManifest`: the branch is proven to be a
  * designated A/B branch by construction, not by call order. It resolves only
- * after every reported operation reaches `finished`, so nothing connects to a
+ * after every reported operation is terminal and not a failure (`finished`, or
+ * `skipped` for a step Neon did not need to perform), so nothing connects to a
  * branch that is still being overwritten. Poll interval and timeout are
  * injectable so tests do not sleep.
  */

--- a/services/api/src/cli/discovery-ab.neon.ts
+++ b/services/api/src/cli/discovery-ab.neon.ts
@@ -1,0 +1,163 @@
+/**
+ * Attestation and reset for the two durable A/B branches.
+ *
+ * `discovery-env-matrix.neon.ts` is deliberately read-only. Reset is the one
+ * write this harness needs, so it lives here, refuses any branch outside the
+ * attested manifest, and never surfaces a response body: control-plane
+ * responses can carry credentials, and a `DATABASE_URL` carries a password —
+ * only status codes and field names are ever put into an error.
+ *
+ * Deliberate deviation from `attestMatrixTargets`: matrix children must carry a
+ * future `expiresAt` because they are ephemeral. The A/B branches are durable by
+ * design, so expiry is not required; the safety property is preserved
+ * differently — the name check is *exact* rather than a prefix, and the branches
+ * are reset from base before every run, so they never accumulate state worth
+ * protecting. Every other check (non-primary, parent is the attested base,
+ * endpoint host matches the URL) is kept unchanged.
+ */
+import { isEndpointHost, type NeonControlPlane } from './discovery-env-matrix.neon';
+
+const NEON_API_ORIGIN = 'https://console.neon.tech/api/v2';
+const BASE_NAME = 'eval-discovery-base';
+
+export const AB_BRANCH_NAMES = { a: 'eval-ab-a', b: 'eval-ab-b' } as const;
+
+export interface AbTarget { sideId: 'a' | 'b'; branchId: string; endpointId: string; databaseUrl: string }
+export interface AbManifest { projectId: string; baseBranchId: string; targets: readonly [AbTarget, AbTarget] }
+
+function asRecord(value: unknown, message: string): Record<string, unknown> {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) throw new Error(message);
+  return value as Record<string, unknown>;
+}
+
+function asString(value: unknown, field: string): string {
+  if (typeof value !== 'string' || value.length === 0) {
+    throw new Error(`Discovery A/B manifest ${field} must be a non-empty string`);
+  }
+  return value;
+}
+
+/** Parses a URL without letting the input (which carries a password) into the error. */
+function parseUrl(value: string): URL | null {
+  try {
+    return new URL(value);
+  } catch {
+    return null;
+  }
+}
+
+/** The same target shape the matrix bootstrap accepts: a Neon-hosted postgres URL. */
+function assertNeonPostgresUrl(value: string, field: string): void {
+  const url = parseUrl(value);
+  if (!url || (url.protocol !== 'postgres:' && url.protocol !== 'postgresql:') || !url.hostname.endsWith('.neon.tech')) {
+    throw new Error(`Discovery A/B manifest ${field} must be a postgres URL on a Neon host`);
+  }
+}
+
+function parseTarget(value: unknown, index: number): AbTarget {
+  const entry = asRecord(value, `Discovery A/B manifest target ${index} must be an object`);
+  const sideId = entry.sideId;
+  if (sideId !== 'a' && sideId !== 'b') throw new Error(`Discovery A/B manifest target ${index} sideId must be "a" or "b"`);
+  const target: AbTarget = {
+    sideId,
+    branchId: asString(entry.branchId, `target ${index} branchId`),
+    endpointId: asString(entry.endpointId, `target ${index} endpointId`),
+    databaseUrl: asString(entry.databaseUrl, `target ${index} databaseUrl`),
+  };
+  assertNeonPostgresUrl(target.databaseUrl, `target ${index} databaseUrl`);
+  return target;
+}
+
+/**
+ * Decodes the operator-supplied manifest. Every field is type-checked rather
+ * than cast: a JSON value of the wrong type (a number where a branch id is
+ * expected) would otherwise surface as an unhelpful `TypeError` deep inside the
+ * control-plane call, or worse, be sent to Neon as-is.
+ *
+ * The two sides are returned in canonical order (a, then b) so callers can index
+ * them without re-sorting.
+ */
+export function parseAbManifest(raw: string | undefined): AbManifest {
+  if (raw === undefined || raw.trim() === '') throw new Error('Discovery A/B manifest is required');
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(raw);
+  } catch {
+    throw new Error('Discovery A/B manifest must be valid JSON');
+  }
+  const root = asRecord(parsed, 'Discovery A/B manifest must be an object');
+  const projectId = asString(root.projectId, 'projectId');
+  const baseBranchId = asString(root.baseBranchId, 'baseBranchId');
+  if (!Array.isArray(root.targets) || root.targets.length !== 2) {
+    throw new Error('Discovery A/B manifest must name exactly two sides');
+  }
+  const targets = root.targets.map(parseTarget);
+  const sideA = targets.find((target) => target.sideId === 'a');
+  const sideB = targets.find((target) => target.sideId === 'b');
+  if (!sideA || !sideB) throw new Error('Discovery A/B manifest must name one side a and one side b');
+  if (sideA.branchId === sideB.branchId || sideA.endpointId === sideB.endpointId) {
+    throw new Error('Discovery A/B manifest sides must name distinct branches and endpoints');
+  }
+  if (sideA.branchId === baseBranchId || sideB.branchId === baseBranchId) {
+    throw new Error('Discovery A/B manifest sides must not name the base branch');
+  }
+  return { projectId, baseBranchId, targets: [sideA, sideB] };
+}
+
+/**
+ * Verifies both sides are the designated A/B branches, parented on the protected
+ * base. Durability replaces the matrix's expiry check (see the module note); the
+ * name check is exact rather than a prefix.
+ */
+export async function attestAbTargets(input: { manifest: AbManifest; controlPlane: NeonControlPlane }): Promise<AbManifest> {
+  const { manifest, controlPlane } = input;
+  const base = await controlPlane.getBranch(manifest.projectId, manifest.baseBranchId);
+  if (base.id !== manifest.baseBranchId || base.name !== BASE_NAME || base.primary) {
+    throw new Error('Neon control-plane base branch identity is invalid');
+  }
+  for (const target of manifest.targets) {
+    const branch = await controlPlane.getBranch(manifest.projectId, target.branchId);
+    if (branch.id !== target.branchId || branch.name !== AB_BRANCH_NAMES[target.sideId]
+      || branch.parentId !== base.id || branch.primary) {
+      throw new Error(`Neon control-plane side ${target.sideId} identity is invalid`);
+    }
+    // Parsed defensively: a URL failure must not put the password into the error.
+    const url = parseUrl(target.databaseUrl);
+    const endpoints = await controlPlane.listEndpoints(manifest.projectId, target.branchId);
+    const endpoint = endpoints.find((candidate) => candidate.id === target.endpointId);
+    if (!url || !endpoint || endpoint.branchId !== target.branchId || !isEndpointHost(url.hostname, endpoint.host)) {
+      throw new Error(`Neon control-plane side ${target.sideId} endpoint host does not match DATABASE_URL`);
+    }
+  }
+  return manifest;
+}
+
+/**
+ * Resets one attested A/B branch to the head of the attested base. The only
+ * mutating call this harness makes.
+ *
+ * Neon v2 has no `reset_to_parent` operation: the current spec exposes
+ * `POST /projects/{project_id}/branches/{branch_id}/restore`
+ * (`restoreProjectBranch`), which restores to the head of `source_branch_id`
+ * when no LSN or timestamp is given.
+ */
+export async function resetAbBranch(input: {
+  manifest: AbManifest; branchId: string; apiKey: string; fetchImpl?: typeof fetch;
+}): Promise<void> {
+  const { manifest, branchId, apiKey } = input;
+  if (!manifest.targets.some((target) => target.branchId === branchId)) {
+    throw new Error(`${branchId} is not a designated A/B branch; refusing to reset it`);
+  }
+  const send = input.fetchImpl ?? fetch;
+  const response = await send(
+    `${NEON_API_ORIGIN}/projects/${encodeURIComponent(manifest.projectId)}/branches/${encodeURIComponent(branchId)}/restore`,
+    {
+      method: 'POST',
+      headers: { Authorization: `Bearer ${apiKey}`, Accept: 'application/json', 'Content-Type': 'application/json' },
+      body: JSON.stringify({ source_branch_id: manifest.baseBranchId }),
+      redirect: 'error',
+    },
+  );
+  // The body may echo credentials; only the status is safe to report.
+  if (!response.ok) throw new Error(`Neon control-plane reset failed with status ${response.status}`);
+}

--- a/services/api/src/cli/discovery-ab.neon.ts
+++ b/services/api/src/cli/discovery-ab.neon.ts
@@ -14,16 +14,39 @@
  * are reset from base before every run, so they never accumulate state worth
  * protecting. Every other check (non-primary, parent is the attested base,
  * endpoint host matches the URL) is kept unchanged.
+ *
+ * Because that reset *is* the compensating control, it must be provably aimed
+ * and provably complete: `resetAbBranch` accepts only an `AttestedAbManifest`
+ * (a brand no caller can forge, so the wrong call order does not compile) and
+ * resolves only once every restore operation Neon reported has reached
+ * `finished` on the control plane.
  */
 import { isEndpointHost, type NeonControlPlane } from './discovery-env-matrix.neon';
 
 const NEON_API_ORIGIN = 'https://console.neon.tech/api/v2';
 const BASE_NAME = 'eval-discovery-base';
+const DEFAULT_POLL_INTERVAL_MS = 1_000;
+const DEFAULT_POLL_TIMEOUT_MS = 120_000;
 
 export const AB_BRANCH_NAMES = { a: 'eval-ab-a', b: 'eval-ab-b' } as const;
 
 export interface AbTarget { sideId: 'a' | 'b'; branchId: string; endpointId: string; databaseUrl: string }
 export interface AbManifest { projectId: string; baseBranchId: string; targets: readonly [AbTarget, AbTarget] }
+
+/**
+ * Module-private brand. It is `declare`d, so it exists only in the type system
+ * and only this module can produce a value carrying it: `attestAbTargets` is the
+ * sole way to obtain an `AttestedAbManifest`.
+ */
+declare const ATTESTED: unique symbol;
+
+/**
+ * An `AbManifest` whose branch identities were checked against the control
+ * plane. `resetAbBranch` takes nothing else, so a hand-built (or merely parsed)
+ * manifest cannot reach the one mutating call: the mistake is a compile error
+ * rather than a convention. The runtime membership check is kept as well.
+ */
+export type AttestedAbManifest = AbManifest & { readonly [ATTESTED]: true };
 
 function asRecord(value: unknown, message: string): Record<string, unknown> {
   if (!value || typeof value !== 'object' || Array.isArray(value)) throw new Error(message);
@@ -46,11 +69,24 @@ function parseUrl(value: string): URL | null {
   }
 }
 
-/** The same target shape the matrix bootstrap accepts: a Neon-hosted postgres URL. */
+/**
+ * The same target shape the matrix bootstrap accepts, checked by the same rules
+ * as `assertLocalTarget` in `discovery-env-matrix.neon.ts`: a postgres URL on a
+ * Neon host, whose database is exactly `protocol_eval` and whose port, if given,
+ * is exactly 5432. Neon's canonical and `-pooler` URLs both use 5432, so pinning
+ * the port rejects nothing legitimate; pinning the database name is what keeps a
+ * side from being pointed at some other database on a Neon host.
+ */
 function assertNeonPostgresUrl(value: string, field: string): void {
   const url = parseUrl(value);
   if (!url || (url.protocol !== 'postgres:' && url.protocol !== 'postgresql:') || !url.hostname.endsWith('.neon.tech')) {
     throw new Error(`Discovery A/B manifest ${field} must be a postgres URL on a Neon host`);
+  }
+  if (url.pathname !== '/protocol_eval') {
+    throw new Error(`Discovery A/B manifest ${field} database must be exactly protocol_eval`);
+  }
+  if (url.port && url.port !== '5432') {
+    throw new Error(`Discovery A/B manifest ${field} port must be exactly 5432`);
   }
 }
 
@@ -109,7 +145,7 @@ export function parseAbManifest(raw: string | undefined): AbManifest {
  * base. Durability replaces the matrix's expiry check (see the module note); the
  * name check is exact rather than a prefix.
  */
-export async function attestAbTargets(input: { manifest: AbManifest; controlPlane: NeonControlPlane }): Promise<AbManifest> {
+export async function attestAbTargets(input: { manifest: AbManifest; controlPlane: NeonControlPlane }): Promise<AttestedAbManifest> {
   const { manifest, controlPlane } = input;
   const base = await controlPlane.getBranch(manifest.projectId, manifest.baseBranchId);
   if (base.id !== manifest.baseBranchId || base.name !== BASE_NAME || base.primary) {
@@ -129,7 +165,87 @@ export async function attestAbTargets(input: { manifest: AbManifest; controlPlan
       throw new Error(`Neon control-plane side ${target.sideId} endpoint host does not match DATABASE_URL`);
     }
   }
-  return manifest;
+  // The only place the brand is applied: every identity above was checked.
+  return manifest as AttestedAbManifest;
+}
+
+/** Neon's `OperationStatus` enum. Anything else is treated as unrecognized. */
+const OPERATION_STATUSES = ['scheduling', 'running', 'finished', 'failed', 'error', 'cancelling', 'cancelled', 'skipped'] as const;
+type OperationStatus = (typeof OPERATION_STATUSES)[number];
+/** States that may still become `finished`; every other state is terminal. */
+const PENDING_STATUSES: ReadonlySet<OperationStatus> = new Set<OperationStatus>(['scheduling', 'running', 'cancelling']);
+
+function isOperationStatus(value: unknown): value is OperationStatus {
+  return typeof value === 'string' && (OPERATION_STATUSES as readonly string[]).includes(value);
+}
+
+/** Reads JSON without letting a parse failure put body text into the error. */
+async function readJson(response: Response, context: string): Promise<unknown> {
+  try {
+    return await response.json();
+  } catch {
+    throw new Error(`Neon control-plane ${context} response was not valid JSON`);
+  }
+}
+
+/**
+ * Restore replies with `BranchOperations`; the operation ids are the only thing
+ * taken from the body, and they are never echoed anywhere.
+ */
+function readOperationIds(body: unknown): string[] {
+  const root = asRecord(body, 'Neon control-plane restore response is not an object');
+  const operations = root.operations;
+  if (!Array.isArray(operations) || operations.length === 0) {
+    throw new Error('Neon control-plane restore response did not report any operations');
+  }
+  return operations.map((value) => {
+    const operation = asRecord(value, 'Neon control-plane restore response operation is not an object');
+    if (typeof operation.id !== 'string' || operation.id.length === 0) {
+      throw new Error('Neon control-plane restore response operation is missing id');
+    }
+    return operation.id;
+  });
+}
+
+const delay = (ms: number): Promise<void> => new Promise((resolve) => { setTimeout(resolve, ms); });
+
+async function readOperationStatus(input: {
+  projectId: string; operationId: string; apiKey: string; send: typeof fetch;
+}): Promise<OperationStatus> {
+  const response = await input.send(
+    `${NEON_API_ORIGIN}/projects/${encodeURIComponent(input.projectId)}/operations/${encodeURIComponent(input.operationId)}`,
+    { method: 'GET', headers: { Authorization: `Bearer ${input.apiKey}`, Accept: 'application/json' }, redirect: 'error' },
+  );
+  if (!response.ok) throw new Error(`Neon control-plane operation poll failed with status ${response.status}`);
+  const root = asRecord(await readJson(response, 'operation'), 'Neon control-plane operation response is not an object');
+  const operation = 'operation' in root ? asRecord(root.operation, 'Neon control-plane operation response wrapper is invalid') : root;
+  // Only the enumerated state is reported; an unrecognized value is not echoed.
+  if (!isOperationStatus(operation.status)) throw new Error('Neon control-plane operation response has an unrecognized status');
+  return operation.status;
+}
+
+/**
+ * Restore is asynchronous: Neon interrupts existing connections and the branch
+ * is only overwritten when the operation finishes. Resolving on the 2xx alone
+ * would let a caller connect mid-restore, or read the previous run's rows, and
+ * would report success for an operation that later fails.
+ */
+async function awaitOperations(input: {
+  projectId: string; operationIds: readonly string[]; apiKey: string; send: typeof fetch;
+  pollIntervalMs: number; pollTimeoutMs: number;
+}): Promise<void> {
+  const deadline = Date.now() + input.pollTimeoutMs;
+  for (const operationId of input.operationIds) {
+    for (;;) {
+      const status = await readOperationStatus({ projectId: input.projectId, operationId, apiKey: input.apiKey, send: input.send });
+      if (status === 'finished') break;
+      if (!PENDING_STATUSES.has(status)) throw new Error(`Neon control-plane reset operation ended with status ${status}`);
+      if (Date.now() >= deadline) {
+        throw new Error(`Neon control-plane reset did not finish within ${input.pollTimeoutMs}ms`);
+      }
+      await delay(input.pollIntervalMs);
+    }
+  }
 }
 
 /**
@@ -140,9 +256,16 @@ export async function attestAbTargets(input: { manifest: AbManifest; controlPlan
  * `POST /projects/{project_id}/branches/{branch_id}/restore`
  * (`restoreProjectBranch`), which restores to the head of `source_branch_id`
  * when no LSN or timestamp is given.
+ *
+ * The manifest must be an `AttestedAbManifest`: the branch is proven to be a
+ * designated A/B branch by construction, not by call order. It resolves only
+ * after every reported operation reaches `finished`, so nothing connects to a
+ * branch that is still being overwritten. Poll interval and timeout are
+ * injectable so tests do not sleep.
  */
 export async function resetAbBranch(input: {
-  manifest: AbManifest; branchId: string; apiKey: string; fetchImpl?: typeof fetch;
+  manifest: AttestedAbManifest; branchId: string; apiKey: string; fetchImpl?: typeof fetch;
+  pollIntervalMs?: number; pollTimeoutMs?: number;
 }): Promise<void> {
   const { manifest, branchId, apiKey } = input;
   if (!manifest.targets.some((target) => target.branchId === branchId)) {
@@ -160,4 +283,13 @@ export async function resetAbBranch(input: {
   );
   // The body may echo credentials; only the status is safe to report.
   if (!response.ok) throw new Error(`Neon control-plane reset failed with status ${response.status}`);
+  const operationIds = readOperationIds(await readJson(response, 'restore'));
+  await awaitOperations({
+    projectId: manifest.projectId,
+    operationIds,
+    apiKey,
+    send,
+    pollIntervalMs: input.pollIntervalMs ?? DEFAULT_POLL_INTERVAL_MS,
+    pollTimeoutMs: input.pollTimeoutMs ?? DEFAULT_POLL_TIMEOUT_MS,
+  });
 }

--- a/services/api/src/cli/discovery-ab.plan.ts
+++ b/services/api/src/cli/discovery-ab.plan.ts
@@ -1,0 +1,43 @@
+/**
+ * Turns a selection and two configurations into slots.
+ *
+ * Selection is shared: two sides that ran different cases or different
+ * repetition counts are not comparable, so it is one input, not two.
+ */
+import { assertAbEnvConfig, type AbEnvConfig } from './discovery-ab.flags';
+import type { HistoricalMatrixFixture } from './discovery-env-matrix.shared';
+
+export type AbSideId = 'a' | 'b';
+export interface AbSide { id: AbSideId; config: AbEnvConfig }
+export interface AbSlot { matrixCase: HistoricalMatrixFixture; side: AbSide; repetition: number }
+
+/** Keys where the two sides disagree. Agreed keys explain no difference and are omitted. */
+export function configDiff(a: AbEnvConfig, b: AbEnvConfig): Array<{ key: string; a: string | null; b: string | null }> {
+  return [...new Set([...Object.keys(a), ...Object.keys(b)])]
+    .sort()
+    .filter((key) => a[key] !== b[key])
+    .map((key) => ({ key, a: a[key] ?? null, b: b[key] ?? null }));
+}
+
+export function buildAbPlan(
+  cases: readonly HistoricalMatrixFixture[],
+  sides: readonly [AbSide, AbSide],
+  repetitions: number,
+): AbSlot[] {
+  if (cases.length === 0) throw new Error('A discovery A/B run requires at least one case');
+  if (!Number.isInteger(repetitions) || repetitions < 1) {
+    throw new Error(`A discovery A/B run requires a positive repetition count (received ${repetitions})`);
+  }
+  for (const side of sides) assertAbEnvConfig(side.config);
+  const differences = configDiff(sides[0].config, sides[1].config);
+  if (differences.length === 0) {
+    throw new Error('Both sides have identical configurations; the run would measure noise, not a difference');
+  }
+  const slots: AbSlot[] = [];
+  for (const matrixCase of cases) {
+    for (let repetition = 0; repetition < repetitions; repetition += 1) {
+      for (const side of sides) slots.push({ matrixCase, side, repetition });
+    }
+  }
+  return slots;
+}

--- a/services/api/src/cli/discovery-ab.plan.ts
+++ b/services/api/src/cli/discovery-ab.plan.ts
@@ -11,7 +11,12 @@ export type AbSideId = 'a' | 'b';
 export interface AbSide { id: AbSideId; config: AbEnvConfig }
 export interface AbSlot { matrixCase: HistoricalMatrixFixture; side: AbSide; repetition: number }
 
-/** Keys where the two sides disagree. Agreed keys explain no difference and are omitted. */
+/**
+ * Keys where the two sides disagree. Agreed keys explain no difference and are
+ * omitted. A `null` means the key is absent on that side; `buildAbPlan` refuses
+ * plans that would produce one, so every row of a planned run's diff compares a
+ * real value against a real value.
+ */
 export function configDiff(a: AbEnvConfig, b: AbEnvConfig): Array<{ key: string; a: string | null; b: string | null }> {
   return [...new Set([...Object.keys(a), ...Object.keys(b)])]
     .sort()
@@ -19,16 +24,74 @@ export function configDiff(a: AbEnvConfig, b: AbEnvConfig): Array<{ key: string;
     .map((key) => ({ key, a: a[key] ?? null, b: b[key] ?? null }));
 }
 
+/**
+ * Two sides must be two sides: one `a`, one `b`, in that order.
+ *
+ * Side ids arrive from externally supplied JSON, not only from local callers.
+ * Two sides sharing an id collapse into a single row downstream (the runner
+ * keys rows by `slot.side.id` and the report aggregates by it), so the artifact
+ * would claim a comparison that was never made. A reversed pair is just as
+ * dishonest in the quieter way: `configDiff` is called as (sides[0], sides[1]),
+ * so side b's values would be filed under the artifact's `a` column.
+ */
+function assertOrderedDistinctSides(sides: readonly [AbSide, AbSide]): void {
+  if (sides[0].id !== 'a' || sides[1].id !== 'b') {
+    throw new Error(
+      `A discovery A/B run requires side 'a' first and side 'b' second `
+      + `(received '${sides[0].id}' then '${sides[1].id}'); two sides sharing an id collapse into one row `
+      + `downstream, and a reversed pair reports side b's values under the artifact's a column`,
+    );
+  }
+}
+
+/**
+ * Both sides must declare the same key set, so every diff row compares a real
+ * value against a real value.
+ *
+ * A key set on one side only reads as `null` on the other, and `null` means
+ * "unset" — which means the graph applies its *own* default, a default that can
+ * equal the other side's explicit value. `{}` against
+ * `{ DISCOVERY_ALLOWED_TYPES: 'intent,profile' }` is the worst case: the default
+ * *is* `intent,profile` (packages/protocol/src/opportunity/discovery.env.ts:46),
+ * so both sides behave identically, yet the run is accepted and whatever noise
+ * it measures is attributed to that flag. That is exactly what the
+ * identical-configuration guard exists to prevent, arriving through the side
+ * door.
+ *
+ * Requiring symmetry removes the ambiguity at its root rather than guessing
+ * defaults here — a copy of nine defaults is the same fiction one level up.
+ * It is workable because every flag's unset behaviour is reachable by a value
+ * an operator can type (defaults verified at their read sites: ALLOWED_TYPES
+ * `intent,profile`, PROFILE_SOURCE `premise`, CONTEXT_TO_INTENT any non-`0`,
+ * REJECTION_COOLDOWN_DAYS `7`, SOURCE_PREMISE_LIMIT `40`,
+ * INCLUDE_OTHER_INTENTS `true`, MAX_TURNS_CHAT `4`, MAX_TURNS_AMBIENT `6`,
+ * RUN_OPPORTUNITY_EVAL_IN_PARALLEL `false`).
+ */
+function assertSymmetricKeySets(sides: readonly [AbSide, AbSide]): void {
+  for (const [side, other] of [[sides[0], sides[1]], [sides[1], sides[0]]] as const) {
+    for (const key of Object.keys(side.config).sort()) {
+      if (Object.prototype.hasOwnProperty.call(other.config, key)) continue;
+      throw new Error(
+        `${key} is set on side ${side.id} but omitted on side ${other.id}; an omitted flag takes the `
+        + `graph's own default, which may equal side ${side.id}'s value and make the run measure nothing. `
+        + `State ${key} explicitly on both sides so the comparison is explicit versus explicit`,
+      );
+    }
+  }
+}
+
 export function buildAbPlan(
   cases: readonly HistoricalMatrixFixture[],
   sides: readonly [AbSide, AbSide],
   repetitions: number,
 ): AbSlot[] {
+  assertOrderedDistinctSides(sides);
   if (cases.length === 0) throw new Error('A discovery A/B run requires at least one case');
   if (!Number.isInteger(repetitions) || repetitions < 1) {
     throw new Error(`A discovery A/B run requires a positive repetition count (received ${repetitions})`);
   }
   for (const side of sides) assertAbEnvConfig(side.config);
+  assertSymmetricKeySets(sides);
   const differences = configDiff(sides[0].config, sides[1].config);
   if (differences.length === 0) {
     throw new Error('Both sides have identical configurations; the run would measure noise, not a difference');

--- a/services/api/src/cli/discovery-ab.ts
+++ b/services/api/src/cli/discovery-ab.ts
@@ -19,8 +19,8 @@
  * read what the command requires *before* they have any of it.
  */
 import { AB_BRANCH_NAMES, attestAbTargets, parseAbManifest, type AbManifest } from './discovery-ab.neon';
-import { AB_SIDE_BRANCH_ENV, AbGateError, assertAbConfirmation } from './discovery-ab.gate';
-import { abUsage, describeAbFailure } from './discovery-ab.contract';
+import { AB_SIDE_BRANCH_ENV, assertAbConfirmation } from './discovery-ab.gate';
+import { abAttestationRefusal, abUsage, describeAbFailure, type AbInvocationRole } from './discovery-ab.contract';
 import { createNeonControlPlane } from './discovery-env-matrix.neon';
 
 import type { AbSideId } from './discovery-ab.plan';
@@ -29,23 +29,28 @@ import type { AbSideId } from './discovery-ab.plan';
  * Attests both targets, reporting a refusal an operator can act on without
  * echoing anything the control plane said.
  *
- * The underlying errors are already authored to carry only status codes and
- * field names, but they reach this boundary through `response.json()`, whose
- * own parse failures can quote response text. So the refusal is a fixed string:
- * it names what was refused (attestation) and what would satisfy it, and keeps
- * the original as `cause` for anyone holding the error rather than printing it.
+ * The refusal itself is authored in `discovery-ab.contract.ts`, per role: the
+ * same attestation runs in the parent and in every child, and a child is
+ * attesting *after* the parent already reset both branches and spawned it, so
+ * the two cannot truthfully say the same thing about cost.
  */
-async function attestOrRefuse(manifest: AbManifest): Promise<void> {
+async function attestOrRefuse(manifest: AbManifest, role: AbInvocationRole): Promise<void> {
   try {
     await attestAbTargets({ manifest, controlPlane: createNeonControlPlane(process.env.NEON_API_KEY ?? '') });
   } catch (error) {
-    throw new AbGateError(
-      `Refusing to run: DISCOVERY_AB_TARGETS was not attested as the two designated A/B branches `
-      + `(${AB_BRANCH_NAMES.a}, ${AB_BRANCH_NAMES.b}) parented on eval-discovery-base. `
-      + 'Nothing was reset and nothing was spawned.',
-      { cause: error },
-    );
+    throw abAttestationRefusal(role, { cause: error });
   }
+}
+
+/**
+ * Parent or child, decided by the presence of `--side` alone.
+ *
+ * Deliberately not `childSideId`: a malformed `--side` value still names a
+ * child invocation, and reporting one as a parent would print a run-level cost
+ * claim from a process that has no idea what the run cost.
+ */
+function abInvocationRole(args: readonly string[]): AbInvocationRole {
+  return args.includes('--side') ? 'child' : 'parent';
 }
 
 /** The side this process runs, or undefined for the parent invocation. */
@@ -67,7 +72,7 @@ async function main(): Promise<void> {
   // reach the control plane, let alone a database.
   assertAbConfirmation(process.env);
   const manifest = parseAbManifest(process.env.DISCOVERY_AB_TARGETS);
-  await attestOrRefuse(manifest);
+  await attestOrRefuse(manifest, abInvocationRole(args));
   const sideId = childSideId(args);
   if (sideId !== undefined) {
     const target = manifest.targets.find((candidate) => candidate.sideId === sideId);
@@ -86,8 +91,10 @@ if (import.meta.main) {
     // message is safe to print (gate refusals name environment variables;
     // spend reports name stages; everything else is generic, because provider,
     // database and control-plane errors can carry credentials and response
-    // bodies) and which exit code an operator should act on.
-    const report = describeAbFailure(error);
+    // bodies) and which exit code an operator should act on. The role is passed
+    // because a child that failed after running the graph has already spent the
+    // run, and must not print the parent's "nothing was spent" line.
+    const report = describeAbFailure(error, abInvocationRole(process.argv.slice(2)));
     console.error(report.message);
     process.exitCode = report.exitCode;
   });

--- a/services/api/src/cli/discovery-ab.ts
+++ b/services/api/src/cli/discovery-ab.ts
@@ -1,0 +1,86 @@
+#!/usr/bin/env bun
+/**
+ * Dependency-free attesting bootstrap for the discovery A/B harness.
+ *
+ * The property this file exists to preserve is an ordering one: the gate is
+ * checked and both Neon targets are attested *before* anything that could
+ * compose a database singleton is imported. `discovery-ab.main.ts` reaches
+ * `@indexnetwork/protocol` through its very first import, so importing it
+ * eagerly here would load the graph before the branches were proven. Every
+ * import above is either `node:`-free control-plane code or the pure gate.
+ *
+ * Mirrors `discovery-env-matrix.ts`, with one difference: the A/B manifest
+ * carries the same fields for parent and child, so there is no separate
+ * attested projection to hand down — the child re-parses `DISCOVERY_AB_TARGETS`
+ * and checks its own `DATABASE_URL` against it.
+ */
+import { AB_BRANCH_NAMES, attestAbTargets, parseAbManifest, type AbManifest } from './discovery-ab.neon';
+import { AB_SIDE_BRANCH_ENV, AbGateError, assertAbConfirmation } from './discovery-ab.gate';
+import { createNeonControlPlane } from './discovery-env-matrix.neon';
+
+import type { AbSideId } from './discovery-ab.plan';
+
+/**
+ * Attests both targets, reporting a refusal an operator can act on without
+ * echoing anything the control plane said.
+ *
+ * The underlying errors are already authored to carry only status codes and
+ * field names, but they reach this boundary through `response.json()`, whose
+ * own parse failures can quote response text. So the refusal is a fixed string:
+ * it names what was refused (attestation) and what would satisfy it, and keeps
+ * the original as `cause` for anyone holding the error rather than printing it.
+ */
+async function attestOrRefuse(manifest: AbManifest): Promise<void> {
+  try {
+    await attestAbTargets({ manifest, controlPlane: createNeonControlPlane(process.env.NEON_API_KEY ?? '') });
+  } catch (error) {
+    throw new AbGateError(
+      `Refusing to run: DISCOVERY_AB_TARGETS was not attested as the two designated A/B branches `
+      + `(${AB_BRANCH_NAMES.a}, ${AB_BRANCH_NAMES.b}) parented on eval-discovery-base. `
+      + 'Nothing was reset and nothing was spawned.',
+      { cause: error },
+    );
+  }
+}
+
+/** The side this process runs, or undefined for the parent invocation. */
+function childSideId(args: readonly string[]): AbSideId | undefined {
+  const index = args.indexOf('--side');
+  if (index === -1) return undefined;
+  const side = args[index + 1];
+  // Anything malformed is left to `parseAbChildArgs`, which owns that contract
+  // and refuses it by name; this only decides whether a child is being asked for.
+  return side === 'a' || side === 'b' ? side : undefined;
+}
+
+async function main(): Promise<void> {
+  const args = process.argv.slice(2);
+  if (args.includes('--help') || args.includes('-h')) {
+    return void console.log('Discovery A/B eval\n\nRequires DISCOVERY_AB_CONFIRM=1, TEST_DATABASE_SAFE=1, NEON_API_KEY and an attested DISCOVERY_AB_TARGETS manifest.\nRun it with --help through the command itself for the full contract.');
+  }
+  // First, and before any network call: an unconfirmed run must not even
+  // reach the control plane, let alone a database.
+  assertAbConfirmation(process.env);
+  const manifest = parseAbManifest(process.env.DISCOVERY_AB_TARGETS);
+  await attestOrRefuse(manifest);
+  const sideId = childSideId(args);
+  if (sideId !== undefined) {
+    const target = manifest.targets.find((candidate) => candidate.sideId === sideId);
+    if (!target) throw new Error(`Discovery A/B manifest does not name side ${sideId}`);
+    // The branch label is derived from the attested manifest, never from
+    // operator-supplied text, so the child's gate checks an attested fact.
+    process.env.DATABASE_URL = target.databaseUrl;
+    process.env[AB_SIDE_BRANCH_ENV] = AB_BRANCH_NAMES[sideId];
+  }
+  await (await import('./discovery-ab.main')).main(args);
+}
+
+if (import.meta.main) {
+  main().catch((error: unknown) => {
+    // Gate refusals are authored to be read and name only environment variable
+    // names. Everything else is reported generically: provider, database and
+    // control-plane errors can carry credentials and response bodies.
+    console.error(error instanceof AbGateError ? error.message : 'Discovery A/B command failed');
+    process.exitCode = 2;
+  });
+}

--- a/services/api/src/cli/discovery-ab.ts
+++ b/services/api/src/cli/discovery-ab.ts
@@ -13,9 +13,14 @@
  * carries the same fields for parent and child, so there is no separate
  * attested projection to hand down — the child re-parses `DISCOVERY_AB_TARGETS`
  * and checks its own `DATABASE_URL` against it.
+ *
+ * `--help` is answered above all of it, from `discovery-ab.contract.ts`, which
+ * imports nothing that can compose a database: an operator has to be able to
+ * read what the command requires *before* they have any of it.
  */
 import { AB_BRANCH_NAMES, attestAbTargets, parseAbManifest, type AbManifest } from './discovery-ab.neon';
 import { AB_SIDE_BRANCH_ENV, AbGateError, assertAbConfirmation } from './discovery-ab.gate';
+import { abUsage, describeAbFailure } from './discovery-ab.contract';
 import { createNeonControlPlane } from './discovery-env-matrix.neon';
 
 import type { AbSideId } from './discovery-ab.plan';
@@ -55,9 +60,9 @@ function childSideId(args: readonly string[]): AbSideId | undefined {
 
 async function main(): Promise<void> {
   const args = process.argv.slice(2);
-  if (args.includes('--help') || args.includes('-h')) {
-    return void console.log('Discovery A/B eval\n\nRequires DISCOVERY_AB_CONFIRM=1, TEST_DATABASE_SAFE=1, NEON_API_KEY and an attested DISCOVERY_AB_TARGETS manifest.\nRun it with --help through the command itself for the full contract.');
-  }
+  // Before the gate, and before any environment variable is read: the full
+  // contract, printed to anyone who asks for it.
+  if (args.includes('--help') || args.includes('-h')) return void console.log(abUsage());
   // First, and before any network call: an unconfirmed run must not even
   // reach the control plane, let alone a database.
   assertAbConfirmation(process.env);
@@ -77,10 +82,13 @@ async function main(): Promise<void> {
 
 if (import.meta.main) {
   main().catch((error: unknown) => {
-    // Gate refusals are authored to be read and name only environment variable
-    // names. Everything else is reported generically: provider, database and
-    // control-plane errors can carry credentials and response bodies.
-    console.error(error instanceof AbGateError ? error.message : 'Discovery A/B command failed');
-    process.exitCode = 2;
+    // `describeAbFailure` decides both halves of the report: which authored
+    // message is safe to print (gate refusals name environment variables;
+    // spend reports name stages; everything else is generic, because provider,
+    // database and control-plane errors can carry credentials and response
+    // bodies) and which exit code an operator should act on.
+    const report = describeAbFailure(error);
+    console.error(report.message);
+    process.exitCode = report.exitCode;
   });
 }

--- a/services/api/src/cli/discovery-env-matrix.main.ts
+++ b/services/api/src/cli/discovery-env-matrix.main.ts
@@ -22,7 +22,7 @@ const BASELINE_PATH = path.resolve(import.meta.dir, '../../eval/discovery-env-ma
 const HARNESS = 'discovery-env-matrix';
 // Candidate policy now scores final evaluator outcomes, with raw retrieval retained separately.
 const HARNESS_VERSION = '2';
-const ATTEMPT_TIMEOUT_MS = 180_000;
+export const ATTEMPT_TIMEOUT_MS = 180_000;
 // A child owns five sequential slots. Each may exhaust three 180s attempts plus
 // 1s/2s retry backoff (45m15s total), so leave bounded startup/cleanup headroom.
 export const DEFAULT_CHILD_TIMEOUT_MS = 50 * 60_000;
@@ -412,7 +412,7 @@ const protocolSourcePath = (relativePath: string): string => path.resolve(import
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 const loadModule = (modulePath: string): Promise<any> => import(modulePath);
 
-async function loadMatrixEval() {
+export async function loadMatrixEval() {
   const [cases, policy, reporter, shared] = await Promise.all([
     loadModule(protocolEvalPath('discovery-env-matrix/historical-matrix.cases.js')),
     loadModule(protocolEvalPath('discovery-env-matrix/historical-matrix.policy.js')),
@@ -422,7 +422,7 @@ async function loadMatrixEval() {
   return { ...cases, ...policy, ...reporter, ...shared };
 }
 
-async function loadJudge(): Promise<(output: unknown, criteria: string) => Promise<void>> {
+export async function loadJudge(): Promise<(output: unknown, criteria: string) => Promise<void>> {
   return (await loadModule(protocolSourcePath('shared/agent/tests/llm-assert.js'))).assertLLM;
 }
 
@@ -487,7 +487,7 @@ Canary (never baselineable):
 }
 
 /** Rewrites audit fixture participant IDs to the deterministic IDs seeded in the protected base. */
-function databaseCase(matrixCase: HistoricalMatrixFixture): DatabaseCase {
+export function databaseCase(matrixCase: HistoricalMatrixFixture): DatabaseCase {
   const seeded = baseSeedPayload([matrixCase]);
   const idsByProfile = new Map(seeded.users.map((user) => [user.intro, user.id]));
   const mapId = (id: string): string => {
@@ -702,7 +702,7 @@ export function collectEvaluatorTraces(
   });
 }
 
-async function createChildDependencies() {
+export async function createChildDependencies() {
   const [adapterModule, embedderModule, cacheModule] = await Promise.all([
     import('../adapters/database.adapter'),
     import('../adapters/embedder.adapter'),
@@ -719,7 +719,7 @@ async function createChildDependencies() {
 }
 
 /** Closes process-global clients created by the child composition, even after partial initialization. */
-async function closeChildResources(): Promise<void> {
+export async function closeChildResources(): Promise<void> {
   const [drizzleModule, cacheModule] = await Promise.all([
     import('../lib/drizzle/drizzle'),
     import('../adapters/cache.adapter'),
@@ -729,7 +729,7 @@ async function closeChildResources(): Promise<void> {
   if (failure) throw failure.reason;
 }
 
-async function composeCaseRuntime(
+export async function composeCaseRuntime(
   deps: Awaited<ReturnType<typeof createChildDependencies>>,
   matrixCase: DatabaseCase,
   network: { id: string; title: string; prompt: string },

--- a/services/api/src/cli/discovery-env-matrix.neon.ts
+++ b/services/api/src/cli/discovery-env-matrix.neon.ts
@@ -73,8 +73,12 @@ function assertLocalTarget(url: URL): void {
   if (!url.hostname.endsWith('.neon.tech')) throw new Error('Discovery environment matrix target must use a Neon host');
 }
 
-/** Accept precisely Neon's canonical endpoint host or its one pooled counterpart. */
-function isEndpointHost(urlHost: string, endpointHost: string): boolean {
+/**
+ * Accept precisely Neon's canonical endpoint host or its one pooled counterpart.
+ * Exported so `discovery-ab.neon.ts` attests hosts by the same rule rather than
+ * keeping a second, looser copy of it.
+ */
+export function isEndpointHost(urlHost: string, endpointHost: string): boolean {
   const firstDot = endpointHost.indexOf('.');
   if (firstDot <= 0) return false;
   const pooledHost = `${endpointHost.slice(0, firstDot)}-pooler${endpointHost.slice(firstDot)}`;

--- a/services/api/src/cli/discovery-env-matrix.runtime.ts
+++ b/services/api/src/cli/discovery-env-matrix.runtime.ts
@@ -1,3 +1,4 @@
+import { assertAbEnvConfig, type AbEnvConfig } from './discovery-ab.flags';
 import type { HistoricalMatrixFixture } from './discovery-env-matrix.shared';
 
 export const MATRIX_REPETITIONS = 3;
@@ -63,20 +64,36 @@ export function buildCanaryPlan<TCase, TRow extends MatrixRowEnvironment>(
   return rows.map((row) => ({ matrixCase, row, repetition: 0, childKey: matrixChildKey(row.id, 0) }));
 }
 
-/** Restores both graph gates even when provider execution throws or times out. */
-export async function withMatrixEnvironment<T>(row: MatrixRowEnvironment, run: () => Promise<T>): Promise<T> {
-  const previousAllowedTypes = process.env.DISCOVERY_ALLOWED_TYPES;
-  const previousProfileSource = process.env.DISCOVERY_PROFILE_SOURCE;
-  process.env.DISCOVERY_ALLOWED_TYPES = row.allowedTypes;
-  process.env.DISCOVERY_PROFILE_SOURCE = row.profileSource;
+/**
+ * Applies an environment configuration for exactly one run and restores the
+ * previous state, including deleting keys that were previously unset. Values
+ * are applied to `process.env` because the graph reads them there at call
+ * time; the child process running this is single-purpose, so no other work is
+ * observing these keys.
+ */
+export async function withDiscoveryEnvironment<T>(config: AbEnvConfig, run: () => Promise<T>): Promise<T> {
+  assertAbEnvConfig(config);
+  const previous = new Map<string, string | undefined>();
+  for (const [key, value] of Object.entries(config)) {
+    previous.set(key, process.env[key]);
+    process.env[key] = value;
+  }
   try {
     return await run();
   } finally {
-    if (previousAllowedTypes === undefined) delete process.env.DISCOVERY_ALLOWED_TYPES;
-    else process.env.DISCOVERY_ALLOWED_TYPES = previousAllowedTypes;
-    if (previousProfileSource === undefined) delete process.env.DISCOVERY_PROFILE_SOURCE;
-    else process.env.DISCOVERY_PROFILE_SOURCE = previousProfileSource;
+    for (const [key, value] of previous) {
+      if (value === undefined) delete process.env[key];
+      else process.env[key] = value;
+    }
   }
+}
+
+/** Restores both graph gates even when provider execution throws or times out. */
+export async function withMatrixEnvironment<T>(row: MatrixRowEnvironment, run: () => Promise<T>): Promise<T> {
+  return withDiscoveryEnvironment(
+    { DISCOVERY_ALLOWED_TYPES: row.allowedTypes, DISCOVERY_PROFILE_SOURCE: row.profileSource },
+    run,
+  );
 }
 
 /** Baselines are valid only when every requested matrix slot completed successfully. */

--- a/services/api/src/cli/tests/discovery-ab.artifact.spec.ts
+++ b/services/api/src/cli/tests/discovery-ab.artifact.spec.ts
@@ -28,7 +28,21 @@ const sides: [AbSide, AbSide] = [
 
 const git = { revision: 'abc123', dirty: false };
 const meta = await buildAbArtifactMeta({ sides, cases, repetitions: 3, startedAt: '2026-08-04T00:00:00.000Z', git });
-const { scoreMatrixSlot, buildScorecard, buildEvalArtifact, EVAL_RUN_REPORT_ARTIFACT_TYPE } = await loadMatrixEval();
+const { scoreMatrixSlot, buildScorecard, buildEvalArtifact, EVAL_RUN_REPORT_ARTIFACT_TYPE, resolveEvalJudgeModelId } = await loadMatrixEval();
+const judgeModelId = resolveEvalJudgeModelId() as string;
+
+/** Builds a meta with CHAT_MODEL set to whatever the case under test needs. */
+const metaWithChatModel = async (chatModel: string | undefined): Promise<Record<string, unknown>> => {
+  const previous = process.env.CHAT_MODEL;
+  if (chatModel === undefined) delete process.env.CHAT_MODEL;
+  else process.env.CHAT_MODEL = chatModel;
+  try {
+    return await buildAbArtifactMeta({ sides, cases, repetitions: 3, startedAt: '2026-08-04T00:00:00.000Z', git });
+  } finally {
+    if (previous === undefined) delete process.env.CHAT_MODEL;
+    else process.env.CHAT_MODEL = previous;
+  }
+};
 
 describe('buildAbArtifactMeta', () => {
   it('describes a pair these two sides could actually be planned as', () => {
@@ -92,9 +106,22 @@ describe('buildAbArtifactMeta', () => {
     expect(filtered.selection).toEqual({ fullCorpus: false, filters: { case: 'c1' } });
   });
 
-  it('names distinct models, because the envelope refuses a repeated model ID', () => {
-    const models = meta.models as string[];
-    expect(new Set(models).size).toBe(models.length);
+  /**
+   * The runtime and judge models are configured independently, and an operator
+   * running the judge model as CHAT_MODEL is the case that would otherwise fail
+   * at the write, at the end of a forty-minute paid run. Asserting only that the
+   * list has no duplicates proves nothing here: in a test environment CHAT_MODEL
+   * is unset, so the two entries differ whether or not anything de-duplicates
+   * them. So the collision is set up explicitly.
+   */
+  it('collapses a CHAT_MODEL that equals the judge model, which the envelope would refuse', async () => {
+    const collided = await metaWithChatModel(judgeModelId);
+    expect(collided.models).toEqual([judgeModelId]);
+  });
+
+  it('keeps both models when they differ', async () => {
+    const distinct = await metaWithChatModel('some-other-runtime-model');
+    expect(distinct.models).toEqual(['some-other-runtime-model', judgeModelId]);
   });
 });
 

--- a/services/api/src/cli/tests/discovery-ab.artifact.spec.ts
+++ b/services/api/src/cli/tests/discovery-ab.artifact.spec.ts
@@ -1,0 +1,274 @@
+import { describe, expect, it } from 'bun:test';
+
+import { assertAbConfigProvenance, buildAbArtifactMeta, buildAbSlotScoreInput, formatAbConfigDiff, toGovernedRunMeta } from '../discovery-ab.main';
+import { buildAbPlan, type AbSide } from '../discovery-ab.plan';
+import { buildMatrixArtifactEvidence, loadMatrixEval, type MatrixExecutionEvidence, type MatrixSlotResult } from '../discovery-env-matrix.main';
+
+import type { HistoricalMatrixFixture } from '../discovery-env-matrix.shared';
+
+const cases: HistoricalMatrixFixture[] = [{
+  id: 'c1', description: 'c1', networkContext: 'ctx', sourceUserId: 'u1',
+  expectedUserId: 'u2', excludedUserIds: [],
+  participants: ['u1', 'u2'].map((id) => ({
+    id, profileText: `c1 ${id} profile`, location: 'fixture city', interests: [], skills: [],
+    intent: { text: `c1 ${id} intent` },
+  })),
+}];
+
+/**
+ * Symmetric on purpose. The plan's key-set rule refuses a flag stated on one
+ * side only (an omitted flag takes the graph's own default, which may equal the
+ * other side's value), so an asymmetric pair could never reach an artifact and
+ * a fixture built that way would be testing an unreachable shape.
+ */
+const sides: [AbSide, AbSide] = [
+  { id: 'a', config: { DISCOVERY_ALLOWED_TYPES: 'intent', DISCOVERY_SOURCE_PREMISE_LIMIT: '40' } },
+  { id: 'b', config: { DISCOVERY_ALLOWED_TYPES: 'intent,profile', DISCOVERY_SOURCE_PREMISE_LIMIT: '5' } },
+];
+
+const git = { revision: 'abc123', dirty: false };
+const meta = await buildAbArtifactMeta({ sides, cases, repetitions: 3, startedAt: '2026-08-04T00:00:00.000Z', git });
+const { scoreMatrixSlot, buildScorecard, buildEvalArtifact, EVAL_RUN_REPORT_ARTIFACT_TYPE } = await loadMatrixEval();
+
+describe('buildAbArtifactMeta', () => {
+  it('describes a pair these two sides could actually be planned as', () => {
+    expect(buildAbPlan(cases, sides, 3)).toHaveLength(6);
+  });
+
+  it('names the harness and does not claim a baseline', () => {
+    expect(meta.harness).toBe('discovery-ab');
+    expect(meta).not.toHaveProperty('baselinePath');
+    expect(meta.selection).toMatchObject({ fullCorpus: true, filters: {} });
+  });
+
+  it("records each side's exact configuration", () => {
+    expect(meta.configs).toEqual({
+      a: { DISCOVERY_ALLOWED_TYPES: 'intent', DISCOVERY_SOURCE_PREMISE_LIMIT: '40' },
+      b: { DISCOVERY_ALLOWED_TYPES: 'intent,profile', DISCOVERY_SOURCE_PREMISE_LIMIT: '5' },
+    });
+  });
+
+  it('records the diff, so the artifact says what produced any difference', () => {
+    expect(meta.configDiff).toEqual([
+      { key: 'DISCOVERY_ALLOWED_TYPES', a: 'intent', b: 'intent,profile' },
+      { key: 'DISCOVERY_SOURCE_PREMISE_LIMIT', a: '40', b: '5' },
+    ]);
+  });
+
+  it('fingerprints the corpus and the scoring configuration', () => {
+    expect(meta.corpusFingerprint).toMatch(/^[a-f0-9]{64}$/);
+    expect(meta.configFingerprint).toMatch(/^[a-f0-9]{64}$/);
+  });
+
+  it('gives different configurations different scoring fingerprints', async () => {
+    const other = await buildAbArtifactMeta({
+      sides: [sides[0], { id: 'b', config: { DISCOVERY_ALLOWED_TYPES: 'profile', DISCOVERY_SOURCE_PREMISE_LIMIT: '5' } }],
+      cases, repetitions: 3, startedAt: '2026-08-04T00:00:00.000Z', git,
+    });
+    expect(other.configFingerprint).not.toBe(meta.configFingerprint);
+  });
+
+  it('gives different repetition counts different scoring fingerprints', async () => {
+    const other = await buildAbArtifactMeta({ sides, cases, repetitions: 1, startedAt: '2026-08-04T00:00:00.000Z', git });
+    expect(other.configFingerprint).not.toBe(meta.configFingerprint);
+  });
+
+  it('gives the same comparison the same fingerprints, whatever order the flags were typed in', async () => {
+    const reordered = await buildAbArtifactMeta({
+      sides: [
+        { id: 'a', config: { DISCOVERY_SOURCE_PREMISE_LIMIT: '40', DISCOVERY_ALLOWED_TYPES: 'intent' } },
+        { id: 'b', config: { DISCOVERY_SOURCE_PREMISE_LIMIT: '5', DISCOVERY_ALLOWED_TYPES: 'intent,profile' } },
+      ],
+      cases, repetitions: 3, startedAt: '2026-08-04T00:00:00.000Z', git,
+    });
+    expect(reordered.configFingerprint).toBe(meta.configFingerprint);
+    expect(reordered.corpusFingerprint).toBe(meta.corpusFingerprint);
+  });
+
+  it('reports a filtered run as a filtered run rather than as the full corpus', async () => {
+    const filtered = await buildAbArtifactMeta({
+      sides, cases, repetitions: 1, startedAt: '2026-08-04T00:00:00.000Z', git, filters: { case: 'c1' },
+    });
+    expect(filtered.selection).toEqual({ fullCorpus: false, filters: { case: 'c1' } });
+  });
+
+  it('names distinct models, because the envelope refuses a repeated model ID', () => {
+    const models = meta.models as string[];
+    expect(new Set(models).size).toBe(models.length);
+  });
+});
+
+describe('toGovernedRunMeta', () => {
+  const execution: MatrixExecutionEvidence = { policy: 'strict', runs: [] };
+  const governed = toGovernedRunMeta(meta, { completedAt: '2026-08-04T00:10:00.000Z', execution });
+
+  it('carries every field the governed envelope requires', () => {
+    expect(governed).toMatchObject({
+      harness: 'discovery-ab',
+      runs: 1,
+      corpusFingerprint: meta.corpusFingerprint,
+      configFingerprint: meta.configFingerprint,
+      startedAt: '2026-08-04T00:00:00.000Z',
+      completedAt: '2026-08-04T00:10:00.000Z',
+    });
+    expect(governed.execution).toBe(execution);
+  });
+
+  it('drops configs and configDiff, because the envelope and payload schemas are strict', () => {
+    // Asserted rather than assumed: the meta really does carry them, and the
+    // projection really is what removes them. Per-case configDeltas is where
+    // the same information reaches disk.
+    expect(meta.configs).toBeDefined();
+    expect(meta.configDiff).toBeDefined();
+    expect(Object.keys(governed)).not.toContain('configs');
+    expect(Object.keys(governed)).not.toContain('configDiff');
+  });
+
+  it('refuses a meta missing a field the envelope requires, rather than writing an invalid artifact', () => {
+    const { corpusFingerprint: _dropped, ...incomplete } = meta;
+    expect(() => toGovernedRunMeta(incomplete, { completedAt: '2026-08-04T00:10:00.000Z', execution }))
+      .toThrow(/corpusFingerprint/);
+  });
+});
+
+describe('formatAbConfigDiff', () => {
+  it('prints the difference for the operator, since the artifact keeps it per case', () => {
+    const printed = formatAbConfigDiff(meta);
+    expect(printed).toContain('DISCOVERY_ALLOWED_TYPES: a=intent  b=intent,profile');
+    expect(printed).toContain('DISCOVERY_SOURCE_PREMISE_LIMIT: a=40  b=5');
+  });
+
+  it('says so plainly when there is no recorded difference', () => {
+    expect(formatAbConfigDiff({ configDiff: [] })).toMatch(/no recorded difference/);
+  });
+});
+
+describe('assertAbConfigProvenance', () => {
+  const slot = (side: AbSide) => ({ matrixCase: cases[0]!, side, repetition: 0 });
+
+  /** Scores one A/B slot exactly the way the child does, judge aside. */
+  const score = async (side: AbSide, completed: boolean): Promise<MatrixSlotResult> => {
+    const { caseId, ...scoreInput } = buildAbSlotScoreInput(slot(side), { candidates: [], completed });
+    return { ...(await scoreMatrixSlot(scoreInput)), caseId } as MatrixSlotResult;
+  };
+
+  it('accepts slots scored through the real policy on the completed path', async () => {
+    const slots = [await score(sides[0], true), await score(sides[1], true)];
+    expect(() => assertAbConfigProvenance(slots, sides)).not.toThrow();
+    expect(slots[0]!.configDeltas).toEqual([
+      { key: 'DISCOVERY_ALLOWED_TYPES', before: null, after: 'intent' },
+      { key: 'DISCOVERY_SOURCE_PREMISE_LIMIT', before: null, after: '40' },
+    ]);
+  });
+
+  it('accepts the failed-slot fallback, which is where a configuration is easiest to lose', async () => {
+    const failed = await score(sides[1], false);
+    const evidence: MatrixExecutionEvidence = {
+      policy: 'strict',
+      runs: [{ runId: 'r', caseId: failed.caseId, runIndex: 0, outcome: 'failed', recovered: false, attempts: [] }],
+    };
+    const artifact = buildMatrixArtifactEvidence([failed], evidence);
+    expect(artifact.slots[0]!.runs).toBe(0);
+    expect(() => assertAbConfigProvenance(artifact.slots, sides)).not.toThrow();
+    expect(artifact.slots[0]!.configDeltas).toEqual([
+      { key: 'DISCOVERY_ALLOWED_TYPES', before: null, after: 'intent,profile' },
+      { key: 'DISCOVERY_SOURCE_PREMISE_LIMIT', before: null, after: '5' },
+    ]);
+  });
+
+  it('refuses a slot whose configuration went missing, which would hide what was compared', async () => {
+    const stripped = { ...(await score(sides[0], true)), configDeltas: [] };
+    expect(() => assertAbConfigProvenance([stripped], sides)).toThrow(/does not record side a's configuration/);
+  });
+
+  it('refuses a slot recording the other side\'s configuration', async () => {
+    const mislabelled = { ...(await score(sides[1], true)), rowId: 'a' };
+    expect(() => assertAbConfigProvenance([mislabelled as MatrixSlotResult], sides)).toThrow(/does not record side a's configuration/);
+  });
+
+  it('refuses a slot from a side this run did not compare', async () => {
+    const foreign = { ...(await score(sides[0], true)), rowId: 'intent-only' };
+    expect(() => assertAbConfigProvenance([foreign as MatrixSlotResult], sides)).toThrow(/did not compare/);
+  });
+});
+
+/**
+ * The write path itself, without a database: real scored slots, real execution
+ * evidence and the real envelope builder the parent writes through. It is the
+ * only thing that proves `toGovernedRunMeta` produces something the strict
+ * schema accepts — a projection that typechecks but cannot be written would
+ * fail for the first time at the end of a forty-minute live run.
+ */
+describe('the artifact the parent writes', () => {
+  const slot = (side: AbSide) => ({ matrixCase: cases[0]!, side, repetition: 0 });
+  // The envelope requires every attempt to fall inside the run window, so the
+  // window is anchored to now rather than to a fixed date.
+  const runStartedAt = new Date(Date.now() - 120_000).toISOString();
+  const runCompletedAt = new Date(Date.now() - 1_000).toISOString();
+  const attemptAt = (outcome: 'success' | 'failure') => ({
+    attemptId: 'placeholder::attempt:1', runId: 'placeholder', runIndex: 0, attemptNumber: 1,
+    startedAt: new Date(Date.now() - 110_000).toISOString(),
+    completedAt: new Date(Date.now() - 58_000).toISOString(),
+    durationMs: 52_000,
+    outcome, retryable: false, backoffMs: 0,
+    ...(outcome === 'success' ? {} : { error: { class: 'MatrixExecutionError', message: 'matrix_graph_failure' } }),
+  });
+
+  /** One side's child output, built exactly as the child builds it. */
+  const sideOutput = async (side: AbSide, completed: boolean) => {
+    const { caseId, ...scoreInput } = buildAbSlotScoreInput(slot(side), { candidates: [], completed });
+    const scored = { ...(await scoreMatrixSlot(scoreInput)), caseId } as MatrixSlotResult;
+    return buildMatrixArtifactEvidence([scored], {
+      policy: 'strict',
+      runs: [{
+        runId: 'placeholder', caseId, runIndex: 0,
+        outcome: completed ? 'success' : 'failed', recovered: false,
+        attempts: [attemptAt(completed ? 'success' : 'failure')],
+      }],
+    } as MatrixExecutionEvidence);
+  };
+
+  const buildArtifact = async (bothCompleted: boolean) => {
+    const outputs = [await sideOutput(sides[0], true), await sideOutput(sides[1], bothCompleted)];
+    const slots = outputs.flatMap((output) => output.slots);
+    const execution: MatrixExecutionEvidence = { policy: 'strict', runs: outputs.flatMap((output) => output.execution.runs) };
+    const runMeta = await buildAbArtifactMeta({
+      sides, cases, repetitions: 1, startedAt: runStartedAt,
+      git: { revision: 'a'.repeat(40), dirty: false },
+    });
+    return buildEvalArtifact(
+      EVAL_RUN_REPORT_ARTIFACT_TYPE,
+      buildScorecard(slots, { model: 'configured runtime models', runs: 1 }),
+      toGovernedRunMeta(runMeta, { completedAt: runCompletedAt, execution }),
+    ) as { harness: string; completeness: { complete: boolean }; payload: { rules: Array<{ rule: string }>; cases: Array<Record<string, unknown>> } };
+  };
+
+  it('is accepted by the strict governed envelope, projection and all', async () => {
+    expect((await buildArtifact(true)).harness).toBe('discovery-ab');
+  });
+
+  it('holds both sides as its two rules', async () => {
+    expect((await buildArtifact(true)).payload.rules.map((rule) => rule.rule).sort()).toEqual(['a', 'b']);
+  });
+
+  it('carries each configuration on its case rows, which is where configs live on disk', async () => {
+    const artifact = await buildArtifact(true);
+    const byCase = new Map(artifact.payload.cases.map((entry) => [entry.caseId as string, entry.configDeltas]));
+    expect(byCase.get('c1/a/r1')).toEqual([
+      { key: 'DISCOVERY_ALLOWED_TYPES', before: null, after: 'intent' },
+      { key: 'DISCOVERY_SOURCE_PREMISE_LIMIT', before: null, after: '40' },
+    ]);
+    expect(byCase.get('c1/b/r1')).toEqual([
+      { key: 'DISCOVERY_ALLOWED_TYPES', before: null, after: 'intent,profile' },
+      { key: 'DISCOVERY_SOURCE_PREMISE_LIMIT', before: null, after: '5' },
+    ]);
+  });
+
+  it('marks a complete run complete', async () => {
+    expect((await buildArtifact(true)).completeness.complete).toBe(true);
+  });
+
+  it('marks a run with a failed slot incomplete, without anyone setting the flag', async () => {
+    expect((await buildArtifact(false)).completeness.complete).toBe(false);
+  });
+});

--- a/services/api/src/cli/tests/discovery-ab.child.spec.ts
+++ b/services/api/src/cli/tests/discovery-ab.child.spec.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from 'bun:test';
 
+import { MATRIX_ROWS } from '../../../../../packages/protocol/eval/discovery-env-matrix/historical-matrix.policy.js';
 import { AB_ALLOWED_EVIDENCE, abConfigDeltas, abSlotCaseId, buildAbSlotScoreInput, invokeAbDiscoveryGraph, parseAbChildArgs, selectAbSideSlots } from '../discovery-ab.main';
 import { buildAbPlan, type AbSide, type AbSlot } from '../discovery-ab.plan';
 
@@ -115,6 +116,16 @@ describe('parseAbChildArgs', () => {
 describe('AB_ALLOWED_EVIDENCE', () => {
   it('lists every evidence kind, which is what makes it a relaxation of the row gate', () => {
     expect([...AB_ALLOWED_EVIDENCE].sort()).toEqual(['intent', 'premise', 'user_context']);
+  });
+
+  // The seam `scoreMatrixSlot` takes this through is `any`-typed, so a fourth
+  // evidence kind added to MATRIX_ROWS would not fail to compile here; it would
+  // fail `allowed_evidence` on every A/B slot citing it, 40 minutes into a live
+  // run. Fail in a second here instead.
+  it('covers every evidence kind the matrix rows allow, or a new kind would fail every slot citing it', () => {
+    const matrixEvidence = new Set<string>(MATRIX_ROWS.flatMap((row) => [...row.allowedEvidence]));
+    const allowed = new Set<string>(AB_ALLOWED_EVIDENCE);
+    expect([...matrixEvidence].filter((kind) => !allowed.has(kind))).toEqual([]);
   });
 });
 

--- a/services/api/src/cli/tests/discovery-ab.child.spec.ts
+++ b/services/api/src/cli/tests/discovery-ab.child.spec.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'bun:test';
 
-import { AB_ALLOWED_EVIDENCE, abConfigDeltas, abSlotCaseId, invokeAbDiscoveryGraph, parseAbChildArgs, selectAbSideSlots } from '../discovery-ab.main';
+import { AB_ALLOWED_EVIDENCE, abConfigDeltas, abSlotCaseId, buildAbSlotScoreInput, invokeAbDiscoveryGraph, parseAbChildArgs, selectAbSideSlots } from '../discovery-ab.main';
 import { buildAbPlan, type AbSide, type AbSlot } from '../discovery-ab.plan';
 
 import type { HistoricalMatrixFixture } from '../discovery-env-matrix.shared';
@@ -8,6 +8,19 @@ import type { HistoricalMatrixFixture } from '../discovery-env-matrix.shared';
 const testCase = (id: string): HistoricalMatrixFixture => ({
   id, description: id, networkContext: 'ctx', sourceUserId: 'u1', expectedUserId: 'u2',
   excludedUserIds: [], participants: [],
+});
+
+/** A fixture complete enough for `databaseCase` to map its participant ids. */
+const seedableCase = (id: string): HistoricalMatrixFixture => ({
+  ...testCase(id),
+  participants: ['u1', 'u2'].map((participantId) => ({
+    id: participantId,
+    profileText: `${id} ${participantId} profile`,
+    location: 'fixture city',
+    interests: [],
+    skills: [],
+    intent: { text: `${id} ${participantId} intent` },
+  })),
 });
 
 const sideA: AbSide = { id: 'a', config: { DISCOVERY_ALLOWED_TYPES: 'intent' } };
@@ -100,8 +113,75 @@ describe('parseAbChildArgs', () => {
 });
 
 describe('AB_ALLOWED_EVIDENCE', () => {
-  it('states plainly that A/B does not gate evidence per configuration', () => {
+  it('lists every evidence kind, which is what makes it a relaxation of the row gate', () => {
     expect([...AB_ALLOWED_EVIDENCE].sort()).toEqual(['intent', 'premise', 'user_context']);
+  });
+});
+
+describe('buildAbSlotScoreInput', () => {
+  const scored = {
+    candidates: [{ id: 'u2', finalRank: 1, evidenceTypes: ['intent' as const], evidenceIds: {} }],
+    rawCandidates: [{ id: 'u2', retrievalRank: 1, evidenceTypes: ['intent' as const], evidenceIds: {} }],
+    evaluatorTraces: [{ id: 'u2', retrievalRank: 1, evaluatorReturned: true, evaluatorScore: 90, finalIncluded: true, finalRank: 1 }],
+    completed: true,
+  };
+  const failed = { candidates: [], completed: false };
+  const slot = (side: AbSide, repetition = 0): AbSlot => ({ matrixCase: seedableCase('c1'), side, repetition });
+
+  it('states the allowed evidence on a scored slot, without which every candidate-bearing slot throws on an unknown row', () => {
+    expect(buildAbSlotScoreInput(slot(sideA), scored).allowedEvidence).toBe(AB_ALLOWED_EVIDENCE);
+  });
+
+  it('states the allowed evidence on a failed slot too, so the fallback cannot drift from the scored path', () => {
+    expect(buildAbSlotScoreInput(slot(sideB), failed).allowedEvidence).toBe(AB_ALLOWED_EVIDENCE);
+  });
+
+  it('scores the slot against the side, not a matrix row, and names the repetition one-based', () => {
+    const input = buildAbSlotScoreInput(slot(sideB, 2), scored);
+    expect(input.rowId).toBe('b');
+    expect(input.repetition).toBe(2);
+    expect(input.caseId).toBe('c1/b/r3');
+  });
+
+  it('records the side configuration as sorted deltas on a scored slot', () => {
+    const side: AbSide = { id: 'a', config: { NEGOTIATION_MAX_TURNS_CHAT: '6', DISCOVERY_ALLOWED_TYPES: 'intent' } };
+    expect(buildAbSlotScoreInput(slot(side), scored).configDeltas).toEqual([
+      { key: 'DISCOVERY_ALLOWED_TYPES', before: null, after: 'intent' },
+      { key: 'NEGOTIATION_MAX_TURNS_CHAT', before: null, after: '6' },
+    ]);
+  });
+
+  it('records the side configuration on a failed slot too, so a failure says which configuration produced it', () => {
+    const side: AbSide = { id: 'b', config: { NEGOTIATION_MAX_TURNS_CHAT: '6', DISCOVERY_ALLOWED_TYPES: 'intent,profile' } };
+    expect(buildAbSlotScoreInput(slot(side), failed).configDeltas).toEqual([
+      { key: 'DISCOVERY_ALLOWED_TYPES', before: null, after: 'intent,profile' },
+      { key: 'NEGOTIATION_MAX_TURNS_CHAT', before: null, after: '6' },
+    ]);
+  });
+
+  it('still states the allowed evidence when the configuration is empty and there are no deltas', () => {
+    const input = buildAbSlotScoreInput(slot({ id: 'a', config: {} }), scored);
+    expect(input.configDeltas).toEqual([]);
+    expect(input.allowedEvidence).toBe(AB_ALLOWED_EVIDENCE);
+  });
+
+  it('carries the outcome through and maps participant ids to their protected-base ids', () => {
+    const input = buildAbSlotScoreInput(slot(sideA), scored);
+    expect(input.candidates).toBe(scored.candidates);
+    expect(input.rawCandidates).toBe(scored.rawCandidates);
+    expect(input.evaluatorTraces).toBe(scored.evaluatorTraces);
+    expect(input.completed).toBe(true);
+    expect(input.matrixCase.id).toBe('c1');
+    expect(input.matrixCase.sourceUserId).toMatch(/^eval-discovery-matrix-user-/);
+    expect(input.matrixCase.expectedUserId).not.toBe(input.matrixCase.sourceUserId);
+  });
+
+  it('omits the diagnostic fields a failed slot has none of, exactly as the fallback did inline', () => {
+    const input = buildAbSlotScoreInput(slot(sideA), failed);
+    expect(input.candidates).toEqual([]);
+    expect(input.completed).toBe(false);
+    expect(Object.keys(input).includes('rawCandidates')).toBe(false);
+    expect(Object.keys(input).includes('evaluatorTraces')).toBe(false);
   });
 });
 

--- a/services/api/src/cli/tests/discovery-ab.child.spec.ts
+++ b/services/api/src/cli/tests/discovery-ab.child.spec.ts
@@ -1,0 +1,158 @@
+import { describe, expect, it } from 'bun:test';
+
+import { AB_ALLOWED_EVIDENCE, abConfigDeltas, abSlotCaseId, invokeAbDiscoveryGraph, parseAbChildArgs, selectAbSideSlots } from '../discovery-ab.main';
+import { buildAbPlan, type AbSide, type AbSlot } from '../discovery-ab.plan';
+
+import type { HistoricalMatrixFixture } from '../discovery-env-matrix.shared';
+
+const testCase = (id: string): HistoricalMatrixFixture => ({
+  id, description: id, networkContext: 'ctx', sourceUserId: 'u1', expectedUserId: 'u2',
+  excludedUserIds: [], participants: [],
+});
+
+const sideA: AbSide = { id: 'a', config: { DISCOVERY_ALLOWED_TYPES: 'intent' } };
+const sideB: AbSide = { id: 'b', config: { DISCOVERY_ALLOWED_TYPES: 'intent,profile' } };
+
+describe('abSlotCaseId', () => {
+  it('reports repetitions one-based, matching the matrix harness', () => {
+    const plan = buildAbPlan([testCase('c1')], [sideA, sideB], 2);
+    expect(plan.map(abSlotCaseId)).toEqual([
+      'c1/a/r1', 'c1/b/r1', 'c1/a/r2', 'c1/b/r2',
+    ]);
+  });
+
+  it('names the side, so a slot is attributable to the configuration that produced it', () => {
+    expect(abSlotCaseId({ matrixCase: testCase('historical/case'), side: sideB, repetition: 0 })).toBe('historical/case/b/r1');
+  });
+});
+
+describe('abConfigDeltas', () => {
+  it('records every key of the side configuration as an applied value', () => {
+    expect(abConfigDeltas({ DISCOVERY_ALLOWED_TYPES: 'intent', DISCOVERY_SOURCE_PREMISE_LIMIT: '5' })).toEqual([
+      { key: 'DISCOVERY_ALLOWED_TYPES', before: null, after: 'intent' },
+      { key: 'DISCOVERY_SOURCE_PREMISE_LIMIT', before: null, after: '5' },
+    ]);
+  });
+
+  it('is independent of the order the operator typed the flags in', () => {
+    expect(abConfigDeltas({ NEGOTIATION_MAX_TURNS_CHAT: '6', DISCOVERY_ALLOWED_TYPES: 'intent' }))
+      .toEqual(abConfigDeltas({ DISCOVERY_ALLOWED_TYPES: 'intent', NEGOTIATION_MAX_TURNS_CHAT: '6' }));
+  });
+
+  it('records an empty configuration as no deltas rather than inventing one', () => {
+    expect(abConfigDeltas({})).toEqual([]);
+  });
+});
+
+describe('selectAbSideSlots', () => {
+  const plan = buildAbPlan([testCase('c1'), testCase('c2')], [sideA, sideB], 3);
+
+  it('keeps only the slots of the requested side, in plan order', () => {
+    const selection = selectAbSideSlots('b', plan);
+    expect(selection.side).toBe(sideB);
+    expect(selection.slots).toHaveLength(6);
+    expect(selection.slots.every((slot) => slot.side.id === 'b')).toBe(true);
+    expect(selection.slots.map(abSlotCaseId)).toEqual(['c1/b/r1', 'c1/b/r2', 'c1/b/r3', 'c2/b/r1', 'c2/b/r2', 'c2/b/r3']);
+  });
+
+  it('gives each side the same case and repetition coverage', () => {
+    const strip = (slots: readonly AbSlot[]): string[] => slots.map((slot) => `${slot.matrixCase.id}/r${slot.repetition}`);
+    expect(strip(selectAbSideSlots('a', plan).slots)).toEqual(strip(selectAbSideSlots('b', plan).slots));
+  });
+
+  it('refuses a side with no slots rather than writing an empty artifact', () => {
+    expect(() => selectAbSideSlots('a', selectAbSideSlots('b', plan).slots)).toThrow(/owns no slots/);
+  });
+
+  it('refuses two configurations under one side id, which this process cannot run', () => {
+    const conflicting: AbSlot[] = [
+      { matrixCase: testCase('c1'), side: sideA, repetition: 0 },
+      { matrixCase: testCase('c1'), side: { id: 'a', config: { DISCOVERY_ALLOWED_TYPES: 'profile' } }, repetition: 1 },
+    ];
+    expect(() => selectAbSideSlots('a', conflicting)).toThrow(/more than one configuration/);
+  });
+
+  it('accepts an equal configuration supplied as a different object', () => {
+    const equivalent: AbSlot[] = [
+      { matrixCase: testCase('c1'), side: sideA, repetition: 0 },
+      { matrixCase: testCase('c1'), side: { id: 'a', config: { DISCOVERY_ALLOWED_TYPES: 'intent' } }, repetition: 1 },
+    ];
+    expect(selectAbSideSlots('a', equivalent).slots).toHaveLength(2);
+  });
+});
+
+describe('parseAbChildArgs', () => {
+  it('reads the child invocation contract', () => {
+    expect(parseAbChildArgs(['--side', 'b', '--child-output', '/tmp/side-b.json']))
+      .toEqual({ sideId: 'b', outputPath: '/tmp/side-b.json' });
+  });
+
+  it.each([
+    [['--child-output', '/tmp/x.json'], /--side must be exactly a or b/],
+    [['--side', '--child-output', '/tmp/x.json'], /--side must be exactly a or b/],
+    [['--side', 'c', '--child-output', '/tmp/x.json'], /--side must be exactly a or b/],
+    [['--side', 'a'], /--child-output/],
+    [['--side', 'a', '--child-output'], /--child-output/],
+    [['--side', 'a', '--child-output', '--force'], /--child-output/],
+  ])('refuses %p', (args, message) => {
+    expect(() => parseAbChildArgs(args)).toThrow(message);
+  });
+});
+
+describe('AB_ALLOWED_EVIDENCE', () => {
+  it('states plainly that A/B does not gate evidence per configuration', () => {
+    expect([...AB_ALLOWED_EVIDENCE].sort()).toEqual(['intent', 'premise', 'user_context']);
+  });
+});
+
+describe('invokeAbDiscoveryGraph', () => {
+  const runtime = { sourceUserId: 'user-1', networkId: 'network-1', triggerIntentId: 'intent-1' };
+
+  it('runs the graph inside the side configuration and restores the environment afterwards', async () => {
+    process.env.DISCOVERY_ALLOWED_TYPES = 'intent';
+    delete process.env.DISCOVERY_SOURCE_PREMISE_LIMIT;
+    const observed: Array<Record<string, string | undefined>> = [];
+    const calls: unknown[] = [];
+    const signals: Array<AbortSignal | undefined> = [];
+    const controller = new AbortController();
+    const graph = {
+      invoke: async (input: unknown, config?: { signal?: AbortSignal }) => {
+        calls.push(input);
+        signals.push(config?.signal);
+        observed.push({
+          DISCOVERY_ALLOWED_TYPES: process.env.DISCOVERY_ALLOWED_TYPES,
+          DISCOVERY_SOURCE_PREMISE_LIMIT: process.env.DISCOVERY_SOURCE_PREMISE_LIMIT,
+        });
+        return { candidates: [] };
+      },
+    };
+
+    await invokeAbDiscoveryGraph(
+      graph,
+      runtime,
+      { DISCOVERY_ALLOWED_TYPES: 'intent,profile', DISCOVERY_SOURCE_PREMISE_LIMIT: '5' },
+      controller.signal,
+    );
+
+    expect(calls).toEqual([{ userId: 'user-1', networkId: 'network-1', triggerIntentId: 'intent-1', options: { minScore: 50 } }]);
+    expect(signals).toEqual([controller.signal]);
+    expect(observed).toEqual([{ DISCOVERY_ALLOWED_TYPES: 'intent,profile', DISCOVERY_SOURCE_PREMISE_LIMIT: '5' }]);
+    expect(process.env.DISCOVERY_ALLOWED_TYPES).toBe('intent');
+    expect(process.env.DISCOVERY_SOURCE_PREMISE_LIMIT).toBeUndefined();
+  });
+
+  it('restores the environment when the graph fails, so the next slot is not contaminated', async () => {
+    process.env.DISCOVERY_ALLOWED_TYPES = 'intent';
+    const graph = { invoke: async () => { throw new Error('graph failed'); } };
+
+    await expect(invokeAbDiscoveryGraph(graph, runtime, { DISCOVERY_ALLOWED_TYPES: 'profile' }))
+      .rejects.toThrow('graph failed');
+    expect(process.env.DISCOVERY_ALLOWED_TYPES).toBe('intent');
+  });
+
+  it('refuses a configuration naming a flag the graph cannot read', async () => {
+    const graph = { invoke: async () => ({}) };
+    await expect(invokeAbDiscoveryGraph(graph, runtime, { POOL_QUESTIONS_MODE: 'on' }))
+      .rejects.toThrow(/POOL_QUESTIONS_MODE/);
+  });
+});

--- a/services/api/src/cli/tests/discovery-ab.contract.spec.ts
+++ b/services/api/src/cli/tests/discovery-ab.contract.spec.ts
@@ -31,7 +31,24 @@ async function staticImportClosure(entry: string): Promise<{ files: string[]; pa
     // because a lone quoted string is also what `export const X = 'y';` looks
     // like. A dynamic `await import(...)` is matched by neither, and deferring
     // the runtime behind one is the point.
-    for (const match of source.matchAll(/^(?:(?:import|export)\b[^;]*?\bfrom\s+|import\s+)['"]([^'"]+)['"]\s*;/gm)) {
+    //
+    // The three tolerances are what an import a linter would not flag can
+    // actually look like, each of which used to slip past this guard entirely:
+    // `^\s*` because leading whitespace is legal (a top-level import is not
+    // required to sit in column 0), `import\s*` because the quote may follow
+    // `import` with no space at all, and no trailing semicolon at all, because
+    // `eslint.config.mjs` sets no `semi` rule — so `import './main'` would have
+    // loaded the runtime with this test still green.
+    //
+    // The bare form is tried *first*, and only that ordering makes the
+    // semicolon optional safely: `[^;]` spans newlines, so against an
+    // unterminated `import './main'` the `from` alternative would otherwise run
+    // on into the *next* statement's `from './plan'` and report that specifier
+    // instead — swallowing the very import this test exists to catch. The
+    // lookahead keeps the quotes in the shared tail so both alternatives share
+    // one capture group, and falls through to the `from` form for everything
+    // that is not a bare side-effect import.
+    for (const match of source.matchAll(/^\s*(?:import\s*(?=['"])|(?:import|export)\b[^;]*?\bfrom\s+)['"]([^'"]+)['"]/gm)) {
       const specifier = match[1]!;
       if (specifier.startsWith('.')) queue.push(path.resolve(path.dirname(file), `${specifier}.ts`));
       else packages.add(specifier);
@@ -181,7 +198,19 @@ describe('classifyAbParentFailure', () => {
     expect(report.message).toContain('after the run artifact was written');
     expect(report.message).toContain('The artifact on disk is real');
     expect(report.message).not.toContain('nothing of this run survives');
-    expect(report.message).not.toContain('No artifact was written');
+    expect(report.message).not.toContain('No run report was written');
+  });
+
+  /**
+   * `runAbChild` writes its output and exits 0 even when every slot failed, so
+   * both sides can complete with `runs: 0` everywhere and the artifact still be
+   * written. Attempts were certainly made; a paid run is not something this
+   * stage can assert, so it hedges like every other stage.
+   */
+  it('hedges the spend at the written stage, since both sides can complete having scored nothing', () => {
+    const report = describeAbFailure(classifyAbParentFailure('written', new Error('EBUSY'), { artifactPath: '/repo/runs/x.json' }));
+    expect(report.message).toContain('a live run may have been spent');
+    expect(report.message).not.toContain('a live run was spent');
   });
 
   it('still reports the written stage honestly when no path was recorded', () => {
@@ -190,13 +219,29 @@ describe('classifyAbParentFailure', () => {
     expect(message).not.toContain('undefined');
   });
 
-  it('reports a failure after a side was spawned as a spend with nothing to show for it', () => {
+  it('reports a failure after a side was spawned as a spend with no run report and no verdict', () => {
     const classified = classifyAbParentFailure('spawned', new Error('child died'));
     const report = describeAbFailure(classified);
     expect(report.exitCode).toBe(AB_EXIT_SPENT_WITHOUT_ARTIFACT);
     expect(report.exitCode).not.toBe(AB_EXIT_PREFLIGHT_REFUSED);
     expect(report.message).toContain('after spawning a side');
-    expect(report.message).toContain('No artifact was written');
+    expect(report.message).toContain('No run report was written');
+    expect(report.message).toContain('there is no verdict');
+  });
+
+  /**
+   * Both sides run in parallel, so side a can finish and write its child
+   * artifact while side b times out. The parent's `finally` then calls
+   * `finalizeAbChildArtifacts(dir, false)`, which retains that directory and
+   * prints what is in it - and this message is printed immediately after it.
+   * "Nothing of this run survives" would deny, in the same console, the scored
+   * slots the harness had just named.
+   */
+  it('does not deny the child artifacts a failed run keeps, which the harness itself has just named', () => {
+    const report = describeAbFailure(classifyAbParentFailure('spawned', new Error('child b timed out')));
+    expect(report.message).not.toContain('nothing of this run survives');
+    expect(report.message).not.toContain('No artifact was written');
+    expect(report.message).toContain('any child artifact this run kept is named above');
   });
 
   /**
@@ -209,7 +254,7 @@ describe('classifyAbParentFailure', () => {
     expect(report.message).not.toContain('wall-clock time are gone');
     // It is still certain about the two things the stage does fix.
     expect(report.message).toContain('both A/B branches were reset');
-    expect(report.message).toContain('nothing of this run survives');
+    expect(report.message).toContain('there is no verdict');
   });
 
   it('keeps the original failure as a cause without ever printing it', () => {

--- a/services/api/src/cli/tests/discovery-ab.contract.spec.ts
+++ b/services/api/src/cli/tests/discovery-ab.contract.spec.ts
@@ -2,7 +2,7 @@ import { describe, expect, it } from 'bun:test';
 import { readFile } from 'node:fs/promises';
 import path from 'node:path';
 
-import { AB_EXIT_COMPARISON, AB_EXIT_INSUFFICIENT_EVIDENCE, AB_EXIT_PREFLIGHT_REFUSED, AB_EXIT_SPENT_WITHOUT_ARTIFACT, AbSpentRunError, abUsage, classifyAbParentFailure, describeAbFailure } from '../discovery-ab.contract';
+import { AB_EXIT_COMPARISON, AB_EXIT_INSUFFICIENT_EVIDENCE, AB_EXIT_PREFLIGHT_REFUSED, AB_EXIT_SPENT_WITHOUT_ARTIFACT, AbSpentRunError, abAttestationRefusal, abUsage, classifyAbParentFailure, describeAbFailure } from '../discovery-ab.contract';
 import { AbGateError } from '../discovery-ab.gate';
 
 const CLI_DIR = path.resolve(import.meta.dir, '..');
@@ -24,9 +24,14 @@ async function staticImportClosure(entry: string): Promise<{ files: string[]; pa
     if (seen.has(file)) continue;
     seen.add(file);
     const source = await readFile(file, 'utf8');
-    // Static `import`/`export ... from` only: a dynamic `await import(...)` has
-    // no `from` clause, and deferring the runtime behind one is the point.
-    for (const match of source.matchAll(/^(?:import|export)\b[^;]*?\bfrom\s+'([^']+)';/gm)) {
+    // Every *static* form: `import x from 'y'`, `export ... from "y"`, and the
+    // bare side-effect `import 'y'`, which has no `from` clause at all and would
+    // load the runtime just as eagerly. Single and double quotes both count.
+    // The two alternatives are kept separate rather than making `from` optional,
+    // because a lone quoted string is also what `export const X = 'y';` looks
+    // like. A dynamic `await import(...)` is matched by neither, and deferring
+    // the runtime behind one is the point.
+    for (const match of source.matchAll(/^(?:(?:import|export)\b[^;]*?\bfrom\s+|import\s+)['"]([^'"]+)['"]\s*;/gm)) {
       const specifier = match[1]!;
       if (specifier.startsWith('.')) queue.push(path.resolve(path.dirname(file), `${specifier}.ts`));
       else packages.add(specifier);
@@ -111,7 +116,9 @@ describe('abUsage', () => {
   });
 
   it('states what each exit code means, since two of them are failures with very different costs', () => {
-    expect(usage).toContain('Exit codes:');
+    expect(usage).toContain('Exit codes, for the parent invocation an operator runs');
+    // The codes describe a parent run; a child's code is the parent's to consume.
+    expect(usage).toContain("consumed by the parent's supervision");
     for (const code of [AB_EXIT_COMPARISON, AB_EXIT_PREFLIGHT_REFUSED, AB_EXIT_INSUFFICIENT_EVIDENCE, AB_EXIT_SPENT_WITHOUT_ARTIFACT]) {
       expect(usage).toContain(`\n  ${code}   `);
     }
@@ -150,14 +157,59 @@ describe('classifyAbParentFailure', () => {
     expect(report.message).toContain('no artifact was written');
   });
 
+  /**
+   * The first restore is the most likely post-attestation failure there is, and
+   * when it is refused *nothing* has been overwritten. Claiming both branches
+   * were is exactly the kind of false certainty these messages exist to remove.
+   */
+  it('reports a failure during the resets without claiming both branches were overwritten', () => {
+    const report = describeAbFailure(classifyAbParentFailure('resetting', new Error('restore refused with status 500')));
+    expect(report.exitCode).toBe(AB_EXIT_SPENT_WITHOUT_ARTIFACT);
+    expect(report.message).toContain('while resetting the A/B branches');
+    expect(report.message).toContain('one or both branches may have been overwritten');
+    expect(report.message).not.toContain('both branches were overwritten');
+    // It can still be certain about the two things the stage does fix.
+    expect(report.message).toContain('No side was spawned, no run was spent');
+    expect(report.message).toContain('no artifact was written');
+  });
+
+  it('names the artifact when the failure landed after it was written, rather than saying nothing survived', () => {
+    const runPath = '/repo/eval/discovery-ab/runs/2026-08-04T00-00-00-000Z.json';
+    const report = describeAbFailure(classifyAbParentFailure('written', new Error('EBUSY: rm /tmp/discovery-ab-x'), { artifactPath: runPath }));
+    expect(report.exitCode).toBe(AB_EXIT_SPENT_WITHOUT_ARTIFACT);
+    expect(report.message).toContain(runPath);
+    expect(report.message).toContain('after the run artifact was written');
+    expect(report.message).toContain('The artifact on disk is real');
+    expect(report.message).not.toContain('nothing of this run survives');
+    expect(report.message).not.toContain('No artifact was written');
+  });
+
+  it('still reports the written stage honestly when no path was recorded', () => {
+    const message = new AbSpentRunError('written').message;
+    expect(message).toContain('after the run artifact was written:');
+    expect(message).not.toContain('undefined');
+  });
+
   it('reports a failure after a side was spawned as a spend with nothing to show for it', () => {
     const classified = classifyAbParentFailure('spawned', new Error('child died'));
     const report = describeAbFailure(classified);
     expect(report.exitCode).toBe(AB_EXIT_SPENT_WITHOUT_ARTIFACT);
     expect(report.exitCode).not.toBe(AB_EXIT_PREFLIGHT_REFUSED);
     expect(report.message).toContain('after spawning a side');
-    expect(report.message).toContain('provider spend and wall-clock time are gone');
     expect(report.message).toContain('No artifact was written');
+  });
+
+  /**
+   * The stage is set the moment a side *process* exists, and a side that died
+   * at its own gate spent nothing at all - so the spend can only be hedged.
+   */
+  it('hedges the spend after a spawn, because a side can die before it costs anything', () => {
+    const report = describeAbFailure(classifyAbParentFailure('spawned', new Error('child exited with code 2')));
+    expect(report.message).toContain('provider spend and wall-clock time may already be gone');
+    expect(report.message).not.toContain('wall-clock time are gone');
+    // It is still certain about the two things the stage does fix.
+    expect(report.message).toContain('both A/B branches were reset');
+    expect(report.message).toContain('nothing of this run survives');
   });
 
   it('keeps the original failure as a cause without ever printing it', () => {
@@ -184,7 +236,60 @@ describe('describeAbFailure', () => {
     expect(report.message).not.toContain('hunter2secret');
   });
 
+  /**
+   * A child reaches this same fallback after it has run the graph, written to
+   * its branch and paid providers - the child-artifact write, closing its
+   * resources, assembling its evidence. The parent's line would be printed into
+   * the operator's console in the middle of the loss it denies.
+   */
+  it('makes no cost claim for a child, which cannot know what the run cost', () => {
+    const report = describeAbFailure(new Error('EBUSY writing /tmp/discovery-ab-x/a.json'), 'child');
+    expect(report.exitCode).toBe(AB_EXIT_PREFLIGHT_REFUSED);
+    expect(report.message).toContain('A child makes no claim about what this run cost');
+    expect(report.message).toContain("the parent's exit code is the one to act on");
+    for (const claim of ['nothing was spent', 'no run was spent', 'no branch was mutated', 'before anything was reset']) {
+      expect(report.message).not.toContain(claim);
+    }
+    expect(report.message).not.toContain('EBUSY');
+  });
+
+  it('prints a gate refusal verbatim in a child too, since a refusal names only variables', () => {
+    const refusal = new AbGateError('Refusing to mutate: DISCOVERY_AB_SIDE_BRANCH must be exactly eval-ab-a for side a');
+    expect(describeAbFailure(refusal, 'child')).toEqual({
+      exitCode: AB_EXIT_PREFLIGHT_REFUSED,
+      message: refusal.message,
+    });
+  });
+
   it('classifies a thrown non-error too, rather than crashing the reporter', () => {
     expect(describeAbFailure('something went wrong').exitCode).toBe(AB_EXIT_PREFLIGHT_REFUSED);
+  });
+});
+
+describe('abAttestationRefusal', () => {
+  it('names what was refused and what would satisfy it, without the control-plane error', () => {
+    const refusal = abAttestationRefusal('parent', { cause: new Error('status 401 for hunter2secret') });
+    expect(refusal).toBeInstanceOf(AbGateError);
+    expect(refusal.message).toContain('DISCOVERY_AB_TARGETS was not attested');
+    expect(refusal.message).toContain('eval-ab-a, eval-ab-b');
+    expect(refusal.message).toContain('eval-discovery-base');
+    expect(refusal.message).not.toContain('hunter2secret');
+    expect(describeAbFailure(refusal)).toEqual({ exitCode: AB_EXIT_PREFLIGHT_REFUSED, message: refusal.message });
+  });
+
+  it('claims nothing was reset or spawned only for the parent, which is the one that would know', () => {
+    expect(abAttestationRefusal('parent').message).toContain('Nothing was reset and nothing was spawned.');
+  });
+
+  /**
+   * A child attests after the parent has already reset both branches and
+   * spawned it, so the parent's tail printed from a child is false.
+   */
+  it('speaks only for the side when a child refuses, since by then the parent has reset and spawned', () => {
+    const message = abAttestationRefusal('child').message;
+    expect(message).toContain('This side did not run');
+    expect(message).toContain('reported by the parent invocation');
+    expect(message).not.toContain('Nothing was reset');
+    expect(message).not.toContain('nothing was spawned');
   });
 });

--- a/services/api/src/cli/tests/discovery-ab.contract.spec.ts
+++ b/services/api/src/cli/tests/discovery-ab.contract.spec.ts
@@ -1,0 +1,190 @@
+import { describe, expect, it } from 'bun:test';
+import { readFile } from 'node:fs/promises';
+import path from 'node:path';
+
+import { AB_EXIT_COMPARISON, AB_EXIT_INSUFFICIENT_EVIDENCE, AB_EXIT_PREFLIGHT_REFUSED, AB_EXIT_SPENT_WITHOUT_ARTIFACT, AbSpentRunError, abUsage, classifyAbParentFailure, describeAbFailure } from '../discovery-ab.contract';
+import { AbGateError } from '../discovery-ab.gate';
+
+const CLI_DIR = path.resolve(import.meta.dir, '..');
+const BOOTSTRAP = path.resolve(CLI_DIR, 'discovery-ab.ts');
+
+/**
+ * The bootstrap's whole reason to exist is an import-ordering property: nothing
+ * that can compose a database may be *statically* reachable from it, or the
+ * graph would load before the branches were attested. So the closure is walked
+ * for real rather than asserted on one file's text — moving the help text into
+ * a shared module is exactly the kind of change that could have broken it.
+ */
+async function staticImportClosure(entry: string): Promise<{ files: string[]; packages: string[] }> {
+  const seen = new Set<string>();
+  const packages = new Set<string>();
+  const queue = [entry];
+  while (queue.length > 0) {
+    const file = queue.pop()!;
+    if (seen.has(file)) continue;
+    seen.add(file);
+    const source = await readFile(file, 'utf8');
+    // Static `import`/`export ... from` only: a dynamic `await import(...)` has
+    // no `from` clause, and deferring the runtime behind one is the point.
+    for (const match of source.matchAll(/^(?:import|export)\b[^;]*?\bfrom\s+'([^']+)';/gm)) {
+      const specifier = match[1]!;
+      if (specifier.startsWith('.')) queue.push(path.resolve(path.dirname(file), `${specifier}.ts`));
+      else packages.add(specifier);
+    }
+  }
+  return { files: [...seen], packages: [...packages] };
+}
+
+describe('the discovery A/B bootstrap import closure', () => {
+  it('still reaches nothing that can compose a database', async () => {
+    const { files, packages } = await staticImportClosure(BOOTSTRAP);
+    // Every static dependency is either local CLI code or a node builtin.
+    expect(packages.filter((specifier) => !specifier.startsWith('node:'))).toEqual([]);
+    expect(packages).not.toContain('@indexnetwork/protocol');
+    expect(packages.filter((specifier) => specifier.includes('drizzle'))).toEqual([]);
+    expect(files.map((file) => path.basename(file))).not.toContain('discovery-ab.main.ts');
+    expect(files.map((file) => path.basename(file)).sort()).toContain('discovery-ab.contract.ts');
+  });
+
+  it('reaches the runtime only through a dynamic import, and prints no error text', async () => {
+    const source = await readFile(BOOTSTRAP, 'utf8');
+    expect(source).toContain("await import('./discovery-ab.main')");
+    expect(source).not.toContain('error.message');
+  });
+});
+
+describe('discovery-ab --help', () => {
+  /**
+   * Run with `env: {}`: the help text exists to tell an operator what this
+   * command requires, so needing any of it first would make it useless.
+   */
+  const runHelp = async (flag: string) => {
+    const child = Bun.spawn({
+      cmd: [process.execPath, BOOTSTRAP, flag],
+      env: {},
+      stdout: 'pipe',
+      stderr: 'pipe',
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([
+      new Response(child.stdout).text(),
+      new Response(child.stderr).text(),
+      child.exited,
+    ]);
+    return { stdout, stderr, exitCode };
+  };
+
+  it('prints the full contract and exits 0 with no environment at all', async () => {
+    const { stdout, stderr, exitCode } = await runHelp('--help');
+    expect(exitCode).toBe(0);
+    expect(stderr).toBe('');
+    // The whole contract, not a summary telling the operator to run --help.
+    expect(stdout).toBe(`${abUsage()}\n`);
+    expect(stdout).not.toContain('for the full contract');
+  }, 30_000);
+
+  it('answers -h the same way', async () => {
+    const { stdout, exitCode } = await runHelp('-h');
+    expect(exitCode).toBe(0);
+    expect(stdout).toBe(`${abUsage()}\n`);
+  }, 30_000);
+});
+
+describe('abUsage', () => {
+  const usage = abUsage();
+
+  it('states the manifest shape, so an operator can build one from the help alone', () => {
+    expect(usage).toContain('DISCOVERY_AB_TARGETS');
+    expect(usage).toContain('"sideId":"a"');
+    expect(usage).toContain('"baseBranchId":"br-..."');
+  });
+
+  it('states every flag', () => {
+    for (const flag of ['--case', '--runs', '--a KEY=VALUE', '--b KEY=VALUE', '--force']) {
+      expect(usage).toContain(flag);
+    }
+  });
+
+  it('states the reset-from-base behaviour and the no-baseline property', () => {
+    expect(usage).toContain('resets both attested');
+    expect(usage).toContain('eval-discovery-base');
+    expect(usage).toContain('never reads, writes or compares a baseline');
+  });
+
+  it('states what each exit code means, since two of them are failures with very different costs', () => {
+    expect(usage).toContain('Exit codes:');
+    for (const code of [AB_EXIT_COMPARISON, AB_EXIT_PREFLIGHT_REFUSED, AB_EXIT_INSUFFICIENT_EVIDENCE, AB_EXIT_SPENT_WITHOUT_ARTIFACT]) {
+      expect(usage).toContain(`\n  ${code}   `);
+    }
+    expect(usage).toContain('nothing was spent');
+    expect(usage).toContain('may have been spent');
+  });
+});
+
+describe('exit codes', () => {
+  it('gives every outcome its own code', () => {
+    const codes = [AB_EXIT_COMPARISON, AB_EXIT_PREFLIGHT_REFUSED, AB_EXIT_INSUFFICIENT_EVIDENCE, AB_EXIT_SPENT_WITHOUT_ARTIFACT];
+    expect(new Set(codes).size).toBe(codes.length);
+    expect(AB_EXIT_COMPARISON).toBe(0);
+    // 3 is the shared eval CLI's EVAL_EXIT_INSUFFICIENT_EVIDENCE, restated here.
+    expect(AB_EXIT_INSUFFICIENT_EVIDENCE).toBe(3);
+  });
+});
+
+describe('classifyAbParentFailure', () => {
+  it('leaves a pre-flight failure exactly as it was, because its own message is the useful one', () => {
+    const refusal = new AbGateError('Refusing to mutate: set DISCOVERY_AB_CONFIRM=1');
+    expect(classifyAbParentFailure(null, refusal)).toBe(refusal);
+    expect(describeAbFailure(classifyAbParentFailure(null, refusal))).toEqual({
+      exitCode: AB_EXIT_PREFLIGHT_REFUSED,
+      message: 'Refusing to mutate: set DISCOVERY_AB_CONFIRM=1',
+    });
+  });
+
+  it('reports a failure after the resets as branches overwritten and nothing spent', () => {
+    const classified = classifyAbParentFailure('reset', new Error('neon restore blew up'));
+    expect(classified).toBeInstanceOf(AbSpentRunError);
+    const report = describeAbFailure(classified);
+    expect(report.exitCode).toBe(AB_EXIT_SPENT_WITHOUT_ARTIFACT);
+    expect(report.message).toContain('after resetting the A/B branches');
+    expect(report.message).toContain('no run was spent');
+    expect(report.message).toContain('no artifact was written');
+  });
+
+  it('reports a failure after a side was spawned as a spend with nothing to show for it', () => {
+    const classified = classifyAbParentFailure('spawned', new Error('child died'));
+    const report = describeAbFailure(classified);
+    expect(report.exitCode).toBe(AB_EXIT_SPENT_WITHOUT_ARTIFACT);
+    expect(report.exitCode).not.toBe(AB_EXIT_PREFLIGHT_REFUSED);
+    expect(report.message).toContain('after spawning a side');
+    expect(report.message).toContain('provider spend and wall-clock time are gone');
+    expect(report.message).toContain('No artifact was written');
+  });
+
+  it('keeps the original failure as a cause without ever printing it', () => {
+    const cause = new Error('postgresql://user:hunter2secret@ep-a.neon.tech/protocol_eval refused');
+    const classified = classifyAbParentFailure('spawned', cause) as AbSpentRunError;
+    expect(classified.cause).toBe(cause);
+    expect(classified.stage).toBe('spawned');
+    expect(describeAbFailure(classified).message).not.toContain('hunter2secret');
+  });
+});
+
+describe('describeAbFailure', () => {
+  it('prints a gate refusal verbatim, since it names only environment variables', () => {
+    expect(describeAbFailure(new AbGateError('Refusing to run: NEON_API_KEY is required'))).toEqual({
+      exitCode: AB_EXIT_PREFLIGHT_REFUSED,
+      message: 'Refusing to run: NEON_API_KEY is required',
+    });
+  });
+
+  it('reports an unclassified failure as pre-flight, and says so rather than staying silent about cost', () => {
+    const report = describeAbFailure(new Error('postgresql://user:hunter2secret@ep-a.neon.tech/protocol_eval refused'));
+    expect(report.exitCode).toBe(AB_EXIT_PREFLIGHT_REFUSED);
+    expect(report.message).toContain('no branch was mutated and no run was spent');
+    expect(report.message).not.toContain('hunter2secret');
+  });
+
+  it('classifies a thrown non-error too, rather than crashing the reporter', () => {
+    expect(describeAbFailure('something went wrong').exitCode).toBe(AB_EXIT_PREFLIGHT_REFUSED);
+  });
+});

--- a/services/api/src/cli/tests/discovery-ab.env.spec.ts
+++ b/services/api/src/cli/tests/discovery-ab.env.spec.ts
@@ -1,0 +1,60 @@
+import { describe, expect, it } from 'bun:test';
+
+import { withDiscoveryEnvironment, withMatrixEnvironment } from '../discovery-env-matrix.runtime';
+
+describe('withDiscoveryEnvironment', () => {
+  it('applies every configured key for the duration of the run', async () => {
+    delete process.env.DISCOVERY_ALLOWED_TYPES;
+    process.env.DISCOVERY_SOURCE_PREMISE_LIMIT = '40';
+    const seen = await withDiscoveryEnvironment(
+      { DISCOVERY_ALLOWED_TYPES: 'intent', DISCOVERY_SOURCE_PREMISE_LIMIT: '5' },
+      async () => ({
+        allowed: process.env.DISCOVERY_ALLOWED_TYPES,
+        limit: process.env.DISCOVERY_SOURCE_PREMISE_LIMIT,
+      }),
+    );
+    expect(seen).toEqual({ allowed: 'intent', limit: '5' });
+  });
+
+  it('deletes keys that were unset before, rather than leaving them behind', async () => {
+    delete process.env.DISCOVERY_ALLOWED_TYPES;
+    await withDiscoveryEnvironment({ DISCOVERY_ALLOWED_TYPES: 'intent' }, async () => undefined);
+    expect('DISCOVERY_ALLOWED_TYPES' in process.env).toBe(false);
+  });
+
+  it('restores the previous value of keys that were set before', async () => {
+    process.env.DISCOVERY_SOURCE_PREMISE_LIMIT = '40';
+    await withDiscoveryEnvironment({ DISCOVERY_SOURCE_PREMISE_LIMIT: '5' }, async () => undefined);
+    expect(process.env.DISCOVERY_SOURCE_PREMISE_LIMIT).toBe('40');
+    delete process.env.DISCOVERY_SOURCE_PREMISE_LIMIT;
+  });
+
+  it('restores even when the run throws', async () => {
+    process.env.DISCOVERY_SOURCE_PREMISE_LIMIT = '40';
+    await expect(withDiscoveryEnvironment(
+      { DISCOVERY_SOURCE_PREMISE_LIMIT: '5' },
+      async () => { throw new Error('graph failed'); },
+    )).rejects.toThrow('graph failed');
+    expect(process.env.DISCOVERY_SOURCE_PREMISE_LIMIT).toBe('40');
+    delete process.env.DISCOVERY_SOURCE_PREMISE_LIMIT;
+  });
+
+  it('refuses a key the graph cannot reach', async () => {
+    await expect(withDiscoveryEnvironment(
+      { POOL_QUESTIONS_MODE: 'on' }, async () => undefined,
+    )).rejects.toThrow(/POOL_QUESTIONS_MODE/);
+  });
+});
+
+describe('withMatrixEnvironment', () => {
+  it('still applies the two matrix keys unchanged', async () => {
+    const seen = await withMatrixEnvironment(
+      { id: 'intent-only', allowedTypes: 'intent', profileSource: 'premise' },
+      async () => ({
+        allowed: process.env.DISCOVERY_ALLOWED_TYPES,
+        source: process.env.DISCOVERY_PROFILE_SOURCE,
+      }),
+    );
+    expect(seen).toEqual({ allowed: 'intent', source: 'premise' });
+  });
+});

--- a/services/api/src/cli/tests/discovery-ab.flags.spec.ts
+++ b/services/api/src/cli/tests/discovery-ab.flags.spec.ts
@@ -1,0 +1,64 @@
+import { describe, expect, it } from 'bun:test';
+import path from 'node:path';
+
+import { AB_FLAGS, assertAbEnvConfig, reachableEnvKeys } from '../discovery-ab.flags';
+
+const PROFILE_ENV_ALLOWLIST = [
+  'DISCOVERY_ALLOWED_TYPES',
+  'DISCOVERY_CONTEXT_TO_INTENT',
+  'DISCOVERY_PROFILE_SOURCE',
+  'DISCOVERY_REJECTION_COOLDOWN_DAYS',
+  'DISCOVERY_SOURCE_PREMISE_LIMIT',
+  'INTRODUCER_DISCOVERY_ENABLED',
+  'NEGOTIATION_EVIDENCE_QUESTIONS_MODE',
+  'NEGOTIATION_INCLUDE_OTHER_INTENTS',
+  'NEGOTIATION_MAX_TURNS_AMBIENT',
+  'NEGOTIATION_MAX_TURNS_CHAT',
+  'OUTCOME_QUESTIONS_MODE',
+  'POOL_QUESTIONS_MINING',
+  'POOL_QUESTIONS_MODE',
+  'POOL_QUESTIONS_PUSH',
+  'POOL_QUESTIONS_RANKING',
+  'RUN_OPPORTUNITY_EVAL_IN_PARALLEL',
+];
+
+const GRAPH_ENTRY = path.resolve(
+  import.meta.dir,
+  '../../../../../packages/protocol/src/opportunity/application/opportunity.graph.ts',
+);
+
+describe('AB_FLAGS', () => {
+  it('is exactly the set of allowlisted keys the discovery graph can reach', () => {
+    const reachable = reachableEnvKeys(GRAPH_ENTRY, PROFILE_ENV_ALLOWLIST);
+    expect([...reachable].sort()).toEqual([...AB_FLAGS].sort());
+  });
+
+  it('offers nine flags and excludes every queue-only key', () => {
+    expect(AB_FLAGS).toHaveLength(9);
+    for (const key of [
+      'POOL_QUESTIONS_MODE',
+      'POOL_QUESTIONS_PUSH',
+      'POOL_QUESTIONS_RANKING',
+      'POOL_QUESTIONS_MINING',
+      'OUTCOME_QUESTIONS_MODE',
+      'NEGOTIATION_EVIDENCE_QUESTIONS_MODE',
+      'INTRODUCER_DISCOVERY_ENABLED',
+    ]) {
+      expect(AB_FLAGS).not.toContain(key);
+    }
+  });
+});
+
+describe('assertAbEnvConfig', () => {
+  it('accepts a config drawn from the offered flags', () => {
+    expect(() => assertAbEnvConfig({ DISCOVERY_ALLOWED_TYPES: 'intent' })).not.toThrow();
+  });
+
+  it('refuses a key the graph cannot reach, naming it', () => {
+    expect(() => assertAbEnvConfig({ POOL_QUESTIONS_MODE: 'on' })).toThrow(/POOL_QUESTIONS_MODE/);
+  });
+
+  it('refuses an empty value, because unset and empty are not the same thing', () => {
+    expect(() => assertAbEnvConfig({ DISCOVERY_ALLOWED_TYPES: '   ' })).toThrow(/DISCOVERY_ALLOWED_TYPES/);
+  });
+});

--- a/services/api/src/cli/tests/discovery-ab.flags.spec.ts
+++ b/services/api/src/cli/tests/discovery-ab.flags.spec.ts
@@ -1,26 +1,13 @@
 import { describe, expect, it } from 'bun:test';
 import path from 'node:path';
 
+// The allowlist is imported, never re-typed: a hand-kept copy would silently
+// stop noticing a seventeenth flag added at the source of truth, which is the
+// same drift this module exists to prevent. Imported by path because
+// @indexnetwork/protocol only exports its built `dist` entry point, and
+// ops.allowlist.ts is deliberately dependency-free so any consumer can read it.
+import { PROFILE_ENV_ALLOWLIST } from '../../../../../packages/protocol/eval/ops/ops.allowlist';
 import { AB_FLAGS, assertAbEnvConfig, reachableEnvKeys } from '../discovery-ab.flags';
-
-const PROFILE_ENV_ALLOWLIST = [
-  'DISCOVERY_ALLOWED_TYPES',
-  'DISCOVERY_CONTEXT_TO_INTENT',
-  'DISCOVERY_PROFILE_SOURCE',
-  'DISCOVERY_REJECTION_COOLDOWN_DAYS',
-  'DISCOVERY_SOURCE_PREMISE_LIMIT',
-  'INTRODUCER_DISCOVERY_ENABLED',
-  'NEGOTIATION_EVIDENCE_QUESTIONS_MODE',
-  'NEGOTIATION_INCLUDE_OTHER_INTENTS',
-  'NEGOTIATION_MAX_TURNS_AMBIENT',
-  'NEGOTIATION_MAX_TURNS_CHAT',
-  'OUTCOME_QUESTIONS_MODE',
-  'POOL_QUESTIONS_MINING',
-  'POOL_QUESTIONS_MODE',
-  'POOL_QUESTIONS_PUSH',
-  'POOL_QUESTIONS_RANKING',
-  'RUN_OPPORTUNITY_EVAL_IN_PARALLEL',
-];
 
 const GRAPH_ENTRY = path.resolve(
   import.meta.dir,

--- a/services/api/src/cli/tests/discovery-ab.gate.spec.ts
+++ b/services/api/src/cli/tests/discovery-ab.gate.spec.ts
@@ -1,0 +1,126 @@
+import { describe, expect, it } from 'bun:test';
+
+import { AB_SIDE_BRANCH_ENV, AbGateError, assertAbConfirmation, assertAbSideEnvironment } from '../discovery-ab.gate';
+
+const SIDE_A_URL = 'postgresql://evaluser:hunter2secret@ep-side-a-123456.eu-central-1.aws.neon.tech/protocol_eval';
+const SIDE_B_URL = 'postgresql://evaluser:hunter2secret@ep-side-b-123456.eu-central-1.aws.neon.tech/protocol_eval';
+
+const env = (overrides: NodeJS.ProcessEnv = {}): NodeJS.ProcessEnv => ({
+  DISCOVERY_AB_CONFIRM: '1',
+  TEST_DATABASE_SAFE: '1',
+  NEON_API_KEY: 'neon-api-key',
+  DISCOVERY_AB_TARGETS: '{"projectId":"p"}',
+  DATABASE_URL: SIDE_A_URL,
+  [AB_SIDE_BRANCH_ENV]: 'eval-ab-a',
+  ...overrides,
+});
+
+describe('assertAbConfirmation', () => {
+  it('accepts an explicitly attested run', () => {
+    expect(() => assertAbConfirmation(env())).not.toThrow();
+  });
+
+  it('refuses without the confirm variable, naming it', () => {
+    expect(() => assertAbConfirmation(env({ DISCOVERY_AB_CONFIRM: undefined }))).toThrow(/set DISCOVERY_AB_CONFIRM=1/);
+  });
+
+  it.each(['0', 'true', 'yes', ''])('refuses DISCOVERY_AB_CONFIRM=%p, because only an exact 1 is consent', (value) => {
+    expect(() => assertAbConfirmation(env({ DISCOVERY_AB_CONFIRM: value }))).toThrow(/DISCOVERY_AB_CONFIRM=1/);
+  });
+
+  it('refuses without the disposable-database marker', () => {
+    expect(() => assertAbConfirmation(env({ TEST_DATABASE_SAFE: undefined }))).toThrow(/TEST_DATABASE_SAFE=1/);
+  });
+
+  it('refuses without the control-plane key, which every process needs to attest its targets', () => {
+    expect(() => assertAbConfirmation(env({ NEON_API_KEY: undefined }))).toThrow(/NEON_API_KEY is required/);
+    expect(() => assertAbConfirmation(env({ NEON_API_KEY: '' }))).toThrow(/NEON_API_KEY is required/);
+  });
+
+  it('refuses without a targets manifest, naming the variable rather than restating its contract', () => {
+    expect(() => assertAbConfirmation(env({ DISCOVERY_AB_TARGETS: undefined }))).toThrow(/DISCOVERY_AB_TARGETS must declare/);
+    expect(() => assertAbConfirmation(env({ DISCOVERY_AB_TARGETS: '  ' }))).toThrow(/DISCOVERY_AB_TARGETS must declare/);
+  });
+
+  it('raises a refusal the bootstrap is allowed to print', () => {
+    expect(() => assertAbConfirmation({})).toThrow(AbGateError);
+  });
+});
+
+describe('assertAbSideEnvironment', () => {
+  it('accepts a side composed against its own designated A/B branch', () => {
+    const resolved = assertAbSideEnvironment(env(), 'a');
+    expect(resolved.branch).toBe('eval-ab-a');
+    expect(resolved.databaseUrl.pathname).toBe('/protocol_eval');
+  });
+
+  it('applies the confirmation gate first, so an unconfirmed child never reaches a URL check', () => {
+    expect(() => assertAbSideEnvironment(env({ DISCOVERY_AB_CONFIRM: undefined }), 'a')).toThrow(/DISCOVERY_AB_CONFIRM=1/);
+  });
+
+  it('refuses a missing or unparseable DATABASE_URL', () => {
+    expect(() => assertAbSideEnvironment(env({ DATABASE_URL: undefined }), 'a')).toThrow(/valid Neon protocol_eval URL/);
+    expect(() => assertAbSideEnvironment(env({ DATABASE_URL: 'not a url' }), 'a')).toThrow(/valid Neon protocol_eval URL/);
+  });
+
+  it('refuses a non-postgres URL', () => {
+    expect(() => assertAbSideEnvironment(env({ DATABASE_URL: 'https://ep-side-a.neon.tech/protocol_eval' }), 'a'))
+      .toThrow(/must use postgres/);
+  });
+
+  it('refuses a non-Neon host, naming only the host', () => {
+    expect(() => assertAbSideEnvironment(env({ DATABASE_URL: 'postgresql://u:p@db.example.com/protocol_eval' }), 'a'))
+      .toThrow(/Refusing non-Neon DATABASE_URL host: db.example.com/);
+  });
+
+  it('refuses any database other than protocol_eval', () => {
+    expect(() => assertAbSideEnvironment(env({ DATABASE_URL: SIDE_A_URL.replace('/protocol_eval', '/index') }), 'a'))
+      .toThrow(/must be exactly \/protocol_eval/);
+  });
+
+  it('refuses a port other than 5432', () => {
+    expect(() => assertAbSideEnvironment(env({ DATABASE_URL: SIDE_A_URL.replace('.neon.tech', '.neon.tech:6543') }), 'a'))
+      .toThrow(/port must be exactly 5432/);
+  });
+
+  it('refuses a missing branch label', () => {
+    expect(() => assertAbSideEnvironment(env({ [AB_SIDE_BRANCH_ENV]: undefined }), 'a'))
+      .toThrow(/DISCOVERY_AB_SIDE_BRANCH must be exactly eval-ab-a/);
+  });
+
+  it('refuses a branch that is not a designated A/B branch', () => {
+    for (const branch of ['dev', 'production', 'eval-discovery-base', 'eval-ab-a-backup']) {
+      expect(() => assertAbSideEnvironment(env({ [AB_SIDE_BRANCH_ENV]: branch }), 'a')).toThrow(/must be exactly eval-ab-a/);
+    }
+  });
+
+  it("refuses side b's branch under side a's flag, which would misattribute a whole side", () => {
+    expect(() => assertAbSideEnvironment(env({ DATABASE_URL: SIDE_B_URL, [AB_SIDE_BRANCH_ENV]: 'eval-ab-b' }), 'a'))
+      .toThrow(/must be exactly eval-ab-a for side a/);
+  });
+
+  it('accepts side b on its own branch', () => {
+    expect(assertAbSideEnvironment(env({ DATABASE_URL: SIDE_B_URL, [AB_SIDE_BRANCH_ENV]: 'eval-ab-b' }), 'b').branch)
+      .toBe('eval-ab-b');
+  });
+
+  it('never puts the DATABASE_URL password into a refusal', () => {
+    for (const overrides of [
+      { DATABASE_URL: SIDE_A_URL.replace('/protocol_eval', '/index') },
+      { DATABASE_URL: SIDE_A_URL.replace('.neon.tech', '.example.com') },
+      { DATABASE_URL: SIDE_A_URL.replace('.neon.tech', '.neon.tech:6543') },
+      { [AB_SIDE_BRANCH_ENV]: 'dev' },
+    ]) {
+      const error = (() => {
+        try {
+          assertAbSideEnvironment(env(overrides), 'a');
+          return null;
+        } catch (caught) {
+          return caught as Error;
+        }
+      })();
+      expect(error).not.toBeNull();
+      expect(error!.message).not.toContain('hunter2secret');
+    }
+  });
+});

--- a/services/api/src/cli/tests/discovery-ab.neon.spec.ts
+++ b/services/api/src/cli/tests/discovery-ab.neon.spec.ts
@@ -1,0 +1,192 @@
+import { describe, expect, it } from 'bun:test';
+
+import { attestAbTargets, parseAbManifest, resetAbBranch, type AbManifest } from '../discovery-ab.neon';
+import type { NeonControlPlane } from '../discovery-env-matrix.neon';
+
+const manifest: AbManifest = {
+  projectId: 'proj-1',
+  baseBranchId: 'br-base',
+  targets: [
+    { sideId: 'a', branchId: 'br-a', endpointId: 'ep-a', databaseUrl: 'postgresql://u:p@ep-a.neon.tech/protocol_eval' },
+    { sideId: 'b', branchId: 'br-b', endpointId: 'ep-b', databaseUrl: 'postgresql://u:p@ep-b.neon.tech/protocol_eval' },
+  ],
+};
+
+const controlPlane = (overrides: Record<string, Partial<{ name: string; parentId: string | null; primary: boolean }>> = {}): NeonControlPlane => ({
+  getBranch: async (_projectId, branchId) => ({
+    id: branchId,
+    name: { 'br-base': 'eval-discovery-base', 'br-a': 'eval-ab-a', 'br-b': 'eval-ab-b' }[branchId] ?? 'unknown',
+    parentId: branchId === 'br-base' ? null : 'br-base',
+    expiresAt: null,
+    primary: false,
+    ...overrides[branchId],
+  }),
+  listEndpoints: async (_projectId, branchId) => [
+    { id: `ep-${branchId.slice(3)}`, branchId, host: `ep-${branchId.slice(3)}.neon.tech` },
+  ],
+});
+
+const manifestJson = (overrides: Record<string, unknown> = {}): string => JSON.stringify({
+  projectId: 'proj-1',
+  baseBranchId: 'br-base',
+  targets: manifest.targets,
+  ...overrides,
+});
+
+describe('attestAbTargets', () => {
+  it('accepts two A/B branches parented on the attested base', async () => {
+    await expect(attestAbTargets({ manifest, controlPlane: controlPlane() })).resolves.toBeDefined();
+  });
+
+  it('refuses a branch whose name is not a designated A/B branch', async () => {
+    await expect(attestAbTargets({ manifest, controlPlane: controlPlane({ 'br-a': { name: 'dev' } }) }))
+      .rejects.toThrow(/identity is invalid/);
+  });
+
+  it('refuses a branch that is not parented on the base', async () => {
+    await expect(attestAbTargets({ manifest, controlPlane: controlPlane({ 'br-b': { parentId: 'br-production' } }) }))
+      .rejects.toThrow(/identity is invalid/);
+  });
+
+  it('refuses the primary branch outright', async () => {
+    await expect(attestAbTargets({ manifest, controlPlane: controlPlane({ 'br-a': { primary: true } }) }))
+      .rejects.toThrow(/identity is invalid/);
+  });
+
+  it('refuses a base branch that is not the protected fixture base', async () => {
+    await expect(attestAbTargets({ manifest, controlPlane: controlPlane({ 'br-base': { name: 'production' } }) }))
+      .rejects.toThrow(/base branch identity is invalid/);
+  });
+
+  it('refuses a side whose endpoint host is not the host in its DATABASE_URL', async () => {
+    const crossed: AbManifest = {
+      ...manifest,
+      targets: [manifest.targets[0], { ...manifest.targets[1], databaseUrl: 'postgresql://u:p@ep-production.neon.tech/protocol_eval' }],
+    };
+    await expect(attestAbTargets({ manifest: crossed, controlPlane: controlPlane() }))
+      .rejects.toThrow(/endpoint host does not match DATABASE_URL/);
+  });
+
+  it('never puts a DATABASE_URL in the error, because it carries a password', async () => {
+    const malformed: AbManifest = {
+      ...manifest,
+      targets: [{ ...manifest.targets[0], databaseUrl: 'not-a-url://u:hunter2@' }, manifest.targets[1]],
+    };
+    const error = await attestAbTargets({ manifest: malformed, controlPlane: controlPlane() })
+      .catch((caught: Error) => caught);
+    expect(error).toBeInstanceOf(Error);
+    expect((error as Error).message).not.toContain('hunter2');
+  });
+});
+
+describe('resetAbBranch', () => {
+  it('refuses to reset a branch that is not in the attested manifest', async () => {
+    await expect(resetAbBranch({ manifest, branchId: 'br-production', apiKey: 'k' }))
+      .rejects.toThrow(/not a designated/i);
+  });
+
+  it('posts a restore from the attested base for an attested A/B branch', async () => {
+    const calls: string[] = [];
+    const bodies: unknown[] = [];
+    await resetAbBranch({
+      manifest, branchId: 'br-a', apiKey: 'k',
+      fetchImpl: (async (url: string, init?: RequestInit) => {
+        calls.push(`${init?.method ?? 'GET'} ${url}`);
+        bodies.push(JSON.parse(String(init?.body ?? 'null')));
+        return new Response('{}', { status: 200 });
+      }) as unknown as typeof fetch,
+    });
+    expect(calls).toEqual(['POST https://console.neon.tech/api/v2/projects/proj-1/branches/br-a/restore']);
+    expect(bodies).toEqual([{ source_branch_id: 'br-base' }]);
+  });
+
+  it('raises a sanitized error when the control plane refuses', async () => {
+    await expect(resetAbBranch({
+      manifest, branchId: 'br-a', apiKey: 'k',
+      fetchImpl: (async () => new Response('{"message":"token sk-secret invalid"}', { status: 401 })) as unknown as typeof fetch,
+    })).rejects.toThrow(/Neon control-plane reset failed/);
+  });
+
+  it('never puts the response body in the error, because it can carry credentials', async () => {
+    const error = await resetAbBranch({
+      manifest, branchId: 'br-a', apiKey: 'k',
+      fetchImpl: (async () => new Response('{"message":"token sk-secret invalid"}', { status: 401 })) as unknown as typeof fetch,
+    }).catch((caught: Error) => caught);
+    expect((error as Error).message).not.toContain('sk-secret');
+  });
+
+  it('never puts the API key in the error either', async () => {
+    const error = await resetAbBranch({
+      manifest, branchId: 'br-a', apiKey: 'neon_api_key_secret',
+      fetchImpl: (async () => new Response('{}', { status: 403 })) as unknown as typeof fetch,
+    }).catch((caught: Error) => caught);
+    expect((error as Error).message).not.toContain('neon_api_key_secret');
+  });
+});
+
+describe('parseAbManifest', () => {
+  it('refuses a manifest that does not name exactly two sides', () => {
+    expect(() => parseAbManifest(JSON.stringify({ projectId: 'p', baseBranchId: 'b', targets: [] })))
+      .toThrow(/exactly two/i);
+  });
+
+  it('refuses a missing manifest', () => {
+    expect(() => parseAbManifest(undefined)).toThrow(/manifest/i);
+  });
+
+  it('refuses a manifest that is not valid JSON', () => {
+    expect(() => parseAbManifest('{')).toThrow(/valid JSON/i);
+  });
+
+  it('accepts a well-formed manifest and orders the sides a then b', () => {
+    const parsed = parseAbManifest(manifestJson({ targets: [manifest.targets[1], manifest.targets[0]] }));
+    expect(parsed.targets.map((target) => target.sideId)).toEqual(['a', 'b']);
+    expect(parsed.projectId).toBe('proj-1');
+  });
+
+  it('refuses a projectId of the wrong type instead of failing later on it', () => {
+    expect(() => parseAbManifest(manifestJson({ projectId: 42 }))).toThrow(/projectId/);
+  });
+
+  it('refuses a target field of the wrong type instead of failing later on it', () => {
+    expect(() => parseAbManifest(manifestJson({ targets: [{ ...manifest.targets[0], branchId: 7 }, manifest.targets[1]] })))
+      .toThrow(/branchId/);
+  });
+
+  it('refuses a side id that is not a or b', () => {
+    expect(() => parseAbManifest(manifestJson({ targets: [{ ...manifest.targets[0], sideId: 'c' }, manifest.targets[1]] })))
+      .toThrow(/sideId/);
+  });
+
+  it('refuses two targets naming the same side', () => {
+    expect(() => parseAbManifest(manifestJson({ targets: [manifest.targets[0], { ...manifest.targets[1], sideId: 'a' }] })))
+      .toThrow(/one side a and one side b/i);
+  });
+
+  it('refuses two sides pointed at the same branch', () => {
+    expect(() => parseAbManifest(manifestJson({ targets: [manifest.targets[0], { ...manifest.targets[1], branchId: 'br-a' }] })))
+      .toThrow(/distinct/i);
+  });
+
+  it('refuses a side pointed at the base branch itself', () => {
+    expect(() => parseAbManifest(manifestJson({ targets: [{ ...manifest.targets[0], branchId: 'br-base' }, manifest.targets[1]] })))
+      .toThrow(/base branch/i);
+  });
+
+  it('refuses a databaseUrl that is not a Neon postgres URL', () => {
+    expect(() => parseAbManifest(manifestJson({ targets: [{ ...manifest.targets[0], databaseUrl: 'https://evil.example.com/db' }, manifest.targets[1]] })))
+      .toThrow(/databaseUrl/);
+  });
+
+  it('never echoes a rejected databaseUrl, because it carries a password', () => {
+    const error = ((): Error => {
+      try {
+        parseAbManifest(manifestJson({ targets: [{ ...manifest.targets[0], databaseUrl: 'https://u:hunter2@evil.example.com/db' }, manifest.targets[1]] }));
+      } catch (caught) {
+        return caught as Error;
+      }
+      throw new Error('expected parseAbManifest to reject');
+    })();
+    expect(error.message).not.toContain('hunter2');
+  });
+});

--- a/services/api/src/cli/tests/discovery-ab.neon.spec.ts
+++ b/services/api/src/cli/tests/discovery-ab.neon.spec.ts
@@ -120,7 +120,7 @@ describe('resetAbBranch', () => {
       manifest: await attest(), branchId: 'br-a', apiKey: 'k', pollIntervalMs: 0, pollTimeoutMs: 1_000,
       fetchImpl: (async (url: string, init?: RequestInit) => {
         if ((init?.method ?? 'GET') === 'POST') bodies.push(JSON.parse(String(init?.body ?? 'null')));
-        return send(url as unknown as RequestInfo, init);
+        return send(url, init);
       }) as unknown as typeof fetch,
     });
     expect(calls).toEqual([`POST ${RESTORE_URL}`, `GET ${OPERATION_URL('op-1')}`, `GET ${OPERATION_URL('op-1')}`]);

--- a/services/api/src/cli/tests/discovery-ab.neon.spec.ts
+++ b/services/api/src/cli/tests/discovery-ab.neon.spec.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'bun:test';
 
-import { attestAbTargets, parseAbManifest, resetAbBranch, type AbManifest } from '../discovery-ab.neon';
+import { attestAbTargets, parseAbManifest, resetAbBranch, type AbManifest, type AttestedAbManifest } from '../discovery-ab.neon';
 import type { NeonControlPlane } from '../discovery-env-matrix.neon';
 
 const manifest: AbManifest = {
@@ -25,6 +25,33 @@ const controlPlane = (overrides: Record<string, Partial<{ name: string; parentId
     { id: `ep-${branchId.slice(3)}`, branchId, host: `ep-${branchId.slice(3)}.neon.tech` },
   ],
 });
+
+/** The only supported way to obtain the branded manifest `resetAbBranch` takes. */
+const attest = (): Promise<AttestedAbManifest> => attestAbTargets({ manifest, controlPlane: controlPlane() });
+
+const RESTORE_URL = 'https://console.neon.tech/api/v2/projects/proj-1/branches/br-a/restore';
+const OPERATION_URL = (id: string): string => `https://console.neon.tech/api/v2/projects/proj-1/operations/${id}`;
+
+/**
+ * A restore that reports `operationIds`, then answers every poll with the next
+ * status in `statuses` (repeating the last one forever, which is how a stuck
+ * operation looks).
+ */
+const restoreFetch = (input: { operationIds: string[]; statuses: string[]; calls: string[] }): typeof fetch => {
+  let poll = 0;
+  return (async (url: string, init?: RequestInit) => {
+    input.calls.push(`${init?.method ?? 'GET'} ${url}`);
+    if ((init?.method ?? 'GET') === 'POST') {
+      return new Response(JSON.stringify({
+        branch: { id: 'br-a' },
+        operations: input.operationIds.map((id) => ({ id, status: 'running', action: 'apply_config' })),
+      }), { status: 200 });
+    }
+    const status = input.statuses[Math.min(poll, input.statuses.length - 1)] ?? 'finished';
+    poll += 1;
+    return new Response(JSON.stringify({ operation: { id: 'op-1', status, error: 'token sk-secret invalid' } }), { status: 200 });
+  }) as unknown as typeof fetch;
+};
 
 const manifestJson = (overrides: Record<string, unknown> = {}): string => JSON.stringify({
   projectId: 'proj-1',
@@ -81,35 +108,108 @@ describe('attestAbTargets', () => {
 
 describe('resetAbBranch', () => {
   it('refuses to reset a branch that is not in the attested manifest', async () => {
-    await expect(resetAbBranch({ manifest, branchId: 'br-production', apiKey: 'k' }))
+    await expect(resetAbBranch({ manifest: await attest(), branchId: 'br-production', apiKey: 'k' }))
       .rejects.toThrow(/not a designated/i);
   });
 
-  it('posts a restore from the attested base for an attested A/B branch', async () => {
+  it('posts a restore from the attested base and waits for the operation to finish', async () => {
     const calls: string[] = [];
     const bodies: unknown[] = [];
+    const send = restoreFetch({ operationIds: ['op-1'], statuses: ['running', 'finished'], calls });
     await resetAbBranch({
-      manifest, branchId: 'br-a', apiKey: 'k',
+      manifest: await attest(), branchId: 'br-a', apiKey: 'k', pollIntervalMs: 0, pollTimeoutMs: 1_000,
       fetchImpl: (async (url: string, init?: RequestInit) => {
-        calls.push(`${init?.method ?? 'GET'} ${url}`);
-        bodies.push(JSON.parse(String(init?.body ?? 'null')));
-        return new Response('{}', { status: 200 });
+        if ((init?.method ?? 'GET') === 'POST') bodies.push(JSON.parse(String(init?.body ?? 'null')));
+        return send(url as unknown as RequestInfo, init);
       }) as unknown as typeof fetch,
     });
-    expect(calls).toEqual(['POST https://console.neon.tech/api/v2/projects/proj-1/branches/br-a/restore']);
+    expect(calls).toEqual([`POST ${RESTORE_URL}`, `GET ${OPERATION_URL('op-1')}`, `GET ${OPERATION_URL('op-1')}`]);
     expect(bodies).toEqual([{ source_branch_id: 'br-base' }]);
+  });
+
+  it('waits for every reported operation, not just the first', async () => {
+    const calls: string[] = [];
+    await resetAbBranch({
+      manifest: await attest(), branchId: 'br-a', apiKey: 'k', pollIntervalMs: 0, pollTimeoutMs: 1_000,
+      fetchImpl: restoreFetch({ operationIds: ['op-1', 'op-2'], statuses: ['finished'], calls }),
+    });
+    expect(calls).toEqual([`POST ${RESTORE_URL}`, `GET ${OPERATION_URL('op-1')}`, `GET ${OPERATION_URL('op-2')}`]);
+  });
+
+  it('throws when an operation ends in failed, because the branch was not reset', async () => {
+    const calls: string[] = [];
+    await expect(resetAbBranch({
+      manifest: await attest(), branchId: 'br-a', apiKey: 'k', pollIntervalMs: 0, pollTimeoutMs: 1_000,
+      fetchImpl: restoreFetch({ operationIds: ['op-1'], statuses: ['running', 'failed'], calls }),
+    })).rejects.toThrow(/reset operation ended with status failed/);
+  });
+
+  it.each(['error', 'cancelled', 'skipped'])('throws when an operation ends in %s', async (status) => {
+    const calls: string[] = [];
+    await expect(resetAbBranch({
+      manifest: await attest(), branchId: 'br-a', apiKey: 'k', pollIntervalMs: 0, pollTimeoutMs: 1_000,
+      fetchImpl: restoreFetch({ operationIds: ['op-1'], statuses: [status], calls }),
+    })).rejects.toThrow(new RegExp(`reset operation ended with status ${status}`));
+  });
+
+  it('never puts the operation body in the failure error, because it can carry credentials', async () => {
+    const calls: string[] = [];
+    const error = await resetAbBranch({
+      manifest: await attest(), branchId: 'br-a', apiKey: 'neon_api_key_secret', pollIntervalMs: 0, pollTimeoutMs: 1_000,
+      fetchImpl: restoreFetch({ operationIds: ['op-1'], statuses: ['failed'], calls }),
+    }).catch((caught: Error) => caught);
+    expect((error as Error).message).not.toContain('sk-secret');
+    expect((error as Error).message).not.toContain('neon_api_key_secret');
+  });
+
+  it('gives up within the injected timeout when an operation never finishes', async () => {
+    const calls: string[] = [];
+    const started = Date.now();
+    await expect(resetAbBranch({
+      manifest: await attest(), branchId: 'br-a', apiKey: 'k', pollIntervalMs: 1, pollTimeoutMs: 25,
+      fetchImpl: restoreFetch({ operationIds: ['op-1'], statuses: ['running'], calls }),
+    })).rejects.toThrow(/did not finish within 25ms/);
+    expect(Date.now() - started).toBeLessThan(2_000);
+    expect(calls.length).toBeGreaterThan(1);
+  });
+
+  it('refuses a restore that reports no operations, because completion is then unknowable', async () => {
+    await expect(resetAbBranch({
+      manifest: await attest(), branchId: 'br-a', apiKey: 'k', pollIntervalMs: 0, pollTimeoutMs: 1_000,
+      fetchImpl: (async () => new Response('{}', { status: 200 })) as unknown as typeof fetch,
+    })).rejects.toThrow(/did not report any operations/);
+  });
+
+  it('reports only a status when an operation poll is refused', async () => {
+    const error = await resetAbBranch({
+      manifest: await attest(), branchId: 'br-a', apiKey: 'k', pollIntervalMs: 0, pollTimeoutMs: 1_000,
+      fetchImpl: (async (_url: string, init?: RequestInit) => ((init?.method ?? 'GET') === 'POST'
+        ? new Response(JSON.stringify({ operations: [{ id: 'op-1' }] }), { status: 200 })
+        : new Response('{"message":"token sk-secret invalid"}', { status: 401 }))) as unknown as typeof fetch,
+    }).catch((caught: Error) => caught);
+    expect((error as Error).message).toMatch(/operation poll failed with status 401/);
+    expect((error as Error).message).not.toContain('sk-secret');
+  });
+
+  it('refuses an unrecognized operation status rather than echoing it', async () => {
+    await expect(resetAbBranch({
+      manifest: await attest(), branchId: 'br-a', apiKey: 'k', pollIntervalMs: 0, pollTimeoutMs: 1_000,
+      fetchImpl: (async (_url: string, init?: RequestInit) => ((init?.method ?? 'GET') === 'POST'
+        ? new Response(JSON.stringify({ operations: [{ id: 'op-1' }] }), { status: 200 })
+        : new Response(JSON.stringify({ operation: { status: 'sk-secret' } }), { status: 200 }))) as unknown as typeof fetch,
+    })).rejects.toThrow(/unrecognized status/);
   });
 
   it('raises a sanitized error when the control plane refuses', async () => {
     await expect(resetAbBranch({
-      manifest, branchId: 'br-a', apiKey: 'k',
+      manifest: await attest(), branchId: 'br-a', apiKey: 'k',
       fetchImpl: (async () => new Response('{"message":"token sk-secret invalid"}', { status: 401 })) as unknown as typeof fetch,
     })).rejects.toThrow(/Neon control-plane reset failed/);
   });
 
   it('never puts the response body in the error, because it can carry credentials', async () => {
     const error = await resetAbBranch({
-      manifest, branchId: 'br-a', apiKey: 'k',
+      manifest: await attest(), branchId: 'br-a', apiKey: 'k',
       fetchImpl: (async () => new Response('{"message":"token sk-secret invalid"}', { status: 401 })) as unknown as typeof fetch,
     }).catch((caught: Error) => caught);
     expect((error as Error).message).not.toContain('sk-secret');
@@ -117,10 +217,47 @@ describe('resetAbBranch', () => {
 
   it('never puts the API key in the error either', async () => {
     const error = await resetAbBranch({
-      manifest, branchId: 'br-a', apiKey: 'neon_api_key_secret',
+      manifest: await attest(), branchId: 'br-a', apiKey: 'neon_api_key_secret',
       fetchImpl: (async () => new Response('{}', { status: 403 })) as unknown as typeof fetch,
     }).catch((caught: Error) => caught);
     expect((error as Error).message).not.toContain('neon_api_key_secret');
+  });
+});
+
+describe('resetAbBranch attestation brand', () => {
+  /**
+   * The reviewer's attack: a manifest built through the real `parseAbManifest`
+   * that names production as a side and dev as the base, never attested. It
+   * must not compile, and must still be refused at runtime if the brand is cast
+   * away.
+   */
+  const forged = parseAbManifest(JSON.stringify({
+    projectId: 'shiny-cloud-34341469',
+    baseBranchId: 'br-late-tooth-ahlsfgdb',
+    targets: [
+      { sideId: 'a', branchId: 'br-fragrant-brook-ahexgsek', endpointId: 'ep-prod', databaseUrl: 'postgresql://u:p@ep-prod.neon.tech/protocol_eval' },
+      { sideId: 'b', branchId: 'br-b', endpointId: 'ep-b', databaseUrl: 'postgresql://u:p@ep-b.neon.tech/protocol_eval' },
+    ],
+  }));
+
+  const neverCalled = (async () => {
+    throw new Error('resetAbBranch must not reach the control plane');
+  }) as unknown as typeof fetch;
+
+  it('does not accept an unattested manifest at the type level', async () => {
+    await expect(resetAbBranch({
+      // @ts-expect-error - resetAbBranch takes only an AttestedAbManifest; a parsed
+      // manifest is not one, so the forged-manifest attack cannot be compiled.
+      manifest: forged,
+      branchId: 'br-b', apiKey: 'k', fetchImpl: neverCalled,
+    })).rejects.toThrow();
+  });
+
+  it('still refuses a branch outside the manifest when the brand is cast away', async () => {
+    await expect(resetAbBranch({
+      manifest: forged as AttestedAbManifest,
+      branchId: 'br-production', apiKey: 'k', fetchImpl: neverCalled,
+    })).rejects.toThrow(/not a designated/i);
   });
 });
 
@@ -176,6 +313,27 @@ describe('parseAbManifest', () => {
   it('refuses a databaseUrl that is not a Neon postgres URL', () => {
     expect(() => parseAbManifest(manifestJson({ targets: [{ ...manifest.targets[0], databaseUrl: 'https://evil.example.com/db' }, manifest.targets[1]] })))
       .toThrow(/databaseUrl/);
+  });
+
+  it('refuses a databaseUrl naming a database other than protocol_eval', () => {
+    expect(() => parseAbManifest(manifestJson({ targets: [{ ...manifest.targets[0], databaseUrl: 'postgresql://u:p@ep-a.neon.tech/production' }, manifest.targets[1]] })))
+      .toThrow(/must be exactly protocol_eval/);
+  });
+
+  it('refuses the URL shape the matrix bootstrap would have rejected', () => {
+    expect(() => parseAbManifest(manifestJson({ targets: [{ ...manifest.targets[0], databaseUrl: 'postgresql://u:p@ep-a.neon.tech:6543/production?options=endpoint%3Dep-prod' }, manifest.targets[1]] })))
+      .toThrow(/must be exactly protocol_eval/);
+  });
+
+  it('refuses a port other than 5432', () => {
+    expect(() => parseAbManifest(manifestJson({ targets: [{ ...manifest.targets[0], databaseUrl: 'postgresql://u:p@ep-a.neon.tech:6543/protocol_eval' }, manifest.targets[1]] })))
+      .toThrow(/port must be exactly 5432/);
+  });
+
+  it('accepts the pooled Neon URL shape, which uses the default port', () => {
+    const pooled = 'postgresql://u:p@ep-a-pooler.neon.tech:5432/protocol_eval?sslmode=require';
+    const parsed = parseAbManifest(manifestJson({ targets: [{ ...manifest.targets[0], databaseUrl: pooled }, manifest.targets[1]] }));
+    expect(parsed.targets[0].databaseUrl).toBe(pooled);
   });
 
   it('never echoes a rejected databaseUrl, because it carries a password', () => {

--- a/services/api/src/cli/tests/discovery-ab.neon.spec.ts
+++ b/services/api/src/cli/tests/discovery-ab.neon.spec.ts
@@ -144,12 +144,47 @@ describe('resetAbBranch', () => {
     })).rejects.toThrow(/reset operation ended with status failed/);
   });
 
-  it.each(['error', 'cancelled', 'skipped'])('throws when an operation ends in %s', async (status) => {
+  it.each(['error', 'cancelled'])('throws when an operation ends in %s', async (status) => {
     const calls: string[] = [];
     await expect(resetAbBranch({
       manifest: await attest(), branchId: 'br-a', apiKey: 'k', pollIntervalMs: 0, pollTimeoutMs: 1_000,
       fetchImpl: restoreFetch({ operationIds: ['op-1'], statuses: [status], calls }),
     })).rejects.toThrow(new RegExp(`reset operation ended with status ${status}`));
+  });
+
+  // Restore reports the whole operation chain, and Neon marks a step it did not
+  // need to perform `skipped`. Treating that as fatal aborted a reset that had
+  // in fact succeeded, and said the branches might have been overwritten.
+  it('accepts a skipped operation, because skipped means the step was unnecessary, not failed', async () => {
+    const calls: string[] = [];
+    await resetAbBranch({
+      manifest: await attest(), branchId: 'br-a', apiKey: 'k', pollIntervalMs: 0, pollTimeoutMs: 1_000,
+      fetchImpl: restoreFetch({ operationIds: ['op-1'], statuses: ['skipped'], calls }),
+    });
+    expect(calls).toEqual([`POST ${RESTORE_URL}`, `GET ${OPERATION_URL('op-1')}`]);
+  });
+
+  it('completes a restore whose compute sub-operation is skipped and whose restore finishes', async () => {
+    const statusById: Record<string, string> = { 'op-restore': 'finished', 'op-suspend': 'skipped' };
+    const calls: string[] = [];
+    await resetAbBranch({
+      manifest: await attest(), branchId: 'br-a', apiKey: 'k', pollIntervalMs: 0, pollTimeoutMs: 1_000,
+      fetchImpl: (async (url: string, init?: RequestInit) => {
+        calls.push(`${init?.method ?? 'GET'} ${url}`);
+        if ((init?.method ?? 'GET') === 'POST') {
+          return new Response(JSON.stringify({
+            branch: { id: 'br-a' },
+            operations: [
+              { id: 'op-restore', status: 'running', action: 'restore_branch' },
+              { id: 'op-suspend', status: 'running', action: 'suspend_compute' },
+            ],
+          }), { status: 200 });
+        }
+        const id = url.slice(url.lastIndexOf('/') + 1);
+        return new Response(JSON.stringify({ operation: { id, status: statusById[id] } }), { status: 200 });
+      }) as unknown as typeof fetch,
+    });
+    expect(calls).toEqual([`POST ${RESTORE_URL}`, `GET ${OPERATION_URL('op-restore')}`, `GET ${OPERATION_URL('op-suspend')}`]);
   });
 
   it('never puts the operation body in the failure error, because it can carry credentials', async () => {

--- a/services/api/src/cli/tests/discovery-ab.parent.spec.ts
+++ b/services/api/src/cli/tests/discovery-ab.parent.spec.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from 'bun:test';
 
-import { AB_DEFAULT_REPETITIONS, AB_EXIT_INSUFFICIENT_EVIDENCE, AB_MAX_REPETITIONS, abChildTimeoutMs, abSelectionFilters, formatAbRunArgs, parseAbRunArgs, resolveAbCases, resolveAbRunOutcome } from '../discovery-ab.main';
+import { AB_EXIT_PREFLIGHT_REFUSED, AB_EXIT_SPENT_WITHOUT_ARTIFACT, AbSpentRunError, describeAbFailure } from '../discovery-ab.contract';
+import { AB_DEFAULT_REPETITIONS, AB_EXIT_INSUFFICIENT_EVIDENCE, AB_MAX_REPETITIONS, abChildTimeoutMs, abSelectionFilters, finalizeAbChildArtifacts, formatAbRunArgs, parseAbRunArgs, resolveAbCases, resolveAbRunOutcome, withAbSpendAccounting } from '../discovery-ab.main';
 import { buildAbPlan, type AbSide } from '../discovery-ab.plan';
 
 import type { MatrixSlotResult } from '../discovery-env-matrix.main';
@@ -191,5 +192,106 @@ describe('resolveAbRunOutcome', () => {
     const outcome = resolveAbRunOutcome({ slots, sides, expectedSlotsPerSide: 2 });
     expect(outcome.sides[0]).toMatchObject({ sideId: 'a', scored: 1, failed: 1, passes: 1 });
     expect(outcome.verdict).toBeNull();
+  });
+
+  it('gives an incomplete run a different code to a failure that wrote nothing at all', () => {
+    const slots = [slot('a', 'c1/a/r1', 1, 1), slot('b', 'c1/b/r1', 0, 0)];
+    const incomplete = resolveAbRunOutcome({ slots, sides, expectedSlotsPerSide: 1 });
+    // 3 says the artifact is on disk and says nothing; 4 says there is no artifact.
+    expect(incomplete.exitCode).toBe(AB_EXIT_INSUFFICIENT_EVIDENCE);
+    expect(incomplete.exitCode).not.toBe(AB_EXIT_SPENT_WITHOUT_ARTIFACT);
+  });
+});
+
+/**
+ * This is the wrapper `runAbParent` runs its whole body through, so what it
+ * decides is what the operator's exit code is.
+ */
+describe('withAbSpendAccounting', () => {
+  it('passes a successful run through untouched', async () => {
+    await expect(withAbSpendAccounting(async () => undefined)).resolves.toBeUndefined();
+  });
+
+  it('leaves a failure before the first reset as the pre-flight refusal it is', async () => {
+    const refusal = new Error('--runs must be a positive integer (received 0)');
+    const thrown = await withAbSpendAccounting(async () => { throw refusal; }).catch((error: unknown) => error);
+    expect(thrown).toBe(refusal);
+    expect(describeAbFailure(thrown).exitCode).toBe(AB_EXIT_PREFLIGHT_REFUSED);
+  });
+
+  it('reports a failure after the branches were reset as a mutation, not a refusal', async () => {
+    const thrown = await withAbSpendAccounting(async (progress) => {
+      progress.stage = 'reset';
+      throw new Error('mkdtemp failed');
+    }).catch((error: unknown) => error);
+    expect(thrown).toBeInstanceOf(AbSpentRunError);
+    expect(describeAbFailure(thrown)).toMatchObject({ exitCode: AB_EXIT_SPENT_WITHOUT_ARTIFACT });
+    expect(describeAbFailure(thrown).message).toContain('after resetting the A/B branches');
+  });
+
+  it('reports a failure after a side was spawned as a spend with no artifact', async () => {
+    const thrown = await withAbSpendAccounting(async (progress) => {
+      progress.stage = 'reset';
+      progress.stage = 'spawned';
+      // The dead-child case: supervision aborts and nothing was written.
+      throw new Error('Discovery A/B child exited with code 1');
+    }).catch((error: unknown) => error);
+    const report = describeAbFailure(thrown);
+    expect(report.exitCode).toBe(AB_EXIT_SPENT_WITHOUT_ARTIFACT);
+    expect(report.message).toContain('provider spend and wall-clock time are gone');
+    expect(report.message).toContain('No artifact was written');
+    // The underlying failure text is never printed; only kept as a cause.
+    expect(report.message).not.toContain('exited with code 1');
+  });
+});
+
+describe('finalizeAbChildArtifacts', () => {
+  const fakeFs = (entries: string[] | Error) => {
+    const removed: string[] = [];
+    return {
+      removed,
+      fs: {
+        readdir: (async () => {
+          if (entries instanceof Error) throw entries;
+          return entries;
+        }) as never,
+        rm: (async (target: string) => { removed.push(target); }) as never,
+      },
+    };
+  };
+  const warnings: string[] = [];
+  const logger = { warn: (message: string) => { warnings.push(message); } };
+
+  it('removes the directory when the run succeeded', async () => {
+    const { fs, removed } = fakeFs(['a.json', 'b.json']);
+    warnings.length = 0;
+    await finalizeAbChildArtifacts('/tmp/discovery-ab-x', true, fs, logger);
+    expect(removed).toEqual(['/tmp/discovery-ab-x']);
+    expect(warnings).toEqual([]);
+  });
+
+  it('names this harness, not the matrix, and says how many artifacts it kept', async () => {
+    const { fs, removed } = fakeFs(['b.json', 'a.json']);
+    warnings.length = 0;
+    await finalizeAbChildArtifacts('/tmp/discovery-ab-y', false, fs, logger);
+    expect(removed).toEqual([]);
+    expect(warnings[0]).toContain('Discovery A/B retained 2 child artifact(s)');
+    expect(warnings[0]).toContain('/tmp/discovery-ab-y: a.json, b.json');
+    expect(warnings[0]).not.toContain('matrix');
+  });
+
+  it('does not promise artifacts that are not there, which is the usual dead-child case', async () => {
+    const { fs, removed } = fakeFs([]);
+    warnings.length = 0;
+    await finalizeAbChildArtifacts('/tmp/discovery-ab-z', false, fs, logger);
+    expect(warnings).toEqual(['Discovery A/B kept no child artifacts: neither side wrote one before the run failed']);
+    expect(removed).toEqual(['/tmp/discovery-ab-z']);
+  });
+
+  it('reports rather than throws when the directory cannot be read', async () => {
+    const { fs } = fakeFs(new Error('ENOENT'));
+    warnings.length = 0;
+    await expect(finalizeAbChildArtifacts('/tmp/discovery-ab-gone', false, fs, logger)).resolves.toBeUndefined();
+    expect(warnings[0]).toContain('kept no child artifacts');
   });
 });

--- a/services/api/src/cli/tests/discovery-ab.parent.spec.ts
+++ b/services/api/src/cli/tests/discovery-ab.parent.spec.ts
@@ -247,7 +247,7 @@ describe('withAbSpendAccounting', () => {
     expect(describeAbFailure(thrown).message).toContain('after resetting the A/B branches');
   });
 
-  it('reports a failure after a side was spawned as a spend with no artifact', async () => {
+  it('reports a failure after a side was spawned as a spend with no run report', async () => {
     const thrown = await withAbSpendAccounting(async (progress) => {
       progress.stage = 'reset';
       progress.stage = 'spawned';
@@ -259,7 +259,10 @@ describe('withAbSpendAccounting', () => {
     // Hedged: a side that died at its own gate spent nothing, and this process
     // cannot tell that case from a side that ran for forty minutes.
     expect(report.message).toContain('provider spend and wall-clock time may already be gone');
-    expect(report.message).toContain('No artifact was written');
+    expect(report.message).toContain('No run report was written');
+    // The temp directory the `finally` retains is named in the console line
+    // printed just before this one; the message must not deny it.
+    expect(report.message).not.toContain('nothing of this run survives');
     // The underlying failure text is never printed; only kept as a cause.
     expect(report.message).not.toContain('exited with code 1');
   });

--- a/services/api/src/cli/tests/discovery-ab.parent.spec.ts
+++ b/services/api/src/cli/tests/discovery-ab.parent.spec.ts
@@ -219,6 +219,24 @@ describe('withAbSpendAccounting', () => {
     expect(describeAbFailure(thrown).exitCode).toBe(AB_EXIT_PREFLIGHT_REFUSED);
   });
 
+  /**
+   * The reset loop is the likeliest place to fail after attestation, and inside
+   * it nothing may have been overwritten yet. The stage that reports it must
+   * not claim both branches were.
+   */
+  it('hedges a failure inside the reset loop, which may have overwritten nothing at all', async () => {
+    const thrown = await withAbSpendAccounting(async (progress) => {
+      progress.stage = 'resetting';
+      // The first restore refused: side b was never even requested.
+      throw new Error('Neon control-plane reset failed with status 500');
+    }).catch((error: unknown) => error);
+    const report = describeAbFailure(thrown);
+    expect(report.exitCode).toBe(AB_EXIT_SPENT_WITHOUT_ARTIFACT);
+    expect(report.message).toContain('one or both branches may have been overwritten');
+    expect(report.message).not.toContain('both branches were overwritten');
+    expect(report.message).not.toContain('status 500');
+  });
+
   it('reports a failure after the branches were reset as a mutation, not a refusal', async () => {
     const thrown = await withAbSpendAccounting(async (progress) => {
       progress.stage = 'reset';
@@ -238,10 +256,34 @@ describe('withAbSpendAccounting', () => {
     }).catch((error: unknown) => error);
     const report = describeAbFailure(thrown);
     expect(report.exitCode).toBe(AB_EXIT_SPENT_WITHOUT_ARTIFACT);
-    expect(report.message).toContain('provider spend and wall-clock time are gone');
+    // Hedged: a side that died at its own gate spent nothing, and this process
+    // cannot tell that case from a side that ran for forty minutes.
+    expect(report.message).toContain('provider spend and wall-clock time may already be gone');
     expect(report.message).toContain('No artifact was written');
     // The underlying failure text is never printed; only kept as a cause.
     expect(report.message).not.toContain('exited with code 1');
+  });
+
+  /**
+   * The console formatting and the temp-directory cleanup both run after
+   * `writeRunReport`. A run whose artifact is on disk - including a wholly
+   * successful one whose cleanup hit EBUSY - must not be told nothing survived.
+   */
+  it('names the artifact when the failure came after it was written', async () => {
+    const runPath = '/repo/eval/discovery-ab/runs/2026-08-04T00-00-00-000Z.json';
+    const thrown = await withAbSpendAccounting(async (progress) => {
+      progress.stage = 'reset';
+      progress.stage = 'spawned';
+      progress.artifactPath = runPath;
+      progress.stage = 'written';
+      throw new Error('EBUSY: resource busy or locked, rm /tmp/discovery-ab-x');
+    }).catch((error: unknown) => error);
+    const report = describeAbFailure(thrown);
+    expect(report.exitCode).toBe(AB_EXIT_SPENT_WITHOUT_ARTIFACT);
+    expect(report.message).toContain(runPath);
+    expect(report.message).toContain('The artifact on disk is real');
+    expect(report.message).not.toContain('nothing of this run survives');
+    expect(report.message).not.toContain('EBUSY');
   });
 });
 

--- a/services/api/src/cli/tests/discovery-ab.parent.spec.ts
+++ b/services/api/src/cli/tests/discovery-ab.parent.spec.ts
@@ -1,0 +1,195 @@
+import { describe, expect, it } from 'bun:test';
+
+import { AB_DEFAULT_REPETITIONS, AB_EXIT_INSUFFICIENT_EVIDENCE, AB_MAX_REPETITIONS, abChildTimeoutMs, abSelectionFilters, formatAbRunArgs, parseAbRunArgs, resolveAbCases, resolveAbRunOutcome } from '../discovery-ab.main';
+import { buildAbPlan, type AbSide } from '../discovery-ab.plan';
+
+import type { MatrixSlotResult } from '../discovery-env-matrix.main';
+import type { HistoricalMatrixFixture } from '../discovery-env-matrix.shared';
+
+const testCase = (id: string): HistoricalMatrixFixture => ({
+  id, description: id, networkContext: 'ctx', sourceUserId: 'u1', expectedUserId: 'u2',
+  excludedUserIds: [], participants: [],
+});
+const corpus = [testCase('c1'), testCase('c2'), testCase('c3')];
+
+const sides: [AbSide, AbSide] = [
+  { id: 'a', config: { DISCOVERY_ALLOWED_TYPES: 'intent', DISCOVERY_SOURCE_PREMISE_LIMIT: '40' } },
+  { id: 'b', config: { DISCOVERY_ALLOWED_TYPES: 'intent,profile', DISCOVERY_SOURCE_PREMISE_LIMIT: '5' } },
+];
+const configArgs = [
+  '--a', 'DISCOVERY_ALLOWED_TYPES=intent', '--a', 'DISCOVERY_SOURCE_PREMISE_LIMIT=40',
+  '--b', 'DISCOVERY_ALLOWED_TYPES=intent,profile', '--b', 'DISCOVERY_SOURCE_PREMISE_LIMIT=5',
+];
+
+describe('parseAbRunArgs', () => {
+  it('reads a shared selection and one configuration per side', () => {
+    expect(parseAbRunArgs(['--case', 'c1', '--runs', '2', ...configArgs])).toEqual({
+      caseIds: ['c1'],
+      repetitions: 2,
+      sides,
+      force: false,
+    });
+  });
+
+  it('defaults to the full corpus at three repetitions, which is what makes flakiness visible', () => {
+    const selection = parseAbRunArgs(configArgs);
+    expect(selection.caseIds).toEqual([]);
+    expect(selection.repetitions).toBe(AB_DEFAULT_REPETITIONS);
+    expect(selection.force).toBe(false);
+  });
+
+  it('accepts a repeated --case and keeps the operator ordering', () => {
+    expect(parseAbRunArgs(['--case', 'c3', '--case', 'c1', ...configArgs]).caseIds).toEqual(['c3', 'c1']);
+  });
+
+  it('reads --force, the only consent to replace an existing artifact', () => {
+    expect(parseAbRunArgs([...configArgs, '--force']).force).toBe(true);
+  });
+
+  it('produces sides a plan will accept', () => {
+    const selection = parseAbRunArgs(['--runs', '1', ...configArgs]);
+    expect(buildAbPlan([testCase('c1')], selection.sides, selection.repetitions)).toHaveLength(2);
+  });
+
+  it.each([
+    [['--case', '--runs', '1', ...configArgs], /--case requires a value/],
+    [['--case', 'c1', '--case', 'c1', ...configArgs], /same case twice/],
+    [['--runs', '0', ...configArgs], /--runs must be a positive integer/],
+    [['--runs', 'two', ...configArgs], /--runs must be a positive integer/],
+    [['--runs', '-1', ...configArgs], /--runs must be a positive integer \(received -1\)/],
+    [['--runs', ...configArgs], /--runs requires a value/],
+    [['--runs', '1', '--runs', '2', ...configArgs], /at most once/],
+    [[...configArgs, '--runs', String(AB_MAX_REPETITIONS + 1)], /must not exceed/],
+    [['--b', 'DISCOVERY_ALLOWED_TYPES=intent'], /Side a has no configuration/],
+    [['--a', 'DISCOVERY_ALLOWED_TYPES=intent'], /Side b has no configuration/],
+    [['--a', 'DISCOVERY_ALLOWED_TYPES', '--b', 'DISCOVERY_ALLOWED_TYPES=x'], /--a expects KEY=VALUE/],
+    [['--a', 'X=1', '--a', 'X=2', '--b', 'X=3'], /--a sets X twice/],
+    [['--a', '--b', 'X=1'], /--a requires a value/],
+  ])('refuses %p', (args, message) => {
+    expect(() => parseAbRunArgs(args)).toThrow(message);
+  });
+
+  it('cannot be tricked into writing through an object prototype', () => {
+    const selection = parseAbRunArgs(['--a', '__proto__=polluted', '--b', '__proto__=other']);
+    expect(Object.getPrototypeOf(selection.sides[0].config)).toBe(Object.prototype);
+    expect(({} as Record<string, unknown>).polluted).toBeUndefined();
+  });
+});
+
+describe('formatAbRunArgs', () => {
+  it('round-trips, so both children plan from exactly what the parent parsed', () => {
+    const selection = parseAbRunArgs(['--case', 'c2', '--runs', '2', ...configArgs, '--force']);
+    // --force is deliberately not forwarded: only the parent writes an artifact.
+    expect(parseAbRunArgs(formatAbRunArgs(selection))).toEqual({ ...selection, force: false });
+  });
+
+  it('is independent of the order the operator typed the flags in', () => {
+    const typed = parseAbRunArgs(['--b', 'DISCOVERY_SOURCE_PREMISE_LIMIT=5', '--a', 'DISCOVERY_SOURCE_PREMISE_LIMIT=40',
+      '--b', 'DISCOVERY_ALLOWED_TYPES=intent,profile', '--a', 'DISCOVERY_ALLOWED_TYPES=intent']);
+    expect(formatAbRunArgs(typed)).toEqual(formatAbRunArgs(parseAbRunArgs(configArgs)));
+  });
+
+  it('states the repetition count explicitly, so a default change cannot split the two children', () => {
+    expect(formatAbRunArgs(parseAbRunArgs(configArgs))).toContain('--runs');
+  });
+});
+
+describe('resolveAbCases', () => {
+  it('runs the whole corpus when no case is named', () => {
+    expect(resolveAbCases(corpus, []).map((entry) => entry.id)).toEqual(['c1', 'c2', 'c3']);
+  });
+
+  it('resolves named cases in the order they were named', () => {
+    expect(resolveAbCases(corpus, ['c3', 'c1']).map((entry) => entry.id)).toEqual(['c3', 'c1']);
+  });
+
+  it('refuses an unknown case rather than silently running fewer', () => {
+    expect(() => resolveAbCases(corpus, ['c9'])).toThrow(/Unknown discovery A\/B case: c9/);
+  });
+});
+
+describe('abSelectionFilters', () => {
+  it('reports an unfiltered run as having no filters, which is what fullCorpus means', () => {
+    expect(abSelectionFilters([])).toEqual({});
+  });
+
+  it('records every named case, because a filtered artifact must say what it left out', () => {
+    expect(abSelectionFilters(['c1', 'c2'])).toEqual({ case: 'c1,c2' });
+  });
+});
+
+describe('abChildTimeoutMs', () => {
+  it('bounds a side by the work it may legitimately do, not by a fixed guess', () => {
+    // Five slots is what a matrix child owns, and its watchdog is 50 minutes.
+    expect(abChildTimeoutMs(5)).toBe(3_015_000);
+    expect(abChildTimeoutMs(15)).toBeGreaterThan(abChildTimeoutMs(5));
+  });
+
+  it('refuses a side with no slots', () => {
+    expect(() => abChildTimeoutMs(0)).toThrow(/at least one slot/);
+  });
+});
+
+const slot = (rowId: 'a' | 'b', caseId: string, runs: number, passes: number): MatrixSlotResult => ({
+  caseId, rule: rowId, rowId, repetition: 0, runs, passes,
+  passRate: runs === 0 ? 0 : passes / runs, flaky: false,
+});
+
+describe('resolveAbRunOutcome', () => {
+  const complete = [
+    slot('a', 'c1/a/r1', 1, 1), slot('a', 'c2/a/r1', 1, 0),
+    slot('b', 'c1/b/r1', 1, 1), slot('b', 'c2/b/r1', 1, 1),
+  ];
+
+  it('reports both sides when every planned slot was scored', () => {
+    const outcome = resolveAbRunOutcome({ slots: complete, sides, expectedSlotsPerSide: 2 });
+    expect(outcome.exitCode).toBe(0);
+    expect(outcome.incompleteSides).toEqual([]);
+    expect(outcome.verdict).toEqual([
+      { sideId: 'a', passes: 1, runs: 2, passRate: 0.5 },
+      { sideId: 'b', passes: 2, runs: 2, passRate: 1 },
+    ]);
+    expect(outcome.summary).toContain('side a 1/2');
+    expect(outcome.summary).toContain('side b 2/2');
+  });
+
+  it('reports no verdict and exits non-zero when one side has a failed slot', () => {
+    const slots = [complete[0]!, complete[1]!, complete[2]!, slot('b', 'c2/b/r1', 0, 0)];
+    const outcome = resolveAbRunOutcome({ slots, sides, expectedSlotsPerSide: 2 });
+    expect(outcome.verdict).toBeNull();
+    expect(outcome.exitCode).toBe(AB_EXIT_INSUFFICIENT_EVIDENCE);
+    expect(outcome.exitCode).not.toBe(0);
+    expect(outcome.incompleteSides).toEqual(['b']);
+    expect(outcome.summary).toContain('no verdict');
+    expect(outcome.summary).toContain('side b scored 1/2 slot(s), 1 failed');
+  });
+
+  it('reports no verdict when a side returned fewer slots than it was planned', () => {
+    const outcome = resolveAbRunOutcome({ slots: complete.slice(0, 3), sides, expectedSlotsPerSide: 2 });
+    expect(outcome.verdict).toBeNull();
+    expect(outcome.exitCode).toBe(AB_EXIT_INSUFFICIENT_EVIDENCE);
+    expect(outcome.incompleteSides).toEqual(['b']);
+  });
+
+  it('reports no verdict when a side produced nothing at all, rather than a one-sided result', () => {
+    const outcome = resolveAbRunOutcome({ slots: complete.slice(0, 2), sides, expectedSlotsPerSide: 2 });
+    expect(outcome.verdict).toBeNull();
+    expect(outcome.sides.find((entry) => entry.sideId === 'b')).toMatchObject({ produced: 0, scored: 0, complete: false });
+    expect(outcome.summary).toContain('side b scored 0/2');
+  });
+
+  it('names both sides when both failed', () => {
+    const slots = [slot('a', 'c1/a/r1', 0, 0), slot('b', 'c1/b/r1', 0, 0)];
+    const outcome = resolveAbRunOutcome({ slots, sides, expectedSlotsPerSide: 1 });
+    expect(outcome.incompleteSides).toEqual(['a', 'b']);
+    expect(outcome.summary).toContain('side a');
+    expect(outcome.summary).toContain('side b');
+  });
+
+  it('counts only scored runs, so a failed slot is a failure rather than a zero', () => {
+    const slots = [slot('a', 'c1/a/r1', 1, 1), slot('a', 'c2/a/r1', 0, 0), slot('b', 'c1/b/r1', 1, 1), slot('b', 'c2/b/r1', 1, 1)];
+    const outcome = resolveAbRunOutcome({ slots, sides, expectedSlotsPerSide: 2 });
+    expect(outcome.sides[0]).toMatchObject({ sideId: 'a', scored: 1, failed: 1, passes: 1 });
+    expect(outcome.verdict).toBeNull();
+  });
+});

--- a/services/api/src/cli/tests/discovery-ab.plan.spec.ts
+++ b/services/api/src/cli/tests/discovery-ab.plan.spec.ts
@@ -38,6 +38,32 @@ describe('buildAbPlan', () => {
       .toThrow(/POOL_QUESTIONS_MODE/);
   });
 
+  it('refuses a key set present on one side only, because the omitted side takes the graph default', () => {
+    expect(() => buildAbPlan(
+      [testCase('c1')],
+      [{ id: 'a', config: {} }, { id: 'b', config: { DISCOVERY_ALLOWED_TYPES: 'intent,profile' } }],
+      1,
+    )).toThrow(/DISCOVERY_ALLOWED_TYPES/);
+  });
+
+  it('accepts that same comparison once both sides state the key explicitly', () => {
+    const plan = buildAbPlan(
+      [testCase('c1')],
+      [{ id: 'a', config: { DISCOVERY_ALLOWED_TYPES: 'intent' } }, { id: 'b', config: { DISCOVERY_ALLOWED_TYPES: 'intent,profile' } }],
+      1,
+    );
+    expect(plan).toHaveLength(2);
+  });
+
+  it('refuses two sides sharing an id, which would collapse into one row downstream', () => {
+    expect(() => buildAbPlan([testCase('c1')], [sideA, { id: 'a', config: sideB.config }], 1))
+      .toThrow(/'a' then 'a'/);
+  });
+
+  it('refuses sides given in the reverse order, which would file b under the a column', () => {
+    expect(() => buildAbPlan([testCase('c1')], [sideB, sideA], 1)).toThrow(/'b' then 'a'/);
+  });
+
   it('refuses a non-positive repetition count', () => {
     expect(() => buildAbPlan([testCase('c1')], [sideA, sideB], 0)).toThrow(/repetition/i);
   });

--- a/services/api/src/cli/tests/discovery-ab.plan.spec.ts
+++ b/services/api/src/cli/tests/discovery-ab.plan.spec.ts
@@ -1,0 +1,68 @@
+import { describe, expect, it } from 'bun:test';
+
+import { buildAbPlan, configDiff, type AbSide } from '../discovery-ab.plan';
+import type { HistoricalMatrixFixture } from '../discovery-env-matrix.shared';
+
+const testCase = (id: string): HistoricalMatrixFixture => ({
+  id, description: id, networkContext: 'ctx', sourceUserId: 'u1', expectedUserId: 'u2',
+  excludedUserIds: [], participants: [],
+});
+
+const sideA: AbSide = { id: 'a', config: { DISCOVERY_ALLOWED_TYPES: 'intent' } };
+const sideB: AbSide = { id: 'b', config: { DISCOVERY_ALLOWED_TYPES: 'intent,profile' } };
+
+describe('buildAbPlan', () => {
+  it('produces cases x repetitions x two sides', () => {
+    const plan = buildAbPlan([testCase('c1'), testCase('c2')], [sideA, sideB], 3);
+    expect(plan).toHaveLength(12);
+    expect(plan.filter((slot) => slot.side.id === 'a')).toHaveLength(6);
+    expect(plan.filter((slot) => slot.side.id === 'b')).toHaveLength(6);
+  });
+
+  it('gives both sides identical case and repetition coverage', () => {
+    const plan = buildAbPlan([testCase('c1'), testCase('c2')], [sideA, sideB], 2);
+    const coverage = (side: string) => plan
+      .filter((slot) => slot.side.id === side)
+      .map((slot) => `${slot.matrixCase.id}/r${slot.repetition}`)
+      .sort();
+    expect(coverage('a')).toEqual(coverage('b'));
+  });
+
+  it('refuses identical configurations, which would spend a run measuring noise', () => {
+    expect(() => buildAbPlan([testCase('c1')], [sideA, { id: 'b', config: sideA.config }], 1))
+      .toThrow(/identical/i);
+  });
+
+  it('refuses a flag the graph cannot reach', () => {
+    expect(() => buildAbPlan([testCase('c1')], [sideA, { id: 'b', config: { POOL_QUESTIONS_MODE: 'on' } }], 1))
+      .toThrow(/POOL_QUESTIONS_MODE/);
+  });
+
+  it('refuses a non-positive repetition count', () => {
+    expect(() => buildAbPlan([testCase('c1')], [sideA, sideB], 0)).toThrow(/repetition/i);
+  });
+
+  it('refuses an empty case selection', () => {
+    expect(() => buildAbPlan([], [sideA, sideB], 1)).toThrow(/case/i);
+  });
+});
+
+describe('configDiff', () => {
+  it('reports differing, added and removed keys with null for absent', () => {
+    expect(configDiff(
+      { DISCOVERY_ALLOWED_TYPES: 'intent', DISCOVERY_SOURCE_PREMISE_LIMIT: '40' },
+      { DISCOVERY_ALLOWED_TYPES: 'profile', NEGOTIATION_MAX_TURNS_CHAT: '6' },
+    )).toEqual([
+      { key: 'DISCOVERY_ALLOWED_TYPES', a: 'intent', b: 'profile' },
+      { key: 'DISCOVERY_SOURCE_PREMISE_LIMIT', a: '40', b: null },
+      { key: 'NEGOTIATION_MAX_TURNS_CHAT', a: null, b: '6' },
+    ]);
+  });
+
+  it('omits keys the two sides agree on, because they explain no difference', () => {
+    expect(configDiff(
+      { DISCOVERY_ALLOWED_TYPES: 'intent' },
+      { DISCOVERY_ALLOWED_TYPES: 'intent', NEGOTIATION_MAX_TURNS_CHAT: '6' },
+    )).toEqual([{ key: 'NEGOTIATION_MAX_TURNS_CHAT', a: null, b: '6' }]);
+  });
+});

--- a/services/api/tsconfig.spec.json
+++ b/services/api/tsconfig.spec.json
@@ -1,0 +1,38 @@
+{
+  // Type-checks the discovery A/B CLI specs, which the build tsconfig excludes
+  // (`src/**/*.spec.ts`) and CI's `bun run build` therefore never compiles.
+  //
+  // That exclusion is normally harmless — until a spec's assertion *is* a
+  // type-level assertion. `discovery-ab.neon.spec.ts` carries the only guard
+  // proving `resetAbBranch` refuses an unattested manifest at compile time: a
+  // `@ts-expect-error` on a forged manifest. Widen that parameter back to
+  // `AbManifest` and the directive becomes unused, which is an error TypeScript
+  // reports — but only in a compilation that includes the file. Without this
+  // config, nothing in CI includes it, and the brand's whole protection could be
+  // removed with every check green.
+  //
+  // Scope note: this is deliberately `discovery-ab.*.spec.ts` and not the whole
+  // `src/cli/tests` directory. Four unrelated specs
+  // (`backfill-intent-verification-analysis.spec.ts`,
+  // `discovery-env-matrix.spec.ts`, `discovery-retrieval-smoke.spec.ts`,
+  // `discovery-env-matrix-base-indexer.isolated.ts`) carry ten pre-existing type
+  // errors; adopting them here would mean fixing unrelated tests in this change.
+  // Widening the `include` below is the whole of that follow-up.
+  //
+  // `noEmit`, and `rootDir` is relaxed to the repo root because
+  // `discovery-ab.flags.spec.ts` reads
+  // `packages/protocol/eval/ops/ops.allowlist.ts` by path (that module is
+  // deliberately dependency-free so any consumer can import it) and it is
+  // outside `src/`.
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "noEmit": true,
+    "rootDir": "../.."
+  },
+  "include": [
+    "src/cli/tests/discovery-ab.*.spec.ts"
+  ],
+  "exclude": [
+    "node_modules"
+  ]
+}


### PR DESCRIPTION
## Make discovery env strategies genuinely testable

Closes the gap behind IND-627. **Nothing here has run against a live database or real Neon** — see "What this branch has not done".

### Why

The 16 allowlisted `PROFILE_ENV_ALLOWLIST` values were editable in eval-ops while **no eval harness read any of them**. Traced over the full transitive import closure of every harness entry point:

| Harness | Files in closure | Of the 16 env flags, read |
|---|---|---|
| matching / premise / profile | 44 / 30 / 30 | **0** |
| opportunity | 127 | 0 executed |
| hyde / discovery-retrieval / clarification / canary / stance | 15–63 | **0** |

Those flags are read by `startup.env.ts` and `opportunity.graph.ts` — the running product, which no eval executes. So `DISCOVERY_SOURCE_PREMISE_LIMIT=5` and `=50` produced identical results everywhere. To compare strategies, something has to run the code that reads them.

### What this adds

`discovery-ab`: two operator-chosen env configurations, the real `OpportunityGraphFactory`, the same cases, one child process per side on its own Neon branch reset from the protected base, one artifact holding both sides.

```
gate → parse manifest → attest → reset eval-ab-a / eval-ab-b → spawn a | b → aggregate → artifact
```

**Nine flags** are offerable — the ones the graph actually reads — and the list is *derived by test*, not hand-maintained: `discovery-ab.flags.spec.ts` recomputes the reachable set from `opportunity.graph.ts`'s import closure and fails if it disagrees. The other seven are named in the docs as **not reachable from the discovery graph** (not "untestable" — for most, the behaviour is in `packages/protocol` and only scheduling is in API queues; IND-630 tracks the decision).

### Safety

The graph writes to whatever database it is given, so:

- **Attest before importing.** `discovery-ab.ts` is dependency-free; it attests before `await import('./discovery-ab.main')`, the only path that pulls `@indexnetwork/protocol`. A refusal never loads the graph. Guarded by a closure test that now catches bare, unquoted, unsemicoloned and indented import forms.
- **`resetAbBranch` accepts only a branded `AttestedAbManifest`**, produced solely by `attestAbTargets` — a reviewer had demonstrated a forged manifest restoring **production from dev**; that is now a compile error, plus a runtime membership check.
- **Production (`br-fragrant-brook-ahexgsek`) and dev are unreachable by construction**, verified adversarially: as a target, as the base, via a matching endpoint host, and via a branch legitimately *named* `eval-ab-a` but parented elsewhere.
- **Reset completes before anything connects** — Neon's restore is asynchronous, so the operation is polled to a terminal state.
- Control-plane bodies can carry credentials; only status codes and field names ever reach a message.

### Two design decisions worth reading

**No baseline.** Arbitrary configurations have none — the pair *is* the result.

**The artifact's top-level `configs`/`configDiff` rollup is deliberately absent.** The governed envelope and payload are zod `.strict()`, and `buildEvalArtifact` copies only named meta fields, so a rollup is silently dropped on write or makes the file unreadable. Widening a schema shared by every harness and every committed baseline, for a rollup that is derivable, was the wrong trade. Instead the sanctioned extension point carries it: `caseResultSchema` is `.passthrough()`, so **every case row records that side's specified overrides**, and `assertAbConfigProvenance` makes that load-bearing rather than incidental. Spec §7 is amended in-branch to record this.

### Corrections found while building

- **Neon's `reset_to_parent` endpoint no longer exists.** The current operation is `POST /branches/{id}/restore` with `{source_branch_id}`, confirmed against the published v2 OpenAPI spec. The originally planned path would have 404'd every reset.
- **`scoreMatrixSlot` could not accept a non-matrix `rowId`** — it resolved the row for `allowedEvidence` and threw on every candidate-bearing slot. Fixed additively with an optional `allowedEvidence`; the matrix path is byte-identical and an unknown row still throws. **A/B therefore does not enforce per-row evidence gating** — that is the fixed matrix's question — and this is stated in the code and the operator guide.
- **The corpus is 5 cases, not 15**, so a default run is 30 invocations (~13 min), not 90 (~40). Spec and plan corrected.
- A `skipped` Neon sub-operation would have aborted a *successful* reset while claiming the branches "may have been half-overwritten".

### Verification

327 api CLI tests, 22 protocol matrix tests, `eval:verify` 13/13, `tsc --noEmit`, the new `typecheck:cli-specs`, lint (0 errors), `bun install --frozen-lockfile`. **These specs now run in CI** via a new `eval-cli-tests` job that builds `packages/protocol` first — previously none of them did.

Every task went through an independent reviewer, and load-bearing tests were proven non-tautological by mutation: deleting the flag-derivation guard, the `allowedEvidence` argument, the fallback `configDeltas`, or the model dedup each fails a test; commenting out a real `process.env` read fails the derivation.

### What this branch has NOT done

- **No live run.** `runAbComparison` — the wiring that resets, spawns and aggregates — has no execution evidence. Components are covered; the composition is not.
- **The base fixture does not exist.** `eval-discovery-base` is absent from Neon; IND-626 must create and seed it (it needs embeddings and HyDE vectors, which is why the design clones rather than re-seeds). `eval-ab-a`/`eval-ab-b` are then branched from it. The tool never creates or deletes branches.
- A runbook in `development-reference.md` covers those steps in order.

Versions: protocol 8.10.0 → 8.11.0, api 0.72.0 → 0.73.0, `bun.lock` synced.
