### PR TITLE
Fix negotiation lifecycle labels

### DIFF
--- a/apps/web/src/components/ChatSidebar.tsx
+++ b/apps/web/src/components/ChatSidebar.tsx
@@ -8,7 +8,7 @@ import { useConversation } from '@/contexts/ConversationContext';
 import { isVisibleH2HConversation } from '@/lib/conversation-visibility';
 import { resolveConversationPreview } from '@/lib/conversation-preview';
 import { countNegotiationsRequiringAction } from '@/lib/negotiation-inbox';
-import { groupNegotiationOutline, opportunityStatusPresentation } from '@/lib/negotiation-outline';
+import { groupNegotiationOutline } from '@/lib/negotiation-outline';
 
 interface RecentChat {
   groupId: string;
@@ -208,7 +208,7 @@ export default function ChatSidebar() {
                     {expanded && (
                       <div id={regionId} className="ml-5 border-l border-gray-200 pl-2" role="region" aria-label={`${counterparty.name} opportunities`}>
                         {counterparty.opportunities.map((opportunity) => {
-                          const presentation = opportunity.status ? opportunityStatusPresentation[opportunity.status] : null;
+                          const presentation = opportunity.presentation;
                           const selected = pathname === `/chat/${opportunity.conversationId}`
                             && selectedTaskId === (opportunity.taskId ?? null);
                           const opportunityMenuId = `negotiation:${opportunity.conversationId}:${opportunity.taskId ?? 'latest'}`;
@@ -221,11 +221,11 @@ export default function ChatSidebar() {
                                 className="relative flex min-w-0 flex-1 items-center gap-2 rounded-md px-2 py-2 text-left focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-[-2px] focus-visible:outline-[#4091bb]"
                               >
                                 {selected && <span className="absolute inset-y-1 left-0 w-0.5 rounded-full bg-[#041729]" aria-hidden="true" />}
-                                <span className={`h-1.5 w-1.5 shrink-0 rounded-full ${presentation?.dotClass ?? 'bg-gray-300'}`} aria-hidden="true" />
+                                <span className={`h-1.5 w-1.5 shrink-0 rounded-full ${presentation.dotClass}`} aria-hidden="true" />
                                 <span className="min-w-0 flex-1">
                                   <span className="block truncate text-xs font-medium text-gray-800">{opportunity.title}</span>
                                   <span className="block truncate font-ibm-plex-mono text-[10px] text-gray-400">
-                                    {presentation?.label ?? 'No lifecycle status'}
+                                    {presentation.label}
                                   </span>
                                 </span>
                               </button>

--- a/apps/web/src/components/NegotiationsInbox.tsx
+++ b/apps/web/src/components/NegotiationsInbox.tsx
@@ -6,40 +6,12 @@ import { ContentContainer } from '@/components/layout';
 import UserAvatar from '@/components/UserAvatar';
 import { useAuthContext } from '@/contexts/AuthContext';
 import { useConversation } from '@/contexts/ConversationContext';
-import { deriveNegotiationInbox, flattenNegotiationInbox, type NegotiationInboxItem, type NegotiationInboxStatus } from '@/lib/negotiation-inbox';
-
-const CHIP_CLASS: Record<NegotiationInboxStatus, string> = {
-  answer: 'border-[#041729] bg-[#041729] text-white',
-  agreed: 'border-emerald-200 bg-emerald-50 text-emerald-700',
-  live: 'border-amber-200 bg-amber-50 text-amber-700',
-  waiting: 'border-gray-200 bg-gray-100 text-gray-600',
-  accepted: 'border-emerald-200 bg-emerald-50 text-emerald-700',
-  started: 'border-emerald-200 bg-emerald-50 text-emerald-700',
-  rejected: 'border-red-200 bg-red-50 text-red-700',
-  stalled: 'border-amber-200 bg-amber-50 text-amber-700',
-  // IND-610: a decision by the viewer's own agent, not a counterparty verdict.
-  // Deliberately neutral rather than red — nothing was rejected, and nobody
-  // else was ever involved.
-  not_sent: 'border-gray-200 bg-gray-100 text-gray-600',
-};
-
-function statusLabel(item: NegotiationInboxItem): string {
-  switch (item.status) {
-    case 'answer': return 'Answer your agent';
-    case 'agreed': return 'Agents agreed';
-    case 'live': return `● Live · turn ${item.turnCount} of ${item.maxTurns}`;
-    case 'waiting': return 'Waiting on their agent';
-    case 'accepted': return 'Accepted by you';
-    case 'started': return 'Chat started';
-    case 'rejected': return 'No opportunity';
-    case 'stalled': return 'Stalled';
-    case 'not_sent': return 'Not sent';
-  }
-}
+import { deriveNegotiationInbox, flattenNegotiationInbox, type NegotiationInboxItem } from '@/lib/negotiation-inbox';
+import { chipClass, statusLabel } from '@/lib/negotiation-chips';
 
 function StatusChip({ item }: { item: NegotiationInboxItem }) {
   return (
-    <span className={`inline-flex shrink-0 items-center whitespace-nowrap rounded-full border px-2.5 py-1 text-[10px] font-semibold font-ibm-plex-mono ${CHIP_CLASS[item.status]}`}>
+    <span className={`inline-flex shrink-0 items-center whitespace-nowrap rounded-full border px-2.5 py-1 text-[10px] font-semibold font-ibm-plex-mono ${chipClass(item.status)}`}>
       {statusLabel(item)}
     </span>
   );
@@ -113,12 +85,12 @@ function NegotiationRow({ item, flash, rowRef, onOpen }: {
 
       <div className="ml-auto flex shrink-0 items-center gap-2">
         <StatusChip item={item} />
-        {item.status === 'agreed' && (
+        {item.status === 'awaiting_review' && (
           <span className="rounded-sm bg-[#041729] px-3 py-1.5 text-xs font-semibold text-white">
             Review
           </span>
         )}
-        {(item.status === 'live' || item.status === 'waiting') && (
+        {item.status === 'negotiating' && (
           <span className="h-2 w-2 rounded-full bg-amber-400 animate-pulse" aria-hidden="true" />
         )}
       </div>
@@ -190,7 +162,7 @@ export default function NegotiationsInbox() {
   // that surface is gone, and /questions was already this path's fallback
   // (IND-558).
   const openNegotiation = useCallback((item: NegotiationInboxItem) => {
-    if (item.status !== 'answer') {
+    if (item.status !== 'needs_input') {
       navigate(`/chat/${item.conversationId}`);
       return;
     }

--- a/apps/web/src/components/__tests__/ChatSidebar.test.tsx
+++ b/apps/web/src/components/__tests__/ChatSidebar.test.tsx
@@ -61,6 +61,7 @@ function negotiation(
       parts: [{ kind: 'data', data: { action: input.action ?? 'counter' } }],
       senderId: input.senderId ?? `agent:${id}-peer`,
       createdAt: '2026-07-24T11:00:00.000Z',
+      taskId: `${id}-task`,
     },
     metadata: null,
     via: [],

--- a/apps/web/src/components/__tests__/ChatSidebar.test.tsx
+++ b/apps/web/src/components/__tests__/ChatSidebar.test.tsx
@@ -264,10 +264,10 @@ describe('ChatSidebar negotiations tab (IND-523)', () => {
     fireEvent.click(mira);
     expect(mira).toHaveAttribute('aria-expanded', 'true');
     expect(screen.getByText("Mira Chen's opportunity")).toBeInTheDocument();
-    expect(screen.getByText('Negotiating')).toBeInTheDocument();
+    expect(screen.getByText('Needs your input')).toBeInTheDocument();
 
     fireEvent.click(screen.getByRole('button', { name: /Jonas Berg/ }));
-    expect(screen.getByText('Rejected')).toBeInTheDocument();
+    expect(screen.getByText('No match')).toBeInTheDocument();
   });
 
   it('shows mode-aware empty copy and the persistent inbox footer link', async () => {
@@ -331,7 +331,7 @@ describe('ChatSidebar negotiations tab (IND-523)', () => {
     fireEvent.click(screen.getByRole('button', { name: /Dana Okafor/ }));
     // No opportunity title survives the projection, so the row is generic —
     // but its lifecycle status is still truthful.
-    expect(screen.getByText('Pending')).toBeInTheDocument();
+    expect(screen.getByText('Awaiting your review')).toBeInTheDocument();
     fireEvent.click(screen.getByText('Negotiation'));
     await waitFor(() => expect(currentPath.value).toBe('/chat/ungrouped?taskId=ungrouped-task'));
   });
@@ -343,7 +343,7 @@ describe('ChatSidebar negotiations tab (IND-523)', () => {
     await openNegotiationsTab();
 
     fireEvent.click(screen.getByRole('button', { name: /Dana Okafor/ }));
-    expect(screen.getByText('No lifecycle status')).toBeInTheDocument();
+    expect(screen.getByText('Not started')).toBeInTheDocument();
     fireEvent.click(screen.getByText('Negotiation'));
     await waitFor(() => expect(currentPath.value).toBe('/chat/ungrouped'));
   });

--- a/apps/web/src/lib/__tests__/negotiation-inbox.test.ts
+++ b/apps/web/src/lib/__tests__/negotiation-inbox.test.ts
@@ -31,6 +31,7 @@ function conversation(
       parts: [{ kind: 'data', data: { action } }],
       senderId: input.senderId ?? `agent:${id}-peer`,
       createdAt: '2026-07-24T11:00:00.000Z',
+      taskId: `${id}-task`,
     },
     metadata: null,
     via: [],

--- a/apps/web/src/lib/__tests__/negotiation-inbox.test.ts
+++ b/apps/web/src/lib/__tests__/negotiation-inbox.test.ts
@@ -76,8 +76,8 @@ describe('negotiations inbox presentation', () => {
     ], 'viewer', NOW);
 
     expect(groups.yourMove.map((item) => [item.conversationId, item.status])).toEqual([
-      ['question', 'answer'],
-      ['agreement', 'agreed'],
+      ['question', 'needs_input'],
+      ['agreement', 'awaiting_review'],
     ]);
     expect(countNegotiationsRequiringAction([
       conversation('question', { state: 'input_required', action: 'ask_user', senderId: 'agent:viewer' }),
@@ -94,15 +94,15 @@ describe('negotiations inbox presentation', () => {
       conversation('accepted', { state: 'completed', opportunityStatus: 'accepted', action: 'accept', acceptedByViewer: true }),
     ], 'viewer', NOW);
 
-    expect(groups.yourMove[0]?.status).toBe('agreed');
-    expect(groups.resolved[0]?.status).toBe('accepted');
-    expect(groups.resolved[0]?.lastAction).toBe('you started the chat');
+    expect(groups.yourMove[0]?.status).toBe('awaiting_review');
+    expect(groups.resolved[0]?.status).toBe('accepted_by_viewer');
+    expect(groups.resolved[0]?.lastAction).toBe('you accepted the connection');
 
     const counterpartStarted = deriveNegotiationInbox([
       conversation('counterpart-started', { state: 'completed', opportunityStatus: 'accepted', action: 'accept' }),
     ], 'viewer', NOW);
-    expect(counterpartStarted.resolved[0]?.status).toBe('started');
-    expect(counterpartStarted.resolved[0]?.lastAction).toBe('the chat was started');
+    expect(counterpartStarted.resolved[0]?.status).toBe('connection_accepted');
+    expect(counterpartStarted.resolved[0]?.lastAction).toBe('the connection was accepted');
   });
 
   it('maps active and negative outcomes to calm lifecycle labels', () => {
@@ -113,11 +113,11 @@ describe('negotiations inbox presentation', () => {
       conversation('stalled', { state: 'completed', opportunityStatus: 'stalled', outcome: { hasOpportunity: false, reason: 'turn_cap' } }),
     ], 'viewer', NOW);
 
-    expect(groups.inProgress.map((item) => item.status).sort()).toEqual(['live', 'waiting']);
-    expect(groups.resolved.map((item) => item.status).sort()).toEqual(['rejected', 'stalled']);
-    expect(groups.resolved.find((item) => item.status === 'stalled')?.lastAction)
+    expect(groups.inProgress.map((item) => item.status).sort()).toEqual(['negotiating', 'negotiating']);
+    expect(groups.resolved.map((item) => item.status).sort()).toEqual(['no_agreement', 'no_match']);
+    expect(groups.resolved.find((item) => item.status === 'no_agreement')?.lastAction)
       .toBe('agents could not reach agreement within the turn limit');
-    expect(groups.resolved.find((item) => item.status === 'rejected')?.lastAction)
+    expect(groups.resolved.find((item) => item.status === 'no_match')?.lastAction)
       .toBe('agents did not recommend moving forward');
   });
 
@@ -142,7 +142,7 @@ describe('negotiations inbox presentation', () => {
     expect(groups.resolved).toHaveLength(1);
     const [row] = groups.resolved;
     expect(row.conversationId).toBe('gated');
-    expect(row.status).toBe('not_sent');
+    expect(row.status).toBe('not_started');
     expect(row.lastAction).toBe('Your agent did not reach out');
     expect(row.turnCount).toBe(0);
     // The row is a link to the existing card; it must not leak the reasoning

--- a/apps/web/src/lib/__tests__/negotiation-outline.test.ts
+++ b/apps/web/src/lib/__tests__/negotiation-outline.test.ts
@@ -100,6 +100,39 @@ const screenedOutConversation: ConversationSummary = {
 };
 
 describe('groupNegotiationOutline', () => {
+  it('does not leak the latest session action into another projected opportunity', () => {
+    const multiSession = {
+      ...conversation,
+      lastMessage: {
+        parts: [{ kind: 'data', data: { action: 'ask_user' } }],
+        senderId: 'agent:viewer',
+        createdAt: '2026-01-03T00:00:00.000Z',
+        taskId: 'task-b',
+      },
+      negotiationOpportunities: [
+        { ...conversation.negotiationOpportunities![0], taskId: 'task-a', state: 'working', opportunityStatus: 'negotiating', updatedAt: '2026-01-02T00:00:00.000Z' },
+        { ...conversation.negotiationOpportunities![1], taskId: 'task-b', state: 'input_required', opportunityStatus: 'negotiating', acceptedByViewer: false, outcome: null, updatedAt: '2026-01-03T00:00:00.000Z' },
+      ],
+    } satisfies ConversationSummary;
+
+    const rows = groupNegotiationOutline([multiSession], 'viewer')[0]?.opportunities ?? [];
+    expect(rows.find((row) => row.taskId === 'task-a')?.presentation.label).toBe('Negotiating');
+    expect(rows.find((row) => row.taskId === 'task-a')?.presentation.label).not.toMatch(/Awaiting your review|Needs your input/);
+    expect(rows.find((row) => row.taskId === 'task-b')?.presentation.label).toBe('Needs your input');
+  });
+
+  it('uses a fallback turn only when it belongs to the latest lifecycle task', () => {
+    const matching = {
+      ...ungroupableConversation,
+      negotiation: { ...ungroupableConversation.negotiation!, state: 'input_required', opportunityStatus: 'negotiating' },
+      lastMessage: { parts: [{ kind: 'data', data: { action: 'ask_user' } }], senderId: 'agent:viewer', createdAt: '2026-01-04T00:00:00.000Z', taskId: '07979837-5e29-4dd9-83dc-26f593972ca6' },
+    } satisfies ConversationSummary;
+    const mismatched = { ...matching, lastMessage: { ...matching.lastMessage, taskId: 'another-task' } };
+
+    expect(groupNegotiationOutline([matching], 'viewer')[0]?.opportunities[0]?.presentation.label).toBe('Needs your input');
+    expect(groupNegotiationOutline([mismatched], 'viewer')[0]?.opportunities[0]?.presentation.label).toBe('Negotiating');
+  });
+
   it('groups multiple opportunity sessions under one counterparty and retains their task ids', () => {
     const groups = groupNegotiationOutline([conversation], 'viewer');
 

--- a/apps/web/src/lib/__tests__/negotiation-outline.test.ts
+++ b/apps/web/src/lib/__tests__/negotiation-outline.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from 'vitest';
 import { countNegotiationsRequiringAction } from '@/lib/negotiation-inbox';
-import { groupNegotiationOutline, opportunityStatusPresentation } from '@/lib/negotiation-outline';
+import { groupNegotiationOutline } from '@/lib/negotiation-outline';
+import { presentationForStatus } from '@/lib/negotiation-presentation';
 import type { ConversationSummary } from '@/services/conversation';
 
 const lastMessage: NonNullable<ConversationSummary['lastMessage']> = {
@@ -120,7 +121,7 @@ describe('groupNegotiationOutline', () => {
       opportunityId: '6426226c-9d63-42a9-8aea-764bbe0c5b8b',
       taskId: '07979837-5e29-4dd9-83dc-26f593972ca6',
       title: 'Negotiation',
-      status: 'pending',
+      presentation: expect.objectContaining({ label: 'Awaiting your review', status: 'awaiting_review' }),
       updatedAt: '2026-01-04T00:00:00.000Z',
       ungrouped: true,
     }]);
@@ -145,7 +146,7 @@ describe('groupNegotiationOutline', () => {
     expect(asOwner[0]?.opportunities).toMatchObject([{
       conversationId: 'c5e8a825-ddcb-479c-b8dc-a8ad05690d71',
       taskId: '7bfba641-245c-4a92-9269-a798eba5c9e7',
-      status: 'rejected',
+      presentation: expect.objectContaining({ label: 'No match', status: 'no_match' }),
       ungrouped: true,
     }]);
 
@@ -169,9 +170,9 @@ describe('groupNegotiationOutline', () => {
     expect(listed).toContain(ungroupableConversation.id);
   });
 
-  it('uses only supported lifecycle labels', () => {
-    expect(opportunityStatusPresentation.accepted.label).toBe('Accepted');
-    expect(opportunityStatusPresentation.negotiating.label).toBe('Negotiating');
-    expect(Object.keys(opportunityStatusPresentation)).not.toContain('exploring');
+  it('uses only agreed user-facing lifecycle labels', () => {
+    expect(presentationForStatus('awaiting_review').label).toBe('Awaiting your review');
+    expect(presentationForStatus('negotiating').label).toBe('Negotiating');
+    expect(presentationForStatus('no_match').label).toBe('No match');
   });
 });

--- a/apps/web/src/lib/__tests__/negotiation-presentation.test.ts
+++ b/apps/web/src/lib/__tests__/negotiation-presentation.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, it } from 'vitest';
+
+import { deriveNegotiationPresentation } from '@/lib/negotiation-presentation';
+import type { ConversationNegotiationLifecycle } from '@/services/conversation';
+
+function lifecycle(input: Partial<ConversationNegotiationLifecycle> = {}): ConversationNegotiationLifecycle {
+  return {
+    taskId: 'task', state: 'working', statusTimestamp: null, opportunityId: 'opportunity', opportunityStatus: 'negotiating', acceptedByViewer: false, turnCount: 1, maxTurns: 6, signalCount: 1, outcome: null, updatedAt: '2026-08-19T00:00:00.000Z', ...input,
+  };
+}
+
+describe('deriveNegotiationPresentation', () => {
+  it.each([
+    ['input required by the viewer agent', lifecycle({ state: 'input_required' }), 'ask_user', 'agent:viewer', 'needs_input', 'Needs your input'],
+    ['successful pending opportunity', lifecycle({ state: 'completed', opportunityStatus: 'pending', outcome: { hasOpportunity: true, reason: null } }), 'accept', 'agent:peer', 'awaiting_review', 'Awaiting your review'],
+    ['in-flight task', lifecycle(), 'counter', 'agent:peer', 'negotiating', 'Negotiating'],
+    ['viewer accepted', lifecycle({ state: 'completed', opportunityStatus: 'accepted', acceptedByViewer: true }), 'accept', 'agent:viewer', 'accepted_by_viewer', 'Accepted by you'],
+    ['counterparty accepted', lifecycle({ state: 'completed', opportunityStatus: 'accepted' }), 'accept', 'agent:peer', 'connection_accepted', 'Connection accepted'],
+    ['rejected opportunity', lifecycle({ state: 'completed', opportunityStatus: 'rejected' }), 'decline', 'agent:peer', 'no_match', 'No match'],
+    ['stalled outcome', lifecycle({ state: 'completed', opportunityStatus: 'stalled', outcome: { hasOpportunity: false, reason: 'turn_cap' } }), null, null, 'no_agreement', 'No agreement'],
+    ['expired opportunity', lifecycle({ state: 'completed', opportunityStatus: 'expired' }), null, null, 'expired', 'Expired'],
+    ['terminal task failure', lifecycle({ state: 'failed', opportunityStatus: 'negotiating' }), null, null, 'couldnt_complete', 'Couldn\'t complete'],
+    ['cancelled task', lifecycle({ state: 'canceled', opportunityStatus: 'negotiating' }), null, null, 'couldnt_complete', 'Couldn\'t complete'],
+    ['task requiring authorization', lifecycle({ state: 'auth_required', opportunityStatus: 'negotiating' }), null, null, 'couldnt_complete', 'Couldn\'t complete'],
+    ['rejected task', lifecycle({ state: 'rejected', opportunityStatus: 'negotiating' }), 'decline', 'agent:peer', 'no_match', 'No match'],
+    ['draft opportunity', lifecycle({ state: 'submitted', opportunityStatus: 'draft', turnCount: 0 }), null, null, 'not_started', 'Not started'],
+    ['latent opportunity', lifecycle({ state: 'submitted', opportunityStatus: 'latent', turnCount: 0 }), null, null, 'not_started', 'Not started'],
+  ])('%s is presented as %s', (_case, value, action, senderId, status, label) => {
+    const presentation = deriveNegotiationPresentation({ lifecycle: value, latestAction: action, latestSenderId: senderId, viewerUserId: 'viewer' });
+    expect(presentation).toMatchObject({ status, label });
+  });
+
+  it('does not treat another agent’s request for guidance as the viewer’s action', () => {
+    expect(deriveNegotiationPresentation({
+      lifecycle: lifecycle({ state: 'input_required' }), latestAction: 'ask_user', latestSenderId: 'agent:peer', viewerUserId: 'viewer',
+    }).status).toBe('negotiating');
+  });
+});

--- a/apps/web/src/lib/__tests__/negotiation-presentation.test.ts
+++ b/apps/web/src/lib/__tests__/negotiation-presentation.test.ts
@@ -35,4 +35,18 @@ describe('deriveNegotiationPresentation', () => {
       lifecycle: lifecycle({ state: 'input_required' }), latestAction: 'ask_user', latestSenderId: 'agent:peer', viewerUserId: 'viewer',
     }).status).toBe('negotiating');
   });
+
+  it.each([
+    ['stale request for guidance', lifecycle({ state: 'input_required', opportunityStatus: 'stalled' }), 'ask_user', 'agent:viewer'],
+    ['stale acceptance', lifecycle({ state: 'completed', opportunityStatus: 'stalled', outcome: { hasOpportunity: true, reason: null } }), 'accept', 'agent:peer'],
+  ])('keeps a stalled opportunity authoritative over %s', (_case, value, action, senderId) => {
+    expect(deriveNegotiationPresentation({ lifecycle: value, latestAction: action, latestSenderId: senderId, viewerUserId: 'viewer' }))
+      .toMatchObject({ status: 'no_agreement', label: 'No agreement' });
+  });
+
+  it.each(['draft', 'latent'] as const)('does not promote a %s opportunity from a stale acceptance', (opportunityStatus) => {
+    expect(deriveNegotiationPresentation({
+      lifecycle: lifecycle({ state: 'submitted', opportunityStatus }), latestAction: 'accept', latestSenderId: 'agent:peer', viewerUserId: 'viewer',
+    }).status).toBe('not_started');
+  });
 });

--- a/apps/web/src/lib/negotiation-chips.ts
+++ b/apps/web/src/lib/negotiation-chips.ts
@@ -1,30 +1,10 @@
 import type { NegotiationInboxItem, NegotiationInboxStatus } from '@/lib/negotiation-inbox';
+import { presentationForStatus } from '@/lib/negotiation-presentation';
 
-// Copied from NegotiationsInbox.tsx so the /chat tab renders the same chips as
-// the inbox without the two surfaces diverging. NegotiationsInbox keeps its
-// local copies for now; dedupe into this module is a follow-up cleanup.
-export const CHIP_CLASS: Record<NegotiationInboxStatus, string> = {
-  answer: 'border-[#041729] bg-[#041729] text-white',
-  agreed: 'border-emerald-200 bg-emerald-50 text-emerald-700',
-  live: 'border-amber-200 bg-amber-50 text-amber-700',
-  waiting: 'border-gray-200 bg-gray-100 text-gray-600',
-  accepted: 'border-emerald-200 bg-emerald-50 text-emerald-700',
-  started: 'border-emerald-200 bg-emerald-50 text-emerald-700',
-  rejected: 'border-red-200 bg-red-50 text-red-700',
-  stalled: 'border-amber-200 bg-amber-50 text-amber-700',
-  not_sent: 'border-gray-200 bg-gray-100 text-gray-600',
-};
+export function chipClass(status: NegotiationInboxStatus): string {
+  return presentationForStatus(status).chipClass;
+}
 
 export function statusLabel(item: NegotiationInboxItem): string {
-  switch (item.status) {
-    case 'answer': return 'Answer your agent';
-    case 'agreed': return 'Agents agreed';
-    case 'live': return `● Live · turn ${item.turnCount} of ${item.maxTurns}`;
-    case 'waiting': return 'Waiting on their agent';
-    case 'accepted': return 'Accepted by you';
-    case 'started': return 'Chat started';
-    case 'rejected': return 'No opportunity';
-    case 'stalled': return 'Stalled';
-    case 'not_sent': return 'Not sent';
-  }
+  return presentationForStatus(item.status).label;
 }

--- a/apps/web/src/lib/negotiation-inbox.ts
+++ b/apps/web/src/lib/negotiation-inbox.ts
@@ -44,6 +44,16 @@ export function readLastTurn(parts: unknown[]): LastTurnData {
   return { action: null };
 }
 
+/**
+ * Conversation summaries contain one last message, while a durable A2A
+ * conversation can contain several task sessions. Only use that message to
+ * classify a task when its projected task id proves the session relationship.
+ */
+export function sessionScopedLastTurn(conversation: ConversationSummary, taskId: string | null | undefined): LastTurnData & { senderId: string | null } {
+  if (!taskId || conversation.lastMessage?.taskId !== taskId) return { action: null, senderId: null };
+  return { ...readLastTurn(conversation.lastMessage.parts), senderId: conversation.lastMessage.senderId };
+}
+
 function formatTimeAgo(timestamp: number, now: number): string {
   const seconds = Math.max(0, Math.floor((now - timestamp) / 1000));
   if (seconds < 60) return 'just now';
@@ -87,14 +97,15 @@ function describeResolved(status: NegotiationInboxStatus, reason: string | null)
   return 'agents did not recommend moving forward';
 }
 
-function classifyConversation(conversation: ConversationSummary, action: string | null, viewerUserId: string | undefined): {
+function classifyConversation(conversation: ConversationSummary, viewerUserId: string | undefined): {
   group: NegotiationInboxGroup;
   status: NegotiationInboxStatus;
 } {
+  const latestTurn = sessionScopedLastTurn(conversation, conversation.negotiation?.taskId);
   const presentation = deriveNegotiationPresentation({
     lifecycle: conversation.negotiation,
-    latestAction: action,
-    latestSenderId: conversation.lastMessage?.senderId,
+    latestAction: latestTurn.action,
+    latestSenderId: latestTurn.senderId,
     viewerUserId,
   });
   return { group: presentation.group, status: presentation.status };
@@ -180,7 +191,7 @@ export function deriveNegotiationInbox(
     }
 
     const lastTurn = readLastTurn(conversation.lastMessage.parts);
-    const classification = classifyConversation(conversation, lastTurn.action, viewerUserId);
+    const classification = classifyConversation(conversation, viewerUserId);
     const lifecycle = conversation.negotiation;
     const sortTimestamp = new Date(
       lifecycle?.updatedAt

--- a/apps/web/src/lib/negotiation-inbox.ts
+++ b/apps/web/src/lib/negotiation-inbox.ts
@@ -1,17 +1,8 @@
 import type { ConversationSummary } from '@/services/conversation';
+import { deriveNegotiationPresentation, type NegotiationPresentationStatus } from '@/lib/negotiation-presentation';
 
 export type NegotiationInboxGroup = 'your_move' | 'in_progress' | 'resolved';
-export type NegotiationInboxStatus =
-  | 'answer'
-  | 'agreed'
-  | 'live'
-  | 'waiting'
-  | 'accepted'
-  | 'started'
-  | 'rejected'
-  | 'stalled'
-  /** IND-610: the owner's own agent declined before any contact. Owner-only. */
-  | 'not_sent';
+export type NegotiationInboxStatus = NegotiationPresentationStatus;
 
 export interface NegotiationCounterpart {
   id: string;
@@ -38,14 +29,11 @@ export interface NegotiationInboxGroups {
   resolved: NegotiationInboxItem[];
 }
 
-interface LastTurnData {
+export interface LastTurnData {
   action: string | null;
 }
 
-const REJECT_ACTIONS = new Set(['reject', 'decline', 'withdraw']);
-const STALL_REASONS = new Set(['turn_cap', 'timeout']);
-
-function readLastTurn(parts: unknown[]): LastTurnData {
+export function readLastTurn(parts: unknown[]): LastTurnData {
   for (const part of parts) {
     if (typeof part !== 'object' || part === null || Array.isArray(part)) continue;
     const record = part as Record<string, unknown>;
@@ -86,13 +74,15 @@ function describeAction(action: string | null, isOwnAgent: boolean): string {
 }
 
 function describeResolved(status: NegotiationInboxStatus, reason: string | null): string {
-  if (status === 'accepted') return 'you started the chat';
-  if (status === 'started') return 'the chat was started';
-  if (status === 'stalled') {
+  if (status === 'accepted_by_viewer') return 'you accepted the connection';
+  if (status === 'connection_accepted') return 'the connection was accepted';
+  if (status === 'no_agreement') {
     return reason === 'timeout'
       ? 'the dialogue ended before the agents reached agreement'
       : 'agents could not reach agreement within the turn limit';
   }
+  if (status === 'couldnt_complete') return 'the negotiation could not complete';
+  if (status === 'expired') return 'the opportunity expired';
   if (reason === 'screened_out') return 'agents did not find enough mutual value to continue';
   return 'agents did not recommend moving forward';
 }
@@ -101,38 +91,13 @@ function classifyConversation(conversation: ConversationSummary, action: string 
   group: NegotiationInboxGroup;
   status: NegotiationInboxStatus;
 } {
-  const lifecycle = conversation.negotiation;
-  const opportunityStatus = lifecycle?.opportunityStatus;
-
-  if (opportunityStatus === 'accepted') {
-    return { group: 'resolved', status: lifecycle?.acceptedByViewer ? 'accepted' : 'started' };
-  }
-  if (opportunityStatus === 'rejected') return { group: 'resolved', status: 'rejected' };
-  if (opportunityStatus === 'stalled' || opportunityStatus === 'expired') {
-    return { group: 'resolved', status: 'stalled' };
-  }
-  if (lifecycle?.state === 'input_required' && action === 'ask_user' && conversation.lastMessage?.senderId === `agent:${viewerUserId}`) {
-    return { group: 'your_move', status: 'answer' };
-  }
-  if (opportunityStatus === 'pending') return { group: 'your_move', status: 'agreed' };
-
-  if (lifecycle?.outcome?.hasOpportunity === true) return { group: 'your_move', status: 'agreed' };
-  if (lifecycle?.outcome?.hasOpportunity === false) {
-    return STALL_REASONS.has(lifecycle.outcome.reason ?? '')
-      ? { group: 'resolved', status: 'stalled' }
-      : { group: 'resolved', status: 'rejected' };
-  }
-  if (lifecycle && ['failed', 'canceled', 'auth_required'].includes(lifecycle.state)) {
-    return { group: 'resolved', status: 'stalled' };
-  }
-  if (lifecycle?.state === 'rejected' || (action && REJECT_ACTIONS.has(action))) {
-    return { group: 'resolved', status: 'rejected' };
-  }
-  if (action === 'accept') return { group: 'your_move', status: 'agreed' };
-
-  return lifecycle?.turnCount && lifecycle.turnCount > 0
-    ? { group: 'in_progress', status: 'live' }
-    : { group: 'in_progress', status: 'waiting' };
+  const presentation = deriveNegotiationPresentation({
+    lifecycle: conversation.negotiation,
+    latestAction: action,
+    latestSenderId: conversation.lastMessage?.senderId,
+    viewerUserId,
+  });
+  return { group: presentation.group, status: presentation.status };
 }
 
 /**
@@ -204,7 +169,7 @@ export function deriveNegotiationInbox(
         conversationId: conversation.id,
         counterpart,
         group: 'resolved',
-        status: 'not_sent',
+        status: 'not_started',
         signalCount: Math.max(conversation.negotiation?.signalCount ?? 0, conversation.via.length),
         lastAction: 'Your agent did not reach out',
         timeAgo: formatTimeAgo(gateSafeTimestamp, now),
@@ -245,7 +210,7 @@ export function deriveNegotiationInbox(
   const byNewest = (left: NegotiationInboxItem, right: NegotiationInboxItem) => right.sortTimestamp - left.sortTimestamp;
   const yourMove = items
     .filter((item) => item.group === 'your_move')
-    .sort((left, right) => (left.status === right.status ? byNewest(left, right) : left.status === 'answer' ? -1 : 1));
+    .sort((left, right) => (left.status === right.status ? byNewest(left, right) : left.status === 'needs_input' ? -1 : 1));
 
   return {
     yourMove,

--- a/apps/web/src/lib/negotiation-outline.ts
+++ b/apps/web/src/lib/negotiation-outline.ts
@@ -1,4 +1,4 @@
-import { isVisibleNegotiationConversation, readLastTurn, resolveNegotiationCounterpart } from '@/lib/negotiation-inbox';
+import { isVisibleNegotiationConversation, resolveNegotiationCounterpart, sessionScopedLastTurn } from '@/lib/negotiation-inbox';
 import { deriveNegotiationPresentation, type NegotiationPresentation } from '@/lib/negotiation-presentation';
 import type { ConversationSummary } from '@/services/conversation';
 
@@ -52,7 +52,9 @@ function buildFallbackOpportunity(
   viewerUserId: string | undefined,
 ): NegotiationOutlineOpportunity {
   const lifecycle = conversation.negotiation ?? null;
-  const lastTurn = readLastTurn(conversation.lastMessage?.parts ?? []);
+  // `negotiation` is the latest task projection; the message is eligible only
+  // when its task id confirms it is from that same session.
+  const lastTurn = sessionScopedLastTurn(conversation, lifecycle?.taskId);
   return {
     conversationId: conversation.id,
     counterpartId,
@@ -62,7 +64,7 @@ function buildFallbackOpportunity(
     presentation: deriveNegotiationPresentation({
       lifecycle,
       latestAction: lastTurn.action,
-      latestSenderId: conversation.lastMessage?.senderId,
+      latestSenderId: lastTurn.senderId,
       viewerUserId,
     }),
     updatedAt: lifecycle?.updatedAt ?? conversation.lastMessageAt ?? conversation.createdAt,
@@ -101,7 +103,8 @@ export function groupNegotiationOutline(
       group.opportunities.push(buildFallbackOpportunity(conversation, counterpart.id, viewerUserId));
     } else {
       for (const opportunity of projected) {
-        const lastTurn = readLastTurn(conversation.lastMessage?.parts ?? []);
+        // Do not leak the conversation's latest turn across task sessions.
+        const lastTurn = sessionScopedLastTurn(conversation, opportunity.taskId);
         group.opportunities.push({
           conversationId: conversation.id,
           counterpartId: counterpart.id,
@@ -111,7 +114,7 @@ export function groupNegotiationOutline(
           presentation: deriveNegotiationPresentation({
             lifecycle: opportunity,
             latestAction: lastTurn.action,
-            latestSenderId: conversation.lastMessage?.senderId,
+            latestSenderId: lastTurn.senderId,
             viewerUserId,
           }),
           updatedAt: opportunity.updatedAt,

--- a/apps/web/src/lib/negotiation-outline.ts
+++ b/apps/web/src/lib/negotiation-outline.ts
@@ -1,5 +1,6 @@
-import { isVisibleNegotiationConversation, resolveNegotiationCounterpart } from '@/lib/negotiation-inbox';
-import type { ConversationSummary, NegotiationOpportunityStatus } from '@/services/conversation';
+import { isVisibleNegotiationConversation, readLastTurn, resolveNegotiationCounterpart } from '@/lib/negotiation-inbox';
+import { deriveNegotiationPresentation, type NegotiationPresentation } from '@/lib/negotiation-presentation';
+import type { ConversationSummary } from '@/services/conversation';
 
 export interface NegotiationOutlineOpportunity {
   conversationId: string;
@@ -9,7 +10,7 @@ export interface NegotiationOutlineOpportunity {
   /** Null when no task session is addressable; the row then opens the latest one. */
   taskId: string | null;
   title: string;
-  status: NegotiationOpportunityStatus | null;
+  presentation: NegotiationPresentation;
   updatedAt: string;
   /**
    * True for a fallback row standing in for a conversation the opportunity
@@ -48,15 +49,22 @@ function timestampOf(value: string | null | undefined): number {
 function buildFallbackOpportunity(
   conversation: ConversationSummary,
   counterpartId: string,
+  viewerUserId: string | undefined,
 ): NegotiationOutlineOpportunity {
   const lifecycle = conversation.negotiation ?? null;
+  const lastTurn = readLastTurn(conversation.lastMessage?.parts ?? []);
   return {
     conversationId: conversation.id,
     counterpartId,
     opportunityId: lifecycle?.opportunityId ?? null,
     taskId: lifecycle?.taskId ?? null,
     title: conversation.via[0]?.title ?? conversation.metadata?.title ?? 'Negotiation',
-    status: lifecycle?.opportunityStatus ?? null,
+    presentation: deriveNegotiationPresentation({
+      lifecycle,
+      latestAction: lastTurn.action,
+      latestSenderId: conversation.lastMessage?.senderId,
+      viewerUserId,
+    }),
     updatedAt: lifecycle?.updatedAt ?? conversation.lastMessageAt ?? conversation.createdAt,
     ungrouped: true,
   };
@@ -90,16 +98,22 @@ export function groupNegotiationOutline(
     };
     const projected = conversation.negotiationOpportunities ?? [];
     if (projected.length === 0) {
-      group.opportunities.push(buildFallbackOpportunity(conversation, counterpart.id));
+      group.opportunities.push(buildFallbackOpportunity(conversation, counterpart.id, viewerUserId));
     } else {
       for (const opportunity of projected) {
+        const lastTurn = readLastTurn(conversation.lastMessage?.parts ?? []);
         group.opportunities.push({
           conversationId: conversation.id,
           counterpartId: counterpart.id,
           opportunityId: opportunity.opportunityId,
           taskId: opportunity.taskId,
           title: opportunity.title,
-          status: opportunity.opportunityStatus,
+          presentation: deriveNegotiationPresentation({
+            lifecycle: opportunity,
+            latestAction: lastTurn.action,
+            latestSenderId: conversation.lastMessage?.senderId,
+            viewerUserId,
+          }),
           updatedAt: opportunity.updatedAt,
           ungrouped: false,
         });
@@ -119,14 +133,3 @@ export function groupNegotiationOutline(
       timestampOf(right.opportunities[0]?.updatedAt) - timestampOf(left.opportunities[0]?.updatedAt)
     ));
 }
-
-export const opportunityStatusPresentation: Record<NegotiationOpportunityStatus, { label: string; dotClass: string }> = {
-  latent: { label: 'Latent', dotClass: 'bg-gray-400' },
-  draft: { label: 'Draft', dotClass: 'bg-gray-400' },
-  negotiating: { label: 'Negotiating', dotClass: 'bg-amber-500' },
-  pending: { label: 'Pending', dotClass: 'bg-amber-500' },
-  stalled: { label: 'Stalled', dotClass: 'bg-amber-500' },
-  accepted: { label: 'Accepted', dotClass: 'bg-emerald-600' },
-  rejected: { label: 'Rejected', dotClass: 'bg-red-600' },
-  expired: { label: 'Expired', dotClass: 'bg-gray-400' },
-};

--- a/apps/web/src/lib/negotiation-presence.ts
+++ b/apps/web/src/lib/negotiation-presence.ts
@@ -3,10 +3,10 @@ import type { ConversationSummary } from '@/services/conversation';
 
 /**
  * In-flight statuses: the agents are still talking (the negotiation has not
- * resolved and is not waiting on a human accept). 'answer' is in-flight too —
- * the negotiation continues once the viewer replies.
+ * resolved and is not waiting on a human accept). A request for the viewer's
+ * input is in-flight too — the negotiation continues once they reply.
  */
-const IN_FLIGHT_STATUSES: ReadonlySet<NegotiationInboxStatus> = new Set(['answer', 'live', 'waiting']);
+const IN_FLIGHT_STATUSES: ReadonlySet<NegotiationInboxStatus> = new Set(['needs_input', 'negotiating']);
 
 export interface LiveNegotiation extends NegotiationInboxItem {
   /** Opportunity this negotiation is about (null for pre-opportunity dialogues). */

--- a/apps/web/src/lib/negotiation-presentation.ts
+++ b/apps/web/src/lib/negotiation-presentation.ts
@@ -63,25 +63,27 @@ export function deriveNegotiationPresentation(input: {
   const opportunityStatus = lifecycle.opportunityStatus;
   const outcome = lifecycle.outcome;
 
-  // An opportunity's completed human decision is authoritative over stale task
-  // snapshots. The rest is ordered by the negotiation's latest known outcome.
+  // Opportunity terminal states are authoritative over stale task snapshots,
+  // outcomes, and turns. Draft/latent rows likewise cannot be promoted by a
+  // turn from another session.
   if (opportunityStatus === 'accepted') {
     return lifecycle.acceptedByViewer ? PRESENTATIONS.accepted_by_viewer : PRESENTATIONS.connection_accepted;
   }
   if (opportunityStatus === 'rejected') return PRESENTATIONS.no_match;
+  if (opportunityStatus === 'stalled') return PRESENTATIONS.no_agreement;
   if (opportunityStatus === 'expired') return PRESENTATIONS.expired;
+  if (opportunityStatus === 'latent' || opportunityStatus === 'draft') return PRESENTATIONS.not_started;
+  if (STALL_REASONS.has(outcome?.reason ?? '')) return PRESENTATIONS.no_agreement;
   if (lifecycle.state === 'input_required' && latestAction === 'ask_user' && isViewerAgent) {
     return PRESENTATIONS.needs_input;
   }
   if (opportunityStatus === 'pending' || outcome?.hasOpportunity === true || latestAction === 'accept') {
     return PRESENTATIONS.awaiting_review;
   }
-  if (opportunityStatus === 'stalled' || STALL_REASONS.has(outcome?.reason ?? '')) return PRESENTATIONS.no_agreement;
   if (['failed', 'canceled', 'auth_required'].includes(lifecycle.state)) return PRESENTATIONS.couldnt_complete;
   if (lifecycle.state === 'rejected' || outcome?.hasOpportunity === false || (latestAction && REJECT_ACTIONS.has(latestAction))) {
     return PRESENTATIONS.no_match;
   }
-  if (opportunityStatus === 'latent' || opportunityStatus === 'draft') return PRESENTATIONS.not_started;
   if (lifecycle.state === 'completed') return PRESENTATIONS.no_agreement;
   if (['submitted', 'working', 'waiting_for_agent', 'claimed', 'input_required'].includes(lifecycle.state) || opportunityStatus === 'negotiating') {
     return PRESENTATIONS.negotiating;

--- a/apps/web/src/lib/negotiation-presentation.ts
+++ b/apps/web/src/lib/negotiation-presentation.ts
@@ -1,0 +1,90 @@
+import type { ConversationNegotiationLifecycle, ConversationNegotiationOpportunity } from '@/services/conversation';
+
+export type NegotiationPresentationStatus =
+  | 'needs_input'
+  | 'awaiting_review'
+  | 'negotiating'
+  | 'accepted_by_viewer'
+  | 'connection_accepted'
+  | 'no_match'
+  | 'no_agreement'
+  | 'expired'
+  | 'couldnt_complete'
+  | 'not_started';
+
+export type NegotiationPresentationGroup = 'your_move' | 'in_progress' | 'resolved';
+
+export interface NegotiationPresentation {
+  status: NegotiationPresentationStatus;
+  group: NegotiationPresentationGroup;
+  label: string;
+  /** Shared by the compact rail dot and the inbox chip. */
+  dotClass: string;
+  chipClass: string;
+}
+
+type Lifecycle = ConversationNegotiationLifecycle | ConversationNegotiationOpportunity | null | undefined;
+
+const PRESENTATIONS: Record<NegotiationPresentationStatus, NegotiationPresentation> = {
+  needs_input: { status: 'needs_input', group: 'your_move', label: 'Needs your input', dotClass: 'bg-[#041729]', chipClass: 'border-[#041729] bg-[#041729] text-white' },
+  awaiting_review: { status: 'awaiting_review', group: 'your_move', label: 'Awaiting your review', dotClass: 'bg-amber-500', chipClass: 'border-amber-200 bg-amber-50 text-amber-700' },
+  negotiating: { status: 'negotiating', group: 'in_progress', label: 'Negotiating', dotClass: 'bg-amber-500', chipClass: 'border-amber-200 bg-amber-50 text-amber-700' },
+  accepted_by_viewer: { status: 'accepted_by_viewer', group: 'resolved', label: 'Accepted by you', dotClass: 'bg-emerald-600', chipClass: 'border-emerald-200 bg-emerald-50 text-emerald-700' },
+  connection_accepted: { status: 'connection_accepted', group: 'resolved', label: 'Connection accepted', dotClass: 'bg-emerald-600', chipClass: 'border-emerald-200 bg-emerald-50 text-emerald-700' },
+  no_match: { status: 'no_match', group: 'resolved', label: 'No match', dotClass: 'bg-red-600', chipClass: 'border-red-200 bg-red-50 text-red-700' },
+  no_agreement: { status: 'no_agreement', group: 'resolved', label: 'No agreement', dotClass: 'bg-gray-400', chipClass: 'border-gray-200 bg-gray-100 text-gray-600' },
+  expired: { status: 'expired', group: 'resolved', label: 'Expired', dotClass: 'bg-gray-400', chipClass: 'border-gray-200 bg-gray-100 text-gray-600' },
+  couldnt_complete: { status: 'couldnt_complete', group: 'resolved', label: 'Couldn\'t complete', dotClass: 'bg-gray-400', chipClass: 'border-gray-200 bg-gray-100 text-gray-600' },
+  not_started: { status: 'not_started', group: 'in_progress', label: 'Not started', dotClass: 'bg-gray-400', chipClass: 'border-gray-200 bg-gray-100 text-gray-600' },
+};
+
+export function presentationForStatus(status: NegotiationPresentationStatus): NegotiationPresentation {
+  return PRESENTATIONS[status];
+}
+
+const REJECT_ACTIONS = new Set(['reject', 'decline', 'withdraw']);
+const STALL_REASONS = new Set(['turn_cap', 'timeout']);
+
+/**
+ * Converts database lifecycle fields into the single state a viewer needs to
+ * understand. This is deliberately the only presentation path for the inbox
+ * and chat rail: neither surface should expose a raw task or opportunity state.
+ */
+export function deriveNegotiationPresentation(input: {
+  lifecycle: Lifecycle;
+  latestAction?: string | null;
+  latestSenderId?: string | null;
+  viewerUserId?: string;
+}): NegotiationPresentation {
+  const { lifecycle, latestAction } = input;
+  if (!lifecycle) return PRESENTATIONS.not_started;
+
+  const isViewerAgent = input.latestSenderId === `agent:${input.viewerUserId}`;
+  const opportunityStatus = lifecycle.opportunityStatus;
+  const outcome = lifecycle.outcome;
+
+  // An opportunity's completed human decision is authoritative over stale task
+  // snapshots. The rest is ordered by the negotiation's latest known outcome.
+  if (opportunityStatus === 'accepted') {
+    return lifecycle.acceptedByViewer ? PRESENTATIONS.accepted_by_viewer : PRESENTATIONS.connection_accepted;
+  }
+  if (opportunityStatus === 'rejected') return PRESENTATIONS.no_match;
+  if (opportunityStatus === 'expired') return PRESENTATIONS.expired;
+  if (lifecycle.state === 'input_required' && latestAction === 'ask_user' && isViewerAgent) {
+    return PRESENTATIONS.needs_input;
+  }
+  if (opportunityStatus === 'pending' || outcome?.hasOpportunity === true || latestAction === 'accept') {
+    return PRESENTATIONS.awaiting_review;
+  }
+  if (opportunityStatus === 'stalled' || STALL_REASONS.has(outcome?.reason ?? '')) return PRESENTATIONS.no_agreement;
+  if (['failed', 'canceled', 'auth_required'].includes(lifecycle.state)) return PRESENTATIONS.couldnt_complete;
+  if (lifecycle.state === 'rejected' || outcome?.hasOpportunity === false || (latestAction && REJECT_ACTIONS.has(latestAction))) {
+    return PRESENTATIONS.no_match;
+  }
+  if (opportunityStatus === 'latent' || opportunityStatus === 'draft') return PRESENTATIONS.not_started;
+  if (lifecycle.state === 'completed') return PRESENTATIONS.no_agreement;
+  if (['submitted', 'working', 'waiting_for_agent', 'claimed', 'input_required'].includes(lifecycle.state) || opportunityStatus === 'negotiating') {
+    return PRESENTATIONS.negotiating;
+  }
+  return PRESENTATIONS.not_started;
+}

--- a/apps/web/src/services/conversation.ts
+++ b/apps/web/src/services/conversation.ts
@@ -69,7 +69,8 @@ export interface ConversationNegotiationOpportunity extends Omit<ConversationNeg
 export interface ConversationSummary {
   id: string;
   participants: { participantId: string; participantType: 'user' | 'agent'; name: string | null; avatar: string | null; ownerName?: string | null }[];
-  lastMessage: { parts: unknown[]; senderId: string; createdAt: string } | null;
+  /** The task session that produced the latest message, when it has one. */
+  lastMessage: { parts: unknown[]; senderId: string; createdAt: string; taskId?: string | null } | null;
   metadata: { title?: string; shareToken?: string } | null;
   /** Viewer-scoped opportunity signal provenance, latest first. */
   via: Array<{ intentId: string; opportunityId: string; title: string }>;

--- a/services/api/src/adapters/conversation.database.adapter.ts
+++ b/services/api/src/adapters/conversation.database.adapter.ts
@@ -682,6 +682,7 @@ export class ConversationDatabaseAdapter {
           parts: schema.messages.parts,
           senderId: schema.messages.senderId,
           createdAt: schema.messages.createdAt,
+          taskId: schema.messages.taskId,
         })
         .from(schema.messages)
         .where(inArray(schema.messages.conversationId, ids))
@@ -852,7 +853,7 @@ export class ConversationDatabaseAdapter {
       participantsByConv.set(p.conversationId, list);
     }
 
-    const lastMessageByConv = new Map<string, { parts: unknown[]; senderId: string; createdAt: Date }>();
+    const lastMessageByConv = new Map<string, { parts: unknown[]; senderId: string; createdAt: Date; taskId: string | null }>();
     for (const r of lastMessages) {
       const hiddenAt = hiddenAtByConv.get(r.conversationId);
       if (hiddenAt && r.createdAt <= hiddenAt) continue;
@@ -860,6 +861,7 @@ export class ConversationDatabaseAdapter {
         parts: r.parts as unknown[],
         senderId: r.senderId,
         createdAt: r.createdAt,
+        taskId: r.taskId,
       });
     }
 

--- a/services/api/src/adapters/database.shared.ts
+++ b/services/api/src/adapters/database.shared.ts
@@ -717,7 +717,8 @@ export interface ConversationSummary {
   createdAt: Date;
   updatedAt: Date;
   participants: ResolvedParticipant[];
-  lastMessage: { parts: unknown[]; senderId: string; createdAt: Date } | null;
+  /** The task session that produced the latest message, when it has one. */
+  lastMessage: { parts: unknown[]; senderId: string; createdAt: Date; taskId: string | null } | null;
   metadata: Record<string, unknown> | null;
   via: Array<{ intentId: string; opportunityId: string; title: string }>;
   unreadCount: number;


### PR DESCRIPTION
## Summary

Centralizes negotiation lifecycle presentation so the Chat sidebar and Negotiations inbox derive one user-facing state from task lifecycle, opportunity lifecycle, latest action, and viewer identity.

The successful-agent-outcome plus pending-opportunity case now reads **Awaiting your review** in both surfaces. The shared vocabulary also distinguishes viewer acceptance, counterparty acceptance, input needed, active negotiation, no match, no agreement, expired, failures, and not-started states.

## Root cause

The Chat outline retained only the raw opportunity status and rendered it directly, so a completed negotiation with a pending opportunity appeared unfinished as “Pending.” The inbox had a separate derivation with different terminology.

## Validation

- `bun --cwd apps/web test src/lib/__tests__/negotiation-presentation.test.ts src/lib/__tests__/negotiation-inbox.test.ts src/lib/__tests__/negotiation-outline.test.ts src/components/__tests__/ChatSidebar.test.tsx` (39 passing)
- `bun --cwd apps/web lint` (passes with existing repository warnings)
- `bun --cwd apps/web build` remains blocked by an existing unresolved `@indexnetwork/protocol/question-block` import.
- `tsc --noEmit -p apps/web/tsconfig.json` remains blocked by existing missing shared types/modules outside this change.
