### PR TITLE
feat(negotiations): a prior decision is not the client's evidence

### DIFF
--- a/packages/protocol/src/negotiations/negotiation.stance.contracts.ts
+++ b/packages/protocol/src/negotiations/negotiation.stance.contracts.ts
@@ -9,11 +9,11 @@
  *
  * `NEGOTIATOR_STANCE` makes that stance configurable instead of hard-coded:
  *
- * | stance      | framing                              | value bar        | query rule              | consult propensity      | responder check          | deadlock  |
- * |-------------|--------------------------------------|------------------|-------------------------|-------------------------|--------------------------|-----------|
- * | `advocate`  | argue the case (today)               | none             | mandate (today)         | none (today)            | none (today)             | bargain   |
- * | `evaluator` | assess first, advocate if it survives | opportunity-cost | necessary-not-sufficient| prefer over assumption  | verify the opening       | bargain   |
- * | `skeptic`   | + "most matches are not worth making" | opportunity-cost | necessary-not-sufficient| + unverified = don't proceed | + probe before accepting | stalemate |
+ * | stance      | framing                              | value bar        | query rule              | consult propensity      | evidence provenance      | responder check          | deadlock  |
+ * |-------------|--------------------------------------|------------------|-------------------------|-------------------------|--------------------------|--------------------------|-----------|
+ * | `advocate`  | argue the case (today)               | none             | mandate (today)         | none (today)            | none (today)             | none (today)             | bargain   |
+ * | `evaluator` | assess first, advocate if it survives | opportunity-cost | necessary-not-sufficient| prefer over assumption  | own record ≠ client's evidence | verify the opening | bargain   |
+ * | `skeptic`   | + "most matches are not worth making" | opportunity-cost | necessary-not-sufficient| + unverified = don't proceed | (same — no sharpening) | + probe before accepting | stalemate |
  *
  * Design constraints (hard):
  * - **`advocate` is byte-identical.** Every fragment below is additive and
@@ -43,6 +43,12 @@
  * renders them only there. They still name no action and no mechanism, so the
  * seat's own rules and the graph's grants stay the sole authority on what this
  * turn may actually do.
+ *
+ * The seat parameter is a scoping tool, not a licence to fork: a duty both
+ * seats hold stays in the shared prefix even when the failure that motivated it
+ * showed up on one seat. `EVIDENCE_PROVENANCE_RULE` is the case in point — it
+ * was written for a responder accept, and it renders seat-blind, because an
+ * initiator can cite its own prior openings' claims exactly as readily.
  */
 
 import type { NegotiationSeat } from "../shared/schemas/negotiation-state.schema.js";
