### PR TITLE
docs(env): warn that protocol_prod names the data, not the environment

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -44,6 +44,14 @@
 ########################################
 
 # Postgres connection
+# Neon naming caution: every Neon branch (production, dev, local-dev alike)
+# hosts a `protocol_prod` database holding a copy of real user data. The name
+# marks the DATA, not the environment — it drives the fail-closed guard in
+# services/api/src/lib/drizzle/test-database-readiness.ts and must not be
+# renamed. Never infer "this is production" from the database name (check the
+# Neon branch/endpoint instead; see docs/guides/development-reference.md,
+# "Neon Database Topology"), and never report fork query results as production
+# numbers. Tests use the empty disposable `neondb` on the same branch.
 DATABASE_URL=postgresql://username:password@localhost:5432/protocol_db
 
 # Server (PORT is also read by the apps/web preview server)


### PR DESCRIPTION
Every Neon branch (production, dev, local-dev alike) carries a `protocol_prod` database holding a copy of real user data. The name marks the **data**, not the environment — it drives the fail-closed guard in `test-database-readiness.ts` and must not be renamed. That same naming led to fork query results being reported as production numbers.

This adds a caution next to `DATABASE_URL` in the canonical `.env.example`: never infer environment from the database name (check the Neon branch/endpoint via the topology map in `docs/guides/development-reference.md`), and tests use the disposable `neondb` on the same branch.

No variable lines added or changed — `env-example-drift.spec.ts` only parses `VAR=` lines, so the schema sync check is unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)