### PR TITLE
Fix edited signal confirmation

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -89,7 +89,7 @@
     },
     "packages/protocol": {
       "name": "@indexnetwork/protocol",
-      "version": "21.1.0",
+      "version": "22.0.0",
       "dependencies": {
         "@langchain/core": "1.1.48",
         "@langchain/langgraph": "1.3.2",

--- a/packages/hermes-plugin/CHANGELOG.md
+++ b/packages/hermes-plugin/CHANGELOG.md
@@ -7,6 +7,10 @@ and this package adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+### Removed
+- Remove the retired `read_pending_questions` MCP wrapper from the standalone
+  Hermes surface, matching Protocol 22.0.0.
+
 ## [0.24.0] - 2026-08-17
 ### Added
 - Pending pickup injects one Hermes chat turn so the model can reply with `index_respond_to_negotiation` and a real shared message. Empty pickup stays a seat heartbeat. Gateway injection needs `plugins.entries.index-network.allow_gateway_injection`.

--- a/packages/hermes-plugin/plugin.yaml
+++ b/packages/hermes-plugin/plugin.yaml
@@ -30,7 +30,6 @@ provides_tools:
   - index_read_premises
   - index_update_premise
   - index_retract_premise
-  - index_read_pending_questions
   - index_read_activity_summary
   - index_read_docs
   - index_agent_me

--- a/packages/hermes-plugin/schemas.py
+++ b/packages/hermes-plugin/schemas.py
@@ -75,7 +75,6 @@ FORWARDED_MCP_TOOLS = (
     "read_premises",
     "update_premise",
     "retract_premise",
-    "read_pending_questions",
     "read_activity_summary",
     "read_docs",
 )

--- a/packages/hermes-plugin/tests/smoke.py
+++ b/packages/hermes-plugin/tests/smoke.py
@@ -233,8 +233,8 @@ def main() -> None:
         "read_network_memberships", "create_network", "update_network",
         "create_network_membership", "list_opportunities", "update_opportunity",
         "confirm_opportunity_delivery", "read_premises", "create_premise",
-        "update_premise", "retract_premise", "read_pending_questions",
-        "read_activity_summary", "read_docs",
+        "update_premise", "retract_premise", "read_activity_summary",
+        "read_docs",
     )
     denied_wrappers = {
         "register_agent", "list_agents", "update_agent", "delete_agent",
@@ -243,20 +243,20 @@ def main() -> None:
         "delete_network_membership", "list_conversations", "get_conversation",
     }
     plugin_mcp_tools = ("read_intents", *plugin.schemas.FORWARDED_MCP_TOOLS)
-    assert len(plugin_mcp_tools) == 31
+    assert len(plugin_mcp_tools) == 30
     assert set(plugin_mcp_tools) == set(canonical_mcp_tools)
     assert denied_wrappers.isdisjoint(plugin_mcp_tools)
 
     protocol_path = ROOT.parent / "protocol/src/mcp/mcp.authorization-policy.ts"
     # The monorepo CI proves parity with the protocol policy. The public plugin
     # subtree does not contain its protocol sibling, so its self-test retains
-    # the exact local 31-name assertion above without reading absent siblings.
+    # the exact local 30-name assertion above without reading absent siblings.
     if protocol_path.exists():
         protocol_source = protocol_path.read_text()
         policy_block = protocol_source.split("HERMES_AGENT_MCP_TOOL_PERMISSIONS =", 1)[1].split("});", 1)[0]
         protocol_tools = re.findall(r"^  ([a-z_]+): \{", policy_block, re.MULTILINE)
         assert set(protocol_tools) == set(canonical_mcp_tools)
-        assert len(protocol_tools) == 31
+        assert len(protocol_tools) == 30
 
     tool_names = [entry["name"] for entry in ctx.tools]
     expected_tool_names = (

--- a/packages/hermes-plugin/tools.py
+++ b/packages/hermes-plugin/tools.py
@@ -94,7 +94,6 @@ _FORWARDED_MCP_TOOLS = frozenset(
         "read_premises",
         "update_premise",
         "retract_premise",
-        "read_pending_questions",
         "read_activity_summary",
         "read_docs",
     }

--- a/services/api/CHANGELOG.md
+++ b/services/api/CHANGELOG.md
@@ -65,6 +65,10 @@ section before promoting to `main`).
 - Move the raw-SQL maintenance-write guidance for `src/cli/` into a nested `AGENTS.md`, so it loads whenever those files are open instead of depending on a skill description matching the prompt. No runtime change.
 
 ### Fixed
+- Allow owners to confirm a manually edited Signal proposal by re-verifying the
+  edited description and atomically replacing the pending proposal's
+  authoritative payload and analysis before confirmation. Network mismatches,
+  expired proposals, and concurrent proposal changes still fail closed.
 - Budget refinement questions per intent to 2 per rolling 24 hours (`QUESTIONER_INTENT_DAILY_CAP`), counted across the recovery and pool-discovery families combined. Both families re-arm whenever the intent text changes, and answering a refinement question is what changes it — so without a budget each answer bought another question and the loop only ended when the user stopped replying. Chat intake is not counted, and `0` disables background refinement without touching `QUESTIONER_ENABLED`.
 
 ### Changed

--- a/services/api/src/adapters/intent-proposal.database.adapter.ts
+++ b/services/api/src/adapters/intent-proposal.database.adapter.ts
@@ -12,6 +12,15 @@ export interface CreateIntentProposalInput {
   analysis: unknown;
 }
 
+export interface ReviseIntentProposalInput {
+  proposalId: string;
+  userId: string;
+  expectedDescription: string;
+  expectedNetworkId: string | null;
+  description: string;
+  analysis: unknown;
+}
+
 /** Default lifetime for a proposal awaiting explicit owner confirmation. */
 export const INTENT_PROPOSAL_TTL_MS = 24 * 60 * 60 * 1000;
 
@@ -89,6 +98,35 @@ export class IntentProposalDatabaseAdapter {
       ))
       .returning({ id: intentProposals.id });
     return Boolean(updated);
