### PR TITLE
feat(radar): sweep-and-log warmup card

### DIFF
--- a/apps/web/src/app/globals.css
+++ b/apps/web/src/app/globals.css
@@ -373,3 +373,60 @@ button {
   }
   .signal-think-dot { animation: none; opacity: 0.5; }
 }
+
+/* Radar warmup card: a slow conic sweep standing in for the discovery run, plus
+   the pulsing dot on the log line the run is currently sitting on. Decorative
+   only — the card states are all readable with the animation off. */
+@keyframes radar-sweep {
+  to { transform: rotate(360deg); }
+}
+.radar-sweep {
+  position: relative;
+  display: block;
+  flex: none;
+  width: 34px;
+  height: 34px;
+  border-radius: 9999px;
+  border: 1px solid #e5e7eb;
+  background: radial-gradient(circle, rgba(4, 23, 41, 0.06) 0%, rgba(4, 23, 41, 0) 70%);
+  overflow: hidden;
+}
+.radar-sweep::before {
+  content: "";
+  position: absolute;
+  inset: 0;
+  border-radius: inherit;
+  background: conic-gradient(
+    from 0deg,
+    rgba(4, 23, 41, 0.38) 0deg,
+    rgba(4, 23, 41, 0.10) 40deg,
+    rgba(4, 23, 41, 0) 80deg,
+    rgba(4, 23, 41, 0) 360deg
+  );
+  animation: radar-sweep 3.4s linear infinite;
+}
+.radar-sweep::after {
+  content: "";
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  width: 3px;
+  height: 3px;
+  margin: -1.5px 0 0 -1.5px;
+  border-radius: 9999px;
+  background: #041729;
+  opacity: 0.55;
+}
+/* Settled run: the dish stops, the wedge stays as a faint bearing mark. */
+.radar-sweep-idle::before {
+  animation: none;
+  opacity: 0.3;
+}
+.warmup-pulse {
+  animation: dot-pulse 1.6s ease-in-out infinite;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .radar-sweep::before { animation: none; }
+  .warmup-pulse { animation: none; }
+}

--- a/apps/web/src/app/i/[intentId]/page.tsx
+++ b/apps/web/src/app/i/[intentId]/page.tsx
@@ -13,6 +13,7 @@ import { Button } from "@/components/ui/button";
 import OpportunityCard, { NegotiationPresenceChip, OpportunitySkeleton, type NegotiationPresence } from "@/components/chat/OpportunityCardInChat";
 import IntentMemoryStrip from "@/components/IntentMemoryStrip";
 import IntentNegotiatorChat from "@/components/IntentNegotiatorChat";
+import DiscoveryWarmupLog from "@/components/DiscoveryWarmupLog";
 import NegotiationActivity from "@/components/NegotiationActivity";
 import { useAuthContext } from "@/contexts/AuthContext";
 import { useConversations, useIntents, useOpportunities } from "@/contexts/APIContext";
@@ -23,11 +24,12 @@ import { useRadarLiveRefresh } from "@/hooks/useRadarLiveRefresh";
 import { useIntentVisitPing } from "@/hooks/useIntentVisitPing";
 import type { NegotiationActivityGroup } from "@/services/conversation";
 import type { RadarCardItem, OpportunityLifecycleStatus } from "@/services/opportunities";
-import type { DiscoveryProgress, IntentLifecycleStatus, MutableIntentLifecycleStatus } from "@/services/intents";
+import type { IntentLifecycleStatus, MutableIntentLifecycleStatus } from "@/services/intents";
 import { cn } from "@/lib/utils";
 import { intentNegotiationActivityRevision } from "@/lib/intent-negotiation-activity";
 import { normalizeNegotiationActivity } from "@/lib/negotiation-activity";
 import { deriveLiveNegotiations, formatLatestMove, liveNegotiationsByOpportunity } from "@/lib/negotiation-presence";
+import type { WarmupConversation } from "@/lib/discovery-warmup-log";
 import { DEFAULT_RADAR_BUCKET, radarBucketBadgeTone } from "@/lib/radar-buckets";
 
 /** Raw opportunity status -> radar display bucket (mirrors the Hermes dashboard). */
@@ -63,36 +65,6 @@ function normalizeIntentLifecycleStatus(status: unknown): IntentLifecycleStatus 
     return status;
   }
   return "ACTIVE";
-}
-
-function DiscoveryWarmup({ progress, communities }: { progress?: DiscoveryProgress; communities: Array<{ id: string; title: string }> }) {
-  const status = progress?.status ?? "unknown";
-  const active = status === "queued" || status === "running" || status === "retrying";
-  const assignmentLabel = status === "blocked" || communities.length === 0
-    ? "Needs attention"
-    : `${progress?.assignedCommunityCount ?? communities.length} ${communities.length === 1 ? "community" : "communities"}`;
-  const findingLabel: Record<string, string> = {
-    queued: "Queued", running: "Finding", retrying: "Retrying", completed: "Completed", failed: "Needs attention", blocked: "Needs attention", unknown: "Status unavailable",
-  };
-  return (
-    <section className="rounded-lg border border-dashed border-gray-300 bg-gray-50/60 p-4" aria-label="Conversation preparation status" data-testid="discovery-warmup">
-      <h4 className="text-sm font-semibold text-gray-900">Preparing your first conversations</h4>
-      <dl className="mt-3 space-y-2 text-xs text-gray-600">
-        <div className="flex justify-between gap-3"><dt>Signal created</dt><dd className="font-medium text-gray-800">✓</dd></div>
-        <div className="flex justify-between gap-3"><dt>Shared with communities</dt><dd className="text-right font-medium text-gray-800">{assignmentLabel}</dd></div>
-        <div className="flex justify-between gap-3"><dt>Finding relevant signals</dt><dd className="font-medium text-gray-800">{findingLabel[status]}</dd></div>
-        <div className="flex justify-between gap-3"><dt>Agent conversations</dt><dd className="font-medium text-gray-800">{progress?.conversationsStartedCount ? `${progress.conversationsStartedCount} started` : "Next"}</dd></div>
-      </dl>
-      {status === "blocked" || communities.length === 0 ? (
-        <p className="mt-3 text-xs text-gray-600">Matching cannot begin until this signal is shared with an active community.</p>
-      ) : status === "completed" ? (
-        <p className="mt-3 text-xs text-gray-600">We completed this search with no promising conversations yet.</p>
-      ) : (
-        <p className="mt-3 text-xs text-gray-600">We’ll show conversations here once a promising overlap is found.</p>
-      )}
-      {active && <p className="mt-1 text-xs text-gray-500">You can leave this page—matching continues in the background.</p>}
-    </section>
-  );
 }
 
 /** Bounded intent-refinement poll: interval (ms) and maximum total wait (ms). */
@@ -513,20 +485,41 @@ export default function IntentDetailPage() {
     () => liveNegotiations.filter((item) => intentId !== undefined && item.intentIds.includes(intentId)),
     [liveNegotiations, intentId],
   );
+  /** The warmup card's live lane: one entry per in-flight negotiation on this signal. */
+  const warmupConversations = useMemo<WarmupConversation[]>(() => {
+    const byId = new Map(negotiations.map((conversation) => [conversation.id, conversation]));
+    return intentLiveNegotiations.map((item) => ({
+      id: item.conversationId,
+      counterpartLabel: item.counterpart.name,
+      // The conversation's own creation time — the moment the agents started
+      // talking. `sortTimestamp` is last-activity and would misdate the line.
+      startedAt: byId.get(item.conversationId)?.createdAt ?? null,
+    }));
+  }, [intentLiveNegotiations, negotiations]);
+
   const refreshLiveRadar = useCallback(() => {
     void loadOpportunities(true);
     void loadNegotiationActivity();
-  }, [loadNegotiationActivity, loadOpportunities]);
+    // The SSE feed never carries the intent snapshot, so a finished run's final
+    // tallies would otherwise sit unread until the next 15s progress poll.
+    if (intentId) void intentsService.getIntent(intentId).then(setIntent).catch(() => {});
+  }, [intentId, intentsService, loadNegotiationActivity, loadOpportunities]);
 
   // Refresh only the owner-scoped progress snapshot while work is non-terminal;
   // this intentionally leaves the negotiator chat mounted and untouched.
