### PR TITLE
feat(api): deliver parked-negotiation questions into the signal's DM

### DIFF
--- a/services/api/.test-isolated
+++ b/services/api/.test-isolated
@@ -130,3 +130,4 @@ src/controllers/tests/webhooks.controller.isolated.ts
 src/controllers/tests/agent.controller.error-sanitization.isolated.ts
 src/lib/testing/tests/fixtures/isolated-import-target.isolated.ts
 src/adapters/tests/embedder.provider-free.isolated.ts
+src/queues/tests/question-message.queue.isolated.ts

--- a/services/api/src/adapters/parked-negotiation.reader.adapter.ts
+++ b/services/api/src/adapters/parked-negotiation.reader.adapter.ts
@@ -1,0 +1,287 @@
+/**
+ * Parked-negotiation reader (conversational-questions delivery spine).
+ *
+ * Given `(userId, intentId)`, returns this user's parked negotiations on that
+ * signal — the durable record of every open information need the regeneration
+ * job renders into the signal's question-message
+ * (docs/plans/2026-08-18-conversational-questions.md). "Parked" is derived,
+ * never stored, and covers both flavours:
+ *
+ * - **Mid-flight consult**: the negotiation's exact task is `input_required`
+ *   and its `metadata.turnContext.askUserBinding` names this user and intent
+ *   as the recipient. The binding is written in the same flow that flips the
+ *   state, so the pair is authoritative for whose input is required.
+ * - **Post-stall park**: the opportunity is `stalled` AND the negotiation
+ *   record ends in an `ask_user` gap message authored by this user's agent
+ *   with `assessment.reasoning === NEGOTIATION_PARK_REASONING`. A stalled
+ *   opportunity WITHOUT that trailing message is a terminal stall (past the
+ *   ask cap, no gap authored, or the authored question was dropped as
+ *   unsafe) — never routable, never surfaced.
+ *
+ * Read-only, scoped to the requesting user's own side by construction: the
+ * mid-flight query matches the ask-user binding's recipient pair, and the
+ * post-stall query requires the gap to be authored by `agent:<userId>` — the
+ * counterparty's parks are unreachable through either predicate (the other
+ * side's park is `classifyParkedNegotiation`'s `wrong_recipient` case, which
+ * must never enter this user's message).
+ *
+ * TODO(#1432): `classifyParkedNegotiation` in the protocol package is the
+ * canonical per-negotiation park predicate; this reader mirrors its
+ * semantics set-wise (adapters may not import the protocol package). When
+ * the answer-wiring PR lands, converge the two — either by lifting this
+ * reader's predicate checks to a layer that can import the classifier, or by
+ * a contract test asserting they agree.
+ */
+import { and, asc, db, eq, inArray, schema, sql } from './database.shared';
+import { notArchivedNegotiationTaskWhere } from './negotiation-attempt.atomic';
+import { log } from '../lib/log';
+
+const logger = log.lib.from('parked-negotiation.reader.adapter');
+
+/**
+ * Fixed reasoning stamped on a post-stall park turn. Duplicated from the
+ * protocol package's `negotiation.stall-gap.ts` rather than imported —
+ * adapters may not import `@indexnetwork/protocol`, the value is the shape of
+ * a stored row, and both writer and reader pinning the same literal is what
+ * keeps them honest if either is refactored (the same pattern
+ * `negotiator-client-dm.retrieval.adapter.ts` uses for its scope type).
+ */
+export const NEGOTIATION_PARK_REASONING = "Negotiation parked pending the client's answer.";
+
+/**
+ * More parked negotiations than one message can carry (the question block
+ * caps at 20 questions). The reader keeps the oldest parks; the rest surface
+ * on a later regeneration once earlier ones resolve.
+ */
+const MAX_PARKED_NEGOTIATIONS = 20;
+
+/** Structural mirror of the protocol's `StructuredQuestion` (renderer quartet). */
+export interface ParkedNegotiationQuestion {
+  title: string;
+  prompt: string;
+  options: Array<{ label: string; description: string }>;
+  multiSelect?: boolean;
+}
+
+/** One transcript entry, reduced to what grounds a question-message. */
+export interface ParkedNegotiationTurn {
+  action: string;
+  reasoning: string;
+  message?: string;
+}
+
+export interface ParkedNegotiation {
+  /** The opportunity row the negotiation runs on — its durable identity. */
+  opportunityId: string;
+  kind: 'mid_flight' | 'post_stall';
+  /** Closed consultation category from the park turn's `askUser.reason`. */
+  reason?: string;
+  /**
+   * The negotiator-authored question persisted at park time. Absent only when
+   * the mid-flight safety gate stripped it from the turn.
+   */
+  question?: ParkedNegotiationQuestion;
+  /** The negotiation's turns, oldest first, ending in the park turn. */
+  transcript: ParkedNegotiationTurn[];
+  /** When the park turn landed; parks are returned oldest first. */
+  parkedAt: Date;
+}
+
+interface RawTurn {
+  action?: unknown;
+  assessment?: { reasoning?: unknown };
+  message?: unknown;
+  askUser?: { reason?: unknown; question?: unknown };
+}
+
+/** The `data` payload of an A2A turn message, or null for non-turn parts. */
+function turnFromParts(parts: unknown): RawTurn | null {
+  if (!Array.isArray(parts)) return null;
+  const dataPart = parts.find((part) =>
+    Boolean(part) && typeof part === 'object' && (part as { kind?: unknown }).kind === 'data');
+  const data = (dataPart as { data?: unknown } | undefined)?.data;
+  return data && typeof data === 'object' ? (data as RawTurn) : null;
+}
+
+function questionFrom(value: unknown): ParkedNegotiationQuestion | undefined {
+  if (!value || typeof value !== 'object') return undefined;
+  const question = value as Record<string, unknown>;
+  if (typeof question.title !== 'string' || typeof question.prompt !== 'string' || !Array.isArray(question.options)) {
+    return undefined;
+  }
+  const options = question.options.flatMap((option) => {
+    const candidate = option as Record<string, unknown> | null;
+    return candidate && typeof candidate.label === 'string' && typeof candidate.description === 'string'
+      ? [{ label: candidate.label, description: candidate.description }]
+      : [];
+  });
+  if (options.length === 0) return undefined;
+  return {
+    title: question.title,
+    prompt: question.prompt,
+    options,
+    ...(typeof question.multiSelect === 'boolean' ? { multiSelect: question.multiSelect } : {}),
+  };
+}
+
+interface NegotiationRecord {
+  turns: ParkedNegotiationTurn[];
+  lastTurn: RawTurn | null;
+  lastSenderId: string | null;
+  lastCreatedAt: Date | null;
+}
+
+export class ParkedNegotiationReaderAdapter {
+  /**
+   * Reads the user's parked negotiations on one signal, oldest park first.
+   * Resolves `[]` when the intent is not owned by the user — the caller never
+   * has to pre-validate ownership.
+   */
+  async readParkedNegotiations(userId: string, intentId: string): Promise<ParkedNegotiation[]> {
+    const normalizedIntentId = intentId?.trim();
+    if (!userId || !normalizedIntentId) return [];
+
+    const [ownedIntent] = await db
+      .select({ id: schema.intents.id })
+      .from(schema.intents)
+      .where(and(eq(schema.intents.id, normalizedIntentId), eq(schema.intents.userId, userId)))
+      .limit(1);
+    if (!ownedIntent) return [];
+
+    const midFlightRows = await db
+      .select({ opportunityId: sql<string | null>`${schema.tasks.metadata}->>'opportunityId'` })
+      .from(schema.tasks)
+      .where(and(
+        eq(schema.tasks.state, 'input_required'),
+        sql`${schema.tasks.metadata}->>'type' = 'negotiation'`,
+        notArchivedNegotiationTaskWhere(),
+        sql`${schema.tasks.metadata}->'participantBindings' @> ${JSON.stringify([{
+          userId,
+          intentId: normalizedIntentId,
+        }])}::jsonb`,
+        sql`${schema.tasks.metadata}->'turnContext'->'askUserBinding' @> ${JSON.stringify({
+          recipientUserId: userId,
+          recipientIntentId: normalizedIntentId,
+        })}::jsonb`,
+      ));
+
+    const stalledRows = await db
+      .select({ id: schema.opportunities.id })
+      .from(schema.opportunities)
+      .where(and(
+        eq(schema.opportunities.status, 'stalled'),
+        sql`${schema.opportunities.actors} @> ${JSON.stringify([{
+          userId,
+          intent: normalizedIntentId,
+        }])}::jsonb`,
+      ));
+
+    const midFlightIds = [...new Set(midFlightRows.flatMap((row) => (row.opportunityId ? [row.opportunityId] : [])))];
+    const stalledIds = stalledRows.map((row) => row.id).filter((id) => !midFlightIds.includes(id));
+    if (midFlightIds.length === 0 && stalledIds.length === 0) return [];
+
+    const records = await this.loadNegotiationRecords([...midFlightIds, ...stalledIds]);
+
+    const parked: ParkedNegotiation[] = [];
+    for (const opportunityId of midFlightIds) {
+      const record = records.get(opportunityId);
+      // The exact task's `input_required` state is authoritative for a
+      // mid-flight park; the trailing ask_user turn supplies the authored
+      // question when the safety gate let it persist.
+      if (!record) continue;
+      parked.push(this.toParkedNegotiation(opportunityId, 'mid_flight', record));
+    }
+    for (const opportunityId of stalledIds) {
+      const record = records.get(opportunityId);
+      // Parked iff the record ends in the park gap authored by this user's
+      // agent. Anything else on a stalled opportunity is a terminal stall.
+      if (
+        !record
+        || record.lastTurn?.action !== 'ask_user'
+        || record.lastTurn.assessment?.reasoning !== NEGOTIATION_PARK_REASONING
+        || record.lastSenderId !== `agent:${userId}`
+      ) continue;
+      parked.push(this.toParkedNegotiation(opportunityId, 'post_stall', record));
+    }
+
+    parked.sort((a, b) => a.parkedAt.getTime() - b.parkedAt.getTime());
+    if (parked.length > MAX_PARKED_NEGOTIATIONS) {
+      logger.warn('Parked set exceeds one message; keeping the oldest parks', {
+        userId,
+        intentId: normalizedIntentId,
+        parked: parked.length,
+        kept: MAX_PARKED_NEGOTIATIONS,
+      });
+      return parked.slice(0, MAX_PARKED_NEGOTIATIONS);
+    }
+    return parked;
+  }
+
+  /** Negotiation records (turns oldest first) for the given opportunities. */
+  private async loadNegotiationRecords(opportunityIds: string[]): Promise<Map<string, NegotiationRecord>> {
+    const taskRows = await db
+      .select({
+        id: schema.tasks.id,
+        opportunityId: sql<string>`${schema.tasks.metadata}->>'opportunityId'`,
+      })
+      .from(schema.tasks)
+      .where(and(
+        sql`${schema.tasks.metadata}->>'type' = 'negotiation'`,
+        notArchivedNegotiationTaskWhere(),
+        inArray(sql`${schema.tasks.metadata}->>'opportunityId'`, opportunityIds),
+      ));
+    if (taskRows.length === 0) return new Map();
+
+    const opportunityByTask = new Map(taskRows.map((task) => [task.id, task.opportunityId]));
+    const messageRows = await db
+      .select({
+        taskId: schema.messages.taskId,
+        senderId: schema.messages.senderId,
+        parts: schema.messages.parts,
+        createdAt: schema.messages.createdAt,
+      })
+      .from(schema.messages)
+      .where(inArray(schema.messages.taskId, taskRows.map((task) => task.id)))
+      .orderBy(asc(schema.messages.createdAt), asc(schema.messages.id));
+
+    const records = new Map<string, NegotiationRecord>();
+    for (const row of messageRows) {
+      const opportunityId = row.taskId ? opportunityByTask.get(row.taskId) : undefined;
+      if (!opportunityId) continue;
+      const record = records.get(opportunityId)
+        ?? { turns: [], lastTurn: null, lastSenderId: null, lastCreatedAt: null };
+      const turn = turnFromParts(row.parts);
+      if (turn) {
+        record.turns.push({
+          action: typeof turn.action === 'string' ? turn.action : 'unknown',
+          reasoning: typeof turn.assessment?.reasoning === 'string' ? turn.assessment.reasoning : '',
+          ...(typeof turn.message === 'string' && turn.message.trim() ? { message: turn.message } : {}),
+        });
+      }
+      record.lastTurn = turn;
+      record.lastSenderId = row.senderId;
+      record.lastCreatedAt = row.createdAt;
+      records.set(opportunityId, record);
+    }
+    return records;
+  }
+
+  private toParkedNegotiation(
+    opportunityId: string,
+    kind: ParkedNegotiation['kind'],
+    record: NegotiationRecord,
+  ): ParkedNegotiation {
+    const askUser = record.lastTurn?.action === 'ask_user' ? record.lastTurn.askUser : undefined;
+    const question = questionFrom(askUser?.question);
+    return {
+      opportunityId,
+      kind,
+      ...(typeof askUser?.reason === 'string' ? { reason: askUser.reason } : {}),
+      ...(question ? { question } : {}),
+      transcript: record.turns,
+      parkedAt: record.lastCreatedAt ?? new Date(0),
+    };
+  }
+}
+
+export const parkedNegotiationReaderAdapter = new ParkedNegotiationReaderAdapter();

