### PR TITLE
docs(specs): repair path references the protocol renames left behind

### DIFF
--- a/docs/specs/2026-05-12-discover-opportunities-rename-design.md
+++ b/docs/specs/2026-05-12-discover-opportunities-rename-design.md
@@ -32,7 +32,7 @@ The misnamed tool reads as "make me some opportunities," when the actual semanti
 ### What is renamed
 
 - `"create_opportunities"` (snake_case string literal) → `"discover_opportunities"` everywhere it appears as:
-  - MCP tool `name` field (canonical definition in `packages/protocol/src/opportunity/opportunity.tools.ts`)
+  - MCP tool `name` field (canonical definition in `packages/protocol/src/opportunities/application/opportunity.tools.ts`)
   - Tool-call assertions in tests (`hasToolCall(..., "create_opportunities")`, `t.name === "create_opportunities"`)
   - Prompt module triggers (`triggers: ["create_opportunities", ...]`)
   - Cross-tool references in description strings (`contact.tools.ts`, `intent.tools.ts`, `network.tools.ts`, `utility.tools.ts`)
@@ -62,7 +62,7 @@ See IND-270 for the full inventory. High-level groups:
 
 - **Protocol tool layer**: `opportunity/opportunity.tools.ts`, `chat/chat.agent.ts`, `chat/chat.prompt.ts`, `chat/chat.prompt.modules.ts`, `contact/contact.tools.ts`, `intent/intent.tools.ts`, `network/network.tools.ts`, `shared/agent/utility.tools.ts`, `opportunity/opportunity.discover.ts`, `opportunity/opportunity.graph.ts`, `opportunity/opportunity.state.ts`
 - **Protocol tests**: `chat/tests/chat.prompt.modules.spec.ts`, `chat/tests/chat.prompt.spec.ts`, `chat/tests/chat.agent.spec.ts`, `chat/tests/chat.graph.mocks.ts`, `opportunity/tests/opportunity.state.dedupAlreadyAccepted.spec.ts`, `shared/agent/tests/tool.factory.spec.ts`
-- **Backend tests**: `services/api/src/controllers/tests/tool.controller.spec.ts`, `services/api/tests/mcp.spec.ts`
+- **Backend tests**: `services/api/src/controllers/tests/tool.controller.contract.spec.ts`, `services/api/tests/mcp.spec.ts`
 - **CLI**: `packages/cli/src/opportunity.command.ts`, `packages/cli/src/output/base.ts`, `packages/cli/tests/opportunity.command.spec.ts`, `packages/cli/tests/tool-calls.spec.ts`
 - **Frontend**: `apps/web/src/components/chat/ToolCallsDisplay.tsx`
 - **Plugins**: `packages/claude-plugin/skills/index-orchestrator/SKILL.md`
@@ -83,7 +83,7 @@ See IND-270 for the full inventory. High-level groups:
   - `bun test src/chat/tests/chat.prompt.modules.spec.ts`
   - `bun test src/chat/tests/chat.prompt.spec.ts`
   - `bun test src/chat/tests/chat.agent.spec.ts`
-  - `bun test src/controllers/tests/tool.controller.spec.ts` (in backend)
+  - `bun test src/controllers/tests/tool.controller.contract.spec.ts` (in backend)
   - `bun test tests/mcp.spec.ts` (in backend)
   - `bun test tests/opportunity.command.spec.ts` (in packages/cli)
   - `bun test tests/tool-calls.spec.ts` (in packages/cli)