+  // `blocked` belongs here: a blocked card can only observe its own recovery
+  // (the signal joining an active community) by polling for it.
+  const discoveryStatus = intent?.discoveryProgress?.status;
   useEffect(() => {
-    if (!intentId || !intent || !["queued", "running", "retrying"].includes(intent.discoveryProgress?.status ?? "")) return;
+    // Depend on the status alone, not the whole intent: refetching the intent
+    // replaces the object on every live refresh, which would reset this
+    // interval before it ever fired.
+    if (!intentId || !["queued", "running", "retrying", "blocked"].includes(discoveryStatus ?? "")) return;
     const timer = window.setInterval(() => {
       void intentsService.getIntent(intentId).then(setIntent).catch(() => {});
     }, 15_000);
     return () => window.clearInterval(timer);
-  }, [intentId, intent, intentsService]);
+  }, [intentId, discoveryStatus, intentsService]);
 
   useRadarLiveRefresh({
     intentId,
@@ -1066,7 +1059,11 @@ export default function IntentDetailPage() {
                     <div className="mb-3">
                       {negotiationActivity.length === 0 && !hasActualNegotiationActivity && !negotiationActivityLoading && !negotiationActivityError
                         && (intent?.warming || intent?.discoveryProgress) ? (
-                          <DiscoveryWarmup progress={intent?.discoveryProgress} communities={intent?.networks ?? []} />
+                          <DiscoveryWarmupLog
+                            progress={intent?.discoveryProgress}
+                            communities={intent?.networks ?? []}
+                            conversations={warmupConversations}
+                          />
                         ) : <NegotiationActivity groups={negotiationActivity} loading={negotiationActivityLoading} error={negotiationActivityError} />}
                     </div>
                   )}

--- a/apps/web/src/components/DiscoveryWarmupLog.tsx
+++ b/apps/web/src/components/DiscoveryWarmupLog.tsx
@@ -1,0 +1,109 @@
+/**
+ * The radar's warmup card: a sweep and a terse activity log.
+ *
+ * It replaces a static checklist whose four rows were frozen for the whole run.
+ * The point of the change is that the owner watches the agent work, so every
+ * line here has to be something that actually happened at a time we can name —
+ * see `@/lib/discovery-warmup-log` for the derivation and what it refuses to
+ * invent.
+ *
+ * The sweep is decorative: every state reads correctly with the animation off
+ * (`prefers-reduced-motion` stops it in `globals.css`).
+ */
+import { useMemo } from "react";
+
+import type { DiscoveryProgress, DiscoveryProgressStatus } from "@/services/intents";
+import { ACTIVE_DISCOVERY_STATUSES, DISCOVERY_STATUS_CHIP, WARMUP_PAUSED_HEADLINE, buildWarmupLog, formatLogClock, warmupHeadline, type WarmupConversation } from "@/lib/discovery-warmup-log";
+import { cn } from "@/lib/utils";
+
+const STATUS_TONE: Record<DiscoveryProgressStatus, string> = {
+  queued: "border-gray-200 bg-gray-100 text-gray-600",
+  running: "border-gray-200 bg-gray-100 text-gray-600",
+  retrying: "border-amber-200 bg-amber-50 text-amber-700",
+  completed: "border-emerald-200 bg-emerald-50 text-emerald-700",
+  failed: "border-amber-200 bg-amber-50 text-amber-700",
+  blocked: "border-amber-200 bg-amber-50 text-amber-700",
+  unknown: "border-gray-200 bg-gray-100 text-gray-500",
+};
+
+export default function DiscoveryWarmupLog({
+  progress,
+  communities,
+  conversations,
+}: {
+  progress?: DiscoveryProgress;
+  communities: Array<{ id: string; title: string }>;
+  conversations?: WarmupConversation[];
+}) {
+  const status = progress?.status ?? "unknown";
+  const active = ACTIVE_DISCOVERY_STATUSES.has(status);
+  // No community means no run can start, whatever the stored row last said.
+  const paused = status === "blocked" || communities.length === 0;
+  const chipStatus: DiscoveryProgressStatus = paused ? "blocked" : status;
+  const log = useMemo(() => buildWarmupLog({ progress, conversations }), [progress, conversations]);
+  const headline = useMemo(
+    () => (paused ? { ...WARMUP_PAUSED_HEADLINE } : warmupHeadline(progress, communities.length)),
+    [paused, communities.length, progress],
+  );
+
+  return (
+    <section
+      className="rounded-lg border border-dashed border-gray-300 bg-gray-50/60 p-4"
+      aria-label="Signal warmup activity"
+      data-testid="discovery-warmup"
+    >
+      <div className="flex items-start gap-3">
+        <span
+          className={cn("radar-sweep", !active && "radar-sweep-idle")}
+          data-testid="discovery-warmup-sweep"
+          aria-hidden="true"
+        />
+        <div className="min-w-0 flex-1">
+          <h4 className="text-sm font-semibold text-gray-900">{headline.title}</h4>
+          <p className="mt-0.5 font-ibm-plex-mono text-[11px] tabular-nums text-gray-600">{headline.summary}</p>
+        </div>
+        <span
+          className={cn(
+            "shrink-0 rounded-full border px-2 py-0.5 font-ibm-plex-mono text-[10px] font-semibold uppercase tracking-wide",
+            STATUS_TONE[chipStatus],
+          )}
+          data-testid="discovery-warmup-status"
+        >
+          {DISCOVERY_STATUS_CHIP[chipStatus]}
+        </span>
+      </div>
+
+      {log.length > 0 && (
+        <ol
+          className="mt-3 space-y-1.5 font-ibm-plex-mono text-[11px] tabular-nums text-gray-600"
+          data-testid="discovery-warmup-log"
+        >
+          {log.map((entry) => (
+            <li key={entry.id} className="flex items-start gap-2" data-lane={entry.lane}>
+              <span className="shrink-0 text-gray-400">{formatLogClock(entry.at)}</span>
+              <span
+                aria-hidden="true"
+                className={cn(
+                  "mt-[5px] h-1.5 w-1.5 shrink-0 rounded-full",
+                  entry.lane === "progress" ? "bg-gray-400" : "border border-gray-400",
+                  entry.current && "warmup-pulse",
+                )}
+              />
+              <span className={cn("min-w-0 flex-1", entry.current && "text-gray-900")}>{entry.text}</span>
+            </li>
+          ))}
+        </ol>
+      )}
+
+      {paused ? (
+        <p className="mt-3 text-xs text-amber-700">
+          Matching can’t begin until this signal is shared with an active community.
+        </p>
+      ) : active ? (
+        <p className="mt-3 text-xs text-gray-500">
+          You can leave this page — matching continues in the background.
+        </p>
+      ) : null}
+    </section>
+  );
+}

--- a/apps/web/src/components/__tests__/DiscoveryWarmupLog.test.tsx
+++ b/apps/web/src/components/__tests__/DiscoveryWarmupLog.test.tsx
@@ -1,0 +1,254 @@
+/**
+ * The radar's warmup card. What is load-bearing here is honesty, not chrome:
+ *
+ *  - every log line is derived from a durable timestamp, so a reload rebuilds
+ *    the identical log and nothing is stamped with "now";
+ *  - a completed run that found nothing still reports its tallies — an empty
+ *    card would read as "the agent never ran";
+ *  - a signal with no active community says so instead of showing a scan that
+ *    cannot start;
+ *  - a signal with no durable row admits the status is unavailable rather than
+ *    inventing a run out of freshness.
+ */
+import { render, screen, within } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+
+import DiscoveryWarmupLog from '../DiscoveryWarmupLog';
+import { buildWarmupLog, formatLogClock } from '@/lib/discovery-warmup-log';
+import type { DiscoveryProgress } from '@/services/intents';
+
+const QUEUED_AT = '2026-08-19T09:14:00.000Z';
+const STARTED_AT = '2026-08-19T09:15:00.000Z';
+const COMPLETED_AT = '2026-08-19T09:21:00.000Z';
+
+const progress = (overrides: Partial<DiscoveryProgress> = {}): DiscoveryProgress => ({
+  status: 'running',
+  attempt: 1,
+  maxAttempts: 3,
+  assignedCommunityCount: 4,
+  processedCommunityCount: 0,
+  possibleOverlapCount: 0,
+  conversationsStartedCount: 0,
+  queuedAt: QUEUED_AT,
+  startedAt: STARTED_AT,
+  completedAt: null,
+  updatedAt: STARTED_AT,
+  ...overrides,
+});
+
+const communities = [
+  { id: 'c1', title: 'Builders' },
+  { id: 'c2', title: 'Climate Founders' },
+];
+
+const logLines = () =>
+  within(screen.getByTestId('discovery-warmup-log'))
+    .getAllByRole('listitem')
+    .map((item) => item.textContent ?? '');
+
+describe('DiscoveryWarmupLog states', () => {
+  it('running: narrates the run in progress and says the page can be left', () => {
+    render(<DiscoveryWarmupLog progress={progress()} communities={communities} />);
+
+    expect(screen.getByTestId('discovery-warmup-status')).toHaveTextContent('scanning');
+    expect(screen.getByText('Finding your first conversations')).toBeInTheDocument();
+    expect(screen.getByText('Scanning 4 communities for possible overlaps.')).toBeInTheDocument();
+    expect(logLines().join('\n')).toContain('scanning 4 communities…');
+    expect(screen.getByText(/matching continues in the background/i)).toBeInTheDocument();
+  });
+
+  it('retrying: names the attempt out of its cap', () => {
+    render(
+      <DiscoveryWarmupLog
+        progress={progress({ status: 'retrying', attempt: 2 })}
+        communities={communities}
+      />,
+    );
+
+    expect(screen.getByTestId('discovery-warmup-status')).toHaveTextContent('retrying');
+    expect(logLines().join('\n')).toContain('attempt 2 of 3 — retrying');
+  });
+
+  it('blocked: says matching cannot begin, and does not claim a scan', () => {
+    render(
+      <DiscoveryWarmupLog
+        progress={progress({ status: 'blocked', assignedCommunityCount: 0, startedAt: null, completedAt: COMPLETED_AT })}
+        communities={[]}
+      />,
+    );
+
+    expect(screen.getByTestId('discovery-warmup-status')).toHaveTextContent('blocked');
+    expect(screen.getByText('Scanning is paused')).toBeInTheDocument();
+    expect(screen.getByText(/can’t begin until this signal is shared with an active community/i)).toBeInTheDocument();
+    // The run never started, so no log line may claim communities were scanned.
+    expect(logLines().join('\n')).not.toMatch(/scann(ing|ed)/i);
+    expect(screen.queryByText(/matching continues in the background/i)).toBeNull();
+  });
+
+  it('blocked: an intent with no community is paused even when the row says otherwise', () => {
+    render(<DiscoveryWarmupLog progress={progress({ status: 'running' })} communities={[]} />);
+
+    expect(screen.getByTestId('discovery-warmup-status')).toHaveTextContent('blocked');
+    expect(screen.getByText('Scanning is paused')).toBeInTheDocument();
+  });
+
+  it('completed: keeps the tallies in the summary', () => {
+    render(
+      <DiscoveryWarmupLog
+        progress={progress({
+          status: 'completed',
+          processedCommunityCount: 4,
+          possibleOverlapCount: 11,
+          conversationsStartedCount: 2,
+          completedAt: COMPLETED_AT,
+        })}
+        communities={communities}
+      />,
+    );
+
+    expect(screen.getByTestId('discovery-warmup-status')).toHaveTextContent('completed');
+    expect(screen.getByText('First scan complete')).toBeInTheDocument();
+    expect(screen.getByText('Scanned 4 communities — 11 possible overlaps, 2 conversations started')).toBeInTheDocument();
+    expect(logLines().join('\n')).toContain('＋ 11 possible overlaps found, 2 conversations started');
+  });
+
+  it('completed with nothing found: reports the zero run rather than an empty card', () => {
+    render(
+      <DiscoveryWarmupLog
+        progress={progress({ status: 'completed', processedCommunityCount: 4, completedAt: COMPLETED_AT })}
+        communities={communities}
+      />,
+    );
+
+    expect(screen.getByText('Scanned 4 communities — no overlaps yet')).toBeInTheDocument();
+    expect(logLines().join('\n')).toContain('＋ 0 possible overlaps found, 0 conversations started');
+    // Past tense: the scan is over, so the line must not read as still running.
+    expect(logLines().join('\n')).toContain('scanned 4 communities');
+  });
+
+  it('unknown: admits the status is unavailable and fabricates no log', () => {
+    render(<DiscoveryWarmupLog communities={communities} />);
+
+    expect(screen.getByTestId('discovery-warmup-status')).toHaveTextContent('unknown');
+    expect(screen.getByText('Status unavailable.')).toBeInTheDocument();
+    expect(screen.queryByTestId('discovery-warmup-log')).toBeNull();
+  });
+
+  it('renders under reduced motion (the sweep is decorative, not a state)', () => {
+    // jsdom reports no motion preference; the card must be complete either way.
+    render(<DiscoveryWarmupLog progress={progress()} communities={communities} />);
+
+    expect(screen.getByTestId('discovery-warmup-sweep')).toHaveAttribute('aria-hidden', 'true');
+    expect(screen.getByTestId('discovery-warmup-log')).toBeInTheDocument();
+  });
+});
+
+describe('DiscoveryWarmupLog conversation lane', () => {
+  it('logs each started negotiation, merged into the progress lane by time', () => {
+    render(
+      <DiscoveryWarmupLog
+        progress={progress({
+          status: 'completed',
+          processedCommunityCount: 4,
+          possibleOverlapCount: 3,
+          conversationsStartedCount: 1,
+          completedAt: COMPLETED_AT,
+        })}
+        communities={communities}
+        conversations={[{ id: 'conv-1', counterpartLabel: 'Ashley', startedAt: '2026-08-19T09:18:00.000Z' }]}
+      />,
+    );
+
+    const lines = logLines();
+    expect(lines.some((line) => line.includes("conversation with Ashley's agent started"))).toBe(true);
+    // Merged chronologically: started 09:15 → conversation 09:18 → completed 09:21.
+    const order = lines.map((line) => line.replace(/^\d{2}:\d{2}/, ''));
+    expect(order.findIndex((line) => line.includes('scanned'))).toBeLessThan(
+      order.findIndex((line) => line.includes('Ashley')),
+    );
+    expect(order.findIndex((line) => line.includes('Ashley'))).toBeLessThan(
+      order.findIndex((line) => line.includes('possible overlaps found')),
+    );
+  });
+
+  it('marks the two lanes apart so the live feed is distinguishable', () => {
+    render(
+      <DiscoveryWarmupLog
+        progress={progress()}
+        communities={communities}
+        conversations={[{ id: 'conv-1', counterpartLabel: 'Ashley', startedAt: '2026-08-19T09:18:00.000Z' }]}
+      />,
+    );
+
+    const lanes = within(screen.getByTestId('discovery-warmup-log'))
+      .getAllByRole('listitem')
+      .map((item) => item.getAttribute('data-lane'));
+    expect(lanes).toContain('progress');
+    expect(lanes).toContain('conversation');
+  });
+});
+
+describe('buildWarmupLog', () => {
+  it('derives one line per durable timestamp, in clock order', () => {
+    const entries = buildWarmupLog({
+      progress: progress({
+        status: 'completed',
+        processedCommunityCount: 4,
+        possibleOverlapCount: 3,
+        conversationsStartedCount: 1,
+        completedAt: COMPLETED_AT,
+      }),
+    });
+
+    expect(entries.map((entry) => entry.id)).toEqual(['queued', 'scanning', 'completed']);
+    expect(entries.map((entry) => entry.at)).toEqual([
+      new Date(QUEUED_AT).getTime(),
+      new Date(STARTED_AT).getTime(),
+      new Date(COMPLETED_AT).getTime(),
+    ]);
+  });
+
+  it('drops rows with no timestamp instead of inventing one', () => {
+    const entries = buildWarmupLog({
+      progress: progress({ queuedAt: null, startedAt: null, completedAt: null, updatedAt: null }),
+      conversations: [{ id: 'conv-1', counterpartLabel: 'Ashley', startedAt: null }],
+    });
+
+    expect(entries).toEqual([]);
+  });
+
+  it('is stable across reloads: the same snapshot yields the same log', () => {
+    const snapshot = {
+      progress: progress({ status: 'completed', completedAt: COMPLETED_AT }),
+      conversations: [{ id: 'conv-1', counterpartLabel: 'Ashley', startedAt: '2026-08-19T09:18:00.000Z' }],
+    };
+
+    expect(buildWarmupLog(snapshot)).toEqual(buildWarmupLog(snapshot));
+  });
+
+  it('caps the live lane at the most recent conversations', () => {
+    const conversations = Array.from({ length: 8 }, (_, index) => ({
+      id: `conv-${index}`,
+      counterpartLabel: `Person ${index}`,
+      startedAt: new Date(Date.parse(STARTED_AT) + index * 60_000).toISOString(),
+    }));
+
+    const lane = buildWarmupLog({ conversations }).filter((entry) => entry.lane === 'conversation');
+
+    expect(lane).toHaveLength(5);
+    expect(lane[0]!.text).toContain('Person 3');
+    expect(lane[4]!.text).toContain('Person 7');
+  });
+
+  it('marks only the line the run is currently sitting on', () => {
+    const entries = buildWarmupLog({ progress: progress({ status: 'running' }) });
+
+    expect(entries.filter((entry) => entry.current).map((entry) => entry.id)).toEqual(['scanning']);
+  });
+});
+
+describe('formatLogClock', () => {
+  it('renders HH:MM in 24-hour form', () => {
+    expect(formatLogClock(Date.parse(STARTED_AT))).toMatch(/^\d{2}:\d{2}$/);
+  });
+});

--- a/apps/web/src/lib/discovery-warmup-log.ts
+++ b/apps/web/src/lib/discovery-warmup-log.ts
@@ -1,0 +1,210 @@
+/**
+ * Derivation for the radar's warmup card (see `DiscoveryWarmupLog`).
+ *
+ * The log is derived, never recorded: both lanes are rebuilt from durable data
+ * on every render, so a reload reproduces the identical log and no client-side
+ * delta tracking (or new table) is involved.
+ *
+ *  - Lane ● reads the `intent_discovery_progress` row the from-intent worker
+ *    writes at its run boundaries (queued / started / retried / succeeded).
+ *  - Lane ○ reads the negotiation conversations the page already fetches.
+ *
+ * There is deliberately no per-community narration ("scanning Climate
+ * Founders…"): the discovery graph runs once across every valid network and
+ * exposes no per-community boundary outside the protocol graph, so such a line
+ * would be fiction.
+ */
+import type { DiscoveryProgress, DiscoveryProgressStatus } from '@/services/intents';
+
+/** A negotiation conversation on this signal, for the live lane. */
+export interface WarmupConversation {
+  /** Conversation id; stable log key across refreshes. */
+  id: string;
+  counterpartLabel: string;
+  /** Conversation creation time — when the agents actually started talking. */
+  startedAt: string | null;
+}
+
+export interface WarmupLogEntry {
+  id: string;
+  lane: 'progress' | 'conversation';
+  text: string;
+  /** Epoch ms; entries without a durable timestamp are never invented. */
+  at: number;
+  /** The line the run is sitting on right now. */
+  current: boolean;
+  /** Tie-break for entries sharing a timestamp (a retry starts its own scan). */
+  order: number;
+}
+
+/** Statuses where a run is still in flight. */
+export const ACTIVE_DISCOVERY_STATUSES: ReadonlySet<DiscoveryProgressStatus> = new Set([
+  'queued',
+  'running',
+  'retrying',
+]);
+
+/** Mono uppercase pill copy, one word per status. */
+export const DISCOVERY_STATUS_CHIP: Record<DiscoveryProgressStatus, string> = {
+  queued: 'queued',
+  running: 'scanning',
+  retrying: 'retrying',
+  completed: 'completed',
+  failed: 'failed',
+  blocked: 'blocked',
+  unknown: 'unknown',
+};
+
+function epoch(value: string | null | undefined): number | null {
+  if (!value) return null;
+  const parsed = new Date(value).getTime();
+  return Number.isFinite(parsed) ? parsed : null;
+}
+
+function count(value: number, one: string, many: string): string {
+  return `${value} ${value === 1 ? one : many}`;
+}
+
+/** HH:MM, 24-hour, in the reader's own timezone. */
+export function formatLogClock(at: number): string {
+  return new Date(at).toLocaleTimeString([], { hour: '2-digit', minute: '2-digit', hour12: false });
+}
+
+/**
+ * Rebuild the whole log from the durable snapshot. Entries with no timestamp
+ * are dropped rather than stamped with "now" — an invented clock time is the
+ * one thing a log like this cannot survive.
+ */
+export function buildWarmupLog({
+  progress,
+  conversations = [],
+  maxConversations = 5,
+}: {
+  progress?: DiscoveryProgress;
+  conversations?: WarmupConversation[];
+  maxConversations?: number;
+}): WarmupLogEntry[] {
+  const status = progress?.status ?? 'unknown';
+  const active = ACTIVE_DISCOVERY_STATUSES.has(status);
+  const entries: WarmupLogEntry[] = [];
+
+  // `unknown` means no durable row (legacy signals, or a worker heartbeat gone
+  // stale). Report the absence; never reconstruct a run from freshness.
+  if (progress && status !== 'unknown') {
+    const queuedAt = epoch(progress.queuedAt);
+    if (queuedAt !== null) {
+      entries.push({ id: 'queued', lane: 'progress', text: 'queued', at: queuedAt, current: status === 'queued', order: 0 });
+    }
+
+    const startedAt = epoch(progress.startedAt);
+    if (progress.attempt > 1) {
+      const retriedAt = startedAt ?? epoch(progress.updatedAt);
+      if (retriedAt !== null) {
+        entries.push({
+          id: 'attempt',
+          lane: 'progress',
+          text: `attempt ${progress.attempt} of ${progress.maxAttempts} — retrying`,
+          at: retriedAt,
+          current: status === 'retrying',
+          order: 1,
+        });
+      }
+    }
+
+    if (startedAt !== null) {
+      const communities = count(progress.assignedCommunityCount, 'community', 'communities');
+      entries.push({
+        id: 'scanning',
+        lane: 'progress',
+        text: active ? `scanning ${communities}…` : `scanned ${communities}`,
+        at: startedAt,
+        current: status === 'running',
+        order: 2,
+      });
+    }
+
+    const completedAt = epoch(progress.completedAt);
+    if (completedAt !== null && status === 'completed') {
+      entries.push({
+        id: 'completed',
+        lane: 'progress',
+        text: `＋ ${count(progress.possibleOverlapCount, 'possible overlap', 'possible overlaps')} found, `
+          + `${count(progress.conversationsStartedCount, 'conversation', 'conversations')} started`,
+        at: completedAt,
+        current: false,
+        order: 3,
+      });
+    }
+  }
+
+  const conversationEntries = conversations
+    .flatMap((conversation): WarmupLogEntry[] => {
+      const at = epoch(conversation.startedAt);
+      if (at === null) return [];
+      return [{
+        id: `conversation:${conversation.id}`,
+        lane: 'conversation',
+        text: `conversation with ${conversation.counterpartLabel}'s agent started`,
+        at,
+        current: false,
+        order: 4,
+      }];
+    })
+    .sort((left, right) => left.at - right.at)
+    .slice(-maxConversations);
+
+  return [...entries, ...conversationEntries]
+    .sort((left, right) => left.at - right.at || left.order - right.order);
+}
+
+/** The card's paused copy — one wording for both ways a run can be unable to start. */
+export const WARMUP_PAUSED_HEADLINE = {
+  title: 'Scanning is paused',
+  summary: 'This signal is not shared with an active community yet.',
+} as const;
+
+/** Title + one-line summary. Completed runs keep their tallies, zeroes included. */
+export function warmupHeadline(
+  progress: DiscoveryProgress | undefined,
+  communityCount: number,
+): { title: string; summary: string } {
+  const status = progress?.status ?? 'unknown';
+  const assigned = progress?.assignedCommunityCount ?? communityCount;
+
+  if (status === 'blocked') return { ...WARMUP_PAUSED_HEADLINE };
+  if (status === 'unknown') {
+    return { title: 'Preparing your first conversations', summary: 'Status unavailable.' };
+  }
+  if (status === 'completed') {
+    // `processedCommunityCount` is written only by runs that carried a graph
+    // summary; older rows fall back to what the run was assigned.
+    const scanned = progress?.processedCommunityCount || assigned;
+    const overlaps = progress?.possibleOverlapCount ?? 0;
+    const conversations = progress?.conversationsStartedCount ?? 0;
+    // A zero-result run still reports its tallies — an empty card would read as
+    // "nothing happened" when in fact the whole search ran and found nothing.
+    const tally = overlaps === 0 && conversations === 0
+      ? 'no overlaps yet'
+      : `${count(overlaps, 'possible overlap', 'possible overlaps')}, ${count(conversations, 'conversation', 'conversations')} started`;
+    return {
+      title: 'First scan complete',
+      summary: `Scanned ${count(scanned, 'community', 'communities')} — ${tally}`,
+    };
+  }
+  if (status === 'failed') {
+    return {
+      title: 'Scanning needs attention',
+      summary: `Stopped after ${count(progress?.attempt ?? 0, 'attempt', 'attempts')}. It will be picked up again.`,
+    };
+  }
+  if (status === 'queued') {
+    return {
+      title: 'Finding your first conversations',
+      summary: `Queued — ${count(assigned, 'community', 'communities')} to scan.`,
+    };
+  }
+  return {
+    title: 'Finding your first conversations',
+    summary: `Scanning ${count(assigned, 'community', 'communities')} for possible overlaps.`,
+  };
+}

--- a/apps/web/tests/intent-page-negotiator.test.tsx
+++ b/apps/web/tests/intent-page-negotiator.test.tsx
@@ -7,12 +7,13 @@
  * refine input. The old static questions block is retired with the card
  * questions (conversational-questions plan, "Retirements").
  */
-import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { act, fireEvent, render, screen, waitFor } from '@testing-library/react';
 import { Route, Routes } from 'react-router';
 import { MemoryRouter } from 'react-router';
 import { beforeEach, describe, expect, test, vi } from 'vitest';
 
 import IntentDetailPage from '@/app/i/[intentId]/page';
+import { RADAR_REFRESH_INTERVAL_MS } from '@/hooks/useRadarLiveRefresh';
 
 const mocks = vi.hoisted(() => ({
   authState: {
@@ -164,14 +165,16 @@ describe('Intent page — negotiator chat gating', () => {
       discoveryProgress: {
         status: 'retrying', attempt: 2, maxAttempts: 3, assignedCommunityCount: 1,
         processedCommunityCount: 0, possibleOverlapCount: 0, conversationsStartedCount: 0,
-        queuedAt: null, startedAt: null, completedAt: null, updatedAt: null,
+        queuedAt: '2026-08-19T09:14:00.000Z', startedAt: '2026-08-19T09:15:00.000Z',
+        completedAt: null, updatedAt: '2026-08-19T09:15:00.000Z',
       },
     });
     renderIntentPage();
     await screen.findByText('Looking for a technical co-founder');
     fireEvent.click(screen.getByRole('button', { name: /Negotiating/ }));
-    expect(await screen.findByText('Preparing your first conversations')).toBeInTheDocument();
-    expect(screen.getByText('Retrying')).toBeInTheDocument();
+    expect(await screen.findByText('Finding your first conversations')).toBeInTheDocument();
+    expect(screen.getByTestId('discovery-warmup-status')).toHaveTextContent('retrying');
+    expect(screen.getByText(/attempt 2 of 3 . retrying/i)).toBeInTheDocument();
     expect(screen.queryByText(/still talking with theirs/i)).toBeNull();
   });
 
@@ -189,6 +192,95 @@ describe('Intent page — negotiator chat gating', () => {
     renderIntentPage();
     await screen.findByText('Looking for a technical co-founder');
     fireEvent.click(screen.getByRole('button', { name: /Negotiating/ }));
-    expect(await screen.findByText(/completed this search with no promising conversations/i)).toBeInTheDocument();
+    // A zero-result run still reports its tally; an empty card would read as
+    // though the agent never ran.
+    expect(await screen.findByText('Scanned 1 community — no overlaps yet')).toBeInTheDocument();
+    expect(screen.getByTestId('discovery-warmup-status')).toHaveTextContent('completed');
+  });
+  test('refreshes the signal snapshot so a finished run lands on the card', async () => {
+    // The SSE-driven radar refresh never carried the intent snapshot, so a
+    // completed run's tallies used to sit unread until the slower progress poll.
+    const warmingIntent = {
+      id: 'intent-1', payload: 'Looking for a technical co-founder', summary: null,
+      createdAt: new Date().toISOString(), warming: true,
+      networks: [{ id: 'community-1', title: 'Builders' }, { id: 'community-2', title: 'Climate' }],
+      discoveryProgress: {
+        status: 'running', attempt: 1, maxAttempts: 3, assignedCommunityCount: 2,
+        processedCommunityCount: 0, possibleOverlapCount: 0, conversationsStartedCount: 0,
+        queuedAt: '2026-08-19T09:14:00.000Z', startedAt: '2026-08-19T09:15:00.000Z',
+        completedAt: null, updatedAt: '2026-08-19T09:15:00.000Z',
+      },
+    };
+    mocks.intentsService.getIntent
+      .mockResolvedValueOnce(warmingIntent)
+      .mockResolvedValue({
+        ...warmingIntent,
+        discoveryProgress: {
+          ...warmingIntent.discoveryProgress,
+          status: 'completed', processedCommunityCount: 2, possibleOverlapCount: 3,
+          conversationsStartedCount: 1, completedAt: '2026-08-19T09:21:00.000Z',
+        },
+      });
+
+    vi.useFakeTimers({ shouldAdvanceTime: true });
+    try {
+      renderIntentPage();
+      await screen.findByText('Looking for a technical co-founder');
+      fireEvent.click(screen.getByRole('button', { name: /Negotiating/ }));
+      await screen.findByText('Finding your first conversations');
+
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(RADAR_REFRESH_INTERVAL_MS);
+      });
+
+      expect(
+        await screen.findByText('Scanned 2 communities — 3 possible overlaps, 1 conversation started'),
+      ).toBeInTheDocument();
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  test('a blocked card is not frozen: it observes the signal joining a community', async () => {
+    // `blocked` used to sit outside the poll allowlist, so the card could never
+    // see its own recovery and stayed on "Needs attention" indefinitely.
+    const blockedIntent = {
+      id: 'intent-1', payload: 'Looking for a technical co-founder', summary: null,
+      createdAt: new Date().toISOString(), warming: true, networks: [],
+      discoveryProgress: {
+        status: 'blocked', attempt: 0, maxAttempts: 3, assignedCommunityCount: 0,
+        processedCommunityCount: 0, possibleOverlapCount: 0, conversationsStartedCount: 0,
+        queuedAt: '2026-08-19T09:14:00.000Z', startedAt: null,
+        completedAt: '2026-08-19T09:14:00.000Z', updatedAt: '2026-08-19T09:14:00.000Z',
+      },
+    };
+    mocks.intentsService.getIntent
+      .mockResolvedValueOnce(blockedIntent)
+      .mockResolvedValue({
+        ...blockedIntent,
+        networks: [{ id: 'community-1', title: 'Builders' }],
+        discoveryProgress: {
+          ...blockedIntent.discoveryProgress,
+          status: 'running', attempt: 1, assignedCommunityCount: 1,
+          startedAt: '2026-08-19T09:16:00.000Z', completedAt: null,
+        },
+      });
+
+    vi.useFakeTimers({ shouldAdvanceTime: true });
+    try {
+      renderIntentPage();
+      await screen.findByText('Looking for a technical co-founder');
+      fireEvent.click(screen.getByRole('button', { name: /Negotiating/ }));
+      await screen.findByText('Scanning is paused');
+
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(15_000);
+      });
+
+      expect(await screen.findByText('Finding your first conversations')).toBeInTheDocument();
+      expect(screen.getByTestId('discovery-warmup-status')).toHaveTextContent('scanning');
+    } finally {
+      vi.useRealTimers();
+    }
   });
 });

