### PR TITLE
fix(web): repair route smoke test mocks

### DIFF
--- a/apps/web/CHANGELOG.md
+++ b/apps/web/CHANGELOG.md
@@ -21,6 +21,7 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
 
 ### Fixed
 
+- Keep the existing route-rendering smoke harness aligned with current web context contracts so its 21 covered route components mount under production-shaped empty states.
 - Make the existing QuestionsContext poll an invalidation-only signal for intent workspaces (IND-507): authoritative lifecycle filtering removes stale negotiation IDs from the stable revision and triggers one passive exact-intent pending+answered refetch without visit-time pool mining or a second poller. Exact answered exchanges remain once after continuation/reload; stale responses are ignored and cards replace/dedupe by durable question ID. Unproven anchors and all unanchored answered/pending cards trail deterministically, while the one mounted `IntentNegotiatorChat` and existing mobile FocusScope/inert/focus-restoration and desktop labelled-region layout remain unchanged.
 
 - Restore the initially closed Personal Agent/Questions column on desktop intent workspaces by limiting drawer-only hidden, non-interactive, and translated state styles to mobile viewports (IND-505).

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@indexnetwork/web",
-  "version": "0.50.1",
+  "version": "0.50.2",
   "license": "MIT",
   "scripts": {
     "dev": "vite --host 127.0.0.1",

--- a/apps/web/src/test/test-utils.test.tsx
+++ b/apps/web/src/test/test-utils.test.tsx
@@ -1,0 +1,19 @@
+import { screen } from '@testing-library/react';
+import { useParams } from 'react-router';
+import { expect, test } from 'vitest';
+
+import { renderWithRouter } from './test-utils';
+
+function RouteParamProbe() {
+  const { id } = useParams<{ id: string }>();
+  return <span>{id ?? 'missing'}</span>;
+}
+
+test('renderWithRouter supplies params from a matching route pattern', () => {
+  renderWithRouter(<RouteParamProbe />, {
+    route: '/d/session-42',
+    routePattern: '/d/:id',
+  });
+
+  expect(screen.getByText('session-42')).toBeInTheDocument();
+});

--- a/apps/web/src/test/test-utils.tsx
+++ b/apps/web/src/test/test-utils.tsx
@@ -1,6 +1,6 @@
 import { ReactElement } from 'react';
 import { render, RenderOptions } from '@testing-library/react';
-import { MemoryRouter } from 'react-router';
+import { MemoryRouter, Route, Routes } from 'react-router';
 
 /**
  * Renders a component wrapped in a MemoryRouter for route-aware testing.
@@ -11,12 +11,19 @@ export function renderWithRouter(
   ui: ReactElement,
   {
     route = '/',
+    routePattern,
     ...renderOptions
-  }: { route?: string } & Omit<RenderOptions, 'wrapper'> = {}
+  }: { route?: string; routePattern?: string } & Omit<RenderOptions, 'wrapper'> = {}
 ) {
   return render(ui, {
     wrapper: ({ children }) => (
-      <MemoryRouter initialEntries={[route]}>{children}</MemoryRouter>
+      <MemoryRouter initialEntries={[route]}>
+        {routePattern ? (
+          <Routes>
+            <Route path={routePattern} element={children} />
+          </Routes>
+        ) : children}
+      </MemoryRouter>
     ),
     ...renderOptions,
   });

--- a/apps/web/tests/routes.test.tsx
+++ b/apps/web/tests/routes.test.tsx
@@ -38,6 +38,7 @@ vi.mock('@/lib/api', () => {
   };
   return {
     apiClient: mockApi,
+    apiUrl: (path: string) => path,
     APIError: class APIError extends Error {
       status: number;
       constructor(msg: string, status: number) {
@@ -77,6 +78,8 @@ vi.mock('@/contexts/APIContext', () => {
     useAPI: () =>
       new Proxy({}, { get: () => noopService }),
     useIndexes: () => noopService,
+    useNetworks: () => noopService,
+    useNetworkRequests: () => noopService,
     useIntents: () => noopService,
     useConnections: () => noopService,
     useSynthesis: () => noopService,
@@ -86,6 +89,7 @@ vi.mock('@/contexts/APIContext', () => {
     useIntegrations: () => noopService,
     useUsers: () => noopService,
     useOpportunities: () => noopService,
+    useConversations: () => noopService,
     useQuestionsService: () => noopService,
   };
 });
@@ -122,42 +126,64 @@ vi.mock('@/contexts/AIChatSessionsContext', () => ({
   }),
 }));
 
-// Mock AIChatContext — use a Proxy so any property access returns a safe default
+// Mock AIChatContext
 vi.mock('@/contexts/AIChatContext', () => ({
   AIChatProvider: ({ children }: { children: React.ReactNode }) => <>{children}</>,
-  useAIChat: () =>
-    new Proxy(
-      {
-        messages: [],
-        isStreaming: false,
-        isLoading: false,
-        sessionId: null,
-        tools: [],
-        debugMeta: null,
-        suggestions: [],
-        opportunities: [],
-      },
-      {
-        get(target, prop) {
-          if (prop in target) return (target as Record<string | symbol, unknown>)[prop];
-          // Any unknown property returns a no-op function (covers setters, send, clear, etc.)
-          return vi.fn();
-        },
-      }
-    ),
+  useAIChat: () => ({
+    messages: [],
+    isLoading: false,
+    stopStream: vi.fn(),
+    sendWebMessage: vi.fn(),
+    clearChat: vi.fn(),
+    startSignalSession: vi.fn(),
+    loadSession: vi.fn().mockResolvedValue(false),
+    loadPreviousMessages: vi.fn(),
+    hasPreviousSession: false,
+    isLoadingPreviousMessages: false,
+    sessionLoadState: { status: 'idle', targetSessionId: null, error: null },
+    isSessionReady: vi.fn().mockReturnValue(false),
+    sessionId: null,
+    sessionTitle: null,
+    sessionPersona: null,
+    turnBlock: null,
+    suggestions: [],
+    chatScope: null,
+    setChatScope: vi.fn(),
+    setScopeNetworkId: vi.fn(),
+    sessionNetworkId: null,
+    updateSessionTitle: vi.fn(),
+    cancelQueuedMessage: vi.fn(),
+    submitMidStreamMessage: vi.fn(),
+    liveQuestions: [],
+  }),
 }));
 
 // Mock ConversationContext
 vi.mock('@/contexts/ConversationContext', () => ({
   ConversationProvider: ({ children }: { children: React.ReactNode }) => <>{children}</>,
   useConversation: () =>
-    new Proxy({}, { get: () => vi.fn() }),
+    new Proxy(
+      {
+        conversations: [],
+        negotiations: [],
+        messages: new Map(),
+        sessionHistory: new Map(),
+        sessionOpportunityMap: new Map(),
+        isConnected: false,
+      },
+      {
+        get(target, prop) {
+          if (prop in target) return (target as Record<string | symbol, unknown>)[prop];
+          return vi.fn().mockResolvedValue(undefined);
+        },
+      },
+    ),
 }));
 
 // Mock IndexesContext
 vi.mock('@/contexts/IndexesContext', () => ({
-  IndexesProvider: ({ children }: { children: React.ReactNode }) => <>{children}</>,
-  useIndexesState: () => ({
+  NetworksProvider: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+  useNetworksState: () => ({
     indexes: [],
     loading: false,
     error: null,
@@ -168,12 +194,29 @@ vi.mock('@/contexts/IndexesContext', () => ({
   }),
 }));
 
-// Mock IndexFilterContext
+// Mock NetworkFilterContext
 vi.mock('@/contexts/IndexFilterContext', () => ({
-  IndexFilterProvider: ({ children }: { children: React.ReactNode }) => <>{children}</>,
-  useIndexFilter: () => ({
-    selectedIndexIds: [],
-    setSelectedIndexIds: vi.fn(),
+  NetworkFilterProvider: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+  useNetworkFilter: () => ({
+    selectedNetworkIds: [],
+    setSelectedNetworkIds: vi.fn(),
+  }),
+}));
+
+// Mock QuestionsContext
+vi.mock('@/contexts/QuestionsContext', () => ({
+  QuestionsProvider: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+  useQuestions: () => ({
+    questions: [],
+    count: 0,
+    globalPending: 0,
+    pushedPoolPending: 0,
+    personalAgentPending: 0,
+    pendingRevision: 'anonymous:',
+    loading: false,
+    answer: vi.fn(),
+    dismiss: vi.fn(),
+    refresh: vi.fn().mockResolvedValue(undefined),
   }),
 }));
 

--- a/apps/web/tests/routes.test.tsx
+++ b/apps/web/tests/routes.test.tsx
@@ -6,6 +6,7 @@
  * every route component can mount without throwing -- NOT to test
  * functionality.
  */
+import { waitFor } from '@testing-library/react';
 import { describe, test, expect, vi, beforeAll } from 'vitest';
 import { renderWithRouter } from '@/test/test-utils';
 
@@ -67,30 +68,83 @@ vi.mock('@/contexts/AuthContext', () => ({
   }),
 }));
 
