### PR TITLE
chore: run database-backed tests against local Postgres

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -573,6 +573,14 @@ QUESTIONER_UPTAKE_AUTHORITY_THRESHOLD=70
 # Database-backed tests fail closed unless this marker is explicitly enabled.
 # DATABASE_URL must point to a dedicated disposable database, never shared/prod.
 # TEST_DATABASE_SAFE=1
+#
+# Provision that database locally with `bun run db:setup:local` (Homebrew
+# postgresql@17 + pgvector, database `index_test`, migrations applied), then set
+# the repo-root .env.test to:
+#   DATABASE_URL=postgresql://<your-unix-user>@localhost:5432/index_test
+# Local Postgres is strongly preferred over a remote branch: the same four
+# questioner adapter suites take ~0.6 s locally versus ~340 s against remote
+# Neon, and the remote runs were intermittently stalling for minutes at a time.
 
 # Opt into live/paid provider tests (also requires each provider credential).
 # RUN_PAID_INTEGRATION_TESTS=1

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -96,6 +96,11 @@ them, and only after proving `DATABASE_URL` points at a dedicated, disposable da
 then set `TEST_DATABASE_SAFE=1`. The guard is fail-closed by design; never bypass it, and
 never set the marker before the URL has been proven disposable.
 
+Use **local Postgres**, provisioned with `bun run db:setup:local` — it satisfies that
+proof (database `index_test`, nothing but test data) and is roughly 500x faster than a
+remote branch. CI's `test` job only runs hermetic specs that mock the database, so the
+database-backed suite is gated nowhere except your machine.
+
 ## Finishing a branch
 
 The full checklist lives in the Development Reference under **Git Workflow → Finishing a

--- a/docs/guides/development-reference.md
+++ b/docs/guides/development-reference.md
@@ -1029,6 +1029,31 @@ bun test                                    # Run ALL tests (avoid unless necess
 
 **Test locations**: `services/api/tests/` (integration/E2E), `services/api/src/lib/*/tests/` (unit tests).
 
+### Database-backed tests
+
+Run them against **local Postgres**, not a remote Neon branch. Provision once:
+
+```bash
+bun run db:setup:local            # postgresql@17 + pgvector, database `index_test`, migrations
+bun run db:setup:local --recreate # start over from an empty database
+```
+
+Then set the repo-root `.env.test` to `DATABASE_URL=postgresql://<your-unix-user>@localhost:5432/index_test`
+and run with `TEST_DATABASE_SAFE=1`. The `index_test` name matters: the fail-closed
+guard in `src/lib/drizzle/test-database-readiness.ts` refuses any database whose name
+matches `/^(.*_)?(prod|production)$/`, which is what every Neon branch calls its copy of
+real user data.
+
+Why local: the four questioner adapter suites take **~0.6 s** locally against **~340 s**
+on a remote branch, individual specs were taking 25-90 s, and one stalled for 905 s.
+That latency was also the source of failures indistinguishable from real ones —
+`questioner.recovery.lifecycle.spec.ts` failed intermittently on remote and passes
+consistently on local.
+
+Note that CI's `test` job runs only the hermetic specs that mock Redis, the LLM and the
+database, so the database-backed suite is gated **nowhere** except locally. Running it
+before pushing is the only coverage it gets.
+
 **Standards**: Load env at top before imports. Import from `bun:test` (destructured). Use `describe` grouping. Set timeouts (agent: 30s, graph: 60s, LLM: 120s). Clean up in `afterAll`. Mock externals. Test success and error paths. Never commit without running affected tests.
 
 ## Database Workflow

--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
     "lint": "eslint .",
     "lint:mac-universal-links": "eslint --config apps/mac/eslint.config.mjs apps/mac/eslint.config.mjs apps/mac/api/deeplink.mjs apps/mac/api/deeplink.spec.mjs apps/mac/scripts/deep-link-host.spec.mjs apps/mac/scripts/link-host.spec.mjs apps/mac/scripts/notarize.spec.mjs apps/mac/scripts/provisioning-profile.spec.mjs apps/mac/src/ui/app.jsx",
     "check:subtree-parity": "bun scripts/check-subtree-package-parity.ts",