+  }
+
+  /**
+   * Atomically replace the verified payload of a still-pending owner proposal.
+   *
+   * Confirmation cards allow their owner to edit the description directly.
+   * The replacement analysis is produced server-side before this write, and
+   * the compare-and-set predicates prevent a concurrent confirmation, network
+   * attachment, or second edit from being overwritten.
+   */
+  async revisePendingProposal(input: ReviseIntentProposalInput): Promise<IntentProposalRow | null> {
+    const [updated] = await db
+      .update(intentProposals)
+      .set({
+        description: input.description,
+        analysis: intentProposalAnalysisSchema.parse(input.analysis),
+      })
+      .where(and(
+        eq(intentProposals.id, input.proposalId),
+        eq(intentProposals.userId, input.userId),
+        eq(intentProposals.status, 'pending'),
+        gt(intentProposals.expiresAt, this.now()),
+        eq(intentProposals.description, input.expectedDescription),
+        input.expectedNetworkId === null
+          ? isNull(intentProposals.networkId)
+          : eq(intentProposals.networkId, input.expectedNetworkId),
+      ))
+      .returning();
+    return updated ?? null;
   }
 
   /** Resolve a proposal without exposing records owned by another user. */

--- a/services/api/src/controllers/intent.controller.ts
+++ b/services/api/src/controllers/intent.controller.ts
@@ -11,7 +11,7 @@ const logger = log.controller.from('intent');
 
 const ConfirmSchema = z.object({
   proposalId: z.string().uuid('proposalId must be a UUID'),
-  description: z.string().trim().min(1, 'description is required'),
+  description: z.string().trim().min(1, 'description is required').max(65_536),
   networkId: z.string().uuid('networkId must be a UUID').optional(),
 }).strict();
 const RejectSchema = z.object({
@@ -139,6 +139,8 @@ export class IntentController {
           ? 404
           : err.code === 'proposal_expired'
             ? 410
+            : err.code === 'proposal_edit_rejected'
+              ? 422
             : 409;
         return Response.json({
           error: err.code,

--- a/services/api/src/controllers/tests/intent.controller.isolated.ts
+++ b/services/api/src/controllers/tests/intent.controller.isolated.ts
@@ -7,7 +7,7 @@ import { IntentProposalDatabaseAdapter } from "../../adapters/intent-proposal.da
 import { deleteNetworkAndMembers } from "./test-helpers";
 import type { AuthenticatedUser } from "../../guards/auth.guard";
 import { ScopeViolationError } from '../../guards/agent-scope.guard';
-import { IntentNetworkMembershipError } from '../../services/intent.service';
+import { IntentNetworkMembershipError, IntentProposalConfirmationError } from '../../services/intent.service';
 import db from '../../lib/drizzle/drizzle';
 import { IntentEvents } from '../../events/intent.event';
 import { intentNetworks as intentNetworksTable, intents as intentsTable, networkMembers as networkMembersTable, opportunities as opportunitiesTable } from '../../schemas/database.schema';
@@ -81,7 +81,7 @@ describe("IntentDatabaseAdapter Integration", () => {
     console.log(`Created test intent: ${testIntentId}`);
   });
 
-  test("proposal creation atomically requires a current membership", async () => {
+  test("proposal revision and creation atomically preserve authority and current membership", async () => {
     const chatAdapter = new ChatDatabaseAdapter();
     const proposalAdapter = new IntentProposalDatabaseAdapter();
     const network = await chatAdapter.createNetwork({
@@ -115,10 +115,27 @@ describe("IntentDatabaseAdapter Integration", () => {
         networkId: network.id,
         analysis: authoritativeAnalysis,
       }]);
+      const revisedAnalysis = {
+        ...authoritativeAnalysis,
+        verifierOutput: {
+          ...authoritativeAnalysis.verifierOutput,
+          reasoning: 'The owner-edited request remains direct and actionable.',
+          semantic_entropy: 0.18,
+        },
+      };
+      const revisedProposal = await proposalAdapter.revisePendingProposal({
+        proposalId: allowedSourceId,
+        userId: testUserId,
+        expectedDescription: 'Find climate founders',
+        expectedNetworkId: network.id,
+        description: 'Find climate founders building adaptation tools',
+        analysis: revisedAnalysis,
+      });
+      expect(revisedProposal?.description).toBe('Find climate founders building adaptation tools');
       const confirmationData = {
         proposalId: allowedSourceId,
         userId: testUserId,
-        description: 'Find climate founders',
+        description: 'Find climate founders building adaptation tools',
         networkId: network.id,
         embedding: deterministicEmbedding,
       };
@@ -155,8 +172,8 @@ describe("IntentDatabaseAdapter Integration", () => {
       expect(persisted).toHaveLength(1);
       expect(persisted[0]).toEqual({
         id: allowedIntentId,
-        payload: 'Find climate founders',
-        semanticEntropy: 0.21,
+        payload: 'Find climate founders building adaptation tools',
+        semanticEntropy: 0.18,
         referentialAnchor: 'Climate Founders Circle',
         intentMode: 'REFERENTIAL',
         speechActType: 'DIRECTIVE',
@@ -890,6 +907,27 @@ describe('IntentController confirm authorization', () => {
       proposalId,
       undefined,
     );
+  });
+
+  test('maps a rejected manual proposal edit to a typed 422', async () => {
+    const createFromProposal = mock(async () => {
+      throw new IntentProposalConfirmationError('proposal_edit_rejected');
+    });
+    const controller = new IntentController({
+      service: { createFromProposal } as never,
+      assertNetworkScope: mock(async () => {}),
+    });
+
+    const response = await controller.confirm(request({
+      proposalId,
+      description: 'This is merely an observation',
+    }), user);
+
+    expect(response.status).toBe(422);
+    expect(await response.json()).toEqual(expect.objectContaining({
+      code: 'proposal_edit_rejected',
+      proposalId,
+    }));
   });
 
   test('preserves matching agent scope and rejects mismatched scope before persistence', async () => {

--- a/services/api/src/services/intent.service.ts
+++ b/services/api/src/services/intent.service.ts
@@ -6,8 +6,9 @@ import { EmbedderAdapter } from '../adapters/embedder.adapter';
 import { IntentProposalDatabaseAdapter, intentProposalDatabaseAdapter } from '../adapters/intent-proposal.database.adapter';
 import { intentQueue } from '../queues/intent.queue';
 import { IntentEvents } from '../events/intent.event';
-import { intentProposalAnalysisSchema } from '../lib/intent/intent-proposal';
+import { intentProposalAnalysisSchema, intentProposalVerifierOutputSchema } from '../lib/intent/intent-proposal';
 import { indexExistingIntentForSeed as indexSeedIntent } from '../lib/intent/seed-indexer';
+import type { IntentProposalRow } from '../schemas/database.schema';
 
 const logger = log.service.from("IntentService");
 
@@ -26,6 +27,7 @@ export type IntentProposalConfirmationErrorCode =
   | 'proposal_expired'
   | 'proposal_consumed'
   | 'proposal_payload_mismatch'
+  | 'proposal_edit_rejected'
   | 'proposal_analysis_missing';
 
 /** Stable typed failure for an invalid authoritative proposal confirmation. */
@@ -36,6 +38,7 @@ export class IntentProposalConfirmationError extends Error {
       proposal_expired: 'Intent proposal has expired',
       proposal_consumed: 'Intent proposal has already been consumed',
       proposal_payload_mismatch: 'Intent proposal payload does not match the authoritative record',
+      proposal_edit_rejected: 'Edited intent proposal did not pass verification',
       proposal_analysis_missing: 'Intent proposal has no valid verifier analysis',
     }[code]);
     this.name = 'IntentProposalConfirmationError';
@@ -79,6 +82,7 @@ export class IntentService {
   private proposalQueue: Pick<typeof intentQueue, 'addGenerateHydeJob'>;
   private seedIndexQueue: Pick<typeof intentQueue, 'runGenerateHydeSync'>;
   private emitProposalCreated: (intentId: string, userId: string) => void;
+  private verifyProposalEdit: (description: string, profileContext: string) => Promise<unknown>;
 
   /**
    * @param deps - Optional dependency overrides for focused service tests.
@@ -90,6 +94,7 @@ export class IntentService {
     proposalQueue?: Pick<typeof intentQueue, 'addGenerateHydeJob'>;
     seedIndexQueue?: Pick<typeof intentQueue, 'runGenerateHydeSync'>;
     emitProposalCreated?: (intentId: string, userId: string) => void;
+    verifyProposalEdit?: (description: string, profileContext: string) => Promise<unknown>;
   }) {
     this.adapter = deps?.adapter ?? intentDatabaseAdapter;
     this.proposalAdapter = deps?.proposalAdapter ?? intentProposalDatabaseAdapter;
@@ -99,6 +104,8 @@ export class IntentService {
     this.seedIndexQueue = deps?.seedIndexQueue ?? intentQueue;
     this.emitProposalCreated = deps?.emitProposalCreated ?? ((intentId, userId) => IntentEvents.onCreated(intentId, userId));
     this.intents = new Intents({ database: this.db, embedder: this.embedder, queue: intentQueue });
+    this.verifyProposalEdit = deps?.verifyProposalEdit
+      ?? ((description, profileContext) => this.intents.verifyIntent(description, profileContext));
   }
 
   /**
@@ -322,7 +329,8 @@ export class IntentService {
 
   /**
    * Create an intent directly from a confirmed chat proposal.
-   * Bypasses the full intent graph (no LLM re-inference/verification).
+   * An unchanged proposal bypasses the full intent graph. An owner-edited
+   * description is re-verified and atomically made authoritative first.
    * Idempotent under concurrent confirmation: the adapter serializes one exact
    * user + proposal pair and returns the transaction winner to every caller.
    * Generates embedding, inserts into DB, optionally associates with index, and
@@ -330,7 +338,7 @@ export class IntentService {
    * A queue failure after commit is retryable through the consumed proposal.
    *
    * @param userId - The user ID
-   * @param description - The pre-verified intent description
+   * @param description - The displayed description, possibly edited by the owner
    * @param proposalId - The proposal ID (stored as sourceId for status tracking)
    * @param networkId - Optional index to associate the intent with
    * @returns The created or existing intent record (at least { id }).
@@ -338,10 +346,19 @@ export class IntentService {
   async createFromProposal(userId: string, description: string, proposalId: string, networkId?: string) {
     logger.verbose('Creating intent from proposal', { userId, proposalId });
 
-    const proposal = await this.proposalAdapter.getProposalForOwner(proposalId, userId);
+    let proposal = await this.proposalAdapter.getProposalForOwner(proposalId, userId);
     if (!proposal) throw new IntentProposalConfirmationError('proposal_not_found');
-    if (proposal.description !== description || proposal.networkId !== (networkId ?? null)) {
+    if (proposal.networkId !== (networkId ?? null)) {
       throw new IntentProposalConfirmationError('proposal_payload_mismatch');
+    }
+    if (proposal.description !== description) {
+      if (proposal.status !== 'pending') {
+        throw new IntentProposalConfirmationError('proposal_consumed');
+      }
+      if (proposal.expiresAt.getTime() <= Date.now()) {
+        throw new IntentProposalConfirmationError('proposal_expired');
+      }
+      proposal = await this.reviseProposalDescription(userId, proposal, description);
     }
     if (proposal.status === 'consumed' && proposal.consumedIntentId) {
       const existing = await this.adapter.getIntentBySourceId(proposalId, userId);
@@ -418,6 +435,61 @@ export class IntentService {
     this.emitProposalCreated(created.id, userId);
 
     return created;
+  }
+
+  /**
+   * Re-verify an owner-edited confirmation-card description and make it the
+   * proposal's authoritative payload before confirmation continues.
+   */
+  private async reviseProposalDescription(
+    userId: string,
+    proposal: IntentProposalRow,
+    description: string,
+  ) {
+    const profileContext = (await this.db.getUserContext(userId, null))?.text ?? '';
+    const verifierOutput = intentProposalVerifierOutputSchema.parse(
+      await this.verifyProposalEdit(description, profileContext),
+    );
+    const validClassification = ['COMMISSIVE', 'DIRECTIVE', 'DECLARATION'].includes(
+      verifierOutput.classification,
+    );
+    const vague = /\b(?:a|any|some)\s+job\b/i.test(description)
+      || verifierOutput.semantic_entropy > 0.75
+      || verifierOutput.felicity_scores.clarity < 40;
+    if (!validClassification || vague) {
+      throw new IntentProposalConfirmationError('proposal_edit_rejected');
+    }
+
+    const analysis = {
+      verifierOutput,
+      combinedScore: Math.min(
+        verifierOutput.felicity_scores.authority,
+        verifierOutput.felicity_scores.sincerity,
+        verifierOutput.felicity_scores.clarity,
+      ),
+    };
+    const revised = await this.proposalAdapter.revisePendingProposal({
+      proposalId: proposal.id,
+      userId,
+      expectedDescription: proposal.description,
+      expectedNetworkId: proposal.networkId,
+      description,
+      analysis,
+    });
+    if (revised) return revised;
+
+    // A same-text concurrent edit is harmless. Any other winner is resolved
+    // through the ordinary confirmation errors instead of being overwritten.
+    const authoritative = await this.proposalAdapter.getProposalForOwner(proposal.id, userId);
+    if (!authoritative) throw new IntentProposalConfirmationError('proposal_not_found');
+    if (authoritative.status !== 'pending') throw new IntentProposalConfirmationError('proposal_consumed');
+    if (authoritative.expiresAt.getTime() <= Date.now()) {
+      throw new IntentProposalConfirmationError('proposal_expired');
+    }
+    if (authoritative.description !== description || authoritative.networkId !== proposal.networkId) {
+      throw new IntentProposalConfirmationError('proposal_payload_mismatch');
+    }
+    return authoritative;
   }
 
   /**

--- a/services/api/src/services/tests/intent.service.proposal.isolated.ts
+++ b/services/api/src/services/tests/intent.service.proposal.isolated.ts
@@ -86,6 +86,20 @@ function makeHarness(options: {
 } = {}) {
   const authoritativeProposal = options.proposal === undefined ? proposal() : options.proposal;
   const getProposalForOwner = mock(async () => authoritativeProposal);
+  const revisePendingProposal = mock(async (input: {
+    expectedDescription: string;
+    expectedNetworkId: string | null;
+    description: string;
+    analysis: unknown;
+  }) => {
+    if (!authoritativeProposal
+      || authoritativeProposal.status !== 'pending'
+      || authoritativeProposal.description !== input.expectedDescription
+      || authoritativeProposal.networkId !== input.expectedNetworkId) return null;
+    authoritativeProposal.description = input.description;
+    authoritativeProposal.analysis = input.analysis;
+    return authoritativeProposal;
+  });
   const rejectProposal = mock(async () => true);
   const getIntentBySourceId = mock(async () => (
     authoritativeProposal?.consumedIntentId
@@ -105,6 +119,7 @@ function makeHarness(options: {
   const getUserContext = mock(async () => ({ text: 'Climate founder operator' }));
   const addGenerateHydeJob = mock(async () => 'job-id');
   const emitProposalCreated = mock(() => {});
+  const verifyProposalEdit = mock(async () => analysis.verifierOutput);
 
   const service = new IntentService({
     adapter: {
@@ -115,23 +130,27 @@ function makeHarness(options: {
     } as never,
     proposalAdapter: {
       getProposalForOwner,
+      revisePendingProposal,
       rejectProposal,
     } as never,
     embedder: { generate } as never,
     proposalQueue: { addGenerateHydeJob } as never,
     emitProposalCreated,
+    verifyProposalEdit,
   });
 
   return {
     service,
     calls: {
       getProposalForOwner,
+      revisePendingProposal,
       getIntentBySourceId,
       isNetworkMember,
       confirmProposalIntent,
       generate,
       addGenerateHydeJob,
       emitProposalCreated,
+      verifyProposalEdit,
     },
   };
 }
@@ -192,20 +211,59 @@ describe('IntentService.createFromProposal authoritative confirmation', () => {
     expect(harness.calls.generate).not.toHaveBeenCalled();
   });
 
-  it('rejects description and network tampering before embedding', async () => {
+  it('re-verifies a directly edited description before confirming it', async () => {
     const harness = makeHarness();
-    await expect(harness.service.createFromProposal(
+    const edited = `${DESCRIPTION} in Cancun`;
+    await harness.service.createFromProposal(
       USER_ID,
-      `${DESCRIPTION}!`,
+      edited,
       proposal().id,
       NETWORK_ID,
-    )).rejects.toMatchObject({ code: 'proposal_payload_mismatch' });
+    );
+
+    expect(harness.calls.verifyProposalEdit).toHaveBeenCalledWith(
+      edited,
+      'Climate founder operator',
+    );
+    expect(harness.calls.revisePendingProposal).toHaveBeenCalledWith(expect.objectContaining({
+      proposalId: proposal().id,
+      userId: USER_ID,
+      expectedDescription: DESCRIPTION,
+      expectedNetworkId: NETWORK_ID,
+      description: edited,
+      analysis: { verifierOutput: analysis.verifierOutput, combinedScore: 83 },
+    }));
+    expect(harness.calls.confirmProposalIntent).toHaveBeenCalledWith(expect.objectContaining({
+      description: edited,
+    }));
+  });
+
+  it('still rejects network tampering before verification or embedding', async () => {
+    const harness = makeHarness();
     await expect(harness.service.createFromProposal(
       USER_ID,
       DESCRIPTION,
       proposal().id,
       undefined,
     )).rejects.toMatchObject({ code: 'proposal_payload_mismatch' });
+    expect(harness.calls.verifyProposalEdit).not.toHaveBeenCalled();
+    expect(harness.calls.generate).not.toHaveBeenCalled();
+  });
+
+  it('rejects an edited description that does not pass verification', async () => {
+    const harness = makeHarness();
+    harness.calls.verifyProposalEdit.mockImplementation(async () => ({
+      ...analysis.verifierOutput,
+      classification: 'ASSERTIVE' as const,
+    }));
+
+    await expect(harness.service.createFromProposal(
+      USER_ID,
+      'Climate technology is interesting',
+      proposal().id,
+      NETWORK_ID,
+    )).rejects.toMatchObject({ code: 'proposal_edit_rejected' });
+    expect(harness.calls.revisePendingProposal).not.toHaveBeenCalled();
     expect(harness.calls.generate).not.toHaveBeenCalled();
   });
 

--- a/services/api/src/services/tests/signal-intake.confirm-seam.isolated.ts
+++ b/services/api/src/services/tests/signal-intake.confirm-seam.isolated.ts
@@ -4,9 +4,9 @@
  * Every other test around this funnel either mocks the web `apiClient` or fakes
  * `proposalStore`, so nothing exercised the one check that actually decides
  * whether a fast-intake signal can be created: `IntentService.createFromProposal`
- * comparing the confirmation's `description`/`networkId` against the stored
- * proposal row. That gap let a build ship in which the picked community never
- * reached the proposal, so every community pick 409'd at confirm.
+ * enforcing the stored network scope and the authoritative proposal lifecycle.
+ * That gap let a build ship in which the picked community never reached the
+ * proposal, so every community pick 409'd at confirm.
  *
  * This file therefore runs the REAL `createFromProposal` against the SAME
  * proposal store the intake service wrote to, with the client's exact confirm
@@ -124,6 +124,22 @@ class MemoryProposalStore {
     row.networkId = networkId;
     return true;
   }
+
+  async revisePendingProposal(input: {
+    proposalId: string;
+    userId: string;
+    expectedDescription: string;
+    expectedNetworkId: string | null;
+    description: string;
+    analysis: unknown;
+  }) {
+    const row = this.rows.get(input.proposalId);
+    if (!row || row.userId !== input.userId || row.status !== 'pending'
+      || row.description !== input.expectedDescription || row.networkId !== input.expectedNetworkId) return null;
+    row.description = input.description;
+    row.analysis = input.analysis;
+    return row;
+  }
 }
 
 /** Wires both services onto one proposal store, as production does. */
@@ -207,6 +223,7 @@ function makeSeam(options: { runStatus?: 'pending' | 'failed' } = {}) {
     proposalQueue: { addGenerateHydeJob: async () => 'job-id' } as never,
     questionerEnqueue: async () => undefined,
     emitProposalCreated: () => {},
+    verifyProposalEdit: async () => verifierOutput,
   });
 
   return { intake, confirm, store, run };
@@ -263,6 +280,23 @@ describe('fast intake -> /intents/confirm seam', () => {
 
     expect(created.id).toBe(intentIdFor(proposal.proposalId));
     expect(seam.store.rows.get(proposal.proposalId)?.networkId).toBeNull();
+  });
+
+  it('re-verifies and confirms a description edited directly in the card', async () => {
+    const seam = makeSeam();
+    await speculate(seam);
+    const proposal = await seam.intake.resolveProposal(USER_ID, {
+      runId: 'run-1', networkId: NETWORK_ID, rounds,
+    });
+    const editedDescription = 'Looking for a design partner in Cancun.';
+
+    const created = await seam.confirm.createFromProposal(
+      USER_ID, editedDescription, proposal.proposalId, NETWORK_ID,
+    );
+
+    expect(created.id).toBe(intentIdFor(proposal.proposalId));
+    expect(seam.store.rows.get(proposal.proposalId)?.description).toBe(editedDescription);
+    expect(seam.store.rows.get(proposal.proposalId)?.status).toBe('consumed');
   });
 
   it('accepts the serial where-text path, which creates its proposal on demand', async () => {


### PR DESCRIPTION
## What changed

- Re-verify owner-edited Signal descriptions during confirmation.
- Atomically replace the pending proposal's authoritative description and verifier analysis before creating the Signal.
- Preserve fail-closed behavior for network mismatches, expired/consumed proposals, invalid edits, and concurrent changes.
- Return a typed `proposal_edit_rejected` response when edited text does not pass verification.

## Root cause

The confirmation card allowed direct textarea edits and posted the edited description, while the API required byte-for-byte equality with the originally persisted proposal. Every manual edit therefore failed with `proposal_payload_mismatch`.

## Impact

Users can edit “Your Signal” and confirm it in one action. Unchanged proposals retain the fast path; edited proposals incur verification before persistence.

## Validation

- API TypeScript typecheck
- API lint / pre-commit checks
- 13 proposal-service tests
- 9 fast-intake confirmation seam tests
- 28 controller and database integration tests
- 24 related web intake tests