### PR TITLE
feat(mac): allow owner sign-in on ad-hoc development builds

### DIFF
--- a/apps/mac/README.md
+++ b/apps/mac/README.md
@@ -54,6 +54,13 @@ This will:
 
 The app will hot-reload as you edit files, great for UI tweaking.
 
+`dev.sh` defaults `INDEX_DEVELOPMENT_BUILD=1`: the build enables the web
+inspector and, because an ad-hoc build carries no provisioning-profile-authorized
+Keychain access group, stores the owner credential in the login keychain so
+sign-in works locally. Production (signed) builds are unaffected and still fail
+closed without the authorized owner group. Override with
+`INDEX_DEVELOPMENT_BUILD=0 ./dev.sh`.
+
 **To manually reload** during development, press **Cmd+R** (standard browser reload) in the app, or close and relaunch.
 
 ### Troubleshooting Build

--- a/apps/mac/Sources/AppDelegate.swift
+++ b/apps/mac/Sources/AppDelegate.swift
@@ -690,17 +690,26 @@ final class AppDelegate: NSObject, NSApplicationDelegate, WKNavigationDelegate, 
     }
 
     private func configureOwnerCredentialStore() {
-        guard let accessGroup = AppConfig.ownerKeychainAccessGroup,
-              let root = FileManager.default.urls(for: .applicationSupportDirectory, in: .userDomainMask).first else {
+        guard let root = FileManager.default.urls(for: .applicationSupportDirectory, in: .userDomainMask).first else {
             ownerStartupFailure = "This build has no authorized owner Keychain group. Use a signed Index build."
             return
         }
         let support = root.appendingPathComponent(CredentialStore.service, isDirectory: true)
         do {
-            var store = try OwnerCredentialStore(
-                accessGroup: accessGroup,
-                applicationSupportDirectory: support
-            )
+            var store: OwnerCredentialStore
+            if let accessGroup = AppConfig.ownerKeychainAccessGroup {
+                store = try OwnerCredentialStore(
+                    accessGroup: accessGroup,
+                    applicationSupportDirectory: support
+                )
+            } else {
+#if INDEX_DEVELOPMENT_BUILD
+                store = OwnerCredentialStore(developmentLoginKeychainAt: support)
+#else
+                ownerStartupFailure = "This build has no authorized owner Keychain group. Use a signed Index build."
+                return
+#endif
+            }
             ownerMigrationJournal = try store.prepareForStartup(installationId: ownerInstallationId)
             ownerCredentialStore = store
         } catch {

--- a/apps/mac/Sources/OwnerCredentialStore.swift
+++ b/apps/mac/Sources/OwnerCredentialStore.swift
@@ -91,6 +91,27 @@ struct OwnerCredentialStore {
         self.files = files
     }
 
+#if INDEX_DEVELOPMENT_BUILD
+    /// Ad-hoc development builds carry no provisioning-profile-authorized
+    /// access group, so the data-protection keychain is unavailable to them.
+    /// Store the credential in the login keychain instead. Never compiled
+    /// into production builds.
+    init(
+        developmentLoginKeychainAt applicationSupportDirectory: URL,
+        keychain: IndexKeychainStore = IndexKeychainStore(),
+        files: OwnerCredentialFileOperations = .live
+    ) {
+        self.keychain = keychain
+        self.descriptor = IndexKeychainItemDescriptor(
+            service: Self.service,
+            account: Self.account,
+            accessGroup: nil
+        )
+        self.applicationSupportDirectory = applicationSupportDirectory
+        self.files = files
+    }
+#endif
+
     var legacyCredentialURL: URL {
         applicationSupportDirectory.appendingPathComponent(Self.legacyCredentialFileName, isDirectory: false)
     }

--- a/apps/mac/scripts/dev.sh
+++ b/apps/mac/scripts/dev.sh
@@ -2,6 +2,10 @@
 # dev.sh — watch sources, rebuild, and relaunch dist/Index.app on every change.
 cd "$(dirname "$0")/.." || exit 1
 
+# The hot-reload loop is a development workflow: default to the development
+# build (web inspector + login-keychain owner credential fallback).
+export INDEX_DEVELOPMENT_BUILD="${INDEX_DEVELOPMENT_BUILD:-1}"
+
 snapshot() {
   stat -f '%m %N' \
     scripts/assemble.py scripts/build.sh \


### PR DESCRIPTION
## New Features

- Ad-hoc (unsigned) local builds can now complete owner sign-in when compiled with `INDEX_DEVELOPMENT_BUILD=1`. Such builds carry no provisioning-profile-authorized Keychain access group, so `configureOwnerCredentialStore()` previously failed closed ("This build has no authorized owner Keychain group") and the login button hung on "waiting for browser…". Development builds now fall back to a login-keychain owner credential store (no access group, still Keychain — never a plaintext file). The fallback init is fenced with `#if INDEX_DEVELOPMENT_BUILD` and compiles away entirely in production builds, which keep the exact fail-closed behavior.
- `scripts/dev.sh` (hot-reload loop) now defaults `INDEX_DEVELOPMENT_BUILD=1`; override with `INDEX_DEVELOPMENT_BUILD=0 ./dev.sh`.

## Documentation

- `apps/mac/README.md`: documented the dev.sh default and the login-keychain fallback in the Hot-Reload section.

## Verification

- `INDEX_DEVELOPMENT_BUILD=1 ./scripts/build.sh` — dev build compiles, ad-hoc signs, app launches without the startup alert and browser sign-in proceeds.
- `./scripts/build.sh` (production, no flag) — compiles; fallback code absent; production trust-pin checks pass.
- `./scripts/build.sh --fixture OwnerCredentialMigrationFixture` — passes (fixture compiles OwnerCredentialStore without the dev define).
- `bun test api/native-api-bridge.spec.mjs api/agent-runtime.spec.mjs api/agent-runtime-saga.spec.mjs hermes-runtime.spec.mjs` — 97 pass, 0 fail (1145 expect() calls).