### PR TITLE
feat(hermes-plugin): pending pickup injects a Hermes A2A turn

### DIFF
--- a/apps/mac/Sources/HermesRuntime.swift
+++ b/apps/mac/Sources/HermesRuntime.swift
@@ -1063,11 +1063,19 @@ private final class HermesEnvironmentFile {
     }
 
     func removeOwnedValues() throws {
-        let keys = Set(Self.ownedKeys)
+        try removeKeys(Self.ownedKeys)
+    }
+
+    func removeKeys(_ keys: [String]) throws {
+        let allowed = Set(Self.ownedKeys)
+        guard keys.allSatisfy({ allowed.contains($0) }) else {
+            throw HermesRuntimeFailure.invalidArguments
+        }
+        let drop = Set(keys)
         try mutate { lines in
             lines.removeAll { line in
                 guard let separator = line.firstIndex(of: "=") else { return false }
-                return keys.contains(String(line[..<separator]))
+                return drop.contains(String(line[..<separator]))
             }
         }
     }
@@ -1545,12 +1553,10 @@ final class HermesRuntimeManager {
     }
 
     private func cronOwnership(_ installation: HermesInstallationRecord) throws -> HermesCronOwnership? {
-        let fields = [
-            installation.currentCronJobId,
-            installation.currentOwnerId,
-            installation.currentCronSetupAttemptId,
-        ]
-        if fields.allSatisfy({ $0 == nil }) { return nil }
+        if validValue(installation.currentCronJobId) == nil
+            && validValue(installation.currentCronSetupAttemptId) == nil {
+            return nil
+        }
         guard let jobId = validValue(installation.currentCronJobId),
               let ownerId = validValue(installation.currentOwnerId),
               let setupAttemptId = validValue(installation.currentCronSetupAttemptId) else {
@@ -1835,15 +1841,9 @@ final class HermesRuntimeManager {
                 && (journal.setupAttemptId != installation.currentSetupAttemptId
                     || journal.ownerId != installation.currentOwnerId
                     || journal.executorId != installation.currentExecutorId)
-            let cronPublishedStages: Set<HermesSetupStage> = [
-                .scheduleDisabled, .enabling, .awaitingHeartbeat,
-                .disconnecting, .disconnectCleanupComplete,
-            ]
             let mismatchedCronFence = journal.cronJobId != nil
                 && journal.cronJobId != installation.currentCronJobId
-            let missingCronFence = cronPublishedStages.contains(journal.stage)
-                && journal.cronJobId == nil
-            if generationMismatch || mismatchedCronFence || missingCronFence {
+            if generationMismatch || mismatchedCronFence {
                 if let ownership = try cronOwnership(installation) {
                     try quarantineAttributableCron(ownership)
                 }
@@ -1899,58 +1899,17 @@ final class HermesRuntimeManager {
             throw HermesRuntimeFailure.invalidArguments
         }
 
-        // Resolve a historical job once before publishing the new generation.
-        // A pre-owner record has no owner with which to construct ordinary
-        // ownership, so its one explicit rebind path runs first and accepts only
-        // a paused immutable ID with exact installation + old-generation markers
-        // and the shipping sandbox. Every attributed generation then uses the
-        // ordinary strict owner validation below.
+        // Resolve a leftover owned job once so configure can pause and remove it.
+        // SSE keepalive already stamps the seat; this Mac must not also run the
+        // historical 1-minute Personal Agent cron.
         try adoptLegacyCronIfNeeded(installation: &installation, store: store)
-        var priorCron: HermesCronJob?
-        let preOwnerGeneration = validValue(installation.currentSetupAttemptId)
-        let preOwnerRecord = preOwnerGeneration != nil
-            && installation.currentOwnerId == nil
-            && installation.currentExecutorId == nil
-        if preOwnerRecord {
-            guard try store.loadJournal() == nil,
-                  let jobId = validValue(installation.currentCronJobId),
-                  installation.currentCronSetupAttemptId == preOwnerGeneration else {
-                throw HermesRuntimeFailure.installationStoreInvalid
-            }
-            let candidate = try cronStore.preOwnerRebindJob(
-                jobId: jobId,
-                installationId: installation.installationId,
-                setupAttemptId: preOwnerGeneration!
-            )
-            guard isExactOwnedCron(candidate)
-                    || isExactHistoricalPreOwnerCron(
-                        candidate,
-                        installationId: installation.installationId,
-                        setupAttemptId: preOwnerGeneration!
-                    ) else {
-                throw HermesRuntimeFailure.cronStoreInvalid
-            }
-            priorCron = candidate
-        } else {
-            guard installation.currentOwnerId == nil
-                    || installation.currentOwnerId == ownerId else {
-                throw HermesRuntimeFailure.ownerMismatch
-            }
-            if let ownership = try cronOwnership(installation) {
-                let inventory = try cronStore.inventory(ownership: ownership)
-                if !inventory.isExact
-                    || inventory.ownedJob.map({ isExactOwnedCron($0) }) != true {
-                    try quarantineAttributableCron(ownership)
-                }
-                guard let stored = try cronStore.job(id: ownership.jobId) else {
-                    throw HermesRuntimeFailure.cronStoreInvalid
-                }
-                priorCron = stored
-            }
+        guard installation.currentOwnerId == nil
+                || installation.currentOwnerId == ownerId else {
+            throw HermesRuntimeFailure.ownerMismatch
         }
 
         // Journal first: a crash after this point makes relaunch inspection
-        // pause any owned schedule before JavaScript performs server rollback.
+        // pause any leftover schedule before JavaScript performs server rollback.
         try saveStage(
             .preparing, owner: ownerId, attempt: setupAttemptId,
             executor: executorId, cronJobId: installation.currentCronJobId, store: store
@@ -1961,8 +1920,11 @@ final class HermesRuntimeManager {
         try store.saveInstallation(installation)
 
         let hermes = try requireHermesBinary()
-        if priorCron?.enabled == true {
-            try pauseCronByID(hermes, jobId: priorCron!.id)
+        if let jobId = validValue(installation.currentCronJobId),
+           try cronStore.job(id: jobId)?.enabled == true {
+            try pauseCronByID(hermes, jobId: jobId)
+        } else if let leftover = try cronStore.legacyJob(), leftover.enabled {
+            try pauseCronByID(hermes, jobId: leftover.id)
         }
 
         do {
@@ -1972,8 +1934,8 @@ final class HermesRuntimeManager {
                 ("INDEX_MCP_URL", AppConfig.trimTrailingSlash(AppConfig.apiURL) + "/mcp"),
                 ("INDEX_AGENT_ID", executorId),
                 ("INDEX_INSTALLATION_ID", installation.installationId),
-                ("INDEX_PLUGIN_MODE", "negotiator"),
             ])
+            try environment.removeKeys(["INDEX_PLUGIN_MODE"])
         } catch let failure as HermesRuntimeFailure {
             throw failure
         } catch {
@@ -1991,16 +1953,14 @@ final class HermesRuntimeManager {
             executor: executorId, store: store
         )
 
-        try reconcileDisabledCron(
+        try removeLeftoverOwnedCron(
             hermes,
             installation: &installation,
-            ownerId: ownerId,
-            setupAttemptId: setupAttemptId,
             store: store
         )
         try saveStage(
             .scheduleDisabled, owner: ownerId, attempt: setupAttemptId,
-            executor: executorId, cronJobId: installation.currentCronJobId, store: store
+            executor: executorId, cronJobId: nil, store: store
         )
 
         return try success(request, stage: HermesSetupStage.scheduleDisabled.rawValue)
@@ -2033,39 +1993,21 @@ final class HermesRuntimeManager {
             throw HermesRuntimeFailure.installationStoreInvalid
         }
 
-        guard let (_, job) = try verifiedOwnedCron(installation: installation) else {
-            throw HermesRuntimeFailure.cronStoreInvalid
-        }
         if let stage = alreadyEnabledCurrentGeneration(
             journal: journal,
-            attempt: expectedSetupAttemptId,
-            job: job
+            attempt: expectedSetupAttemptId
         ) {
             return try success(request, stage: stage)
         }
 
         try saveStage(
             .enabling, owner: ownerId, attempt: expectedSetupAttemptId,
-            executor: executor, cronJobId: job.id, store: store
+            executor: executor, store: store
         )
         let hermes = try requireHermesBinary()
-        if !job.enabled {
-            let resume = try runner.run(executable: hermes, arguments: ["cron", "resume", job.id])
-            guard resume.status == 0 else { throw HermesRuntimeFailure.cronResumeFailed }
-            guard let (_, resumed) = try verifiedOwnedCron(installation: installation),
-                  resumed.id == job.id,
-                  resumed.enabled == true else {
-                throw HermesRuntimeFailure.cronResumeFailed
-            }
-        }
-
         do {
             try startOrRestartGateway(hermes)
         } catch let failure as HermesRuntimeFailure {
-            // Retain the enabling journal for relaunch recovery. A gateway
-            // failure is safe only after the exact resumed job is confirmed
-            // paused; otherwise report a distinct retryable rollback failure.
-            try rollbackActivation(hermes, job: job)
             switch failure {
             case .gatewayStatusFailed, .commandTimedOut:
                 throw failure
@@ -2073,12 +2015,11 @@ final class HermesRuntimeManager {
                 throw HermesRuntimeFailure.gatewayFailed
             }
         } catch {
-            try rollbackActivation(hermes, job: job)
             throw HermesRuntimeFailure.gatewayFailed
         }
         try saveStage(
             .awaitingHeartbeat, owner: ownerId, attempt: expectedSetupAttemptId,
-            executor: executor, cronJobId: job.id, store: store
+            executor: executor, store: store
         )
         return try success(request, stage: HermesSetupStage.awaitingHeartbeat.rawValue)
     }
@@ -2092,29 +2033,10 @@ final class HermesRuntimeManager {
             && job.enabledToolsets == [Self.ownedCronToolset]
     }
 
-    private func isExactHistoricalPreOwnerCron(
-        _ job: HermesCronJob,
-        installationId: String,
-        setupAttemptId: String
-    ) -> Bool {
-        job.name == Self.ownedCronName
-            && job.schedule == Self.ownedCronSchedule
-            && job.prompt == Self.historicalPreOwnerCronPrompt
-            && job.skills.isEmpty
-            && job.legacySkill == nil
-            && job.enabledToolsets.isEmpty
-            && job.appInstallationId == installationId
-            && job.appOwnerId == nil
-            && job.appSetupAttemptId == setupAttemptId
-            && !job.enabled
-    }
-
     private func alreadyEnabledCurrentGeneration(
         journal: HermesSetupJournal?,
-        attempt: String,
-        job: HermesCronJob
+        attempt: String
     ) -> String? {
-        guard job.enabled else { return nil }
         if journal == nil { return "confirmed_healthy" }
         guard journal?.setupAttemptId == attempt,
               journal?.stage == .awaitingHeartbeat else { return nil }
@@ -2148,13 +2070,7 @@ final class HermesRuntimeManager {
         }
 
         // Invocation of confirmHealthy is the JS saga's attestation that the
-        // backend observed an active pickup heartbeat for this generation. The
-        // immutable job and sandbox are reverified before recovery evidence is
-        // cleared, closing the enable-to-heartbeat tamper window.
-        guard let (_, job) = try verifiedOwnedCron(installation: installation),
-              job.enabled else {
-            throw HermesRuntimeFailure.cronStoreInvalid
-        }
+        // backend observed an active pickup heartbeat for this generation.
         try store.deleteJournal()
         return try success(request, stage: "confirmed_healthy")
     }
@@ -2179,18 +2095,15 @@ final class HermesRuntimeManager {
         installation: HermesInstallationRecord
     ) throws {
         try verifyNoEnabledAttributableCron(installation: installation)
-        if let ownership = try cronOwnership(installation) {
-            let inventory = try cronStore.inventory(ownership: ownership)
-            guard inventory.isExact,
-                  let job = inventory.ownedJob,
-                  isExactOwnedCron(job),
-                  job.enabled == false else {
-                throw HermesRuntimeFailure.cronStoreInvalid
-            }
-        } else {
-            guard try cronStore.markedJobs(installationId: installation.installationId).isEmpty else {
-                throw HermesRuntimeFailure.cronStoreInvalid
-            }
+        if try cronStore.legacyJob() != nil {
+            throw HermesRuntimeFailure.cronStoreInvalid
+        }
+        if let storedId = validValue(installation.currentCronJobId),
+           try cronStore.job(id: storedId) != nil {
+            throw HermesRuntimeFailure.cronStoreInvalid
+        }
+        guard try cronStore.markedJobs(installationId: installation.installationId).isEmpty else {
+            throw HermesRuntimeFailure.cronStoreInvalid
         }
         let env = try environment.values()
         guard env["INDEX_API_KEY"] == nil,
@@ -2209,11 +2122,10 @@ final class HermesRuntimeManager {
             return try success(request, stage: "disable_noop")
         }
         try adoptLegacyCronIfNeeded(installation: &installation, store: store)
-        guard let (_, job) = try verifiedOwnedCron(installation: installation) else {
-            return try success(request, stage: "disabled")
-        }
-        if job.enabled {
-            try pauseCronByID(try requireHermesBinary(), jobId: job.id)
+        if let hermes = availableHermesBinary() {
+            try removeLeftoverOwnedCron(hermes, installation: &installation, store: store)
+        } else if try leftoverOwnedCronPresent(installation: installation) {
+            throw HermesRuntimeFailure.hermesNotFound
         }
         try verifyNoEnabledAttributableCron(installation: installation)
         return try success(request, stage: "disabled")
@@ -2244,8 +2156,10 @@ final class HermesRuntimeManager {
         var pendingFailure: HermesRuntimeFailure?
         do {
             try adoptLegacyCronIfNeeded(installation: &installation, store: store)
-            if let (_, job) = try verifiedOwnedCron(installation: installation), job.enabled {
-                try pauseCronByID(try requireHermesBinary(), jobId: job.id)
+            if let hermes = availableHermesBinary() {
+                try removeLeftoverOwnedCron(hermes, installation: &installation, store: store)
+            } else if try leftoverOwnedCronPresent(installation: installation) {
+                throw HermesRuntimeFailure.hermesNotFound
             }
             try verifyNoEnabledAttributableCron(installation: installation)
         } catch let failure as HermesRuntimeFailure {
@@ -2331,11 +2245,6 @@ final class HermesRuntimeManager {
             if let disconnectOwnership {
                 let inventory = try cronStore.inventory(ownership: disconnectOwnership)
                 attributableJobs = inventory.attributableJobs
-                // A missing immutable ID with no remaining marker cannot be
-                // proven removed: it may have been renamed and stripped.
-                if inventory.ownedJob == nil && attributableJobs.isEmpty {
-                    pendingFailure = .cronStoreInvalid
-                }
                 try quarantineAttributableCron(disconnectOwnership)
                 attributableJobs = try cronStore.inventory(
                     ownership: disconnectOwnership
@@ -2344,6 +2253,10 @@ final class HermesRuntimeManager {
                 attributableJobs = try cronStore.markedJobs(
                     installationId: installation.installationId
                 )
+            }
+            if let leftover = try cronStore.legacyJob(),
+               !attributableJobs.contains(where: { $0.id == leftover.id }) {
+                attributableJobs.append(leftover)
             }
         } catch let failure as HermesRuntimeFailure {
             if pendingFailure == nil { pendingFailure = failure }
@@ -2496,105 +2409,41 @@ final class HermesRuntimeManager {
         guard result.status == 0 else { throw failure }
     }
 
-    private func reconcileDisabledCron(
-        _ hermes: String,
-        installation: inout HermesInstallationRecord,
-        ownerId: String,
-        setupAttemptId: String,
-        store: HermesLocalStore
-    ) throws {
-        let job: HermesCronJob
-        if let storedId = installation.currentCronJobId {
-            guard let stored = try cronStore.job(id: storedId) else {
-                throw HermesRuntimeFailure.cronStoreInvalid
-            }
-            job = stored
-        } else {
-            guard try cronStore.markedJobs(
-                installationId: installation.installationId
-            ).isEmpty else {
-                throw HermesRuntimeFailure.cronStoreInvalid
-            }
-            if let legacy = try cronStore.legacyJob() {
-                job = legacy
-            } else {
-                let created = try runner.run(
-                    executable: hermes,
-                    arguments: [
-                        "cron", "create", Self.ownedCronSchedule, Self.ownedCronPrompt,
-                        "--name", Self.ownedCronName,
-                    ]
-                )
-                guard created.status == 0,
-                      let createdJob = try cronStore.legacyJob() else {
-                    throw HermesRuntimeFailure.cronCreateFailed
-                }
-                job = createdJob
-            }
+    private func leftoverOwnedCronPresent(
+        installation: HermesInstallationRecord
+    ) throws -> Bool {
+        if let storedId = validValue(installation.currentCronJobId),
+           try cronStore.job(id: storedId) != nil {
+            return true
         }
-
-        // Persist the generated/adopted immutable ID and its generation before
-        // the first pause/edit. A crash can therefore never force a later
-        // display-name lookup.
-        installation.currentCronJobId = job.id
-        installation.currentCronSetupAttemptId = setupAttemptId
-        try store.saveInstallation(installation)
-        if let journal = try store.loadJournal(),
-           journal.setupAttemptId == setupAttemptId {
-            try store.saveJournal(HermesSetupJournal(
-                setupAttemptId: journal.setupAttemptId,
-                stage: journal.stage,
-                ownerId: journal.ownerId,
-                executorId: journal.executorId,
-                cronJobId: job.id
-            ))
-        }
-        let ownership = HermesCronOwnership(
-            jobId: job.id,
-            installationId: installation.installationId,
-            ownerId: ownerId,
-            setupAttemptId: setupAttemptId
-        )
-
-        if job.enabled { try pauseCronByID(hermes, jobId: job.id) }
-        let edited = try runner.run(
-            executable: hermes,
-            arguments: [
-                "cron", "edit", job.id,
-                "--schedule", Self.ownedCronSchedule,
-                "--prompt", Self.ownedCronPrompt,
-                "--name", Self.ownedCronName,
-            ]
-        )
-        guard edited.status == 0 else { throw HermesRuntimeFailure.cronEditFailed }
-
-        // Hermes CLI supports skill attachment but not enabled_toolsets or our
-        // marker fence. Update all of them under the official cron store lock.
-        try cronStore.enforceOwnedSandbox(ownership: ownership)
-        var inventory = try cronStore.inventory(ownership: ownership)
-        guard inventory.isExact, let reconciled = inventory.ownedJob else {
-            try quarantineAttributableCron(ownership)
-            throw HermesRuntimeFailure.cronStoreInvalid
-        }
-        if reconciled.enabled {
-            try pauseCronByID(hermes, jobId: reconciled.id)
-            inventory = try cronStore.inventory(ownership: ownership)
-        }
-        guard inventory.isExact,
-              let verified = inventory.ownedJob,
-              isExactOwnedCron(verified),
-              verified.enabled == false else {
-            try quarantineAttributableCron(ownership)
-            throw HermesRuntimeFailure.cronStoreInvalid
-        }
+        return try cronStore.legacyJob() != nil
     }
 
-    private func rollbackActivation(_ hermes: String, job: HermesCronJob) throws {
-        do {
-            try pauseCronByID(hermes, jobId: job.id)
-        } catch {
-            throw HermesRuntimeFailure.activationRollbackFailed
+    private func removeLeftoverOwnedCron(
+        _ hermes: String,
+        installation: inout HermesInstallationRecord,
+        store: HermesLocalStore
+    ) throws {
+        var ids = Set<String>()
+        if let storedId = validValue(installation.currentCronJobId) {
+            ids.insert(storedId)
         }
+        if let leftover = try cronStore.legacyJob() {
+            ids.insert(leftover.id)
+        }
+        for jobId in ids {
+            guard try cronStore.job(id: jobId) != nil else { continue }
+            let removed = try runner.run(
+                executable: hermes,
+                arguments: ["cron", "remove", jobId]
+            )
+            guard try removed.status == 0 || cronStore.job(id: jobId) == nil else {
+                throw HermesRuntimeFailure.cronRemoveFailed
+            }
+        }
+        installation.currentCronJobId = nil
+        installation.currentCronSetupAttemptId = nil
+        try store.saveInstallation(installation)
     }
 
     private func gatewayState(_ hermes: String) throws -> HermesGatewayState {

--- a/apps/mac/Sources/HermesSetup.swift
+++ b/apps/mac/Sources/HermesSetup.swift
@@ -57,11 +57,24 @@ enum HermesSetup {
         if status != 0 {
             return ["ok": false, "error": "hermes \(args.joined(separator: " ")): \(String(output.suffix(300)))"]
         }
-        // The plugin self-installs its Hermes Desktop bundle into
-        // ~/.hermes/desktop-plugins when the gateway loads it (see the
-        // plugin's __init__.py), so the restart below covers the desktop app.
+        // Point Hermes Desktop at the plugin's desktop/dist without waiting
+        // for gateway register() to copy it (see plugin __init__.py).
+        linkDesktopPlugin()
         restartGatewayIfRunning(hermes)
         return ["ok": true]
+    }
+
+    /// ~/.hermes/desktop-plugins/index-network → plugins/index-network/desktop/dist
+    private static func linkDesktopPlugin() {
+        let home = NSHomeDirectory() + "/.hermes"
+        let dest = home + "/desktop-plugins/index-network"
+        let src = home + "/plugins/index-network/desktop/dist"
+        let fm = FileManager.default
+        guard fm.fileExists(atPath: src + "/plugin.js") else { return }
+        try? fm.createDirectory(
+            atPath: home + "/desktop-plugins", withIntermediateDirectories: true)
+        try? fm.removeItem(atPath: dest)
+        try? fm.createSymbolicLink(atPath: dest, withDestinationPath: src)
     }
 
     /// Plugins only load at gateway startup: if a gateway is running, bounce

--- a/apps/mac/Tests/HermesPersistenceCompatibility.swift
+++ b/apps/mac/Tests/HermesPersistenceCompatibility.swift
@@ -52,6 +52,8 @@ private final class FixtureRunner: HermesCommandRunning {
                 job["state"] = "paused"
                 job["enabled"] = false
             }
+        } else if arguments.starts(with: ["cron", "remove"]), arguments.count == 3 {
+            try deleteJob(id: arguments[2])
         } else if arguments.starts(with: ["cron", "edit"]), arguments.count >= 3 {
             let id = arguments[2]
             try mutateJob(id: id) { job in
@@ -84,6 +86,18 @@ private final class FixtureRunner: HermesCommandRunning {
             throw FixtureFailure.assertion("runner could not find cron job \(id)")
         }
         mutation(&jobs[index])
+        root["jobs"] = jobs
+        try JSONSerialization.data(withJSONObject: root, options: [.prettyPrinted, .sortedKeys])
+            .write(to: jobsURL, options: .atomic)
+    }
+
+    private func deleteJob(id: String) throws {
+        let data = try Data(contentsOf: jobsURL)
+        guard var root = try JSONSerialization.jsonObject(with: data) as? [String: Any],
+              var jobs = root["jobs"] as? [[String: Any]] else {
+            throw FixtureFailure.assertion("runner could not read cron store")
+        }
+        jobs.removeAll { $0["id"] as? String == id }
         root["jobs"] = jobs
         try JSONSerialization.data(withJSONObject: root, options: [.prettyPrinted, .sortedKeys])
             .write(to: jobsURL, options: .atomic)
@@ -196,9 +210,9 @@ struct HermesPersistenceCompatibilityFixture {
         let reloadedStore = try HermesLocalStore(applicationSupportURL: layout.applicationSupport)
         let reloaded = try reloadedStore.loadOrCreateInstallation()
         try require(reloaded.installationId == "installation-old", "reload changed installation ID")
-        try require(reloaded.currentCronJobId == historicalCronID, "reload changed immutable cron ID")
+        try require(reloaded.currentCronJobId == nil, "configure left a leftover cron ID")
         try require(reloaded.currentSetupAttemptId == "attempt-new", "reload lost rebound setup")
-        try require(reloaded.currentCronSetupAttemptId == "attempt-new", "reload lost cron setup marker")
+        try require(reloaded.currentCronSetupAttemptId == nil, "configure left a leftover cron generation")
         try require(reloaded.currentOwnerId == "owner-new", "reload lost owner")
         try require(reloaded.currentExecutorId == "executor-new", "reload lost executor")
 
@@ -216,15 +230,12 @@ struct HermesPersistenceCompatibilityFixture {
         let afterForeignAttempt = try HermesLocalStore(
             applicationSupportURL: layout.applicationSupport
         ).loadOrCreateInstallation()
-        try require(afterForeignAttempt.currentCronJobId == historicalCronID, "foreign rebind changed cron ID")
+        try require(afterForeignAttempt.currentCronJobId == nil, "foreign rebind restored leftover cron")
         try require(afterForeignAttempt.currentSetupAttemptId == "attempt-new", "foreign rebind changed setup")
         try require(afterForeignAttempt.currentOwnerId == "owner-new", "foreign rebind changed owner")
 
-        let cron = try onlyCron(at: layout.jobsURL)
-        try require(cron["id"] as? String == historicalCronID, "cron ID changed during rebind")
-        try require(cron["index_app_installation_id"] as? String == "installation-old", "cron lost installation marker")
-        try require(cron["index_app_owner_id"] as? String == "owner-new", "cron lost owner marker")
-        try require(cron["index_app_setup_attempt_id"] as? String == "attempt-new", "cron lost setup marker")
+        let leftoverCount = try cronJobCount(at: layout.jobsURL)
+        try require(leftoverCount == 0, "leftover Personal Agent cron was not removed")
     }
 
     private static func makeManager(_ layout: FixtureLayout) -> HermesRuntimeManager {
@@ -295,14 +306,13 @@ struct HermesPersistenceCompatibilityFixture {
         )
     }
 
-    private static func onlyCron(at jobsURL: URL) throws -> [String: Any] {
+    private static func cronJobCount(at jobsURL: URL) throws -> Int {
         let data = try Data(contentsOf: jobsURL)
         guard let root = try JSONSerialization.jsonObject(with: data) as? [String: Any],
-              let jobs = root["jobs"] as? [[String: Any]],
-              jobs.count == 1 else {
-            throw FixtureFailure.assertion("cron store did not contain exactly one job")
+              let jobs = root["jobs"] as? [[String: Any]] else {
+            throw FixtureFailure.assertion("cron store was unreadable")
         }
-        return jobs[0]
+        return jobs.count
     }
 
     private static func throwsError(_ body: () throws -> Void) -> Bool {

--- a/apps/mac/api/agent-runtime-saga.mjs
+++ b/apps/mac/api/agent-runtime-saga.mjs
@@ -72,8 +72,8 @@ function requireSelectionNativeResult(result, {
     && state?.executorId === executorId
     && state?.setupAttemptId === setupAttemptId
     && state?.pluginInstalled === true
-    && state?.negotiatorMode === true
-    && state?.schedulePresent === true
+    && state?.negotiatorMode === false
+    && state?.schedulePresent === false
     && state?.scheduleEnabled === scheduleEnabled;
   if (!matches) throw generationMismatch(command, successful);
   return successful;
@@ -436,7 +436,7 @@ export async function runHermesSelectionSaga({
       await nativeRuntime('enable', { ownerId, setupAttemptId }, { signal }),
       {
         command: 'enable', expectedStage: 'awaitingHeartbeat',
-        ownerId, installationId, executorId, setupAttemptId, scheduleEnabled: true,
+        ownerId, installationId, executorId, setupAttemptId, scheduleEnabled: false,
       },
     );
     const binding = requireActivatedBinding(
@@ -448,7 +448,7 @@ export async function runHermesSelectionSaga({
       await nativeRuntime('confirmHealthy', { ownerId, setupAttemptId }, { signal }),
       {
         command: 'confirmHealthy', expectedStage: 'confirmed_healthy',
-        ownerId, installationId, executorId, setupAttemptId, scheduleEnabled: true,
+        ownerId, installationId, executorId, setupAttemptId, scheduleEnabled: false,
       },
     );
 

--- a/apps/mac/api/agent-runtime-saga.spec.mjs
+++ b/apps/mac/api/agent-runtime-saga.spec.mjs
@@ -31,9 +31,9 @@ const ACTIVE = {
 const LOCAL_DISABLED = {
   ownerId: OWNER,
   installationId: INSTALLATION, executorId: EXECUTOR, pluginInstalled: true,
-  negotiatorMode: true, schedulePresent: true, scheduleEnabled: false, setupAttemptId: ATTEMPT,
+  negotiatorMode: false, schedulePresent: false, scheduleEnabled: false, setupAttemptId: ATTEMPT,
 };
-const LOCAL_ENABLED = { ...LOCAL_DISABLED, scheduleEnabled: true };
+const LOCAL_ENABLED = LOCAL_DISABLED;
 
 function selectionHarness({ failAt, rolledBack = true } = {}) {
   const calls = [];
@@ -1035,7 +1035,7 @@ describe('authentication epoch and operation revision coordinator', () => {
         return { ok: true, stage: 'scheduleDisabled', state: local };
       }
       if (command === 'enable') {
-        local = { ...local, scheduleEnabled: true };
+        local = { ...local, scheduleEnabled: false };
         return { ok: true, stage: 'awaitingHeartbeat', state: local };
       }
       if (command === 'confirmHealthy') {
@@ -1078,7 +1078,7 @@ describe('authentication epoch and operation revision coordinator', () => {
     ]);
     expect(coordinator.snapshot()).toMatchObject({
       binding,
-      localState: { ownerId: OWNER, executorId: EXECUTOR, scheduleEnabled: true },
+      localState: { ownerId: OWNER, executorId: EXECUTOR, scheduleEnabled: false },
       operation: null,
     });
     coordinator.dispose();

--- a/apps/mac/api/agent-runtime.mjs
+++ b/apps/mac/api/agent-runtime.mjs
@@ -322,9 +322,8 @@ export function mapAgentRuntimeState({ binding, localState, operation }) {
       && localState.executorId === executor.id
       && localState.setupAttemptId
       && localState.pluginInstalled === true
-      && localState.negotiatorMode === true
-      && localState.schedulePresent === true
-      && localState.scheduleEnabled === true
+      && localState.negotiatorMode === false
+      && localState.scheduleEnabled === false
     );
     if (!completeMatchingWiring) {
       return {

--- a/apps/mac/api/agent-runtime.spec.mjs
+++ b/apps/mac/api/agent-runtime.spec.mjs
@@ -12,8 +12,8 @@ const LOCAL = {
   installationId: 'installation-local',
   executorId: 'executor-hermes',
   pluginInstalled: true,
-  negotiatorMode: true,
-  schedulePresent: true,
+  negotiatorMode: false,
+  schedulePresent: false,
   scheduleEnabled: false,
   setupAttemptId: 'setup-current',
 };
@@ -47,7 +47,7 @@ describe('agent runtime state mapper', () => {
       selectorValue: 'hermes', visualState: 'connecting', canRetry: false, canDisconnect: false,
     });
 
-    expect(mapAgentRuntimeState({ binding: HERMES_ACTIVE, localState: { ...LOCAL, scheduleEnabled: true }, operation: null })).toEqual({
+    expect(mapAgentRuntimeState({ binding: HERMES_ACTIVE, localState: LOCAL, operation: null })).toEqual({
       selectorValue: 'hermes',
       visualState: 'active',
       statusLine: 'Hermes is active. Index takes over when Hermes is unavailable.',
@@ -59,7 +59,7 @@ describe('agent runtime state mapper', () => {
     for (const health of ['stale', 'never-seen']) {
       expect(mapAgentRuntimeState({
         binding: { ...HERMES_ACTIVE, health, indexCovering: true },
-        localState: { ...LOCAL, scheduleEnabled: true },
+        localState: LOCAL,
         operation: null,
       })).toEqual({
         selectorValue: 'hermes',
@@ -152,17 +152,16 @@ describe('agent runtime state mapper', () => {
     });
   });
 
-  it('requires complete matching enabled local wiring before reporting Hermes active', () => {
+  it('requires complete matching heartbeat wiring before reporting Hermes active', () => {
     const incompleteStates = [
       null,
-      { ...LOCAL, installationId: null, scheduleEnabled: true },
-      { ...LOCAL, executorId: null, scheduleEnabled: true },
-      { ...LOCAL, setupAttemptId: null, scheduleEnabled: true },
-      { ...LOCAL, pluginInstalled: false, scheduleEnabled: true },
-      { ...LOCAL, negotiatorMode: false, scheduleEnabled: true },
-      { ...LOCAL, schedulePresent: false, scheduleEnabled: true },
-      { ...LOCAL, scheduleEnabled: false },
-      { ...LOCAL, executorId: 'wrong-executor', scheduleEnabled: true },
+      { ...LOCAL, installationId: null },
+      { ...LOCAL, executorId: null },
+      { ...LOCAL, setupAttemptId: null },
+      { ...LOCAL, pluginInstalled: false },
+      { ...LOCAL, negotiatorMode: true },
+      { ...LOCAL, scheduleEnabled: true },
+      { ...LOCAL, executorId: 'wrong-executor' },
     ];
     for (const localState of incompleteStates) {
       expect(mapAgentRuntimeState({ binding: HERMES_ACTIVE, localState, operation: null })).toMatchObject({
@@ -171,7 +170,7 @@ describe('agent runtime state mapper', () => {
     }
     expect(mapAgentRuntimeState({
       binding: { ...HERMES_ACTIVE, executor: { ...HERMES_ACTIVE.executor, status: 'inactive' } },
-      localState: { ...LOCAL, scheduleEnabled: true },
+      localState: LOCAL,
       operation: null,
     })).toMatchObject({ selectorValue: 'index', visualState: 'needs-attention' });
   });
@@ -185,11 +184,11 @@ describe('agent runtime state mapper', () => {
     });
     expect(mapAgentRuntimeState({
       binding: { ...HERMES_ACTIVE, health: 'stale', indexCovering: true },
-      localState: { ...LOCAL, scheduleEnabled: true }, operation: null,
+      localState: LOCAL, operation: null,
     })).toMatchObject({ retryAction: 'select-hermes', canRetry: true });
     expect(mapAgentRuntimeState({
       binding: HERMES_ACTIVE,
-      localState: { ...LOCAL, executorId: 'wrong', scheduleEnabled: true },
+      localState: { ...LOCAL, executorId: 'wrong' },
       operation: null,
     })).toMatchObject({ retryAction: 'reconcile', canRetry: true });
     expect(mapAgentRuntimeState({ binding: INDEX, localState: null, operation: null }))
@@ -199,19 +198,19 @@ describe('agent runtime state mapper', () => {
   it('gives operation and wiring mismatch precedence, then stale covering precedence', () => {
     expect(mapAgentRuntimeState({
       binding: HERMES_ACTIVE,
-      localState: { ...LOCAL, scheduleEnabled: true },
+      localState: LOCAL,
       operation: { kind: 'select-index', status: 'running' },
     })).toMatchObject({ selectorValue: 'index', visualState: 'connecting' });
 
     expect(mapAgentRuntimeState({
       binding: { ...HERMES_ACTIVE, health: 'stale', indexCovering: true },
-      localState: { ...LOCAL, executorId: 'wrong-executor', scheduleEnabled: true },
+      localState: { ...LOCAL, executorId: 'wrong-executor' },
       operation: null,
     })).toMatchObject({ selectorValue: 'index', visualState: 'needs-attention' });
 
     expect(mapAgentRuntimeState({
       binding: { ...HERMES_ACTIVE, health: 'stale', indexCovering: true },
-      localState: { ...LOCAL, scheduleEnabled: true },
+      localState: LOCAL,
       operation: null,
     })).toMatchObject({ selectorValue: 'hermes', visualState: 'unavailable' });
 
@@ -221,7 +220,7 @@ describe('agent runtime state mapper', () => {
     ]) {
       expect(mapAgentRuntimeState({
         binding: contradictory,
-        localState: { ...LOCAL, scheduleEnabled: true },
+        localState: LOCAL,
         operation: null,
       })).toMatchObject({ selectorValue: 'index', visualState: 'needs-attention' });
     }

--- a/apps/mac/api/task-5-acceptance.spec.ts
+++ b/apps/mac/api/task-5-acceptance.spec.ts
@@ -56,13 +56,12 @@ describe('Task 5 production-boundary acceptance', () => {
           installationId: payload.installationId,
           executorId: payload.executorId,
           setupAttemptId: payload.setupAttemptId,
-          pluginInstalled: true, negotiatorMode: true,
-          schedulePresent: true, scheduleEnabled: false,
+          pluginInstalled: true, negotiatorMode: false,
+          schedulePresent: false, scheduleEnabled: false,
         };
         return { ok: true, stage: 'scheduleDisabled', state: local };
       }
       if (command === 'enable') {
-        local = { ...local, scheduleEnabled: true };
         return { ok: true, stage: 'awaitingHeartbeat', state: local };
       }
       if (command === 'confirmHealthy') return { ok: true, stage: 'confirmed_healthy', state: local };

--- a/apps/mac/hermes-runtime.spec.mjs
+++ b/apps/mac/hermes-runtime.spec.mjs
@@ -62,24 +62,13 @@ function injectedEnvFile({ readExisting, writeReplacement }) {
   };
 }
 
-async function injectedActivation({ journal, runner, readOwnedJob }) {
-  const job = readOwnedJob();
-  const resume = await runner('resume', job.id);
-  if (resume !== 0 || readOwnedJob()?.enabled !== true) return 'cron_resume_failed';
+async function injectedActivation({ journal, runner }) {
   try {
-    const gateway = await runner('gateway', job.id);
+    const gateway = await runner('gateway');
     if (gateway !== 0) throw new Error('gateway');
     journal.stage = 'awaitingHeartbeat';
     return 'ok';
   } catch {
-    try {
-      const pause = await runner('pause', job.id);
-      if (pause !== 0) throw new Error('pause');
-      const verified = readOwnedJob();
-      if (!verified || verified.id !== job.id || verified.enabled !== false) throw new Error('verify');
-    } catch {
-      return 'activation_rollback_failed';
-    }
     return 'gateway_failed';
   }
 }
@@ -301,43 +290,23 @@ function injectedCronOwnershipInventory({ jobs, ownership }) {
   };
 }
 
-function injectedPreOwnerConfigureRebind({ installation, cron, request }) {
-  const preOwner = installation.currentSetupAttemptId
-    && installation.currentOwnerId == null
-    && installation.currentExecutorId == null;
-  if (!preOwner) {
-    if (installation.currentOwnerId && installation.currentOwnerId !== request.ownerId) {
-      throw new Error('owner_mismatch');
-    }
-    throw new Error('not_pre_owner');
+function injectedPreOwnerConfigureRemove({ installation, cron, request }) {
+  if (installation.currentOwnerId && installation.currentOwnerId !== request.ownerId) {
+    throw new Error('owner_mismatch');
   }
-  const exact = installation.installationId === request.installationId
-    && installation.currentCronJobId === cron.id
-    && installation.currentCronSetupAttemptId === installation.currentSetupAttemptId
-    && cron.index_app_installation_id === installation.installationId
-    && cron.index_app_setup_attempt_id === installation.currentSetupAttemptId
-    && cron.index_app_owner_id == null
-    && cron.enabled === false
-    && cron.name === OWNED_NAME
-    && cron.schedule === OWNED_SCHEDULE
-    && cron.prompt === OWNED_PROMPT
-    && cron.skills?.length === 1 && cron.skills[0] === OWNED_SKILL
-    && cron.skill === OWNED_SKILL
-    && cron.enabled_toolsets?.length === 1 && cron.enabled_toolsets[0] === OWNED_TOOLSET;
-  if (!exact) throw new Error('cron_store_invalid');
   installation.currentOwnerId = request.ownerId;
   installation.currentExecutorId = request.executorId;
   installation.currentSetupAttemptId = request.setupAttemptId;
-  installation.currentCronSetupAttemptId = request.setupAttemptId;
-  cron.index_app_owner_id = request.ownerId;
-  cron.index_app_setup_attempt_id = request.setupAttemptId;
+  installation.currentCronJobId = null;
+  installation.currentCronSetupAttemptId = null;
+  cron.removed = true;
   return {
     installationId: installation.installationId,
     ownerId: installation.currentOwnerId,
     executorId: installation.currentExecutorId,
     setupAttemptId: installation.currentSetupAttemptId,
-    schedulePresent: true,
-    scheduleEnabled: cron.enabled,
+    schedulePresent: false,
+    scheduleEnabled: false,
   };
 }
 
@@ -537,14 +506,15 @@ test('preserves existing Hermes env unless a readable UTF-8 file or ENOENT is es
   }
 });
 
-test('writes only the owned Index env keys with negotiator mode and secure file permissions', () => {
+test('writes only the owned Index env keys and scrubs leftover negotiator mode', () => {
   for (const key of [
     'INDEX_API_KEY', 'INDEX_API_URL', 'INDEX_MCP_URL', 'INDEX_AGENT_ID',
     'INDEX_INSTALLATION_ID', 'INDEX_PLUGIN_MODE',
   ]) {
     expect(runtime).toContain(`"${key}"`);
   }
-  expect(runtime).toContain('("INDEX_PLUGIN_MODE", "negotiator")');
+  expect(runtime).not.toContain('("INDEX_PLUGIN_MODE", "negotiator")');
+  expect(runtime).toContain('removeKeys(["INDEX_PLUGIN_MODE"])');
   expect(runtime).toContain('mode_t(0o600)');
   expect(runtime).toContain('O_CREAT | O_EXCL | O_NOFOLLOW');
   expect(runtime).toContain('forbiddenEnvValueCharacters');
@@ -582,8 +552,11 @@ test('persists immutable cron ID and generation markers, adopting by exact name 
   expect(runtime).toContain('index_app_installation_id');
   expect(runtime).toContain('index_app_owner_id');
   expect(runtime).toContain('index_app_setup_attempt_id');
-  expect(runtime).toContain('installation.currentCronJobId = job.id');
-  expect(runtime).toContain('installation.currentCronSetupAttemptId = setupAttemptId');
+  expect(runtime).toContain('installation.currentCronJobId = legacy.id');
+  expect(runtime).toContain('installation.currentCronSetupAttemptId = generation');
+  expect(runtime).toContain('installation.currentCronJobId = nil');
+  expect(runtime).toContain('removeLeftoverOwnedCron');
+  expect(runtime).not.toContain('"cron", "create"');
   expect(runtime).not.toContain('func ownedJob()');
 });
 
@@ -623,7 +596,7 @@ test('immutable ownership detects rename, marker removal, duplicate ID and broad
   expect(runtime).toContain('verifyNoEnabledAttributableCron');
 });
 
-test('reconciles exactly one paused sandboxed owned cron without touching unrelated jobs', () => {
+test('does not create or enable the owned Personal Agent cron; leftover jobs are removed', () => {
   expect(runtime).toContain(`static let ownedCronName = "${OWNED_NAME}"`);
   expect(runtime).toContain(`static let ownedCronSchedule = "${OWNED_SCHEDULE}"`);
   expect(runtime).toContain(`static let ownedCronPrompt = #"${OWNED_PROMPT}"#`);
@@ -632,18 +605,11 @@ test('reconciles exactly one paused sandboxed owned cron without touching unrela
   expect(runtime).toContain(`static let ownedCronSkill = "${OWNED_SKILL}"`);
   expect(runtime).toContain(`static let ownedCronToolset = "${OWNED_TOOLSET}"`);
   expect(runtime).toContain('lockName: ".jobs.lock"');
-  expect(runtime).toContain('jobs[index]["enabled_toolsets"] = [HermesRuntimeManager.ownedCronToolset]');
-  expect(runtime).toContain('jobs[index]["index_app_installation_id"] = ownership.installationId');
-  expect(runtime).toContain('jobs[index]["skills"] = [HermesRuntimeManager.ownedCronSkill]');
-  expect(runtime).toContain('isExactOwnedCron(verified)');
-  expect(runtime).toContain('job.enabledToolsets == [Self.ownedCronToolset]');
-  expect(runtime).toContain('job.skills == [Self.ownedCronSkill]');
-  for (const command of ['"create"', '"edit"', '"pause"', '"resume"', '"remove"']) {
-    expect(runtime).toContain(command);
-  }
+  expect(runtime).toContain('removeLeftoverOwnedCron');
   expect(runtime).toContain('["cron", "pause", jobId]');
-  expect(runtime).toContain('["cron", "resume", job.id]');
   expect(runtime).toContain('["cron", "remove", jobId]');
+  expect(runtime).not.toContain('"cron", "create"');
+  expect(runtime).not.toContain('["cron", "resume", job.id]');
   expect(runtime).not.toContain('removeAllCron');
   expect(runtime).not.toContain('cron", "remove"].map');
 });
@@ -745,16 +711,15 @@ test('migrates a pre-owner confirmed generation by pausing before surfacing pres
     localStateBlock.indexOf('verifiedOwnedCron'),
   );
 
-  // Complete the source state-machine path using the immutable ID persisted by
-  // inspect and the paused state observed by localState. Only exact historical
-  // installation/setup markers permit configureDisabled to publish the owner.
+  // Inspect paused the leftover job. Configure then removes it rather than
+  // rebinding the historical one-minute schedule as a heartbeat.
   Object.assign(cron, {
     name: OWNED_NAME, schedule: OWNED_SCHEDULE, prompt: OWNED_PROMPT,
     skills: [OWNED_SKILL], skill: OWNED_SKILL, enabled_toolsets: [OWNED_TOOLSET],
     index_app_installation_id: 'installation-old', index_app_owner_id: null,
     index_app_setup_attempt_id: 'attempt-old',
   });
-  expect(injectedPreOwnerConfigureRebind({
+  expect(injectedPreOwnerConfigureRemove({
     installation: persistedInstallation,
     cron,
     request: {
@@ -763,25 +728,19 @@ test('migrates a pre-owner confirmed generation by pausing before surfacing pres
     },
   })).toMatchObject({
     ownerId: 'owner-new', executorId: 'executor-new', setupAttemptId: 'attempt-new',
-    scheduleEnabled: false,
+    schedulePresent: false, scheduleEnabled: false,
   });
+  expect(persistedInstallation.currentCronJobId).toBeNull();
 });
 
-test('configureDisabled explicitly rebinds only the exact paused pre-owner generation', () => {
+test('configureDisabled removes leftover Personal Agent cron and keeps SSE heartbeat only', () => {
   const configureBlock = runtime.match(/private func configureDisabled\([\s\S]*?private func enable/)?.[0] ?? '';
-  expect(configureBlock).toContain('preOwnerRecord');
-  expect(configureBlock).toContain('preOwnerRebindJob');
-  expect(configureBlock.indexOf('preOwnerRebindJob')).toBeLessThan(
-    configureBlock.indexOf('cronOwnership(installation)'),
-  );
-  expect(configureBlock).toContain('installation.currentCronSetupAttemptId == preOwnerGeneration');
+  expect(configureBlock).toContain('removeLeftoverOwnedCron');
   expect(configureBlock).toContain('installation.currentOwnerId == ownerId');
-  const resolver = runtime.match(/func preOwnerRebindJob\([\s\S]*?func markedJobs/)?.[0] ?? '';
-  for (const fence of [
-    'attributable.count == 1', 'job.id == jobId',
-    'job.appInstallationId == installationId', 'job.appSetupAttemptId == setupAttemptId',
-    'job.appOwnerId == nil', 'job.enabled == false',
-  ]) expect(resolver).toContain(fence);
+  expect(configureBlock).not.toContain('preOwnerRebindJob');
+  expect(configureBlock).not.toContain('"cron", "create"');
+  expect(configureBlock).not.toContain('("INDEX_PLUGIN_MODE", "negotiator")');
+  expect(configureBlock).toContain('removeKeys(["INDEX_PLUGIN_MODE"])');
 
   const installation = {
     installationId: 'installation-old', currentOwnerId: null, currentExecutorId: null,
@@ -798,15 +757,18 @@ test('configureDisabled explicitly rebinds only the exact paused pre-owner gener
     installationId: 'installation-old', ownerId: 'owner-new', executorId: 'executor-new',
     setupAttemptId: 'attempt-new',
   };
-  expect(injectedPreOwnerConfigureRebind({
+  expect(injectedPreOwnerConfigureRemove({
     installation: structuredClone(installation), cron: structuredClone(cron), request,
   })).toEqual({
     installationId: 'installation-old', ownerId: 'owner-new', executorId: 'executor-new',
-    setupAttemptId: 'attempt-new', schedulePresent: true, scheduleEnabled: false,
+    setupAttemptId: 'attempt-new', schedulePresent: false, scheduleEnabled: false,
   });
 
+  const foreign = { installation: structuredClone(installation), cron: structuredClone(cron) };
+  foreign.installation.currentOwnerId = 'owner-other';
+  expect(() => injectedPreOwnerConfigureRemove({ ...foreign, request })).toThrow('owner_mismatch');
+
   for (const mutate of [
-    (state) => { state.installation.currentOwnerId = 'owner-other'; },
     (state) => { state.installation.currentCronSetupAttemptId = 'attempt-newer'; },
     (state) => { state.cron.index_app_installation_id = 'installation-tampered'; },
     (state) => { state.cron.prompt = 'Run arbitrary broad tools.'; },
@@ -814,56 +776,33 @@ test('configureDisabled explicitly rebinds only the exact paused pre-owner gener
   ]) {
     const state = { installation: structuredClone(installation), cron: structuredClone(cron) };
     mutate(state);
-    expect(() => injectedPreOwnerConfigureRebind({ ...state, request })).toThrow();
+    expect(injectedPreOwnerConfigureRemove({ ...state, request })).toMatchObject({
+      schedulePresent: false, scheduleEnabled: false,
+    });
   }
 });
 
-test('gateway failure performs checked exact-job rollback and retains recovery journal', async () => {
+test('gateway failure retains the enabling journal without cron rollback', async () => {
   expect(runtime).toContain('protocol HermesCommandRunning');
-  expect(runtime).toContain('private func rollbackActivation');
-  expect(runtime).toContain('throw HermesRuntimeFailure.activationRollbackFailed');
-  expect(runtime).toContain('cronStore.job(id: jobId)');
-  expect(runtime).toContain('verified.enabled == false');
-  const enableBlock = runtime.match(/private func enable\([\s\S]*?private func confirmHealthy/)?.[0] ?? '';
+  expect(runtime).not.toContain('private func rollbackActivation');
+  const enableBlock = runtime.match(/private func enable\([\s\S]*?private func isExactOwnedCron/)?.[0] ?? '';
   expect(enableBlock).not.toContain('deleteJournal');
-
-  for (const failure of ['throw', 'nonzero', 'still-enabled']) {
-    const journal = { stage: 'enabling' };
-    const job = { id: 'owned-current', enabled: false };
-    const calls = [];
-    const result = await injectedActivation({
-      journal,
-      runner: async (command, id) => {
-        calls.push([command, id]);
-        if (command === 'resume') { job.enabled = true; return 0; }
-        if (command === 'gateway') throw new Error('gateway failed');
-        if (failure === 'throw') throw new Error('pause failed');
-        if (failure === 'nonzero') return 1;
-        return 0;
-      },
-      readOwnedJob: () => ({ ...job }),
-    });
-    expect(result).toBe('activation_rollback_failed');
-    expect(journal.stage).toBe('enabling');
-    expect(calls).toContainEqual(['pause', 'owned-current']);
-  }
+  expect(enableBlock).not.toContain('cron", "resume"');
+  expect(enableBlock).toContain('startOrRestartGateway');
 
   const journal = { stage: 'enabling' };
-  const job = { id: 'owned-current', enabled: false };
+  const calls = [];
   const result = await injectedActivation({
     journal,
-    runner: async (command, id) => {
-      expect(id).toBe('owned-current');
-      if (command === 'resume') { job.enabled = true; return 0; }
+    runner: async (command) => {
+      calls.push(command);
       if (command === 'gateway') throw new Error('gateway failed');
-      if (command === 'pause') { job.enabled = false; return 0; }
-      return 1;
+      return 0;
     },
-    readOwnedJob: () => ({ ...job }),
   });
   expect(result).toBe('gateway_failed');
-  expect(job.enabled).toBe(false);
   expect(journal.stage).toBe('enabling');
+  expect(calls).toEqual(['gateway']);
 });
 
 test('native logout preparation and completion independently require no key and no attributable enabled cron', () => {

--- a/packages/hermes-plugin/CHANGELOG.md
+++ b/packages/hermes-plugin/CHANGELOG.md
@@ -7,6 +7,10 @@ and this package adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+## [0.24.0] - 2026-08-17
+### Added
+- Pending pickup injects one Hermes chat turn so the model can reply with `index_respond_to_negotiation` and a real shared message. Empty pickup stays a seat heartbeat. Gateway injection needs `plugins.entries.index-network.allow_gateway_injection`.
+
 ### Changed
 - Browser login treats the `/cli-auth` CLI key as bootstrap only: after the handshake the plugin reuses or registers the Hermes agent, mints an agent-bound token into `INDEX_API_KEY`, and revokes the CLI key. Login still succeeds if minting fails so Discover can keep the owner key.
 

--- a/packages/hermes-plugin/CHANGELOG.md
+++ b/packages/hermes-plugin/CHANGELOG.md
@@ -7,6 +7,9 @@ and this package adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+### Changed
+- Browser login treats the `/cli-auth` CLI key as bootstrap only: after the handshake the plugin reuses or registers the Hermes agent, mints an agent-bound token into `INDEX_API_KEY`, and revokes the CLI key. Login still succeeds if minting fails so Discover can keep the owner key.
+
 ## [0.23.0] - 2026-08-14
 ### Added
 - Conversation SSE wake for ordinary agent keys: `negotiation_wake` listens to `GET /conversations/stream`, stamps negotiation pickup on keepalive (~15s) and non-own negotiation messages, and runs one conservative consult/respond pass when a turn is pending. Desktop reuses the existing 15s inbox poll tick (no second scheduler).

--- a/packages/hermes-plugin/README.md
+++ b/packages/hermes-plugin/README.md
@@ -20,6 +20,8 @@ Optional overrides: `INDEX_API_URL` and `INDEX_MCP_URL` (default to production e
 
 Pickup and `GET /agents/me` need the agent-bound token, not the CLI owner key. The agent token can be revoked from web settings.
 
+Full-mode wake listens to `GET /conversations/stream` (and the Discover 15s inbox tick) and POSTs pickup so Index keeps parking turns on Hermes. Empty pickup only refreshes the seat. Pending pickup claims the turn and injects one Hermes chat to reply with `index_respond_to_negotiation` (real message, not a canned stall). Gateway injection needs `plugins.entries.index-network.allow_gateway_injection: true` plus a live Hermes session.
+
 ## Modes and capability boundary
 
 `full` (the default) registers the normal Index tool/dashboard surface. `negotiator` registers exactly four handlers:

--- a/packages/hermes-plugin/README.md
+++ b/packages/hermes-plugin/README.md
@@ -8,17 +8,17 @@ The Index plugin connects Hermes to Index over plain HTTPS, authenticated with a
 hermes plugins install indexnetwork/hermes-plugin
 ```
 
-Connect to Index by opening the **Index** dashboard and choosing **log in with browser** — the same `/cli-auth` handshake the Index CLI and Mac app use. It mints a 90-day CLI API key and persists it as `INDEX_API_KEY` in `~/.hermes/.env`; **Sign out** revokes it and clears the file. On a headless host the dashboard shows the login link to open elsewhere.
+Connect to Index by opening the **Index** dashboard and choosing **log in with browser** — the same `/cli-auth` handshake the Index CLI and Mac app use. The handshake mints a CLI owner key, then the plugin registers or reuses the Hermes agent, mints an agent-bound token, and persists that token as `INDEX_API_KEY` in `~/.hermes/.env`. The CLI key is revoked after bootstrap. **Sign out** clears the local key. On a headless host the dashboard shows the login link to open elsewhere.
 
-Manual override: set the key yourself instead of using the browser flow:
+Manual override: set an agent API key yourself instead of using the browser flow:
 
 ```bash
-export INDEX_API_KEY=<your Index API key>
+export INDEX_API_KEY=<your Index agent API key>
 ```
 
 Optional overrides: `INDEX_API_URL` and `INDEX_MCP_URL` (default to production endpoints). Browser login pairs with the configured API environment (`INDEX_APP_BASE_URL` wins, else derived from `INDEX_API_URL`).
 
-The key is an ordinary Index API key: it can be revoked at any time from web settings, and it expires per its configured lifetime.
+Pickup and `GET /agents/me` need the agent-bound token, not the CLI owner key. The agent token can be revoked from web settings.
 
 ## Modes and capability boundary
 

--- a/packages/hermes-plugin/__init__.py
+++ b/packages/hermes-plugin/__init__.py
@@ -178,9 +178,10 @@ def register(ctx):
     _register_skills(ctx)
     # Ordinary agent keys: keep lastNegotiationPickupAt fresh via conversation
     # SSE keepalive (~15s) so Index parks turns for Hermes instead of taking
-    # them inline. Best-effort — missing API key must not break register().
+    # them inline. Pickup is a seat heartbeat only — no auto consult/respond.
     if negotiation_wake is not None:
         try:
+            negotiation_wake.bind_plugin_context(ctx)
             negotiation_wake.start_listener()
         except Exception:  # noqa: BLE001
             pass

--- a/packages/hermes-plugin/dashboard/README.md
+++ b/packages/hermes-plugin/dashboard/README.md
@@ -4,7 +4,7 @@ The dashboard is the optional full-mode UI for the Index Hermes plugin. It is no
 
 ## Connection and status
 
-In full mode the tab displays connection status. When no `INDEX_API_KEY` is configured, the login screen offers **log in with browser**: `POST /auth/login/start` binds a loopback callback and opens the web `/cli-auth` handshake (returning the URL as a manual link for headless hosts), and the UI polls `GET /auth/login/status` until the minted key is persisted to `~/.hermes/.env`. **Sign out** (`POST /auth/logout`) best-effort revokes the key and clears it. Setting `INDEX_API_KEY` manually still works as an override.
+In full mode the tab displays connection status. When no `INDEX_API_KEY` is configured, the login screen offers **log in with browser**: `POST /auth/login/start` binds a loopback callback and opens the web `/cli-auth` handshake (returning the URL as a manual link for headless hosts), and the UI polls `GET /auth/login/status` until a Hermes agent-bound token is persisted to `~/.hermes/.env`. The CLI owner key is bootstrap-only. **Sign out** (`POST /auth/logout`) clears the local key. Setting `INDEX_API_KEY` manually still works as an override.
 
 ## Scope
 

--- a/packages/hermes-plugin/dashboard/agent_bootstrap.py
+++ b/packages/hermes-plugin/dashboard/agent_bootstrap.py
@@ -1,0 +1,157 @@
+"""Promote a CLI owner key to a Hermes agent-bound API key.
+
+Browser `/cli-auth` mints an unbound CLI key. Pickup and `GET /agents/me`
+need an agent-bound secret. This helper reuses (or registers) the Hermes
+agent, mints a token, and returns that secret for persistence.
+"""
+
+from __future__ import annotations
+
+import json
+from typing import Any, Callable
+
+_HERMES_NAME = "hermes"
+_REGISTER_NAME = "Hermes"
+_TOKEN_NAME = "Hermes API Key"
+_PERMISSIONS = ["manage:negotiations", "manage:intents", "manage:opportunities"]
+
+
+class BootstrapError(RuntimeError):
+    """Hermes agent/token bootstrap could not complete."""
+
+
+def select_hermes_agent(agents: list[Any]) -> dict[str, Any] | None:
+    """Pick the reusable Hermes external agent, preferring the negotiator."""
+    matches: list[dict[str, Any]] = []
+    for agent in agents:
+        if not isinstance(agent, dict):
+            continue
+        name = str(agent.get("name") or "").strip().casefold()
+        kind = str(agent.get("type") or "").strip().casefold()
+        status = str(agent.get("status") or "").strip().casefold()
+        if name == _HERMES_NAME and kind == "external" and status == "active":
+            matches.append(agent)
+    if not matches:
+        return None
+    negotiating = [agent for agent in matches if agent.get("handleNegotiations") is True]
+    return (negotiating or matches)[0]
+
+
+def _error_text(payload: dict[str, Any], fallback: str) -> str:
+    details = payload.get("details")
+    if isinstance(details, dict):
+        for key in ("error", "message"):
+            value = details.get(key)
+            if isinstance(value, str) and value.strip():
+                return value.strip()
+    for key in ("error", "message"):
+        value = payload.get(key)
+        if isinstance(value, str) and value.strip():
+            return value.strip()
+    return fallback
+
+
+def _decode_mcp(result: dict[str, Any]) -> dict[str, Any]:
+    structured = result.get("structuredContent")
+    if isinstance(structured, dict):
+        payload = dict(structured)
+        if "success" not in payload:
+            payload["success"] = not bool(result.get("isError"))
+        return payload
+    content = result.get("content")
+    if isinstance(content, list):
+        texts = [item.get("text") for item in content if isinstance(item, dict) and item.get("type") == "text"]
+        text = "\n".join(str(item) for item in texts if item is not None).strip()
+        if text:
+            try:
+                parsed = json.loads(text)
+            except json.JSONDecodeError:
+                parsed = None
+            if isinstance(parsed, dict):
+                if "success" not in parsed:
+                    parsed["success"] = not bool(result.get("isError"))
+                return parsed
+            return {"success": not bool(result.get("isError")), "text": text}
+    return {"success": not bool(result.get("isError")), "data": result}
+
+
+def _agent_from_register(payload: dict[str, Any]) -> dict[str, Any]:
+    data = payload.get("data")
+    agent = data.get("agent") if isinstance(data, dict) else None
+    if not isinstance(agent, dict):
+        agent = payload.get("agent")
+    if not isinstance(agent, dict) or not str(agent.get("id") or "").strip():
+        raise BootstrapError("Hermes agent registration returned no agent.")
+    return agent
+
+
+def _token_from_rest(payload: dict[str, Any]) -> tuple[str, str | None]:
+    token = payload.get("token")
+    data = payload.get("data")
+    if not isinstance(token, dict) and isinstance(data, dict):
+        token = data.get("token")
+    if not isinstance(token, dict):
+        raise BootstrapError("Agent token response did not include a key.")
+    key = str(token.get("key") or "").strip()
+    if not key:
+        raise BootstrapError("Agent token response did not include a key.")
+    token_id = str(token.get("id") or "").strip() or None
+    return key, token_id
+
+
+def promote(
+    transport: Any,
+    persist_api_key: Callable[[str, str | None], None],
+    cli_key: str,
+    cli_key_id: str | None,
+) -> dict[str, Any]:
+    """Replace the CLI owner key with a Hermes agent token.
+
+    Uses `transport` while it still authenticates as the CLI key. On failure
+    the CLI key stays persisted so Discover can still sign in.
+    """
+    try:
+        listed = transport.request_rest("GET", "/agents")
+        if not isinstance(listed, dict) or listed.get("success") is False:
+            raise BootstrapError(_error_text(listed if isinstance(listed, dict) else {}, "Could not list agents."))
+        agents = listed.get("agents")
+        if not isinstance(agents, list) and isinstance(listed.get("data"), dict):
+            agents = listed["data"].get("agents")
+        if not isinstance(agents, list):
+            agents = []
+        agent = select_hermes_agent(agents)
+        if agent is None:
+            mcp_result = transport.call_mcp("register_agent", {
+                "name": _REGISTER_NAME,
+                "description": "Hermes on this host",
+                "permissions": list(_PERMISSIONS),
+            })
+            if not isinstance(mcp_result, dict):
+                raise BootstrapError("Hermes agent registration returned no agent.")
+            registered = _decode_mcp(mcp_result)
+            if registered.get("success") is False:
+                raise BootstrapError(_error_text(registered, "Could not register Hermes."))
+            agent = _agent_from_register(registered)
+        agent_id = str(agent.get("id") or "").strip()
+        if not agent_id:
+            raise BootstrapError("Hermes agent registration returned no agent.")
+        minted = transport.request_rest("POST", f"/agents/{agent_id}/tokens", {"name": _TOKEN_NAME})
+        if not isinstance(minted, dict) or minted.get("success") is False:
+            raise BootstrapError(_error_text(minted if isinstance(minted, dict) else {}, "Could not mint a Hermes agent key."))
+        secret, token_id = _token_from_rest(minted)
+    except BootstrapError as exc:
+        return {"negotiatorReady": False, "error": str(exc)}
+    except Exception as exc:  # noqa: BLE001 - login must not fail closed on bootstrap.
+        return {"negotiatorReady": False, "error": str(exc)}
+
+    if cli_key and cli_key_id:
+        try:
+            transport.request_rest(
+                "POST",
+                "/auth/cli-credential/revoke",
+                {"keyId": cli_key_id, "targetKey": cli_key},
+            )
+        except Exception:  # noqa: BLE001 - revoke is best-effort.
+            pass
+    persist_api_key(secret, token_id)
+    return {"negotiatorReady": True}

--- a/packages/hermes-plugin/dashboard/auth_login.py
+++ b/packages/hermes-plugin/dashboard/auth_login.py
@@ -6,8 +6,8 @@ Runs the same `/cli-auth` handshake used by `apps/mac` and `packages/cli`:
 2. Open `{appUrl}/cli-auth?callback=…&version=2&state=…` in the browser.
 3. The web app mints a CLI API key and redirects to the callback with
    `api_key` + `key_id`.
-4. Persist the key into `~/.hermes/.env` and `os.environ` so subsequent
-   `_api_request` / MCP calls in this process use it immediately.
+4. Persist that CLI key, then replace it with a Hermes agent-bound token
+   (register/reuse the agent and mint) so pickup can authenticate.
 
 Login start returns right away; the frontend polls the status until the
 callback lands (or the attempt times out). Only one login runs at a time.
@@ -21,6 +21,7 @@ import threading
 import time
 from http.server import BaseHTTPRequestHandler, HTTPServer
 from pathlib import Path
+from typing import Any, Callable
 from urllib.parse import parse_qs, urlencode, urlparse
 
 _API_KEY_ENV = "INDEX_API_KEY"
@@ -30,6 +31,13 @@ _LOGIN_TIMEOUT_SECONDS = 180.0
 
 _lock = threading.Lock()
 _session: "_LoginSession | None" = None
+_post_login: Callable[[str, str | None], dict[str, Any]] | None = None
+
+
+def set_post_login(callback: Callable[[str, str | None], dict[str, Any]] | None) -> None:
+    """Install the CLI→agent-key promotion run after a successful handshake."""
+    global _post_login
+    _post_login = callback
 
 
 def _env_path() -> Path:
@@ -188,11 +196,13 @@ def start_login(app_base_url: str) -> str:
     return f"{app_base_url.rstrip('/')}/cli-auth?{query}"
 
 
-def poll_status() -> dict[str, str | None]:
+def poll_status() -> dict[str, Any]:
     """Report and, on success, persist the pending login's result.
 
-    Returns `{status: idle|pending|success|failed, error?}`. Success and
-    failure are terminal: the loopback listener is torn down before returning.
+    Returns `{status: idle|pending|success|failed, error?, negotiatorReady?}`.
+    Success and failure are terminal: the loopback listener is torn down
+    before returning. The CLI key is persisted first, then optional
+    post-login promotion may replace it with a Hermes agent token.
     """
     with _lock:
         session = _session
@@ -210,7 +220,13 @@ def poll_status() -> dict[str, str | None]:
             return {"status": "failed", "error": error}
         else:
             return {"status": "pending"}
-    if api_key:
-        persist_api_key(api_key, key_id)
-        return {"status": "success"}
-    return {"status": "failed", "error": "Login completed without a credential."}
+    if not api_key:
+        return {"status": "failed", "error": "Login completed without a credential."}
+    persist_api_key(api_key, key_id)
+    extra: dict[str, Any] = {}
+    if _post_login is not None:
+        try:
+            extra = _post_login(api_key, key_id) or {}
+        except Exception as exc:  # noqa: BLE001 - login stays signed in as the CLI key.
+            extra = {"negotiatorReady": False, "error": str(exc)}
+    return {"status": "success", **extra}

--- a/packages/hermes-plugin/dashboard/manifest.json
+++ b/packages/hermes-plugin/dashboard/manifest.json
@@ -3,7 +3,7 @@
   "label": "Discover",
   "description": "Intent-centric Index Network overview: each intent carries its own questions and opportunity radar, with a separate Networks view.",
   "icon": "Sparkles",
-  "version": "0.23.0",
+  "version": "0.24.0",
   "tab": {
     "path": "/index-network",
     "position": "after:skills"

--- a/packages/hermes-plugin/dashboard/plugin_api.py
+++ b/packages/hermes-plugin/dashboard/plugin_api.py
@@ -200,7 +200,10 @@ auth_login.set_post_login(_promote_cli_key)
 
 
 def _load_negotiation_wake():
-    """Load negotiation_wake once under the dashboard runtime package."""
+    """Load negotiation_wake once. Prefer the plugin-package copy if register() already imported it."""
+    canonical = sys.modules.get("_index_network_negotiation_wake_runtime")
+    if canonical is not None:
+        return canonical
     package_name = "index_network_hermes_dashboard_runtime"
     module_name = f"{package_name}.negotiation_wake"
     existing = sys.modules.get(module_name)
@@ -2252,16 +2255,8 @@ def list_conversations() -> dict[str, Any]:
     """List the caller's conversations (participant-gated) as counterpart summaries."""
     # Desktop polls this every 15s because the REST bridge buffers SSE. Reuse
     # that tick as the negotiation heartbeat instead of a second scheduler.
-    # Run off-thread so a slow/failed pickup never stalls or starves the inbox
-    # list (and so hermetic tests' FakeResponse queues stay ordered).
-    try:
-        threading.Thread(
-            target=lambda: _load_negotiation_wake().tick(),
-            name="index-negotiation-wake-tick",
-            daemon=True,
-        ).start()
-    except Exception:  # noqa: BLE001 - wake must never break the inbox list
-        pass
+    # Run the list first, then tick off-thread, so pickup never starves inbox
+    # FakeResponse queues in hermetic tests (or a slow pickup).
     current_user_id = _resolve_user_id()
     if not current_user_id:
         return {"success": False, "error": "Could not resolve the current user from the configured API key."}
@@ -2273,6 +2268,14 @@ def list_conversations() -> dict[str, Any]:
         for row in _list(payload.get("conversations"))
         if isinstance(row, dict) and _is_h2h(row)
     ]
+    try:
+        threading.Thread(
+            target=lambda: _load_negotiation_wake().tick(),
+            name="index-negotiation-wake-tick",
+            daemon=True,
+        ).start()
+    except Exception:  # noqa: BLE001 - wake must never break the inbox list
+        pass
     return {"success": True, "conversations": conversations, "currentUserId": current_user_id}
 
 

--- a/packages/hermes-plugin/dashboard/plugin_api.py
+++ b/packages/hermes-plugin/dashboard/plugin_api.py
@@ -176,6 +176,27 @@ def _load_tools_module():
 
 tools = _load_tools_module()
 auth_login = _load_module("index_network_hermes_dashboard_auth_login", _DASHBOARD_DIR / "auth_login.py")
+agent_bootstrap = _load_module(
+    "index_network_hermes_dashboard_agent_bootstrap",
+    _DASHBOARD_DIR / "agent_bootstrap.py",
+)
+
+
+def _promote_cli_key(cli_key: str, cli_key_id: str | None) -> dict[str, Any]:
+    """Swap the CLI owner key for a Hermes agent token, then rebuild transport."""
+    tools.reset_transport()
+    try:
+        return agent_bootstrap.promote(
+            tools.get_transport(),
+            auth_login.persist_api_key,
+            cli_key,
+            cli_key_id,
+        )
+    finally:
+        tools.reset_transport()
+
+
+auth_login.set_post_login(_promote_cli_key)
 
 
 def _load_negotiation_wake():
@@ -1212,14 +1233,13 @@ def auth_login_start(_body: dict[str, Any] | None = Body(default=None)) -> dict[
 
 @full_router.get("/auth/login/status")
 def auth_login_status() -> dict[str, Any]:
-    """Poll the pending login; on success the key is already persisted server-side."""
+    """Poll the pending login; on success the Hermes agent key is persisted."""
     result = auth_login.poll_status()
-    if result.get("status") == "success":
-        # The next transport build must read the freshly persisted key.
-        tools.reset_transport()
     payload: dict[str, Any] = {"success": result.get("status") != "failed", "status": result.get("status")}
     if result.get("error"):
         payload["error"] = result.get("error")
+    if "negotiatorReady" in result:
+        payload["negotiatorReady"] = result["negotiatorReady"]
     return payload
 
 

--- a/packages/hermes-plugin/negotiation_wake.py
+++ b/packages/hermes-plugin/negotiation_wake.py
@@ -2,17 +2,16 @@
 
 Gateway process: listen to GET /conversations/stream. Keepalive (~15s) and
 non-own negotiation messages each run one cheap pickup. Empty pickup stamps
-lastNegotiationPickupAt; pending pickup takes one conservative consult or
-respond pass. One in-flight pass at a time.
-
-Desktop: the inbox polls every 15s because the REST bridge buffers SSE — call
-tick() from that path instead of inventing a second scheduler.
+lastNegotiationPickupAt. Pending pickup claims the turn, then asks Hermes
+to run one model turn. No auto consult or respond from this thread.
 """
 
 from __future__ import annotations
 
 import json
 import logging
+import os
+import sys
 import threading
 from typing import Any, Callable
 
@@ -22,18 +21,17 @@ _WAKE_LOCK = threading.Lock()
 _INFLIGHT = False
 _LISTENER_STARTED = False
 _STOP = threading.Event()
+_TURN_STARTER: Callable[[str], None] | None = None
+_STARTED_IDS: set[str] = set()
+_RUNTIME_KEY = "_index_network_negotiation_wake_runtime"
 
-# Prefer owner consult; never auto-accept/decline. Fallback respond maps closed
-# Hermes directives onto ordinary-key turn bodies.
-_CONSULT_REASON = "insufficient_commitment_authority"
-_MESSAGE_TEMPLATES = {
-    "request_time": "I need more time before deciding.",
-    "continue": "I am open to continuing within the current scope.",
-}
-_ACTION_CANDIDATES = {
-    "request_time": ("counter", "outreach", "propose"),
-    "continue": ("question", "outreach", "propose", "counter"),
-}
+_TURN_PROMPT = (
+    "Index negotiation {negotiation_id} is already claimed on this Hermes seat. "
+    "Do not call index_pickup_negotiation. Read the claimed thread, then reply "
+    "once with index_respond_to_negotiation using a protocol action and a real "
+    "message written for this counterpart. Consult the owner only if the thread "
+    "needs Seref. Do not stall with request_time."
+)
 
 
 def _transport():
@@ -116,59 +114,50 @@ def _resolve_me(transport) -> tuple[str | None, str | None]:
     return agent_id, owner_id
 
 
-def _protocol_action(preferred: str, allowed: list[str]) -> str | None:
-    allowed_set = set(allowed)
-    for candidate in _ACTION_CANDIDATES.get(preferred, ()):
-        if candidate in allowed_set:
-            return candidate
-    for fallback in ("question", "outreach", "propose", "counter"):
-        if fallback in allowed_set:
-            return fallback
-    return None
+def set_turn_starter(starter: Callable[[str], None] | None) -> None:
+    """Tests and register() install the Hermes turn hook. Wake never POSTs respond."""
+    global _TURN_STARTER
+    _TURN_STARTER = starter
 
 
-def _respond_body(allowed: list[str]) -> dict[str, Any] | None:
-    for preferred in ("request_time", "continue"):
-        action = _protocol_action(preferred, allowed)
-        if action:
-            return {
-                "action": action,
-                "message": _MESSAGE_TEMPLATES[preferred],
-                "assessment": {
-                    "reasoning": f"Hermes wake selected a conservative {preferred} turn.",
-                    "suggestedRoles": {"ownUser": "peer", "otherUser": "peer"},
-                },
-            }
-    return None
+def bind_plugin_context(ctx) -> None:
+    """Start one Hermes chat turn after a pending claim via inject_message."""
+
+    def start(negotiation_id: str) -> None:
+        if not hasattr(ctx, "inject_message"):
+            return
+        prompt = _TURN_PROMPT.format(negotiation_id=negotiation_id)
+        session = os.environ.get("INDEX_HERMES_SESSION_KEY", "").strip() or None
+        try:
+            ok = (
+                ctx.inject_message(prompt, session_key=session)
+                if session
+                else ctx.inject_message(prompt)
+            )
+            if ok is False:
+                logger.warning("negotiation wake inject returned false for %s", negotiation_id)
+        except Exception as exc:  # noqa: BLE001
+            logger.warning("negotiation wake inject failed: %s", exc)
+
+    set_turn_starter(start)
 
 
-def _handle_pending(transport, agent_id: str, pickup: dict[str, Any]) -> None:
-    negotiation_id = pickup.get("negotiationId")
-    if not isinstance(negotiation_id, str) or not negotiation_id:
+def _maybe_start_turn(negotiation_id: str) -> None:
+    with _WAKE_LOCK:
+        if negotiation_id in _STARTED_IDS:
+            return
+        _STARTED_IDS.add(negotiation_id)
+        starter = _TURN_STARTER
+    if starter is None:
         return
-    consult = transport.request_rest(
-        "POST",
-        f"/agents/{agent_id}/negotiations/{negotiation_id}/consult",
-        {"reason": _CONSULT_REASON},
-    )
-    if isinstance(consult, dict) and consult.get("success") is not False and consult.get("status") == "input_required":
-        return
-    allowed = pickup.get("allowedActions")
-    if not isinstance(allowed, list):
-        allowed = []
-    allowed_actions = [a for a in allowed if isinstance(a, str)]
-    body = _respond_body(allowed_actions)
-    if not body:
-        return
-    transport.request_rest(
-        "POST",
-        f"/agents/{agent_id}/negotiations/{negotiation_id}/respond",
-        body,
-    )
+    try:
+        starter(negotiation_id)
+    except Exception as exc:  # noqa: BLE001
+        logger.debug("negotiation wake turn start failed: %s", exc)
 
 
 def run_pickup_pass(transport=None) -> dict[str, Any]:
-    """One pickup; empty is silent success. Pending → consult then maybe respond."""
+    """One pickup. Empty stamps the seat. Pending claims, then one Hermes turn."""
     global _INFLIGHT
     with _WAKE_LOCK:
         if _INFLIGHT:
@@ -188,8 +177,11 @@ def run_pickup_pass(transport=None) -> dict[str, Any]:
             return {"ok": True, "pending": False}
         if pickup.get("pending") is not True and not pickup.get("negotiationId"):
             return {"ok": True, "pending": False}
-        _handle_pending(transport, agent_id, pickup)
-        return {"ok": True, "pending": True, "negotiationId": pickup.get("negotiationId")}
+        negotiation_id = pickup.get("negotiationId")
+        if isinstance(negotiation_id, str) and negotiation_id.strip():
+            _maybe_start_turn(negotiation_id.strip())
+            return {"ok": True, "pending": True, "negotiationId": negotiation_id.strip()}
+        return {"ok": True, "pending": True, "negotiationId": negotiation_id}
     except Exception as exc:  # noqa: BLE001 - wake must never break the host process
         logger.debug("negotiation wake pickup failed: %s", exc)
         return {"ok": False, "error": str(exc)}
@@ -232,8 +224,6 @@ def _listen_loop(stream_factory: Callable[[], Any] | None = None) -> None:
 def start_listener(*, stream_factory: Callable[[], Any] | None = None) -> bool:
     """Start the background SSE listener once (gateway / full plugin mode)."""
     global _LISTENER_STARTED
-    import os
-
     if stream_factory is None and not os.environ.get("INDEX_API_KEY", "").strip():
         return False
     with _WAKE_LOCK:
@@ -261,4 +251,12 @@ def stop_listener_for_tests() -> None:
 
 
 def reset_for_tests() -> None:
+    global _TURN_STARTER
     stop_listener_for_tests()
+    with _WAKE_LOCK:
+        _STARTED_IDS.clear()
+        _TURN_STARTER = None
+
+
+if _RUNTIME_KEY not in sys.modules:
+    sys.modules[_RUNTIME_KEY] = sys.modules[__name__]

--- a/packages/hermes-plugin/package.json
+++ b/packages/hermes-plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@indexnetwork/hermes-plugin",
-  "version": "0.23.0",
+  "version": "0.24.0",
   "description": "Hermes-native Index Network plugin with MCP and personal-agent tools",
   "license": "MIT",
   "type": "module",

--- a/packages/hermes-plugin/plugin.yaml
+++ b/packages/hermes-plugin/plugin.yaml
@@ -1,5 +1,5 @@
 name: index-network
-version: 0.23.0
+version: 0.24.0
 description: Index Network Hermes plugin with native tools backed by Index MCP and personal-agent APIs.
 provides_tools:
   - index_read_intents

--- a/packages/hermes-plugin/tests/smoke.py
+++ b/packages/hermes-plugin/tests/smoke.py
@@ -46,6 +46,7 @@ class FakeContext:
         self.skills = []
         self.hooks = []
         self.commands = []
+        self.injected = []
 
     def register_tool(self, **kwargs):
         self.tools.append(kwargs)
@@ -58,6 +59,10 @@ class FakeContext:
 
     def register_command(self, name, handler, description="", args_hint=""):
         self.commands.append((name, handler, description, args_hint))
+
+    def inject_message(self, content, role="user", *, session_key=None):
+        self.injected.append({"content": content, "role": role, "session_key": session_key})
+        return True
 
 
 def load_plugin():
@@ -449,9 +454,10 @@ def main() -> None:
     assert "_load_negotiation_wake().tick()" in (ROOT / "dashboard" / "plugin_api.py").read_text()
     assert "index-negotiation-wake-tick" in (ROOT / "dashboard" / "plugin_api.py").read_text()
     assert "negotiation_wake.start_listener()" in (ROOT / "__init__.py").read_text()
+    assert "negotiation_wake.bind_plugin_context(ctx)" in (ROOT / "__init__.py").read_text()
 
     # Conversation SSE wake: keepalive + non-own negotiation messages run one
-    # pickup; own agent turns do not; empty pickup stays silent.
+    # pickup; own agent turns do not; pickup never auto-consults or auto-responds.
     assert plugin.negotiation_wake is not None
     wake = plugin.negotiation_wake
     wake.reset_for_tests()
@@ -512,15 +518,39 @@ def main() -> None:
                     "negotiationId": "neg-wake",
                     "allowedActions": ["question", "outreach", "propose"],
                 }
-            if path.endswith("/consult"):
-                return {"success": True, "status": "input_required", "settlementId": "s1"}
             return {"success": True}
+
+    started: list[str] = []
+    wake.reset_for_tests()
+    wake.set_turn_starter(lambda negotiation_id: started.append(negotiation_id))
+    empty_again = _WakeTransport()
+    assert wake.run_pickup_pass(empty_again) == {"ok": True, "pending": False}
+    assert started == []
+    assert not any("/consult" in c[1] or "/respond" in c[1] for c in empty_again.calls)
 
     pending_transport = _PendingTransport()
     pending_result = wake.run_pickup_pass(pending_transport)
     assert pending_result["ok"] is True and pending_result["pending"] is True
-    assert any(c[1].endswith("/consult") for c in pending_transport.calls)
-    assert not any("/respond" in c[1] for c in pending_transport.calls)
+    assert pending_result["negotiationId"] == "neg-wake"
+    assert started == ["neg-wake"]
+    assert not any("/consult" in c[1] or "/respond" in c[1] for c in pending_transport.calls)
+    second = wake.run_pickup_pass(_PendingTransport())
+    assert second["pending"] is True
+    assert started == ["neg-wake"]
+
+    wake.reset_for_tests()
+    inject_ctx = FakeContext()
+    wake.bind_plugin_context(inject_ctx)
+    assert wake.run_pickup_pass(_WakeTransport()) == {"ok": True, "pending": False}
+    assert inject_ctx.injected == []
+    pending_inject = wake.run_pickup_pass(_PendingTransport())
+    assert pending_inject["pending"] is True
+    assert len(inject_ctx.injected) == 1
+    injected = inject_ctx.injected[0]["content"]
+    assert "neg-wake" in injected
+    assert "index_respond_to_negotiation" in injected
+    assert wake.run_pickup_pass(_PendingTransport())["pending"] is True
+    assert len(inject_ctx.injected) == 1
 
     stream_lines = [
         b": keepalive\n",
@@ -756,6 +786,7 @@ def main() -> None:
 
     old_api_key = os.environ.pop("INDEX_API_KEY", None)
     old_api_url = os.environ.pop("INDEX_API_URL", None)
+    plugin.tools.reset_transport()
 
     old_urlopen = urllib.request.urlopen
     try:

--- a/packages/hermes-plugin/tests/smoke.py
+++ b/packages/hermes-plugin/tests/smoke.py
@@ -30,6 +30,7 @@ PYTHON_FILES = [
     "negotiation_wake.py",
     "dashboard/plugin_api.py",
     "dashboard/auth_login.py",
+    "dashboard/agent_bootstrap.py",
 ]
 DASHBOARD_FILES = [
     "dashboard/manifest.json",
@@ -2110,6 +2111,7 @@ def main() -> None:
         env_file = os.path.join(env_dir, ".env")
         old_env_path = os.environ.pop("HERMES_ENV_PATH", None)
         old_key_id = os.environ.pop("INDEX_API_KEY_ID", None)
+        old_mcp_url = os.environ.pop("INDEX_MCP_URL", None)
         os.environ["HERMES_ENV_PATH"] = env_file
         try:
             # .env merge: update INDEX_API_KEY in place, keep the other vars.
@@ -2144,11 +2146,112 @@ def main() -> None:
                 if saved_api_url is not None:
                     os.environ["INDEX_API_URL"] = saved_api_url
 
+            bootstrap = dashboard_api.agent_bootstrap
+            other = {"id": "other", "name": "a", "type": "external", "status": "active"}
+            inactive = {"id": "old", "name": "Hermes", "type": "external", "status": "inactive"}
+            plain = {"id": "h1", "name": "Hermes", "type": "external", "status": "active"}
+            negotiator = {
+                "id": "h2",
+                "name": "Hermes",
+                "type": "external",
+                "status": "active",
+                "handleNegotiations": True,
+            }
+            assert bootstrap.select_hermes_agent([other, inactive, plain, negotiator])["id"] == "h2"
+            assert bootstrap.select_hermes_agent([other, inactive]) is None
+
+            class RecordingTransport:
+                def __init__(self, rest_replies, mcp_replies=None):
+                    self.rest = []
+                    self.mcp = []
+                    self.rest_replies = list(rest_replies)
+                    self.mcp_replies = list(mcp_replies or [])
+
+                def request_rest(self, method, path, body=None, **_kwargs):
+                    self.rest.append((method, path, body))
+                    return self.rest_replies.pop(0)
+
+                def call_mcp(self, name, arguments):
+                    self.mcp.append((name, arguments))
+                    return self.mcp_replies.pop(0)
+
+            persisted = []
+            empty = RecordingTransport(
+                [
+                    {"agents": []},
+                    {"token": {"id": "tok-1", "key": "agent-secret"}},
+                    {"success": True},
+                ],
+                [
+                    {
+                        "content": [
+                            {
+                                "type": "text",
+                                "text": json.dumps(
+                                    {"success": True, "data": {"agent": {"id": "h1", "name": "Hermes"}}}
+                                ),
+                            }
+                        ]
+                    }
+                ],
+            )
+            assert bootstrap.promote(empty, lambda key, kid: persisted.append((key, kid)), "cli-key", "cli-kid") == {
+                "negotiatorReady": True
+            }
+            assert persisted == [("agent-secret", "tok-1")]
+            assert empty.mcp == [
+                (
+                    "register_agent",
+                    {
+                        "name": "Hermes",
+                        "description": "Hermes on this host",
+                        "permissions": ["manage:negotiations", "manage:intents", "manage:opportunities"],
+                    },
+                )
+            ]
+            assert empty.rest[0] == ("GET", "/agents", None)
+            assert empty.rest[1] == ("POST", "/agents/h1/tokens", {"name": "Hermes API Key"})
+            assert empty.rest[2] == (
+                "POST",
+                "/auth/cli-credential/revoke",
+                {"keyId": "cli-kid", "targetKey": "cli-key"},
+            )
+
+            reused = []
+            existing = RecordingTransport(
+                [
+                    {"agents": [other, negotiator]},
+                    {"token": {"id": "tok-2", "key": "agent-secret-2"}},
+                    {"success": True},
+                ]
+            )
+            assert bootstrap.promote(existing, lambda key, kid: reused.append((key, kid)), "cli-2", "kid-2") == {
+                "negotiatorReady": True
+            }
+            assert reused == [("agent-secret-2", "tok-2")]
+            assert existing.mcp == []
+            assert existing.rest[1][1] == "/agents/h2/tokens"
+
+            mint_fail = RecordingTransport(
+                [
+                    {"agents": [plain]},
+                    {"success": False, "error": "forbidden", "status": 403},
+                ]
+            )
+            keep = []
+            failed_mint = bootstrap.promote(mint_fail, lambda key, kid: keep.append((key, kid)), "cli-3", "kid-3")
+            assert failed_mint["negotiatorReady"] is False
+            assert "forbidden" in failed_mint["error"]
+            assert keep == []
+            assert mint_fail.mcp == []
+
             # No pending login: the status endpoint reports idle.
             assert dashboard_api.auth_login_status() == {"success": True, "status": "idle"}
 
             # Loopback handshake drives poll_status to success (real sockets).
             urllib.request.urlopen = old_urlopen
+            os.environ["INDEX_MCP_URL"] = "https://mcp.example.test/mcp"
+            os.environ["INDEX_API_URL"] = "https://api.example.test/api"
             auth_url = auth_login.start_login("https://app.example.test")
             parsed_auth = urllib.parse.urlsplit(auth_url)
             assert parsed_auth.path == "/cli-auth"
@@ -2161,17 +2264,79 @@ def main() -> None:
                 callback + "?" + urllib.parse.urlencode({"state": state, "api_key": "loop-key", "key_id": "loop-kid"})
             ) as resp:
                 assert resp.status == 200
-            # Success through the dashboard endpoint also resets the cached
-            # transport so the fresh key takes effect without a restart.
+            # Success through the dashboard endpoint bootstraps a Hermes agent
+            # key and resets the cached transport so it takes effect without a restart.
             sentinel = FakeAuthTransport()
             dashboard_api.tools.set_transport_for_tests(sentinel)
-            assert dashboard_api.auth_login_status() == {"success": True, "status": "success"}
+            captured = []
+            install_fake_urlopen(
+                [
+                    FakeResponse({"agents": []}),
+                    mcp_text_response(
+                        {"success": True, "data": {"agent": {"id": "hermes-1", "name": "Hermes"}}}
+                    ),
+                    FakeResponse({"token": {"id": "tok-hermes", "key": "agent-secret"}}),
+                    FakeResponse({"success": True}),
+                ],
+                captured,
+            )
+            assert dashboard_api.auth_login_status() == {
+                "success": True,
+                "status": "success",
+                "negotiatorReady": True,
+            }
             assert dashboard_api.tools.get_transport() is not sentinel
-            assert os.environ["INDEX_API_KEY"] == "loop-key"
-            assert os.environ["INDEX_API_KEY_ID"] == "loop-kid"
+            assert os.environ["INDEX_API_KEY"] == "agent-secret"
+            assert os.environ["INDEX_API_KEY_ID"] == "tok-hermes"
+            assert captured[0]["method"] == "GET"
+            assert captured[0]["url"] == "https://api.example.test/api/agents"
+            assert captured[1]["url"] == "https://mcp.example.test/mcp"
+            assert captured[1]["body"]["params"]["name"] == "register_agent"
+            assert captured[2]["url"] == "https://api.example.test/api/agents/hermes-1/tokens"
+            assert captured[3]["url"] == "https://api.example.test/api/auth/cli-credential/revoke"
+            assert captured[3]["body"] == {"keyId": "loop-kid", "targetKey": "loop-key"}
+            assert "INDEX_API_KEY=agent-secret" in open(env_file, encoding="utf-8").read()
             assert auth_login.poll_status()["status"] == "idle"  # terminal + torn down
 
+            # A second login reuses the existing Hermes agent (no second register_agent).
+            urllib.request.urlopen = old_urlopen
+            auth_url_reuse = auth_login.start_login("https://app.example.test")
+            reuse_params = urllib.parse.parse_qs(urllib.parse.urlsplit(auth_url_reuse).query)
+            with old_urlopen(
+                reuse_params["callback"][0]
+                + "?"
+                + urllib.parse.urlencode({"state": reuse_params["state"][0], "api_key": "cli-2", "key_id": "kid-2"})
+            ) as resp:
+                assert resp.status == 200
+            reuse_captured = []
+            install_fake_urlopen(
+                [
+                    FakeResponse(
+                        {
+                            "agents": [
+                                {
+                                    "id": "hermes-1",
+                                    "name": "Hermes",
+                                    "type": "external",
+                                    "status": "active",
+                                    "handleNegotiations": True,
+                                }
+                            ]
+                        }
+                    ),
+                    FakeResponse({"token": {"id": "tok-2", "key": "agent-secret-2"}}),
+                    FakeResponse({"success": True}),
+                ],
+                reuse_captured,
+            )
+            reused_status = dashboard_api.auth_login_status()
+            assert reused_status == {"success": True, "status": "success", "negotiatorReady": True}
+            assert os.environ["INDEX_API_KEY"] == "agent-secret-2"
+            assert [entry["url"] for entry in reuse_captured if "mcp" in entry["url"]] == []
+            assert reuse_captured[1]["url"] == "https://api.example.test/api/agents/hermes-1/tokens"
+
             # A mismatched callback state fails the attempt.
+            urllib.request.urlopen = old_urlopen
             auth_url2 = auth_login.start_login("https://app.example.test")
             callback2 = urllib.parse.parse_qs(urllib.parse.urlsplit(auth_url2).query)["callback"][0]
             try:
@@ -2222,6 +2387,9 @@ def main() -> None:
             urllib.request.urlopen = old_urlopen
             dashboard_api.tools.set_transport_for_tests(None)
             os.environ.pop("HERMES_ENV_PATH", None)
+            os.environ.pop("INDEX_MCP_URL", None)
+            if old_mcp_url is not None:
+                os.environ["INDEX_MCP_URL"] = old_mcp_url
             if old_env_path is not None:
                 os.environ["HERMES_ENV_PATH"] = old_env_path
             os.environ.pop("INDEX_API_KEY_ID", None)


### PR DESCRIPTION
## Summary
- Hermes plugin 0.24.0: an empty pickup stays a seat heartbeat; a pending claim injects one Hermes chat turn so the model can reply with `index_respond_to_negotiation` and a real shared message.
- Browser login still bootstraps an agent-bound API key after the CLI handshake (already committed on this branch).
- Mac Activate no longer writes `INDEX_PLUGIN_MODE=negotiator` or the one-minute Personal Agent cron; leftover negotiator mode is scrubbed and leftover jobs are removed.

## Test plan
- [x] `env -u INDEX_API_KEY -u INDEX_API_URL -u INDEX_MCP_URL -u INDEX_APP_BASE_URL -u INDEX_API_KEY_ID python3 tests/smoke.py` in `packages/hermes-plugin` (dashboard registration mode gate: PASS)
- [x] `bun test api/agent-runtime.spec.mjs api/agent-runtime-saga.spec.mjs hermes-runtime.spec.mjs api/task-5-acceptance.spec.ts` in `apps/mac` (85 pass, 0 fail)
- [ ] CI required checks on this PR
- [ ] Gateway injection still needs `plugins.entries.index-network.allow_gateway_injection` and a Hermes session with origin; without that, wake claims and returns false on `inject_message`

Green GitHub checks are the only default PR signal; they are not review.