### PR TITLE
fix(mac): make owner sign-in work end to end in signed builds

### DIFF
--- a/apps/mac/Security/Sources/IndexKeychainStore.swift
+++ b/apps/mac/Security/Sources/IndexKeychainStore.swift
@@ -104,6 +104,10 @@ struct IndexKeychainStore {
         ]
         if let accessGroup = descriptor.accessGroup {
             attributes[kSecAttrAccessGroup as String] = accessGroup
+            // Access groups only exist in the data protection keychain on
+            // macOS; without this flag the group attribute is not honored and
+            // items written can never be read back through this descriptor.
+            attributes[kSecUseDataProtectionKeychain as String] = true
         }
         return attributes
     }

--- a/apps/mac/Sources/AppDelegate.swift
+++ b/apps/mac/Sources/AppDelegate.swift
@@ -857,11 +857,14 @@ final class AppDelegate: NSObject, NSApplicationDelegate, WKNavigationDelegate, 
                                 self.finishLogin(.failure(LoopbackAuthServer.AuthError.invalidCallback), admittedGeneration: admittedGeneration); return
                             }
                             var page = URLComponents(string: AppConfig.trimTrailingSlash(AppConfig.appURL) + "/index-app-authorize")
-                            page?.queryItems = [
-                                URLQueryItem(name: "request_id", value: created.requestId),
-                                URLQueryItem(name: "state", value: state),
-                                URLQueryItem(name: "redirect_uri", value: redirect),
-                            ]
+                            // The authorize page requires every query value in strict
+                            // encodeURIComponent canonical form; URLQueryItem leaves
+                            // ':' and '/' unescaped, which the page rejects.
+                            page?.percentEncodedQuery = [
+                                "request_id=\(Self.encodeURIComponent(created.requestId))",
+                                "state=\(Self.encodeURIComponent(state))",
+                                "redirect_uri=\(Self.encodeURIComponent(redirect))",
+                            ].joined(separator: "&")
                             if let url = page?.url { NSWorkspace.shared.open(url) }
                         }
                     }
@@ -910,10 +913,13 @@ final class AppDelegate: NSObject, NSApplicationDelegate, WKNavigationDelegate, 
                       let store = self.ownerCredentialStore else {
                     DispatchQueue.main.async { self.notifyAuthChanged(authenticated: false, admittedGeneration: admittedGeneration) }; return
                 }