-// Mock APIContext
+// Mock APIContext with the empty response shape each covered route expects.
 vi.mock('@/contexts/APIContext', () => {
-  const noopService = new Proxy(
-    {},
-    { get: () => vi.fn().mockResolvedValue({}) }
-  );
+  const indexesService = {
+    discoverPublicIndexes: vi.fn().mockResolvedValue({ data: [] }),
+    getCurrentUserMemberSettings: vi.fn().mockResolvedValue({ isOwner: false }),
+    getNetwork: vi.fn().mockRejectedValue(new Error('Network not found')),
+    getSharedIndexes: vi.fn().mockResolvedValue([]),
+    joinIndex: vi.fn().mockResolvedValue({ alreadyMember: false }),
+  };
+  const networkRequestsService = {
+    listMine: vi.fn().mockResolvedValue({ requests: [], canReview: false }),
+    listPending: vi.fn().mockResolvedValue([]),
+    create: vi.fn(),
+    update: vi.fn(),
+    dismiss: vi.fn().mockResolvedValue(undefined),
+    review: vi.fn(),
+  };
+  const intentsService = {
+    getIntent: vi.fn().mockRejectedValue(new Error('Signal not found')),
+    visitIntent: vi.fn().mockResolvedValue(undefined),
+    archiveIntent: vi.fn(),
+    setIntentStatus: vi.fn(),
+    refineIntent: vi.fn(),
+  };
+  const opportunitiesService = {
+    getRadarView: vi.fn().mockResolvedValue({
+      items: [],
+      meta: { totalOpportunities: 0 },
+    }),
+  };
+  const conversationsService = {
+    getNegotiationActivity: vi.fn().mockResolvedValue([]),
+  };
+  const questionsService = {
+    getPending: vi.fn().mockResolvedValue([]),
+    getAnswered: vi.fn().mockResolvedValue([]),
+    getByConversation: vi.fn().mockResolvedValue([]),
+    answer: vi.fn(),
+    dismiss: vi.fn(),
+  };
+  const usersService = {
+    getUserProfile: vi.fn().mockResolvedValue(null),
+    triggerDiscoveryNegotiation: vi.fn(),
+  };
+  const noopService = new Proxy({}, { get: () => vi.fn().mockResolvedValue(undefined) });
+  const services = {
+    indexesService,
+    networkRequestsService,
+    intentsService,
+    connectionsService: noopService,
+    synthesisService: noopService,
+    discoverService: noopService,
+    authService: noopService,
+    integrationsService: noopService,
+    usersService,
+    opportunitiesService,
+    conversationService: conversationsService,
+    apiKeysService: noopService,
+    agentsService: noopService,
+    questionsService,
+  };
   return {
     APIProvider: ({ children }: { children: React.ReactNode }) => <>{children}</>,
-    useAPI: () =>
-      new Proxy({}, { get: () => noopService }),
-    useIndexes: () => noopService,
-    useNetworks: () => noopService,
-    useNetworkRequests: () => noopService,
-    useIntents: () => noopService,
+    useAPI: () => services,
+    useIndexes: () => indexesService,
+    useNetworks: () => indexesService,
+    useNetworkRequests: () => networkRequestsService,
+    useIntents: () => intentsService,
     useConnections: () => noopService,
     useSynthesis: () => noopService,
     useDiscover: () => noopService,
-    useSync: () => noopService,
     useAuth: () => noopService,
     useIntegrations: () => noopService,
-    useUsers: () => noopService,
-    useOpportunities: () => noopService,
-    useConversations: () => noopService,
-    useQuestionsService: () => noopService,
+    useUsers: () => usersService,
+    useOpportunities: () => opportunitiesService,
+    useConversations: () => conversationsService,
+    useQuestionsService: () => questionsService,
   };
 });
 
