### PR TITLE
feat(negotiations): park stalled negotiations with their gap, and bound the rounds

### DIFF
--- a/packages/protocol/src/negotiations/negotiation.agent.ts
+++ b/packages/protocol/src/negotiations/negotiation.agent.ts
@@ -220,7 +220,7 @@ function isValidTimeoutMs(n: number): boolean {
   return Number.isFinite(n) && n > 0 && n <= Number.MAX_SAFE_INTEGER;
 }
 
-function resolveTurnTimeoutMs(override?: number): number {
+export function resolveTurnTimeoutMs(override?: number): number {
   if (typeof override === "number" && isValidTimeoutMs(override)) return override;
   const envValue = process.env.NEGOTIATOR_TURN_TIMEOUT_MS;
   if (envValue) {

--- a/packages/protocol/src/negotiations/negotiation.graph.finalize.ts
+++ b/packages/protocol/src/negotiations/negotiation.graph.finalize.ts
@@ -7,19 +7,20 @@ import { requestContext } from "../shared/observability/request-context.js";
 import type { NegotiationContinuationReceipt } from "../shared/interfaces/database.interface.js";
 import type { NegotiationTurnPayload } from "../shared/interfaces/agent-dispatcher.interface.js";
 import { type NegotiationTurn, type NegotiationOutcome } from "./negotiation.state.js";
-import { allowedActionsFor, askUserAnswerWindowMs, configuredAskUserEnabled, configuredProtocolVersion, fallbackActionFor, isRejectLikeAction, isTerminalAction, readProtocolVersion, rejectActionFor } from "./negotiation.protocol.js";
+import { allowedActionsFor, askUserAnswerWindowMs, configuredAskUserEnabled, configuredProtocolVersion, fallbackActionFor, isRejectLikeAction, isTerminalAction, negotiationAskRoundsCap, readProtocolVersion, rejectActionFor } from "./negotiation.protocol.js";
 import { assessConsultationEligibility, consultationPromptFor, negotiationConsultationPolicyMode, type NegotiationConsultationReason } from "./negotiation.consultation-policy.js";
 import { blocksNegotiationBeforeFirstTurn, type ScreenDecision, type ScreenDecisionRecord } from "./negotiation.screen.js";
 import { configuredScreenMode } from "./negotiation.screen.contracts.js";
 import { assessDeadlock, configuredDeadlockShiftEnabled, configuredDeadlockThreshold, type DeadlockAssessment, type DeadlockShiftRecord } from "./negotiation.deadlock.js";
 import type { NegotiationSeat, NegotiationProtocolVersion } from "../shared/schemas/negotiation-state.schema.js";
-import { NEGOTIATION_QUESTION_GENERIC_COUNTERPARTY, NEGOTIATION_QUESTION_GENERIC_NETWORK, negotiationQuestionSettlementId } from './negotiation.question-safety.js';
+import { NEGOTIATION_QUESTION_GENERIC_COUNTERPARTY, NEGOTIATION_QUESTION_GENERIC_NETWORK, isSafeAuthoredNegotiationQuestion, negotiationQuestionSettlementId } from './negotiation.question-safety.js';
+import { NEGOTIATION_PARK_REASONING, type NegotiationStallReason } from './negotiation.stall-gap.js';
 import { buildIntentSnapshots } from "./negotiation.intent-snapshot-provenance.js";
 import { holdsNegotiationConversationLock } from "./negotiation.task-lock-policy.js";
 import { isNegotiationTurnCapReached } from "./negotiation.turn-cap.js";
 import { expectedNegotiationSpeaker } from "./negotiation.expected-speaker.js";
 import { buildSeededAttribution } from './negotiation.attribution.js';
-import { buildAttributedDialogue, finalizeLog, hasPriorAskUser, initLog, memoryQueryText, negotiateCandidatesLog, resolveTaskAttribution, retrieveMemory, screenNodeLog, turnLog, turnsFromMessages } from "./negotiation.graph.shared.js";
+import { buildAttributedDialogue, countNegotiationAskRounds, finalizeLog, hasPriorAskUser, initLog, memoryQueryText, negotiateCandidatesLog, resolveTaskAttribution, retrieveClientDm, retrieveMemory, screenNodeLog, turnLog, turnsFromMessages } from "./negotiation.graph.shared.js";
 import type { NegotiationGraphDeps, NegotiationState } from "./negotiation.graph.shared.js";
 
 
@@ -139,6 +140,132 @@ export async function finalizeNode(state: NegotiationState, deps: NegotiationGra
         ? { reason: "turn_cap" as const }
         : {}),
   };
+
+  // Unconcluded end: no opportunity, no explicit reject, and turns actually
+  // happened — turn cap, timeout, or a plain stall. Feeds both the post-stall
+  // park below and the legacy questioner enqueue further down.
+  const endedUnconcluded = !hasOpportunity && !screenedOut && !isRejectLikeAction(lastTurn?.action) && state.turnCount > 0;
+  const stallReason: NegotiationStallReason = atCap
+    ? 'turn_cap'
+    : (state.error && /timeout/i.test(state.error))
+      ? 'timeout'
+      : 'stalled';
+
+  // ─── Post-stall park (conversational-questions plan) ──────────────────
+  // Instead of ending silently, an unconcluded negotiation parks carrying
+  // the ONE question that would let a retry conclude — authored by the
+  // negotiator from this negotiation's transcript and the signal's client
+  // DM, exactly the grounding the mid-flight consult uses. The gap is
+  // persisted as an `ask_user` message in the negotiation's own record: the
+  // parked negotiation is the only durable record of the information need,
+  // the same substrate the per-side ration reads, and an `ask_user` last
+  // message keeps the floor with the asking side on retry.
+  //
+  // Bounded per negotiation: past the ask-rounds cap the negotiation stalls
+  // TERMINALLY — no authoring call, no park — so two agents cannot
+  // ping-pong their humans indefinitely. Runs on continuations too (a
+  // resumed negotiation may park again); the cap is what bounds the loop.
+  //
+  // Every failure — authoring, safety gate, persistence — degrades to
+  // today's terminal stall. A park is additive state, never a new way for
+  // finalize to fail.
+  if (
+    endedUnconcluded
+    && deps.stallGapAuthor
+    && state.opportunityId
+    && state.sourceIntentId
+    && state.indexContext.networkId
+  ) {
+    const askRounds = countNegotiationAskRounds(state.messages);
+    const askRoundsCap = negotiationAskRoundsCap();
+    if (askRounds >= askRoundsCap) {
+      finalizeLog.info('negotiation_ask_cap_terminal', {
+        taskId: state.taskId,
+        opportunityId: state.opportunityId,
+        askRounds,
+        askRoundsCap,
+        stallReason,
+      });
+      emitWide({
+        type: 'negotiation_ask_cap_terminal',
+        opportunityId: state.opportunityId,
+        askRounds,
+        askRoundsCap,
+      });
+    } else {
+      try {
+        const clientDm = await retrieveClientDm(deps, state.sourceUser.id, state.sourceIntentId);
+        const parkIntent = state.sourceUser.intents.find((intent) => intent.id === state.sourceIntentId);
+        const gap = await deps.stallGapAuthor.author({
+          userName: state.sourceUser.profile.name ?? 'your user',
+          signal: parkIntent
+            ? { title: parkIntent.title, description: parkIntent.description }
+            : { title: 'Signal', description: 'the signal attached to this match' },
+          seedReasoning: state.seedAssessment.reasoning,
+          history,
+          stallReason,
+          ...(clientDm.length > 0 && { clientDm }),
+        });
+        // Same identifier-aware gate as the mid-flight authored question, with
+        // the same inputs in hand: the counterparty's name and the evaluator's
+        // reasoning. An unsafe question never parks — there is no enum-only
+        // downgrade here because a park without its gap records nothing.
+        const counterpartyName = state.candidateUser.profile?.name?.trim();
+        const seedReasoning = state.seedAssessment?.reasoning?.trim();
+        const safeGap = gap && isSafeAuthoredNegotiationQuestion(gap.question, {
+          ...(counterpartyName ? { forbiddenIdentifiers: [counterpartyName] } : {}),
+          ...(seedReasoning ? { forbiddenSourceText: [seedReasoning] } : {}),
+        });
+        if (safeGap) {
+          const parkTurn: NegotiationTurn = {
+            action: 'ask_user',
+            assessment: {
+              reasoning: NEGOTIATION_PARK_REASONING,
+              suggestedRoles: lastTurn?.assessment.suggestedRoles ?? { ownUser: 'peer', otherUser: 'peer' },
+            },
+            message: null,
+            askUser: { reason: gap.reason, question: gap.question },
+          };
+          await deps.database.createMessage({
+            conversationId: state.conversationId,
+            senderId: `agent:${state.sourceUser.id}`,
+            role: 'agent',
+            parts: [{ kind: 'data', data: parkTurn }],
+            taskId: state.taskId,
+            ...(state.continuationExecution ? { continuationExecution: state.continuationExecution } : {}),
+          });
+          finalizeLog.info('negotiation_parked', {
+            taskId: state.taskId,
+            opportunityId: state.opportunityId,
+            recipientUserId: state.sourceUser.id,
+            recipientIntentId: state.sourceIntentId,
+            askRounds: askRounds + 1,
+            askRoundsCap,
+            stallReason,
+          });
+          emitWide({
+            type: 'negotiation_parked',
+            opportunityId: state.opportunityId,
+            negotiationConversationId: state.conversationId,
+            askRounds: askRounds + 1,
+            askRoundsCap,
+            stallReason,
+          });
+        } else if (gap) {
+          finalizeLog.warn('Dropping unsafe post-stall gap question; negotiation stalls without a park', {
+            taskId: state.taskId,
+            opportunityId: state.opportunityId,
+          });
+        }
+      } catch (err) {
+        finalizeLog.error('Failed to park stalled negotiation with its gap', {
+          taskId: state.taskId,
+          opportunityId: state.opportunityId,
+          error: err,
+        });
+      }
+    }
+  }
 
   try {
     await deps.database.updateTaskState(state.taskId, "completed", undefined, state.continuationExecution);
@@ -262,13 +389,9 @@ export async function finalizeNode(state: NegotiationState, deps: NegotiationGra
 
   // Enqueue question generation for stalled/capped negotiations (not accepted or explicitly rejected).
   // Require turnCount > 0 so early init/turn errors don't enqueue with empty context.
-  if (!hasOpportunity && !isRejectLikeAction(lastTurn?.action) && state.turnCount > 0 && state.opportunityId && state.sourceIntentId && state.indexContext.networkId && deps.questionerEnqueue && !state.continuationExecution) {
-    const stallReason: 'turn_cap' | 'timeout' | 'stalled' = atCap
-      ? 'turn_cap'
-      : (state.error && /timeout/i.test(state.error))
-        ? 'timeout'
-        : 'stalled';
-
+  // Kept alongside the post-stall park above until the conversational-questions
+  // delivery lane retires the blind questioner path.
+  if (endedUnconcluded && state.opportunityId && state.sourceIntentId && state.indexContext.networkId && deps.questionerEnqueue && !state.continuationExecution) {
     const userContext = (await deps.database.getUserContext(state.sourceUser.id, null))?.text ?? '';
     const sourceIntent = state.sourceUser.intents.find((intent) => intent.id === state.sourceIntentId);
     deps.questionerEnqueue({

--- a/packages/protocol/src/negotiations/negotiation.graph.shared.ts
+++ b/packages/protocol/src/negotiations/negotiation.graph.shared.ts
@@ -27,6 +27,7 @@ import type { QuestionerEnqueueFn } from "../questions/question.module.js";
 import type { ReflectEnqueueFn } from "./negotiation.reflect.js";
 import type { NegotiatorMemoryEntry, NegotiatorMemoryRetrieveFn, NegotiatorMemoryScope } from "./negotiation.memory.js";
 import type { NegotiatorClientDmMessage, NegotiatorClientDmRetrieveFn } from "./negotiation.client-dm.js";
+import type { NegotiationStallGapAuthor } from "./negotiation.stall-gap.js";
 import { NEGOTIATION_QUESTION_GENERIC_COUNTERPARTY, NEGOTIATION_QUESTION_GENERIC_NETWORK, negotiationQuestionSettlementId } from './negotiation.question-safety.js';
 import { buildIntentSnapshots } from "./negotiation.intent-snapshot-provenance.js";
 import { holdsNegotiationConversationLock } from "./negotiation.task-lock-policy.js";
@@ -53,6 +54,8 @@ export interface NegotiationGraphDeps {
   clientDmRetrieve?: NegotiatorClientDmRetrieveFn;
   /** In-process negotiator used when no personal agent answers. */
   systemAgent: IndexNegotiator;
+  /** Authors the post-stall gap question at finalize (park-on-stall). */
+  stallGapAuthor?: NegotiationStallGapAuthor;
   /** Outreach gate for fresh negotiations. */
   screener: NegotiationScreener;
 }
@@ -74,6 +77,16 @@ export function turnsFromMessages(messages: Array<{ parts: unknown[] }>): Negoti
     .filter(Boolean);
 }
 
+/** Sender ids of every persisted `ask_user` park in this negotiation's messages. */
+function askUserSenderIds(messages: Array<{ senderId: string; parts: unknown[] }>): string[] {
+  return messages
+    .filter((m) => {
+      const dataPart = (m.parts as Array<{ kind?: string; data?: { action?: string } }>).find((p) => p.kind === "data");
+      return dataPart?.data?.action === "ask_user";
+    })
+    .map((m) => m.senderId);
+}
+
 /**
  * Whether `userId`'s side has already spent its one `ask_user` client
  * consultation in THIS negotiation (P3.2 rationing: max one per negotiation per
@@ -86,12 +99,23 @@ export function hasPriorAskUser(
   messages: Array<{ senderId: string; parts: unknown[] }>,
   userId: string,
 ): boolean {
-  const sender = `agent:${userId}`;
-  return messages.some((m) => {
-    if (m.senderId !== sender) return false;
-    const dataPart = (m.parts as Array<{ kind?: string; data?: { action?: string } }>).find((p) => p.kind === "data");
-    return dataPart?.data?.action === "ask_user";
-  });
+  return askUserSenderIds(messages).includes(`agent:${userId}`);
+}
+
+/**
+ * How many ask rounds this negotiation has already spent, BOTH sides combined.
+ * A round is one persisted `ask_user` park — a mid-flight client consultation
+ * or a post-stall park — each of which suspends the negotiation on a human
+ * answer. Same substrate as {@link hasPriorAskUser} (the negotiation's own
+ * message record, spanning all of its sessions), read negotiation-wide rather
+ * than per side: the cap this feeds bounds the park → answer → resume loop for
+ * the negotiation as a whole, so two agents cannot ping-pong their humans
+ * indefinitely.
+ */
+export function countNegotiationAskRounds(
+  messages: Array<{ senderId: string; parts: unknown[] }>,
+): number {
+  return askUserSenderIds(messages).length;
 }
 
 /**

--- a/packages/protocol/src/negotiations/negotiation.graph.ts
+++ b/packages/protocol/src/negotiations/negotiation.graph.ts
@@ -13,6 +13,7 @@ import type { NegotiationTimeoutQueue } from "../shared/interfaces/negotiation-e
 import type { AgentDispatcher } from "../shared/interfaces/agent-dispatcher.interface.js";
 import { NegotiationGraphState } from "./negotiation.state.js";
 import { IndexNegotiator } from "./negotiation.agent.js";
+import { NegotiationStallGapAuthor } from "./negotiation.stall-gap.js";
 import { blocksNegotiationBeforeFirstTurn, NegotiationScreener } from "./negotiation.screen.js";
 import { configuredScreenMode } from "./negotiation.screen.contracts.js";
 import { isTerminalAction } from "./negotiation.protocol.js";
@@ -57,6 +58,7 @@ export class NegotiationGraphFactory {
       memoryRetrieve,
       clientDmRetrieve,
       systemAgent: new IndexNegotiator(),
+      stallGapAuthor: new NegotiationStallGapAuthor(),
       screener: new NegotiationScreener(),
     };
   }

--- a/packages/protocol/src/negotiations/negotiation.graph.turn.ts
+++ b/packages/protocol/src/negotiations/negotiation.graph.turn.ts
@@ -7,7 +7,7 @@ import { requestContext } from "../shared/observability/request-context.js";
 import type { NegotiationContinuationReceipt } from "../shared/interfaces/database.interface.js";
 import type { NegotiationTurnPayload } from "../shared/interfaces/agent-dispatcher.interface.js";
 import { type NegotiationTurn, type NegotiationOutcome } from "./negotiation.state.js";
-import { allowedActionsFor, askUserAnswerWindowMs, configuredAskUserEnabled, configuredProtocolVersion, fallbackActionFor, isRejectLikeAction, isTerminalAction, readProtocolVersion, rejectActionFor } from "./negotiation.protocol.js";
+import { allowedActionsFor, askUserAnswerWindowMs, configuredAskUserEnabled, configuredProtocolVersion, fallbackActionFor, isRejectLikeAction, isTerminalAction, negotiationAskRoundsCap, readProtocolVersion, rejectActionFor } from "./negotiation.protocol.js";
 import { assessConsultationEligibility, consultationPromptFor, negotiationConsultationPolicyMode, type NegotiationConsultationReason } from "./negotiation.consultation-policy.js";
 import { blocksNegotiationBeforeFirstTurn, type ScreenDecision, type ScreenDecisionRecord } from "./negotiation.screen.js";
 import { configuredScreenMode } from "./negotiation.screen.contracts.js";
@@ -19,7 +19,7 @@ import { holdsNegotiationConversationLock } from "./negotiation.task-lock-policy
 import { isNegotiationTurnCapReached } from "./negotiation.turn-cap.js";
 import { expectedNegotiationSpeaker } from "./negotiation.expected-speaker.js";
 import { buildSeededAttribution } from './negotiation.attribution.js';
-import { buildAttributedDialogue, finalizeLog, hasPriorAskUser, initLog, memoryQueryText, negotiateCandidatesLog, resolveTaskAttribution, retrieveClientDm, retrieveMemory, screenNodeLog, turnLog, turnsFromMessages } from "./negotiation.graph.shared.js";
+import { buildAttributedDialogue, countNegotiationAskRounds, finalizeLog, hasPriorAskUser, initLog, memoryQueryText, negotiateCandidatesLog, resolveTaskAttribution, retrieveClientDm, retrieveMemory, screenNodeLog, turnLog, turnsFromMessages } from "./negotiation.graph.shared.js";
 import type { NegotiationGraphDeps, NegotiationState } from "./negotiation.graph.shared.js";
 
 
@@ -58,6 +58,12 @@ export async function turnNode(state: NegotiationState, deps: NegotiationGraphDe
     // against), v2 non-final non-opening turn, and this side's one client
     // consultation not yet spent (rationing). Shadow is observational and
     // must preserve this legacy path byte-for-byte except for telemetry.
+    //
+    // The negotiation-wide ask-rounds cap reads the same message substrate
+    // as the per-side ration. It cannot bind on mid-flight consults alone
+    // (one per side < default cap); it exists so post-stall parks — which
+    // also persist `ask_user` messages — count against the same budget,
+    // and a negotiation near its cap cannot spend a further round here.
     const policyMode = negotiationConsultationPolicyMode();
     const askUserAvailable =
       version === 'v2'
@@ -69,7 +75,8 @@ export async function turnNode(state: NegotiationState, deps: NegotiationGraphDe
       && !!ownIntentId
       && !!state.indexContext.networkId
       && !(state.turnCount === 0 && !state.isContinuation)
-      && !hasPriorAskUser(state.messages, ownUser.id);
+      && !hasPriorAskUser(state.messages, ownUser.id)
+      && countNegotiationAskRounds(state.messages) < negotiationAskRoundsCap();
 
     // ─── Deadlock detection → persuasion→bargaining stance (IND-428) ──────
     // Deterministic trailing-run inspection of the persisted history — no

--- a/packages/protocol/src/negotiations/negotiation.module.ts
+++ b/packages/protocol/src/negotiations/negotiation.module.ts
@@ -23,15 +23,20 @@ export type { NegotiationDigest } from "./insight.generator.js";
 
 export {
   ASK_USER_LOCK_SLACK_MS,
+  DEFAULT_NEGOTIATION_ASK_ROUNDS_CAP,
   allowedActionsFor,
   askUserAnswerWindowMs,
   configuredAskUserEnabled,
   isRejectLikeAction,
   isTerminalAction,
+  negotiationAskRoundsCap,
   readProtocolVersion,
   resolveSeat,
   seatViolationMessage,
 } from "./negotiation.protocol.js";
+export { countNegotiationAskRounds } from "./negotiation.graph.shared.js";
+export { NEGOTIATION_PARK_REASONING, NegotiationStallGapAuthor } from "./negotiation.stall-gap.js";
+export type { NegotiationStallGap, NegotiationStallReason, StallGapAuthorInput } from "./negotiation.stall-gap.js";
 export {
   HERMES_OWNER_DIRECTIVE,
   HERMES_SHARED_MESSAGE_TEMPLATES,

--- a/packages/protocol/src/negotiations/negotiation.protocol.ts
+++ b/packages/protocol/src/negotiations/negotiation.protocol.ts
@@ -210,6 +210,29 @@ export function configuredAskUserEnabled(): boolean {
   return process.env.NEGOTIATION_ASK_USER_ENABLED === "true";
 }
 
+/**
+ * Default per-negotiation ask cap: total client-consultation rounds (mid-flight
+ * `ask_user` pauses and post-stall parks, both sides combined) before the
+ * negotiation stalls terminally instead of parking again. Three admits one
+ * post-stall park even after each side has spent its one mid-flight consult.
+ */
+export const DEFAULT_NEGOTIATION_ASK_ROUNDS_CAP = 3;
+
+/**
+ * Per-negotiation ask cap, overridable via `NEGOTIATION_ASK_ROUNDS_CAP`.
+ * Invalid or non-positive values fall back to the default — zero is not an
+ * off switch here; the cap exists so two agents cannot ping-pong their humans
+ * indefinitely. It tunes the bound, it does not gate the behaviour.
+ */
+export function negotiationAskRoundsCap(): number {
+  const raw = process.env.NEGOTIATION_ASK_ROUNDS_CAP;
+  if (raw) {
+    const parsed = Number(raw);
+    if (Number.isInteger(parsed) && parsed > 0) return parsed;
+  }
+  return DEFAULT_NEGOTIATION_ASK_ROUNDS_CAP;
+}
+
 /** Default answer window for a paused `ask_user` negotiation: 24 hours. */
 export const DEFAULT_ASK_USER_WINDOW_MS = 24 * 60 * 60 * 1000;
 

--- a/packages/protocol/src/negotiations/negotiation.stall-gap.ts
+++ b/packages/protocol/src/negotiations/negotiation.stall-gap.ts
@@ -1,0 +1,201 @@
+/**
+ * Post-stall gap authoring (conversational-questions plan).
+ *
+ * When a negotiation ends unconcluded — no opportunity, no explicit reject:
+ * turn cap, timeout, or stall — the finalize node asks the negotiator for the
+ * ONE question whose answer would let a retry conclude, and parks the
+ * negotiation carrying that gap as an `ask_user` message in its own record.
+ * This module owns that single extra model call.
+ *
+ * Grounding is exactly what mid-flight authoring (P3.2 / IND-401 A2H) uses:
+ * this negotiation's transcript, plus the client's own negotiator DM for the
+ * signal when the caller retrieved one. Same non-naming and non-echo rules;
+ * the caller re-checks the output with `isSafeAuthoredNegotiationQuestion`
+ * (identifiers in hand) before persisting anything.
+ *
+ * Fail-open contract: any model failure, timeout, or invalid output resolves
+ * to null — the negotiation then stalls exactly as it did before this feature,
+ * never half-parks.
+ */
+
+import { z } from "zod";
+
+import { createStructuredModel } from "../shared/agent/model.config.js";
+import { invokeWithAbortSignal } from "../shared/agent/model-signal.js";
+import { StructuredQuestionSchema, type StructuredQuestion } from "../shared/schemas/structured-question.schema.js";
+import { NegotiationConsultationReasonSchema, type NegotiationConsultationReason } from "../shared/schemas/negotiation-state.schema.js";
+import { renderNegotiatorClientDmSection, type NegotiatorClientDmMessage } from "./negotiation.client-dm.js";
+import { resolveTurnTimeoutMs } from "./negotiation.agent.js";
+import { protocolLogger } from "../shared/observability/protocol.logger.js";
+import type { NegotiationTurn } from "./negotiation.state.js";
+
+const stallGapLog = protocolLogger("NegotiationStallGapAuthor");
+
+/**
+ * Fixed transcript reasoning for a post-stall park turn. Deliberately not
+ * model-authored: assessment reasoning enters the shared A2A record, and the
+ * park's "why" already lives in the guarded question itself — a second,
+ * unguarded free-text channel would reopen the leak surface the question gate
+ * closes.
+ */
+export const NEGOTIATION_PARK_REASONING = "Negotiation parked pending the client's answer.";
+
+/** Why the negotiation failed to conclude, as finalize classified it. */
+export type NegotiationStallReason = "turn_cap" | "timeout" | "stalled";
+
+const STALL_REASON_LABELS: Record<NegotiationStallReason, string> = {
+  turn_cap: "the turn limit was reached without agreement",
+  timeout: "the negotiation timed out",
+  stalled: "the exchange stalled without reaching a conclusion",
+};
+
+/** The authored gap: what a retry needs from the client, and why the pause is warranted. */
+export interface NegotiationStallGap {
+  reason: NegotiationConsultationReason;
+  question: StructuredQuestion;
+}
+
+export interface StallGapAuthorInput {
+  /** Display name of the client the question is addressed to. */
+  userName: string;
+  /** The client's signal this negotiation was about. */
+  signal: { title: string; description: string };
+  /** Why the match was suggested (evaluator output; context, never copy). */
+  seedReasoning: string;
+  /** This negotiation's full transcript, oldest first. */
+  history: NegotiationTurn[];
+  stallReason: NegotiationStallReason;
+  /** Recent excerpt of the client's negotiator DM for this signal, most recent last. */
+  clientDm?: NegotiatorClientDmMessage[];
+}
+
+/**
+ * Structured output for the gap call. `hasGap: false` is a first-class answer:
+ * when no single client answer would change a retry's outcome, the negotiation
+ * must stall terminally rather than park on a filler question. Nullable
+ * declarations mirror `AskUserPayloadSchema.question` — strict structured-output
+ * conversion rejects optional-without-nullable, and a returned null reads as
+ * absent.
+ */
+const StallGapOutputSchema = z.object({
+  hasGap: z.boolean(),
+  reason: NegotiationConsultationReasonSchema.nullable().optional().transform((value) => value ?? undefined),
+  question: StructuredQuestionSchema.nullable().optional().transform((value) => value ?? undefined),
+});
+
+const SYSTEM_PROMPT = `You are the Index Negotiator, an AI agent acting on behalf of {userName}. A negotiation you conducted for them about a potential connection has just ended without conclusion: {stallReasonLabel}.
+
+Your job now is a single decision: is there ONE piece of information only {userName} holds whose answer would let a retry of this negotiation reach a conclusion? Read the exchange below and judge where it actually stuck.
+
+- If no single answer from {userName} would change a retry's outcome — the match is simply weak, the counterparty is the blocker, or the stall had nothing to do with missing input from {userName} — set hasGap to false and omit the question. Do not invent a question to have something to ask; asking costs {userName} attention and pauses nothing useful.
+- If yes, set hasGap to true and author the question:
+  - reason: exactly one closed server category recording WHY the pause is warranted: "unresolved_owner_constraint" | "consequential_disclosure_permission" | "repeated_non_convergence" | "insufficient_commitment_authority". It is not the wording {userName} sees.
+  - title: at most 12 characters — a noun for the decision domain, e.g. "Stage", "Timing", "Budget", "Scope".
+  - prompt: at most 2 sentences and 400 characters, ending in a question mark. Ask about the specific thing that was actually stuck in this negotiation, in {userName}'s own terms, grounded in the exchange below. Never a generic template.
+  - options: 2–4 of {userName}'s real decision options. Each label at most 120 characters; each description at most 280 characters, stating the CONSEQUENCE of choosing that option — what the retry would do with it — not what it means. Never add an "Other" option; clients provide a free-text fallback automatically.
+  - multiSelect: true ONLY when the options are not mutually exclusive; false for a single either/or decision.
+  - Do not name, quote, or describe the counterparty. {userName} can read the transcript, but the question itself must stand on its own without their identity or profile in it.
+  - Do NOT reference internal system details like scores, pre-screens, or evaluator outputs.{dmGroundingRule}`;
+
+/**
+ * Appended only when the call actually carries a client-DM excerpt, mirroring
+ * `ASK_USER_DM_GROUNDING_RULE`: a call with no DM must not carry a rule that
+ * dangles with nothing in the prompt to check against.
+ */
+const DM_GROUNDING_RULE = `
+  - Ground the question in your conversation with {userName} about this signal (shown below) as well as in the exchange. Do NOT ask what they have already answered there: if their own words settle the point, there is no gap on it. Use their terms for the thing at stake — the words, numbers, and framing they used, not your paraphrase of them.`;
+
+function formatTurnLine(turn: NegotiationTurn, index: number): string {
+  const msgPart = turn.message ? ` — message: ${turn.message}` : "";
+  return `Turn ${index + 1}: ${turn.action} — reasoning: ${turn.assessment.reasoning}${msgPart}`;
+}
+
+export interface NegotiationStallGapAuthorConfig {
+  /** Hard ceiling on the model round-trip, in ms. Same resolution as the negotiator turn timeout. */
+  timeoutMs?: number;
+}
+
+/**
+ * Authors the post-stall gap. One instance lives in the graph's dependency bag
+ * beside `systemAgent`; the finalize node calls it at most once per stalled
+ * session.
+ */
+export class NegotiationStallGapAuthor {
+  private readonly timeoutMs: number;
+
+  constructor(config?: NegotiationStallGapAuthorConfig) {
+    this.timeoutMs = resolveTurnTimeoutMs(config?.timeoutMs);
+  }
+
+  /**
+   * @returns The authored gap, or null when there is none to ask — the model
+   *          said so, produced invalid output after a retry, or failed. The
+   *          caller treats every null identically: terminal stall, no park.
+   */
+  async author(input: StallGapAuthorInput): Promise<NegotiationStallGap | null> {
+    const clientDm = input.clientDm ?? [];
+    const model = createStructuredModel("negotiator", StallGapOutputSchema, { name: "negotiation_stall_gap" });
+
+    const systemPrompt = SYSTEM_PROMPT
+      .replace("{stallReasonLabel}", STALL_REASON_LABELS[input.stallReason])
+      .replace("{dmGroundingRule}", clientDm.length > 0 ? DM_GROUNDING_RULE : "")
+      .replace(/{userName}/g, input.userName);
+
+    const transcript = input.history.length > 0
+      ? `\n\nNegotiation transcript:\n${input.history.map(formatTurnLine).join("\n")}`
+      : "";
+
+    const userMessage = `{userName}'s signal under negotiation:
+- ${input.signal.title}: ${input.signal.description}
+
+Why this match was suggested: ${input.seedReasoning}${transcript}${renderNegotiatorClientDmSection(clientDm, input.userName)}
+
+Decide whether one question to {userName} would let a retry conclude, and author it if so.`.replace(/{userName}/g, input.userName);
+
+    const chatMessages = [
+      { role: "system", content: systemPrompt },
+      { role: "user", content: userMessage },
+    ];
+
+    try {
+      // Same validate → retry-once → give-up loop as the negotiator turn,
+      // except giving up resolves to null (terminal stall) instead of a
+      // fallback action — there is no conservative fallback question.
+      for (let attempt = 0; attempt < 2; attempt++) {
+        const result = await this.callModel(model, chatMessages);
+        const parsed = StallGapOutputSchema.safeParse(result);
+        if (!parsed.success) {
+          stallGapLog.warn("Stall-gap output failed schema validation", {
+            attempt: attempt + 1,
+            issues: parsed.error.issues.map((issue) => issue.message).slice(0, 3),
+          });
+          continue;
+        }
+        if (!parsed.data.hasGap) return null;
+        if (!parsed.data.question || !parsed.data.reason) {
+          stallGapLog.warn("Stall-gap output claimed a gap without question or reason", { attempt: attempt + 1 });
+          continue;
+        }
+        return { reason: parsed.data.reason, question: parsed.data.question };
+      }
+      return null;
+    } catch (err) {
+      stallGapLog.warn("Stall-gap authoring failed; negotiation stalls without a park", {
+        error: err instanceof Error ? err.message : String(err),
+      });
+      return null;
+    }
+  }
+
+  /**
+   * Raw structured-model round trip. Split out as a seam so tests can drive
+   * the validate→retry→null loop without a live provider — same pattern as
+   * `IndexNegotiator.callModel`.
+   */
+  protected async callModel(
+    model: ReturnType<typeof createStructuredModel>,
+    chatMessages: Array<{ role: string; content: string }>,
+  ): Promise<unknown> {
+    return invokeWithAbortSignal(model, chatMessages, AbortSignal.timeout(this.timeoutMs));
+  }
+}

--- a/packages/protocol/src/negotiations/tests/negotiation.ask-user.spec.ts
+++ b/packages/protocol/src/negotiations/tests/negotiation.ask-user.spec.ts
@@ -2,6 +2,7 @@ import { describe, it, expect, beforeAll, afterAll, beforeEach, afterEach } from
 import { NegotiationGraphFactory } from "../negotiation.graph.js";
 import { NegotiationGraphState } from "../negotiation.state.js";
 import { IndexNegotiator, type NegotiationAgentInput } from "../negotiation.agent.js";
+import { NegotiationStallGapAuthor } from "../negotiation.stall-gap.js";
 import { allowedActionsFor, turnSchemaFor, configuredAskUserEnabled, askUserAnswerWindowMs, DEFAULT_ASK_USER_WINDOW_MS, ASK_USER_LOCK_SLACK_MS, InitiatorTurnSchema, CounterpartyTurnSchema, InitiatorAskUserTurnSchema, CounterpartyAskUserTurnSchema } from "../negotiation.protocol.js";
 import { SystemNegotiationTurnSchema, FinalNegotiationTurnSchema } from "../negotiation.state.js";
 import type { NegotiationTurn } from "../negotiation.state.js";
@@ -320,6 +321,14 @@ describe("negotiation graph — ask_user pause (IND-401)", () => {
   const origScreenMode = process.env.NEGOTIATION_SCREEN_MODE;
   const origPolicyMode = process.env.NEGOTIATION_CONSULTATION_POLICY_MODE;
 
+  // Post-stall parking authors a gap at finalize, which is its own model call
+  // and its own ask_user message. This spec is about the mid-flight
+  // consultation policy, so it holds parking to "no gap" throughout —
+  // otherwise every unconcluded case here would consume a scripted turn and
+  // emit an ask_user message that has nothing to do with what is under test.
+  // Parking itself is covered by negotiation.park-on-stall.spec.ts.
+  let origStallGapAuthor: typeof NegotiationStallGapAuthor.prototype.author;
+
   beforeAll(() => {
     origAgentInvoke = IndexNegotiator.prototype.invoke;
     IndexNegotiator.prototype.invoke = async function (input: NegotiationAgentInput) {
@@ -328,10 +337,15 @@ describe("negotiation graph — ask_user pause (IND-401)", () => {
       if (!turn) throw new Error("agent script exhausted");
       return turn;
     };
+    origStallGapAuthor = NegotiationStallGapAuthor.prototype.author;
+    NegotiationStallGapAuthor.prototype.author = async function () {
+      return null;
+    };
   });
 
   afterAll(() => {
     IndexNegotiator.prototype.invoke = origAgentInvoke;
+    NegotiationStallGapAuthor.prototype.author = origStallGapAuthor;
   });
 
   beforeEach(() => {
@@ -835,6 +849,29 @@ describe("negotiation graph — ask_user pause (IND-401)", () => {
     agentScript = [{ ...declineTurn, action: "withdraw" }];
     await runGraph(stubs2);
     expect(agentInputs[0].canAskUser).toBeUndefined();
+  });
+
+  it("caps ask rounds negotiation-wide: parks from EITHER side count against NEGOTIATION_ASK_ROUNDS_CAP", async () => {
+    const origCap = process.env.NEGOTIATION_ASK_ROUNDS_CAP;
+    process.env.NEGOTIATION_ASK_ROUNDS_CAP = "1";
+    try {
+      // Same seed as the per-side rationing case: u-src consulted, u-cand
+      // never did. Under the default cap the candidate keeps the option
+      // (pinned above); at cap 1 the negotiation as a whole is out of rounds.
+      const stubs = mkStubs({
+        priorMessages: [
+          priorMsg("u-src", "outreach", 0),
+          priorMsg("u-cand", "counter", 1),
+          priorMsg("u-src", "ask_user", 2),
+          priorMsg("u-src", "counter", 3),
+        ],
+      });
+      agentScript = [declineTurn];
+      await runGraph(stubs);
+      expect(agentInputs[0].canAskUser).toBeUndefined();
+    } finally {
+      if (origCap === undefined) delete process.env.NEGOTIATION_ASK_ROUNDS_CAP; else process.env.NEGOTIATION_ASK_ROUNDS_CAP = origCap;
+    }
   });
 
   it("coerces an unavailable ask_user to the conservative fallback before persisting", async () => {

--- a/packages/protocol/src/negotiations/tests/negotiation.park-on-stall.spec.ts
+++ b/packages/protocol/src/negotiations/tests/negotiation.park-on-stall.spec.ts
@@ -1,0 +1,342 @@
+import { describe, it, expect, beforeAll, afterAll, beforeEach, afterEach } from "bun:test";
+import { NegotiationGraphFactory } from "../negotiation.graph.js";
+import { NegotiationGraphState } from "../negotiation.state.js";
+import { IndexNegotiator } from "../negotiation.agent.js";
+import { NegotiationStallGapAuthor, NEGOTIATION_PARK_REASONING, type NegotiationStallGap, type StallGapAuthorInput } from "../negotiation.stall-gap.js";
+import { negotiationAskRoundsCap, DEFAULT_NEGOTIATION_ASK_ROUNDS_CAP } from "../negotiation.protocol.js";
+import { countNegotiationAskRounds, hasPriorAskUser } from "../negotiation.graph.shared.js";
+import { requestContext } from "../../shared/observability/request-context.js";
+import type { NegotiationTurn } from "../negotiation.state.js";
+import type { QuestionerEnqueuePayload } from "../../questions/question.input.js";
+
+/**
+ * Post-stall park with a bounded ask cap (conversational-questions plan).
+ *
+ * Pins:
+ * - an unconcluded negotiation (turn cap here) parks: the authored gap is
+ *   persisted as an `ask_user` message in the negotiation's own record, with
+ *   the fixed park reasoning and the source's agent as sender,
+ * - grounding: the gap call receives the transcript, the stall reason, and
+ *   the signal's client-DM excerpt retrieved for (sourceUser, sourceIntentId),
+ * - bounding: at or past the per-negotiation ask-rounds cap the negotiation
+ *   stalls terminally — no authoring call, no park, telemetry only,
+ * - the flag defaults off and off means byte-identical legacy behavior,
+ * - a null gap (nothing to ask) and an unsafe question both degrade to
+ *   today's terminal stall,
+ * - the legacy questioner enqueue still fires alongside a park (its removal
+ *   belongs to the delivery lane's retirement sweep),
+ * - round counting shares the per-side ration's substrate: `ask_user`
+ *   messages, counted negotiation-wide.
+ */
+
+const gapQuestion = {
+  title: "Timing",
+  prompt: "When could you realistically start a collaboration?",
+  options: [
+    { label: "This quarter", description: "A retry will push for an immediate start." },
+    { label: "Later this year", description: "A retry will propose a slower ramp-up." },
+  ],
+  multiSelect: false,
+};
+
+const safeGap: NegotiationStallGap = { reason: "unresolved_owner_constraint", question: gapQuestion };
+
+type FakeMessage = { id: string; senderId: string; role: "agent"; parts: unknown[]; createdAt: Date };
+
+function priorMsg(senderUserId: string, action: string, idx: number): FakeMessage {
+  return {
+    id: `prior-${idx}`,
+    senderId: `agent:${senderUserId}`,
+    role: "agent",
+    parts: [{ kind: "data", data: { action, assessment: { reasoning: "r", suggestedRoles: { ownUser: "peer", otherUser: "peer" } }, message: null } }],
+    createdAt: new Date(Date.now() - (100 - idx) * 1000),
+  };
+}
+
+function mkStubs(opts?: { priorMessages?: FakeMessage[] }) {
+  const createdMessages: Array<{ senderId: string; taskId?: string; parts: Array<{ kind: string; data: NegotiationTurn }> }> = [];
+  const stateWrites: string[] = [];
+  const opportunityStatuses: string[] = [];
+  const database = {
+    getOrCreateDM: async () => ({ id: "conv-1" }),
+    createTask: async (conversationId: string) => ({ id: "task-1", conversationId, state: "submitted" }),
+    updateOpportunityStatus: async (_id: string, status: string) => { opportunityStatuses.push(status); },
+    createMessage: async (p: { senderId: string; taskId?: string; parts: Array<{ kind: string; data: NegotiationTurn }> }) => {
+      createdMessages.push(p);
+      return { id: `msg-${createdMessages.length}`, senderId: p.senderId, parts: p.parts, createdAt: new Date() };
+    },
+    updateTaskState: async (_taskId: string, state: string) => { stateWrites.push(state); },
+    createArtifact: async () => ({ id: "artifact-1" }),
+    setTaskTurnContext: async () => {},
+    getMessagesForConversation: async () => opts?.priorMessages ?? [],
+    getNegotiationMessages: async () => opts?.priorMessages ?? [],
+    getOpportunityUserAnswers: async () => [],
+    getNegotiationTaskForOpportunity: async () => null,
+    getLatestNegotiationTaskForConversation: async () => null,
+    getUserContext: async () => ({ text: "user ctx" }),
+  } as unknown as ConstructorParameters<typeof NegotiationGraphFactory>[0];
+
+  const dispatcher = {
+    hasExternalAgent: async () => false,
+    dispatch: async () => ({ handled: false, reason: "no_agent" }),
+  } as unknown as ConstructorParameters<typeof NegotiationGraphFactory>[1];
+
+  const questionerEnqueues: QuestionerEnqueuePayload[] = [];
+  const questionerEnqueue = async (input: QuestionerEnqueuePayload) => { questionerEnqueues.push(input); };
+
+  const clientDmQueries: Array<{ userId: string; intentId: string }> = [];
+  const clientDmRetrieve = async (query: { userId: string; intentId: string }) => {
+    clientDmQueries.push(query);
+    return [{ role: "client" as const, content: "I only want equity partnerships" }];
+  };
+
+  return { database, dispatcher, questionerEnqueue, clientDmRetrieve, createdMessages, stateWrites, opportunityStatuses, questionerEnqueues, clientDmQueries };
+}
+
+async function runGraph(stubs: ReturnType<typeof mkStubs>, events?: Array<Record<string, unknown>>) {
+  const graph = new NegotiationGraphFactory(
+    stubs.database,
+    stubs.dispatcher,
+    undefined,
+    stubs.questionerEnqueue,
+    undefined,
+    undefined,
+    stubs.clientDmRetrieve,
+  ).createGraph();
+  const invoke = () => graph.invoke({
+    sourceUser: { id: "u-src", intents: [{ id: "intent-src", title: "Build AI", description: "Find an AI collaborator", confidence: 1 }], profile: { name: "Alice", bio: "PM" } },
+    candidateUser: { id: "u-cand", intents: [{ id: "intent-cand", title: "Apply ML", description: "Join an AI product", confidence: 1 }], profile: { name: "Bob", bio: "ML engineer" } },
+    sourceIntentId: "intent-src",
+    candidateIntentId: "intent-cand",
+    indexContext: { networkId: "net-1", prompt: "" },
+    seedAssessment: { reasoning: "x", valencyRole: "peer" },
+    opportunityId: "opp-1",
+    maxTurns: 2,
+  } as Partial<typeof NegotiationGraphState.State>);
+  if (!events) return invoke();
+  return requestContext.run({ traceEmitter: ((e: Record<string, unknown>) => events.push(e)) as never }, invoke);
+}
+
+// Scripted seams.
+let agentScript: NegotiationTurn[] = [];
+let authorInputs: StallGapAuthorInput[] = [];
+let authorResult: NegotiationStallGap | null = null;
+
+const counterTurn: NegotiationTurn = {
+  action: "counter",
+  assessment: { reasoning: "still apart", suggestedRoles: { ownUser: "peer", otherUser: "peer" } },
+  message: null,
+};
+
+describe("negotiation graph — post-stall park", () => {
+  let origAgentInvoke: typeof IndexNegotiator.prototype.invoke;
+  let origAuthor: typeof NegotiationStallGapAuthor.prototype.author;
+  const origCap = process.env.NEGOTIATION_ASK_ROUNDS_CAP;
+  const origScreenMode = process.env.NEGOTIATION_SCREEN_MODE;
+
+  beforeAll(() => {
+    origAgentInvoke = IndexNegotiator.prototype.invoke;
+    IndexNegotiator.prototype.invoke = async function () {
+      const turn = agentScript.shift();
+      if (!turn) throw new Error("agent script exhausted");
+      return turn;
+    };
+    origAuthor = NegotiationStallGapAuthor.prototype.author;
+    NegotiationStallGapAuthor.prototype.author = async function (input: StallGapAuthorInput) {
+      authorInputs.push(input);
+      return authorResult;
+    };
+  });
+
+  afterAll(() => {
+    IndexNegotiator.prototype.invoke = origAgentInvoke;
+    NegotiationStallGapAuthor.prototype.author = origAuthor;
+  });
+
+  beforeEach(() => {
+    agentScript = [
+      { ...counterTurn, action: "propose" },
+      counterTurn,
+    ];
+    authorInputs = [];
+    authorResult = safeGap;
+    process.env.NEGOTIATION_SCREEN_MODE = "off";
+    delete process.env.NEGOTIATION_ASK_ROUNDS_CAP;
+  });
+
+  afterEach(() => {
+    if (origCap === undefined) delete process.env.NEGOTIATION_ASK_ROUNDS_CAP; else process.env.NEGOTIATION_ASK_ROUNDS_CAP = origCap;
+    if (origScreenMode === undefined) delete process.env.NEGOTIATION_SCREEN_MODE; else process.env.NEGOTIATION_SCREEN_MODE = origScreenMode;
+  });
+
+  it("parks a turn-capped negotiation with its authored gap as an ask_user message", async () => {
+    const stubs = mkStubs();
+    const events: Array<Record<string, unknown>> = [];
+    await runGraph(stubs, events);
+
+    // Two turns + the park message, appended last.
+    expect(stubs.createdMessages).toHaveLength(3);
+    const park = stubs.createdMessages[2];
+    expect(park.senderId).toBe("agent:u-src");
+    expect(park.taskId).toBe("task-1");
+    const parkTurn = park.parts[0].data;
+    expect(parkTurn.action).toBe("ask_user");
+    expect(parkTurn.assessment.reasoning).toBe(NEGOTIATION_PARK_REASONING);
+    expect(parkTurn.askUser).toEqual({ reason: "unresolved_owner_constraint", question: gapQuestion });
+
+    // The negotiation still finalizes exactly as before: completed + stalled.
+    expect(stubs.stateWrites).toContain("completed");
+    expect(stubs.opportunityStatuses).toContain("stalled");
+
+    // Authoring was grounded in the transcript, stall reason, and client DM.
+    expect(authorInputs).toHaveLength(1);
+    expect(authorInputs[0].stallReason).toBe("turn_cap");
+    expect(authorInputs[0].userName).toBe("Alice");
+    expect(authorInputs[0].signal).toEqual({ title: "Build AI", description: "Find an AI collaborator" });
+    expect(authorInputs[0].history).toHaveLength(2);
+    expect(authorInputs[0].clientDm).toEqual([{ role: "client", content: "I only want equity partnerships" }]);
+    expect(stubs.clientDmQueries).toEqual([{ userId: "u-src", intentId: "intent-src" }]);
+
+    // The legacy blind enqueue is untouched — retirement is the delivery lane's.
+    expect(stubs.questionerEnqueues).toHaveLength(1);
+    expect(stubs.questionerEnqueues[0].purpose).toBe("stalled_followup");
+
+    expect(events.filter((e) => e.type === "negotiation_parked")).toHaveLength(1);
+    const parked = events.find((e) => e.type === "negotiation_parked")!;
+    expect(parked.opportunityId).toBe("opp-1");
+    expect(parked.askRounds).toBe(1);
+    expect(parked.stallReason).toBe("turn_cap");
+  });
+
+  it("stalls terminally at the ask-rounds cap: no authoring, no park, telemetry only", async () => {
+    // The negotiation has already spent three rounds across both sides.
+    const stubs = mkStubs({
+      priorMessages: [
+        priorMsg("u-src", "propose", 0),
+        priorMsg("u-cand", "ask_user", 1),
+        priorMsg("u-cand", "counter", 2),
+        priorMsg("u-src", "ask_user", 3),
+        priorMsg("u-src", "ask_user", 4),
+      ],
+    });
+    // Floor: last message is u-src ask_user → source speaks again.
+    agentScript = [counterTurn, counterTurn];
+    const events: Array<Record<string, unknown>> = [];
+    await runGraph(stubs, events);
+
+    expect(authorInputs).toHaveLength(0);
+    expect(stubs.createdMessages.map((m) => m.parts[0].data.action)).not.toContain("ask_user");
+    expect(events.filter((e) => e.type === "negotiation_parked")).toHaveLength(0);
+    const terminal = events.filter((e) => e.type === "negotiation_ask_cap_terminal");
+    expect(terminal).toHaveLength(1);
+    expect(terminal[0].askRounds).toBe(3);
+    expect(terminal[0].askRoundsCap).toBe(DEFAULT_NEGOTIATION_ASK_ROUNDS_CAP);
+    // The stall itself is unchanged — the legacy enqueue still fires.
+    expect(stubs.questionerEnqueues).toHaveLength(1);
+  });
+
+  it("does not park when the negotiator reports no gap", async () => {
+    authorResult = null;
+    const stubs = mkStubs();
+    const events: Array<Record<string, unknown>> = [];
+    await runGraph(stubs, events);
+
+    expect(authorInputs).toHaveLength(1);
+    expect(stubs.createdMessages).toHaveLength(2);
+    expect(events.filter((e) => e.type === "negotiation_parked")).toHaveLength(0);
+  });
+
+  it("drops an unsafe gap question instead of parking (names the counterparty)", async () => {
+    authorResult = {
+      reason: "consequential_disclosure_permission",
+      question: { ...gapQuestion, prompt: "May I tell Bob your budget range?" },
+    };
+    const stubs = mkStubs();
+    await runGraph(stubs);
+
+    expect(authorInputs).toHaveLength(1);
+    expect(stubs.createdMessages).toHaveLength(2);
+    expect(stubs.createdMessages.map((m) => m.parts[0].data.action)).not.toContain("ask_user");
+  });
+
+  it("does not park an accepted negotiation", async () => {
+    agentScript = [
+      { ...counterTurn, action: "propose" },
+      { ...counterTurn, action: "accept" },
+    ];
+    const stubs = mkStubs();
+    await runGraph(stubs);
+
+    expect(authorInputs).toHaveLength(0);
+    expect(stubs.createdMessages).toHaveLength(2);
+  });
+
+  it("does not park an explicitly rejected negotiation", async () => {
+    agentScript = [
+      { ...counterTurn, action: "propose" },
+      { ...counterTurn, action: "reject" },
+    ];
+    const stubs = mkStubs();
+    await runGraph(stubs);
+
+    expect(authorInputs).toHaveLength(0);
+    expect(stubs.createdMessages).toHaveLength(2);
+  });
+
+  it("keeps finalizing when the park write fails", async () => {
+    const stubs = mkStubs();
+    let calls = 0;
+    const originalCreate = stubs.database.createMessage.bind(stubs.database);
+    (stubs.database as { createMessage: typeof originalCreate }).createMessage = async (p: Parameters<typeof originalCreate>[0]) => {
+      calls += 1;
+      if (calls === 3) throw new Error("db down");
+      return originalCreate(p);
+    };
+    await runGraph(stubs);
+
+    expect(stubs.stateWrites).toContain("completed");
+    expect(stubs.opportunityStatuses).toContain("stalled");
+    expect(stubs.questionerEnqueues).toHaveLength(1);
+  });
+});
+
+describe("ask-rounds cap config", () => {
+  it("cap defaults to 3 and rejects invalid overrides", () => {
+    const origCap = process.env.NEGOTIATION_ASK_ROUNDS_CAP;
+    try {
+      delete process.env.NEGOTIATION_ASK_ROUNDS_CAP;
+      expect(negotiationAskRoundsCap()).toBe(DEFAULT_NEGOTIATION_ASK_ROUNDS_CAP);
+      process.env.NEGOTIATION_ASK_ROUNDS_CAP = "2";
+      expect(negotiationAskRoundsCap()).toBe(2);
+      process.env.NEGOTIATION_ASK_ROUNDS_CAP = "0";
+      expect(negotiationAskRoundsCap()).toBe(DEFAULT_NEGOTIATION_ASK_ROUNDS_CAP);
+      process.env.NEGOTIATION_ASK_ROUNDS_CAP = "2.5";
+      expect(negotiationAskRoundsCap()).toBe(DEFAULT_NEGOTIATION_ASK_ROUNDS_CAP);
+      process.env.NEGOTIATION_ASK_ROUNDS_CAP = "nope";
+      expect(negotiationAskRoundsCap()).toBe(DEFAULT_NEGOTIATION_ASK_ROUNDS_CAP);
+    } finally {
+      if (origCap === undefined) delete process.env.NEGOTIATION_ASK_ROUNDS_CAP; else process.env.NEGOTIATION_ASK_ROUNDS_CAP = origCap;
+    }
+  });
+});
+
+describe("countNegotiationAskRounds — one substrate with hasPriorAskUser", () => {
+  const messages = [
+    priorMsg("u-src", "propose", 0),
+    priorMsg("u-cand", "ask_user", 1),
+    priorMsg("u-cand", "counter", 2),
+    priorMsg("u-src", "ask_user", 3),
+  ];
+
+  it("counts ask_user parks negotiation-wide, both sides combined", () => {
+    expect(countNegotiationAskRounds(messages)).toBe(2);
+    expect(countNegotiationAskRounds([])).toBe(0);
+    expect(countNegotiationAskRounds([priorMsg("u-src", "counter", 0)])).toBe(0);
+  });
+
+  it("keeps hasPriorAskUser per-side over the same messages", () => {
+    expect(hasPriorAskUser(messages, "u-src")).toBe(true);
+    expect(hasPriorAskUser(messages, "u-cand")).toBe(true);
+    expect(hasPriorAskUser(messages.slice(0, 2), "u-src")).toBe(false);
+  });
+});

--- a/packages/protocol/src/negotiations/tests/negotiation.stall-gap.spec.ts
+++ b/packages/protocol/src/negotiations/tests/negotiation.stall-gap.spec.ts
@@ -1,0 +1,155 @@
+import { describe, it, expect } from "bun:test";
+import { NegotiationStallGapAuthor, NEGOTIATION_PARK_REASONING, type StallGapAuthorInput } from "../negotiation.stall-gap.js";
+import type { NegotiationTurn } from "../negotiation.state.js";
+
+/**
+ * Post-stall gap authoring (conversational-questions plan).
+ *
+ * Pins:
+ * - output contract: a gap requires hasGap + question + reason together;
+ *   hasGap:false is a first-class "nothing to ask" answer, not an error,
+ * - the validate→retry-once→null loop via the `callModel` seam (no provider),
+ * - fail-open: a throwing model call resolves to null, never rejects,
+ * - prompt grounding: the transcript is rendered; the client-DM section and
+ *   its grounding rule appear exactly when an excerpt is supplied,
+ * - the park reasoning constant stays fixed, not model-authored.
+ */
+
+class ScriptedGapAuthor extends NegotiationStallGapAuthor {
+  calls: Array<Array<{ role: string; content: string }>> = [];
+  constructor(private outputs: unknown[]) {
+    super({ timeoutMs: 1000 });
+  }
+  protected override async callModel(
+    _model: unknown,
+    chatMessages: Array<{ role: string; content: string }>,
+  ): Promise<unknown> {
+    this.calls.push(chatMessages);
+    const out = this.outputs[Math.min(this.calls.length - 1, this.outputs.length - 1)];
+    if (out instanceof Error) throw out;
+    return out;
+  }
+}
+
+const history: NegotiationTurn[] = [
+  {
+    action: "propose",
+    assessment: { reasoning: "worth exploring", suggestedRoles: { ownUser: "peer", otherUser: "peer" } },
+    message: "Shall we collaborate?",
+  },
+  {
+    action: "counter",
+    assessment: { reasoning: "timing unclear", suggestedRoles: { ownUser: "peer", otherUser: "peer" } },
+    message: "What timeline are you on?",
+  },
+];
+
+const baseInput: StallGapAuthorInput = {
+  userName: "Alice",
+  signal: { title: "Build AI", description: "Find an AI collaborator" },
+  seedReasoning: "complementary skills",
+  history,
+  stallReason: "turn_cap",
+};
+
+const gapOutput = {
+  hasGap: true,
+  reason: "unresolved_owner_constraint",
+  question: {
+    title: "Timing",
+    prompt: "When could you realistically start a collaboration?",
+    options: [
+      { label: "This quarter", description: "The retry will push for an immediate start." },
+      { label: "Later this year", description: "The retry will propose a slower ramp-up." },
+    ],
+    multiSelect: false,
+  },
+};
+
+describe("NegotiationStallGapAuthor — output contract", () => {
+  it("returns the gap when the model reports one with question and reason", async () => {
+    const author = new ScriptedGapAuthor([gapOutput]);
+    const gap = await author.author(baseInput);
+    expect(gap).toEqual({ reason: "unresolved_owner_constraint", question: gapOutput.question });
+    expect(author.calls).toHaveLength(1);
+  });
+
+  it("returns null without retrying when the model reports no gap", async () => {
+    const author = new ScriptedGapAuthor([{ hasGap: false, reason: null, question: null }]);
+    expect(await author.author(baseInput)).toBeNull();
+    expect(author.calls).toHaveLength(1);
+  });
+
+  it("retries once on schema-invalid output, then succeeds", async () => {
+    const author = new ScriptedGapAuthor([{ nonsense: true }, gapOutput]);
+    const gap = await author.author(baseInput);
+    expect(gap?.question.title).toBe("Timing");
+    expect(author.calls).toHaveLength(2);
+  });
+
+  it("returns null after two invalid attempts", async () => {
+    const author = new ScriptedGapAuthor([{ nonsense: true }, { nonsense: true }]);
+    expect(await author.author(baseInput)).toBeNull();
+    expect(author.calls).toHaveLength(2);
+  });
+
+  it("treats a claimed gap without question or reason as invalid (retry, then null)", async () => {
+    const author = new ScriptedGapAuthor([{ hasGap: true, reason: null, question: null }]);
+    expect(await author.author(baseInput)).toBeNull();
+    expect(author.calls).toHaveLength(2);
+  });
+
+  it("fails open to null when the model call throws", async () => {
+    const author = new ScriptedGapAuthor([new Error("provider down")]);
+    expect(await author.author(baseInput)).toBeNull();
+  });
+});
+
+describe("NegotiationStallGapAuthor — prompt grounding", () => {
+  it("renders the transcript, the stall reason, and the user's name", async () => {
+    const author = new ScriptedGapAuthor([gapOutput]);
+    await author.author(baseInput);
+    const [system, user] = author.calls[0];
+    expect(system.role).toBe("system");
+    expect(system.content).toContain("the turn limit was reached without agreement");
+    expect(system.content).toContain("Alice");
+    expect(system.content).not.toContain("{userName}");
+    expect(user.content).toContain("Turn 1: propose — reasoning: worth exploring — message: Shall we collaborate?");
+    expect(user.content).toContain("Turn 2: counter");
+    expect(user.content).toContain("Build AI: Find an AI collaborator");
+    expect(user.content).toContain("complementary skills");
+  });
+
+  it("includes the client-DM section and its grounding rule only when an excerpt is supplied", async () => {
+    const without = new ScriptedGapAuthor([gapOutput]);
+    await without.author(baseInput);
+    expect(without.calls[0][0].content).not.toContain("Do NOT ask what they have already answered");
+    expect(without.calls[0][1].content).not.toContain("conversation with Alice about this signal");
+
+    const withDm = new ScriptedGapAuthor([gapOutput]);
+    await withDm.author({
+      ...baseInput,
+      clientDm: [{ role: "client", content: "I only want equity partnerships" }],
+    });
+    expect(withDm.calls[0][0].content).toContain("Do NOT ask what they have already answered");
+    expect(withDm.calls[0][1].content).toContain("conversation with Alice about this signal");
+    expect(withDm.calls[0][1].content).toContain("I only want equity partnerships");
+  });
+
+  it("labels each stall reason distinctly", async () => {
+    for (const [stallReason, label] of [
+      ["timeout", "timed out"],
+      ["stalled", "stalled without reaching a conclusion"],
+    ] as const) {
+      const author = new ScriptedGapAuthor([gapOutput]);
+      await author.author({ ...baseInput, stallReason });
+      expect(author.calls[0][0].content).toContain(label);
+    }
+  });
+});
+
+describe("NEGOTIATION_PARK_REASONING", () => {
+  it("is a fixed transcript-safe constant", () => {
+    expect(NEGOTIATION_PARK_REASONING).toBe("Negotiation parked pending the client's answer.");
+  });
+});


### PR DESCRIPTION
## What

An unconcluded negotiation (turn cap, timeout, stall — no opportunity, no explicit reject) now **parks carrying the one question that would let a retry conclude**, instead of ending silently. And the park → answer → resume loop is **bounded per negotiation** by an ask-rounds cap, so two agents cannot ping-pong their humans indefinitely.

Implements the park-on-stall lane of [conversational questions](docs/plans/2026-08-18-conversational-questions.md), on top of #1428's authoring path. Protocol package only — nothing under `services/api` or `apps/web`.

## How

**The park (finalize).** One extra model call per stalled negotiation: the new `NegotiationStallGapAuthor` (`negotiation.stall-gap.ts`) asks the negotiator for the gap, grounded exactly as #1428 established — the negotiation transcript plus the signal's client DM via `retrieveClientDm`. The gap persists as an `ask_user` message in the negotiation's own record (fixed `NEGOTIATION_PARK_REASONING`, question in `askUser.question`, sender = the parked side's agent):

- the **parked negotiation is the only durable record** of the information need — no second store to drift;
- the gap lands in the transcript the delivery lane's regeneration job grounds on;
- `expectedNegotiationSpeaker` already keeps the floor with an `ask_user` sender, so a retry resumes with the answered side speaking.

Fail-open throughout: authoring failure, `hasGap: false` (a first-class "nothing to ask" answer), or a question rejected by the identifier-aware `isSafeAuthoredNegotiationQuestion` gate all degrade to today's terminal stall. Parks run on continuation sessions too — a resumed negotiation may legitimately park again; the cap is what bounds the loop.

**The cap.** `countNegotiationAskRounds` shares `hasPriorAskUser`'s substrate — the negotiation's persisted `ask_user` messages — read negotiation-wide instead of per side (one extraction, two views; no second counter). At or past `NEGOTIATION_ASK_ROUNDS_CAP` (default 3: leaves one post-stall park even after both sides spent their mid-flight consult) the negotiation stalls **terminally**: no authoring call, no park, telemetry only. `askUserAvailable` also respects the cap mid-flight.

**Routing contract (for the delivery lane).** A stalled opportunity whose negotiation record ends in the park message is *parked*; a stalled opportunity without it is a *terminal* stall and must never enter a question block. Task re-resolution stays server-side from the opportunity id — a post-stall park completes its task and the retry claims a new one, so no taskId is ever snapshotted anywhere.

## Not in this PR (deliberately)

- The `questionerEnqueue` call at finalize stays alongside the park — its retirement belongs to the delivery lane's sweep.
- Answer consumption / routed resume: routes against the question-block schema landing separately (`feat/question-block-schema`, contract blessed cross-session).
- No rollout flag: parking is unconditional; the cap tunes the bound, it does not gate the behaviour.

## Tests

- `negotiation.stall-gap.spec.ts` — authoring contract (gap requires question+reason, `hasGap:false` short-circuits), validate→retry-once→null loop, fail-open on throw, prompt grounding incl. DM-conditional sections.
- `negotiation.park-on-stall.spec.ts` — park message shape and telemetry, cap-terminal path, no-gap and unsafe-question degradation, park-write failure isolation, DM query scoping, counter/ration coexistence, config parsing.
- `negotiation.ask-user.spec.ts` — new negotiation-wide cap pin beside the per-side rationing pin; suite hardened against the always-on park path.

Full protocol suite: **2237 pass, 0 fail** (architecture tests green too).

🤖 Generated with [Claude Code](https://claude.com/claude-code)