### PR TITLE
feat(protocol): question block contract for conversational questions

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -14,6 +14,7 @@
     "test:e2e:ui": "playwright test --ui"
   },
   "dependencies": {
+    "@indexnetwork/protocol": "workspace:*",
     "@radix-ui/react-alert-dialog": "^1.1.15",
     "@radix-ui/react-dialog": "^1.1.14",
     "@radix-ui/react-dismissable-layer": "1.1.11",

--- a/bun.lock
+++ b/bun.lock
@@ -21,6 +21,7 @@
       "name": "@indexnetwork/web",
       "version": "0.58.0",
       "dependencies": {
+        "@indexnetwork/protocol": "workspace:*",
         "@radix-ui/react-alert-dialog": "^1.1.15",
         "@radix-ui/react-dialog": "^1.1.14",
         "@radix-ui/react-dismissable-layer": "1.1.11",
@@ -88,7 +89,7 @@
     },
     "packages/protocol": {
       "name": "@indexnetwork/protocol",
-      "version": "21.0.0",
+      "version": "21.1.0",
       "dependencies": {
         "@langchain/core": "1.1.48",
         "@langchain/langgraph": "1.3.2",

--- a/packages/protocol/CHANGELOG.md
+++ b/packages/protocol/CHANGELOG.md
@@ -20,6 +20,27 @@ went 6.7.1 → 8.0.2 with no 7.x in between because the whole 7.x line shipped a
 prereleases between the two promotions. To track every change, read `rc`; to
 pin a supported release, use `latest`.
 
+## 21.1.0 - 2026-08-18
+
+### Added
+
+- The **question block contract** for conversational questions
+  (`docs/plans/2026-08-18-conversational-questions.md`):
+  `QuestionBlockSchema`, `QuestionBlockQuestionSchema`,
+  `parseQuestionMessage`, `serializeQuestionMessage`,
+  `QUESTION_BLOCK_MARKER`, `QUESTION_BLOCK_VERSION` and the
+  `QuestionBlock`/`QuestionBlockQuestion`/`ParsedQuestionMessage` types.
+  The block is the rendering contract embedded as a terminal
+  ` ```index-questions ` fenced section in the negotiator's question-message;
+  the parser fails closed (malformed → `null` → render as plain text), and a
+  question's identity is its primary `opportunityId` ref (negotiations have
+  no table of their own) — there are no question ids and no block-level state.
+- First package **subpath exports**, `@indexnetwork/protocol/question-block`
+  and `.../question-block/fixture`, so the browser client can import the
+  contract (and its canonical fixture) without pulling the node-only package
+  root into a bundle. STABILITY.md now documents browser-safe subpaths as part
+  of the public contract.
+
 ## 21.0.0 - 2026-08-17
 
 ### Removed

--- a/packages/protocol/STABILITY.md
+++ b/packages/protocol/STABILITY.md
@@ -7,8 +7,16 @@ change. It is the reference behind the tier annotations in `src/index.ts`.
 
 ## The public contract
 
-- The **only** supported entry point is the package root:
-  `import { ... } from "@indexnetwork/protocol"`.
+- The supported entry points are the package root:
+  `import { ... } from "@indexnetwork/protocol"` — and the **browser-safe
+  subpaths** listed in `package.json` `exports` (as of 21.1.0:
+  `@indexnetwork/protocol/question-block` and
+  `@indexnetwork/protocol/question-block/fixture`). A browser-safe subpath
+  exposes one shared-schema module whose only runtime dependency is `zod`, for
+  consumers (the web client) that cannot load the node-only package root. The
+  schema module's symbols are also re-exported from the root (the fixture is
+  subpath-only, to keep test data out of the runtime barrel), and the subpaths
+  carry the Stable tier.
 - Deep imports (`@indexnetwork/protocol/dist/...` or `/src/...`) are **not** part
   of the contract and may change or disappear in any release — do not rely on them.
 - The contract is exactly the set of symbols re-exported from `src/index.ts`.

--- a/packages/protocol/package.json
+++ b/packages/protocol/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@indexnetwork/protocol",
-  "version": "21.0.0",
+  "version": "21.1.0",
   "type": "module",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
@@ -8,6 +8,14 @@
     ".": {
       "import": "./dist/index.js",
       "types": "./dist/index.d.ts"
+    },
+    "./question-block": {
+      "types": "./dist/shared/schemas/question-block.schema.d.ts",
+      "import": "./dist/shared/schemas/question-block.schema.js"
+    },
+    "./question-block/fixture": {
+      "types": "./dist/shared/schemas/question-block.fixture.d.ts",
+      "import": "./dist/shared/schemas/question-block.fixture.js"
     }
   },
   "files": [

--- a/packages/protocol/src/index.ts
+++ b/packages/protocol/src/index.ts
@@ -97,6 +97,17 @@ export type {
   McpResolvedIdentity,
 } from "./shared/schemas/mcp-auth.schema.js";
 export type { DiscoveryNegotiation } from "./shared/schemas/discovery-question.schema.js";
+export {
+  QUESTION_BLOCK_MARKER,
+  QUESTION_BLOCK_VERSION,
+  QuestionBlockSchema,
+  QuestionBlockQuestionSchema,
+  parseQuestionMessage,
+  serializeQuestionMessage,
+  type QuestionBlock,
+  type QuestionBlockQuestion,
+  type ParsedQuestionMessage,
+} from "./shared/schemas/question-block.schema.js";
 export type { NetworkAssignmentMetadata } from "./shared/schemas/network-assignment.schema.js";
 export { DEFAULT_NETWORK_ASSIGNMENT_THRESHOLD, resolveAssignmentNetworkScope, buildNetworkAssignmentDecision } from "./shared/assignment/network-assignment.policy.js";
 

--- a/packages/protocol/src/shared/schemas/question-block.fixture.ts
+++ b/packages/protocol/src/shared/schemas/question-block.fixture.ts
@@ -1,0 +1,51 @@
+/**
+ * Canonical question-message fixture for the question block contract.
+ *
+ * `questionMessageFixture` is a literal — not derived from the serializer — so
+ * a serializer change that would alter the wire format breaks the spec loudly.
+ * The web client's steps-UI tests should import this via
+ * `@indexnetwork/protocol/question-block/fixture` instead of minting their own.
+ */
+import type { QuestionBlock } from "./question-block.schema.js";
+
+export const questionProseFixture = [
+  "I moved three conversations forward on your search for a technical co-founder.",
+  "Two of them are waiting on details only you can give — answer here and I will",
+  "pick the negotiations back up.",
+].join("\n");
+
+export const questionBlockFixture: QuestionBlock = {
+  version: 1,
+  questions: [
+    {
+      prompt: "Both counterparts asked about equity: what range are you prepared to offer a founding engineer?",
+      opportunityId: "0b0e8a9c-6d3f-4d6a-9f2e-1c5b7a4d8e01",
+      alsoUnblocks: ["7f3d2c1b-8a90-4e5f-b6c7-d8e9f0a1b2c3"],
+    },
+    {
+      prompt: "The Berlin robotics lab wants to know whether you can be on-site one week per month.",
+      opportunityId: "4a5b6c7d-8e9f-4a1b-8c2d-3e4f5a6b7c8d",
+    },
+  ],
+};
+
+export const questionMessageFixture = `${questionProseFixture}
+
+\`\`\`index-questions
+{
+  "version": 1,
+  "questions": [
+    {
+      "prompt": "Both counterparts asked about equity: what range are you prepared to offer a founding engineer?",
+      "opportunityId": "0b0e8a9c-6d3f-4d6a-9f2e-1c5b7a4d8e01",
+      "alsoUnblocks": [
+        "7f3d2c1b-8a90-4e5f-b6c7-d8e9f0a1b2c3"
+      ]
+    },
+    {
+      "prompt": "The Berlin robotics lab wants to know whether you can be on-site one week per month.",
+      "opportunityId": "4a5b6c7d-8e9f-4a1b-8c2d-3e4f5a6b7c8d"
+    }
+  ]
+}
+\`\`\``;

--- a/packages/protocol/src/shared/schemas/question-block.schema.ts
+++ b/packages/protocol/src/shared/schemas/question-block.schema.ts
@@ -1,0 +1,139 @@
+/**
+ * The question block: the rendering contract between the negotiator's
+ * question-message and the web client's steps UI, and the routing contract
+ * for answers (docs/plans/2026-08-18-conversational-questions.md).
+ *
+ * The block is a *view* of the currently-parked negotiations for one intent
+ * scope, regenerated fresh on every change — it is not a persistence schema
+ * and must never grow state (answered flags, timestamps, question ids).
+ * A question's identity is its primary negotiation reference: the id of the
+ * opportunity row the negotiation runs on. Task re-resolution from that row
+ * is server-side and never encoded here — deliberately, because a snapshotted
+ * task id would go stale: answer routing branches on what it re-resolves
+ * (an `input_required` task → mid-flight consult, answered via the exact
+ * continuation's successor task; a completed task on a stalled opportunity
+ * with a trailing ask_user gap → post-stall park, answered via a retry).
+ *
+ * This module must stay browser-safe: it may import zod and nothing else.
+ * It is exposed to the web client via the `@indexnetwork/protocol/question-block`
+ * subpath export (see STABILITY.md).
+ */
+import { z } from "zod";
+
+/** Info string of the fenced section that carries the block in a message body. */
+export const QUESTION_BLOCK_MARKER = "index-questions";
+
+/** Bump when the block shape changes; parsers fail closed on unknown versions. */
+export const QUESTION_BLOCK_VERSION = 1;
+
+/**
+ * A negotiation reference: the id of the opportunity row the negotiation runs
+ * on. There is no negotiations table — opportunity id is the durable identity
+ * used by every negotiation binding (see NegotiationQuestionProvenanceSchema).
+ */
+const NegotiationRefSchema = z.string().uuid();
+
+export const QuestionBlockQuestionSchema = z.object({
+  /** Agent-authored question text, rendered as one step. */
+  prompt: z.string().min(1).max(2000),
+  /** Primary negotiation this question unparks; doubles as the question's identity. */
+  opportunityId: NegotiationRefSchema,
+  /** Further negotiations parked on the same gap that this answer also unparks. */
+  alsoUnblocks: z.array(NegotiationRefSchema).max(8).optional(),
+}).strict();
+export type QuestionBlockQuestion = z.infer<typeof QuestionBlockQuestionSchema>;
+
+export const QuestionBlockSchema = z.object({
+  version: z.literal(QUESTION_BLOCK_VERSION),
+  questions: z.array(QuestionBlockQuestionSchema).min(1).max(20),
+}).strict().superRefine((block, ctx) => {
+  // Identity is the negotiation ref, so a ref may appear exactly once in the
+  // whole block — a duplicate would make answer routing ambiguous.
+  const seen = new Set<string>();
+  block.questions.forEach((question, questionIndex) => {
+    const refs = [question.opportunityId, ...(question.alsoUnblocks ?? [])];
+    refs.forEach((ref, refIndex) => {
+      if (seen.has(ref)) {
+        ctx.addIssue({
+          code: z.ZodIssueCode.custom,
+          path: refIndex === 0
+            ? ["questions", questionIndex, "opportunityId"]
+            : ["questions", questionIndex, "alsoUnblocks", refIndex - 1],
+          message: `negotiation ref ${ref} appears more than once in the block`,
+        });
+      }
+      seen.add(ref);
+    });
+  });
+});
+export type QuestionBlock = z.infer<typeof QuestionBlockSchema>;
+
+/** A parsed question-message: the agent's prose and the block that followed it. */
+export interface ParsedQuestionMessage {
+  prose: string;
+  block: QuestionBlock;
+}
+
+const openFencePattern = new RegExp(`^(\`{3,})${QUESTION_BLOCK_MARKER}[ \\t]*\\r?$`, "m");
+
+function longestBacktickRun(text: string): number {
+  let longest = 0;
+  for (const run of text.match(/`+/g) ?? []) longest = Math.max(longest, run.length);
+  return longest;
+}
+
+/**
+ * Embed a block after the agent's prose. The block is always the terminal
+ * section of the body: prose, a blank line, then a fenced section whose info
+ * string is the marker. The fence is lengthened past any backtick run in the
+ * payload so the payload can never close it early.
+ *
+ * Throws on a block that fails the schema — serializing an invalid block is a
+ * producer bug, not a rendering condition.
+ */
+export function serializeQuestionMessage(prose: string, block: QuestionBlock): string {
+  const payload = JSON.stringify(QuestionBlockSchema.parse(block), null, 2);
+  const fence = "`".repeat(Math.max(3, longestBacktickRun(payload) + 1));
+  const trimmedProse = prose.trimEnd();
+  const fenced = `${fence}${QUESTION_BLOCK_MARKER}\n${payload}\n${fence}`;
+  return trimmedProse.length > 0 ? `${trimmedProse}\n\n${fenced}` : fenced;
+}
+
+/**
+ * Extract the block from a message body. Fails closed: any body that does not
+ * end in exactly one well-formed, schema-valid block returns null, and the
+ * caller renders the whole body as plain text — never a broken steps UI.
+ */
+export function parseQuestionMessage(body: string): ParsedQuestionMessage | null {
+  // Anchor on the last marker fence so prose that merely mentions the marker
+  // earlier in the body cannot shadow the real block.
+  let open: RegExpExecArray | null = null;
+  const searchPattern = new RegExp(openFencePattern.source, "gm");
+  for (let match = searchPattern.exec(body); match; match = searchPattern.exec(body)) {
+    open = match;
+  }
+  if (!open) return null;
+
+  const fenceLength = open[1].length;
+  const payloadStart = open.index + open[0].length + 1; // past the fence line's newline
+  if (payloadStart > body.length) return null;
+
+  const closePattern = new RegExp(`^\`{${fenceLength}}[ \\t]*\\r?$`, "m");
+  const close = closePattern.exec(body.slice(payloadStart));
+  if (!close) return null;
+
+  // The block must terminate the message: nothing but whitespace may follow.
+  const afterClose = body.slice(payloadStart + close.index + close[0].length);
+  if (afterClose.trim().length > 0) return null;
+
+  let parsedPayload: unknown;
+  try {
+    parsedPayload = JSON.parse(body.slice(payloadStart, payloadStart + close.index));
+  } catch {
+    return null;
+  }
+  const block = QuestionBlockSchema.safeParse(parsedPayload);
+  if (!block.success) return null;
+
+  return { prose: body.slice(0, open.index).trimEnd(), block: block.data };
+}

--- a/packages/protocol/src/shared/schemas/tests/question-block.schema.spec.ts
+++ b/packages/protocol/src/shared/schemas/tests/question-block.schema.spec.ts
@@ -1,0 +1,188 @@
+/** Config */
+import { config } from "dotenv";
+config({ path: '.env.test', override: true });
+
+import { describe, it, expect } from "bun:test";
+
+import { QuestionBlockSchema, parseQuestionMessage, serializeQuestionMessage } from "../question-block.schema.js";
+import { questionBlockFixture, questionMessageFixture, questionProseFixture } from "../question-block.fixture.js";
+
+const REF_A = "0b0e8a9c-6d3f-4d6a-9f2e-1c5b7a4d8e01";
+const REF_B = "7f3d2c1b-8a90-4e5f-b6c7-d8e9f0a1b2c3";
+
+const minimalBlock = {
+  version: 1 as const,
+  questions: [{ prompt: "What equity range works for you?", opportunityId: REF_A }],
+};
+
+describe("QuestionBlockSchema", () => {
+  it("accepts a minimal block and the fixture block", () => {
+    expect(QuestionBlockSchema.safeParse(minimalBlock).success).toBe(true);
+    expect(QuestionBlockSchema.safeParse(questionBlockFixture).success).toBe(true);
+  });
+
+  it("rejects unknown fields at both levels (strict)", () => {
+    expect(QuestionBlockSchema.safeParse({ ...minimalBlock, answered: [] }).success).toBe(false);
+    expect(QuestionBlockSchema.safeParse({
+      version: 1,
+      questions: [{ ...minimalBlock.questions[0], id: "q1" }],
+    }).success).toBe(false);
+  });
+
+  it("rejects an unknown version", () => {
+    expect(QuestionBlockSchema.safeParse({ ...minimalBlock, version: 2 }).success).toBe(false);
+  });
+
+  it("rejects an empty questions array", () => {
+    expect(QuestionBlockSchema.safeParse({ version: 1, questions: [] }).success).toBe(false);
+  });
+
+  it("rejects refs that are not opportunity uuids", () => {
+    expect(QuestionBlockSchema.safeParse({
+      version: 1,
+      questions: [{ prompt: "x", opportunityId: "" }],
+    }).success).toBe(false);
+    expect(QuestionBlockSchema.safeParse({
+      version: 1,
+      questions: [{ prompt: "x", opportunityId: "not-a-row-anywhere" }],
+    }).success).toBe(false);
+  });
+
+  it("rejects a ref appearing twice anywhere in the block", () => {
+    // Twice as primary.
+    expect(QuestionBlockSchema.safeParse({
+      version: 1,
+      questions: [
+        { prompt: "a", opportunityId: REF_A },
+        { prompt: "b", opportunityId: REF_A },
+      ],
+    }).success).toBe(false);
+    // Primary of one question inside another's alsoUnblocks.
+    expect(QuestionBlockSchema.safeParse({
+      version: 1,
+      questions: [
+        { prompt: "a", opportunityId: REF_A, alsoUnblocks: [REF_B] },
+        { prompt: "b", opportunityId: REF_B },
+      ],
+    }).success).toBe(false);
+    // Primary repeated in its own alsoUnblocks.
+    expect(QuestionBlockSchema.safeParse({
+      version: 1,
+      questions: [{ prompt: "a", opportunityId: REF_A, alsoUnblocks: [REF_A] }],
+    }).success).toBe(false);
+  });
+});
+
+describe("serialize → parse round trip", () => {
+  it("is lossless for prose and block", () => {
+    const prose = "Two negotiations are waiting on you.\n\nDetails below.";
+    const message = serializeQuestionMessage(prose, minimalBlock);
+    const parsed = parseQuestionMessage(message);
+    expect(parsed).not.toBeNull();
+    expect(parsed!.prose).toBe(prose);
+    expect(parsed!.block).toEqual(minimalBlock);
+    // Re-serializing the parse result reproduces the message byte-for-byte.
+    expect(serializeQuestionMessage(parsed!.prose, parsed!.block)).toBe(message);
+  });
+
+  it("survives prose that mentions the marker or contains fences", () => {
+    const prose = "Earlier I sent a block like:\n\n```index-questions\nnot the real one\n```\n\nHere is the update.";
+    const message = serializeQuestionMessage(prose, minimalBlock);
+    const parsed = parseQuestionMessage(message);
+    expect(parsed).not.toBeNull();
+    expect(parsed!.prose).toBe(prose);
+    expect(parsed!.block).toEqual(minimalBlock);
+  });
+
+  it("escalates the fence past backtick runs in prompts", () => {
+    const block = {
+      version: 1 as const,
+      questions: [{ prompt: "Should I share the ```internal``` repo name?", opportunityId: REF_A }],
+    };
+    const message = serializeQuestionMessage("Prose.", block);
+    const parsed = parseQuestionMessage(message);
+    expect(parsed).not.toBeNull();
+    expect(parsed!.block).toEqual(block);
+  });
+
+  it("serializes a proseless body as the block alone", () => {
+    const message = serializeQuestionMessage("", minimalBlock);
+    const parsed = parseQuestionMessage(message);
+    expect(parsed).not.toBeNull();
+    expect(parsed!.prose).toBe("");
+    expect(parsed!.block).toEqual(minimalBlock);
+  });
+
+  it("throws on serializing a block the schema rejects", () => {
+    expect(() => serializeQuestionMessage("Prose.", {
+      version: 1,
+      questions: [],
+    } as never)).toThrow();
+  });
+});
+
+describe("parseQuestionMessage fails closed", () => {
+  const validMessage = serializeQuestionMessage("Prose.", minimalBlock);
+
+  it("returns null for a plain message with no block", () => {
+    expect(parseQuestionMessage("Just catching up — no questions today.")).toBeNull();
+  });
+
+  it("returns null for a truncated block (no closing fence)", () => {
+    const truncated = validMessage.slice(0, validMessage.length - 10);
+    expect(parseQuestionMessage(truncated)).toBeNull();
+  });
+
+  it("returns null for a fence cut off right after the marker line", () => {
+    expect(parseQuestionMessage("Prose.\n\n```index-questions")).toBeNull();
+    expect(parseQuestionMessage("Prose.\n\n```index-questions\n")).toBeNull();
+  });
+
+  it("returns null for malformed JSON inside the fence", () => {
+    expect(parseQuestionMessage("Prose.\n\n```index-questions\n{ not json\n```")).toBeNull();
+  });
+
+  it("returns null for valid JSON that is not a valid block", () => {
+    expect(parseQuestionMessage("Prose.\n\n```index-questions\n[]\n```")).toBeNull();
+    expect(parseQuestionMessage("Prose.\n\n```index-questions\n{ \"version\": 1, \"questions\": [] }\n```")).toBeNull();
+    // Unknown field smuggled into an otherwise valid block.
+    const withUnknown = JSON.stringify({ ...minimalBlock, sneaky: true });
+    expect(parseQuestionMessage(`Prose.\n\n\`\`\`index-questions\n${withUnknown}\n\`\`\``)).toBeNull();
+    // Ref that cannot point at an opportunity row.
+    const badRef = JSON.stringify({ version: 1, questions: [{ prompt: "x", opportunityId: "ref-to-nothing" }] });
+    expect(parseQuestionMessage(`Prose.\n\n\`\`\`index-questions\n${badRef}\n\`\`\``)).toBeNull();
+  });
+
+  it("returns null for a block that parses but violates ref uniqueness", () => {
+    // Must render as plain text, never partially render the steps UI.
+    const duplicated = JSON.stringify({
+      version: 1,
+      questions: [
+        { prompt: "a", opportunityId: REF_A },
+        { prompt: "b", opportunityId: REF_A },
+      ],
+    });
+    expect(parseQuestionMessage(`Prose.\n\n\`\`\`index-questions\n${duplicated}\n\`\`\``)).toBeNull();
+  });
+
+  it("returns null when the block is not the terminal section", () => {
+    expect(parseQuestionMessage(`${validMessage}\n\nP.S. one more thing.`)).toBeNull();
+  });
+
+  it("tolerates trailing whitespace after the closing fence", () => {
+    expect(parseQuestionMessage(`${validMessage}\n  \n`)).not.toBeNull();
+  });
+});
+
+describe("fixture message", () => {
+  it("parses into the fixture prose and block", () => {
+    const parsed = parseQuestionMessage(questionMessageFixture);
+    expect(parsed).not.toBeNull();
+    expect(parsed!.prose).toBe(questionProseFixture);
+    expect(parsed!.block).toEqual(questionBlockFixture);
+  });
+
+  it("is exactly what the serializer emits, byte-for-byte", () => {
+    expect(serializeQuestionMessage(questionProseFixture, questionBlockFixture)).toBe(questionMessageFixture);
+  });
+});


### PR DESCRIPTION
## What

The question block: the single shared contract between the delivery lane (services/api renders and regenerates the negotiator's question-message, apps/web parses it into steps) and the protocol lane (answer routing by negotiation refs). Contract only, per [the plan](docs/plans/2026-08-18-conversational-questions.md) — the regeneration queue job, exhaustion evaluator, message update seam, steps UI, and notification logic all come after this merges.

## The contract

- **`QuestionBlockSchema`** — `{ version: 1, questions: [{ prompt, opportunityId, alsoUnblocks? }] }`, strict at both levels. The ref is the **opportunity id**: negotiations have no table of their own, and every existing negotiation binding (`NegotiationQuestionProvenanceSchema`) keys on it. No question ids and no block-level state — the block is a regenerated view, and identity is the ref, so every ref is unique block-wide (primaries + alsoUnblocks). No `taskId`: both park kinds invalidate a snapshotted task id (mid-flight parks resume into a successor task; post-stall parks complete their task), so routing re-resolves server-side from the ref.
- **Embedding** — the block is the terminal ` ```index-questions ` fenced JSON section after the agent's prose. `serializeQuestionMessage` escalates the fence past any backtick run in the payload; `parseQuestionMessage` anchors on the last marker fence, requires the block to terminate the body, and **fails closed**: truncated fence, malformed JSON, unknown fields, bad or duplicate refs, wrong version, or trailing content → `null` → the client renders plain text, never a broken steps UI.
- **Placement** — `packages/protocol/src/shared/schemas/`, re-exported from the root barrel (the api pattern). Web can't load the node-only package root, so this adds the package's first **browser-safe subpath exports**: `@indexnetwork/protocol/question-block` and `.../question-block/fixture` (zod-only modules). STABILITY.md amended to bless them; protocol bumped to 21.1.0; `apps/web` gains the workspace dependency (verified: both subpaths typecheck and run from inside apps/web).
- **Tests** — 21 specs: schema acceptance/rejection, lossless serialize→parse round trips (marker-mentioning prose, backtick-laden prompts, proseless bodies), fail-closed parser cases, and a literal fixture message asserted byte-for-byte against the serializer for the web lane to reuse.

## Review

Design blessed by the orchestration session (field renamed to `opportunityId`; uniqueness-violation fail-closed test added). Routing blessed by the park-on-stall lane (refactor-negotiation-questions) on all three decisions: opportunity-id refs, no taskId, block-wide ref uniqueness.

`packages/protocol/src/negotiations` untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)