+    "db:setup:local": "bash scripts/setup-local-testdb.sh",
     "skills:validate": "bun .agents/skills/learn-skill/scripts/skillctl.ts validate all && bun scripts/validate-codex-skills.ts",
     "pr:snapshot": "bun scripts/pr-snapshot.ts",
     "test:scripts": "bun test scripts/tests",

--- a/scripts/setup-local-testdb.sh
+++ b/scripts/setup-local-testdb.sh
@@ -1,0 +1,89 @@
+#!/usr/bin/env bash
+#
+# Provision the local Postgres that database-backed tests run against.
+#
+# The suite used to point at a remote Neon branch, which made it slow enough
+# that nobody ran it: individual adapter specs took 25-90 s and one stalled for
+# 905 s, and the flakiness that produced was indistinguishable from real
+# failures. Against local Postgres the same four questioner suites finish in
+# under a second.
+#
+# Requirements this has to satisfy:
+#   - Postgres 17, matching the Neon branches the app runs against
+#   - the `vector` extension (the schema stores 2000-dimension embeddings)
+#   - a database whose NAME is not production-like, because the fail-closed
+#     guard in services/api/src/lib/drizzle/test-database-readiness.ts refuses
+#     anything matching /^(.*_)?(prod|production)$/
+#
+# Idempotent: safe to re-run. Re-running does not drop data; use --recreate for
+# a clean database.
+#
+# Usage:
+#   bun run db:setup:local
+#   bun run db:setup:local --recreate
+
+set -euo pipefail
+
+PG_FORMULA="postgresql@17"
+DB_NAME="${LOCAL_TEST_DB_NAME:-index_test}"
+RECREATE=0
+[ "${1:-}" = "--recreate" ] && RECREATE=1
+
+REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+
+if ! command -v brew >/dev/null 2>&1; then
+  echo "Error: Homebrew is required. See https://brew.sh" >&2
+  exit 1
+fi
+
+PG_BIN="$(brew --prefix)/opt/${PG_FORMULA}/bin"
+
+if [ ! -x "$PG_BIN/psql" ]; then
+  echo "Installing ${PG_FORMULA} and pgvector..."
+  brew install "$PG_FORMULA" pgvector
+else
+  echo "  [postgres] ${PG_FORMULA} already installed"
+fi
+
+export PATH="$PG_BIN:$PATH"
+
+if ! pg_isready -q 2>/dev/null; then
+  echo "  [postgres] starting service..."
+  brew services start "$PG_FORMULA" >/dev/null
+  until pg_isready -q 2>/dev/null; do sleep 1; done
+fi
+echo "  [postgres] ready"
+
+if [ "$RECREATE" = "1" ]; then
+  echo "  [database] dropping ${DB_NAME}"
+  dropdb --if-exists "$DB_NAME"
+fi
+
+if psql -lqt | cut -d'|' -f1 | grep -qw "$DB_NAME"; then
+  echo "  [database] ${DB_NAME} already exists"
+else
+  createdb "$DB_NAME"
+  echo "  [database] ${DB_NAME} created"
+fi
+
+# The migrations also declare this, but creating it up front means a failure
+# here reports "pgvector missing" rather than a confusing migration error.
+psql -d "$DB_NAME" -qtAc "CREATE EXTENSION IF NOT EXISTS vector;" >/dev/null
+echo "  [extension] vector $(psql -d "$DB_NAME" -tAc "SELECT extversion FROM pg_extension WHERE extname='vector';")"
+
+DB_URL="postgresql://$(whoami)@localhost:5432/${DB_NAME}"
+
+echo "  [migrations] applying..."
+(cd "$REPO_ROOT/services/api" && TEST_DATABASE_SAFE=1 NODE_ENV=test DATABASE_URL="$DB_URL" bun run db:migrate:test 2>&1 | tail -1)
+
+cat <<EOF
+
+Done. Point the test environment at it by setting this in the repo-root .env.test:
+
+  DATABASE_URL=${DB_URL}
+
+Then run database-backed tests with TEST_DATABASE_SAFE=1, for example:
+
+  cd services/api && TEST_DATABASE_SAFE=1 bun test src/adapters/tests/questioner.lifecycle.spec.ts
+
+EOF

