### PR TITLE
refactor: an intent derives only from the user's answers

### DIFF
--- a/packages/protocol/src/chat/signal.prompt.ts
+++ b/packages/protocol/src/chat/signal.prompt.ts
@@ -66,14 +66,14 @@ export function buildSignalIntakeGuidance(stage: SignalIntakeStage | null): stri
   if (stage === "interview") {
     return `
 ## NEW SIGNAL INTAKE (ACTIVE)
-This is a guided New Signal kickoff. The user's preloaded identity/profile context is available above; use it to make your questions feel specific to this person, but do not expose raw JSON, IDs, or internal vocabulary.
+This is a guided New Signal kickoff. The user's preloaded identity/profile context is available above; use it to decide WHICH questions to ask and to make them feel specific to this person, but do not expose raw JSON, IDs, or internal vocabulary. It informs the questions only — the signal itself is written from this conversation's answers.
 
 Conduct a short interview in plain conversation — no questionnaires, no numbered forms, one message per question, at most three questions total. Cover, in order:
 1. Who they want to meet or find right now. Suggest two or three concrete recipient profiles drawn from their context (a peer, collaborator, customer, mentor, a specific expertise gap), not generic "anyone" choices.
 2. What they bring to this connection and what gap the other person should fill. Ground the suggestions in their answer so far plus the preloaded context; mutual exchange is a valid shape.
 3. Where to look — only communities already present in the preloaded membership list, by their exact titles, plus "Everywhere". Never invent a community, expose an ID, or imply the question changes membership.
 
-Skip a question when the user has already answered it unprompted. When you have enough, stop asking: combine the answers with the preloaded identity/profile context into one clear, specific signal describing who they want to meet, what they bring or need, and where to look, and call \`create_intent\` with that description (and only an existing-membership networkId if the user explicitly selected one). The tool is proposal-only: never persist or auto-approve. Pass the tool-produced \`\`\`intent_proposal\`\`\` block through verbatim and do not invent one.`;
+Skip a question when the user has already answered it unprompted. When you have enough, stop asking: compose the answers the user gave in THIS conversation into one clear, specific signal describing who they want to meet, what they bring or need, and where to look, and call \`create_intent\` with that description (and only an existing-membership networkId if the user explicitly selected one). The signal text is composed from their answers alone: never carry a background, employer, seniority, industry, or capability from the preloaded context into the description unless the user stated or selected it here. If that leaves the signal too vague to match on, ask about it rather than filling the gap from their profile. The tool is proposal-only: never persist or auto-approve. Pass the tool-produced \`\`\`intent_proposal\`\`\` block through verbatim and do not invent one.`;
   }
 
   return `

--- a/packages/protocol/src/chat/tests/signal.persona.spec.ts
+++ b/packages/protocol/src/chat/tests/signal.persona.spec.ts
@@ -260,6 +260,21 @@ describe("guided New Signal intake", () => {
     expect(prompt).toContain("proposal-only");
   });
 
+  it("scopes the preloaded profile to the questions, never to the signal text", () => {
+    // The profile legitimately shapes WHICH questions get asked. It may not
+    // put a background into the signal the user never stated: when an answer
+    // leaves the signal vague, the agent asks rather than filling the gap.
+    const prompt = buildSignalSystemContent(context, iteration());
+
+    expect(prompt).toContain("use it to decide WHICH questions to ask");
+    expect(prompt).toContain("the signal itself is written from this conversation's answers");
+    expect(prompt).toContain("compose the answers the user gave in THIS conversation");
+    expect(prompt).toContain("The signal text is composed from their answers alone");
+    expect(prompt).toContain("never carry a background, employer, seniority, industry, or capability from the preloaded context into the description");
+    expect(prompt).toContain("ask about it rather than filling the gap from their profile");
+    expect(prompt).not.toContain("combine the answers with the preloaded identity/profile context");
+  });
+
   it("asks the Signal Agent to return a replacement proposal when preview feedback arrives", () => {
     const complete = buildSignalSystemContent(context, {
       ...iteration(),

--- a/packages/protocol/src/intents/graph/intent.graph.execute.ts
+++ b/packages/protocol/src/intents/graph/intent.graph.execute.ts
@@ -9,7 +9,7 @@ import { getAbortSignalConfig } from "../../shared/agent/model-signal.js";
 import { timed } from "../../shared/observability/performance.js";
 import { requestContext } from "../../shared/observability/request-context.js";
 import type { DebugMetaAgent } from "../../agents/agent.module.js";
-import { buildExplicitUpdateActions, enforceIntentActionBoundary, enrichVagueIntentWithContext, generateIntentEmbedding, getSpecificityWarning, isVague, logger, MAX_PERMISSIBLE_ENTROPY, MIN_CLEAR_INTENT_SCORE, toSpeechActType, type IntentGraphDeps, type IntentState } from "./intent.graph.shared.js";
+import { buildExplicitUpdateActions, enforceIntentActionBoundary, generateIntentEmbedding, getSpecificityWarning, isVague, logger, MAX_PERMISSIBLE_ENTROPY, MIN_CLEAR_INTENT_SCORE, toSpeechActType, type IntentGraphDeps, type IntentState } from "./intent.graph.shared.js";
 
     /**
      * Node 4: Executor

--- a/packages/protocol/src/intents/graph/intent.graph.infer.ts
+++ b/packages/protocol/src/intents/graph/intent.graph.infer.ts
@@ -9,7 +9,7 @@ import { getAbortSignalConfig } from "../../shared/agent/model-signal.js";
 import { timed } from "../../shared/observability/performance.js";
 import { requestContext } from "../../shared/observability/request-context.js";
 import type { DebugMetaAgent } from "../../agents/agent.module.js";
-import { buildExplicitUpdateActions, enforceIntentActionBoundary, enrichVagueIntentWithContext, generateIntentEmbedding, getSpecificityWarning, isVague, logger, MAX_PERMISSIBLE_ENTROPY, MIN_CLEAR_INTENT_SCORE, toSpeechActType, type IntentGraphDeps, type IntentState } from "./intent.graph.shared.js";
+import { buildExplicitUpdateActions, enforceIntentActionBoundary, generateIntentEmbedding, getSpecificityWarning, isVague, logger, MAX_PERMISSIBLE_ENTROPY, MIN_CLEAR_INTENT_SCORE, toSpeechActType, type IntentGraphDeps, type IntentState } from "./intent.graph.shared.js";
 
     /**
      * Node 0: Prep

--- a/packages/protocol/src/intents/graph/intent.graph.reconcile.ts
+++ b/packages/protocol/src/intents/graph/intent.graph.reconcile.ts
@@ -9,7 +9,7 @@ import { getAbortSignalConfig } from "../../shared/agent/model-signal.js";
 import { timed } from "../../shared/observability/performance.js";
 import { requestContext } from "../../shared/observability/request-context.js";
 import type { DebugMetaAgent } from "../../agents/agent.module.js";
-import { buildExplicitUpdateActions, enforceIntentActionBoundary, enrichVagueIntentWithContext, generateIntentEmbedding, getSpecificityWarning, isVague, logger, MAX_PERMISSIBLE_ENTROPY, MIN_CLEAR_INTENT_SCORE, toSpeechActType, type IntentGraphDeps, type IntentState } from "./intent.graph.shared.js";
+import { buildExplicitUpdateActions, enforceIntentActionBoundary, generateIntentEmbedding, getSpecificityWarning, isVague, logger, MAX_PERMISSIBLE_ENTROPY, MIN_CLEAR_INTENT_SCORE, toSpeechActType, type IntentGraphDeps, type IntentState } from "./intent.graph.shared.js";
 
 
     /**
@@ -41,39 +41,13 @@ export async function verificationNode(state: IntentState, deps: IntentGraphDeps
         { intent: VerifiedIntent } | { failure: IntentValidationFailure }
       > => {
         try {
-          let description = intent.description;
+          const description = intent.description;
           const _traceEmitterVerifier = requestContext.getStore()?.traceEmitter;
-          const verifierStart1 = Date.now();
+          const verifierStart = Date.now();
           _traceEmitterVerifier?.({ type: "agent_start", name: "intent-verifier" });
-          let verdict = await deps.verifier.invoke(description, state.userProfile);
-          agentTimingsAccum.push({ name: 'intent.verifier', durationMs: Date.now() - verifierStart1 });
-          _traceEmitterVerifier?.({ type: "agent_end", name: "intent-verifier", durationMs: Date.now() - verifierStart1, summary: `Verified: ${verdict.classification}` });
-
-          if (isVague(description, verdict.semantic_entropy, verdict.felicity_scores.clarity)) {
-            // Role-hint enrichment for vague job intents reads the global
-            // user_context paragraph instead of the structured profile fields.
-            const roleHintContext = (await deps.database.getUserContext(state.userId, null))?.text ?? '';
-            const enrichedDescription = enrichVagueIntentWithContext(description, roleHintContext);
-            if (enrichedDescription !== description) {
-              logger.verbose("Enriched vague intent using profile context", {
-                before: description,
-                after: enrichedDescription,
-              });
-              const _traceEmitterVerifier2 = requestContext.getStore()?.traceEmitter;
-              const verifierStart2 = Date.now();
-              _traceEmitterVerifier2?.({ type: "agent_start", name: "intent-verifier" });
-              const enrichedVerdict = await deps.verifier.invoke(enrichedDescription, state.userProfile);
-              agentTimingsAccum.push({ name: 'intent.verifier', durationMs: Date.now() - verifierStart2 });
-              _traceEmitterVerifier2?.({ type: "agent_end", name: "intent-verifier", durationMs: Date.now() - verifierStart2, summary: `Verified (enriched): ${enrichedVerdict.classification}` });
-              const becameClear =
-                enrichedVerdict.semantic_entropy < verdict.semantic_entropy ||
-                enrichedVerdict.felicity_scores.clarity > verdict.felicity_scores.clarity;
-              if (becameClear) {
-                description = enrichedDescription;
-                verdict = enrichedVerdict;
-              }
-            }
-          }
+          const verdict = await deps.verifier.invoke(description, state.userProfile);
+          agentTimingsAccum.push({ name: 'intent.verifier', durationMs: Date.now() - verifierStart });
+          _traceEmitterVerifier?.({ type: "agent_end", name: "intent-verifier", durationMs: Date.now() - verifierStart, summary: `Verified: ${verdict.classification}` });
 
           // Filter Logic: Must be a Commissive, Directive, or Declaration
           const VALID_TYPES = ['COMMISSIVE', 'DIRECTIVE', 'DECLARATION'];
@@ -89,6 +63,9 @@ export async function verificationNode(state: IntentState, deps: IntentGraphDeps
             };
           }
 
+          // A vague description is rejected, never rewritten from the user's
+          // profile: when the system lacks information it asks. Callers turn
+          // this failure into a clarifying question.
           if (isVague(description, verdict.semantic_entropy, verdict.felicity_scores.clarity)) {
             logger.warn('Dropping vague intent after verification', {
               description,

--- a/packages/protocol/src/intents/graph/intent.graph.shared.ts
+++ b/packages/protocol/src/intents/graph/intent.graph.shared.ts
@@ -98,49 +98,6 @@ export const MAX_PERMISSIBLE_ENTROPY = 0.75;
 export const MIN_CLEAR_INTENT_SCORE = 40;
 export const GENERIC_JOB_PHRASE = /\b(?:a|any|some)\s+job\b/i;
 
-export const inferRoleFromContextText = (text: string): string | null => {
-  const normalized = text.toLowerCase();
-  if (/\b(engineer|developer)\b/.test(normalized)) return "software engineering";
-  if (/\b(designer|ux|ui)\b/.test(normalized)) return "product design";
-  if (/\b(marketing|marketer|growth)\b/.test(normalized)) return "marketing";
-  if (/\b(product manager|product)\b/.test(normalized)) return "product management";
-  if (/\b(data scientist|machine learning|ml|ai)\b/.test(normalized)) return "AI/ML";
-  if (/\b(sales|account executive|business development)\b/.test(normalized)) return "sales";
-  return null;
-};
-
-/**
- * Derive a job-role qualifier from the user's global user_context paragraph
- * (the identity text that replaced the legacy profile projection). Role is
- * inferred from the free text; the old structured skills/interests extraction
- * is gone with the removed profile fields.
- */
-export const buildJobQualifierFromContext = (contextText: string): string | null => {
-  const roleHint = inferRoleFromContextText(contextText ?? "");
-  return roleHint ? `${roleHint} role` : null;
-};
-
-export const enrichVagueIntentWithContext = (description: string, userContext: string): string => {
-  const trimmed = description?.trim();
-  if (!trimmed) return description;
-
-  const isGenericJobRequest =
-    GENERIC_JOB_PHRASE.test(trimmed) ||
-    /\b(?:find|get|look(?:ing)?\s+for|want)\s+(?:to\s+)?(?:find\s+)?job\b/i.test(trimmed);
-  if (!isGenericJobRequest) return description;
-
-  const qualifier = buildJobQualifierFromContext(userContext);
-  if (!qualifier) return description;
-
-  const enriched = trimmed
-    .replace(/\ba job\b/i, `a ${qualifier}`)
-    .replace(/\bjob\b/i, `${qualifier}`)
-    .replace(/\s{2,}/g, " ")
-    .trim();
-
-  return enriched.length > 0 ? enriched : description;
-};
-
 export const isVague = (description: string, entropy: number, clarity: number): boolean => {
   if (GENERIC_JOB_PHRASE.test(description)) return true;
   if (entropy > MAX_PERMISSIBLE_ENTROPY) return true;

--- a/packages/protocol/src/intents/intake/intake.orchestrator.ts
+++ b/packages/protocol/src/intents/intake/intake.orchestrator.ts
@@ -27,9 +27,14 @@ export interface IntakeRound {
   answer: IntakeAnswer;
 }
 
-/** Everything synthesis needs to write the signal. */
+/**
+ * Everything synthesis needs to write the signal.
+ *
+ * Deliberately has no brief: an intent derives only from what the person
+ * answered. The brief sources questions and answer options upstream, but
+ * nothing it says may reach the synthesized signal unless the person said it.
+ */
 export interface SynthesisInput {
-  brief: string;
   rounds: IntakeRound[];
   /** Free-text place/community constraint from the where round. */
   whereText?: string;
@@ -165,13 +170,18 @@ pianist should return null.`;
 
 const SYNTHESIS_SYSTEM_PROMPT = `You write one clear signal for a networking product.
 
-Combine the brief and the person's answers into a specific description of who they
-want to meet, what they bring or need, and any stated constraint. Write it in the
-person's own voice, first person, 1-3 sentences, concrete and free of hype. Also
-return short "lookingFor" and "youBring" summaries for the confirmation card.
+You receive ONLY the interview: each question the person was asked and the answer
+they gave. Compose and normalize those answers into a specific description of who
+they want to meet, what they bring or need, and any stated constraint. Write it in
+the person's own voice, first person, 1-3 sentences, concrete and free of hype.
+Also return short "lookingFor" and "youBring" summaries for the confirmation card.
 When revision feedback is present, it is the person correcting a draft they
 already read: apply it to the whole signal rather than treating it as a place or
-community constraint. Never invent facts beyond the brief and the answers.`;
+community constraint.
+
+Tighten the wording; never extend it. Do not weave in background, employer,
+seniority, industry, capability, or commercial goal that the answers do not state.
+Every claim in the output must trace back to something the person answered.`;
 
 /**
  * Render an answer as a human-readable label.
@@ -314,7 +324,7 @@ export class SignalIntakeOrchestrator {
    * Write the signal from every answered round, any where-constraint, and any
    * revision feedback.
    *
-   * @param input - Brief, ordered rounds, optional where constraint, optional feedback
+   * @param input - Ordered rounds, optional where constraint, optional feedback
    * @returns Description plus card summary fields
    * @throws Propagates model failure so the caller can mark the run failed
    */
@@ -331,7 +341,7 @@ export class SignalIntakeOrchestrator {
     const result = await this.synthesisModel.invoke([
       new SystemMessage(SYNTHESIS_SYSTEM_PROMPT),
       new HumanMessage(
-        `Brief:\n${input.brief}\n\n${roundsText}${whereLine}${feedbackLine}\n\nWrite the signal.`,
+        `INTERVIEW:\n${roundsText}${whereLine}${feedbackLine}\n\nWrite the signal.`,
       ),
     ]);
     return {

--- a/packages/protocol/src/intents/intent.inferrer.ts
+++ b/packages/protocol/src/intents/intent.inferrer.ts
@@ -191,11 +191,16 @@ export class ExplicitIntentInferrer {
         ? '(No content provided. Please infer intents from Profile Narrative and Aspirations)'
         : '(No content to analyze. Return empty intents list.)';
 
+    // No profile means no profile section at all. Callers that deliberately run
+    // profile-blind (the signal-intake propose path) must not see an empty
+    // heading the model could try to fill in.
+    const profileSection = profileContext?.trim()
+      ? `# User Memory Profile\n      ${profileContext}\n`
+      : '';
+
     const prompt = `
       Context:
-      # User Memory Profile
-      ${profileContext}
-
+      ${profileSection}
       ${conversationSection}${contentSection}
 
       # Operation Context

--- a/packages/protocol/src/intents/tests/intake.orchestrator.spec.ts
+++ b/packages/protocol/src/intents/tests/intake.orchestrator.spec.ts
@@ -285,11 +285,10 @@ describe("SignalIntakeOrchestrator.synthesize", () => {
   };
 
   it("renders every round into the synthesis prompt", async () => {
-    const capture: { prompt?: string } = {};
+    const capture: Capture = {};
     const orchestrator = new SignalIntakeOrchestrator({ synthesis: stub(synthesis, capture) });
 
     const result = await orchestrator.synthesize({
-      brief: "Ada builds developer tools.",
       rounds: [
         { prompt: "Who do you want to meet?", answer: { selectedOptions: ["A design partner"] } },
         { prompt: "What do you bring?", answer: { selectedOptions: ["Engineering depth"] } },
@@ -304,11 +303,10 @@ describe("SignalIntakeOrchestrator.synthesize", () => {
   });
 
   it("appends where and feedback lines when present", async () => {
-    const capture: { prompt?: string } = {};
+    const capture: Capture = {};
     const orchestrator = new SignalIntakeOrchestrator({ synthesis: stub(synthesis, capture) });
 
     await orchestrator.synthesize({
-      brief: "b",
       rounds: [{ prompt: "p", answer: { selectedOptions: ["x"] } }],
       whereText: "Berlin",
       feedback: "shorter please",
@@ -324,23 +322,59 @@ describe("SignalIntakeOrchestrator.synthesize", () => {
     });
 
     await expect(orchestrator.synthesize({
-      brief: "b",
       rounds: [{ prompt: "p", answer: { selectedOptions: ["x"] } }],
     })).rejects.toThrow("model down");
   });
 
   it("renders revision feedback in its own slot, never as a where constraint", async () => {
-    const capture: { prompt?: string } = {};
+    const capture: Capture = {};
     const orchestrator = new SignalIntakeOrchestrator({ synthesis: stub(synthesis, capture) });
 
     await orchestrator.synthesize({
-      brief: "b",
       rounds: [{ prompt: "p", answer: { selectedOptions: ["x"] } }],
       feedback: "shorter please",
     });
 
     expect(capture.prompt).toContain("Revision feedback on the previous draft: shorter please");
     expect(capture.prompt).not.toContain("Where constraint");
+  });
+
+  it("sends the interview and nothing else, so no profile fact can reach the prompt", async () => {
+    const capture: Capture = {};
+    const orchestrator = new SignalIntakeOrchestrator({ synthesis: stub(synthesis, capture) });
+
+    // The pack brief that sourced these questions says the person is an
+    // ex-Google staff engineer. They never answered anything of the sort, so
+    // synthesis must never see it — there is no input that could carry it.
+    await orchestrator.synthesize({
+      rounds: [
+        { prompt: "Who do you want to meet?", answer: { selectedOptions: ["A design partner"] } },
+        { prompt: "What do you bring?", answer: { selectedOptions: [], freeText: "I can build the thing" } },
+      ],
+    });
+
+    const everythingSent = (capture.messages ?? []).join("\n");
+    for (const profileFact of ["ex-Google", "Google", "staff engineer", "Brief:"]) {
+      expect(everythingSent).not.toContain(profileFact);
+    }
+    expect(capture.prompt).toContain("INTERVIEW:");
+    expect(capture.prompt).toContain("A: A design partner");
+    expect(capture.prompt).toContain("A: I can build the thing");
+  });
+
+  it("instructs the model to compose the answers rather than weave in background", async () => {
+    const capture: Capture = {};
+    const orchestrator = new SignalIntakeOrchestrator({ synthesis: stub(synthesis, capture) });
+
+    await orchestrator.synthesize({
+      rounds: [{ prompt: "Who?", answer: { selectedOptions: ["A design partner"] } }],
+    });
+
+    const systemPrompt = capture.messages?.[0] ?? "";
+    expect(systemPrompt).toContain("ONLY the interview");
+    expect(systemPrompt).toContain("Tighten the wording; never extend it.");
+    expect(systemPrompt).toContain("trace back to something the person answered");
+    expect(systemPrompt).not.toContain("brief");
   });
 });
 

--- a/packages/protocol/src/intents/tests/intent.graph.vague-rejection.spec.ts
+++ b/packages/protocol/src/intents/tests/intent.graph.vague-rejection.spec.ts
@@ -1,0 +1,175 @@
+/**
+ * Verification never rewrites a description from the user's profile.
+ *
+ * A vague signal used to be silently enriched with a role inferred from the
+ * global user_context paragraph ("a job" → "a software engineering role") and
+ * re-verified, so profile text could land in a persisted payload the user never
+ * wrote. An intent derives only from what the person said: when the description
+ * is too vague to match on, verification rejects it and the callers ask.
+ */
+import { describe, expect, it } from "bun:test";
+
+import { IntentGraphFactory } from "../graph/intent.graph.js";
+import { verificationNode } from "../graph/intent.graph.reconcile.js";
+
+import type { SemanticVerifierOutput } from "../intent.verifier.js";
+import type { IntentGraphDeps, IntentState } from "../graph/intent.graph.shared.js";
+import type { IntentGraphDatabase } from "../../shared/interfaces/database.interface.js";
+
+const CLEAR_VERDICT: SemanticVerifierOutput = {
+  reasoning: "Actionable directive",
+  classification: "DIRECTIVE",
+  felicity_scores: { authority: 90, sincerity: 90, clarity: 90 },
+  semantic_entropy: 0.2,
+  referential_breadth: "narrow",
+  referential_anchor: "a design partner",
+  missing_selectional_constraints: [],
+  specificity_warning: null,
+  flags: [],
+};
+
+const VAGUE_VERDICT: SemanticVerifierOutput = {
+  ...CLEAR_VERDICT,
+  reasoning: "Too broad to act on",
+  felicity_scores: { authority: 90, sincerity: 90, clarity: 20 },
+  semantic_entropy: 0.9,
+  referential_anchor: null,
+};
+
+/**
+ * Build the verification node's dependencies. Both the verifier and the
+ * user_context reader count their calls, so a test can assert the node stopped
+ * at one verification pass and never went looking for the profile.
+ */
+function makeDeps(verdicts: SemanticVerifierOutput[]) {
+  const verifierCalls: string[] = [];
+  let contextReads = 0;
+  const deps = {
+    database: {
+      getUserContext: async () => {
+        contextReads += 1;
+        return { text: "Ada is a staff software engineer at a large search company." };
+      },
+    },
+    verifier: {
+      invoke: async (description: string) => {
+        verifierCalls.push(description);
+        return verdicts[Math.min(verifierCalls.length - 1, verdicts.length - 1)];
+      },
+    },
+  } as unknown as IntentGraphDeps;
+  return { deps, verifierCalls, contextReads: () => contextReads };
+}
+
+/** Minimal state carrying one inferred intent through verification. */
+function makeState(description: string, operationMode: IntentState["operationMode"]): IntentState {
+  return {
+    userId: "u1",
+    userProfile: "",
+    operationMode,
+    inferredIntents: [{
+      type: "goal",
+      description,
+      reasoning: "Stated by the user",
+      confidence: "high",
+    }],
+  } as unknown as IntentState;
+}
+
+describe("verificationNode vague handling", () => {
+  it("rejects a vague description instead of rewriting it from the profile", async () => {
+    const { deps, verifierCalls, contextReads } = makeDeps([VAGUE_VERDICT]);
+
+    const result = await verificationNode(makeState("Find a job", "create"), deps);
+
+    expect(result.verifiedIntents).toHaveLength(0);
+    expect(result.validationFailures?.[0]?.category).toBe("vague_or_invalid");
+    // One verification pass, on exactly what the user said.
+    expect(verifierCalls).toEqual(["Find a job"]);
+    expect(contextReads()).toBe(0);
+  });
+
+  it("leaves a generic job phrase untouched even when the verdict scores well", async () => {
+    // The enrichment branch fired on this shape specifically: a clear-looking
+    // verdict on "a job" used to be rewritten to "a software engineering role".
+    const { deps, verifierCalls, contextReads } = makeDeps([CLEAR_VERDICT]);
+
+    const result = await verificationNode(makeState("I want to find a job", "create"), deps);
+
+    expect(result.verifiedIntents).toHaveLength(0);
+    expect(result.validationFailures?.[0]?.category).toBe("vague_or_invalid");
+    expect(verifierCalls).toEqual(["I want to find a job"]);
+    expect(contextReads()).toBe(0);
+  });
+
+  it("rejects rather than crashing in update mode", async () => {
+    const { deps, contextReads } = makeDeps([VAGUE_VERDICT]);
+
+    const result = await verificationNode(makeState("Find a job", "update"), deps);
+
+    expect(result.verifiedIntents).toHaveLength(0);
+    expect(result.validationFailures?.[0]?.category).toBe("vague_or_invalid");
+    expect(contextReads()).toBe(0);
+  });
+
+  it("still passes a clear description through verification unchanged", async () => {
+    const { deps } = makeDeps([CLEAR_VERDICT]);
+
+    const result = await verificationNode(
+      makeState("Find a design partner to test my developer tooling", "create"),
+      deps,
+    );
+
+    expect(result.verifiedIntents).toHaveLength(1);
+    expect(result.verifiedIntents?.[0]?.description)
+      .toBe("Find a design partner to test my developer tooling");
+    expect(result.validationFailures).toHaveLength(0);
+  });
+});
+
+describe("intent graph propose mode", () => {
+  /**
+   * `SignalIntakeService.runSynthesis` treats an empty `verifiedIntents` as
+   * `verification_rejected` and answers the wizard with a clarifying question
+   * (HTTP 422). A vague signal has to actually land there rather than being
+   * enriched into something that verifies.
+   */
+  it("returns nothing verified for a vague signal, which is the wizard's clarify trigger", async () => {
+    let contextReads = 0;
+    const database = {
+      getProfile: async () => ({ identity: { name: "Ada" } }),
+      getActiveIntents: async () => [],
+      getUserContext: async () => {
+        contextReads += 1;
+        return { text: "Ada is a staff software engineer." };
+      },
+    } as unknown as IntentGraphDatabase;
+
+    const graph = new IntentGraphFactory(database, undefined, undefined, {
+      inferrer: {
+        invoke: async () => ({
+          intents: [{
+            type: "goal" as const,
+            description: "Find a job",
+            confidence: "high" as const,
+            reasoning: "Stated by the user",
+          }],
+        }),
+      },
+      verifier: { invoke: async () => VAGUE_VERDICT },
+      reconciler: { invoke: async () => ({ actions: [] }) },
+    }).createGraph();
+
+    const result = await graph.invoke({
+      userId: "ada",
+      // The propose path attaches no profile at all.
+      userProfile: "",
+      operationMode: "propose",
+      inputContent: "Find a job",
+    });
+
+    expect(result.verifiedIntents).toEqual([]);
+    expect(result.validationFailures?.[0]?.category).toBe("vague_or_invalid");
+    expect(contextReads).toBe(0);
+  });
+});

--- a/packages/protocol/src/intents/tests/intent.inferrer.spec.ts
+++ b/packages/protocol/src/intents/tests/intent.inferrer.spec.ts
@@ -240,4 +240,25 @@ Interests: AI agents, decentralized systems, venture capital
     );
     expect(hasPhotograph).toBe(true);
   }, 30000);
+
+  it('omits the profile section entirely when the caller passes no profile', async () => {
+    // The signal-intake propose path runs profile-blind. An empty heading is
+    // still an invitation to invent a background, so it must not be rendered.
+    await inferrer.invoke('Find a design partner', '', {
+      allowProfileFallback: false,
+      operationMode: 'create',
+    });
+
+    const prompt = String(capturedCalls.at(-1)?.at(-1)?.content ?? '');
+    expect(prompt).not.toContain('User Memory Profile');
+    expect(prompt).toContain('## New Content\n\nFind a design partner');
+
+    await inferrer.invoke('Find a design partner', richProfile, {
+      allowProfileFallback: false,
+      operationMode: 'create',
+    });
+
+    // The section still renders for callers that do supply a profile.
+    expect(String(capturedCalls.at(-1)?.at(-1)?.content ?? '')).toContain('User Memory Profile');
+  }, 30000);
 });

--- a/packages/protocol/src/shared/interfaces/database.capabilities.ts
+++ b/packages/protocol/src/shared/interfaces/database.capabilities.ts
@@ -273,7 +273,8 @@ export type IntentGraphDatabase = Pick<
   | 'getUser'
   // Profile check (prepNode gate for write operations)
   | 'getProfile'
-  // Global user_context paragraph for questioner intent prompts
+  // Global user_context paragraph, read to verify an owner-edited proposal.
+  // Never used to rewrite a description: intents derive from what the user said.
   | 'getUserContext'
   // Personal network auto-assignment
   | 'getPersonalIndexesForContact'

--- a/services/api/src/services/signal-intake.service.ts
+++ b/services/api/src/services/signal-intake.service.ts
@@ -77,9 +77,12 @@ export interface SignalIntakeServiceDeps {
   getPremises: (userId: string) => Promise<Array<{ text: string }>>;
   getNetworkTitles: (userId: string) => Promise<string[]>;
   getGlobalContext: (userId: string) => Promise<string | null>;
+  /**
+   * Verify-only intent-graph invocation. Deliberately profile-blind: the
+   * propose path verifies exactly what the person answered.
+   */
   invokeIntentGraph: (input: {
     userId: string;
-    userProfile: string;
     inputContent: string;
   }) => Promise<{ verifiedIntents?: Array<Record<string, unknown>> }>;
   now?: () => Date;
@@ -365,14 +368,12 @@ export class SignalIntakeService {
     networkId?: string,
   ): Promise<IntakeProposal> {
     try {
-      const { brief } = await this.getOrCreatePack(userId);
-      const synthesis = await this.deps.intents.synthesizeIntake({ brief, ...answers });
+      // Synthesis and verification both run on the answers alone. The pack
+      // brief sources the questions upstream; it never reaches the signal.
+      const synthesis = await this.deps.intents.synthesizeIntake(answers);
 
-      // The brief stands in for the profile graph here: it is already a
-      // distilled identity paragraph, so `propose` skips that leg entirely.
       const graphResult = await this.deps.invokeIntentGraph({
         userId,
-        userProfile: brief,
         inputContent: synthesis.description,
       });
 
@@ -514,15 +515,15 @@ const productionIntents = new Intents({
 });
 const compiledIntentGraph = productionIntents.createGraph();
 
-/** Verify-only invocation of the intent graph, skipping the profile-graph leg
- * by supplying the precomputed pack brief as `userProfile` directly. */
+/** Verify-only invocation of the intent graph. The profile-graph leg is skipped
+ * and nothing is supplied in its place: an intent derives only from the person's
+ * answers, so inference and verification see the synthesized signal alone. */
 async function invokeIntentGraphProduction(input: {
   userId: string;
-  userProfile: string;
   inputContent: string;
 }): Promise<{ verifiedIntents?: Array<Record<string, unknown>> }> {
   const result = await compiledIntentGraph.invoke(
-    { ...input, operationMode: 'propose' as const },
+    { ...input, userProfile: '', operationMode: 'propose' as const },
     { recursionLimit: 100 },
   );
   return result as { verifiedIntents?: Array<Record<string, unknown>> };

--- a/services/api/src/services/tests/signal-intake.service.isolated.ts
+++ b/services/api/src/services/tests/signal-intake.service.isolated.ts
@@ -362,6 +362,29 @@ describe('SignalIntakeService.resolveProposal', () => {
     expect(result.proposalId).not.toBe('prop-1');
   });
 
+  it('synthesizes and verifies from the answers alone, with no profile attached', async () => {
+    const deps = makeDeps({
+      proposalStore: {
+        createProposals: mock(async () => undefined),
+        getProposalForOwner: mock(async () => storedProposal({ status: 'consumed' })),
+        setProposalNetwork: mock(async () => true),
+      },
+    });
+    const service = new SignalIntakeService(deps as never);
+
+    await service.resolveProposal('u1', { runId: 'run-1', rounds });
+
+    // The pack brief sources the questions upstream; it must not travel with
+    // the answers into synthesis, nor stand in for a profile on the graph.
+    const [synthesisInput] = deps.intents.synthesizeIntake.mock.calls[0] as [Record<string, unknown>];
+    expect(synthesisInput).not.toHaveProperty('brief');
+    expect(synthesisInput.rounds).toEqual(rounds);
+
+    const [graphInput] = deps.invokeIntentGraph.mock.calls[0] as [Record<string, unknown>];
+    expect(graphInput).not.toHaveProperty('userProfile');
+    expect(graphInput).toEqual({ userId: 'u1', inputContent: 'Looking for a design partner.' });
+  });
+
   it('surfaces verification rejection with a clarification question', async () => {
     const deps = makeDeps({
       runStore: {


### PR DESCRIPTION
The signal-intake wizard could put things in a signal the user never said. Premises, user contexts, and community titles legitimately source the *questions* and the *answer options* — but once a question is answered, the synthesized signal must be derivable from the answered rounds alone.

This mirrors the "consult, don't assume" principle from the negotiation side (#1445): when the system lacks information, it asks rather than filling the gap from the profile.

## Four seams closed

**1. Answer-only synthesis** (`intake.orchestrator.ts`)
`SynthesisInput` no longer carries the pack brief — the type itself makes it impossible to pass. The prompt is now `INTERVIEW:` plus each round's question and answer, and the system prompt asks the model to *compose and normalize* what was answered instead of weaving in background: "Tighten the wording; never extend it… Every claim in the output must trace back to something the person answered."

**2. Profile-blind propose path** (`signal-intake.service.ts`, `intent.inferrer.ts`)
`runSynthesis` no longer passes the brief as `userProfile` (nor reads the pack at all — the only thing it wanted from it was the brief). The inferrer now omits its `# User Memory Profile` section entirely when no profile is supplied, rather than rendering an empty heading the model could try to fill in. Other callers — MCP `create_intent`, update mode — are unchanged.

