### PR TITLE
docs(design): drop the removed eval:verify gate from the protocol gate baseline

### DIFF
--- a/docs/design/protocol-architecture-gates.md
+++ b/docs/design/protocol-architecture-gates.md
@@ -37,8 +37,14 @@ The audit recorded these commands at the audited commit:
 | --- | --- | --- |
 | Package build | `cd packages/protocol && bun run build` | PASS |
 | Package lint | `bunx eslint packages/protocol/src --format stylish` | PASS with 0 errors, 251 warnings |
-| Provider-free eval gate | `cd packages/protocol && env -u OPENROUTER_API_KEY -u OPENAI_API_KEY bun run eval:verify` | PASS: 9 suite inventories, type-checks, and provider-free tests |
 | Isolated source tests | `cd packages/protocol && env -u OPENROUTER_API_KEY -u OPENAI_API_KEY TEST_CONCURRENCY=4 bun run test:isolated` | Recorded baseline: 2,150 pass, 30 fail, 0 errors across 198 files in 303.5s |
+
+The audit also recorded a provider-free eval gate (`bun run eval:verify`). That
+gate no longer exists: #1419 removed the eval system, archived at
+`archive/eval-2026-08-16`, and the follow-up review (`d51b6097d`) deliberately
+restored only `services/api`'s `typecheck:specs` and the CLI test job — not
+`eval:verify`. Nothing currently checks that protocol source-path references
+from outside `src/` still resolve.
 
 ### IND-514 branch result
 


### PR DESCRIPTION
`bun run eval:verify` no longer exists — #1419 removed the eval system (archived at `archive/eval-2026-08-16`) and the follow-up review (`d51b6097d`) deliberately restored only `services/api`'s `typecheck:specs` and the CLI test job, not the eval gate.

`docs/design/protocol-architecture-gates.md` still listed it in the credential-free baseline table, pointing readers at a script that is gone. That row is replaced with a note recording the removal and the gap it leaves: nothing now checks that protocol source-path references from outside `src/` still resolve. That gap is not hypothetical — it is what caught the stale `eval/ops` env-flag pins and a stale import during #1418.

## Deliberately not changed

The other 15 `eval:verify` mentions are all dated artifacts that record what passed at a point in time, and rewriting them would falsify the record:

- six `docs/research/*validation-receipt*.md` files
- `docs/design/protocol-package-audit.html` (a point-in-time audit report — it records a FAIL row alongside the passes)
- dated plans and specs under `docs/plans/`, `docs/specs/`, and `docs/superpowers/`

## Separate finding, not fixed here

The same document's "Capability facades" section describes `src/capabilities/*.facade.ts` as providing the outward contracts. That directory no longer exists and there are zero `*.facade.ts` files in `packages/protocol/src` — the facades were collapsed into one `index.ts` barrel per capability. Correcting that means rewriting architecture prose rather than deleting a dead command, so it is left for a deliberate pass.

Docs-only; no code, tests, or package versions touched.