--- a/scripts/setup-local-testdb.sh
+++ b/scripts/setup-local-testdb.sh
@@ -39,10 +39,19 @@ fi
 PG_BIN="$(brew --prefix)/opt/${PG_FORMULA}/bin"
 
 if [ ! -x "$PG_BIN/psql" ]; then
-  echo "Installing ${PG_FORMULA} and pgvector..."
-  brew install "$PG_FORMULA" pgvector
+  echo "Installing ${PG_FORMULA}..."
+  brew install "$PG_FORMULA"
 else
   echo "  [postgres] ${PG_FORMULA} already installed"
+fi
+
+# Check pgvector independently: PostgreSQL may already be installed while the
+# extension is absent. `CREATE EXTENSION` below cannot install the extension.
+if ! brew list --formula pgvector >/dev/null 2>&1; then
+  echo "Installing pgvector..."
+  brew install pgvector
+else
+  echo "  [pgvector] already installed"
 fi
 
 export PATH="$PG_BIN:$PATH"


### PR DESCRIPTION
## Problem

Database-backed tests pointed at a remote Neon branch, which made them slow enough that
in practice they didn't get run. Individual adapter specs took 25-90 s, one stalled for
905 s, and that latency produced failures indistinguishable from real ones —
`questioner.recovery.lifecycle.spec.ts` failed intermittently against remote and passes
consistently against local.

Same four questioner adapter suites, same code:

| target | wall clock | result |
|---|---|---|
| remote Neon branch | ~340 s | 34 pass, intermittent failures |
| local Postgres | **0.57 s** | 34 pass, stable |

## Change

`bun run db:setup:local` — idempotent, `--recreate` for a clean start. Installs
`postgresql@17` (matching the Neon branches the app runs against) and `pgvector` (the
schema stores 2000-dimension embeddings), starts the service, creates `index_test`, and
applies the 125 migrations.

The database name matters: the fail-closed guard in `test-database-readiness.ts` refuses
anything matching `/^(.*_)?(prod|production)$/`, which is exactly what every Neon branch
calls its copy of real user data. `index_test` satisfies the "prove it is disposable"
requirement by construction.

Documented in the Development Reference, `CLAUDE.md` and `.env.example`. The env files
that select the database are gitignored, so each developer points their repo-root
`.env.test` at the URL the script prints.

## What this surfaced

The full baseline is runnable for the first time: **2786 pass, 40 fail, 158 s**.

Those 40 failures are **pre-existing, not caused by this change** — `questioner.adapter`'s
two `findPending` specs fail identically when pointed back at the old remote database, and
they fail the same way on `dev` as on a feature branch.

They have never been gated anywhere. CI's `test` job, by its own comment, "runs the
hermetic pinning/characterization specs that mock all external systems (Redis/LLM/DB)", so
the database-backed suite has no CI coverage at all. Fixing those 40 is left for a separate
change; this PR just makes them visible and cheap to iterate on.

## Validation

| check | result |
|---|---|
| `db:setup:local` on an existing database | idempotent, no data loss |
| `db:setup:local --recreate` from empty | database created, 125 migrations applied |
| 4 questioner adapter suites on the fresh database | 34 pass, 0 fail, 569 ms |
| previously-flaky `questioner.recovery.lifecycle` | passes consistently |
| `bash -n` + `shellcheck` on the script | clean |
| `package.json` parse | valid |

No package versions change, so no bump is required.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