@@ -126,37 +180,56 @@ vi.mock('@/contexts/AIChatSessionsContext', () => ({
   }),
 }));
 
-// Mock AIChatContext
-vi.mock('@/contexts/AIChatContext', () => ({
-  AIChatProvider: ({ children }: { children: React.ReactNode }) => <>{children}</>,
-  useAIChat: () => ({
+type AIChatContextContract = ReturnType<
+  typeof import('@/contexts/AIChatContext')['useAIChat']
+>;
+
+// Mock AIChatContext with a compile-time-complete context contract.
+vi.mock('@/contexts/AIChatContext', () => {
+  const context = {
+    isOpen: false,
+    setIsOpen: vi.fn(),
     messages: [],
-    isLoading: false,
-    stopStream: vi.fn(),
-    sendWebMessage: vi.fn(),
-    clearChat: vi.fn(),
-    startSignalSession: vi.fn(),
-    loadSession: vi.fn().mockResolvedValue(false),
-    loadPreviousMessages: vi.fn(),
-    hasPreviousSession: false,
-    isLoadingPreviousMessages: false,
-    sessionLoadState: { status: 'idle', targetSessionId: null, error: null },
-    isSessionReady: vi.fn().mockReturnValue(false),
     sessionId: null,
     sessionTitle: null,
     sessionPersona: null,
-    turnBlock: null,
-    suggestions: [],
+    setSessionId: vi.fn(),
+    sessionNetworkId: null,
     chatScope: null,
     setChatScope: vi.fn(),
+    scopeNetworkId: null,
     setScopeNetworkId: vi.fn(),
-    sessionNetworkId: null,
-    updateSessionTitle: vi.fn(),
+    resolveIntentSession: vi.fn().mockResolvedValue(null),
+    suggestions: [],
+    isLoading: false,
+    turnBlock: null,
+    stopStream: vi.fn(),
+    sendMessage: vi.fn().mockResolvedValue(undefined),
+    sendWebMessage: vi.fn().mockResolvedValue(undefined),
+    clearChat: vi.fn(),
+    startSignalSession: vi.fn(),
+    startReporterSession: vi.fn().mockResolvedValue(false),
+    loadSession: vi.fn().mockResolvedValue(false),
+    loadPreviousMessages: vi.fn().mockResolvedValue(undefined),
+    hasPreviousSession: false,
+    isLoadingPreviousMessages: false,
+    sessionLoadState: {
+      status: 'error',
+      targetSessionId: 'mock-session-id',
+      error: 'Conversation not found',
+    },
+    isSessionReady: vi.fn().mockReturnValue(false),
+    updateSessionTitle: vi.fn().mockResolvedValue(false),
+    pendingQueue: [],
     cancelQueuedMessage: vi.fn(),
     submitMidStreamMessage: vi.fn(),
     liveQuestions: [],
-  }),
-}));
+  } satisfies AIChatContextContract;
+  return {
+    AIChatProvider: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+    useAIChat: () => context,
+  };
+});
 
 // Mock ConversationContext
 vi.mock('@/contexts/ConversationContext', () => ({
@@ -237,14 +310,15 @@ vi.mock('@/contexts/SaveBarContext', () => ({
   useSaveBarVisible: () => false,
 }));
 
-// Mock indexes service (standalone, used by /l/[code])
-const noopServiceProxy = () =>
-  new Proxy({}, { get: () => vi.fn().mockResolvedValue({}) });
-
-vi.mock('@/services/indexes', () => ({
-  indexesService: noopServiceProxy(),
-  createIndexesService: () => noopServiceProxy(),
-  useIndexService: () => noopServiceProxy(),
+// Mock the public/authenticated network services used by /l/[code].
+vi.mock('@/services/networks', () => ({
+  indexesService: {
+    getIndexByShareCode: vi.fn().mockRejectedValue(new Error('Invitation not found')),
+  },
+  createIndexesService: vi.fn(),
+  useNetworkService: () => ({
+    acceptInvitation: vi.fn().mockResolvedValue(undefined),
+  }),
 }));
 
 // Mock v2 indexes service (used by IndexesContext)
@@ -288,12 +362,18 @@ vi.mock('@/components/FeedbackWidget', () => ({
   default: () => null,
 }));
 
-// Stub global fetch
+// Stub global fetch with endpoint-specific empty response contracts.
 beforeAll(() => {
-  global.fetch = vi.fn().mockResolvedValue({
-    ok: true,
-    json: () => Promise.resolve([]),
-    text: () => Promise.resolve(''),
+  global.fetch = vi.fn().mockImplementation((input: string | URL | Request) => {
+    const url = String(input);
+    const body = url.includes('/api/chat/shared/')
+      ? { session: { id: 'shared-session', createdAt: new Date(0).toISOString() }, messages: [] }
+      : [];
+    return Promise.resolve({
+      ok: true,
+      json: () => Promise.resolve(body),
+      text: () => Promise.resolve(''),
+    });
   });
 });
 
@@ -330,6 +410,7 @@ describe('Route rendering smoke tests', () => {
     const { Component } = await import('@/app/blog/[slug]/page');
     const { container } = renderWithRouter(<Component />, {
       route: '/blog/test-post',
+      routePattern: '/blog/:slug',
     });
     expect(container).toBeTruthy();
   });
@@ -344,24 +425,27 @@ describe('Route rendering smoke tests', () => {
     const { Component } = await import('@/app/d/[id]/page');
     const { container } = renderWithRouter(<Component />, {
       route: '/d/mock-session-id',
+      routePattern: '/d/:id',
     });
-    expect(container).toBeTruthy();
+    await waitFor(() => expect(container.textContent).toContain('Could not load this chat'));
   });
 
   test('/i/:intentId — Intent detail page renders without crashing', async () => {
     const { Component } = await import('@/app/i/[intentId]/page');
     const { container } = renderWithRouter(<Component />, {
       route: '/i/mock-intent-id',
+      routePattern: '/i/:intentId',
     });
-    expect(container).toBeTruthy();
+    await waitFor(() => expect(container.textContent).toContain('Signal not found'));
   });
 
   test('/l/:code — Invitation page renders without crashing', async () => {
     const { Component } = await import('@/app/l/[code]/page');
     const { container } = renderWithRouter(<Component />, {
       route: '/l/mock-invite-code',
+      routePattern: '/l/:code',
     });
-    expect(container).toBeTruthy();
+    await waitFor(() => expect(container.textContent).toContain('Invitation unavailable'));
   });
 
   test('/networks — Networks page renders without crashing', async () => {
@@ -369,15 +453,16 @@ describe('Route rendering smoke tests', () => {
     const { container } = renderWithRouter(<Component />, {
       route: '/networks',
     });
-    expect(container).toBeTruthy();
+    await waitFor(() => expect(container.textContent).toContain('Networks'));
   });
 
   test('/networks/:id — Network detail page renders without crashing', async () => {
     const { Component } = await import('@/app/networks/[id]/page');
     const { container } = renderWithRouter(<Component />, {
       route: '/networks/mock-network-id',
+      routePattern: '/networks/:id/*',
     });
-    expect(container).toBeTruthy();
+    await waitFor(() => expect(container.textContent).toContain('Network not found'));
   });
 
   test('/pages/privacy-policy — Privacy policy page renders without crashing', async () => {
@@ -400,14 +485,16 @@ describe('Route rendering smoke tests', () => {
     const { Component } = await import('@/app/s/[token]/page');
     const { container } = renderWithRouter(<Component />, {
       route: '/s/mock-share-token',
+      routePattern: '/s/:token',
     });
-    expect(container).toBeTruthy();
+    await waitFor(() => expect(container.textContent).toContain('Shared conversation'));
   });
 
   test('/c/:code — Connect-link landing page renders without crashing', async () => {
     const { Component } = await import('@/app/c/[code]/page');
     const { container } = renderWithRouter(<Component />, {
       route: '/c/mock-connect-code',
+      routePattern: '/c/:code',
     });
     expect(container).toBeTruthy();
     expect(container.textContent).toContain('Open in the Index app');
@@ -417,6 +504,7 @@ describe('Route rendering smoke tests', () => {
     const { Component } = await import('@/app/o/[id]/page');
     const { container } = renderWithRouter(<Component />, {
       route: '/o/mock-opportunity-id',
+      routePattern: '/o/:id',
     });
     expect(container).toBeTruthy();
     expect(container.textContent).toContain('Open in the Index app');
@@ -436,14 +524,16 @@ describe('Route rendering smoke tests', () => {
     const { Component } = await import('@/app/u/[id]/page');
     const { container } = renderWithRouter(<Component />, {
       route: '/u/mock-user-id',
+      routePattern: '/u/:id',
     });
-    expect(container).toBeTruthy();
+    await waitFor(() => expect(container.textContent).toContain('User not found'));
   });
 
   test('/u/:id/chat — User chat page renders without crashing', async () => {
     const { Component } = await import('@/app/u/[id]/chat/page');
     const { container } = renderWithRouter(<Component />, {
       route: '/u/mock-user-id/chat',
+      routePattern: '/u/:id/chat',
     });
     expect(container).toBeTruthy();
   });

--- a/bun.lock
+++ b/bun.lock
@@ -41,7 +41,7 @@
     },
     "apps/web": {
       "name": "@indexnetwork/web",
-      "version": "0.50.1",
+      "version": "0.50.2",
       "dependencies": {
         "@radix-ui/react-alert-dialog": "^1.1.15",
         "@radix-ui/react-dialog": "^1.1.14",


### PR DESCRIPTION
## Fixes

- align the route-rendering smoke harness with current API, network, chat, conversation, filter, and questions context contracts;
- route dynamic pages through matching `Route` patterns so `useParams()` receives production-shaped values;
- use endpoint/service-specific empty and error contracts instead of generic proxy responses;
- await parameter-dependent terminal states so asynchronous crashes cannot escape the smoke tests;
- constrain the AI chat mock against the full current `useAIChat` return type;
- restore all 21 covered route smoke tests, including the seven baseline failures;
- bump web to `0.50.2` with matching lockfile and changelog.

No production route behavior changes.

## Validation

- `cd apps/web && bun run test -- tests/routes.test.tsx src/test/test-utils.test.tsx` — **22 passed, 0 failed**;
- scoped ESLint for all changed TypeScript test surfaces — passed;
- `bun install --frozen-lockfile` — passed;
- `git diff --check` — passed;
- independent review plus two scoped fix re-reviews — final **PASS**, no remaining findings.

## Existing typecheck baseline

A direct `bunx tsc --noEmit -p apps/web/tsconfig.json` remains red on pre-existing web errors (including the broken `apps/web/src/types` symlink/import surface, raw HTML module declarations, and unrelated component typing). The changed route/test utilities have no ESLint or focused-test failures.
