### PR TITLE
fix(mac): repair owner-group contract test after profile widening

### DIFF
--- a/apps/mac/IndexConnector/connector-contract.spec.mjs
+++ b/apps/mac/IndexConnector/connector-contract.spec.mjs
@@ -146,7 +146,14 @@ test('production app profile, signed entitlements, and operator docs carry the o
   const readme = read('../README.md');
 
   expect(profileHelper).toContain('keychain-access-groups');
-  expect(profileHelper).toContain('does not authorize exactly the owner Keychain group');
+  // Apple issues Developer ID profiles with the team wildcard, so the profile
+  // may carry the exact owner group or that wildcard and nothing else. Pin the
+  // predicate itself: silently re-tightening it breaks Developer ID signing,
+  // and widening it further would admit a foreign team's groups. The runtime
+  // behaviour is covered in scripts/provisioning-profile.spec.mjs.
+  expect(profileHelper).toContain("groups not in ([expected_owner_group], [f'{expected_team}.*'])");
+  expect(profileHelper).toContain('does not authorize the owner Keychain group');
+  // The signed entitlement stays exact even when the profile carries the wildcard.
   expect(profileHelper).toContain('does not match the signed owner Keychain entitlement');
   expect(appBuild).toContain('validate_embedded_profile "${APP}" "$LINK_HOST"');
   expect(readme).toContain('all four required inputs');


### PR DESCRIPTION
## Summary
`dev` is currently red. #1379 relaxed the provisioning-profile check to accept Apple's portal-issued team wildcard (`TEAM.*`) alongside the exact owner group, which changed the failure message from `does not authorize exactly the owner Keychain group` to `does not authorize the owner Keychain group`. `IndexConnector/connector-contract.spec.mjs:149` pinned the old string, so it has failed on every commit since that merge.

#1379 was merged at 20:27:24Z while its own CI was still running — the `build` job reported the failure ~16s earlier and never gated the merge.

## Approach
Rather than re-point the grep at the new string, this pins the predicate itself:

```js
expect(profileHelper).toContain("groups not in ([expected_owner_group], [f'{expected_team}.*'])");
```

The old assertion only checked that *some* error message existed. The new one fails in both directions that matter:

- **re-tightened** to `groups != [expected_owner_group]` → fails (this is what breaks Developer ID signing)
- **over-widened** to accept `'*'` → fails (this would admit a foreign team's groups)

Both verified by mutation, not just by observing green.

Runtime behaviour is already covered in `scripts/provisioning-profile.spec.mjs`, which accepts `TEAM123.*`, rejects `WRONGTEAM.*`, and still rejects a wildcard in the *signed* entitlement — so this test stays a source contract and does not duplicate it.

## Verification
- `bun test IndexConnector/connector-contract.spec.mjs` — 19 pass, 0 fail
- `bun test IndexConnector/connector-contract.spec.mjs scripts/provisioning-profile.spec.mjs` — 39 pass, 0 fail
- Only the spec file changes; no production code touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)