### PR TITLE
fix(api): drop Telegram inbound when the gateway cannot reply

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -346,6 +346,9 @@ CONTACTS_ENABLED=false
 # HIDING THE GATEWAY: leave TELEGRAM_BOT_TOKEN/TELEGRAM_WEBHOOK_SECRET unset and the
 # gateway is fully off — no webhook registration, outbound sends no-op with one warning.
 # The Telegram identity binding on user socials and delivery data stay intact.
+# Setting only the SECRET is a half-configured gateway: updates authenticate but can
+# never be answered, so they are acknowledged (200) and dropped before the chat agent
+# runs. Unset both rather than one.
 # TELEGRAM_BOT_TOKEN=          # Bot token from @BotFather
 # TELEGRAM_BOT_USERNAME=       # Bot username without @, e.g. IndexBot
 # TELEGRAM_WEBHOOK_SECRET=     # Random secret for webhook validation

--- a/bun.lock
+++ b/bun.lock
@@ -126,7 +126,7 @@
     },
     "services/api": {
       "name": "@indexnetwork/api",
-      "version": "0.74.0",
+      "version": "0.74.1",
       "dependencies": {
         "@aws-sdk/client-s3": "^3.939.0",
         "@aws-sdk/s3-request-presigner": "^3.983.0",

--- a/docs/specs/api-reference.md
+++ b/docs/specs/api-reference.md
@@ -2526,6 +2526,8 @@ Inbound endpoint for Telegram Bot API updates. Called by Telegram when the bot r
 
 **Response**: Always `200 OK`. Inbound handling is fire-and-forget so the endpoint never blocks Telegram's delivery pipeline.
 
+**Half-configured gateway**: inbound is gated by `TELEGRAM_WEBHOOK_SECRET` and outbound by `TELEGRAM_BOT_TOKEN`, so a deployment with only the secret set authenticates updates it can never answer. When the bot token is missing the update is acknowledged and **dropped without running the inbound path** — the chat agent does not run, no chat session or message rows are written, and one warning is logged per process. The response stays `200` deliberately: a non-2xx makes Telegram retry the same update indefinitely. To disable the gateway cleanly, unset both variables.
+
 > Registered automatically at backend startup via `setWebhook` when `TELEGRAM_BOT_TOKEN` and `TELEGRAM_WEBHOOK_SECRET` are configured.
 
 ---

--- a/services/api/.test-isolated
+++ b/services/api/.test-isolated
@@ -121,3 +121,4 @@ src/services/tests/signal-intake.confirm-seam.isolated.ts
 src/queues/tests/usercontext.intake-pack.isolated.ts
 src/lib/tests/staff.isolated.ts
 src/controllers/tests/network-request.controller.authz.isolated.ts
+src/controllers/tests/webhooks.controller.isolated.ts

--- a/services/api/package.json
+++ b/services/api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@indexnetwork/api",
-  "version": "0.74.0",
+  "version": "0.74.1",
   "license": "MIT",
   "private": true,
   "scripts": {

--- a/services/api/src/controllers/tests/webhooks.controller.isolated.ts
+++ b/services/api/src/controllers/tests/webhooks.controller.isolated.ts
@@ -1,0 +1,96 @@
+import { config } from 'dotenv';
+config({ path: '.env.test', override: true });
+
+import { describe, it, expect, beforeEach, afterEach, mock } from 'bun:test';
+
+/**
+ * The half-configured gateway.
+ *
+ * Inbound is gated by `TELEGRAM_WEBHOOK_SECRET`, outbound by
+ * `TELEGRAM_BOT_TOKEN`. With only the secret set, Telegram updates authenticate
+ * successfully but no reply can ever be delivered — so the expensive inbound
+ * path must not run at all. These tests pin that, plus the two configurations
+ * either side of it.
+ */
+
+let inboundCalls: Array<{ chatId: string; text: string }> = [];
+
+mock.module('../../gateways/telegram.gateway', () => ({
+  handleInbound: mock(async (chatId: string, text: string) => {
+    inboundCalls.push({ chatId, text });
+  }),
+}));
+
+const { WebhooksController } = await import('../webhooks.controller');
+
+const SECRET = 'webhook-secret-under-test';
+const ORIGINAL_SECRET = process.env.TELEGRAM_WEBHOOK_SECRET;
+const ORIGINAL_TOKEN = process.env.TELEGRAM_BOT_TOKEN;
+
+function updateRequest(secret: string | null, text = 'hello there'): Request {
+  return new Request('https://api.test/webhooks/telegram', {
+    method: 'POST',
+    headers: secret === null ? {} : { 'X-Telegram-Bot-Api-Secret-Token': secret },
+    body: JSON.stringify({ message: { chat: { id: 4242 }, text, from: { username: 'someone' } } }),
+  });
+}
+
+beforeEach(() => {
+  inboundCalls = [];
+  process.env.TELEGRAM_WEBHOOK_SECRET = SECRET;
+});
+
+afterEach(() => {
+  if (ORIGINAL_SECRET === undefined) delete process.env.TELEGRAM_WEBHOOK_SECRET;
+  else process.env.TELEGRAM_WEBHOOK_SECRET = ORIGINAL_SECRET;
+  if (ORIGINAL_TOKEN === undefined) delete process.env.TELEGRAM_BOT_TOKEN;
+  else process.env.TELEGRAM_BOT_TOKEN = ORIGINAL_TOKEN;
+});
+
+describe('POST /webhooks/telegram — credential configurations', () => {
+  it('drops the update without running the inbound path when the bot token is missing', async () => {
+    delete process.env.TELEGRAM_BOT_TOKEN;
+
+    const res = await new WebhooksController().telegram(updateRequest(SECRET));
+
+    // 200, because a non-2xx makes Telegram retry the same update forever.
+    expect(res.status).toBe(200);
+    expect(inboundCalls).toHaveLength(0);
+  });
+
+  it('treats a whitespace-only bot token as unconfigured', async () => {
+    process.env.TELEGRAM_BOT_TOKEN = '   ';
+
+    const res = await new WebhooksController().telegram(updateRequest(SECRET));
+
+    expect(res.status).toBe(200);
+    expect(inboundCalls).toHaveLength(0);
+  });
+
+  it('runs the inbound path when both credentials are set', async () => {
+    process.env.TELEGRAM_BOT_TOKEN = 'real-token';
+
+    const res = await new WebhooksController().telegram(updateRequest(SECRET, 'run me'));
+
+    expect(res.status).toBe(200);
+    expect(inboundCalls).toEqual([{ chatId: '4242', text: 'run me' }]);
+  });
+
+  it('still rejects a wrong or missing secret before anything else', async () => {
+    process.env.TELEGRAM_BOT_TOKEN = 'real-token';
+
+    expect((await new WebhooksController().telegram(updateRequest('wrong'))).status).toBe(401);
+    expect((await new WebhooksController().telegram(updateRequest(null))).status).toBe(401);
+    expect(inboundCalls).toHaveLength(0);
+  });
+
+  it('fails closed when the webhook secret itself is unset', async () => {
+    delete process.env.TELEGRAM_WEBHOOK_SECRET;
+    process.env.TELEGRAM_BOT_TOKEN = 'real-token';
+
+    const res = await new WebhooksController().telegram(updateRequest('anything'));
+
+    expect(res.status).toBe(401);
+    expect(inboundCalls).toHaveLength(0);
+  });
+});

--- a/services/api/src/controllers/webhooks.controller.ts
+++ b/services/api/src/controllers/webhooks.controller.ts
@@ -1,9 +1,13 @@
 import { RateLimit } from '../guards/limiter.guard';
 import { Controller, Post, UseGuards } from '../lib/router/router.decorators';
 import { handleInbound } from '../gateways/telegram.gateway';
+import { isTelegramOutboundConfigured } from '../lib/telegram/bot-api';
 import { log } from '../lib/log';
 
 const logger = log.controller.from('webhooks');
+
+/** Warn once per process that inbound updates are being dropped. */
+let droppedInboundWarned = false;
 
 /** Shape of a Telegram Update object (only fields we use). */
 interface TelegramUpdate {
@@ -40,6 +44,24 @@ export class WebhooksController {
       body = (await req.json()) as TelegramUpdate;
     } catch {
       return new Response('Bad Request', { status: 400 });
+    }
+
+    // Inbound (`TELEGRAM_WEBHOOK_SECRET`) and outbound (`TELEGRAM_BOT_TOKEN`)
+    // are gated separately, so a half-configured deployment authenticates
+    // updates it can never answer. Without this guard the full LLM graph runs
+    // — real token spend, chat session and message rows written — and every
+    // reply is then discarded at the bot-api boundary. Drop early instead.
+    //
+    // Still 200: a non-2xx makes Telegram retry the same update indefinitely.
+    if (!isTelegramOutboundConfigured()) {
+      if (!droppedInboundWarned) {
+        droppedInboundWarned = true;
+        logger.warn(
+          'Telegram inbound dropped: TELEGRAM_WEBHOOK_SECRET is set but TELEGRAM_BOT_TOKEN is not. '
+          + 'Unset both to disable the gateway cleanly.',
+        );
+      }
+      return new Response('OK', { status: 200 });
     }
 
     const message = body.message;

--- a/services/api/src/lib/telegram/bot-api.ts
+++ b/services/api/src/lib/telegram/bot-api.ts
@@ -24,6 +24,19 @@ function botToken(): string | null {
   return token ? token : null;
 }
 
+/**
+ * Whether the gateway can actually reply.
+ *
+ * Inbound and outbound are gated by different variables
+ * (`TELEGRAM_WEBHOOK_SECRET` vs `TELEGRAM_BOT_TOKEN`), so a half-configured
+ * deployment can authenticate updates it can never answer. Callers on the
+ * inbound path use this to stop before doing expensive work whose reply would
+ * be discarded here anyway.
+ */
+export function isTelegramOutboundConfigured(): boolean {
+  return botToken() !== null;
+}
+
 /** Warn once per process that Telegram outbound is disabled, then stay quiet. */
 function warnDisabled(method: string): void {
   if (missingTokenWarned) return;


### PR DESCRIPTION
Closes IND-623.

## The gap

Hiding the Telegram gateway is an ops action — unset the credentials — because the gateway was already credential-gated at `main.ts:530`. PR #1325 deliberately added no flag for it. But the *half*-configured case was undefended.

With `TELEGRAM_WEBHOOK_SECRET` set and `TELEGRAM_BOT_TOKEN` unset:

- `webhooks.controller.ts` authenticates the update (the secret matches),
- `handleInbound` runs the **full LLM graph** — real token spend, `createChatSession` / `createChatMessage` rows written,
- and every reply then silently no-ops at the bot-api boundary, because #1325 made outbound helpers return early when the token is missing.

Net effect: **the user is ignored while we pay for the inference.**

## The fix

`isTelegramOutboundConfigured()` is now exported from `lib/telegram/bot-api.ts` — one source of truth for "can we actually reply?", sharing the same `botToken()` resolution as the outbound helpers (so whitespace-only tokens count as unset). The webhook checks it before handing off to the gateway.

**It returns 200, not 4xx.** A non-2xx makes Telegram retry the same update indefinitely; acknowledging and dropping is the correct handling for an update we can never answer. Warns once per process and names the remedy — unset both variables to disable the gateway cleanly, which is what `.env.example` already documents.

Chose the early-drop over promoting partial config to a startup error (the other option in the issue): a hard boot failure would take the whole API down over a Telegram misconfiguration, which is a much worse trade than dropping updates for a gateway that is already non-functional.

## Verification

New isolated spec, `services/api/src/controllers/tests/webhooks.controller.isolated.ts` (registered in `.test-isolated`), covering all five configurations:

| Configuration | Expected | Result |
|---|---|---|
| secret set, token **unset** | 200, inbound **not** called | ✅ |
| secret set, token whitespace-only | 200, inbound **not** called | ✅ |
| both set | 200, inbound called with chatId + text | ✅ |
| wrong / missing secret | 401, inbound not called | ✅ |
| webhook secret itself unset | 401 (fails closed) | ✅ |

**Mutation-checked:** replacing the guard condition with `if (false)` drops the suite to 3 pass / 2 fail, so the two new cases are genuinely load-bearing.

Also: `services/api` `tsc --noEmit` clean; existing `lib/telegram` suites 29/29 pass; `bun install --frozen-lockfile` clean.

`services/api` 0.74.0 → 0.74.1 with the root lockfile synced, per the versioning policy.

## Scope

No behavior change when the gateway is fully configured, and none for unauthenticated requests. Does not touch the identity binding, delivery paths, or the gateway's conversation logic.