+                // The .iso8601 Keychain encoding drops fractional seconds, so
+                // truncate up front or the read-back equality check can never
+                // match a server timestamp carrying milliseconds.
                 let record = OwnerCredentialRecord(
                     credential: exchange.credential, credentialId: exchange.credentialId,
                     installationId: exchange.installationId, generation: exchange.generation,
-                    expiresAt: expiry
+                    expiresAt: Date(timeIntervalSince1970: expiry.timeIntervalSince1970.rounded(.down))
                 )
                 do { try store.putAndVerify(record) }
                 catch {
@@ -1094,6 +1100,15 @@ final class AppDelegate: NSObject, NSApplicationDelegate, WKNavigationDelegate, 
         if (typeof window.__indexAuthChanged === 'function') { window.__indexAuthChanged(\(value)); }
         """
         webView.evaluateJavaScript(js, completionHandler: nil)
+    }
+
+    /// Matches JavaScript encodeURIComponent exactly: only A-Za-z0-9 and
+    /// !'()*-._~ stay literal, everything else becomes uppercase %XX.
+    static func encodeURIComponent(_ value: String) -> String {
+        let allowed = CharacterSet(
+            charactersIn: "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789-_.!~*'()"
+        )
+        return value.addingPercentEncoding(withAllowedCharacters: allowed) ?? value
     }
 
     private func secureRandomState() throws -> String {

--- a/apps/mac/scripts/provisioning-profile.sh
+++ b/apps/mac/scripts/provisioning-profile.sh
@@ -75,9 +75,11 @@ if expected_domain not in domains and 'applinks:*' not in domains and '*' not in
 canonical_owner_group = f'{expected_team}.{bundle_id}.owner-credentials'
 if expected_owner_group != canonical_owner_group:
     fail('owner Keychain group does not match the signing Team and bundle')
+# Apple issues Developer ID profiles with the team wildcard group; the signed
+# app entitlement (validated separately) still pins exactly the owner group.
 groups = entitlements.get('keychain-access-groups')
-if groups != [expected_owner_group]:
-    fail('does not authorize exactly the owner Keychain group')
+if groups not in ([expected_owner_group], [f'{expected_team}.*']):
+    fail('does not authorize the owner Keychain group')
 PY
 }
 

--- a/apps/mac/scripts/provisioning-profile.spec.mjs
+++ b/apps/mac/scripts/provisioning-profile.spec.mjs
@@ -201,18 +201,31 @@ describe('Developer ID provisioning profile validation', () => {
       'com.apple.developer.team-identifier': 'TEAM123',
       'com.apple.developer.associated-domains': ['applinks:dev.index.network'],
     }});
-    await expectRejected(path, 'does not authorize exactly the owner Keychain group');
+    await expectRejected(path, 'does not authorize the owner Keychain group');
   });
 
-  test('rejects wildcard and mismatched Keychain groups', async () => {
-    for (const group of ['TEAM123.*', 'TEAM123.network.index.connector.credentials']) {
+  test('accepts the portal-issued team wildcard Keychain group', async () => {
+    const path = await writeProfile({ Entitlements: {
+      'com.apple.application-identifier': 'TEAM123.network.index.system6',
+      'com.apple.developer.team-identifier': 'TEAM123',
+      'com.apple.developer.associated-domains': ['applinks:dev.index.network'],
+      'keychain-access-groups': ['TEAM123.*'],
+    }});
+    expect(validate(path).exitCode).toBe(0);
+  });
+
+  test('rejects mismatched and foreign-team Keychain groups', async () => {
+    for (const group of [
+      'TEAM123.network.index.connector.credentials',
+      'WRONGTEAM.*',
+    ]) {
       const path = await writeProfile({ Entitlements: {
         'com.apple.application-identifier': 'TEAM123.network.index.system6',
         'com.apple.developer.team-identifier': 'TEAM123',
         'com.apple.developer.associated-domains': ['applinks:dev.index.network'],
         'keychain-access-groups': [group],
       }});
-      await expectRejected(path, 'does not authorize exactly the owner Keychain group');
+      await expectRejected(path, 'does not authorize the owner Keychain group');
     }
   });
 


### PR DESCRIPTION
## Summary

Owner sign-in from the macOS app failed silently at "waiting for browser…". Four stacked defects, each masking the next:

1. **Provisioning profile gate was unsatisfiable** — `scripts/provisioning-profile.sh` required the profile itself to list exactly the owner Keychain group, but Apple's portal only issues Developer ID profiles with the team wildcard (`TEAM.*`). The profile check now accepts the team wildcard; the signed app entitlement check still pins exactly the owner group, which remains the runtime boundary.
2. **Authorize URL encoding rejected by the web page** — the URL was built with `URLQueryItem`, which leaves `:` and `/` bare in query values; the authorize page's strict `encodeURIComponent` canonicality check rejected `redirect_uri` and showed "Sign-in unavailable". Query values are now encoded in JS-exact canonical form.
3. **Keychain access group never honored** — `IndexKeychainStore` passed `kSecAttrAccessGroup` without `kSecUseDataProtectionKeychain`; macOS only supports access groups in the data protection keychain, so every credential write was unreadable through the same descriptor and sign-in rolled itself back.
4. **Expiry equality could never pass** — the stored record round-trips through `.iso8601` coding that drops fractional seconds while the in-memory record kept the server's milliseconds, so the post-write read-back equality check always failed. The expiry is truncated to whole seconds before storage.

## Test plan

- `bun test api/native-api-bridge.spec.mjs api/agent-runtime.spec.mjs api/agent-runtime-saga.spec.mjs hermes-runtime.spec.mjs scripts/provisioning-profile.spec.mjs` — 117 pass
- Manual: Developer ID-signed build against dev.index.network completes browser sign-in end to end (consent → loopback callback → exchange → Keychain write → activation) and the app enters the signed-in state

🤖 Generated with [Claude Code](https://claude.com/claude-code)