--- a/services/api/src/controllers/mcp.controller.ts
+++ b/services/api/src/controllers/mcp.controller.ts
@@ -21,6 +21,7 @@ import { enricherAdapter } from '../adapters/enricher.adapter';
 import { QuestionerAdapter } from '../adapters/questioner.adapter';
 import type { AdapterPersistableQuestion } from '../adapters/questioner.adapter';
 import { questionerQueue } from '../queues/questioner.queue';
+import { routeParkedQuestionEnqueue } from '../queues/question-message.queue';
 import { stampNewbornOpportunities } from '../queues/pool/newborn.shared';
 import { awaitChatQuestionAnswers } from '../lib/chat-question.events';
 import { checkMcpRateLimit, checkMcpHttpRateLimit } from '../lib/limiter/mcp';
@@ -176,6 +177,9 @@ const protocolDeps = {
   chatQuestions: chatQuestionsHost,
   ...(isQuestionerEnabled() && {
     questionerEnqueue: async (input: QuestionerEnqueuePayload) => {
+      // Park-path payloads route to the question-message regeneration job
+      // (conversational-questions delivery spine); see questionerEnqueueIfEnabled.
+      if (await routeParkedQuestionEnqueue(input)) return;
       await questionerQueue.addGenerateJob(input);
     },
   }),

--- a/services/api/src/controllers/queues.controller.ts
+++ b/services/api/src/controllers/queues.controller.ts
@@ -21,6 +21,7 @@ import { negotiationRunExistingQueue } from '../queues/negotiations/run-existing
 import { enrichmentQueue } from '../queues/enrichment.queue';
 import { emailQueue } from '../queues/email.queue';
 import { poolQuestionPushQueue } from '../queues/pool/questionpush.queue';
+import { questionMessageQueue } from '../queues/question-message.queue';
 import { log } from '../lib/log';
 
 const logger = log.controller.from('dev/queues');
@@ -44,6 +45,7 @@ createBullBoard({
     new BullMQAdapter(enrichmentQueue.queue),
     new BullMQAdapter(emailQueue.queue),
     new BullMQAdapter(poolQuestionPushQueue.queue),
+    new BullMQAdapter(questionMessageQueue.queue),
   ],
   serverAdapter,
 });

--- a/services/api/src/lib/question/negotiation-question.contract.ts
+++ b/services/api/src/lib/question/negotiation-question.contract.ts
@@ -36,6 +36,28 @@ export function isSafeNegotiationQuestionPayload(payload: AdapterQuestionPayload
   return payload.options.length >= 2 && payload.options.length <= 4;
 }
 
