### PR TITLE
feat(web): render question-messages as steps in the negotiator DM

### DIFF
--- a/apps/web/src/components/IntentNegotiatorChat.tsx
+++ b/apps/web/src/components/IntentNegotiatorChat.tsx
@@ -7,6 +7,7 @@ import type { AnsweredThreadEntry } from "@/components/InjectedQuestions/Answere
 import { InjectedQuestions } from "@/components/InjectedQuestions/InjectedQuestions";
 import { QuestionsEmptyState } from "@/components/InjectedQuestions/QuestionsEmptyState";
 import AssistantMessageContent from "@/components/chat/AssistantMessageContent";
+import { QuestionRegenerationIndicator } from "@/components/chat/QuestionSteps";
 import { ToolCallsDisplay } from "@/components/chat/ToolCallsDisplay";
 import { buildIntentQuestionTimeline } from "@/components/intent-question.timeline";
 import type { PendingQuestion, AnswerBody } from "@/services/questions";
@@ -41,6 +42,15 @@ export interface IntentNegotiatorChatProps {
    * be incoming — render a typing indicator below the question cards.
    */
   questionChainPending?: boolean;
+  /**
+   * A question-message regeneration is queued or running for this
+   * conversation — show an agent-working indicator so the user doesn't
+   * answer a message that's about to be replaced. Contract agreed with the
+   * delivery spine: the API exposes `questionRegenerationPending` on the
+   * POST /chat/negotiator/session response (wired by a follow-up there);
+   * until the parent passes it through, this stays absent and inert.
+   */
+  questionRegenerationPending?: boolean;
   /** Monotonic signal to reload server-appended Beat narration. */
   refreshVersion?: number;
   /** Opportunity card plumbing shared with the page's Radar panel. */
@@ -78,6 +88,7 @@ export default function IntentNegotiatorChat({
   onAnswerQuestion,
   onDismissQuestion,
   questionChainPending,
+  questionRegenerationPending,
   refreshVersion = 0,
   opportunityStatusMap,
   opportunityActionLoading,
@@ -102,6 +113,7 @@ export default function IntentNegotiatorChat({
   const [restoredHistoryLoaded, setRestoredHistoryLoaded] = useState(false);
   const [input, setInput] = useState("");
   const scrollRef = useRef<HTMLDivElement>(null);
+  const inputRef = useRef<HTMLInputElement>(null);
   const clearChatRef = useRef(clearChat);
   const appliedRefreshVersionRef = useRef(0);
   useEffect(() => {
@@ -159,7 +171,16 @@ export default function IntentNegotiatorChat({
   // Follow the stream.
   useEffect(() => {
     scrollRef.current?.scrollIntoView({ behavior: "smooth", block: "end" });
-  }, [answered.length, messages, questions.length, questionChainPending, ready]);
+  }, [answered.length, messages, questions.length, questionChainPending, questionRegenerationPending, ready]);
+
+  // Tap-to-quote from a question step: prefill the input with the question
+  // being answered so the agent can route the reply. The answer itself stays
+  // a plain chat message through the normal send path.
+  const handleQuestionQuote = useCallback((prompt: string) => {
+    const quoted = prompt.length > 140 ? `${prompt.slice(0, 139).trimEnd()}…` : prompt;
+    setInput(`"${quoted}" — `);
+    inputRef.current?.focus();
+  }, []);
 
   const handleSend = useCallback(async () => {
     const text = input.trim();
@@ -343,6 +364,7 @@ export default function IntentNegotiatorChat({
                         onIntentProposalReject={handleProposalReject}
                         onIntentProposalUndo={handleProposalUndo}
                         intentProposalStatusMap={proposalStatusMap}
+                        onQuestionQuote={handleQuestionQuote}
                       />
                     </div>
                   )}
@@ -363,6 +385,8 @@ export default function IntentNegotiatorChat({
                 "trailing-pending",
                 questionChainPending,
               )}
+
+            {questionRegenerationPending && <QuestionRegenerationIndicator />}
           </>
         )}
         <div ref={scrollRef} />
@@ -370,6 +394,7 @@ export default function IntentNegotiatorChat({
 
       <div className="mt-2 flex shrink-0 items-center gap-2 border-t border-gray-100 pt-2">
         <input
+          ref={inputRef}
           type="text"
           value={input}
           onChange={(e) => setInput(e.target.value)}

--- a/apps/web/src/components/chat/AssistantMessageContent.tsx
+++ b/apps/web/src/components/chat/AssistantMessageContent.tsx
@@ -2,9 +2,11 @@ import type { ComponentType, ComponentPropsWithoutRef } from "react";
 import ReactMarkdown from "react-markdown";
 import remarkGfm from "remark-gfm";
 import { Loader2 } from "lucide-react";
+import { parseQuestionMessage } from "@indexnetwork/protocol/question-block";
 import OpportunityCard, { type OpportunityCardData, OpportunitySkeleton } from "@/components/chat/OpportunityCardInChat";
 import IntentProposalCard, { type IntentProposalData, IntentProposalSkeleton } from "@/components/chat/IntentProposalCard";
 import NetworksPanel from "@/components/chat/NetworksPanel";
+import { QuestionSteps } from "@/components/chat/QuestionSteps";
 import { cn } from "@/lib/utils";
 import { mentionsToMarkdownLinks } from "@/lib/mentions";
 
@@ -167,6 +169,11 @@ export interface AssistantMessageContentProps {
   OAuthLink?: ComponentType<ComponentPropsWithoutRef<"a">>;
   onNetworkJoin?: (networkId: string, networkTitle: string) => void;
   networkPanelPendingJoinIds?: Set<string>;
+  /**
+   * Tap-to-quote for question-message steps: prefill the surface's chat input
+   * with the question being answered. Answers are plain chat replies.
+   */
+  onQuestionQuote?: (prompt: string) => void;
 }
 
 /**
@@ -189,7 +196,32 @@ export default function AssistantMessageContent({
   OAuthLink,
   onNetworkJoin,
   networkPanelPendingJoinIds,
+  onQuestionQuote,
 }: AssistantMessageContentProps) {
+  // Question-message: a body whose terminal section is a valid ```index-questions
+  // block renders as prose + steps. parseQuestionMessage fails closed — on any
+  // malformed block it returns null and the whole body falls through to the
+  // normal rendering path unchanged (the fence shows as a plain code block).
+  const parsedQuestions = parseQuestionMessage(content);
+  if (parsedQuestions) {
+    const prose = normalizeBlockquotes(mentionsToMarkdownLinks(parsedQuestions.prose));
+    return (
+      <div>
+        {prose.trim() && (
+          <div className="chat-markdown max-w-none">
+            <ReactMarkdown
+              remarkPlugins={[remarkGfm]}
+              components={OAuthLink ? { a: OAuthLink } : undefined}
+            >
+              {prose}
+            </ReactMarkdown>
+          </div>
+        )}
+        <QuestionSteps block={parsedQuestions.block} onQuote={onQuestionQuote} />
+      </div>
+    );
+  }
+
   const displayedContent = normalizeBlockquotes(mentionsToMarkdownLinks(content));
 
   if (!displayedContent && isStreaming) {

--- a/apps/web/src/components/chat/QuestionSteps.tsx
+++ b/apps/web/src/components/chat/QuestionSteps.tsx
@@ -1,0 +1,76 @@
+import { CornerDownRight } from "lucide-react";
+import type { QuestionBlock } from "@indexnetwork/protocol/question-block";
+
+export interface QuestionStepsProps {
+  block: QuestionBlock;
+  /**
+   * Tap-to-quote: prefill the chat input with the question being answered.
+   * Answering stays a plain chat reply — this is a convenience, not a submit path.
+   */
+  onQuote?: (prompt: string) => void;
+}
+
+/**
+ * Steps UI for a parsed question-message
+ * (docs/plans/2026-08-18-conversational-questions.md).
+ *
+ * One step per question: an ordinal and the agent-authored prompt. The block's
+ * negotiation refs (opportunityId / alsoUnblocks) are answer-routing data for
+ * the server and are deliberately never displayed. There is no form and no
+ * submit path — the user answers by typing in the conversation's input.
+ */
+export function QuestionSteps({ block, onQuote }: QuestionStepsProps) {
+  return (
+    <ol className="my-3 flex flex-col gap-2" data-testid="question-steps">
+      {block.questions.map((question, index) => (
+        <li
+          key={question.opportunityId}
+          className="flex items-start gap-3 rounded-lg border border-gray-200 bg-[#FCFCFC] px-3 py-2.5"
+          data-testid="question-step"
+        >
+          <span
+            aria-hidden="true"
+            className="mt-0.5 flex h-5 w-5 shrink-0 items-center justify-center rounded-full bg-[#041729] text-[10px] font-medium text-white font-ibm-plex-mono"
+          >
+            {index + 1}
+          </span>
+          <span className="min-w-0 flex-1 text-sm text-gray-900">{question.prompt}</span>
+          {onQuote && (
+            <button
+              type="button"
+              onClick={() => onQuote(question.prompt)}
+              aria-label={`Answer question ${index + 1}`}
+              title="Answer this question"
+              className="mt-0.5 shrink-0 rounded-full p-1 text-gray-400 transition-colors hover:bg-gray-100 hover:text-gray-700"
+            >
+              <CornerDownRight className="h-3.5 w-3.5" />
+            </button>
+          )}
+        </li>
+      ))}
+    </ol>
+  );
+}
+
+/**
+ * Agent-working indicator for a pending question-message regeneration: the
+ * server is rewriting the conversation's question-message, so what is on
+ * screen may be about to be replaced. Shown while the regeneration job for
+ * this conversation is queued or running.
+ */
+export function QuestionRegenerationIndicator() {
+  return (
+    <div
+      data-testid="question-regeneration-indicator"
+      aria-label="Your agent is updating its questions"
+      className="flex items-center gap-2 px-2 py-2"
+    >
+      <span className="flex items-center gap-1">
+        <span className="h-1.5 w-1.5 animate-pulse rounded-full bg-gray-400" />
+        <span className="h-1.5 w-1.5 animate-pulse rounded-full bg-gray-400 [animation-delay:150ms]" />
+        <span className="h-1.5 w-1.5 animate-pulse rounded-full bg-gray-400 [animation-delay:300ms]" />
+      </span>
+      <span className="text-xs text-gray-500 font-ibm-plex-mono">updating questions…</span>
+    </div>
+  );
+}

--- a/apps/web/src/components/chat/__tests__/QuestionMessage.test.tsx
+++ b/apps/web/src/components/chat/__tests__/QuestionMessage.test.tsx
@@ -1,0 +1,142 @@
+/**
+ * Question-message rendering against the question block contract
+ * (docs/plans/2026-08-18-conversational-questions.md).
+ *
+ * The canonical message comes from the protocol fixture subpath — these tests
+ * must not mint their own wire format. Contract under test: a body ending in a
+ * valid ```index-questions block renders as prose + steps (negotiation refs
+ * never displayed); any malformed variant fails closed and the ENTIRE body
+ * renders through the normal plain-text path; a body with no block is
+ * untouched.
+ */
+import { render, screen, fireEvent } from "@testing-library/react";
+import { MemoryRouter } from "react-router";
+import { describe, expect, it, vi } from "vitest";
+
+import { questionBlockFixture, questionMessageFixture } from "@indexnetwork/protocol/question-block/fixture";
+
+import AssistantMessageContent from "@/components/chat/AssistantMessageContent";
+import { QuestionRegenerationIndicator, QuestionSteps } from "@/components/chat/QuestionSteps";
+
+const [firstQuestion, secondQuestion] = questionBlockFixture.questions;
+
+function renderMessage(content: string, onQuestionQuote?: (prompt: string) => void) {
+  return render(
+    <MemoryRouter>
+      <AssistantMessageContent
+        content={content}
+        isStreaming={false}
+        {...(onQuestionQuote ? { onQuestionQuote } : {})}
+      />
+    </MemoryRouter>,
+  );
+}
+
+describe("question-message rendering", () => {
+  it("renders the fixture as prose plus one step per question", () => {
+    const { container } = renderMessage(questionMessageFixture);
+
+    expect(screen.getByTestId("question-steps")).toBeInTheDocument();
+    expect(screen.getAllByTestId("question-step")).toHaveLength(
+      questionBlockFixture.questions.length,
+    );
+    expect(screen.getByText(firstQuestion.prompt)).toBeInTheDocument();
+    expect(screen.getByText(secondQuestion.prompt)).toBeInTheDocument();
+    // The prose renders as a normal message above the steps.
+    expect(container.textContent).toContain(
+      "I moved three conversations forward on your search for a technical co-founder.",
+    );
+    expect(container.textContent?.indexOf("I moved three conversations")).toBeLessThan(
+      container.textContent?.indexOf(firstQuestion.prompt) ?? -1,
+    );
+  });
+
+  it("never displays the negotiation refs — they are routing data", () => {
+    const { container } = renderMessage(questionMessageFixture);
+
+    const text = container.textContent ?? "";
+    expect(text).not.toContain(firstQuestion.opportunityId);
+    expect(text).not.toContain(firstQuestion.alsoUnblocks?.[0]);
+    expect(text).not.toContain(secondQuestion.opportunityId);
+    expect(text).not.toContain("opportunityId");
+  });
+
+  it("offers no submit path — answering is a plain chat reply", () => {
+    renderMessage(questionMessageFixture);
+
+    expect(screen.queryByRole("button")).toBeNull();
+    expect(screen.queryByRole("textbox")).toBeNull();
+  });
+
+  describe("fails closed to plain text", () => {
+    const malformedVariants: Array<[name: string, body: string]> = [
+      [
+        "broken JSON in the block",
+        questionMessageFixture.replace('"version": 1,', '"version": 1,,'),
+      ],
+      [
+        "unknown block version",
+        questionMessageFixture.replace('"version": 1', '"version": 2'),
+      ],
+      [
+        "duplicate negotiation ref across questions",
+        questionMessageFixture.replace(
+          secondQuestion.opportunityId,
+          firstQuestion.opportunityId,
+        ),
+      ],
+      [
+        "text after the closing fence — the block must terminate the message",
+        `${questionMessageFixture}\n\nOne more thing.`,
+      ],
+      [
+        "unterminated fence",
+        questionMessageFixture.replace(/\n`{3,}\s*$/, ""),
+      ],
+    ];
+
+    it.each(malformedVariants)("%s renders the whole body as today", (_name, body) => {
+      const { container } = renderMessage(body);
+
+      // No steps, not even for the questions a partial parse could recover.
+      expect(screen.queryByTestId("question-steps")).toBeNull();
+      // The entire body, raw block payload included, goes through the normal
+      // rendering path — the refs are visible as code-block text.
+      expect(container.textContent).toContain(firstQuestion.opportunityId);
+      expect(container.textContent).toContain(
+        "I moved three conversations forward on your search for a technical co-founder.",
+      );
+    });
+  });
+
+  it("leaves a message without a block untouched", () => {
+    const { container } = renderMessage("Just a **normal** update, no questions.");
+
+    expect(screen.queryByTestId("question-steps")).toBeNull();
+    expect(container.querySelector("strong")?.textContent).toBe("normal");
+    expect(container.textContent).toContain("Just a normal update, no questions.");
+  });
+});
+
+describe("QuestionSteps quote affordance", () => {
+  it("passes the tapped question's prompt to onQuote", () => {
+    const onQuote = vi.fn();
+    render(<QuestionSteps block={questionBlockFixture} onQuote={onQuote} />);
+
+    fireEvent.click(screen.getByRole("button", { name: "Answer question 2" }));
+    expect(onQuote).toHaveBeenCalledWith(secondQuestion.prompt);
+  });
+
+  it("renders no buttons without an onQuote handler", () => {
+    render(<QuestionSteps block={questionBlockFixture} />);
+    expect(screen.queryByRole("button")).toBeNull();
+  });
+});
+
+describe("QuestionRegenerationIndicator", () => {
+  it("announces that the agent is updating its questions", () => {
+    render(<QuestionRegenerationIndicator />);
+    const indicator = screen.getByTestId("question-regeneration-indicator");
+    expect(indicator.getAttribute("aria-label")).toBe("Your agent is updating its questions");
+  });
+});

--- a/apps/web/tests/intent-negotiator-chat.test.tsx
+++ b/apps/web/tests/intent-negotiator-chat.test.tsx
@@ -69,7 +69,22 @@ vi.mock('@/components/InjectedQuestions/InjectedQuestions', () => ({
 }));
 
 vi.mock('@/components/chat/AssistantMessageContent', () => ({
-  default: ({ content }: { content: string }) => <div data-testid="assistant-content">{content}</div>,
+  default: ({
+    content,
+    onQuestionQuote,
+  }: {
+    content: string;
+    onQuestionQuote?: (prompt: string) => void;
+  }) => (
+    <div data-testid="assistant-content">
+      {content}
+      {onQuestionQuote && (
+        <button type="button" onClick={() => onQuestionQuote('Which equity range works for you?')}>
+          quote-question
+        </button>
+      )}
+    </div>
+  ),
 }));
 
 vi.mock('@/components/chat/ToolCallsDisplay', () => ({
@@ -322,6 +337,32 @@ describe('IntentNegotiatorChat', () => {
 
     unmount();
     expect(mocks.chat.clearChat).toHaveBeenCalledWith({ abortStream: false });
+  });
+
+  test('shows the agent-working indicator while a question-message regeneration is pending', async () => {
+    renderChat({ questionRegenerationPending: true });
+
+    expect(await screen.findByTestId('question-regeneration-indicator')).toBeInTheDocument();
+  });
+
+  test('hides the regeneration indicator when the prop is absent', async () => {
+    renderChat();
+
+    await screen.findByTestId('negotiator-chat-input');
+    expect(screen.queryByTestId('question-regeneration-indicator')).toBeNull();
+  });
+
+  test('tap-to-quote prefills the input with the question being answered', async () => {
+    mocks.chat.messages = [
+      { id: 'm1', role: 'assistant', content: 'Some questions for you.', timestamp: new Date() },
+    ];
+    renderChat();
+
+    fireEvent.click(await screen.findByRole('button', { name: 'quote-question' }));
+
+    const input = screen.getByTestId('negotiator-chat-input') as HTMLInputElement;
+    expect(input.value).toBe('"Which equity range works for you?" — ');
+    expect(document.activeElement).toBe(input);
   });
 
   test('renders streamed messages from the shared context', async () => {

--- a/apps/web/vitest.config.ts
+++ b/apps/web/vitest.config.ts
@@ -13,5 +13,14 @@ export default defineConfig({
     environment: 'happy-dom',
     setupFiles: ['./src/test/setup.ts'],
     include: ['tests/**/*.test.{ts,tsx}', 'src/**/*.{test,spec}.{ts,tsx}'],
+    server: {
+      deps: {
+        // zod's entry re-exports its API as a namespace binding (`export { z }`),
+        // which the externalized-module interop drops under the Bun-run vitest
+        // pipeline (z arrives undefined). Inlining runs it through the vite
+        // transform, which preserves the binding.
+        inline: ['zod'],
+      },
+    },
   },
 });


### PR DESCRIPTION
## What

The web half of conversational question delivery (docs/plans/2026-08-18-conversational-questions.md): the negotiator now delivers questions as a message in the signal's A2H DM whose body ends in a ```` ```index-questions ```` fenced JSON block. This PR detects that block and renders it as steps.

- **Block rendering.** `AssistantMessageContent` parses agent messages with `parseQuestionMessage` from `@indexnetwork/protocol/question-block` (browser-safe subpath, #1429). On a parse: the prose renders as a normal message and each question as one step (new `QuestionSteps` component). The `opportunityId`/`alsoUnblocks` refs are answer-routing data and are never displayed.
- **Fail closed.** On `null` — malformed JSON, unknown version, duplicate refs, trailing text after the fence, unterminated fence — the entire message renders exactly as before (the fence shows as a plain code block). No partial rendering, enforced by tests.
- **Answering is a plain chat reply.** No forms, no submit path, no answer API. A step's tap-to-quote affordance prefills the chat input with the question being answered (`IntentNegotiatorChat.handleQuestionQuote`).
- **Loading state behind a prop.** `questionRegenerationPending` on `IntentNegotiatorChat` shows an agent-working indicator while a question-message regeneration is pending. Contract agreed with the delivery-spine session: the API will expose `questionRegenerationPending: boolean` on the `POST /chat/negotiator/session` response (true iff the `question-message.${userId}.${intentId}` job is waiting/delayed/active). That field lands in a spine follow-up; until the parent wires it, the prop is absent and inert.

## Tests

Against the contract fixture (`@indexnetwork/protocol/question-block/fixture`): fixture renders as steps with prose above; refs never displayed; five malformed variants each fall back to plain text; a block-free message is untouched; quote affordance and indicator plumbing covered in the `IntentNegotiatorChat` suite.

Note: `apps/web/vitest.config.ts` now inlines `zod` — the externalized-module interop drops zod's namespace-binding re-export (`export { z }`) under the Bun-run vitest pipeline, which broke importing the protocol subpath in tests. Production bundling (rollup) is unaffected; `vite build` verified.

## Out of scope

`services/api` / `packages/protocol` (delivery spine + answer consumption are active there), notifications, and Questions-page retirement (page and DM coexist for now).

🤖 Generated with [Claude Code](https://claude.com/claude-code)