### PR TITLE
Group negotiation conversations by opportunity

### DIFF
--- a/apps/web/src/app/chat/[conversationId]/page.tsx
+++ b/apps/web/src/app/chat/[conversationId]/page.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useMemo, useRef, useState } from 'react';
-import { useParams, useNavigate } from 'react-router';
+import { useParams, useNavigate, useSearchParams } from 'react-router';
 import { Loader2 } from 'lucide-react';
 import { ContentContainer } from '@/components/layout';
 import { useAuthContext } from '@/contexts/AuthContext';
@@ -26,6 +26,7 @@ export default function NegotiationDetailPage() {
 
   const { conversationId } = useParams();
   const navigate = useNavigate();
+  const [searchParams] = useSearchParams();
   const { user } = useAuthContext();
   const { negotiations, messages, loadSessionHistory, loadPreviousSessionMessages, refreshNegotiations, sessionHistory, sessionOpportunityMap } = useConversation();
   const [loading, setLoading] = useState(true);
@@ -35,7 +36,11 @@ export default function NegotiationDetailPage() {
   const conversation = negotiations.find((c) => c.id === conversationId);
   const conversationMessages = useMemo(() => messages.get(conversationId!) ?? [], [messages, conversationId]);
   const history = conversationId ? sessionHistory.get(conversationId) : undefined;
-  const lifecycle = conversation?.negotiation ?? null;
+  const selectedTaskId = searchParams.get('taskId');
+  const selectedOpportunity = conversation?.negotiationOpportunities?.find((opportunity) => opportunity.taskId === selectedTaskId) ?? null;
+  // A selected row owns the transcript's lifecycle; plain conversation links
+  // preserve the existing latest-session behavior.
+  const lifecycle = selectedOpportunity ?? conversation?.negotiation ?? null;
 
   const { handleOpportunityAction, opportunityStatusMap, opportunityActionLoading, opportunityModalElement } =
     useOpportunityActions({
@@ -45,11 +50,11 @@ export default function NegotiationDetailPage() {
   useEffect(() => {
     if (!conversationId) return;
     let cancelled = false;
-    loadSessionHistory(conversationId).finally(() => {
+    loadSessionHistory(conversationId, selectedTaskId ? { taskId: selectedTaskId } : undefined).finally(() => {
       if (!cancelled) setLoading(false);
     });
     return () => { cancelled = true; };
-  }, [conversationId, loadSessionHistory]);
+  }, [conversationId, selectedTaskId, loadSessionHistory]);
 
   useEffect(() => {
     messagesEndRef.current?.scrollIntoView({ behavior: 'smooth' });
@@ -132,9 +137,11 @@ export default function NegotiationDetailPage() {
     () => resolveGateDecision({
       turnCount: turns.length,
       outcomeReason,
-      screenDecision: lifecycle?.screenDecision ?? null,
+      // Screen decisions are intentionally only projected for the latest task
+      // and its owner; an explicitly selected opportunity cannot inherit one.
+      screenDecision: selectedOpportunity ? null : conversation?.negotiation?.screenDecision ?? null,
     }),
-    [turns.length, outcomeReason, lifecycle?.screenDecision],
+    [turns.length, outcomeReason, selectedOpportunity, conversation?.negotiation?.screenDecision],
   );
 
   return (
@@ -213,7 +220,7 @@ export default function NegotiationDetailPage() {
                   firstTurnCreatedAt: firstTurn?.createdAt ?? null,
                   opportunityTitle,
                   opportunityStatus,
-                  latestSectionTitle: conversation?.via[0]?.title ?? null,
+                  latestSectionTitle: selectedOpportunity?.title ?? conversation?.via[0]?.title ?? null,
                 });
 
                 return (

--- a/apps/web/src/components/ChatSidebar.tsx
+++ b/apps/web/src/components/ChatSidebar.tsx
@@ -1,14 +1,14 @@
 import { useEffect, useMemo, useState, useRef } from 'react';
 import { useNavigate, useLocation } from 'react-router';
-import { EyeOff, MoreHorizontal, Trash2 } from 'lucide-react';
+import { MoreHorizontal, Trash2, ChevronRight } from 'lucide-react';
 import UserAvatar from '@/components/UserAvatar';
 import ConversationPreviewLine from '@/components/ConversationPreviewLine';
 import { useAuthContext } from '@/contexts/AuthContext';
 import { useConversation } from '@/contexts/ConversationContext';
 import { isVisibleH2HConversation } from '@/lib/conversation-visibility';
 import { resolveConversationPreview } from '@/lib/conversation-preview';
-import { countNegotiationsRequiringAction, deriveNegotiationInbox, type NegotiationInboxItem } from '@/lib/negotiation-inbox';
-import { CHIP_CLASS, statusLabel } from '@/lib/negotiation-chips';
+import { countNegotiationsRequiringAction } from '@/lib/negotiation-inbox';
+import { groupNegotiationOutline, opportunityStatusPresentation } from '@/lib/negotiation-outline';
 
 interface RecentChat {
   groupId: string;
@@ -47,7 +47,7 @@ const formatConversationTime = (timestamp: number) => {
 
 export default function ChatSidebar() {
   const navigate = useNavigate();
-  const { pathname } = useLocation();
+  const { pathname, search } = useLocation();
   const { user } = useAuthContext();
   const { conversations, negotiations, isConnected, refreshConversations, refreshNegotiations, hideConversation } = useConversation();
 
@@ -59,13 +59,7 @@ export default function ChatSidebar() {
   const [mode, setMode] = useState<'h2h' | 'a2a'>('h2h');
   const chatMenuRef = useRef<HTMLDivElement>(null);
 
-  // 30s tick keeps relative timestamps (subline timeAgo, row times) fresh
-  // instead of frozen at fetch time (IND-555).
-  const [now, setNow] = useState(() => Date.now());
-  useEffect(() => {
-    const interval = setInterval(() => setNow(Date.now()), 30_000);
-    return () => clearInterval(interval);
-  }, []);
+  const [expandedCounterpartIds, setExpandedCounterpartIds] = useState<Set<string>>(new Set());
 
   useEffect(() => {
     if (!user?.id) return;
@@ -82,24 +76,11 @@ export default function ChatSidebar() {
     () => countNegotiationsRequiringAction(negotiations, user?.id),
     [negotiations, user?.id],
   );
-  const inbox = useMemo(
-    () => (mode === 'a2a' ? deriveNegotiationInbox(negotiations, user?.id, now) : null),
-    [mode, negotiations, user?.id, now],
+  const negotiationOutline = useMemo(
+    () => groupNegotiationOutline(negotiations, user?.id),
+    [negotiations, user?.id],
   );
-  // Flat posture order — your move → live → waiting → resolved — with
-  // hairline dividers between runs. No group headers in a rail this narrow.
-  const negotiationRuns = useMemo(() => {
-    if (!inbox) return [];
-    return [
-      { key: 'your-move', items: inbox.yourMove },
-      { key: 'live', items: inbox.inProgress.filter((item) => item.status === 'live') },
-      { key: 'waiting', items: inbox.inProgress.filter((item) => item.status === 'waiting') },
-      { key: 'resolved', items: inbox.resolved },
-    ].filter((run) => run.items.length > 0);
-  }, [inbox]);
-  const negotiationCount = inbox
-    ? inbox.yourMove.length + inbox.inProgress.length + inbox.resolved.length
-    : 0;
+  const negotiationCount = negotiationOutline.reduce((count, group) => count + group.opportunities.length, 0);
 
   const recentChats: RecentChat[] = mode === 'h2h'
     ? conversations.filter(isVisibleH2HConversation).map((conv) => {
@@ -130,17 +111,8 @@ export default function ChatSidebar() {
     return () => document.removeEventListener('mousedown', handleClickOutside);
   }, [chatMenuOpen]);
 
-  const openNegotiation = (item: NegotiationInboxItem) => {
-    // Answer rows go to /questions — the transcript is read-only and can't
-    // take an answer. These used to get-or-create the negotiator DM; that
-    // surface is gone, and the questions inbox is where the answer lands.
-    if (item.status === 'answer') {
-      navigate('/questions');
-      return;
-    }
-    // Agreed rows land on the transcript's review affordance; live, waiting,
-    // and resolved rows open the transcript as before.
-    navigate(`/chat/${item.conversationId}`);
+  const openNegotiation = (conversationId: string, taskId: string) => {
+    navigate(`/chat/${conversationId}?taskId=${encodeURIComponent(taskId)}`);
   };
 
   const renderSkeleton = () => (
@@ -158,68 +130,7 @@ export default function ChatSidebar() {
     </div>
   );
 
-  const renderNegotiationRow = (item: NegotiationInboxItem) => {
-    const isResolved = item.group === 'resolved';
-    return (
-      <div
-        key={item.conversationId}
-        className={`relative group flex items-center py-2 px-2 -mx-2 rounded-md transition-colors hover:bg-gray-50 ${isResolved ? 'opacity-80' : ''}`}
-      >
-        <button
-          onClick={() => openNegotiation(item)}
-          className="flex-1 flex items-center gap-3 text-sm text-left pr-10 min-w-0 text-gray-700 hover:text-black"
-        >
-          <UserAvatar avatar={item.counterpart.avatar} id={item.counterpart.id} name={item.counterpart.name} size={28} className="flex-shrink-0" />
-          <div className="min-w-0 flex-1">
-            <p className="text-sm font-medium text-black flex items-center gap-1.5">
-              <span className="truncate">{item.counterpart.name}</span>
-              <span className={`inline-flex shrink-0 items-center whitespace-nowrap rounded-full border px-2 py-0.5 text-[10px] font-semibold font-ibm-plex-mono ${CHIP_CLASS[item.status]}`}>
-                {statusLabel(item)}
-              </span>
-            </p>
-            <p className="truncate text-[11px] font-ibm-plex-mono text-gray-400">
-              {item.signalCount} signal{item.signalCount === 1 ? '' : 's'} · {item.lastAction} · {item.timeAgo}
-            </p>
-            {(item.status === 'answer' || item.status === 'agreed') && (
-              <p className="truncate text-[11px] text-gray-400">
-                {item.status === 'answer' ? 'Tap to answer in your agent chat' : 'Tap to review and start the chat'}
-              </p>
-            )}
-          </div>
-        </button>
-        <span className="absolute right-8 top-2 text-[11px] leading-none font-normal text-gray-400">
-          {formatConversationTime(item.sortTimestamp)}
-        </span>
-        <button
-          onClick={(e) => {
-            e.stopPropagation();
-            setChatMenuOpen(chatMenuOpen === item.conversationId ? null : item.conversationId);
-          }}
-          aria-label="Negotiation options"
-          className="p-1 opacity-0 group-hover:opacity-100 hover:bg-gray-100 rounded transition-all flex-shrink-0"
-        >
-          <MoreHorizontal className="w-4 h-4 text-gray-400" />
-        </button>
-        {chatMenuOpen === item.conversationId && (
-          <div
-            ref={chatMenuRef}
-            className="absolute right-0 top-full mt-1 bg-white border border-gray-200 rounded-lg shadow-lg py-1 min-w-[140px] z-30"
-          >
-            <button
-              onClick={async (e) => {
-                e.stopPropagation();
-                setChatMenuOpen(null);
-                await hideConversation(item.conversationId);
-              }}
-              className="w-full flex items-center gap-2 px-3 py-2 text-sm text-red-600 hover:bg-red-50 transition-colors"
-            >
-              <EyeOff className="w-4 h-4" /> Hide
-            </button>
-          </div>
-        )}
-      </div>
-    );
-  };
+  const selectedTaskId = new URLSearchParams(search).get('taskId');
 
   return (
     <div className="flex flex-col h-full overflow-hidden">
@@ -269,13 +180,82 @@ export default function ChatSidebar() {
               <p className="mt-1.5 text-[11px] leading-relaxed text-gray-400">Your agents’ connection work will appear here.</p>
             </div>
           ) : (
-            <div className="space-y-1">
-              {negotiationRuns.map((run, runIndex) => (
-                <div key={run.key}>
-                  {runIndex > 0 && <div className="mx-2 my-1 h-px bg-gray-100" aria-hidden="true" />}
-                  {run.items.map(renderNegotiationRow)}
-                </div>
-              ))}
+            <div className="space-y-1" data-testid="negotiation-outline">
+              {negotiationOutline.map((counterparty) => {
+                const expanded = expandedCounterpartIds.has(counterparty.id);
+                const regionId = `negotiations-${counterparty.id}`;
+                return (
+                  <div key={counterparty.id} className="rounded-md">
+                    <button
+                      type="button"
+                      aria-expanded={expanded}
+                      aria-controls={regionId}
+                      onClick={() => setExpandedCounterpartIds((previous) => {
+                        const next = new Set(previous);
+                        if (next.has(counterparty.id)) next.delete(counterparty.id);
+                        else next.add(counterparty.id);
+                        return next;
+                      })}
+                      className="flex w-full items-center gap-2 rounded-md px-2 py-2 text-left hover:bg-gray-50 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-[-2px] focus-visible:outline-[#4091bb]"
+                    >
+                      <ChevronRight className={`h-4 w-4 shrink-0 text-gray-400 transition-transform ${expanded ? 'rotate-90' : ''}`} aria-hidden="true" />
+                      <UserAvatar avatar={counterparty.avatar} id={counterparty.id} name={counterparty.name} size={28} className="flex-shrink-0" />
+                      <span className="min-w-0 flex-1 truncate text-sm font-semibold text-black">{counterparty.name}</span>
+                      <span className="font-ibm-plex-mono text-[10px] text-gray-400">{counterparty.opportunities.length}</span>
+                    </button>
+                    {expanded && (
+                      <div id={regionId} className="ml-5 border-l border-gray-200 pl-2" role="region" aria-label={`${counterparty.name} opportunities`}>
+                        {counterparty.opportunities.map((opportunity) => {
+                          const presentation = opportunity.status ? opportunityStatusPresentation[opportunity.status] : null;
+                          const selected = pathname === `/chat/${opportunity.conversationId}` && selectedTaskId === opportunity.taskId;
+                          const opportunityMenuId = `negotiation:${opportunity.conversationId}:${opportunity.taskId}`;
+                          return (
+                            <div key={`${opportunity.conversationId}-${opportunity.taskId}`} className={`group relative flex min-w-0 items-center rounded-md ${selected ? 'bg-[#f1f5f7]' : 'hover:bg-gray-50'}`}>
+                              <button
+                                type="button"
+                                onClick={() => openNegotiation(opportunity.conversationId, opportunity.taskId)}
+                                aria-current={selected ? 'page' : undefined}
+                                className="relative flex min-w-0 flex-1 items-center gap-2 rounded-md px-2 py-2 text-left focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-[-2px] focus-visible:outline-[#4091bb]"
+                              >
+                                {selected && <span className="absolute inset-y-1 left-0 w-0.5 rounded-full bg-[#041729]" aria-hidden="true" />}
+                                <span className={`h-1.5 w-1.5 shrink-0 rounded-full ${presentation?.dotClass ?? 'bg-gray-300'}`} aria-hidden="true" />
+                                <span className="min-w-0 flex-1">
+                                  <span className="block truncate text-xs font-medium text-gray-800">{opportunity.title}</span>
+                                  <span className="block truncate font-ibm-plex-mono text-[10px] text-gray-400">
+                                    {presentation?.label ?? 'No lifecycle status'}
+                                  </span>
+                                </span>
+                              </button>
+                              <button
+                                type="button"
+                                aria-label="Negotiation options"
+                                onClick={() => setChatMenuOpen(chatMenuOpen === opportunityMenuId ? null : opportunityMenuId)}
+                                className="mr-1 rounded p-1 opacity-0 transition-opacity hover:bg-gray-100 group-hover:opacity-100 focus-visible:opacity-100"
+                              >
+                                <MoreHorizontal className="h-4 w-4 text-gray-400" />
+                              </button>
+                              {chatMenuOpen === opportunityMenuId && (
+                                <div ref={chatMenuRef} className="absolute right-0 top-full z-30 min-w-[140px] rounded-lg border border-gray-200 bg-white py-1 shadow-lg">
+                                  <button
+                                    type="button"
+                                    onClick={async () => {
+                                      setChatMenuOpen(null);
+                                      await hideConversation(opportunity.conversationId);
+                                    }}
+                                    className="flex w-full items-center gap-2 px-3 py-2 text-sm text-red-600 transition-colors hover:bg-red-50"
+                                  >
+                                    <Trash2 className="h-4 w-4" /> Hide
+                                  </button>
+                                </div>
+                              )}
+                            </div>
+                          );
+                        })}
+                      </div>
+                    )}
+                  </div>
+                );
+              })}
             </div>
           )
         ) : recentChats.length === 0 && refreshing ? (

--- a/apps/web/src/components/__tests__/ChatSidebar.test.tsx
+++ b/apps/web/src/components/__tests__/ChatSidebar.test.tsx
@@ -80,6 +80,20 @@ function negotiation(
       outcome: null,
       updatedAt: '2026-07-24T11:00:00.000Z',
     },
+    negotiationOpportunities: [{
+      intentId: `${id}-intent`,
+      opportunityId: `${id}-opportunity`,
+      title: `${counterpartName}'s opportunity`,
+      taskId: `${id}-task`,
+      state: input.state ?? 'working',
+      opportunityStatus: input.opportunityStatus ?? 'negotiating',
+      acceptedByViewer: false,
+      turnCount: input.turnCount ?? 1,
+      maxTurns: 6,
+      signalCount: 2,
+      outcome: null,
+      updatedAt: '2026-07-24T11:00:00.000Z',
+    }],
   };
 }
 
@@ -120,10 +134,10 @@ vi.mock('@/lib/api', async (importOriginal) => ({
 const currentPath = { value: '/' };
 
 function LocationProbe() {
-  const { pathname } = useLocation();
+  const { pathname, search } = useLocation();
   useEffect(() => {
-    currentPath.value = pathname;
-  }, [pathname]);
+    currentPath.value = `${pathname}${search}`;
+  }, [pathname, search]);
   return null;
 }
 
@@ -203,7 +217,7 @@ describe('ChatSidebar negotiations tab (IND-523)', () => {
     expect(screen.queryByTestId('chat-negotiations-your-move-badge')).not.toBeInTheDocument();
   });
 
-  it('renders chip rows in posture order with muted resolved rows', async () => {
+  it('groups opportunities by counterparty and exposes truthful lifecycle labels', async () => {
     mocks.conversations = [];
     mocks.negotiations = [
       negotiation('resolved', 'Jonas Berg', { opportunityStatus: 'rejected', action: 'decline' }),
@@ -214,24 +228,15 @@ describe('ChatSidebar negotiations tab (IND-523)', () => {
     renderSidebar();
     await openNegotiationsTab();
 
-    const names = ['Mira Chen', 'Aisha Khan', 'Tom Wolfe', 'Jonas Berg'];
-    const rows = names.map((name) => screen.getByText(name));
-    for (let i = 1; i < rows.length; i += 1) {
-      expect(rows[i - 1].compareDocumentPosition(rows[i]) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy();
-    }
+    const mira = screen.getByRole('button', { name: /Mira Chen/ });
+    expect(mira).toHaveAttribute('aria-expanded', 'false');
+    fireEvent.click(mira);
+    expect(mira).toHaveAttribute('aria-expanded', 'true');
+    expect(screen.getByText("Mira Chen's opportunity")).toBeInTheDocument();
+    expect(screen.getByText('Negotiating')).toBeInTheDocument();
 
-    // Chip labels come from the shared inbox projection.
-    expect(screen.getByText('Answer your agent')).toBeInTheDocument();
-    expect(screen.getByText('● Live · turn 3 of 6')).toBeInTheDocument();
-    expect(screen.getByText('Waiting on their agent')).toBeInTheDocument();
-    expect(screen.getByText('No opportunity')).toBeInTheDocument();
-
-    // Subline: N signals · last move · timeAgo.
-    expect(screen.getByText(/2 signals · your agent asked for guidance ·/)).toBeInTheDocument();
-
-    // Resolved rows are visually retired.
-    const resolvedRow = screen.getByText('Jonas Berg').closest('div[class*="opacity-80"]');
-    expect(resolvedRow).not.toBeNull();
+    fireEvent.click(screen.getByRole('button', { name: /Jonas Berg/ }));
+    expect(screen.getByText('Rejected')).toBeInTheDocument();
   });
 
   it('shows mode-aware empty copy and the persistent inbox footer link', async () => {
@@ -246,37 +251,25 @@ describe('ChatSidebar negotiations tab (IND-523)', () => {
     expect(screen.queryByText('No messages yet')).not.toBeInTheDocument();
   });
 
-  it('labels the a2a row menu action Hide', async () => {
+  it('preserves the negotiation hide action on an opportunity row', async () => {
     mocks.conversations = [];
-    mocks.negotiations = [answerNegotiation];
+    mocks.negotiations = [negotiation('live', 'Aisha Khan')];
     renderSidebar();
     await openNegotiationsTab();
 
+    fireEvent.click(screen.getByRole('button', { name: /Aisha Khan/ }));
     fireEvent.click(screen.getByRole('button', { name: 'Negotiation options' }));
     expect(screen.getByText('Hide')).toBeInTheDocument();
-    expect(screen.queryByText('Delete')).not.toBeInTheDocument();
   });
 
-  // Answer rows used to get-or-create the negotiator DM; that surface is gone
-  // and the questions inbox is where the answer is actually given.
-  it('routes answer rows to /questions without resolving a session', async () => {
-    mocks.conversations = [];
-    mocks.negotiations = [answerNegotiation];
-    renderSidebar();
-    await openNegotiationsTab();
-
-    fireEvent.click(screen.getByText('Mira Chen'));
-    await waitFor(() => expect(currentPath.value).toBe('/questions'));
-    expect(mocks.apiGet).not.toHaveBeenCalled();
-  });
-
-  it('routes live rows to the transcript', async () => {
+  it('routes an opportunity to its exact task session', async () => {
     mocks.conversations = [];
     mocks.negotiations = [negotiation('live', 'Aisha Khan', { turnCount: 3 })];
     renderSidebar();
     await openNegotiationsTab();
 
-    fireEvent.click(screen.getByText('Aisha Khan'));
-    await waitFor(() => expect(currentPath.value).toBe('/chat/live'));
+    fireEvent.click(screen.getByRole('button', { name: /Aisha Khan/ }));
+    fireEvent.click(screen.getByText("Aisha Khan's opportunity"));
+    await waitFor(() => expect(currentPath.value).toBe('/chat/live?taskId=live-task'));
   });
 });

--- a/apps/web/src/lib/__tests__/negotiation-outline.test.ts
+++ b/apps/web/src/lib/__tests__/negotiation-outline.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, it } from 'vitest';
+import { groupNegotiationOutline, opportunityStatusPresentation } from '@/lib/negotiation-outline';
+import type { ConversationSummary } from '@/services/conversation';
+
+const conversation: ConversationSummary = {
+  id: 'conversation-1',
+  participants: [
+    { participantId: 'agent:viewer', participantType: 'agent', name: 'Helper', avatar: null, ownerName: 'Viewer' },
+    { participantId: 'agent:peer', participantType: 'agent', name: 'Helper', avatar: null, ownerName: 'Peer' },
+  ],
+  lastMessage: null,
+  metadata: null,
+  via: [],
+  unreadCount: 0,
+  lastMessageAt: null,
+  createdAt: '2026-01-01T00:00:00.000Z',
+  negotiationOpportunities: [
+    { intentId: 'intent-a', opportunityId: 'opportunity-a', title: 'Find a design partner', taskId: 'task-a', state: 'working', opportunityStatus: 'negotiating', acceptedByViewer: false, turnCount: 2, maxTurns: 6, signalCount: 1, outcome: null, updatedAt: '2026-01-02T00:00:00.000Z' },
+    { intentId: 'intent-b', opportunityId: 'opportunity-b', title: 'Discuss research collaboration', taskId: 'task-b', state: 'completed', opportunityStatus: 'accepted', acceptedByViewer: true, turnCount: 3, maxTurns: 6, signalCount: 1, outcome: { hasOpportunity: true, reason: null }, updatedAt: '2026-01-03T00:00:00.000Z' },
+  ],
+};
+
+describe('groupNegotiationOutline', () => {
+  it('groups multiple opportunity sessions under one counterparty and retains their task ids', () => {
+    const groups = groupNegotiationOutline([conversation], 'viewer');
+
+    expect(groups).toHaveLength(1);
+    expect(groups[0]).toMatchObject({ id: 'peer', name: 'Peer' });
+    expect(groups[0]?.opportunities.map((opportunity) => [opportunity.opportunityId, opportunity.taskId]))
+      .toEqual([['opportunity-b', 'task-b'], ['opportunity-a', 'task-a']]);
+  });
+
+  it('uses only supported lifecycle labels', () => {
+    expect(opportunityStatusPresentation.accepted.label).toBe('Accepted');
+    expect(opportunityStatusPresentation.negotiating.label).toBe('Negotiating');
+    expect(Object.keys(opportunityStatusPresentation)).not.toContain('exploring');
+  });
+});

--- a/apps/web/src/lib/negotiation-chips.ts
+++ b/apps/web/src/lib/negotiation-chips.ts
@@ -12,6 +12,7 @@ export const CHIP_CLASS: Record<NegotiationInboxStatus, string> = {
   started: 'border-emerald-200 bg-emerald-50 text-emerald-700',
   rejected: 'border-red-200 bg-red-50 text-red-700',
   stalled: 'border-amber-200 bg-amber-50 text-amber-700',
+  not_sent: 'border-gray-200 bg-gray-100 text-gray-600',
 };
 
 export function statusLabel(item: NegotiationInboxItem): string {
@@ -24,5 +25,6 @@ export function statusLabel(item: NegotiationInboxItem): string {
     case 'started': return 'Chat started';
     case 'rejected': return 'No opportunity';
     case 'stalled': return 'Stalled';
+    case 'not_sent': return 'Not sent';
   }
 }

--- a/apps/web/src/lib/negotiation-outline.ts
+++ b/apps/web/src/lib/negotiation-outline.ts
@@ -1,0 +1,75 @@
+import type { ConversationSummary, NegotiationOpportunityStatus } from '@/services/conversation';
+
+export interface NegotiationOutlineOpportunity {
+  conversationId: string;
+  counterpartId: string;
+  opportunityId: string;
+  taskId: string;
+  title: string;
+  status: NegotiationOpportunityStatus | null;
+  updatedAt: string;
+}
+
+export interface NegotiationOutlineCounterparty {
+  id: string;
+  name: string;
+  avatar: string | null;
+  opportunities: NegotiationOutlineOpportunity[];
+}
+
+/** Groups only viewer-visible opportunity/task projections for the chat rail. */
+export function groupNegotiationOutline(
+  negotiations: ConversationSummary[],
+  viewerUserId: string | undefined,
+): NegotiationOutlineCounterparty[] {
+  const ownAgentId = viewerUserId ? `agent:${viewerUserId}` : null;
+  const groups = new Map<string, NegotiationOutlineCounterparty>();
+
+  for (const conversation of negotiations) {
+    const counterpart = conversation.participants.find((participant) => participant.participantId !== ownAgentId);
+    if (!counterpart) continue;
+    const counterpartId = counterpart.participantId.replace(/^agent:/, '');
+    const group = groups.get(counterpartId) ?? {
+      id: counterpartId,
+      name: counterpart.ownerName ?? conversation.metadata?.title ?? counterpart.name ?? 'Unknown user',
+      avatar: counterpart.avatar,
+      opportunities: [],
+    };
+    for (const opportunity of conversation.negotiationOpportunities ?? []) {
+      group.opportunities.push({
+        conversationId: conversation.id,
+        counterpartId,
+        opportunityId: opportunity.opportunityId,
+        taskId: opportunity.taskId,
+        title: opportunity.title,
+        status: opportunity.opportunityStatus,
+        updatedAt: opportunity.updatedAt,
+      });
+    }
+    groups.set(counterpartId, group);
+  }
+
+  return [...groups.values()]
+    .filter((group) => group.opportunities.length > 0)
+    .map((group) => ({
+      ...group,
+      opportunities: group.opportunities.sort((left, right) => (
+        new Date(right.updatedAt).getTime() - new Date(left.updatedAt).getTime()
+      )),
+    }))
+    .sort((left, right) => (
+      new Date(right.opportunities[0]?.updatedAt ?? 0).getTime()
+      - new Date(left.opportunities[0]?.updatedAt ?? 0).getTime()
+    ));
+}
+
+export const opportunityStatusPresentation: Record<NegotiationOpportunityStatus, { label: string; dotClass: string }> = {
+  latent: { label: 'Latent', dotClass: 'bg-gray-400' },
+  draft: { label: 'Draft', dotClass: 'bg-gray-400' },
+  negotiating: { label: 'Negotiating', dotClass: 'bg-amber-500' },
+  pending: { label: 'Pending', dotClass: 'bg-amber-500' },
+  stalled: { label: 'Stalled', dotClass: 'bg-amber-500' },
+  accepted: { label: 'Accepted', dotClass: 'bg-emerald-600' },
+  rejected: { label: 'Rejected', dotClass: 'bg-red-600' },
+  expired: { label: 'Expired', dotClass: 'bg-gray-400' },
+};

--- a/apps/web/src/services/conversation.ts
+++ b/apps/web/src/services/conversation.ts
@@ -57,6 +57,15 @@ export interface ConversationNegotiationLifecycle {
   } | null;
 }
 
+/** A viewer-visible opportunity and the exact negotiation task that owns its session. */
+export interface ConversationNegotiationOpportunity extends Omit<ConversationNegotiationLifecycle, 'taskId' | 'opportunityId' | 'opportunityStatus' | 'statusTimestamp' | 'screenDecision'> {
+  intentId: string;
+  title: string;
+  taskId: string;
+  opportunityId: string;
+  opportunityStatus: NegotiationOpportunityStatus | null;
+}
+
 export interface ConversationSummary {
   id: string;
   participants: { participantId: string; participantType: 'user' | 'agent'; name: string | null; avatar: string | null; ownerName?: string | null }[];
@@ -70,6 +79,7 @@ export interface ConversationSummary {
   createdAt: string;
   /** Latest task and opportunity lifecycle for A2A negotiation summaries. */
   negotiation?: ConversationNegotiationLifecycle | null;
+  negotiationOpportunities?: ConversationNegotiationOpportunity[];
 }
 
 export interface ConversationMessage {

--- a/services/api/src/adapters/conversation.database.adapter.ts
+++ b/services/api/src/adapters/conversation.database.adapter.ts
@@ -623,6 +623,7 @@ export class ConversationDatabaseAdapter {
       allMeta,
       unreadRows,
       latestNegotiationTasks,
+      negotiationTasks,
     ] = await Promise.all([
       db
         .select()
@@ -711,6 +712,43 @@ export class ConversationDatabaseAdapter {
             statusTimestamp: schema.tasks.statusTimestamp,
             metadata: schema.tasks.metadata,
             updatedAt: schema.tasks.updatedAt,
+            artifactParts: schema.artifacts.parts,
+            opportunityStatus: opportunities.status,
+            opportunityAcceptedBy: opportunities.acceptedBy,
+            currentTurnCount: sql<number>`(
+              SELECT count(*)::int
+              FROM ${schema.messages}
+              WHERE ${schema.messages.taskId} = ${schema.tasks.id}
+            )`,
+          })
+          .from(schema.tasks)
+          .leftJoin(
+            schema.artifacts,
+            and(
+              eq(schema.artifacts.taskId, schema.tasks.id),
+              eq(schema.artifacts.name, 'negotiation-outcome'),
+            ),
+          )
+          .leftJoin(opportunities, sql`${schema.tasks.metadata}->>'opportunityId' = ${opportunities.id}`)
+          .where(and(
+            inArray(schema.tasks.conversationId, ids),
+            sql`${schema.tasks.metadata}->>'type' = 'negotiation'`,
+            notArchivedNegotiationTaskWhere(),
+          ))
+          .orderBy(schema.tasks.conversationId, desc(schema.tasks.createdAt), desc(schema.tasks.id))
+        : Promise.resolve([]),
+      // All task rows are fetched in one batch so each viewer-visible
+      // opportunity can link to its own durable session. This intentionally
+      // avoids loading task history per rail row.
+      includeNegotiationLifecycle
+        ? db
+          .select({
+            conversationId: schema.tasks.conversationId,
+            taskId: schema.tasks.id,
+            state: schema.tasks.state,
+            metadata: schema.tasks.metadata,
+            updatedAt: schema.tasks.updatedAt,
+            createdAt: schema.tasks.createdAt,
             artifactParts: schema.artifacts.parts,
             opportunityStatus: opportunities.status,
             opportunityAcceptedBy: opportunities.acceptedBy,
@@ -908,6 +946,53 @@ export class ConversationDatabaseAdapter {
       });
     }
 
+    // One durable A2A conversation can carry many task sessions. Project only
+    // opportunities already visible to this viewer through match provenance,
+    // then choose the newest task for each opportunity as its session target.
+    const negotiationOpportunitiesByConv = new Map<string, NonNullable<ConversationSummary['negotiationOpportunities']>>();
+    const latestTaskByOpportunity = new Map<string, typeof negotiationTasks[number]>();
+    for (const row of negotiationTasks) {
+      const metadata = typeof row.metadata === 'object' && row.metadata !== null && !Array.isArray(row.metadata)
+        ? row.metadata as Record<string, unknown>
+        : {};
+      const opportunityId = typeof metadata.opportunityId === 'string' ? metadata.opportunityId : null;
+      if (!opportunityId) continue;
+      const key = `${row.conversationId}:${opportunityId}`;
+      if (!latestTaskByOpportunity.has(key)) latestTaskByOpportunity.set(key, row);
+    }
+    for (const conversation of convs) {
+      const visibleByOpportunity = new Map(
+        (viaByConv.get(conversation.id) ?? []).map((entry) => [entry.opportunityId, entry]),
+      );
+      const projected = [...visibleByOpportunity.values()].flatMap((via) => {
+        const row = latestTaskByOpportunity.get(`${conversation.id}:${via.opportunityId}`);
+        if (!row) return [];
+        const metadata = typeof row.metadata === 'object' && row.metadata !== null && !Array.isArray(row.metadata)
+          ? row.metadata as Record<string, unknown>
+          : {};
+        const outcome = readNegotiationOutcome(row.artifactParts);
+        const priorTurnCount = typeof metadata.priorTurnCount === 'number' && Number.isFinite(metadata.priorTurnCount)
+          ? metadata.priorTurnCount
+          : 0;
+        const maxTurns = typeof metadata.maxTurns === 'number' && Number.isFinite(metadata.maxTurns)
+          ? metadata.maxTurns
+          : null;
+        return [{
+          ...via,
+          taskId: row.taskId,
+          state: row.state,
+          opportunityStatus: row.opportunityStatus,
+          acceptedByViewer: row.opportunityAcceptedBy === viewerUserId,
+          turnCount: priorTurnCount + (outcome?.turnCount ?? Number(row.currentTurnCount)),
+          maxTurns,
+          signalCount: readNegotiationSignalCount(metadata),
+          outcome: outcome ? { hasOpportunity: outcome.hasOpportunity, reason: outcome.reason } : null,
+          updatedAt: row.updatedAt,
+        }];
+      });
+      negotiationOpportunitiesByConv.set(conversation.id, projected);
+    }
+
     return convs.map((c) => ({
       ...c,
       participants: participantsByConv.get(c.id) ?? [],
@@ -916,6 +1001,7 @@ export class ConversationDatabaseAdapter {
       via: viaByConv.get(c.id) ?? [],
       unreadCount: unreadCountByConv.get(c.id) ?? 0,
       ...(includeNegotiationLifecycle ? { negotiation: negotiationByConv.get(c.id) ?? null } : {}),
+      ...(includeNegotiationLifecycle ? { negotiationOpportunities: negotiationOpportunitiesByConv.get(c.id) ?? [] } : {}),
     }));
   }
 

--- a/services/api/src/adapters/database.shared.ts
+++ b/services/api/src/adapters/database.shared.ts
@@ -710,6 +710,24 @@ export interface ConversationSummary {
   unreadCount: number;
   /** Present only when negotiation lifecycle projection was requested. */
   negotiation?: NegotiationLifecycleSummary | null;
+  /**
+   * Viewer-scoped opportunities with an addressable negotiation task. Unlike
+   * `negotiation`, this is not limited to the conversation's latest task.
+   */
+  negotiationOpportunities?: Array<{
+    intentId: string;
+    opportunityId: string;
+    title: string;
+    taskId: string;
+    state: NegotiationLifecycleSummary['state'];
+    opportunityStatus: NegotiationLifecycleSummary['opportunityStatus'];
+    acceptedByViewer: boolean;
+    turnCount: number;
+    maxTurns: number | null;
+    signalCount: number;
+    outcome: NegotiationLifecycleSummary['outcome'];
+    updatedAt: Date;
+  }>;
 }
 
 /**

--- a/services/api/src/adapters/tests/conversation.database.adapter.spec.ts
+++ b/services/api/src/adapters/tests/conversation.database.adapter.spec.ts
@@ -518,6 +518,62 @@ describe('ConversationDatabaseAdapter', () => {
     }, 30000);
   });
 
+  describe('getConversationsForUser — opportunity session projection', () => {
+    it('projects every viewer-visible opportunity with its newest task without exposing the counterpart intent', async () => {
+      const run = crypto.randomUUID();
+      const viewerId = `outline-viewer-${run}`;
+      const counterpartId = `outline-counterpart-${run}`;
+      const viewerIntentId = `outline-intent-${run}`;
+      const counterpartIntentId = `outline-private-${run}`;
+      const firstOpportunityId = `outline-opportunity-a-${run}`;
+      const secondOpportunityId = `outline-opportunity-b-${run}`;
+      createdUserIds.push(viewerId, counterpartId);
+      createdIntentIds.push(viewerIntentId, counterpartIntentId);
+      createdOpportunityIds.push(firstOpportunityId, secondOpportunityId);
+
+      await db.insert(schema.users).values([
+        { id: viewerId, email: `${viewerId}@test.com`, name: 'Outline Viewer' },
+        { id: counterpartId, email: `${counterpartId}@test.com`, name: 'Outline Counterpart' },
+      ]);
+      await db.insert(schema.intents).values([
+        { id: viewerIntentId, userId: viewerId, payload: 'Need a design partner', summary: 'Design partner' },
+        { id: counterpartIntentId, userId: counterpartId, payload: 'Private counterpart intent', summary: 'Private signal' },
+      ]);
+      await db.insert(schema.opportunities).values([firstOpportunityId, secondOpportunityId].map((id, index) => ({
+        id,
+        detection: { source: 'manual', timestamp: new Date().toISOString() },
+        actors: [{ networkId: 'outline-network', userId: viewerId, role: 'peer' }, { networkId: 'outline-network', userId: counterpartId, role: 'peer' }],
+        interpretation: { category: 'test', reasoning: 'Projection test', confidence: 0.8 },
+        context: {}, confidence: '0.8', status: index === 0 ? 'negotiating' as const : 'accepted' as const,
+      })));
+      const conversation = await adapter.createConversation([
+        { participantId: `agent:${viewerId}`, participantType: 'agent' },
+        { participantId: `agent:${counterpartId}`, participantType: 'agent' },
+      ]);
+      createdIds.push(conversation.id);
+      for (const opportunityId of [firstOpportunityId, secondOpportunityId]) {
+        await adapter.appendMatchProvenance(conversation.id, {
+          opportunityId,
+          intents: [{ userId: viewerId, intentId: viewerIntentId }, { userId: counterpartId, intentId: counterpartIntentId }],
+          recordedAt: new Date().toISOString(),
+        });
+      }
+      const olderTask = await adapter.createTask(conversation.id, { type: 'negotiation', sourceUserId: viewerId, candidateUserId: counterpartId, opportunityId: firstOpportunityId });
+      const newestTask = await adapter.createTask(conversation.id, { type: 'negotiation', sourceUserId: viewerId, candidateUserId: counterpartId, opportunityId: firstOpportunityId });
+      const secondTask = await adapter.createTask(conversation.id, { type: 'negotiation', sourceUserId: viewerId, candidateUserId: counterpartId, opportunityId: secondOpportunityId });
+      await db.update(schema.tasks).set({ createdAt: new Date(Date.now() - 1_000) }).where(eq(schema.tasks.id, olderTask.id));
+
+      const summary = (await adapter.getConversationsForUser(`agent:${viewerId}`, viewerId, true))
+        .find((candidate) => candidate.id === conversation.id);
+      expect(summary?.negotiationOpportunities).toEqual(expect.arrayContaining([
+        expect.objectContaining({ intentId: viewerIntentId, opportunityId: firstOpportunityId, title: 'Design partner', taskId: newestTask.id, opportunityStatus: 'negotiating' }),
+        expect.objectContaining({ intentId: viewerIntentId, opportunityId: secondOpportunityId, title: 'Design partner', taskId: secondTask.id, opportunityStatus: 'accepted' }),
+      ]));
+      expect(summary?.negotiationOpportunities?.some((item) => item.taskId === olderTask.id)).toBeFalse();
+      expect(JSON.stringify(summary?.negotiationOpportunities)).not.toContain(counterpartIntentId);
+    }, 30000);
+  });
+
   describe('getConversationsForUser — screenDecision privacy (IND-610)', () => {
     it('projects named screenDecision fields to the initiator only, never to the non-owner counterparty, even for a mutually-visible negotiation', async () => {
       const run = `${Date.now()}-${crypto.randomUUID()}`;


### PR DESCRIPTION
## What changed
- Projects viewer-visible opportunity lifecycle and newest task IDs alongside negotiation conversation summaries in one batched query.
- Reworks the existing Negotiations tab into an accessible Counterparty → Opportunity rail with supported lifecycle indicators and preserved Hide actions.
- Deep-links opportunity rows to `?taskId=` and loads that task’s exact durable transcript/session.

## Verification
- `bunx eslint` on changed web and API files
- `bun --bun vitest run src/components/__tests__/ChatSidebar.test.tsx src/lib/__tests__/negotiation-outline.test.ts` (9 passing)
- `bun run typecheck` and `bun run typecheck:specs` in `services/api`
- API adapter projection test passes in the focused adapter suite

## Notes
- Full web build remains blocked by the pre-existing unresolved import `@indexnetwork/protocol/question-block`.
- The broader adapter suite has two unrelated pre-existing failures around durable-session history and lifecycle turn-count expectations.