### PR TITLE
feat(web): point the download page at the Index Hermes plugin deeplink

### DIFF
--- a/apps/web/src/app/download/page.tsx
+++ b/apps/web/src/app/download/page.tsx
@@ -19,11 +19,12 @@ export const MAC_APP_DOWNLOAD_SIZE: string =
   import.meta.env.VITE_MAC_APP_DOWNLOAD_SIZE || "";
 
 /**
- * Hermes Desktop / plugin install destination. Defaults to the public Hermes
- * agent site; override with `VITE_HERMES_INSTALL_URL` for staging or docs links.
+ * Hermes Desktop plugin-install deeplink. Override with
+ * `VITE_HERMES_INSTALL_URL` for staging or docs links.
  */
 export const HERMES_INSTALL_URL: string =
-  import.meta.env.VITE_HERMES_INSTALL_URL || "https://hermes-agent.nousresearch.com/";
+  import.meta.env.VITE_HERMES_INSTALL_URL ||
+  "hermes://plugin/install?repo=indexnetwork/hermes-plugin&enable=1";
 
 /** Shown on the Index for Mac card. */
 export const MAC_APP_REQUIREMENTS = "macOS 13+ · Apple silicon";
@@ -105,8 +106,6 @@ export default function Download() {
               <a
                 className="download-btn download-btn--ghost"
                 href={HERMES_INSTALL_URL}
-                target="_blank"
-                rel="noopener noreferrer"
                 aria-label="Install Hermes plugin"
               >
                 INSTALL

--- a/apps/web/tests/download-page.test.tsx
+++ b/apps/web/tests/download-page.test.tsx
@@ -37,6 +37,9 @@ describe("/download", () => {
     expect(screen.getByText(/Coming soon/i)).toBeInTheDocument();
     expect(screen.getByText(mod.MAC_APP_REQUIREMENTS)).toBeInTheDocument();
 
+    expect(mod.HERMES_INSTALL_URL).toBe(
+      "hermes://plugin/install?repo=indexnetwork/hermes-plugin&enable=1",
+    );
     const hermes = screen.getByRole("link", { name: /install hermes plugin/i });
     expect(hermes).toHaveAttribute("href", mod.HERMES_INSTALL_URL);
 


### PR DESCRIPTION
## Summary
- Point the `/download` Hermes plugin INSTALL button at `hermes://plugin/install?repo=indexnetwork/hermes-plugin&enable=1` so Hermes Desktop can install the Index plugin directly.
- Drop `target="_blank"` on that link (custom protocol, not a website). `VITE_HERMES_INSTALL_URL` still overrides.

## Test plan
- [x] `bun --cwd apps/web test tests/download-page.test.tsx`
- [ ] Open `/download` with Hermes Desktop installed and confirm INSTALL opens the plugin install deeplink
- [ ] Confirm the Mac card is unchanged