### PR TITLE
test(mac): cover the two owner sign-in fixes from #1379

### DIFF
--- a/apps/mac/Tests/OwnerCredentialMigrationFixture.swift
+++ b/apps/mac/Tests/OwnerCredentialMigrationFixture.swift
@@ -131,5 +131,58 @@ enum OwnerCredentialMigrationFixture {
             try keychainOwner.putAndVerify(record)
             throw FixtureFailure.assertion("Keychain read-back mismatch accepted")
         } catch IndexKeychainStoreError.verificationFailed {}
+
+        // Access groups only exist in the data protection keychain on macOS.
+        // Without kSecUseDataProtectionKeychain the group attribute is ignored
+        // and a signed build can never read back what it just wrote, so assert
+        // the flag rides along on exactly the queries carrying an access group.
+        var captured: [NSDictionary] = []
+        var stored = Data()
+        let capturing = IndexKeychainSecurityOperations(
+            add: { query, _ in
+                let attributes = query as NSDictionary
+                captured.append(attributes)
+                stored = (attributes[kSecValueData as String] as? Data) ?? Data()
+                return errSecSuccess
+            },
+            copyMatching: { query, result in
+                captured.append(query as NSDictionary)
+                result?.pointee = stored as CFData
+                return errSecSuccess
+            },
+            update: { query, _ in captured.append(query as NSDictionary); return errSecSuccess },
+            delete: { query in captured.append(query as NSDictionary); return errSecSuccess }
+        )
+        let flagStore = IndexKeychainStore(security: capturing)
+        let probe = Data("data-protection-probe".utf8)
+
+        let grouped = IndexKeychainItemDescriptor(
+            service: "index.fixture", account: "grouped", accessGroup: group
+        )
+        try flagStore.putAndVerify(probe, descriptor: grouped)
+        _ = try flagStore.read(descriptor: grouped)
+        try flagStore.delete(descriptor: grouped)
+        try require(!captured.isEmpty, "no grouped Keychain queries were issued")
+        for query in captured {
+            try require(
+                query[kSecUseDataProtectionKeychain as String] as? Bool == true,
+                "access-group query omitted kSecUseDataProtectionKeychain"
+            )
+        }
+
+        // The flag is scoped to grouped descriptors; an ungrouped descriptor
+        // must not silently opt into a different keychain.
+        captured.removeAll()
+        let ungrouped = IndexKeychainItemDescriptor(service: "index.fixture", account: "ungrouped")
+        try flagStore.putAndVerify(probe, descriptor: ungrouped)
+        _ = try flagStore.read(descriptor: ungrouped)
+        try flagStore.delete(descriptor: ungrouped)
+        try require(!captured.isEmpty, "no ungrouped Keychain queries were issued")
+        for query in captured {
+            try require(
+                query[kSecUseDataProtectionKeychain as String] == nil,
+                "ungrouped query opted into the data protection keychain"
+            )
+        }
     }
 }

--- a/apps/mac/api/native-api-bridge.spec.mjs
+++ b/apps/mac/api/native-api-bridge.spec.mjs
@@ -352,6 +352,33 @@ describe('native owner migration and transport source contracts', () => {
     expect(mainSwift).not.toMatch(/api_key|session_token|targetKey/);
   });
 
+  it('percent-encodes the authorize query with exactly encodeURIComponent semantics', () => {
+    // The authorize page parses the tuple with decodeURIComponent, so the
+    // native side has to match it character for character. URLQueryItem leaves
+    // ':' and '/' literal, which is what broke loopback redirect_uri sign-in.
+    const declared = appDelegate.match(
+      /static func encodeURIComponent[\s\S]*?charactersIn:\s*"([^"]*)"/,
+    )?.[1];
+    expect(declared).toBeTruthy();
+
+    // Derive the expectation from the real thing rather than restating the
+    // literal, so a hand-edited charset cannot quietly agree with a hand-edited
+    // test. Every ASCII character encodeURIComponent leaves alone, and no other.
+    const unreserved = Array.from({ length: 128 }, (_, code) => String.fromCharCode(code))
+      .filter((character) => encodeURIComponent(character) === character)
+      .join('');
+    expect([...declared].sort().join('')).toBe([...unreserved].sort().join(''));
+
+    // Guard the specific regression: these must not survive unescaped.
+    for (const character of [':', '/', '+', '&', '=', '?', '#', ' ']) {
+      expect(declared).not.toContain(character);
+    }
+
+    // And the encoded string has to actually reach the URL.
+    expect(appDelegate).toContain('percentEncodedQuery');
+    expect(appDelegate).not.toMatch(/page\?\.queryItems\s*=/);
+  });
+
   it('requires the owner-only access group and macOS 13 production inspection boundary', () => {
     expect(ownerStore).toContain('network.index.system6.owner-credentials');
     expect(ownerStore).not.toContain('network.index.connector.credentials');


### PR DESCRIPTION
## Summary
#1379 fixed owner sign-in for signed builds but landed without coverage for either fix. The weak grep assertions that would have arrived with #1378 went away when that PR was closed as superseded, so both fixes are currently untested on `dev`:

- `encodeURIComponent` appears only in `client.mjs` / `notifications.mjs` — production JS, nothing asserting the Swift helper's behaviour.
- `kSecUseDataProtectionKeychain` appears only in `IndexKeychainStore.swift` itself.

## Percent-encoding (`api/native-api-bridge.spec.mjs`)
Rather than restating the charset literal in the test — which would let a hand-edited charset quietly agree with a hand-edited test — the expectation is **derived from the real thing**:

```js
const unreserved = Array.from({ length: 128 }, (_, code) => String.fromCharCode(code))
  .filter((character) => encodeURIComponent(character) === character)
  .join('');
```

Every ASCII character `encodeURIComponent` leaves alone, and no other. Plus an explicit guard that `:`, `/`, `+`, `&`, `=`, `?`, `#` and space never survive unescaped, and that the encoded string still reaches the URL.

## Data protection keychain (`Tests/OwnerCredentialMigrationFixture.swift`)
Captures the Security queries through the existing `IndexKeychainSecurityOperations` seam and asserts the flag rides along on **exactly** the grouped descriptors — present on every query carrying an access group, absent on every ungrouped one, so the fix cannot drift into opting everything into a different keychain.

## Verified by mutation, not by observing green
Each of these fails the new tests:

| mutation | result |
|---|---|
| charset regains `:` and `/` (the original bug) | 1 fail |
| revert `percentEncodedQuery` → `queryItems` | 1 fail |
| drop `kSecUseDataProtectionKeychain` | fixture exits 133 |

The fixture failure names its assertion: `FixtureFailure.assertion("access-group query omitted kSecUseDataProtectionKeychain")`.

## CI
Both locations already run in CI — `OwnerCredentialMigrationFixture` in `mac-app-build.yml`, `native-api-bridge.spec.mjs` in `hermes-runtime-security.yml`. Tests only; no production code touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)