### PR TITLE
feat: regenerate the open question-message in place — the edit rule

### DIFF
--- a/apps/web/src/components/IntentNegotiatorChat.tsx
+++ b/apps/web/src/components/IntentNegotiatorChat.tsx
@@ -2,6 +2,7 @@ import { Fragment, useCallback, useEffect, useMemo, useRef, useState } from "rea
 import { ArrowUp, BotMessageSquare, Square } from "lucide-react";
 
 import { useAIChat } from "@/contexts/AIChatContext";
+import { useConversation } from "@/contexts/ConversationContext";
 import { AnsweredQuestionLog } from "@/components/InjectedQuestions/AnsweredQuestionLog";
 import type { AnsweredThreadEntry } from "@/components/InjectedQuestions/AnsweredQuestionLog";
 import { InjectedQuestions } from "@/components/InjectedQuestions/InjectedQuestions";
@@ -47,9 +48,10 @@ export interface IntentNegotiatorChatProps {
    * conversation — show an agent-working indicator so the user doesn't
    * answer a message that's about to be replaced. The component seeds this
    * from `questionRegenerationPending` on the POST /chat/negotiator/session
-   * bootstrap response (the contract agreed with the delivery spine); pass
-   * the prop only to override with a fresher signal than the bootstrap
-   * snapshot.
+   * bootstrap response and then tracks the live SSE flips published by the
+   * regeneration queue (reloading the session when a regeneration finishes,
+   * so an in-place rewrite never lands silently); pass the prop only to
+   * override both with an even fresher signal.
    */
   questionRegenerationPending?: boolean;
   /** Monotonic signal to reload server-appended Beat narration. */
@@ -108,9 +110,13 @@ export default function IntentNegotiatorChat({
     clearChat,
     sessionId,
   } = useAIChat();
+  const { subscribeQuestionRegeneration } = useConversation();
 
   const [agentName, setAgentName] = useState<string | null>(null);
   const [bootstrapRegenerationPending, setBootstrapRegenerationPending] = useState(false);
+  const [liveRegenerationPending, setLiveRegenerationPending] = useState<boolean | null>(null);
+  const [regenerationReloadToken, setRegenerationReloadToken] = useState(0);
+  const appliedRegenerationReloadRef = useRef(0);
   const [ready, setReady] = useState(false);
   const [restoredHistoryLoaded, setRestoredHistoryLoaded] = useState(false);
   const [input, setInput] = useState("");
@@ -126,8 +132,34 @@ export default function IntentNegotiatorChat({
   const [proposalStatusMap, setProposalStatusMap] = useState<Record<string, "pending" | "created" | "rejected">>({});
   const [proposalIntentMap, setProposalIntentMap] = useState<Record<string, string>>({});
 
-  // The prop overrides the bootstrap snapshot when the parent has a fresher signal.
-  const regenerationPending = questionRegenerationPending ?? bootstrapRegenerationPending;
+  // The prop overrides everything; otherwise the live SSE flip supersedes the
+  // bootstrap snapshot once the first event for this intent arrives.
+  const regenerationPending = questionRegenerationPending ?? liveRegenerationPending ?? bootstrapRegenerationPending;
+
+  // Live regeneration flips from the shared conversation SSE stream: pending
+  // true shows the indicator immediately; pending false means the job wrote
+  // (possibly rewriting the open question-message in place), so the session
+  // reloads to render the current content. The component remounts per intent
+  // (key={intentId}), so the live state resets structurally.
+  useEffect(() => {
+    return subscribeQuestionRegeneration((event) => {
+      if (event.intentId !== intentId) return;
+      setLiveRegenerationPending(event.pending);
+      if (!event.pending) setRegenerationReloadToken((token) => token + 1);
+    });
+  }, [intentId, subscribeQuestionRegeneration]);
+
+  // Apply the reload outside the active stream: while the negotiator is
+  // streaming, the shared context owns the message list, so wait for
+  // isLoading to settle (the effect re-runs) before pulling fresh history.
+  useEffect(() => {
+    if (!ready || !sessionId || regenerationReloadToken === appliedRegenerationReloadRef.current) return;
+    if (isLoading) return;
+    appliedRegenerationReloadRef.current = regenerationReloadToken;
+    void loadSession(sessionId).catch((error) => {
+      logger.warn("Failed to reload after question-message regeneration", { error, intentId });
+    });
+  }, [intentId, isLoading, loadSession, ready, regenerationReloadToken, sessionId]);
 
   // Bootstrap: get-or-create the per-intent negotiator session, then load it
   // into the shared chat context. One session per (user, intent, persona) —

--- a/apps/web/src/contexts/ConversationContext.tsx
+++ b/apps/web/src/contexts/ConversationContext.tsx
@@ -22,6 +22,17 @@ export interface SessionOpportunityInfo {
   status: string | null;
 }
 
+/**
+ * Live flip of the `questionRegenerationPending` signal for one signal scope,
+ * published on the conversation SSE channel by the question-message
+ * regeneration queue: true at enqueue, false when the job finishes and the
+ * negotiator DM content is current.
+ */
+export interface QuestionRegenerationEvent {
+  intentId: string;
+  pending: boolean;
+}
+
 interface ConversationContextType {
   conversations: ConversationSummary[];
   negotiations: ConversationSummary[];
@@ -39,6 +50,11 @@ interface ConversationContextType {
   markConversationRead: (conversationId: string) => Promise<void>;
   hideConversation: (conversationId: string) => Promise<void>;
   getOrCreateDM: (peerUserId: string) => Promise<ConversationSummary>;
+  /**
+   * Subscribe to live question-regeneration flips from the SSE stream.
+   * Returns the unsubscribe function.
+   */
+  subscribeQuestionRegeneration: (handler: (event: QuestionRegenerationEvent) => void) => () => void;
 }
 
 const ConversationContext = createContext<ConversationContextType | null>(null);
@@ -62,6 +78,17 @@ export function ConversationProvider({ children }: { children: React.ReactNode }
   const refreshConversationsRef = useRef<() => Promise<void>>(() => Promise.resolve());
   const refreshNegotiationsRef = useRef<() => Promise<void>>(() => Promise.resolve());
   const negotiationsRefreshTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const questionRegenerationHandlersRef = useRef(new Set<(event: QuestionRegenerationEvent) => void>());
+
+  const subscribeQuestionRegeneration = useCallback(
+    (handler: (event: QuestionRegenerationEvent) => void) => {
+      questionRegenerationHandlersRef.current.add(handler);
+      return () => {
+        questionRegenerationHandlersRef.current.delete(handler);
+      };
+    },
+    [],
+  );
 
   // --- REST helpers (use apiClient directly, same pattern as AIChatContext) ---
 
@@ -384,6 +411,19 @@ export function ConversationProvider({ children }: { children: React.ReactNode }
               }, 500);
               break;
             }
+            case 'question_regeneration': {
+              // Question-message regeneration flip for one signal scope. Fan
+              // out to the mounted negotiator DM (if any); no inbox state to
+              // touch — the negotiator conversation is not an H2H summary.
+              const intentId = data.intentId as string | undefined;
+              if (!intentId) break;
+              const regenerationEvent: QuestionRegenerationEvent = {
+                intentId,
+                pending: Boolean(data.pending),
+              };
+              questionRegenerationHandlersRef.current.forEach((handler) => handler(regenerationEvent));
+              break;
+            }
           }
         } catch {
           // Ignore parse errors (e.g. keepalive comments)
@@ -479,6 +519,7 @@ export function ConversationProvider({ children }: { children: React.ReactNode }
         markConversationRead,
         hideConversation,
         getOrCreateDM,
+        subscribeQuestionRegeneration,
       }}
     >
       {children}

--- a/apps/web/tests/intent-negotiator-chat.test.tsx
+++ b/apps/web/tests/intent-negotiator-chat.test.tsx
@@ -6,7 +6,7 @@
  * pending questions as opening turns (existing questions pipeline), send
  * flow, unavailable fallback, and context release on unmount.
  */
-import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { act, render, screen, fireEvent, waitFor } from '@testing-library/react';
 import { beforeEach, describe, expect, test, vi } from 'vitest';
 
 import IntentNegotiatorChat from '@/components/IntentNegotiatorChat';
@@ -31,6 +31,7 @@ const mocks = vi.hoisted(() => ({
     isLoadingPreviousMessages: false,
     clearChat: vi.fn(),
   },
+  regenerationHandlers: new Set<(event: { intentId: string; pending: boolean }) => void>(),
 }));
 
 vi.mock('@/lib/api', () => ({
@@ -41,6 +42,24 @@ vi.mock('@/lib/api', () => ({
 vi.mock('@/contexts/AIChatContext', () => ({
   useAIChat: () => mocks.chat,
 }));
+
+vi.mock('@/contexts/ConversationContext', () => ({
+  useConversation: () => ({
+    subscribeQuestionRegeneration: (handler: (event: { intentId: string; pending: boolean }) => void) => {
+      mocks.regenerationHandlers.add(handler);
+      return () => {
+        mocks.regenerationHandlers.delete(handler);
+      };
+    },
+  }),
+}));
+
+/** Emit a live SSE regeneration flip to every mounted subscriber. */
+function emitRegeneration(event: { intentId: string; pending: boolean }) {
+  act(() => {
+    mocks.regenerationHandlers.forEach((handler) => handler(event));
+  });
+}
 
 vi.mock('@/components/InjectedQuestions/InjectedQuestions', () => ({
   InjectedQuestions: ({
@@ -138,6 +157,7 @@ function renderChat(overrides: Partial<Parameters<typeof IntentNegotiatorChat>[0
 describe('IntentNegotiatorChat', () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    mocks.regenerationHandlers.clear();
     mocks.chat.messages = [];
     mocks.chat.isLoading = false;
     mocks.chat.sessionId = null;
@@ -350,6 +370,67 @@ describe('IntentNegotiatorChat', () => {
 
     await screen.findByTestId('negotiator-chat-input');
     expect(screen.queryByTestId('question-regeneration-indicator')).toBeNull();
+  });
+
+  test('shows the indicator on a live pending flip and reloads the session when it completes', async () => {
+    mocks.chat.sessionId = 'neg-intent-sess-1';
+    renderChat();
+    await screen.findByTestId('negotiator-chat-input');
+    await waitFor(() => expect(mocks.chat.loadSession).toHaveBeenCalledTimes(1));
+
+    // A regeneration starts while the user is viewing: indicator, no reload.
+    emitRegeneration({ intentId: 'intent-1', pending: true });
+    expect(await screen.findByTestId('question-regeneration-indicator')).toBeInTheDocument();
+    expect(mocks.chat.loadSession).toHaveBeenCalledTimes(1);
+
+    // It finishes: the indicator clears and the session reloads so an
+    // in-place rewrite of the open question-message renders.
+    emitRegeneration({ intentId: 'intent-1', pending: false });
+    await waitFor(() => expect(mocks.chat.loadSession).toHaveBeenCalledTimes(2));
+    expect(mocks.chat.loadSession).toHaveBeenLastCalledWith('neg-intent-sess-1');
+    expect(screen.queryByTestId('question-regeneration-indicator')).toBeNull();
+  });
+
+  test('the live flip supersedes a stale bootstrap pending snapshot', async () => {
+    mocks.chat.sessionId = 'neg-intent-sess-1';
+    mocks.apiClient.post.mockResolvedValue({ ...SESSION_RESPONSE, questionRegenerationPending: true });
+    renderChat();
+
+    expect(await screen.findByTestId('question-regeneration-indicator')).toBeInTheDocument();
+
+    emitRegeneration({ intentId: 'intent-1', pending: false });
+    await waitFor(() => expect(screen.queryByTestId('question-regeneration-indicator')).toBeNull());
+  });
+
+  test('ignores live regeneration flips for other signals', async () => {
+    mocks.chat.sessionId = 'neg-intent-sess-1';
+    renderChat();
+    await screen.findByTestId('negotiator-chat-input');
+    await waitFor(() => expect(mocks.chat.loadSession).toHaveBeenCalledTimes(1));
+
+    emitRegeneration({ intentId: 'someone-elses-intent', pending: true });
+    expect(screen.queryByTestId('question-regeneration-indicator')).toBeNull();
+
+    emitRegeneration({ intentId: 'someone-elses-intent', pending: false });
+    expect(mocks.chat.loadSession).toHaveBeenCalledTimes(1);
+  });
+
+  test('defers the completion reload while a response is streaming, then applies it', async () => {
+    mocks.chat.sessionId = 'neg-intent-sess-1';
+    const { rerender, props } = renderChat();
+    await screen.findByTestId('negotiator-chat-input');
+    await waitFor(() => expect(mocks.chat.loadSession).toHaveBeenCalledTimes(1));
+
+    // Regeneration completes while the negotiator is mid-stream: hold the reload.
+    mocks.chat.isLoading = true;
+    rerender(<IntentNegotiatorChat {...props} />);
+    emitRegeneration({ intentId: 'intent-1', pending: false });
+    expect(mocks.chat.loadSession).toHaveBeenCalledTimes(1);
+
+    // The stream settles: the held reload applies.
+    mocks.chat.isLoading = false;
+    rerender(<IntentNegotiatorChat {...props} />);
+    await waitFor(() => expect(mocks.chat.loadSession).toHaveBeenCalledTimes(2));
   });
 
   test('tap-to-quote prefills the input with the question being answered', async () => {

--- a/apps/web/tests/intent-page-negotiator.test.tsx
+++ b/apps/web/tests/intent-page-negotiator.test.tsx
@@ -125,7 +125,7 @@ vi.mock('@/contexts/APIContext', () => ({
 
 
 vi.mock('@/contexts/ConversationContext', () => ({
-  useConversation: () => ({ negotiations: [] }),
+  useConversation: () => ({ negotiations: [], subscribeQuestionRegeneration: () => () => {} }),
 }));
 
 vi.mock('@/contexts/QuestionsContext', () => ({

--- a/apps/web/tests/intent-page-responsive.test.tsx
+++ b/apps/web/tests/intent-page-responsive.test.tsx
@@ -87,7 +87,7 @@ vi.mock('@/contexts/APIContext', () => ({
 }));
 
 vi.mock('@/contexts/ConversationContext', () => ({
-  useConversation: () => ({ negotiations: [] }),
+  useConversation: () => ({ negotiations: [], subscribeQuestionRegeneration: () => () => {} }),
 }));
 
 vi.mock('@/contexts/QuestionsContext', () => ({

--- a/apps/web/tests/pool-discovery-questions.test.tsx
+++ b/apps/web/tests/pool-discovery-questions.test.tsx
@@ -80,7 +80,7 @@ vi.mock('@/contexts/APIContext', () => ({
 }));
 
 vi.mock('@/contexts/ConversationContext', () => ({
-  useConversation: () => ({ negotiations: [] }),
+  useConversation: () => ({ negotiations: [], subscribeQuestionRegeneration: () => () => {} }),
 }));
 
 function primePageServices() {

--- a/services/api/src/adapters/conversation.database.adapter.ts
+++ b/services/api/src/adapters/conversation.database.adapter.ts
@@ -5372,6 +5372,75 @@ export class ConversationDatabaseAdapter {
   }
 
   /**
+   * The newest message in a chat conversation, by the same (createdAt, id)
+   * order every conversation read uses, or null when it has none. This is the
+   * edit-rule anchor read: the question-message regeneration job uses it to
+   * decide between rewriting the open question-message and appending a fresh
+   * one.
+   *
+   * @param sessionId - Conversation identifier retained for the legacy chat-session API.
+   * @returns The newest chat message, or null for an empty conversation.
+   */
+  async getNewestChatMessage(sessionId: string): Promise<ChatMessage | null> {
+    const [row] = await db.select()
+      .from(schema.messages)
+      .where(eq(schema.messages.conversationId, sessionId))
+      .orderBy(desc(schema.messages.createdAt), desc(schema.messages.id))
+      .limit(1);
+    return row ? this.toChatMessages(sessionId, [row])[0] : null;
+  }
+
+  /**
+   * Content update for the question-message edit rule (conversational
+   * questions): rewrite one agent-authored message inside the caller's
+   * ('negotiator-intent', intentId) session, but only while it is still the
+   * newest message in its conversation.
+   *
+   * All three guards — agent-authored, negotiator-intent scope, still-newest —
+   * live in the UPDATE statement itself, so a user reply racing the
+   * regeneration wins: once the reply row is visible, the newest check fails,
+   * the statement no-ops, and the caller falls back to appending a fresh
+   * message instead of rewriting text above an answer.
+   *
+   * @returns Whether the update was applied.
+   */
+  async updateNewestAgentQuestionMessage(params: {
+    userId: string;
+    intentId: string;
+    messageId: string;
+    content: string;
+    regeneratedAt: Date;
+  }): Promise<boolean> {
+    const regeneratedMeta = JSON.stringify({ regeneratedAt: params.regeneratedAt.toISOString() });
+    const updated = await db
+      .update(schema.messages)
+      .set({
+        parts: [{ type: 'text', text: params.content }],
+        metadata: sql`coalesce(${schema.messages.metadata}, '{}'::jsonb) || ${regeneratedMeta}::jsonb`,
+      })
+      .where(and(
+        eq(schema.messages.id, params.messageId),
+        eq(schema.messages.role, 'agent'),
+        sql`EXISTS (
+          SELECT 1 FROM ${schema.chatSessionScopes}
+          WHERE ${schema.chatSessionScopes.conversationId} = ${schema.messages.conversationId}
+            AND ${schema.chatSessionScopes.userId} = ${params.userId}
+            AND ${schema.chatSessionScopes.scopeType} = ${NEGOTIATOR_INTENT_SCOPE_TYPE}
+            AND ${schema.chatSessionScopes.scopeId} = ${params.intentId}
+        )`,
+        // The alias hides the inner table, so the qualified "messages" columns
+        // inside resolve to the UPDATE target: newer-than-this-row.
+        sql`NOT EXISTS (
+          SELECT 1 FROM ${schema.messages} newer
+          WHERE newer.conversation_id = ${schema.messages.conversationId}
+            AND (newer.created_at, newer.id) > (${schema.messages.createdAt}, ${schema.messages.id})
+        )`,
+      ))
+      .returning({ id: schema.messages.id });
+    return updated.length > 0;
+  }
+
+  /**
    * Get chat messages for a conversation in chronological order.
    *
    * @param sessionId - Conversation identifier retained for the legacy chat-session API.

--- a/services/api/src/adapters/database.shared.ts
+++ b/services/api/src/adapters/database.shared.ts
@@ -437,6 +437,11 @@ export interface ChatMessageMeta {
   discoveries?: unknown;
   /** Set to true when the assistant message was partially generated before a steer interrupt. */
   interrupted?: boolean;
+  /**
+   * ISO timestamp of the last in-place question-message regeneration (the
+   * conversational-questions edit rule). Absent on messages never edited.
+   */
+  regeneratedAt?: string;
   [key: string]: unknown;
 }
 

--- a/services/api/src/adapters/tests/conversation.question-message-edit.spec.ts
+++ b/services/api/src/adapters/tests/conversation.question-message-edit.spec.ts
@@ -1,0 +1,157 @@
+/**
+ * The question-message content-update seam (conversational-questions edit
+ * rule): `updateNewestAgentQuestionMessage` may only rewrite an agent-authored
+ * message in the caller's ('negotiator-intent', intentId) session, and only
+ * while that message is still the newest in its conversation — with every
+ * guard enforced inside the UPDATE statement itself, against the real
+ * database. A user reply racing the regeneration must flip the update into a
+ * clean no-op so the caller falls back to appending a fresh message.
+ */
+import { config } from 'dotenv';
+config({ path: '.env.test', override: true });
+
+import { afterAll as bunAfterAll, beforeAll as bunBeforeAll, describe, expect, test } from 'bun:test';
+import { eq } from 'drizzle-orm/sql';
+
+import { conversationDatabaseAdapter, UserDatabaseAdapter } from '../database.adapter';
+import { chatSessionService } from '../../services/chat.service';
+import db from '../../lib/drizzle/drizzle';
+import { withMinimumDatabaseHookBudget } from '../../lib/testing/database-test-budget';
+import { messages } from '../../schemas/conversation.schema';
+import { intents } from '../../schemas/database.schema';
+
+const EMAIL = 'test-question-message-edit@example.com';
+const beforeAll = withMinimumDatabaseHookBudget(bunBeforeAll, 30_000);
+const afterAll = withMinimumDatabaseHookBudget(bunAfterAll, 30_000);
+
+describe('ConversationDatabaseAdapter question-message content update', () => {
+  const users = new UserDatabaseAdapter();
+  let userId: string;
+  let intentId: string;
+  let otherIntentId: string;
+  const sessionIds = new Set<string>();
+
+  async function createIntent(): Promise<string> {
+    const id = crypto.randomUUID();
+    await db.insert(intents).values({
+      id,
+      userId,
+      payload: 'Find a collaborator',
+      summary: 'Find a collaborator',
+      status: 'ACTIVE',
+    });
+    return id;
+  }
+
+  async function pinnedSession(forIntentId: string): Promise<string> {
+    const resolved = await chatSessionService.resolveNegotiatorIntentSession(userId, forIntentId);
+    if ('error' in resolved) throw new Error(resolved.error);
+    sessionIds.add(resolved.session.id);
+    return resolved.session.id;
+  }
+
+  beforeAll(async () => {
+    const existing = await users.findByEmail(EMAIL);
+    if (existing) {
+      await db.delete(intents).where(eq(intents.userId, existing.id));
+      await users.deleteById(existing.id);
+    }
+    userId = (await users.create({ email: EMAIL, name: 'Edit Rule User' })).id;
+    intentId = await createIntent();
+    otherIntentId = await createIntent();
+  });
+
+  afterAll(async () => {
+    for (const id of sessionIds) await conversationDatabaseAdapter.deleteChatSession(id).catch(() => {});
+    await db.delete(intents).where(eq(intents.userId, userId)).catch(() => {});
+    await users.deleteById(userId).catch(() => {});
+  });
+
+  test('rewrites the newest agent message in place and stamps regeneratedAt', async () => {
+    const sessionId = await pinnedSession(intentId);
+    expect(await conversationDatabaseAdapter.getNewestChatMessage(sessionId)).toBeNull();
+
+    const messageId = await chatSessionService.addMessage({
+      sessionId,
+      role: 'assistant',
+      content: 'The first rendering.',
+    });
+
+    const regeneratedAt = new Date();
+    const updated = await conversationDatabaseAdapter.updateNewestAgentQuestionMessage({
+      userId,
+      intentId,
+      messageId,
+      content: 'The regenerated rendering.',
+      regeneratedAt,
+    });
+    expect(updated).toBe(true);
+
+    const newest = await conversationDatabaseAdapter.getNewestChatMessage(sessionId);
+    expect(newest?.id).toBe(messageId);
+    expect(newest?.role).toBe('assistant');
+    expect(newest?.content).toBe('The regenerated rendering.');
+
+    const [row] = await db.select({ metadata: messages.metadata }).from(messages).where(eq(messages.id, messageId));
+    expect((row.metadata as { regeneratedAt?: string }).regeneratedAt).toBe(regeneratedAt.toISOString());
+  });
+
+  test('no-ops once a user reply is newer — the reply wins the race', async () => {
+    const sessionId = await pinnedSession(intentId);
+    const questionMessageId = await chatSessionService.addMessage({
+      sessionId,
+      role: 'assistant',
+      content: 'Open question-message.',
+    });
+    await chatSessionService.addMessage({
+      sessionId,
+      role: 'user',
+      content: 'A reply that must stay below unchanged text.',
+    });
+
+    const updated = await conversationDatabaseAdapter.updateNewestAgentQuestionMessage({
+      userId,
+      intentId,
+      messageId: questionMessageId,
+      content: 'A rewrite that would corrupt the thread.',
+      regeneratedAt: new Date(),
+    });
+    expect(updated).toBe(false);
+
+    const [row] = await db.select({ parts: messages.parts }).from(messages).where(eq(messages.id, questionMessageId));
+    expect((row.parts as Array<{ text?: string }>)[0]?.text).toBe('Open question-message.');
+  });
+
+  test('refuses a user-authored message and a foreign intent scope', async () => {
+    const sessionId = await pinnedSession(intentId);
+    const userMessageId = await chatSessionService.addMessage({
+      sessionId,
+      role: 'user',
+      content: 'User words are never rewritten.',
+    });
+    expect(await conversationDatabaseAdapter.updateNewestAgentQuestionMessage({
+      userId,
+      intentId,
+      messageId: userMessageId,
+      content: 'Rewritten.',
+      regeneratedAt: new Date(),
+    })).toBe(false);
+
+    const agentMessageId = await chatSessionService.addMessage({
+      sessionId,
+      role: 'assistant',
+      content: 'Newest agent message.',
+    });
+    // Same message, wrong scope: another intent's regeneration may not touch it.
+    expect(await conversationDatabaseAdapter.updateNewestAgentQuestionMessage({
+      userId,
+      intentId: otherIntentId,
+      messageId: agentMessageId,
+      content: 'Rewritten from the wrong scope.',
+      regeneratedAt: new Date(),
+    })).toBe(false);
+
+    const newest = await conversationDatabaseAdapter.getNewestChatMessage(sessionId);
+    expect(newest?.content).toBe('Newest agent message.');
+  });
+});

--- a/services/api/src/lib/bullmq/bullmq.ts
+++ b/services/api/src/lib/bullmq/bullmq.ts
@@ -65,7 +65,12 @@ const DEFAULT_JOB_OPTS: JobsOptions = {
   },
 };
 
-function useHermeticRedis(): boolean {
+/**
+ * True when queue infrastructure must stay in-memory: tests without
+ * RUN_REDIS_INTEGRATION_TESTS=1. Exported so queue collaborators that reach
+ * for Redis outside BullMQ (e.g. SSE publishes) can apply the same guard.
+ */
+export function useHermeticRedis(): boolean {
   return process.env.NODE_ENV === 'test'
     && process.env.RUN_REDIS_INTEGRATION_TESTS !== '1';
 }

--- a/services/api/src/lib/conversation-events.ts
+++ b/services/api/src/lib/conversation-events.ts
@@ -60,3 +60,25 @@ export async function publishConversationMessageEvent(
     publisher.publish(`conversations:user:${userId}`, event)
   )));
 }
+
+/**
+ * Publishes a question-message regeneration flip for one signal scope to the
+ * owner's existing conversation SSE channel. `pending: true` means the
+ * scope's regeneration job was just enqueued; `pending: false` means it
+ * finished and the conversation content is current — the web client shows the
+ * regeneration indicator on true and reloads the negotiator session on false,
+ * so a delivered message never changes under a viewer without a signal.
+ *
+ * @param userId - Owner of the signal's negotiator DM.
+ * @param event - The scope (intentId) and the new pending state.
+ */
+export async function publishQuestionRegenerationEvent(
+  userId: string,
+  event: { intentId: string; pending: boolean },
+): Promise<void> {
+  const publisher = getRedisClient();
+  await publisher.publish(
+    `conversations:user:${userId}`,
+    JSON.stringify({ type: 'question_regeneration', ...event }),
+  );
+}

--- a/services/api/src/queues/question-message.queue.ts
+++ b/services/api/src/queues/question-message.queue.ts
@@ -18,10 +18,18 @@
  * these two payload families stop reaching it (retirements are a later
  * phase).
  *
- * Create-only for now: a regeneration always appends a fresh message. The
- * edit rule (update the newest message in place) is the next change, so a
- * second park while a message is already open produces a second message —
- * known and accepted.
+ * Delivery follows the edit rule: regenerate in place only while the
+ * question-message is still the newest message in the conversation; anything
+ * else (user replied since, no prior message, unparseable block) appends a
+ * fresh message. The open message is the newest message in the conversation
+ * when it is agent-authored and references ≥1 still-parked negotiation. The
+ * newest check is re-enforced inside the update statement itself, so a reply
+ * racing the update wins and the job falls back to create.
+ *
+ * Each regeneration also flips the `questionRegenerationPending` signal on
+ * the owner's conversation SSE channel — true at enqueue, false when the job
+ * finishes — so an open DM shows the indicator and reloads instead of letting
+ * the message change silently under the viewer.
  */
 import { Job } from 'bullmq';
 
@@ -29,7 +37,7 @@ import { classifyParkedNegotiation, consumeQuestionBlockAnswers, parseQuestionMe
 import type { NegotiationAnswerConsumptionPorts, QuestionerEnqueuePayload } from '@indexnetwork/protocol';
 
 import { log } from '../lib/log';
-import { QueueFactory } from '../lib/bullmq/bullmq';
+import { QueueFactory, useHermeticRedis } from '../lib/bullmq/bullmq';
 import { QuestionMessageAuthor } from '../lib/question/question-message.author';
 import { QuestionAnswerRouter } from '../lib/question/question-answer.router';
 import type { ParkedNegotiationReaderAdapter } from '../adapters/parked-negotiation.reader.adapter';
@@ -55,8 +63,9 @@ export interface QuestionAnswerJobData {
   questionMessageId: string;
   /**
    * The question-message's body as delivered. Carried in the payload rather
-   * than re-read: the spine is create-only (no content update exists), so the
-   * body is immutable, and the reply answers the message the client saw.
+   * than re-read: the reply answers the message the client saw at reply time,
+   * and the edit rule cannot rewrite it afterwards (the reply itself became
+   * the newest message), so the captured body stays authoritative.
    */
   questionMessageBody: string;
   /** ISO timestamp of the reply; fixed at enqueue so retries are stable. */
@@ -92,6 +101,19 @@ export interface QuestionMessageChatSessions {
     | { error: string; status: 400 | 403 | 404 | 500 }
   >;
   addMessage(params: { sessionId: string; role: 'user' | 'assistant' | 'system'; content: string }): Promise<string>;
+  /** Newest message in the conversation — the edit rule's anchor read. */
+  getNewestMessage(sessionId: string): Promise<{ id: string; role: 'user' | 'assistant' | 'system'; content: string } | null>;
+  /**
+   * In-place rewrite of the open question-message. Returns false when the
+   * data layer's newest-message guard rejected the write (a reply raced the
+   * regeneration) and the caller must append a fresh message instead.
+   */
+  updateQuestionMessageInPlace(params: {
+    userId: string;
+    intentId: string;
+    messageId: string;
+    content: string;
+  }): Promise<boolean>;
 }
 
 /** Optional deps for testing; production resolves the real collaborators lazily. */
@@ -105,6 +127,8 @@ export interface QuestionMessageQueueDeps {
   /** Answer-consumption seams (#1432); production builds them from the adapters. */
   answerPorts?: NegotiationAnswerConsumptionPorts;
   answerRouter?: Pick<QuestionAnswerRouter, 'route'>;
+  /** SSE flip for the live `questionRegenerationPending` signal; production publishes to the owner's conversation channel. */
+  publishRegenerationEvent?: (userId: string, event: { intentId: string; pending: boolean }) => Promise<void>;
 }
 
 export class QuestionMessageQueue {
@@ -127,13 +151,18 @@ export class QuestionMessageQueue {
    * Enqueue a regeneration for one signal's question-message. The singleton
    * job id dedups triggers while a job is queued; completed and failed jobs
    * are removed immediately so the id is reusable for the next park.
+   *
+   * Also flips the live pending signal on: an open DM shows the regeneration
+   * indicator from enqueue, not from the next bootstrap.
    */
-  addRegenerateJob(data: QuestionMessageJobData): Promise<Job<QuestionMessageJobData | QuestionAnswerJobData>> {
-    return this.queue.add('regenerate_question_message', data, {
+  async addRegenerateJob(data: QuestionMessageJobData): Promise<Job<QuestionMessageJobData | QuestionAnswerJobData>> {
+    const job = await this.queue.add('regenerate_question_message', data, {
       jobId: questionMessageJobId(data.userId, data.intentId),
       removeOnComplete: true,
       removeOnFail: true,
     });
+    await this.publishRegenerationPending(data.userId, data.intentId, true);
+    return job;
   }
 
   /**
@@ -182,6 +211,10 @@ export class QuestionMessageQueue {
     switch (name) {
       case 'regenerate_question_message':
         await this.handleRegenerate(data as QuestionMessageJobData);
+        // Flip the live pending signal off only on success: a throw leaves the
+        // job queued for retry, and pending stays true with it. A client stuck
+        // on true after a terminal failure recovers on its next bootstrap.
+        await this.publishRegenerationPending(data.userId, data.intentId, false);
         break;
       case 'consume_question_answers':
         await this.handleConsumeAnswers(data as QuestionAnswerJobData);
@@ -263,6 +296,43 @@ export class QuestionMessageQueue {
       return;
     }
 
+    // The edit rule: regenerate in place only while the question-message is
+    // still the newest message in the conversation; otherwise send a fresh
+    // one. Open = newest + agent-authored + references ≥1 still-parked
+    // negotiation (the parked set just read IS this user's still-parked side).
+    const openMessage = this.findOpenQuestionMessage(
+      await chatSessions.getNewestMessage(resolved.session.id),
+      parked,
+    );
+    if (openMessage) {
+      const updated = await chatSessions.updateQuestionMessageInPlace({
+        userId,
+        intentId,
+        messageId: openMessage.id,
+        content: body,
+      });
+      if (updated) {
+        this.logger.info('question_message_regenerated_in_place', {
+          userId,
+          intentId,
+          sessionId: resolved.session.id,
+          messageId: openMessage.id,
+          parked: parked.length,
+          questions: authored.questions.length,
+        });
+        return;
+      }
+      // The data layer's newest guard rejected the write: a reply landed
+      // between the anchor read and the update. The reply wins — fall through
+      // to a fresh message below it.
+      this.logger.info('question_message_update_lost_newest_race', {
+        userId,
+        intentId,
+        sessionId: resolved.session.id,
+        messageId: openMessage.id,
+      });
+    }
+
     await chatSessions.addMessage({
       sessionId: resolved.session.id,
       role: 'assistant',
@@ -275,6 +345,52 @@ export class QuestionMessageQueue {
       parked: parked.length,
       questions: authored.questions.length,
     });
+  }
+
+  /**
+   * The open question-message, per the plan's definition: the newest message
+   * in the conversation, when it is agent-authored, carries a parseable
+   * question block, and that block references at least one negotiation in
+   * the current parked set. Anything else — user replied since, plain agent
+   * prose, an unparseable block, refs all resolved — is not open, and the
+   * regeneration appends instead.
+   */
+  private findOpenQuestionMessage(
+    newest: { id: string; role: 'user' | 'assistant' | 'system'; content: string } | null,
+    parked: ReadonlyArray<{ opportunityId: string }>,
+  ): { id: string } | null {
+    if (!newest || newest.role !== 'assistant') return null;
+    const parsed = parseQuestionMessage(newest.content);
+    if (!parsed) return null;
+    const parkedRefs = new Set(parked.map((negotiation) => negotiation.opportunityId));
+    const referencesParked = parsed.block.questions.some((question) =>
+      [question.opportunityId, ...(question.alsoUnblocks ?? [])].some((ref) => parkedRefs.has(ref)));
+    return referencesParked ? { id: newest.id } : null;
+  }
+
+  /**
+   * Best-effort flip of the live `questionRegenerationPending` signal on the
+   * owner's conversation SSE channel. Never throws — the signal is a UX
+   * enhancement over the bootstrap snapshot, and a Redis hiccup must not
+   * break the enqueue path or fail a finished job. Skipped entirely under
+   * hermetic tests unless a publisher is injected.
+   */
+  private async publishRegenerationPending(userId: string, intentId: string, pending: boolean): Promise<void> {
+    try {
+      const publish = this.deps?.publishRegenerationEvent
+        ?? (useHermeticRedis()
+          ? null
+          : (await import('../lib/conversation-events')).publishQuestionRegenerationEvent);
+      if (!publish) return;
+      await publish(userId, { intentId, pending });
+    } catch (err) {
+      this.queueLogger.warn('question_regeneration_pending_publish_failed', {
+        userId,
+        intentId,
+        pending,
+        error: err instanceof Error ? err.message : String(err),
+      });
+    }
   }
 
   /**

--- a/services/api/src/queues/tests/question-message.queue.isolated.ts
+++ b/services/api/src/queues/tests/question-message.queue.isolated.ts
@@ -9,12 +9,13 @@
  */
 import { describe, expect, it } from 'bun:test';
 
-import { negotiationParkAnswerId, negotiationQuestionSettlementId, parseQuestionMessage } from '@indexnetwork/protocol';
+import { negotiationParkAnswerId, negotiationQuestionSettlementId, parseQuestionMessage, serializeQuestionMessage } from '@indexnetwork/protocol';
 import type { NegotiationAnswerConsumptionPorts, QuestionerEnqueuePayload, RoutedAnswer } from '@indexnetwork/protocol';
 import { questionBlockFixture, questionMessageFixture, questionProseFixture } from '@indexnetwork/protocol/question-block/fixture';
 
-import { QUESTION_ANSWER_CLARIFICATION_MESSAGE, QuestionMessageQueue, enqueueQuestionAnswerReply, parkedQuestionMessageTarget, questionMessageJobId } from '../question-message.queue';
+import { QUESTION_ANSWER_CLARIFICATION_MESSAGE, QUEUE_NAME, QuestionMessageQueue, enqueueQuestionAnswerReply, parkedQuestionMessageTarget, questionMessageJobId } from '../question-message.queue';
 import type { QuestionAnswerJobData } from '../question-message.queue';
+import { QueueFactory } from '../../lib/bullmq/bullmq';
 import type { ParkedNegotiation } from '../../adapters/parked-negotiation.reader.adapter';
 
 const USER_ID = 'user-1';
@@ -54,12 +55,31 @@ interface DeliveredMessage {
   content: string;
 }
 
+interface UpdatedMessage {
+  userId: string;
+  intentId: string;
+  messageId: string;
+  content: string;
+}
+
+interface PublishedPendingFlip {
+  userId: string;
+  intentId: string;
+  pending: boolean;
+}
+
 function buildQueue(options: {
   parked: ParkedNegotiation[];
   authorResult?: { prose: string; questions: typeof questionBlockFixture.questions } | null;
   resolveResult?: { session: { id: string } } | { error: string; status: 400 | 403 | 404 | 500 };
+  /** Newest message in the conversation at regeneration time (default: empty conversation). */
+  newestMessage?: { id: string; role: 'user' | 'assistant' | 'system'; content: string } | null;
+  /** What the update seam reports; false simulates the in-statement newest check failing. */
+  updateResult?: boolean;
 }) {
   const delivered: DeliveredMessage[] = [];
+  const updated: UpdatedMessage[] = [];
+  const published: PublishedPendingFlip[] = [];
   const calls = { author: 0, resolve: 0 };
   const queue = new QuestionMessageQueue({
     parkedSet: { readParkedNegotiations: async () => options.parked },
@@ -82,9 +102,17 @@ function buildQueue(options: {
         delivered.push(params);
         return `message-${delivered.length}`;
       },
+      getNewestMessage: async () => options.newestMessage ?? null,
+      updateQuestionMessageInPlace: async (params) => {
+        updated.push(params);
+        return options.updateResult ?? true;
+      },
+    },
+    publishRegenerationEvent: async (userId, event) => {
+      published.push({ userId, ...event });
     },
   });
-  return { queue, delivered, calls };
+  return { queue, delivered, updated, published, calls };
 }
 
 describe('QuestionMessageQueue regeneration job', () => {
@@ -154,6 +182,132 @@ describe('QuestionMessageQueue regeneration job', () => {
       queue.processJob('regenerate_question_message', { userId: USER_ID, intentId: INTENT_ID }),
     ).rejects.toThrow('database unavailable');
     expect(delivered).toHaveLength(0);
+  });
+});
+
+// ─── The edit rule (regenerate in place vs fresh message) ─────────────────────
+
+/** A previously delivered question-message over the same block refs. */
+const OPEN_MESSAGE_BODY = serializeQuestionMessage(
+  'An earlier rendering of these questions.',
+  questionBlockFixture,
+);
+
+describe('QuestionMessageQueue edit rule', () => {
+  it('regenerates the open question-message in place — same id, fresh valid block, no new message', async () => {
+    const { queue, delivered, updated } = buildQueue({
+      parked: [parkedNegotiation(FIXTURE_PRIMARY_1, 0)],
+      newestMessage: { id: 'open-1', role: 'assistant', content: OPEN_MESSAGE_BODY },
+    });
+
+    await queue.processJob('regenerate_question_message', { userId: USER_ID, intentId: INTENT_ID });
+
+    expect(delivered).toHaveLength(0);
+    expect(updated).toHaveLength(1);
+    expect(updated[0]).toEqual({
+      userId: USER_ID,
+      intentId: INTENT_ID,
+      messageId: 'open-1',
+      content: questionMessageFixture,
+    });
+    // The rewritten body is a valid question-message in its own right.
+    const parsed = parseQuestionMessage(updated[0].content);
+    expect(parsed).not.toBeNull();
+    expect(parsed!.block).toEqual(questionBlockFixture);
+  });
+
+  it('creates a fresh message when the user replied since — the old message is untouched', async () => {
+    const { queue, delivered, updated } = buildQueue({
+      parked: [parkedNegotiation(FIXTURE_PRIMARY_1, 0)],
+      newestMessage: { id: 'reply-1', role: 'user', content: 'March at the earliest.' },
+    });
+
+    await queue.processJob('regenerate_question_message', { userId: USER_ID, intentId: INTENT_ID });
+
+    expect(updated).toHaveLength(0);
+    expect(delivered).toHaveLength(1);
+    expect(delivered[0].content).toBe(questionMessageFixture);
+  });
+
+  it('creates a fresh message when the newest agent message carries no parseable block', async () => {
+    const { queue, delivered, updated } = buildQueue({
+      parked: [parkedNegotiation(FIXTURE_PRIMARY_1, 0)],
+      newestMessage: { id: 'prose-1', role: 'assistant', content: 'Got it — I will keep you posted.' },
+    });
+
+    await queue.processJob('regenerate_question_message', { userId: USER_ID, intentId: INTENT_ID });
+
+    expect(updated).toHaveLength(0);
+    expect(delivered).toHaveLength(1);
+  });
+
+  it('creates a fresh message when the newest block references no still-parked negotiation', async () => {
+    // The old message's refs all resolved; the new park is a different
+    // negotiation. The old message is closed, so it is preserved as history.
+    const { queue, delivered, updated } = buildQueue({
+      parked: [parkedNegotiation('opportunity-parked-elsewhere', 0)],
+      newestMessage: { id: 'closed-1', role: 'assistant', content: OPEN_MESSAGE_BODY },
+    });
+
+    await queue.processJob('regenerate_question_message', { userId: USER_ID, intentId: INTENT_ID });
+
+    expect(updated).toHaveLength(0);
+    expect(delivered).toHaveLength(1);
+  });
+
+  it('falls back to create when the data layer rejects the update (reply raced the newest check)', async () => {
+    const { queue, delivered, updated } = buildQueue({
+      parked: [parkedNegotiation(FIXTURE_PRIMARY_1, 0)],
+      newestMessage: { id: 'open-1', role: 'assistant', content: OPEN_MESSAGE_BODY },
+      updateResult: false,
+    });
+
+    await queue.processJob('regenerate_question_message', { userId: USER_ID, intentId: INTENT_ID });
+
+    expect(updated).toHaveLength(1);
+    expect(delivered).toHaveLength(1);
+    expect(delivered[0].content).toBe(questionMessageFixture);
+  });
+});
+
+// ─── Live pending flips on the conversation SSE channel ──────────────────────
+
+describe('questionRegenerationPending live flips', () => {
+  it('publishes pending: true at enqueue and pending: false when the job finishes', async () => {
+    const { queue, published } = buildQueue({ parked: [] });
+
+    await queue.addRegenerateJob({ userId: 'flip-user', intentId: 'flip-intent' });
+    expect(published).toEqual([{ userId: 'flip-user', intentId: 'flip-intent', pending: true }]);
+
+    await queue.processJob('regenerate_question_message', { userId: 'flip-user', intentId: 'flip-intent' });
+    expect(published).toEqual([
+      { userId: 'flip-user', intentId: 'flip-intent', pending: true },
+      { userId: 'flip-user', intentId: 'flip-intent', pending: false },
+    ]);
+  });
+
+  it('does not flip pending off when the job throws — the retry still owns the scope', async () => {
+    const { queue, published } = buildQueue({
+      parked: [parkedNegotiation(FIXTURE_PRIMARY_1, 0)],
+      resolveResult: { error: 'database unavailable', status: 500 },
+    });
+
+    await expect(
+      queue.processJob('regenerate_question_message', { userId: USER_ID, intentId: INTENT_ID }),
+    ).rejects.toThrow('database unavailable');
+    expect(published).toHaveLength(0);
+  });
+
+  it('never breaks the enqueue path on a publish failure', async () => {
+    const queue = new QuestionMessageQueue({
+      parkedSet: { readParkedNegotiations: async () => [] },
+      publishRegenerationEvent: async () => {
+        throw new Error('redis unavailable');
+      },
+    });
+
+    const job = await queue.addRegenerateJob({ userId: 'flip-user-2', intentId: 'flip-intent-2' });
+    expect(job).toBeTruthy();
   });
 });
 
@@ -346,6 +500,10 @@ function buildAnswerHarness(options: AnswerHarnessOptions) {
         calls.delivered.push(params);
         return `message-${calls.delivered.length}`;
       },
+      getNewestMessage: async () => null,
+      updateQuestionMessageInPlace: async () => {
+        throw new Error('answer consumption must never rewrite the question-message');
+      },
     },
   });
   return { queue, calls };
@@ -516,5 +674,131 @@ describe('enqueueQuestionAnswerReply detection', () => {
       addConsumeAnswerJob: async () => { throw new Error('must not enqueue'); },
     });
     expect(result).toBe(false);
+  });
+});
+
+// ─── Regeneration ↔ answer serialization through the shared queue ────────────
+
+describe('regeneration ↔ answer serialization', () => {
+  it('an answer arriving mid-regeneration waits for the regeneration to finish — no interleave', async () => {
+    const RACE_USER = 'race-user';
+    const RACE_INTENT = 'race-intent';
+    const events: string[] = [];
+    let releaseAuthor!: () => void;
+    const authorGate = new Promise<void>((resolve) => {
+      releaseAuthor = resolve;
+    });
+
+    const queue = new QuestionMessageQueue({
+      parkedSet: { readParkedNegotiations: async () => [parkedNegotiation(FIXTURE_PRIMARY_1, 0)] },
+      clientDm: async () => [],
+      getIntentText: async () => 'A signal about finding a technical co-founder',
+      author: {
+        author: async () => {
+          events.push('regenerate:author_start');
+          await authorGate;
+          return { prose: questionProseFixture, questions: questionBlockFixture.questions };
+        },
+      },
+      chatSessions: {
+        resolveNegotiatorIntentSession: async () => ({ session: { id: 'session-race' } }),
+        addMessage: async () => {
+          events.push('regenerate:delivered');
+          return 'message-race-1';
+        },
+        getNewestMessage: async () => null,
+        updateQuestionMessageInPlace: async () => {
+          throw new Error('no open message in this scenario');
+        },
+      },
+      answerPorts: {
+        database: {
+          getNegotiationTaskForOpportunity: async (opportunityId: string) => {
+            events.push('consume:classify');
+            if (opportunityId !== FIXTURE_PRIMARY_1) return null;
+            return {
+              id: `task-${opportunityId}`,
+              conversationId: 'conv-race',
+              state: 'input_required',
+              metadata: {
+                turnContext: {
+                  askUserBinding: {
+                    settlementId: negotiationQuestionSettlementId(`task-${opportunityId}`),
+                    recipientUserId: RACE_USER,
+                    recipientIntentId: RACE_INTENT,
+                    networkId: 'network-1',
+                    opportunityId,
+                  },
+                },
+              },
+              createdAt: new Date(),
+              updatedAt: new Date(),
+            };
+          },
+          getNegotiationMessages: async () => [],
+        },
+        settleInflightAnswer: async () => {
+          events.push('consume:settled');
+          return 'settled';
+        },
+        enqueueInflightResume: async () => {
+          events.push('consume:resumed');
+        },
+        recordOpportunityAnswer: async () => {
+          events.push('consume:recorded');
+        },
+        enqueueStalledRetry: async () => {
+          events.push('consume:retried');
+        },
+      },
+      answerRouter: {
+        route: async () => {
+          events.push('consume:routed');
+          return { addressesQuestions: true, answers: [{ ref: FIXTURE_PRIMARY_1, answerText: 'Yes.' }] };
+        },
+      },
+      publishRegenerationEvent: async (_userId, event) => {
+        events.push(`pending:${event.pending}`);
+      },
+    });
+
+    // The hermetic broker is shared per queue name: drain jobs left waiting by
+    // earlier tests so the worker only sees this scenario's two jobs.
+    for (const staleJob of await queue.queue.getJobs(['waiting', 'delayed'])) {
+      await staleJob.remove();
+    }
+
+    queue.startWorker();
+    const queueEvents = QueueFactory.createQueueEvents(QUEUE_NAME);
+    try {
+      const regenerateJob = await queue.addRegenerateJob({ userId: RACE_USER, intentId: RACE_INTENT });
+      const consumeJob = await queue.addConsumeAnswerJob({
+        ...answerJob('Yes.'),
+        userId: RACE_USER,
+        intentId: RACE_INTENT,
+      });
+      events.push('enqueue:consume');
+      releaseAuthor();
+
+      await regenerateJob.waitUntilFinished(queueEvents, 5_000);
+      await consumeJob.waitUntilFinished(queueEvents, 5_000);
+    } finally {
+      await queueEvents.close();
+      await queue.close();
+    }
+
+    // The answer really did arrive while the regeneration was in flight…
+    const deliveredAt = events.indexOf('regenerate:delivered');
+    expect(events.indexOf('enqueue:consume')).toBeGreaterThanOrEqual(0);
+    expect(events.indexOf('enqueue:consume')).toBeLessThan(deliveredAt);
+    // …and every consumption step ran only after the regeneration's write.
+    const firstConsume = events.findIndex((event) => event.startsWith('consume:'));
+    expect(firstConsume).toBeGreaterThan(deliveredAt);
+    expect(events).toContain('consume:settled');
+    expect(events).toContain('consume:resumed');
+    // The pending flip bracketed the regeneration, not the answer.
+    expect(events.indexOf('pending:true')).toBeLessThan(deliveredAt);
+    expect(events.indexOf('pending:false')).toBeGreaterThan(deliveredAt);
+    expect(events.indexOf('pending:false')).toBeLessThan(firstConsume);
   });
 });

--- a/services/api/src/services/chat.service.ts
+++ b/services/api/src/services/chat.service.ts
@@ -590,6 +590,36 @@ export class ChatSessionService {
   }
 
   /**
+   * The newest message in a session, by the same order the session reads use.
+   * Anchor read for the question-message edit rule.
+   *
+   * @param sessionId - The session ID
+   * @returns The newest message, or null for an empty session
+   */
+  async getNewestMessage(sessionId: string) {
+    return this.db.getNewestChatMessage(sessionId);
+  }
+
+  /**
+   * In-place regeneration of an open question-message (the conversational
+   * questions edit rule). The write is guarded inside the data layer: it only
+   * applies to an agent-authored message in the caller's
+   * ('negotiator-intent', intentId) session while that message is still the
+   * newest in its conversation.
+   *
+   * @returns False when the message lost the newest-message race (or is out
+   *   of scope) and the caller should append a fresh message instead.
+   */
+  async updateQuestionMessageInPlace(params: {
+    userId: string;
+    intentId: string;
+    messageId: string;
+    content: string;
+  }): Promise<boolean> {
+    return this.db.updateNewestAgentQuestionMessage({ ...params, regeneratedAt: new Date() });
+  }
+
+  /**
    * Get messages for a session in chronological order.
    *
    * @param sessionId - The session ID


### PR DESCRIPTION
Item 2 of "What is left" in [the conversational-questions plan](docs/plans/2026-08-18-conversational-questions.md): the delivery spine was create-only, so every park while a question-message sat open appended a second message. This PR makes regeneration follow the plan's edit rule, verbatim: **regenerate in place only while the question-message is still the newest message in the conversation; otherwise send a fresh one.**

## Content-update seam (`services/api`)

`updateNewestAgentQuestionMessage` on the conversation adapter rewrites one agent-authored message in a `('negotiator-intent', intentId)` session. All three guards — agent-authored, negotiator-intent scope, still-newest — live inside the single UPDATE statement (scope via `chat_session_scopes`, newest via a `NOT EXISTS` over the same `(created_at, id)` order every conversation read uses), so a user reply racing the regeneration wins cleanly: the statement no-ops and the job falls back to create. The rewrite stamps `metadata.regeneratedAt` for provenance.

## Edit rule in the regeneration job

The job resolves the open message — newest message in the conversation, agent-authored, parseable question block, referencing ≥1 negotiation in the just-read parked set — and updates it in place; anything else (user replied since, plain prose, unparseable block, refs all resolved) appends. No new locking: serialization stays with the existing `question-message.${userId}.${intentId}` singleton key that #1435 routed answer handling through.

## Live pending flip (deferred from #1434)

The mutation and the signal guarding it land together: a message must not change under a viewer with no indicator. The web app's only live conversation channel is the user-scoped SSE stream (`/conversations/stream` → `ConversationContext`), so the queue publishes `{type: 'question_regeneration', intentId, pending}` on it — `true` at enqueue, `false` when the job finishes. The negotiator DM subscribes: indicator from enqueue, and on completion it reloads the session (deferred while a response is streaming) so an in-place rewrite renders. The steps component from #1431 re-renders from new content as-is (`parseQuestionMessage` runs per render) — verified, no changes needed there.

## Tests

- Update-in-place: open message + new park → same message id, regenerated block valid per `parseQuestionMessage`, no second message.
- Fallback-to-create: user reply between park and regeneration → old message untouched, fresh message appended; plus the unparseable-block and no-still-parked-ref shapes.
- No-op update path: the seam's in-statement newest check fails → caller creates instead.
- Race: an answer enqueued mid-regeneration through the shared key runs strictly after the regeneration completes (hermetic worker, concurrency 1) — no interleave, and the pending flip brackets the regeneration.
- DB-backed spec for the guarded UPDATE against the real schema: in-place rewrite + `regeneratedAt` stamp, reply-wins no-op, agent-only and scope guards.
- Web: live flip shows/clears the indicator, completion reloads the session, stale bootstrap snapshot superseded, other intents ignored, reload deferred while streaming.

`services/api` typecheck, lint, and the isolated suite pass (the 7 isolated files failing here fail identically on the dev baseline — pre-existing, unrelated). Full web suite: 448 pass.

Out of scope, per the plan: the exhaustion evaluator (triggers stay per-park), notifications (no notify-on-update logic), retirements, `packages/protocol`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)