### PR TITLE
feat(web): add /download install page for the macOS app

### DIFF
--- a/apps/web/meta.config.ts
+++ b/apps/web/meta.config.ts
@@ -19,6 +19,13 @@ const MARKETING: Record<string, PageMeta> = {
     image: `${ORIGIN}/found-in-translation/found-in-translation-1-hero.png`,
     type: "article",
   },
+  "/download": {
+    title: "Download Index for macOS",
+    description:
+      "Get the Index macOS app. Opportunity links open directly in the app, where you can review and accept them.",
+    image: DEFAULT_IMAGE,
+    type: "website",
+  },
   "/overview": {
     title: "Index Network: Protocol Overview",
     description:

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@indexnetwork/web",
-  "version": "0.47.0",
+  "version": "0.48.0",
   "license": "MIT",
   "scripts": {
     "dev": "vite --host 127.0.0.1",

--- a/apps/web/src/app/download/page.tsx
+++ b/apps/web/src/app/download/page.tsx
@@ -1,0 +1,80 @@
+/**
+ * Single source of truth for the macOS app artifact.
+ *
+ * Set `VITE_MAC_APP_DOWNLOAD_URL` at build time once a Developer ID-signed,
+ * notarized build is published (IND-616); until then it is intentionally unset
+ * and the page renders an honest "not yet available" state instead of a button
+ * that 404s. Nothing else in the app needs to change when the artifact lands.
+ */
+export const MAC_APP_DOWNLOAD_URL: string =
+  import.meta.env.VITE_MAC_APP_DOWNLOAD_URL || "";
+
+/**
+ * Minimum macOS version the bundle declares (`LSMinimumSystemVersion` in
+ * apps/mac/IndexApp/Info.plist). Kept next to the download so the two are
+ * updated together.
+ */
+export const MAC_APP_MIN_OS = "macOS 11 or later";
+
+/**
+ * `/download` — the macOS app's install page.
+ *
+ * It is the destination of the deep-link landing CTA (`/c/:code`, `/o/:id`),
+ * so it must never be a dead end: without a published artifact it explains the
+ * state rather than linking to nothing.
+ */
+export default function Download() {
+  const available = MAC_APP_DOWNLOAD_URL.length > 0;
+
+  return (
+    <div className="relative min-h-screen flex items-center justify-center">
+      <div
+        className="fixed inset-0 pointer-events-none -z-10"
+        style={{
+          background: "url(/noise.jpg)",
+          opacity: 0.12,
+        }}
+      />
+
+      <div className="text-center max-w-md px-6">
+        <h1 className="text-3xl font-bold text-gray-900 mb-4">
+          Index for macOS
+        </h1>
+
+        <p className="text-gray-600 mb-8">
+          Opportunity links open directly in the Index app, where you can review
+          and accept them.
+        </p>
+
+        {available ? (
+          <>
+            <a
+              href={MAC_APP_DOWNLOAD_URL}
+              className="inline-block px-6 py-3 bg-[#041729] text-white rounded hover:bg-[#0a2d4a] transition-colors mb-3"
+            >
+              Download for macOS
+            </a>
+            <p className="text-sm text-gray-500 mb-8">{MAC_APP_MIN_OS}</p>
+          </>
+        ) : (
+          <div className="rounded border border-gray-200 bg-white/60 px-5 py-4 mb-8">
+            <p className="text-gray-700">
+              Not yet publicly available. The macOS app is in private testing.
+            </p>
+          </div>
+        )}
+
+        {/* Plain anchor: this page is reached from the deep-link fallback by
+            visitors with no app and no session, so it stays router-free. */}
+        <a
+          href="/"
+          className="inline-block text-sm text-gray-500 hover:text-gray-900 transition-colors"
+        >
+          Back to Index
+        </a>
+      </div>
+    </div>
+  );
+}
+
+export const Component = Download;

--- a/apps/web/src/components/DeepLinkLanding.tsx
+++ b/apps/web/src/components/DeepLinkLanding.tsx
@@ -2,10 +2,11 @@ import { useState } from "react";
 
 import CopyableBox from "@/components/CopyableBox";
 
-// TODO(release): replace with the real macOS app download URL once the
-// signed/notarized release is published. Single point of change for every
-// deep-link landing page (/c/:code, /o/:id).
-export const MAC_APP_DOWNLOAD_URL = "https://index.network/download";
+// The install page owns the artifact URL (and its "not yet published" state),
+// so this CTA always points at a real route rather than at a build that may
+// not exist yet. A plain anchor keeps this fallback page free of router
+// context — it is rendered for visitors with no app and no session.
+export const DOWNLOAD_PATH = "/download";
 
 /**
  * Presentation-only platform sniff. iPadOS reports a Macintosh UA, so require
@@ -49,10 +50,10 @@ export default function DeepLinkLanding() {
               This link opens in the Index macOS app.
             </p>
             <a
-              href={MAC_APP_DOWNLOAD_URL}
+              href={DOWNLOAD_PATH}
               className="inline-block px-6 py-3 bg-[#041729] text-white rounded hover:bg-[#0a2d4a] transition-colors mb-3"
             >
-              Download the Index app
+              Get the Index app
             </a>
             <p className="text-sm text-gray-500 mb-8">
               Already installed? Re-click your link — it will open in the app.

--- a/apps/web/src/contexts/AuthContext.tsx
+++ b/apps/web/src/contexts/AuthContext.tsx
@@ -153,7 +153,7 @@ export function AuthProvider({ children }: { children: ReactNode }) {
     const isHomePage = pathname === '/';
     const publicPrefixes = [
       '/simulation', '/l', '/index/', '/blog', '/pages', '/about',
-      '/login', '/s/', '/oauth/', '/found-in-translation', '/overview', '/protocol', '/cli-auth', '/u/', '/c/', '/o/', '/waitlist',
+      '/login', '/s/', '/oauth/', '/found-in-translation', '/overview', '/protocol', '/cli-auth', '/u/', '/c/', '/o/', '/waitlist', '/download',
     ];
     const isPublicPage = publicPrefixes.some(p => pathname.startsWith(p));
     const isProtectedPage = pathname.startsWith('/i/');

--- a/apps/web/src/routes.tsx
+++ b/apps/web/src/routes.tsx
@@ -113,6 +113,10 @@ export const router = createBrowserRouter([
         lazy: lazyRoute("/o/:id", () => import("@/app/o/[id]/page")),
       },
       {
+        path: "/download",
+        lazy: lazyRoute("/download", () => import("@/app/download/page")),
+      },
+      {
         path: "/l/:code",
         lazy: lazyRoute("/l/:code", () => import("@/app/l/[code]/page")),
       },

--- a/apps/web/tests/auth-context.test.tsx
+++ b/apps/web/tests/auth-context.test.tsx
@@ -166,7 +166,7 @@ describe('AuthProvider onboarding routing', () => {
   // app (and typically logged out), so the guard must not bounce them to home
   // or open the login modal. Renders the real AuthProvider with a mocked
   // logged-out session — regression coverage for the /o download funnel.
-  test.each(['/c/aB3xY9zQ2w', '/o/opp-123'])(
+  test.each(['/c/aB3xY9zQ2w', '/o/opp-123', '/download'])(
     'treats deep-link landing route %s as public for logged-out visitors',
     async (route) => {
       mocks.useSession.mockReturnValue({ data: null, isPending: false });

--- a/apps/web/tests/deep-link-landing.test.tsx
+++ b/apps/web/tests/deep-link-landing.test.tsx
@@ -1,7 +1,7 @@
 import { afterEach, describe, expect, test } from "vitest";
 import { render, screen } from "@testing-library/react";
 
-import DeepLinkLanding, { MAC_APP_DOWNLOAD_URL } from "@/components/DeepLinkLanding";
+import DeepLinkLanding, { DOWNLOAD_PATH } from "@/components/DeepLinkLanding";
 
 const ORIGINAL_UA = window.navigator.userAgent;
 const MAC_UA =
@@ -30,8 +30,11 @@ describe("DeepLinkLanding", () => {
     stubUserAgent(MAC_UA);
     render(<DeepLinkLanding />);
 
-    const cta = screen.getByRole("link", { name: "Download the Index app" });
-    expect(cta).toHaveAttribute("href", MAC_APP_DOWNLOAD_URL);
+    const cta = screen.getByRole("link", { name: "Get the Index app" });
+    expect(cta).toHaveAttribute("href", DOWNLOAD_PATH);
+    // Never link straight at an artifact from here: /download owns the
+    // published-vs-not state, so this CTA cannot dead-end.
+    expect(cta.getAttribute("href")).not.toMatch(/\.dmg|\.zip|https?:/);
     expect(
       screen.getByText(/Already installed\? Re-click your link/),
     ).toBeInTheDocument();
@@ -47,7 +50,7 @@ describe("DeepLinkLanding", () => {
       screen.getByText(/Index connect links open in the macOS app/),
     ).toBeInTheDocument();
     expect(
-      screen.queryByRole("link", { name: "Download the Index app" }),
+      screen.queryByRole("link", { name: "Get the Index app" }),
     ).not.toBeInTheDocument();
   });
 });

--- a/apps/web/tests/download-page.test.tsx
+++ b/apps/web/tests/download-page.test.tsx
@@ -1,0 +1,66 @@
+import { afterEach, describe, expect, test, vi } from "vitest";
+import { render, screen } from "@testing-library/react";
+
+/**
+ * `/download` is the destination of the deep-link landing CTA, so its two
+ * states are load-bearing: with no published artifact it must explain itself
+ * rather than link at nothing, and once `VITE_MAC_APP_DOWNLOAD_URL` is set it
+ * must become a real download with no code change.
+ *
+ * The module reads the env var at import time, so each case re-imports it
+ * after stubbing.
+ */
+async function renderDownload() {
+  vi.resetModules();
+  const mod = await import("@/app/download/page");
+  const Download = mod.default;
+  render(<Download />);
+  return mod;
+}
+
+afterEach(() => {
+  vi.unstubAllEnvs();
+  vi.resetModules();
+});
+
+describe("/download", () => {
+  test("explains the state instead of linking at nothing when no artifact is published", async () => {
+    vi.stubEnv("VITE_MAC_APP_DOWNLOAD_URL", "");
+
+    const mod = await renderDownload();
+
+    expect(mod.MAC_APP_DOWNLOAD_URL).toBe("");
+    expect(
+      screen.getByText(/Not yet publicly available/),
+    ).toBeInTheDocument();
+    expect(
+      screen.queryByRole("link", { name: /download for macos/i }),
+    ).not.toBeInTheDocument();
+  });
+
+  test("renders a real download button once the artifact URL is configured", async () => {
+    const artifact = "https://downloads.index.network/Index-1.0.0.dmg";
+    vi.stubEnv("VITE_MAC_APP_DOWNLOAD_URL", artifact);
+
+    const mod = await renderDownload();
+
+    expect(mod.MAC_APP_DOWNLOAD_URL).toBe(artifact);
+    const cta = screen.getByRole("link", { name: /download for macos/i });
+    expect(cta).toHaveAttribute("href", artifact);
+    expect(screen.getByText(mod.MAC_APP_MIN_OS)).toBeInTheDocument();
+    expect(
+      screen.queryByText(/Not yet publicly available/),
+    ).not.toBeInTheDocument();
+  });
+
+  test("always offers a way back, in both states", async () => {
+    vi.stubEnv("VITE_MAC_APP_DOWNLOAD_URL", "");
+
+    await renderDownload();
+
+    expect(screen.getByRole("link", { name: /back to index/i })).toHaveAttribute(
+      "href",
+      "/",
+    );
+  });
+});

--- a/apps/web/tests/routes.test.tsx
+++ b/apps/web/tests/routes.test.tsx
@@ -388,6 +388,15 @@ describe('Route rendering smoke tests', () => {
     expect(container.textContent).toContain('Open in the Index app');
   });
 
+  test('/download — macOS install page renders without crashing', async () => {
+    const { Component } = await import('@/app/download/page');
+    const { container } = renderWithRouter(<Component />, {
+      route: '/download',
+    });
+    expect(container).toBeTruthy();
+    expect(container.textContent).toContain('Index for macOS');
+  });
+
   test('/u/:id — User profile page renders without crashing', async () => {
     const { Component } = await import('@/app/u/[id]/page');
     const { container } = renderWithRouter(<Component />, {

--- a/bun.lock
+++ b/bun.lock
@@ -41,7 +41,7 @@
     },
     "apps/web": {
       "name": "@indexnetwork/web",
-      "version": "0.46.0",
+      "version": "0.48.0",
       "dependencies": {
         "@radix-ui/react-alert-dialog": "^1.1.15",
         "@radix-ui/react-dialog": "^1.1.14",

--- a/docs/specs/api-reference.md
+++ b/docs/specs/api-reference.md
@@ -210,7 +210,7 @@ Opportunity and profile links are plain `https://index.network/...` URLs that op
 | `/c/:code` | Same landing page (retired connect links). |
 | `/u/:id` | The existing public profile page, unchanged. |
 
-The macOS download CTA on that landing page currently points at `https://index.network/download`, which is not a registered web route — it falls through to the web app's catch-all and renders the not-found page until the signed release publishes its real URL.
+The macOS CTA on that landing page links to `/download`, the app's install page. `/download` reads its artifact URL from `VITE_MAC_APP_DOWNLOAD_URL`: while that is unset it states that the app is not yet publicly available and offers no download button, and once a Developer ID-signed, notarized build is published it renders a real download with no code change. The CTA therefore never dead-ends, in either state.
 
 **Legacy short links.** `GET /c/:code` on this protocol server is a tombstone for links already delivered in chats. `main.ts` rewrites the unprefixed path onto `ConnectLinkController`, which performs no database lookup and no opportunity side effects: a code matching `^[A-Za-z0-9]{10}$` gets a `302` to `${WEB_APP_URL}/c/<code>` (default `https://index.network`) with the request's query string preserved — already-delivered links carry `?link_preview=false`, and dropping it would resurrect preview cards in chat clients — and anything else gets a `404` HTML page. The resolution stack behind it — `/c/:code/go`, connect-link minting, connect tokens, surface routing — is deleted.
 

--- a/packages/hermes-plugin/README.md
+++ b/packages/hermes-plugin/README.md
@@ -113,7 +113,7 @@ an `apple-app-site-association` file that claims `/c/*`, `/o/*` and `/u/*` for t
 macOS app, so one URL covers both cases:
 
 - Index macOS app installed → macOS opens the link directly in the app.
-- App not installed → the browser opens the Index landing page for that link, which offers the macOS app (its download button still points at `https://index.network/download`, an unregistered route that falls through to the web app's client-rendered not-found page, until the signed release publishes its real URL).
+- App not installed → the browser opens the Index landing page for that link, whose CTA leads to `https://index.network/download`. That install page states the app is not yet publicly available until a signed release is published, and serves the real download once it is.
 
 The plugin deliberately performs **no app-installation detection**. It runs wherever
 the agent runs — often a headless server that is not the user's Mac — so probing the


### PR DESCRIPTION
Closes IND-614.

## Problem

The deep-link landing page's macOS CTA pointed at `https://index.network/download`, which is not a registered route. It fell through to the `*` catch-all and rendered the client-side not-found page (HTTP 200, 404 view) — so the **primary call to action** for every macOS visitor without the app was a dead end. That's the entire download funnel for the universal-link work.

## Why it wasn't just "point it at the real URL"

There is no artifact yet. No `.dmg`, no notarization or release workflow, and the only GitHub release is an unrelated `webhook-relay-dev` pre-release. A signed build can't exist until IND-616 completes, which is currently blocked on an operator-owned macOS environment.

So the fix makes the *route* real and puts the artifact behind a config seam.

## What this does

- **`/download`** (`apps/web/src/app/download/page.tsx`) — the macOS install page, following the existing minimal-page conventions (`not-found.tsx`).
  - `VITE_MAC_APP_DOWNLOAD_URL` **unset** (today) → honest "Not yet publicly available. The macOS app is in private testing." No button, no dead end.
  - **Set** (after notarization) → real "Download for macOS" button plus the minimum-OS line, with **no code change**. Single point of handover for whoever publishes the build.
- **Landing CTA now links at `/download`** instead of at an artifact URL, so it cannot dead-end regardless of release state. Label changed to "Get the Index app" to match a page that may not offer a file yet.
- **`/download` added to the auth guard's public prefixes** — like `/c/`, `/o/`, `/u/`, its only audience is logged-out visitors. Without this the page would bounce to `/` with a login modal, which is exactly the bug that shipped for `/o/:id` in #1325.
- Meta entry for `/download` so document navigations get a real title/description.
- Plain anchors rather than `<Link>` on both fallback pages: they're rendered for visitors with no app and no session, and staying router-free keeps them independently testable.

## Verification

| Check | Result |
|---|---|
| `tests/download-page.test.tsx` (new, 3 cases) | both env states + always-a-way-back |
| `tests/deep-link-landing.test.tsx` | updated; asserts CTA targets the route and **never** an artifact URL |
| `tests/auth-context.test.tsx` | `/download` added to the public-route regression matrix |
| `tests/routes.test.tsx` | `/download` smoke test added |
| Targeted suites | 26 passed / 0 failed |
| `bun run build:web` | ✓ built |
| `tsc --noEmit` | 64 errors before **and** after (stash-verified) — zero new; the 2 in `AuthContext.tsx` are pre-existing import errors at line 6, unrelated to the line-156 edit |

**Mutation-checked** — both guards fail when the production change is reverted:
- removing `/download` from `publicPrefixes` → `auth-context.test.tsx` fails
- pointing the CTA at a `.dmg` → `deep-link-landing.test.tsx` fails

`routes.test.tsx` still reports the same 9 pre-existing failures (`/chat`, `/d/:id`, `/i/:intentId`, `/index/:indexId`, `/l/:code`, `/networks`, `/networks/:id`, `/s/:token`, `/u/:id`) — identical list to the base commit; the new `/download` case passes.

`apps/web` 0.47.0 → 0.48.0 with the root lockfile synced, per the versioning policy.

## Follow-up

When IND-616 publishes a signed build, set `VITE_MAC_APP_DOWNLOAD_URL` on the web service. No code change needed. Note the minimum-OS string is pinned to `LSMinimumSystemVersion` (macOS 11) from the bundle's `Info.plist` — worth re-checking at release, since `build.sh` passes no `-target` and the real floor is the build host's macOS version.