+/**
+ * Text-level gate for negotiator-authored question-message content (the
+ * conversational-questions delivery spine). Prose renders as chat copy, so it
+ * is held to the internal-leak and unsupported-claim patterns; the
+ * named-person pattern is skipped because ordinary sentences ("This is …")
+ * trip it, and the message author never receives counterparty identity.
+ */
+export function isSafeQuestionMessageProse(text: string): boolean {
+  return Boolean(text.trim())
+    && !INTERNAL_OR_PRIVATE_PATTERN.test(text)
+    && !hasUnsupportedOpportunityClaim(text);
+}
+
+/**
+ * Question prompts additionally reject named-person claims — a prompt is one
+ * short question, so the pattern's false-positive surface is small, and a
+ * prompt naming a person is exactly the leak the park-time gate closes.
+ */
+export function isSafeQuestionMessagePrompt(text: string): boolean {
+  return isSafeQuestionMessageProse(text) && !NAMED_PERSON_CLAIM_PATTERN.test(text);
+}
+
 /** Pure terminal-state contract for answered/dismissed historical rows. */
 export function derivePendingQuestionCounts(rows: Array<{
   detection: { mode: string; pushedAt?: string };

--- a/services/api/src/lib/question/question-message.author.ts
+++ b/services/api/src/lib/question/question-message.author.ts
@@ -1,0 +1,253 @@
+/**
+ * Question-message author (conversational-questions delivery spine).
+ *
+ * One model call in the negotiator's voice that renders the current parked
+ * set for one signal into the question-message: a short preamble plus one
+ * conversational question per open gap, merging negotiations parked on the
+ * same gap (docs/plans/2026-08-18-conversational-questions.md). Grounding is
+ * exactly what park-time authoring uses (#1428 / #1430): the parked
+ * negotiations' transcripts and park-time questions, plus the client's own
+ * negotiator DM excerpt for the signal.
+ *
+ * Runs ONLY for the in-process system agent — the regeneration queue is the
+ * sole caller. External seats never reach this module, which is why the DM
+ * excerpt may appear in its prompt at all (see negotiation.client-dm.ts).
+ *
+ * Fail-open contract, in the delivery direction: a model failure, invalid
+ * mapping, or unsafe output degrades to a deterministic composition of the
+ * park-time questions (each already passed the identifier-aware safety gate
+ * before it persisted) under fixed server-owned prose. Only a parked set with
+ * no renderable question at all resolves to null — then there is no message.
+ */
+import { ChatOpenAI } from '@langchain/openai';
+import { z } from 'zod';
+
+import type { QuestionBlockQuestion } from '@indexnetwork/protocol';
+import { QuestionBlockSchema } from '@indexnetwork/protocol';
+
+import type { ParkedNegotiation } from '../../adapters/parked-negotiation.reader.adapter';
+import type { NegotiatorClientDmMessage } from '../../adapters/negotiator-client-dm.retrieval.adapter';
+import { isSafeQuestionMessageProse, isSafeQuestionMessagePrompt } from './negotiation-question.contract';
+import { log } from '../log';
+
+const logger = log.lib.from('question-message.author');
+
+/**
+ * Server-owned preamble used when the model call fails or its output is
+ * rejected. Fixed copy, never model text — the fallback path must not reopen
+ * the surface the gates close.
+ */
+export const QUESTION_MESSAGE_FALLBACK_PROSE =
+  'Some of the conversations I am running on this signal are waiting on details only you can provide. '
+  + 'Answer here and I will pick them back up.';
+
+/** Prompt budget per transcript: the tail is what says where it stuck. */
+const MAX_TRANSCRIPT_TURNS = 8;
+const MAX_TURN_CHARS = 600;
+const MAX_DM_CHARS = 1200;
+
+export interface QuestionMessageAuthorInput {
+  /** The signal's own text (intent payload), for grounding only. */
+  signalText?: string;
+  /** The parked set, oldest park first. Must be non-empty. */
+  parked: ParkedNegotiation[];
+  /** Recent excerpt of the client's negotiator DM, most recent last. */
+  clientDm: NegotiatorClientDmMessage[];
+}
+
+export interface AuthoredQuestionMessage {
+  prose: string;
+  questions: QuestionBlockQuestion[];
+}
+
+/**
+ * Model output references parked negotiations by index; the author maps them
+ * back to opportunity ids. The model never sees or emits an id, so it cannot
+ * mint a ref the block would route to the wrong negotiation.
+ */
+const AuthoredOutputSchema = z.object({
+  prose: z.string().min(1).max(2000),
+  questions: z.array(z.object({
+    prompt: z.string().min(1).max(2000),
+    unblocks: z.array(z.number().int().min(0)).min(1).max(9),
+  })).min(1).max(20),
+});
+
+function truncate(text: string, max: number): string {
+  const trimmed = text.trim();
+  return trimmed.length > max ? `${trimmed.slice(0, max)}…` : trimmed;
+}
+
+function renderParkedNegotiation(parked: ParkedNegotiation, index: number): string {
+  const lines = [`Parked negotiation ${index}:`];
+  if (parked.reason) lines.push(`- Pause category: ${parked.reason}`);
+  if (parked.question) {
+    const options = parked.question.options
+      .map((option) => `${option.label} (${option.description})`)
+      .join('; ');
+    lines.push(`- Question authored at park time: [${parked.question.title}] ${parked.question.prompt}`);
+    lines.push(`- Its decision options: ${options}`);
+  } else {
+    lines.push('- No question was authored at park time; derive the gap from the transcript.');
+  }
+  const tail = parked.transcript.slice(-MAX_TRANSCRIPT_TURNS);
+  if (tail.length > 0) {
+    lines.push('- Transcript tail:');
+    tail.forEach((turn, turnIndex) => {
+      const message = turn.message ? ` — message: ${truncate(turn.message, MAX_TURN_CHARS)}` : '';
+      lines.push(`  ${turnIndex + 1}. ${turn.action}: ${truncate(turn.reasoning, MAX_TURN_CHARS)}${message}`);
+    });
+  }
+  return lines.join('\n');
+}
+
+function renderClientDm(clientDm: NegotiatorClientDmMessage[]): string {
+  if (clientDm.length === 0) return '';
+  const lines = clientDm.map((message) =>
+    `- ${message.role === 'client' ? 'Client' : 'You'}: ${truncate(message.content, MAX_DM_CHARS)}`);
+  return `\n\nYour recent conversation with the client about this signal (most recent last):\n${lines.join('\n')}`;
+}
+
+const SYSTEM_PROMPT = `You are the Index Negotiator, an AI agent negotiating on behalf of your client. Several negotiations you are running for one of their signals are paused because they need information only your client holds. Write them ONE chat message that asks for all of it.
+
+Rules:
+- "prose" is a short preamble (2-3 sentences, second person, plain language): what you have been doing on this signal and why you are pausing to ask. No greetings, no sign-off, no bullet lists.
+- "questions" are the asks. Merge negotiations parked on the same gap into one question; keep genuinely different gaps separate. Each question's "unblocks" lists the parked negotiation indices that one answer would resume — every index must appear in exactly one question.
+- Each prompt is at most 2 sentences ending in a question mark, grounded in what actually stuck in that negotiation, in the client's own terms. Where a park-time question exists, preserve its substance; fold its decision options into the prompt when they help the client answer.
+- Never name, quote, or describe any counterparty; the client can read the transcripts, but this message must stand on its own without their identity in it.
+- Do not reference internal system details: ids, scores, pre-screens, evaluator or assessment reasoning.
+- Do not ask anything the client already settled in your conversation with them below; if their own words settle a gap, drop it from that question.`;
+
+export interface QuestionMessageAuthorConfig {
+  /** Model override; defaults to the negotiator's model. */
+  model?: string;
+}
+
+export class QuestionMessageAuthor {
+  private readonly modelName: string;
+
+  constructor(config?: QuestionMessageAuthorConfig) {
+    this.modelName = config?.model ?? 'google/gemini-2.5-flash';
+  }
+
+  /**
+   * Renders the parked set into prose + block questions. Never throws; falls
+   * back to the deterministic composition on any model failure, and to null
+   * only when nothing is renderable.
+   */
+  async author(input: QuestionMessageAuthorInput): Promise<AuthoredQuestionMessage | null> {
+    if (input.parked.length === 0) return null;
+
+    const userMessage = [
+      input.signalText ? `The client's signal: ${truncate(input.signalText, 800)}\n` : '',
+      input.parked.map(renderParkedNegotiation).join('\n\n'),
+      renderClientDm(input.clientDm),
+      '\n\nWrite the message: the prose preamble and the questions with their "unblocks" indices.',
+    ].join('\n');
+
+    try {
+      // Validate → retry once → fall back, the same loop as park-time
+      // authoring — except giving up composes deterministically instead of
+      // dropping delivery: the parked set must reach the client either way.
+      for (let attempt = 0; attempt < 2; attempt++) {
+        const raw = await this.callModel([
+          { role: 'system', content: SYSTEM_PROMPT },
+          { role: 'user', content: userMessage },
+        ]);
+        const authored = this.validate(raw, input.parked);
+        if (authored) return authored;
+        logger.warn('Question-message model output rejected', { attempt: attempt + 1 });
+      }
+    } catch (err) {
+      logger.warn('Question-message authoring failed; composing deterministically', {
+        error: err instanceof Error ? err.message : String(err),
+      });
+    }
+    return this.compose(input.parked);
+  }
+
+  /** Schema + coverage + safety validation of one model round trip. */
+  private validate(raw: unknown, parked: ParkedNegotiation[]): AuthoredQuestionMessage | null {
+    const parsed = AuthoredOutputSchema.safeParse(raw);
+    if (!parsed.success) return null;
+
+    // Every parked negotiation must be unblocked by exactly one question —
+    // the message is a complete view of the parked set, and a duplicate ref
+    // would make answer routing ambiguous (QuestionBlockSchema also rejects it).
+    const seen = new Set<number>();
+    for (const question of parsed.data.questions) {
+      for (const index of question.unblocks) {
+        if (index >= parked.length || seen.has(index)) return null;
+        seen.add(index);
+      }
+    }
+    if (seen.size !== parked.length) return null;
+
+    if (!isSafeQuestionMessageProse(parsed.data.prose)) return null;
+    if (!parsed.data.questions.every((question) => isSafeQuestionMessagePrompt(question.prompt))) return null;
+
+    const questions = parsed.data.questions.map((question) => {
+      const [primary, ...rest] = question.unblocks;
+      return {
+        prompt: question.prompt.trim(),
+        opportunityId: parked[primary].opportunityId,
+        ...(rest.length > 0 ? { alsoUnblocks: rest.map((index) => parked[index].opportunityId) } : {}),
+      };
+    });
+    return this.toAuthoredMessage(parsed.data.prose.trim(), questions);
+  }
+
+  /**
+   * Deterministic composition: fixed prose over the park-time questions,
+   * verbatim. Negotiations whose park-time question was stripped as unsafe
+   * have nothing renderable and are left for a later regeneration.
+   */
+  private compose(parked: ParkedNegotiation[]): AuthoredQuestionMessage | null {
+    const questions = parked.flatMap((negotiation) =>
+      negotiation.question
+        ? [{ prompt: negotiation.question.prompt, opportunityId: negotiation.opportunityId }]
+        : []);
+    if (questions.length === 0) {
+      logger.warn('Parked set has no renderable question; skipping message', { parked: parked.length });
+      return null;
+    }
+    return this.toAuthoredMessage(QUESTION_MESSAGE_FALLBACK_PROSE, questions);
+  }
+
+  /** Final block validation — an invalid block must never reach the serializer. */
+  private toAuthoredMessage(prose: string, questions: QuestionBlockQuestion[]): AuthoredQuestionMessage | null {
+    const block = QuestionBlockSchema.safeParse({ version: 1, questions });
+    if (!block.success) {
+      logger.warn('Authored question block failed schema validation', {
+        issues: block.error.issues.map((issue) => issue.message).slice(0, 3),
+      });
+      return null;
+    }
+    return { prose, questions: block.data.questions };
+  }
+
+  /**
+   * Raw structured-model round trip. A seam so tests drive the
+   * validate → retry → fallback loop without a live provider — the model is
+   * constructed here, not in the constructor, so tests never need a key.
+   */
+  protected async callModel(messages: Array<{ role: string; content: string }>): Promise<unknown> {
+    const apiKey = process.env.OPENROUTER_API_KEY;
+    if (!apiKey?.trim()) throw new Error('QuestionMessageAuthor: OPENROUTER_API_KEY is required');
+    const timeoutEnv = Number.parseInt(process.env.OPENROUTER_REQUEST_TIMEOUT_MS ?? '', 10);
+    const model = new ChatOpenAI({
+      model: this.modelName,
+      configuration: {
+        baseURL: process.env.OPENROUTER_BASE_URL ?? 'https://openrouter.ai/api/v1',
+        apiKey,
+      },
+      temperature: 0.3,
+      maxTokens: 2048,
+      timeout: Number.isFinite(timeoutEnv) && timeoutEnv > 0 ? timeoutEnv : 60_000,
+      maxRetries: 1,
+    });
+    return model
+      .withStructuredOutput(AuthoredOutputSchema, { name: 'question_message' })
+      .invoke(messages);
+  }
+}

--- a/services/api/src/lib/question/tests/question-message.author.spec.ts
+++ b/services/api/src/lib/question/tests/question-message.author.spec.ts
@@ -1,0 +1,156 @@
+/**
+ * QuestionMessageAuthor: the validate → retry → deterministic-fallback loop.
+ * `callModel` is a seam, so no provider or key is touched. The invariants
+ * under test: the model maps questions to parked negotiations by index and
+ * must cover the whole parked set exactly once; anything invalid or unsafe
+ * degrades to the park-time questions under fixed prose; a parked set with
+ * nothing renderable resolves to null.
+ */
+import { describe, expect, it } from 'bun:test';
+
+import { QUESTION_MESSAGE_FALLBACK_PROSE, QuestionMessageAuthor } from '../question-message.author';
+import type { QuestionMessageAuthorInput } from '../question-message.author';
+import type { ParkedNegotiation } from '../../../adapters/parked-negotiation.reader.adapter';
+
+const OPPORTUNITY_A = '0b0e8a9c-6d3f-4d6a-9f2e-1c5b7a4d8e01';
+const OPPORTUNITY_B = '7f3d2c1b-8a90-4e5f-b6c7-d8e9f0a1b2c3';
+const OPPORTUNITY_C = '4a5b6c7d-8e9f-4a1b-8c2d-3e4f5a6b7c8d';
+
+class StubbedAuthor extends QuestionMessageAuthor {
+  calls = 0;
+  constructor(private readonly results: Array<unknown | Error>) {
+    super();
+  }
+  protected override async callModel(): Promise<unknown> {
+    const result = this.results[Math.min(this.calls, this.results.length - 1)];
+    this.calls += 1;
+    if (result instanceof Error) throw result;
+    return result;
+  }
+}
+
+function parked(opportunityId: string, withQuestion = true): ParkedNegotiation {
+  return {
+    opportunityId,
+    kind: 'mid_flight',
+    ...(withQuestion
+      ? {
+        question: {
+          title: 'Budget',
+          prompt: `What budget range works for ${opportunityId.slice(0, 4)}?`,
+          options: [
+            { label: 'Under 10k', description: 'The retry proposes the smaller engagement.' },
+            { label: 'Above 10k', description: 'The retry keeps the full scope on the table.' },
+          ],
+        },
+      }
+      : {}),
+    transcript: [{ action: 'ask_user', reasoning: 'Paused for the client.' }],
+    parkedAt: new Date(0),
+  };
+}
+
+function input(parkedSet: ParkedNegotiation[]): QuestionMessageAuthorInput {
+  return { parked: parkedSet, clientDm: [] };
+}
+
+const VALID_OUTPUT = {
+  prose: 'I moved these conversations forward and paused on details only you can settle.',
+  questions: [
+    { prompt: 'What equity range are you prepared to offer?', unblocks: [0, 1] },
+    { prompt: 'Can you be on-site one week per month?', unblocks: [2] },
+  ],
+};
+
+describe('QuestionMessageAuthor', () => {
+  it('maps model output indices to opportunity refs, merged refs included', async () => {
+    const author = new StubbedAuthor([VALID_OUTPUT]);
+    const result = await author.author(input([parked(OPPORTUNITY_A), parked(OPPORTUNITY_B), parked(OPPORTUNITY_C)]));
+
+    expect(result).not.toBeNull();
+    expect(result!.prose).toBe(VALID_OUTPUT.prose);
+    expect(result!.questions).toEqual([
+      {
+        prompt: 'What equity range are you prepared to offer?',
+        opportunityId: OPPORTUNITY_A,
+        alsoUnblocks: [OPPORTUNITY_B],
+      },
+      {
+        prompt: 'Can you be on-site one week per month?',
+        opportunityId: OPPORTUNITY_C,
+      },
+    ]);
+    expect(author.calls).toBe(1);
+  });
+
+  it('retries once on invalid output, then accepts a valid second attempt', async () => {
+    const author = new StubbedAuthor([{ nonsense: true }, VALID_OUTPUT]);
+    const result = await author.author(input([parked(OPPORTUNITY_A), parked(OPPORTUNITY_B), parked(OPPORTUNITY_C)]));
+
+    expect(author.calls).toBe(2);
+    expect(result!.prose).toBe(VALID_OUTPUT.prose);
+  });
+
+  it('falls back to park-time questions when the model misses coverage', async () => {
+    // Index 1 is never unblocked — the message would silently drop a parked
+    // negotiation, so the mapping is rejected.
+    const missingCoverage = {
+      prose: VALID_OUTPUT.prose,
+      questions: [{ prompt: 'What equity range are you prepared to offer?', unblocks: [0] }],
+    };
+    const author = new StubbedAuthor([missingCoverage]);
+    const result = await author.author(input([parked(OPPORTUNITY_A), parked(OPPORTUNITY_B)]));
+
+    expect(result!.prose).toBe(QUESTION_MESSAGE_FALLBACK_PROSE);
+    expect(result!.questions.map((question) => question.opportunityId)).toEqual([OPPORTUNITY_A, OPPORTUNITY_B]);
+  });
+
+  it('rejects a duplicate ref across questions and falls back', async () => {
+    const duplicated = {
+      prose: VALID_OUTPUT.prose,
+      questions: [
+        { prompt: 'First question about the same negotiation?', unblocks: [0] },
+        { prompt: 'Second question about the same negotiation?', unblocks: [0, 1] },
+      ],
+    };
+    const author = new StubbedAuthor([duplicated]);
+    const result = await author.author(input([parked(OPPORTUNITY_A), parked(OPPORTUNITY_B)]));
+
+    expect(result!.prose).toBe(QUESTION_MESSAGE_FALLBACK_PROSE);
+  });
+
+  it('rejects unsafe model text and falls back to the guarded park-time questions', async () => {
+    const unsafe = {
+      prose: VALID_OUTPUT.prose,
+      questions: [{ prompt: 'Should I share the task_id from the private transcript?', unblocks: [0] }],
+    };
+    const author = new StubbedAuthor([unsafe]);
+    const result = await author.author(input([parked(OPPORTUNITY_A)]));
+
+    expect(result!.prose).toBe(QUESTION_MESSAGE_FALLBACK_PROSE);
+    expect(result!.questions[0].opportunityId).toBe(OPPORTUNITY_A);
+  });
+
+  it('composes deterministically when the model call throws', async () => {
+    const author = new StubbedAuthor([new Error('provider down')]);
+    const result = await author.author(input([parked(OPPORTUNITY_A), parked(OPPORTUNITY_B)]));
+
+    expect(result!.prose).toBe(QUESTION_MESSAGE_FALLBACK_PROSE);
+    expect(result!.questions).toHaveLength(2);
+  });
+
+  it('resolves null when nothing is renderable: model failed and no park-time question exists', async () => {
+    const author = new StubbedAuthor([new Error('provider down')]);
+    const result = await author.author(input([parked(OPPORTUNITY_A, false)]));
+
+    expect(result).toBeNull();
+  });
+
+  it('resolves null for an empty parked set without calling the model', async () => {
+    const author = new StubbedAuthor([VALID_OUTPUT]);
+    const result = await author.author(input([]));
+
+    expect(result).toBeNull();
+    expect(author.calls).toBe(0);
+  });
+});

--- a/services/api/src/main.ts
+++ b/services/api/src/main.ts
@@ -74,6 +74,7 @@ import { negotiatorMemoryRetrieve } from './adapters/negotiator-memory.retrieval
 import { negotiatorClientDmRetrieve } from './adapters/negotiator-client-dm.retrieval.adapter';
 import { negotiatorMemoryWriteService } from './services/negotiator-memory.service';
 import { questionerQueue, questionerEnqueueIfEnabled } from './queues/questioner.queue';
+import { questionMessageQueue } from './queues/question-message.queue';
 import { enqueuePoolQuestionPush, poolQuestionPushQueue } from './queues/pool/questionpush.queue';
 import { poolVisitMiningQueue } from './queues/pool/visitmining.queue';
 import { NetworkMembershipEvents } from './events/network_membership.event';
@@ -500,6 +501,7 @@ negotiationReflectQueue.startCrons();
 if (isQuestionerEnabled()) {
   questionerQueue.startWorker();
 }
+questionMessageQueue.startWorker();
 poolQuestionPushQueue.startWorker();
 poolQuestionPushQueue.startRecoveryScheduler();
 poolVisitMiningQueue.startWorker();
@@ -975,6 +977,7 @@ const shutdown = async () => {
     negotiationTimeoutQueue.close(),
     negotiationClaimTimeoutQueue.close(),
     questionerQueue.close(),
+    questionMessageQueue.close(),
     poolQuestionPushQueue.close(),
     poolVisitMiningQueue.close(),
     premiseQueue.close(),

--- a/services/api/src/queues/question-message.queue.ts
+++ b/services/api/src/queues/question-message.queue.ts
@@ -1,0 +1,238 @@
+/**
+ * Question-message regeneration queue (conversational-questions delivery
+ * spine, docs/plans/2026-08-18-conversational-questions.md).
+ *
+ * All question-message work for one signal funnels through one singleton job
+ * keyed `question-message.${userId}.${intentId}`, so two negotiations parking
+ * at the same moment cannot race to write the message. The job is a pure
+ * regeneration: read the parked set, author the message via the negotiator
+ * (grounded in the parked transcripts and the signal's client-DM excerpt),
+ * serialize the question block, deliver into the signal's A2H DM — the
+ * conversation keyed ('negotiator-intent', intentId). An empty parked set
+ * means there is nothing to say and the job is done.
+ *
+ * This queue also owns the trigger routing: the payloads with which the park
+ * paths used to enqueue the QuestionerAgent (`negotiation_inflight` consults
+ * and `stalled_followup` post-stall parks) are re-routed here by the
+ * questioner enqueue wrappers. The old generator's machinery stays; only
+ * these two payload families stop reaching it (retirements are a later
+ * phase).
+ *
+ * Create-only for now: a regeneration always appends a fresh message. The
+ * edit rule (update the newest message in place) is the next change, so a
+ * second park while a message is already open produces a second message —
+ * known and accepted.
+ */
+import { Job } from 'bullmq';
+
+import { serializeQuestionMessage } from '@indexnetwork/protocol';
+import type { QuestionerEnqueuePayload } from '@indexnetwork/protocol';
+
+import { log } from '../lib/log';
+import { QueueFactory } from '../lib/bullmq/bullmq';
+import { QuestionMessageAuthor } from '../lib/question/question-message.author';
+import type { ParkedNegotiationReaderAdapter } from '../adapters/parked-negotiation.reader.adapter';
+import type { NegotiatorClientDmRetrieveFn } from '../adapters/negotiator-client-dm.retrieval.adapter';
+
+export const QUEUE_NAME = 'question-message-queue';
+
+export interface QuestionMessageJobData {
+  userId: string;
+  intentId: string;
+}
+
+/**
+ * Singleton job id per scope: while a regeneration is queued for a signal,
+ * further triggers coalesce into it instead of racing it. Dashes only —
+ * BullMQ reserves colons for Redis key namespacing.
+ */
+export function questionMessageJobId(userId: string, intentId: string): string {
+  return `question-message.${userId}.${intentId}`;
+}
+
+/**
+ * Structural slice of ChatSessionService: resolve-or-create the signal's
+ * negotiator DM, then append into it. Kept structural so tests can stub it
+ * without the full service type.
+ */
+export interface QuestionMessageChatSessions {
+  resolveNegotiatorIntentSession(userId: string, intentId: string): Promise<
+    | { session: { id: string } }
+    | { error: string; status: 400 | 403 | 404 | 500 }
+  >;
+  addMessage(params: { sessionId: string; role: 'user' | 'assistant' | 'system'; content: string }): Promise<string>;
+}
+
+/** Optional deps for testing; production resolves the real collaborators lazily. */
+export interface QuestionMessageQueueDeps {
+  parkedSet?: Pick<ParkedNegotiationReaderAdapter, 'readParkedNegotiations'>;
+  clientDm?: NegotiatorClientDmRetrieveFn;
+  author?: Pick<QuestionMessageAuthor, 'author'>;
+  chatSessions?: QuestionMessageChatSessions;
+  /** Signal text for grounding; null when unavailable. */
+  getIntentText?: (intentId: string) => Promise<string | null>;
+}
+
+export class QuestionMessageQueue {
+  static readonly QUEUE_NAME = QUEUE_NAME;
+
+  readonly queue = QueueFactory.createQueue<QuestionMessageJobData>(QUEUE_NAME);
+
+  private readonly logger = log.job.from('QuestionMessageJob');
+  private readonly queueLogger = log.queue.from('QuestionMessageQueue');
+  private readonly deps: QuestionMessageQueueDeps | undefined;
+  private author: Pick<QuestionMessageAuthor, 'author'> | null;
+  private worker: ReturnType<typeof QueueFactory.createWorker<QuestionMessageJobData>> | null = null;
+
+  constructor(deps?: QuestionMessageQueueDeps) {
+    this.deps = deps;
+    this.author = deps?.author ?? null; // lazy — created on first job
+  }
+
+  /**
+   * Enqueue a regeneration for one signal's question-message. The singleton
+   * job id dedups triggers while a job is queued; completed and failed jobs
+   * are removed immediately so the id is reusable for the next park.
+   */
+  addRegenerateJob(data: QuestionMessageJobData): Promise<Job<QuestionMessageJobData>> {
+    return this.queue.add('regenerate_question_message', data, {
+      jobId: questionMessageJobId(data.userId, data.intentId),
+      removeOnComplete: true,
+      removeOnFail: true,
+    });
+  }
+
+  /** Run a job handler (used by the worker and by tests with injected deps). */
+  async processJob(name: string, data: QuestionMessageJobData): Promise<void> {
+    switch (name) {
+      case 'regenerate_question_message':
+        await this.handleRegenerate(data);
+        break;
+      default:
+        this.queueLogger.warn('Unknown job name', { name });
+    }
+  }
+
+  /** Start the BullMQ worker. Idempotent; call from the protocol server only. */
+  startWorker(): void {
+    if (this.worker) return;
+    const processor = async (job: Job<QuestionMessageJobData>) => {
+      this.queueLogger.info('Processing job', { jobId: job.id, jobName: job.name });
+      await this.processJob(job.name, job.data);
+    };
+    this.worker = QueueFactory.createWorker<QuestionMessageJobData>(QUEUE_NAME, processor);
+  }
+
+  /** Close the worker and queue connections (graceful shutdown). */
+  async close(): Promise<void> {
+    if (this.worker) {
+      await this.worker.close();
+      this.worker = null;
+    }
+    await this.queue.close();
+  }
+
+  private async handleRegenerate(data: QuestionMessageJobData): Promise<void> {
+    const { userId, intentId } = data;
+
+    const parkedSet = this.deps?.parkedSet ?? (await import('../adapters/parked-negotiation.reader.adapter')).parkedNegotiationReaderAdapter;
+    const parked = await parkedSet.readParkedNegotiations(userId, intentId);
+    if (parked.length === 0) {
+      // Normal, not exceptional: the trigger may have raced an unpark, or the
+      // stall it fired for was terminal (no gap).
+      this.logger.info('question_message_empty_parked_set', { userId, intentId });
+      return;
+    }
+
+    const clientDmRetrieve = this.deps?.clientDm
+      ?? (await import('../adapters/negotiator-client-dm.retrieval.adapter')).negotiatorClientDmRetrieve();
+    const clientDm = await clientDmRetrieve({ userId, intentId });
+
+    const getIntentText = this.deps?.getIntentText ?? (async (id: string) => {
+      const { chatDatabaseAdapter } = await import('../adapters/database.adapter');
+      const intent = await chatDatabaseAdapter.getIntentForIndexing(id);
+      return intent?.payload ?? null;
+    });
+    const signalText = await getIntentText(intentId).catch(() => null);
+
+    const author = this.getAuthor();
+    const authored = await author.author({
+      ...(signalText ? { signalText } : {}),
+      parked,
+      clientDm,
+    });
+    if (!authored) {
+      this.logger.warn('question_message_nothing_renderable', { userId, intentId, parked: parked.length });
+      return;
+    }
+
+    const body = serializeQuestionMessage(authored.prose, { version: 1, questions: authored.questions });
+
+    const chatSessions = this.deps?.chatSessions ?? (await import('../services/chat.service')).chatSessionService;
+    const resolved = await chatSessions.resolveNegotiatorIntentSession(userId, intentId);
+    if ('error' in resolved) {
+      // 400/403/404 are permanent for this scope (archived or foreign
+      // intent): suppress rather than retry, mirroring the pool push queue.
+      if (resolved.status === 500) {
+        throw new Error(`Negotiator session resolution failed: ${resolved.error}`);
+      }
+      this.logger.warn('question_message_session_unavailable', {
+        userId,
+        intentId,
+        status: resolved.status,
+        error: resolved.error,
+      });
+      return;
+    }
+
+    await chatSessions.addMessage({
+      sessionId: resolved.session.id,
+      role: 'assistant',
+      content: body,
+    });
+    this.logger.info('question_message_delivered', {
+      userId,
+      intentId,
+      sessionId: resolved.session.id,
+      parked: parked.length,
+      questions: authored.questions.length,
+    });
+  }
+
+  private getAuthor(): Pick<QuestionMessageAuthor, 'author'> {
+    if (!this.author) this.author = new QuestionMessageAuthor();
+    return this.author;
+  }
+}
+
+/** Singleton question-message queue. Use for adding jobs and starting the worker. */
+export const questionMessageQueue = new QuestionMessageQueue();
+
+/**
+ * The regeneration target carried by a park-path questioner payload, or null
+ * for every payload family that still belongs to the QuestionerAgent.
+ * Both park families name the parked side as `negotiation.recipient*` — the
+ * user whose input is required and the signal whose DM carries the question.
+ */
+export function parkedQuestionMessageTarget(input: QuestionerEnqueuePayload): QuestionMessageJobData | null {
+  const isParkFamily =
+    (input.mode === 'negotiation_inflight' && input.purpose === 'inflight_consultation')
+    || (input.mode === 'negotiation' && input.purpose === 'stalled_followup');
+  if (!isParkFamily || !input.negotiation) return null;
+  const { recipientUserId, recipientIntentId } = input.negotiation;
+  if (!recipientUserId || !recipientIntentId) return null;
+  return { userId: recipientUserId, intentId: recipientIntentId };
+}
+
+/**
+ * Trigger hook for the park paths: when the payload is one a park used to
+ * hand the QuestionerAgent, enqueue the regeneration job for the parked
+ * side's scope instead and report the payload as handled. Everything else
+ * returns false and flows to the questioner unchanged.
+ */
+export async function routeParkedQuestionEnqueue(input: QuestionerEnqueuePayload): Promise<boolean> {
+  const target = parkedQuestionMessageTarget(input);
+  if (!target) return false;
+  await questionMessageQueue.addRegenerateJob(target);
+  return true;
+}

--- a/services/api/src/queues/questioner.queue.ts
+++ b/services/api/src/queues/questioner.queue.ts
@@ -13,6 +13,7 @@ import type { PoolQuestionPostPersist } from './pool/question.shared';
 import { isPoolArtifactFresh } from './pool/poolquestions.constants';
 import { isSafeNegotiationQuestionPayload } from '../lib/question/negotiation-question.contract';
 import { emitConsultationDeliveredTelemetry } from '../lib/question/consultation-policy.telemetry';
+import { routeParkedQuestionEnqueue } from './question-message.queue';
 
 /** BullMQ queue name for question generation jobs. */
 export const QUEUE_NAME = 'questioner-queue';
@@ -547,6 +548,12 @@ export const questionerQueue = new QuestionerQueue();
 export function questionerEnqueueIfEnabled(): QuestionerEnqueueFn | undefined {
   if (!isQuestionerEnabled()) return undefined;
   return async (input) => {
+    // Park-path payloads (mid-flight consults, post-stall parks) no longer
+    // generate QuestionerAgent rows: the parked negotiation is the durable
+    // record, and the question-message regeneration job renders it into the
+    // signal's DM (conversational-questions delivery spine). The generator's
+    // machinery stays for the remaining modes; retirements come later.
+    if (await routeParkedQuestionEnqueue(input)) return;
     await questionerQueue.addGenerateJob(input);
   };
 }

--- a/services/api/src/queues/tests/question-message.queue.isolated.ts
+++ b/services/api/src/queues/tests/question-message.queue.isolated.ts
@@ -1,0 +1,219 @@
+/**
+ * Question-message regeneration job (conversational-questions delivery
+ * spine): parked set → one delivered message whose body is exactly
+ * `serializeQuestionMessage(prose, block)`; empty parked set → no message.
+ * Deps are injected, so no database, Redis, or model is touched. The
+ * happy-path assertion reuses the contract's canonical fixture byte-for-byte,
+ * pinning this job's delivery to the same wire format the web steps UI tests
+ * against.
+ */
+import { describe, expect, it } from 'bun:test';
+
+import { parseQuestionMessage } from '@indexnetwork/protocol';
+import type { QuestionerEnqueuePayload } from '@indexnetwork/protocol';
+import { questionBlockFixture, questionMessageFixture, questionProseFixture } from '@indexnetwork/protocol/question-block/fixture';
+
+import { QuestionMessageQueue, parkedQuestionMessageTarget, questionMessageJobId } from '../question-message.queue';
+import type { ParkedNegotiation } from '../../adapters/parked-negotiation.reader.adapter';
+
+const USER_ID = 'user-1';
+const INTENT_ID = 'intent-1';
+
+/** The three negotiation refs the contract fixture's block routes to. */
+const [FIXTURE_PRIMARY_1, FIXTURE_ALSO_1] = [
+  questionBlockFixture.questions[0].opportunityId,
+  questionBlockFixture.questions[0].alsoUnblocks![0],
+];
+const FIXTURE_PRIMARY_2 = questionBlockFixture.questions[1].opportunityId;
+
+function parkedNegotiation(opportunityId: string, index: number): ParkedNegotiation {
+  return {
+    opportunityId,
+    kind: index === 2 ? 'post_stall' : 'mid_flight',
+    reason: 'unresolved_owner_constraint',
+    question: {
+      title: 'Timing',
+      prompt: `Park-time question ${index}?`,
+      options: [
+        { label: 'Yes', description: 'The negotiation resumes with a yes.' },
+        { label: 'No', description: 'The negotiation resumes with a no.' },
+      ],
+    },
+    transcript: [
+      { action: 'propose', reasoning: 'Opening terms.' },
+      { action: 'ask_user', reasoning: 'Paused for the client.' },
+    ],
+    parkedAt: new Date(1000 + index),
+  };
+}
+
+interface DeliveredMessage {
+  sessionId: string;
+  role: string;
+  content: string;
+}
+
+function buildQueue(options: {
+  parked: ParkedNegotiation[];
+  authorResult?: { prose: string; questions: typeof questionBlockFixture.questions } | null;
+  resolveResult?: { session: { id: string } } | { error: string; status: 400 | 403 | 404 | 500 };
+}) {
+  const delivered: DeliveredMessage[] = [];
+  const calls = { author: 0, resolve: 0 };
+  const queue = new QuestionMessageQueue({
+    parkedSet: { readParkedNegotiations: async () => options.parked },
+    clientDm: async () => [],
+    getIntentText: async () => 'A signal about finding a technical co-founder',
+    author: {
+      author: async () => {
+        calls.author += 1;
+        return options.authorResult === undefined
+          ? { prose: questionProseFixture, questions: questionBlockFixture.questions }
+          : options.authorResult;
+      },
+    },
+    chatSessions: {
+      resolveNegotiatorIntentSession: async () => {
+        calls.resolve += 1;
+        return options.resolveResult ?? { session: { id: 'session-1' } };
+      },
+      addMessage: async (params) => {
+        delivered.push(params);
+        return `message-${delivered.length}`;
+      },
+    },
+  });
+  return { queue, delivered, calls };
+}
+
+describe('QuestionMessageQueue regeneration job', () => {
+  it('renders a non-empty parked set into one DM message carrying a valid block', async () => {
+    const parked = [
+      parkedNegotiation(FIXTURE_PRIMARY_1, 0),
+      parkedNegotiation(FIXTURE_ALSO_1, 1),
+      parkedNegotiation(FIXTURE_PRIMARY_2, 2),
+    ];
+    const { queue, delivered } = buildQueue({ parked });
+
+    await queue.processJob('regenerate_question_message', { userId: USER_ID, intentId: INTENT_ID });
+
+    expect(delivered).toHaveLength(1);
+    expect(delivered[0].sessionId).toBe('session-1');
+    expect(delivered[0].role).toBe('assistant');
+    // Byte-for-byte the contract fixture: the delivery wire format and the
+    // web client's parser fixture are the same artifact.
+    expect(delivered[0].content).toBe(questionMessageFixture);
+
+    const parsed = parseQuestionMessage(delivered[0].content);
+    expect(parsed).not.toBeNull();
+    expect(parsed!.prose).toBe(questionProseFixture);
+    expect(parsed!.block).toEqual(questionBlockFixture);
+  });
+
+  it('does nothing on an empty parked set — no authoring, no session, no message', async () => {
+    const { queue, delivered, calls } = buildQueue({ parked: [] });
+
+    await queue.processJob('regenerate_question_message', { userId: USER_ID, intentId: INTENT_ID });
+
+    expect(calls.author).toBe(0);
+    expect(calls.resolve).toBe(0);
+    expect(delivered).toHaveLength(0);
+  });
+
+  it('skips delivery when the author has nothing renderable', async () => {
+    const { queue, delivered, calls } = buildQueue({
+      parked: [parkedNegotiation(FIXTURE_PRIMARY_1, 0)],
+      authorResult: null,
+    });
+
+    await queue.processJob('regenerate_question_message', { userId: USER_ID, intentId: INTENT_ID });
+
+    expect(calls.resolve).toBe(0);
+    expect(delivered).toHaveLength(0);
+  });
+
+  it('suppresses delivery permanently when the session scope is gone (404)', async () => {
+    const { queue, delivered } = buildQueue({
+      parked: [parkedNegotiation(FIXTURE_PRIMARY_1, 0)],
+      resolveResult: { error: 'Intent not found', status: 404 },
+    });
+
+    await queue.processJob('regenerate_question_message', { userId: USER_ID, intentId: INTENT_ID });
+
+    expect(delivered).toHaveLength(0);
+  });
+
+  it('throws on a transient session failure (500) so BullMQ retries', async () => {
+    const { queue, delivered } = buildQueue({
+      parked: [parkedNegotiation(FIXTURE_PRIMARY_1, 0)],
+      resolveResult: { error: 'database unavailable', status: 500 },
+    });
+
+    await expect(
+      queue.processJob('regenerate_question_message', { userId: USER_ID, intentId: INTENT_ID }),
+    ).rejects.toThrow('database unavailable');
+    expect(delivered).toHaveLength(0);
+  });
+});
+
+describe('park-path trigger routing', () => {
+  const inflightPayload: QuestionerEnqueuePayload = {
+    mode: 'negotiation_inflight',
+    purpose: 'inflight_consultation',
+    userId: USER_ID,
+    sourceType: 'opportunity',
+    sourceId: FIXTURE_PRIMARY_1,
+    negotiation: {
+      purpose: 'inflight_consultation',
+      recipientUserId: USER_ID,
+      recipientIntentId: INTENT_ID,
+      opportunityId: FIXTURE_PRIMARY_1,
+      taskId: 'task-1',
+      networkId: 'network-1',
+    },
+    context: {
+      negotiationId: 'task-1',
+      counterpartyHint: 'another member of this community',
+      indexContext: 'a shared community',
+      consultationPolicyReason: 'unresolved_owner_constraint',
+    },
+  } as QuestionerEnqueuePayload;
+
+  it('routes mid-flight consult payloads to the parked side scope', () => {
+    expect(parkedQuestionMessageTarget(inflightPayload)).toEqual({ userId: USER_ID, intentId: INTENT_ID });
+  });
+
+  it('routes post-stall follow-up payloads to the parked side scope', () => {
+    const stalled = {
+      ...inflightPayload,
+      mode: 'negotiation',
+      purpose: 'stalled_followup',
+      negotiation: { ...inflightPayload.negotiation!, purpose: 'stalled_followup' },
+    } as unknown as QuestionerEnqueuePayload;
+    expect(parkedQuestionMessageTarget(stalled)).toEqual({ userId: USER_ID, intentId: INTENT_ID });
+  });
+
+  it('leaves every other generator payload with the questioner', () => {
+    const uptake = {
+      ...inflightPayload,
+      mode: 'negotiation',
+      purpose: 'uptake',
+      negotiation: { ...inflightPayload.negotiation!, purpose: 'uptake', taskId: undefined },
+    } as unknown as QuestionerEnqueuePayload;
+    expect(parkedQuestionMessageTarget(uptake)).toBeNull();
+
+    const intentMode = {
+      mode: 'intent',
+      userId: USER_ID,
+      sourceType: 'intent',
+      sourceId: INTENT_ID,
+      context: { intentId: INTENT_ID, payload: 'a signal' },
+    } as unknown as QuestionerEnqueuePayload;
+    expect(parkedQuestionMessageTarget(intentMode)).toBeNull();
+  });
+
+  it('keys the singleton job per (user, intent) scope without colons', () => {
+    expect(questionMessageJobId(USER_ID, INTENT_ID)).toBe(`question-message.${USER_ID}.${INTENT_ID}`);
+    expect(questionMessageJobId(USER_ID, INTENT_ID)).not.toContain(':');
+  });
+});


### PR DESCRIPTION
The conversational-questions delivery spine (docs/plans/2026-08-18-conversational-questions.md): **a negotiation parks → a question-message appears in that signal's A2H DM** — the conversation keyed `('negotiator-intent', intentId)`. Create-only: no edit rule, no exhaustion evaluator, no UI. Sits on #1428 (authored questions + client-DM grounding), #1429 (question-block contract), and #1430 (park-on-stall); merge order from here is this PR → #1432 → answer wiring.

## Parked-set reader — `parked-negotiation.reader.adapter.ts`

Given `(userId, intentId)`, this user's parked negotiations on that signal, oldest park first. "Parked" is derived, never stored, and covers both flavours in one reader:

- **Mid-flight consult**: the exact task is `input_required` and `metadata.turnContext.askUserBinding` names this user and intent as recipient — the binding is written in the same flow that flips the state, so the pair is authoritative for whose input is required.
- **Post-stall park** (#1430): the opportunity is `stalled` AND the negotiation record ends in an `ask_user` gap authored by `agent:<userId>` with `assessment.reasoning === NEGOTIATION_PARK_REASONING`. A stalled opportunity without that trailing gap is a terminal stall — past the ask cap, no gap authored, or the question was dropped as unsafe — and never surfaces.

The counterparty's parks are unreachable by construction (both predicates key on the recipient side — `classifyParkedNegotiation`'s `wrong_recipient` case). The park literal is pinned locally because adapters may not import the protocol package — the same stored-row-shape pattern `negotiator-client-dm.retrieval.adapter.ts` uses for its scope type. A `TODO(#1432)` records the agreed convergence path: the answer-wiring PR adds a contract test asserting this reader and `classifyParkedNegotiation` agree on the same fixtures.

## Regeneration job — `question-message.queue.ts`

All message work for one signal funnels through the singleton `jobId = question-message.${userId}.${intentId}`, so two negotiations parking at the same moment coalesce instead of racing (`removeOnComplete`/`removeOnFail: true` keep the id reusable per park). The job:

1. reads the parked set — **empty means done** (the trigger raced an unpark, or the stall was terminal);
2. authors the message via the negotiator (below), grounded per #1428: the parked transcripts plus the signal's DM excerpt via the `negotiator-client-dm` retrieval adapter;
3. serializes with `serializeQuestionMessage` from the question-block contract;
4. delivers through the same resolve-or-create negotiator session + `addMessage` path pool narration uses. Session `400/403/404` suppresses (archived/foreign scope, mirroring the pool push queue); `500` throws so BullMQ retries.

## Message author — `question-message.author.ts`

One model call in the negotiator's voice. The model maps questions to parked negotiations **by index** and must cover the set exactly once — it never sees or emits an opportunity id, so it cannot mint a ref that routes an answer to the wrong negotiation. Output passes new api-side text gates (`isSafeQuestionMessageProse/Prompt`, built from the existing patterns in `negotiation-question.contract.ts`). Anything invalid or unsafe degrades to deterministic composition — fixed server-owned prose over the park-time questions, which already passed the identifier-aware gate before they persisted. Only a parked set with nothing renderable produces no message.

## Trigger hook

Both questioner enqueue wrappers (`questionerEnqueueIfEnabled` and the MCP composition root's inline enqueue) now route the two park families — `negotiation_inflight`/`inflight_consultation` and `negotiation`/`stalled_followup` — to the regeneration job for the parked side's `(recipientUserId, recipientIntentId)` instead of the QuestionerAgent. Routing both is the cross-lane contract (the spine silences both old generators); for a terminal stall the routed job finds an empty parked set and does nothing, which is the intended replacement for the `stalled_followup` question row. The generator's machinery — queue, worker, presets, admission — is untouched for the remaining modes; retirements are a later phase.

## Tests

- `question-message.queue.isolated.ts`: parked set → one delivered message whose body is **byte-for-byte the contract fixture** (`questionMessageFixture`), so delivery and the web steps-UI parser pin the same artifact; empty set → no authoring, no session, no message; 404 suppress; 500 rethrow; the trigger-routing table.
- `question-message.author.spec.ts`: the validate → retry → deterministic-fallback loop through the `callModel` seam (index mapping incl. `alsoUnblocks`, coverage and duplicate-ref rejection, unsafe-text rejection, model-failure fallback, nothing-renderable → null).

Full API suite compared against clean dev as failure sets: identical — every failing file fails the same way on `origin/dev` (notably `questioner.queue.isolated.ts` "stamps exact inflight task provenance", whose context predates the #1428 contract, and the two ask-user e2e files).

## Accepted limitations (next PRs, by design)

- **No edit rule**: a second park while a message is open creates a second message. Next PR adds the message content-update seam + newest-message rule.
- **Continuation re-park gap**: finalize's `stalled_followup` enqueue skips continuation sessions, so a post-stall re-park after resume has no trigger until the answer-wiring PR's stopgap (assigned there) and, later, the exhaustion evaluator.
- **Loading-state field**: the `questionRegenerationPending` contract agreed with #1431 lands in a follow-up wiring PR, not here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
