### PR TITLE
fix(negotiations,api): MCP conclude writes the opportunity status; snapshot projects question frames

### DIFF
--- a/docs/plans/2026-08-18-conversational-questions.md
+++ b/docs/plans/2026-08-18-conversational-questions.md
@@ -256,10 +256,32 @@ post-merge).
 
 ## What is left
 
-Nothing from this plan. Notifications and the empty-set close-out shipped
-last; the one open item is unrelated to the question loop: the MCP
-`respond_to_negotiation` terminal branch never writes `opportunities.status`
-(pre-existing, independent fix).
+Nothing. Notifications and the empty-set close-out shipped last, and the two
+recorded follow-ups are now closed too: the MCP conclude writes the
+opportunity status, and the notification snapshot projects question frames.
+
+**MCP conclude → opportunity status: shipped.** Every branch of
+`respond_to_negotiation` that finalizes a negotiation — the caller's own
+terminal action, the counterparty's, the user's agent's, and each turn-cap —
+now advances the opportunity through `updateOpportunityStatus`, the same waist
+the graph's finalize node uses and the one that carries the post-commit
+transition emit. Before, the task completed and the outcome artifact landed
+while the row stayed `negotiating`: the transition hook never fired there (no
+question-message regeneration or prune on either side), radar buckets kept
+counting it, and the expiry sweep saw a phantom active opportunity. Mapping is
+the version-independent one: accept → `pending`, reject-like → `rejected`,
+turn cap → `stalled`. The write is best-effort — the conclude has already
+committed, so a failed flip is logged rather than returned as a tool error.
+
+**Snapshot question frames: shipped.** `/notifications/snapshot` now projects
+one `question.new` frame per signal with an open question-message, with the
+same id, server-owned copy and `/i/:intentId` link as the live frame (both are
+built by one projection helper), so a client offline at delivery finds the
+question without opening the DM. Open is re-derived at snapshot time — the
+newest agent message in the signal's DM whose block still references a parked
+negotiation, over the same reader and predicate the regeneration job uses — so
+answering and the close-out remove the frame by themselves. Still no stored
+read/unread state anywhere.
 
 **Notifications: shipped.** The regeneration job compares the outgoing
 block's negotiation refs against the refs of the message it replaces — a

