### PR TITLE
feat(negotiations): consume answers — route a reply to its parked negotiations and resume

### DIFF
--- a/packages/protocol/src/index.ts
+++ b/packages/protocol/src/index.ts
@@ -321,3 +321,25 @@ export {
   NEGOTIATION_QUESTION_GENERIC_UPTAKE_ACTIVITY,
   negotiationQuestionSettlementId,
 } from "./negotiations/negotiation.module.js";
+
+// ─── Negotiation answer consumption (conversational questions) ──────────────
+
+export {
+  classifyParkedNegotiation,
+  consumeQuestionBlockAnswers,
+  negotiationParkAnswerId,
+  resumeParkedNegotiation,
+  routeAnswerRef,
+} from "./negotiations/negotiation.module.js";
+export type {
+  AnswerRoute,
+  InflightAnswerSettlementInput,
+  InflightAnswerSettlementResult,
+  NegotiationAnswerConsumptionPorts,
+  NegotiationAnswerInput,
+  NegotiationAnswerResumeOutcome,
+  ParkClassification,
+  QuestionBlockAnswerConsumptionInput,
+  QuestionBlockAnswerConsumptionResult,
+  RoutedAnswer,
+} from "./negotiations/negotiation.module.js";

--- a/packages/protocol/src/negotiations/negotiation.answer-consumption.ts
+++ b/packages/protocol/src/negotiations/negotiation.answer-consumption.ts
@@ -1,0 +1,453 @@
+/**
+ * Answer consumption: route a client's DM reply to its parked negotiations and
+ * resume them (conversational-questions plan, "Answers").
+ *
+ * The delivery surface decides that a chat reply answers a question-message
+ * and maps the reply's content onto block refs; this module owns everything
+ * after that decision — the RESUME SEAM. Given a routed answer and the block
+ * it answers, it re-resolves each referenced negotiation to its current park
+ * and resumes it exactly once:
+ *
+ * - A mid-flight consult park (`input_required` task with a captured ask-user
+ *   binding) resumes through the same durable settlement → exact continuation
+ *   path the card answer used: settle the exact task, then enqueue the
+ *   settlement-keyed resume. The settle is a CAS on the parked task, so a
+ *   second delivery finds it already settled and only re-enqueues the
+ *   idempotent continuation — never a double resume.
+ * - A post-stall park (completed task on a stalled opportunity whose trailing
+ *   turn is the authored `ask_user` gap, `NEGOTIATION_PARK_REASONING`) resumes
+ *   as a fresh negotiation attempt: the answer is recorded on the opportunity
+ *   (where continuation prompts already read it via
+ *   `getOpportunityUserAnswers`) and a retry is enqueued. Exactly-once is the
+ *   attempt claim: concurrent retries race `createNegotiationTaskForAttempt`
+ *   and all but one lose.
+ *
+ * Idempotency is a property of the negotiation, not of any settlement record
+ * kept here: re-resolution + the `input_required` admission gate (mid-flight)
+ * and the atomic attempt claim (post-stall) make a repeated delivery a no-op.
+ * A ref that matches nothing in the block resumes NOTHING — misrouting resumes
+ * the wrong negotiation with the wrong fact, which is worse than asking again —
+ * and is reported back so the delivery surface can ask a clarifying follow-up.
+ *
+ * A resumed negotiation may park again; the ask-rounds cap (#1430) bounds that
+ * loop at park time. This module deliberately adds no second counter.
+ */
+
+import { NEGOTIATION_PARK_REASONING } from "./negotiation.stall-gap.js";
+import { negotiationQuestionSettlementId } from "./negotiation.question-safety.js";
+import { turnsFromMessages } from "./negotiation.graph.shared.js";
+import { protocolLogger } from "../shared/observability/protocol.logger.js";
+import type { NegotiationGraphDatabase, NegotiationUserAnswer } from "../shared/interfaces/database.interface.js";
+import type { QuestionBlock, QuestionBlockQuestion } from "../shared/schemas/question-block.schema.js";
+import type { NegotiationTurn } from "./negotiation.state.js";
+
+const answerLog = protocolLogger("NegotiationAnswerConsumption");
+
+// ─── Routing: block ref → resume set ─────────────────────────────────────────
+
+/** One answer the delivery agent routed onto a block ref. */
+export interface RoutedAnswer {
+  /** The block ref the reply was matched to — primary or alsoUnblocks alike. */
+  ref: string;
+  /** The client's answer for that question, as free text. */
+  answerText: string;
+}
+
+/** A resolved route: the owning question and every negotiation its answer resumes. */
+export interface AnswerRoute {
+  question: QuestionBlockQuestion;
+  /** Primary first, then `alsoUnblocks` — one answer resumes them all. */
+  opportunityIds: string[];
+}
+
+/**
+ * Resolve a matched ref to its question and full resume set. The block schema
+ * guarantees every ref appears exactly once across the whole block, so this is
+ * a lookup — ambiguity is a producer-side error that cannot reach here through
+ * a parsed block. Returns null for a ref the block does not carry: the caller
+ * must ask a clarifying follow-up, never resume speculatively.
+ */
+export function routeAnswerRef(block: QuestionBlock, ref: string): AnswerRoute | null {
+  for (const question of block.questions) {
+    const opportunityIds = [question.opportunityId, ...(question.alsoUnblocks ?? [])];
+    if (opportunityIds.includes(ref)) return { question, opportunityIds };
+  }
+  return null;
+}
+
+// ─── Park classification: what the ref currently points at ──────────────────
+
+/** The minimal ask-user binding a mid-flight resume needs, read off task metadata. */
+interface AskUserResumeBinding {
+  settlementId: string;
+  recipientUserId: string;
+  recipientIntentId: string;
+  networkId: string;
+  opportunityId: string;
+}
+
+function nonEmptyString(value: unknown): value is string {
+  return typeof value === "string" && value.length > 0;
+}
+
+function readAskUserResumeBinding(metadata: Record<string, unknown> | null): AskUserResumeBinding | null {
+  const turnContext = metadata?.turnContext as Record<string, unknown> | undefined;
+  const binding = turnContext?.askUserBinding as Record<string, unknown> | undefined;
+  if (
+    !binding
+    || !nonEmptyString(binding.settlementId)
+    || !nonEmptyString(binding.recipientUserId)
+    || !nonEmptyString(binding.recipientIntentId)
+    || !nonEmptyString(binding.networkId)
+    || !nonEmptyString(binding.opportunityId)
+  ) return null;
+  return {
+    settlementId: binding.settlementId,
+    recipientUserId: binding.recipientUserId,
+    recipientIntentId: binding.recipientIntentId,
+    networkId: binding.networkId,
+    opportunityId: binding.opportunityId,
+  };
+}
+
+/**
+ * The trailing canonical turn of a negotiation's own messages, when it is the
+ * authored post-stall gap. Non-turn messages are skipped, mirroring
+ * `turnsFromMessages`; any other trailing turn means the negotiation is not
+ * parked post-stall.
+ */
+function trailingParkMessage(
+  messages: Array<{ senderId: string; parts: unknown[]; taskId?: string | null }>,
+): { senderId: string; taskId?: string | null; turn: NegotiationTurn } | null {
+  for (let index = messages.length - 1; index >= 0; index -= 1) {
+    const message = messages[index]!;
+    const turn = turnsFromMessages([message])[0];
+    if (!turn) continue;
+    return turn.action === "ask_user" && turn.assessment?.reasoning === NEGOTIATION_PARK_REASONING
+      ? { senderId: message.senderId, taskId: message.taskId, turn }
+      : null;
+  }
+  return null;
+}
+
+/** What answering a given ref would resume, as re-resolved right now. */
+export type ParkClassification =
+  | { kind: "inflight"; taskId: string; binding: AskUserResumeBinding }
+  | { kind: "post_stall"; taskId: string }
+  /** No negotiation task exists for the ref at all. */
+  | { kind: "no_negotiation" }
+  /** A negotiation exists but holds no live park — already resumed, expired, or terminal. */
+  | { kind: "not_parked" }
+  /** Parked, but awaiting the OTHER side's client — this user's answer must not resume it. */
+  | { kind: "wrong_recipient" };
+
+/**
+ * Re-resolve a negotiation ref to its current park. This is the exact task
+ * re-resolution the graph itself uses (`getNegotiationTaskForOpportunity`),
+ * never a snapshot: answer routing branches on what the negotiation is NOW,
+ * so a park that was answered, expired, or superseded since the block was
+ * authored classifies as `not_parked` and the answer no-ops.
+ */
+export async function classifyParkedNegotiation(
+  database: Pick<NegotiationGraphDatabase, "getNegotiationTaskForOpportunity" | "getNegotiationMessages">,
+  input: { opportunityId: string; userId: string },
+): Promise<ParkClassification> {
+  const task = await database.getNegotiationTaskForOpportunity(input.opportunityId);
+  if (!task) return { kind: "no_negotiation" };
+
+  if (task.state === "input_required") {
+    const binding = readAskUserResumeBinding(task.metadata);
+    if (
+      !binding
+      || binding.opportunityId !== input.opportunityId
+      || binding.settlementId !== negotiationQuestionSettlementId(task.id)
+    ) {
+      answerLog.warn("input_required negotiation task carries no coherent ask-user binding; answer cannot resume it", {
+        taskId: task.id,
+        opportunityId: input.opportunityId,
+      });
+      return { kind: "not_parked" };
+    }
+    if (binding.recipientUserId !== input.userId) return { kind: "wrong_recipient" };
+    return { kind: "inflight", taskId: task.id, binding };
+  }
+
+  if (task.state === "completed") {
+    const messages = await database.getNegotiationMessages(input.opportunityId);
+    const park = trailingParkMessage(messages);
+    if (!park) return { kind: "not_parked" };
+    // The gap was written by the finalizing session's task — the most recent
+    // one. A trailing park from an older task means state has moved on.
+    if (park.taskId != null && park.taskId !== task.id) return { kind: "not_parked" };
+    if (park.senderId !== `agent:${input.userId}`) return { kind: "wrong_recipient" };
+    return { kind: "post_stall", taskId: task.id };
+  }
+
+  // submitted/working/waiting_for_agent: a session is live (possibly the very
+  // resume a first delivery triggered); canceled: a settled consult awaiting
+  // its successor; failed/rejected: terminal. None hold an answerable park.
+  return { kind: "not_parked" };
+}
+
+// ─── Ports ───────────────────────────────────────────────────────────────────
+
+/** Everything a mid-flight settle needs; all fields come from the re-resolved binding. */
+export interface InflightAnswerSettlementInput {
+  taskId: string;
+  settlementId: string;
+  opportunityId: string;
+  recipientUserId: string;
+  recipientIntentId: string;
+  networkId: string;
+  answer: { selectedOptions: string[]; freeText?: string; answeredAt: string };
+}
+
+/**
+ * - `settled`: this call closed the exact `input_required` task and durably
+ *   stored the answer for the continuation claim to read.
+ * - `already_settled`: an earlier delivery settled it; the stored settlement
+ *   stands. Resuming is still correct — the continuation enqueue and claim are
+ *   settlement-keyed and idempotent, so re-enqueueing recovers a lost job
+ *   without a double resume.
+ * - `lost`: the admission gate refused — the task is no longer
+ *   `input_required` (answer-window expiry or another path won). No resume.
+ */
+export type InflightAnswerSettlementResult = "settled" | "already_settled" | "lost";
+
+export interface NegotiationAnswerConsumptionPorts {
+  /** The same reads the negotiation graph resolves parks with. */
+  database: Pick<NegotiationGraphDatabase, "getNegotiationTaskForOpportunity" | "getNegotiationMessages">;
+  /**
+   * Settle the exact mid-flight consult: CAS the `input_required` task closed
+   * under the deterministic settlement lock and durably store the answer where
+   * the continuation claim reads its private consultation. Implementations
+   * must be answer-vs-timeout safe (the expiry worker races this) and must
+   * report a repeat delivery as `already_settled`, never settle twice.
+   */
+  settleInflightAnswer(input: InflightAnswerSettlementInput): Promise<InflightAnswerSettlementResult>;
+  /**
+   * Enqueue the exact durable continuation — the same settlement-keyed resume
+   * the card answer path enqueues. Must be idempotent per settlementId.
+   */
+  enqueueInflightResume(input: {
+    opportunityId: string;
+    userId: string;
+    taskId: string;
+    settlementId: string;
+    recipientIntentId: string;
+    networkId: string;
+  }): Promise<void>;
+  /**
+   * Append the routed answer to the opportunity's `userAnswers`, where
+   * continuation prompts already read between-session context. Implementations
+   * MUST ignore an append whose `questionId` is already present — that key is
+   * deterministic per park, so a repeated delivery records nothing twice.
+   */
+  recordOpportunityAnswer(input: { opportunityId: string; answer: NegotiationUserAnswer }): Promise<void>;
+  /**
+   * Enqueue a fresh negotiate-existing retry of the stalled opportunity.
+   * `parkTaskId` identifies the answered park; implementations should dedupe
+   * on it. Over-enqueueing is safe regardless: every retry races the atomic
+   * attempt claim and all but one lose.
+   */
+  enqueueStalledRetry(input: { opportunityId: string; userId: string; parkTaskId: string }): Promise<void>;
+}
+
+/** Deterministic identity of a post-stall park's recorded answer (dedup key, never rendered). */
+export function negotiationParkAnswerId(parkTaskId: string): string {
+  return `negotiation-park-answer-v1-${parkTaskId}`;
+}
+
+// ─── The resume seam ─────────────────────────────────────────────────────────
+
+export type NegotiationAnswerResumeOutcome =
+  | "resumed_inflight"
+  | "resumed_retry"
+  | "not_parked"
+  | "no_negotiation"
+  | "wrong_recipient";
+
+export interface NegotiationAnswerInput {
+  /** The negotiation to resume: one ref out of a routed answer's resume set. */
+  opportunityId: string;
+  /** The answering client — the park must be awaiting THIS user's side. */
+  userId: string;
+  answerText: string;
+  /** ISO timestamp of the reply; defaults to now. */
+  answeredAt?: string;
+}
+
+/**
+ * Resume one parked negotiation with a routed answer, exactly once. Both
+ * outcomes that resume enqueue asynchronously — the negotiation continues on
+ * its queue, not inline. Every other outcome resumes nothing. Throws only on
+ * port failure; every step is safe to repeat, so the caller may simply
+ * redeliver.
+ */
+export async function resumeParkedNegotiation(
+  ports: NegotiationAnswerConsumptionPorts,
+  input: NegotiationAnswerInput,
+): Promise<NegotiationAnswerResumeOutcome> {
+  const classification = await classifyParkedNegotiation(ports.database, {
+    opportunityId: input.opportunityId,
+    userId: input.userId,
+  });
+  const answeredAt = input.answeredAt ?? new Date().toISOString();
+
+  if (classification.kind === "inflight") {
+    const settlement = await ports.settleInflightAnswer({
+      taskId: classification.taskId,
+      settlementId: classification.binding.settlementId,
+      opportunityId: input.opportunityId,
+      recipientUserId: classification.binding.recipientUserId,
+      recipientIntentId: classification.binding.recipientIntentId,
+      networkId: classification.binding.networkId,
+      answer: { selectedOptions: [], freeText: input.answerText, answeredAt },
+    });
+    if (settlement === "lost") {
+      answerLog.info("negotiation_answer_settlement_lost", {
+        taskId: classification.taskId,
+        opportunityId: input.opportunityId,
+      });
+      return "not_parked";
+    }
+    // Settlement is durable; enqueue after it, never before — a crash between
+    // the two is recovered by redelivery (`already_settled` → enqueue again).
+    await ports.enqueueInflightResume({
+      opportunityId: input.opportunityId,
+      userId: classification.binding.recipientUserId,
+      taskId: classification.taskId,
+      settlementId: classification.binding.settlementId,
+      recipientIntentId: classification.binding.recipientIntentId,
+      networkId: classification.binding.networkId,
+    });
+    answerLog.info("negotiation_answer_resumed_inflight", {
+      taskId: classification.taskId,
+      opportunityId: input.opportunityId,
+      settlement,
+    });
+    return "resumed_inflight";
+  }
+
+  if (classification.kind === "post_stall") {
+    // Record before enqueueing: the retry's continuation prompt must see the
+    // answer. The deterministic id makes the append idempotent, so the
+    // crash-recovery order (record, then enqueue, redeliver on failure) holds.
+    await ports.recordOpportunityAnswer({
+      opportunityId: input.opportunityId,
+      answer: {
+        questionId: negotiationParkAnswerId(classification.taskId),
+        selectedOptions: [],
+        freeText: input.answerText,
+        answeredAt,
+      },
+    });
+    await ports.enqueueStalledRetry({
+      opportunityId: input.opportunityId,
+      userId: input.userId,
+      parkTaskId: classification.taskId,
+    });
+    answerLog.info("negotiation_answer_resumed_retry", {
+      taskId: classification.taskId,
+      opportunityId: input.opportunityId,
+    });
+    return "resumed_retry";
+  }
+
+  if (classification.kind === "wrong_recipient") {
+    answerLog.warn("Answer routed to a negotiation parked on the counterparty's side; not resuming", {
+      opportunityId: input.opportunityId,
+    });
+  }
+  return classification.kind;
+}
+
+// ─── Block-level consumption ─────────────────────────────────────────────────
+
+export interface QuestionBlockAnswerConsumptionInput {
+  /** The parsed block the reply answers (see `parseQuestionMessage`). */
+  block: QuestionBlock;
+  /** The replying client — the DM's owner. */
+  userId: string;
+  /** The reply's content routed onto block refs; empty when nothing matched. */
+  answers: RoutedAnswer[];
+  /** ISO timestamp of the reply; defaults to now. */
+  answeredAt?: string;
+}
+
+export interface QuestionBlockAnswerConsumptionResult {
+  resumed: Array<{ opportunityId: string; outcome: "resumed_inflight" | "resumed_retry" }>;
+  skipped: Array<{
+    opportunityId: string;
+    outcome: "not_parked" | "no_negotiation" | "wrong_recipient" | "duplicate_route" | "failed";
+  }>;
+  /** Routed answers whose ref the block does not carry — resume nothing, ask again. */
+  unmatched: RoutedAnswer[];
+  /**
+   * True when the reply left something unresolved on the routing side: no
+   * answer matched at all, or a ref matched nothing in the block. The caller
+   * owns the clarifying follow-up; this seam only ever refuses to guess.
+   */
+  needsClarification: boolean;
+}
+
+/**
+ * Consume a client reply against the block it answers: resolve each routed
+ * answer to its question, then resume the primary negotiation and every
+ * `alsoUnblocks` ref with that answer, exactly once each. Failures are
+ * per-negotiation — one broken target never blocks the rest of the reply.
+ */
+export async function consumeQuestionBlockAnswers(
+  ports: NegotiationAnswerConsumptionPorts,
+  input: QuestionBlockAnswerConsumptionInput,
+): Promise<QuestionBlockAnswerConsumptionResult> {
+  const answeredAt = input.answeredAt ?? new Date().toISOString();
+  const result: QuestionBlockAnswerConsumptionResult = {
+    resumed: [],
+    skipped: [],
+    unmatched: [],
+    needsClarification: false,
+  };
+  const consumedQuestions = new Set<string>();
+
+  for (const answer of input.answers) {
+    const route = routeAnswerRef(input.block, answer.ref);
+    if (!route) {
+      result.unmatched.push(answer);
+      continue;
+    }
+    // Two routed answers can name refs of the same question; the first wins.
+    // The later one is surfaced as a duplicate rather than silently merged —
+    // choosing between conflicting phrasings is the delivery agent's job.
+    if (consumedQuestions.has(route.question.opportunityId)) {
+      result.skipped.push({ opportunityId: route.question.opportunityId, outcome: "duplicate_route" });
+      continue;
+    }
+    consumedQuestions.add(route.question.opportunityId);
+
+    for (const opportunityId of route.opportunityIds) {
+      try {
+        const outcome = await resumeParkedNegotiation(ports, {
+          opportunityId,
+          userId: input.userId,
+          answerText: answer.answerText,
+          answeredAt,
+        });
+        if (outcome === "resumed_inflight" || outcome === "resumed_retry") {
+          result.resumed.push({ opportunityId, outcome });
+        } else {
+          result.skipped.push({ opportunityId, outcome });
+        }
+      } catch (err) {
+        answerLog.error("Failed to resume an answered negotiation; continuing with the rest of the reply", {
+          opportunityId,
+          error: err instanceof Error ? err.message : String(err),
+        });
+        result.skipped.push({ opportunityId, outcome: "failed" });
+      }
+    }
+  }
+
+  result.needsClarification = input.answers.length === 0 || result.unmatched.length > 0;
+  return result;
+}

