### PR TITLE
feat: surface question-message regeneration as a pending signal in the DM

### DIFF
--- a/apps/web/src/components/IntentNegotiatorChat.tsx
+++ b/apps/web/src/components/IntentNegotiatorChat.tsx
@@ -45,10 +45,11 @@ export interface IntentNegotiatorChatProps {
   /**
    * A question-message regeneration is queued or running for this
    * conversation — show an agent-working indicator so the user doesn't
-   * answer a message that's about to be replaced. Contract agreed with the
-   * delivery spine: the API exposes `questionRegenerationPending` on the
-   * POST /chat/negotiator/session response (wired by a follow-up there);
-   * until the parent passes it through, this stays absent and inert.
+   * answer a message that's about to be replaced. The component seeds this
+   * from `questionRegenerationPending` on the POST /chat/negotiator/session
+   * bootstrap response (the contract agreed with the delivery spine); pass
+   * the prop only to override with a fresher signal than the bootstrap
+   * snapshot.
    */
   questionRegenerationPending?: boolean;
   /** Monotonic signal to reload server-appended Beat narration. */
@@ -109,6 +110,7 @@ export default function IntentNegotiatorChat({
   } = useAIChat();
 
   const [agentName, setAgentName] = useState<string | null>(null);
+  const [bootstrapRegenerationPending, setBootstrapRegenerationPending] = useState(false);
   const [ready, setReady] = useState(false);
   const [restoredHistoryLoaded, setRestoredHistoryLoaded] = useState(false);
   const [input, setInput] = useState("");
@@ -124,6 +126,9 @@ export default function IntentNegotiatorChat({
   const [proposalStatusMap, setProposalStatusMap] = useState<Record<string, "pending" | "created" | "rejected">>({});
   const [proposalIntentMap, setProposalIntentMap] = useState<Record<string, string>>({});
 
+  // The prop overrides the bootstrap snapshot when the parent has a fresher signal.
+  const regenerationPending = questionRegenerationPending ?? bootstrapRegenerationPending;
+
   // Bootstrap: get-or-create the per-intent negotiator session, then load it
   // into the shared chat context. One session per (user, intent, persona) —
   // repeat visits land in the same conversation. The parent remounts this
@@ -135,10 +140,12 @@ export default function IntentNegotiatorChat({
         session: { id: string };
         created: boolean;
         agent: { id: string; name: string; description: string | null };
+        questionRegenerationPending?: boolean;
       }>("/chat/negotiator/session", { intentId })
-      .then(async ({ session, created, agent }) => {
+      .then(async ({ session, created, agent, questionRegenerationPending: pendingAtBootstrap }) => {
         if (!active) return;
         setAgentName(agent.name);
+        setBootstrapRegenerationPending(Boolean(pendingAtBootstrap));
         const historyLoaded = await loadSession(session.id);
         if (active) {
           if (!created && historyLoaded) setRestoredHistoryLoaded(true);
@@ -171,7 +178,7 @@ export default function IntentNegotiatorChat({
   // Follow the stream.
   useEffect(() => {
     scrollRef.current?.scrollIntoView({ behavior: "smooth", block: "end" });
-  }, [answered.length, messages, questions.length, questionChainPending, questionRegenerationPending, ready]);
+  }, [answered.length, messages, questions.length, questionChainPending, regenerationPending, ready]);
 
   // Tap-to-quote from a question step: prefill the input with the question
   // being answered so the agent can route the reply. The answer itself stays
@@ -386,7 +393,7 @@ export default function IntentNegotiatorChat({
                 questionChainPending,
               )}
 
-            {questionRegenerationPending && <QuestionRegenerationIndicator />}
+            {regenerationPending && <QuestionRegenerationIndicator />}
           </>
         )}
         <div ref={scrollRef} />

--- a/services/api/src/controllers/chat.controller.ts
+++ b/services/api/src/controllers/chat.controller.ts
@@ -13,6 +13,7 @@ import { userService } from "../services/user.service";
 import { questionService } from "../services/question.service";
 import { isNegotiatorChatEnabled } from "../lib/negotiator-feature";
 import { negotiationReflectQueue } from "../queues/negotiations/reflect.queue";
+import { questionMessageQueue } from "../queues/question-message.queue";
 import { SuggestionGenerator, ChatInterruptClassifier, NEGOTIATOR_PERSONA_ID, ONBOARDING_PERSONA_ID, SIGNAL_PERSONA_ID } from '@indexnetwork/protocol';
 import { createDoneEvent, createErrorEvent, createStatusEvent, createSteerOrQueueEvent, formatSSEEvent } from "../types/chat-streaming.types";
 import { emitChatInterrupt, onChatInterrupt } from '../lib/chat-interrupt.events';
@@ -854,10 +855,16 @@ export class ChatController {
       return Response.json({ error: result.error }, { status: result.status });
     }
 
+    // Loading-state contract with the steps UI (#1431): true iff this
+    // scope's singleton regeneration job is queued or running, so the DM can
+    // show a pending indicator instead of a half-stale question-message.
+    const questionRegenerationPending = await questionMessageQueue.isRegenerationPending(user.id, intentId);
+
     return Response.json({
       session: result.session,
       created: result.created,
       agent: { id: agent.id, name: agent.name, description: agent.description },
+      questionRegenerationPending,
     });
   }
 

--- a/services/api/src/queues/question-message.queue.ts
+++ b/services/api/src/queues/question-message.queue.ts
@@ -102,6 +102,30 @@ export class QuestionMessageQueue {
     });
   }
 
+  /**
+   * True iff the signal's regeneration job is queued or running — the
+   * `questionRegenerationPending` loading-state contract with the web steps
+   * UI (#1431): while true, the DM shows a pending indicator instead of a
+   * half-stale message. Fails open to false; a Redis hiccup must not break
+   * session resolution.
+   */
+  async isRegenerationPending(userId: string, intentId: string): Promise<boolean> {
+    try {
+      const job = await this.queue.getJob(questionMessageJobId(userId, intentId));
+      if (!job) return false;
+      const state = await job.getState();
+      return state === 'waiting' || state === 'delayed' || state === 'active'
+        || state === 'prioritized' || state === 'waiting-children';
+    } catch (err) {
+      this.queueLogger.warn('Regeneration-pending lookup failed; reporting not pending', {
+        userId,
+        intentId,
+        error: err instanceof Error ? err.message : String(err),
+      });
+      return false;
+    }
+  }
+
   /** Run a job handler (used by the worker and by tests with injected deps). */
   async processJob(name: string, data: QuestionMessageJobData): Promise<void> {
     switch (name) {

--- a/services/api/src/queues/tests/question-message.queue.isolated.ts
+++ b/services/api/src/queues/tests/question-message.queue.isolated.ts
@@ -217,3 +217,18 @@ describe('park-path trigger routing', () => {
     expect(questionMessageJobId(USER_ID, INTENT_ID)).not.toContain(':');
   });
 });
+
+describe('questionRegenerationPending lookup', () => {
+  it('reports pending while the scope job is queued and false otherwise', async () => {
+    const queue = new QuestionMessageQueue({
+      parkedSet: { readParkedNegotiations: async () => [] },
+    });
+
+    expect(await queue.isRegenerationPending(USER_ID, INTENT_ID)).toBe(false);
+
+    await queue.addRegenerateJob({ userId: USER_ID, intentId: INTENT_ID });
+    expect(await queue.isRegenerationPending(USER_ID, INTENT_ID)).toBe(true);
+    // Scoped to its own (user, intent): a sibling scope stays not-pending.
+    expect(await queue.isRegenerationPending(USER_ID, 'other-intent')).toBe(false);
+  });
+});


### PR DESCRIPTION
The loading-state half of the contract locked between #1431 (steps UI) and #1433 (delivery spine): `questionRegenerationPending: boolean` on the POST `/chat/negotiator/session` response, true iff the BullMQ job `question-message.${userId}.${intentId}` on `question-message-queue` is waiting/delayed/active (plus `prioritized`/`waiting-children`), and the one-line web wiring of the indicator #1431 built behind an inert prop.

- **API**: `QuestionMessageQueue.isRegenerationPending` (fails open to `false` so a Redis hiccup never breaks session resolve) + the field on the session-resolve response — the single agreed location; the message-list response deliberately does not carry it.
- **Web**: `IntentNegotiatorChat` seeds the indicator from the bootstrap response; the existing prop stays as an override for a future fresher signal. Known limit, by scope: the value is a bootstrap-time snapshot and does not flip live; re-polling belongs to a later change.
- **Tests**: hermetic queue test (no job → false; queued scope job → true; sibling scope → false); existing negotiator controller and web component suites pass unchanged.

Authorized scope note: the `apps/web` touch is the prop wiring only, per the orchestration hand-off after the steps-UI session closed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)