### PR TITLE
fix(web): the negotiations rail lists what the badge counts

### DIFF
--- a/apps/web/src/components/ChatSidebar.tsx
+++ b/apps/web/src/components/ChatSidebar.tsx
@@ -111,8 +111,10 @@ export default function ChatSidebar() {
     return () => document.removeEventListener('mousedown', handleClickOutside);
   }, [chatMenuOpen]);
 
-  const openNegotiation = (conversationId: string, taskId: string) => {
-    navigate(`/chat/${conversationId}?taskId=${encodeURIComponent(taskId)}`);
+  // A fallback row has no addressable task; the detail page then falls back to
+  // the conversation's latest session, which is the pre-#1444 behavior.
+  const openNegotiation = (conversationId: string, taskId: string | null) => {
+    navigate(taskId ? `/chat/${conversationId}?taskId=${encodeURIComponent(taskId)}` : `/chat/${conversationId}`);
   };
 
   const renderSkeleton = () => (
@@ -207,10 +209,11 @@ export default function ChatSidebar() {
                       <div id={regionId} className="ml-5 border-l border-gray-200 pl-2" role="region" aria-label={`${counterparty.name} opportunities`}>
                         {counterparty.opportunities.map((opportunity) => {
                           const presentation = opportunity.status ? opportunityStatusPresentation[opportunity.status] : null;
-                          const selected = pathname === `/chat/${opportunity.conversationId}` && selectedTaskId === opportunity.taskId;
-                          const opportunityMenuId = `negotiation:${opportunity.conversationId}:${opportunity.taskId}`;
+                          const selected = pathname === `/chat/${opportunity.conversationId}`
+                            && selectedTaskId === (opportunity.taskId ?? null);
+                          const opportunityMenuId = `negotiation:${opportunity.conversationId}:${opportunity.taskId ?? 'latest'}`;
                           return (
-                            <div key={`${opportunity.conversationId}-${opportunity.taskId}`} className={`group relative flex min-w-0 items-center rounded-md ${selected ? 'bg-[#f1f5f7]' : 'hover:bg-gray-50'}`}>
+                            <div key={`${opportunity.conversationId}-${opportunity.taskId ?? 'latest'}`} className={`group relative flex min-w-0 items-center rounded-md ${selected ? 'bg-[#f1f5f7]' : 'hover:bg-gray-50'}`}>
                               <button
                                 type="button"
                                 onClick={() => openNegotiation(opportunity.conversationId, opportunity.taskId)}

--- a/apps/web/src/components/__tests__/ChatSidebar.test.tsx
+++ b/apps/web/src/components/__tests__/ChatSidebar.test.tsx
@@ -103,6 +103,37 @@ const answerNegotiation = negotiation('question', 'Mira Chen', {
   senderId: 'agent:me',
 });
 
+/**
+ * The dev shape that made the badge and the list disagree after #1444: the API
+ * projected no `negotiationOpportunities` (the conversation carries no match
+ * provenance for this viewer) while `negotiation` still describes a pending
+ * opportunity the your-move badge counts.
+ */
+const ungroupableNegotiation: ConversationSummary = {
+  ...negotiation('ungrouped', 'Dana Okafor', { state: 'completed', opportunityStatus: 'pending' }),
+  via: [],
+  negotiationOpportunities: [],
+};
+
+/** A zero-message screened-out shell: owner-only, and never grouped. */
+const screenedOutNegotiation: ConversationSummary = {
+  ...negotiation('screened', 'Ilya Roth', { state: 'completed', opportunityStatus: 'rejected' }),
+  lastMessage: null,
+  lastMessageAt: null,
+  negotiationOpportunities: [],
+  negotiation: {
+    ...negotiation('screened', 'Ilya Roth', { state: 'completed', opportunityStatus: 'rejected' }).negotiation!,
+    screenDecision: {
+      source: 'screen',
+      decision: 'pass',
+      reasoning: 'not enough mutual value',
+      counterpartyPremiseFit: null,
+      intentAlignment: null,
+      screenedAt: '2026-07-24T11:00:00.000Z',
+    },
+  },
+};
+
 const mocks = vi.hoisted(() => ({
   conversations: [] as ConversationSummary[],
   negotiations: [] as ConversationSummary[],
@@ -271,5 +302,49 @@ describe('ChatSidebar negotiations tab (IND-523)', () => {
     fireEvent.click(screen.getByRole('button', { name: /Aisha Khan/ }));
     fireEvent.click(screen.getByText("Aisha Khan's opportunity"));
     await waitFor(() => expect(currentPath.value).toBe('/chat/live?taskId=live-task'));
+  });
+
+  it('never advertises a badge count over an empty list', async () => {
+    mocks.conversations = [];
+    mocks.negotiations = [ungroupableNegotiation, screenedOutNegotiation];
+    renderSidebar();
+
+    // The badge counts the pending negotiation…
+    expect(screen.getByTestId('chat-negotiations-your-move-badge')).toHaveTextContent('1');
+
+    // …and the list must be able to show it. Before the fallback bucket, both
+    // conversations projected zero opportunities and the rail rendered
+    // "No negotiations yet" underneath a badge reading 1.
+    await openNegotiationsTab();
+    expect(screen.queryByText('No negotiations yet')).not.toBeInTheDocument();
+    expect(screen.getByTestId('negotiation-outline')).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /Dana Okafor/ })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /Ilya Roth/ })).toBeInTheDocument();
+  });
+
+  it('opens a fallback row on its lifecycle task and labels its lifecycle status', async () => {
+    mocks.conversations = [];
+    mocks.negotiations = [ungroupableNegotiation];
+    renderSidebar();
+    await openNegotiationsTab();
+
+    fireEvent.click(screen.getByRole('button', { name: /Dana Okafor/ }));
+    // No opportunity title survives the projection, so the row is generic —
+    // but its lifecycle status is still truthful.
+    expect(screen.getByText('Pending')).toBeInTheDocument();
+    fireEvent.click(screen.getByText('Negotiation'));
+    await waitFor(() => expect(currentPath.value).toBe('/chat/ungrouped?taskId=ungrouped-task'));
+  });
+
+  it('opens a fallback row with no addressable task on the latest session', async () => {
+    mocks.conversations = [];
+    mocks.negotiations = [{ ...ungroupableNegotiation, negotiation: null }];
+    renderSidebar();
+    await openNegotiationsTab();
+
+    fireEvent.click(screen.getByRole('button', { name: /Dana Okafor/ }));
+    expect(screen.getByText('No lifecycle status')).toBeInTheDocument();
+    fireEvent.click(screen.getByText('Negotiation'));
+    await waitFor(() => expect(currentPath.value).toBe('/chat/ungrouped'));
   });
 });

--- a/apps/web/src/lib/__tests__/negotiation-outline.test.ts
+++ b/apps/web/src/lib/__tests__/negotiation-outline.test.ts
@@ -1,6 +1,13 @@
 import { describe, expect, it } from 'vitest';
+import { countNegotiationsRequiringAction } from '@/lib/negotiation-inbox';
 import { groupNegotiationOutline, opportunityStatusPresentation } from '@/lib/negotiation-outline';
 import type { ConversationSummary } from '@/services/conversation';
+
+const lastMessage: NonNullable<ConversationSummary['lastMessage']> = {
+  parts: [{ kind: 'data', data: { action: 'counter' } }],
+  senderId: 'agent:peer',
+  createdAt: '2026-01-03T00:00:00.000Z',
+};
 
 const conversation: ConversationSummary = {
   id: 'conversation-1',
@@ -8,16 +15,87 @@ const conversation: ConversationSummary = {
     { participantId: 'agent:viewer', participantType: 'agent', name: 'Helper', avatar: null, ownerName: 'Viewer' },
     { participantId: 'agent:peer', participantType: 'agent', name: 'Helper', avatar: null, ownerName: 'Peer' },
   ],
+  lastMessage,
+  metadata: null,
+  via: [],
+  unreadCount: 0,
+  lastMessageAt: '2026-01-03T00:00:00.000Z',
+  createdAt: '2026-01-01T00:00:00.000Z',
+  negotiationOpportunities: [
+    { intentId: 'intent-a', opportunityId: 'opportunity-a', title: 'Find a design partner', taskId: 'task-a', state: 'working', opportunityStatus: 'negotiating', acceptedByViewer: false, turnCount: 2, maxTurns: 6, signalCount: 1, outcome: null, updatedAt: '2026-01-02T00:00:00.000Z' },
+    { intentId: 'intent-b', opportunityId: 'opportunity-b', title: 'Discuss research collaboration', taskId: 'task-b', state: 'completed', opportunityStatus: 'accepted', acceptedByViewer: true, turnCount: 3, maxTurns: 6, signalCount: 1, outcome: { hasOpportunity: true, reason: null }, updatedAt: '2026-01-03T00:00:00.000Z' },
+  ],
+};
+
+/**
+ * The dev shape behind the badge/list disagreement after #1444: a live
+ * negotiation whose conversation carries no `matchProvenance`, so the API
+ * projects `negotiationOpportunities: []` while `negotiation` still describes a
+ * pending opportunity the badge counts.
+ */
+const ungroupableConversation: ConversationSummary = {
+  id: '93c58ea7-71f5-4a63-b5e4-23aee8b9d7bf',
+  participants: [
+    { participantId: 'agent:viewer', participantType: 'agent', name: 'Helper', avatar: null, ownerName: 'Viewer' },
+    { participantId: 'agent:peer-2', participantType: 'agent', name: 'Helper', avatar: null, ownerName: 'Dana' },
+  ],
+  lastMessage: { ...lastMessage, senderId: 'agent:peer-2' },
+  metadata: null,
+  via: [],
+  unreadCount: 0,
+  lastMessageAt: '2026-01-04T00:00:00.000Z',
+  createdAt: '2026-01-01T00:00:00.000Z',
+  negotiation: {
+    taskId: '07979837-5e29-4dd9-83dc-26f593972ca6',
+    state: 'completed',
+    statusTimestamp: '2026-01-04T00:00:00.000Z',
+    opportunityId: '6426226c-9d63-42a9-8aea-764bbe0c5b8b',
+    opportunityStatus: 'pending',
+    acceptedByViewer: false,
+    turnCount: 2,
+    maxTurns: 6,
+    signalCount: 1,
+    outcome: null,
+    updatedAt: '2026-01-04T00:00:00.000Z',
+  },
+  negotiationOpportunities: [],
+};
+
+/** The screened-out sibling: no messages, no opportunities, viewer is the initiator. */
+const screenedOutConversation: ConversationSummary = {
+  id: 'c5e8a825-ddcb-479c-b8dc-a8ad05690d71',
+  participants: [
+    { participantId: 'agent:viewer', participantType: 'agent', name: 'Helper', avatar: null, ownerName: 'Viewer' },
+    { participantId: 'agent:peer-3', participantType: 'agent', name: 'Helper', avatar: null, ownerName: 'Ilya' },
+  ],
   lastMessage: null,
   metadata: null,
   via: [],
   unreadCount: 0,
   lastMessageAt: null,
   createdAt: '2026-01-01T00:00:00.000Z',
-  negotiationOpportunities: [
-    { intentId: 'intent-a', opportunityId: 'opportunity-a', title: 'Find a design partner', taskId: 'task-a', state: 'working', opportunityStatus: 'negotiating', acceptedByViewer: false, turnCount: 2, maxTurns: 6, signalCount: 1, outcome: null, updatedAt: '2026-01-02T00:00:00.000Z' },
-    { intentId: 'intent-b', opportunityId: 'opportunity-b', title: 'Discuss research collaboration', taskId: 'task-b', state: 'completed', opportunityStatus: 'accepted', acceptedByViewer: true, turnCount: 3, maxTurns: 6, signalCount: 1, outcome: { hasOpportunity: true, reason: null }, updatedAt: '2026-01-03T00:00:00.000Z' },
-  ],
+  negotiation: {
+    taskId: '7bfba641-245c-4a92-9269-a798eba5c9e7',
+    state: 'completed',
+    statusTimestamp: '2026-01-05T00:00:00.000Z',
+    opportunityId: '08b143c0-6f01-4c61-9fe9-08718744e86a',
+    opportunityStatus: 'rejected',
+    acceptedByViewer: false,
+    turnCount: 0,
+    maxTurns: 6,
+    signalCount: 1,
+    outcome: null,
+    updatedAt: '2026-01-05T00:00:00.000Z',
+    screenDecision: {
+      source: 'screen',
+      decision: 'pass',
+      reasoning: 'no mutual value',
+      counterpartyPremiseFit: null,
+      intentAlignment: null,
+      screenedAt: '2026-01-05T00:00:00.000Z',
+    },
+  },
+  negotiationOpportunities: [],
 };
 
 describe('groupNegotiationOutline', () => {
@@ -28,6 +106,67 @@ describe('groupNegotiationOutline', () => {
     expect(groups[0]).toMatchObject({ id: 'peer', name: 'Peer' });
     expect(groups[0]?.opportunities.map((opportunity) => [opportunity.opportunityId, opportunity.taskId]))
       .toEqual([['opportunity-b', 'task-b'], ['opportunity-a', 'task-a']]);
+    expect(groups[0]?.opportunities.every((opportunity) => !opportunity.ungrouped)).toBe(true);
+  });
+
+  it('lists an ungroupable negotiation as a fallback row instead of dropping it', () => {
+    const groups = groupNegotiationOutline([ungroupableConversation], 'viewer');
+
+    expect(groups).toHaveLength(1);
+    expect(groups[0]?.name).toBe('Dana');
+    expect(groups[0]?.opportunities).toEqual([{
+      conversationId: '93c58ea7-71f5-4a63-b5e4-23aee8b9d7bf',
+      counterpartId: 'peer-2',
+      opportunityId: '6426226c-9d63-42a9-8aea-764bbe0c5b8b',
+      taskId: '07979837-5e29-4dd9-83dc-26f593972ca6',
+      title: 'Negotiation',
+      status: 'pending',
+      updatedAt: '2026-01-04T00:00:00.000Z',
+      ungrouped: true,
+    }]);
+  });
+
+  it('titles a fallback row from provenance or conversation metadata when either exists', () => {
+    const viaTitled = groupNegotiationOutline(
+      [{ ...ungroupableConversation, via: [{ intentId: 'i', opportunityId: 'o', title: 'Find a co-founder' }] }],
+      'viewer',
+    );
+    expect(viaTitled[0]?.opportunities[0]?.title).toBe('Find a co-founder');
+
+    const metadataTitled = groupNegotiationOutline(
+      [{ ...ungroupableConversation, metadata: { title: 'Dana and Viewer' } }],
+      'viewer',
+    );
+    expect(metadataTitled[0]?.opportunities[0]?.title).toBe('Dana and Viewer');
+  });
+
+  it('lists the owner-visible zero-message screened-out negotiation but not the counterparty view', () => {
+    const asOwner = groupNegotiationOutline([screenedOutConversation], 'viewer');
+    expect(asOwner[0]?.opportunities).toMatchObject([{
+      conversationId: 'c5e8a825-ddcb-479c-b8dc-a8ad05690d71',
+      taskId: '7bfba641-245c-4a92-9269-a798eba5c9e7',
+      status: 'rejected',
+      ungrouped: true,
+    }]);
+
+    // The API never projects `screenDecision` to the counterparty, so the same
+    // zero-message shell stays invisible on their rail — the outreach gate is
+    // private to the seat that ran it.
+    const asCounterparty = groupNegotiationOutline(
+      [{ ...screenedOutConversation, negotiation: { ...screenedOutConversation.negotiation!, screenDecision: null } }],
+      'peer-3',
+    );
+    expect(asCounterparty).toEqual([]);
+  });
+
+  it('never shows fewer negotiations than the your-move badge counts', () => {
+    const negotiations = [conversation, ungroupableConversation, screenedOutConversation];
+    const listed = groupNegotiationOutline(negotiations, 'viewer')
+      .flatMap((group) => group.opportunities.map((opportunity) => opportunity.conversationId));
+
+    expect(countNegotiationsRequiringAction(negotiations, 'viewer')).toBe(1);
+    // The pending negotiation the badge counts is exactly the one #1444 dropped.
+    expect(listed).toContain(ungroupableConversation.id);
   });
 
   it('uses only supported lifecycle labels', () => {

--- a/apps/web/src/lib/negotiation-inbox.ts
+++ b/apps/web/src/lib/negotiation-inbox.ts
@@ -13,9 +13,15 @@ export type NegotiationInboxStatus =
   /** IND-610: the owner's own agent declined before any contact. Owner-only. */
   | 'not_sent';
 
+export interface NegotiationCounterpart {
+  id: string;
+  name: string;
+  avatar: string | null;
+}
+
 export interface NegotiationInboxItem {
   conversationId: string;
-  counterpart: { id: string; name: string; avatar: string | null };
+  counterpart: NegotiationCounterpart;
   group: NegotiationInboxGroup;
   status: NegotiationInboxStatus;
   signalCount: number;
@@ -129,6 +135,51 @@ function classifyConversation(conversation: ConversationSummary, action: string 
     : { group: 'in_progress', status: 'waiting' };
 }
 
+/**
+ * Resolve the non-viewer seat of an A2A conversation. Shared with the chat
+ * rail's outline so both surfaces name a counterparty the same way.
+ */
+export function resolveNegotiationCounterpart(
+  conversation: ConversationSummary,
+  viewerUserId: string | undefined,
+): NegotiationCounterpart | null {
+  const ownAgentId = viewerUserId ? `agent:${viewerUserId}` : null;
+  const counterpart = conversation.participants.find((participant) => participant.participantId !== ownAgentId);
+  if (!counterpart) return null;
+  return {
+    id: counterpart.participantId.replace(/^agent:/, ''),
+    name: counterpart.ownerName ?? conversation.metadata?.title ?? counterpart.name ?? 'Unknown user',
+    avatar: counterpart.avatar,
+  };
+}
+
+/**
+ * The one rule for "does this negotiation conversation exist for this viewer".
+ *
+ * Zero-turn rows are normally invisible (abandoned task shells). The one
+ * exception is the viewer's OWN outreach gate decision: it has no messages by
+ * definition, so this filter is what made the IND-610 gate card reachable only
+ * by direct link.
+ *
+ * The owner boundary is NOT re-derived here. `negotiation.screenDecision` is
+ * projected by the API only when `initiatorUserId === viewerUserId`
+ * (services/api/src/adapters/negotiation-lifecycle.projection.ts), so its mere
+ * presence IS the owner proof. A counterparty never receives the field and
+ * therefore never gets this row.
+ *
+ * Both the inbox (which feeds the your-move badge) and the chat rail's outline
+ * enumerate conversations through this predicate. Anything the badge can count
+ * is therefore something the rail must be able to render — a negotiation the
+ * badge advertises can never be missing from the list.
+ */
+export function isVisibleNegotiationConversation(
+  conversation: ConversationSummary,
+  viewerUserId: string | undefined,
+): boolean {
+  if (!resolveNegotiationCounterpart(conversation, viewerUserId)) return false;
+  return Boolean(conversation.lastMessage) || Boolean(conversation.negotiation?.screenDecision);
+}
+
 /** Derive user-facing inbox groups without exposing raw task or opportunity states. */
 export function deriveNegotiationInbox(
   negotiations: ConversationSummary[],
@@ -137,23 +188,13 @@ export function deriveNegotiationInbox(
 ): NegotiationInboxGroups {
   const ownAgentId = viewerUserId ? `agent:${viewerUserId}` : null;
   const items = negotiations.flatMap<NegotiationInboxItem>((conversation) => {
-    const counterpart = conversation.participants.find((participant) => participant.participantId !== ownAgentId);
+    // Visibility and counterparty naming come from the shared helpers above so
+    // the rail's outline enumerates exactly the same conversations.
+    if (!isVisibleNegotiationConversation(conversation, viewerUserId)) return [];
+    const counterpart = resolveNegotiationCounterpart(conversation, viewerUserId);
     if (!counterpart) return [];
 
-    // Zero-turn rows are normally invisible (abandoned task shells), matching
-    // ChatSidebar's A2A rule. The one exception is the viewer's OWN outreach
-    // gate decision: it has no messages by definition, so this filter is what
-    // made the IND-610 gate card reachable only by direct link.
-    //
-    // The owner boundary is NOT re-derived here. `negotiation.screenDecision`
-    // is projected by the API only when `initiatorUserId === viewerUserId`
-    // (services/api/src/adapters/negotiation-lifecycle.projection.ts), so its
-    // mere presence IS the owner proof. A counterparty never receives the
-    // field and therefore never gets this row.
     if (!conversation.lastMessage) {
-      const gateDecision = conversation.negotiation?.screenDecision;
-      if (!gateDecision) return [];
-
       const gateTimestamp = new Date(
         conversation.negotiation?.updatedAt ?? conversation.lastMessageAt ?? conversation.createdAt,
       ).getTime();
@@ -161,11 +202,7 @@ export function deriveNegotiationInbox(
 
       return [{
         conversationId: conversation.id,
-        counterpart: {
-          id: counterpart.participantId.replace(/^agent:/, ''),
-          name: counterpart.ownerName ?? conversation.metadata?.title ?? counterpart.name ?? 'Unknown user',
-          avatar: counterpart.avatar,
-        },
+        counterpart,
         group: 'resolved',
         status: 'not_sent',
         signalCount: Math.max(conversation.negotiation?.signalCount ?? 0, conversation.via.length),
@@ -191,11 +228,7 @@ export function deriveNegotiationInbox(
 
     return [{
       conversationId: conversation.id,
-      counterpart: {
-        id: counterpart.participantId.replace(/^agent:/, ''),
-        name: counterpart.ownerName ?? conversation.metadata?.title ?? counterpart.name ?? 'Unknown user',
-        avatar: counterpart.avatar,
-      },
+      counterpart,
       group: classification.group,
       status: classification.status,
       signalCount: Math.max(lifecycle?.signalCount ?? 0, conversation.via.length),

--- a/apps/web/src/lib/negotiation-outline.ts
+++ b/apps/web/src/lib/negotiation-outline.ts
@@ -1,13 +1,22 @@
+import { isVisibleNegotiationConversation, resolveNegotiationCounterpart } from '@/lib/negotiation-inbox';
 import type { ConversationSummary, NegotiationOpportunityStatus } from '@/services/conversation';
 
 export interface NegotiationOutlineOpportunity {
   conversationId: string;
   counterpartId: string;
-  opportunityId: string;
-  taskId: string;
+  /** Null when the API projected no opportunity for this conversation. */
+  opportunityId: string | null;
+  /** Null when no task session is addressable; the row then opens the latest one. */
+  taskId: string | null;
   title: string;
   status: NegotiationOpportunityStatus | null;
   updatedAt: string;
+  /**
+   * True for a fallback row standing in for a conversation the opportunity
+   * projection could not group. Such a row is deliberately coarse, but it is
+   * never omitted — see `buildFallbackOpportunity`.
+   */
+  ungrouped: boolean;
 }
 
 export interface NegotiationOutlineCounterparty {
@@ -17,49 +26,97 @@ export interface NegotiationOutlineCounterparty {
   opportunities: NegotiationOutlineOpportunity[];
 }
 
-/** Groups only viewer-visible opportunity/task projections for the chat rail. */
+function timestampOf(value: string | null | undefined): number {
+  const parsed = new Date(value ?? 0).getTime();
+  return Number.isFinite(parsed) ? parsed : 0;
+}
+
+/**
+ * The rail row for a conversation with no viewer-visible opportunity projection.
+ *
+ * `negotiationOpportunities` is gated on match provenance: the API only
+ * projects an opportunity the viewer can already see through a `via` entry
+ * naming one of their own intents (conversation.database.adapter.ts). A
+ * negotiation whose conversation metadata carries no `matchProvenance` — or
+ * whose provenance intent no longer resolves to the viewer — projects an empty
+ * array while `negotiation` still carries a full lifecycle. Dropping those left
+ * the your-move badge counting a negotiation the list refused to render.
+ *
+ * The lifecycle summary supplies the session target, so this row still opens
+ * the right transcript; only the opportunity title is unavailable.
+ */
+function buildFallbackOpportunity(
+  conversation: ConversationSummary,
+  counterpartId: string,
+): NegotiationOutlineOpportunity {
+  const lifecycle = conversation.negotiation ?? null;
+  return {
+    conversationId: conversation.id,
+    counterpartId,
+    opportunityId: lifecycle?.opportunityId ?? null,
+    taskId: lifecycle?.taskId ?? null,
+    title: conversation.via[0]?.title ?? conversation.metadata?.title ?? 'Negotiation',
+    status: lifecycle?.opportunityStatus ?? null,
+    updatedAt: lifecycle?.updatedAt ?? conversation.lastMessageAt ?? conversation.createdAt,
+    ungrouped: true,
+  };
+}
+
+/**
+ * Groups the chat rail's negotiation conversations by counterparty.
+ *
+ * Membership is decided by `isVisibleNegotiationConversation`, the same
+ * predicate the inbox uses for the your-move badge, so the badge and this list
+ * can never disagree about what a negotiation is. Within a visible
+ * conversation, viewer-visible opportunity projections become one row each; a
+ * conversation with none still gets a single fallback row.
+ */
 export function groupNegotiationOutline(
   negotiations: ConversationSummary[],
   viewerUserId: string | undefined,
 ): NegotiationOutlineCounterparty[] {
-  const ownAgentId = viewerUserId ? `agent:${viewerUserId}` : null;
   const groups = new Map<string, NegotiationOutlineCounterparty>();
 
   for (const conversation of negotiations) {
-    const counterpart = conversation.participants.find((participant) => participant.participantId !== ownAgentId);
+    if (!isVisibleNegotiationConversation(conversation, viewerUserId)) continue;
+    const counterpart = resolveNegotiationCounterpart(conversation, viewerUserId);
     if (!counterpart) continue;
-    const counterpartId = counterpart.participantId.replace(/^agent:/, '');
-    const group = groups.get(counterpartId) ?? {
-      id: counterpartId,
-      name: counterpart.ownerName ?? conversation.metadata?.title ?? counterpart.name ?? 'Unknown user',
+
+    const group = groups.get(counterpart.id) ?? {
+      id: counterpart.id,
+      name: counterpart.name,
       avatar: counterpart.avatar,
       opportunities: [],
     };
-    for (const opportunity of conversation.negotiationOpportunities ?? []) {
-      group.opportunities.push({
-        conversationId: conversation.id,
-        counterpartId,
-        opportunityId: opportunity.opportunityId,
-        taskId: opportunity.taskId,
-        title: opportunity.title,
-        status: opportunity.opportunityStatus,
-        updatedAt: opportunity.updatedAt,
-      });
+    const projected = conversation.negotiationOpportunities ?? [];
+    if (projected.length === 0) {
+      group.opportunities.push(buildFallbackOpportunity(conversation, counterpart.id));
+    } else {
+      for (const opportunity of projected) {
+        group.opportunities.push({
+          conversationId: conversation.id,
+          counterpartId: counterpart.id,
+          opportunityId: opportunity.opportunityId,
+          taskId: opportunity.taskId,
+          title: opportunity.title,
+          status: opportunity.opportunityStatus,
+          updatedAt: opportunity.updatedAt,
+          ungrouped: false,
+        });
+      }
     }
-    groups.set(counterpartId, group);
+    groups.set(counterpart.id, group);
   }
 
   return [...groups.values()]
-    .filter((group) => group.opportunities.length > 0)
     .map((group) => ({
       ...group,
       opportunities: group.opportunities.sort((left, right) => (
-        new Date(right.updatedAt).getTime() - new Date(left.updatedAt).getTime()
+        timestampOf(right.updatedAt) - timestampOf(left.updatedAt)
       )),
     }))
     .sort((left, right) => (
-      new Date(right.opportunities[0]?.updatedAt ?? 0).getTime()
-      - new Date(left.opportunities[0]?.updatedAt ?? 0).getTime()
+      timestampOf(right.opportunities[0]?.updatedAt) - timestampOf(left.opportunities[0]?.updatedAt)
     ));
 }
 

--- a/apps/web/tests/chat-sidebar-unread.test.tsx
+++ b/apps/web/tests/chat-sidebar-unread.test.tsx
@@ -84,16 +84,21 @@ describe('ChatSidebar unread indicators', () => {
     expect(screen.queryByTestId('chat-unread-conv-1')).toBeNull();
   });
 
-  test('suppresses unread counts on negotiation rows while preserving status and action guidance', () => {
+  test('suppresses unread counts on negotiation rows while still listing the negotiation', () => {
     mocks.negotiations = [negotiationSummary(4)];
     render(<MemoryRouter><ChatSidebar /></MemoryRouter>);
 
     fireEvent.click(screen.getByRole('button', { name: /Negotiations/ }));
 
-    expect(screen.getAllByText('Agent negotiation').length).toBeGreaterThan(0);
-    expect(screen.getByText(/their agent recommended moving forward/)).toBeInTheDocument();
-    expect(screen.getByText('Agents agreed')).toBeInTheDocument();
-    expect(screen.getByText('Tap to review and start the chat')).toBeInTheDocument();
+    // #1444 replaced the inbox-style rows with the counterparty outline, so the
+    // rail no longer renders last-action guidance — but the negotiation must
+    // still be reachable. This summary projects no opportunities, so it lands
+    // in the fallback bucket rather than disappearing.
+    const counterparty = screen.getByRole('button', { name: /Agent negotiation/ });
+    expect(counterparty).toBeInTheDocument();
+    fireEvent.click(counterparty);
+    expect(screen.getByText('No lifecycle status')).toBeInTheDocument();
+
     expect(screen.queryByTestId('chat-unread-neg-1')).toBeNull();
     expect(screen.queryByLabelText('4 unread messages')).toBeNull();
   });


### PR DESCRIPTION
The chat sidebar's **Negotiations** tab showed a badge of `1` over "No negotiations yet". Fixes the disagreement between the badge and the list introduced by #1444.

## Root cause

The badge and the list read the same `negotiations` array but derived membership two different ways:

- **badge** — `deriveNegotiationInbox(...).yourMove`, keyed off the conversation's `negotiation` lifecycle;
- **list** (new in #1444) — `groupNegotiationOutline`, which groups `negotiationOpportunities`.

The API projects `negotiationOpportunities` only for opportunities the viewer can already see through a `via` match-provenance entry (`conversation.database.adapter.ts`). But `matchProvenance` is written **exclusively onto the H2H DM** when a user starts a chat from an accepted opportunity (`opportunity.service.ts:782,841`) — never onto the A2A negotiation conversation.

So `negotiationOpportunities` is empty for negotiation rows, every group was filtered out by `.filter(group => group.opportunities.length > 0)`, and the rail rendered empty while the badge kept counting. Confirmed against the dev DB: **0 of 14** negotiation conversations carry `matchProvenance`. The reported badge-1 case is opportunity `6426226c…` (`pending`, so `your_move`) on conversation `93c58ea7…`, whose `conversation_metadata` row does not exist at all.

This was not a narrow edge case — the rail was blank for every user on dev.

## Fix

One membership rule for both surfaces. `isVisibleNegotiationConversation` and `resolveNegotiationCounterpart` move into `negotiation-inbox.ts` and are used by both the inbox derivation and the outline, so the badge can never count a conversation the rail refuses to render.

A conversation with no projected opportunity now gets a **fallback row** built from its lifecycle summary instead of being dropped:

- it carries the lifecycle's real `taskId`, so it still opens the correct transcript;
- it shows the real `opportunityStatus`;
- the title falls back to `via[0].title → metadata.title → "Negotiation"`;
- a row with no addressable task opens `/chat/:id` with no `taskId`, which is the pre-#1444 latest-session behavior.

The zero-message rule is preserved exactly as the inbox had it, so a counterparty still never sees the initiator's screened-out outreach shell.

## Tests

Seven new tests, all verified red against the pre-fix grouping and green after. They cover the three dev shapes named in the report:

- **grouped** — unchanged multi-opportunity grouping;
- **ungroupable** — pending opportunity, no provenance → fallback row with the real task id and status, and the invariant that the list is never smaller than the badge count;
- **zero-message screened-out** — listed for the owner, invisible to the counterparty.

`tests/chat-sidebar-unread.test.tsx` was left red by #1444 (it asserted the removed inbox-style rows); it now asserts the outline while keeping its real point — no unread badges on negotiation rows.

Pre-existing failures on `dev` (`QuestionMessage`, `chat-content-opportunity-history`, `intent-page-lifecycle`, two `routes` smoke tests, and `NegotiationActivity` from #1447/#1448) are unchanged. Lint: 0 errors.

## Follow-up worth deciding separately

The fallback row's title reads "Negotiation" because nothing else exists for it. Restoring real opportunity titles means giving the adapter a viewer-scoped source other than `matchProvenance` — either recording provenance on the A2A conversation too, or deriving visibility from `opportunities.actors` where the viewer is an actor and taking the title from their own intent. Both are design calls about the privacy boundary rather than part of this bug, so they are deliberately not in this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)