### PR TITLE
feat(protocol): consult-propensity fragment under the assessing stances

### DIFF
--- a/packages/protocol/src/negotiations/negotiation.stance.contracts.ts
+++ b/packages/protocol/src/negotiations/negotiation.stance.contracts.ts
@@ -9,11 +9,11 @@
  *
  * `NEGOTIATOR_STANCE` makes that stance configurable instead of hard-coded:
  *
- * | stance      | framing                              | value bar        | query rule              | deadlock  |
- * |-------------|--------------------------------------|------------------|-------------------------|-----------|
- * | `advocate`  | argue the case (today)               | none             | mandate (today)         | bargain   |
- * | `evaluator` | assess first, advocate if it survives | opportunity-cost | necessary-not-sufficient| bargain   |
- * | `skeptic`   | + "most matches are not worth making" | opportunity-cost | necessary-not-sufficient| stalemate |
+ * | stance      | framing                              | value bar        | query rule              | consult propensity      | deadlock  |
+ * |-------------|--------------------------------------|------------------|-------------------------|-------------------------|-----------|
+ * | `advocate`  | argue the case (today)               | none             | mandate (today)         | none (today)            | bargain   |
+ * | `evaluator` | assess first, advocate if it survives | opportunity-cost | necessary-not-sufficient| prefer over assumption  | bargain   |
+ * | `skeptic`   | + "most matches are not worth making" | opportunity-cost | necessary-not-sufficient| + unverified = don't proceed | stalemate |
  *
  * Design constraints (hard):
  * - **`advocate` is byte-identical.** Every fragment below is additive and