@@ -176,6 +182,50 @@ const CONSULT_PROPENSITY_RULE = `
 const SKEPTIC_CONSULT_SHARPENING = ` For you this is a gate, not a preference: an UNVERIFIED assumption that the two sides' intents actually align is a reason NOT to proceed, and consulting {userName} is how that assumption gets verified.`;
 
 /**
+ * Evidence provenance — assessing stances, BOTH seats.
+ *
+ * The third sibling of the consult-propensity and responder-verification
+ * fragments, and written for the way the second one was formally obeyed and
+ * substantively evaded. A responder accepted a first contact grounded — as the
+ * responder rule demands — in its OWN side's record rather than in the
+ * opening's characterization. But the record it reached for was its own prior
+ * conclusions, surfaced through memory and prior dialogue: "{userName}'s
+ * previous acceptances ... reinforce this strong alignment", from acceptances
+ * this same negotiator had made under a weaker bar. Circular verification —
+ * I accepted before, therefore accepting is grounded.
+ *
+ * So the rule the verification duty was missing: an agent's own output is not
+ * its client's evidence. Verification grounds in what a PERSON authored — never
+ * in what an agent concluded about them, on either side of the table. The
+ * fragment names exactly the client-authored sections this prompt actually
+ * renders (intents, profile, and the client's own answers between sessions),
+ * so the ground it points at is one the negotiator can see.
+ *
+ * Two boundaries it deliberately does not cross:
+ * - **It does not ban memory.** Memory keeps the job it has (advisory notes on
+ *   how to argue, what has been asked, what each side said); what changes is
+ *   only what may count as verification. A fragment that told the negotiator to
+ *   ignore its memory would fight `renderNegotiatorMemorySection` rather than
+ *   complete it.
+ * - **It does not forbid resolving a repeat signal quickly.** The continuation
+ *   policy in `negotiation.agent.ts` ("materially the same as one you
+ *   previously evaluated ... you may resolve quickly") governs how much EFFORT
+ *   a re-run deserves; this governs what counts as GROUNDS. The nearest
+ *   existing neighbor is the IND-569 attribution policy — "do not treat their
+ *   conclusions as decisions about this opportunity" — which scopes conclusions
+ *   across opportunities; this scopes them across the decision/evidence line.
+ *
+ * No `skeptic` sharpening: the prior that most matches are not worth making
+ * does not change what an unverified assertion is worth. It is worth nothing
+ * under either assessing stance, and a sharpening here would only restate the
+ * rule louder.
+ *
+ * Names no action and no mechanism, like every other fragment in this module.
+ */
+const EVIDENCE_PROVENANCE_RULE = `
+- YOUR OWN RECORD IS DECISIONS, NOT EVIDENCE: your earlier turns, the connections you proposed or accepted on {userName}'s behalf, and the conclusions you carry in memory are YOUR record — decisions you made for them, reached under whatever bar you applied at the time. Leaning on one ("they have been open to this before", "the fit was already established") re-asserts a judgment instead of checking it, and reads your own past eagerness back as {userName}'s interest. Ground the fit in what a person stated for themselves: {userName}'s own intents, profile, and the answers they gave you directly on your side; the counterparty's own intents and profile on theirs. Prior dialogue and memory keep their job — what has already been asked, what each side actually said, how to pitch this one — but they are the history of the argument, not grounds for it. A fit that was not verified does not become verified by having been asserted before.`;
+
+/**
  * Responder verification — assessing stances, RESPONDING seat only.
  *
  * Two structural gaps this closes, both visible in the failure it was written
@@ -223,9 +273,15 @@ const SKEPTIC_RESPONDER_SHARPENING = ` For you an accept on the first exchange i
  * own rules. Empty under `advocate` → byte-identical.
  *
  * `seat` scopes the responder verification rules to the seat that did NOT
- * open. Everything else here is seat-blind: the value bar and the consult
- * propensity are duties of both seats, and the seat parameter must not become
- * a reason to fork them.
+ * open. Everything else here is seat-blind: the value bar, the consult
+ * propensity and the evidence-provenance rule are duties of both seats, and
+ * the seat parameter must not become a reason to fork them.
+ *
+ * Order matters twice over. The seat-blind rules come first, so the initiator's
+ * rendering stays a strict PREFIX of the responder's — the invariant the stance
+ * spec checks by subtraction. And provenance lands immediately before the
+ * responder rules, so "ground the accept in what {userName} themselves stated"
+ * is already qualified by whose statements count when the responder reads it.
  */
 export function stanceActionRules(stance: NegotiatorStance, seat: NegotiationSeat): string {
   if (!stanceAppliesValueBar(stance)) return "";
@@ -235,7 +291,7 @@ export function stanceActionRules(stance: NegotiatorStance, seat: NegotiationSea
   const responderRule = seat === "counterparty" && stanceVerifiesResponderFit(stance)
     ? RESPONDER_VERIFICATION_RULE + (stance === "skeptic" ? SKEPTIC_RESPONDER_SHARPENING : "")
     : "";
-  return VALUE_BAR_RULE + consultRule + responderRule;
+  return VALUE_BAR_RULE + consultRule + EVIDENCE_PROVENANCE_RULE + responderRule;
 }
 
 /**

--- a/packages/protocol/src/negotiations/tests/negotiation.stance.spec.ts
+++ b/packages/protocol/src/negotiations/tests/negotiation.stance.spec.ts
@@ -273,6 +273,127 @@ describe("evaluator / skeptic — additive, gated fragments", () => {
 });
 
 /**
+ * Evidence provenance — the agent's own record is its decisions, not its
+ * client's evidence.
+ *
+ * The failure it exists for is the responder verification duty being formally
+ * obeyed and substantively evaded: an accept grounded in the responder's OWN
+ * side's record, where that record was the same negotiator's earlier
+ * acceptances, recalled through memory and prior dialogue. Circular
+ * verification survives every check the previous fragment makes.
+ *
+ * Seat-blind by choice: an initiator can cite its own prior openings' claims
+ * just as readily, so the rule renders in the shared prefix. That makes the
+ * strict-prefix invariant below the load-bearing pin — it is what keeps this
+ * fragment out of the responder-only tail.
+ */
+const PROVENANCE_MARKER = "YOUR OWN RECORD IS DECISIONS, NOT EVIDENCE";
+
+describe("evidence provenance — prior decisions are not the client's evidence", () => {
+  it("renders on EVERY prompt in the matrix under evaluator and skeptic", async () => {
+    for (const stance of ["evaluator", "skeptic"]) {
+      const rendered = await renderMatrix(stance);
+      for (const entry of PROMPT_MATRIX) {
+        const prompt = rendered[entry.id];
+        expect(prompt).toContain(PROVENANCE_MARKER);
+        // The three sources that get mistaken for evidence, all named.
+        expect(prompt).toContain("your earlier turns");
+        expect(prompt).toContain("the connections you proposed or accepted on Alice's behalf");
+        expect(prompt).toContain("the conclusions you carry in memory");
+      }
+    }
+  });
+
+  it("distinguishes the agent's decisions from the client's evidence", async () => {
+    const rendered = await renderMatrix("skeptic");
+    const prompt = rendered["v2-counterparty"];
+    // Decisions side: authored by the agent, under whatever bar applied then.
+    expect(prompt).toContain("decisions you made for them, reached under whatever bar you applied at the time");
+    // The circular move, named as the thing it is.
+    expect(prompt).toContain("re-asserts a judgment instead of checking it");
+    expect(prompt).toContain("reads your own past eagerness back as Alice's interest");
+    // Evidence side: authored by a person, on either side of the table.
+    expect(prompt).toContain("Ground the fit in what a person stated for themselves");
+    // Grounds named are the client-authored sections this prompt actually
+    // renders — intents, profile, and Alice's own answers between sessions.
+    expect(prompt).toContain("Alice's own intents, profile, and the answers they gave you directly");
+    expect(prompt).toContain("the counterparty's own intents and profile on theirs");
+    // The closing principle.
+    expect(prompt).toContain(
+      "A fit that was not verified does not become verified by having been asserted before",
+    );
+  });
+
+  it("does not ban memory or prior dialogue — it re-scopes what they establish", () => {
+    for (const stance of ["evaluator", "skeptic"] as const)
+    for (const seat of ["initiator", "counterparty"] as const) {
+      const rules = stanceActionRules(stance, seat);
+      // Memory keeps its job: this fragment changes what counts as
+      // verification, not what gets injected (`renderNegotiatorMemorySection`
+      // is untouched), so no wording may tell the negotiator to drop it.
+      expect(rules).toContain("Prior dialogue and memory keep their job");
+      expect(rules).toContain("what has already been asked");
+      expect(rules).toContain("the history of the argument, not grounds for it");
+      expect(rules).not.toMatch(/ignore (your |the )?(prior |negotiator )?(dialogue|memory|memories)/i);
+      expect(rules).not.toMatch(/disregard/i);
+      expect(rules).not.toMatch(/do not use (your )?memory/i);
+    }
+  });
+
+  it("never renders under advocate — on either seat", async () => {
+    for (const stance of [undefined, "advocate", "nonsense-stance"]) {
+      const rendered = await renderMatrix(stance);
+      for (const entry of PROMPT_MATRIX) {
+        expect(rendered[entry.id]).not.toContain(PROVENANCE_MARKER);
+      }
+    }
+    expect(stanceActionRules("advocate", "initiator")).not.toContain(PROVENANCE_MARKER);
+    expect(stanceActionRules("advocate", "counterparty")).not.toContain(PROVENANCE_MARKER);
+  });
+
+  it("lives in the seat-blind prefix, not in the responder-only tail", () => {
+    for (const stance of ["evaluator", "skeptic"] as const) {
+      // Both seats hold the duty...
+      expect(stanceActionRules(stance, "initiator")).toContain(PROVENANCE_MARKER);
+      expect(stanceActionRules(stance, "counterparty")).toContain(PROVENANCE_MARKER);
+      // ...so it is absent from the responder-only portion, and the strict
+      // prefix invariant (asserted inside `responderPortion`) still holds.
+      expect(responderPortion(stance)).not.toContain(PROVENANCE_MARKER);
+    }
+  });
+
+  it("is identical under evaluator and skeptic — no sharpening was forced", () => {
+    const provenanceOf = (stance: NegotiatorStance) => {
+      const rules = stanceActionRules(stance, "initiator");
+      return rules.slice(rules.indexOf(PROVENANCE_MARKER));
+    };
+    expect(provenanceOf("skeptic")).toBe(provenanceOf("evaluator"));
+  });
+
+  it("sits immediately before the responder rules, so it qualifies them", () => {
+    const rules = stanceActionRules("skeptic", "counterparty");
+    expect(rules.indexOf(PROVENANCE_MARKER)).toBeGreaterThan(rules.indexOf("CONSULT, DON'T ASSUME"));
+    expect(rules.indexOf(PROVENANCE_MARKER)).toBeLessThan(rules.indexOf(OPENING_MARKER));
+  });
+
+  it("names no action and no mechanism", () => {
+    for (const stance of ["evaluator", "skeptic"] as const) {
+      const rules = stanceActionRules(stance, "initiator");
+      const provenance = rules.slice(rules.indexOf(PROVENANCE_MARKER));
+      expect(provenance).not.toContain("ask_user");
+      expect(provenance).not.toContain('"withdraw"');
+      expect(provenance).not.toContain('"accept"');
+      expect(provenance).not.toContain('"counter"');
+      expect(provenance).not.toContain('"decline"');
+      expect(provenance).not.toContain('"question"');
+      expect(provenance).not.toContain('"outreach"');
+    }
+    // And no stance leaks those tokens into a seat that has no grant for them.
+    // (The matrix-wide sweep lives in the seat-invariants block below.)
+  });
+});
+
+/**
  * Responder verification (the sibling of the consult-propensity fragment).
  *
  * The failure it exists for: a first-contact outreach accepted in one


### PR DESCRIPTION
Third sibling of #1438 (consult propensity) and #1446 (responder verification), and written for a live dev failure that happened **after** #1446 deployed.

## The failure

A responder accepted a first contact under `skeptic` with reasoning that *"Christopher's **previous acceptances** to discuss linguistics applications further reinforce this strong alignment"*, and message copy saying Christopher *"**remains**" open*.

#1446's verification duty was formally obeyed. The accept was grounded in the responder's **own side's** record rather than in the opening's characterization of the client — exactly what that fragment asks for. But the record it reached for was *its own prior conclusions*: eager accepts made before these fixes, recalled through negotiator memory and the prior DM dialogue. Circular verification — I accepted before, therefore accepting is grounded. Every check #1446 makes survives it.

## The rule

> **Your own prior turns, past acceptances, and remembered conclusions are your prior DECISIONS, not your client's evidence.** Verification grounds in what a person authored for themselves — stated intents, profile, the answers the client gave directly — not in what an agent concluded about them. Prior dialogue and memory keep informing tone, strategy, and what has already been asked; they cannot be the grounds on which fit is established. A fit that was never verified does not become verified by having been asserted before.

`EVIDENCE_PROVENANCE_RULE`, gated to `evaluator`/`skeptic` like its siblings.

## Seat scoping: seat-neutral, deliberately

The failure was a responder accept, but the duty is not seat-specific — an initiator can cite its own prior openings' claims as established just as readily, and the same memory/prior-dialogue seams feed both seats. #1446's strict-prefix invariant (`counterparty` rules start with the `initiator` rules) is satisfied by a shared-prefix rule, so responder-only scoping would have been a fork with no principle behind it. The header now says as much: the `seat` parameter is a scoping tool, not a licence to fork.

Placement is between the consult rule and the responder rules, so "ground the accept in what {userName} themselves stated" is already qualified by whose statements count by the time the responding seat reads it. A spec pins that ordering, and another pins that the fragment is absent from the responder-only tail — which keeps #1446's prefix invariant load-bearing rather than incidental.

## What it does not do

- **It does not ban memory.** Nothing in the retrieval path moves: `renderNegotiatorMemorySection`, the `NegotiatorMemoryRetrieveFn` seam and `negotiatorMemory` injection are untouched. Memory keeps its job of shaping how the agent argues; what changes is only what may count as *verification*. The fragment says so explicitly ("Prior dialogue and memory keep their job — what has already been asked, what each side actually said, how to pitch this one"), and a spec pins the absence of any "ignore/disregard your memory" wording.
- **It does not forbid resolving a repeat signal quickly.** The continuation policy in `negotiation.agent.ts` governs how much EFFORT a re-run deserves; this governs what counts as GROUNDS. Nearest existing neighbor is the IND-569 attribution policy ("do not treat their conclusions as decisions about this opportunity"), which scopes conclusions *across opportunities*; this scopes them across the decision/evidence line.
- **No `skeptic` sharpening.** The not-worth-making prior does not change what an unverified assertion is worth — nothing, under either assessing stance — so a sharpening would only restate the rule louder. A spec pins that the two stances render it identically, so the omission is a decision rather than a gap.

## Constraints held

Prompt-only, same discipline as the siblings: no seat vocabulary (`allowedActionsFor`), schema, graph-routing, memory-retrieval or grounding-seam change. The fragment names no action and no mechanism — no `ask_user`, no quoted `"withdraw"`/`"accept"`/`"counter"`/`"decline"`. `advocate` is byte-identical; the golden prompt matrix is the guard and still passes on every entry. Grounds named in the copy are the client-authored sections this prompt actually renders (intents, profile, the client's own answers between sessions), so it points at something the negotiator can see.

## Specs (`negotiation.stance.spec.ts`, +8)

Renders on every matrix prompt under `evaluator` and `skeptic`, on neither seat under `advocate`/unset/nonsense; decisions-vs-evidence wording pinned on both halves; memory explicitly not banned; lives in the seat-blind prefix and absent from the responder-only portion; identical under both assessing stances; ordered between the consult and responder rules; forbidden-token sweep.

`bun test src/negotiations` — 538 pass, 2 fail. Both failures are the live-LLM judge assertions in `negotiator-discovery-query.spec.ts`, which fail identically on `dev` at `d2686eb0` without this change and pass when that file is run on its own.

## Files

- `packages/protocol/src/negotiations/negotiation.stance.contracts.ts`
- `packages/protocol/src/negotiations/tests/negotiation.stance.spec.ts`

`negotiation.agent.ts` needed no change — the seat parameter #1446 added is reused as-is, and a shared-prefix fragment needs no new plumbing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
