### PR TITLE
fix(mac): allow the radar's lifecycle and presentation query params

### DIFF
--- a/apps/mac/Sources/NativeAPIRequestBridge.swift
+++ b/apps/mac/Sources/NativeAPIRequestBridge.swift
@@ -756,8 +756,15 @@ final class NativeAPIRequestBridge {
         case "/networks/discovery/public": allowed = ["page", "limit"]
         case let value where value.range(of: #"^/users/[^/?]+/negotiations$"#, options: .regularExpression) != nil:
             allowed = ["status", "limit", "offset"]
-        case "/opportunities", "/opportunities/radar":
+        // The list and the radar do not take the same filter: the list reads a
+        // single `status`, the radar reads a comma-joined `statuses` plus the
+        // two-phase `presentation` mode. Sharing one set silently denied every
+        // radar call the app actually makes, so they are spelled out separately
+        // and each mirrors what its own handler reads.
+        case "/opportunities":
             allowed = ["status", "limit", "offset", "scopeType", "scopeId", "noCache"]
+        case "/opportunities/radar":
+            allowed = ["statuses", "presentation", "limit", "offset", "scopeType", "scopeId", "noCache"]
         case "/opportunities/chat-context": allowed = ["peerUserId"]
         case "/questions": allowed = ["status", "sourceId", "scopeType", "scopeId", "limit", "offset"]
         case let value where value.range(of: #"^/conversations/[^/?]+/messages$"#, options: .regularExpression) != nil:

--- a/apps/mac/Tests/NativeAPIBodyValidationFixture.swift
+++ b/apps/mac/Tests/NativeAPIBodyValidationFixture.swift
@@ -58,6 +58,19 @@ enum NativeAPIBodyValidationFixture {
         try require(NativeAPIRequestBridge.validateHTTPBodyForFixture(method: "GET", path: "/networks/discovery/public", body: nil), "public network discovery rejected")
         try require(NativeAPIRequestBridge.validateHTTPBodyForFixture(method: "GET", path: "/networks/discovery/public?page=1&limit=50", body: nil), "paged public network discovery rejected")
         try require(!NativeAPIRequestBridge.validateHTTPBodyForFixture(method: "GET", path: "/networks/discovery/public?cursor=1", body: nil), "unknown discovery query accepted")
+        // The intent radar is the app's only radar caller and it always sends the
+        // lifecycle filter, plus `presentation=skeleton` on the first of its two
+        // phases. Denying either leaves the radar stuck on "looking for your people".
+        let radarStatuses = "latent,pending,negotiating,stalled,accepted,expired"
+        let intentId = "00000000-0000-4000-8000-000000000001"
+        try require(NativeAPIRequestBridge.validateHTTPBodyForFixture(method: "GET", path: "/opportunities/radar?statuses=\(radarStatuses)&scopeType=intent&scopeId=\(intentId)", body: nil), "intent radar lifecycle query rejected")
+        try require(NativeAPIRequestBridge.validateHTTPBodyForFixture(method: "GET", path: "/opportunities/radar?statuses=\(radarStatuses)&presentation=skeleton&scopeType=intent&scopeId=\(intentId)", body: nil), "intent radar skeleton query rejected")
+        try require(NativeAPIRequestBridge.validateHTTPBodyForFixture(method: "GET", path: "/opportunities/radar?noCache=true", body: nil), "radar noCache query rejected")
+        try require(!NativeAPIRequestBridge.validateHTTPBodyForFixture(method: "GET", path: "/opportunities/radar?networkId=n1", body: nil), "unrequested radar query accepted")
+        // `statuses` belongs to the radar, `status` to the list; neither route takes the other's.
+        try require(NativeAPIRequestBridge.validateHTTPBodyForFixture(method: "GET", path: "/opportunities?status=pending&limit=10", body: nil), "opportunity list status query rejected")
+        try require(!NativeAPIRequestBridge.validateHTTPBodyForFixture(method: "GET", path: "/opportunities?statuses=\(radarStatuses)", body: nil), "opportunity list plural statuses accepted")
+        try require(!NativeAPIRequestBridge.validateHTTPBodyForFixture(method: "GET", path: "/opportunities/radar?status=pending", body: nil), "radar singular status accepted")
         try require(NativeAPIRequestBridge.validateSSEBodyForFixture(method: "GET", path: "/notifications/stream", body: nil), "valid notification stream rejected")
         try require(NativeAPIRequestBridge.validateSSEBodyForFixture(method: "POST", path: "/chat/stream", body: object(["message": string("hello"), "persona": string("negotiator")])), "valid chat stream rejected")
         try require(NativeAPIRequestBridge.validateMCPForFixture(arguments: object(["description": string("Meet founders"), "autoApprove": .bool(true)])), "valid create_intent rejected")

--- a/apps/mac/api/client.spec.mjs
+++ b/apps/mac/api/client.spec.mjs
@@ -129,6 +129,10 @@ describe('mac Index API client endpoint contract', () => {
     await expectCall('opportunities.radar', (client) => client.opportunities.radar({ noCache: true }), { path: '/opportunities/radar?noCache=true' });
     await expectCall('opportunities.radar scoped intent', (client) => client.opportunities.radar({ scopeType: 'intent', scopeId: SELECTED_INTENT_ID, noCache: true }), { path: `/opportunities/radar?scopeType=intent&scopeId=${SELECTED_INTENT_ID}&noCache=true` });
     await expectCall('opportunities.radarForIntent', (client) => client.opportunities.radarForIntent(SELECTED_INTENT_ID, { noCache: true }), { path: `/opportunities/radar?noCache=true&scopeType=intent&scopeId=${SELECTED_INTENT_ID}` });
+    // What the radar column actually calls on every poll, both phases of it.
+    const RADAR_STATUSES = 'latent,pending,negotiating,stalled,accepted,expired';
+    await expectCall('opportunities.radarForIntent lifecycle', (client) => client.opportunities.radarForIntent(SELECTED_INTENT_ID, { statuses: RADAR_STATUSES }), { path: `/opportunities/radar?statuses=${encodeURIComponent(RADAR_STATUSES)}&scopeType=intent&scopeId=${SELECTED_INTENT_ID}` });
+    await expectCall('opportunities.radarForIntent skeleton', (client) => client.opportunities.radarForIntent(SELECTED_INTENT_ID, { statuses: RADAR_STATUSES, presentation: 'skeleton' }), { path: `/opportunities/radar?statuses=${encodeURIComponent(RADAR_STATUSES)}&presentation=skeleton&scopeType=intent&scopeId=${SELECTED_INTENT_ID}` });
     await expectCall('opportunities.chatContext', (client) => client.opportunities.chatContext('user/1'), { path: '/opportunities/chat-context?peerUserId=user%2F1' });
     await expectCall('opportunities.get', (client) => client.opportunities.get('opp/1'), { path: '/opportunities/opp%2F1' });
     await expectCall('opportunities.inviteMessage', (client) => client.opportunities.inviteMessage('opp/1'), { path: '/opportunities/opp%2F1/invite-message' });


### PR DESCRIPTION
### Fixed

- **The mac radar never loaded.** All four tabs (`awaiting you` / `negotiating` / `accepted` / `missed`) stayed at 0 and the discovery checklist hung forever on "scanning counterparties" with no count next to it.

  The native bridge's per-route query allowlist (`NativeAPIRequestBridge.hasAllowedQuery`) gave `/opportunities/radar` the same parameter names as the `/opportunities` list — including `status`, singular. The radar column sends `statuses` (the comma-joined lifecycle filter) and, on the first of its two fetch phases, `presentation=skeleton`. Neither name was listed, so `isAllowedHTTP` denied every radar request in Swift before it reached the network.

  `core.jsx` swallows the rejection (`.catch(() => null)`), so `applyRadar` returned early on every 5s poll and neither `people` nor `discoveryMetrics` was ever populated. That is exactly the stalled screen: `mapping reach` checks off because it comes from `/networks` (allowed), and every later step is fed by the radar (denied).

  `/opportunities` and `/opportunities/radar` are now separate cases, each mirroring what its own handler actually reads.

### Testing

- `apps/mac/Tests/NativeAPIBodyValidationFixture.swift` — pins both radar phases (lifecycle-only and `presentation=skeleton`), keeps `noCache`, and asserts the two routes reject each other's filter (`/opportunities?statuses=…` and `/opportunities/radar?status=…` both denied), plus an unrequested `networkId`.
- `apps/mac/api/client.spec.mjs` — pins the exact paths the radar column emits on every poll. The existing coverage only exercised `radar({ noCache: true })`, which the old allowlist happened to permit, which is why the drift shipped.

### Evidence

- `apps/mac/scripts/build.sh --fixture NativeAPIBodyValidationFixture` — passes; verified it **fails** with the fix stashed (`FixtureFailure.assertion("intent radar lifecycle query rejected")`), so it reproduces the bug.
- `apps/mac/scripts/build.sh --fixture NativeAPIQuarantineFixture` — passes (also compiles the changed bridge).
- `bun test apps/mac/api/client.spec.mjs apps/mac/api/native-api-bridge.spec.mjs` — 17 pass, 0 fail.
- `bun test services/api/src/guards/tests/native-client-route-parity.spec.ts` — 9 pass, 0 fail.

No version bump: the branch touches only `apps/mac`, which carries no semver package version.

### Note

The route-parity spec (`native-client-route-parity.spec.ts`) pins bridge **routes** against the server audiences but not their **query parameters**, which is the gap this drift fell through. Closing it generally would mean deriving each handler's accepted `searchParams` — worth a follow-up, out of scope here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)