### PR TITLE
feat(negotiations): a verification duty for the responding seat

### DIFF
--- a/packages/protocol/src/negotiations/negotiation.agent.ts
+++ b/packages/protocol/src/negotiations/negotiation.agent.ts
@@ -305,6 +305,12 @@ export class IndexNegotiator {
     // via the domain contract, exactly like `configuredScreenMode()`. Under the
     // `advocate` default every stance fragment below is the legacy string, so
     // the rendered prompt is byte-identical to the pre-IND-611 build.
+    //
+    // `stanceActionRules` also takes the resolved `seat`: the responder
+    // verification rules are a duty of the seat that did NOT open, so they
+    // render only there. The resolved seat, not `input.seat`, so the v1
+    // `isDiscoverer` fallback decides it there too — under v1 the discoverer
+    // is likewise the side that opens.
     const stance = configuredNegotiatorStance();
     const schema = turnSchemaFor(version, seat, isFinalTurn, {
       system: SystemNegotiationTurnSchema,
@@ -317,7 +323,7 @@ export class IndexNegotiator {
     const networkContext = input.indexContext.prompt || "General discovery";
     const actionRules = (version === "v2"
       ? (seat === "initiator" ? V2_INITIATOR_RULES : V2_COUNTERPARTY_RULES)
-      : V1_ACTION_RULES) + stanceActionRules(stance)
+      : V1_ACTION_RULES) + stanceActionRules(stance, seat)
       + (canAskUser
         ? ASK_USER_RULE
           + (preContactConsult ? PRE_CONTACT_ASK_USER_RULE + stancePreContactConsultRule(stance) : "")

--- a/packages/protocol/src/negotiations/negotiation.stance.contracts.ts
+++ b/packages/protocol/src/negotiations/negotiation.stance.contracts.ts
@@ -9,11 +9,11 @@
  *
  * `NEGOTIATOR_STANCE` makes that stance configurable instead of hard-coded:
  *
- * | stance      | framing                              | value bar        | query rule              | consult propensity      | deadlock  |
- * |-------------|--------------------------------------|------------------|-------------------------|-------------------------|-----------|
- * | `advocate`  | argue the case (today)               | none             | mandate (today)         | none (today)            | bargain   |
- * | `evaluator` | assess first, advocate if it survives | opportunity-cost | necessary-not-sufficient| prefer over assumption  | bargain   |
- * | `skeptic`   | + "most matches are not worth making" | opportunity-cost | necessary-not-sufficient| + unverified = don't proceed | stalemate |
+ * | stance      | framing                              | value bar        | query rule              | consult propensity      | responder check          | deadlock  |
+ * |-------------|--------------------------------------|------------------|-------------------------|-------------------------|--------------------------|-----------|
+ * | `advocate`  | argue the case (today)               | none             | mandate (today)         | none (today)            | none (today)             | bargain   |
+ * | `evaluator` | assess first, advocate if it survives | opportunity-cost | necessary-not-sufficient| prefer over assumption  | verify the opening       | bargain   |
+ * | `skeptic`   | + "most matches are not worth making" | opportunity-cost | necessary-not-sufficient| + unverified = don't proceed | + probe before accepting | stalemate |
  *
  * Design constraints (hard):
  * - **`advocate` is byte-identical.** Every fragment below is additive and
@@ -35,7 +35,17 @@
  * Fragments deliberately never contain the literal `ask_user` or a quoted
  * `"withdraw"`: they render into every seat and protocol version, and the seat
  * specs pin that those tokens appear only where the seat legally holds them.
+ *
+ * One family of fragments is the exception to that seat-blindness by
+ * construction rather than by accident: the responder verification rules
+ * (`stanceVerifiesResponderFit`) address a duty only the RESPONDING seat has —
+ * reading someone else's opening — so `stanceActionRules` takes the seat and
+ * renders them only there. They still name no action and no mechanism, so the
+ * seat's own rules and the graph's grants stay the sole authority on what this
+ * turn may actually do.
  */
+
+import type { NegotiationSeat } from "../shared/schemas/negotiation-state.schema.js";
 
 export const NEGOTIATOR_STANCES = ["advocate", "evaluator", "skeptic"] as const;
 
@@ -67,6 +77,14 @@ export function stanceAppliesValueBar(stance: NegotiatorStance): boolean {
  * continuing to evaluate rather than as a mandate to connect.
  */
 export function stanceQueryMatchIsNecessaryNotSufficient(stance: NegotiatorStance): boolean {
+  return stance !== "advocate";
+}
+
+/**
+ * Whether this stance asks the RESPONDING seat to verify the opening's account
+ * of the fit before accepting it, rather than reading that account as evidence.
+ */
+export function stanceVerifiesResponderFit(stance: NegotiatorStance): boolean {
   return stance !== "advocate";
 }
 
@@ -158,15 +176,66 @@ const CONSULT_PROPENSITY_RULE = `
 const SKEPTIC_CONSULT_SHARPENING = ` For you this is a gate, not a preference: an UNVERIFIED assumption that the two sides' intents actually align is a reason NOT to proceed, and consulting {userName} is how that assumption gets verified.`;
 
 /**
+ * Responder verification — assessing stances, RESPONDING seat only.
+ *
+ * Two structural gaps this closes, both visible in the failure it was written
+ * for: a first-contact outreach accepted in one exchange, on reasoning that
+ * restated the opening's own fit claim back as the reason for accepting.
+ *
+ * 1. The opening enters the prompt as if it were evidence. It is not: it is
+ *    advocacy authored by the counterparty's agent, and its most load-bearing
+ *    move is characterizing what THIS client wants. Nothing else in the prompt
+ *    tells the responding seat to treat that characterization as a claim.
+ * 2. `VALUE_BAR_RULE` has no bite in this seat. "Most matches are not worth
+ *    making" reads as being about MAKING matches, and a responder frames its
+ *    decision as "would my client be open to connecting?" — nearly costless,
+ *    nearly certain to be yes. So the same opportunity-cost currency is
+ *    restated in the terms this seat actually spends it: accepting puts a
+ *    connection in front of the client for approval.
+ *
+ * Conditional by construction: the steer applies where the fit case RESTS on
+ * the initiator's interpretation. A match the client's own criteria and the
+ * counterparty's own evidence support independently may still be accepted on
+ * first contact — which is why no "always"/"never accept" wording appears here
+ * and a spec pins its absence.
+ *
+ * Names no action and no mechanism, like every other fragment in this module:
+ * "one more exchange" and "consulting {userName}" describe the move, and the
+ * seat's own rules decide which token carries it (and whether the grant for it
+ * is even live this turn).
+ */
+const RESPONDER_VERIFICATION_RULE = `
+- THE OPENING IS ADVOCACY, NOT EVIDENCE: what reached {userName} was written by the other side's agent to make this match sound worth taking, and its account of the fit — what {userName} is looking for, why the two sides line up — is that agent's CLAIM about {userName}, not a fact you have checked. Test it against {userName}'s OWN intent and against what the counterparty's own profile and intents actually show. Restating the opening's fit claim back as your reason is agreement, not verification.
+- WHAT ACCEPTING SPENDS: accepting is not the free or agreeable option — it puts a connection in front of {userName} for approval and spends the same finite attention the bar above governs. "Would {userName} be open to connecting?" is a bar almost anything clears, and it is not the bar. An accept on the first exchange has to be grounded in what {userName} themselves stated they were looking for, met by evidence about the counterparty that stands up without the opening's reading of it. Where the case for fit still rests on how the other agent characterized {userName}'s needs, the cheap move is one more exchange — put the specific gap to them, or counter with what would have to be true — and where the doubt is about {userName}'s own criteria rather than the counterparty's evidence, consulting {userName} settles it instead.`;
+
+/**
+ * `skeptic` sharpening of the responder rule, appended to the same bullet (the
+ * same additive pattern as `SKEPTIC_CONSULT_SHARPENING`): under the
+ * not-worth-making prior, closing on the opening alone is the exception rather
+ * than the default. The escape hatch is restated explicitly here because this
+ * is where the pressure is highest and an over-read would turn a lean into a
+ * ban on first-contact accepts.
+ */
+const SKEPTIC_RESPONDER_SHARPENING = ` For you an accept on the first exchange is the exception, not the default: where the fit case still rests on the opening's own characterization, probe once before accepting — one exchange costs the counterparty nothing and {userName} very little, while an accept you cannot ground spends their attention on a match no one has checked. Where {userName}'s stated criteria and the counterparty's own evidence carry the fit without that characterization, accepting straight away is still the right call.`;
+
+/**
  * Extra action-rule lines contributed by the stance, appended after the seat's
  * own rules. Empty under `advocate` → byte-identical.
+ *
+ * `seat` scopes the responder verification rules to the seat that did NOT
+ * open. Everything else here is seat-blind: the value bar and the consult
+ * propensity are duties of both seats, and the seat parameter must not become
+ * a reason to fork them.
  */
-export function stanceActionRules(stance: NegotiatorStance): string {
+export function stanceActionRules(stance: NegotiatorStance, seat: NegotiationSeat): string {
   if (!stanceAppliesValueBar(stance)) return "";
   const consultRule = stance === "skeptic"
     ? CONSULT_PROPENSITY_RULE + SKEPTIC_CONSULT_SHARPENING
     : CONSULT_PROPENSITY_RULE;
-  return VALUE_BAR_RULE + consultRule;
+  const responderRule = seat === "counterparty" && stanceVerifiesResponderFit(stance)
+    ? RESPONDER_VERIFICATION_RULE + (stance === "skeptic" ? SKEPTIC_RESPONDER_SHARPENING : "")
+    : "";
+  return VALUE_BAR_RULE + consultRule + responderRule;
 }
 
 /**

--- a/packages/protocol/src/negotiations/tests/negotiation.stance.spec.ts
+++ b/packages/protocol/src/negotiations/tests/negotiation.stance.spec.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, afterEach } from "bun:test";
 import { IndexNegotiator, type NegotiationAgentInput } from "../negotiation.agent.js";
-import { NEGOTIATOR_STANCES, DEFAULT_NEGOTIATOR_STANCE, configuredNegotiatorStance, stanceAppliesValueBar, stanceQueryMatchIsNecessaryNotSufficient, stanceResolvesDeadlockByStalemate, stanceJobFraming, stanceActionRules, stanceQuerySatisfiedRule, type NegotiatorStance } from "../negotiation.stance.contracts.js";
+import { NEGOTIATOR_STANCES, DEFAULT_NEGOTIATOR_STANCE, configuredNegotiatorStance, stanceAppliesValueBar, stanceQueryMatchIsNecessaryNotSufficient, stanceResolvesDeadlockByStalemate, stanceVerifiesResponderFit, stanceJobFraming, stanceActionRules, stanceQuerySatisfiedRule, type NegotiatorStance } from "../negotiation.stance.contracts.js";
 import { renderBargainingShiftSection } from "../negotiation.deadlock.js";
 import { PROMPT_MATRIX } from "./fixtures/negotiator-prompt-matrix.js";
 import GOLDEN from "./fixtures/negotiator-advocate-prompts.golden.json" with { type: "json" };
@@ -76,6 +76,24 @@ async function renderMatrix(stance: string | undefined): Promise<Record<string, 
   }
 }
 
+/** Render one ad-hoc input under a stance — for shapes outside the fixed matrix. */
+async function renderPrompt(
+  input: NegotiationAgentInput,
+  stance: string,
+  action: string,
+): Promise<string> {
+  const original = process.env.NEGOTIATOR_STANCE;
+  process.env.NEGOTIATOR_STANCE = stance;
+  try {
+    const agent = new CapturingNegotiator(validTurn(action));
+    await agent.invoke(input);
+    return agent.prompt;
+  } finally {
+    if (original === undefined) delete process.env.NEGOTIATOR_STANCE;
+    else process.env.NEGOTIATOR_STANCE = original;
+  }
+}
+
 const ORIGINAL_STANCE = process.env.NEGOTIATOR_STANCE;
 afterEach(() => {
   if (ORIGINAL_STANCE === undefined) delete process.env.NEGOTIATOR_STANCE;
@@ -104,16 +122,17 @@ describe("configuredNegotiatorStance", () => {
   });
 
   it("exposes the documented capability matrix", () => {
-    const matrix: Record<NegotiatorStance, [boolean, boolean, boolean]> = {
-      // [value bar, necessary-not-sufficient query, stalemate deadlock]
-      advocate: [false, false, false],
-      evaluator: [true, true, false],
-      skeptic: [true, true, true],
+    const matrix: Record<NegotiatorStance, [boolean, boolean, boolean, boolean]> = {
+      // [value bar, necessary-not-sufficient query, responder verification, stalemate deadlock]
+      advocate: [false, false, false, false],
+      evaluator: [true, true, true, false],
+      skeptic: [true, true, true, true],
     };
     for (const stance of NEGOTIATOR_STANCES) {
       expect([
         stanceAppliesValueBar(stance),
         stanceQueryMatchIsNecessaryNotSufficient(stance),
+        stanceVerifiesResponderFit(stance),
         stanceResolvesDeadlockByStalemate(stance),
       ]).toEqual(matrix[stance]);
     }
@@ -147,7 +166,8 @@ describe("NEGOTIATOR_STANCE=advocate — byte-identical prompt invariant", () =>
   });
 
   it("contributes no fragments at all under advocate", () => {
-    expect(stanceActionRules("advocate")).toBe("");
+    expect(stanceActionRules("advocate", "initiator")).toBe("");
+    expect(stanceActionRules("advocate", "counterparty")).toBe("");
     expect(stanceJobFraming("advocate")).toBe(
       "Argue their case honestly — acknowledge weaknesses, but advocate for genuine fit.",
     );
@@ -220,8 +240,9 @@ describe("evaluator / skeptic — additive, gated fragments", () => {
   });
 
   it("the consult rule stays conditional — no wording that fights the ask-rounds cap", () => {
-    for (const stance of ["evaluator", "skeptic"] as const) {
-      const rules = stanceActionRules(stance);
+    for (const stance of ["evaluator", "skeptic"] as const)
+    for (const seat of ["initiator", "counterparty"] as const) {
+      const rules = stanceActionRules(stance, seat);
       // Conditional on client-resolvable uncertainty, never an unconditional urge:
       // when the cap is reached the action is simply not offered, and the prompt
       // must not push against that.
@@ -248,6 +269,182 @@ describe("evaluator / skeptic — additive, gated fragments", () => {
   it("stance fragments never appear on a prompt that has no discovery query", async () => {
     const rendered = await renderMatrix("skeptic");
     expect(rendered["v2-initiator"]).not.toContain("PRECONDITION for continuing to evaluate");
+  });
+});
+
+/**
+ * Responder verification (the sibling of the consult-propensity fragment).
+ *
+ * The failure it exists for: a first-contact outreach accepted in one
+ * exchange, where the accept's reasoning restated the OPENING's own fit claim
+ * — the initiator's agent characterizing what this client wants — as the
+ * reason for accepting. Two fragments answer it, and both are duties of the
+ * seat that did not open, so seat-scoping is the invariant this file pins
+ * hardest: initiator prompts must stay free of responder-facing copy in both
+ * directions.
+ *
+ * Seats here are the RESOLVED ones. Under v1 there is no `seat` on the input
+ * at all, so the `isDiscoverer` fallback decides it: `v1` (not the discoverer)
+ * responds, `v1-discovery-query` (the discoverer) opens. Those two entries are
+ * what make the derivation itself a checked claim.
+ */
+const OPENING_MARKER = "THE OPENING IS ADVOCACY, NOT EVIDENCE";
+const SPEND_MARKER = "WHAT ACCEPTING SPENDS";
+const SKEPTIC_RESPONDER_MARKER = "an accept on the first exchange is the exception, not the default";
+
+/**
+ * The responder-only tail of a stance's action rules: what the responding seat
+ * gets and the initiating seat does not. Derived by subtraction rather than by
+ * re-quoting the fragment, so it stays honest if the wording moves.
+ */
+function responderPortion(stance: NegotiatorStance): string {
+  const initiator = stanceActionRules(stance, "initiator");
+  const counterparty = stanceActionRules(stance, "counterparty");
+  expect(counterparty.startsWith(initiator)).toBe(true);
+  return counterparty.slice(initiator.length);
+}
+
+/** Matrix entries whose RESOLVED seat is the responding one. */
+const RESPONDER_IDS = ["v2-counterparty", "v2-counterparty-discovery-query", "v1"];
+const INITIATOR_IDS = PROMPT_MATRIX.map((e) => e.id).filter((id) => !RESPONDER_IDS.includes(id));
+
+describe("responder verification — the opening is a claim, not evidence", () => {
+  it("covers both resolved seats in the matrix, v1 fallback included", () => {
+    // Guards the two id lists above against drifting out of the matrix.
+    expect(RESPONDER_IDS.every((id) => PROMPT_MATRIX.some((e) => e.id === id))).toBe(true);
+    expect(INITIATOR_IDS).toContain("v1-discovery-query");
+    expect(INITIATOR_IDS).toContain("v2-initiator");
+  });
+
+  it("renders on responder turns under evaluator and skeptic", async () => {
+    for (const stance of ["evaluator", "skeptic"]) {
+      const rendered = await renderMatrix(stance);
+      for (const id of RESPONDER_IDS) {
+        const prompt = rendered[id];
+        expect(prompt).toContain(OPENING_MARKER);
+        expect(prompt).toContain("is that agent's CLAIM about Alice, not a fact you have checked");
+        expect(prompt).toContain("Restating the opening's fit claim back as your reason is agreement, not verification");
+        expect(prompt).toContain(SPEND_MARKER);
+        // The opportunity-cost currency restated in the terms this seat spends it.
+        expect(prompt).toContain("it puts a connection in front of Alice for approval");
+        expect(prompt).toContain('"Would Alice be open to connecting?" is a bar almost anything clears');
+        // The grounding bar and the two cheap moves when it is not met.
+        expect(prompt).toContain("what Alice themselves stated they were looking for");
+        expect(prompt).toContain("the cheap move is one more exchange");
+        expect(prompt).toContain("consulting Alice settles it instead");
+      }
+    }
+  });
+
+  it("never renders under advocate — on any seat", async () => {
+    for (const stance of [undefined, "advocate", "nonsense-stance"]) {
+      const rendered = await renderMatrix(stance);
+      for (const entry of PROMPT_MATRIX) {
+        expect(rendered[entry.id]).not.toContain(OPENING_MARKER);
+        expect(rendered[entry.id]).not.toContain(SPEND_MARKER);
+        expect(rendered[entry.id]).not.toContain(SKEPTIC_RESPONDER_MARKER);
+      }
+    }
+  });
+
+  it("never leaks onto an initiator turn under any stance", async () => {
+    for (const stance of NEGOTIATOR_STANCES) {
+      const rendered = await renderMatrix(stance);
+      for (const id of INITIATOR_IDS) {
+        expect(rendered[id]).not.toContain(OPENING_MARKER);
+        expect(rendered[id]).not.toContain(SPEND_MARKER);
+        expect(rendered[id]).not.toContain(SKEPTIC_RESPONDER_MARKER);
+      }
+    }
+  });
+
+  it("leaves the seat-blind fragments identical on both seats", () => {
+    for (const stance of ["evaluator", "skeptic"] as const) {
+      const initiator = stanceActionRules(stance, "initiator");
+      const counterparty = stanceActionRules(stance, "counterparty");
+      // The responder rules are strictly appended: the initiator's rendering is
+      // a prefix of the responder's, so the value bar and consult propensity
+      // cannot fork by seat.
+      expect(counterparty.startsWith(initiator)).toBe(true);
+      expect(counterparty.length).toBeGreaterThan(initiator.length);
+      expect(initiator).not.toContain(OPENING_MARKER);
+      expect(initiator).not.toContain(SPEND_MARKER);
+    }
+  });
+
+  it("skeptic sharpens the responder rule additively over evaluator", async () => {
+    const evaluator = await renderMatrix("evaluator");
+    const skeptic = await renderMatrix("skeptic");
+    for (const id of RESPONDER_IDS) {
+      // Everything the evaluator says about the opening survives verbatim.
+      expect(evaluator[id]).toContain(OPENING_MARKER);
+      expect(skeptic[id]).toContain(OPENING_MARKER);
+      expect(evaluator[id]).not.toContain(SKEPTIC_RESPONDER_MARKER);
+      expect(skeptic[id]).toContain(SKEPTIC_RESPONDER_MARKER);
+      expect(skeptic[id]).toContain("probe once before accepting");
+      expect(skeptic[id]).toContain("one exchange costs the counterparty nothing and Alice very little");
+    }
+    // Additive at the fragment level too: the whole evaluator responder body
+    // survives verbatim inside the skeptic's, which only appends to it.
+    expect(stanceActionRules("skeptic", "counterparty")).toContain(responderPortion("evaluator"));
+  });
+
+  it("does not urge unconditional probing — the steer is conditional on the opening carrying the fit case", () => {
+    for (const stance of ["evaluator", "skeptic"] as const) {
+      const portion = responderPortion(stance);
+      // No blanket instruction in either direction: a match the client's own
+      // criteria independently support may still be accepted on first contact.
+      expect(portion).not.toMatch(/never accept/i);
+      expect(portion).not.toMatch(/\balways\b/i);
+      expect(portion).not.toMatch(/\bnever\b/i);
+      // Both fragments are conditioned on the fit case resting on the opening.
+      expect(portion).toContain("Where the case for fit still rests on how the other agent characterized");
+    }
+    // The skeptic's sharpening keeps the escape hatch explicit: an
+    // independently supported match may still be accepted on first contact.
+    expect(stanceActionRules("skeptic", "counterparty")).toContain(
+      "Where {userName}'s stated criteria and the counterparty's own evidence carry the fit without that characterization, accepting straight away is still the right call",
+    );
+  });
+
+  it("renders on every responder turn shape, not only the matrix ones", async () => {
+    const responderBase = PROMPT_MATRIX.find((e) => e.id === "v2-counterparty")!.input;
+    const shapes: Array<[string, NegotiationAgentInput, string]> = [
+      // The exact shape the failure came from: one opening turn to respond to.
+      ["first response", { ...responderBase, history: responderBase.history.slice(0, 1) }, "accept"],
+      ["final turn", { ...responderBase, isFinalTurn: true }, "accept"],
+      ["with consult grant", { ...responderBase, canAskUser: true }, "accept"],
+      ["continuation", { ...responderBase, isContinuation: true }, "accept"],
+    ];
+    for (const [, input, action] of shapes) {
+      const prompt = await renderPrompt(input, "skeptic", action);
+      expect(prompt).toContain(OPENING_MARKER);
+      expect(prompt).toContain(SPEND_MARKER);
+      expect(prompt).toContain(SKEPTIC_RESPONDER_MARKER);
+    }
+  });
+
+  it("names no action and no mechanism the responding seat may not hold", async () => {
+    for (const stance of ["evaluator", "skeptic"] as const) {
+      const rules = stanceActionRules(stance, "counterparty");
+      // Same discipline as every other fragment here: the seat's own rules and
+      // the graph's grants decide which token carries "one more exchange".
+      expect(rules).not.toContain("ask_user");
+      expect(rules).not.toContain('"withdraw"');
+      expect(rules).not.toContain('"question"');
+      expect(rules).not.toContain('"accept"');
+      expect(rules).not.toContain('"counter"');
+      expect(rules).not.toContain('"decline"');
+      expect(rules).not.toContain('"outreach"');
+    }
+    // And the rendered responder prompts still carry no withdraw vocabulary.
+    for (const stance of NEGOTIATOR_STANCES) {
+      const rendered = await renderMatrix(stance);
+      for (const id of RESPONDER_IDS) {
+        expect(rendered[id]).not.toContain('"withdraw"');
+        expect(rendered[id]).not.toContain("ask_user");
+      }
+    }
   });
 });
 


### PR DESCRIPTION
The sibling of #1438, for the other seat.

## What went wrong on dev

Under `skeptic`, a first-contact `outreach → accept` closed in a single exchange. The accept's reasoning restated the opening's own fit claim — "the alignment ... is very strong", the initiator's words — as the reason for accepting. The counterparty's actual evidence (mathematical frameworks for human-AI collaboration) was not what the client had asked for (topic-classification / linguistics research). The initiator's pitch did the interpretive work; the responder bought the characterization and passed it on.

Two structural causes, both prompt-level, both specific to the responding seat.

**The opportunity-cost bar has no bite there.** Skeptic's "most matches are not worth making" reads as being about *making* matches. A responder frames its decision as "would my client be open to connecting?" — nearly free, and nearly certain to be yes. `WHAT ACCEPTING SPENDS` restates the same currency in the terms this seat actually spends it: accepting puts a connection in front of the client for approval, and that question is a bar almost anything clears.

**The opening enters the prompt as if it were evidence.** It is advocacy, authored by the counterparty's agent, and its most load-bearing move is characterizing what *this* client wants. `THE OPENING IS ADVOCACY, NOT EVIDENCE` names it as a claim to test against the client's own intent and the counterparty's own profile and intents — and says outright that restating it back is agreement, not verification.

## Seat-scoping

New for this module: `stanceActionRules` now takes the resolved seat, and the responder rules render only for the seat that did NOT open. Under v1 there is no seat on the input, so the `isDiscoverer` fallback decides it — the discoverer is the opener there too, which the `v1` / `v1-discovery-query` matrix entries pin in both directions.

Everything else the stance contributes stays seat-blind. A spec pins the initiator rendering as a strict prefix of the responder's, so the seat parameter cannot become a reason to fork the value bar or the consult propensity.

## Not an unconditional probe

`skeptic` sharpens additively, same pattern as the existing sharpenings: a first-contact accept is the exception rather than the default, probe once before accepting. It is conditioned on the fit case resting on the opening's characterization, and its own last sentence keeps the escape hatch explicit — a match the client's stated criteria and the counterparty's own evidence carry independently may still be accepted straight away. A spec pins the absence of "always" / "never accept" phrasing in the responder-only tail.

## Constraints held

- **`advocate` byte-identical** — every pre-existing golden capture unchanged; the fragments are empty on that stance for both seats. No new matrix entries, so the golden's provenance story is untouched.
- **Prompt-only** — no vocabulary, schema, graph, or admission-policy change. `assessConsultationEligibility` already admits the mid-flight consult the fragment steers toward.
- **Names no action, no mechanism** — no `ask_user`, no quoted `"withdraw"` or any other seat token; "one more exchange" and "consulting {userName}" describe the move and leave the seat's own rules in charge of which token carries it.
- #1445's pre-contact machinery untouched.

## Tests

`negotiation.stance.spec.ts` (35 pass): renders on responder turns under evaluator and skeptic, and on every responder turn shape — first response, final turn, with the consult grant, continuation; absent under `advocate` on every seat, including the unrecognized-value fallback; never leaks onto an initiator turn under any stance; the skeptic body strictly contains the evaluator's; forbidden-token sweep across the matrix; capability matrix extended to the fourth column.

Full protocol suite green (2218 pass, 196 files), typecheck and lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)