### PR TITLE
refactor(protocol): flatten contacts module

### DIFF
--- a/packages/protocol/src/README.md
+++ b/packages/protocol/src/README.md
@@ -100,7 +100,7 @@ anywhere.
 | Opportunity Presenter | `opportunities/application/opportunity.presenter.ts` | Home graph, opportunity tools — generates role-appropriate descriptions (Grice's Maxim of Relation) |
 | Opportunity Introducer | `opportunities/application/opportunity.introducer.ts` | Introducer-driven contact-pair discovery |
 | Questioner Agent | `questions/question.agent.ts` | Mode-driven decision-question generation (discovery, intent, enrichment, negotiation, chat) |
-| Contact Inviter | `contacts/application/contact.inviter.ts` | Invite flow — generates personalized invite messages |
+| Contact Inviter | `contacts/contact.inviter.ts` | Invite flow — generates personalized invite messages |
 | Index Negotiator | `negotiations/negotiation.agent.ts` | Negotiation graph — system AI that drafts/evaluates a turn when no personal agent responds |
 | Negotiation Insights Generator | `negotiations/insight.generator.ts` | Negotiation graph — synthesizes negotiation session insights |
 | Negotiation Summarizer | `negotiations/negotiation.summarizer.ts` | Negotiation — builds the discovery negotiation digest (deterministic fallback when LLM unavailable) |

--- a/packages/protocol/src/contacts/contact.repository.port.ts
+++ b/packages/protocol/src/contacts/contact.repository.port.ts
@@ -1,5 +1,5 @@
 /**
- * contacts/ports — ContactServiceAdapter persistence port.
+ * contacts — ContactServiceAdapter persistence port.
  *
  * Injected boundary for contact management persistence. Implemented by
  * the host application and passed into the protocol layer at the composition root.

--- a/packages/protocol/src/contacts/contact.tools.port.ts
+++ b/packages/protocol/src/contacts/contact.tools.port.ts
@@ -1,5 +1,5 @@
 /**
- * contacts/ports — ContactToolDeps tool host port.
+ * contacts — ContactToolDeps tool host port.
  *
  * Narrow port type consumed by createContactTools. The host provides a
  * ContactServiceAdapter.
@@ -11,8 +11,7 @@
  * Its shape remains structurally equivalent to the matching
  * ToolRegistryCompositionDeps fields.
  *
- * IND-549: extracted from capabilities/contacts.tools.port.ts into the
- * contacts capability's dedicated ports layer.
+ * This root-level contract keeps the capability dependency surface compact.
  */
 
 import type { ContactServiceAdapter } from "./contact.repository.port.js";

--- a/packages/protocol/src/contacts/contact.tools.ts
+++ b/packages/protocol/src/contacts/contact.tools.ts
@@ -1,5 +1,5 @@
 /**
- * contacts/application — createContactTools canonical implementation.
+ * contacts — createContactTools canonical implementation.
  *
  * Creates contact management tools for the chat agent. Enables listing,
  * removing, and searching the user's personal network.

--- a/packages/protocol/src/contacts/contact.types.ts
+++ b/packages/protocol/src/contacts/contact.types.ts
@@ -1,9 +1,9 @@
 /**
- * contacts/domain — pure contact entity value types.
+ * contacts — pure contact entity value types.
  *
  * No application logic, no LLM calls, no cross-capability imports.
  *
- * IND-549: canonical domain layer for the contacts capability.
+ * Canonical contact types for the contacts capability.
  */
 
 /** Contact with user details, as returned by listContacts. */


### PR DESCRIPTION
## Summary\n- flatten contacts domain, ports, and tool implementation into the capability root\n- update imports, exports, tests, and documentation\n\n## Validation\n- bun run build:package:protocol\n- bun test src/contacts/tests/contact.tools.spec.ts src/contacts/tests/search-contacts.spec.ts