### PR TITLE
feat(mac): add protected dev prereleases

### DIFF
--- a/.github/workflows/mac-dev-release.yml
+++ b/.github/workflows/mac-dev-release.yml
@@ -1,0 +1,62 @@
+name: Publish macOS dev prerelease
+
+on:
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: Unique prerelease tag (macos-dev-YYYYMMDD.N)
+        required: true
+        type: string
+
+permissions:
+  contents: write
+
+concurrency:
+  group: macos-dev-release
+  cancel-in-progress: false
+
+jobs:
+  release:
+    if: github.ref == 'refs/heads/dev'
+    environment: macos-dev-release
+    runs-on: macos-14
+    timeout-minutes: 120
+    steps:
+      - name: Checkout the dispatched dev commit
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
+        with:
+          ref: ${{ github.sha }}
+          fetch-depth: 0
+          persist-credentials: false
+
+      - name: Install pinned Bun runtime
+        uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
+        with:
+          bun-version: "1.3.14"
+
+      - name: Verify dev release source
+        run: |
+          set -euo pipefail
+          test "$GITHUB_REF" = refs/heads/dev
+          test "$(git rev-parse HEAD)" = "$GITHUB_SHA"
+          git diff-index --quiet "$GITHUB_SHA" --
+          bash -n apps/mac/scripts/dev-release.sh
+          cd apps/mac
+          bun test \
+            scripts/assemble.spec.mjs \
+            api/client.spec.mjs \
+            api/native-api-bridge.spec.mjs \
+            api/agent-runtime-ui.spec.mjs \
+            api/notifications.spec.mjs
+
+      - name: Build, notarize, and publish prerelease
+        env:
+          GH_TOKEN: ${{ github.token }}
+          INDEX_DEV_RELEASE_TAG: ${{ inputs.tag }}
+          INDEX_DEVELOPER_ID_CERTIFICATE_P12: ${{ secrets.INDEX_DEVELOPER_ID_CERTIFICATE_P12 }}
+          INDEX_DEVELOPER_ID_CERTIFICATE_PASSWORD: ${{ secrets.INDEX_DEVELOPER_ID_CERTIFICATE_PASSWORD }}
+          INDEX_APP_PROVISIONING_PROFILE_BASE64: ${{ secrets.INDEX_APP_PROVISIONING_PROFILE_BASE64 }}
+          INDEX_NOTARY_API_KEY_BASE64: ${{ secrets.INDEX_NOTARY_API_KEY_BASE64 }}
+          INDEX_NOTARY_KEY_ID: ${{ secrets.INDEX_NOTARY_KEY_ID }}
+          INDEX_NOTARY_ISSUER_ID: ${{ secrets.INDEX_NOTARY_ISSUER_ID }}
+        run: apps/mac/scripts/dev-release.sh

