### PR TITLE
feat: show discovery progress for warming signals

### DIFF
--- a/apps/web/src/app/i/[intentId]/page.tsx
+++ b/apps/web/src/app/i/[intentId]/page.tsx
@@ -23,7 +23,7 @@ import { useRadarLiveRefresh } from "@/hooks/useRadarLiveRefresh";
 import { useIntentVisitPing } from "@/hooks/useIntentVisitPing";
 import type { NegotiationActivityGroup } from "@/services/conversation";
 import type { RadarCardItem, OpportunityLifecycleStatus } from "@/services/opportunities";
-import type { IntentLifecycleStatus, MutableIntentLifecycleStatus } from "@/services/intents";
+import type { DiscoveryProgress, IntentLifecycleStatus, MutableIntentLifecycleStatus } from "@/services/intents";
 import { cn } from "@/lib/utils";
 import { intentNegotiationActivityRevision } from "@/lib/intent-negotiation-activity";
 import { normalizeNegotiationActivity } from "@/lib/negotiation-activity";
@@ -63,6 +63,36 @@ function normalizeIntentLifecycleStatus(status: unknown): IntentLifecycleStatus 
     return status;
   }
   return "ACTIVE";
+}
+
+function DiscoveryWarmup({ progress, communities }: { progress?: DiscoveryProgress; communities: Array<{ id: string; title: string }> }) {
+  const status = progress?.status ?? "unknown";
+  const active = status === "queued" || status === "running" || status === "retrying";
+  const assignmentLabel = status === "blocked" || communities.length === 0
+    ? "Needs attention"
+    : `${progress?.assignedCommunityCount ?? communities.length} ${communities.length === 1 ? "community" : "communities"}`;
+  const findingLabel: Record<string, string> = {
+    queued: "Queued", running: "Finding", retrying: "Retrying", completed: "Completed", failed: "Needs attention", blocked: "Needs attention", unknown: "Status unavailable",
+  };
+  return (
+    <section className="rounded-lg border border-dashed border-gray-300 bg-gray-50/60 p-4" aria-label="Conversation preparation status" data-testid="discovery-warmup">
+      <h4 className="text-sm font-semibold text-gray-900">Preparing your first conversations</h4>
+      <dl className="mt-3 space-y-2 text-xs text-gray-600">
+        <div className="flex justify-between gap-3"><dt>Signal created</dt><dd className="font-medium text-gray-800">✓</dd></div>
+        <div className="flex justify-between gap-3"><dt>Shared with communities</dt><dd className="text-right font-medium text-gray-800">{assignmentLabel}</dd></div>
+        <div className="flex justify-between gap-3"><dt>Finding relevant signals</dt><dd className="font-medium text-gray-800">{findingLabel[status]}</dd></div>
+        <div className="flex justify-between gap-3"><dt>Agent conversations</dt><dd className="font-medium text-gray-800">{progress?.conversationsStartedCount ? `${progress.conversationsStartedCount} started` : "Next"}</dd></div>
+      </dl>
+      {status === "blocked" || communities.length === 0 ? (
+        <p className="mt-3 text-xs text-gray-600">Matching cannot begin until this signal is shared with an active community.</p>
+      ) : status === "completed" ? (
+        <p className="mt-3 text-xs text-gray-600">We completed this search with no promising conversations yet.</p>
+      ) : (
+        <p className="mt-3 text-xs text-gray-600">We’ll show conversations here once a promising overlap is found.</p>
+      )}
+      {active && <p className="mt-1 text-xs text-gray-500">You can leave this page—matching continues in the background.</p>}
+    </section>
+  );
 }
 
 /** Bounded intent-refinement poll: interval (ms) and maximum total wait (ms). */
@@ -488,6 +518,16 @@ export default function IntentDetailPage() {
     void loadNegotiationActivity();
   }, [loadNegotiationActivity, loadOpportunities]);
 
