### PR TITLE
feat(hermes-plugin): rename the Hermes sidebar entry to Discover

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -106,7 +106,7 @@
     },
     "packages/hermes-plugin": {
       "name": "@indexnetwork/hermes-plugin",
-      "version": "0.21.0",
+      "version": "0.22.1",
     },
     "packages/protocol": {
       "name": "@indexnetwork/protocol",

--- a/packages/hermes-plugin/CHANGELOG.md
+++ b/packages/hermes-plugin/CHANGELOG.md
@@ -7,6 +7,10 @@ and this package adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+## [0.22.1] - 2026-08-13
+### Changed
+- Rename the Hermes sidebar entry from Index to Discover.
+
 ## [0.22.0] - 2026-08-13
 ### Added
 - Restore the browser login gate in the dashboard: **log in with browser** runs the same web `/cli-auth` v2 loopback handshake as the Index CLI and Mac app, persists the minted key to `~/.hermes/.env` (`INDEX_API_KEY`/`INDEX_API_KEY_ID`), and takes effect in-process without a restart. Sign out best-effort revokes the key via `/auth/cli-credential/revoke` and clears it. `INDEX_API_KEY` remains a manual override.

--- a/packages/hermes-plugin/dashboard/manifest.json
+++ b/packages/hermes-plugin/dashboard/manifest.json
@@ -1,9 +1,9 @@
 {
   "name": "index-network",
-  "label": "Index",
+  "label": "Discover",
   "description": "Intent-centric Index Network overview: each intent carries its own questions and opportunity radar, with a separate Networks view.",
   "icon": "Sparkles",
-  "version": "0.22.0",
+  "version": "0.22.1",
   "tab": {
     "path": "/index-network",
     "position": "after:skills"

--- a/packages/hermes-plugin/desktop/dist/plugin.js
+++ b/packages/hermes-plugin/desktop/dist/plugin.js
@@ -4765,14 +4765,14 @@ export default {
       {
         id: 'page',
         area: ROUTES_AREA,
-        title: 'Index',
+        title: 'Discover',
         data: { path: '/index-network' },
         render: function () { return React.createElement(DesktopPage) }
       },
       {
         id: 'nav',
         area: SIDEBAR_NAV_AREA,
-        data: { path: '/index-network', label: 'Index', codicon: 'sparkle' }
+        data: { path: '/index-network', label: 'Discover', codicon: 'sparkle' }
       },
       {
         id: 'open',

--- a/packages/hermes-plugin/desktop/tail.js
+++ b/packages/hermes-plugin/desktop/tail.js
@@ -172,14 +172,14 @@ export default {
       {
         id: 'page',
         area: ROUTES_AREA,
-        title: 'Index',
+        title: 'Discover',
         data: { path: '/index-network' },
         render: function () { return React.createElement(DesktopPage) }
       },
       {
         id: 'nav',
         area: SIDEBAR_NAV_AREA,
-        data: { path: '/index-network', label: 'Index', codicon: 'sparkle' }
+        data: { path: '/index-network', label: 'Discover', codicon: 'sparkle' }
       },
       {
         id: 'open',

--- a/packages/hermes-plugin/package.json
+++ b/packages/hermes-plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@indexnetwork/hermes-plugin",
-  "version": "0.22.0",
+  "version": "0.22.1",
   "description": "Hermes-native Index Network plugin with MCP and personal-agent tools",
   "license": "MIT",
   "type": "module",

--- a/packages/hermes-plugin/plugin.yaml
+++ b/packages/hermes-plugin/plugin.yaml
@@ -1,5 +1,5 @@
 name: index-network
-version: 0.22.0
+version: 0.22.1
 description: Index Network Hermes plugin with native tools backed by Index MCP and personal-agent APIs.
 provides_tools:
   - index_read_intents

--- a/packages/hermes-plugin/tests/smoke.py
+++ b/packages/hermes-plugin/tests/smoke.py
@@ -413,7 +413,7 @@ def main() -> None:
     )
     assert dashboard_manifest["version"] == package_json["version"] == plugin_yaml_version
     assert dashboard_manifest["name"] == "index-network"
-    assert dashboard_manifest["label"] == "Index"
+    assert dashboard_manifest["label"] == "Discover"
     assert dashboard_manifest["entry"] == "dist/index.js"
     assert dashboard_manifest["css"] == "dist/style.css"
     assert dashboard_manifest["api"] == "plugin_api.py"
@@ -532,6 +532,7 @@ def main() -> None:
     # on the source fragment because the shared dashboard bundle has its own
     # browser transport implementation in the same generated module.
     desktop_tail = (ROOT / "desktop" / "tail.js").read_text()
+    assert "label: 'Discover'" in desktop_tail
     assert "ctx.socket" in desktop_tail
     assert "ctx.rest" in desktop_tail
     assert "window.fetch" not in desktop_tail


### PR DESCRIPTION
## Summary
- Rename the Index Hermes plugin sidebar (gateway dashboard label and desktop nav) from Index to Discover.
- Bump `@indexnetwork/hermes-plugin` to 0.22.1.

## Test plan
- [x] `node tests/desktop-notifications.mjs` in `packages/hermes-plugin`
- [x] `/opt/homebrew/bin/python3 tests/smoke.py` in `packages/hermes-plugin` (system `python3` is 3.9 and cannot import the plugin)
- [ ] Confirm the Hermes sidebar shows Discover after installing this plugin build