### PR TITLE
chore: enable pi bridge orchestration

### DIFF
--- a/.pi/settings.json
+++ b/.pi/settings.json
@@ -6,6 +6,7 @@
     "npm:@juicesharp/rpiv-ask-user-question",
     "npm:@juicesharp/rpiv-btw",
     "npm:@juicesharp/rpiv-todo",
-    "npm:@juicesharp/rpiv-web-tools"
+    "npm:@juicesharp/rpiv-web-tools",
+    "git:github.com/yanekyuk/pi-bridge"
   ]
 }

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -13,3 +13,8 @@ This file provides guidance to coding agents working in this repository.
 - This repository overrides generic full-suite branch-finishing guidance: follow the Development Reference’s targeted-validation policy.
 - For each change, run affected tests plus applicable build, typecheck, static-inventory, lint, and generated-artifact checks; report exact evidence in the PR.
 - Run database-backed tests only when the changed behavior requires them and only after proving `DATABASE_URL` is dedicated and disposable and setting `TEST_DATABASE_SAFE=1`; never bypass the fail-closed guard.
+
+## Pi orchestration
+
+When Superpowers coordinates work through Pi Subagents or RPIV, the top-level parent must load and follow the `using-pi-bridge` skill before dispatching.
+Spawned children execute only their assigned task and do not orchestrate.


### PR DESCRIPTION
## New Features
- register the public `yanekyuk/pi-bridge` Pi package for project-local portability
- instruct top-level Superpowers/RPIV parents to load `using-pi-bridge` and keep children non-orchestrating

## Bug Fixes
- None.

## Refactors
- None.

## Documentation
- add repository-wide Pi orchestration guidance to `AGENTS.md`

## Tests
- `jq` package-entry uniqueness validation
- `git diff --check origin/dev...HEAD`
- `pi list` project-package discovery
- installed `pi-bridge.mechanical-worker` runtime smoke (Kimi Highspeed, fresh context)
- installed `pi-bridge.standard-reviewer` runtime smoke (GPT-5.6 Terra, fresh context)