--- a/docs/specs/2026-07-30-fast-signal-intake-design.md
+++ b/docs/specs/2026-07-30-fast-signal-intake-design.md
@@ -32,7 +32,7 @@ question wording (`packages/protocol/src/questions/application/question.ask.tool
 Synthesis is a fourth pro turn that calls `create_intent`, which invokes the
 **profile graph** and then the **intent graph** (inference → verification) before
 a proposal card can render
-(`packages/protocol/src/signals/application/intent.tools.ts`).
+(`packages/protocol/src/intents/application/intent.tools.ts`).
 
 Two structural observations drive this design:
 
@@ -154,7 +154,7 @@ the profile-graph invocation in the propose path.
 ### Placement
 
 The generator lives in
-`packages/protocol/src/signals/application/intake.pack.generator.ts` so protocol
+`packages/protocol/src/intents/application/intake.pack.generator.ts` so protocol
 owns synthesis with no host dependencies. The table and queue wiring live in
 `services/api`, preserving the existing protocol/host boundary.
 
@@ -232,9 +232,9 @@ place constraint, and must not be rendered into the `Where constraint:` slot.
 
 ### Modules
 
-- `packages/protocol/src/signals/application/intake.pack.generator.ts` — brief and
+- `packages/protocol/src/intents/application/intake.pack.generator.ts` — brief and
   round-1 question, structured output, no tools.
-- `packages/protocol/src/signals/application/intake.orchestrator.ts` — pure stage
+- `packages/protocol/src/intents/application/intake.orchestrator.ts` — pure stage
   logic: next-question generation, synthesis, `whereText` invalidation. Takes
   ports for pack read, proposal creation, and the intent graph. Owns no I/O.
 - `services/api/src/controllers/intent-intake.controller.ts` — the five endpoints,

--- a/docs/specs/2026-08-02-configurable-intake-questions-design.md
+++ b/docs/specs/2026-08-02-configurable-intake-questions-design.md
@@ -72,7 +72,7 @@ behavior.
 **Server — `services/api/src/services/signal-intake.service.ts` +
 `intent-intake.controller.ts`:** thin per-endpoint wrappers; no funnel state.
 
-**Protocol — `packages/protocol/src/signals/application/intake.orchestrator.ts`:**
+**Protocol — `packages/protocol/src/intents/application/intake.orchestrator.ts`:**
 `nextQuestion({ brief, whoAnswer })` → one `IntakePackQuestion`;
 `synthesize(...)` → `{ description, lookingFor, youBring }` from a fixed
 two-answer prompt. Structured-output models with static fallbacks


### PR DESCRIPTION
Three protocol capability renames landed on `dev` in quick succession — #1408 (`refactor(protocol)!: name capability directories for what the code says`), #1411 (test layout), #1412 (`shared/hyde` → `discovery`). They updated the code and their own docs, but not the older design specs pointing into the renamed directories. `docs/specs/` is normative per the Development Reference, so these paths misdirect anyone following them.

Found while verifying that a separate PR's own path references survived those renames.

### Fixed

| Was | Now | Refs |
|---|---|---|
| `packages/protocol/src/signals/application/` | `packages/protocol/src/intents/application/` | 4 |
| `packages/protocol/src/opportunity/opportunity.tools.ts` | `packages/protocol/src/opportunities/application/opportunity.tools.ts` | 1 |
| `services/api/src/controllers/tests/tool.controller.spec.ts` | `…/tool.controller.contract.spec.ts` | 2 |

The last one is unrelated to the protocol work — it was renamed in #1171 and missed since.

Files: `2026-05-12-discover-opportunities-rename-design.md`, `2026-07-30-fast-signal-intake-design.md`, `2026-08-02-configurable-intake-questions-design.md`.

### Method

Each stale path was resolved by locating the current file and confirming exactly one candidate, not by blanket find-and-replace — the `opportunity.tools.ts` case proves the point, since it moved into `application/` as well as being renamed, so a directory-only substitution would have produced a second wrong path.

### Verification

Every repo-relative path in all of `docs/specs/` now resolves on disk:

```
grep -rhoE "\b(packages|services|apps|scripts)/[^ ]+\.(ts|tsx|md|json|mjs|sh)" docs/specs/ \
  | sort -u | while read p; do [ -e "$p" ] || echo "STALE $p"; done
```

Clean, with one deliberate exception below. Docs-only diff — no code, no config, no version bump.

### Deliberately not fixed

`packages/openclaw-plugin/**` (7 refs across `2026-05-06-expose-introducer-opportunities-to-pollers-design.md`, `2026-05-06-seren-formatting-design.md`, `2026-05-06-welcome-message-design.md`). That package was **deliberately removed** in `903949442`, so there is no correct path to point at. Whether those three specs should be archived, deleted, or annotated as describing extracted code is a content call for a human, not a path repair.

**Nothing has reviewed this PR.** There is no automated reviewer on this project — green checks are the only signal it carries.

🤖 Generated with [Claude Code](https://claude.com/claude-code)