+  // Refresh only the owner-scoped progress snapshot while work is non-terminal;
+  // this intentionally leaves the negotiator chat mounted and untouched.
+  useEffect(() => {
+    if (!intentId || !intent || !["queued", "running", "retrying"].includes(intent.discoveryProgress?.status ?? "")) return;
+    const timer = window.setInterval(() => {
+      void intentsService.getIntent(intentId).then(setIntent).catch(() => {});
+    }, 15_000);
+    return () => window.clearInterval(timer);
+  }, [intentId, intent, intentsService]);
+
   useRadarLiveRefresh({
     intentId,
     activityRevision: negotiationActivityRevision,
@@ -634,6 +674,8 @@ export default function IntentDetailPage() {
     () => opportunities.filter((item) => bucketOf(item) === selectedBucket),
     [opportunities, bucketOf, selectedBucket],
   );
+  const hasActualNegotiationActivity = negotiationActivity.length > 0
+    || opportunities.some((item) => bucketOf(item) === "negotiating");
 
   const title = (
     intent?.summary && intent.summary.trim().length > 0
@@ -1022,11 +1064,10 @@ export default function IntentDetailPage() {
                   <div className="min-h-0 flex-1 lg:overflow-y-auto lg:pr-1">
                   {selectedBucket === "negotiating" && (
                     <div className="mb-3">
-                      <NegotiationActivity
-                        groups={negotiationActivity}
-                        loading={negotiationActivityLoading}
-                        error={negotiationActivityError}
-                      />
+                      {negotiationActivity.length === 0 && !hasActualNegotiationActivity && !negotiationActivityLoading && !negotiationActivityError
+                        && (intent?.warming || intent?.discoveryProgress) ? (
+                          <DiscoveryWarmup progress={intent?.discoveryProgress} communities={intent?.networks ?? []} />
+                        ) : <NegotiationActivity groups={negotiationActivity} loading={negotiationActivityLoading} error={negotiationActivityError} />}
                     </div>
                   )}
                   {opportunitiesLoading ? (

--- a/apps/web/src/components/NegotiationActivity.tsx
+++ b/apps/web/src/components/NegotiationActivity.tsx
@@ -29,7 +29,7 @@ export default function NegotiationActivity({
     return <p role="status" className="text-xs text-red-600">Agent messages could not be loaded. Radar will retry automatically.</p>;
   }
   if (groups.length === 0) {
-    return <p className="text-xs text-gray-500">Your agent is still talking with theirs. Messages will appear here as they are persisted.</p>;
+    return <p className="text-xs text-gray-500">No agent conversations have started yet.</p>;
   }
 
   return (

--- a/apps/web/src/services/intents.ts
+++ b/apps/web/src/services/intents.ts
@@ -2,6 +2,21 @@ import type { Intent, PaginatedResponse, APIResponse } from '../types';
 
 export type IntentLifecycleStatus = 'ACTIVE' | 'PAUSED' | 'FULFILLED' | 'EXPIRED';
 export type MutableIntentLifecycleStatus = Extract<IntentLifecycleStatus, 'ACTIVE' | 'PAUSED'>;
+export type DiscoveryProgressStatus = 'queued' | 'running' | 'retrying' | 'completed' | 'failed' | 'blocked' | 'unknown';
+export interface DiscoveryProgress {
+  status: DiscoveryProgressStatus;
+  attempt: number;
+  maxAttempts: number;
+  assignedCommunityCount: number;
+  processedCommunityCount: number;
+  possibleOverlapCount: number;
+  conversationsStartedCount: number;
+  queuedAt: string | null;
+  startedAt: string | null;
+  completedAt: string | null;
+  updatedAt: string | null;
+}
+export type IntentDetail = Intent & { warming?: boolean; networks?: Array<{ id: string; title: string }>; discoveryProgress?: DiscoveryProgress };
 
 export interface IntentStatusResult {
   id: string;
@@ -61,8 +76,8 @@ export const createIntentsService = (api: ReturnType<typeof import('../lib/api')
   },
 
   // Get single intent by ID
-  getIntent: async (id: string): Promise<Intent> => {
-    const response = await api.get<APIResponse<Intent>>(`/intents/${id}`);
+  getIntent: async (id: string): Promise<IntentDetail> => {
+    const response = await api.get<APIResponse<IntentDetail>>(`/intents/${id}`);
     if (!response.intent) {
       throw new Error('Signal not found');
     }

--- a/apps/web/tests/intent-page-negotiator.test.tsx
+++ b/apps/web/tests/intent-page-negotiator.test.tsx
@@ -7,7 +7,7 @@
  * refine input. The old static questions block is retired with the card
  * questions (conversational-questions plan, "Retirements").
  */
-import { render, screen, waitFor } from '@testing-library/react';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
 import { Route, Routes } from 'react-router';
 import { MemoryRouter } from 'react-router';
 import { beforeEach, describe, expect, test, vi } from 'vitest';
@@ -154,5 +154,41 @@ describe('Intent page — negotiator chat gating', () => {
     expect(
       await screen.findByPlaceholderText(/tell the agent anything about this signal/i),
     ).toBeInTheDocument();
+  });
+
+  test('shows truthful discovery preparation instead of claiming agents are talking', async () => {
+    mocks.intentsService.getIntent.mockResolvedValue({
+      id: 'intent-1', payload: 'Looking for a technical co-founder', summary: null,
+      createdAt: new Date().toISOString(), warming: true,
+      networks: [{ id: 'community-1', title: 'Builders' }],
+      discoveryProgress: {
+        status: 'retrying', attempt: 2, maxAttempts: 3, assignedCommunityCount: 1,
+        processedCommunityCount: 0, possibleOverlapCount: 0, conversationsStartedCount: 0,
+        queuedAt: null, startedAt: null, completedAt: null, updatedAt: null,
+      },
+    });
+    renderIntentPage();
+    await screen.findByText('Looking for a technical co-founder');
+    fireEvent.click(screen.getByRole('button', { name: /Negotiating/ }));
+    expect(await screen.findByText('Preparing your first conversations')).toBeInTheDocument();
+    expect(screen.getByText('Retrying')).toBeInTheDocument();
+    expect(screen.queryByText(/still talking with theirs/i)).toBeNull();
+  });
+
+  test('reports a completed search with no conversations distinctly from failure', async () => {
+    mocks.intentsService.getIntent.mockResolvedValue({
+      id: 'intent-1', payload: 'Looking for a technical co-founder', summary: null,
+      createdAt: new Date().toISOString(), warming: false,
+      networks: [{ id: 'community-1', title: 'Builders' }],
+      discoveryProgress: {
+        status: 'completed', attempt: 1, maxAttempts: 3, assignedCommunityCount: 1,
+        processedCommunityCount: 1, possibleOverlapCount: 0, conversationsStartedCount: 0,
+        queuedAt: null, startedAt: null, completedAt: new Date().toISOString(), updatedAt: null,
+      },
+    });
+    renderIntentPage();
+    await screen.findByText('Looking for a technical co-founder');
+    fireEvent.click(screen.getByRole('button', { name: /Negotiating/ }));
+    expect(await screen.findByText(/completed this search with no promising conversations/i)).toBeInTheDocument();
   });
 });

--- a/services/api/drizzle/0137_add_intent_discovery_progress.sql
+++ b/services/api/drizzle/0137_add_intent_discovery_progress.sql
@@ -1,0 +1,23 @@
+CREATE TYPE "public"."intent_discovery_progress_status" AS ENUM('queued', 'running', 'succeeded', 'failed', 'blocked');
+--> statement-breakpoint
+CREATE TABLE "intent_discovery_progress" (
+  "intent_id" text PRIMARY KEY NOT NULL,
+  "user_id" text NOT NULL,
+  "status" "intent_discovery_progress_status" DEFAULT 'queued' NOT NULL,
+  "attempt" integer DEFAULT 0 NOT NULL,
+  "max_attempts" integer DEFAULT 3 NOT NULL,
+  "assigned_community_count" integer DEFAULT 0 NOT NULL,
+  "processed_community_count" integer DEFAULT 0 NOT NULL,
+  "possible_overlap_count" integer DEFAULT 0 NOT NULL,
+  "conversations_started_count" integer DEFAULT 0 NOT NULL,
+  "queued_at" timestamp with time zone DEFAULT now() NOT NULL,
+  "started_at" timestamp with time zone,
+  "completed_at" timestamp with time zone,
+  "updated_at" timestamp with time zone DEFAULT now() NOT NULL
+);
+--> statement-breakpoint
+ALTER TABLE "intent_discovery_progress" ADD CONSTRAINT "intent_discovery_progress_intent_id_intents_id_fk" FOREIGN KEY ("intent_id") REFERENCES "public"."intents"("id") ON DELETE cascade;
+--> statement-breakpoint
+ALTER TABLE "intent_discovery_progress" ADD CONSTRAINT "intent_discovery_progress_user_id_users_id_fk" FOREIGN KEY ("user_id") REFERENCES "public"."users"("id") ON DELETE cascade;
+--> statement-breakpoint
+CREATE INDEX "intent_discovery_progress_user_updated_idx" ON "intent_discovery_progress" USING btree ("user_id","updated_at");

--- a/services/api/drizzle/meta/_journal.json
+++ b/services/api/drizzle/meta/_journal.json
@@ -953,6 +953,13 @@
       "when": 1786886087816,
       "tag": "0136_dismiss_retired_chat_questions",
       "breakpoints": true
+    },
+    {
+      "idx": 137,
+      "version": "7",
+      "when": 1786886087817,
+      "tag": "0137_add_intent_discovery_progress",
+      "breakpoints": true
     }
   ]
 }

--- a/services/api/src/adapters/chat.database.adapter.ts
+++ b/services/api/src/adapters/chat.database.adapter.ts
@@ -1020,6 +1020,24 @@ export class ChatDatabaseAdapter {
       .where(and(eq(intents.id, intentId), isNull(intents.firstDiscoverySucceededAt)));
   }
 
+  /** Persist aggregate-only worker lifecycle data; safe to expose to the owner. */
+  async recordIntentDiscoveryProgress(input: {
+    intentId: string; userId: string; status: 'queued' | 'running' | 'succeeded' | 'failed' | 'blocked'; attempt: number; assignedCommunityCount?: number;
+  }): Promise<void> {
+    const now = new Date();
+    await db.insert(schema.intentDiscoveryProgress).values({
+      ...input, ...(input.assignedCommunityCount != null ? { assignedCommunityCount: input.assignedCommunityCount } : {}),
+      ...(input.status === 'queued' ? { queuedAt: now, completedAt: null, startedAt: null } : {}),
+      ...(input.status === 'running' ? { startedAt: now } : {}),
+      ...(input.status === 'succeeded' || input.status === 'blocked' ? { completedAt: now } : {}), updatedAt: now,
+    }).onConflictDoUpdate({ target: schema.intentDiscoveryProgress.intentId, set: {
+      status: input.status, attempt: input.attempt, ...(input.assignedCommunityCount != null ? { assignedCommunityCount: input.assignedCommunityCount } : {}), updatedAt: now,
+      ...(input.status === 'queued' ? { queuedAt: now, completedAt: null, startedAt: null } : {}),
+      ...(input.status === 'running' ? { startedAt: now } : {}),
+      ...(input.status === 'succeeded' || input.status === 'blocked' ? { completedAt: now } : {}),
+    }});
+  }
+
   async getNetworkMemberContext(networkId: string, userId: string) {
     const rows = await db
       .select({

--- a/services/api/src/adapters/database.shared.ts
+++ b/services/api/src/adapters/database.shared.ts
@@ -184,6 +184,19 @@ export interface IntentListRow {
   waitingOpportunityCount: number;
   /** True while a fresh intent has not completed its first discovery run. */
   warming: boolean;
+  discoveryProgress?: {
+    status: 'queued' | 'running' | 'retrying' | 'completed' | 'failed' | 'blocked' | 'unknown';
+    attempt: number;
+    maxAttempts: number;
+    assignedCommunityCount: number;
+    processedCommunityCount: number;
+    possibleOverlapCount: number;
+    conversationsStartedCount: number;
+    queuedAt: Date | null;
+    startedAt: Date | null;
+    completedAt: Date | null;
+    updatedAt: Date | null;
+  };
 }
 // UserIdentity shape (aligned with `@indexnetwork/protocol`'s UserIdentity; defined
 // locally to honor the adapter layering rule of not importing protocol interfaces).

--- a/services/api/src/adapters/intent.database.adapter.ts
+++ b/services/api/src/adapters/intent.database.adapter.ts
@@ -585,8 +585,10 @@ export class IntentDatabaseAdapter {
       db.select({ count: count() }).from(schema.intents).where(where),
     ]);
 
-    const { rows: withExtras, totalWaitingOpportunities } = await this.attachIntentExtras(rows, userId);
+    const { rows: withExtras, totalWaitingOpportunities } = await this.attachIntentExtras(rows, userId, false);
     return {
+      // Progress is intentionally a single-signal owner detail contract; keep
+      // the existing list payload stable and inexpensive for dashboards.
       rows: withExtras,
       total: Number(totalResult[0]?.count ?? 0),
       totalWaitingOpportunities,
@@ -612,13 +614,15 @@ export class IntentDatabaseAdapter {
       firstDiscoverySucceededAt: Date | null;
     })[],
     userId: string,
+    includeDiscoveryProgress = true,
   ): Promise<{ rows: IntentListRow[]; totalWaitingOpportunities: number }> {
     if (rows.length === 0) return { rows: [], totalWaitingOpportunities: 0 };
     const intentIds = rows.map(r => r.id);
     const warmingCutoff = new Date(Date.now() - 24 * 60 * 60 * 1000);
-    const [networks, countResult] = await Promise.all([
+    const [networks, countResult, progress] = await Promise.all([
       this.networksByIntent(intentIds),
       this.countsByIntent(intentIds, userId),
+      includeDiscoveryProgress ? this.discoveryProgressByIntent(intentIds, userId) : Promise.resolve(new Map()),
     ]);
     return {
       rows: rows.map(({ firstDiscoverySucceededAt, ...r }) => ({
@@ -628,9 +632,44 @@ export class IntentDatabaseAdapter {
         waitingOpportunityCount: countResult.byIntent.get(r.id)?.opportunities ?? 0,
         warming: r.createdAt > warmingCutoff
           && firstDiscoverySucceededAt == null,
+        ...(includeDiscoveryProgress ? { discoveryProgress: progress.get(r.id) ?? {
+          // Legacy signals have no durable worker row. Do not infer a run from
+          // freshness; report the absence honestly, except known historical success.
+          status: firstDiscoverySucceededAt ? 'completed' : 'unknown',
+          attempt: 0, maxAttempts: 3, assignedCommunityCount: (networks.get(r.id) ?? []).length,
+          processedCommunityCount: 0, possibleOverlapCount: 0, conversationsStartedCount: 0,
+          queuedAt: null, startedAt: null, completedAt: firstDiscoverySucceededAt, updatedAt: null,
+        }} : {}),
       })),
       totalWaitingOpportunities: countResult.totalWaitingOpportunities,
     };
+  }
+
+  private async discoveryProgressByIntent(intentIds: string[], userId: string): Promise<Map<string, NonNullable<IntentListRow['discoveryProgress']>>> {
+    const result = new Map<string, NonNullable<IntentListRow['discoveryProgress']>>();
+    if (!intentIds.length) return result;
+    const rows = await db.select().from(schema.intentDiscoveryProgress).where(and(
+      inArray(schema.intentDiscoveryProgress.intentId, intentIds),
+      eq(schema.intentDiscoveryProgress.userId, userId),
+    ));
+    for (const row of rows) {
+      // A worker heartbeat is the durable row's update time. Do not present a
+      // retained/dead BullMQ job as active after a worker crash or redelivery
+      // gap; its precise state is no longer knowable.
+      const stale = (row.status === 'queued' || row.status === 'running')
+        && Date.now() - row.updatedAt.getTime() > 30 * 60 * 1000;
+      result.set(row.intentId, {
+        status: stale ? 'unknown' : row.status === 'succeeded' ? 'completed' : row.status === 'failed'
+          ? (row.attempt < row.maxAttempts ? 'retrying' : 'failed') : row.status,
+        attempt: row.attempt, maxAttempts: row.maxAttempts,
+        assignedCommunityCount: row.assignedCommunityCount,
+        processedCommunityCount: row.processedCommunityCount,
+        possibleOverlapCount: row.possibleOverlapCount,
+        conversationsStartedCount: row.conversationsStartedCount,
+        queuedAt: row.queuedAt, startedAt: row.startedAt, completedAt: row.completedAt, updatedAt: row.updatedAt,
+      });
+    }
+    return result;
   }
 
 

--- a/services/api/src/controllers/intent.controller.ts
+++ b/services/api/src/controllers/intent.controller.ts
@@ -255,6 +255,13 @@ export class IntentController {
         createdAt: r.createdAt.toISOString(),
         updatedAt: r.updatedAt.toISOString(),
         archivedAt: r.archivedAt?.toISOString() ?? null,
+        discoveryProgress: r.discoveryProgress && {
+          ...r.discoveryProgress,
+          queuedAt: r.discoveryProgress.queuedAt?.toISOString() ?? null,
+          startedAt: r.discoveryProgress.startedAt?.toISOString() ?? null,
+          completedAt: r.discoveryProgress.completedAt?.toISOString() ?? null,
+          updatedAt: r.discoveryProgress.updatedAt?.toISOString() ?? null,
+        },
       },
     });
   }

--- a/services/api/src/queues/opportunity/from-intent.queue.ts
+++ b/services/api/src/queues/opportunity/from-intent.queue.ts
@@ -23,7 +23,7 @@ export interface FromIntentJobData {
 
 export type FromIntentDatabase = Pick<
   ChatDatabaseAdapter,
-  'getIntentForIndexing' | 'getNetworkIdsForIntent' | 'getAssignmentNetworkMembershipsForUser' | 'markIntentFirstDiscoverySucceeded'
+  'getIntentForIndexing' | 'getNetworkIdsForIntent' | 'getAssignmentNetworkMembershipsForUser' | 'markIntentFirstDiscoverySucceeded' | 'recordIntentDiscoveryProgress'
 >;
 
 export interface FromIntentDeps {
@@ -66,6 +66,7 @@ export class FromIntentQueue {
       deduplication?: DeduplicationOptions;
     },
   ): Promise<Job<FromIntentJobData>> {
+    await this.recordProgress(data, 'queued', 0);
     return this.queue.add('discover_opportunities', data, {
       attempts: 3,
       backoff: { type: 'exponential', delay: 1000 },
@@ -80,17 +81,27 @@ export class FromIntentQueue {
     });
   }
 
-  async processJob(name: string, data: FromIntentJobData): Promise<void> {
+  private async recordProgress(data: FromIntentJobData, status: 'queued' | 'running' | 'succeeded' | 'failed' | 'blocked', attempt: number, assignedCommunityCount?: number): Promise<void> {
+    const record = (this.database as Partial<FromIntentDatabase>).recordIntentDiscoveryProgress;
+    // Isolated queue tests and a rolling deploy may run a worker before its
+    // adapter has been updated. Production adapters always provide this.
+    if (!record) return;
+    await record.call(this.database, {
+      intentId: data.intentId, userId: data.userId, status, attempt, assignedCommunityCount,
+    });
+  }
+
+  async processJob(name: string, data: FromIntentJobData, attempt = 1): Promise<void> {
     switch (name) {
       case 'discover_opportunities':
-        await this.handleDiscover(data);
+        await this.handleDiscover(data, attempt);
         break;
       default:
         this.queueLogger.warn('Unknown job name', { name });
     }
   }
 
-  private async handleDiscover(data: FromIntentJobData): Promise<void> {
+  private async handleDiscover(data: FromIntentJobData, attempt: number): Promise<void> {
     const { intentId, userId, networkIds } = data;
     // `this.database` is already `deps?.database ?? new ChatDatabaseAdapter()` and
     // setRuntimeDeps never replaces `database`, so this is the injected db when provided.
@@ -124,6 +135,7 @@ export class FromIntentQueue {
     // scope is narrowing-only. Any empty intersection must stop before the graph
     // or the evidence shadow can observe an unscoped run.
     if (validNetworkIds.length === 0) {
+      await this.recordProgress(data, 'blocked', 0, 0);
       this.logger.warn('Intent has no valid discovery networks, skipping fail-closed', {
         intentId,
         userId,
@@ -131,6 +143,8 @@ export class FromIntentQueue {
       });
       return;
     }
+
+    await this.recordProgress(data, 'running', attempt, validNetworkIds.length);
 
     this.logger.info('Starting discovery', { intentId, userId, networkIds: validNetworkIds });
 
@@ -183,6 +197,7 @@ export class FromIntentQueue {
         error: error instanceof Error ? error.message : String(error),
       });
     }
+    await this.recordProgress(data, 'succeeded', attempt, stampNetworkIds.length);
 
     // Lens C negotiation-evidence shadow (IND-433): fire-and-forget on its
     // own flag. Formerly triggered through the pool-discriminator mining hook;
@@ -213,7 +228,13 @@ export class FromIntentQueue {
     if (this.worker) return;
     const processor = async (job: Job<FromIntentJobData>) => {
       this.queueLogger.info('Processing job', { jobId: job.id });
-      await this.processJob(job.name, job.data);
+      try {
+        await this.processJob(job.name, job.data, job.attemptsMade + 1);
+      } catch (error) {
+        const attempt = job.attemptsMade + 1;
+        await this.recordProgress(job.data, 'failed', attempt);
+        throw error;
+      }
     };
     this.worker = QueueFactory.createWorker<FromIntentJobData>(QUEUE_NAME, processor);
   }

--- a/services/api/src/queues/tests/from-intent.queue.isolated.ts
+++ b/services/api/src/queues/tests/from-intent.queue.isolated.ts
@@ -55,6 +55,7 @@ const asDb = (db: FromIntentDatabaseOverrides): FromIntentDatabase => ({
     db.getAssignmentNetworkMembershipsForUser
     ?? (async () => [{ networkId: 'idx1', isPersonal: false }]),
   markIntentFirstDiscoverySucceeded: db.markIntentFirstDiscoverySucceeded ?? (async () => {}),
+  recordIntentDiscoveryProgress: db.recordIntentDiscoveryProgress ?? (async () => {}),
 });
 
 describe('FromIntentQueue', () => {
@@ -118,6 +119,20 @@ describe('FromIntentQueue', () => {
   });
 
   describe('processJob', () => {
+    it('records aggregate queued, running, and completed lifecycle states without candidate data', async () => {
+      const recordIntentDiscoveryProgress = mock(async () => {});
+      const queue = new FromIntentQueue({
+        database: asDb({
+          getIntentForIndexing: async () => ({ id: 'i1', payload: 'P', userId: 'u1', sourceType: null, sourceId: null }),
+          recordIntentDiscoveryProgress,
+        }),
+        invokeOpportunityGraph: async () => {},
+      });
+      await queue.processJob('discover_opportunities', { intentId: 'i1', userId: 'u1' }, 2);
+      expect(recordIntentDiscoveryProgress).toHaveBeenCalledWith(expect.objectContaining({ status: 'running', attempt: 2, assignedCommunityCount: 1 }));
+      expect(recordIntentDiscoveryProgress).toHaveBeenCalledWith(expect.objectContaining({ status: 'succeeded', attempt: 2 }));
+    });
+
     it('unknown job name logs warning and does not throw', async () => {
       const queue = new FromIntentQueue();
       await expect(

--- a/services/api/src/schemas/database.schema.ts
+++ b/services/api/src/schemas/database.schema.ts
@@ -17,6 +17,7 @@ export const permissionScopeEnum = pgEnum('permission_scope', ['global', 'node',
 export const premiseStatusEnum = pgEnum('premise_status', ['ACTIVE', 'RETRACTED', 'EXPIRED']);
 export const questionStatusEnum = pgEnum('question_status', ['pending', 'answered', 'dismissed']);
 export const discoveryRunStatusEnum = pgEnum('discovery_run_status', ['queued', 'running', 'succeeded', 'failed', 'cancelled']);
+export const intentDiscoveryProgressStatusEnum = pgEnum('intent_discovery_progress_status', ['queued', 'running', 'succeeded', 'failed', 'blocked']);
 export const intentProposalStatusEnum = pgEnum('intent_proposal_status', ['pending', 'consumed', 'rejected']);
 
 export interface HistoricalQualityBaseAttestation {
@@ -1020,6 +1021,29 @@ export const files = pgTable('files', {
   updatedAt: timestamp('updated_at').defaultNow().notNull(),
   deletedAt: timestamp('deleted_at'),
 });
+
+/**
+ * Owner-visible, aggregate-only observability for the ordinary from-intent
+ * worker. Unlike BullMQ retention this survives completed, failed and stale
+ * jobs and deliberately has no error payload or candidate-level data.
+ */
+export const intentDiscoveryProgress = pgTable('intent_discovery_progress', {
+  intentId: text('intent_id').primaryKey().references(() => intents.id, { onDelete: 'cascade' }),
+  userId: text('user_id').notNull().references(() => users.id, { onDelete: 'cascade' }),
+  status: intentDiscoveryProgressStatusEnum('status').notNull().default('queued'),
+  attempt: integer('attempt').notNull().default(0),
+  maxAttempts: integer('max_attempts').notNull().default(3),
+  assignedCommunityCount: integer('assigned_community_count').notNull().default(0),
+  processedCommunityCount: integer('processed_community_count').notNull().default(0),
+  possibleOverlapCount: integer('possible_overlap_count').notNull().default(0),
+  conversationsStartedCount: integer('conversations_started_count').notNull().default(0),
+  queuedAt: timestamp('queued_at', { withTimezone: true }).notNull().defaultNow(),
+  startedAt: timestamp('started_at', { withTimezone: true }),
+  completedAt: timestamp('completed_at', { withTimezone: true }),
+  updatedAt: timestamp('updated_at', { withTimezone: true }).notNull().defaultNow(),
+}, (table) => ({
+  userUpdatedIdx: index('intent_discovery_progress_user_updated_idx').on(table.userId, table.updatedAt),
+}));
 
 export const intentNetworks = pgTable('intent_networks', {
   intentId: text('intent_id').notNull().references(() => intents.id),


### PR DESCRIPTION
## Summary

- persist aggregate-only discovery lifecycle records for ordinary signal discovery jobs
- expose owner-scoped `discoveryProgress` only on the single-signal detail response
- show a compact Negotiating warm-up panel for queued, running, retrying, blocked, unknown, and completed-without-conversations states

## Why

Fresh signals previously used the `warming` freshness hint and an empty negotiation feed could claim that agents were talking when no conversation had started. The new contract is based on durable queue lifecycle data and never includes candidate identities, transcripts, raw errors, or internal traces.

## Deployment

Apply migration `0137_add_intent_discovery_progress.sql` before deploying workers. Existing signals safely report `unknown` when there is no durable run record; previously stamped successful signals report `completed`. Retained active records older than 30 minutes also report unknown rather than falsely appearing active.

## Verification / visual proof

- `bun run typecheck` in `services/api`
- `bun test ./src/queues/tests/from-intent.queue.isolated.ts` in `services/api` (22 passing)
- `bun run build` in `apps/web`
- `bun --bun vitest run tests/intent-page-negotiator.test.tsx` in `apps/web` (5 passing)

The focused page test renders and asserts the retrying warm-up panel and the completed-with-no-promising-conversations panel, including that the old false talking claim is absent.
