### PR TITLE
fix(negotiations): scope negotiation state to its match, not the conversation

### DIFF
--- a/packages/protocol/src/agents/tests/agent.tools.canonical-actions.spec.ts
+++ b/packages/protocol/src/agents/tests/agent.tools.canonical-actions.spec.ts
@@ -1,8 +1,8 @@
 import { describe, expect, test } from 'bun:test';
 import type { z } from 'zod';
 
-import { createAgentTools } from '../application/agent.tools.js';
-import type { AgentToolDeps } from '../ports/index.js';
+import { createAgentTools } from '../agent.tools.js';
+import type { AgentToolDeps } from '../agent.tools.port.js';
 
 /**
  * IND-582 — canonical-only permission actions at the public participant-agent

--- a/packages/protocol/src/index.ts
+++ b/packages/protocol/src/index.ts
@@ -299,8 +299,8 @@ export type {
 
 // ─── Negotiation seat rules (v2 client-advocate protocol) ───────────────────
 
-export { isNegotiationTurnCapReached, expectedNegotiationSpeaker, allowedActionsFor, askUserAnswerWindowMs, configuredAskUserEnabled, isTerminalAction, isRejectLikeAction, readProtocolVersion, resolveSeat, seatViolationMessage } from "./negotiations/negotiation.module.js";
-export type { NegotiationSpeakerParticipants, NegotiationSpeakerMessage } from "./negotiations/negotiation.module.js";
+export { isNegotiationTurnCapReached, expectedNegotiationSpeaker, negotiationScopeKey, readNegotiationMessages, allowedActionsFor, askUserAnswerWindowMs, configuredAskUserEnabled, isTerminalAction, isRejectLikeAction, readProtocolVersion, resolveSeat, seatViolationMessage } from "./negotiations/negotiation.module.js";
+export type { NegotiationSpeakerParticipants, NegotiationSpeakerMessage, NegotiationScopeMetadata } from "./negotiations/negotiation.module.js";
 export { assessConsultationEligibility, consultationPromptFor, negotiationConsultationPolicyMode } from "./negotiations/negotiation.module.js";
 export type { ConsultationEligibility, ConsultationEligibilityInput, NegotiationConsultationPolicyMode } from "./negotiations/negotiation.module.js";
 export {

--- a/packages/protocol/src/negotiations/negotiation.agent.ts
+++ b/packages/protocol/src/negotiations/negotiation.agent.ts
@@ -292,12 +292,20 @@ ${stanceQuerySatisfiedRule(stance, otherName, userName)}`
       ? ' Prior turns from OTHER opportunities are background only — do not treat their conclusions as decisions about this opportunity.'
       : '';
 
-    const continuationHasHistory = hasAttributedDialogue || input.history.length > 0;
-    const continuationContext = input.isContinuation && continuationHasHistory
+    // The pair's shared DM carries every negotiation they have ever had. It is
+    // rendered whenever it exists — NOT only on continuations — because a fresh
+    // match in a long-running DM is exactly the case where that context is
+    // worth having. What it may not do is stand in for this negotiation's own
+    // exchange, so the policy line differs by whether this one has opened.
+    const hasPriorDialogue = hasAttributedDialogue || input.history.length > 0;
+    const priorDialoguePolicy = input.isContinuation
+      ? 'Policy: You are continuing a prior dialogue. If this signal is materially the same as one you previously evaluated, you may resolve quickly. If materially different, evaluate on its own merits.'
+      : 'Policy: This signal is NEW — you have not negotiated it before. The dialogue above concluded on other signals and is background only. Evaluate this one on its own merits and make your own case for it.';
+    const priorDialogueContext = hasPriorDialogue
       ? `\n\n--- Prior dialogue with this counterparty ---\n${attributionPreamble}${priorDialogueBody}\n\n--- New signal under evaluation ---\n${input.discoveryQuery
   ? `Discovery query: "${input.discoveryQuery}"`
   : `Seed assessment: ${input.seedAssessment.reasoning}`
-}\n\nPolicy: You are continuing a prior dialogue. If this signal is materially the same as one you previously evaluated, you may resolve quickly. If materially different, evaluate on its own merits.${attributionPolicy}`
+}\n\n${priorDialoguePolicy}${attributionPolicy}`
       : '';
 
     const userAnswersContext = input.userAnswers && input.userAnswers.length > 0
@@ -332,7 +340,7 @@ Skills: ${input.otherUser.profile.skills?.join(", ") ?? "N/A"}
 Intents:
 ${input.otherUser.intents.map((i) => `- ${i.title}: ${i.description}`).join("\n")}
 
-Why this match was suggested: ${input.seedAssessment.reasoning}${input.isContinuation ? continuationContext : historyText}${userAnswersContext}${privateConsultationContext}
+Why this match was suggested: ${input.seedAssessment.reasoning}${hasPriorDialogue ? priorDialogueContext : historyText}${userAnswersContext}${privateConsultationContext}
 ${discoveryQueryReminder}
 ${input.history.length === 0 && !input.isContinuation ? (version === "v2" && seat === "initiator" ? "This is the opening turn. Make the outreach case." : "This is the opening turn. Propose the connection case.") : "Evaluate the latest arguments and respond."}`;
 

--- a/packages/protocol/src/negotiations/negotiation.detail-reader.ts
+++ b/packages/protocol/src/negotiations/negotiation.detail-reader.ts
@@ -141,7 +141,10 @@ export async function readAuthorizedNegotiationDetail(
     isUsersTurn,
     isContinuation: metadata.isContinuation ?? false,
     priorTurnCount,
-    turnsAdded: turnCount - priorTurnCount,
+    // Clamped: `turnCount` is match-scoped, but a task stamped before that
+    // change carries a conversation-wide `priorTurnCount`, which would other-
+    // wise report a negative delta for negotiations in flight across the deploy.
+    turnsAdded: Math.max(0, turnCount - priorTurnCount),
     turns,
     outcome,
     lifecycle: buildLifecycleNarration(

--- a/packages/protocol/src/negotiations/negotiation.expected-speaker.ts
+++ b/packages/protocol/src/negotiations/negotiation.expected-speaker.ts
@@ -1,6 +1,12 @@
 export interface NegotiationSpeakerParticipants {
   sourceUserId?: unknown;
   candidateUserId?: unknown;
+  /**
+   * The seat that opens this negotiation (v2 stamp). An unopened negotiation
+   * starts with its initiator; `sourceUserId` is the pre-stamp fallback, which
+   * is what the stamp defaults to anyway.
+   */
+  initiatorUserId?: unknown;
 }
 
 export interface NegotiationSpeakerMessage {
@@ -27,12 +33,20 @@ function participantId(value: unknown): string | null {
 /**
  * Resolves the participant whose agent owns the next canonical bilateral turn.
  *
+ * `messages` must be THIS negotiation's messages (see
+ * `getNegotiationMessages`), never the whole conversation. Two agents share one
+ * DM across every match they are ever paired on, so conversation-scoped parity
+ * makes a fresh negotiation inherit the turn order of an unrelated, concluded
+ * one — handing the floor to the counterparty, who may `accept` immediately and
+ * conclude the match before its initiator has spoken.
+ *
  * Participant identities must be nonempty and distinct. Unrelated agent,
  * system, and owner-settlement messages are ignored while finding the latest
  * source/candidate message. An ordinary canonical message passes the floor to
  * the other participant; `ask_user` retains it for the consulting sender's
- * exact successor. A valid conversation with no canonical history starts with
- * the source participant. Invalid participant metadata always fails closed.
+ * exact successor. A negotiation with no canonical history of its own has not
+ * opened yet, so it starts with its initiator. Invalid participant metadata
+ * always fails closed.
  */
 export function expectedNegotiationSpeaker(
   participants: NegotiationSpeakerParticipants,
@@ -55,5 +69,9 @@ export function expectedNegotiationSpeaker(
       : sender === source ? candidate : source;
   }
 
-  return source;
+  // Unopened: the initiator seat speaks first. Mirrors the
+  // `initiatorUserId ?? sourceUserId` precedence in `resolveSeat`, and falls
+  // back to source when the stamp is absent or names a non-participant.
+  const initiator = participantId(participants.initiatorUserId);
+  return initiator === candidate ? candidate : source;
 }

--- a/packages/protocol/src/negotiations/negotiation.graph.init.ts
+++ b/packages/protocol/src/negotiations/negotiation.graph.init.ts
@@ -18,6 +18,7 @@ import { buildIntentSnapshots } from "./negotiation.intent-snapshot-provenance.j
 import { holdsNegotiationConversationLock } from "./negotiation.task-lock-policy.js";
 import { isNegotiationTurnCapReached } from "./negotiation.turn-cap.js";
 import { expectedNegotiationSpeaker } from "./negotiation.expected-speaker.js";
+import { readNegotiationMessages } from "./negotiation.scope.js";
 import { buildSeededAttribution } from './negotiation.attribution.js';
 import { buildAttributedDialogue, finalizeLog, hasPriorAskUser, initLog, memoryQueryText, negotiateCandidatesLog, resolveTaskAttribution, retrieveMemory, screenNodeLog, turnLog, turnsFromMessages } from "./negotiation.graph.shared.js";
 import type { NegotiationGraphDeps, NegotiationState } from "./negotiation.graph.shared.js";
@@ -85,13 +86,18 @@ export async function initNode(state: NegotiationState, deps: NegotiationGraphDe
     }
 
     // --- Load this negotiation's own prior turns ---
-    // A negotiation is keyed by opportunity, not task: an ask_user pause resumes
-    // into a successor task, and both tasks' turns are the same negotiation.
-    // Without an opportunity there is no negotiation identity to scope to, so
-    // the run is by definition unopened.
-    const negotiationMessages = state.opportunityId
-      ? await deps.database.getNegotiationMessages(state.opportunityId)
-      : [];
+    // Resolved through the shared scope rule, not a local copy of it: the graph
+    // and the respond/polling surfaces must agree on what "this negotiation's
+    // messages" means, or an external agent can be told it is not its turn
+    // forever. That rule also owns the unkeyed case — a run with no opportunity
+    // has no identity apart from its conversation.
+    const negotiationMessages = await readNegotiationMessages({
+      byNegotiation: (id) => deps.database.getNegotiationMessages(id),
+      byConversation: async () => conversationMessages,
+    }, {
+      conversationId: conversation.id,
+      metadata: { opportunityId: state.opportunityId },
+    });
     const priorTurns: NegotiationTurn[] = turnsFromMessages(negotiationMessages);
 
     // `isContinuation` means THIS negotiation has already spoken — not that the

--- a/packages/protocol/src/negotiations/negotiation.graph.init.ts
+++ b/packages/protocol/src/negotiations/negotiation.graph.init.ts
@@ -35,7 +35,12 @@ export async function initNode(state: NegotiationState, deps: NegotiationGraphDe
       : await deps.database.getOrCreateDM(agentIdA, agentIdB, 'agent');
 
     // --- Lock gate: check for an active task on this conversation ---
-    const priorMessages = await deps.database.getMessagesForConversation(conversation.id);
+    // Two reads with two jobs. `conversationMessages` is the pair's whole shared
+    // DM — CONTEXT, including negotiations for other matches, which reaches the
+    // agent only as labelled prior dialogue. `negotiationMessages` is THIS
+    // match's own turns, and is the sole input to this negotiation's state:
+    // whether it has opened, whose turn it is, how far it has run.
+    const conversationMessages = await deps.database.getMessagesForConversation(conversation.id);
 
     if (
       Boolean(state.resumeFromTaskId) !== Boolean(state.continuationSettlementId)
@@ -79,19 +84,20 @@ export async function initNode(state: NegotiationState, deps: NegotiationGraphDe
       return { error: 'busy' };
     }
 
-    // --- Load prior messages and determine continuation ---
-    const priorTurns: NegotiationTurn[] = turnsFromMessages(priorMessages);
+    // --- Load this negotiation's own prior turns ---
+    // A negotiation is keyed by opportunity, not task: an ask_user pause resumes
+    // into a successor task, and both tasks' turns are the same negotiation.
+    // Without an opportunity there is no negotiation identity to scope to, so
+    // the run is by definition unopened.
+    const negotiationMessages = state.opportunityId
+      ? await deps.database.getNegotiationMessages(state.opportunityId)
+      : [];
+    const priorTurns: NegotiationTurn[] = turnsFromMessages(negotiationMessages);
 
+    // `isContinuation` means THIS negotiation has already spoken — not that the
+    // pair has history. A fresh match in a long-running DM is not a
+    // continuation, and must still open.
     const isContinuation = priorTurns.length > 0;
-
-    const expectedSpeaker = expectedNegotiationSpeaker({
-      sourceUserId: state.sourceUser.id,
-      candidateUserId: state.candidateUser.id,
-    }, priorMessages);
-    if (!expectedSpeaker) return { error: 'invalid negotiation participants' };
-    const currentSpeaker: 'source' | 'candidate' = expectedSpeaker === state.sourceUser.id
-      ? 'source'
-      : 'candidate';
 
     // Determine scenario-based maxTurns
     const scope = { action: 'manage:negotiations', scopeType: 'network', scopeId: state.indexContext.networkId };
@@ -138,6 +144,19 @@ export async function initNode(state: NegotiationState, deps: NegotiationGraphDe
         }
       }
     }
+
+    // --- Floor: derived from this negotiation's turns, after the seat is known ---
+    // Resolved here rather than above because an unopened negotiation starts
+    // with its initiator, which the tie-break may only just have settled.
+    const expectedSpeaker = expectedNegotiationSpeaker({
+      sourceUserId: state.sourceUser.id,
+      candidateUserId: state.candidateUser.id,
+      initiatorUserId,
+    }, negotiationMessages);
+    if (!expectedSpeaker) return { error: 'invalid negotiation participants' };
+    const currentSpeaker: 'source' | 'candidate' = expectedSpeaker === state.sourceUser.id
+      ? 'source'
+      : 'candidate';
 
     // --- Protocol version: pinned per negotiation, re-stamped per match ---
     // A prior task for this same negotiation (exact continuation resume or
@@ -212,24 +231,28 @@ export async function initNode(state: NegotiationState, deps: NegotiationGraphDe
         })
       : [];
 
-    // Seed messages with prior turns (additive reducer appends new turns on top).
-    // taskId is preserved so the turn/screen nodes can separate this
-    // session's turns from seeded prior-task turns (IND-569).
-    const seedMessages = isContinuation ? priorMessages.map((m) => ({
+    // Seed messages with THIS negotiation's prior turns (additive reducer
+    // appends new turns on top). taskId is preserved so the turn/screen nodes
+    // can separate this session's turns from earlier sessions of the same
+    // negotiation (IND-569).
+    const seedMessages = negotiationMessages.map((m) => ({
       id: m.id,
       senderId: m.senderId,
       role: 'agent' as const,
       parts: m.parts,
       createdAt: m.createdAt,
       taskId: (m as { taskId?: string | null }).taskId ?? null,
-    })) : [];
+    }));
 
-    // IND-569: attribute seeded prior turns to their originating opportunity
-    // once, up front. Earlier-opportunity and legacy unattributed blocks are
-    // immutable for the session; the current block is composed per turn.
-    const priorAttribution = isContinuation
+    // IND-569: attribute the pair's whole shared DM to its originating
+    // negotiations, once, up front. Earlier-match and legacy unattributed
+    // blocks are immutable for the session; the current block is composed per
+    // turn. Keyed on the conversation, not on `isContinuation`: a fresh match
+    // has no turns of its own but the pair's history is exactly the context
+    // worth carrying into it.
+    const priorAttribution = conversationMessages.length > 0
       ? await buildSeededAttribution(
-          priorMessages
+          conversationMessages
             .map((m) => ({ taskId: (m as { taskId?: string | null }).taskId ?? null, turn: turnsFromMessages([m])[0] }))
             .filter((e): e is { taskId: string | null; turn: NegotiationTurn } => Boolean(e.turn)),
           state.opportunityId,

--- a/packages/protocol/src/negotiations/negotiation.graph.shared.ts
+++ b/packages/protocol/src/negotiations/negotiation.graph.shared.ts
@@ -69,9 +69,11 @@ export function turnsFromMessages(messages: Array<{ parts: unknown[] }>): Negoti
 
 /**
  * Whether `userId`'s side has already spent its one `ask_user` client
- * consultation in this conversation (P3.2 rationing: max one per negotiation
- * per side, checked against the full message history so continuations count
- * prior sessions' consultations too).
+ * consultation in THIS negotiation (P3.2 rationing: max one per negotiation per
+ * side). Callers pass `state.messages`, which carries this negotiation's turns
+ * across all of its sessions — so an earlier session of the same negotiation
+ * counts, while a consultation spent on a different match with the same
+ * counterparty does not.
  */
 export function hasPriorAskUser(
   messages: Array<{ senderId: string; parts: unknown[] }>,
@@ -175,7 +177,9 @@ try {
 export function buildAttributedDialogue(
   state: NegotiationState,
 ): AttributedPriorDialogue | null {
-  if (!state.isContinuation || !state.priorAttribution) return null;
+  // Not gated on `isContinuation`: that now means "this negotiation has spoken",
+  // and the pair's earlier matches are context worth carrying into a fresh one.
+  if (!state.priorAttribution) return null;
   const currentSessionTurns = turnsFromMessages(
     state.messages.filter((m) => (m as { taskId?: string | null }).taskId === state.taskId),
   );

--- a/packages/protocol/src/negotiations/negotiation.module.ts
+++ b/packages/protocol/src/negotiations/negotiation.module.ts
@@ -44,6 +44,7 @@ export {
 } from "./negotiation.hermes-contract.js";
 export { DEFAULT_NEGOTIATION_MAX_TURNS, isNegotiationTurnCapReached } from "./negotiation.turn-cap.js";
 export { expectedNegotiationSpeaker } from "./negotiation.expected-speaker.js";
+export { negotiationScopeKey, readNegotiationMessages } from "./negotiation.scope.js";
 export {
   assessConsultationEligibility,
   consultationPromptFor,
@@ -77,5 +78,6 @@ export type {
   UserNegotiationContext,
 } from "./negotiation.state.js";
 export type { NegotiationSpeakerMessage, NegotiationSpeakerParticipants } from "./negotiation.expected-speaker.js";
+export type { NegotiationScopeMetadata } from "./negotiation.scope.js";
 export type { NegotiatorMemoryEntry } from "./negotiation.memory.js";
 export type { NegotiationToolDeps } from "./negotiation.tools.port.js";

--- a/packages/protocol/src/negotiations/negotiation.scope.ts
+++ b/packages/protocol/src/negotiations/negotiation.scope.ts
@@ -1,0 +1,57 @@
+/**
+ * The boundary between a negotiation and the conversation it runs in.
+ *
+ * Two agents share one DM permanently — `getOrCreateDM` keys on the agent pair
+ * alone — so that conversation accumulates every negotiation the pair has ever
+ * had. A negotiation is a bounded episode about ONE match inside it.
+ *
+ * Every question about a negotiation's own state (whose turn it is, whether it
+ * has opened, how many turns it has run) must be answered from the
+ * negotiation's messages. Conversation-wide reads remain valid for CONTEXT —
+ * what the pair discussed before — but must never decide state, or a fresh
+ * match inherits the turn parity of an unrelated concluded one.
+ *
+ * Every surface that resolves the floor shares this rule. If the graph and the
+ * respond/polling surfaces disagreed about a negotiation's scope, an external
+ * agent would be told it is not its turn forever.
+ */
+
+/** Minimal task-metadata shape needed to identify a negotiation. */
+export interface NegotiationScopeMetadata {
+  opportunityId?: unknown;
+}
+
+/**
+ * The opportunity a negotiation belongs to, or null when the task carries no
+ * opportunity. Keyed on opportunity rather than task because an `ask_user`
+ * pause resumes into a successor task: both tasks' turns are one negotiation.
+ */
+export function negotiationScopeKey(
+  metadata: NegotiationScopeMetadata | null | undefined,
+): string | null {
+  const id = metadata?.opportunityId;
+  return typeof id === 'string' && id.length > 0 ? id : null;
+}
+
+/**
+ * Reads the messages that constitute one negotiation.
+ *
+ * A task with no opportunity has no identity separate from its conversation
+ * (direct and legacy invocations), so the conversation is its scope — there is
+ * no other match it could be confused with.
+ */
+export async function readNegotiationMessages<M>(
+  readers: {
+    byNegotiation: (opportunityId: string) => Promise<M[]>;
+    byConversation: (conversationId: string) => Promise<M[]>;
+  },
+  scope: {
+    conversationId: string;
+    metadata: NegotiationScopeMetadata | null | undefined;
+  },
+): Promise<M[]> {
+  const opportunityId = negotiationScopeKey(scope.metadata);
+  return opportunityId
+    ? readers.byNegotiation(opportunityId)
+    : readers.byConversation(scope.conversationId);
+}

--- a/packages/protocol/src/negotiations/negotiation.screen.ts
+++ b/packages/protocol/src/negotiations/negotiation.screen.ts
@@ -134,10 +134,14 @@ export class NegotiationScreener {
 
     // IND-569: prefer the attributed rendering (labeled per-opportunity blocks)
     // when the graph supplies it; otherwise fall back to the flat prior-turn list.
-    const hasAttributed = input.isContinuation
-      && input.priorDialogueAttributed != null
+    //
+    // Deliberately NOT gated on `isContinuation`, which means "this negotiation
+    // has already spoken". The gate this section exists for is the opposite
+    // case — a FRESH signal against a counterparty the client has prior dialogue
+    // with (IND-563), which is precisely when duplicate outreach must be caught.
+    const hasAttributed = input.priorDialogueAttributed != null
       && !attributedDialogueIsEmpty(input.priorDialogueAttributed);
-    const flatPriorDialogue = input.isContinuation && input.priorDialogue && input.priorDialogue.length > 0
+    const flatPriorDialogue = input.priorDialogue && input.priorDialogue.length > 0
       ? input.priorDialogue
       : [];
     const priorDialogueBody = hasAttributed

--- a/packages/protocol/src/negotiations/negotiation.tools.ts
+++ b/packages/protocol/src/negotiations/negotiation.tools.ts
@@ -15,6 +15,7 @@ import { readAuthorizedNegotiationDetail } from './negotiation.detail-reader.js'
 import { buildLifecycleNarration } from './negotiation.lifecycle-narration.js';
 import { isNegotiationTurnCapReached } from './negotiation.turn-cap.js';
 import { expectedNegotiationSpeaker } from './negotiation.expected-speaker.js';
+import { readNegotiationMessages } from './negotiation.scope.js';
 
 export { buildLifecycleNarration } from './negotiation.lifecycle-narration.js';
 
@@ -189,8 +190,12 @@ export function createNegotiationTools(defineTool: DefineTool, deps: Negotiation
           const isSource = meta.sourceUserId === context.userId;
           const counterpartyId = isSource ? meta.candidateUserId : meta.sourceUserId;
 
-          // Get messages for preview (and turns when narrative detail requested)
-          const messages = await negotiationDatabase.getMessagesForConversation(task.conversationId);
+          // This negotiation's own turns: the preview, turn count and floor all
+          // describe THIS match, and the pair's DM also holds other matches.
+          const messages = await readNegotiationMessages({
+            byNegotiation: (id) => negotiationDatabase.getNegotiationMessages(id),
+            byConversation: (id) => negotiationDatabase.getMessagesForConversation(id),
+          }, { conversationId: task.conversationId, metadata: meta });
           const lastMessage = messages[messages.length - 1];
           const lastTurnData = lastMessage
             ? ((lastMessage.parts as Array<{ kind?: string; data?: unknown }>)?.find(p => p.kind === 'data')?.data as { action?: string; assessment?: { reasoning?: string }; message?: string | null } | undefined)
@@ -371,7 +376,10 @@ export function createNegotiationTools(defineTool: DefineTool, deps: Negotiation
           metadata: meta,
           callerUserId: context.userId,
           callerRole: isSource ? 'source' : 'candidate',
-          readMessages: (conversationId) => negotiationDatabase.getMessagesForConversation(conversationId),
+          readMessages: (conversationId) => readNegotiationMessages({
+            byNegotiation: (id) => negotiationDatabase.getNegotiationMessages(id),
+            byConversation: (id) => negotiationDatabase.getMessagesForConversation(id),
+          }, { conversationId, metadata: meta }),
           readArtifacts: (taskId) => negotiationDatabase.getArtifactsForTask(taskId),
           readLifecycleEvidence: (opportunityIds, ownerUserId) =>
             readOpportunityLifecycles(negotiationDatabase, opportunityIds, ownerUserId),
@@ -428,6 +436,7 @@ export function createNegotiationTools(defineTool: DefineTool, deps: Negotiation
           sourceUserId?: string;
           candidateUserId?: string;
           initiatorUserId?: string;
+          opportunityId?: string;
           protocolVersion?: string;
           type?: string;
           maxTurns?: number;
@@ -486,7 +495,10 @@ export function createNegotiationTools(defineTool: DefineTool, deps: Negotiation
           return error(seatViolationMessage(query.action, seat, protocolVersion));
         }
 
-        const messages = await negotiationDatabase.getMessagesForConversation(task.conversationId);
+        const messages = await readNegotiationMessages({
+          byNegotiation: (id) => negotiationDatabase.getNegotiationMessages(id),
+          byConversation: (id) => negotiationDatabase.getMessagesForConversation(id),
+        }, { conversationId: task.conversationId, metadata: meta });
         const turnCount = messages.length;
         const expectedSpeaker = expectedNegotiationSpeaker(meta, messages);
 

--- a/packages/protocol/src/negotiations/tests/negotiation.ask-user.spec.ts
+++ b/packages/protocol/src/negotiations/tests/negotiation.ask-user.spec.ts
@@ -240,6 +240,7 @@ function mkStubs(opts?: {
       return bindingFor(input.recipientUserId as string, input);
     },
     getMessagesForConversation: async () => opts?.priorMessages ?? [],
+    getNegotiationMessages: async () => opts?.priorMessages ?? [],
     getOpportunityUserAnswers: async () => [],
     getNegotiationTaskForOpportunity: async () => {
       opportunityTaskReads += 1;

--- a/packages/protocol/src/negotiations/tests/negotiation.continuation-screen.spec.ts
+++ b/packages/protocol/src/negotiations/tests/negotiation.continuation-screen.spec.ts
@@ -121,6 +121,7 @@ function mkStubs(opts?: { priorMessages?: FakeMessage[]; exact?: boolean }) {
     getNegotiationTaskForOpportunity: async () => null,
     getOpportunityUserAnswers: async () => [],
     getMessagesForConversation: async () => opts?.priorMessages ?? [],
+    getNegotiationMessages: async () => opts?.priorMessages ?? [],
     getLatestNegotiationTaskForConversation: async () => null,
     getUserContext: async () => ({ text: "Bob builds ML systems." }),
     getTask: async (id: string) => tasksById.get(id) ?? null,

--- a/packages/protocol/src/negotiations/tests/negotiation.continuation-withdraw.spec.ts
+++ b/packages/protocol/src/negotiations/tests/negotiation.continuation-withdraw.spec.ts
@@ -61,6 +61,7 @@ function mkStubs(priorMessages: FakeMessage[] = []) {
     getNegotiationTaskForOpportunity: async () => null,
     getOpportunityUserAnswers: async () => [],
     getMessagesForConversation: async () => priorMessages,
+    getNegotiationMessages: async () => priorMessages,
     getLatestNegotiationTaskForConversation: async () => null,
     getUserContext: async () => null,
     getTask: async () => null,

--- a/packages/protocol/src/negotiations/tests/negotiation.continuation.spec.ts
+++ b/packages/protocol/src/negotiations/tests/negotiation.continuation.spec.ts
@@ -26,6 +26,7 @@ function createMockDatabase(overrides: Partial<Record<string, unknown>> = {}) {
     getTasksForUser: async () => [],
     getTask: async () => null,
     getMessagesForConversation: async () => [],
+    getNegotiationMessages: async () => [],
     getArtifactsForTask: async () => [],
     updateOpportunityStatus: async () => ({ id: "opp-1", status: "negotiating" }),
     ...overrides,
@@ -281,8 +282,10 @@ describe("Negotiation continuation telemetry", () => {
       return { action: "accept", assessment: { reasoning: "r", suggestedRoles: { ownUser: "peer", otherUser: "peer" } } } as never;
     };
 
+    // Same match, earlier session: the prior turn belongs to THIS opportunity.
     const db = createMockDatabase({
       getMessagesForConversation: async () => priorMessages,
+      getNegotiationMessages: async () => priorMessages,
     });
     const dispatcher = createMockDispatcher();
     const graph = new NegotiationGraphFactory(db, dispatcher).createGraph();
@@ -292,12 +295,59 @@ describe("Negotiation continuation telemetry", () => {
       candidateUser,
       indexContext,
       seedAssessment: seed,
+      opportunityId: "opp-same",
       maxTurns: 2,
     } as Partial<typeof NegotiationGraphState.State>);
 
     expect(result.isContinuation).toBe(true);
     expect(result.priorTurnCount).toBe(1);
     expect(result.outcome).not.toBeNull();
+
+    IndexNegotiator.prototype.invoke = origInvoke;
+  }, 30_000);
+
+  it("fresh match in an established conversation is NOT a continuation", async () => {
+    // The pair's DM holds a concluded negotiation for a DIFFERENT match. That
+    // is context, not state: this negotiation has not spoken, so it still owes
+    // an opening and its turn counters start at zero.
+    const priorTurn = {
+      action: "accept",
+      assessment: { reasoning: "other match", suggestedRoles: { ownUser: "peer", otherUser: "peer" } },
+    };
+    const priorMessages = [{
+      id: "msg-other-1",
+      senderId: `agent:${sourceUser.id}`,
+      role: "agent" as const,
+      taskId: "task-other",
+      parts: [{ kind: "data" as const, data: priorTurn }],
+      createdAt: new Date(Date.now() - 60_000),
+    }];
+
+    IndexNegotiator.prototype.invoke = async function () {
+      return { action: "accept", assessment: { reasoning: "r", suggestedRoles: { ownUser: "peer", otherUser: "peer" } } } as never;
+    };
+
+    const db = createMockDatabase({
+      getMessagesForConversation: async () => priorMessages,
+      // Nothing has been said about THIS match yet.
+      getNegotiationMessages: async () => [],
+    });
+    const graph = new NegotiationGraphFactory(db, createMockDispatcher()).createGraph();
+
+    const result = await graph.invoke({
+      sourceUser,
+      candidateUser,
+      indexContext,
+      seedAssessment: seed,
+      opportunityId: "opp-fresh",
+      maxTurns: 2,
+    } as Partial<typeof NegotiationGraphState.State>);
+
+    expect(result.isContinuation).toBe(false);
+    expect(result.priorTurnCount).toBe(0);
+    // The initiator opened rather than the counterparty closing on turn 0.
+    const created = (db as unknown as { _messages: Array<{ senderId: string }> })._messages;
+    expect(created[0].senderId).toBe(`agent:${sourceUser.id}`);
 
     IndexNegotiator.prototype.invoke = origInvoke;
   }, 30_000);
@@ -328,6 +378,7 @@ describe("Negotiation continuation telemetry", () => {
 
     const db = createMockDatabase({
       getMessagesForConversation: async () => priorMessages,
+      getNegotiationMessages: async () => priorMessages,
       getOpportunityUserAnswers: async () => mockAnswers,
     });
     const dispatcher = createMockDispatcher();

--- a/packages/protocol/src/negotiations/tests/negotiation.deadlock-shift.spec.ts
+++ b/packages/protocol/src/negotiations/tests/negotiation.deadlock-shift.spec.ts
@@ -53,6 +53,7 @@ function mkStubs(opts?: {
       },
     }),
     getMessagesForConversation: async () => [],
+    getNegotiationMessages: async () => [],
     getOpportunityUserAnswers: async () => [],
     getNegotiationTaskForOpportunity: async () => null,
     getLatestNegotiationTaskForConversation: async () => null,
@@ -362,6 +363,7 @@ describe("get_negotiation — deadlockShift metadata privacy (IND-428)", () => {
       negotiationDatabase: {
         getTask: async () => task,
         getMessagesForConversation: async () => [],
+        getNegotiationMessages: async () => [],
         getArtifactsForTask: async () => [],
       },
     } as never);

--- a/packages/protocol/src/negotiations/tests/negotiation.graph.spec.ts
+++ b/packages/protocol/src/negotiations/tests/negotiation.graph.spec.ts
@@ -22,6 +22,7 @@ function mkStubs() {
     createArtifact: async () => {},
     setTaskTurnContext: async () => {},
     getMessagesForConversation: async () => [],
+    getNegotiationMessages: async () => [],
     getNegotiationTaskForOpportunity: async () => null,
   } as unknown as ConstructorParameters<typeof NegotiationGraphFactory>[0];
 

--- a/packages/protocol/src/negotiations/tests/negotiation.initiator.spec.ts
+++ b/packages/protocol/src/negotiations/tests/negotiation.initiator.spec.ts
@@ -45,6 +45,7 @@ function mkStubs(opts?: {
     createArtifact: async () => {},
     setTaskTurnContext: async () => {},
     getMessagesForConversation: async () => [],
+    getNegotiationMessages: async () => [],
     getOpportunityUserAnswers: async () => [],
     getNegotiationTaskForOpportunity: async () => opts?.priorOpportunityTask ?? null,
     ...(opts?.omitConversationLookup

--- a/packages/protocol/src/negotiations/tests/negotiation.match-scoped-floor.spec.ts
+++ b/packages/protocol/src/negotiations/tests/negotiation.match-scoped-floor.spec.ts
@@ -1,0 +1,229 @@
+import { describe, it, expect, beforeAll, afterAll } from "bun:test";
+import { NegotiationGraphFactory } from "../negotiation.graph.js";
+import { NegotiationGraphState } from "../negotiation.state.js";
+import { IndexNegotiator } from "../negotiation.agent.js";
+
+/**
+ * A negotiation owns its own turn state; the conversation only supplies context.
+ *
+ * Two agents share one DM forever (`getOrCreateDM` keys on the agent pair), so a
+ * fresh match lands in a room that already holds concluded negotiations for other
+ * matches. The floor and the opening requirement must be derived from the match
+ * under negotiation — never from the room — or a new match silently inherits the
+ * turn parity of an unrelated one and the counterparty can accept before the
+ * initiator has spoken.
+ */
+
+type TaskRecord = {
+  id: string;
+  conversationId: string;
+  state: string;
+  metadata: Record<string, unknown> | null;
+  createdAt: Date;
+  updatedAt: Date;
+};
+
+const INITIATOR = "u-init";
+const COUNTERPARTY = "u-counter";
+
+function priorTurnMessage(opts: {
+  id: string;
+  taskId: string;
+  senderId: string;
+  action: string;
+  createdAt: Date;
+}) {
+  return {
+    id: opts.id,
+    senderId: opts.senderId,
+    role: "agent" as const,
+    taskId: opts.taskId,
+    parts: [{
+      kind: "data" as const,
+      data: {
+        action: opts.action,
+        assessment: {
+          reasoning: "prior",
+          suggestedRoles: { ownUser: "peer", otherUser: "peer" },
+        },
+      },
+    }],
+    createdAt: opts.createdAt,
+  };
+}
+
+function mkStubs(opts: {
+  priorMessages: ReturnType<typeof priorTurnMessage>[];
+  tasks: Record<string, TaskRecord>;
+}) {
+  const created: Array<{ senderId: string; parts: unknown[]; taskId?: string }> = [];
+  let counter = 0;
+
+  const database = {
+    createConversation: async () => ({ id: "conv-1" }),
+    getOrCreateDM: async () => ({ id: "conv-1" }),
+    createTask: async (conversationId: string, metadata: Record<string, unknown>) => ({
+      id: "task-new", conversationId, state: "submitted", metadata,
+    }),
+    createMessage: async (p: { senderId: string; parts: unknown[]; taskId?: string }) => {
+      created.push(p);
+      return {
+        id: `msg-new-${++counter}`,
+        senderId: p.senderId,
+        parts: p.parts,
+        taskId: p.taskId ?? null,
+        createdAt: new Date(),
+      };
+    },
+    updateTaskState: async () => {},
+    createArtifact: async () => {},
+    setTaskTurnContext: async () => {},
+    updateOpportunityStatus: async () => {},
+    getOpportunityUserAnswers: async () => [],
+    getArtifactsForTask: async () => [],
+    getUserContext: async () => null,
+    getMessagesForConversation: async () => opts.priorMessages,
+    // In-memory stand-in for the messages⋈tasks join: a message belongs to the
+    // negotiation whose task carries that opportunityId.
+    getNegotiationMessages: async (opportunityId: string) => opts.priorMessages.filter(
+      (m) => opts.tasks[m.taskId]?.metadata?.opportunityId === opportunityId,
+    ),
+    getTask: async (taskId: string) => opts.tasks[taskId] ?? null,
+    getNegotiationTaskForOpportunity: async () => null,
+    getLatestNegotiationTaskForConversation: async () => null,
+  } as unknown as ConstructorParameters<typeof NegotiationGraphFactory>[0];
+
+  const dispatcher = {
+    hasExternalAgent: async () => false,
+    dispatch: async () => ({ handled: false, reason: "no_agent" }),
+  } as unknown as ConstructorParameters<typeof NegotiationGraphFactory>[1];
+
+  return { database, dispatcher, created };
+}
+
+function actionOf(parts: unknown[]): string | undefined {
+  const part = (parts as Array<{ kind?: string; data?: { action?: string } }>)
+    .find((p) => p.kind === "data");
+  return part?.data?.action;
+}
+
+describe("negotiation floor is scoped to the match, not the conversation", () => {
+  let origInvoke: typeof IndexNegotiator.prototype.invoke;
+  let origVersion: string | undefined;
+  let origScreen: string | undefined;
+
+  beforeAll(() => {
+    origVersion = process.env.NEGOTIATION_PROTOCOL_VERSION;
+    origScreen = process.env.NEGOTIATION_SCREEN_MODE;
+    process.env.NEGOTIATION_PROTOCOL_VERSION = "v2";
+    process.env.NEGOTIATION_SCREEN_MODE = "off";
+    origInvoke = IndexNegotiator.prototype.invoke;
+    // Both sides are willing. The counterparty seat's `accept` is what
+    // terminates a negotiation on turn 0 when the floor is wrong.
+    IndexNegotiator.prototype.invoke = async function () {
+      return {
+        action: "accept" as const,
+        assessment: {
+          reasoning: "stub",
+          suggestedRoles: { ownUser: "peer" as const, otherUser: "peer" as const },
+        },
+        message: "yes",
+      };
+    };
+  });
+
+  afterAll(() => {
+    IndexNegotiator.prototype.invoke = origInvoke;
+    if (origVersion === undefined) delete process.env.NEGOTIATION_PROTOCOL_VERSION;
+    else process.env.NEGOTIATION_PROTOCOL_VERSION = origVersion;
+    if (origScreen === undefined) delete process.env.NEGOTIATION_SCREEN_MODE;
+    else process.env.NEGOTIATION_SCREEN_MODE = origScreen;
+  });
+
+  it("a fresh match opens with its initiator even when the room's last turn was the initiator's", async () => {
+    // A concluded negotiation for a DIFFERENT match, whose last turn was the
+    // initiator's. Conversation-scoped parity would hand the floor straight to
+    // the counterparty — who may accept, terminating before any opening.
+    const stubs = mkStubs({
+      priorMessages: [
+        priorTurnMessage({
+          id: "msg-old-1", taskId: "task-old", senderId: `agent:${COUNTERPARTY}`,
+          action: "outreach", createdAt: new Date(Date.now() - 120_000),
+        }),
+        priorTurnMessage({
+          id: "msg-old-2", taskId: "task-old", senderId: `agent:${INITIATOR}`,
+          action: "accept", createdAt: new Date(Date.now() - 60_000),
+        }),
+      ],
+      tasks: {
+        "task-old": {
+          id: "task-old",
+          conversationId: "conv-1",
+          state: "completed",
+          metadata: { type: "negotiation", opportunityId: "opp-old" },
+          createdAt: new Date(Date.now() - 180_000),
+          updatedAt: new Date(Date.now() - 60_000),
+        },
+      },
+    });
+
+    const graph = new NegotiationGraphFactory(stubs.database, stubs.dispatcher).createGraph();
+    await graph.invoke({
+      sourceUser: { id: INITIATOR, intents: [], profile: { name: "Alice" } },
+      candidateUser: { id: COUNTERPARTY, intents: [], profile: { name: "Bob" } },
+      indexContext: { networkId: "net-1", prompt: "" },
+      seedAssessment: { reasoning: "new match", valencyRole: "peer" },
+      opportunityId: "opp-new",
+      initiatorUserId: INITIATOR,
+      maxTurns: 2,
+    } as Partial<typeof NegotiationGraphState.State>);
+
+    expect(stubs.created.length).toBeGreaterThan(0);
+    // The initiator speaks first on its own match.
+    expect(stubs.created[0].senderId).toBe(`agent:${INITIATOR}`);
+    // And it must open, not close.
+    expect(actionOf(stubs.created[0].parts)).toBe("outreach");
+    // A real exchange, not a single-turn accept.
+    expect(stubs.created.length).toBe(2);
+    expect(stubs.created[1].senderId).toBe(`agent:${COUNTERPARTY}`);
+  }, 30_000);
+
+  it("within one match, the floor still passes to the other side", async () => {
+    // Same match resumed (e.g. after an ask_user pause or a timeout park):
+    // prior turns belong to THIS opportunity, so normal alternation applies and
+    // no second opening is forced.
+    const stubs = mkStubs({
+      priorMessages: [
+        priorTurnMessage({
+          id: "msg-cur-1", taskId: "task-cur", senderId: `agent:${INITIATOR}`,
+          action: "outreach", createdAt: new Date(Date.now() - 60_000),
+        }),
+      ],
+      tasks: {
+        "task-cur": {
+          id: "task-cur",
+          conversationId: "conv-1",
+          state: "completed",
+          metadata: { type: "negotiation", opportunityId: "opp-new" },
+          createdAt: new Date(Date.now() - 120_000),
+          updatedAt: new Date(Date.now() - 60_000),
+        },
+      },
+    });
+
+    const graph = new NegotiationGraphFactory(stubs.database, stubs.dispatcher).createGraph();
+    await graph.invoke({
+      sourceUser: { id: INITIATOR, intents: [], profile: { name: "Alice" } },
+      candidateUser: { id: COUNTERPARTY, intents: [], profile: { name: "Bob" } },
+      indexContext: { networkId: "net-1", prompt: "" },
+      seedAssessment: { reasoning: "same match", valencyRole: "peer" },
+      opportunityId: "opp-new",
+      initiatorUserId: INITIATOR,
+      maxTurns: 2,
+    } as Partial<typeof NegotiationGraphState.State>);
+
+    expect(stubs.created.length).toBe(1);
+    expect(stubs.created[0].senderId).toBe(`agent:${COUNTERPARTY}`);
+    expect(actionOf(stubs.created[0].parts)).toBe("accept");
+  }, 30_000);
+});

--- a/packages/protocol/src/negotiations/tests/negotiation.memory-injection.spec.ts
+++ b/packages/protocol/src/negotiations/tests/negotiation.memory-injection.spec.ts
@@ -33,6 +33,7 @@ function mkStubs() {
   const database = {
     getOrCreateDM: async () => ({ id: "conv-1" }),
     getMessagesForConversation: async () => [],
+    getNegotiationMessages: async () => [],
     getNegotiationTaskForOpportunity: async () => null,
     getLatestNegotiationTaskForConversation: async () => null,
     createTask: async (conversationId: string, metadata: Record<string, unknown>) => {

--- a/packages/protocol/src/negotiations/tests/negotiation.prior-dialogue-attribution.spec.ts
+++ b/packages/protocol/src/negotiations/tests/negotiation.prior-dialogue-attribution.spec.ts
@@ -259,6 +259,7 @@ function createWiringDatabase() {
     getTask: async (id: string) => tasks[id] ?? null,
     getArtifactsForTask: async (id: string) => artifacts[id] ?? [],
     getMessagesForConversation: async () => priorMessages,
+    getNegotiationMessages: async () => priorMessages,
     getUserContext: async () => ({ text: "" }),
     updateOpportunityStatus: async () => ({ id: "opp-current", status: "negotiating" }),
   } as unknown as NegotiationGraphDatabase;

--- a/packages/protocol/src/negotiations/tests/negotiation.reflect.spec.ts
+++ b/packages/protocol/src/negotiations/tests/negotiation.reflect.spec.ts
@@ -153,6 +153,7 @@ function mkStubs() {
     createArtifact: async () => {},
     setTaskTurnContext: async () => {},
     getMessagesForConversation: async () => [],
+    getNegotiationMessages: async () => [],
     getOpportunityUserAnswers: async () => [],
     getNegotiationTaskForOpportunity: async () => null,
     getLatestNegotiationTaskForConversation: async () => null,

--- a/packages/protocol/src/negotiations/tests/negotiation.screen-routing.spec.ts
+++ b/packages/protocol/src/negotiations/tests/negotiation.screen-routing.spec.ts
@@ -47,7 +47,14 @@ function priorMsg(senderUserId: string, action: string, idx: number): FakeMessag
 }
 
 function mkStubs(opts?: {
+  /** The pair's whole shared DM. */
   priorMessages?: FakeMessage[];
+  /**
+   * This negotiation's own turns. Defaults to the whole DM (same-match
+   * resume); pass `[]` to model a FRESH match in a DM that already holds
+   * concluded negotiations for other matches.
+   */
+  negotiationMessages?: FakeMessage[];
   userContextText?: string;
   omitSetTaskScreenDecision?: boolean;
 }) {
@@ -80,6 +87,7 @@ function mkStubs(opts?: {
       },
     }),
     getMessagesForConversation: async () => opts?.priorMessages ?? [],
+    getNegotiationMessages: async () => opts?.negotiationMessages ?? opts?.priorMessages ?? [],
     getOpportunityUserAnswers: async () => [],
     getNegotiationTaskForOpportunity: async () => null,
     getLatestNegotiationTaskForConversation: async () => null,
@@ -205,22 +213,35 @@ describe("negotiation graph — screen node routing (IND-398)", () => {
     expect(result.outcome).not.toBeNull();
   });
 
-  it("shadow: regular continuations screen once but still proceed (IND-563)", async () => {
+  it("shadow: a fresh match in an established DM screens with the pair's history as context (IND-563)", async () => {
     process.env.NEGOTIATION_SCREEN_MODE = "shadow";
     const stubs = mkStubs({
+      // The pair has talked before — on a DIFFERENT, concluded match.
       priorMessages: [priorMsg("u-src", "propose", 0), priorMsg("u-cand", "counter", 1)],
+      negotiationMessages: [],
     });
 
     const result = await runGraph(stubs);
 
-    // IND-563: the continuation is screened (prior dialogue forwarded), but a
-    // shadow decision never blocks — the negotiation proceeds to a turn.
+    // The gate still runs before re-engaging the counterparty, and a shadow
+    // decision never blocks.
     expect(screenerInputs.length).toBe(1);
-    expect(screenerInputs[0].isContinuation).toBe(true);
-    expect(screenerInputs[0].priorDialogue?.length).toBe(2);
     expect(stubs.screenWrites.length).toBe(1);
     expect(stubs.createdMessages.length).toBeGreaterThanOrEqual(1);
     expect(result.outcome).not.toBeNull();
+
+    // This negotiation has not spoken, so it is NOT a continuation and has no
+    // turns of its own — the pair's earlier match reaches the screener through
+    // the labelled attributed channel instead, as context.
+    expect(screenerInputs[0].isContinuation).toBe(false);
+    expect(screenerInputs[0].priorDialogue).toBeUndefined();
+    const attributed = screenerInputs[0].priorDialogueAttributed;
+    expect(attributed).toBeDefined();
+    expect([
+      ...attributed!.unattributed,
+      ...attributed!.earlier.flatMap((g) => g.turns),
+    ].length).toBe(2);
+    expect(attributed!.current.length).toBe(0);
   });
 
   it("shadow: screen failure fails OPEN — proceeds with failedOpen reach_out recorded", async () => {

--- a/packages/protocol/src/negotiations/tests/negotiation.screen-routing.spec.ts
+++ b/packages/protocol/src/negotiations/tests/negotiation.screen-routing.spec.ts
@@ -221,7 +221,9 @@ describe("negotiation graph — screen node routing (IND-398)", () => {
       negotiationMessages: [],
     });
 
-    const result = await runGraph(stubs);
+    // A real fresh match carries its own opportunity; that is what scopes it
+    // apart from the concluded negotiation already in this DM.
+    const result = await runGraph(stubs, { opportunityId: "opp-fresh" });
 
     // The gate still runs before re-engaging the counterparty, and a shadow
     // decision never blocks.

--- a/packages/protocol/src/negotiations/tests/negotiation.screen.spec.ts
+++ b/packages/protocol/src/negotiations/tests/negotiation.screen.spec.ts
@@ -187,19 +187,35 @@ describe("NegotiationScreener.invoke", () => {
     expect(user).toContain("on its own merits");
   });
 
-  it("omits the prior-dialogue section when not a continuation (byte-identical path)", async () => {
+  it("renders the prior-dialogue section for a FRESH signal against a known counterparty (IND-563)", async () => {
     const screener = new SeamScreener({
       decision: "pass",
       reasoning: "r",
       evidence: { counterpartyPremiseFit: "", intentAlignment: "" },
     });
-    // priorDialogue present but isContinuation not set → still omitted.
+    // `isContinuation` means "this negotiation has already spoken", so it is
+    // false here — a NEW signal against a counterparty the client has prior
+    // dialogue with. That is exactly the case this gate exists to catch, so the
+    // section must render rather than be suppressed.
     await screener.invoke({
       ...baseInput,
       priorDialogue: [
         { action: "outreach", assessment: { reasoning: "x", suggestedRoles: { ownUser: "peer", otherUser: "peer" } }, message: null },
       ],
     });
+
+    const user = screener.capturedMessages.find((m) => m.role === "user")!.content;
+    expect(user).toContain("Prior dialogue with");
+    expect(user).toContain("Do NOT reach out again on generic overlap");
+  });
+
+  it("omits the prior-dialogue section when there is no prior dialogue at all", async () => {
+    const screener = new SeamScreener({
+      decision: "pass",
+      reasoning: "r",
+      evidence: { counterpartyPremiseFit: "", intentAlignment: "" },
+    });
+    await screener.invoke({ ...baseInput });
 
     const user = screener.capturedMessages.find((m) => m.role === "user")!.content;
     expect(user).not.toContain("Prior dialogue with");

--- a/packages/protocol/src/negotiations/tests/negotiation.seat-rules.spec.ts
+++ b/packages/protocol/src/negotiations/tests/negotiation.seat-rules.spec.ts
@@ -69,6 +69,7 @@ function mkStubs(opts?: {
     createArtifact: async () => {},
     setTaskTurnContext: async () => {},
     getMessagesForConversation: async () => opts?.priorMessages ?? [],
+    getNegotiationMessages: async () => opts?.priorMessages ?? [],
     getOpportunityUserAnswers: async () => [],
     getNegotiationTaskForOpportunity: async () => opts?.priorOpportunityTask ?? null,
     getLatestNegotiationTaskForConversation: async () => opts?.conversationTask ?? null,

--- a/packages/protocol/src/negotiations/tests/negotiation.tools.seat.spec.ts
+++ b/packages/protocol/src/negotiations/tests/negotiation.tools.seat.spec.ts
@@ -69,6 +69,7 @@ function makeDeps(task: unknown, messages: unknown[]) {
       negotiationDatabase: {
         getTask: async () => task,
         getMessagesForConversation: async () => messages,
+        getNegotiationMessages: async () => messages,
         createMessage: async (m: { senderId: string; parts: Array<{ data: { action: string } }> }) => {
           createdMessages.push(m);
           return { id: "msg-new", senderId: m.senderId, role: "agent", parts: m.parts, createdAt: new Date() };

--- a/packages/protocol/src/negotiations/tests/negotiation.tools.spec.ts
+++ b/packages/protocol/src/negotiations/tests/negotiation.tools.spec.ts
@@ -86,6 +86,7 @@ describe("list_negotiations — isUsersTurn", () => {
       negotiationDatabase: {
         getTasksForUser: async () => [task],
         getMessagesForConversation: async () => [msg],
+        getNegotiationMessages: async () => [msg],
       },
     };
 
@@ -105,6 +106,7 @@ describe("list_negotiations — isUsersTurn", () => {
       negotiationDatabase: {
         getTasksForUser: async () => [task],
         getMessagesForConversation: async () => [],
+        getNegotiationMessages: async () => [],
       },
     };
 
@@ -152,6 +154,7 @@ describe("list_negotiations — latestMessagePreview", () => {
       negotiationDatabase: {
         getTasksForUser: async () => [task],
         getMessagesForConversation: async () => [msg],
+        getNegotiationMessages: async () => [msg],
       },
     };
 
@@ -173,6 +176,7 @@ describe("list_negotiations — latestMessagePreview", () => {
       negotiationDatabase: {
         getTasksForUser: async () => [task],
         getMessagesForConversation: async () => [msg],
+        getNegotiationMessages: async () => [msg],
       },
     };
 
@@ -201,6 +205,7 @@ describe("list_negotiations — pagination", () => {
       negotiationDatabase: {
         getTasksForUser: async () => tasks,
         getMessagesForConversation: async () => [],
+        getNegotiationMessages: async () => [],
       },
     };
 
@@ -222,6 +227,7 @@ describe("list_negotiations — pagination", () => {
       negotiationDatabase: {
         getTasksForUser: async () => tasks,
         getMessagesForConversation: async () => [],
+        getNegotiationMessages: async () => [],
       },
     };
 
@@ -241,6 +247,7 @@ describe("list_negotiations — pagination", () => {
       negotiationDatabase: {
         getTasksForUser: async () => tasks,
         getMessagesForConversation: async () => [],
+        getNegotiationMessages: async () => [],
       },
     };
 
@@ -261,6 +268,7 @@ describe("list_negotiations — pagination", () => {
       negotiationDatabase: {
         getTasksForUser: async () => tasks,
         getMessagesForConversation: async () => [],
+        getNegotiationMessages: async () => [],
       },
     };
 
@@ -295,6 +303,7 @@ describe("list_negotiations — intent scope", () => {
         getTasksForUser: async () => [matching, differentIntent, withoutOpportunity, withoutIntent],
         getIntentIdsForOpportunities,
         getMessagesForConversation: async () => [],
+        getNegotiationMessages: async () => [],
       },
     };
 
@@ -316,6 +325,7 @@ describe("list_negotiations — intent scope", () => {
       negotiationDatabase: {
         getTasksForUser: async () => [first, second],
         getMessagesForConversation: async () => [],
+        getNegotiationMessages: async () => [],
       },
     };
 
@@ -337,6 +347,7 @@ describe("list_negotiations — intent scope", () => {
       negotiationDatabase: {
         getTasksForUser: async () => [task],
         getMessagesForConversation: async () => [],
+        getNegotiationMessages: async () => [],
       },
     };
 
@@ -361,6 +372,7 @@ describe("get_negotiation — isUsersTurn", () => {
       negotiationDatabase: {
         getTask: async () => task,
         getMessagesForConversation: async () => [msg],
+        getNegotiationMessages: async () => [msg],
         getArtifactsForTask: async () => [],
       },
     };
@@ -754,6 +766,7 @@ describe("list_negotiations — network scope", () => {
       negotiationDatabase: {
         getTasksForUser: async () => [inScope, outOfScope],
         getMessagesForConversation: async () => [],
+        getNegotiationMessages: async () => [],
       },
     };
 
@@ -775,6 +788,7 @@ describe("list_negotiations — network scope", () => {
       negotiationDatabase: {
         getTasksForUser: async () => [t1, t2],
         getMessagesForConversation: async () => [],
+        getNegotiationMessages: async () => [],
       },
     };
 
@@ -797,6 +811,7 @@ describe("list_negotiations — network scope", () => {
       negotiationDatabase: {
         getTasksForUser: async () => [legacy],
         getMessagesForConversation: async () => [],
+        getNegotiationMessages: async () => [],
       },
     };
 
@@ -847,6 +862,7 @@ describe('list_negotiations — detail:"narrative"', () => {
       negotiationDatabase: {
         getTasksForUser: async () => [task],
         getMessagesForConversation: async () => [],
+        getNegotiationMessages: async () => [],
       },
     };
 
@@ -870,6 +886,7 @@ describe('list_negotiations — detail:"narrative"', () => {
       negotiationDatabase: {
         getTasksForUser: async () => [task],
         getMessagesForConversation: async () => [],
+        getNegotiationMessages: async () => [],
       },
     };
 
@@ -890,6 +907,7 @@ describe('list_negotiations — detail:"narrative"', () => {
       negotiationDatabase: {
         getTasksForUser: async () => [task],
         getMessagesForConversation: async () => [],
+        getNegotiationMessages: async () => [],
       },
     };
 
@@ -915,6 +933,7 @@ describe('list_negotiations — detail:"narrative"', () => {
       negotiationDatabase: {
         getTasksForUser: async () => [task],
         getMessagesForConversation: async () => messages,
+        getNegotiationMessages: async () => messages,
       },
     };
 
@@ -941,6 +960,7 @@ describe('list_negotiations — detail:"narrative"', () => {
       negotiationDatabase: {
         getTasksForUser: async () => [task],
         getMessagesForConversation: async () => messages,
+        getNegotiationMessages: async () => messages,
       },
     };
 
@@ -969,6 +989,7 @@ describe('list_negotiations — detail:"narrative"', () => {
       negotiationDatabase: {
         getTasksForUser: async () => [task],
         getMessagesForConversation: async () => messages,
+        getNegotiationMessages: async () => messages,
       },
     };
 
@@ -990,6 +1011,7 @@ describe('list_negotiations — detail:"narrative"', () => {
       negotiationDatabase: {
         getTasksForUser: async () => [task],
         getMessagesForConversation: async () => [],
+        getNegotiationMessages: async () => [],
         getArtifactsForTask: async () => { artifactsCalled = true; return []; },
       },
     };
@@ -1015,6 +1037,7 @@ describe('list_negotiations — detail:"narrative"', () => {
       negotiationDatabase: {
         getTasksForUser: async () => [task],
         getMessagesForConversation: async () => [],
+        getNegotiationMessages: async () => [],
         getArtifactsForTask: async () => [artifact],
       },
     };
@@ -1037,6 +1060,7 @@ describe('list_negotiations — detail:"narrative"', () => {
       negotiationDatabase: {
         getTasksForUser: async () => [task],
         getMessagesForConversation: async () => [],
+        getNegotiationMessages: async () => [],
         getArtifactsForTask: async () => [],
       },
     };
@@ -1063,6 +1087,9 @@ describe('list_negotiations — detail:"narrative"', () => {
       negotiationDatabase: {
         getTasksForUser: async () => tasks,
         getMessagesForConversation: async () => [
+          makeMessage('accept', 'Agent-side assessment.', 'I accept this potential match.'),
+        ],
+        getNegotiationMessages: async () => [
           makeMessage('accept', 'Agent-side assessment.', 'I accept this potential match.'),
         ],
         getArtifactsForTask: async () => [{
@@ -1125,6 +1152,7 @@ describe('list_negotiations — detail:"narrative"', () => {
       negotiationDatabase: {
         getTasksForUser: async () => tasks,
         getMessagesForConversation: async () => [],
+        getNegotiationMessages: async () => [],
         getOpportunityLifecyclesForNegotiations: async () => ({
           'opp-owner': { status: 'accepted', acceptedByOwner: true },
           'opp-other': { status: 'accepted', acceptedByOwner: false },
@@ -1181,6 +1209,7 @@ describe("get_negotiation — network scope", () => {
       negotiationDatabase: {
         getTask: async () => task,
         getMessagesForConversation: async () => [],
+        getNegotiationMessages: async () => [],
         getArtifactsForTask: async () => [],
       },
     };
@@ -1204,6 +1233,7 @@ describe("get_negotiation — network scope", () => {
       negotiationDatabase: {
         getTask: async () => task,
         getMessagesForConversation: async () => [],
+        getNegotiationMessages: async () => [],
         getArtifactsForTask: async () => [],
       },
     };
@@ -1232,6 +1262,7 @@ describe("get_negotiation — participant-only A2A visibility (IND-608)", () => 
       negotiationDatabase: {
         getTask: async () => task,
         getMessagesForConversation: async () => { messageReads += 1; return []; },
+        getNegotiationMessages: async () => { messageReads += 1; return []; },
         getArtifactsForTask: async () => { artifactReads += 1; return []; },
       },
     };
@@ -1258,6 +1289,7 @@ describe("get_negotiation — participant-only A2A visibility (IND-608)", () => 
       negotiationDatabase: {
         getTask: async () => task,
         getMessagesForConversation: async () => [],
+        getNegotiationMessages: async () => [],
         getArtifactsForTask: async () => [],
       },
     };
@@ -1285,6 +1317,7 @@ describe("respond_to_negotiation — network scope", () => {
       negotiationDatabase: {
         getTask: async () => outOfScope,
         getMessagesForConversation: async () => [],
+        getNegotiationMessages: async () => [],
         createMessage: async () => { throw new Error("must not be called"); },
         updateTaskState: async () => { throw new Error("must not be called"); },
         createArtifact: async () => { throw new Error("must not be called"); },

--- a/packages/protocol/src/negotiations/tests/negotiation.turn0-withdraw.spec.ts
+++ b/packages/protocol/src/negotiations/tests/negotiation.turn0-withdraw.spec.ts
@@ -65,6 +65,7 @@ function mkStubs(priorMessages: FakeMessage[] = []) {
     getNegotiationTaskForOpportunity: async () => null,
     getOpportunityUserAnswers: async () => [],
     getMessagesForConversation: async () => priorMessages,
+    getNegotiationMessages: async () => priorMessages,
     getLatestNegotiationTaskForConversation: async () => null,
     getUserContext: async () => null,
     getTask: async () => null,

--- a/packages/protocol/src/opportunities/negotiation-context.loader.ts
+++ b/packages/protocol/src/opportunities/negotiation-context.loader.ts
@@ -31,7 +31,7 @@ const logger = protocolLogger('NegotiationContextLoader');
  */
 export type NegotiationContextDatabase = Pick<
   NegotiationGraphDatabase,
-  'getNegotiationTaskForOpportunity' | 'getMessagesForConversation' | 'getArtifactsForTask'
+  'getNegotiationTaskForOpportunity' | 'getNegotiationMessages' | 'getArtifactsForTask'
 >;
 
 /**
@@ -86,7 +86,9 @@ export async function loadNegotiationContext(
 
   const turnCap = readNumber(task.metadata, 'maxTurns') ?? 0;
 
-  const messages = await db.getMessagesForConversation(task.conversationId);
+  // Scoped to this opportunity: `turnCount`/`turns` describe THIS negotiation,
+  // and the pair's shared DM also holds concluded negotiations for other matches.
+  const messages = await db.getNegotiationMessages(opportunityId);
   const turns = extractTurns(messages);
   const turnCount = turns.length;
 

--- a/packages/protocol/src/opportunities/tests/negotiation-context.loader.spec.ts
+++ b/packages/protocol/src/opportunities/tests/negotiation-context.loader.spec.ts
@@ -55,7 +55,7 @@ function outcomeArtifact(
 function buildDb(overrides: Partial<NegotiationContextDatabase> = {}): NegotiationContextDatabase {
   return {
     getNegotiationTaskForOpportunity: async () => null,
-    getMessagesForConversation: async () => [],
+    getNegotiationMessages: async () => [],
     getArtifactsForTask: async () => [],
     ...overrides,
   };
@@ -106,7 +106,7 @@ describe("loadNegotiationContext", () => {
         createdAt: new Date(),
         updatedAt: new Date(),
       }),
-      getMessagesForConversation: async () => [
+      getNegotiationMessages: async () => [
         turnMessage("propose", "Start with a pitch."),
         turnMessage("counter", "Suggest a different angle."),
       ],
@@ -138,7 +138,7 @@ describe("loadNegotiationContext", () => {
         createdAt: new Date(),
         updatedAt: new Date(),
       }),
-      getMessagesForConversation: async () => [
+      getNegotiationMessages: async () => [
         turnMessage("propose", "Pitch the alignment."),
         turnMessage("accept", "Looks good."),
       ],
@@ -166,7 +166,7 @@ describe("loadNegotiationContext", () => {
         createdAt: new Date(),
         updatedAt: new Date(),
       }),
-      getMessagesForConversation: async () => [
+      getNegotiationMessages: async () => [
         turnMessage("propose", "Pitch."),
         turnMessage("counter", "Counter."),
         turnMessage("counter", "Counter again."),
@@ -191,7 +191,7 @@ describe("loadNegotiationContext", () => {
         createdAt: new Date(),
         updatedAt: new Date(),
       }),
-      getMessagesForConversation: async () => [],
+      getNegotiationMessages: async () => [],
       getArtifactsForTask: async () => [outcomeArtifact(false, "screened_out")],
     });
 
@@ -210,7 +210,7 @@ describe("loadNegotiationContext", () => {
         createdAt: new Date(),
         updatedAt: new Date(),
       }),
-      getMessagesForConversation: async () => [turnMessage("propose", "pitch")],
+      getNegotiationMessages: async () => [turnMessage("propose", "pitch")],
       getArtifactsForTask: async () => [outcomeArtifact(true)],
     });
 
@@ -229,7 +229,7 @@ describe("loadNegotiationContext", () => {
         createdAt: new Date(),
         updatedAt: new Date(),
       }),
-      getMessagesForConversation: async () => [turnMessage("propose", "pitch")],
+      getNegotiationMessages: async () => [turnMessage("propose", "pitch")],
       getArtifactsForTask: async () => [],
     });
 

--- a/packages/protocol/src/opportunities/tests/opportunity.tools.digest-dedup.spec.ts
+++ b/packages/protocol/src/opportunities/tests/opportunity.tools.digest-dedup.spec.ts
@@ -144,6 +144,7 @@ function makeDeps(opts: {
     negotiationDatabase: {
       getNegotiationTaskForOpportunity: async () => null,
       getMessagesForConversation: async () => [],
+      getNegotiationMessages: async () => [],
       getArtifactsForTask: async () => [],
     } as unknown as ToolDeps['negotiationDatabase'],
     deliveryLedger: deliveryLedger as unknown as ToolDeps['deliveryLedger'],

--- a/packages/protocol/src/opportunities/tests/opportunity.tools.digest-presenter.spec.ts
+++ b/packages/protocol/src/opportunities/tests/opportunity.tools.digest-presenter.spec.ts
@@ -139,6 +139,7 @@ function makeDeps(overrides: Partial<Parameters<typeof createOpportunityTools>[1
     negotiationDatabase: {
       getNegotiationTaskForOpportunity,
       getMessagesForConversation: mock(async () => []),
+      getNegotiationMessages: mock(async () => []),
       getArtifactsForTask: mock(async () => []),
     } as unknown as ToolDeps["negotiationDatabase"],
     graphs: {

--- a/packages/protocol/src/opportunities/tests/radar.graph.spec.ts
+++ b/packages/protocol/src/opportunities/tests/radar.graph.spec.ts
@@ -52,6 +52,7 @@ function createMockDb(opportunities: Opportunity[] = []): RadarGraphDatabase {
     getUser: (id: string) => Promise.resolve({ id, name: 'User ' + id, email: '', avatar: null, socials: [] }),
     getNegotiationTaskForOpportunity: () => Promise.resolve(null),
     getMessagesForConversation: () => Promise.resolve([]),
+    getNegotiationMessages: () => Promise.resolve([]),
     getArtifactsForTask: () => Promise.resolve([]),
   };
 }
@@ -853,6 +854,7 @@ function createIntroMockDb(opportunities: Opportunity[]): RadarGraphDatabase {
     getUser: (id: string) => Promise.resolve(USER_MAP[id] ?? { id, name: 'Unknown User', email: '', avatar: null, socials: [] }),
     getNegotiationTaskForOpportunity: () => Promise.resolve(null),
     getMessagesForConversation: () => Promise.resolve([]),
+    getNegotiationMessages: () => Promise.resolve([]),
     getArtifactsForTask: () => Promise.resolve([]),
   };
 }

--- a/packages/protocol/src/opportunities/tests/radar.graph.status-filter.spec.ts
+++ b/packages/protocol/src/opportunities/tests/radar.graph.status-filter.spec.ts
@@ -60,6 +60,7 @@ function createMockDb(
     getUser: (id: string) => Promise.resolve({ id, name: 'User ' + id, email: '', avatar: null, socials: [] }),
     getNegotiationTaskForOpportunity: () => Promise.resolve(null),
     getMessagesForConversation: () => Promise.resolve([]),
+    getNegotiationMessages: () => Promise.resolve([]),
     getArtifactsForTask: () => Promise.resolve([]),
   };
 }

--- a/packages/protocol/src/shared/interfaces/database.capabilities.ts
+++ b/packages/protocol/src/shared/interfaces/database.capabilities.ts
@@ -369,6 +369,6 @@ export type RadarGraphDatabase = Pick<
 > & Pick<
   NegotiationGraphDatabase,
   | 'getNegotiationTaskForOpportunity'
-  | 'getMessagesForConversation'
+  | 'getNegotiationMessages'
   | 'getArtifactsForTask'
 >;

--- a/packages/protocol/src/shared/interfaces/database.negotiation.ts
+++ b/packages/protocol/src/shared/interfaces/database.negotiation.ts
@@ -282,6 +282,31 @@ export type NegotiationGraphDatabase = Pick<
     taskId?: string | null;
   }>>;
 
+  /**
+   * Gets the messages belonging to ONE negotiation — those written by tasks
+   * carrying `type: 'negotiation'` and the given `opportunityId` — ordered by
+   * creation time.
+   *
+   * A negotiation is keyed by opportunity, not by task: an `ask_user` pause
+   * parks its task and resumes into a pre-claimed successor, so one negotiation
+   * spans several tasks. This is the read behind every question ABOUT a
+   * negotiation (whose turn it is, whether it has opened, how many turns it has
+   * run). `getMessagesForConversation` remains the read for conversation-wide
+   * CONTEXT — prior matches between the same pair — which must never determine
+   * a negotiation's own state.
+   *
+   * Messages with no `taskId`, or whose task carries no opportunityId, are not
+   * part of any negotiation and are never returned here.
+   */
+  getNegotiationMessages(opportunityId: string): Promise<Array<{
+    id: string;
+    senderId: string;
+    role: 'user' | 'agent';
+    parts: unknown[];
+    createdAt: Date;
+    taskId?: string | null;
+  }>>;
+
   /** Gets artifacts for a task (e.g. negotiation outcome). */
   getArtifactsForTask(taskId: string): Promise<Array<{
     id: string;

--- a/services/api/src/adapters/chat.database.adapter.ts
+++ b/services/api/src/adapters/chat.database.adapter.ts
@@ -61,6 +61,7 @@ export class ChatDatabaseAdapter {
   async getNegotiationTaskForOpportunity(opportunityId: string) { return _convDb().getNegotiationTaskForOpportunity(opportunityId); }
   async getNegotiationTasksForOpportunity(opportunityId: string) { return _convDb().getNegotiationTasksForOpportunity(opportunityId); }
   async getMessagesForConversation(conversationId: string) { return _convDb().getMessagesForConversation(conversationId); }
+  async getNegotiationMessages(opportunityId: string) { return _convDb().getNegotiationMessages(opportunityId); }
   async getMessagesByTaskIds(taskIds: string[]) { return _convDb().getMessagesByTaskIds(taskIds); }
   async getArtifactsForTask(taskId: string) { return _convDb().getArtifactsForTask(taskId); }
 

--- a/services/api/src/adapters/conversation.database.adapter.ts
+++ b/services/api/src/adapters/conversation.database.adapter.ts
@@ -11,12 +11,45 @@ import type { ContinuationExecutionFence, ContinuationReceipt } from './negotiat
 import { negotiationTimeoutExecutionId, parseNegotiationTimeoutExecution, timeoutExecutionMatches } from '../lib/negotiation/timeout-execution';
 import type { AcquiredNegotiationTimeoutExecution, NegotiationTimeoutAtomicStep, NegotiationTimeoutCompletionPlan, NegotiationTimeoutExecutionIdentity, NegotiationTimeoutExecutionRecord } from '../lib/negotiation/timeout-execution';
 import { deriveLegacyNegotiationParkOrigin, type TimeoutUpgradeJobIntent } from '../lib/negotiation/timeout-upgrade-reconciliation';
-import { expectedNegotiationSpeaker } from '../lib/negotiation/expected-speaker';
+import { expectedNegotiationSpeaker, negotiationScopeKey } from '../lib/negotiation/expected-speaker';
 import { acquireNegotiationAttemptLock, acquireNegotiationPairLock, notArchivedNegotiationTaskWhere, qualifyingNegotiationAttemptTaskWhere, qualifyingPairNegotiationTaskWhere, type NegotiationAttemptTransaction } from './negotiation-attempt.atomic';
 import { consultationActorSetMatchesBinding, externalConsultationCoordinatesFor } from '../lib/negotiation/consultation';
 import { authorizeNegotiationMutationInTransaction } from '../lib/agent/negotiation-runtime-authority';
 import { isDedicatedHermesNegotiationAudience, type NegotiationCredentialPrincipal } from '../lib/agent/hermes-credential';
 import { digestHermesRunId, issueHermesRunCapability, parseHermesRunCapabilityBinding, verifyHermesRunCapability, type HermesRunOutcome } from '../lib/agent/hermes-negotiation-run';
+
+/**
+ * In-transaction read of ONE negotiation's turn history, for the locked floor
+ * checks below.
+ *
+ * Mirrors `getNegotiationMessages`, but must run inside the caller's `tx` so
+ * the check and the write it guards observe the same snapshot. A task with no
+ * opportunity has no identity apart from its conversation, so the conversation
+ * is its scope.
+ */
+async function selectNegotiationTurnHistoryInTransaction(
+  tx: { select: typeof db.select },
+  scope: { conversationId: string; metadata: Record<string, unknown> | null },
+): Promise<Array<{ id: string; senderId: string; parts: unknown }>> {
+  const opportunityId = negotiationScopeKey(scope.metadata);
+  const columns = {
+    id: schema.messages.id,
+    senderId: schema.messages.senderId,
+    parts: schema.messages.parts,
+  };
+  if (!opportunityId) {
+    return tx.select(columns).from(schema.messages)
+      .where(eq(schema.messages.conversationId, scope.conversationId))
+      .orderBy(asc(schema.messages.createdAt), asc(schema.messages.id));
+  }
+  return tx.select(columns).from(schema.messages)
+    .innerJoin(schema.tasks, eq(schema.messages.taskId, schema.tasks.id))
+    .where(and(
+      sql`${schema.tasks.metadata}->>'type' = 'negotiation'`,
+      sql`${schema.tasks.metadata}->>'opportunityId' = ${opportunityId}`,
+    ))
+    .orderBy(asc(schema.messages.createdAt), asc(schema.messages.id));
+}
 
 export type AtomicNegotiationPickupResult =
   | { kind: 'unauthorized' }
@@ -2230,9 +2263,10 @@ export class ConversationDatabaseAdapter {
       )).limit(1).for('update');
       if (!current) return null;
       if (ownerId) {
-        const history = await tx.select({ senderId: schema.messages.senderId, parts: schema.messages.parts }).from(schema.messages)
-          .where(eq(schema.messages.conversationId, current.conversationId))
-          .orderBy(asc(schema.messages.createdAt), asc(schema.messages.id));
+        const history = await selectNegotiationTurnHistoryInTransaction(tx, {
+          conversationId: current.conversationId,
+          metadata: metadataRecord(current.metadata),
+        });
         if (expectedNegotiationSpeaker(metadataRecord(current.metadata), history) !== ownerId) return null;
       }
 
@@ -2667,10 +2701,10 @@ export class ConversationDatabaseAdapter {
       // The orchestration plan includes the exact model turn but sender identity
       // is derived from locked authoritative history, never trusted from a
       // provider response.
-      const bilateralHistory = await tx.select({ senderId: schema.messages.senderId, parts: schema.messages.parts })
-        .from(schema.messages)
-        .where(eq(schema.messages.conversationId, task.conversationId))
-        .orderBy(asc(schema.messages.createdAt), asc(schema.messages.id));
+      const bilateralHistory = await selectNegotiationTurnHistoryInTransaction(tx, {
+        conversationId: task.conversationId,
+        metadata: taskMetadata,
+      });
       const speakerUserId = expectedNegotiationSpeaker(taskMetadata, bilateralHistory);
       if (!speakerUserId) throw new Error('Timeout execution has malformed bilateral speaker metadata');
       await tx.insert(schema.messages).values({
@@ -3038,10 +3072,10 @@ export class ConversationDatabaseAdapter {
         || (metadata.sourceUserId !== input.ownerId && metadata.candidateUserId !== input.ownerId)
       ) return { kind: 'not_found' } as const;
 
-      const messages = await tx.select({ id: schema.messages.id, senderId: schema.messages.senderId, parts: schema.messages.parts })
-        .from(schema.messages)
-        .where(eq(schema.messages.conversationId, current.conversationId))
-        .orderBy(asc(schema.messages.createdAt), asc(schema.messages.id));
+      const messages = await selectNegotiationTurnHistoryInTransaction(tx, {
+        conversationId: current.conversationId,
+        metadata: metadata as Record<string, unknown> | null,
+      });
       if (
         messages.length !== input.expectedTurnCount
         || expectedNegotiationSpeaker(metadata, messages) !== input.ownerId
@@ -4414,6 +4448,55 @@ export class ConversationDatabaseAdapter {
       .from(schema.messages)
       .where(eq(schema.messages.conversationId, conversationId))
       .orderBy(asc(schema.messages.createdAt));
+
+    return rows.map((r) => ({
+      ...r,
+      parts: (r.parts as unknown[]) ?? [],
+    }));
+  }
+
+  /**
+   * Gets the messages belonging to ONE negotiation, ordered by creation time.
+   *
+   * Keyed on opportunity rather than task: an `ask_user` pause parks its task
+   * and resumes into a pre-claimed successor, so a single negotiation spans
+   * several tasks. Messages with no `taskId` — or whose task carries no
+   * opportunityId — belong to no negotiation and are excluded; they remain
+   * visible through `getMessagesForConversation` as context.
+   *
+   * Served by `tasks_metadata_opportunity_id_idx` (partial, on
+   * `metadata->>'opportunityId'` where type = negotiation) and
+   * `messages_task_id_idx`.
+   *
+   * @param opportunityId - The negotiation's opportunity
+   * @returns Array of message records
+   */
+  async getNegotiationMessages(opportunityId: string): Promise<Array<{
+    id: string;
+    senderId: string;
+    role: 'user' | 'agent';
+    parts: unknown[];
+    createdAt: Date;
+    taskId?: string | null;
+  }>> {
+    const rows = await db
+      .select({
+        id: schema.messages.id,
+        senderId: schema.messages.senderId,
+        role: schema.messages.role,
+        parts: schema.messages.parts,
+        createdAt: schema.messages.createdAt,
+        taskId: schema.messages.taskId,
+      })
+      .from(schema.messages)
+      .innerJoin(schema.tasks, eq(schema.messages.taskId, schema.tasks.id))
+      .where(
+        and(
+          sql`${schema.tasks.metadata}->>'type' = 'negotiation'`,
+          sql`${schema.tasks.metadata}->>'opportunityId' = ${opportunityId}`,
+        ),
+      )
+      .orderBy(asc(schema.messages.createdAt), asc(schema.messages.id));
 
     return rows.map((r) => ({
       ...r,

--- a/services/api/src/adapters/conversation.database.adapter.ts
+++ b/services/api/src/adapters/conversation.database.adapter.ts
@@ -2325,8 +2325,14 @@ export class ConversationDatabaseAdapter {
       )).limit(1).for('update');
       if (!current) return null;
 
-      const turns = await tx.select({ id: schema.messages.id }).from(schema.messages)
-        .where(eq(schema.messages.conversationId, current.conversationId));
+      // Match-scoped: the arming side counts THIS negotiation's turns
+      // (`payload.history.length`), so a conversation-wide count would never
+      // agree in a DM that already holds another negotiation, and the parked
+      // turn would never get its fallback.
+      const turns = await selectNegotiationTurnHistoryInTransaction(tx, {
+        conversationId: current.conversationId,
+        metadata: metadataRecord(current.metadata),
+      });
       if (turns.length !== input.turnNumber) return null;
 
       const hasContinuation = hasNegotiationContinuationIdentity(current.metadata);
@@ -2438,8 +2444,14 @@ export class ConversationDatabaseAdapter {
         current.state !== 'waiting_for_agent'
         || metadataRecord(current.metadata).negotiationParkGeneration !== input.parkGeneration
       ) return null;
-      const turns = await tx.select({ id: schema.messages.id }).from(schema.messages)
-        .where(eq(schema.messages.conversationId, current.conversationId));
+      // Match-scoped: the arming side counts THIS negotiation's turns
+      // (`payload.history.length`), so a conversation-wide count would never
+      // agree in a DM that already holds another negotiation and the parked
+      // turn would never receive its system-agent fallback.
+      const turns = await selectNegotiationTurnHistoryInTransaction(tx, {
+        conversationId: current.conversationId,
+        metadata: metadataRecord(current.metadata),
+      });
       if (turns.length !== input.turnNumber) return null;
 
       const hasContinuation = hasNegotiationContinuationIdentity(current.metadata);
@@ -2557,8 +2569,12 @@ export class ConversationDatabaseAdapter {
         || current.claimedByAgentId !== input.claimedByAgentId
         || current.claimedAt?.getTime() !== input.claimedAt.getTime()
       ) return null;
-      const turns = await tx.select({ id: schema.messages.id }).from(schema.messages)
-        .where(eq(schema.messages.conversationId, current.conversationId));
+      // Match-scoped, as above: pickup arms this timer with the negotiation's
+      // own turn count.
+      const turns = await selectNegotiationTurnHistoryInTransaction(tx, {
+        conversationId: current.conversationId,
+        metadata: metadataRecord(current.metadata),
+      });
       if (turns.length !== input.turnNumber) return null;
       const hasContinuation = hasNegotiationContinuationIdentity(current.metadata);
       let continuationExecution: ContinuationExecutionFence | null = null;
@@ -2902,8 +2918,12 @@ export class ConversationDatabaseAdapter {
         const deadlineAt = priorOutbox?.generation === generation && typeof priorOutbox.deadlineAt === 'string'
           ? priorOutbox.deadlineAt
           : new Date(parkStartedAt.getTime() + input.parkWindowMs).toISOString();
-        const messageRows = await tx.select({ id: schema.messages.id }).from(schema.messages)
-          .where(eq(schema.messages.conversationId, row.conversationId));
+        // Arms `turnNumber` for the acquire CAS above, which is match-scoped;
+        // a conversation-wide count here would never satisfy it.
+        const messageRows = await selectNegotiationTurnHistoryInTransaction(tx, {
+          conversationId: row.conversationId,
+          metadata,
+        });
         const rawContinuation = metadata.continuationExecution && typeof metadata.continuationExecution === 'object'
           && !Array.isArray(metadata.continuationExecution)
           ? metadata.continuationExecution as Record<string, unknown>
@@ -3446,8 +3466,11 @@ export class ConversationDatabaseAdapter {
         sql`COALESCE(${schema.tasks.metadata}->'continuationExecution'->>'status', '') <> 'parked'`,
       )).limit(1).for('update');
       if (!current) return null;
-      const turns = await tx.select({ id: schema.messages.id }).from(schema.messages)
-        .where(eq(schema.messages.conversationId, current.conversationId));
+      // Match-scoped, matching how this turnNumber was armed.
+      const turns = await selectNegotiationTurnHistoryInTransaction(tx, {
+        conversationId: current.conversationId,
+        metadata: metadataRecord(current.metadata),
+      });
       if (turns.length !== input.turnNumber) return null;
       const now = new Date();
       const [task] = await tx.update(schema.tasks).set({
@@ -3645,10 +3668,13 @@ export class ConversationDatabaseAdapter {
         || boundCoordinates.counterpartyIntentId !== input.expectedMaterial.counterpartyIntentId
       ) return null;
 
-      const [{ value: turnCount }] = await tx.select({ value: count() })
-        .from(schema.messages)
-        .where(eq(schema.messages.conversationId, task.conversationId));
-      if (Number(turnCount) !== input.expectedTurnCount || input.expectedTurnCount < 1) return null;
+      // Match-scoped: the caller derives `expectedTurnCount` from this
+      // negotiation's messages.
+      const turnRows = await selectNegotiationTurnHistoryInTransaction(tx, {
+        conversationId: task.conversationId,
+        metadata,
+      });
+      if (turnRows.length !== input.expectedTurnCount || input.expectedTurnCount < 1) return null;
       const [intent] = await tx.select({
         userId: schema.intents.userId,
         payload: schema.intents.payload,
@@ -3703,11 +3729,14 @@ export class ConversationDatabaseAdapter {
         ));
       if (new Set(members.map((member) => member.userId)).size !== 2) return null;
 
-      const [precedingMessage] = await tx.select({ senderId: schema.messages.senderId, parts: schema.messages.parts })
-        .from(schema.messages)
-        .where(eq(schema.messages.conversationId, task.conversationId))
-        .orderBy(desc(schema.messages.createdAt), desc(schema.messages.id))
-        .limit(1);
+      // The turn being paused after must belong to THIS negotiation: the last
+      // message in the shared DM may be the tail of an entirely different match,
+      // which would validate the counterparty check against the wrong exchange.
+      const precedingTurns = await selectNegotiationTurnHistoryInTransaction(tx, {
+        conversationId: task.conversationId,
+        metadata,
+      });
+      const precedingMessage = precedingTurns[precedingTurns.length - 1];
       const precedingData = Array.isArray(precedingMessage?.parts)
         ? (precedingMessage.parts as Array<{ kind?: unknown; data?: unknown }>).find((part) => part.kind === 'data')?.data
         : null;

--- a/services/api/src/adapters/tests/negotiation-scope.static.spec.ts
+++ b/services/api/src/adapters/tests/negotiation-scope.static.spec.ts
@@ -1,0 +1,83 @@
+import { describe, expect, it } from 'bun:test';
+import { readFileSync } from 'node:fs';
+
+/**
+ * A negotiation's state must never be read from the whole conversation.
+ *
+ * Two agents share one DM permanently, so it accumulates every negotiation the
+ * pair has run. Any turn count, floor check or "preceding turn" derived from
+ * `conversation_id` silently mixes matches together. That is subtle to spot in
+ * review — the queries look ordinary — and the failures are severe and quiet:
+ * a CAS armed with a match-scoped count can never satisfy a conversation-wide
+ * comparison, so parked turns strand and timeouts never fire.
+ *
+ * This freezes the audit. Negotiation-state reads go through
+ * `selectNegotiationTurnHistoryInTransaction`; the only methods permitted to
+ * select messages by conversation are the genuinely conversation-level ones
+ * below. Adding a method here should be a deliberate act.
+ */
+
+const adapterSource = readFileSync(
+  new URL('../conversation.database.adapter.ts', import.meta.url),
+  'utf8',
+);
+
+/** Methods whose subject genuinely IS the conversation, not one negotiation. */
+const CONVERSATION_SCOPED_BY_DESIGN = new Set([
+  // The context read: the pair's whole shared DM, labelled per match downstream.
+  'getMessagesForConversation',
+  // Chat sessions are not negotiations.
+  'getChatSessionDetail',
+  'getChatSessionMessages',
+  // The scope helper's own documented fallback for tasks with no opportunity.
+  'selectNegotiationTurnHistoryInTransaction',
+]);
+
+/** Control-flow keywords that look like declarations to a source-level scan. */
+const NOT_DECLARATIONS = new Set(['if', 'for', 'while', 'switch', 'catch', 'return', 'await']);
+
+/** Enclosing top-level function/method name for a source offset. */
+function enclosingMethod(source: string, offset: number): string | null {
+  const declarations = [...source.matchAll(
+    /\n(?:async function |function | {2}(?:private |public )?(?:async )?)([A-Za-z0-9_]+)\s*[(<]/g,
+  )].filter((declaration) => !NOT_DECLARATIONS.has(declaration[1]));
+  let name: string | null = null;
+  for (const declaration of declarations) {
+    if (declaration.index! < offset) name = declaration[1];
+    else break;
+  }
+  return name;
+}
+
+describe('negotiation state is never read from the whole conversation', () => {
+  it('only conversation-level methods select messages by conversationId', () => {
+    const offenders = [...adapterSource.matchAll(
+      /from\(schema\.messages\)\s*\n?\s*\.where\(eq\(schema\.messages\.conversationId/g,
+    )]
+      .map((match) => enclosingMethod(adapterSource, match.index!))
+      .filter((method): method is string => method !== null)
+      .filter((method) => !CONVERSATION_SCOPED_BY_DESIGN.has(method));
+
+    expect(offenders).toEqual([]);
+  });
+
+  it('every turn-count CAS resolves its history through the scoped helper', () => {
+    // Each method comparing against an armed turn count must derive that count
+    // the same way the arming side did — via the helper, never a raw select.
+    const casMethods = new Set(
+      [...adapterSource.matchAll(/input\.(?:turnNumber|expectedTurnCount)/g)]
+        .map((match) => enclosingMethod(adapterSource, match.index!))
+        .filter((method): method is string => method !== null),
+    );
+
+    const helperUsers = new Set(
+      [...adapterSource.matchAll(/selectNegotiationTurnHistoryInTransaction\(tx/g)]
+        .map((match) => enclosingMethod(adapterSource, match.index!))
+        .filter((method): method is string => method !== null),
+    );
+
+    expect(casMethods.size).toBeGreaterThan(0);
+    const unscoped = [...casMethods].filter((method) => !helperUsers.has(method));
+    expect(unscoped).toEqual([]);
+  });
+});

--- a/services/api/src/controllers/debug.controller.ts
+++ b/services/api/src/controllers/debug.controller.ts
@@ -745,7 +745,9 @@ export class DebugController {
         const sourceUserId = typeof taskMeta.sourceUserId === 'string' ? taskMeta.sourceUserId : '';
         const candidateUserId = typeof taskMeta.candidateUserId === 'string' ? taskMeta.candidateUserId : '';
 
-        // Fetch turn messages for this negotiation conversation
+        // Fetch THIS negotiation's turns. Scoped by opportunity, not by
+        // conversation: the pair's DM holds every negotiation they have run, so
+        // a conversation-wide read shows each entry the union of all of them.
         const TURN_LIMIT = 20;
         const negMessages = await db
           .select({
@@ -755,8 +757,12 @@ export class DebugController {
             createdAt: messages.createdAt,
           })
           .from(messages)
-          .where(eq(messages.conversationId, task.conversationId))
-          .orderBy(asc(messages.createdAt))
+          .innerJoin(tasks, eq(messages.taskId, tasks.id))
+          .where(and(
+            sql`${tasks.metadata}->>'type' = 'negotiation'`,
+            sql`${tasks.metadata}->>'opportunityId' = ${oppId}`,
+          ))
+          .orderBy(asc(messages.createdAt), asc(messages.id))
           .limit(TURN_LIMIT + 1);
 
         const turnsTruncated = negMessages.length > TURN_LIMIT;

--- a/services/api/src/lib/negotiation/expected-speaker.ts
+++ b/services/api/src/lib/negotiation/expected-speaker.ts
@@ -1,9 +1,20 @@
 /**
  * API compatibility seam for the protocol-owned canonical speaker resolver.
  * Keep API consumers on one implementation rather than copying turn semantics.
+ *
+ * `expectedNegotiationSpeaker` must be given ONE negotiation's messages, not a
+ * whole conversation — use `readNegotiationMessages` to fetch them. Every
+ * surface has to agree on that scope: if the graph and the respond/polling
+ * surfaces disagreed, an external agent would be told it is not its turn
+ * forever.
  */
-export { expectedNegotiationSpeaker } from '@indexnetwork/protocol';
+export {
+  expectedNegotiationSpeaker,
+  negotiationScopeKey,
+  readNegotiationMessages,
+} from '@indexnetwork/protocol';
 export type {
   NegotiationSpeakerParticipants as NegotiationSpeakerMetadata,
   NegotiationSpeakerMessage,
+  NegotiationScopeMetadata,
 } from '@indexnetwork/protocol';

--- a/services/api/src/queues/negotiations/claim-timeout.queue.ts
+++ b/services/api/src/queues/negotiations/claim-timeout.queue.ts
@@ -6,7 +6,7 @@ import type { ConversationDatabaseAdapter } from '../../adapters/conversation.da
 import { QueueFactory } from '../../lib/bullmq/bullmq';
 import { log } from '../../lib/log';
 import type { NegotiationTaskMeta, ResumableTimeoutFaultStep, TimeoutNegotiatorInvoke } from './timeout.shared';
-import { runResumableTimeoutFallback } from './timeout.shared';
+import { negotiationMessagesFor, runResumableTimeoutFallback } from './timeout.shared';
 import type { NegotiationTimeoutExecutionStore } from '../../lib/negotiation/timeout-execution';
 
 /** BullMQ queue name for negotiation claim-timeout jobs. */
@@ -232,7 +232,7 @@ export class NegotiationClaimTimeoutQueue {
       this.logger.warn('Task is not a negotiation, skipping', { negotiationId });
       return;
     }
-    const messages = await database.getMessagesForConversation(acquired.task.conversationId);
+    const messages = await negotiationMessagesFor(database, acquired.task);
     const { AMBIENT_PARK_WINDOW_MS } = await import('@indexnetwork/protocol');
     await runResumableTimeoutFallback({
       database,

--- a/services/api/src/queues/negotiations/reflect.queue.ts
+++ b/services/api/src/queues/negotiations/reflect.queue.ts
@@ -25,6 +25,7 @@ import { NegotiationReflector, NEGOTIATOR_PERSONA_ID } from '@indexnetwork/proto
 import type { NegotiationReflectJobData, ReflectEnqueueFn, ReflectionTranscriptEntry, DistilledMemory } from '@indexnetwork/protocol';
 
 import { log } from '../../lib/log';
+import { readNegotiationMessages } from '../../lib/negotiation/expected-speaker';
 import { QueueFactory } from '../../lib/bullmq/bullmq';
 import { conversationDatabaseAdapter } from '../../adapters/database.adapter';
 import { chatSessionService } from '../../services/chat.service';
@@ -54,6 +55,12 @@ type ReflectQueueJobData = ReflectJobData | ChatReflectJobData;
 export interface ReflectQueueDeps {
   conversations?: {
     getMessagesForConversation: (conversationId: string) => Promise<Array<{
+      id: string;
+      senderId: string;
+      parts: unknown[];
+      createdAt: Date;
+    }>>;
+    getNegotiationMessages: (opportunityId: string) => Promise<Array<{
       id: string;
       senderId: string;
       parts: unknown[];
@@ -178,7 +185,15 @@ export class NegotiationReflectQueue {
 
     const conversations: NonNullable<ReflectQueueDeps['conversations']> =
       this.deps?.conversations ?? conversationDatabaseAdapter;
-    const messages = await conversations.getMessagesForConversation(data.conversationId);
+    // Reflect on THIS negotiation only. Distilling the pair's whole DM would
+    // attribute turns from other matches to this one's memories.
+    const messages = await readNegotiationMessages({
+      byNegotiation: (id) => conversations.getNegotiationMessages(id),
+      byConversation: (id) => conversations.getMessagesForConversation(id),
+    }, {
+      conversationId: data.conversationId,
+      metadata: { opportunityId: data.opportunityId },
+    });
 
     // Extract turn data parts (same projection the graph uses).
     const turns = messages

--- a/services/api/src/queues/negotiations/timeout.queue.ts
+++ b/services/api/src/queues/negotiations/timeout.queue.ts
@@ -6,7 +6,7 @@ import { QueueFactory } from '../../lib/bullmq/bullmq';
 import { log } from '../../lib/log';
 import type { ConversationDatabaseAdapter } from '../../adapters/conversation.database.adapter';
 
-import { runResumableTimeoutFallback, type NegotiationTaskMeta, type ResumableTimeoutFaultStep, type TimeoutNegotiatorInvoke } from './timeout.shared';
+import { negotiationMessagesFor, runResumableTimeoutFallback, type NegotiationTaskMeta, type ResumableTimeoutFaultStep, type TimeoutNegotiatorInvoke } from './timeout.shared';
 import type { NegotiationTimeoutExecutionStore } from '../../lib/negotiation/timeout-execution';
 
 /** BullMQ queue name for negotiation timeout jobs. */
@@ -309,7 +309,7 @@ export class NegotiationTimeoutQueue {
       this.logger.warn('Task is not a negotiation, skipping', { negotiationId });
       return;
     }
-    const messages = await database.getMessagesForConversation(acquired.task.conversationId);
+    const messages = await negotiationMessagesFor(database, acquired.task);
     const parkWindowMs = this.deps?.parkWindowMs
       ?? (await import('@indexnetwork/protocol')).AMBIENT_PARK_WINDOW_MS;
     await runResumableTimeoutFallback({

--- a/services/api/src/queues/negotiations/timeout.shared.ts
+++ b/services/api/src/queues/negotiations/timeout.shared.ts
@@ -3,9 +3,26 @@ import { isNegotiationTurnCapReached, type NegotiationContinuationTimeoutIdentit
 import { log } from '../../lib/log';
 import type { ContinuationExecutionFence } from '../../adapters/negotiation-continuation.atomic';
 import { remainingDeadlineDelayMs, type AcquiredNegotiationTimeoutExecution, type NegotiationTimeoutAtomicStep, type NegotiationTimeoutCompletionPlan, type NegotiationTimeoutExecutionStore } from '../../lib/negotiation/timeout-execution';
-import { expectedNegotiationSpeaker } from '../../lib/negotiation/expected-speaker';
+import { expectedNegotiationSpeaker, readNegotiationMessages } from '../../lib/negotiation/expected-speaker';
 
 type TimeoutLogger = ReturnType<typeof log.job.from>;
+
+/**
+ * The parked negotiation's own messages. A timeout resumes ONE match; the pair's
+ * shared DM also holds the negotiations they ran for every other match.
+ */
+export function negotiationMessagesFor(
+  database: Pick<NegotiationGraphDatabase, 'getNegotiationMessages' | 'getMessagesForConversation'>,
+  task: { conversationId: string; metadata: unknown },
+) {
+  return readNegotiationMessages({
+    byNegotiation: (id) => database.getNegotiationMessages(id),
+    byConversation: (id) => database.getMessagesForConversation(id),
+  }, {
+    conversationId: task.conversationId,
+    metadata: task.metadata as { opportunityId?: unknown } | null,
+  });
+}
 
 type NegotiationSeat = 'initiator' | 'counterparty';
 
@@ -343,8 +360,9 @@ export async function runTimeoutFallback(params: {
     continuationExecution,
   } = params;
 
-  // Determine the bilateral speaker from authoritative participant history.
-  // Unrelated/system senders do not move the seat; no history means source.
+  // Determine the bilateral speaker from this negotiation's own turn history.
+  // Unrelated/system senders do not move the seat; no history means the
+  // negotiation has not opened, so the floor sits with its initiator.
   const expectedSpeaker = expectedNegotiationSpeaker(meta, messages);
   if (!expectedSpeaker) throw new Error('Timeout fallback has malformed bilateral speaker metadata');
   const currentSpeaker = expectedSpeaker === meta.sourceUserId ? 'source' : 'candidate';

--- a/services/api/src/queues/tests/claim-timeout.queue.spec.ts
+++ b/services/api/src/queues/tests/claim-timeout.queue.spec.ts
@@ -58,6 +58,7 @@ function makeDb(messages: unknown[]) {
     acquireClaimedNegotiationTimeoutExecution,
     acquireWaitingNegotiationTimeoutExecution: mock(async () => null),
     getMessagesForConversation: mock(async () => messages),
+    getNegotiationMessages: mock(async () => messages),
     recordNegotiationTimeoutInvocation: mock(async (input: { turn: never }) => {
       if (!current || !execution) return null;
       execution = { ...execution, status: 'invoked', turn: input.turn, invokedAt: '2026-08-07T00:00:03.000Z' };

--- a/services/api/src/queues/tests/reflect.queue.isolated.ts
+++ b/services/api/src/queues/tests/reflect.queue.isolated.ts
@@ -62,7 +62,10 @@ function mkQueue(opts?: {
 
   const queue = new NegotiationReflectQueue({
     conversations: {
-      getMessagesForConversation: async () => [
+      // Reflection distils ONE negotiation, so the worker reads that
+      // negotiation's turns rather than the pair's whole shared DM.
+      getMessagesForConversation: async () => [],
+      getNegotiationMessages: async () => [
         turnMessage('u-alice', 'outreach', 'hello'),
         turnMessage('u-bob', 'accept', 'deal'),
       ],

--- a/services/api/src/queues/tests/timeout.queue.spec.ts
+++ b/services/api/src/queues/tests/timeout.queue.spec.ts
@@ -100,6 +100,7 @@ function makeDb(task: unknown, messages: unknown[]) {
     acquireWaitingNegotiationTimeoutExecution,
     acquireClaimedNegotiationTimeoutExecution: mock(async () => null),
     getMessagesForConversation: mock(async () => messages),
+    getNegotiationMessages: mock(async () => messages),
     recordNegotiationTimeoutInvocation: mock(async (input: { turn: never }) => {
       if (!current || !execution) return null;
       execution = { ...execution, status: 'invoked', turn: input.turn, invokedAt: '2026-08-07T00:00:01.000Z' };

--- a/services/api/src/queues/tests/timeout.shared.seat.spec.ts
+++ b/services/api/src/queues/tests/timeout.shared.seat.spec.ts
@@ -26,6 +26,7 @@ const invokeNegotiator = async (input: Record<string, unknown>) => {
 function makeDb() {
   return {
     getMessagesForConversation: mock(async () => []),
+    getNegotiationMessages: mock(async () => []),
     createMessage: mock(async () => ({ id: 'm-new' })),
     updateTaskState: mock(async () => {}),
     createArtifact: mock(async () => {}),

--- a/services/api/src/services/negotiation-polling.service.ts
+++ b/services/api/src/services/negotiation-polling.service.ts
@@ -18,7 +18,7 @@ import { assessExternalConsultationEligibility, buildExternalConsultationQuestio
 import { isDedicatedHermesNegotiationAudience, type NegotiationCredentialPrincipal } from '../lib/agent/hermes-credential';
 import type { AtomicHermesResponseInput, AtomicHermesResponseResult, HermesRunMutationAuthority } from '../adapters/conversation.database.adapter';
 import { remainingDeadlineDelayMs } from '../lib/negotiation/timeout-execution';
-import { expectedNegotiationSpeaker } from '../lib/negotiation/expected-speaker';
+import { expectedNegotiationSpeaker, readNegotiationMessages } from '../lib/negotiation/expected-speaker';
 import { hermesRuntimeTelemetry, type HermesRuntimeTelemetry } from '../lib/agent/hermes-runtime-telemetry';
 import { logNegotiationPickupConflict } from '../lib/agent/negotiation-polling.log';
 
@@ -232,11 +232,29 @@ function hermesResponseIdentity(taskId: string, capability: string): AtomicHerme
 export type HermesResponsePersistence = Pick<typeof conversationDatabaseAdapter,
   | 'getTask'
   | 'getMessagesForConversation'
+  | 'getNegotiationMessages'
   | 'getPendingHermesResponseOutboxes'
   | 'getHermesResponseReplay'
   | 'respondHermesNegotiationAtomically'
   | 'markHermesResponseOutboxDelivered'
 >;
+
+/**
+ * This negotiation's own messages — turn numbers, floor checks and turn caps all
+ * describe one match, while the pair's DM accumulates every match they share.
+ */
+function negotiationMessagesFor(
+  reader: Pick<typeof conversationDatabaseAdapter, 'getNegotiationMessages' | 'getMessagesForConversation'>,
+  task: { conversationId: string; metadata: unknown },
+) {
+  return readNegotiationMessages({
+    byNegotiation: (id) => reader.getNegotiationMessages(id),
+    byConversation: (id) => reader.getMessagesForConversation(id),
+  }, {
+    conversationId: task.conversationId,
+    metadata: task.metadata as { opportunityId?: unknown } | null,
+  });
+}
 
 /** Durable successor markers require a current continuation fence; never downgrade to generic CAS. */
 function hasContinuationIdentity(metadata: unknown): boolean {
@@ -336,7 +354,7 @@ export class NegotiationPollingService {
     const claimed = pickup.task;
     const claimedAt = claimed.claimedAt?.toISOString();
     if (!claimedAt) throw new Error(`Claimed negotiation ${claimed.id} has no claim generation`);
-    const messages = await conversationDatabaseAdapter.getMessagesForConversation(claimed.conversationId);
+    const messages = await negotiationMessagesFor(conversationDatabaseAdapter, claimed);
     const turnNumber = messages.length;
     const remainingMs = computeRemainingBudgetMs(pickup.parkStartTime, AMBIENT_PARK_WINDOW_MS);
     const execution = (claimed.metadata as {
@@ -426,7 +444,7 @@ export class NegotiationPollingService {
       throw new NotFoundError(`Negotiation ${negotiationId} not found`);
     }
 
-    const messages = await conversationDatabaseAdapter.getMessagesForConversation(task.conversationId);
+    const messages = await negotiationMessagesFor(conversationDatabaseAdapter, task);
     const persistedTurns = this.persistedTurns(messages);
     const questionerEnqueue = questionerEnqueueIfEnabled();
     const policyMode = negotiationConsultationPolicyMode();
@@ -639,7 +657,7 @@ export class NegotiationPollingService {
     }
     const protocolVersion = (readProtocolVersion(metadata) ?? 'v1') as NegotiationProtocolVersion;
     const seat = resolveSeat(userId, metadata);
-    const messages = await this.responsePersistence.getMessagesForConversation(preflight.conversationId);
+    const messages = await negotiationMessagesFor(this.responsePersistence, preflight);
     if (expectedNegotiationSpeaker(metadata, messages) !== userId) {
       throw new SeatViolationError('It is not this owner\'s turn to respond in the negotiation');
     }
@@ -781,7 +799,7 @@ export class NegotiationPollingService {
     }
     const protocolVersion = (readProtocolVersion(preflightMeta) ?? 'v1') as NegotiationProtocolVersion;
     const seat = resolveSeat(userId, preflightMeta);
-    const preflightMessages = await conversationDatabaseAdapter.getMessagesForConversation(preflight.conversationId);
+    const preflightMessages = await negotiationMessagesFor(conversationDatabaseAdapter, preflight);
     if (expectedNegotiationSpeaker(preflightMeta, preflightMessages) !== userId) {
       throw new SeatViolationError('It is not this owner\'s turn to respond in the negotiation');
     }
@@ -840,7 +858,7 @@ export class NegotiationPollingService {
 
     // 4. The caller IS the current speaker (they claimed the turn) — attribute
     //    the message to them directly rather than deriving from turn parity.
-    const messages = await conversationDatabaseAdapter.getMessagesForConversation(task.conversationId);
+    const messages = await negotiationMessagesFor(conversationDatabaseAdapter, task);
     const currentTurnCount = messages.length;
     const currentSpeaker: 'source' | 'candidate' = meta.sourceUserId === userId ? 'source' : 'candidate';
     const senderId = `agent:${userId}`;
@@ -1032,8 +1050,8 @@ export class NegotiationPollingService {
       }
     }
 
-    // Load turn history
-    const messages = await conversationDatabaseAdapter.getMessagesForConversation(task.conversationId);
+    // Load turn history — this negotiation's own turns
+    const messages = await negotiationMessagesFor(conversationDatabaseAdapter, task);
     const turnNumber = messages.length;
 
     const history: PickupResult['turn']['history'] = messages.map((m, idx) => {

--- a/services/api/src/services/tests/negotiation-polling.consult.isolated.ts
+++ b/services/api/src/services/tests/negotiation-polling.consult.isolated.ts
@@ -49,6 +49,7 @@ const getMaterial = mock(async () => material);
 const adapter = {
   getTask: mock(async () => task),
   getMessagesForConversation: mock(async () => messages),
+  getNegotiationMessages: mock(async () => messages),
   getClaimedNegotiationConsultationMaterial: getMaterial,
   pauseClaimedNegotiationForConsultation: pause,
   transitionClaimedTaskToWorking: transition,

--- a/services/api/src/services/tests/negotiation-polling.max-turns.isolated.ts
+++ b/services/api/src/services/tests/negotiation-polling.max-turns.isolated.ts
@@ -90,6 +90,7 @@ const adapter = {
   })),
   getTask: mock(async () => task()),
   getMessagesForConversation: mock(async () => messages),
+  getNegotiationMessages: mock(async () => messages),
   getPendingHermesResponseOutboxes: mock(async () => []),
   getHermesResponseReplay: mock(async () => null),
   respondHermesNegotiationAtomically: commitHermesResponse,

--- a/services/api/src/services/tests/negotiation-polling.pickup-authority.isolated.ts
+++ b/services/api/src/services/tests/negotiation-polling.pickup-authority.isolated.ts
@@ -47,6 +47,7 @@ const markOutboxDelivered = mock(async () => true);
 const adapter = {
   pickupNegotiationAtomically: atomicPickup,
   getMessagesForConversation: getMessages,
+  getNegotiationMessages: getMessages,
   getPendingHermesResponseOutboxes: pendingOutboxes,
   markHermesResponseOutboxDelivered: markOutboxDelivered,
 };

--- a/services/api/src/services/tests/negotiation-polling.respond-atomic.isolated.ts
+++ b/services/api/src/services/tests/negotiation-polling.respond-atomic.isolated.ts
@@ -106,6 +106,7 @@ const markDelivered = mock(async () => true);
 const responsePersistence = {
   getTask,
   getMessagesForConversation: getMessages,
+  getNegotiationMessages: getMessages,
   getPendingHermesResponseOutboxes: async () => [],
   getHermesResponseReplay: getReplay,
   respondHermesNegotiationAtomically: commit,

--- a/services/api/tests/debug.chat.negotiations.spec.ts
+++ b/services/api/tests/debug.chat.negotiations.spec.ts
@@ -105,6 +105,10 @@ beforeAll(async () => {
         conversationId: negConvId,
         taskId: task.id,
         senderId: `agent:${userId}`, // source actor
+        // Explicit, distinct timestamps: both rows would otherwise share one
+        // `defaultNow()` from the single INSERT, leaving the turn order this
+        // test asserts undetermined by the data.
+        createdAt: new Date(Date.now() - 60_000),
         role: 'user',
         parts: [
           {
@@ -123,6 +127,7 @@ beforeAll(async () => {
         conversationId: negConvId,
         taskId: task.id,
         senderId: `agent:${candidateUserId}`, // candidate actor
+        createdAt: new Date(Date.now() - 30_000),
         role: 'agent',
         parts: [
           {

--- a/services/api/tests/mcp.spec.ts
+++ b/services/api/tests/mcp.spec.ts
@@ -2585,6 +2585,7 @@ describe('MCP Server Factory', () => {
       getIntentIdsForOpportunities: async () => ({}),
       getOpportunityLifecyclesForNegotiations: async () => ({}),
       getMessagesForConversation: async () => [],
+      getNegotiationMessages: async () => [],
       getArtifactsForTask: async () => [],
     } as unknown as ToolDeps['negotiationDatabase'];
 

--- a/services/api/tests/negotiation.graph.spec.ts
+++ b/services/api/tests/negotiation.graph.spec.ts
@@ -38,6 +38,7 @@ function createDeps() {
     getTasksForUser: mock(() => Promise.resolve([])),
     getTask: mock(() => Promise.resolve(null)),
     getMessagesForConversation: mock(() => Promise.resolve([])),
+    getNegotiationMessages: mock(() => Promise.resolve([])),
     getArtifactsForTask: mock(() => Promise.resolve([])),
     getNegotiationTaskForOpportunity: mock(() => Promise.resolve(null)),
     getOpportunityUserAnswers: mock(() => Promise.resolve([])),


### PR DESCRIPTION
## The bug

A match concluded in **one turn**: the counterparty's agent accepted with no opening from the initiator and no exchange. The accept could not be justified from anything inside that negotiation.

## Root cause — a conceptual inversion

Two agents share **one DM permanently** — `getOrCreateDM` keys on the sorted agent pair alone — so that conversation accumulates every negotiation the pair has ever run. Negotiation state was derived from it:

- **Whose turn it is** — `expectedNegotiationSpeaker` read the last message in the *room* and passed the floor to the other side.
- **Whether an opening is required** — `isContinuation` meant "the room has messages", and the opening rule was skipped whenever it was true.

So a brand-new match inherited the turn parity of an unrelated, concluded one. The room's last turn was the initiator's, from an older match, so the floor went to the counterparty — whose seat may `accept` from turn one, and `accept` is terminal.

A conversation is a channel. A negotiation is a bounded episode about one match. Conversation history may enrich the reasoning; it must never supply the opening, decide the floor, or stand in for an exchange that never happened.

Three layers had already adopted this model and each worked around the state layer instead of fixing it: prompt attribution (IND-569), transcript grouping (IND-565/570), and the outcome banner's per-task recount (IND-566, which notes the stored count "folds in `priorTurnCount` from earlier negotiations"). This fixes the ownership.

## The change

- **`getNegotiationMessages(opportunityId)`** — a negotiation's own messages. Keyed on opportunity, not task: an `ask_user` pause resumes into a successor task and both tasks' turns are one negotiation. Served by existing indexes; no migration.
- **`negotiation.scope.ts`** — one shared scope rule. **All twelve floor-resolving sites move together**: if the graph and the respond/polling surfaces disagreed, an external agent polling for its turn would get a permanent `SeatViolationError`.
- **Floor** — `expectedNegotiationSpeaker` takes one negotiation's messages, and an unopened negotiation starts with its **initiator** rather than defaulting to source (reusing `resolveSeat`'s existing precedence).
- **`isContinuation`** — redefined rather than supplemented: it means *this negotiation has spoken*.
- **Agent input split** — `history` carries this negotiation's turns only; earlier matches reach the agent through the labelled attributed channel, which now renders on fresh matches too (it was gated on `isContinuation`, so a fresh match in an established DM would otherwise have lost that context entirely).
- **`ask_user` rationing** — follows as a consequence: a consultation spent on a previous match no longer denies one on a new match.

## Decisions

- `history` in the dispatch payload is **this negotiation only** — a content change for external agents, not a schema change.
- **Legacy data is not a constraint.** Messages with `taskId = null` are context only: no fallback, no migration. Unattributed turns never hold the floor.

## Verification

- **Failing test written first** (`negotiation.match-scoped-floor.spec.ts`) reproducing the single-turn accept, plus a guard that same-match resumes still alternate normally.
- **Protocol suite:** zero new failures. **API suite:** zero new failures (41 → 41).
- Baselines were captured against a **pristine rebuilt `dist`** — the first attempt was contaminated by stashed source running against a newer build.
- `bun run architecture:check` passes (capability `Pick<>` boundaries are enforced).
- **Watch item checked, not assumed:** `tasks_negotiation_continuation_settlement_uniq` is a partial index on `isContinuation = 'true'`. `resumeFromTaskId` is written only on exact continuations, which always have same-match prior turns and so keep the flag — coverage over the constrained rows is unchanged.

## Found while verifying

- **A 12th call site**: `debug.controller.ts` read the whole conversation for each per-negotiation entry.
- **A pre-existing flake** in `debug.chat.negotiations.spec.ts`: both fixture messages are inserted in one statement, sharing `defaultNow()`, so the asserted turn order wasn't determined by the data. Fixed in the fixture rather than by weakening the assertion.

## Deploy note

This changes the floor rule on every surface at once, including the polling/respond API. Negotiations in flight across the deploy could have their turn order re-evaluated. A drain window is the safer sequencing.

## Follow-up (not in this PR)

`apps/web/src/app/chat/[conversationId]/page.tsx:88-96` can revert to `lifecycle.turnCount` now that `priorTurnCount` is match-scoped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
