### PR TITLE
fix(eval): bind legacy Neon TLS after attestation

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -126,7 +126,7 @@
     },
     "services/api": {
       "name": "@indexnetwork/api",
-      "version": "0.84.1",
+      "version": "0.84.2",
       "dependencies": {
         "@aws-sdk/client-s3": "^3.939.0",
         "@aws-sdk/s3-request-presigner": "^3.983.0",

--- a/services/api/CHANGELOG.md
+++ b/services/api/CHANGELOG.md
@@ -14,6 +14,7 @@ section before promoting to `main`).
 - Record production evidence for the separately gated `opportunity_discovery_runs` Release 2 cleanup; no destructive migration is included.
 
 ### Fixed
+- Require TLS for legacy discovery children only after exact Neon target attestation and handoff equality, without changing strict query-free manifests or generic Drizzle behavior (API 0.84.2).
 - Refuse legacy discovery runs before target attestation or reset when provider/Redis runtime prerequisites are missing or ambiguous, and report child failures by sanitized code-owned execution stage.
 
 ### Added

--- a/services/api/package.json
+++ b/services/api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@indexnetwork/api",
-  "version": "0.84.1",
+  "version": "0.84.2",
   "license": "MIT",
   "private": true,
   "scripts": {

--- a/services/api/src/cli/discovery-neon-tls.ts
+++ b/services/api/src/cli/discovery-neon-tls.ts
@@ -1,0 +1,24 @@
+/**
+ * Adds the internal TLS policy for a database URL whose Neon authority has
+ * already been established by the caller. External manifests and handoffs must
+ * retain their original attested URL.
+ *
+ * @param alreadyAttestedDatabaseUrl Exact URL proven against the Neon control plane.
+ * @returns An internal-only URL with an explicit TLS policy.
+ * @throws A fixed credential-free error when the value is not a Neon postgres URL.
+ */
+export function bindAttestedNeonTls(alreadyAttestedDatabaseUrl: string): string {
+  let internalUrl: URL;
+  try {
+    internalUrl = new URL(alreadyAttestedDatabaseUrl);
+  } catch {
+    throw new Error('TLS binding requires an attested Neon postgres URL');
+  }
+  if ((internalUrl.protocol !== 'postgres:' && internalUrl.protocol !== 'postgresql:')
+    || !internalUrl.hostname.endsWith('.neon.tech')) {
+    throw new Error('TLS binding requires an attested Neon postgres URL');
+  }
+  if (internalUrl.searchParams.has('sslmode')) return alreadyAttestedDatabaseUrl;
+  internalUrl.searchParams.set('sslmode', 'require');
+  return internalUrl.toString();
+}

--- a/services/api/src/cli/discovery-quality-tls.ts
+++ b/services/api/src/cli/discovery-quality-tls.ts
@@ -1,3 +1,5 @@
+import { bindAttestedNeonTls } from './discovery-neon-tls';
+
 /**
  * Runtime-only TLS authority for historical-quality database URLs that have
  * already passed the strict query-free manifest and control-plane attestations.
@@ -11,9 +13,8 @@ export function bindHistoricalQualityTls(alreadyAttestedDatabaseUrl: string): Re
   if (internalUrl.search !== '' || internalUrl.hash !== '') {
     throw new Error('Historical quality TLS binding requires an attested query-free database URL');
   }
-  internalUrl.searchParams.set('sslmode', 'require');
   return Object.freeze({
     postgresOptions: Object.freeze({ ssl: 'require' as const }),
-    internalDatabaseUrl: internalUrl.toString(),
+    internalDatabaseUrl: bindAttestedNeonTls(alreadyAttestedDatabaseUrl),
   });
 }

--- a/services/api/src/cli/discovery.main.ts
+++ b/services/api/src/cli/discovery.main.ts
@@ -1225,6 +1225,18 @@ const productionAbChildMainDependencies: AbChildMainDependencies = {
   runChild: runAbChild,
 };
 
+/** Verifies the bootstrap's one permitted internal URL transformation. */
+function matchesLegacyChildTlsBinding(attestedUrl: string, internalUrl: URL): boolean {
+  const externalUrl = new URL(attestedUrl);
+  if (externalUrl.searchParams.has('sslmode')) {
+    return externalUrl.toString() === internalUrl.toString();
+  }
+  if (internalUrl.searchParams.get('sslmode') !== 'require') return false;
+  const projectedExternalUrl = new URL(internalUrl);
+  projectedExternalUrl.searchParams.delete('sslmode');
+  return projectedExternalUrl.toString() === externalUrl.toString();
+}
+
 /** Child-only entry after bootstrap attestation; all checks here are preflight. */
 export async function runAbChildInvocation(
   args: readonly string[],
@@ -1235,7 +1247,7 @@ export async function runAbChildInvocation(
   const environment = assertAbSideEnvironment(processEnvironment, sideId);
   const manifest = parseAbManifest(processEnvironment.DISCOVERY_TARGETS);
   const target = manifest.targets.find((candidate) => candidate.sideId === sideId);
-  if (!target || new URL(target.databaseUrl).toString() !== environment.databaseUrl.toString()) {
+  if (!target || !matchesLegacyChildTlsBinding(target.databaseUrl, environment.databaseUrl)) {
     throw new AbGateError(`Refusing to mutate: side ${sideId} is not composed against the database its manifest entry declares`);
   }
   const selection = parseAbRunArgs(args);

--- a/services/api/src/cli/discovery.ts
+++ b/services/api/src/cli/discovery.ts
@@ -19,9 +19,10 @@
  * read what the command requires *before* they have any of it.
  */
 import { AB_BRANCH_NAMES, attestAbTargets, parseLegacyAbManifest, type AbManifest } from './discovery.neon';
-import { AB_SIDE_BRANCH_ENV, assertAbConfirmation, assertAbRuntimePrerequisites } from './discovery.gate';
+import { AB_SIDE_BRANCH_ENV, AbGateError, assertAbConfirmation, assertAbRuntimePrerequisites } from './discovery.gate';
 import { abAttestationRefusal, abUsage, describeAbFailure, type AbInvocationRole } from './discovery.contract';
 import { createNeonControlPlane } from './discovery-env-matrix.neon';
+import { bindAttestedNeonTls } from './discovery-neon-tls';
 import { formatHistoricalQualityCost, hasHistoricalQualityHelp, historicalQualityUsage, isHistoricalQualityRequest, parseHistoricalQualityArgs, type HistoricalQualityRequest } from './discovery-quality.contract';
 
 import type { AbSideId } from './discovery.plan';
@@ -79,6 +80,7 @@ export interface DiscoveryBootstrapDependencies {
   assertRuntimePrerequisites(env: NodeJS.ProcessEnv): void;
   parseManifest(raw: string | undefined): AbManifest;
   attestTargets(manifest: AbManifest, role: AbInvocationRole): Promise<void>;
+  bindLegacyChildTls?(alreadyAttestedDatabaseUrl: string): string;
   importRuntime(): Promise<DiscoveryRuntime>;
   importQualityRuntime?(): Promise<{
     runHistoricalQualityRuntime(request: HistoricalQualityRequest): Promise<unknown>;
@@ -93,6 +95,7 @@ const productionBootstrapDependencies: DiscoveryBootstrapDependencies = {
   assertRuntimePrerequisites: assertAbRuntimePrerequisites,
   parseManifest: parseLegacyAbManifest,
   attestTargets: attestOrRefuse,
+  bindLegacyChildTls: bindAttestedNeonTls,
   importRuntime: async () => await import('./discovery.main'),
   importQualityRuntime: async () => await import('./discovery-quality.runtime'),
   importQualityChildRuntime: async (environment) => {
@@ -151,9 +154,17 @@ export async function runDiscoveryBootstrap(
   if (sideId !== undefined) {
     const target = manifest.targets.find((candidate) => candidate.sideId === sideId);
     if (!target) throw new Error(`Discovery manifest does not name side ${sideId}`);
+    // Compare the raw handoff before deriving any internal representation. This
+    // keeps the parent's exact attested URL authoritative and prevents a child
+    // from normalizing a different URL into an apparently compatible target.
+    if (env.DATABASE_URL !== target.databaseUrl) {
+      throw new AbGateError(`Refusing to mutate: side ${sideId} is not composed against the database its manifest entry declares`);
+    }
+    // Only the child process receives the internal TLS projection. The
+    // manifest remains query-free for strict v2 and byte-for-byte unchanged.
+    env.DATABASE_URL = (dependencies.bindLegacyChildTls ?? bindAttestedNeonTls)(target.databaseUrl);
     // The branch label is derived from the attested manifest, never from
     // operator-supplied text, so the child's gate checks an attested fact.
-    env.DATABASE_URL = target.databaseUrl;
     env[AB_SIDE_BRANCH_ENV] = AB_BRANCH_NAMES[sideId];
   }
   const runtime = await dependencies.importRuntime();

--- a/services/api/src/cli/tests/discovery-legacy-tls.spec.ts
+++ b/services/api/src/cli/tests/discovery-legacy-tls.spec.ts
@@ -1,0 +1,180 @@
+import { readFile } from 'node:fs/promises';
+import { describe, expect, it } from 'bun:test';
+
+import { describeAbFailure } from '../discovery.contract';
+import { bindAttestedNeonTls } from '../discovery-neon-tls';
+import { bindHistoricalQualityTls } from '../discovery-quality-tls';
+import { runDiscoveryBootstrap, type DiscoveryBootstrapDependencies } from '../discovery';
+
+const sideAUrl = 'postgresql://legacy-user:legacy-password@ep-a.neon.tech/protocol_eval';
+const sideBUrl = 'postgresql://legacy-user:other-password@ep-b.neon.tech/protocol_eval';
+
+function manifest(sideDatabaseUrl = sideAUrl) {
+  return {
+    projectId: 'project',
+    baseBranchId: 'base',
+    targets: [
+      { sideId: 'a' as const, branchId: 'branch-a', endpointId: 'endpoint-a', databaseUrl: sideDatabaseUrl },
+      { sideId: 'b' as const, branchId: 'branch-b', endpointId: 'endpoint-b', databaseUrl: sideBUrl },
+    ] as const,
+  };
+}
+
+function childDependencies(input: {
+  parsed?: ReturnType<typeof manifest>;
+  calls: string[];
+  bind?: (databaseUrl: string) => string;
+  attest?: () => Promise<void>;
+  importRuntime?: () => Promise<{ main(args: readonly string[]): Promise<void> }>;
+}): DiscoveryBootstrapDependencies {
+  return {
+    assertConfirmation: () => { input.calls.push('gate'); },
+    assertRuntimePrerequisites: () => { input.calls.push('runtime-prerequisites'); },
+    parseManifest: () => { input.calls.push('parse'); return input.parsed ?? manifest(); },
+    attestTargets: async () => {
+      input.calls.push('attest');
+      await input.attest?.();
+    },
+    bindLegacyChildTls: (databaseUrl) => {
+      input.calls.push('bind');
+      return (input.bind ?? bindAttestedNeonTls)(databaseUrl);
+    },
+    importRuntime: input.importRuntime ?? (async () => {
+      input.calls.push('import');
+      return { main: async () => { input.calls.push('main'); } };
+    }),
+  };
+}
+
+describe('legacy discovery post-attestation Neon TLS binding', () => {
+  it('adds sslmode=require to a query-free attested Neon URL', () => {
+    expect(bindAttestedNeonTls(sideAUrl)).toBe(`${sideAUrl}?sslmode=require`);
+  });
+
+  it('preserves an explicit compatible legacy sslmode byte-for-byte', () => {
+    const explicit = `${sideAUrl}?application_name=legacy&sslmode=verify-full`;
+    expect(bindAttestedNeonTls(explicit)).toBe(explicit);
+  });
+
+  it('preserves unrelated compatible legacy query parameters while adding TLS', () => {
+    const internal = new URL(bindAttestedNeonTls(`${sideAUrl}?application_name=legacy&connect_timeout=10`));
+    expect([...internal.searchParams.entries()]).toEqual([
+      ['application_name', 'legacy'],
+      ['connect_timeout', '10'],
+      ['sslmode', 'require'],
+    ]);
+  });
+
+  it('retains historical-quality strict query and hash rejection unchanged', () => {
+    for (const unsafe of [`${sideAUrl}?application_name=quality`, `${sideAUrl}#quality`]) {
+      expect(() => bindHistoricalQualityTls(unsafe))
+        .toThrow('Historical quality TLS binding requires an attested query-free database URL');
+    }
+  });
+
+  it('orders parse and attestation before binding, then binds before runtime import', async () => {
+    const calls: string[] = [];
+    const environment = { DATABASE_URL: sideAUrl, DISCOVERY_TARGETS: JSON.stringify(manifest()) };
+
+    await runDiscoveryBootstrap(
+      ['--side', 'a', '--child-output', '/tmp/provider-free-output.json'],
+      environment,
+      { log: () => {}, error: () => {} },
+      childDependencies({ calls }),
+    );
+
+    expect(calls).toEqual(['gate', 'runtime-prerequisites', 'parse', 'attest', 'bind', 'import', 'main']);
+    expect(environment.DATABASE_URL).toBe(`${sideAUrl}?sslmode=require`);
+  });
+
+  it('never binds or imports after failed authority or exact child equality checks', async () => {
+    const authorityCalls: string[] = [];
+    await expect(runDiscoveryBootstrap(
+      ['--side', 'a'],
+      { DATABASE_URL: sideAUrl, DISCOVERY_TARGETS: JSON.stringify(manifest()) },
+      { log: () => {}, error: () => {} },
+      childDependencies({
+        calls: authorityCalls,
+        attest: async () => { throw new Error('credential-bearing-control-plane-error'); },
+      }),
+    )).rejects.toThrow('credential-bearing-control-plane-error');
+    expect(authorityCalls).toEqual(['gate', 'runtime-prerequisites', 'parse', 'attest']);
+
+    const equalityCalls: string[] = [];
+    await expect(runDiscoveryBootstrap(
+      ['--side', 'a'],
+      { DATABASE_URL: sideBUrl, DISCOVERY_TARGETS: JSON.stringify(manifest()) },
+      { log: () => {}, error: () => {} },
+      childDependencies({ calls: equalityCalls }),
+    )).rejects.toThrow(/manifest entry declares/);
+    expect(equalityCalls).toEqual(['gate', 'runtime-prerequisites', 'parse', 'attest']);
+  });
+
+  it('changes only the child internal environment and leaves manifest object and string byte-for-byte unchanged', async () => {
+    const parsed = manifest();
+    const originalObject = JSON.stringify(parsed);
+    const originalManifest = ` ${originalObject} `;
+    const environment = { DATABASE_URL: sideAUrl, DISCOVERY_TARGETS: originalManifest };
+    const calls: string[] = [];
+
+    await runDiscoveryBootstrap(
+      ['--side', 'a'],
+      environment,
+      { log: () => {}, error: () => {} },
+      childDependencies({
+        parsed,
+        calls,
+        importRuntime: async () => {
+          calls.push('import');
+          expect(environment.DATABASE_URL).toBe(`${sideAUrl}?sslmode=require`);
+          expect(environment.DISCOVERY_TARGETS).toBe(originalManifest);
+          expect(JSON.stringify(parsed)).toBe(originalObject);
+          expect(parsed.targets[0].databaseUrl).toBe(sideAUrl);
+          return { main: async () => { calls.push('main'); } };
+        },
+      }),
+    );
+
+    expect(environment.DISCOVERY_TARGETS).toBe(originalManifest);
+    expect(JSON.stringify(parsed)).toBe(originalObject);
+  });
+
+  it('uses fixed sanitized failures and emits no URL, password, or raw error', async () => {
+    const local = 'postgresql://local-user:local-password@localhost:5432/protocol_eval';
+    const localError = await Promise.resolve().then(() => bindAttestedNeonTls(local)).catch((error: Error) => error);
+    expect(localError.message).toBe('TLS binding requires an attested Neon postgres URL');
+    expect(localError.message).not.toContain('local-password');
+
+    const output: string[] = [];
+    const failure = await runDiscoveryBootstrap(
+      ['--side', 'a'],
+      { DATABASE_URL: sideBUrl, DISCOVERY_TARGETS: JSON.stringify(manifest()) },
+      { log: (value?: unknown) => output.push(String(value)), error: (value?: unknown) => output.push(String(value)) },
+      childDependencies({ calls: [] }),
+    ).catch((error: unknown) => error);
+    const report = describeAbFailure(failure, 'child');
+    expect(output).toEqual([]);
+    expect(report.message).not.toContain(sideAUrl);
+    expect(report.message).not.toContain('legacy-password');
+    expect(report.message).not.toContain('other-password');
+  });
+
+  it('leaves parent/local behavior and the generic Drizzle client untouched', async () => {
+    const calls: string[] = [];
+    const local = 'postgresql://local-user:local-password@localhost:5432/local_database';
+    const environment = { DATABASE_URL: local, DISCOVERY_TARGETS: JSON.stringify(manifest()) };
+
+    await runDiscoveryBootstrap(
+      ['--env', 'DISCOVERY_ALLOWED_TYPES=intent'],
+      environment,
+      { log: () => {}, error: () => {} },
+      childDependencies({ calls }),
+    );
+
+    expect(calls).toEqual(['gate', 'runtime-prerequisites', 'parse', 'attest', 'import', 'main']);
+    expect(environment.DATABASE_URL).toBe(local);
+    const genericDrizzle = await readFile(new URL('../../lib/drizzle/drizzle.ts', import.meta.url), 'utf8');
+    expect(genericDrizzle).toContain('postgres(connectionString, { prepare: false })');
+    expect(genericDrizzle).not.toContain('sslmode');
+  });
+});

--- a/services/api/src/cli/tests/discovery.child.spec.ts
+++ b/services/api/src/cli/tests/discovery.child.spec.ts
@@ -142,11 +142,11 @@ describe('discovery bootstrap child compatibility', () => {
       attestTargets: async () => { calls.push('attest'); },
       importRuntime: async () => ({ main: async (received) => { seen.push([...received]); } }),
     };
-    const env = {};
+    const env = { DATABASE_URL: 'postgres://u:p@a.neon.tech/protocol_eval' };
     await runDiscoveryBootstrap(args, env, { log: () => {}, error: () => {} }, dependencies);
     expect(calls).toEqual(['gate', 'runtime-prerequisites', 'attest']);
     expect(seen).toEqual([args]);
-    expect(env).toMatchObject({ DATABASE_URL: 'postgres://u:p@a.neon.tech/protocol_eval' });
+    expect(env).toMatchObject({ DATABASE_URL: 'postgres://u:p@a.neon.tech/protocol_eval?sslmode=require' });
   });
 });
 

--- a/services/api/src/cli/tests/discovery.preflight-stages.spec.ts
+++ b/services/api/src/cli/tests/discovery.preflight-stages.spec.ts
@@ -115,7 +115,7 @@ describe('production child stage wiring', () => {
     '--env', 'DISCOVERY_ALLOWED_TYPES=intent', '--runs', '1',
   ];
   const childEnvironment = confirmedEnvironment({
-    DATABASE_URL: manifest.targets[0].databaseUrl,
+    DATABASE_URL: `${manifest.targets[0].databaseUrl}?sslmode=require`,
     DISCOVERY_SIDE_BRANCH: 'eval-ab-a',
     DISCOVERY_TARGETS: JSON.stringify(manifest),
   });


### PR DESCRIPTION
## Summary

- add an internal Neon TLS binder for legacy discovery children after exact target attestation and handoff equality
- preserve strict query-free historical-quality manifests, explicit legacy TLS policy, unrelated compatible query parameters, and generic/local Drizzle behavior
- prove binding occurs before runtime/database import without mutating the manifest or leaking credentials

## Context

After PR #1377 added pre-reset runtime gating and sanitized stages, the separately authorized repaired legacy smoke localized its failure to `base-verification`. Read-only diagnosis found that legacy children passed strict query-free attested Neon URLs directly to postgres.js, whose default SSL policy is off. Base verification's metadata query was the first DB connection. Historical-quality already adds TLS after attestation.

No additional live retry was performed. This PR is provider-free remediation only.

## Validation

Exact head `c55b49048a7394ce324814498ff373548d978aa8` on base `8753736755677ece48695987131c43f948223fa2`:

- 321 affected provider-free tests passed, 0 failed, 821 expectations, using absolute paths from a fresh mode-0700 cwd
- API build passed
- API typecheck passed
- CLI-spec typecheck passed
- API lint passed with 0 errors (45 unrelated existing warnings)
- historical-quality contract audit passed 9/9
- isolated inventory passed 14/14
- adapter naming and subtree parity passed
- `git diff --check` passed
- independent full-diff review: READY, no Critical/Important/Minor findings

The complete `opportunity.graph.spec.ts` was intentionally not run because it contains an unrelated live-provider test.

## Rollout boundary

This PR does not authorize or perform another legacy smoke, quality smoke, ten-slot pilot, secret migration, database mutation, or provider spend. Every operation remains separately authorized under the IND-638 runbook.

Related: IND-638