--- a/apps/mac/scripts/dev-release.sh
+++ b/apps/mac/scripts/dev-release.sh
@@ -1,0 +1,180 @@
+#!/usr/bin/env bash
+# Build, sign, notarize, package, and publish a dev-channel macOS prerelease.
+# Intended only for the protected macos-dev-release GitHub Environment.
+set -euo pipefail
+set +x
+
+MAC_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$MAC_ROOT"
+
+: "${GH_TOKEN:?GH_TOKEN is required}"
+: "${GITHUB_SHA:?GITHUB_SHA is required}"
+: "${GITHUB_RUN_ID:?GITHUB_RUN_ID is required}"
+: "${RUNNER_TEMP:?RUNNER_TEMP is required}"
+: "${INDEX_DEV_RELEASE_TAG:?INDEX_DEV_RELEASE_TAG is required}"
+: "${INDEX_DEVELOPER_ID_CERTIFICATE_P12:?INDEX_DEVELOPER_ID_CERTIFICATE_P12 is required}"
+: "${INDEX_DEVELOPER_ID_CERTIFICATE_PASSWORD:?INDEX_DEVELOPER_ID_CERTIFICATE_PASSWORD is required}"
+: "${INDEX_APP_PROVISIONING_PROFILE_BASE64:?INDEX_APP_PROVISIONING_PROFILE_BASE64 is required}"
+: "${INDEX_NOTARY_API_KEY_BASE64:?INDEX_NOTARY_API_KEY_BASE64 is required}"
+: "${INDEX_NOTARY_KEY_ID:?INDEX_NOTARY_KEY_ID is required}"
+: "${INDEX_NOTARY_ISSUER_ID:?INDEX_NOTARY_ISSUER_ID is required}"
+
+[[ "$INDEX_DEV_RELEASE_TAG" =~ ^macos-dev-[0-9]{8}\.[1-9][0-9]*$ ]] || {
+  echo "dev release tag must match macos-dev-YYYYMMDD.N" >&2
+  exit 64
+}
+[[ "$GITHUB_SHA" =~ ^[0-9a-f]{40}$ ]] || { echo "GITHUB_SHA must be a full lowercase commit" >&2; exit 64; }
+
+source "$MAC_ROOT/scripts/link-host.sh"
+source "$MAC_ROOT/scripts/provisioning-profile.sh"
+
+work="$(mktemp -d "$RUNNER_TEMP/index-macos-dev.XXXXXX")"
+keychain="$work/release.keychain-db"
+keychain_password="$(openssl rand -hex 32)"
+p12="$work/developer-id.p12"
+profile="$work/app.provisionprofile"
+notary_key="$work/notary.p8"
+plist_backup="$work/Info.plist"
+notary_profile="index-dev-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT:-1}"
+release_created=0
+plist_modified=0
+
+cleanup() {
+  local status=$?
+  set +e
+  set +x
+  if [[ "$release_created" == 1 && "$status" -ne 0 ]]; then
+    gh release delete "$INDEX_DEV_RELEASE_TAG" --repo "$GITHUB_REPOSITORY" --yes --cleanup-tag >/dev/null 2>&1 || true
+    gh api --method DELETE "repos/$GITHUB_REPOSITORY/git/refs/tags/$INDEX_DEV_RELEASE_TAG" >/dev/null 2>&1 || true
+  fi
+  if [[ "$plist_modified" == 1 && -f "$plist_backup" ]]; then
+    cp "$plist_backup" "$MAC_ROOT/Info.plist"
+  fi
+  security list-keychains -d user -s "$HOME/Library/Keychains/login.keychain-db" /Library/Keychains/System.keychain >/dev/null 2>&1 || true
+  security delete-keychain "$keychain" >/dev/null 2>&1 || true
+  rm -rf "$work"
+  unset INDEX_DEVELOPER_ID_CERTIFICATE_P12 INDEX_DEVELOPER_ID_CERTIFICATE_PASSWORD
+  unset INDEX_APP_PROVISIONING_PROFILE_BASE64 INDEX_NOTARY_API_KEY_BASE64
+  unset INDEX_NOTARY_KEY_ID INDEX_NOTARY_ISSUER_ID
+  exit "$status"
+}
+trap cleanup EXIT
+
+python3 - "$p12" "$profile" "$notary_key" <<'PY'
+import base64
+import os
+import sys
+
+for variable, destination in zip(
+    (
+        "INDEX_DEVELOPER_ID_CERTIFICATE_P12",
+        "INDEX_APP_PROVISIONING_PROFILE_BASE64",
+        "INDEX_NOTARY_API_KEY_BASE64",
+    ),
+    sys.argv[1:],
+):
+    try:
+        encoded = "".join(os.environ[variable].split())
+        value = base64.b64decode(encoded, validate=True)
+    except Exception as error:
+        raise SystemExit(f"{variable} is not valid base64: {error}")
+    if not value:
+        raise SystemExit(f"{variable} decoded to an empty file")
+    with open(destination, "wb") as output:
+        output.write(value)
+    os.chmod(destination, 0o600)
+PY
+
+security create-keychain -p "$keychain_password" "$keychain" >/dev/null
+security set-keychain-settings -lut 21600 "$keychain" >/dev/null
+security unlock-keychain -p "$keychain_password" "$keychain" >/dev/null
+security import "$p12" -k "$keychain" -P "$INDEX_DEVELOPER_ID_CERTIFICATE_PASSWORD" -T /usr/bin/codesign -T /usr/bin/security >/dev/null
+security set-key-partition-list -S apple-tool:,apple: -s -k "$keychain_password" "$keychain" >/dev/null
+security list-keychains -d user -s "$keychain" /Library/Keychains/System.keychain >/dev/null
+
+security cms -D -i "$profile" -o "$work/profile.plist" >/dev/null 2>&1
+team_id="$(/usr/libexec/PlistBuddy -c 'Print :TeamIdentifier:0' "$work/profile.plist")"
+[[ "$team_id" =~ ^[A-Z0-9]{10}$ ]] || { echo "profile TeamIdentifier is malformed" >&2; exit 1; }
+
+identity=""
+while IFS= read -r candidate; do
+  if [[ "$(certificate_team_id "$candidate" || true)" == "$team_id" ]]; then
+    identity="$candidate"
+    break
+  fi
+done < <(security find-identity -v -p codesigning "$keychain" 2>/dev/null | sed -n 's/.*"\(Developer ID Application:[^"]*\)".*/\1/p')
+[[ -n "$identity" ]] || { echo "no Developer ID Application identity matches the profile" >&2; exit 1; }
+
+owner_group="${team_id}.network.index.system6.owner-credentials"
+validate_profile_plist "$work/profile.plist" "$team_id" network.index.system6 dev.index.network "$owner_group"
+
+xcrun notarytool store-credentials "$notary_profile" \
+  --key "$notary_key" \
+  --key-id "$INDEX_NOTARY_KEY_ID" \
+  --issuer "$INDEX_NOTARY_ISSUER_ID" \
+  --keychain "$keychain" >/dev/null
+
+cp "$MAC_ROOT/Info.plist" "$plist_backup"
+plist_modified=1
+/usr/libexec/PlistBuddy -c 'Delete :API_URL' "$MAC_ROOT/Info.plist" >/dev/null 2>&1 || true
+/usr/libexec/PlistBuddy -c 'Delete :APP_URL' "$MAC_ROOT/Info.plist" >/dev/null 2>&1 || true
+/usr/libexec/PlistBuddy -c 'Add :API_URL string https://protocol.dev.index.network' "$MAC_ROOT/Info.plist"
+/usr/libexec/PlistBuddy -c 'Add :APP_URL string https://dev.index.network' "$MAC_ROOT/Info.plist"
+
+INDEX_LINK_HOST=dev.index.network \
+INDEX_DEVELOPMENT_BUILD=1 \
+INDEX_APP_IDENTIFIER_PREFIX="${team_id}." \
+CODESIGN_IDENTITY="$identity" \
+PROVISIONING_PROFILE="$profile" \
+  "$MAC_ROOT/scripts/build.sh"
+
+cp "$plist_backup" "$MAC_ROOT/Info.plist"
+plist_modified=0
+
+app="$MAC_ROOT/dist/Index.app"
+[[ "$(/usr/libexec/PlistBuddy -c 'Print :API_URL' "$app/Contents/Info.plist")" == "https://protocol.dev.index.network" ]]
+[[ "$(/usr/libexec/PlistBuddy -c 'Print :APP_URL' "$app/Contents/Info.plist")" == "https://dev.index.network" ]]
+[[ "$(/usr/libexec/PlistBuddy -c 'Print :IndexDeepLinkHost' "$app/Contents/Info.plist")" == "dev.index.network" ]]
+
+NOTARYTOOL_PROFILE="$notary_profile" "$MAC_ROOT/scripts/notarize.sh"
+NOTARYTOOL_PROFILE="$notary_profile" "$MAC_ROOT/scripts/dmg.sh"
+
+artifact="$MAC_ROOT/dist/Index-macOS-${INDEX_DEV_RELEASE_TAG}.dmg"
+mv "$MAC_ROOT/dist/Index.dmg" "$artifact"
+checksum="${artifact}.sha256"
+(
+  cd "$(dirname "$artifact")"
+  shasum -a 256 "$(basename "$artifact")" >"$(basename "$checksum")"
+)
+xcrun stapler validate "$artifact"
+
+if gh release view "$INDEX_DEV_RELEASE_TAG" --repo "$GITHUB_REPOSITORY" >/dev/null 2>&1; then
+  echo "release already exists: $INDEX_DEV_RELEASE_TAG" >&2
+  exit 1
+fi
+if git ls-remote --exit-code --tags origin "refs/tags/$INDEX_DEV_RELEASE_TAG" >/dev/null 2>&1; then
+  echo "tag already exists without a release: $INDEX_DEV_RELEASE_TAG" >&2
+  exit 1
+fi
+
+notes="$work/release-notes.md"
+cat >"$notes" <<EOF
+Development prerelease from \`dev\` commit \`$GITHUB_SHA\`.
+
+- Web: https://dev.index.network
+- API: https://protocol.dev.index.network
+- Channel: development; not for production distribution
+EOF
+
+release_created=1
+gh release create "$INDEX_DEV_RELEASE_TAG" \
+  --repo "$GITHUB_REPOSITORY" \
+  --target "$GITHUB_SHA" \
+  --title "Index macOS Dev ${INDEX_DEV_RELEASE_TAG#macos-dev-}" \
+  --notes-file "$notes" \
+  --draft \
+  --prerelease
+gh release upload "$INDEX_DEV_RELEASE_TAG" --repo "$GITHUB_REPOSITORY" "$artifact" "$checksum"
+gh release edit "$INDEX_DEV_RELEASE_TAG" --repo "$GITHUB_REPOSITORY" --draft=false --prerelease --latest=false
+release_created=0
+printf 'published %s\n' "$INDEX_DEV_RELEASE_TAG"

--- a/apps/mac/scripts/dev-release.spec.mjs
+++ b/apps/mac/scripts/dev-release.spec.mjs
@@ -1,0 +1,40 @@
+import { expect, test } from 'bun:test';
+import { readFileSync } from 'node:fs';
+
+const workflow = readFileSync(new URL('../../../.github/workflows/mac-dev-release.yml', import.meta.url), 'utf8');
+const script = readFileSync(new URL('./dev-release.sh', import.meta.url), 'utf8');
+
+const secretNames = [
+  'INDEX_DEVELOPER_ID_CERTIFICATE_P12',
+  'INDEX_DEVELOPER_ID_CERTIFICATE_PASSWORD',
+  'INDEX_APP_PROVISIONING_PROFILE_BASE64',
+  'INDEX_NOTARY_API_KEY_BASE64',
+  'INDEX_NOTARY_KEY_ID',
+  'INDEX_NOTARY_ISSUER_ID',
+];
+
+test('dev prerelease workflow is manual, protected, dev-only, and fail-closed', () => {
+  expect(workflow).toContain('workflow_dispatch:');
+  expect(workflow).toContain("if: github.ref == 'refs/heads/dev'");
+  expect(workflow).toContain('environment: macos-dev-release');
+  expect(workflow).toContain('cancel-in-progress: false');
+  expect(workflow).toContain('api/native-api-bridge.spec.mjs');
+  expect(workflow).not.toMatch(/pull_request:|push:/);
+  for (const name of secretNames) {
+    expect(workflow).toContain(`${name}: \${{ secrets.${name} }}`);
+  }
+});
+
+test('release script pins dev endpoints and publishes only after notarization', () => {
+  expect(script).toContain('https://protocol.dev.index.network');
+  expect(script).toContain('https://dev.index.network');
+  expect(script).toContain('validate_profile_plist');
+  expect(script).toContain('network.index.system6.owner-credentials');
+  expect(script.indexOf('scripts/notarize.sh')).toBeLessThan(script.indexOf('gh release create'));
+  expect(script.indexOf('scripts/dmg.sh')).toBeLessThan(script.indexOf('gh release create'));
+  expect(script.indexOf('gh release upload')).toBeLessThan(script.indexOf('--draft=false'));
+  expect(script).toContain('--prerelease --latest=false');
+  expect(script).toContain('security delete-keychain');
+  expect(script).toContain('gh release delete');
+  expect(script).not.toContain('set -x');
+});


### PR DESCRIPTION
## Summary
- add a manually dispatched `dev`-only workflow using the protected `macos-dev-release` environment
- import Developer ID and App Store Connect credentials into a temporary keychain
- enforce the exact owner Keychain provisioning profile and dev endpoints
- sign, notarize, staple, package, checksum, and publish a GitHub prerelease
- remove a partial draft/tag and temporary credentials on failure

## Verification
- `bash -n apps/mac/scripts/dev-release.sh`
- `cd apps/mac && bun test scripts/dev-release.spec.mjs`
- 2 tests passed
- related signing/notarization/DMG tests: 48 passed after detaching a stale `/Volumes/Index` mount

## Dependencies / blockers
- merge #1371 before the first release so the assembled app does not render a blank blue screen
- the release workflow intentionally runs `api/native-api-bridge.spec.mjs`; current `dev` fails that test because the newly merged notification path uses a JavaScript-visible API key. The first release is fail-closed until that regression is repaired.
- configure the six required `macos-dev-release` environment secrets before dispatch
