### PR TITLE
feat(api): question-message notifications, deep-linked, plus the empty-set close-out

### DIFF
--- a/docs/plans/2026-08-18-conversational-questions.md
+++ b/docs/plans/2026-08-18-conversational-questions.md
@@ -1,8 +1,9 @@
 # Conversational questions
 
-**Status:** core loop shipped 2026-08-18 (create-only delivery). On `dev`:
-park → question-message in the DM → steps render. Not yet built: notifications and the
-retirements — see [What is left](#what-is-left) at the end.
+**Status:** shipped 2026-08-18. On `dev`: park → question-message in the DM →
+steps render → notification → answer → resume. Nothing in this plan is
+outstanding; see [What is left](#what-is-left) for the one unrelated fix it
+surfaced.
 
 | PR | What landed |
 | --- | --- |
@@ -15,6 +16,8 @@ retirements — see [What is left](#what-is-left) at the end.
 | [#1435](https://github.com/indexnetwork/index/pull/1435) | Answer wiring — DM replies routed to parked-negotiation resume; `'stalled'` retry claims admitted; continuation re-park stopgap |
 | [#1436](https://github.com/indexnetwork/index/pull/1436) | The edit rule — in-place regeneration of the open message, guarded update seam, live pending flip |
 | [#1437](https://github.com/indexnetwork/index/pull/1437) | Exhaustion evaluator — transition-driven regeneration; unpark-prune and exhaustion regrouping; stopgap subsumed |
+| [#1439](https://github.com/indexnetwork/index/pull/1439) | Retirements — card generators, `QuestionerAgent`, read surface, questions-table adapter |
+| [#1440](https://github.com/indexnetwork/index/pull/1440) | Notifications — new-question detection, deep-linked delivery, empty-set close-out |
 
 Built on [#1428](https://github.com/indexnetwork/index/pull/1428), the authoring
 half of the superseded plan.
@@ -174,6 +177,13 @@ question on it without any dedicated write-back.
 The message is the notification unit. This is the difference between batched
 and spam-with-extra-steps.
 
+Shipped as a set difference over the block's negotiation refs: the outgoing
+block against the block it replaces, which is the notification's only input.
+The two silent clauses fall out of it — pruning and regrouping add no ref,
+and an answer only ever removes one. It follows that a delivery is silent
+whenever it asks nothing new, including a fresh message that re-states known
+questions below a client reply.
+
 ## Revisions to the 2026-08-17 plan
 
 PR 1 (authoring: payload, grounding seam, DM excerpt, safety guard) is the
@@ -197,10 +207,7 @@ and the Questions page join the list.
 
 ## New machinery
 
-> Partially built — see the PR table at the top. The block format, the
-> regeneration queue, the ask cap, and the trigger reroutes are on `dev`. The
-> chat-message content update (edit rule) and the exhaustion evaluator are
-> NOT built; they are items in [What is left](#what-is-left).
+> All built — see the PR table at the top.
 
 - **Chat message content update.** Shipped in #1436:
   `updateNewestAgentQuestionMessage`, all guards inside the single UPDATE.
@@ -249,15 +256,25 @@ post-merge).
 
 ## What is left
 
-One item. Everything else in this plan is on `dev`. The exhaustion evaluator
-shipped as [#1437](https://github.com/indexnetwork/index/pull/1437); two
-follow-ups it surfaced: regenerate the open message to a closed state when
-the parked set empties (folds into notifications), and the MCP
+Nothing from this plan. Notifications and the empty-set close-out shipped
+last; the one open item is unrelated to the question loop: the MCP
 `respond_to_negotiation` terminal branch never writes `opportunities.status`
 (pre-existing, independent fix).
 
-**1. Notifications.** The policy (create → notify; update with new
-questions → notify; otherwise silent) is designed but unimplemented.
+**Notifications: shipped.** The regeneration job compares the outgoing
+block's negotiation refs against the refs of the message it replaces — a
+plain set difference, no stored state — and enqueues one notification-stream
+frame (`question.new`, deep-linked to `/i/:intentId`) when the delivery names
+a negotiation the client has not been asked about. Creation compares against
+the empty set and therefore always notifies; pruning, regrouping, prose
+rewrites, answer-driven shrinkage, and the close-out stay silent. One frame
+per message, never per question.
+
+**Close-out: shipped.** A regeneration that finds the parked set empty under
+an open question-message rewrites it to fixed prose with no block, through
+the same guarded update seam — so no stale question lingers. Silent, and
+bounded by the same newest-message rule: if the client replied since, the
+reply wins and the message is left alone (its block simply stops being open).
 
 **Retirements: shipped.** The five card generators (pre-accept uptake,
 pool-discriminator mining with its push cycle and answer chaining,

--- a/docs/plans/2026-08-18-conversational-questions.md
+++ b/docs/plans/2026-08-18-conversational-questions.md
@@ -17,7 +17,7 @@ surfaced.
 | [#1436](https://github.com/indexnetwork/index/pull/1436) | The edit rule — in-place regeneration of the open message, guarded update seam, live pending flip |
 | [#1437](https://github.com/indexnetwork/index/pull/1437) | Exhaustion evaluator — transition-driven regeneration; unpark-prune and exhaustion regrouping; stopgap subsumed |
 | [#1439](https://github.com/indexnetwork/index/pull/1439) | Retirements — card generators, `QuestionerAgent`, read surface, questions-table adapter |
-| [#1440](https://github.com/indexnetwork/index/pull/1440) | Notifications — new-question detection, deep-linked delivery, empty-set close-out |
+| [#1441](https://github.com/indexnetwork/index/pull/1441) | Notifications — new-question detection, deep-linked delivery, empty-set close-out |
 
 Built on [#1428](https://github.com/indexnetwork/index/pull/1428), the authoring
 half of the superseded plan.
@@ -124,8 +124,8 @@ already use (e.g. `enrichment.queue.ts:99`), keyed
 `question-message.${userId}.${intentId}`. The job:
 
 1. Reads the current parked set for the intent (this user's side only).
-2. If empty → nothing to do (a regeneration triggered by the last unpark may
-   find the message already closed).
+2. If empty → close out an open message if there is one (rewrite it to prose
+   with no block), otherwise nothing to do.
 3. Authors the message via the negotiator, grounded exactly as PR 1 built:
    transcripts of the parked negotiations plus the signal's DM excerpt.
 4. Applies the edit rule: update in place or create.

--- a/services/api/src/lib/notification-stream-events.ts
+++ b/services/api/src/lib/notification-stream-events.ts
@@ -11,6 +11,13 @@ export interface NotificationStreamEvent {
   id: string;
   title: string;
   body: string;
+  /**
+   * Absolute deep link to the surface that resolves the notification, when
+   * the frame has one. Optional: `opportunity.new` frames are routed by the
+   * client from (type, id), while `question.new` names the signal's DM
+   * explicitly — the question lives in a conversation, not on a card.
+   */
+  link?: string;
 }
 
 /** Injectable delivery boundary shared by realtime publication and isolated tests. */

--- a/services/api/src/lib/question/tests/question-exhaustion.evaluator.isolated.ts
+++ b/services/api/src/lib/question/tests/question-exhaustion.evaluator.isolated.ts
@@ -250,6 +250,7 @@ describe('evaluator → regeneration job composition', () => {
       },
       chatSessions: {
         resolveNegotiatorIntentSession: async () => ({ session: { id: 'session-1' } }),
+        findNegotiatorIntentSession: async () => ({ id: 'session-1' }),
         addMessage: async (params) => {
           delivered.push(params);
           return `message-${delivered.length}`;
@@ -261,6 +262,7 @@ describe('evaluator → regeneration job composition', () => {
         },
       },
       publishRegenerationEvent: async () => {},
+      notify: async () => {},
     });
     return { queue, delivered, updated };
   }

--- a/services/api/src/queues/notification.queue.ts
+++ b/services/api/src/queues/notification.queue.ts
@@ -7,8 +7,11 @@ import { userService } from '../services/user.service';
 import { emailQueue } from './email.queue';
 import { opportunityNotificationTemplate } from '../lib/email/templates/opportunity-notification.template';
 import { emitOpportunityNotification, emitTelegramNotification } from '../lib/notification-events';
+import { publishNotificationStreamEvent, type NotificationStreamPublisher } from '../lib/notification-stream-events';
 import { getRedisClient } from '../adapters/cache.adapter';
 import { userDatabaseAdapter } from '../adapters/database.adapter';
+import { buildQuestionMessageNotification } from '../services/notification-projection';
+import { loadNotificationIntentLabel } from '../services/notification-delivery.service';
 
 /** BullMQ queue name for opportunity notification jobs. */
 export const QUEUE_NAME = 'notification-queue';
@@ -23,6 +26,26 @@ export interface NotificationJobData {
   priority: NotificationPriority;
 }
 
+/**
+ * Payload for one question-message notification (conversational questions,
+ * docs/plans/2026-08-18-conversational-questions.md). The regeneration job
+ * enqueues exactly one of these per delivered message that asks something
+ * new — never one per question.
+ */
+export interface QuestionMessageNotificationJobData {
+  /** The signal's owner: the DM's user and the notification's recipient. */
+  userId: string;
+  /** The signal whose DM carries the message; the deep link's target. */
+  intentId: string;
+  /** Persisted id of the delivered question-message; the frame's id and the job's dedup key. */
+  messageId: string;
+  /** Questions in the delivered block — copy only. */
+  questionCount: number;
+}
+
+/** Everything this queue processes. */
+export type NotificationQueueJobData = NotificationJobData | QuestionMessageNotificationJobData;
+
 /** Minimal database interface for notification queue (used when deps provided in tests). */
 export type NotificationQueueDatabase = Pick<ChatDatabaseAdapter, 'getOpportunity'> & {
   getTelegramPrefs(userId: string): Promise<import('../schemas/database.schema').TelegramPrefs | null>;
@@ -34,6 +57,10 @@ export type NotificationQueueDatabase = Pick<ChatDatabaseAdapter, 'getOpportunit
  */
 export interface NotificationQueueDeps {
   database?: NotificationQueueDatabase;
+  /** Notification-stream publisher (Redis pub/sub → the SSE stream). */
+  publishStreamEvent?: NotificationStreamPublisher;
+  /** Signal label for question-message copy; undefined when the signal has none. */
+  getIntentLabel?: (intentId: string) => Promise<string | undefined>;
 }
 
 const API_URL = process.env.API_URL || 'https://protocol.index.network';
@@ -50,6 +77,10 @@ const DIGEST_TTL_SEC = 7 * 24 * 3600;
  * (WebSocket emit), high (send email), or low (add to weekly digest). Uses email queue and Redis
  * for digest/dedupe.
  *
+ * Also handles `process_question_message_notification`: one notification-stream
+ * frame per delivered question-message, deep-linked to the signal's DM
+ * (conversational questions — the message, not the question, is the unit).
+ *
  * @remarks
  * Workers are started only by the protocol server via {@link NotificationQueue.startWorker}.
  * CLI scripts may add jobs without starting a worker.
@@ -57,17 +88,21 @@ const DIGEST_TTL_SEC = 7 * 24 * 3600;
 export class NotificationQueue {
   static readonly QUEUE_NAME = QUEUE_NAME;
 
-  readonly queue = QueueFactory.createQueue<NotificationJobData>(QUEUE_NAME);
+  readonly queue = QueueFactory.createQueue<NotificationQueueJobData>(QUEUE_NAME);
 
   private readonly logger = log.job.from('NotificationJob');
   private readonly queueLogger = log.queue.from('NotificationQueue');
   private readonly database: NotificationQueueDatabase;
-  private worker: ReturnType<typeof QueueFactory.createWorker<NotificationJobData>> | null = null;
+  private readonly publishStreamEvent: NotificationStreamPublisher;
+  private readonly getIntentLabel: (intentId: string) => Promise<string | undefined>;
+  private worker: ReturnType<typeof QueueFactory.createWorker<NotificationQueueJobData>> | null = null;
 
   /**
    * @param deps - Optional overrides for database (for tests).
    */
   constructor(deps?: NotificationQueueDeps) {
+    this.publishStreamEvent = deps?.publishStreamEvent ?? publishNotificationStreamEvent;
+    this.getIntentLabel = deps?.getIntentLabel ?? loadNotificationIntentLabel;
     if (deps?.database) {
       this.database = deps.database;
     } else {
@@ -90,7 +125,7 @@ export class NotificationQueue {
     opportunityId: string,
     recipientId: string,
     priority: NotificationPriority
-  ): Promise<Job<NotificationJobData>> {
+  ): Promise<Job<NotificationQueueJobData>> {
     const priorityNum = priority === 'immediate' ? 0 : priority === 'high' ? 5 : 10;
     return this.queue.add(
       'process_opportunity_notification',
@@ -106,14 +141,44 @@ export class NotificationQueue {
   }
 
   /**
+   * Enqueue the notification for one delivered question-message. Called by the
+   * regeneration job only when the delivered block asks something the client
+   * has not already seen — creation, or a regeneration that added a
+   * negotiation reference (docs/plans/2026-08-18-conversational-questions.md).
+   *
+   * The job id is the message's, so a redelivered enqueue coalesces: the
+   * message is the notification unit, and one message notifies once. It is
+   * reusable across regenerations because completed jobs are removed
+   * immediately — a later regeneration of the same message that adds a new
+   * question notifies again, as the policy requires.
+   *
+   * @param data - Recipient, signal scope, delivered message, question count
+   * @returns The BullMQ job
+   */
+  async queueQuestionMessageNotification(
+    data: QuestionMessageNotificationJobData,
+  ): Promise<Job<NotificationQueueJobData>> {
+    return this.queue.add('process_question_message_notification', data, {
+      jobId: `question-message-notification.${data.messageId}`,
+      attempts: 3,
+      backoff: { type: 'exponential', delay: 1000 },
+      removeOnComplete: true,
+      removeOnFail: true,
+    });
+  }
+
+  /**
    * Run the job handler for a given job name and payload. Used by the worker and by tests with injected deps.
-   * @param name - Job name (`process_opportunity_notification`)
+   * @param name - Job name (`process_opportunity_notification`, `process_question_message_notification`)
    * @param data - Job payload
    */
-  async processJob(name: string, data: NotificationJobData): Promise<void> {
+  async processJob(name: string, data: NotificationQueueJobData): Promise<void> {
     switch (name) {
       case 'process_opportunity_notification':
         await this.processOpportunityNotification(data as NotificationJobData);
+        break;
+      case 'process_question_message_notification':
+        await this.processQuestionMessageNotification(data as QuestionMessageNotificationJobData);
         break;
       default:
         this.queueLogger.warn('Unknown job name', { name });
@@ -125,11 +190,11 @@ export class NotificationQueue {
    */
   startWorker(): void {
     if (this.worker) return;
-    const processor = async (job: Job<NotificationJobData>) => {
+    const processor = async (job: Job<NotificationQueueJobData>) => {
       this.queueLogger.info('Processing job', { jobId: job.id, jobName: job.name });
       await this.processJob(job.name, job.data);
     };
-    this.worker = QueueFactory.createWorker<NotificationJobData>(QUEUE_NAME, processor);
+    this.worker = QueueFactory.createWorker<NotificationQueueJobData>(QUEUE_NAME, processor);
   }
 
   async close(): Promise<void> {
@@ -138,6 +203,49 @@ export class NotificationQueue {
       this.worker = null;
     }
     await this.queue.close();
+  }
+
+  /**
+   * Deliver one question-message notification: a single user-scoped frame on
+   * the notification stream, deep-linked to the signal's DM — the surface
+   * that actually answers it. Copy is server-owned (headline, question count,
+   * signal label); the agent-authored question text stays in the DM.
+   *
+   * One frame per message, no email or digest tier: an unanswered question is
+   * a live conversation the client returns to, not a match to catch up on
+   * weekly.
+   */
+  private async processQuestionMessageNotification(data: QuestionMessageNotificationJobData): Promise<void> {
+    const { userId, intentId, messageId, questionCount } = data;
+    // A missing label degrades the copy, never the notification.
+    const signalLabel = await this.getIntentLabel(intentId).catch((err) => {
+      this.logger.warn('Question-message signal label lookup failed', {
+        userId,
+        intentId,
+        error: err instanceof Error ? err.message : String(err),
+      });
+      return undefined;
+    });
+
+    const projection = buildQuestionMessageNotification({
+      intentId,
+      questionCount,
+      ...(signalLabel ? { signalLabel } : {}),
+      webAppUrl: WEB_APP_URL,
+    });
+    await this.publishStreamEvent(userId, {
+      type: 'question.new',
+      id: messageId,
+      title: projection.headline,
+      body: projection.summary,
+      link: projection.link,
+    });
+    this.logger.info('Published question-message notification', {
+      userId,
+      intentId,
+      messageId,
+      questionCount,
+    });
   }
 
   private async processOpportunityNotification(data: NotificationJobData): Promise<void> {
@@ -314,6 +422,6 @@ export async function queueOpportunityNotification(
   opportunityId: string,
   recipientId: string,
   priority: NotificationPriority
-): Promise<Job<NotificationJobData>> {
+): Promise<Job<NotificationQueueJobData>> {
   return notificationQueue.queueOpportunityNotification(opportunityId, recipientId, priority);
 }

--- a/services/api/src/queues/question-message.queue.ts
+++ b/services/api/src/queues/question-message.queue.ts
@@ -9,7 +9,9 @@
  * (grounded in the parked transcripts and the signal's client-DM excerpt),
  * serialize the question block, deliver into the signal's A2H DM — the
  * conversation keyed ('negotiator-intent', intentId). An empty parked set
- * means there is nothing to say and the job is done.
+ * means there is nothing left to ask: if the DM still shows an open
+ * question-message, the job rewrites it to a closed state (prose, no block)
+ * so no stale question lingers; otherwise the job is done.
  *
  * This queue also owns the trigger routing: the payloads with which the park
  * paths used to enqueue the QuestionerAgent (`negotiation_inflight` consults
@@ -30,11 +32,18 @@
  * the owner's conversation SSE channel — true at enqueue, false when the job
  * finishes — so an open DM shows the indicator and reloads instead of letting
  * the message change silently under the viewer.
+ *
+ * Notification hangs off the delivered MESSAGE, never off its questions: a
+ * delivery notifies iff its block references a negotiation the previous
+ * question-message did not (a plain set difference over the block's refs —
+ * nothing about "asked" or "answered" is stored anywhere). Creation compares
+ * against the empty set and therefore always notifies; a regeneration that
+ * only prunes, regroups, or rewrites prose, and a close-out, stay silent.
  */
 import { Job } from 'bullmq';
 
 import { classifyParkedNegotiation, consumeQuestionBlockAnswers, parseQuestionMessage, serializeQuestionMessage } from '@indexnetwork/protocol';
-import type { NegotiationAnswerConsumptionPorts, QuestionerEnqueuePayload } from '@indexnetwork/protocol';
+import type { NegotiationAnswerConsumptionPorts, QuestionBlock, QuestionBlockQuestion, QuestionerEnqueuePayload } from '@indexnetwork/protocol';
 
 import { log } from '../lib/log';
 import { QueueFactory, useHermeticRedis } from '../lib/bullmq/bullmq';
@@ -42,6 +51,7 @@ import { QuestionMessageAuthor } from '../lib/question/question-message.author';
 import { QuestionAnswerRouter } from '../lib/question/question-answer.router';
 import type { ParkedNegotiationReaderAdapter } from '../adapters/parked-negotiation.reader.adapter';
 import type { NegotiatorClientDmRetrieveFn } from '../adapters/negotiator-client-dm.retrieval.adapter';
+import type { QuestionMessageNotificationJobData } from './notification.queue';
 
 export const QUEUE_NAME = 'question-message-queue';
 
@@ -73,6 +83,17 @@ export interface QuestionAnswerJobData {
 }
 
 /**
+ * Server-owned close-out prose for an open question-message whose parked set
+ * emptied — the questions were answered, withdrawn, or expired while the
+ * message sat there. Fixed copy, never model text: the close-out is a
+ * bookkeeping rewrite, not something worth a model call, and it carries no
+ * question block, so the message stops being open the moment it lands.
+ */
+export const QUESTION_MESSAGE_CLOSED_BODY =
+  'Those questions are settled — the negotiations they were holding up have '
+  + 'moved on, so there is nothing here for you to answer right now.';
+
+/**
  * Server-owned clarifying follow-up for a reply that tried to answer but
  * could not be routed to any question. Fixed copy, never model text — same
  * rule as the fallback prose above.
@@ -100,6 +121,13 @@ export interface QuestionMessageChatSessions {
     | { session: { id: string } }
     | { error: string; status: 400 | 403 | 404 | 500 }
   >;
+  /**
+   * The signal's DM if it exists, without creating one — the close-out's
+   * anchor read. A close-out only ever rewrites a message that is already
+   * there, so it must not conjure a conversation for a signal whose parks
+   * resolved before the job ran.
+   */
+  findNegotiatorIntentSession(userId: string, intentId: string): Promise<{ id: string } | null>;
   addMessage(params: { sessionId: string; role: 'user' | 'assistant' | 'system'; content: string }): Promise<string>;
   /** Newest message in the conversation — the edit rule's anchor read. */
   getNewestMessage(sessionId: string): Promise<{ id: string; role: 'user' | 'assistant' | 'system'; content: string } | null>;
@@ -129,6 +157,18 @@ export interface QuestionMessageQueueDeps {
   answerRouter?: Pick<QuestionAnswerRouter, 'route'>;
   /** SSE flip for the live `questionRegenerationPending` signal; production publishes to the owner's conversation channel. */
   publishRegenerationEvent?: (userId: string, event: { intentId: string; pending: boolean }) => Promise<void>;
+  /** Notification seam; production enqueues onto the notification queue. */
+  notify?: (data: QuestionMessageNotificationJobData) => Promise<unknown>;
+}
+
+/**
+ * Every negotiation a block's questions reference — primaries plus each
+ * question's `alsoUnblocks`. This set IS the message's identity for
+ * notification purposes: the block carries no question ids, and a rewritten
+ * prompt over the same negotiation is the same ask.
+ */
+function questionBlockRefs(questions: ReadonlyArray<QuestionBlockQuestion>): Set<string> {
+  return new Set(questions.flatMap((question) => [question.opportunityId, ...(question.alsoUnblocks ?? [])]));
 }
 
 export class QuestionMessageQueue {
@@ -250,8 +290,11 @@ export class QuestionMessageQueue {
     const parked = await parkedSet.readParkedNegotiations(userId, intentId);
     if (parked.length === 0) {
       // Normal, not exceptional: the trigger may have raced an unpark, or the
-      // stall it fired for was terminal (no gap).
+      // stall it fired for was terminal (no gap). Nothing left to ask, but an
+      // open message from the last round would still be showing questions
+      // nobody can answer — close it out.
       this.logger.info('question_message_empty_parked_set', { userId, intentId });
+      await this.closeOutOpenQuestionMessage(userId, intentId);
       return;
     }
 
@@ -304,6 +347,15 @@ export class QuestionMessageQueue {
       await chatSessions.getNewestMessage(resolved.session.id),
       parked,
     );
+
+    // The notification decision, taken once for this delivery: which
+    // negotiations does the outgoing block ask about that the message it
+    // replaces did not? No prior open message means nothing has been asked
+    // yet, so every ref is new and the creation notifies.
+    const outgoingRefs = questionBlockRefs(authored.questions);
+    const priorRefs = openMessage ? questionBlockRefs(openMessage.block.questions) : new Set<string>();
+    const newRefs = [...outgoingRefs].filter((ref) => !priorRefs.has(ref));
+
     if (openMessage) {
       const updated = await chatSessions.updateQuestionMessageInPlace({
         userId,
@@ -319,7 +371,14 @@ export class QuestionMessageQueue {
           messageId: openMessage.id,
           parked: parked.length,
           questions: authored.questions.length,
+          newRefs: newRefs.length,
         });
+        await this.notifyIfAsksSomethingNew({
+          userId,
+          intentId,
+          messageId: openMessage.id,
+          questionCount: authored.questions.length,
+        }, newRefs);
         return;
       }
       // The data layer's newest guard rejected the write: a reply landed
@@ -333,7 +392,7 @@ export class QuestionMessageQueue {
       });
     }
 
-    await chatSessions.addMessage({
+    const messageId = await chatSessions.addMessage({
       sessionId: resolved.session.id,
       role: 'assistant',
       content: body,
@@ -342,9 +401,105 @@ export class QuestionMessageQueue {
       userId,
       intentId,
       sessionId: resolved.session.id,
+      messageId,
       parked: parked.length,
       questions: authored.questions.length,
+      newRefs: newRefs.length,
     });
+    await this.notifyIfAsksSomethingNew({
+      userId,
+      intentId,
+      messageId,
+      questionCount: authored.questions.length,
+    }, newRefs);
+  }
+
+  /**
+   * Close out an open question-message whose parked set emptied: rewrite it
+   * to prose with no block, through the same guarded update seam the edit
+   * rule uses. Silent by policy — nothing is being asked — and bounded by the
+   * same newest-message rule: if the client replied since, the reply wins and
+   * the message is left exactly as it is (the block simply stops being open,
+   * because none of its refs is parked any more).
+   *
+   * Never throws: the parked set is already empty, so there is no delivery to
+   * retry for and a failed tidy-up must not fail the job.
+   */
+  private async closeOutOpenQuestionMessage(userId: string, intentId: string): Promise<void> {
+    try {
+      const chatSessions = this.deps?.chatSessions ?? (await import('../services/chat.service')).chatSessionService;
+      const session = await chatSessions.findNegotiatorIntentSession(userId, intentId);
+      if (!session) return;
+
+      const newest = await chatSessions.getNewestMessage(session.id);
+      // Deliberately looser than the edit rule's open-message predicate: with
+      // an empty parked set no block can reference a parked negotiation, so
+      // "newest, agent-authored, parseable block" IS the message to close.
+      if (!newest || newest.role !== 'assistant' || !parseQuestionMessage(newest.content)) return;
+
+      const updated = await chatSessions.updateQuestionMessageInPlace({
+        userId,
+        intentId,
+        messageId: newest.id,
+        content: QUESTION_MESSAGE_CLOSED_BODY,
+      });
+      this.logger.info(updated ? 'question_message_closed_out' : 'question_message_close_out_lost_newest_race', {
+        userId,
+        intentId,
+        sessionId: session.id,
+        messageId: newest.id,
+      });
+    } catch (err) {
+      this.logger.warn('question_message_close_out_failed', {
+        userId,
+        intentId,
+        error: err instanceof Error ? err.message : String(err),
+      });
+    }
+  }
+
+  /**
+   * Notify iff this delivery asks about a negotiation the message it replaces
+   * did not — the plan's policy in one place: create → notify (empty prior
+   * set), new questions → notify, pruning/regrouping/prose rewrites and
+   * answer-driven shrinkage → silent.
+   *
+   * Best-effort: the message is already delivered, and a failed enqueue must
+   * not throw the job back onto the retry path where it would deliver again.
+   */
+  private async notifyIfAsksSomethingNew(
+    data: QuestionMessageNotificationJobData,
+    newRefs: ReadonlyArray<string>,
+  ): Promise<void> {
+    if (newRefs.length === 0) {
+      this.logger.info('question_message_notification_suppressed', {
+        userId: data.userId,
+        intentId: data.intentId,
+        messageId: data.messageId,
+      });
+      return;
+    }
+    try {
+      const notify = this.deps?.notify ?? (async (payload: QuestionMessageNotificationJobData) => {
+        const { notificationQueue } = await import('./notification.queue');
+        return notificationQueue.queueQuestionMessageNotification(payload);
+      });
+      await notify(data);
+      this.logger.info('question_message_notification_enqueued', {
+        userId: data.userId,
+        intentId: data.intentId,
+        messageId: data.messageId,
+        questions: data.questionCount,
+        newRefs: newRefs.length,
+      });
+    } catch (err) {
+      this.logger.warn('question_message_notification_enqueue_failed', {
+        userId: data.userId,
+        intentId: data.intentId,
+        messageId: data.messageId,
+        error: err instanceof Error ? err.message : String(err),
+      });
+    }
   }
 
   /**
@@ -354,18 +509,21 @@ export class QuestionMessageQueue {
    * the current parked set. Anything else — user replied since, plain agent
    * prose, an unparseable block, refs all resolved — is not open, and the
    * regeneration appends instead.
+   *
+   * Returns the block along with the id: it is the message this delivery
+   * replaces, so its refs are what the notification decision compares against.
    */
   private findOpenQuestionMessage(
     newest: { id: string; role: 'user' | 'assistant' | 'system'; content: string } | null,
     parked: ReadonlyArray<{ opportunityId: string }>,
-  ): { id: string } | null {
+  ): { id: string; block: QuestionBlock } | null {
     if (!newest || newest.role !== 'assistant') return null;
     const parsed = parseQuestionMessage(newest.content);
     if (!parsed) return null;
     const parkedRefs = new Set(parked.map((negotiation) => negotiation.opportunityId));
     const referencesParked = parsed.block.questions.some((question) =>
       [question.opportunityId, ...(question.alsoUnblocks ?? [])].some((ref) => parkedRefs.has(ref)));
-    return referencesParked ? { id: newest.id } : null;
+    return referencesParked ? { id: newest.id, block: parsed.block } : null;
   }
 
   /**

--- a/services/api/src/queues/tests/notification.queue.isolated.ts
+++ b/services/api/src/queues/tests/notification.queue.isolated.ts
@@ -67,6 +67,7 @@ afterAll(() => {
 });
 
 import { NotificationQueue, QUEUE_NAME, type NotificationJobData, type NotificationPriority, type NotificationQueueDatabase, queueOpportunityNotification } from '../notification.queue';
+import type { NotificationStreamEvent } from '../../lib/notification-stream-events';
 import { onTelegramNotification } from '../../lib/notification-events';
 
 const asNotifDb = (db: { getOpportunity: (id: string) => Promise<unknown> }): NotificationQueueDatabase => ({
@@ -476,5 +477,77 @@ describe('processOpportunityNotification — Telegram delivery', () => {
 
     unsub();
     expect(received).toHaveLength(0);
+  });
+});
+
+// ─── Question-message notifications (conversational questions) ───────────────
+
+describe('question-message notification job', () => {
+  function buildQueue(options: { intentLabel?: string; labelError?: boolean } = {}) {
+    const published: Array<{ userId: string; event: NotificationStreamEvent }> = [];
+    const queue = new NotificationQueue({
+      database: asNotifDb({ getOpportunity: async () => null }),
+      publishStreamEvent: async (userId, event) => { published.push({ userId, event }); },
+      getIntentLabel: async () => {
+        if (options.labelError) throw new Error('database unavailable');
+        return options.intentLabel;
+      },
+    });
+    return { queue, published };
+  }
+
+  it('publishes one stream frame deep-linked to the signal DM', async () => {
+    const { queue, published } = buildQueue({ intentLabel: 'Finding a technical co-founder' });
+
+    await queue.processJob('process_question_message_notification', {
+      userId: 'user-q1',
+      intentId: 'intent-q1',
+      messageId: 'message-q1',
+      questionCount: 2,
+    });
+
+    expect(published).toHaveLength(1);
+    expect(published[0].userId).toBe('user-q1');
+    expect(published[0].event.type).toBe('question.new');
+    // The frame is identified by the message, not by a question: one message,
+    // one notification, whatever it asks.
+    expect(published[0].event.id).toBe('message-q1');
+    expect(published[0].event.title).toBe('Your agent needs an answer');
+    expect(published[0].event.body).toContain('2 questions');
+    expect(published[0].event.body).toContain('Finding a technical co-founder');
+    expect(published[0].event.link).toMatch(/^https?:\/\/.+\/i\/intent-q1$/);
+  });
+
+  it('still notifies when the signal has no label to read', async () => {
+    const { queue, published } = buildQueue({ labelError: true });
+
+    await queue.processJob('process_question_message_notification', {
+      userId: 'user-q2',
+      intentId: 'intent-q2',
+      messageId: 'message-q2',
+      questionCount: 1,
+    });
+
+    expect(published).toHaveLength(1);
+    expect(published[0].event.body).toBe('1 question about one of your signals.');
+    expect(published[0].event.link).toContain('/i/intent-q2');
+  });
+
+  it('enqueues one job per message, keyed by the message id', async () => {
+    mockAdd.mockClear();
+    const { queue } = buildQueue();
+
+    await queue.queueQuestionMessageNotification({
+      userId: 'user-q3',
+      intentId: 'intent-q3',
+      messageId: 'message-q3',
+      questionCount: 3,
+    });
+
+    expect(mockAdd).toHaveBeenCalledTimes(1);
+    const [name, data, opts] = mockAdd.mock.calls[0] as unknown as [string, unknown, { jobId: string }];
+    expect(name).toBe('process_question_message_notification');
+    expect(data).toEqual({ userId: 'user-q3', intentId: 'intent-q3', messageId: 'message-q3', questionCount: 3 });
+    expect(opts.jobId).toBe('question-message-notification.message-q3');
   });
 });

--- a/services/api/src/queues/tests/question-message.queue.isolated.ts
+++ b/services/api/src/queues/tests/question-message.queue.isolated.ts
@@ -10,11 +10,12 @@
 import { describe, expect, it } from 'bun:test';
 
 import { negotiationParkAnswerId, negotiationQuestionSettlementId, parseQuestionMessage, serializeQuestionMessage } from '@indexnetwork/protocol';
-import type { NegotiationAnswerConsumptionPorts, QuestionerEnqueuePayload, RoutedAnswer } from '@indexnetwork/protocol';
+import type { NegotiationAnswerConsumptionPorts, QuestionBlockQuestion, QuestionerEnqueuePayload, RoutedAnswer } from '@indexnetwork/protocol';
 import { questionBlockFixture, questionMessageFixture, questionProseFixture } from '@indexnetwork/protocol/question-block/fixture';
 
-import { QUESTION_ANSWER_CLARIFICATION_MESSAGE, QUEUE_NAME, QuestionMessageQueue, enqueueQuestionAnswerReply, parkedQuestionMessageTarget, questionMessageJobId } from '../question-message.queue';
+import { QUESTION_ANSWER_CLARIFICATION_MESSAGE, QUESTION_MESSAGE_CLOSED_BODY, QUEUE_NAME, QuestionMessageQueue, enqueueQuestionAnswerReply, parkedQuestionMessageTarget, questionMessageJobId } from '../question-message.queue';
 import type { QuestionAnswerJobData } from '../question-message.queue';
+import type { QuestionMessageNotificationJobData } from '../notification.queue';
 import { QueueFactory } from '../../lib/bullmq/bullmq';
 import type { ParkedNegotiation } from '../../adapters/parked-negotiation.reader.adapter';
 
@@ -70,17 +71,20 @@ interface PublishedPendingFlip {
 
 function buildQueue(options: {
   parked: ParkedNegotiation[];
-  authorResult?: { prose: string; questions: typeof questionBlockFixture.questions } | null;
+  authorResult?: { prose: string; questions: QuestionBlockQuestion[] } | null;
   resolveResult?: { session: { id: string } } | { error: string; status: 400 | 403 | 404 | 500 };
   /** Newest message in the conversation at regeneration time (default: empty conversation). */
   newestMessage?: { id: string; role: 'user' | 'assistant' | 'system'; content: string } | null;
   /** What the update seam reports; false simulates the in-statement newest check failing. */
   updateResult?: boolean;
+  /** The signal's DM as the read-only close-out lookup finds it (default: it exists). */
+  existingSession?: { id: string } | null;
 }) {
   const delivered: DeliveredMessage[] = [];
   const updated: UpdatedMessage[] = [];
   const published: PublishedPendingFlip[] = [];
-  const calls = { author: 0, resolve: 0 };
+  const notified: QuestionMessageNotificationJobData[] = [];
+  const calls = { author: 0, resolve: 0, findSession: 0 };
   const queue = new QuestionMessageQueue({
     parkedSet: { readParkedNegotiations: async () => options.parked },
     clientDm: async () => [],
@@ -98,6 +102,10 @@ function buildQueue(options: {
         calls.resolve += 1;
         return options.resolveResult ?? { session: { id: 'session-1' } };
       },
+      findNegotiatorIntentSession: async () => {
+        calls.findSession += 1;
+        return options.existingSession === undefined ? { id: 'session-1' } : options.existingSession;
+      },
       addMessage: async (params) => {
         delivered.push(params);
         return `message-${delivered.length}`;
@@ -111,8 +119,11 @@ function buildQueue(options: {
     publishRegenerationEvent: async (userId, event) => {
       published.push({ userId, ...event });
     },
+    notify: async (data) => {
+      notified.push(data);
+    },
   });
-  return { queue, delivered, updated, published, calls };
+  return { queue, delivered, updated, published, notified, calls };
 }
 
 describe('QuestionMessageQueue regeneration job', () => {
@@ -139,14 +150,17 @@ describe('QuestionMessageQueue regeneration job', () => {
     expect(parsed!.block).toEqual(questionBlockFixture);
   });
 
-  it('does nothing on an empty parked set — no authoring, no session, no message', async () => {
-    const { queue, delivered, calls } = buildQueue({ parked: [] });
+  it('does nothing on an empty parked set with nothing open — no authoring, no session create, no message', async () => {
+    const { queue, delivered, updated, calls } = buildQueue({ parked: [] });
 
     await queue.processJob('regenerate_question_message', { userId: USER_ID, intentId: INTENT_ID });
 
     expect(calls.author).toBe(0);
+    // The close-out looks, but only through the read-only lookup: an empty
+    // parked set must never conjure a DM for a signal that has none.
     expect(calls.resolve).toBe(0);
     expect(delivered).toHaveLength(0);
+    expect(updated).toHaveLength(0);
   });
 
   it('skips delivery when the author has nothing renderable', async () => {
@@ -267,6 +281,231 @@ describe('QuestionMessageQueue edit rule', () => {
     expect(updated).toHaveLength(1);
     expect(delivered).toHaveLength(1);
     expect(delivered[0].content).toBe(questionMessageFixture);
+  });
+});
+
+// ─── Notification policy (create/new questions notify, everything else silent) ─
+
+/** A block over an explicit subset of the fixture's questions. */
+function openMessageOver(questions: QuestionBlockQuestion[], prose = 'An earlier rendering of these questions.'): string {
+  return serializeQuestionMessage(prose, { version: 1, questions });
+}
+
+const [FIXTURE_QUESTION_1, FIXTURE_QUESTION_2] = questionBlockFixture.questions;
+
+describe('QuestionMessageQueue notification policy', () => {
+  it('notifies once when the question-message is created — one notification per message, never per question', async () => {
+    const { queue, delivered, notified } = buildQueue({
+      parked: [parkedNegotiation(FIXTURE_PRIMARY_1, 0)],
+    });
+
+    await queue.processJob('regenerate_question_message', { userId: USER_ID, intentId: INTENT_ID });
+
+    expect(delivered).toHaveLength(1);
+    // Two questions over three negotiation refs; exactly one notification,
+    // naming the delivered message and the signal whose DM carries it.
+    expect(notified).toEqual([{
+      userId: USER_ID,
+      intentId: INTENT_ID,
+      messageId: 'message-1',
+      questionCount: 2,
+    }]);
+  });
+
+  it('notifies on a regeneration that adds a negotiation the open message did not ask about', async () => {
+    const { queue, updated, notified } = buildQueue({
+      parked: [parkedNegotiation(FIXTURE_PRIMARY_1, 0), parkedNegotiation(FIXTURE_PRIMARY_2, 2)],
+      // The open message asked about the equity gap only; the Berlin lab
+      // parked since and joins the regenerated block.
+      newestMessage: { id: 'open-1', role: 'assistant', content: openMessageOver([FIXTURE_QUESTION_1]) },
+    });
+
+    await queue.processJob('regenerate_question_message', { userId: USER_ID, intentId: INTENT_ID });
+
+    expect(updated).toHaveLength(1);
+    expect(notified).toEqual([{
+      userId: USER_ID,
+      intentId: INTENT_ID,
+      messageId: 'open-1',
+      questionCount: 2,
+    }]);
+  });
+
+  it('stays silent when a regeneration only drops refs — pruning is not a new ask', async () => {
+    const { queue, updated, notified } = buildQueue({
+      parked: [parkedNegotiation(FIXTURE_PRIMARY_1, 0)],
+      newestMessage: { id: 'open-1', role: 'assistant', content: openMessageOver(questionBlockFixture.questions) },
+      authorResult: { prose: 'The Berlin lab withdrew; one thing left.', questions: [FIXTURE_QUESTION_1] },
+    });
+
+    await queue.processJob('regenerate_question_message', { userId: USER_ID, intentId: INTENT_ID });
+
+    expect(updated).toHaveLength(1);
+    expect(notified).toHaveLength(0);
+  });
+
+  it('stays silent when a regeneration only regroups the same refs and rewrites the prose', async () => {
+    const { queue, updated, notified } = buildQueue({
+      parked: [parkedNegotiation(FIXTURE_PRIMARY_1, 0), parkedNegotiation(FIXTURE_PRIMARY_2, 2)],
+      newestMessage: { id: 'open-1', role: 'assistant', content: openMessageOver(questionBlockFixture.questions) },
+      // Same three negotiations, merged into one question under new prose.
+      authorResult: {
+        prose: 'Both of these come down to the same thing.',
+        questions: [{
+          prompt: 'What equity range and on-site cadence can you commit to?',
+          opportunityId: FIXTURE_PRIMARY_1,
+          alsoUnblocks: [FIXTURE_ALSO_1, FIXTURE_PRIMARY_2],
+        }],
+      },
+    });
+
+    await queue.processJob('regenerate_question_message', { userId: USER_ID, intentId: INTENT_ID });
+
+    expect(updated).toHaveLength(1);
+    expect(notified).toHaveLength(0);
+  });
+
+  it('stays silent when an answer-driven resume leaves a fresh message that re-states known questions', async () => {
+    // The client replied, so the update loses the newest check and the
+    // remaining question goes into a fresh message below the answer. It is a
+    // new message, but it asks nothing the client has not already seen.
+    const { queue, delivered, updated, notified } = buildQueue({
+      parked: [parkedNegotiation(FIXTURE_PRIMARY_1, 0)],
+      newestMessage: { id: 'open-1', role: 'assistant', content: openMessageOver(questionBlockFixture.questions) },
+      updateResult: false,
+      authorResult: { prose: 'Thanks — one thing still open.', questions: [FIXTURE_QUESTION_1] },
+    });
+
+    await queue.processJob('regenerate_question_message', { userId: USER_ID, intentId: INTENT_ID });
+
+    expect(updated).toHaveLength(1);
+    expect(delivered).toHaveLength(1);
+    expect(notified).toHaveLength(0);
+  });
+
+  it('notifies for a fresh message that asks about a negotiation the old message never named', async () => {
+    // The old message's refs all resolved (it is closed), and the new park is
+    // a different negotiation: a created message asking something new.
+    const { queue, delivered, notified } = buildQueue({
+      parked: [parkedNegotiation(FIXTURE_PRIMARY_2, 2)],
+      newestMessage: { id: 'closed-1', role: 'assistant', content: openMessageOver([FIXTURE_QUESTION_1]) },
+      authorResult: { prose: 'One new thing.', questions: [FIXTURE_QUESTION_2] },
+    });
+
+    await queue.processJob('regenerate_question_message', { userId: USER_ID, intentId: INTENT_ID });
+
+    expect(delivered).toHaveLength(1);
+    expect(notified).toEqual([{
+      userId: USER_ID,
+      intentId: INTENT_ID,
+      messageId: 'message-1',
+      questionCount: 1,
+    }]);
+  });
+
+  it('delivers even when the notification enqueue fails — the message is not retried for it', async () => {
+    const delivered: DeliveredMessage[] = [];
+    const queue = new QuestionMessageQueue({
+      parkedSet: { readParkedNegotiations: async () => [parkedNegotiation(FIXTURE_PRIMARY_1, 0)] },
+      clientDm: async () => [],
+      getIntentText: async () => null,
+      author: { author: async () => ({ prose: questionProseFixture, questions: questionBlockFixture.questions }) },
+      chatSessions: {
+        resolveNegotiatorIntentSession: async () => ({ session: { id: 'session-1' } }),
+        findNegotiatorIntentSession: async () => ({ id: 'session-1' }),
+        addMessage: async (params) => {
+          delivered.push(params);
+          return 'message-1';
+        },
+        getNewestMessage: async () => null,
+        updateQuestionMessageInPlace: async () => true,
+      },
+      publishRegenerationEvent: async () => {},
+      notify: async () => {
+        throw new Error('redis unavailable');
+      },
+    });
+
+    await queue.processJob('regenerate_question_message', { userId: USER_ID, intentId: INTENT_ID });
+
+    expect(delivered).toHaveLength(1);
+  });
+});
+
+// ─── Close-out: the parked set emptied under an open question-message ─────────
+
+describe('QuestionMessageQueue close-out', () => {
+  it('rewrites the open message to a closed state — prose, no block, no notification', async () => {
+    const { queue, delivered, updated, notified } = buildQueue({
+      parked: [],
+      newestMessage: { id: 'open-1', role: 'assistant', content: questionMessageFixture },
+    });
+
+    await queue.processJob('regenerate_question_message', { userId: USER_ID, intentId: INTENT_ID });
+
+    expect(updated).toEqual([{
+      userId: USER_ID,
+      intentId: INTENT_ID,
+      messageId: 'open-1',
+      content: QUESTION_MESSAGE_CLOSED_BODY,
+    }]);
+    // The rewritten body carries no block, so the message stops being open
+    // and the steps UI renders it as plain prose.
+    expect(parseQuestionMessage(updated[0].content)).toBeNull();
+    expect(delivered).toHaveLength(0);
+    expect(notified).toHaveLength(0);
+  });
+
+  it('leaves the message untouched when the client replied since — the reply owns the thread', async () => {
+    const { queue, delivered, updated, notified } = buildQueue({
+      parked: [],
+      newestMessage: { id: 'reply-1', role: 'user', content: 'March at the earliest.' },
+    });
+
+    await queue.processJob('regenerate_question_message', { userId: USER_ID, intentId: INTENT_ID });
+
+    expect(updated).toHaveLength(0);
+    expect(delivered).toHaveLength(0);
+    expect(notified).toHaveLength(0);
+  });
+
+  it('leaves an already-closed message alone', async () => {
+    const { queue, updated } = buildQueue({
+      parked: [],
+      newestMessage: { id: 'closed-1', role: 'assistant', content: QUESTION_MESSAGE_CLOSED_BODY },
+    });
+
+    await queue.processJob('regenerate_question_message', { userId: USER_ID, intentId: INTENT_ID });
+
+    expect(updated).toHaveLength(0);
+  });
+
+  it('does not touch the DM when the signal has none', async () => {
+    const { queue, updated, calls } = buildQueue({
+      parked: [],
+      existingSession: null,
+      newestMessage: { id: 'open-1', role: 'assistant', content: questionMessageFixture },
+    });
+
+    await queue.processJob('regenerate_question_message', { userId: USER_ID, intentId: INTENT_ID });
+
+    expect(calls.findSession).toBe(1);
+    expect(calls.resolve).toBe(0);
+    expect(updated).toHaveLength(0);
+  });
+
+  it('swallows a close-out that loses the newest-message race inside the update', async () => {
+    const { queue, delivered, notified } = buildQueue({
+      parked: [],
+      newestMessage: { id: 'open-1', role: 'assistant', content: questionMessageFixture },
+      updateResult: false,
+    });
+
+    await queue.processJob('regenerate_question_message', { userId: USER_ID, intentId: INTENT_ID });
+
+    // The reply that raced it wins; nothing else is written to the DM.
+    expect(delivered).toHaveLength(0);
+    expect(notified).toHaveLength(0);
   });
 });
 
@@ -411,6 +650,7 @@ function buildAnswerHarness(options: AnswerHarnessOptions) {
     recorded: [] as Array<{ opportunityId: string; questionId: string; freeText?: string }>,
     stalledRetries: [] as Array<{ opportunityId: string; parkTaskId: string }>,
     delivered: [] as DeliveredMessage[],
+    notified: [] as QuestionMessageNotificationJobData[],
   };
   const taskIdFor = (opportunityId: string) => `task-${opportunityId}`;
   const ports: NegotiationAnswerConsumptionPorts = {
@@ -496,6 +736,7 @@ function buildAnswerHarness(options: AnswerHarnessOptions) {
     },
     chatSessions: {
       resolveNegotiatorIntentSession: async () => ({ session: { id: 'session-1' } }),
+      findNegotiatorIntentSession: async () => ({ id: 'session-1' }),
       addMessage: async (params) => {
         calls.delivered.push(params);
         return `message-${calls.delivered.length}`;
@@ -504,6 +745,9 @@ function buildAnswerHarness(options: AnswerHarnessOptions) {
       updateQuestionMessageInPlace: async () => {
         throw new Error('answer consumption must never rewrite the question-message');
       },
+    },
+    notify: async (data) => {
+      calls.notified.push(data);
     },
   });
   return { queue, calls };
@@ -609,6 +853,21 @@ describe('QuestionMessageQueue answer-consumption job', () => {
     expect(calls.settled).toHaveLength(0);
     expect(calls.delivered).toHaveLength(0);
   });
+
+  it('never notifies for an answer-driven resume — the client is already in the conversation', async () => {
+    const { queue, calls } = buildAnswerHarness({
+      parks: { [FIXTURE_PRIMARY_1]: 'inflight', [FIXTURE_ALSO_1]: 'inflight' },
+      routed: {
+        addressesQuestions: true,
+        answers: [{ ref: FIXTURE_PRIMARY_1, answerText: 'Up to two percent.' }],
+      },
+    });
+
+    await queue.processJob('consume_question_answers', answerJob('Up to two percent.'));
+
+    expect(calls.inflightResumes).toHaveLength(2);
+    expect(calls.notified).toHaveLength(0);
+  });
 });
 
 describe('enqueueQuestionAnswerReply detection', () => {
@@ -702,6 +961,7 @@ describe('regeneration ↔ answer serialization', () => {
       },
       chatSessions: {
         resolveNegotiatorIntentSession: async () => ({ session: { id: 'session-race' } }),
+        findNegotiatorIntentSession: async () => ({ id: 'session-race' }),
         addMessage: async () => {
           events.push('regenerate:delivered');
           return 'message-race-1';
@@ -710,6 +970,9 @@ describe('regeneration ↔ answer serialization', () => {
         updateQuestionMessageInPlace: async () => {
           throw new Error('no open message in this scenario');
         },
+      },
+      notify: async () => {
+        events.push('regenerate:notified');
       },
       answerPorts: {
         database: {

--- a/services/api/src/services/chat.service.ts
+++ b/services/api/src/services/chat.service.ts
@@ -481,6 +481,21 @@ export class ChatSessionService {
   }
 
   /**
+   * The user's negotiator session for an intent if it already exists — the
+   * read-only companion to {@link resolveNegotiatorIntentSession}. Background
+   * work that only wants to rewrite what is already in the DM (the
+   * question-message close-out) uses this so it never conjures an empty
+   * conversation for a signal the client has never opened.
+   *
+   * @param userId - The client user
+   * @param intentId - The pinned intent
+   * @returns The session, or null when the DM does not exist yet
+   */
+  async findNegotiatorIntentSession(userId: string, intentId: string) {
+    return this.db.getNegotiatorIntentChatSession(userId, intentId.trim());
+  }
+
+  /**
    * True when the error (or any error in its `cause` chain) is a Postgres
    * unique violation. Drizzle wraps driver errors in `DrizzleQueryError`
    * with the pg error on `cause`, so checking only the top level misses the

--- a/services/api/src/services/notification-projection.ts
+++ b/services/api/src/services/notification-projection.ts
@@ -6,6 +6,23 @@ const OPPORTUNITY_NOTIFICATION_HEADLINE = 'A promising connection';
 const OPPORTUNITY_NOTIFICATION_EMPTY_SUMMARY = 'A new match that might be relevant to you.';
 export const NOTIFICATION_LABEL_MAX_CHARS = 80;
 
+/**
+ * Question-message notification copy (conversational questions,
+ * docs/plans/2026-08-18-conversational-questions.md). The message is the
+ * notification unit, so the frame counts questions and names the signal —
+ * it never renders the agent-authored question text itself, which belongs in
+ * the DM behind the deep link.
+ */
+const QUESTION_NOTIFICATION_HEADLINE = 'Your agent needs an answer';
+const QUESTION_NOTIFICATION_UNLABELLED_SIGNAL = 'one of your signals';
+
+export interface QuestionMessageNotificationProjection {
+  headline: string;
+  summary: string;
+  /** Absolute deep link to the signal's DM. */
+  link: string;
+}
+
 export interface OpportunityNotificationProjection {
   headline: string;
   summary: string;
@@ -38,6 +55,36 @@ export function counterpartForRecipient(
 ): OpportunityRow['actors'][number] | undefined {
   const otherActors = opportunity.actors.filter(({ userId }) => userId !== recipientId);
   return otherActors.find(({ role }) => role !== 'introducer') ?? otherActors[0];
+}
+
+/**
+ * The signal's DM as a link: the web app renders the
+ * ('negotiator-intent', intentId) conversation in the Personal Agent panel of
+ * the signal page, so the DM's address is the signal's address.
+ */
+export function questionMessageDeepLink(intentId: string, webAppUrl: string): string {
+  return `${webAppUrl.replace(/\/+$/, '')}/i/${encodeURIComponent(intentId)}`;
+}
+
+/**
+ * One question-message → one notification frame, whatever it asks. The count
+ * is copy, not a fan-out: batching is the whole point of hanging the
+ * notification off the message rather than off its questions.
+ */
+export function buildQuestionMessageNotification(input: {
+  intentId: string;
+  questionCount: number;
+  signalLabel?: string;
+  webAppUrl: string;
+}): QuestionMessageNotificationProjection {
+  const count = Math.max(1, Math.trunc(input.questionCount));
+  const label = boundedNotificationLabel(input.signalLabel);
+  const signal = label ? `“${label}”` : QUESTION_NOTIFICATION_UNLABELLED_SIGNAL;
+  return {
+    headline: QUESTION_NOTIFICATION_HEADLINE,
+    summary: `${count} ${count === 1 ? 'question' : 'questions'} about ${signal}.`,
+    link: questionMessageDeepLink(input.intentId, input.webAppUrl),
+  };
 }
 
 export function buildOpportunityNotificationEvent(

--- a/services/api/src/services/tests/notification-projection.isolated.ts
+++ b/services/api/src/services/tests/notification-projection.isolated.ts
@@ -1,7 +1,7 @@
 import { describe, expect, test } from 'bun:test';
 
 import type { OpportunityRow, UserIdentity } from '../../adapters/database.shared';
-import { actionableRecipientIds, buildOpportunityNotificationEvent, counterpartForRecipient } from '../notification-projection';
+import { actionableRecipientIds, buildOpportunityNotificationEvent, buildQuestionMessageNotification, counterpartForRecipient, questionMessageDeepLink } from '../notification-projection';
 
 const now = new Date('2026-08-10T12:00:00.000Z');
 
@@ -125,5 +125,43 @@ describe('authoritative opportunity notification projection', () => {
     expect(event.summary).toContain('Casey builds privacy-preserving tools.');
     expect(event.summary).not.toContain('internal scoring');
     expect(event.summary).not.toContain('Ivy Introducer');
+  });
+});
+
+describe('question-message notification copy', () => {
+  const webAppUrl = 'https://index.network';
+
+  test('counts the questions and names the signal, deep-linked to its DM', () => {
+    const projection = buildQuestionMessageNotification({
+      intentId: 'intent-1',
+      questionCount: 2,
+      signalLabel: 'Finding a technical co-founder',
+      webAppUrl,
+    });
+
+    expect(projection.headline).toBe('Your agent needs an answer');
+    expect(projection.summary).toBe('2 questions about \u201cFinding a technical co-founder\u201d.');
+    expect(projection.link).toBe('https://index.network/i/intent-1');
+  });
+
+  test('reads naturally for a single question and for a signal with no label', () => {
+    expect(buildQuestionMessageNotification({ intentId: 'intent-1', questionCount: 1, webAppUrl }).summary)
+      .toBe('1 question about one of your signals.');
+  });
+
+  test('bounds a long signal label the way every other notification does', () => {
+    const projection = buildQuestionMessageNotification({
+      intentId: 'intent-1',
+      questionCount: 1,
+      signalLabel: 'x'.repeat(200),
+      webAppUrl,
+    });
+
+    expect(projection.summary.length).toBeLessThan(120);
+  });
+
+  test('never breaks the link on a trailing slash or an odd intent id', () => {
+    expect(questionMessageDeepLink('intent-1', 'https://index.network/')).toBe('https://index.network/i/intent-1');
+    expect(questionMessageDeepLink('a b', webAppUrl)).toBe('https://index.network/i/a%20b');
   });
 });


### PR DESCRIPTION
Closes the conversational-questions plan (`docs/plans/2026-08-18-conversational-questions.md`) — the last item, Notifications, plus the close-out follow-up #1437 surfaced. The DM question-message notified nobody: a client who did not open the signal's DM never learned their agent was blocked on them.

## New-question detection

The regeneration job compares the outgoing block's negotiation refs against the refs of the message it replaces — the block the edit rule already parsed — and notifies only when the delivery names a negotiation the client has not been asked about. A plain set difference: no stored state, no flags, nothing about "asked" or "answered" persisted anywhere.

| Delivery | Notify? |
| --- | --- |
| Created (no open message to compare against — empty prior set) | ✅ |
| Regenerated in place, block gains a ref | ✅ |
| Fresh message naming a negotiation the old message never did | ✅ |
| Regenerated, refs only dropped (unpark-prune) | 🔕 |
| Regenerated, same refs regrouped / prose rewritten | 🔕 |
| Answer-driven: resume, and the fresh message below the reply re-stating known questions | 🔕 |
| Close-out | 🔕 |

One judgement call worth flagging: the plan's *"message created → notify"* and *"answer-driven changes → silent"* collide for the message the edit rule creates **below a client reply**. I let the set difference decide — a message that asks nothing new is silent even though it is new — because the alternative re-pings a client who just answered. That is the last row of the table, and it is tested.

## Delivery

One notification-stream frame per regeneration, never one per question, enqueued on the existing `notification.queue.ts` (`process_question_message_notification`, keyed by message id so a redelivery coalesces). The frame is `question.new` — the type was already in the union — carrying server-owned copy (headline, question count, signal label; never the agent-authored question text) and a deep link to `/i/:intentId`, the route that renders the `('negotiator-intent', intentId)` conversation.

`NotificationStreamEvent` gains an optional `link`; it is additive, and clients that ignore it are unaffected. No email, digest, or Telegram tier: an unanswered question is a live conversation to return to, not a match to catch up on weekly. The enqueue is best-effort — the message is already delivered, so a failed enqueue must not throw the job onto a retry that would deliver twice.

## Empty-set close-out

A regeneration that finds the parked set empty under an open question-message now rewrites it to fixed prose with no block, instead of early-returning and leaving stale question text sitting in the DM. It goes through the #1436 update seam, so the newest-message rule still bounds it: if the client replied since, the reply wins and the message is left alone (its block simply stops being open). Silent by policy, and it uses a new read-only `findNegotiatorIntentSession` lookup so an empty parked set can never conjure a DM for a signal that has none.

## Tests

`question-message.queue.isolated.ts` — create → one notification; regeneration adding a ref → notification; drop-only and regroup-only → silent; answer-driven resume → silent (both the consumption job and the fresh message below the reply); notification failure does not re-deliver. Close-out: rewritten to the closed body with no parseable block, no notification, no new message; untouched when the client replied since; no-op when already closed, when the DM does not exist, and when the update loses the newest race.
`notification.queue.isolated.ts` — the frame's type, id, copy, and `/i/:intentId` link; label lookup failure still notifies; job keyed by message id.
`notification-projection.isolated.ts` — copy singular/plural, unlabelled signal, label bounding, link composition.

Full isolated suite green apart from three files failing identically on the base commit (`opportunity.service.maintenance`, `tool.controller`, `archive-legacy-negotiations`) — pre-existing, unrelated.

## Not in scope

The `/notifications/snapshot` catch-up still projects opportunities only, so a client who was offline for the live frame finds the question by opening the DM rather than in the snapshot. Worth a follow-up if snapshots become the primary surface.

🤖 Generated with [Claude Code](https://claude.com/claude-code)