--- a/packages/protocol/src/index.ts
+++ b/packages/protocol/src/index.ts
@@ -314,7 +314,6 @@ export type { ConsultationEligibility, ConsultationEligibilityInput, Negotiation
 export {
   NEGOTIATION_QUESTION_GENERIC_COUNTERPARTY,
   NEGOTIATION_QUESTION_GENERIC_NETWORK,
-  NEGOTIATION_QUESTION_GENERIC_UPTAKE_ACTIVITY,
   negotiationQuestionSettlementId,
 } from "./negotiations/negotiation.module.js";
 

--- a/packages/protocol/src/negotiations/negotiation.module.ts
+++ b/packages/protocol/src/negotiations/negotiation.module.ts
@@ -77,7 +77,6 @@ export {
 export {
   NEGOTIATION_QUESTION_GENERIC_COUNTERPARTY,
   NEGOTIATION_QUESTION_GENERIC_NETWORK,
-  NEGOTIATION_QUESTION_GENERIC_UPTAKE_ACTIVITY,
   isSafeAuthoredNegotiationQuestion,
   isSafeNegotiationQuestionText,
   negotiationQuestionSettlementId,

--- a/packages/protocol/src/negotiations/negotiation.question-safety.ts
+++ b/packages/protocol/src/negotiations/negotiation.question-safety.ts
@@ -4,7 +4,6 @@ import { hasUnsupportedOpportunityClaim } from '../shared/utils/claim-safety.js'
 /** Fixed prompt-safe labels; producers must not replace them with raw network/counterparty text. */
 export const NEGOTIATION_QUESTION_GENERIC_COUNTERPARTY = 'the other participant';
 export const NEGOTIATION_QUESTION_GENERIC_NETWORK = 'the selected network';
-export const NEGOTIATION_QUESTION_GENERIC_UPTAKE_ACTIVITY = 'a potential collaboration that may require clarification before you decide';
 
 const INTERNAL_ID_PATTERN = /\b(?:[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}|(?:task|intent|network|opportunity|user|match)[_-]?id)\b/i;
 const PRIVATE_SOURCE_PATTERN = /\b(?:private transcript|raw transcript|assessment(?:\.reasoning)?|seed assessment|evaluator reasoning|match reason|matchReason|internal metadata|counterparty profile)\b/i;

--- a/packages/protocol/src/negotiations/negotiation.tools.ts
+++ b/packages/protocol/src/negotiations/negotiation.tools.ts
@@ -3,10 +3,10 @@ import { z } from 'zod';
 import type { DefineTool } from '../shared/agent/tool.helpers.js';
 import type { NegotiationToolDeps } from './negotiation.tools.port.js';
 import { success, error } from '../shared/agent/tool.helpers.js';
-import type { NegotiationOpportunityLifecycle } from '../shared/interfaces/database.interface.js';
+import type { NegotiationOpportunityLifecycle, OpportunityStatus } from '../shared/interfaces/database.interface.js';
 import { IndexNegotiator } from './negotiation.agent.js';
 import type { NegotiationTurn, UserNegotiationContext, SeedAssessment, NegotiationOutcome } from './negotiation.state.js';
-import { allowedActionsFor, isTerminalAction, readProtocolVersion, rejectActionFor, resolveSeat, seatViolationMessage } from './negotiation.protocol.js';
+import { allowedActionsFor, isRejectLikeAction, isTerminalAction, readProtocolVersion, rejectActionFor, resolveSeat, seatViolationMessage } from './negotiation.protocol.js';
 import { NEGOTIATION_ACTIONS } from '../shared/schemas/negotiation-state.schema.js';
 import type { NegotiationTurnPayload } from '../shared/interfaces/agent-dispatcher.interface.js';
 import { protocolLogger } from '../shared/observability/protocol.logger.js';
@@ -65,6 +65,67 @@ async function readOpportunityLifecycles(
   } catch (err) {
     logger.warn('Failed to load opportunity lifecycle for negotiation narration', { err });
     return {};
+  }
+}
+
+/**
+ * Terminal opportunity status for a negotiation concluded through this tool.
+ * Version-independent mapping, identical to the graph's finalize node:
+ * `accept` → `pending` (the owner gate is still ahead), reject-like →
+ * `rejected`, anything else (the turn cap) → `stalled`.
+ */
+function terminalOpportunityStatus(lastAction: string): OpportunityStatus {
+  if (lastAction === 'accept') return 'pending';
+  return isRejectLikeAction(lastAction) ? 'rejected' : 'stalled';
+}
+
+/**
+ * Conclude a negotiation reached through `respond_to_negotiation`: complete
+ * the task, write the outcome artifact, and advance the opportunity out of
+ * `negotiating`.
+ *
+ * The status write goes through `updateOpportunityStatus` — the same waist the
+ * graph's finalize node uses — because that method is what carries the
+ * post-commit opportunity-transition emit. Writing the column any other way
+ * (or, as this path did before, not at all) leaves the transition hook blind:
+ * neither side's question-message is regenerated or pruned, radar buckets keep
+ * counting a finished negotiation, and the expiry sweep still sees a phantom
+ * active opportunity.
+ *
+ * The status write is best-effort, mirroring finalize: the task is already
+ * completed and the artifact written, so a failed status flip is logged rather
+ * than turned into a tool error the caller would read as "the conclude did not
+ * happen".
+ */
+async function concludeNegotiation(
+  database: NegotiationToolDeps['negotiationDatabase'],
+  input: {
+    taskId: string;
+    opportunityId?: string;
+    lastAction: string;
+    outcome: NegotiationOutcome;
+    turnCount: number;
+  },
+): Promise<void> {
+  await database.updateTaskState(input.taskId, 'completed');
+  await database.createArtifact({
+    taskId: input.taskId,
+    name: 'negotiation-outcome',
+    parts: [{ kind: 'data', data: input.outcome }],
+    metadata: { hasOpportunity: input.outcome.hasOpportunity, turnCount: input.turnCount },
+  });
+
+  if (!input.opportunityId) return;
+  const status = terminalOpportunityStatus(input.lastAction);
+  try {
+    await database.updateOpportunityStatus(input.opportunityId, status);
+  } catch (err) {
+    logger.error('Failed to update opportunity status on MCP conclude', {
+      taskId: input.taskId,
+      opportunityId: input.opportunityId,
+      status,
+      err,
+    });
   }
 }
 
@@ -548,12 +609,12 @@ export function createNegotiationTools(defineTool: DefineTool, deps: Negotiation
           const nextSpeaker = currentSpeaker === 'source' ? 'candidate' : 'source';
           const outcome = buildNegotiationOutcome(history, newTurnCount, query.action, meta.sourceUserId!, meta.candidateUserId!, nextSpeaker);
 
-          await negotiationDatabase.updateTaskState(task.id, 'completed');
-          await negotiationDatabase.createArtifact({
+          await concludeNegotiation(negotiationDatabase, {
             taskId: task.id,
-            name: 'negotiation-outcome',
-            parts: [{ kind: 'data', data: outcome }],
-            metadata: { hasOpportunity: outcome.hasOpportunity, turnCount: newTurnCount },
+            ...(meta.opportunityId ? { opportunityId: meta.opportunityId } : {}),
+            lastAction: query.action,
+            outcome,
+            turnCount: newTurnCount,
           });
 
           return success({
@@ -580,12 +641,12 @@ export function createNegotiationTools(defineTool: DefineTool, deps: Negotiation
           const nextSpeakerForCap = currentSpeaker === 'source' ? 'candidate' : 'source';
           const outcome = buildNegotiationOutcome(history, newTurnCount, 'counter', meta.sourceUserId!, meta.candidateUserId!, nextSpeakerForCap);
 
-          await negotiationDatabase.updateTaskState(task.id, 'completed');
-          await negotiationDatabase.createArtifact({
+          await concludeNegotiation(negotiationDatabase, {
             taskId: task.id,
-            name: 'negotiation-outcome',
-            parts: [{ kind: 'data', data: outcome }],
-            metadata: { hasOpportunity: false, turnCount: newTurnCount },
+            ...(meta.opportunityId ? { opportunityId: meta.opportunityId } : {}),
+            lastAction: 'counter',
+            outcome,
+            turnCount: newTurnCount,
           });
 
           return success({
@@ -722,12 +783,12 @@ export function createNegotiationTools(defineTool: DefineTool, deps: Negotiation
           const fullHistory = [...historyForDispatch, aiTurn];
           const outcome = buildNegotiationOutcome(fullHistory, finalTurnCount, aiTurn.action, meta.sourceUserId!, meta.candidateUserId!, counterpartySpeaker === 'source' ? 'candidate' : 'source');
 
-          await negotiationDatabase.updateTaskState(task.id, 'completed');
-          await negotiationDatabase.createArtifact({
+          await concludeNegotiation(negotiationDatabase, {
             taskId: task.id,
-            name: 'negotiation-outcome',
-            parts: [{ kind: 'data', data: outcome }],
-            metadata: { hasOpportunity: outcome.hasOpportunity, turnCount: finalTurnCount },
+            ...(meta.opportunityId ? { opportunityId: meta.opportunityId } : {}),
+            lastAction: aiTurn.action,
+            outcome,
+            turnCount: finalTurnCount,
           });
 
           return success({
@@ -745,12 +806,12 @@ export function createNegotiationTools(defineTool: DefineTool, deps: Negotiation
           const fullHistory = [...historyForDispatch, aiTurn];
           const outcome = buildNegotiationOutcome(fullHistory, finalTurnCount, 'counter', meta.sourceUserId!, meta.candidateUserId!, counterpartySpeaker === 'source' ? 'candidate' : 'source');
 
-          await negotiationDatabase.updateTaskState(task.id, 'completed');
-          await negotiationDatabase.createArtifact({
+          await concludeNegotiation(negotiationDatabase, {
             taskId: task.id,
-            name: 'negotiation-outcome',
-            parts: [{ kind: 'data', data: outcome }],
-            metadata: { hasOpportunity: false, turnCount: finalTurnCount },
+            ...(meta.opportunityId ? { opportunityId: meta.opportunityId } : {}),
+            lastAction: 'counter',
+            outcome,
+            turnCount: finalTurnCount,
           });
 
           return success({
@@ -851,12 +912,12 @@ export function createNegotiationTools(defineTool: DefineTool, deps: Negotiation
             const userSpeaker = isSource ? 'source' : 'candidate';
             const outcome = buildNegotiationOutcome(fullHistory, userTurnCount, userAgentTurn.action, meta.sourceUserId!, meta.candidateUserId!, userSpeaker === 'source' ? 'candidate' : 'source');
 
-            await negotiationDatabase.updateTaskState(task.id, 'completed');
-            await negotiationDatabase.createArtifact({
+            await concludeNegotiation(negotiationDatabase, {
               taskId: task.id,
-              name: 'negotiation-outcome',
-              parts: [{ kind: 'data', data: outcome }],
-              metadata: { hasOpportunity: outcome.hasOpportunity, turnCount: userTurnCount },
+              ...(meta.opportunityId ? { opportunityId: meta.opportunityId } : {}),
+              lastAction: userAgentTurn.action,
+              outcome,
+              turnCount: userTurnCount,
             });
 
             return success({
@@ -873,12 +934,12 @@ export function createNegotiationTools(defineTool: DefineTool, deps: Negotiation
             const fullHistory = [...historyForDispatch, aiTurn, userAgentTurn];
             const outcome = buildNegotiationOutcome(fullHistory, userTurnCount, 'counter', meta.sourceUserId!, meta.candidateUserId!, isSource ? 'candidate' : 'source');
 
-            await negotiationDatabase.updateTaskState(task.id, 'completed');
-            await negotiationDatabase.createArtifact({
+            await concludeNegotiation(negotiationDatabase, {
               taskId: task.id,
-              name: 'negotiation-outcome',
-              parts: [{ kind: 'data', data: outcome }],
-              metadata: { hasOpportunity: false, turnCount: userTurnCount },
+              ...(meta.opportunityId ? { opportunityId: meta.opportunityId } : {}),
+              lastAction: 'counter',
+              outcome,
+              turnCount: userTurnCount,
             });
 
             return success({

--- a/packages/protocol/src/negotiations/tests/negotiation.tools.conclude-status.spec.ts
+++ b/packages/protocol/src/negotiations/tests/negotiation.tools.conclude-status.spec.ts
@@ -1,0 +1,206 @@
+/**
+ * MCP conclude → opportunity status (follow-up from the conversational-questions
+ * ledger).
+ *
+ * `respond_to_negotiation` finalizes the negotiation itself — task completed,
+ * outcome artifact written — but used to leave `opportunities.status` on
+ * whatever it was before ('negotiating'). The row is the input to the
+ * transition hook, the radar buckets, and the expiry sweep, so a conclude that
+ * skips it leaves a phantom active opportunity behind.
+ *
+ * These tests pin the write AND its route: the status must go through
+ * `updateOpportunityStatus`, the host waist whose post-commit emit is what the
+ * transition hook observes (`ConversationDatabaseAdapter.updateOpportunityStatus`
+ * in the API service). A raw column update would satisfy "status changed" and
+ * still leave the hook blind, so the fake below emits from that method only —
+ * exactly as the adapter does.
+ */
+import { describe, expect, test } from "bun:test";
+import { z } from "zod";
+
+import { createNegotiationTools } from "../negotiation.tools.js";
+import type { ToolDeps, ResolvedToolContext } from "../../shared/agent/tool.helpers.js";
+
+type ToolDepsFixture = Record<string, unknown>;
+
+const OPPORTUNITY_ID = "opp-1";
+
+function makeContext(userId: string): ResolvedToolContext {
+  return {
+    userId,
+    user: { id: userId, name: "Alice", email: "a@test" },
+    userProfile: null,
+    userNetworks: [],
+    isMcp: true,
+  } as unknown as ResolvedToolContext;
+}
+
+function captureRespondTool(deps: ToolDepsFixture) {
+  let captured: { handler: (i: { context: ResolvedToolContext; query: unknown }) => Promise<string>; querySchema?: z.ZodType } | undefined;
+  const defineTool = (def: { name: string; handler: (...args: unknown[]) => unknown }) => {
+    if (def.name === "respond_to_negotiation") captured = def as typeof captured;
+    return def;
+  };
+  createNegotiationTools(defineTool as never, deps as unknown as ToolDeps);
+  return captured!;
+}
+
+function turnMessage(senderUserId: string, action: string) {
+  return {
+    senderId: `agent:${senderUserId}`,
+    parts: [{ kind: "data", data: { action, assessment: { reasoning: "r", suggestedRoles: { ownUser: "peer", otherUser: "peer" } }, message: "m" } }],
+  };
+}
+
+function makeFixture(options: { priorTurns: number; maxTurns?: number; dispatchResult?: unknown }) {
+  const statusWrites: Array<{ opportunityId: string; status: string }> = [];
+  /** Mirrors the host adapter: the transition emit hangs off this method only. */
+  const transitions: Array<{ id: string; status: string }> = [];
+  const taskStates: string[] = [];
+  const priorMessages = Array.from({ length: options.priorTurns }, () => turnMessage("user-cand", "counter"));
+
+  const deps = {
+    negotiationDatabase: {
+      getTask: async () => ({
+        id: "task-1",
+        conversationId: "conv-1",
+        state: "waiting_for_agent",
+        metadata: {
+          type: "negotiation",
+          sourceUserId: "user-src",
+          candidateUserId: "user-cand",
+          opportunityId: OPPORTUNITY_ID,
+          maxTurns: options.maxTurns ?? 6,
+        },
+        createdAt: new Date("2026-01-01"),
+        updatedAt: new Date("2026-01-02"),
+      }),
+      getMessagesForConversation: async () => priorMessages,
+      getNegotiationMessages: async () => priorMessages,
+      createMessage: async () => ({ id: "msg-1", senderId: "s", role: "agent", parts: [], createdAt: new Date() }),
+      updateTaskState: async (_id: string, state: string) => { taskStates.push(state); },
+      createArtifact: async () => ({ id: "artifact-1" }),
+      updateOpportunityStatus: async (opportunityId: string, status: string) => {
+        statusWrites.push({ opportunityId, status });
+        transitions.push({ id: opportunityId, status });
+        return { id: opportunityId, status };
+      },
+    },
+    negotiationTimeoutQueue: { cancelTimeout: async () => {}, enqueueTimeout: async () => {} },
+    agentDispatcher: { dispatch: async () => options.dispatchResult ?? { handled: false, reason: "waiting" } },
+  } satisfies ToolDepsFixture;
+
+  return { deps, statusWrites, transitions, taskStates };
+}
+
+describe("respond_to_negotiation — terminal conclude writes the opportunity status", () => {
+  test.each([
+    ["accept", "pending"],
+    ["reject", "rejected"],
+  ] as const)("%s advances the opportunity to %s and fires the transition", async (action, expectedStatus) => {
+    const fixture = makeFixture({ priorTurns: 2 });
+    const tool = captureRespondTool(fixture.deps);
+
+    const result = JSON.parse(await tool.handler({
+      context: makeContext("user-src"),
+      query: {
+        negotiationId: "task-1",
+        action,
+        reasoning: "Decided",
+        suggestedRoles: { ownUser: "peer", otherUser: "peer" },
+      },
+    }));
+
+    expect(result.success).toBe(true);
+    expect(fixture.taskStates).toContain("completed");
+    expect(fixture.statusWrites).toEqual([{ opportunityId: OPPORTUNITY_ID, status: expectedStatus }]);
+    expect(fixture.transitions).toEqual([{ id: OPPORTUNITY_ID, status: expectedStatus }]);
+  });
+
+  test("the turn cap stalls the opportunity rather than leaving it negotiating", async () => {
+    // maxTurns 3 with 2 prior turns: the caller's counter is the cap turn.
+    const fixture = makeFixture({ priorTurns: 2, maxTurns: 3 });
+    const tool = captureRespondTool(fixture.deps);
+
+    const result = JSON.parse(await tool.handler({
+      context: makeContext("user-src"),
+      query: {
+        negotiationId: "task-1",
+        action: "counter",
+        reasoning: "Keep going",
+        suggestedRoles: { ownUser: "peer", otherUser: "peer" },
+        message: "One more round",
+      },
+    }));
+
+    expect(result.success).toBe(true);
+    expect(fixture.taskStates).toContain("completed");
+    expect(fixture.statusWrites).toEqual([{ opportunityId: OPPORTUNITY_ID, status: "stalled" }]);
+    expect(fixture.transitions).toEqual([{ id: OPPORTUNITY_ID, status: "stalled" }]);
+  });
+
+  test("a counterparty turn that concludes the negotiation writes the status too", async () => {
+    const fixture = makeFixture({
+      priorTurns: 2,
+      dispatchResult: {
+        handled: true,
+        turn: { action: "decline", assessment: { reasoning: "Not a fit", suggestedRoles: { ownUser: "peer", otherUser: "peer" } } },
+      },
+    });
+    const tool = captureRespondTool(fixture.deps);
+
+    const result = JSON.parse(await tool.handler({
+      context: makeContext("user-src"),
+      query: {
+        negotiationId: "task-1",
+        action: "counter",
+        reasoning: "Proposal",
+        suggestedRoles: { ownUser: "peer", otherUser: "peer" },
+        message: "Here is my counter",
+      },
+    }));
+
+    expect(result.success).toBe(true);
+    expect(fixture.statusWrites).toEqual([{ opportunityId: OPPORTUNITY_ID, status: "rejected" }]);
+    expect(fixture.transitions).toEqual([{ id: OPPORTUNITY_ID, status: "rejected" }]);
+  });
+
+  test("a non-terminal turn leaves the opportunity status alone", async () => {
+    const fixture = makeFixture({ priorTurns: 2 });
+    const tool = captureRespondTool(fixture.deps);
+
+    await tool.handler({
+      context: makeContext("user-src"),
+      query: {
+        negotiationId: "task-1",
+        action: "counter",
+        reasoning: "Keep going",
+        suggestedRoles: { ownUser: "peer", otherUser: "peer" },
+        message: "One more round",
+      },
+    });
+
+    expect(fixture.taskStates).not.toContain("completed");
+    expect(fixture.statusWrites).toEqual([]);
+  });
+
+  test("a failed status write does not turn a completed conclude into a tool error", async () => {
+    const fixture = makeFixture({ priorTurns: 2 });
+    (fixture.deps.negotiationDatabase as { updateOpportunityStatus: () => Promise<never> }).updateOpportunityStatus =
+      async () => { throw new Error("status write failed"); };
+    const tool = captureRespondTool(fixture.deps);
+
+    const result = JSON.parse(await tool.handler({
+      context: makeContext("user-src"),
+      query: {
+        negotiationId: "task-1",
+        action: "reject",
+        reasoning: "Not a fit",
+        suggestedRoles: { ownUser: "peer", otherUser: "peer" },
+      },
+    }));
+
+    expect(result.success).toBe(true);
+    expect(fixture.taskStates).toContain("completed");
+  });
+});

--- a/services/api/src/adapters/conversation.database.adapter.ts
+++ b/services/api/src/adapters/conversation.database.adapter.ts
@@ -258,6 +258,18 @@ function intentRegistryScopeType(persona: string): string {
  */
 const NEGOTIATOR_INTENT_SCOPE_TYPE = 'negotiator-intent';
 
+/**
+ * The chat-visible text of a stored message: chat writes a single text part,
+ * so this is the one place that flattens `parts` back to a string for every
+ * chat read.
+ */
+function chatMessageText(parts: unknown): string {
+  const list = parts as Array<{ type?: string; text?: string }> | null | undefined;
+  return list?.find((part) => part?.type === 'text' && typeof part.text === 'string')?.text
+    ?? list?.find((part) => typeof part?.text === 'string')?.text
+    ?? '';
+}
+
 const DEFAULT_CHAT_SESSION_GAP_MS = 24 * 60 * 60 * 1000;
 
 function getChatSessionGapMs(): number {
@@ -5192,6 +5204,54 @@ export class ConversationDatabaseAdapter {
   }
 
   /**
+   * The newest agent-authored message in each of the user's
+   * ('negotiator-intent', intentId) DMs — one row per signal that has one.
+   *
+   * The anchor read behind the notification snapshot's question frames: an
+   * open question-message is the newest agent message in the signal's DM whose
+   * block still references a parked negotiation, and this returns the first
+   * half of that. Deliberately no body filtering here — parsing the question
+   * block and re-deriving the parked set are the caller's job, so this stays
+   * one indexed read instead of a per-signal fan-out.
+   *
+   * @param userId - The signal owner
+   * @returns Newest agent message per negotiator-intent DM, content flattened
+   */
+  async getNewestAgentMessagesForNegotiatorIntents(
+    userId: string,
+  ): Promise<Array<{ intentId: string; sessionId: string; messageId: string; content: string }>> {
+    if (!userId) return [];
+    const rows = await db
+      .selectDistinctOn([schema.chatSessionScopes.scopeId], {
+        intentId: schema.chatSessionScopes.scopeId,
+        sessionId: schema.messages.conversationId,
+        messageId: schema.messages.id,
+        parts: schema.messages.parts,
+      })
+      .from(schema.chatSessionScopes)
+      .innerJoin(
+        schema.messages,
+        eq(schema.messages.conversationId, schema.chatSessionScopes.conversationId),
+      )
+      .where(and(
+        eq(schema.chatSessionScopes.userId, userId),
+        eq(schema.chatSessionScopes.scopeType, NEGOTIATOR_INTENT_SCOPE_TYPE),
+        eq(schema.messages.role, 'agent'),
+      ))
+      .orderBy(
+        schema.chatSessionScopes.scopeId,
+        desc(schema.messages.createdAt),
+        desc(schema.messages.id),
+      );
+    return rows.map((row) => ({
+      intentId: row.intentId,
+      sessionId: row.sessionId,
+      messageId: row.messageId,
+      content: chatMessageText(row.parts),
+    }));
+  }
+
+  /**
    * Content update for the question-message edit rule (conversational
    * questions): rewrite one agent-authored message inside the caller's
    * ('negotiator-intent', intentId) session, but only while it is still the
@@ -5325,11 +5385,7 @@ export class ConversationDatabaseAdapter {
     rows: Array<typeof schema.messages.$inferSelect>,
   ): ChatMessage[] {
     return rows.map((msg) => {
-      const parts = msg.parts as Array<{ type?: string; text?: string }>;
-      const content =
-        parts?.find((p) => p?.type === 'text' && typeof p.text === 'string')?.text
-        ?? parts?.find((p) => typeof p?.text === 'string')?.text
-        ?? '';
+      const content = chatMessageText(msg.parts);
       const meta = (msg.metadata ?? {}) as ChatMessageMeta;
 
       // Map role back: 'agent' -> 'assistant'

--- a/services/api/src/adapters/tests/conversation.negotiator-intent-newest-agent.spec.ts
+++ b/services/api/src/adapters/tests/conversation.negotiator-intent-newest-agent.spec.ts
@@ -1,0 +1,129 @@
+/**
+ * The notification snapshot's anchor read against the real database
+ * (conversational questions): `getNewestAgentMessagesForNegotiatorIntents`
+ * returns the newest AGENT message in each of a user's ('negotiator-intent',
+ * intentId) DMs — one row per signal, never another user's, and never the
+ * client's own reply.
+ *
+ * "Newest agent message" rather than "newest message" on purpose: a client
+ * reply does not un-ask the question it answers. Only consumption and the
+ * regeneration that follows it close a question-message, and both land as new
+ * agent messages.
+ */
+import { config } from 'dotenv';
+config({ path: '.env.test', override: true });
+
+import { afterAll as bunAfterAll, beforeAll as bunBeforeAll, describe, expect, test } from 'bun:test';
+import { eq } from 'drizzle-orm/sql';
+
+import { conversationDatabaseAdapter, UserDatabaseAdapter } from '../database.adapter';
+import { chatSessionService } from '../../services/chat.service';
+import db from '../../lib/drizzle/drizzle';
+import { withMinimumDatabaseHookBudget } from '../../lib/testing/database-test-budget';
+import { intents } from '../../schemas/database.schema';
+
+const EMAIL = 'test-negotiator-intent-newest-agent@example.com';
+const OTHER_EMAIL = 'test-negotiator-intent-newest-agent-other@example.com';
+const beforeAll = withMinimumDatabaseHookBudget(bunBeforeAll, 30_000);
+const afterAll = withMinimumDatabaseHookBudget(bunAfterAll, 30_000);
+
+describe('ConversationDatabaseAdapter newest agent message per negotiator DM', () => {
+  const users = new UserDatabaseAdapter();
+  let userId: string;
+  let otherUserId: string;
+  const sessionIds = new Set<string>();
+
+  async function createIntent(ownerId: string): Promise<string> {
+    const id = crypto.randomUUID();
+    await db.insert(intents).values({
+      id,
+      userId: ownerId,
+      payload: 'Find a collaborator',
+      summary: 'Find a collaborator',
+      status: 'ACTIVE',
+    });
+    return id;
+  }
+
+  async function pinnedSession(ownerId: string, forIntentId: string): Promise<string> {
+    const resolved = await chatSessionService.resolveNegotiatorIntentSession(ownerId, forIntentId);
+    if ('error' in resolved) throw new Error(resolved.error);
+    sessionIds.add(resolved.session.id);
+    return resolved.session.id;
+  }
+
+  async function resetUser(email: string): Promise<string> {
+    const existing = await users.findByEmail(email);
+    if (existing) {
+      await db.delete(intents).where(eq(intents.userId, existing.id));
+      await users.deleteById(existing.id);
+    }
+    return (await users.create({ email, name: 'Snapshot Anchor User' })).id;
+  }
+
+  beforeAll(async () => {
+    userId = await resetUser(EMAIL);
+    otherUserId = await resetUser(OTHER_EMAIL);
+  });
+
+  afterAll(async () => {
+    for (const id of sessionIds) await conversationDatabaseAdapter.deleteChatSession(id).catch(() => {});
+    for (const id of [userId, otherUserId]) {
+      await db.delete(intents).where(eq(intents.userId, id)).catch(() => {});
+      await users.deleteById(id).catch(() => {});
+    }
+  });
+
+  test('returns one row per signal, holding that DM newest agent message', async () => {
+    const firstIntentId = await createIntent(userId);
+    const secondIntentId = await createIntent(userId);
+    const firstSessionId = await pinnedSession(userId, firstIntentId);
+    await pinnedSession(userId, secondIntentId);
+
+    await chatSessionService.addMessage({ sessionId: firstSessionId, role: 'assistant', content: 'An older question.' });
+    const newestAgentId = await chatSessionService.addMessage({
+      sessionId: firstSessionId,
+      role: 'assistant',
+      content: 'The current question.',
+    });
+
+    const rows = await conversationDatabaseAdapter.getNewestAgentMessagesForNegotiatorIntents(userId);
+
+    // The second signal DM has no agent message yet, so it contributes nothing.
+    expect(rows).toEqual([{
+      intentId: firstIntentId,
+      sessionId: firstSessionId,
+      messageId: newestAgentId,
+      content: 'The current question.',
+    }]);
+  });
+
+  test('a client reply does not displace the agent message it answers', async () => {
+    const intentId = await createIntent(userId);
+    const sessionId = await pinnedSession(userId, intentId);
+
+    const questionId = await chatSessionService.addMessage({
+      sessionId,
+      role: 'assistant',
+      content: 'Two questions about your search.',
+    });
+    await chatSessionService.addMessage({ sessionId, role: 'user', content: 'Ten to fifteen percent.' });
+
+    const rows = await conversationDatabaseAdapter.getNewestAgentMessagesForNegotiatorIntents(userId);
+    const row = rows.find((candidate) => candidate.intentId === intentId);
+
+    expect(await conversationDatabaseAdapter.getNewestChatMessage(sessionId)).toMatchObject({ role: 'user' });
+    expect(row).toEqual({ intentId, sessionId, messageId: questionId, content: 'Two questions about your search.' });
+  });
+
+  test('never reaches another user DMs, and reads nothing for an empty user id', async () => {
+    const foreignIntentId = await createIntent(otherUserId);
+    const foreignSessionId = await pinnedSession(otherUserId, foreignIntentId);
+    await chatSessionService.addMessage({ sessionId: foreignSessionId, role: 'assistant', content: 'Their question.' });
+
+    const rows = await conversationDatabaseAdapter.getNewestAgentMessagesForNegotiatorIntents(userId);
+    expect(rows.map(({ intentId }) => intentId)).not.toContain(foreignIntentId);
+
+    expect(await conversationDatabaseAdapter.getNewestAgentMessagesForNegotiatorIntents('')).toEqual([]);
+  });
+});

--- a/services/api/src/lib/question/open-question-message.ts
+++ b/services/api/src/lib/question/open-question-message.ts
@@ -1,0 +1,126 @@
+/**
+ * The open question-message, per signal (conversational questions,
+ * docs/plans/2026-08-18-conversational-questions.md).
+ *
+ * A question-message is OPEN while its block still references at least one
+ * negotiation parked on this user's side: that is what makes it answerable,
+ * and it is derived at read time from the parked set — there is no stored
+ * read/unread or open/closed state anywhere in this design.
+ *
+ * Two surfaces need that predicate over the same parked set:
+ *
+ * - the regeneration job's edit rule, which anchors on the newest message in
+ *   the conversation (a client reply since means the message is no longer the
+ *   one to rewrite), and
+ * - the notification snapshot, which anchors on the newest AGENT message (a
+ *   reply does not un-ask the question; only consumption and the regeneration
+ *   that follows it do).
+ *
+ * The anchor differs, the openness test does not — so the test lives here
+ * once and each caller hands it the message it anchors on.
+ */
+import { parseQuestionMessage } from '@indexnetwork/protocol';
+import type { QuestionBlock, QuestionBlockQuestion } from '@indexnetwork/protocol';
+
+import { log } from '../log';
+
+const logger = log.lib.from('open-question-message');
+
+/** One signal's open question-message, reduced to what a notification needs. */
+export interface OpenQuestionMessage {
+  intentId: string;
+  messageId: string;
+  /** Questions in the open block — the notification's count, not a fan-out. */
+  questionCount: number;
+}
+
+/** A candidate agent message from a signal's DM. */
+export interface QuestionMessageCandidate {
+  id: string;
+  content: string;
+}
+
+/**
+ * Every negotiation a block's questions reference — primaries plus each
+ * question's `alsoUnblocks`. This set IS the message's identity: the block
+ * carries no question ids, and a rewritten prompt over the same negotiation is
+ * the same ask.
+ */
+export function questionBlockRefs(questions: ReadonlyArray<QuestionBlockQuestion>): Set<string> {
+  return new Set(questions.flatMap((question) => [question.opportunityId, ...(question.alsoUnblocks ?? [])]));
+}
+
+/**
+ * The candidate message's block if that block is still open against `parked`,
+ * else null. Anything without a parseable block, or whose refs have all
+ * resolved, is not open.
+ *
+ * @param candidate - The agent message this caller anchors on, or null
+ * @param parked - The user's currently parked negotiations on this signal
+ */
+export function openQuestionBlock(
+  candidate: QuestionMessageCandidate | null,
+  parked: ReadonlyArray<{ opportunityId: string }>,
+): { id: string; block: QuestionBlock } | null {
+  if (!candidate) return null;
+  const parsed = parseQuestionMessage(candidate.content);
+  if (!parsed) return null;
+  const parkedRefs = new Set(parked.map((negotiation) => negotiation.opportunityId));
+  const referencesParked = [...questionBlockRefs(parsed.block.questions)].some((ref) => parkedRefs.has(ref));
+  return referencesParked ? { id: candidate.id, block: parsed.block } : null;
+}
+
+/** Injectable seams; production resolves the real collaborators lazily. */
+export interface OpenQuestionMessageReaderDeps {
+  /** Newest agent message per ('negotiator-intent', intentId) DM of this user. */
+  listNewestAgentMessages?: (userId: string) => Promise<Array<{ intentId: string; messageId: string; content: string }>>;
+  /** This user's parked negotiations on one signal. */
+  readParkedNegotiations?: (userId: string, intentId: string) => Promise<ReadonlyArray<{ opportunityId: string }>>;
+}
+
+/**
+ * Every open question-message this user currently has, one per signal.
+ *
+ * Two-stage on purpose: one indexed read gives the newest agent message per
+ * negotiator DM, and only the ones that actually carry a question block cost a
+ * parked-set read. A signal whose DM has no block — the common case — never
+ * touches the negotiation tables.
+ */
+export async function readOpenQuestionMessages(
+  userId: string,
+  deps?: OpenQuestionMessageReaderDeps,
+): Promise<OpenQuestionMessage[]> {
+  if (!userId) return [];
+
+  const listNewestAgentMessages = deps?.listNewestAgentMessages
+    ?? (async (id: string) => (await import('../../adapters/database.adapter')).conversationDatabaseAdapter
+      .getNewestAgentMessagesForNegotiatorIntents(id));
+  const readParkedNegotiations = deps?.readParkedNegotiations
+    ?? (async (id: string, intentId: string) => (await import('../../adapters/parked-negotiation.reader.adapter'))
+      .parkedNegotiationReaderAdapter.readParkedNegotiations(id, intentId));
+
+  const candidates = await listNewestAgentMessages(userId);
+  const open: OpenQuestionMessage[] = [];
+  for (const candidate of candidates) {
+    // Cheap first: no block, no parked-set read.
+    if (!parseQuestionMessage(candidate.content)) continue;
+    try {
+      const parked = await readParkedNegotiations(userId, candidate.intentId);
+      const openBlock = openQuestionBlock({ id: candidate.messageId, content: candidate.content }, parked);
+      if (!openBlock) continue;
+      open.push({
+        intentId: candidate.intentId,
+        messageId: candidate.messageId,
+        questionCount: openBlock.block.questions.length,
+      });
+    } catch (err) {
+      // One unreadable signal must not cost the caller every other frame.
+      logger.warn('open_question_message_read_failed', {
+        userId,
+        intentId: candidate.intentId,
+        error: err instanceof Error ? err.message : String(err),
+      });
+    }
+  }
+  return open;
+}

--- a/services/api/src/lib/question/tests/open-question-message.spec.ts
+++ b/services/api/src/lib/question/tests/open-question-message.spec.ts
@@ -1,0 +1,125 @@
+import { describe, expect, test } from 'bun:test';
+
+import { questionBlockFixture, questionMessageFixture, questionProseFixture } from '@indexnetwork/protocol/question-block/fixture';
+import { serializeQuestionMessage } from '@indexnetwork/protocol';
+
+import { openQuestionBlock, questionBlockRefs, readOpenQuestionMessages } from '../open-question-message';
+
+const PRIMARY = questionBlockFixture.questions[0].opportunityId;
+const ALSO_UNBLOCKS = questionBlockFixture.questions[0].alsoUnblocks![0];
+const SECOND = questionBlockFixture.questions[1].opportunityId;
+
+const CLOSED_OUT_BODY = 'Those questions are settled — nothing here for you to answer right now.';
+
+function parked(...opportunityIds: string[]) {
+  return opportunityIds.map((opportunityId) => ({ opportunityId }));
+}
+
+describe('openQuestionBlock', () => {
+  test('a block referencing a still-parked negotiation is open', () => {
+    const open = openQuestionBlock({ id: 'msg-1', content: questionMessageFixture }, parked(SECOND));
+    expect(open?.id).toBe('msg-1');
+    expect(open?.block.questions).toHaveLength(2);
+  });
+
+  test('an `alsoUnblocks` ref alone keeps the block open', () => {
+    expect(openQuestionBlock({ id: 'msg-1', content: questionMessageFixture }, parked(ALSO_UNBLOCKS))).not.toBeNull();
+  });
+
+  test('a block whose refs all resolved is closed', () => {
+    expect(openQuestionBlock({ id: 'msg-1', content: questionMessageFixture }, parked('some-other-negotiation'))).toBeNull();
+    expect(openQuestionBlock({ id: 'msg-1', content: questionMessageFixture }, [])).toBeNull();
+  });
+
+  test('prose with no block — the close-out — is never open', () => {
+    expect(openQuestionBlock({ id: 'msg-1', content: CLOSED_OUT_BODY }, parked(PRIMARY))).toBeNull();
+    expect(openQuestionBlock(null, parked(PRIMARY))).toBeNull();
+  });
+
+  test('refs are primaries plus alsoUnblocks', () => {
+    expect([...questionBlockRefs(questionBlockFixture.questions)].sort())
+      .toEqual([PRIMARY, ALSO_UNBLOCKS, SECOND].sort());
+  });
+});
+
+describe('readOpenQuestionMessages', () => {
+  function reader(input: {
+    messages: Array<{ intentId: string; messageId: string; content: string }>;
+    parkedByIntent: Record<string, string[]>;
+    onParkedRead?: (intentId: string) => void;
+  }) {
+    return readOpenQuestionMessages('user-1', {
+      listNewestAgentMessages: async () => input.messages,
+      readParkedNegotiations: async (_userId, intentId) => {
+        input.onParkedRead?.(intentId);
+        return parked(...(input.parkedByIntent[intentId] ?? []));
+      },
+    });
+  }
+
+  test('a parked set under an open question-message yields one entry per signal', async () => {
+    const open = await reader({
+      messages: [{ intentId: 'intent-1', messageId: 'msg-1', content: questionMessageFixture }],
+      parkedByIntent: { 'intent-1': [PRIMARY] },
+    });
+
+    expect(open).toEqual([{ intentId: 'intent-1', messageId: 'msg-1', questionCount: 2 }]);
+  });
+
+  test('an answered question-message disappears as its refs unpark', async () => {
+    // The answer resumed the negotiation, so the regeneration pruned that
+    // question; the remaining block still asks about a parked one.
+    const pruned = serializeQuestionMessage(questionProseFixture, {
+      version: 1,
+      questions: [questionBlockFixture.questions[1]],
+    });
+
+    const stillOpen = await reader({
+      messages: [{ intentId: 'intent-1', messageId: 'msg-2', content: pruned }],
+      parkedByIntent: { 'intent-1': [SECOND] },
+    });
+    expect(stillOpen).toEqual([{ intentId: 'intent-1', messageId: 'msg-2', questionCount: 1 }]);
+
+    // Every question answered: nothing is parked any more.
+    const answered = await reader({
+      messages: [{ intentId: 'intent-1', messageId: 'msg-2', content: pruned }],
+      parkedByIntent: {},
+    });
+    expect(answered).toEqual([]);
+  });
+
+  test('a closed-out message is absent, and costs no parked-set read', async () => {
+    const parkedReads: string[] = [];
+    const open = await reader({
+      messages: [{ intentId: 'intent-1', messageId: 'msg-3', content: CLOSED_OUT_BODY }],
+      parkedByIntent: { 'intent-1': [PRIMARY] },
+      onParkedRead: (intentId) => parkedReads.push(intentId),
+    });
+
+    expect(open).toEqual([]);
+    expect(parkedReads).toEqual([]);
+  });
+
+  test('a signal with no negotiator DM contributes nothing', async () => {
+    expect(await reader({ messages: [], parkedByIntent: { 'intent-1': [PRIMARY] } })).toEqual([]);
+  });
+
+  test('one unreadable signal does not drop the others', async () => {
+    const open = await readOpenQuestionMessages('user-1', {
+      listNewestAgentMessages: async () => [
+        { intentId: 'intent-broken', messageId: 'msg-1', content: questionMessageFixture },
+        { intentId: 'intent-2', messageId: 'msg-2', content: questionMessageFixture },
+      ],
+      readParkedNegotiations: async (_userId, intentId) => {
+        if (intentId === 'intent-broken') throw new Error('parked read failed');
+        return parked(PRIMARY);
+      },
+    });
+
+    expect(open.map(({ intentId }) => intentId)).toEqual(['intent-2']);
+  });
+
+  test('an empty user id reads nothing', async () => {
+    expect(await readOpenQuestionMessages('')).toEqual([]);
+  });
+});

--- a/services/api/src/main.ts
+++ b/services/api/src/main.ts
@@ -164,6 +164,7 @@ const notificationDeliveryService = new NotificationDeliveryService({
   getIdentity: (userId) => notificationOpportunityAdapter.getProfile(userId),
   getIntentLabel: loadNotificationIntentLabel,
   publish: publishNotificationStreamEvent,
+  webAppUrl: process.env.WEB_APP_URL || 'https://index.network',
 });
 
 // Assign callbacks before starting workers to avoid a race with jobs already in Redis.

--- a/services/api/src/queues/notification.queue.ts
+++ b/services/api/src/queues/notification.queue.ts
@@ -10,7 +10,7 @@ import { emitOpportunityNotification, emitTelegramNotification } from '../lib/no
 import { publishNotificationStreamEvent, type NotificationStreamPublisher } from '../lib/notification-stream-events';
 import { getRedisClient } from '../adapters/cache.adapter';
 import { userDatabaseAdapter } from '../adapters/database.adapter';
-import { buildQuestionMessageNotification } from '../services/notification-projection';
+import { buildQuestionMessageStreamEvent } from '../services/notification-projection';
 import { loadNotificationIntentLabel } from '../services/notification-delivery.service';
 
 /** BullMQ queue name for opportunity notification jobs. */
@@ -227,19 +227,13 @@ export class NotificationQueue {
       return undefined;
     });
 
-    const projection = buildQuestionMessageNotification({
+    await this.publishStreamEvent(userId, buildQuestionMessageStreamEvent({
+      messageId,
       intentId,
       questionCount,
       ...(signalLabel ? { signalLabel } : {}),
       webAppUrl: WEB_APP_URL,
-    });
-    await this.publishStreamEvent(userId, {
-      type: 'question.new',
-      id: messageId,
-      title: projection.headline,
-      body: projection.summary,
-      link: projection.link,
-    });
+    }));
     this.logger.info('Published question-message notification', {
       userId,
       intentId,

--- a/services/api/src/queues/question-message.queue.ts
+++ b/services/api/src/queues/question-message.queue.ts
@@ -43,9 +43,10 @@
 import { Job } from 'bullmq';
 
 import { classifyParkedNegotiation, consumeQuestionBlockAnswers, parseQuestionMessage, serializeQuestionMessage } from '@indexnetwork/protocol';
-import type { NegotiationAnswerConsumptionPorts, QuestionBlock, QuestionBlockQuestion, QuestionerEnqueuePayload } from '@indexnetwork/protocol';
+import type { NegotiationAnswerConsumptionPorts, QuestionBlock, QuestionerEnqueuePayload } from '@indexnetwork/protocol';
 
 import { log } from '../lib/log';
+import { openQuestionBlock, questionBlockRefs } from '../lib/question/open-question-message';
 import { QueueFactory, useHermeticRedis } from '../lib/bullmq/bullmq';
 import { QuestionMessageAuthor } from '../lib/question/question-message.author';
 import { QuestionAnswerRouter } from '../lib/question/question-answer.router';
@@ -159,16 +160,6 @@ export interface QuestionMessageQueueDeps {
   publishRegenerationEvent?: (userId: string, event: { intentId: string; pending: boolean }) => Promise<void>;
   /** Notification seam; production enqueues onto the notification queue. */
   notify?: (data: QuestionMessageNotificationJobData) => Promise<unknown>;
-}
-
-/**
- * Every negotiation a block's questions reference — primaries plus each
- * question's `alsoUnblocks`. This set IS the message's identity for
- * notification purposes: the block carries no question ids, and a rewritten
- * prompt over the same negotiation is the same ask.
- */
-function questionBlockRefs(questions: ReadonlyArray<QuestionBlockQuestion>): Set<string> {
-  return new Set(questions.flatMap((question) => [question.opportunityId, ...(question.alsoUnblocks ?? [])]));
 }
 
 export class QuestionMessageQueue {
@@ -510,6 +501,10 @@ export class QuestionMessageQueue {
    * prose, an unparseable block, refs all resolved — is not open, and the
    * regeneration appends instead.
    *
+   * The edit rule owns the first half (newest AND agent-authored); the
+   * openness test itself is `openQuestionBlock`, shared with the notification
+   * snapshot, which anchors on the newest agent message instead.
+   *
    * Returns the block along with the id: it is the message this delivery
    * replaces, so its refs are what the notification decision compares against.
    */
@@ -518,12 +513,7 @@ export class QuestionMessageQueue {
     parked: ReadonlyArray<{ opportunityId: string }>,
   ): { id: string; block: QuestionBlock } | null {
     if (!newest || newest.role !== 'assistant') return null;
-    const parsed = parseQuestionMessage(newest.content);
-    if (!parsed) return null;
-    const parkedRefs = new Set(parked.map((negotiation) => negotiation.opportunityId));
-    const referencesParked = parsed.block.questions.some((question) =>
-      [question.opportunityId, ...(question.alsoUnblocks ?? [])].some((ref) => parkedRefs.has(ref)));
-    return referencesParked ? { id: newest.id, block: parsed.block } : null;
+    return openQuestionBlock({ id: newest.id, content: newest.content }, parked);
   }
 
   /**

--- a/services/api/src/services/notification-delivery.service.ts
+++ b/services/api/src/services/notification-delivery.service.ts
@@ -5,8 +5,9 @@ import type { OpportunityActionablePayload } from '../events/opportunity.event';
 import { log } from '../lib/log';
 import type { NotificationStreamEvent, NotificationStreamPublisher } from '../lib/notification-stream-events';
 import { intents } from '../schemas/database.schema';
+import { readOpenQuestionMessages, type OpenQuestionMessage } from '../lib/question/open-question-message';
 // eslint-disable-next-line boundaries/dependencies -- task-owned pure projection shared by realtime and snapshots.
-import { actionableRecipientIds, boundedNotificationLabel, buildOpportunityNotificationEvent, counterpartForRecipient } from './notification-projection';
+import { actionableRecipientIds, boundedNotificationLabel, buildOpportunityNotificationEvent, buildQuestionMessageStreamEvent, counterpartForRecipient } from './notification-projection';
 
 const logger = log.service.from('NotificationDelivery');
 
@@ -15,7 +16,18 @@ export interface NotificationDeliveryDependencies {
   getIdentity: (userId: string) => Promise<UserIdentity | null>;
   getIntentLabel: (intentId: string) => Promise<string | undefined>;
   publish: NotificationStreamPublisher;
+  /**
+   * The user's open question-messages, one per signal. Derived at snapshot
+   * time from the parked set — the question loop stores no read/unread state,
+   * so "still open" is the only thing that decides whether a frame is in the
+   * snapshot. Defaults to the real reader.
+   */
+  listOpenQuestionMessages?: (userId: string) => Promise<OpenQuestionMessage[]>;
+  /** Origin the question deep link is built against. */
+  webAppUrl?: string;
 }
+
+const DEFAULT_WEB_APP_URL = 'https://index.network';
 
 export async function loadNotificationIntentLabel(intentId: string): Promise<string | undefined> {
   const [row] = await db
@@ -88,10 +100,52 @@ export class NotificationDeliveryService {
     }
   }
 
+  /**
+   * One frame per open question-message. The live `question.new` frame reaches
+   * connected clients only, so a client offline when a question landed would
+   * otherwise find it solely by opening the DM. Nothing here is stored or
+   * marked read: the frames are re-derived from the parked set on every
+   * snapshot, so answering (or the close-out) removes them by itself.
+   */
+  private async projectQuestionMessages(userId: string): Promise<NotificationStreamEvent[]> {
+    const listOpenQuestionMessages = this.deps.listOpenQuestionMessages
+      ?? ((id: string) => readOpenQuestionMessages(id));
+    let open: OpenQuestionMessage[];
+    try {
+      open = await listOpenQuestionMessages(userId);
+    } catch (error) {
+      // The opportunity half of the snapshot is still worth returning.
+      logger.error('Failed to project question-message notifications', {
+        userId,
+        error: error instanceof Error ? error.message : String(error),
+      });
+      return [];
+    }
+
+    return Promise.all(open.map(async (question) => {
+      // A missing label degrades the copy, never the frame — same rule the
+      // live delivery follows.
+      const signalLabel = await this.deps.getIntentLabel(question.intentId).catch(() => undefined);
+      return buildQuestionMessageStreamEvent({
+        messageId: question.messageId,
+        intentId: question.intentId,
+        questionCount: question.questionCount,
+        ...(signalLabel ? { signalLabel } : {}),
+        webAppUrl: this.deps.webAppUrl ?? DEFAULT_WEB_APP_URL,
+      });
+    }));
+  }
+
   async snapshot(userId: string): Promise<NotificationStreamEvent[]> {
-    const opportunities = await this.deps.opportunities.getNotificationSnapshotOpportunities(userId);
+    const [opportunities, questionEvents] = await Promise.all([
+      this.deps.opportunities.getNotificationSnapshotOpportunities(userId),
+      this.projectQuestionMessages(userId),
+    ]);
     const actionableOpportunities = opportunities.filter((opportunity) =>
       actionableRecipientIds(opportunity).includes(userId));
-    return Promise.all(actionableOpportunities.map((opportunity) => this.projectOpportunity(opportunity, userId)));
+    const opportunityEvents = await Promise.all(
+      actionableOpportunities.map((opportunity) => this.projectOpportunity(opportunity, userId)),
+    );
+    return [...opportunityEvents, ...questionEvents];
   }
 }

--- a/services/api/src/services/notification-projection.ts
+++ b/services/api/src/services/notification-projection.ts
@@ -1,6 +1,7 @@
 import { isActionableForViewer, safeFallbackSummary } from '@indexnetwork/protocol';
 
 import type { OpportunityRow, UserIdentity } from '../adapters/database.shared';
+import type { NotificationStreamEvent } from '../lib/notification-stream-events';
 
 const OPPORTUNITY_NOTIFICATION_HEADLINE = 'A promising connection';
 const OPPORTUNITY_NOTIFICATION_EMPTY_SUMMARY = 'A new match that might be relevant to you.';
@@ -84,6 +85,36 @@ export function buildQuestionMessageNotification(input: {
     headline: QUESTION_NOTIFICATION_HEADLINE,
     summary: `${count} ${count === 1 ? 'question' : 'questions'} about ${signal}.`,
     link: questionMessageDeepLink(input.intentId, input.webAppUrl),
+  };
+}
+
+/**
+ * The wire frame for one question-message, built once and used by both
+ * deliveries: the live `question.new` publish when the message lands, and the
+ * `/notifications/snapshot` projection a client offline at that moment reads
+ * on connect. Same id (the message), same server-owned copy, same deep link —
+ * so a client that saw the live frame recognizes the snapshot entry as the
+ * same notification rather than a second one.
+ */
+export function buildQuestionMessageStreamEvent(input: {
+  messageId: string;
+  intentId: string;
+  questionCount: number;
+  signalLabel?: string;
+  webAppUrl: string;
+}): NotificationStreamEvent {
+  const projection = buildQuestionMessageNotification({
+    intentId: input.intentId,
+    questionCount: input.questionCount,
+    ...(input.signalLabel ? { signalLabel: input.signalLabel } : {}),
+    webAppUrl: input.webAppUrl,
+  });
+  return {
+    type: 'question.new',
+    id: input.messageId,
+    title: projection.headline,
+    body: projection.summary,
+    link: projection.link,
   };
 }
 

--- a/services/api/src/services/tests/notification-delivery.service.isolated.ts
+++ b/services/api/src/services/tests/notification-delivery.service.isolated.ts
@@ -80,6 +80,7 @@ describe('NotificationDeliveryService persisted projection', () => {
       },
       getIdentity: async (userId) => identities.get(userId) ?? null,
       getIntentLabel: async (intentId) => intentId === 'intent-1' ? 'privacy collaboration' : undefined,
+      listOpenQuestionMessages: async () => [],
       publish: async (userId, event) => { published.push({ userId, event }); },
     });
 
@@ -140,6 +141,7 @@ describe('NotificationDeliveryService persisted projection', () => {
       },
       getIdentity: async (userId) => identities.get(userId) ?? null,
       getIntentLabel: async () => undefined,
+      listOpenQuestionMessages: async () => [],
       publish: async (userId, event) => { published.push({ userId, event }); },
     });
 
@@ -175,11 +177,91 @@ describe('NotificationDeliveryService persisted projection', () => {
       },
       getIdentity: async () => null,
       getIntentLabel: async () => undefined,
+      listOpenQuestionMessages: async () => [],
       publish: async () => { throw new Error('publisher unavailable'); },
     });
 
     await expect(service.publishOpportunityActionable({
       opportunity: { id: failingOpportunity.id, status: 'pending' },
     })).resolves.toBeUndefined();
+  });
+});
+
+describe('NotificationDeliveryService question-message snapshot', () => {
+  const WEB_APP_URL = 'https://app.example';
+
+  function service(input: {
+    open: Array<{ intentId: string; messageId: string; questionCount: number }> | (() => Promise<never>);
+    label?: string;
+  }) {
+    return new NotificationDeliveryService({
+      opportunities: {
+        getOpportunity: async () => null,
+        getNotificationSnapshotOpportunities: async () => [],
+      },
+      getIdentity: async () => null,
+      getIntentLabel: async () => input.label,
+      listOpenQuestionMessages: typeof input.open === 'function'
+        ? input.open
+        : async () => input.open as Array<{ intentId: string; messageId: string; questionCount: number }>,
+      webAppUrl: WEB_APP_URL,
+      publish: async () => {},
+    });
+  }
+
+  test('an open question-message projects one frame carrying the live copy and deep link', async () => {
+    const snapshot = await service({
+      open: [{ intentId: 'intent-1', messageId: 'message-1', questionCount: 2 }],
+      label: 'technical co-founder',
+    }).snapshot('viewer');
+
+    expect(snapshot).toEqual([{
+      type: 'question.new',
+      id: 'message-1',
+      title: 'Your agent needs an answer',
+      body: '2 questions about “technical co-founder”.',
+      link: `${WEB_APP_URL}/i/intent-1`,
+    }]);
+  });
+
+  test('answered or closed-out question-messages leave nothing behind', async () => {
+    // Both cases reach the service the same way: the reader derives openness
+    // from the parked set, so a resolved question is simply not in the list.
+    expect(await service({ open: [] }).snapshot('viewer')).toEqual([]);
+  });
+
+  test('a signal with no negotiator DM contributes no frame', async () => {
+    expect(await service({ open: [] }).snapshot('viewer')).toEqual([]);
+  });
+
+  test('a question-message read failure still returns the opportunity half', async () => {
+    const failing = new NotificationDeliveryService({
+      opportunities: {
+        getOpportunity: async () => null,
+        getNotificationSnapshotOpportunities: async () => [opportunity({
+          id: 'opportunity-actionable',
+          actors: [
+            { userId: 'viewer', networkId: 'network-1', role: 'patient' },
+            { userId: 'peer', networkId: 'network-1', role: 'agent' },
+          ],
+        })],
+      },
+      getIdentity: async () => null,
+      getIntentLabel: async () => undefined,
+      listOpenQuestionMessages: async () => { throw new Error('reader unavailable'); },
+      webAppUrl: WEB_APP_URL,
+      publish: async () => {},
+    });
+
+    expect((await failing.snapshot('viewer')).map(({ id }) => id)).toEqual(['opportunity-actionable']);
+  });
+
+  test('an unlabelled signal degrades the copy, never the frame', async () => {
+    const [frame] = await service({
+      open: [{ intentId: 'intent-1', messageId: 'message-1', questionCount: 1 }],
+    }).snapshot('viewer');
+
+    expect(frame.body).toBe('1 question about one of your signals.');
+    expect(frame.link).toBe(`${WEB_APP_URL}/i/intent-1`);
   });
 });


### PR DESCRIPTION
Two recorded follow-ups from the conversational-questions rollout (`docs/plans/2026-08-18-conversational-questions.md`, "What is left"). One PR, per instruction.

## 1. MCP `respond_to_negotiation` never wrote `opportunities.status`

Every branch that finalizes a negotiation completed the task and wrote the outcome artifact, then left the opportunity row on `negotiating`. So the #1437 transition hook never fired there (no question-message regeneration or prune for either side), radar buckets kept counting a finished negotiation, and expiry sweeps saw a phantom active opportunity.

Each conclude now goes through one `concludeNegotiation` helper that writes the status via `updateOpportunityStatus` — the waist that carries the post-commit transition emit (`ConversationDatabaseAdapter.updateOpportunityStatus` in the API service). A raw column update would have satisfied "status changed" and left the hook blind.

**Scope note:** the handoff named the caller's own terminal branch (line 543). The identical defect sat in all six conclude sites in that handler — the caller's terminal action and turn cap, the counterparty's, and the user's agent's — so all six route through the helper; fixing one of six would have left the same phantom behind on the other five paths.

Mapping is the version-independent one the graph's finalize node uses: `accept` → `pending`, reject-like → `rejected`, turn cap → `stalled`. The write is best-effort and logged on failure — the conclude has already committed, so a failed flip must not surface to the caller as "the conclude did not happen". No continuation fence is passed, matching the task/artifact writes around it in this handler (fencing only the status write would throw after the task write already landed).

Also deletes the orphaned `NEGOTIATION_QUESTION_GENERIC_UPTAKE_ACTIVITY` constant, whose last consumer went with #1439.

## 2. `/notifications/snapshot` did not project question frames

The live `question.new` frame reaches connected clients only, so a client offline at delivery found the question solely by opening the DM. The snapshot now projects one frame per signal with an open question-message, with the same id (the message), the same server-owned copy and the same `/i/:intentId` link as the live frame — both are built by one projection helper, so parity is structural rather than duplicated.

Open is re-derived at snapshot time, never stored: the newest **agent** message in the signal's `('negotiator-intent', intentId)` DM whose block still references a negotiation parked on this user's side. Newest-agent rather than newest-overall because a client reply does not un-ask the question it answers; only consumption and the regeneration behind it do. The predicate and the parked reader are the regeneration job's — lifted into `lib/question/open-question-message` and shared with it, not restated — so answered and closed-out messages drop out of the snapshot by themselves. No stored read/unread state, consistent with the design.

The anchor read is one indexed `DISTINCT ON` over the user's negotiator DMs; only a DM whose newest agent message actually carries a question block costs a parked-set read. A question-read failure degrades to the opportunity half of the snapshot rather than failing the endpoint.

## Tests

- `negotiation.tools.conclude-status.spec.ts` — terminal (`accept` → pending, `reject` → rejected), turn cap → stalled, counterparty-turn conclude, non-terminal writes nothing, and a failed flip that does not become a tool error. The fake emits the transition from `updateOpportunityStatus` only, exactly as the adapter does, so the route is pinned and not just the value.
- `conversation.negotiator-intent-newest-agent.spec.ts` — DB-backed: one row per signal holding that DM's newest agent message, a client reply does not displace it, never another user's DM.
- `open-question-message.spec.ts` — the openness predicate (primary refs, `alsoUnblocks`, all-resolved, close-out prose) and the reader (parked + open → entry; answered/pruned; closed-out costs no parked read; no DM; one unreadable signal does not drop the others).
- `notification-delivery.service.isolated.ts` — the snapshot frame's copy and deep link, answered/closed-out and no-DM absence, unlabelled-signal copy, and the reader-failure fallback.

Full API suite: 1623 pass / 18 fail — the same 18 failures as the base commit `d7a7e78bd6`, verified by running the suite in a throwaway baseline worktree (failure sets diff clean). Protocol negotiations suite: same 2 pre-existing LLM-judge failures as base. Typecheck (`tsc --noEmit`, spec project) and lint are clean.

No schema changes, no notification-policy changes, no new flags.

🤖 Generated with [Claude Code](https://claude.com/claude-code)