**3. The vague-rewrite is retired** (`intent.graph.reconcile.ts`, `intent.graph.shared.ts`)
Verification used to read the global `user_context` paragraph and silently rewrite a vague description (`"a job"` → `"a software engineering role"`), re-verify, and keep the rewrite if the score improved. It now rejects instead. `enrichVagueIntentWithContext`, `buildJobQualifierFromContext`, and `inferRoleFromContextText` are deleted — nothing else called them.

The rejection is not a new failure mode: the intake flow already turns an empty `verifiedIntents` into `verification_rejected` → `CLARIFICATION_QUESTION` (HTTP 422), and the wizard has a `clarify` stage. Verified end to end by a propose-mode graph test.

This applies to every graph mode, not just intake — the rewrite injected profile text into the payload wherever it fired. Update mode and MCP degrade to the same rejection, never a crash.

**4. Chat-creation prompt alignment** (`signal.prompt.ts`)
The Signal Agent's intake guidance said to "combine the answers with the preloaded identity/profile context into one clear, specific signal". It now says the profile informs *which questions to ask*, and that the signal text is composed from the answers alone — and that a too-vague answer is a reason to ask, not to fill the gap from the profile. Prompt-only; the profile preload that serves the rest of chat is untouched.

## Deliberately unchanged

- **Question-side sourcing** — the pack generator's brief + profile-grounded round-1 options, and the profile-bridge follow-up option. This is the wanted behavior; the brief keeps its job of generating questions, it just never touches the output.
- **HyDE/discovery profile conditioning** — the searched vectors stay profile-conditioned. The payload is what has to stay pure, and it does.
- **The verification-only read for owner-edited proposals** (`intent.service.ts:449`) — reads context to verify, never rewrites.
- **MCP `create_intent` from external agents** — agent-authored text is that surface's contract.

