### PR TITLE
feat(api): consume DM replies — wire answers to parked-negotiation resume

### DIFF
--- a/services/api/src/adapters/conversation.database.adapter.ts
+++ b/services/api/src/adapters/conversation.database.adapter.ts
@@ -333,11 +333,17 @@ function readNegotiationSignalCount(metadata: unknown): number {
 type PersistedOpportunity = typeof opportunities.$inferSelect;
 type PersistedOpportunityStatus = PersistedOpportunity['status'];
 
+// 'stalled' admits the post-stall retry: answering a parked negotiation's
+// question re-enters through negotiate-existing, which reads the current
+// opportunity row and passes its status as `expectedStatus`. The exact
+// status + updatedAt CAS below still applies, so only a caller that observed
+// the stalled row claims the attempt; terminal statuses stay refused.
 const NEGOTIATION_START_STATUSES = new Set<PersistedOpportunityStatus>([
   'latent',
   'draft',
   'pending',
   'negotiating',
+  'stalled',
 ]);
 
 export interface CreateNegotiationTaskForAttemptInput {

--- a/services/api/src/adapters/negotiation-continuation.atomic.ts
+++ b/services/api/src/adapters/negotiation-continuation.atomic.ts
@@ -53,6 +53,8 @@ interface StoredSettlement {
   counterpartyIntentId: string;
   kind: 'answer' | 'dismiss' | 'timeout';
   questionId?: string;
+  /** Row-less DM-path settlements store the client's answer inline instead of on a QUESTIONS row. */
+  answer?: { selectedOptions: string[]; freeText?: string; answeredAt: string };
   continuationStatus: 'requested' | 'completed';
 }
 
@@ -90,6 +92,18 @@ function record(value: unknown): Record<string, unknown> | null {
     : null;
 }
 
+function parseInlineAnswer(value: unknown): StoredSettlement['answer'] | null {
+  const raw = record(value);
+  if (
+    !raw
+    || !Array.isArray(raw.selectedOptions)
+    || !raw.selectedOptions.every((option) => typeof option === 'string')
+    || (raw.freeText !== undefined && typeof raw.freeText !== 'string')
+    || typeof raw.answeredAt !== 'string'
+  ) return null;
+  return raw as StoredSettlement['answer'];
+}
+
 function parseSettlement(value: unknown): StoredSettlement | null {
   const raw = record(value);
   if (
@@ -107,7 +121,10 @@ function parseSettlement(value: unknown): StoredSettlement | null {
     || typeof raw.counterpartyIntentId !== 'string'
     || !['answer', 'dismiss', 'timeout'].includes(String(raw.kind))
     || (raw.questionId !== undefined && typeof raw.questionId !== 'string')
-    || (raw.kind === 'answer' && typeof raw.questionId !== 'string')
+    || (raw.answer !== undefined && parseInlineAnswer(raw.answer) === null)
+    // An answer settlement carries its content either on a question row
+    // (card path, questionId) or inline (row-less DM path) — never neither.
+    || (raw.kind === 'answer' && typeof raw.questionId !== 'string' && raw.answer === undefined)
     || (raw.continuationStatus !== 'requested' && raw.continuationStatus !== 'completed')
   ) return null;
   return raw as unknown as StoredSettlement;
@@ -248,6 +265,18 @@ async function loadPrivateConsultation(
   database: DrizzleDB,
   settlement: StoredSettlement,
 ): Promise<ContinuationConsultation | null> {
+  if (settlement.kind === 'answer' && settlement.answer) {
+    // Row-less DM-path settlement: the answer was stored inline by the
+    // adapter settle, under the same recipient validation the card path
+    // performs on its question row. There is no QUESTIONS row to consult.
+    return {
+      recipientUserId: settlement.recipientUserId,
+      recipientIntentId: settlement.recipientIntentId,
+      kind: 'answer',
+      selectedOptions: settlement.answer.selectedOptions,
+      ...(typeof settlement.answer.freeText === 'string' ? { freeText: settlement.answer.freeText } : {}),
+    };
+  }
   if (settlement.kind === 'answer') {
     const [row] = await database.select({ answer: questions.answer, actors: questions.actors, status: questions.status })
       .from(questions)

--- a/services/api/src/adapters/parked-negotiation.reader.adapter.ts
+++ b/services/api/src/adapters/parked-negotiation.reader.adapter.ts
@@ -25,12 +25,13 @@
  * side's park is `classifyParkedNegotiation`'s `wrong_recipient` case, which
  * must never enter this user's message).
  *
- * TODO(#1432): `classifyParkedNegotiation` in the protocol package is the
- * canonical per-negotiation park predicate; this reader mirrors its
- * semantics set-wise (adapters may not import the protocol package). When
- * the answer-wiring PR lands, converge the two — either by lifting this
- * reader's predicate checks to a layer that can import the classifier, or by
- * a contract test asserting they agree.
+ * `classifyParkedNegotiation` in the protocol package is the canonical
+ * per-negotiation park predicate; this reader mirrors its semantics set-wise
+ * (adapters may not import the protocol package). The two are held together
+ * by the convergence contract test
+ * `tests/parked-negotiation.classifier-convergence.spec.ts`, which runs
+ * both over shared fixtures (mid-flight, post-stall, wrong-recipient,
+ * terminal-stall-without-gap) and asserts they agree.
  */
 import { and, asc, db, eq, inArray, schema, sql } from './database.shared';
 import { notArchivedNegotiationTaskWhere } from './negotiation-attempt.atomic';

--- a/services/api/src/adapters/questioner.adapter.ts
+++ b/services/api/src/adapters/questioner.adapter.ts
@@ -149,6 +149,12 @@ interface AdapterNegotiationQuestionSettlement {
   counterpartyIntentId: string;
   kind: 'answer' | 'dismiss' | 'timeout';
   questionId?: string;
+  /**
+   * Row-less DM-path settlement only: the client's answer stored inline so the
+   * continuation claim can read its private consultation without a QUESTIONS
+   * row. Card-path settlements keep the answer on the question row instead.
+   */
+  answer?: { selectedOptions: string[]; freeText?: string; answeredAt: string };
   continuationStatus: 'requested' | 'completed';
   settledAt: string;
   completedAt?: string;
@@ -498,6 +504,19 @@ function parseAskUserBinding(value: unknown): {
   return binding as ReturnType<typeof parseAskUserBinding>;
 }
 
+function parseInlineSettlementAnswer(value: unknown): { selectedOptions: string[]; freeText?: string; answeredAt: string } | null {
+  if (!value || typeof value !== 'object') return null;
+  const answer = value as Record<string, unknown>;
+  if (
+    !Array.isArray(answer.selectedOptions)
+    || !answer.selectedOptions.every((option) => typeof option === 'string')
+    || (answer.freeText !== undefined && typeof answer.freeText !== 'string')
+    || !isNonEmptyString(answer.answeredAt)
+    || Number.isNaN(Date.parse(answer.answeredAt))
+  ) return null;
+  return answer as { selectedOptions: string[]; freeText?: string; answeredAt: string };
+}
+
 function parseNegotiationQuestionSettlement(value: unknown): AdapterNegotiationQuestionSettlement | null {
   if (!value || typeof value !== 'object') return null;
   const settlement = value as Record<string, unknown>;
@@ -522,7 +541,10 @@ function parseNegotiationQuestionSettlement(value: unknown): AdapterNegotiationQ
     || !isNonEmptyString(settlement.settledAt)
     || Number.isNaN(Date.parse(settlement.settledAt))
     || (settlement.questionId !== undefined && !isNonEmptyString(settlement.questionId))
-    || (settlement.kind === 'answer' && !isNonEmptyString(settlement.questionId))
+    || (settlement.answer !== undefined && parseInlineSettlementAnswer(settlement.answer) === null)
+    // An answer settlement carries its content either on a question row
+    // (card path, questionId) or inline (row-less DM path) — never neither.
+    || (settlement.kind === 'answer' && !isNonEmptyString(settlement.questionId) && settlement.answer === undefined)
   ) return null;
   return settlement as unknown as AdapterNegotiationQuestionSettlement;
 }
@@ -3059,6 +3081,156 @@ export class QuestionerAdapter {
       ));
       return input;
     });
+  }
+
+  /**
+   * Row-less analogue of the card answer settle for the conversational DM
+   * path (docs/plans/2026-08-18-conversational-questions.md): CAS the exact
+   * `input_required` task closed under the same advisory/cohort/settlement
+   * locks and stamped ask-user binding checks as `answer`/`expireInflightQuestion`,
+   * but with no QUESTIONS row — the answer is stored INLINE on the
+   * questionSettlement, where `loadPrivateConsultation` reads it for the
+   * continuation claim. Any pending question-card rows for the task are
+   * dismissed; the DM answer supersedes them.
+   *
+   * Returns 'settled' when this call closed the task, 'already_settled' when
+   * an earlier delivery stored an answer settlement for the same consult (the
+   * settlement-keyed continuation enqueue is idempotent, so re-enqueueing is
+   * correct), and 'lost' when the admission gate refuses — the task is no
+   * longer `input_required`, or a dismiss/timeout settlement won the race.
+   */
+  async settleInflightNegotiationAnswerFromDm(input: {
+    taskId: string;
+    settlementId: string;
+    opportunityId: string;
+    recipientUserId: string;
+    recipientIntentId: string;
+    networkId: string;
+    answer: { selectedOptions: string[]; freeText?: string; answeredAt: string };
+  }): Promise<'settled' | 'already_settled' | 'lost'> {
+    if (input.settlementId !== settlementIdForTask(input.taskId)) return 'lost';
+    const candidate: AdapterNegotiationQuestionCandidate = {
+      purpose: 'inflight_consultation',
+      recipientUserId: input.recipientUserId,
+      recipientIntentId: input.recipientIntentId,
+      opportunityId: input.opportunityId,
+      taskId: input.taskId,
+      networkId: input.networkId,
+    };
+    return this.db.transaction(async (tx) => {
+      await this.lockNegotiationQuestionAdvisory(tx as unknown as DrizzleDB, candidate);
+      const cohort = await this.lockNegotiationQuestionCohort(tx as unknown as DrizzleDB, candidate);
+      await this.lockNegotiationSettlementRows(tx as unknown as DrizzleDB, candidate);
+      const [task] = await tx.select({ state: tasks.state, metadata: tasks.metadata })
+        .from(tasks)
+        .where(eq(tasks.id, input.taskId))
+        .limit(1);
+      if (!task) return 'lost';
+      const metadata = task.metadata as Record<string, unknown> | null;
+      const existingSettlement = parseNegotiationQuestionSettlement(metadata?.questionSettlement);
+      if (existingSettlement) {
+        return existingSettlement.kind === 'answer'
+          && existingSettlement.settlementId === input.settlementId
+          && existingSettlement.recipientUserId === input.recipientUserId
+          && existingSettlement.opportunityId === input.opportunityId
+          ? 'already_settled'
+          : 'lost';
+      }
+      const binding = parseAskUserBinding(
+        (metadata?.turnContext as Record<string, unknown> | undefined)?.askUserBinding,
+      );
+      if (
+        task.state !== 'input_required'
+        || metadata?.type !== 'negotiation'
+        || metadata.opportunityId !== input.opportunityId
+        || metadata.networkId !== input.networkId
+        || !binding
+        || binding.settlementId !== input.settlementId
+        || binding.recipientUserId !== input.recipientUserId
+        || binding.recipientIntentId !== input.recipientIntentId
+        || binding.opportunityId !== input.opportunityId
+        || binding.networkId !== input.networkId
+      ) return 'lost';
+      // Same live revalidation as the card path: the stamped binding must
+      // still describe the current intent/opportunity, or the consult is
+      // stale and the answer must not resume it.
+      const current = await this.resolveNegotiationAdmission(candidate, tx as unknown as DrizzleDB);
+      if (
+        current?.intentFingerprint !== binding.intentFingerprint
+        || current.opportunityStatus !== binding.opportunityStatus
+        || current.opportunityUpdatedAt !== binding.opportunityUpdatedAt
+      ) return 'lost';
+
+      const durableSettlement: AdapterNegotiationQuestionSettlement = {
+        version: 1,
+        settlementId: binding.settlementId,
+        taskId: input.taskId,
+        ...(binding.consultationAttemptId ? { consultationAttemptId: binding.consultationAttemptId } : {}),
+        recipientUserId: input.recipientUserId,
+        recipientIntentId: input.recipientIntentId,
+        opportunityId: input.opportunityId,
+        networkId: input.networkId,
+        intentFingerprint: binding.intentFingerprint,
+        opportunityStatus: binding.opportunityStatus,
+        opportunityUpdatedAt: binding.opportunityUpdatedAt,
+        counterpartyUserId: binding.counterpartyUserId,
+        counterpartyIntentId: binding.counterpartyIntentId,
+        kind: 'answer',
+        answer: {
+          selectedOptions: input.answer.selectedOptions,
+          ...(input.answer.freeText !== undefined ? { freeText: input.answer.freeText } : {}),
+          answeredAt: input.answer.answeredAt,
+        },
+        continuationStatus: 'requested',
+        settledAt: input.answer.answeredAt,
+      };
+      const [claimed] = await tx.update(tasks)
+        .set({
+          state: 'canceled',
+          statusMessage: { reason: 'ask_user_answered', settlementId: durableSettlement.settlementId },
+          metadata: sql`jsonb_set(COALESCE(${tasks.metadata}, '{}'::jsonb), '{questionSettlement}', ${JSON.stringify(durableSettlement)}::jsonb, true)`,
+          statusTimestamp: new Date(),
+          updatedAt: new Date(),
+        })
+        .where(and(eq(tasks.id, input.taskId), eq(tasks.state, 'input_required')))
+        .returning({ id: tasks.id });
+      if (!claimed) return 'lost';
+      for (const row of cohort) {
+        if (row.status === 'pending') {
+          await tx.update(questions).set({ status: 'dismissed' })
+            .where(and(eq(questions.id, row.id), eq(questions.status, 'pending')));
+        }
+      }
+      return 'settled';
+    });
+  }
+
+  /**
+   * Append one routed DM answer to `opportunity.metadata.userAnswers`, where
+   * continuation prompts read between-session context. Idempotent per
+   * `questionId`: an append whose key is already present is ignored, so a
+   * redelivered reply records nothing twice.
+   */
+  async recordOpportunityUserAnswer(
+    opportunityId: string,
+    entry: { questionId: string; selectedOptions: string[]; freeText?: string; answeredAt: string },
+  ): Promise<void> {
+    await this.db.update(opportunities)
+      .set({
+        metadata: sql`jsonb_set(
+          COALESCE(${opportunities.metadata}, '{}'::jsonb),
+          '{userAnswers}',
+          COALESCE(${opportunities.metadata}->'userAnswers', '[]'::jsonb) || ${JSON.stringify([entry])}::jsonb,
+          true
+        )`,
+      })
+      .where(and(
+        eq(opportunities.id, opportunityId),
+        sql`NOT EXISTS (
+          SELECT 1 FROM jsonb_array_elements(COALESCE(${opportunities.metadata}->'userAnswers', '[]'::jsonb)) existing
+          WHERE existing->>'questionId' = ${entry.questionId}
+        )`,
+      ));
   }
 
   /** Atomically validate material binding, create/reuse the exact successor, and acquire its fenced lease. */

--- a/services/api/src/adapters/tests/negotiation-dm-answer.settlement.spec.ts
+++ b/services/api/src/adapters/tests/negotiation-dm-answer.settlement.spec.ts
@@ -1,0 +1,282 @@
+/**
+ * Row-less DM-path settlement (conversational-questions answer wiring).
+ *
+ * The card answer path stores the client's answer on a QUESTIONS row, which
+ * `loadPrivateConsultation` reads when the continuation claim mints the
+ * successor. The DM path has no question row — #1432's known wrinkle — so
+ * `settleInflightNegotiationAnswerFromDm` stores the answer INLINE on the
+ * task's questionSettlement. This spec proves the whole chain against the
+ * real database: settle CASes the exact `input_required` task closed, a
+ * repeat delivery reports `already_settled`, a lost race reports `lost`, and
+ * — the load-bearing assertion — the continuation claim's fenced execution
+ * carries the answer text into the successor's consultation.
+ */
+import { afterAll, describe, expect, setDefaultTimeout, test } from 'bun:test';
+import { randomUUID } from 'crypto';
+import { eq, inArray } from 'drizzle-orm';
+
+import db from '../../lib/drizzle/drizzle';
+import { computeIntentFingerprint } from '../../lib/intent/intent.fingerprint';
+import { questionerAdapter } from '../questioner.adapter.instance';
+import { ConversationDatabaseAdapter } from '../conversation.database.adapter';
+import { intents, intentNetworks, networks, networkMembers, opportunities, users } from '../../schemas/database.schema';
+import { conversations, messages, tasks } from '../../schemas/conversation.schema';
+
+setDefaultTimeout(30_000);
+
+const conversationAdapter = new ConversationDatabaseAdapter();
+
+const cleanup = {
+  users: [] as string[],
+  networks: [] as string[],
+  intents: [] as string[],
+  opportunities: [] as string[],
+  conversations: [] as string[],
+};
+
+afterAll(async () => {
+  if (cleanup.conversations.length > 0) {
+    await db.delete(messages).where(inArray(messages.conversationId, cleanup.conversations));
+    await db.delete(tasks).where(inArray(tasks.conversationId, cleanup.conversations));
+    await db.delete(conversations).where(inArray(conversations.id, cleanup.conversations));
+  }
+  if (cleanup.opportunities.length > 0) await db.delete(opportunities).where(inArray(opportunities.id, cleanup.opportunities));
+  if (cleanup.intents.length > 0) {
+    await db.delete(intentNetworks).where(inArray(intentNetworks.intentId, cleanup.intents));
+    await db.delete(intents).where(inArray(intents.id, cleanup.intents));
+  }
+  if (cleanup.networks.length > 0) {
+    await db.delete(networkMembers).where(inArray(networkMembers.networkId, cleanup.networks));
+    await db.delete(networks).where(inArray(networks.id, cleanup.networks));
+  }
+  if (cleanup.users.length > 0) await db.delete(users).where(inArray(users.id, cleanup.users));
+});
+
+async function seedParkedConsult() {
+  const ownerPayload = 'Find a design partner for a hardware pilot';
+  const [owner, counterparty] = await db.insert(users).values([
+    { email: `dm-answer-owner-${randomUUID()}@test.local`, name: 'DM answer owner' },
+    { email: `dm-answer-counterparty-${randomUUID()}@test.local`, name: 'DM answer counterparty' },
+  ]).returning({ id: users.id });
+  cleanup.users.push(owner.id, counterparty.id);
+  const [network] = await db.insert(networks).values({
+    title: `DM answer ${randomUUID()}`,
+    description: 'row-less settlement fixture',
+    isPersonal: false,
+  }).returning({ id: networks.id });
+  cleanup.networks.push(network.id);
+  await db.insert(networkMembers).values([
+    { networkId: network.id, userId: owner.id, permissions: ['member'] },
+    { networkId: network.id, userId: counterparty.id, permissions: ['member'] },
+  ]);
+  const [ownerIntent] = await db.insert(intents).values({
+    userId: owner.id, payload: ownerPayload, status: 'ACTIVE',
+  }).returning({ id: intents.id, payload: intents.payload, summary: intents.summary });
+  const [counterpartyIntent] = await db.insert(intents).values({
+    userId: counterparty.id, payload: 'Offer design partnership', status: 'ACTIVE',
+  }).returning({ id: intents.id });
+  cleanup.intents.push(ownerIntent.id, counterpartyIntent.id);
+  await db.insert(intentNetworks).values([
+    { intentId: ownerIntent.id, networkId: network.id },
+    { intentId: counterpartyIntent.id, networkId: network.id },
+  ]);
+  const [opportunity] = await db.insert(opportunities).values({
+    detection: { kind: 'test', summary: 'dm answer settlement' } as never,
+    actors: [
+      { userId: counterparty.id, intent: counterpartyIntent.id, networkId: network.id, role: 'peer' },
+      { userId: owner.id, intent: ownerIntent.id, networkId: network.id, role: 'peer' },
+    ] as never,
+    interpretation: { reasoning: 'fixture', category: 'test' } as never,
+    context: { networkId: network.id } as never,
+    confidence: '0.9',
+    status: 'negotiating',
+  }).returning();
+  cleanup.opportunities.push(opportunity.id);
+
+  const conversation = await conversationAdapter.createConversation([
+    { participantId: `agent:${owner.id}`, participantType: 'agent' },
+    { participantId: `agent:${counterparty.id}`, participantType: 'agent' },
+  ]);
+  cleanup.conversations.push(conversation.id);
+  const task = await conversationAdapter.createTask(conversation.id, {
+    type: 'negotiation',
+    opportunityId: opportunity.id,
+    networkId: network.id,
+    sourceUserId: counterparty.id,
+    candidateUserId: owner.id,
+    sourceIntentId: counterpartyIntent.id,
+    candidateIntentId: ownerIntent.id,
+    participantBindings: [
+      { userId: counterparty.id, intentId: counterpartyIntent.id, networkId: network.id },
+      { userId: owner.id, intentId: ownerIntent.id, networkId: network.id },
+    ],
+  });
+
+  const settlementId = `negotiation-question-settlement-v1-${task.id}`;
+  const askUserBinding = {
+    version: 2,
+    settlementId,
+    recipientUserId: owner.id,
+    recipientIntentId: ownerIntent.id,
+    opportunityId: opportunity.id,
+    networkId: network.id,
+    intentFingerprint: computeIntentFingerprint(ownerIntent.payload, ownerIntent.summary),
+    opportunityStatus: opportunity.status,
+    opportunityUpdatedAt: opportunity.updatedAt.toISOString(),
+    counterpartyUserId: counterparty.id,
+    counterpartyIntentId: counterpartyIntent.id,
+  };
+  const [{ metadata }] = await db.select({ metadata: tasks.metadata }).from(tasks).where(eq(tasks.id, task.id));
+  await db.update(tasks).set({
+    state: 'input_required',
+    metadata: { ...(metadata as Record<string, unknown>), turnContext: { askUserBinding } },
+  }).where(eq(tasks.id, task.id));
+
+  return {
+    ownerId: owner.id,
+    ownerIntentId: ownerIntent.id,
+    networkId: network.id,
+    opportunityId: opportunity.id,
+    conversationId: conversation.id,
+    taskId: task.id,
+    settlementId,
+  };
+}
+
+function settleInput(fixture: Awaited<ReturnType<typeof seedParkedConsult>>, freeText: string) {
+  return {
+    taskId: fixture.taskId,
+    settlementId: fixture.settlementId,
+    opportunityId: fixture.opportunityId,
+    recipientUserId: fixture.ownerId,
+    recipientIntentId: fixture.ownerIntentId,
+    networkId: fixture.networkId,
+    answer: { selectedOptions: [], freeText, answeredAt: new Date().toISOString() },
+  };
+}
+
+describe('settleInflightNegotiationAnswerFromDm', () => {
+  test('settles the exact input_required task with the answer inline, once', async () => {
+    const fixture = await seedParkedConsult();
+
+    const first = await questionerAdapter.settleInflightNegotiationAnswerFromDm(
+      settleInput(fixture, 'I can start in March.'),
+    );
+    expect(first).toBe('settled');
+
+    const [task] = await db.select().from(tasks).where(eq(tasks.id, fixture.taskId));
+    expect(task.state).toBe('canceled');
+    expect(task.statusMessage).toMatchObject({ reason: 'ask_user_answered', settlementId: fixture.settlementId });
+    const settlement = (task.metadata as Record<string, unknown>).questionSettlement as Record<string, unknown>;
+    expect(settlement).toMatchObject({
+      kind: 'answer',
+      settlementId: fixture.settlementId,
+      answer: { selectedOptions: [], freeText: 'I can start in March.' },
+    });
+    expect(settlement.questionId).toBeUndefined();
+
+    // Redelivery: the stored settlement stands, the repeat only re-enqueues.
+    const second = await questionerAdapter.settleInflightNegotiationAnswerFromDm(
+      settleInput(fixture, 'I can start in March.'),
+    );
+    expect(second).toBe('already_settled');
+  });
+
+  test('the continuation claim reads the inline answer — the successor actually receives the text', async () => {
+    const fixture = await seedParkedConsult();
+    await questionerAdapter.settleInflightNegotiationAnswerFromDm(
+      settleInput(fixture, 'Budget is capped at 40k; hardware only.'),
+    );
+
+    const claim = await questionerAdapter.claimNegotiationContinuationExecution({
+      taskId: fixture.taskId,
+      settlementId: fixture.settlementId,
+      opportunityId: fixture.opportunityId,
+      userId: fixture.ownerId,
+      recipientIntentId: fixture.ownerIntentId,
+      networkId: fixture.networkId,
+    });
+    expect(claim.status).toBe('claimed');
+    if (claim.status !== 'claimed') return;
+    expect(claim.execution.consultation).toMatchObject({
+      kind: 'answer',
+      recipientUserId: fixture.ownerId,
+      recipientIntentId: fixture.ownerIntentId,
+      selectedOptions: [],
+      freeText: 'Budget is capped at 40k; hardware only.',
+    });
+    // The claim minted a fenced successor for the exact settlement.
+    const [successor] = await db.select().from(tasks).where(eq(tasks.id, claim.execution.successorTaskId));
+    expect(successor.metadata).toMatchObject({
+      resumeFromTaskId: fixture.taskId,
+      continuationSettlementId: fixture.settlementId,
+    });
+  });
+
+  test('a consult already settled by timeout refuses the answer', async () => {
+    const fixture = await seedParkedConsult();
+    // Simulate the expiry worker winning the race: kind 'timeout', task closed.
+    const [{ metadata }] = await db.select({ metadata: tasks.metadata }).from(tasks).where(eq(tasks.id, fixture.taskId));
+    const binding = ((metadata as Record<string, unknown>).turnContext as Record<string, unknown>).askUserBinding as Record<string, unknown>;
+    await db.update(tasks).set({
+      state: 'canceled',
+      metadata: {
+        ...(metadata as Record<string, unknown>),
+        questionSettlement: {
+          version: 1,
+          settlementId: fixture.settlementId,
+          taskId: fixture.taskId,
+          recipientUserId: fixture.ownerId,
+          recipientIntentId: fixture.ownerIntentId,
+          opportunityId: fixture.opportunityId,
+          networkId: fixture.networkId,
+          intentFingerprint: binding.intentFingerprint,
+          opportunityStatus: binding.opportunityStatus,
+          opportunityUpdatedAt: binding.opportunityUpdatedAt,
+          counterpartyUserId: binding.counterpartyUserId,
+          counterpartyIntentId: binding.counterpartyIntentId,
+          kind: 'timeout',
+          continuationStatus: 'requested',
+          settledAt: new Date().toISOString(),
+        },
+      },
+    }).where(eq(tasks.id, fixture.taskId));
+
+    const result = await questionerAdapter.settleInflightNegotiationAnswerFromDm(
+      settleInput(fixture, 'Too late?'),
+    );
+    expect(result).toBe('lost');
+  });
+
+  test('a task that is no longer input_required refuses the answer', async () => {
+    const fixture = await seedParkedConsult();
+    await db.update(tasks).set({ state: 'completed' }).where(eq(tasks.id, fixture.taskId));
+    const result = await questionerAdapter.settleInflightNegotiationAnswerFromDm(
+      settleInput(fixture, 'Anyone there?'),
+    );
+    expect(result).toBe('lost');
+  });
+});
+
+describe('recordOpportunityUserAnswer', () => {
+  test('appends once per questionId — a redelivered append is ignored', async () => {
+    const fixture = await seedParkedConsult();
+    const entry = {
+      questionId: `negotiation-park-answer-v1-${fixture.taskId}`,
+      selectedOptions: [],
+      freeText: 'March works.',
+      answeredAt: new Date().toISOString(),
+    };
+
+    await questionerAdapter.recordOpportunityUserAnswer(fixture.opportunityId, entry);
+    await questionerAdapter.recordOpportunityUserAnswer(fixture.opportunityId, { ...entry, freeText: 'Duplicate delivery.' });
+    await questionerAdapter.recordOpportunityUserAnswer(fixture.opportunityId, { ...entry, questionId: 'other-park-answer' });
+
+    const [row] = await db.select({ metadata: opportunities.metadata }).from(opportunities)
+      .where(eq(opportunities.id, fixture.opportunityId));
+    const answers = ((row.metadata as Record<string, unknown>).userAnswers ?? []) as Array<Record<string, unknown>>;
+    expect(answers).toHaveLength(2);
+    expect(answers[0]).toMatchObject({ questionId: entry.questionId, freeText: 'March works.' });
+    expect(answers[1]).toMatchObject({ questionId: 'other-park-answer' });
+  });
+});

--- a/services/api/src/adapters/tests/negotiation-stalled-retry.database.spec.ts
+++ b/services/api/src/adapters/tests/negotiation-stalled-retry.database.spec.ts
@@ -1,0 +1,149 @@
+/**
+ * Post-stall retry admission (conversational-questions answer wiring).
+ *
+ * Answering a parked negotiation's question resumes it through
+ * negotiate-existing, which reads the CURRENT opportunity row and claims a
+ * fresh attempt with `expectedStatus: opportunity.status` — 'stalled' for a
+ * post-stall park. `NEGOTIATION_START_STATUSES` therefore admits 'stalled';
+ * this spec proves the retry claims a fresh attempt against the real
+ * database, and that widening the set opened no other start path: terminal
+ * statuses stay refused, the exact status+updatedAt CAS still governs, and
+ * the constant still has exactly one consumer (the attempt claim).
+ */
+import { afterAll, describe, expect, setDefaultTimeout, test } from 'bun:test';
+import { readFileSync } from 'node:fs';
+import { randomUUID } from 'crypto';
+import { eq, inArray, sql } from 'drizzle-orm';
+
+import db from '../../lib/drizzle/drizzle';
+import { ConversationDatabaseAdapter } from '../conversation.database.adapter';
+import { opportunities } from '../../schemas/database.schema';
+import { conversations, messages, tasks } from '../../schemas/conversation.schema';
+
+setDefaultTimeout(30_000);
+
+const conversationAdapter = new ConversationDatabaseAdapter();
+
+const createdOpportunityIds: string[] = [];
+const createdConversationIds: string[] = [];
+
+afterAll(async () => {
+  if (createdConversationIds.length > 0) {
+    await db.delete(messages).where(inArray(messages.conversationId, createdConversationIds));
+    await db.delete(tasks).where(inArray(tasks.conversationId, createdConversationIds));
+    await db.delete(conversations).where(inArray(conversations.id, createdConversationIds));
+  }
+  if (createdOpportunityIds.length > 0) {
+    await db.delete(opportunities).where(inArray(opportunities.id, createdOpportunityIds));
+  }
+});
+
+async function seedOpportunity(status: typeof opportunities.$inferSelect['status']) {
+  const [opportunity] = await db.insert(opportunities).values({
+    detection: { kind: 'test', summary: 'stalled retry fixture' } as never,
+    actors: [
+      { userId: randomUUID(), networkId: randomUUID(), role: 'peer' },
+      { userId: randomUUID(), networkId: randomUUID(), role: 'peer' },
+    ] as never,
+    interpretation: { reasoning: 'fixture', category: 'test' } as never,
+    context: {} as never,
+    confidence: '0.8',
+    status,
+  }).returning();
+  createdOpportunityIds.push(opportunity.id);
+  return opportunity;
+}
+
+async function createConversation(): Promise<string> {
+  const [conversation] = await db.insert(conversations).values({}).returning();
+  createdConversationIds.push(conversation.id);
+  return conversation.id;
+}
+
+function attemptInput(opportunity: typeof opportunities.$inferSelect, conversationId: string) {
+  return {
+    conversationId,
+    opportunityId: opportunity.id,
+    expectedStatus: opportunity.status,
+    expectedUpdatedAt: opportunity.updatedAt,
+    metadata: {
+      type: 'negotiation',
+      opportunityId: opportunity.id,
+      intentSnapshots: [],
+    },
+  };
+}
+
+describe('post-stall retry attempt claim', () => {
+  test("a stalled opportunity with a completed park task resumes into exactly one fresh attempt", async () => {
+    // Mimic production ordering: the park task completes FIRST, then finalize
+    // stamps the opportunity 'stalled' — so the completed task predates the
+    // opportunity's updatedAt and does not qualify as an owner of the retry.
+    const opportunity = await seedOpportunity('negotiating');
+    const conversationId = await createConversation();
+    const parkTask = await conversationAdapter.createTask(conversationId, {
+      type: 'negotiation',
+      opportunityId: opportunity.id,
+      intentSnapshots: [],
+    });
+    await db.update(tasks).set({ state: 'completed' }).where(eq(tasks.id, parkTask.id));
+    await new Promise((resolve) => setTimeout(resolve, 20));
+    await db.update(opportunities)
+      .set({ status: 'stalled', updatedAt: new Date() })
+      .where(eq(opportunities.id, opportunity.id));
+    const [stalled] = await db.select().from(opportunities).where(eq(opportunities.id, opportunity.id));
+
+    const attempt = await conversationAdapter.createNegotiationTaskForAttempt(attemptInput(stalled, conversationId));
+    expect(attempt).not.toBeNull();
+
+    const [promoted] = await db.select().from(opportunities).where(eq(opportunities.id, opportunity.id));
+    expect(promoted.status).toBe('negotiating');
+
+    const persistedTasks = await db.select({ id: tasks.id, state: tasks.state }).from(tasks)
+      .where(sql`${tasks.metadata}->>'opportunityId' = ${opportunity.id}`);
+    expect(persistedTasks).toHaveLength(2);
+
+    // Concurrent retries race the claim; the second observer of the stalled
+    // row loses to the exact status+updatedAt CAS.
+    const rematch = await conversationAdapter.createNegotiationTaskForAttempt(
+      attemptInput(stalled, await createConversation()),
+    );
+    expect(rematch).toBeNull();
+  });
+
+  test('terminal statuses stay refused even when the caller expects them exactly', async () => {
+    for (const status of ['accepted', 'rejected', 'expired'] as const) {
+      const opportunity = await seedOpportunity(status);
+      const attempt = await conversationAdapter.createNegotiationTaskForAttempt(
+        attemptInput(opportunity, await createConversation()),
+      );
+      expect(attempt).toBeNull();
+      const [unchanged] = await db.select().from(opportunities).where(eq(opportunities.id, opportunity.id));
+      expect(unchanged.status).toBe(status);
+    }
+  });
+
+  test('a stale stalled expectation is refused once the row has moved on', async () => {
+    const opportunity = await seedOpportunity('stalled');
+    const input = attemptInput(opportunity, await createConversation());
+    await db.update(opportunities)
+      .set({ status: 'accepted', updatedAt: new Date() })
+      .where(eq(opportunities.id, opportunity.id));
+
+    const attempt = await conversationAdapter.createNegotiationTaskForAttempt(input);
+    expect(attempt).toBeNull();
+    const [unchanged] = await db.select().from(opportunities).where(eq(opportunities.id, opportunity.id));
+    expect(unchanged.status).toBe('accepted');
+  });
+
+  test('NEGOTIATION_START_STATUSES still has exactly one consumer — the attempt claim guard', () => {
+    // Widening the set must not silently open a start path for another
+    // caller: the constant is module-private, and its only reference beyond
+    // the declaration is the guard inside
+    // createNegotiationTaskForAttemptInTransaction.
+    const source = readFileSync('src/adapters/conversation.database.adapter.ts', 'utf8');
+    const references = source.match(/NEGOTIATION_START_STATUSES/g) ?? [];
+    expect(references).toHaveLength(2);
+    expect(source).not.toContain('export const NEGOTIATION_START_STATUSES');
+  });
+});

--- a/services/api/src/adapters/tests/parked-negotiation.classifier-convergence.spec.ts
+++ b/services/api/src/adapters/tests/parked-negotiation.classifier-convergence.spec.ts
@@ -1,0 +1,288 @@
+/**
+ * Convergence contract between the parked-set reader and the protocol's
+ * canonical park classifier (conversational-questions answer wiring).
+ *
+ * The reader (`parked-negotiation.reader.adapter.ts`) mirrors
+ * `classifyParkedNegotiation`'s semantics set-wise in SQL because adapters may
+ * not import `@indexnetwork/protocol` — the layering rule stands, so the two
+ * predicates are duplicated by design. This spec is what keeps them honest:
+ * both run over the SAME persisted fixtures — mid-flight consult, post-stall
+ * park, a park awaiting the counterparty, and a terminal stall without a
+ * gap — and must agree on which negotiations are answerable by which user.
+ * A drift in either predicate (including the duplicated
+ * NEGOTIATION_PARK_REASONING literal) fails here before it can misroute an
+ * answer or render a stale question.
+ */
+import { afterAll, describe, expect, setDefaultTimeout, test } from 'bun:test';
+import { randomUUID } from 'crypto';
+import { eq, inArray } from 'drizzle-orm';
+
+import { classifyParkedNegotiation, negotiationQuestionSettlementId } from '@indexnetwork/protocol';
+
+import db from '../../lib/drizzle/drizzle';
+import { chatDatabaseAdapter } from '../database.adapter';
+import { ConversationDatabaseAdapter } from '../conversation.database.adapter';
+import { NEGOTIATION_PARK_REASONING, ParkedNegotiationReaderAdapter } from '../parked-negotiation.reader.adapter';
+import { intents, networks, networkMembers, opportunities, users } from '../../schemas/database.schema';
+import { conversations, messages, tasks } from '../../schemas/conversation.schema';
+
+setDefaultTimeout(30_000);
+
+const conversationAdapter = new ConversationDatabaseAdapter();
+const reader = new ParkedNegotiationReaderAdapter();
+
+const cleanup = {
+  users: [] as string[],
+  networks: [] as string[],
+  intents: [] as string[],
+  opportunities: [] as string[],
+  conversations: [] as string[],
+};
+
+afterAll(async () => {
+  if (cleanup.conversations.length > 0) {
+    const taskRows = await db.select({ id: tasks.id }).from(tasks)
+      .where(inArray(tasks.conversationId, cleanup.conversations));
+    if (taskRows.length > 0) {
+      await db.delete(messages).where(inArray(messages.taskId, taskRows.map((t) => t.id)));
+    }
+    await db.delete(messages).where(inArray(messages.conversationId, cleanup.conversations));
+    await db.delete(tasks).where(inArray(tasks.conversationId, cleanup.conversations));
+    await db.delete(conversations).where(inArray(conversations.id, cleanup.conversations));
+  }
+  if (cleanup.opportunities.length > 0) await db.delete(opportunities).where(inArray(opportunities.id, cleanup.opportunities));
+  if (cleanup.intents.length > 0) await db.delete(intents).where(inArray(intents.id, cleanup.intents));
+  if (cleanup.networks.length > 0) {
+    await db.delete(networkMembers).where(inArray(networkMembers.networkId, cleanup.networks));
+    await db.delete(networks).where(inArray(networks.id, cleanup.networks));
+  }
+  if (cleanup.users.length > 0) await db.delete(users).where(inArray(users.id, cleanup.users));
+});
+
+interface Fixture {
+  ownerId: string;
+  counterpartyId: string;
+  ownerIntentId: string;
+  counterpartyIntentId: string;
+  networkId: string;
+}
+
+async function seedParticipants(): Promise<Fixture> {
+  const [owner, counterparty] = await db.insert(users).values([
+    { email: `convergence-owner-${randomUUID()}@test.local`, name: 'Convergence owner' },
+    { email: `convergence-counterparty-${randomUUID()}@test.local`, name: 'Convergence counterparty' },
+  ]).returning({ id: users.id });
+  cleanup.users.push(owner.id, counterparty.id);
+  const [network] = await db.insert(networks).values({
+    title: `Convergence ${randomUUID()}`,
+    description: 'classifier convergence fixture',
+    isPersonal: false,
+  }).returning({ id: networks.id });
+  cleanup.networks.push(network.id);
+  await db.insert(networkMembers).values([
+    { networkId: network.id, userId: owner.id, permissions: ['member'] },
+    { networkId: network.id, userId: counterparty.id, permissions: ['member'] },
+  ]);
+  const [ownerIntent] = await db.insert(intents).values({
+    userId: owner.id, payload: 'Find a collaborator', status: 'ACTIVE',
+  }).returning({ id: intents.id });
+  const [counterpartyIntent] = await db.insert(intents).values({
+    userId: counterparty.id, payload: 'Offer collaboration', status: 'ACTIVE',
+  }).returning({ id: intents.id });
+  cleanup.intents.push(ownerIntent.id, counterpartyIntent.id);
+  return {
+    ownerId: owner.id,
+    counterpartyId: counterparty.id,
+    ownerIntentId: ownerIntent.id,
+    counterpartyIntentId: counterpartyIntent.id,
+    networkId: network.id,
+  };
+}
+
+async function seedNegotiation(
+  fixture: Fixture,
+  opportunityStatus: 'negotiating' | 'stalled',
+): Promise<{ opportunityId: string; taskId: string; conversationId: string }> {
+  const [opportunity] = await db.insert(opportunities).values({
+    detection: { kind: 'test', summary: 'classifier convergence' } as never,
+    actors: [
+      { userId: fixture.counterpartyId, intent: fixture.counterpartyIntentId, networkId: fixture.networkId, role: 'peer' },
+      { userId: fixture.ownerId, intent: fixture.ownerIntentId, networkId: fixture.networkId, role: 'peer' },
+    ] as never,
+    interpretation: { reasoning: 'fixture', category: 'test' } as never,
+    context: { networkId: fixture.networkId } as never,
+    confidence: '0.9',
+    status: opportunityStatus,
+  }).returning({ id: opportunities.id });
+  cleanup.opportunities.push(opportunity.id);
+  const conversation = await conversationAdapter.createConversation([
+    { participantId: `agent:${fixture.ownerId}`, participantType: 'agent' },
+    { participantId: `agent:${fixture.counterpartyId}`, participantType: 'agent' },
+  ]);
+  cleanup.conversations.push(conversation.id);
+  const task = await conversationAdapter.createTask(conversation.id, {
+    type: 'negotiation',
+    opportunityId: opportunity.id,
+    networkId: fixture.networkId,
+    sourceUserId: fixture.ownerId,
+    candidateUserId: fixture.counterpartyId,
+    sourceIntentId: fixture.ownerIntentId,
+    candidateIntentId: fixture.counterpartyIntentId,
+    participantBindings: [
+      { userId: fixture.ownerId, intentId: fixture.ownerIntentId, networkId: fixture.networkId },
+      { userId: fixture.counterpartyId, intentId: fixture.counterpartyIntentId, networkId: fixture.networkId },
+    ],
+  });
+  return { opportunityId: opportunity.id, taskId: task.id, conversationId: conversation.id };
+}
+
+function parkTurn() {
+  return {
+    action: 'ask_user',
+    message: null,
+    assessment: {
+      reasoning: NEGOTIATION_PARK_REASONING,
+      suggestedRoles: { ownUser: 'peer', otherUser: 'peer' },
+    },
+    askUser: {
+      reason: 'unresolved_owner_constraint',
+      question: {
+        title: 'Timing',
+        prompt: 'When can you start?',
+        options: [
+          { label: 'Now', description: 'Immediately.' },
+          { label: 'Later', description: 'In a few months.' },
+        ],
+      },
+    },
+  };
+}
+
+function ordinaryTurn() {
+  return {
+    action: 'counter',
+    message: 'Counter terms.',
+    assessment: { reasoning: 'ordinary turn', suggestedRoles: { ownUser: 'peer', otherUser: 'peer' } },
+  };
+}
+
+async function appendTurn(conversationId: string, taskId: string, senderId: string, turn: unknown): Promise<void> {
+  await conversationAdapter.createMessage({
+    conversationId,
+    taskId,
+    senderId,
+    role: 'agent',
+    parts: [{ kind: 'data', data: turn }],
+  });
+}
+
+describe('parked-set reader ⇄ classifyParkedNegotiation convergence', () => {
+  test('mid-flight consult: classifier says inflight, reader includes it as mid_flight', async () => {
+    const fixture = await seedParticipants();
+    const negotiation = await seedNegotiation(fixture, 'negotiating');
+    await appendTurn(negotiation.conversationId, negotiation.taskId, `agent:${fixture.counterpartyId}`, ordinaryTurn());
+    await db.update(tasks).set({
+      state: 'input_required',
+      metadata: (await db.select({ metadata: tasks.metadata }).from(tasks).where(eq(tasks.id, negotiation.taskId)))
+        .map((row) => ({
+          ...(row.metadata as Record<string, unknown>),
+          turnContext: {
+            askUserBinding: {
+              version: 2,
+              settlementId: negotiationQuestionSettlementId(negotiation.taskId),
+              recipientUserId: fixture.ownerId,
+              recipientIntentId: fixture.ownerIntentId,
+              opportunityId: negotiation.opportunityId,
+              networkId: fixture.networkId,
+              intentFingerprint: 'fixture-fingerprint',
+              opportunityStatus: 'negotiating',
+              opportunityUpdatedAt: new Date().toISOString(),
+              counterpartyUserId: fixture.counterpartyId,
+              counterpartyIntentId: fixture.counterpartyIntentId,
+            },
+          },
+        }))[0],
+    }).where(eq(tasks.id, negotiation.taskId));
+
+    const classification = await classifyParkedNegotiation(chatDatabaseAdapter, {
+      opportunityId: negotiation.opportunityId,
+      userId: fixture.ownerId,
+    });
+    const parkedSet = await reader.readParkedNegotiations(fixture.ownerId, fixture.ownerIntentId);
+    const entry = parkedSet.find((parked) => parked.opportunityId === negotiation.opportunityId);
+
+    expect(classification.kind).toBe('inflight');
+    expect(entry?.kind).toBe('mid_flight');
+
+    // The counterparty must see it through NEITHER predicate.
+    const counterpartyClassification = await classifyParkedNegotiation(chatDatabaseAdapter, {
+      opportunityId: negotiation.opportunityId,
+      userId: fixture.counterpartyId,
+    });
+    const counterpartySet = await reader.readParkedNegotiations(fixture.counterpartyId, fixture.counterpartyIntentId);
+    expect(counterpartyClassification.kind).toBe('wrong_recipient');
+    expect(counterpartySet.some((parked) => parked.opportunityId === negotiation.opportunityId)).toBe(false);
+  });
+
+  test('post-stall park: classifier says post_stall, reader includes it as post_stall', async () => {
+    const fixture = await seedParticipants();
+    const negotiation = await seedNegotiation(fixture, 'stalled');
+    await appendTurn(negotiation.conversationId, negotiation.taskId, `agent:${fixture.counterpartyId}`, ordinaryTurn());
+    await appendTurn(negotiation.conversationId, negotiation.taskId, `agent:${fixture.ownerId}`, parkTurn());
+    await db.update(tasks).set({ state: 'completed' }).where(eq(tasks.id, negotiation.taskId));
+
+    const classification = await classifyParkedNegotiation(chatDatabaseAdapter, {
+      opportunityId: negotiation.opportunityId,
+      userId: fixture.ownerId,
+    });
+    const parkedSet = await reader.readParkedNegotiations(fixture.ownerId, fixture.ownerIntentId);
+    const entry = parkedSet.find((parked) => parked.opportunityId === negotiation.opportunityId);
+
+    expect(classification.kind).toBe('post_stall');
+    expect(entry?.kind).toBe('post_stall');
+    // The park-time question survives into the reader's rendering payload.
+    expect(entry?.question?.prompt).toBe('When can you start?');
+  });
+
+  test('park awaiting the counterparty: classifier refuses this user, reader scopes it to the other side', async () => {
+    const fixture = await seedParticipants();
+    const negotiation = await seedNegotiation(fixture, 'stalled');
+    await appendTurn(negotiation.conversationId, negotiation.taskId, `agent:${fixture.ownerId}`, ordinaryTurn());
+    // The gap needs the COUNTERPARTY's client, not the owner's.
+    await appendTurn(negotiation.conversationId, negotiation.taskId, `agent:${fixture.counterpartyId}`, parkTurn());
+    await db.update(tasks).set({ state: 'completed' }).where(eq(tasks.id, negotiation.taskId));
+
+    const ownerClassification = await classifyParkedNegotiation(chatDatabaseAdapter, {
+      opportunityId: negotiation.opportunityId,
+      userId: fixture.ownerId,
+    });
+    const ownerSet = await reader.readParkedNegotiations(fixture.ownerId, fixture.ownerIntentId);
+    expect(ownerClassification.kind).toBe('wrong_recipient');
+    expect(ownerSet.some((parked) => parked.opportunityId === negotiation.opportunityId)).toBe(false);
+
+    const counterpartyClassification = await classifyParkedNegotiation(chatDatabaseAdapter, {
+      opportunityId: negotiation.opportunityId,
+      userId: fixture.counterpartyId,
+    });
+    const counterpartySet = await reader.readParkedNegotiations(fixture.counterpartyId, fixture.counterpartyIntentId);
+    expect(counterpartyClassification.kind).toBe('post_stall');
+    expect(counterpartySet.find((parked) => parked.opportunityId === negotiation.opportunityId)?.kind).toBe('post_stall');
+  });
+
+  test('terminal stall without a gap: classifier says not_parked, reader excludes it', async () => {
+    const fixture = await seedParticipants();
+    const negotiation = await seedNegotiation(fixture, 'stalled');
+    await appendTurn(negotiation.conversationId, negotiation.taskId, `agent:${fixture.counterpartyId}`, ordinaryTurn());
+    await appendTurn(negotiation.conversationId, negotiation.taskId, `agent:${fixture.ownerId}`, ordinaryTurn());
+    await db.update(tasks).set({ state: 'completed' }).where(eq(tasks.id, negotiation.taskId));
+
+    const classification = await classifyParkedNegotiation(chatDatabaseAdapter, {
+      opportunityId: negotiation.opportunityId,
+      userId: fixture.ownerId,
+    });
+    const parkedSet = await reader.readParkedNegotiations(fixture.ownerId, fixture.ownerIntentId);
+
+    expect(classification.kind).toBe('not_parked');
+    expect(parkedSet.some((parked) => parked.opportunityId === negotiation.opportunityId)).toBe(false);
+  });
+});

--- a/services/api/src/controllers/chat.controller.ts
+++ b/services/api/src/controllers/chat.controller.ts
@@ -13,7 +13,7 @@ import { userService } from "../services/user.service";
 import { questionService } from "../services/question.service";
 import { isNegotiatorChatEnabled } from "../lib/negotiator-feature";
 import { negotiationReflectQueue } from "../queues/negotiations/reflect.queue";
-import { questionMessageQueue } from "../queues/question-message.queue";
+import { enqueueQuestionAnswerReply, questionMessageQueue } from "../queues/question-message.queue";
 import { SuggestionGenerator, ChatInterruptClassifier, NEGOTIATOR_PERSONA_ID, ONBOARDING_PERSONA_ID, SIGNAL_PERSONA_ID } from '@indexnetwork/protocol';
 import { createDoneEvent, createErrorEvent, createStatusEvent, createSteerOrQueueEvent, formatSSEEvent } from "../types/chat-streaming.types";
 import { emitChatInterrupt, onChatInterrupt } from '../lib/chat-interrupt.events';
@@ -605,10 +605,27 @@ export class ChatController {
             }
           }
 
+          // A user message in the signal's negotiator DM may be an answer to
+          // the open question-message. Detection runs after the reply is
+          // persisted and BEFORE the assistant response is, so the newest
+          // agent message is still the one the client was answering; the
+          // serialized question-message queue owns everything after that.
+          const detectQuestionAnswerReply = async (replyMessageId: string) => {
+            if (sessionPersona !== NEGOTIATOR_PERSONA_ID || effectiveScope?.scopeType !== 'intent') return;
+            await enqueueQuestionAnswerReply({
+              userId: user.id,
+              intentId: effectiveScope.scopeId,
+              sessionId,
+              replyText: messageContent,
+              replyMessageId,
+            });
+          };
+
           // Steer-interrupted: persist partial turn and bail (no done event emitted)
           if (streamInterruptedBySteer) {
             try {
-              await chatSessionService.addMessage({ sessionId, role: 'user', content: messageContent });
+              const interruptedUserMessageId = await chatSessionService.addMessage({ sessionId, role: 'user', content: messageContent });
+              await detectQuestionAnswerReply(interruptedUserMessageId);
               // Use authoritative fullResponse when available; fall back to accumulated
               // partial tokens when the stream was cut before response_complete fired.
               const interruptedContent = (fullResponse || partialResponse).trim();
@@ -638,11 +655,12 @@ export class ChatController {
           }
 
           // Persist user message and assistant response
-          await chatSessionService.addMessage({
+          const userMessageId = await chatSessionService.addMessage({
             sessionId,
             role: "user",
             content: messageContent,
           });
+          await detectQuestionAnswerReply(userMessageId);
           let assistantMessageId: string | undefined;
           if (fullResponse) {
             assistantMessageId = await chatSessionService.addMessage({

--- a/services/api/src/lib/question/negotiation-answer.ports.ts
+++ b/services/api/src/lib/question/negotiation-answer.ports.ts
@@ -1,0 +1,55 @@
+/**
+ * Production implementation of `NegotiationAnswerConsumptionPorts` (#1432) —
+ * the four seams the resume path needs, each over machinery that already
+ * exists:
+ *
+ * - `database`: the same exact-task reads the negotiation graph resolves
+ *   parks with (`ChatDatabaseAdapter` delegates to the conversation adapter).
+ * - `settleInflightAnswer`: the row-less DM settle on the QuestionerAdapter —
+ *   the answer is stored inline on the questionSettlement, where the
+ *   continuation claim's `loadPrivateConsultation` reads it.
+ * - `enqueueInflightResume`: the exact settlement-keyed run-existing job the
+ *   card answer path enqueues; the queue's deterministic
+ *   `negotiation-resume-${settlementId}` job id makes it idempotent.
+ * - `recordOpportunityAnswer`: the `metadata.userAnswers` append, deduped by
+ *   `questionId` at the adapter.
+ * - `enqueueStalledRetry`: a fresh run-existing job with no exact fields.
+ *   Over-enqueueing is safe — every retry races the atomic attempt claim
+ *   (`createNegotiationTaskForAttempt`) and all but one lose.
+ */
+import type { NegotiationAnswerConsumptionPorts } from '@indexnetwork/protocol';
+
+import { chatDatabaseAdapter } from '../../adapters/database.adapter';
+import { questionerAdapter } from '../../adapters/questioner.adapter.instance';
+import { negotiationRunExistingQueue } from '../../queues/negotiations/run-existing.queue';
+
+export function negotiationAnswerConsumptionPorts(): NegotiationAnswerConsumptionPorts {
+  return {
+    database: chatDatabaseAdapter,
+    settleInflightAnswer: (input) => questionerAdapter.settleInflightNegotiationAnswerFromDm({
+      taskId: input.taskId,
+      settlementId: input.settlementId,
+      opportunityId: input.opportunityId,
+      recipientUserId: input.recipientUserId,
+      recipientIntentId: input.recipientIntentId,
+      networkId: input.networkId,
+      answer: input.answer,
+    }),
+    enqueueInflightResume: async (input) => {
+      await negotiationRunExistingQueue.addJob({
+        opportunityId: input.opportunityId,
+        userId: input.userId,
+        taskId: input.taskId,
+        settlementId: input.settlementId,
+        recipientIntentId: input.recipientIntentId,
+        networkId: input.networkId,
+      });
+    },
+    recordOpportunityAnswer: async ({ opportunityId, answer }) => {
+      await questionerAdapter.recordOpportunityUserAnswer(opportunityId, answer);
+    },
+    enqueueStalledRetry: async ({ opportunityId, userId }) => {
+      await negotiationRunExistingQueue.addJob({ opportunityId, userId });
+    },
+  };
+}

--- a/services/api/src/lib/question/question-answer.router.ts
+++ b/services/api/src/lib/question/question-answer.router.ts
@@ -1,0 +1,150 @@
+/**
+ * Question-answer router (conversational-questions answer wiring).
+ *
+ * One model call that maps a client's DM reply onto the questions of the open
+ * question-message (docs/plans/2026-08-18-conversational-questions.md,
+ * "Answers"). The model refers to questions strictly by index — it never sees
+ * or emits a negotiation ref, so it cannot mint one the block would route to
+ * the wrong negotiation. The caller maps indices back to the block's primary
+ * `opportunityId` refs and feeds `consumeQuestionBlockAnswers`.
+ *
+ * Fail-closed contract, in the routing direction: routing is interpretive and
+ * a misroute resumes the wrong negotiation with the wrong fact, so an invalid
+ * mapping, out-of-range index, or duplicate index rejects the round trip.
+ * There is no deterministic fallback — a reply the model cannot route resumes
+ * NOTHING (the caller asks a clarifying follow-up or lets redelivery retry).
+ */
+import { ChatOpenAI } from '@langchain/openai';
+import { z } from 'zod';
+
+import type { QuestionBlock, RoutedAnswer } from '@indexnetwork/protocol';
+
+import { log } from '../log';
+
+const logger = log.lib.from('question-answer.router');
+
+/** Bound on reply text handed to the model; a longer reply is truncated. */
+const MAX_REPLY_CHARS = 6000;
+
+const RoutedOutputSchema = z.object({
+  /**
+   * False when the reply does not attempt to answer any of the questions —
+   * greetings, unrelated requests, questions back to the agent. The caller
+   * skips consumption entirely rather than sending a clarifying follow-up
+   * for ordinary conversation.
+   */
+  addressesQuestions: z.boolean(),
+  answers: z.array(z.object({
+    question: z.number().int().min(0),
+    answerText: z.string().min(1).max(4000),
+  })).max(20),
+});
+
+export interface RoutedReply {
+  /** Whether the reply attempted to answer any question at all. */
+  addressesQuestions: boolean;
+  /** Routed answers keyed by the block's primary refs; may be empty. */
+  answers: RoutedAnswer[];
+}
+
+const SYSTEM_PROMPT = `You are the Index Negotiator. You previously sent your client one message containing numbered questions; the client has now replied in the same chat. Decide which questions the reply answers, and extract the answer content for each.
+
+Rules:
+- "addressesQuestions" is false when the reply does not attempt to answer any question (a greeting, small talk, an unrelated request, a question back to you). Then "answers" is empty.
+- Each entry in "answers" names one question by its index and carries "answerText": what the client said in answer to that question, restated minimally so it stands alone (resolve "yes"/"the first one"/pronouns against the question's own wording). Use only what the client actually said — never add assumptions, preferences, or details the reply does not contain.
+- One reply may answer several questions; split the content accordingly. Answer content that plausibly belongs to two questions goes to the one it fits best — never duplicate it.
+- Route ONLY what is clearly an answer to a specific question. If you cannot tell which question a statement answers, leave it unrouted; answering the wrong negotiation with the wrong fact is worse than asking again.
+- Each question index appears at most once.`;
+
+function truncate(text: string, max: number): string {
+  const trimmed = text.trim();
+  return trimmed.length > max ? `${trimmed.slice(0, max)}…` : trimmed;
+}
+
+export interface QuestionAnswerRouterConfig {
+  /** Model override; defaults to the negotiator's model. */
+  model?: string;
+}
+
+export class QuestionAnswerRouter {
+  private readonly modelName: string;
+
+  constructor(config?: QuestionAnswerRouterConfig) {
+    this.modelName = config?.model ?? 'google/gemini-2.5-flash';
+  }
+
+  /**
+   * Routes one reply against the block it answers. Validates → retries once →
+   * throws: routing has no safe deterministic fallback, and the caller's
+   * queue retry handles a transient model outage.
+   */
+  async route(input: { block: QuestionBlock; replyText: string }): Promise<RoutedReply> {
+    const questionList = input.block.questions
+      .map((question, index) => `${index}. ${question.prompt}`)
+      .join('\n');
+    const userMessage = [
+      'The questions from your message:',
+      questionList,
+      '',
+      `The client's reply:\n${truncate(input.replyText, MAX_REPLY_CHARS)}`,
+      '',
+      'Route the reply: which questions does it answer, and with what content?',
+    ].join('\n');
+
+    for (let attempt = 0; attempt < 2; attempt++) {
+      const raw = await this.callModel([
+        { role: 'system', content: SYSTEM_PROMPT },
+        { role: 'user', content: userMessage },
+      ]);
+      const routed = this.validate(raw, input.block);
+      if (routed) return routed;
+      logger.warn('Question-answer routing output rejected', { attempt: attempt + 1 });
+    }
+    throw new Error('Question-answer routing produced no valid mapping');
+  }
+
+  /** Schema + index-range + uniqueness validation of one model round trip. */
+  private validate(raw: unknown, block: QuestionBlock): RoutedReply | null {
+    const parsed = RoutedOutputSchema.safeParse(raw);
+    if (!parsed.success) return null;
+    if (!parsed.data.addressesQuestions && parsed.data.answers.length > 0) return null;
+
+    const seen = new Set<number>();
+    for (const answer of parsed.data.answers) {
+      if (answer.question >= block.questions.length || seen.has(answer.question)) return null;
+      seen.add(answer.question);
+    }
+    return {
+      addressesQuestions: parsed.data.addressesQuestions,
+      answers: parsed.data.answers.map((answer) => ({
+        ref: block.questions[answer.question].opportunityId,
+        answerText: answer.answerText.trim(),
+      })),
+    };
+  }
+
+  /**
+   * Raw structured-model round trip. A seam so tests drive the
+   * validate → retry loop without a live provider — the model is constructed
+   * here, not in the constructor, so tests never need a key.
+   */
+  protected async callModel(messages: Array<{ role: string; content: string }>): Promise<unknown> {
+    const apiKey = process.env.OPENROUTER_API_KEY;
+    if (!apiKey?.trim()) throw new Error('QuestionAnswerRouter: OPENROUTER_API_KEY is required');
+    const timeoutEnv = Number.parseInt(process.env.OPENROUTER_REQUEST_TIMEOUT_MS ?? '', 10);
+    const model = new ChatOpenAI({
+      model: this.modelName,
+      configuration: {
+        baseURL: process.env.OPENROUTER_BASE_URL ?? 'https://openrouter.ai/api/v1',
+        apiKey,
+      },
+      temperature: 0,
+      maxTokens: 2048,
+      timeout: Number.isFinite(timeoutEnv) && timeoutEnv > 0 ? timeoutEnv : 60_000,
+      maxRetries: 1,
+    });
+    return model
+      .withStructuredOutput(RoutedOutputSchema, { name: 'question_answer_routing' })
+      .invoke(messages);
+  }
+}

--- a/services/api/src/lib/question/tests/question-answer.router.spec.ts
+++ b/services/api/src/lib/question/tests/question-answer.router.spec.ts
@@ -1,0 +1,89 @@
+/**
+ * QuestionAnswerRouter: the model maps a reply onto question INDICES; the
+ * router validates the round trip and maps indices back to the block's
+ * primary refs. Routing is fail-closed — an invalid mapping retries once and
+ * then throws, never degrades to a guess — because a misroute resumes the
+ * wrong negotiation with the wrong fact.
+ */
+import { describe, expect, it } from 'bun:test';
+
+import { questionBlockFixture } from '@indexnetwork/protocol/question-block/fixture';
+
+import { QuestionAnswerRouter } from '../question-answer.router';
+
+class StubRouter extends QuestionAnswerRouter {
+  readonly prompts: Array<Array<{ role: string; content: string }>> = [];
+  private readonly outputs: unknown[];
+
+  constructor(outputs: unknown[]) {
+    super();
+    this.outputs = outputs;
+  }
+
+  protected override async callModel(messages: Array<{ role: string; content: string }>): Promise<unknown> {
+    this.prompts.push(messages);
+    if (this.outputs.length === 0) throw new Error('no scripted output left');
+    return this.outputs.shift();
+  }
+}
+
+const block = questionBlockFixture;
+
+describe('QuestionAnswerRouter', () => {
+  it('maps question indices back to the block primary refs', async () => {
+    const router = new StubRouter([{
+      addressesQuestions: true,
+      answers: [
+        { question: 0, answerText: 'Yes, share the range. ' },
+        { question: 1, answerText: 'March at the earliest.' },
+      ],
+    }]);
+
+    const routed = await router.route({ block, replyText: 'Yes share it; March at the earliest.' });
+
+    expect(routed.addressesQuestions).toBe(true);
+    expect(routed.answers).toEqual([
+      { ref: block.questions[0].opportunityId, answerText: 'Yes, share the range.' },
+      { ref: block.questions[1].opportunityId, answerText: 'March at the earliest.' },
+    ]);
+    // The model sees prompts by index only — never a negotiation ref.
+    expect(router.prompts[0][1].content).not.toContain(block.questions[0].opportunityId);
+  });
+
+  it('reports a non-answer reply without routing anything', async () => {
+    const router = new StubRouter([{ addressesQuestions: false, answers: [] }]);
+    const routed = await router.route({ block, replyText: 'Thanks! How are you?' });
+    expect(routed).toEqual({ addressesQuestions: false, answers: [] });
+  });
+
+  it('rejects an out-of-range index and accepts the retry', async () => {
+    const router = new StubRouter([
+      { addressesQuestions: true, answers: [{ question: 99, answerText: 'Ghost answer.' }] },
+      { addressesQuestions: true, answers: [{ question: 0, answerText: 'Real answer.' }] },
+    ]);
+    const routed = await router.route({ block, replyText: 'Real answer.' });
+    expect(router.prompts).toHaveLength(2);
+    expect(routed.answers).toEqual([{ ref: block.questions[0].opportunityId, answerText: 'Real answer.' }]);
+  });
+
+  it('throws after two invalid round trips — no deterministic fallback exists', async () => {
+    const duplicate = {
+      addressesQuestions: true,
+      answers: [
+        { question: 0, answerText: 'First.' },
+        { question: 0, answerText: 'Second.' },
+      ],
+    };
+    const router = new StubRouter([duplicate, duplicate]);
+    await expect(router.route({ block, replyText: 'ambiguous' })).rejects.toThrow('no valid mapping');
+  });
+
+  it('rejects the contradictory shape: not an answer, yet routed answers', async () => {
+    const router = new StubRouter([
+      { addressesQuestions: false, answers: [{ question: 0, answerText: 'Sneaky.' }] },
+      { addressesQuestions: true, answers: [{ question: 0, answerText: 'Clean.' }] },
+    ]);
+    const routed = await router.route({ block, replyText: 'Clean.' });
+    expect(routed.answers).toEqual([{ ref: block.questions[0].opportunityId, answerText: 'Clean.' }]);
+  });
+});

--- a/services/api/src/queues/negotiations/run-existing.queue.ts
+++ b/services/api/src/queues/negotiations/run-existing.queue.ts
@@ -44,6 +44,9 @@ export interface RunExistingDeps {
     negotiationContinuationReceipt?: NegotiationContinuationReceipt;
   } | void>;
   continuationAdapter?: ContinuationAdapter;
+  /** Stopgap seams (see handleContinuationStalled); production resolves the real collaborators lazily. */
+  classifyPostStallPark?: (input: { opportunityId: string; userId: string }) => Promise<{ kind: string }>;
+  enqueueQuestionMessageRegeneration?: (data: { userId: string; intentId: string }) => Promise<unknown>;
 }
 
 export class NegotiationRunExistingQueue {
@@ -149,7 +152,7 @@ export class NegotiationRunExistingQueue {
     const options = execution ? { negotiationContinuation: execution } : {};
 
     if (this.deps?.invokeOpportunityGraph) {
-      await this.runClaimedContinuation(execution, continuationAdapter, async () => {
+      const receipt = await this.runClaimedContinuation(execution, continuationAdapter, async () => {
         const result = await this.deps!.invokeOpportunityGraph!({
           userId,
           operationMode: 'negotiate_existing',
@@ -159,6 +162,9 @@ export class NegotiationRunExistingQueue {
         return result?.negotiationContinuationReceipt;
       });
       this.logger.info('Negotiation complete', { opportunityId, userId, taskId: exact?.taskId, fence: execution?.fence });
+      if (execution && exact && receipt?.outcome === 'stalled') {
+        await this.handleContinuationStalled(data, exact.recipientIntentId);
+      }
       return;
     }
 
@@ -179,7 +185,7 @@ export class NegotiationRunExistingQueue {
     );
 
     try {
-      await this.runClaimedContinuation(execution, continuationAdapter, async () => {
+      const receipt = await this.runClaimedContinuation(execution, continuationAdapter, async () => {
         const result = await opportunityOperations.negotiateExisting({
           userId: userId as Id<'users'>,
           opportunityId,
@@ -188,9 +194,54 @@ export class NegotiationRunExistingQueue {
         return result.negotiationContinuationReceipt;
       });
       this.logger.info('Negotiation complete', { opportunityId, userId, taskId: exact?.taskId, fence: execution?.fence });
+      if (execution && exact && receipt?.outcome === 'stalled') {
+        await this.handleContinuationStalled(data, exact.recipientIntentId);
+      }
     } catch (err) {
       this.logger.error('Graph failed', { opportunityId, userId, taskId: exact?.taskId, fence: execution?.fence, error: err });
       throw err;
+    }
+  }
+
+  /**
+   * STOPGAP (conversational-questions, docs/plans/2026-08-18): finalize skips
+   * its `stalled_followup` questioner enqueue for continuation executions
+   * (`!state.continuationExecution`), so a negotiation that resumed from a
+   * client's answer and re-parked post-stall would sit invisible — no
+   * question-message regeneration would ever fire for it. Until the
+   * exhaustion evaluator owns this trigger on negotiation state transitions,
+   * detect the narrow case here: a continuation whose terminal receipt is
+   * 'stalled' AND whose negotiation re-resolved to a post-stall park on this
+   * user's side enqueues the regeneration job for the answered signal's
+   * scope. Best-effort: the park itself is durable, and a failure here must
+   * not fail a negotiation that completed.
+   */
+  private async handleContinuationStalled(data: RunExistingJobData, recipientIntentId: string): Promise<void> {
+    try {
+      const classify = this.deps?.classifyPostStallPark
+        ?? (async (input: { opportunityId: string; userId: string }) => {
+          const { classifyParkedNegotiation } = await import('@indexnetwork/protocol');
+          return classifyParkedNegotiation(this.database, input);
+        });
+      const classification = await classify({ opportunityId: data.opportunityId, userId: data.userId });
+      if (classification.kind !== 'post_stall') return;
+      const enqueue = this.deps?.enqueueQuestionMessageRegeneration
+        ?? (async (target: { userId: string; intentId: string }) => {
+          const { questionMessageQueue } = await import('../question-message.queue');
+          return questionMessageQueue.addRegenerateJob(target);
+        });
+      await enqueue({ userId: data.userId, intentId: recipientIntentId });
+      this.logger.info('continuation_repark_question_message_enqueued', {
+        opportunityId: data.opportunityId,
+        userId: data.userId,
+        intentId: recipientIntentId,
+      });
+    } catch (err) {
+      this.logger.error('Failed to enqueue question-message regeneration for a re-parked continuation', {
+        opportunityId: data.opportunityId,
+        userId: data.userId,
+        error: err instanceof Error ? err.message : String(err),
+      });
     }
   }
 
@@ -198,10 +249,9 @@ export class NegotiationRunExistingQueue {
     execution: NegotiationContinuationExecution | undefined,
     continuationAdapter: ContinuationAdapter | null,
     invoke: () => Promise<NegotiationContinuationReceipt | undefined>,
-  ): Promise<void> {
+  ): Promise<NegotiationContinuationReceipt | undefined> {
     if (!execution || !continuationAdapter) {
-      await invoke();
-      return;
+      return invoke();
     }
     let currentExecution = execution;
     let heartbeatFailure: unknown;
@@ -227,9 +277,10 @@ export class NegotiationRunExistingQueue {
       // is deliberately not a terminal receipt for the parent settlement.
       if (receipt.outcome === 'waiting_for_agent' || receipt.outcome === 'input_required') {
         await continuationAdapter.parkNegotiationContinuationExecution(currentExecution);
-        return;
+        return receipt;
       }
       await continuationAdapter.completeNegotiationContinuationExecution(currentExecution, receipt);
+      return receipt;
     } catch (err) {
       clearInterval(timer);
       await heartbeatInFlight.catch(() => undefined);

--- a/services/api/src/queues/question-message.queue.ts
+++ b/services/api/src/queues/question-message.queue.ts
@@ -25,12 +25,13 @@
  */
 import { Job } from 'bullmq';
 
-import { serializeQuestionMessage } from '@indexnetwork/protocol';
-import type { QuestionerEnqueuePayload } from '@indexnetwork/protocol';
+import { classifyParkedNegotiation, consumeQuestionBlockAnswers, parseQuestionMessage, serializeQuestionMessage } from '@indexnetwork/protocol';
+import type { NegotiationAnswerConsumptionPorts, QuestionerEnqueuePayload } from '@indexnetwork/protocol';
 
 import { log } from '../lib/log';
 import { QueueFactory } from '../lib/bullmq/bullmq';
 import { QuestionMessageAuthor } from '../lib/question/question-message.author';
+import { QuestionAnswerRouter } from '../lib/question/question-answer.router';
 import type { ParkedNegotiationReaderAdapter } from '../adapters/parked-negotiation.reader.adapter';
 import type { NegotiatorClientDmRetrieveFn } from '../adapters/negotiator-client-dm.retrieval.adapter';
 
@@ -40,6 +41,36 @@ export interface QuestionMessageJobData {
   userId: string;
   intentId: string;
 }
+
+/** One DM reply to consume against the question-message it answers. */
+export interface QuestionAnswerJobData {
+  userId: string;
+  intentId: string;
+  sessionId: string;
+  /** The client's reply, verbatim. */
+  replyText: string;
+  /** Persisted id of the reply message; keys the job's redelivery dedup. */
+  replyMessageId: string;
+  /** The open question-message the reply answers, captured at reply time. */
+  questionMessageId: string;
+  /**
+   * The question-message's body as delivered. Carried in the payload rather
+   * than re-read: the spine is create-only (no content update exists), so the
+   * body is immutable, and the reply answers the message the client saw.
+   */
+  questionMessageBody: string;
+  /** ISO timestamp of the reply; fixed at enqueue so retries are stable. */
+  repliedAt: string;
+}
+
+/**
+ * Server-owned clarifying follow-up for a reply that tried to answer but
+ * could not be routed to any question. Fixed copy, never model text — same
+ * rule as the fallback prose above.
+ */
+export const QUESTION_ANSWER_CLARIFICATION_MESSAGE =
+  'I could not confidently match that reply to the questions above. '
+  + 'Could you say which question you are answering, or restate the answer together with it?';
 
 /**
  * Singleton job id per scope: while a regeneration is queued for a signal,
@@ -71,18 +102,21 @@ export interface QuestionMessageQueueDeps {
   chatSessions?: QuestionMessageChatSessions;
   /** Signal text for grounding; null when unavailable. */
   getIntentText?: (intentId: string) => Promise<string | null>;
+  /** Answer-consumption seams (#1432); production builds them from the adapters. */
+  answerPorts?: NegotiationAnswerConsumptionPorts;
+  answerRouter?: Pick<QuestionAnswerRouter, 'route'>;
 }
 
 export class QuestionMessageQueue {
   static readonly QUEUE_NAME = QUEUE_NAME;
 
-  readonly queue = QueueFactory.createQueue<QuestionMessageJobData>(QUEUE_NAME);
+  readonly queue = QueueFactory.createQueue<QuestionMessageJobData | QuestionAnswerJobData>(QUEUE_NAME);
 
   private readonly logger = log.job.from('QuestionMessageJob');
   private readonly queueLogger = log.queue.from('QuestionMessageQueue');
   private readonly deps: QuestionMessageQueueDeps | undefined;
   private author: Pick<QuestionMessageAuthor, 'author'> | null;
-  private worker: ReturnType<typeof QueueFactory.createWorker<QuestionMessageJobData>> | null = null;
+  private worker: ReturnType<typeof QueueFactory.createWorker<QuestionMessageJobData | QuestionAnswerJobData>> | null = null;
 
   constructor(deps?: QuestionMessageQueueDeps) {
     this.deps = deps;
@@ -94,9 +128,26 @@ export class QuestionMessageQueue {
    * job id dedups triggers while a job is queued; completed and failed jobs
    * are removed immediately so the id is reusable for the next park.
    */
-  addRegenerateJob(data: QuestionMessageJobData): Promise<Job<QuestionMessageJobData>> {
+  addRegenerateJob(data: QuestionMessageJobData): Promise<Job<QuestionMessageJobData | QuestionAnswerJobData>> {
     return this.queue.add('regenerate_question_message', data, {
       jobId: questionMessageJobId(data.userId, data.intentId),
+      removeOnComplete: true,
+      removeOnFail: true,
+    });
+  }
+
+  /**
+   * Enqueue consumption of one DM reply against its open question-message.
+   * Runs on THIS queue deliberately: the worker processes one job at a time,
+   * so answer consumption is serialized against regeneration under the same
+   * `question-message.${userId}.${intentId}` path — an answer and a
+   * regeneration for the same signal can never interleave. The job id is the
+   * reply message's id, so a redelivered request coalesces instead of
+   * consuming the same reply twice.
+   */
+  addConsumeAnswerJob(data: QuestionAnswerJobData): Promise<Job<QuestionMessageJobData | QuestionAnswerJobData>> {
+    return this.queue.add('consume_question_answers', data, {
+      jobId: `question-message-answer.${data.replyMessageId}`,
       removeOnComplete: true,
       removeOnFail: true,
     });
@@ -127,10 +178,13 @@ export class QuestionMessageQueue {
   }
 
   /** Run a job handler (used by the worker and by tests with injected deps). */
-  async processJob(name: string, data: QuestionMessageJobData): Promise<void> {
+  async processJob(name: string, data: QuestionMessageJobData | QuestionAnswerJobData): Promise<void> {
     switch (name) {
       case 'regenerate_question_message':
-        await this.handleRegenerate(data);
+        await this.handleRegenerate(data as QuestionMessageJobData);
+        break;
+      case 'consume_question_answers':
+        await this.handleConsumeAnswers(data as QuestionAnswerJobData);
         break;
       default:
         this.queueLogger.warn('Unknown job name', { name });
@@ -140,11 +194,11 @@ export class QuestionMessageQueue {
   /** Start the BullMQ worker. Idempotent; call from the protocol server only. */
   startWorker(): void {
     if (this.worker) return;
-    const processor = async (job: Job<QuestionMessageJobData>) => {
+    const processor = async (job: Job<QuestionMessageJobData | QuestionAnswerJobData>) => {
       this.queueLogger.info('Processing job', { jobId: job.id, jobName: job.name });
       await this.processJob(job.name, job.data);
     };
-    this.worker = QueueFactory.createWorker<QuestionMessageJobData>(QUEUE_NAME, processor);
+    this.worker = QueueFactory.createWorker<QuestionMessageJobData | QuestionAnswerJobData>(QUEUE_NAME, processor);
   }
 
   /** Close the worker and queue connections (graceful shutdown). */
@@ -223,6 +277,87 @@ export class QuestionMessageQueue {
     });
   }
 
+  /**
+   * Consume one DM reply against its question-message: verify the message is
+   * still open (≥1 ref still parked on this user's side), route the reply's
+   * content onto block refs via the negotiator, and hand the routed answers
+   * to the resume seam (#1432). A reply that matches nothing resumes
+   * NOTHING — unmatched or empty routing gets a clarifying follow-up in the
+   * DM, never a speculative resume.
+   */
+  private async handleConsumeAnswers(data: QuestionAnswerJobData): Promise<void> {
+    const { userId, intentId, sessionId } = data;
+
+    const parsed = parseQuestionMessage(data.questionMessageBody);
+    if (!parsed) {
+      // Enqueue-time detection parsed this same body; a failure here means a
+      // malformed payload, not a malformed message. Nothing to consume.
+      this.queueLogger.warn('question_answer_unparseable_block', { userId, intentId, questionMessageId: data.questionMessageId });
+      return;
+    }
+    const block = parsed.block;
+
+    const ports = this.deps?.answerPorts
+      ?? (await import('../lib/question/negotiation-answer.ports')).negotiationAnswerConsumptionPorts();
+
+    // Open-message check, re-derived at consumption time: the message is
+    // answerable iff at least one referenced negotiation is still parked
+    // awaiting THIS user. A block whose parks all resolved since the reply
+    // landed is closed — the reply is ordinary conversation, not an answer.
+    let hasParkedRef = false;
+    for (const question of block.questions) {
+      for (const ref of [question.opportunityId, ...(question.alsoUnblocks ?? [])]) {
+        const classification = await classifyParkedNegotiation(ports.database, { opportunityId: ref, userId });
+        if (classification.kind === 'inflight' || classification.kind === 'post_stall') {
+          hasParkedRef = true;
+          break;
+        }
+      }
+      if (hasParkedRef) break;
+    }
+    if (!hasParkedRef) {
+      this.logger.info('question_answer_message_closed', { userId, intentId, questionMessageId: data.questionMessageId });
+      return;
+    }
+
+    // Routing is interpretive (an LLM maps text onto refs) and has no safe
+    // fallback; a hard routing failure throws so the queue's retry policy
+    // covers a transient model outage.
+    const router = this.deps?.answerRouter ?? new QuestionAnswerRouter();
+    const routed = await router.route({ block, replyText: data.replyText });
+    if (!routed.addressesQuestions) {
+      // Ordinary conversation in a DM with an open question-message. The
+      // negotiator's chat reply handles it; consumption stays silent.
+      this.logger.info('question_answer_not_an_answer', { userId, intentId, questionMessageId: data.questionMessageId });
+      return;
+    }
+
+    const result = await consumeQuestionBlockAnswers(ports, {
+      block,
+      userId,
+      answers: routed.answers,
+      answeredAt: data.repliedAt,
+    });
+    this.logger.info('question_answer_consumed', {
+      userId,
+      intentId,
+      questionMessageId: data.questionMessageId,
+      resumed: result.resumed.length,
+      skipped: result.skipped.length,
+      unmatched: result.unmatched.length,
+      needsClarification: result.needsClarification,
+    });
+
+    if (result.needsClarification) {
+      const chatSessions = this.deps?.chatSessions ?? (await import('../services/chat.service')).chatSessionService;
+      await chatSessions.addMessage({
+        sessionId,
+        role: 'assistant',
+        content: QUESTION_ANSWER_CLARIFICATION_MESSAGE,
+      });
+    }
+  }
+
   private getAuthor(): Pick<QuestionMessageAuthor, 'author'> {
     if (!this.author) this.author = new QuestionMessageAuthor();
     return this.author;
@@ -259,4 +394,68 @@ export async function routeParkedQuestionEnqueue(input: QuestionerEnqueuePayload
   if (!target) return false;
   await questionMessageQueue.addRegenerateJob(target);
   return true;
+}
+
+/** Injectable seams for {@link enqueueQuestionAnswerReply}; production uses the real collaborators. */
+export interface QuestionAnswerReplyDetectionDeps {
+  getSessionMessages?: (sessionId: string) => Promise<Array<{ id: string; role: string; content: string }>>;
+  addConsumeAnswerJob?: (data: QuestionAnswerJobData) => Promise<unknown>;
+}
+
+/**
+ * Reply detection for the negotiator DM: when a user message lands in a
+ * ('negotiator-intent', intentId) session, check whether the conversation has
+ * an open question-message — the newest AGENT message, when it carries a
+ * parseable question block — and if so enqueue consumption of the reply
+ * against it. Runs after the reply is persisted and BEFORE the negotiator's
+ * streamed response is, so "newest agent message" is still the message the
+ * client was answering. The still-parked half of the open-message predicate
+ * is deliberately left to the serialized job: it is authoritative there, and
+ * a block whose parks all resolved simply consumes to nothing.
+ *
+ * Returns whether a consumption job was enqueued. Never throws — reply
+ * detection must not break the chat turn.
+ */
+export async function enqueueQuestionAnswerReply(
+  input: {
+    userId: string;
+    intentId: string;
+    sessionId: string;
+    replyText: string;
+    replyMessageId: string;
+  },
+  deps?: QuestionAnswerReplyDetectionDeps,
+): Promise<boolean> {
+  const detectionLogger = log.lib.from('question-answer.reply-detection');
+  try {
+    const getSessionMessages = deps?.getSessionMessages
+      ?? (async (sessionId: string) => (await import('../services/chat.service')).chatSessionService.getSessionMessages(sessionId));
+    const messages = await getSessionMessages(input.sessionId);
+    const newestAgentMessage = [...messages].reverse().find((message) => message.role === 'assistant');
+    if (!newestAgentMessage) return false;
+    const parsed = parseQuestionMessage(newestAgentMessage.content);
+    if (!parsed) return false;
+
+    const addConsumeAnswerJob = deps?.addConsumeAnswerJob
+      ?? ((data: QuestionAnswerJobData) => questionMessageQueue.addConsumeAnswerJob(data));
+    await addConsumeAnswerJob({
+      userId: input.userId,
+      intentId: input.intentId,
+      sessionId: input.sessionId,
+      replyText: input.replyText,
+      replyMessageId: input.replyMessageId,
+      questionMessageId: newestAgentMessage.id,
+      questionMessageBody: newestAgentMessage.content,
+      repliedAt: new Date().toISOString(),
+    });
+    return true;
+  } catch (err) {
+    detectionLogger.error('Question-answer reply detection failed; reply not consumed', {
+      userId: input.userId,
+      intentId: input.intentId,
+      sessionId: input.sessionId,
+      error: err instanceof Error ? err.message : String(err),
+    });
+    return false;
+  }
 }

--- a/services/api/src/queues/tests/question-message.queue.isolated.ts
+++ b/services/api/src/queues/tests/question-message.queue.isolated.ts
@@ -9,11 +9,12 @@
  */
 import { describe, expect, it } from 'bun:test';
 
-import { parseQuestionMessage } from '@indexnetwork/protocol';
-import type { QuestionerEnqueuePayload } from '@indexnetwork/protocol';
+import { negotiationParkAnswerId, negotiationQuestionSettlementId, parseQuestionMessage } from '@indexnetwork/protocol';
+import type { NegotiationAnswerConsumptionPorts, QuestionerEnqueuePayload, RoutedAnswer } from '@indexnetwork/protocol';
 import { questionBlockFixture, questionMessageFixture, questionProseFixture } from '@indexnetwork/protocol/question-block/fixture';
 
-import { QuestionMessageQueue, parkedQuestionMessageTarget, questionMessageJobId } from '../question-message.queue';
+import { QUESTION_ANSWER_CLARIFICATION_MESSAGE, QuestionMessageQueue, enqueueQuestionAnswerReply, parkedQuestionMessageTarget, questionMessageJobId } from '../question-message.queue';
+import type { QuestionAnswerJobData } from '../question-message.queue';
 import type { ParkedNegotiation } from '../../adapters/parked-negotiation.reader.adapter';
 
 const USER_ID = 'user-1';
@@ -230,5 +231,290 @@ describe('questionRegenerationPending lookup', () => {
     expect(await queue.isRegenerationPending(USER_ID, INTENT_ID)).toBe(true);
     // Scoped to its own (user, intent): a sibling scope stays not-pending.
     expect(await queue.isRegenerationPending(USER_ID, 'other-intent')).toBe(false);
+  });
+});
+
+// ─── Answer consumption (conversational-questions answer wiring) ─────────────
+
+/**
+ * Duplicated post-stall park literal (the same duplication the reader makes;
+ * adapters may not import the protocol package). The classifier convergence
+ * spec pins writer and readers to the same value.
+ */
+const PARK_REASONING = "Negotiation parked pending the client's answer.";
+
+interface AnswerHarnessOptions {
+  /** Which refs currently hold a live park, and of which flavour. */
+  parks: Record<string, 'inflight' | 'post_stall'>;
+  routed: { addressesQuestions: boolean; answers: RoutedAnswer[] };
+}
+
+function buildAnswerHarness(options: AnswerHarnessOptions) {
+  const calls = {
+    routerInputs: [] as Array<{ replyText: string }>,
+    settled: [] as Array<{ opportunityId: string; freeText?: string; answeredAt: string }>,
+    inflightResumes: [] as Array<{ opportunityId: string; settlementId: string }>,
+    recorded: [] as Array<{ opportunityId: string; questionId: string; freeText?: string }>,
+    stalledRetries: [] as Array<{ opportunityId: string; parkTaskId: string }>,
+    delivered: [] as DeliveredMessage[],
+  };
+  const taskIdFor = (opportunityId: string) => `task-${opportunityId}`;
+  const ports: NegotiationAnswerConsumptionPorts = {
+    database: {
+      getNegotiationTaskForOpportunity: async (opportunityId: string) => {
+        const park = options.parks[opportunityId];
+        if (!park) return null;
+        if (park === 'inflight') {
+          return {
+            id: taskIdFor(opportunityId),
+            conversationId: 'conv-1',
+            state: 'input_required',
+            metadata: {
+              turnContext: {
+                askUserBinding: {
+                  settlementId: negotiationQuestionSettlementId(taskIdFor(opportunityId)),
+                  recipientUserId: USER_ID,
+                  recipientIntentId: INTENT_ID,
+                  networkId: 'network-1',
+                  opportunityId,
+                },
+              },
+            },
+            createdAt: new Date(),
+            updatedAt: new Date(),
+          };
+        }
+        return {
+          id: taskIdFor(opportunityId),
+          conversationId: 'conv-1',
+          state: 'completed',
+          metadata: {},
+          createdAt: new Date(),
+          updatedAt: new Date(),
+        };
+      },
+      getNegotiationMessages: async (opportunityId: string) =>
+        options.parks[opportunityId] === 'post_stall'
+          ? [{
+              id: 'message-1',
+              senderId: `agent:${USER_ID}`,
+              role: 'agent' as const,
+              parts: [{ kind: 'data', data: {
+                action: 'ask_user',
+                message: null,
+                assessment: { reasoning: PARK_REASONING, suggestedRoles: { ownUser: 'peer', otherUser: 'peer' } },
+                askUser: { reason: 'unresolved_owner_constraint' },
+              } }],
+              createdAt: new Date(),
+              taskId: taskIdFor(opportunityId),
+            }]
+          : [],
+    },
+    settleInflightAnswer: async (input) => {
+      calls.settled.push({
+        opportunityId: input.opportunityId,
+        ...(input.answer.freeText !== undefined ? { freeText: input.answer.freeText } : {}),
+        answeredAt: input.answer.answeredAt,
+      });
+      return 'settled';
+    },
+    enqueueInflightResume: async (input) => {
+      calls.inflightResumes.push({ opportunityId: input.opportunityId, settlementId: input.settlementId });
+    },
+    recordOpportunityAnswer: async ({ opportunityId, answer }) => {
+      calls.recorded.push({
+        opportunityId,
+        questionId: answer.questionId,
+        ...(answer.freeText !== undefined ? { freeText: answer.freeText } : {}),
+      });
+    },
+    enqueueStalledRetry: async (input) => {
+      calls.stalledRetries.push({ opportunityId: input.opportunityId, parkTaskId: input.parkTaskId });
+    },
+  };
+  const queue = new QuestionMessageQueue({
+    answerPorts: ports,
+    answerRouter: {
+      route: async (input) => {
+        calls.routerInputs.push({ replyText: input.replyText });
+        return options.routed;
+      },
+    },
+    chatSessions: {
+      resolveNegotiatorIntentSession: async () => ({ session: { id: 'session-1' } }),
+      addMessage: async (params) => {
+        calls.delivered.push(params);
+        return `message-${calls.delivered.length}`;
+      },
+    },
+  });
+  return { queue, calls };
+}
+
+function answerJob(replyText: string): QuestionAnswerJobData {
+  return {
+    userId: USER_ID,
+    intentId: INTENT_ID,
+    sessionId: 'session-1',
+    replyText,
+    replyMessageId: 'reply-1',
+    questionMessageId: 'question-message-1',
+    questionMessageBody: questionMessageFixture,
+    repliedAt: '2026-08-18T12:00:00.000Z',
+  };
+}
+
+describe('QuestionMessageQueue answer-consumption job', () => {
+  it('routes a reply onto an inflight park and resumes the primary and every alsoUnblocks ref', async () => {
+    const { queue, calls } = buildAnswerHarness({
+      parks: { [FIXTURE_PRIMARY_1]: 'inflight', [FIXTURE_ALSO_1]: 'inflight' },
+      routed: {
+        addressesQuestions: true,
+        answers: [{ ref: FIXTURE_PRIMARY_1, answerText: 'Yes — share the budget range.' }],
+      },
+    });
+
+    await queue.processJob('consume_question_answers', answerJob('Yes, share the budget range.'));
+
+    expect(calls.settled.map((settle) => settle.opportunityId)).toEqual([FIXTURE_PRIMARY_1, FIXTURE_ALSO_1]);
+    // The answered timestamp is the reply's, fixed at enqueue.
+    expect(calls.settled.every((settle) => settle.answeredAt === '2026-08-18T12:00:00.000Z')).toBe(true);
+    expect(calls.settled.every((settle) => settle.freeText === 'Yes — share the budget range.')).toBe(true);
+    expect(calls.inflightResumes).toHaveLength(2);
+    expect(calls.delivered).toHaveLength(0);
+  });
+
+  it('routes a reply onto a post-stall park: records the answer, enqueues the retry', async () => {
+    const { queue, calls } = buildAnswerHarness({
+      parks: { [FIXTURE_PRIMARY_2]: 'post_stall' },
+      routed: {
+        addressesQuestions: true,
+        answers: [{ ref: FIXTURE_PRIMARY_2, answerText: 'March at the earliest.' }],
+      },
+    });
+
+    await queue.processJob('consume_question_answers', answerJob('March at the earliest.'));
+
+    expect(calls.recorded).toEqual([{
+      opportunityId: FIXTURE_PRIMARY_2,
+      questionId: negotiationParkAnswerId(`task-${FIXTURE_PRIMARY_2}`),
+      freeText: 'March at the earliest.',
+    }]);
+    expect(calls.stalledRetries).toEqual([{
+      opportunityId: FIXTURE_PRIMARY_2,
+      parkTaskId: `task-${FIXTURE_PRIMARY_2}`,
+    }]);
+    expect(calls.settled).toHaveLength(0);
+    expect(calls.delivered).toHaveLength(0);
+  });
+
+  it('sends the clarifying follow-up when the reply tried to answer but nothing routed', async () => {
+    const { queue, calls } = buildAnswerHarness({
+      parks: { [FIXTURE_PRIMARY_1]: 'inflight' },
+      routed: { addressesQuestions: true, answers: [] },
+    });
+
+    await queue.processJob('consume_question_answers', answerJob('It depends on the thing I mentioned?'));
+
+    expect(calls.settled).toHaveLength(0);
+    expect(calls.stalledRetries).toHaveLength(0);
+    expect(calls.delivered).toEqual([{
+      sessionId: 'session-1',
+      role: 'assistant',
+      content: QUESTION_ANSWER_CLARIFICATION_MESSAGE,
+    }]);
+  });
+
+  it('stays silent for a reply that does not attempt to answer — never a speculative resume', async () => {
+    const { queue, calls } = buildAnswerHarness({
+      parks: { [FIXTURE_PRIMARY_1]: 'inflight' },
+      routed: { addressesQuestions: false, answers: [] },
+    });
+
+    await queue.processJob('consume_question_answers', answerJob('Thanks! What have you been up to?'));
+
+    expect(calls.routerInputs).toHaveLength(1);
+    expect(calls.settled).toHaveLength(0);
+    expect(calls.recorded).toHaveLength(0);
+    expect(calls.delivered).toHaveLength(0);
+  });
+
+  it('treats a block with no still-parked ref as closed — no routing, no clarification', async () => {
+    const { queue, calls } = buildAnswerHarness({
+      parks: {},
+      routed: { addressesQuestions: true, answers: [{ ref: FIXTURE_PRIMARY_1, answerText: 'Late answer.' }] },
+    });
+
+    await queue.processJob('consume_question_answers', answerJob('Late answer.'));
+
+    expect(calls.routerInputs).toHaveLength(0);
+    expect(calls.settled).toHaveLength(0);
+    expect(calls.delivered).toHaveLength(0);
+  });
+});
+
+describe('enqueueQuestionAnswerReply detection', () => {
+  const reply = {
+    userId: USER_ID,
+    intentId: INTENT_ID,
+    sessionId: 'session-1',
+    replyText: 'March works.',
+    replyMessageId: 'reply-1',
+  };
+
+  it('enqueues consumption when the newest agent message carries a question block', async () => {
+    const enqueued: QuestionAnswerJobData[] = [];
+    const result = await enqueueQuestionAnswerReply(reply, {
+      getSessionMessages: async () => [
+        { id: 'm1', role: 'user', content: 'hello' },
+        { id: 'm2', role: 'assistant', content: questionMessageFixture },
+      ],
+      addConsumeAnswerJob: async (data) => { enqueued.push(data); },
+    });
+
+    expect(result).toBe(true);
+    expect(enqueued).toHaveLength(1);
+    expect(enqueued[0]).toMatchObject({
+      userId: USER_ID,
+      intentId: INTENT_ID,
+      sessionId: 'session-1',
+      replyText: 'March works.',
+      replyMessageId: 'reply-1',
+      questionMessageId: 'm2',
+      questionMessageBody: questionMessageFixture,
+    });
+  });
+
+  it('does nothing when the newest agent message is plain conversation', async () => {
+    const enqueued: QuestionAnswerJobData[] = [];
+    const result = await enqueueQuestionAnswerReply(reply, {
+      // The question-message exists but the negotiator has spoken since: the
+      // newest agent message is the open-message anchor, and it has moved on.
+      getSessionMessages: async () => [
+        { id: 'm1', role: 'assistant', content: questionMessageFixture },
+        { id: 'm2', role: 'user', content: 'earlier reply' },
+        { id: 'm3', role: 'assistant', content: 'Got it — I will keep you posted.' },
+      ],
+      addConsumeAnswerJob: async (data) => { enqueued.push(data); },
+    });
+
+    expect(result).toBe(false);
+    expect(enqueued).toHaveLength(0);
+  });
+
+  it('does nothing when the conversation has no agent message at all', async () => {
+    const result = await enqueueQuestionAnswerReply(reply, {
+      getSessionMessages: async () => [{ id: 'm1', role: 'user', content: 'hello?' }],
+      addConsumeAnswerJob: async () => { throw new Error('must not enqueue'); },
+    });
+    expect(result).toBe(false);
+  });
+
+  it('never throws — a detection failure logs and leaves the chat turn intact', async () => {
+    const result = await enqueueQuestionAnswerReply(reply, {
+      getSessionMessages: async () => { throw new Error('database unavailable'); },
+      addConsumeAnswerJob: async () => { throw new Error('must not enqueue'); },
+    });
+    expect(result).toBe(false);
   });
 });

--- a/services/api/src/queues/tests/run-existing.queue.isolated.ts
+++ b/services/api/src/queues/tests/run-existing.queue.isolated.ts
@@ -272,6 +272,78 @@ describe('NegotiationRunExistingQueue', () => {
     expect(releaseNegotiationContinuationExecution).toHaveBeenCalledWith(claimedExecution);
   });
 
+  describe('continuation re-park stopgap', () => {
+    function buildStopgapQueue(options: {
+      outcome?: typeof receipt.outcome;
+      classification?: string;
+      exact?: boolean;
+      enqueue?: (data: { userId: string; intentId: string }) => Promise<unknown>;
+    }) {
+      const classified: Array<{ opportunityId: string; userId: string }> = [];
+      const enqueued: Array<{ userId: string; intentId: string }> = [];
+      const queue = new NegotiationRunExistingQueue({
+        invokeOpportunityGraph: async () => ({
+          negotiationContinuationReceipt: { ...receipt, outcome: options.outcome ?? 'stalled' as const },
+        }),
+        continuationAdapter: {
+          claimNegotiationContinuationExecution: async () => ({ status: 'claimed', execution: claimedExecution }),
+          heartbeatNegotiationContinuationExecution: async (execution) => execution,
+          releaseNegotiationContinuationExecution: async () => {},
+          parkNegotiationContinuationExecution: async () => {},
+          completeNegotiationContinuationExecution: async () => {},
+        },
+        classifyPostStallPark: async (input) => {
+          classified.push(input);
+          return { kind: options.classification ?? 'post_stall' };
+        },
+        enqueueQuestionMessageRegeneration: options.enqueue
+          ?? (async (data) => { enqueued.push(data); }),
+      });
+      return { queue, classified, enqueued };
+    }
+
+    it('a continuation that re-parks post-stall enqueues the regeneration for the answered scope', async () => {
+      const { queue, classified, enqueued } = buildStopgapQueue({});
+      await queue.processJob('negotiate_existing', exactData);
+      expect(classified).toEqual([{ opportunityId: exactData.opportunityId, userId: exactData.userId }]);
+      expect(enqueued).toEqual([{ userId: exactData.userId, intentId: exactData.recipientIntentId }]);
+    });
+
+    it('a terminal re-stall (no gap authored) enqueues nothing', async () => {
+      const { queue, classified, enqueued } = buildStopgapQueue({ classification: 'not_parked' });
+      await queue.processJob('negotiate_existing', exactData);
+      expect(classified).toHaveLength(1);
+      expect(enqueued).toHaveLength(0);
+    });
+
+    it('non-stalled continuation outcomes never reach the stopgap', async () => {
+      const { queue, classified } = buildStopgapQueue({ outcome: 'accepted' });
+      await queue.processJob('negotiate_existing', exactData);
+      expect(classified).toHaveLength(0);
+    });
+
+    it('a plain retry without exact continuation fields never reaches the stopgap', async () => {
+      const classified: unknown[] = [];
+      const queue = new NegotiationRunExistingQueue({
+        invokeOpportunityGraph: async () => {},
+        classifyPostStallPark: async (input) => {
+          classified.push(input);
+          return { kind: 'post_stall' };
+        },
+        enqueueQuestionMessageRegeneration: async () => {},
+      });
+      await queue.processJob('negotiate_existing', { opportunityId: 'opp-1', userId: 'u1' });
+      expect(classified).toHaveLength(0);
+    });
+
+    it('a stopgap enqueue failure never fails the completed negotiation job', async () => {
+      const { queue } = buildStopgapQueue({
+        enqueue: async () => { throw new Error('redis unavailable'); },
+      });
+      await expect(queue.processJob('negotiate_existing', exactData)).resolves.toBeUndefined();
+    });
+  });
+
   describe('setRuntimeDeps', () => {
     it('is idempotent and merges', () => {
       const queue = new NegotiationRunExistingQueue();


### PR DESCRIPTION
Closes the conversational-questions loop (plan: `docs/plans/2026-08-18-conversational-questions.md`): the spine (#1433) delivers question-messages into the signal's DM, #1432 shipped the resume seam in `@indexnetwork/protocol` — this PR wires the two together in `services/api`. A client's chat reply in the `('negotiator-intent', intentId)` DM becomes routed answers that resume the parked negotiations behind the message.

## Reply detection → serialized consumption

When a user message lands in a negotiator-intent session (`chat.controller.ts`, right after the reply persists and before the assistant response does), `enqueueQuestionAnswerReply` checks whether the conversation has an **open question-message** — the newest agent message, when it carries a parseable question block — and enqueues a `consume_question_answers` job carrying the reply and the block body. The job runs on the **question-message queue** deliberately: that worker processes one job at a time, so answer consumption is serialized against regeneration under the same `question-message.${userId}.${intentId}` path — an answer and a regeneration for one signal can never interleave. The job id is the reply message's id, so redelivery coalesces instead of consuming a reply twice.

The job re-derives the open-message predicate authoritatively (≥1 block ref still classifies as `inflight`/`post_stall` for this user via `classifyParkedNegotiation`), then routes the reply's content onto block refs with one model call (`QuestionAnswerRouter`). The model sees questions **by index only** — it never sees or emits a negotiation ref, so it cannot mint one that routes to the wrong negotiation; validation is fail-closed (out-of-range or duplicate index → retry once → throw into the queue's retry policy — routing has no safe deterministic fallback). The routed pairs feed `consumeQuestionBlockAnswers`.

## `needsClarification` — never a speculative resume

A reply that tried to answer but routed to nothing gets a fixed server-owned clarifying follow-up in the DM (`QUESTION_ANSWER_CLARIFICATION_MESSAGE` — fixed copy, never model text, same rule as the fallback prose). A reply the router classifies as ordinary conversation (greeting, question back to the agent) consumes nothing and stays silent — the negotiator's streamed chat reply already handles it. Nothing ever resumes on a guess.

## `NegotiationAnswerConsumptionPorts` (#1432) — `lib/question/negotiation-answer.ports.ts`

- **`settleInflightAnswer`** → `QuestionerAdapter.settleInflightNegotiationAnswerFromDm`: the row-less analogue of the card settle. Same advisory/cohort/settlement-row locks, same stamped-binding checks and live admission revalidation, same `input_required → canceled` CAS — but the answer is stored **inline on the questionSettlement** (the #1432 wrinkle: `loadPrivateConsultation` read answers off the QUESTIONS row, and the DM path has none). Both settlement parsers and `loadPrivateConsultation` now accept an answer settlement that carries `answer` inline instead of `questionId`; pending question cards for the consult are dismissed as superseded. Verified end-to-end in `negotiation-dm-answer.settlement.spec.ts`: the continuation claim's fenced execution carries the answer text into the successor's consultation.
- **`enqueueInflightResume`** → the exact settlement-keyed run-existing job the card path enqueues (idempotent per `negotiation-resume-${settlementId}` job id).
- **`recordOpportunityAnswer`** → `recordOpportunityUserAnswer`: `metadata.userAnswers` append, **deduped by `questionId`** in SQL so a redelivered reply records nothing twice.
- **`enqueueStalledRetry`** → a run-existing job with no exact fields; over-enqueueing is safe because every retry races the atomic attempt claim.

## `'stalled'` joins `NEGOTIATION_START_STATUSES`

The post-stall retry re-enters through negotiate-existing, which reads the current opportunity row and passes its status as `expectedStatus` — previously the claim refused `'stalled'` and the resume silently no-oped. `negotiation-stalled-retry.database.spec.ts` proves a stalled opportunity with a completed park task resumes into exactly one fresh attempt (the completed task predates the stall stamp, so it doesn't block the claim), that terminal statuses stay refused, that a stale expectation loses the CAS, and — statically — that the constant still has exactly one consumer, so no other caller gained a start path.

## Continuation re-park stopgap

Finalize skips its `stalled_followup` enqueue for continuation executions, so a negotiation that resumes from an answer and re-parks post-stall would sit invisible. Since this wiring is what creates continuations, the run-existing queue now handles the narrow case: a continuation whose terminal receipt is `'stalled'` AND whose negotiation re-resolves to a post-stall park on this user's side enqueues the spine's regeneration job for the answered scope. Best-effort and commented as a stopgap — the exhaustion evaluator subsumes it later.

## Classifier convergence contract

The spine's parked-set reader mirrors `classifyParkedNegotiation` semantics in SQL because adapters may not import the protocol package (rule respected, not "fixed"). The reader's TODO(#1432) is resolved by `parked-negotiation.classifier-convergence.spec.ts`: both predicates run over the same persisted fixtures — mid-flight, post-stall, park-awaiting-the-counterparty, terminal-stall-without-gap — and must agree per user, including the duplicated `NEGOTIATION_PARK_REASONING` literal.

## Ask cap

The resume path re-enters the graph through run-existing, so `countNegotiationAskRounds` over the negotiation's full message history governs the next park exactly as before — a resumed negotiation that stalls again past `negotiationAskRoundsCap` stalls terminally. No second counter, no bypass introduced.

## Out of scope (unchanged)

Exhaustion evaluator beyond the stopgap, the message edit rule, notifications, `apps/web`, `packages/protocol`, retirements.

## Verification

- `tsc --noEmit` and `eslint` clean (one pre-existing unused-import warning in `conversation.database.adapter.ts`).
- New/extended suites, all green:
  - `question-message.queue.isolated.ts` (19 pass): consumption routes inflight (primary + `alsoUnblocks`) and post-stall parks, clarifies on unroutable answer-attempts, stays silent on ordinary chat and on closed blocks; reply detection anchors on the newest agent message and never throws into the chat turn.
  - `question-answer.router.spec.ts` (5 pass): index→ref mapping, fail-closed validation, no refs in prompts.
  - `run-existing.queue.isolated.ts` (21 pass): stopgap fires only for exact continuations ending `'stalled'` that re-resolve to a post-stall park; enqueue failure never fails the completed job.
  - `negotiation-dm-answer.settlement.spec.ts` (DB): settle/already_settled/lost + the continuation claim receiving the inline answer; `recordOpportunityUserAnswer` dedupe.
  - `negotiation-stalled-retry.database.spec.ts` (DB): the retry path above.
  - `parked-negotiation.classifier-convergence.spec.ts` (DB): the convergence contract.
- Pre-existing isolated-suite failures (`questioner.adapter`, `questioner.queue`, ask-user/polling e2e, `tool.controller`, `archive-legacy-negotiations`, `opportunity.service.maintenance`) reproduce identically on unmodified dev with a fresh protocol build — environment/baseline issues, untouched by this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
