### PR TITLE
test(api): drop the retired non_web surface and Signal flag literals

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -126,7 +126,7 @@
     },
     "services/api": {
       "name": "@indexnetwork/api",
-      "version": "0.88.1",
+      "version": "0.88.2",
       "dependencies": {
         "@aws-sdk/client-s3": "^3.939.0",
         "@aws-sdk/s3-request-presigner": "^3.983.0",

--- a/services/api/CHANGELOG.md
+++ b/services/api/CHANGELOG.md
@@ -9,6 +9,9 @@ section before promoting to `main`).
 
 ## [Unreleased]
 
+### Changed
+- Drop the retired `non_web` surface and `WEB_SIGNAL_AGENT_ENABLED` literals from `chat.service.isolated.ts`. The tests passed either way — `"non_web"` fell through to the same branch as `"agent"` — but the strings named a surface that no longer exists, and `tsconfig.json` excludes `src/**/*.isolated.ts`, so nothing would ever have caught the drift.
+
 ### Removed
 - **Breaking (API 0.88.0):** retire the pre-personafication `orchestrator` chat persona. There is no default chat persona: every H2A turn names one, and unknown values fail closed. `POST /api/chat/message` is deleted (it was orchestrator-only), `ChatSessionService.processMessage()` and `getGraphFactory()` are gone, and the `non_web` stream surface is replaced by `agent`, which requires an explicit persona (`CHAT_PERSONA_REQUIRED` when omitted). `signal` and `reporter` remain web-only, so `negotiator` is the persona an API-key client can start.
 - **Breaking:** delete `WEB_SIGNAL_AGENT_ENABLED`. Signal is the permanent web chat persona — with the orchestrator gone, flag-off had no persona to fall back to and left web chat with nothing startable. `features.signalAgent` is removed from `GET /auth/me`; startup warns while the variable is still set.

--- a/services/api/package.json
+++ b/services/api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@indexnetwork/api",
-  "version": "0.88.1",
+  "version": "0.88.2",
   "license": "MIT",
   "private": true,
   "scripts": {

--- a/services/api/src/services/tests/chat.service.isolated.ts
+++ b/services/api/src/services/tests/chat.service.isolated.ts
@@ -68,7 +68,6 @@ mock.module("../../adapters/checkpointer.adapter", () => ({
 }));
 
 afterEach(() => {
-  delete process.env.WEB_SIGNAL_AGENT_ENABLED;
   delete process.env.WEB_AGENT_SURFACE_ENABLED;
 });
 
@@ -356,8 +355,7 @@ describe("ChatSessionService.resolveStreamPersonaPolicy", () => {
   });
 
   it("rejects a requested persona that contradicts the persisted one", () => {
-    process.env.WEB_SIGNAL_AGENT_ENABLED = "true";
-    for (const surface of ["web", "non_web"] as const) {
+    for (const surface of ["web", "agent"] as const) {
       expect(svc.resolveStreamPersonaPolicy({
         surface,
         storedPersona: "onboarding",
@@ -377,8 +375,7 @@ describe("ChatSessionService.resolveStreamPersonaPolicy", () => {
     }
   });
 
-  it("requires an explicit Signal assertion for a new flag-on web chat", () => {
-    process.env.WEB_SIGNAL_AGENT_ENABLED = "true";
+  it("requires an explicit Signal assertion for a new web chat", () => {
 
     const missing = svc.resolveStreamPersonaPolicy({ surface: "web" });
     expect(missing.ok).toBe(false);
@@ -393,7 +390,6 @@ describe("ChatSessionService.resolveStreamPersonaPolicy", () => {
   });
 
   it("inherits a persisted Signal persona without trusting another request assertion", () => {
-    process.env.WEB_SIGNAL_AGENT_ENABLED = "true";
 
     expect(svc.resolveStreamPersonaPolicy({
       surface: "web",
@@ -478,7 +474,7 @@ describe("ChatSessionService.resolveStreamPersonaPolicy", () => {
       requestedPersona: "reporter",
     })).toEqual({ ok: true, persona: "reporter" });
     expect(svc.resolveStreamPersonaPolicy({
-      surface: "non_web",
+      surface: "agent",
       requestedPersona: "reporter",
     })).toMatchObject({
       ok: false,
@@ -507,9 +503,8 @@ describe("ChatSessionService.resolveStreamPersonaPolicy", () => {
   });
 
   it("leaves the separate negotiator persona unchanged", () => {
-    process.env.WEB_SIGNAL_AGENT_ENABLED = "true";
     expect(svc.resolveStreamPersonaPolicy({
-      surface: "non_web",
+      surface: "agent",
       requestedPersona: "negotiator",
     })).toEqual({ ok: true, persona: "negotiator" });
   });


### PR DESCRIPTION
`chat.service.isolated.ts` still set `WEB_SIGNAL_AGENT_ENABLED` and passed `surface: "non_web"` — a flag and a surface that #1402 removed.

The tests passed either way, because `"non_web"` is neither `'onboarding'` nor `'web'` and so fell through to the same policy branch as `"agent"`. They asserted correct behaviour by accident. After the rename they assert it on purpose:

- `surface: "agent"` + `requestedPersona: "reporter"` → 403 `WEB_AGENT_PERSONA_FORBIDDEN`
- `surface: "agent"` + `requestedPersona: "negotiator"` → allowed
- `["web", "agent"]` + `storedPersona: "onboarding"` → 403 `WEB_ONBOARDING_PERSONA_FORBIDDEN`

## Why nothing caught it

`services/api/tsconfig.json` excludes `src/**/*.isolated.ts` (alongside `*.spec.ts` / `*.test.ts`). Isolated specs are therefore outside the type safety net: a string literal naming a removed member of `ChatStreamSurface` type-checks fine because it is never type-checked at all.

That's worth knowing beyond this cleanup — it's a general blind spot for isolated tests, not a one-off. Un-excluding them is likely a real (and larger) piece of work; flagging rather than attempting it here.

## Validation

- `chat.service.isolated.ts` 45 pass / 0 fail — unchanged count, so nothing was silently dropped
- `services/api` `bunx tsc --noEmit` clean
- `bun run lint` 0 errors (438 pre-existing warnings)

`services/api` 0.88.1 → 0.88.2 with a matching changelog line.

> No human has reviewed this. Green checks are the only signal it carries.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