## Tests

- `intake.orchestrator.spec.ts` — a fixture asserting a brief fact ("ex-Google staff engineer") the user never answered cannot reach the prompt, plus a pin on the answers-only system prompt.
- `intent.graph.vague-rejection.spec.ts` (new) — vague verdicts reject with one verification pass and zero `getUserContext` reads, in create *and* update mode; a generic job phrase with a clear-scoring verdict is still rejected rather than rewritten; a clear description still passes through; and propose mode returns empty `verifiedIntents`, which is the wizard's clarify trigger.
- `intent.inferrer.spec.ts` — no profile section renders when no profile is passed; it still renders when one is.
- `signal-intake.service.isolated.ts` — the propose-mode graph invocation carries no `userProfile`, and synthesis receives no `brief`.
- `signal.persona.spec.ts` — wording pin on the reworded intake guidance.

## Verification

- protocol: 2232 pass / 0 fail across 197 files
- api isolated: 1114 pass, 4 pre-existing failures unrelated to this diff (`opportunity.service.{rediscovery,maintenance}` and `tool.controller` fail on a stale partial `mock.module` of `database.adapter` / the `CONTACTS_ENABLED` gate; `archive-legacy-negotiations` on legacy park chronology). None are in this diff's import graph. `intent.controller.isolated` also failed until the local test DB was migrated up to `0137_add_intent_discovery_progress`; it passes now.
- `tsc --noEmit`, `typecheck:specs`, and eslint all clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)