### PR TITLE
docs: drop the Copilot reviewer from the PR workflow

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -111,7 +111,8 @@ Branch**. The parts that are easy to miss:
 - Merge approval is always explicit and separate — never infer it from green checks.
   Merge server-side from a non-canonical checkout; never check out or merge `dev` inside
   a feature worktree.
-- Code review on PRs is GitHub Copilot, triggered manually by the user. Every review
-  conversation must be resolved manually before merge; see the Development Reference for
-  the exact `gh api` reply/resolve flow.
+- There is no automated PR reviewer. Nothing reviews a PR unless a human is asked to,
+  so green checks are the only signal a PR carries by default — and green is not review.
+  Say so plainly when handing one over. If review comments do get opened, resolve every
+  conversation before merge; see the Development Reference for the reply/resolve flow.
 - Sync the canonical root afterwards only with `git pull --ff-only origin dev`.

--- a/docs/guides/development-reference.md
+++ b/docs/guides/development-reference.md
@@ -1182,17 +1182,28 @@ per checkout.
 
 ### Receiving Code Review
 
-Code reviews on this project are done by **GitHub Copilot**, triggered manually by the user (via the Reviewers menu on the PR, or `gh pr edit PR-NUMBER --add-reviewer @copilot`). Copilot does not auto-review on push and replies do not trigger it — only an explicit re-review request does.
+**There is no automated reviewer on this project.** No bot reviews a PR on push, and
+none is triggered by opening one. Unless a human is explicitly asked to look, a PR
+arrives at merge time with nothing but its checks behind it.
 
-When handling Copilot reviews on PRs, follow this workflow:
+That has one consequence worth stating outright, because it is easy to drift into: a
+green PR is an *unreviewed* PR. Checks prove the suite passes, not that the change is
+correct, well-scoped, or wanted. When handing work over, say which it is — "green, not
+reviewed" — rather than letting green imply more than it does. `dev` is unprotected, so
+nothing else will catch the difference.
 
-1. **Fetch unresolved conversations**: Use `gh api` to list all review comments on the PR. Focus on unresolved conversation threads from `github-copilot[bot]`.
-2. **Evaluate each conversation**: For each unresolved thread, decide whether a code fix is actually needed:
-   - **Fix needed**: Implement the fix, push, then **manually resolve the conversation** (Copilot does not auto-resolve when commits are pushed or suggestions are applied).
-   - **No fix needed**: Reply in the comment thread with technical reasoning for why the current code is correct (e.g., YAGNI, reviewer lacks context, breaks existing patterns), then resolve it. Use `gh api repos/{owner}/{repo}/pulls/{pr}/comments/{id}/replies` to reply inline.
-3. **Resolve all conversations**: Every conversation must be manually resolved before the PR can merge.
+When review comments *do* get opened, by a human or anything else:
 
-> **IMPORTANT:** Copilot never sees follow-up comments and will not respond to `@copilot` mentions in threads — replies are for human context only. On re-review, Copilot may re-raise already-resolved comments; that is expected behavior.
+1. **Fetch the threads**: `gh api` lists review comments on the PR; work through the
+   unresolved ones.
+2. **Evaluate each**: decide whether a code fix is actually needed.
+   - **Fix needed**: implement it, push, then resolve the conversation. Pushing a commit
+     does not resolve a thread on its own.
+   - **No fix needed**: reply inline with the technical reasoning for why the current
+     code is right (YAGNI, missing context, conflicts with an existing pattern), then
+     resolve it.
+3. **Resolve everything before merge**: an unresolved thread is an open question, and
+   merging over it silently discards the question rather than answering it.
 
 **Key commands:**
 ```bash
@@ -1202,8 +1213,8 @@ gh api repos/{owner}/{repo}/pulls/{pr}/comments
 # Reply to a specific review comment thread (USE THIS — not gh pr comment)
 gh api repos/{owner}/{repo}/pulls/{pr}/comments/{comment_id}/replies -f body="..."
 
-# Request a Copilot review on an existing PR
-gh pr edit PR-NUMBER --add-reviewer @copilot
+# Ask a human for review
+gh pr edit PR-NUMBER --add-reviewer USERNAME
 ```
 
 ## Session Learning Capture


### PR DESCRIPTION
## Summary
`CLAUDE.md` and the Development Reference both described PR review as **GitHub Copilot, triggered manually by the user**, with a resolve-every-thread gate before merge. That setup no longer exists.

Evidence: the last six merged PRs — #1372, #1375, #1377, #1379, #1381 — carry **zero reviewers**.

## Why it mattered
The stale text reads as a *mandatory* review gate, so an agent finishing a branch defers to a reviewer that will never arrive. That happened in the session that produced this PR: I recommended holding a green, tests-only PR for a Copilot review that could not be requested.

## Changes
- **`CLAUDE.md`** — replaces the Copilot bullet with the actual state: nothing reviews a PR unless a human is asked to, so green checks are the only signal a PR carries by default, and green is not review. Keeps the resolve-before-merge rule for threads that do get opened.
- **`docs/guides/development-reference.md`** — rewrites *Receiving Code Review*. Drops the Copilot-specific mechanics (`--add-reviewer @copilot`, `github-copilot[bot]` threads, the re-review caveats) and keeps the inline reply/resolve workflow generalised, since it applies to any review thread. Adds the point that `dev` is unprotected, so nothing catches the green-vs-reviewed difference automatically.

## Not changed
`.rpiv/artifacts/research/2026-06-19_*.md` still mentions Copilot review rounds. That is a dated research artifact recording what happened at the time, not guidance — it also confirms the setup was real and later lapsed rather than aspirational. Left as history.

## Verification
Docs only; no code paths touched. `git grep -i copilot` returns only the research artifact above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)