### PR TITLE
fix(mac): complete browser owner sign-in

### DIFF
--- a/apps/mac/Sources/AppDelegate.swift
+++ b/apps/mac/Sources/AppDelegate.swift
@@ -5,6 +5,13 @@ import Security
 import UserNotifications
 import CryptoKit
 
+private extension CharacterSet {
+    /// Matches JavaScript encodeURIComponent for the authorization tuple.
+    static let urlQueryValueAllowed = CharacterSet(
+        charactersIn: "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789-_.!~*'()"
+    )
+}
+
 // Pressing noninteractive window chrome asks the native shell to drag the
 // frameless window. Interactive controls and window content remain untouched.
 private let windowDragScript = """
@@ -857,11 +864,15 @@ final class AppDelegate: NSObject, NSApplicationDelegate, WKNavigationDelegate, 
                                 self.finishLogin(.failure(LoopbackAuthServer.AuthError.invalidCallback), admittedGeneration: admittedGeneration); return
                             }
                             var page = URLComponents(string: AppConfig.trimTrailingSlash(AppConfig.appURL) + "/index-app-authorize")
-                            page?.queryItems = [
-                                URLQueryItem(name: "request_id", value: created.requestId),
-                                URLQueryItem(name: "state", value: state),
-                                URLQueryItem(name: "redirect_uri", value: redirect),
+                            let queryValues = [
+                                ("request_id", created.requestId),
+                                ("state", state),
+                                ("redirect_uri", redirect),
                             ]
+                            page?.percentEncodedQuery = queryValues.compactMap { name, value in
+                                value.addingPercentEncoding(withAllowedCharacters: .urlQueryValueAllowed)
+                                    .map { "\(name)=\($0)" }
+                            }.joined(separator: "&")
                             if let url = page?.url { NSWorkspace.shared.open(url) }
                         }
                     }

--- a/apps/mac/Sources/OwnerCredentialStore.swift
+++ b/apps/mac/Sources/OwnerCredentialStore.swift
@@ -242,10 +242,23 @@ struct OwnerCredentialStore {
     }
 }
 
+private enum OwnerCredentialDateCoding {
+    static let fractionalISO8601: ISO8601DateFormatter = {
+        let formatter = ISO8601DateFormatter()
+        formatter.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
+        return formatter
+    }()
+
+    static let wholeSecondISO8601 = ISO8601DateFormatter()
+}
+
 private extension JSONEncoder {
     static var ownerCredential: JSONEncoder {
         let encoder = JSONEncoder()
-        encoder.dateEncodingStrategy = .iso8601
+        encoder.dateEncodingStrategy = .custom { date, encoder in
+            var container = encoder.singleValueContainer()
+            try container.encode(OwnerCredentialDateCoding.fractionalISO8601.string(from: date))
+        }
         encoder.outputFormatting = [.sortedKeys]
         return encoder
     }
@@ -253,7 +266,18 @@ private extension JSONEncoder {
 private extension JSONDecoder {
     static var ownerCredential: JSONDecoder {
         let decoder = JSONDecoder()
-        decoder.dateDecodingStrategy = .iso8601
+        decoder.dateDecodingStrategy = .custom { decoder in
+            let container = try decoder.singleValueContainer()
+            let value = try container.decode(String.self)
+            guard let date = OwnerCredentialDateCoding.fractionalISO8601.date(from: value)
+                    ?? OwnerCredentialDateCoding.wholeSecondISO8601.date(from: value) else {
+                throw DecodingError.dataCorruptedError(
+                    in: container,
+                    debugDescription: "Invalid owner credential expiry"
+                )
+            }
+            return date
+        }
         return decoder
     }
 }

--- a/apps/mac/Tests/OwnerCredentialMigrationFixture.swift
+++ b/apps/mac/Tests/OwnerCredentialMigrationFixture.swift
@@ -131,5 +131,37 @@ enum OwnerCredentialMigrationFixture {
             try keychainOwner.putAndVerify(record)
             throw FixtureFailure.assertion("Keychain read-back mismatch accepted")
         } catch IndexKeychainStoreError.verificationFailed {}
+
+        // Server expiry timestamps include milliseconds. Keychain serialization
+        // must preserve them so strict write/read-back equality does not roll a
+        // successfully exchanged credential back before activation.
+        var storedData: Data?
+        let roundTripSecurity = IndexKeychainSecurityOperations(
+            add: { query, _ in
+                let attributes = query as NSDictionary
+                storedData = attributes[kSecValueData as String] as? Data
+                return errSecSuccess
+            },
+            copyMatching: { _, result in
+                guard let storedData else { return errSecItemNotFound }
+                result?.pointee = storedData as CFData
+                return errSecSuccess
+            },
+            update: { _, _ in errSecSuccess },
+            delete: { _ in errSecSuccess }
+        )
+        let fractionalOwner = try OwnerCredentialStore(
+            accessGroup: group,
+            applicationSupportDirectory: root.appendingPathComponent("fractional-keychain", isDirectory: true),
+            keychain: IndexKeychainStore(security: roundTripSecurity)
+        )
+        let fractionalRecord = OwnerCredentialRecord(
+            credential: "idxo_fractional-expiry", credentialId: UUID().uuidString,
+            installationId: installation, generation: UUID().uuidString,
+            expiresAt: Date(timeIntervalSince1970: 2_000_000_000.270)
+        )
+        try fractionalOwner.putAndVerify(fractionalRecord)
+        let fractionalReadBack = try fractionalOwner.loadCredential()
+        try require(fractionalReadBack == fractionalRecord, "fractional expiry was truncated")
     }
 }

--- a/apps/mac/api/native-api-bridge.spec.mjs
+++ b/apps/mac/api/native-api-bridge.spec.mjs
@@ -349,6 +349,8 @@ describe('native owner migration and transport source contracts', () => {
     expect(logoutBlock.indexOf('beginQuarantine')).toBeLessThan(logoutBlock.indexOf('revokeAndDelete'));
     expect(logoutBlock.indexOf('verifyCredentialDenied')).toBeLessThan(logoutBlock.indexOf('store.deleteAndVerify()'));
     expect(mainSwift).toContain('Set(names) == ["request_id", "code", "state"]');
+    expect(mainSwift).toContain('percentEncodedQuery');
+    expect(mainSwift).toContain('addingPercentEncoding(withAllowedCharacters: .urlQueryValueAllowed)');
     expect(mainSwift).not.toMatch(/api_key|session_token|targetKey/);
   });
 


### PR DESCRIPTION
## Summary
- encode the native authorization tuple with canonical `encodeURIComponent` semantics so the web callback parser accepts loopback redirect URIs
- preserve fractional seconds when storing owner credential expiry in Keychain so strict read-back verification does not revoke a valid exchange before activation
- add source-contract and Swift fixture coverage for both regressions

## Validation
- `./scripts/build.sh --fixture OwnerCredentialMigrationFixture`
- `bun test apps/mac/api/native-api-bridge.spec.mjs` (10 passed)
- related macOS JS/shell suite: 222 tests; initial DMG fixture failed only because `/Volumes/Index Dev` was already mounted, then `bun test apps/mac/scripts/dmg.spec.mjs` passed 11/11 after detaching the stale volume
- rebuilt and launched a local Developer ID compatibility-signed app against `dev.index.network`; signature and owner Keychain entitlement verified

## Local distribution note
The launched app uses the existing wildcard profile only for testing on this Mac. CI/distribution remains fail-closed on the exact owner Keychain provisioning profile.
