### PR TITLE
fix(eval): guard discovery runtime before reset

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -126,7 +126,7 @@
     },
     "services/api": {
       "name": "@indexnetwork/api",
-      "version": "0.84.0",
+      "version": "0.84.1",
       "dependencies": {
         "@aws-sdk/client-s3": "^3.939.0",
         "@aws-sdk/s3-request-presigner": "^3.983.0",

--- a/services/api/CHANGELOG.md
+++ b/services/api/CHANGELOG.md
@@ -13,6 +13,9 @@ section before promoting to `main`).
 - Retire the deprecated REST/chat profile and profile-run tool aliases with protocol 12.0.0; direct Tool API callers must use canonical user-context and enrichment-run names.
 - Record production evidence for the separately gated `opportunity_discovery_runs` Release 2 cleanup; no destructive migration is included.
 
+### Fixed
+- Refuse legacy discovery runs before target attestation or reset when provider/Redis runtime prerequisites are missing or ambiguous, and report child failures by sanitized code-owned execution stage.
+
 ### Added
 - Add guarded historical-quality runtime reconciliation (API 0.83.1), including the compatible quality-attestation migration after the dev-owned Hermes migration history.
 - Add Hermes backend production assurance (API 0.83.0): a provider-free PostgreSQL 16 release gate now migrates the dedicated disposable `hermes_assurance` database and runs real authority, lifecycle/fault, 100,000-row migration-preflight, aggregate expiry-telemetry, stale/expired Index-coverage, and emergency concurrency/rollback evidence. Release dispatch requires explicit approved lock/total thresholds and the immutable currently deployed API digest; CI exercises emergency control in dry-run mode only and publishes fixed-schema credential-free evidence.

--- a/services/api/package.json
+++ b/services/api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@indexnetwork/api",
-  "version": "0.84.0",
+  "version": "0.84.1",
   "license": "MIT",
   "private": true,
   "scripts": {

--- a/services/api/src/cli/discovery-quality.environment.ts
+++ b/services/api/src/cli/discovery-quality.environment.ts
@@ -1,6 +1,7 @@
 import { createHash } from 'node:crypto';
 
 import { assertAbEnvConfig } from './discovery.flags';
+import { DISCOVERY_RUNTIME_REDIS_KEYS, parseDiscoveryRuntimePrerequisites } from './discovery.runtime-prerequisites';
 
 export const HISTORICAL_QUALITY_RUNTIME_CORE_KEYS = [
   'DISCOVERY_TARGETS', 'NEON_API_KEY', 'DISCOVERY_CONFIRM',
@@ -32,9 +33,7 @@ const HISTORICAL_QUALITY_DISCOVERY_MODEL_RUNTIME_POLICY = Object.freeze(
   ) as Readonly<Record<Exclude<keyof typeof HISTORICAL_QUALITY_MODEL_RUNTIME_POLICY, 'OPENROUTER_BASE_URL'>, string>>,
 );
 
-export const HISTORICAL_QUALITY_RUNTIME_REDIS_KEYS = [
-  'REDIS_URL', 'REDIS_HOST', 'REDIS_PORT', 'REDIS_PASSWORD', 'REDIS_DB',
-] as const;
+export const HISTORICAL_QUALITY_RUNTIME_REDIS_KEYS = DISCOVERY_RUNTIME_REDIS_KEYS;
 
 export const HISTORICAL_QUALITY_MODEL_ASSIGNMENT_CARRIERS = [
   'CHAT_MODEL', 'EVAL_MODEL_OVERRIDES',
@@ -73,31 +72,22 @@ export function parseHistoricalQualityRuntimeEnvironment(
     throw new Error('Historical quality runtime forbids a supplied DATABASE_URL');
   }
   const result: Record<string, string> = {};
-  for (const key of HISTORICAL_QUALITY_RUNTIME_CORE_KEYS) result[key] = required(environment, key);
+  for (const key of HISTORICAL_QUALITY_RUNTIME_CORE_KEYS) {
+    if (key !== 'OPENROUTER_API_KEY') result[key] = required(environment, key);
+  }
   if (result.DISCOVERY_CONFIRM !== '1') throw new Error('Historical quality DISCOVERY_CONFIRM must equal 1');
   if (result.TEST_DATABASE_SAFE !== '1') throw new Error('Historical quality TEST_DATABASE_SAFE must equal 1');
+  const runtimePrerequisites = parseDiscoveryRuntimePrerequisites(environment);
+  result.OPENROUTER_API_KEY = runtimePrerequisites.OPENROUTER_API_KEY;
   for (const key of HISTORICAL_QUALITY_RUNTIME_MODEL_KEYS) {
     const value = defined(environment, key);
     if (value !== undefined) result[key] = value;
   }
   Object.assign(result, HISTORICAL_QUALITY_MODEL_RUNTIME_POLICY);
 
-  const redisUrl = defined(environment, 'REDIS_URL');
-  const splitValues = ['REDIS_HOST', 'REDIS_PORT', 'REDIS_PASSWORD', 'REDIS_DB']
-    .map((key) => defined(environment, key));
-  const hasSplit = splitValues.some((value) => value !== undefined);
-  if ((redisUrl !== undefined && hasSplit) || (redisUrl === undefined && !hasSplit)) {
-    throw new Error('Historical quality runtime requires exactly one Redis configuration');
-  }
-  if (redisUrl !== undefined) {
-    result.REDIS_URL = redisUrl;
-  } else {
-    if (splitValues.some((value) => value === undefined)) {
-      throw new Error('Historical quality runtime requires the complete REDIS_HOST/REDIS_PORT/REDIS_PASSWORD/REDIS_DB form');
-    }
-    HISTORICAL_QUALITY_RUNTIME_REDIS_KEYS.slice(1).forEach((key, index) => {
-      result[key] = splitValues[index]!;
-    });
+  for (const key of HISTORICAL_QUALITY_RUNTIME_REDIS_KEYS) {
+    const value = runtimePrerequisites[key];
+    if (value !== undefined) result[key] = value;
   }
   return Object.freeze(result) as HistoricalQualityRuntimeEnvironment;
 }

--- a/services/api/src/cli/discovery.contract.ts
+++ b/services/api/src/cli/discovery.contract.ts
@@ -298,6 +298,27 @@ export class HistoricalQualityLeaseReleaseError extends Error {
 
 export interface AbFailureReport { exitCode: number; message: string }
 
+/** Fixed, value-free operational boundaries reported by a discovery child. */
+export const AB_CHILD_FAILURE_STAGES = [
+  'dependency-initialization',
+  'base-verification',
+  'run-execution',
+  'artifact-write',
+  'resource-cleanup',
+] as const;
+export type AbChildFailureStage = (typeof AB_CHILD_FAILURE_STAGES)[number];
+
+/** Keeps a raw cause in memory while exposing only its code-owned stage. */
+export class AbChildStageError extends Error {
+  readonly stage: AbChildFailureStage;
+
+  constructor(stage: AbChildFailureStage, options?: ErrorOptions) {
+    super(`Discovery side process failed at stage ${stage}.`, options);
+    this.name = 'AbChildStageError';
+    this.stage = stage;
+  }
+}
+
 /**
  * Which invocation is reporting. A parent owns the run-level cost report; a
  * child owns nothing but its own outcome.
@@ -338,6 +359,12 @@ export function describeAbFailure(error: unknown, role: AbInvocationRole = 'pare
   }
   if (error instanceof AbGateError) {
     return { exitCode: AB_EXIT_PREFLIGHT_REFUSED, message: error.message };
+  }
+  if (error instanceof AbChildStageError) {
+    return {
+      exitCode: AB_EXIT_PREFLIGHT_REFUSED,
+      message: `${error.message} The parent invocation remains authoritative for mutation and spend uncertainty.`,
+    };
   }
   return {
     exitCode: AB_EXIT_PREFLIGHT_REFUSED,
@@ -397,6 +424,12 @@ export function abUsage(): string {
     `  DISCOVERY_TARGETS='${manifest}'`,
     '  A strict version-2 historical-quality manifest is also accepted here; legacy',
     '  A/B projects only its two child targets and never binds the base read replica.',
+    '',
+    'Required runtime prerequisites (checked without contacting either service):',
+    '  OPENROUTER_API_KEY=<provider key>',
+    '  Exactly one Redis form:',
+    '    REDIS_URL=<Redis URL>',
+    '    or REDIS_HOST + REDIS_PORT + REDIS_PASSWORD + REDIS_DB',
     '',
     'This command never creates or deletes Neon branches. It resets the attested',
     `branch of every side it runs from ${AB_BASE_BRANCH} before it spawns anything:`,

--- a/services/api/src/cli/discovery.gate.ts
+++ b/services/api/src/cli/discovery.gate.ts
@@ -18,6 +18,7 @@
  * and the offending field name are reported, exactly as the matrix gate does.
  */
 import { AB_BRANCH_NAMES } from './discovery.neon';
+import { DiscoveryRuntimePrerequisiteError, parseDiscoveryRuntimePrerequisites } from './discovery.runtime-prerequisites';
 
 import type { AbSideId } from './discovery.plan';
 
@@ -43,6 +44,18 @@ export const AB_SIDE_BRANCH_ENV = 'DISCOVERY_SIDE_BRANCH';
 export interface AbSideEnvironment {
   databaseUrl: URL;
   branch: string;
+}
+
+/** Requires provider and Redis inputs before parsing or attesting a target. */
+export function assertAbRuntimePrerequisites(env: NodeJS.ProcessEnv): void {
+  try {
+    parseDiscoveryRuntimePrerequisites(env);
+  } catch (error) {
+    if (error instanceof DiscoveryRuntimePrerequisiteError) {
+      throw new AbGateError(`Refusing to run: ${error.message}`, { cause: error });
+    }
+    throw error;
+  }
 }
 
 /**

--- a/services/api/src/cli/discovery.main.ts
+++ b/services/api/src/cli/discovery.main.ts
@@ -27,7 +27,7 @@ import { statSync } from 'node:fs';
 import { mkdtemp, readdir, rm } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 
-import { AB_BASE_BRANCH, AB_DEFAULT_REPETITIONS, AB_EXIT_COMPARISON, AB_EXIT_INSUFFICIENT_EVIDENCE, AB_MAX_REPETITIONS, abUsage, classifyAbParentFailure, type AbRunShape, type AbRunStage } from './discovery.contract';
+import { AB_BASE_BRANCH, AB_DEFAULT_REPETITIONS, AB_EXIT_COMPARISON, AB_EXIT_INSUFFICIENT_EVIDENCE, AB_MAX_REPETITIONS, AbChildStageError, abUsage, classifyAbParentFailure, type AbChildFailureStage, type AbRunShape, type AbRunStage } from './discovery.contract';
 import { AB_SIDE_BRANCH_ENV, AbGateError, assertAbConfirmation, assertAbSideEnvironment } from './discovery.gate';
 import { AB_BRANCH_NAMES, attestAbTargets, parseAbManifest, resetAbBranch, type AbTarget } from './discovery.neon';
 import { buildAbPlan, configDiff, isAbPair } from './discovery.plan';
@@ -210,11 +210,11 @@ async function runAbSide(
   selection: AbSideSelection,
   deps: Awaited<ReturnType<typeof createChildDependencies>>,
   thresholdOverrides: DiscoveryChildThresholdOverrides,
+  matrixEval: Awaited<ReturnType<typeof loadMatrixEval>>,
+  assertLLM: Awaited<ReturnType<typeof loadJudge>>,
 ): Promise<AbChildOutput> {
-  const { HISTORICAL_MATRIX_CASES, scoreMatrixSlot, buildExecutionEvidence, executeRuns } = await loadMatrixEval();
-  const assertLLM = await loadJudge();
+  const { scoreMatrixSlot, buildExecutionEvidence, executeRuns } = matrixEval;
   const { side, slots } = selection;
-  await verifyAbBranchBase(HISTORICAL_MATRIX_CASES as HistoricalMatrixFixture[]);
 
   const batch = await executeRuns(async ({ runIndex, signal }: { runIndex: number; signal: AbortSignal }) => runMatrixBoundary('matrix_runtime_failure', async () => {
     const slot = slots[runIndex]!;
@@ -282,22 +282,122 @@ async function runAbSide(
   );
 }
 
+/** Injected child stages, kept small so every operational failure is classified. */
+export interface AbChildStageDependencies<TDependencies, TOutput> {
+  initializeDependencies(): Promise<TDependencies>;
+  verifyBase(dependencies: TDependencies): Promise<void>;
+  executeRun(dependencies: TDependencies): Promise<TOutput>;
+  writeArtifact(output: TOutput): Promise<void>;
+}
+
+async function atAbChildStage<T>(
+  stage: AbChildFailureStage,
+  operation: () => Promise<T>,
+  observeStage?: (stage: AbChildFailureStage) => void,
+): Promise<T> {
+  try {
+    observeStage?.(stage);
+    return await operation();
+  } catch (error) {
+    if (error instanceof AbChildStageError) throw error;
+    throw new AbChildStageError(stage, { cause: error });
+  }
+}
+
+/** Runs the four ordered child boundaries and never executes beyond a failure. */
+export async function runAbChildStages<TDependencies, TOutput>(
+  stages: AbChildStageDependencies<TDependencies, TOutput>,
+  observeStage?: (stage: AbChildFailureStage) => void,
+): Promise<void> {
+  const dependencies = await atAbChildStage('dependency-initialization', stages.initializeDependencies, observeStage);
+  await atAbChildStage('base-verification', () => stages.verifyBase(dependencies), observeStage);
+  const output = await atAbChildStage('run-execution', () => stages.executeRun(dependencies), observeStage);
+  await atAbChildStage('artifact-write', () => stages.writeArtifact(output), observeStage);
+}
+
+/** Classifies the existing child cleanup boundary without changing its semantics. */
+export async function runAbChildResourceCleanup(
+  cleanup: () => Promise<void>,
+  observeStage?: (stage: AbChildFailureStage) => void,
+): Promise<void> {
+  await atAbChildStage('resource-cleanup', cleanup, observeStage);
+}
+
+export interface AbChildLoadedSetup {
+  slots: readonly AbSlot[];
+  matrixEval: Awaited<ReturnType<typeof loadMatrixEval>>;
+}
+
+export type AbChildSetupSource = readonly AbSlot[] | (() => Promise<AbChildLoadedSetup>);
+
+async function withAbChildEnvironment(
+  config: AbEnvConfig,
+  operation: () => Promise<void>,
+): Promise<void> {
+  let operationCompleted = false;
+  try {
+    await withDiscoveryEnvironment(config, async () => {
+      await operation();
+      operationCompleted = true;
+    });
+  } catch (error) {
+    if (error instanceof AbChildStageError) throw error;
+    throw new AbChildStageError(operationCompleted ? 'resource-cleanup' : 'dependency-initialization', { cause: error });
+  }
+}
+
 /**
  * Runs one side's slots against the branch this process is composed against and
  * writes `{ slots, execution }` — the same artifact shape the matrix child
  * writes, so the parent aggregates both harnesses' children identically.
  */
-export async function runAbChild(sideId: AbSideId, slots: readonly AbSlot[], outputPath: string): Promise<void> {
-  const selection = selectAbSideSlots(sideId, slots);
-  await runWithChildCleanup(async () => {
-    const output = await withDiscoveryEnvironment(selection.side.config, async () => {
-      const thresholdOverrides = discoveryChildThresholdOverrides();
-      const deps = await createChildDependencies(thresholdOverrides);
-      return runAbSide(selection, deps, thresholdOverrides);
-    });
-    await Bun.write(outputPath, JSON.stringify(output));
-    console.log(`Discovery child artifact written: side=${sideId} path=${outputPath}`);
-  }, closeChildResources);
+export async function runAbChild(
+  sideId: AbSideId,
+  setupSource: AbChildSetupSource,
+  outputPath: string,
+  observeStage?: (stage: AbChildFailureStage) => void,
+): Promise<void> {
+  const observedStages = new Set<AbChildFailureStage>();
+  const observeOnce = observeStage === undefined
+    ? undefined
+    : (stage: AbChildFailureStage) => {
+      if (!observedStages.has(stage)) observeStage(stage);
+      observedStages.add(stage);
+    };
+  // This setup previously happened in child main, outside every stage. It has
+  // no composed resources, so a refusal here preserves the former no-cleanup
+  // behavior while gaining an exact dependency-initialization classification.
+  const loaded = await atAbChildStage('dependency-initialization', async () => {
+    const setup = typeof setupSource === 'function'
+      ? await setupSource()
+      : { slots: setupSource, matrixEval: await loadMatrixEval() };
+    return { ...setup, selection: selectAbSideSlots(sideId, setup.slots) };
+  }, observeOnce);
+
+  await runWithChildCleanup(async () => withAbChildEnvironment(loaded.selection.side.config, async () => {
+    await runAbChildStages({
+      initializeDependencies: async () => {
+        const thresholdOverrides = discoveryChildThresholdOverrides();
+        const deps = await createChildDependencies(thresholdOverrides);
+        const assertLLM = await loadJudge();
+        return { deps, thresholdOverrides, assertLLM };
+      },
+      verifyBase: async () => {
+        await verifyAbBranchBase(loaded.matrixEval.HISTORICAL_MATRIX_CASES as HistoricalMatrixFixture[]);
+      },
+      executeRun: async ({ deps, thresholdOverrides, assertLLM }) => runAbSide(
+        loaded.selection,
+        deps,
+        thresholdOverrides,
+        loaded.matrixEval,
+        assertLLM,
+      ),
+      writeArtifact: async (output) => {
+        await Bun.write(outputPath, JSON.stringify(output));
+        console.log(`Discovery child artifact written: side=${sideId} path=${outputPath}`);
+      },
+    }, observeOnce);
+  }), () => runAbChildResourceCleanup(closeChildResources, observeOnce));
 }
 
 // ── Parent half ─────────────────────────────────────────────────────────────
@@ -1114,6 +1214,44 @@ async function runAbParent(args: readonly string[]): Promise<void> {
   await withAbSpendAccounting(async (progress) => runAbComparison(args, progress));
 }
 
+export interface AbChildMainDependencies {
+  loadMatrixEval: typeof loadMatrixEval;
+  runChild: typeof runAbChild;
+  observeStage?: (stage: AbChildFailureStage) => void;
+}
+
+const productionAbChildMainDependencies: AbChildMainDependencies = {
+  loadMatrixEval,
+  runChild: runAbChild,
+};
+
+/** Child-only entry after bootstrap attestation; all checks here are preflight. */
+export async function runAbChildInvocation(
+  args: readonly string[],
+  processEnvironment: NodeJS.ProcessEnv,
+  dependencies: AbChildMainDependencies = productionAbChildMainDependencies,
+): Promise<void> {
+  const { sideId, outputPath } = parseAbChildArgs(args);
+  const environment = assertAbSideEnvironment(processEnvironment, sideId);
+  const manifest = parseAbManifest(processEnvironment.DISCOVERY_TARGETS);
+  const target = manifest.targets.find((candidate) => candidate.sideId === sideId);
+  if (!target || new URL(target.databaseUrl).toString() !== environment.databaseUrl.toString()) {
+    throw new AbGateError(`Refusing to mutate: side ${sideId} is not composed against the database its manifest entry declares`);
+  }
+  const selection = parseAbRunArgs(args);
+  await dependencies.runChild(sideId, async () => {
+    const matrixEval = await dependencies.loadMatrixEval();
+    const cases = resolveAbCases(
+      matrixEval.HISTORICAL_MATRIX_CASES as HistoricalMatrixFixture[],
+      selection.caseIds,
+    );
+    return {
+      matrixEval,
+      slots: buildAbPlan(cases, selection.sides, selection.repetitions),
+    };
+  }, outputPath, dependencies.observeStage);
+}
+
 /**
  * The one entry point, parent and child.
  *
@@ -1124,16 +1262,5 @@ async function runAbParent(args: readonly string[]): Promise<void> {
 export async function main(args: readonly string[] = process.argv.slice(2)): Promise<void> {
   if (args.includes('--help') || args.includes('-h')) return void console.log(abUsage());
   if (!args.includes('--side')) return void await runAbParent(args);
-
-  const { sideId, outputPath } = parseAbChildArgs(args);
-  const environment = assertAbSideEnvironment(process.env, sideId);
-  const manifest = parseAbManifest(process.env.DISCOVERY_TARGETS);
-  const target = manifest.targets.find((candidate) => candidate.sideId === sideId);
-  if (!target || new URL(target.databaseUrl).toString() !== environment.databaseUrl.toString()) {
-    throw new AbGateError(`Refusing to mutate: side ${sideId} is not composed against the database its manifest entry declares`);
-  }
-  const selection = parseAbRunArgs(args);
-  const { HISTORICAL_MATRIX_CASES } = await loadMatrixEval();
-  const cases = resolveAbCases(HISTORICAL_MATRIX_CASES as HistoricalMatrixFixture[], selection.caseIds);
-  await runAbChild(sideId, buildAbPlan(cases, selection.sides, selection.repetitions), outputPath);
+  await runAbChildInvocation(args, process.env);
 }

--- a/services/api/src/cli/discovery.runtime-prerequisites.ts
+++ b/services/api/src/cli/discovery.runtime-prerequisites.ts
@@ -1,0 +1,66 @@
+/** Provider and cache prerequisites shared by discovery runtime entry points. */
+export const DISCOVERY_RUNTIME_REDIS_KEYS = [
+  'REDIS_URL', 'REDIS_HOST', 'REDIS_PORT', 'REDIS_PASSWORD', 'REDIS_DB',
+] as const;
+
+const DISCOVERY_RUNTIME_REDIS_SPLIT_KEYS = DISCOVERY_RUNTIME_REDIS_KEYS.slice(1);
+
+export type DiscoveryRuntimePrerequisites = Readonly<{
+  OPENROUTER_API_KEY: string;
+} & (
+  | { REDIS_URL: string; REDIS_HOST?: never; REDIS_PORT?: never; REDIS_PASSWORD?: never; REDIS_DB?: never }
+  | { REDIS_URL?: never; REDIS_HOST: string; REDIS_PORT: string; REDIS_PASSWORD: string; REDIS_DB: string }
+)>;
+
+/** A fixed, value-free runtime prerequisite refusal safe to show to operators. */
+export class DiscoveryRuntimePrerequisiteError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'DiscoveryRuntimePrerequisiteError';
+  }
+}
+
+function nonblank(
+  environment: Readonly<Record<string, string | undefined>>,
+  key: string,
+): string | undefined {
+  const value = environment[key];
+  return value === undefined || value.trim() === '' ? undefined : value;
+}
+
+/**
+ * Reads no files and contacts no services. It accepts exactly the two Redis
+ * forms supported by the historical-quality production runtime.
+ */
+export function parseDiscoveryRuntimePrerequisites(
+  environment: Readonly<Record<string, string | undefined>>,
+): DiscoveryRuntimePrerequisites {
+  const providerKey = nonblank(environment, 'OPENROUTER_API_KEY');
+  if (providerKey === undefined) {
+    throw new DiscoveryRuntimePrerequisiteError('Discovery runtime requires OPENROUTER_API_KEY');
+  }
+
+  const redisUrl = nonblank(environment, 'REDIS_URL');
+  const splitValues = DISCOVERY_RUNTIME_REDIS_SPLIT_KEYS.map((key) => nonblank(environment, key));
+  const hasSplit = splitValues.some((value) => value !== undefined);
+  if ((redisUrl !== undefined && hasSplit) || (redisUrl === undefined && !hasSplit)) {
+    throw new DiscoveryRuntimePrerequisiteError(
+      'Discovery runtime requires exactly one Redis configuration: REDIS_URL or REDIS_HOST/REDIS_PORT/REDIS_PASSWORD/REDIS_DB',
+    );
+  }
+  if (redisUrl !== undefined) {
+    return Object.freeze({ OPENROUTER_API_KEY: providerKey, REDIS_URL: redisUrl });
+  }
+  if (splitValues.some((value) => value === undefined)) {
+    throw new DiscoveryRuntimePrerequisiteError(
+      'Discovery runtime requires the complete REDIS_HOST/REDIS_PORT/REDIS_PASSWORD/REDIS_DB form',
+    );
+  }
+  return Object.freeze({
+    OPENROUTER_API_KEY: providerKey,
+    REDIS_HOST: splitValues[0]!,
+    REDIS_PORT: splitValues[1]!,
+    REDIS_PASSWORD: splitValues[2]!,
+    REDIS_DB: splitValues[3]!,
+  });
+}

--- a/services/api/src/cli/discovery.ts
+++ b/services/api/src/cli/discovery.ts
@@ -19,7 +19,7 @@
  * read what the command requires *before* they have any of it.
  */
 import { AB_BRANCH_NAMES, attestAbTargets, parseLegacyAbManifest, type AbManifest } from './discovery.neon';
-import { AB_SIDE_BRANCH_ENV, assertAbConfirmation } from './discovery.gate';
+import { AB_SIDE_BRANCH_ENV, assertAbConfirmation, assertAbRuntimePrerequisites } from './discovery.gate';
 import { abAttestationRefusal, abUsage, describeAbFailure, type AbInvocationRole } from './discovery.contract';
 import { createNeonControlPlane } from './discovery-env-matrix.neon';
 import { formatHistoricalQualityCost, hasHistoricalQualityHelp, historicalQualityUsage, isHistoricalQualityRequest, parseHistoricalQualityArgs, type HistoricalQualityRequest } from './discovery-quality.contract';
@@ -76,6 +76,7 @@ interface DiscoveryRuntime {
  */
 export interface DiscoveryBootstrapDependencies {
   assertConfirmation(env: NodeJS.ProcessEnv): void;
+  assertRuntimePrerequisites(env: NodeJS.ProcessEnv): void;
   parseManifest(raw: string | undefined): AbManifest;
   attestTargets(manifest: AbManifest, role: AbInvocationRole): Promise<void>;
   importRuntime(): Promise<DiscoveryRuntime>;
@@ -89,6 +90,7 @@ export interface DiscoveryBootstrapDependencies {
 
 const productionBootstrapDependencies: DiscoveryBootstrapDependencies = {
   assertConfirmation: assertAbConfirmation,
+  assertRuntimePrerequisites: assertAbRuntimePrerequisites,
   parseManifest: parseLegacyAbManifest,
   attestTargets: attestOrRefuse,
   importRuntime: async () => await import('./discovery.main'),
@@ -139,6 +141,10 @@ export async function runDiscoveryBootstrap(
   // First, and before any network call: an unconfirmed run must not even
   // reach the control plane, let alone a database.
   dependencies.assertConfirmation(env);
+  // Pure value-shape validation only: no secret is derived or checked against
+  // a provider. This precedes manifest parsing and every live boundary so a
+  // missing runtime cannot destroy disposable branches before failing.
+  dependencies.assertRuntimePrerequisites(env);
   const manifest = dependencies.parseManifest(env.DISCOVERY_TARGETS);
   await dependencies.attestTargets(manifest, abInvocationRole(args));
   const sideId = childSideId(args);

--- a/services/api/src/cli/tests/discovery.child.spec.ts
+++ b/services/api/src/cli/tests/discovery.child.spec.ts
@@ -109,6 +109,7 @@ describe('discovery bootstrap child compatibility', () => {
     const seen: unknown[] = [];
     const dependencies: DiscoveryBootstrapDependencies = {
       assertConfirmation: () => { throw new Error('legacy gate must not run'); },
+      assertRuntimePrerequisites: () => { throw new Error('legacy runtime gate must not run'); },
       parseManifest: () => { throw new Error('legacy manifest must not parse'); },
       attestTargets: async () => { throw new Error('legacy attestation must not run'); },
       importRuntime: async () => { throw new Error('legacy runtime must not load'); },
@@ -130,6 +131,7 @@ describe('discovery bootstrap child compatibility', () => {
     const calls: string[] = [];
     const dependencies: DiscoveryBootstrapDependencies = {
       assertConfirmation: () => { calls.push('gate'); },
+      assertRuntimePrerequisites: () => { calls.push('runtime-prerequisites'); },
       parseManifest: () => ({
         projectId: 'project', baseBranchId: 'base',
         targets: [
@@ -142,7 +144,7 @@ describe('discovery bootstrap child compatibility', () => {
     };
     const env = {};
     await runDiscoveryBootstrap(args, env, { log: () => {}, error: () => {} }, dependencies);
-    expect(calls).toEqual(['gate', 'attest']);
+    expect(calls).toEqual(['gate', 'runtime-prerequisites', 'attest']);
     expect(seen).toEqual([args]);
     expect(env).toMatchObject({ DATABASE_URL: 'postgres://u:p@a.neon.tech/protocol_eval' });
   });

--- a/services/api/src/cli/tests/discovery.preflight-stages.spec.ts
+++ b/services/api/src/cli/tests/discovery.preflight-stages.spec.ts
@@ -1,0 +1,270 @@
+import { describe, expect, it } from 'bun:test';
+
+import { AbChildStageError, describeAbFailure, type AbChildFailureStage } from '../discovery.contract';
+import { assertAbRuntimePrerequisites } from '../discovery.gate';
+import { runAbChild, runAbChildInvocation, runAbChildResourceCleanup, runAbChildStages, type AbChildMainDependencies } from '../discovery.main';
+import { runDiscoveryBootstrap, type DiscoveryBootstrapDependencies } from '../discovery';
+
+const manifest = {
+  projectId: 'synthetic-project',
+  baseBranchId: 'synthetic-base',
+  targets: [
+    { sideId: 'a' as const, branchId: 'synthetic-a', endpointId: 'synthetic-ea', databaseUrl: 'postgres://user:password@a.neon.tech/protocol_eval' },
+    { sideId: 'b' as const, branchId: 'synthetic-b', endpointId: 'synthetic-eb', databaseUrl: 'postgres://user:password@b.neon.tech/protocol_eval' },
+  ] as const,
+};
+
+function confirmedEnvironment(overrides: NodeJS.ProcessEnv = {}): NodeJS.ProcessEnv {
+  return {
+    DISCOVERY_CONFIRM: '1',
+    TEST_DATABASE_SAFE: '1',
+    NEON_API_KEY: 'synthetic-neon-key',
+    DISCOVERY_TARGETS: '{synthetic-manifest}',
+    OPENROUTER_API_KEY: 'synthetic-provider-key',
+    REDIS_URL: 'redis://synthetic.invalid:6379',
+    ...overrides,
+  };
+}
+
+function bootstrapDependencies(calls: string[]): DiscoveryBootstrapDependencies {
+  return {
+    assertConfirmation: () => { calls.push('confirmation'); },
+    assertRuntimePrerequisites: (environment) => {
+      calls.push('runtime-prerequisites');
+      assertAbRuntimePrerequisites(environment);
+    },
+    parseManifest: () => { calls.push('manifest'); return manifest; },
+    attestTargets: async () => { calls.push('attestation'); },
+    importRuntime: async () => {
+      calls.push('runtime-import');
+      return { main: async () => { calls.push('runtime-main'); } };
+    },
+  };
+}
+
+describe('direct discovery runtime prerequisite preflight', () => {
+  it.each([
+    ['missing provider', { OPENROUTER_API_KEY: undefined }],
+    ['blank provider', { OPENROUTER_API_KEY: '   ' }],
+    ['missing Redis', { REDIS_URL: undefined }],
+    ['ambiguous Redis', { REDIS_HOST: 'cache.invalid', REDIS_PORT: '6379', REDIS_PASSWORD: 'synthetic-password', REDIS_DB: '0' }],
+    ['partial Redis', { REDIS_URL: undefined, REDIS_HOST: 'cache.invalid', REDIS_PORT: '6379' }],
+  ])('refuses %s before manifest, attestation, import, reset, or spawn', async (_label, overrides) => {
+    const calls: string[] = [];
+    const environment = confirmedEnvironment(overrides);
+    const thrown = await runDiscoveryBootstrap(
+      ['--env', 'DISCOVERY_ALLOWED_TYPES=intent'],
+      environment,
+      { log: () => {}, error: () => {} },
+      bootstrapDependencies(calls),
+    ).catch((error: unknown) => error);
+
+    const report = describeAbFailure(thrown);
+    expect(report.exitCode).toBe(2);
+    expect(report.message).toMatch(/OPENROUTER_API_KEY|REDIS_URL|REDIS_HOST\/REDIS_PORT\/REDIS_PASSWORD\/REDIS_DB/);
+    expect(report.message).not.toContain('synthetic-provider-key');
+    expect(report.message).not.toContain('synthetic-password');
+    expect(calls).toEqual(['confirmation', 'runtime-prerequisites']);
+  });
+
+  it('accepts the URL Redis form and advances only to the mocked attestation boundary', async () => {
+    const calls: string[] = [];
+    const dependencies = bootstrapDependencies(calls);
+    dependencies.attestTargets = async () => {
+      calls.push('attestation');
+      throw new Error('raw-attestation-secret-sentinel');
+    };
+
+    await expect(runDiscoveryBootstrap(
+      ['--env', 'DISCOVERY_ALLOWED_TYPES=intent'],
+      confirmedEnvironment(),
+      { log: () => {}, error: () => {} },
+      dependencies,
+    )).rejects.toThrow('raw-attestation-secret-sentinel');
+    expect(calls).toEqual(['confirmation', 'runtime-prerequisites', 'manifest', 'attestation']);
+  });
+
+  it('accepts the complete split Redis form and advances only to the mocked runtime boundary', async () => {
+    const calls: string[] = [];
+    const dependencies = bootstrapDependencies(calls);
+    dependencies.importRuntime = async () => {
+      calls.push('runtime-import');
+      throw new Error('raw-import-secret-sentinel');
+    };
+    const environment = confirmedEnvironment({
+      REDIS_URL: undefined,
+      REDIS_HOST: 'cache.invalid',
+      REDIS_PORT: '6379',
+      REDIS_PASSWORD: 'synthetic-password',
+      REDIS_DB: '0',
+    });
+
+    await expect(runDiscoveryBootstrap(
+      ['--env', 'DISCOVERY_ALLOWED_TYPES=intent'],
+      environment,
+      { log: () => {}, error: () => {} },
+      dependencies,
+    )).rejects.toThrow('raw-import-secret-sentinel');
+    expect(calls).toEqual(['confirmation', 'runtime-prerequisites', 'manifest', 'attestation', 'runtime-import']);
+  });
+});
+
+describe('production child stage wiring', () => {
+  const childArgs = [
+    '--side', 'a', '--child-output', '/tmp/synthetic-child-output.json',
+    '--env', 'DISCOVERY_ALLOWED_TYPES=intent', '--runs', '1',
+  ];
+  const childEnvironment = confirmedEnvironment({
+    DATABASE_URL: manifest.targets[0].databaseUrl,
+    DISCOVERY_SIDE_BRANCH: 'eval-ab-a',
+    DISCOVERY_TARGETS: JSON.stringify(manifest),
+  });
+
+  it('classifies the first production matrix loader as dependency initialization', async () => {
+    const sentinel = 'raw-first-matrix-loader-secret-sentinel';
+    const calls: string[] = [];
+    const stages: AbChildFailureStage[] = [];
+    const dependencies: AbChildMainDependencies = {
+      loadMatrixEval: async () => {
+        calls.push('matrix-loader');
+        throw new Error(sentinel);
+      },
+      runChild: runAbChild,
+      observeStage: (stage) => { stages.push(stage); },
+    };
+
+    const thrown = await runAbChildInvocation(childArgs, childEnvironment, dependencies)
+      .catch((error: unknown) => error);
+
+    expect(thrown).toBeInstanceOf(AbChildStageError);
+    expect((thrown as AbChildStageError).stage).toBe('dependency-initialization');
+    const report = describeAbFailure(thrown, 'child');
+    expect(report).toEqual({
+      exitCode: 2,
+      message: 'Discovery side process failed at stage dependency-initialization. The parent invocation remains authoritative for mutation and spend uncertainty.',
+    });
+    expect(report.message).not.toContain(sentinel);
+    expect(calls).toEqual(['matrix-loader']);
+    expect(stages).toEqual(['dependency-initialization']);
+  });
+
+  it('keeps argument and environment refusals outside operational stage classification', async () => {
+    const calls: string[] = [];
+    const dependencies: AbChildMainDependencies = {
+      loadMatrixEval: async () => { calls.push('matrix-loader'); throw new Error('must not load'); },
+      runChild: runAbChild,
+      observeStage: (stage) => { calls.push(stage); },
+    };
+
+    const badArgs = await runAbChildInvocation(['--side', 'a'], childEnvironment, dependencies)
+      .catch((error: unknown) => error);
+    expect(badArgs).not.toBeInstanceOf(AbChildStageError);
+    expect(describeAbFailure(badArgs, 'child').message).not.toContain('stage ');
+
+    const badEnvironment = await runAbChildInvocation(
+      childArgs,
+      { ...childEnvironment, DATABASE_URL: 'postgres://user:password@not-neon.invalid/protocol_eval' },
+      dependencies,
+    ).catch((error: unknown) => error);
+    expect(badEnvironment).not.toBeInstanceOf(AbChildStageError);
+    expect(describeAbFailure(badEnvironment, 'child')).toMatchObject({ exitCode: 2 });
+    expect(calls).toEqual([]);
+  });
+});
+
+describe('sanitized discovery child stages', () => {
+  const stages: AbChildFailureStage[] = [
+    'dependency-initialization',
+    'base-verification',
+    'run-execution',
+    'artifact-write',
+  ];
+
+  it.each(stages)('classifies %s without leaking the cause or running later stages', async (failingStage) => {
+    const calls: AbChildFailureStage[] = [];
+    const sentinel = `raw-secret-sentinel-${failingStage}`;
+    const operation = async <T>(stage: AbChildFailureStage, value: T): Promise<T> => {
+      calls.push(stage);
+      if (stage === failingStage) throw new Error(sentinel);
+      return value;
+    };
+
+    const thrown = await runAbChildStages({
+      initializeDependencies: async () => operation('dependency-initialization', { synthetic: true }),
+      verifyBase: async () => { await operation('base-verification', undefined); },
+      executeRun: async () => operation('run-execution', { slots: [], execution: { policy: 'strict' as const, runs: [] } }),
+      writeArtifact: async () => { await operation('artifact-write', undefined); },
+    }).catch((error: unknown) => error);
+
+    expect(thrown).toBeInstanceOf(AbChildStageError);
+    expect((thrown as AbChildStageError).stage).toBe(failingStage);
+    expect((thrown as Error).message).not.toContain(sentinel);
+    const report = describeAbFailure(thrown, 'child');
+    expect(report).toEqual({
+      exitCode: 2,
+      message: `Discovery side process failed at stage ${failingStage}. The parent invocation remains authoritative for mutation and spend uncertainty.`,
+    });
+    expect(report.message).not.toContain(sentinel);
+    expect(calls).toEqual(stages.slice(0, stages.indexOf(failingStage) + 1));
+  });
+
+  it('classifies resource cleanup without leaking its cause', async () => {
+    const sentinel = 'raw-resource-cleanup-secret-sentinel';
+    const thrown = await runAbChildResourceCleanup(async () => {
+      throw new Error(sentinel);
+    }).catch((error: unknown) => error);
+
+    expect(thrown).toBeInstanceOf(AbChildStageError);
+    expect((thrown as AbChildStageError).stage).toBe('resource-cleanup');
+    const report = describeAbFailure(thrown, 'child');
+    expect(report).toEqual({
+      exitCode: 2,
+      message: 'Discovery side process failed at stage resource-cleanup. The parent invocation remains authoritative for mutation and spend uncertainty.',
+    });
+    expect(report.message).not.toContain(sentinel);
+  });
+
+  it('keeps side-B SIGTERM fail-fast behavior while preserving side A as the classified first failure', async () => {
+    let sideBStarted = false;
+    let sideBSignal: NodeJS.Signals | undefined;
+    let sideBExit: number | undefined;
+    let releaseSideA!: () => void;
+    const sideAReady = new Promise<void>((resolve) => { releaseSideA = resolve; });
+    let releaseSideB!: () => void;
+    const sideBTerminated = new Promise<void>((resolve) => { releaseSideB = resolve; });
+    const sideBProcess = {
+      kill(signal?: NodeJS.Signals) {
+        sideBSignal = signal;
+        sideBExit = signal === 'SIGTERM' ? 143 : undefined;
+        releaseSideB();
+      },
+    };
+
+    const { runBoundedChildTasks } = await import('../discovery-env-matrix.main');
+    const thrown = await runBoundedChildTasks({
+      items: ['a', 'b'] as const,
+      concurrency: 2,
+      onFailure: () => sideBProcess.kill('SIGTERM'),
+      task: async (side) => {
+        if (side === 'b') {
+          sideBStarted = true;
+          releaseSideA();
+          await sideBTerminated;
+          throw new Error('side-b-exit-143-secret-sentinel');
+        }
+        await sideAReady;
+        throw new AbChildStageError('dependency-initialization', { cause: new Error('side-a-secret-sentinel') });
+      },
+    }).catch((error: unknown) => error);
+
+    expect(sideBStarted).toBe(true);
+    expect(sideBSignal).toBe('SIGTERM');
+    expect(sideBExit).toBe(143);
+    expect(thrown).toBeInstanceOf(AbChildStageError);
+    const report = describeAbFailure(thrown, 'child');
+    expect(report.exitCode).toBe(2);
+    expect(report.message).toContain('dependency-initialization');
+    expect(report.message).not.toContain('side-a-secret-sentinel');
+    expect(report.message).not.toContain('side-b-exit-143-secret-sentinel');
+  });
+});

--- a/services/api/src/cli/tests/discovery.quality.spec.ts
+++ b/services/api/src/cli/tests/discovery.quality.spec.ts
@@ -128,6 +128,7 @@ describe('historical quality provider-free preflight contract', () => {
     };
     const dependencies: DiscoveryBootstrapDependencies = {
       assertConfirmation: () => { calls.confirmation += 1; },
+      assertRuntimePrerequisites: () => { throw new Error('legacy runtime gate must not run'); },
       parseManifest: () => {
         calls.manifestParsing += 1;
         throw new Error('manifest parsing must not run');
@@ -202,6 +203,7 @@ describe('historical quality PR B dispatch acceptance', () => {
     const calls: string[] = [];
     const dependencies = {
       assertConfirmation: () => { calls.push('legacy-confirmation'); },
+      assertRuntimePrerequisites: () => { calls.push('legacy-runtime-prerequisites'); },
       parseManifest: () => { calls.push('legacy-manifest'); throw new Error('legacy parser must not run'); },
       attestTargets: async () => { calls.push('legacy-attest'); },
       importRuntime: async () => ({ main: async () => { calls.push('legacy-runtime'); } }),
@@ -227,6 +229,7 @@ describe('historical quality PR B dispatch acceptance', () => {
     process.exitCode = undefined;
     const dependencies: DiscoveryBootstrapDependencies = {
       assertConfirmation: () => { throw new Error('legacy gate must not run'); },
+      assertRuntimePrerequisites: () => { throw new Error('legacy runtime gate must not run'); },
       parseManifest: () => { throw new Error('legacy manifest must not parse'); },
       attestTargets: async () => { throw new Error('legacy attestation must not run'); },
       importRuntime: async () => { throw new Error('legacy runtime must not load'); },
@@ -251,6 +254,7 @@ describe('historical quality PR B dispatch acceptance', () => {
       }>;
     } = {
       assertConfirmation: () => { calls.push('legacy-confirmation'); },
+      assertRuntimePrerequisites: () => { calls.push('legacy-runtime-prerequisites'); },
       parseManifest: () => {
         calls.push('legacy-manifest');
         throw new Error('quality dispatch must not parse the legacy A/B manifest');


### PR DESCRIPTION
## Summary

- require nonblank OpenRouter and exactly one approved Redis configuration before legacy discovery parses/attests targets, imports runtime code, resets branches, or spawns children
- share the provider/Redis prerequisite contract with historical-quality runtime environment projection
- classify child operational failures with fixed, value-free stages while preserving parent authority for mutation/spend uncertainty and existing fail-fast semantics
- add production-wiring regression coverage for the first matrix loader and every child stage

## Context

The separately authorized IND-638 legacy smoke retry reset both disposable children, then failed after spawn with no artifacts. Read-only diagnosis found that the direct CLI lacked the runtime-key preflight already expected by Eval Ops and that its generic child fallback did not identify the failing operational stage.

No further live retry was performed. This PR is provider-free remediation only.

## Validation

Exact head `433413a3acfe5491c6afeb41043cdac30bb4a947` on base `c39e12c732aed4e2fe4f148ae9ba3ae70f398547`:

- 336 affected provider-free tests passed, 0 failed, 1,335 expectations, from a fresh mode-0700 cwd with absolute paths
- API build passed
- API typecheck passed
- CLI-spec typecheck passed
- API lint passed with 0 errors (45 unrelated existing warnings)
- historical-quality contract audit passed 9/9
- isolated test inventory passed 14/14
- `git diff --check` passed
- independent whole-diff review: READY, no Critical/Important/Minor findings

The complete `opportunity.graph.spec.ts` was intentionally not run because it contains an unrelated live-provider test.

## Rollout boundary

This PR does not authorize or perform another legacy smoke, either quality smoke, the ten-slot pilot, secret migration, database mutation, or provider spend. Any post-merge operation remains separately authorized under the IND-638 runbook.

Related: IND-638