--- a/packages/protocol/src/negotiations/negotiation.module.ts
+++ b/packages/protocol/src/negotiations/negotiation.module.ts
@@ -38,6 +38,25 @@ export { countNegotiationAskRounds } from "./negotiation.graph.shared.js";
 export { NEGOTIATION_PARK_REASONING, NegotiationStallGapAuthor } from "./negotiation.stall-gap.js";
 export type { NegotiationStallGap, NegotiationStallReason, StallGapAuthorInput } from "./negotiation.stall-gap.js";
 export {
+  classifyParkedNegotiation,
+  consumeQuestionBlockAnswers,
+  negotiationParkAnswerId,
+  resumeParkedNegotiation,
+  routeAnswerRef,
+} from "./negotiation.answer-consumption.js";
+export type {
+  AnswerRoute,
+  InflightAnswerSettlementInput,
+  InflightAnswerSettlementResult,
+  NegotiationAnswerConsumptionPorts,
+  NegotiationAnswerInput,
+  NegotiationAnswerResumeOutcome,
+  ParkClassification,
+  QuestionBlockAnswerConsumptionInput,
+  QuestionBlockAnswerConsumptionResult,
+  RoutedAnswer,
+} from "./negotiation.answer-consumption.js";
+export {
   HERMES_OWNER_DIRECTIVE,
   HERMES_SHARED_MESSAGE_TEMPLATES,
   HermesNegotiationActionSchema,

--- a/packages/protocol/src/negotiations/tests/negotiation.answer-consumption.spec.ts
+++ b/packages/protocol/src/negotiations/tests/negotiation.answer-consumption.spec.ts
@@ -1,0 +1,417 @@
+import { describe, it, expect } from "bun:test";
+
+import { classifyParkedNegotiation, consumeQuestionBlockAnswers, negotiationParkAnswerId, resumeParkedNegotiation, routeAnswerRef, type InflightAnswerSettlementInput, type InflightAnswerSettlementResult, type NegotiationAnswerConsumptionPorts } from "../negotiation.answer-consumption.js";
+import { NEGOTIATION_PARK_REASONING } from "../negotiation.stall-gap.js";
+import { negotiationQuestionSettlementId } from "../negotiation.question-safety.js";
+import type { QuestionBlock } from "../../shared/schemas/question-block.schema.js";
+
+/**
+ * Answer consumption — the resume seam (conversational-questions plan).
+ *
+ * Pins:
+ * - routing is a lookup: any ref (primary or alsoUnblocks) resolves to its
+ *   question's full resume set; an unknown ref resolves to nothing and is
+ *   reported for a clarifying follow-up, never resumed speculatively,
+ * - classification is exact re-resolution: an `input_required` task with a
+ *   coherent ask-user binding is a mid-flight park; a completed task whose
+ *   trailing turn is the authored gap is a post-stall park; everything else —
+ *   active sessions, settled consults, terminal tasks, stale parks — no-ops,
+ * - a park awaiting the counterparty's client never resumes on this user's
+ *   answer (misroute guard, both park kinds),
+ * - mid-flight resume order: settle first, enqueue after; a lost settlement
+ *   enqueues nothing; an already-settled one re-enqueues (crash recovery)
+ *   without settling twice,
+ * - post-stall resume order: record the answer (deterministic id) before the
+ *   retry enqueue, so the retry's prompt can see it,
+ * - one answer resumes the primary and every alsoUnblocks ref exactly once,
+ *   and a repeated delivery is a no-op because re-resolution finds no park,
+ * - per-negotiation failures never block the rest of the reply.
+ */
+
+const OPP_A = "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa";
+const OPP_B = "bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb";
+const OPP_C = "cccccccc-cccc-4ccc-8ccc-cccccccccccc";
+const OPP_D = "dddddddd-dddd-4ddd-8ddd-dddddddddddd";
+
+const block: QuestionBlock = {
+  version: 1,
+  questions: [
+    { prompt: "When could you start?", opportunityId: OPP_A, alsoUnblocks: [OPP_B] },
+    { prompt: "What budget range works?", opportunityId: OPP_C },
+  ],
+};
+
+type FakeTask = {
+  id: string;
+  conversationId: string;
+  state: string;
+  metadata: Record<string, unknown> | null;
+  createdAt: Date;
+  updatedAt: Date;
+};
+
+type FakeMessage = { id: string; senderId: string; role: "user" | "agent"; parts: unknown[]; createdAt: Date; taskId?: string | null };
+
+function inflightTask(taskId: string, opportunityId: string, recipientUserId: string, overrides?: Record<string, unknown>): FakeTask {
+  return {
+    id: taskId,
+    conversationId: "conv-1",
+    state: "input_required",
+    metadata: {
+      type: "negotiation",
+      opportunityId,
+      turnContext: {
+        askUserBinding: {
+          version: 2,
+          settlementId: negotiationQuestionSettlementId(taskId),
+          recipientUserId,
+          recipientIntentId: "intent-1",
+          networkId: "network-1",
+          opportunityId,
+          ...overrides,
+        },
+      },
+    },
+    createdAt: new Date(),
+    updatedAt: new Date(),
+  };
+}
+
+function completedTask(taskId: string, opportunityId: string): FakeTask {
+  return {
+    id: taskId,
+    conversationId: "conv-1",
+    state: "completed",
+    metadata: { type: "negotiation", opportunityId },
+    createdAt: new Date(),
+    updatedAt: new Date(),
+  };
+}
+
+function parkMessage(senderUserId: string, taskId?: string | null): FakeMessage {
+  return {
+    id: "msg-park",
+    senderId: `agent:${senderUserId}`,
+    role: "agent",
+    parts: [{
+      kind: "data",
+      data: {
+        action: "ask_user",
+        assessment: { reasoning: NEGOTIATION_PARK_REASONING, suggestedRoles: { ownUser: "peer", otherUser: "peer" } },
+        message: null,
+        askUser: { reason: "unresolved_owner_constraint", question: { title: "Timing", prompt: "When?", options: [], multiSelect: false } },
+      },
+    }],
+    createdAt: new Date(),
+    ...(taskId !== undefined ? { taskId } : {}),
+  };
+}
+
+function turnMessage(senderUserId: string, action: string): FakeMessage {
+  return {
+    id: `msg-${action}`,
+    senderId: `agent:${senderUserId}`,
+    role: "agent",
+    parts: [{ kind: "data", data: { action, assessment: { reasoning: "r", suggestedRoles: { ownUser: "peer", otherUser: "peer" } }, message: "m" } }],
+    createdAt: new Date(),
+  };
+}
+
+function makePorts(opts?: {
+  tasks?: Record<string, FakeTask | null>;
+  messages?: Record<string, FakeMessage[]>;
+  settleResult?: InflightAnswerSettlementResult;
+  failFor?: string;
+}) {
+  const calls = {
+    settles: [] as InflightAnswerSettlementInput[],
+    inflightResumes: [] as Array<Record<string, string>>,
+    recorded: [] as Array<{ opportunityId: string; answer: { questionId: string; selectedOptions: string[]; freeText?: string; answeredAt: string } }>,
+    retries: [] as Array<{ opportunityId: string; userId: string; parkTaskId: string }>,
+    order: [] as string[],
+  };
+  const ports: NegotiationAnswerConsumptionPorts = {
+    database: {
+      getNegotiationTaskForOpportunity: async (opportunityId: string) => {
+        if (opts?.failFor === opportunityId) throw new Error("db down");
+        return opts?.tasks?.[opportunityId] ?? null;
+      },
+      getNegotiationMessages: async (opportunityId: string) => opts?.messages?.[opportunityId] ?? [],
+    },
+    settleInflightAnswer: async (input) => {
+      calls.settles.push(input);
+      calls.order.push(`settle:${input.opportunityId}`);
+      return opts?.settleResult ?? "settled";
+    },
+    enqueueInflightResume: async (input) => {
+      calls.inflightResumes.push(input as unknown as Record<string, string>);
+      calls.order.push(`resume:${input.opportunityId}`);
+    },
+    recordOpportunityAnswer: async (input) => {
+      calls.recorded.push(input);
+      calls.order.push(`record:${input.opportunityId}`);
+    },
+    enqueueStalledRetry: async (input) => {
+      calls.retries.push(input);
+      calls.order.push(`retry:${input.opportunityId}`);
+    },
+  };
+  return { ports, calls };
+}
+
+describe("routeAnswerRef", () => {
+  it("resolves a primary ref to its question's full resume set, primary first", () => {
+    const route = routeAnswerRef(block, OPP_A);
+    expect(route?.question.prompt).toBe("When could you start?");
+    expect(route?.opportunityIds).toEqual([OPP_A, OPP_B]);
+  });
+
+  it("resolves an alsoUnblocks ref to the same set", () => {
+    const route = routeAnswerRef(block, OPP_B);
+    expect(route?.question.opportunityId).toBe(OPP_A);
+    expect(route?.opportunityIds).toEqual([OPP_A, OPP_B]);
+  });
+
+  it("resolves an unknown ref to null, never to a guess", () => {
+    expect(routeAnswerRef(block, OPP_D)).toBeNull();
+  });
+});
+
+describe("classifyParkedNegotiation", () => {
+  it("classifies an input_required task with a coherent binding as inflight", async () => {
+    const { ports } = makePorts({ tasks: { [OPP_A]: inflightTask("task-1", OPP_A, "user-1") } });
+    const c = await classifyParkedNegotiation(ports.database, { opportunityId: OPP_A, userId: "user-1" });
+    expect(c).toEqual({
+      kind: "inflight",
+      taskId: "task-1",
+      binding: {
+        settlementId: negotiationQuestionSettlementId("task-1"),
+        recipientUserId: "user-1",
+        recipientIntentId: "intent-1",
+        networkId: "network-1",
+        opportunityId: OPP_A,
+      },
+    });
+  });
+
+  it("refuses an inflight park awaiting the counterparty's client", async () => {
+    const { ports } = makePorts({ tasks: { [OPP_A]: inflightTask("task-1", OPP_A, "user-2") } });
+    const c = await classifyParkedNegotiation(ports.database, { opportunityId: OPP_A, userId: "user-1" });
+    expect(c.kind).toBe("wrong_recipient");
+  });
+
+  it("treats an incoherent binding (settlement mismatch) as not parked", async () => {
+    const task = inflightTask("task-1", OPP_A, "user-1", { settlementId: negotiationQuestionSettlementId("task-other") });
+    const { ports } = makePorts({ tasks: { [OPP_A]: task } });
+    const c = await classifyParkedNegotiation(ports.database, { opportunityId: OPP_A, userId: "user-1" });
+    expect(c.kind).toBe("not_parked");
+  });
+
+  it("classifies a completed task with a trailing authored gap as post_stall", async () => {
+    const { ports } = makePorts({
+      tasks: { [OPP_A]: completedTask("task-9", OPP_A) },
+      messages: { [OPP_A]: [turnMessage("user-1", "outreach"), turnMessage("user-2", "counter"), parkMessage("user-1", "task-9")] },
+    });
+    const c = await classifyParkedNegotiation(ports.database, { opportunityId: OPP_A, userId: "user-1" });
+    expect(c).toEqual({ kind: "post_stall", taskId: "task-9" });
+  });
+
+  it("refuses a post-stall park authored toward the other side", async () => {
+    const { ports } = makePorts({
+      tasks: { [OPP_A]: completedTask("task-9", OPP_A) },
+      messages: { [OPP_A]: [parkMessage("user-2", "task-9")] },
+    });
+    const c = await classifyParkedNegotiation(ports.database, { opportunityId: OPP_A, userId: "user-1" });
+    expect(c.kind).toBe("wrong_recipient");
+  });
+
+  it("treats a completed task whose trailing turn is not the gap as not parked", async () => {
+    const { ports } = makePorts({
+      tasks: { [OPP_A]: completedTask("task-9", OPP_A) },
+      messages: { [OPP_A]: [parkMessage("user-1", "task-8"), turnMessage("user-2", "decline")] },
+    });
+    const c = await classifyParkedNegotiation(ports.database, { opportunityId: OPP_A, userId: "user-1" });
+    expect(c.kind).toBe("not_parked");
+  });
+
+  it("treats a trailing park written by an older task as not parked", async () => {
+    const { ports } = makePorts({
+      tasks: { [OPP_A]: completedTask("task-9", OPP_A) },
+      messages: { [OPP_A]: [parkMessage("user-1", "task-8")] },
+    });
+    const c = await classifyParkedNegotiation(ports.database, { opportunityId: OPP_A, userId: "user-1" });
+    expect(c.kind).toBe("not_parked");
+  });
+
+  it("classifies a missing negotiation and an active session as no-op kinds", async () => {
+    const working = { ...completedTask("task-9", OPP_A), state: "working" };
+    const { ports } = makePorts({ tasks: { [OPP_A]: null, [OPP_B]: working } });
+    expect((await classifyParkedNegotiation(ports.database, { opportunityId: OPP_A, userId: "user-1" })).kind).toBe("no_negotiation");
+    expect((await classifyParkedNegotiation(ports.database, { opportunityId: OPP_B, userId: "user-1" })).kind).toBe("not_parked");
+  });
+});
+
+describe("resumeParkedNegotiation", () => {
+  it("resumes a mid-flight park: settle with the exact binding, then enqueue the settlement-keyed continuation", async () => {
+    const { ports, calls } = makePorts({ tasks: { [OPP_A]: inflightTask("task-1", OPP_A, "user-1") } });
+    const outcome = await resumeParkedNegotiation(ports, {
+      opportunityId: OPP_A,
+      userId: "user-1",
+      answerText: "This quarter works.",
+      answeredAt: "2026-08-18T12:00:00.000Z",
+    });
+    expect(outcome).toBe("resumed_inflight");
+    expect(calls.settles).toEqual([{
+      taskId: "task-1",
+      settlementId: negotiationQuestionSettlementId("task-1"),
+      opportunityId: OPP_A,
+      recipientUserId: "user-1",
+      recipientIntentId: "intent-1",
+      networkId: "network-1",
+      answer: { selectedOptions: [], freeText: "This quarter works.", answeredAt: "2026-08-18T12:00:00.000Z" },
+    }]);
+    expect(calls.inflightResumes).toEqual([{
+      opportunityId: OPP_A,
+      userId: "user-1",
+      taskId: "task-1",
+      settlementId: negotiationQuestionSettlementId("task-1"),
+      recipientIntentId: "intent-1",
+      networkId: "network-1",
+    }]);
+    expect(calls.order).toEqual([`settle:${OPP_A}`, `resume:${OPP_A}`]);
+  });
+
+  it("re-enqueues an already-settled consult without settling twice", async () => {
+    const { ports, calls } = makePorts({
+      tasks: { [OPP_A]: inflightTask("task-1", OPP_A, "user-1") },
+      settleResult: "already_settled",
+    });
+    const outcome = await resumeParkedNegotiation(ports, { opportunityId: OPP_A, userId: "user-1", answerText: "yes" });
+    expect(outcome).toBe("resumed_inflight");
+    expect(calls.inflightResumes).toHaveLength(1);
+  });
+
+  it("enqueues nothing when the settlement is lost to the answer-window expiry", async () => {
+    const { ports, calls } = makePorts({
+      tasks: { [OPP_A]: inflightTask("task-1", OPP_A, "user-1") },
+      settleResult: "lost",
+    });
+    const outcome = await resumeParkedNegotiation(ports, { opportunityId: OPP_A, userId: "user-1", answerText: "yes" });
+    expect(outcome).toBe("not_parked");
+    expect(calls.inflightResumes).toHaveLength(0);
+  });
+
+  it("resumes a post-stall park: record the answer under its deterministic id, then enqueue the retry", async () => {
+    const { ports, calls } = makePorts({
+      tasks: { [OPP_A]: completedTask("task-9", OPP_A) },
+      messages: { [OPP_A]: [parkMessage("user-1", "task-9")] },
+    });
+    const outcome = await resumeParkedNegotiation(ports, {
+      opportunityId: OPP_A,
+      userId: "user-1",
+      answerText: "Budget is 10k.",
+      answeredAt: "2026-08-18T12:00:00.000Z",
+    });
+    expect(outcome).toBe("resumed_retry");
+    expect(calls.recorded).toEqual([{
+      opportunityId: OPP_A,
+      answer: {
+        questionId: negotiationParkAnswerId("task-9"),
+        selectedOptions: [],
+        freeText: "Budget is 10k.",
+        answeredAt: "2026-08-18T12:00:00.000Z",
+      },
+    }]);
+    expect(calls.retries).toEqual([{ opportunityId: OPP_A, userId: "user-1", parkTaskId: "task-9" }]);
+    expect(calls.order).toEqual([`record:${OPP_A}`, `retry:${OPP_A}`]);
+  });
+
+  it("no-ops a redelivery once the first resume's session is live", async () => {
+    const { ports, calls } = makePorts({ tasks: { [OPP_A]: { ...completedTask("task-10", OPP_A), state: "working" } } });
+    const outcome = await resumeParkedNegotiation(ports, { opportunityId: OPP_A, userId: "user-1", answerText: "again" });
+    expect(outcome).toBe("not_parked");
+    expect(calls.settles).toHaveLength(0);
+    expect(calls.recorded).toHaveLength(0);
+    expect(calls.retries).toHaveLength(0);
+  });
+});
+
+describe("consumeQuestionBlockAnswers", () => {
+  it("resumes the primary and every alsoUnblocks ref with the one answer, exactly once each", async () => {
+    const { ports, calls } = makePorts({
+      tasks: {
+        [OPP_A]: inflightTask("task-1", OPP_A, "user-1"),
+        [OPP_B]: completedTask("task-2", OPP_B),
+      },
+      messages: { [OPP_B]: [parkMessage("user-1", "task-2")] },
+    });
+    const result = await consumeQuestionBlockAnswers(ports, {
+      block,
+      userId: "user-1",
+      answers: [{ ref: OPP_B, answerText: "This quarter." }],
+    });
+    expect(result.resumed).toEqual([
+      { opportunityId: OPP_A, outcome: "resumed_inflight" },
+      { opportunityId: OPP_B, outcome: "resumed_retry" },
+    ]);
+    expect(result.unmatched).toHaveLength(0);
+    expect(result.needsClarification).toBe(false);
+    expect(calls.settles).toHaveLength(1);
+    expect(calls.retries).toHaveLength(1);
+    expect(calls.settles[0]?.answer.freeText).toBe("This quarter.");
+    expect(calls.recorded[0]?.answer.freeText).toBe("This quarter.");
+  });
+
+  it("reports an unmatched ref for clarification and resumes nothing for it", async () => {
+    const { ports, calls } = makePorts({ tasks: { [OPP_A]: inflightTask("task-1", OPP_A, "user-1") } });
+    const result = await consumeQuestionBlockAnswers(ports, {
+      block,
+      userId: "user-1",
+      answers: [{ ref: OPP_D, answerText: "mystery" }],
+    });
+    expect(result.unmatched).toEqual([{ ref: OPP_D, answerText: "mystery" }]);
+    expect(result.needsClarification).toBe(true);
+    expect(result.resumed).toHaveLength(0);
+    expect(calls.order).toHaveLength(0);
+  });
+
+  it("flags an empty routing (nothing matched) as needing clarification", async () => {
+    const { ports } = makePorts();
+    const result = await consumeQuestionBlockAnswers(ports, { block, userId: "user-1", answers: [] });
+    expect(result.needsClarification).toBe(true);
+    expect(result.resumed).toHaveLength(0);
+  });
+
+  it("takes the first of two answers routed to the same question and reports the duplicate", async () => {
+    const { ports, calls } = makePorts({ tasks: { [OPP_A]: inflightTask("task-1", OPP_A, "user-1"), [OPP_B]: null } });
+    const result = await consumeQuestionBlockAnswers(ports, {
+      block,
+      userId: "user-1",
+      answers: [
+        { ref: OPP_A, answerText: "first phrasing" },
+        { ref: OPP_B, answerText: "second phrasing" },
+      ],
+    });
+    expect(calls.settles).toHaveLength(1);
+    expect(calls.settles[0]?.answer.freeText).toBe("first phrasing");
+    expect(result.skipped).toContainEqual({ opportunityId: OPP_A, outcome: "duplicate_route" });
+  });
+
+  it("keeps consuming the rest of the reply when one negotiation fails", async () => {
+    const { ports, calls } = makePorts({
+      tasks: { [OPP_C]: inflightTask("task-3", OPP_C, "user-1") },
+      failFor: OPP_A,
+    });
+    const result = await consumeQuestionBlockAnswers(ports, {
+      block,
+      userId: "user-1",
+      answers: [
+        { ref: OPP_A, answerText: "timing answer" },
+        { ref: OPP_C, answerText: "budget answer" },
+      ],
+    });
+    expect(result.skipped).toContainEqual({ opportunityId: OPP_A, outcome: "failed" });
+    expect(result.resumed).toEqual([{ opportunityId: OPP_C, outcome: "resumed_inflight" }]);
+    expect(calls.settles[0]?.answer.freeText).toBe("budget answer");
+  });
+});


### PR DESCRIPTION
Third item in the conversational-questions lane (plan: `docs/plans/2026-08-18-conversational-questions.md`), after #1429 (question block contract) and #1430 (park on stall). The loop stopped at "parked": nothing consumed a client's answer. This adds the **resume seam** to `packages/protocol/src/negotiations` — protocol package only; the delivery spine owns reply detection, agent routing of text onto block refs, notifications, and the API-side port implementations.

## What it does

Given a routed answer and the block it answers, `consumeQuestionBlockAnswers` / `resumeParkedNegotiation` re-resolve each referenced negotiation to its **current** park and resume it exactly once — the same park → answer → resume path the mid-flight consult uses, entered from the DM instead of a card.

- **Routing is a lookup** (`routeAnswerRef`): the block schema guarantees every ref appears exactly once, so any matched ref (primary or `alsoUnblocks`) resolves to its question's full resume set. An unmatched ref resolves to nothing and is reported back (`needsClarification`) — a clarifying follow-up, never a speculative resume.
- **Classification is exact re-resolution** (`classifyParkedNegotiation`, via `getNegotiationTaskForOpportunity`):
  - `input_required` task + coherent ask-user binding → mid-flight consult: settle the exact task (answer-vs-timeout-safe CAS behind the `settleInflightAnswer` port), then enqueue the settlement-keyed continuation.
  - completed task whose trailing turn is the authored gap (`NEGOTIATION_PARK_REASONING`) → post-stall park: record the answer on the opportunity under a deterministic per-park id (continuation prompts already read it via `getOpportunityUserAnswers`), then enqueue a fresh negotiate-existing retry; the atomic attempt claim makes concurrent retries lose all but one.
  - live sessions, settled consults, stale parks, terminal tasks → no-op. A park awaiting the **counterparty's** client refuses this user's answer (misroute guard, both park kinds).
- **Idempotency is a property of the negotiation** — no settlement records here. A second delivery re-resolves to no live park and no-ops; crash windows recover by redelivery (`already_settled` → re-enqueue; deterministic answer id → duplicate append ignored).
- One answer resumes the primary and every `alsoUnblocks` ref exactly once each; per-negotiation failures never block the rest of the reply. A resumed negotiation may park again — the #1430 ask-rounds cap bounds the loop; no second counter.

## For the delivery spine (out of scope here)

Four ports to implement over the existing machinery (`NegotiationAnswerConsumptionPorts`): `settleInflightAnswer` (row-less analogue of the QuestionerAdapter settle — the continuation claim must read the answer without a question row), `enqueueInflightResume` (run-existing queue, exact fields), `recordOpportunityAnswer` (idempotent per `questionId`), `enqueueStalledRetry` (run-existing, fresh attempt). **Heads-up:** `NEGOTIATION_START_STATUSES` in `conversation.database.adapter.ts` does not yet admit `'stalled'`, so the post-stall retry claim will no-op until the spine extends it.

## Verification

- New spec `negotiation.answer-consumption.spec.ts`: 21 tests pinning routing, classification, both resume orders, the misroute guard, redelivery no-ops, and per-target failure isolation.
- Full protocol suite from `packages/protocol`: **2278 pass, 0 fail** across 204 files.
- `bun run architecture:check` green (host isolation, capability boundaries).
- Nothing under `services/api` or `apps/web` touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)