--- a/services/api/.test-isolated
+++ b/services/api/.test-isolated
@@ -12,6 +12,7 @@
 src/adapters/tests/rejection-cooldown.adapter.isolated.ts
 src/adapters/tests/scraper.adapter.isolated.ts
 src/adapters/tests/storage.adapter.isolated.ts
+src/adapters/tests/intent-discovery-progress.write.isolated.ts
 src/controllers/tests/network.controller.isolated.ts
 src/controllers/tests/notification.controller.isolated.ts
 src/controllers/tests/opportunity.controller.isolated.ts

--- a/services/api/src/adapters/chat.database.adapter.ts
+++ b/services/api/src/adapters/chat.database.adapter.ts
@@ -1020,21 +1020,35 @@ export class ChatDatabaseAdapter {
       .where(and(eq(intents.id, intentId), isNull(intents.firstDiscoverySucceededAt)));
   }
 
-  /** Persist aggregate-only worker lifecycle data; safe to expose to the owner. */
+  /**
+   * Persist aggregate-only worker lifecycle data; safe to expose to the owner.
+   *
+   * The four count columns are optional and omitted-means-unchanged: a run
+   * boundary that does not know a tally (queued/running, or the graph-injection
+   * test path that returns no summary) must not overwrite the last known one
+   * with a zero.
+   */
   async recordIntentDiscoveryProgress(input: {
-    intentId: string; userId: string; status: 'queued' | 'running' | 'succeeded' | 'failed' | 'blocked'; attempt: number; assignedCommunityCount?: number;
+    intentId: string; userId: string; status: 'queued' | 'running' | 'succeeded' | 'failed' | 'blocked'; attempt: number;
+    assignedCommunityCount?: number; processedCommunityCount?: number; possibleOverlapCount?: number; conversationsStartedCount?: number;
   }): Promise<void> {
     const now = new Date();
-    await db.insert(schema.intentDiscoveryProgress).values({
-      ...input, ...(input.assignedCommunityCount != null ? { assignedCommunityCount: input.assignedCommunityCount } : {}),
-      ...(input.status === 'queued' ? { queuedAt: now, completedAt: null, startedAt: null } : {}),
-      ...(input.status === 'running' ? { startedAt: now } : {}),
-      ...(input.status === 'succeeded' || input.status === 'blocked' ? { completedAt: now } : {}), updatedAt: now,
-    }).onConflictDoUpdate({ target: schema.intentDiscoveryProgress.intentId, set: {
-      status: input.status, attempt: input.attempt, ...(input.assignedCommunityCount != null ? { assignedCommunityCount: input.assignedCommunityCount } : {}), updatedAt: now,
+    const counts = {
+      ...(input.assignedCommunityCount != null ? { assignedCommunityCount: input.assignedCommunityCount } : {}),
+      ...(input.processedCommunityCount != null ? { processedCommunityCount: input.processedCommunityCount } : {}),
+      ...(input.possibleOverlapCount != null ? { possibleOverlapCount: input.possibleOverlapCount } : {}),
+      ...(input.conversationsStartedCount != null ? { conversationsStartedCount: input.conversationsStartedCount } : {}),
+    };
+    const timestamps = {
       ...(input.status === 'queued' ? { queuedAt: now, completedAt: null, startedAt: null } : {}),
       ...(input.status === 'running' ? { startedAt: now } : {}),
       ...(input.status === 'succeeded' || input.status === 'blocked' ? { completedAt: now } : {}),
+    };
+    await db.insert(schema.intentDiscoveryProgress).values({
+      intentId: input.intentId, userId: input.userId, status: input.status, attempt: input.attempt,
+      ...counts, ...timestamps, updatedAt: now,
+    }).onConflictDoUpdate({ target: schema.intentDiscoveryProgress.intentId, set: {
+      status: input.status, attempt: input.attempt, ...counts, updatedAt: now, ...timestamps,
     }});
   }
 

--- a/services/api/src/adapters/tests/intent-discovery-progress.write.isolated.ts
+++ b/services/api/src/adapters/tests/intent-discovery-progress.write.isolated.ts
@@ -1,0 +1,132 @@
+/**
+ * The owner-visible discovery-progress row is the radar warmup card's only
+ * durable source. Two properties of the upsert are load-bearing rather than
+ * cosmetic:
+ *
+ *  - a boundary that knows a tally writes it into both the insert values and
+ *    the conflict `set`, so a re-run of the same intent updates the stored
+ *    counts instead of leaving the first run's numbers on screen forever;
+ *  - a boundary that does NOT know a tally (queued/running, or the injected
+ *    graph path that returns no summary) omits the column entirely, so it can
+ *    never overwrite a real count with a zero the worker never measured.
+ *
+ * Hermetic: the drizzle client is replaced with a recorder, so this asserts the
+ * exact statement shape without a database.
+ */
+import { afterAll, beforeEach, describe, expect, it, mock } from 'bun:test';
+
+interface CapturedWrite {
+  values: Record<string, unknown>;
+  set: Record<string, unknown>;
+}
+
+const captured: CapturedWrite[] = [];
+
+const recorderDb = {
+  insert: () => ({
+    values: (values: Record<string, unknown>) => ({
+      onConflictDoUpdate: ({ set }: { set: Record<string, unknown> }) => {
+        captured.push({ values, set });
+        return Promise.resolve();
+      },
+    }),
+  }),
+};
+
+mock.module('../../lib/drizzle/drizzle', () => ({ default: recorderDb, db: recorderDb }));
+
+afterAll(() => {
+  mock.restore();
+});
+
+const { ChatDatabaseAdapter } = await import('../chat.database.adapter');
+
+const adapter = new ChatDatabaseAdapter();
+const base = { intentId: 'intent-1', userId: 'user-1', attempt: 1 } as const;
+
+const only = (): CapturedWrite => {
+  expect(captured).toHaveLength(1);
+  return captured[0]!;
+};
+
+describe('recordIntentDiscoveryProgress', () => {
+  beforeEach(() => {
+    captured.length = 0;
+  });
+
+  it('writes the run tallies on both sides of the upsert', async () => {
+    await adapter.recordIntentDiscoveryProgress({
+      ...base,
+      status: 'succeeded',
+      assignedCommunityCount: 4,
+      processedCommunityCount: 4,
+      possibleOverlapCount: 11,
+      conversationsStartedCount: 2,
+    });
+
+    const write = only();
+    const tallies = {
+      assignedCommunityCount: 4,
+      processedCommunityCount: 4,
+      possibleOverlapCount: 11,
+      conversationsStartedCount: 2,
+    };
+    expect(write.values).toMatchObject({ ...base, status: 'succeeded', ...tallies });
+    expect(write.set).toMatchObject({ status: 'succeeded', attempt: 1, ...tallies });
+    // A success closes the run; the card reads completedAt to timestamp its
+    // last log line.
+    expect(write.values.completedAt).toBeInstanceOf(Date);
+    expect(write.set.completedAt).toBeInstanceOf(Date);
+  });
+
+  it('records an honest zero-result run rather than treating it as unknown', async () => {
+    await adapter.recordIntentDiscoveryProgress({
+      ...base,
+      status: 'succeeded',
+      assignedCommunityCount: 4,
+      processedCommunityCount: 4,
+      possibleOverlapCount: 0,
+      conversationsStartedCount: 0,
+    });
+
+    const write = only();
+    expect(write.values).toMatchObject({ possibleOverlapCount: 0, conversationsStartedCount: 0 });
+    expect(write.set).toMatchObject({ possibleOverlapCount: 0, conversationsStartedCount: 0 });
+  });
+
+  it('omits every unknown tally instead of zeroing it', async () => {
+    await adapter.recordIntentDiscoveryProgress({ ...base, status: 'running', assignedCommunityCount: 4 });
+
+    const write = only();
+    for (const side of [write.values, write.set]) {
+      expect(side).toHaveProperty('assignedCommunityCount', 4);
+      expect(side).not.toHaveProperty('processedCommunityCount');
+      expect(side).not.toHaveProperty('possibleOverlapCount');
+      expect(side).not.toHaveProperty('conversationsStartedCount');
+    }
+    expect(write.values.startedAt).toBeInstanceOf(Date);
+  });
+
+  it('leaves the blocked boundary free of tallies and starts no run', async () => {
+    await adapter.recordIntentDiscoveryProgress({
+      ...base, status: 'blocked', attempt: 0, assignedCommunityCount: 0,
+    });
+
+    const write = only();
+    expect(write.set).toMatchObject({ status: 'blocked', attempt: 0, assignedCommunityCount: 0 });
+    expect(write.set).not.toHaveProperty('possibleOverlapCount');
+    expect(write.set).not.toHaveProperty('startedAt');
+    expect(write.set.completedAt).toBeInstanceOf(Date);
+  });
+
+  it('clears the previous run stamps when the intent is re-queued', async () => {
+    await adapter.recordIntentDiscoveryProgress({ ...base, status: 'queued', attempt: 0 });
+
+    const write = only();
+    expect(write.set).toMatchObject({ startedAt: null, completedAt: null });
+    expect(write.set.queuedAt).toBeInstanceOf(Date);
+    // Re-queuing knows nothing yet, so the last run's counts must survive
+    // until the new run reports its own.
+    expect(write.set).not.toHaveProperty('possibleOverlapCount');
+  });
+});

--- a/services/api/src/queues/opportunity/from-intent.queue.ts
+++ b/services/api/src/queues/opportunity/from-intent.queue.ts
@@ -81,13 +81,20 @@ export class FromIntentQueue {
     });
   }
 
-  private async recordProgress(data: FromIntentJobData, status: 'queued' | 'running' | 'succeeded' | 'failed' | 'blocked', attempt: number, assignedCommunityCount?: number): Promise<void> {
+  private async recordProgress(
+    data: FromIntentJobData,
+    status: 'queued' | 'running' | 'succeeded' | 'failed' | 'blocked',
+    attempt: number,
+    assignedCommunityCount?: number,
+    /** Run tallies, known only at a successful boundary; omitted leaves the stored counts alone. */
+    counts?: { processedCommunityCount: number; possibleOverlapCount: number; conversationsStartedCount: number },
+  ): Promise<void> {
     const record = (this.database as Partial<FromIntentDatabase>).recordIntentDiscoveryProgress;
     // Isolated queue tests and a rolling deploy may run a worker before its
     // adapter has been updated. Production adapters always provide this.
     if (!record) return;
     await record.call(this.database, {
-      intentId: data.intentId, userId: data.userId, status, attempt, assignedCommunityCount,
+      intentId: data.intentId, userId: data.userId, status, attempt, assignedCommunityCount, ...counts,
     });
   }
 
@@ -157,7 +164,10 @@ export class FromIntentQueue {
       triggerIntentId: intentId,
     });
 
-    await runOpportunityDiscovery({
+    // The graph's own summary is the only honest source for the owner-visible
+    // tallies; it is null when the caller injected a graph (test path), in
+    // which case the success write carries no counts at all.
+    const summary = await runOpportunityDiscovery({
       graphDb: this.graphDb,
       deps: this.deps,
       invokeOpts,
@@ -197,7 +207,16 @@ export class FromIntentQueue {
         error: error instanceof Error ? error.message : String(error),
       });
     }
-    await this.recordProgress(data, 'succeeded', attempt, stampNetworkIds.length);
+    await this.recordProgress(data, 'succeeded', attempt, stampNetworkIds.length, summary ? {
+      // The graph runs once across every valid network, so "processed" is the
+      // set that was still valid at the success stamp — there is no per-community
+      // boundary observable from here.
+      processedCommunityCount: stampNetworkIds.length,
+      possibleOverlapCount: summary.candidatesFound,
+      // Each created opportunity enqueues a negotiation run, so this is a count
+      // of conversations the run actually started.
+      conversationsStartedCount: summary.opportunitiesCreated,
+    } : undefined);
 
     // Lens C negotiation-evidence shadow (IND-433): fire-and-forget on its
     // own flag. Formerly triggered through the pool-discriminator mining hook;

--- a/services/api/src/queues/tests/from-intent.queue.isolated.ts
+++ b/services/api/src/queues/tests/from-intent.queue.isolated.ts
@@ -4,7 +4,8 @@
 import { config } from 'dotenv';
 config({ path: '.env.test', override: true });
 
-import { describe, expect, it, mock, afterAll } from 'bun:test';
+import { beforeEach, describe, expect, it, mock, afterAll } from 'bun:test';
+import type { OpportunityDiscoverySummary } from '../opportunity/discovery.shared';
 
 const mockAdd = mock(async () => ({ id: 'job-1', name: 'discover_opportunities', data: {} }));
 const mockCreateWorker = mock(() => ({}));
@@ -36,6 +37,27 @@ mock.module('../questioner/recovery.shared', () => ({
   maybeEnqueueIntentRecovery: async () => {},
 }));
 
+// Stand in for the discovery graph runner so a test can hand the queue a real
+// `OpportunityDiscoverySummary` without building the protocol graph. The
+// injected-graph short-circuit is reproduced faithfully (it returns null), so
+// every existing `invokeOpportunityGraph` test keeps its original semantics.
+const actualDiscoveryShared = await import('../opportunity/discovery.shared');
+let nextDiscoverySummary: OpportunityDiscoverySummary | null = null;
+const runOpportunityDiscoveryMock = mock(async (params: {
+  deps?: { invokeOpportunityGraph?: (opts: unknown) => Promise<void> };
+  invokeOpts: unknown;
+}): Promise<OpportunityDiscoverySummary | null> => {
+  if (params.deps?.invokeOpportunityGraph) {
+    await params.deps.invokeOpportunityGraph(params.invokeOpts);
+    return null;
+  }
+  return nextDiscoverySummary;
+});
+mock.module('../opportunity/discovery.shared', () => ({
+  ...actualDiscoveryShared,
+  runOpportunityDiscovery: runOpportunityDiscoveryMock,
+}));
+
 afterAll(() => {
   mock.restore();
 });
@@ -58,7 +80,35 @@ const asDb = (db: FromIntentDatabaseOverrides): FromIntentDatabase => ({
   recordIntentDiscoveryProgress: db.recordIntentDiscoveryProgress ?? (async () => {}),
 });
 
+type ProgressWrite = Parameters<NonNullable<FromIntentDatabase['recordIntentDiscoveryProgress']>>[0];
+
+/** A complete summary; overrides name only the tallies a test is about. */
+const discoverySummary = (overrides: Partial<OpportunityDiscoverySummary> = {}): OpportunityDiscoverySummary => ({
+  candidatesFound: 0,
+  evaluatedCount: 0,
+  opportunitiesCreated: 0,
+  completionReason: 'created_or_reactivated',
+  sameTriggerDuplicateSuppressions: 0,
+  pairActiveNegotiationSuppressions: 0,
+  crossTriggerAllowedCount: 0,
+  finalAtomicConflictCount: 0,
+  ...overrides,
+});
+
+const progressWrite = (
+  record: { mock: { calls: unknown[][] } },
+  status: ProgressWrite['status'],
+): ProgressWrite => {
+  const call = record.mock.calls.find((args) => (args[0] as ProgressWrite).status === status);
+  if (!call) throw new Error(`no ${status} progress write recorded`);
+  return call[0] as ProgressWrite;
+};
+
 describe('FromIntentQueue', () => {
+  beforeEach(() => {
+    nextDiscoverySummary = null;
+  });
+
   describe('constructor and static', () => {
     it('exposes QUEUE_NAME on class', () => {
       expect(FromIntentQueue.QUEUE_NAME).toBe(QUEUE_NAME);
@@ -131,6 +181,90 @@ describe('FromIntentQueue', () => {
       await queue.processJob('discover_opportunities', { intentId: 'i1', userId: 'u1' }, 2);
       expect(recordIntentDiscoveryProgress).toHaveBeenCalledWith(expect.objectContaining({ status: 'running', attempt: 2, assignedCommunityCount: 1 }));
       expect(recordIntentDiscoveryProgress).toHaveBeenCalledWith(expect.objectContaining({ status: 'succeeded', attempt: 2 }));
+    });
+
+    it('carries the graph summary tallies into the succeeded write', async () => {
+      const recordIntentDiscoveryProgress = mock(async (_input: ProgressWrite) => {});
+      nextDiscoverySummary = discoverySummary({ candidatesFound: 7, evaluatedCount: 4, opportunitiesCreated: 2 });
+      const queue = new FromIntentQueue({
+        database: asDb({
+          getIntentForIndexing: async () => ({ id: 'i1', payload: 'P', userId: 'u1', sourceType: null, sourceId: null }),
+          getNetworkIdsForIntent: async () => ['idx1', 'idx2'],
+          getAssignmentNetworkMembershipsForUser: async () => [
+            { networkId: 'idx1', isPersonal: false },
+            { networkId: 'idx2', isPersonal: false },
+          ],
+          recordIntentDiscoveryProgress,
+        }),
+      });
+
+      await queue.processJob('discover_opportunities', { intentId: 'i1', userId: 'u1' }, 1);
+
+      expect(recordIntentDiscoveryProgress).toHaveBeenCalledWith(expect.objectContaining({
+        status: 'succeeded',
+        assignedCommunityCount: 2,
+        // The graph runs once across every valid network, so the whole
+        // still-valid set is what was processed.
+        processedCommunityCount: 2,
+        possibleOverlapCount: 7,
+        conversationsStartedCount: 2,
+      }));
+    });
+
+    it('writes a zero-result run honestly rather than skipping the tallies', async () => {
+      const recordIntentDiscoveryProgress = mock(async (_input: ProgressWrite) => {});
+      nextDiscoverySummary = discoverySummary({ completionReason: 'no_search_candidates' });
+      const queue = new FromIntentQueue({
+        database: asDb({
+          getIntentForIndexing: async () => ({ id: 'i1', payload: 'P', userId: 'u1', sourceType: null, sourceId: null }),
+          recordIntentDiscoveryProgress,
+        }),
+      });
+
+      await queue.processJob('discover_opportunities', { intentId: 'i1', userId: 'u1' }, 1);
+
+      expect(recordIntentDiscoveryProgress).toHaveBeenCalledWith(expect.objectContaining({
+        status: 'succeeded', processedCommunityCount: 1, possibleOverlapCount: 0, conversationsStartedCount: 0,
+      }));
+    });
+
+    it('omits the tallies entirely when the graph was injected and returned no summary', async () => {
+      const recordIntentDiscoveryProgress = mock(async (_input: ProgressWrite) => {});
+      const queue = new FromIntentQueue({
+        database: asDb({
+          getIntentForIndexing: async () => ({ id: 'i1', payload: 'P', userId: 'u1', sourceType: null, sourceId: null }),
+          recordIntentDiscoveryProgress,
+        }),
+        invokeOpportunityGraph: async () => {},
+      });
+
+      await queue.processJob('discover_opportunities', { intentId: 'i1', userId: 'u1' }, 1);
+
+      const succeeded = progressWrite(recordIntentDiscoveryProgress, 'succeeded');
+      // Omitted, not zeroed: the adapter leaves stored counts untouched, so an
+      // injected graph can never claim a run found nothing.
+      expect(succeeded).not.toHaveProperty('processedCommunityCount');
+      expect(succeeded).not.toHaveProperty('possibleOverlapCount');
+      expect(succeeded).not.toHaveProperty('conversationsStartedCount');
+    });
+
+    it('leaves the blocked write free of tallies', async () => {
+      const recordIntentDiscoveryProgress = mock(async (_input: ProgressWrite) => {});
+      const queue = new FromIntentQueue({
+        database: asDb({
+          getIntentForIndexing: async () => ({ id: 'i1', payload: 'P', userId: 'u1', sourceType: null, sourceId: null }),
+          getAssignmentNetworkMembershipsForUser: async () => [],
+          recordIntentDiscoveryProgress,
+        }),
+        invokeOpportunityGraph: async () => {},
+      });
+
+      await queue.processJob('discover_opportunities', { intentId: 'i1', userId: 'u1' }, 1);
+
+      const blocked = progressWrite(recordIntentDiscoveryProgress, 'blocked');
+      expect(blocked).toMatchObject({ status: 'blocked', attempt: 0, assignedCommunityCount: 0 });
+      expect(blocked).not.toHaveProperty('possibleOverlapCount');
+      expect(blocked).not.toHaveProperty('conversationsStartedCount');
     });
 
     it('unknown job name logs warning and does not throw', async () => {


### PR DESCRIPTION
Replaces the radar's static "Preparing your first conversations" checklist — four rows frozen for the whole run — with a **radar sweep plus a terse, timestamped activity log**, so the owner watches the agent work instead of reading a status form.

The log is **derived, never recorded**: both lanes are rebuilt from durable data on every render, so a reload reproduces the identical log. No client-side delta tracking, no new tables, columns, feature flags or event streams.

## 1. Persist the discovery summary (`services/api`)

`runOpportunityDiscovery` already returns an `OpportunityDiscoverySummary`; `handleDiscover` discarded it. It now flows into the `succeeded` progress write:

| column | source |
| --- | --- |
| `possibleOverlapCount` | `summary.candidatesFound` |
| `conversationsStartedCount` | `summary.opportunitiesCreated` (each created opportunity enqueues a negotiation run) |
| `processedCommunityCount` | `stampNetworkIds.length` — the still-valid network set at the success stamp |

These three columns existed in the schema and in the API response but had **no writer**, so they were always `0`.

`recordIntentDiscoveryProgress` takes them as optional and **omitted-means-unchanged**: a boundary that does not know a tally (queued/running, or the `invokeOpportunityGraph` test short-circuit that returns no summary) writes no count rather than zeroing a real one. Only `from-intent` writes progress; from-introducer/from-enrichment are untouched. The read side (`intent.database.adapter.ts`) already mapped the columns — verified, not reworked.

## 2. Poll blind spots (`apps/web`)

- `blocked` joins the progress-poll allowlist. It was outside it, so a blocked card could never observe its own recovery once the signal joined a community — observed on dev as a card frozen on a double "Needs attention". Interval stays at 15s.
- The poll effect now depends on `discoveryProgress.status` rather than the whole `intent` object, so refetching the intent no longer resets the interval before it can fire.
- `refreshLiveRadar` also refetches the intent, so a completed run's final tallies land on the SSE-driven refresh instead of waiting out the poll.

## 3. The card (`apps/web`)

New `components/DiscoveryWarmupLog.tsx` with the derivation in `lib/discovery-warmup-log.ts`. Same mount condition as before (`intent?.warming || intent?.discoveryProgress`).

- **Chrome** — the product's dashed card. Header row: a 34px conic-gradient sweep (~3.4s, static and faded when not running), a title and one-line mono/tabular summary, and a mono uppercase status chip (`scanning`/`queued` neutral, `retrying`/`blocked`/`failed` amber, `completed` green).
- **Lane ●** — from `discoveryProgress` timestamps: `queued` → `scanning N communities…` (past tense once done) → `attempt x of 3 — retrying` → `＋ N possible overlaps found, N conversations started`. HH:MM, mono.
- **Lane ○** — one entry per in-flight negotiation on this signal, at the conversation's own `createdAt`, capped at the latest 5. Live via `useRadarLiveRefresh`.
- **States** — running/retrying pulse the current line and keep the "you can leave this page" footer; blocked says "Scanning is paused" with the amber note (text only — no new share flow); completed keeps its tallies **even when everything is zero** ("Scanned 4 communities — no overlaps yet"); unknown/legacy keeps today's honest "Status unavailable." with no fabricated log.
- Timestamps are never invented: an entry with no durable time is dropped, not stamped with "now".
- `prefers-reduced-motion` stops the sweep and the pulse; every state reads correctly without animation.

## Notes / follow-ups

- **Per-community narration ("scanning Climate Founders…") is out of scope.** The discovery graph runs once across all valid networks and exposes no per-community boundary outside the protocol graph. Doing it honestly needs a protocol-graph callback — a possible follow-up.
- **The conversation lane is usually empty today, by construction.** The card's surrounding gate hides it as soon as `opportunities.some(bucket === "negotiating")`, so the lane only populates in the window where a negotiation conversation exists but the radar view has not bucketed its opportunity as negotiating yet. Widening that gate is a bigger behavioural change than this PR's scope, so it is flagged rather than taken.
- The 15s progress poll is now partly redundant with the 5s live refresh's intent refetch. Both were specified; the poll remains the narrower, status-scoped safety net.
- No `packages/protocol` changes.

## Tests

- `from-intent.queue.isolated.ts`: succeeded write carries the summary tallies; a zero-result run is written honestly; the injected-graph path writes no tallies; the blocked write is unchanged.
- New `adapters/tests/intent-discovery-progress.write.isolated.ts` (hermetic, drizzle replaced with a recorder): tallies land on both sides of the upsert, zeroes are recorded, unknown tallies are omitted rather than zeroed, re-queue clears the run stamps but keeps the last counts.
- New `DiscoveryWarmupLog.test.tsx`: four states, log derivation from timestamps, lane merge order, zero-result completed copy, reload stability, live-lane cap, reduced-motion render.
- `intent-page-negotiator.test.tsx` updated for the new copy, plus two new tests covering the live-refresh snapshot and the blocked card's recovery. Both were verified to fail without their respective fix.

Full `apps/web` suite: 433 passed. `services/api` full suite failure list is byte-identical to `dev` (26 pre-existing DB/auth-fixture failures, none touching this surface).

🤖 Generated with [Claude Code](https://claude.com/claude-code)