### PR TITLE
fix(api): register optional owner approval secret

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -126,7 +126,7 @@
     },
     "services/api": {
       "name": "@indexnetwork/api",
-      "version": "0.77.1",
+      "version": "0.77.2",
       "dependencies": {
         "@aws-sdk/client-s3": "^3.939.0",
         "@aws-sdk/s3-request-presigner": "^3.983.0",

--- a/services/api/CHANGELOG.md
+++ b/services/api/CHANGELOG.md
@@ -35,6 +35,7 @@ section before promoting to `main`).
   than per network.
 
 ### Added
+- Register `OPPORTUNITY_OWNER_APPROVAL_SECRET` as an optional env var so the documented owner-approval secret is schema-validated.
 - Wire the MCP authorization-observability seam at the host boundary (IND-581;
   protocol 7.8.0, API 0.64.0). The composition root now injects a concrete
   `McpAuthorizationObserver` into `createMcpServer` that records each capability

--- a/services/api/package.json
+++ b/services/api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@indexnetwork/api",
-  "version": "0.77.1",
+  "version": "0.77.2",
   "license": "MIT",
   "private": true,
   "scripts": {

--- a/services/api/src/startup.env.ts
+++ b/services/api/src/startup.env.ts
@@ -55,6 +55,7 @@ const envSchema = z.object({
 
   // 2. Authentication
   BETTER_AUTH_SECRET: requiredUnlessTest,
+  OPPORTUNITY_OWNER_APPROVAL_SECRET: z.string().optional(),
   CONNECT_JWT_SECRET: requiredInProduction,
   GOOGLE_CLIENT_ID: z.string().optional(),
   GOOGLE_CLIENT_SECRET: z.string().optional(),

--- a/services/api/tests/env-example-drift.spec.ts
+++ b/services/api/tests/env-example-drift.spec.ts
@@ -102,4 +102,9 @@ describe('root .env.example ↔ startup.env.ts schema', () => {
       "NEGOTIATION_INCLUDE_OTHER_INTENTS: z.enum(['true', 'false']).optional()",
     );
   });
+
+  it('keeps OPPORTUNITY_OWNER_APPROVAL_SECRET optional', () => {
+    expect(schemaSource).toContain('OPPORTUNITY_OWNER_APPROVAL_SECRET: z.string().optional()');
+    expect(schemaSource).not.toContain('OPPORTUNITY_OWNER_APPROVAL_SECRET: requiredInProduction');
+  });
 });


### PR DESCRIPTION
## Summary
- register OPPORTUNITY_OWNER_APPROVAL_SECRET as an optional API env var
- add regression coverage that keeps it optional
- patch-bump @indexnetwork/api to 0.77.2 and sync bun.lock manually

## Verification
- `bun test tests/env-example-drift.spec.ts` (5 pass)
- `bun test tests/mcp.spec.ts` (73 pass)
- `bunx tsc --noEmit`
- `bun run --cwd packages/protocol build`
- `bun install --frozen-lockfile`
- `bun run lint` (0 errors; pre-existing warnings)

Targets `dev`; do not merge.