@@ -128,11 +128,45 @@ const VALUE_BAR_RULE = `
 - OPPORTUNITY COST: {userName}'s attention is finite and their name is spent on every connection made on their behalf. The bar is "worth that spend", not "does no harm" — absence of a downside is NOT a reason to proceed. Ask what {userName} gives up by spending this attention here instead of on a better match, and say no when the answer is "too much".`;
 
 /**
+ * Consult propensity — assessing stances only.
+ *
+ * The assessing stances demand a judgment ("is this actually worth making for
+ * {userName}?") that sometimes turns on a fact only the client holds: their
+ * current priorities, their real constraints, what "alignment" would mean to
+ * them. The legacy failure mode is resolving that gap by assumption —
+ * guessing, conceding, or accepting on vibes. This rule names the resolution
+ * path instead: consult the client.
+ *
+ * Deliberately names no action and no mechanism: like every fragment here it
+ * renders into all seats and protocol versions, including seats with no
+ * consultation vocabulary, so the seat's own rules decide HOW a consultation
+ * happens and whether one is still available this turn. This only sets when
+ * the agent should WANT one — which is also why it stays conditional on the
+ * uncertainty being client-resolvable: no "always"/"regardless" wording that
+ * would fight the per-negotiation consultation cap
+ * (`negotiationAskRoundsCap`).
+ */
+const CONSULT_PROPENSITY_RULE = `
+- CONSULT, DON'T ASSUME: when your judgment turns on a fact about {userName}'s OWN intent that you do not hold — their current priorities, their real constraints, what "alignment" would actually mean to them — prefer consulting {userName} over resolving that uncertainty by assumption. Guessing their answer, conceding to keep things moving, or proceeding because nothing contradicts the match are all ways of deciding for them what only they can decide.`;
+
+/**
+ * `skeptic` sharpening of the consult rule, appended to the same bullet (the
+ * same additive pattern as `SKEPTIC_FRAMING` over `EVALUATOR_FRAMING`): under
+ * the not-worth-making prior an unverified alignment assumption is itself a
+ * reason not to proceed, and consulting the client is how it gets verified.
+ */
+const SKEPTIC_CONSULT_SHARPENING = ` For you this is a gate, not a preference: an UNVERIFIED assumption that the two sides' intents actually align is a reason NOT to proceed, and consulting {userName} is how that assumption gets verified.`;
+
+/**
  * Extra action-rule lines contributed by the stance, appended after the seat's
  * own rules. Empty under `advocate` → byte-identical.
  */
 export function stanceActionRules(stance: NegotiatorStance): string {
-  return stanceAppliesValueBar(stance) ? VALUE_BAR_RULE : "";
+  if (!stanceAppliesValueBar(stance)) return "";
+  const consultRule = stance === "skeptic"
+    ? CONSULT_PROPENSITY_RULE + SKEPTIC_CONSULT_SHARPENING
+    : CONSULT_PROPENSITY_RULE;
+  return VALUE_BAR_RULE + consultRule;
 }
 
 /**

--- a/packages/protocol/src/negotiations/tests/negotiation.stance.spec.ts
+++ b/packages/protocol/src/negotiations/tests/negotiation.stance.spec.ts
@@ -193,6 +193,45 @@ describe("evaluator / skeptic — additive, gated fragments", () => {
     expect(prompt).toContain("OPPORTUNITY COST");
   });
 
+  it("evaluator prefers consulting the client over resolving intent uncertainty by assumption", async () => {
+    const rendered = await renderMatrix("evaluator");
+    for (const entry of PROMPT_MATRIX) {
+      const prompt = rendered[entry.id];
+      expect(prompt).toContain("CONSULT, DON'T ASSUME");
+      expect(prompt).toContain("prefer consulting Alice over resolving that uncertainty by assumption");
+      // Guessing, conceding, and vibes-acceptance are all named as the failure mode.
+      expect(prompt).toContain("deciding for them what only they can decide");
+      // evaluator does NOT carry the skeptic gate.
+      expect(prompt).not.toContain("a gate, not a preference");
+    }
+  });
+
+  it("skeptic sharpens the consult rule into a gate: unverified alignment is a reason NOT to proceed", async () => {
+    const rendered = await renderMatrix("skeptic");
+    for (const entry of PROMPT_MATRIX) {
+      const prompt = rendered[entry.id];
+      expect(prompt).toContain("CONSULT, DON'T ASSUME");
+      expect(prompt).toContain("a gate, not a preference");
+      expect(prompt).toContain(
+        "an UNVERIFIED assumption that the two sides' intents actually align is a reason NOT to proceed",
+      );
+      expect(prompt).toContain("consulting Alice is how that assumption gets verified");
+    }
+  });
+
+  it("the consult rule stays conditional — no wording that fights the ask-rounds cap", () => {
+    for (const stance of ["evaluator", "skeptic"] as const) {
+      const rules = stanceActionRules(stance);
+      // Conditional on client-resolvable uncertainty, never an unconditional urge:
+      // when the cap is reached the action is simply not offered, and the prompt
+      // must not push against that.
+      expect(rules).not.toMatch(/always/i);
+      expect(rules).not.toMatch(/regardless/i);
+      expect(rules).not.toMatch(/every turn/i);
+      expect(rules).toContain("when your judgment turns on a fact about {userName}'s OWN intent");
+    }
+  });
+
   it("query satisfaction becomes necessary-not-sufficient under evaluator and skeptic", async () => {
     for (const stance of ["evaluator", "skeptic"]) {
       const rendered = await renderMatrix(stance);


### PR DESCRIPTION
## What

Under `NEGOTIATOR_STANCE=evaluator` and `skeptic`, the negotiator prompt now carries a **consult-propensity rule**: when the assessment turns on a fact about the client's own intent that the agent does not hold — their priorities, their constraints, what "alignment" means to them — the agent should prefer consulting its client over resolving the uncertainty by assumption (guessing, conceding, or accepting on vibes).

Under `skeptic` the rule sharpens into a gate: an **unverified** alignment assumption is a reason NOT to proceed, and consulting the client is how it gets verified.

With the conversational-questions loop fully live (#1429–#1437), a consult is cheap and actually reaches the user — this raises how often the agent *wants* one; admission policy still decides whether a pause is *allowed*.

## How

- New `CONSULT_PROPENSITY_RULE` (+ `SKEPTIC_CONSULT_SHARPENING`, same additive pattern as the skeptic framing) in `negotiation.stance.contracts.ts`, appended by `stanceActionRules` after the opportunity-cost bar. No wiring change in `negotiation.agent.ts` — the fragment rides the existing splice and the global `{userName}` replace.

## Constraints held

- **advocate byte-identical**: `stanceActionRules("advocate")` still returns `""`; the golden-fixture matrix specs pin it.
- **No forbidden tokens**: the fragment names no action — no literal `ask_user`, no quoted `"withdraw"` (it renders into every seat and protocol version; existing all-stance matrix specs cover it).
- **Prompt-only**: no `allowedActionsFor`, schema, graph-routing, or `assessConsultationEligibility` change.
- **Respects the ask cap**: wording is conditional on the uncertainty being client-resolvable; a new spec pins the absence of "always"/"regardless"/"every turn" phrasing.

## Tests

- `negotiation.stance.spec.ts`: evaluator renders the rule across the whole prompt matrix (without the skeptic gate); skeptic renders rule + gate; cap-respect wording pin; all existing byte-identity / seat-invariant specs pass.
- Full `src/negotiations` suite green (two `negotiator-discovery-query` live-LLM judge tests flaked once and pass on re-run; unrelated — they run under the advocate default, which is golden-pinned unchanged). `tsc --noEmit` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)