### PR TITLE
fix(negotiations): a failed turn is not a turn

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -208,11 +208,14 @@ OPENROUTER_API_KEY=your-openrouter-api-key
                                            # per /intents/intake/question turn (default, pre-config behavior);
                                            # plural = the whole planned batch (up to n-1) in one turn.
 
-# Per-turn LLM round-trip cap for IndexNegotiator, in ms (default: 15000).
+# Per-turn LLM round-trip cap for IndexNegotiator, in ms (default: 45000).
 # Bounds individual negotiator calls so a single slow upstream tail can't blow
 # the negotiate-phase budget. Valid range: (0, Number.MAX_SAFE_INTEGER]; bad
-# values fall back to the default.
-# NEGOTIATOR_TURN_TIMEOUT_MS=15000
+# values fall back to the default. Measured turn latency on the checklist
+# protocol spans ~10-40 s, so a tighter ceiling aborts ordinary turns — and
+# the abort is what the runnable retry and the cross-vendor fallback need room
+# under, since all three share this one signal.
+# NEGOTIATOR_TURN_TIMEOUT_MS=45000
 
 # Embeddings (default: openai/text-embedding-3-large, 2000 dims)
 # EMBEDDING_MODEL=openai/text-embedding-3-large

--- a/apps/web/src/app/chat/[conversationId]/page.tsx
+++ b/apps/web/src/app/chat/[conversationId]/page.tsx
@@ -14,7 +14,10 @@ import { resolveGateDecision } from '@/components/negotiations/gate-decision';
 import { useTickingNow } from '@/components/negotiations/use-ticking-now';
 import { deriveSectionLabel, extractTurn, formatRelativeTime, groupTurnsBySession, viewerRoleLabel, type TranscriptTurn } from '@/components/negotiations/negotiation-turns';
 
-const STALL_REASONS = new Set(['turn_cap', 'timeout']);
+// `agent_error` joins the stall reasons rather than the reject ones: a run
+// that stopped on repeated agent failures decided nothing, so it must never
+// be presented as a filtered-out match.
+const STALL_REASONS = new Set(['turn_cap', 'timeout', 'agent_error']);
 
 /* eslint-disable react-hooks/preserve-manual-memoization --
    The React Compiler cannot preserve this page's manual memoization (it

--- a/apps/web/src/components/__tests__/ResolvedBanner.test.tsx
+++ b/apps/web/src/components/__tests__/ResolvedBanner.test.tsx
@@ -1,0 +1,44 @@
+/**
+ * The resolved-state banner's stalled copy, which used to make one claim for
+ * four different ends: "The dialogue hit its 6-turn budget without agreement."
+ *
+ * That line was displayed over a transcript holding a single message, for a
+ * negotiation whose responder had failed once — the turn budget was never
+ * touched. What the banner says about how a negotiation ended is the only
+ * account the owner gets, so each end says its own thing now, and the one
+ * caused by our own failures says so.
+ */
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+
+import ResolvedBanner from '../negotiations/ResolvedBanner';
+
+describe('ResolvedBanner — stalled variants', () => {
+  it('claims a spent turn budget only for turn_cap', () => {
+    render(<ResolvedBanner variant="stalled" reason="turn_cap" turnCount={6} maxTurns={6} />);
+    expect(screen.getByText('Stalled — agents ran out of turns')).toBeInTheDocument();
+    expect(screen.getByText(/6-turn budget/)).toBeInTheDocument();
+  });
+
+  it('names an agent error for what it is, and never as an exhausted budget', () => {
+    render(<ResolvedBanner variant="stalled" reason="agent_error" turnCount={1} maxTurns={6} />);
+    expect(screen.getByText('Stalled — the agents hit an error')).toBeInTheDocument();
+    expect(screen.queryByText(/turn budget/)).toBeNull();
+    expect(screen.queryByText(/ran out of turns/)).toBeNull();
+    // The owner is told whose fault it was, and not offered an answer prompt
+    // for a question nobody asked.
+    expect(screen.getByText(/fault on our side/)).toBeInTheDocument();
+    expect(screen.queryByText(/Answering routes through your agent/)).toBeNull();
+  });
+
+  it('falls back to an honest generic line when no reason was recorded', () => {
+    render(<ResolvedBanner variant="stalled" reason={null} turnCount={2} maxTurns={6} />);
+    expect(screen.getByText('Stalled — the dialogue didn’t conclude')).toBeInTheDocument();
+    expect(screen.queryByText(/turn budget/)).toBeNull();
+  });
+
+  it('keeps the timeout wording', () => {
+    render(<ResolvedBanner variant="stalled" reason="timeout" turnCount={3} maxTurns={6} />);
+    expect(screen.getByText('Stalled — the dialogue timed out')).toBeInTheDocument();
+  });
+});

--- a/apps/web/src/components/negotiations/ResolvedBanner.tsx
+++ b/apps/web/src/components/negotiations/ResolvedBanner.tsx
@@ -41,17 +41,35 @@ export function ResolvedBanner({ variant, reason, turnCount, maxTurns, onRevive,
     );
   }
 
+  // Four distinct ends used to share one line of copy: only `turn_cap` is
+  // actually a spent turn budget, and claiming one for the others told the
+  // owner a six-turn dialogue had happened when the transcript held a single
+  // message. `agent_error` is the honest name for the run that stopped on
+  // repeated agent failures — nothing was decided, and nothing was spent.
+  const erroredOut = reason === 'agent_error';
   const timedOut = reason === 'timeout';
+  const heading = erroredOut
+    ? 'Stalled — the agents hit an error'
+    : timedOut
+      ? 'Stalled — the dialogue timed out'
+      : reason === 'turn_cap'
+        ? 'Stalled — agents ran out of turns'
+        : 'Stalled — the dialogue didn’t conclude';
+  const body = erroredOut
+    ? 'The agents stopped after repeated errors, so nothing was decided here — this is a fault on our side, not a verdict on the match.'
+    : timedOut
+      ? 'The dialogue ended before the agents reached agreement.'
+      : reason === 'turn_cap'
+        ? `The dialogue hit its ${maxTurns ?? 6}-turn budget without agreement.`
+        : 'The agents stopped before reaching agreement.';
   return (
     <div className="mt-4 rounded-lg border border-amber-200 bg-amber-50 px-4 py-4">
       <h3 className="font-ibm-plex-mono text-[13px] font-bold text-[#041729]">
-        {timedOut ? 'Stalled — the dialogue timed out' : 'Stalled — agents ran out of turns'}
+        {heading}
       </h3>
       <p className="mt-1 text-[13px] text-[#3D3D3D]">
-        {timedOut
-          ? 'The dialogue ended before the agents reached agreement.'
-          : `The dialogue hit its ${maxTurns ?? 6}-turn budget without agreement.`}
-        {' '}Sometimes a stalled thread is one answer away from resolving.
+        {body}
+        {erroredOut ? '' : ' Sometimes a stalled thread is one answer away from resolving.'}
       </p>
       <div className="mt-3 flex items-center gap-2.5">
         {onRevive && (
@@ -73,9 +91,11 @@ export function ResolvedBanner({ variant, reason, turnCount, maxTurns, onRevive,
           </button>
         )}
       </div>
-      <p className="mt-2.5 font-ibm-plex-mono text-[11px] text-gray-400">
-        Answering routes through your agent and can revive the negotiation.
-      </p>
+      {!erroredOut && (
+        <p className="mt-2.5 font-ibm-plex-mono text-[11px] text-gray-400">
+          Answering routes through your agent and can revive the negotiation.
+        </p>
+      )}
     </div>
   );
 }

--- a/apps/web/src/lib/__tests__/negotiation-presentation.test.ts
+++ b/apps/web/src/lib/__tests__/negotiation-presentation.test.ts
@@ -18,6 +18,10 @@ describe('deriveNegotiationPresentation', () => {
     ['counterparty accepted', lifecycle({ state: 'completed', opportunityStatus: 'accepted' }), 'accept', 'agent:peer', 'connection_accepted', 'Connection accepted'],
     ['rejected opportunity', lifecycle({ state: 'completed', opportunityStatus: 'rejected' }), 'decline', 'agent:peer', 'no_match', 'No match'],
     ['stalled outcome', lifecycle({ state: 'completed', opportunityStatus: 'stalled', outcome: { hasOpportunity: false, reason: 'turn_cap' } }), null, null, 'no_agreement', 'No agreement'],
+    // An error-stalled run reached no agreement because it barely ran, not
+    // because the two sides disagreed — the opportunity still carries
+    // `stalled`, and the reason is what tells them apart.
+    ['agent-error outcome', lifecycle({ state: 'completed', opportunityStatus: 'stalled', outcome: { hasOpportunity: false, reason: 'agent_error' } }), null, null, 'couldnt_complete', 'Couldn\'t complete'],
     ['expired opportunity', lifecycle({ state: 'completed', opportunityStatus: 'expired' }), null, null, 'expired', 'Expired'],
     ['terminal task failure', lifecycle({ state: 'failed', opportunityStatus: 'negotiating' }), null, null, 'couldnt_complete', 'Couldn\'t complete'],
     ['cancelled task', lifecycle({ state: 'canceled', opportunityStatus: 'negotiating' }), null, null, 'couldnt_complete', 'Couldn\'t complete'],

--- a/apps/web/src/lib/negotiation-presentation.ts
+++ b/apps/web/src/lib/negotiation-presentation.ts
@@ -43,7 +43,7 @@ export function presentationForStatus(status: NegotiationPresentationStatus): Ne
 }
 
 const REJECT_ACTIONS = new Set(['reject', 'decline', 'withdraw']);
-const STALL_REASONS = new Set(['turn_cap', 'timeout']);
+const STALL_REASONS = new Set(['turn_cap', 'timeout', 'agent_error']);
 
 /**
  * Converts database lifecycle fields into the single state a viewer needs to
@@ -70,6 +70,10 @@ export function deriveNegotiationPresentation(input: {
     return lifecycle.acceptedByViewer ? PRESENTATIONS.accepted_by_viewer : PRESENTATIONS.connection_accepted;
   }
   if (opportunityStatus === 'rejected') return PRESENTATIONS.no_match;
+  // Checked before the `stalled` status it carries: an error-stalled run has
+  // no agreement to have failed to reach — it never got a dialogue at all —
+  // and "Couldn't complete" is the label that already says so.
+  if (outcome?.reason === 'agent_error') return PRESENTATIONS.couldnt_complete;
   if (opportunityStatus === 'stalled') return PRESENTATIONS.no_agreement;
   if (opportunityStatus === 'expired') return PRESENTATIONS.expired;
   if (opportunityStatus === 'latent' || opportunityStatus === 'draft') return PRESENTATIONS.not_started;

--- a/packages/protocol/src/negotiations/negotiation.agent.ts
+++ b/packages/protocol/src/negotiations/negotiation.agent.ts
@@ -268,13 +268,30 @@ export interface IndexNegotiatorConfig {
    * negotiate-phase budget.
    *
    * Defaults to `NEGOTIATOR_TURN_TIMEOUT_MS` env var when set, otherwise
-   * `DEFAULT_TURN_TIMEOUT_MS`. Sized to clip the p99 tail on Gemini-2.5-Flash
-   * (~20 s today on OpenRouter) without trimming p90 (~12 s).
+   * `DEFAULT_TURN_TIMEOUT_MS`.
    */
   turnTimeoutMs?: number;
 }
 
-const DEFAULT_TURN_TIMEOUT_MS = 15_000;
+/**
+ * Was 15 s, sized to clip a p99 tail believed to sit at ~20 s with p90 ~12 s.
+ * The prompt has grown since — checklist scoring, the client-DM excerpt, the
+ * ask-authoring rules — and the distribution moved with it. Replaying the
+ * responder turn of a real negotiation against Gemini-2.5-Flash on OpenRouter
+ * measured 9.9 / 12.3 / 15.2 / 15.8 / 18.1 / 27.4 / 40.5 s: the old ceiling
+ * sat at the MEDIAN, so roughly half of all turns were aborted mid-flight.
+ *
+ * That is what made a failed turn common enough to matter, and the ceiling cut
+ * below the machinery meant to absorb exactly this: the runnable-level retry
+ * and the cross-vendor fallback share this one signal, so a 15 s budget spent
+ * entirely by the first attempt left neither of them anywhere to run.
+ *
+ * The cost of the larger ceiling is bounded on the other side: a turn that
+ * genuinely hangs now fails after 45 s instead of 15, and the consecutive-
+ * failure bound ends the negotiation after two of those rather than letting
+ * the run continue.
+ */
+const DEFAULT_TURN_TIMEOUT_MS = 45_000;
 
 // Resolver-valid range is `(0, Number.MAX_SAFE_INTEGER]`. The upper bound is
 // the runtime ceiling: `AbortSignal.timeout(N)` throws when N is outside

--- a/packages/protocol/src/negotiations/negotiation.graph.finalize.ts
+++ b/packages/protocol/src/negotiations/negotiation.graph.finalize.ts
@@ -18,6 +18,7 @@ import { NEGOTIATION_PARK_REASONING, type NegotiationStallReason } from './negot
 import { buildIntentSnapshots } from "./negotiation.intent-snapshot-provenance.js";
 import { holdsNegotiationConversationLock } from "./negotiation.task-lock-policy.js";
 import { isNegotiationTurnCapReached } from "./negotiation.turn-cap.js";
+import { isTimeoutFailure } from "./negotiation.turn-failure.js";
 import { expectedNegotiationSpeaker } from "./negotiation.expected-speaker.js";
 import { buildSeededAttribution } from './negotiation.attribution.js';
 import { buildAttributedDialogue, countNegotiationAskRounds, countPrincipalAskUserTurns, finalizeLog, hasPriorAskUser, initLog, memoryQueryText, negotiateCandidatesLog, resolveTaskAttribution, retrieveClientDm, retrieveMemory, screenNodeLog, turnLog, turnsFromMessages } from "./negotiation.graph.shared.js";
@@ -103,7 +104,20 @@ export async function finalizeNode(state: NegotiationState, deps: NegotiationGra
   const blockedByScreenNode = blocksNegotiationBeforeFirstTurn(state.screenDecision, state.turnCount);
   const refusedAtOpeningTurn = state.firstTurnScreenedOut === true;
   const screenedOut = blockedByScreenNode || refusedAtOpeningTurn;
-  const atCap = !screenedOut && isNegotiationTurnCapReached(state.turnCount, state.maxTurns) && !isTerminalAction(lastTurn?.action);
+  // The run ended because the acting agent kept failing, not because the two
+  // sides ran out of things to say.
+  //
+  // `error` set with a failure run still open is exactly that condition: the
+  // turn node sets `error` only at the consecutive-failure bound or when a
+  // turn failed after its message was already persisted, and a landed turn
+  // resets the run to zero. An init-time error (`busy`, an invalid
+  // continuation) carries no failures, so it keeps today's outcome.
+  const errorStalled = !screenedOut && !!state.error && state.consecutiveTurnFailures > 0;
+  // Failed turns no longer advance `turnCount`, so an error-stalled run is
+  // normally nowhere near the cap. The guard is explicit anyway: "ran out of
+  // turns" is a claim about a dialogue, and this is the outcome where the
+  // dialogue is precisely what did not happen.
+  const atCap = !screenedOut && !errorStalled && isNegotiationTurnCapReached(state.turnCount, state.maxTurns) && !isTerminalAction(lastTurn?.action);
 
   let agreedRoles: NegotiationOutcome["agreedRoles"] = [];
   if (hasOpportunity && history.length >= 2) {
@@ -138,18 +152,27 @@ export async function finalizeNode(state: NegotiationState, deps: NegotiationGra
     turnCount: state.turnCount,
     ...(screenedOut
       ? { reason: "screened_out" as const }
-      : atCap
-        ? { reason: "turn_cap" as const }
-        : {}),
+      : errorStalled
+        ? { reason: "agent_error" as const }
+        : atCap
+          ? { reason: "turn_cap" as const }
+          : {}),
   };
 
   // Unconcluded end: no opportunity, no explicit reject, and turns actually
   // happened — turn cap, timeout, or a plain stall. Feeds both the post-stall
   // park below and the legacy questioner enqueue further down.
-  const endedUnconcluded = !hasOpportunity && !screenedOut && !isRejectLikeAction(lastTurn?.action) && state.turnCount > 0;
+  // An error-stalled run is deliberately NOT "unconcluded": it neither parks
+  // with a question nor enqueues the blind stalled-followup questioner. Both
+  // ask the client to settle something the dialogue exposed, and this run has
+  // no dialogue to have exposed anything — the gap is ours, not theirs, and
+  // asking them about it would dress an outage up as an information need. The
+  // opportunity still ends `stalled`, so re-running remains the recovery.
+  const endedUnconcluded = !hasOpportunity && !screenedOut && !errorStalled
+    && !isRejectLikeAction(lastTurn?.action) && state.turnCount > 0;
   const stallReason: NegotiationStallReason = atCap
     ? 'turn_cap'
-    : (state.error && /timeout/i.test(state.error))
+    : isTimeoutFailure(state.error)
       ? 'timeout'
       : 'stalled';
 
@@ -283,8 +306,45 @@ export async function finalizeNode(state: NegotiationState, deps: NegotiationGra
     }
   }
 
+  const lastFailure = state.turnFailures[state.turnFailures.length - 1];
+  if (errorStalled) {
+    finalizeLog.error('negotiation_error_stalled', {
+      taskId: state.taskId,
+      opportunityId: state.opportunityId || undefined,
+      turnCount: state.turnCount,
+      consecutiveTurnFailures: state.consecutiveTurnFailures,
+      seat: lastFailure?.seat,
+      lastError: lastFailure?.error,
+    });
+    if (state.opportunityId) {
+      emitWide({
+        type: 'negotiation_error_stalled',
+        opportunityId: state.opportunityId,
+        negotiationConversationId: state.conversationId,
+        turnCount: state.turnCount,
+        consecutiveTurnFailures: state.consecutiveTurnFailures,
+        seat: lastFailure?.seat,
+      });
+    }
+  }
+
   try {
-    await deps.database.updateTaskState(state.taskId, "completed", undefined, state.continuationExecution);
+    // The terminal status message is the second half of the durable trace:
+    // `metadata.failedTurns` says what failed, this says that the failures are
+    // why the task is over — readable without joining the artifact.
+    await deps.database.updateTaskState(
+      state.taskId,
+      "completed",
+      errorStalled
+        ? {
+            reason: 'negotiation_agent_error',
+            consecutiveTurnFailures: state.consecutiveTurnFailures,
+            ...(lastFailure?.seat && { seat: lastFailure.seat }),
+            ...(lastFailure?.error && { lastError: lastFailure.error }),
+          }
+        : undefined,
+      state.continuationExecution,
+    );
     await deps.database.createArtifact({
       taskId: state.taskId,
       name: "negotiation-outcome",
@@ -307,7 +367,7 @@ export async function finalizeNode(state: NegotiationState, deps: NegotiationGra
       isContinuation: state.isContinuation,
       turnsAdded: state.turnCount,
       priorTurnCount: state.priorTurnCount,
-      outcome: hasOpportunity ? 'accepted' : screenedOut ? 'screened_out' : (atCap ? 'turn_cap' : (lastTurn?.action ?? 'unknown')),
+      outcome: hasOpportunity ? 'accepted' : screenedOut ? 'screened_out' : errorStalled ? 'agent_error' : (atCap ? 'turn_cap' : (lastTurn?.action ?? 'unknown')),
       opportunityId: state.opportunityId || undefined,
     });
 
@@ -329,14 +389,16 @@ export async function finalizeNode(state: NegotiationState, deps: NegotiationGra
   }
 
   if (state.opportunityId) {
-    const emittedOutcome: "accepted" | "rejected_stalled" | "turn_cap" | "timed_out" | "screened_out" =
+    const emittedOutcome: "accepted" | "rejected_stalled" | "turn_cap" | "timed_out" | "screened_out" | "error_stalled" =
       hasOpportunity
         ? "accepted"
         : screenedOut
         ? "screened_out"
+        : errorStalled
+        ? "error_stalled"
         : atCap
         ? "turn_cap"
-        : state.error && /timeout/i.test(state.error)
+        : isTimeoutFailure(state.error)
         ? "timed_out"
         : "rejected_stalled";
 

--- a/packages/protocol/src/negotiations/negotiation.graph.ts
+++ b/packages/protocol/src/negotiations/negotiation.graph.ts
@@ -107,6 +107,14 @@ export function routeAfterTurn(state: NegotiationState): string {
   if (state.status === 'waiting_for_agent') return "finalize";
   if (state.status === 'input_required') return "finalize";
   if (state.error) return "finalize";
+  // A failed turn the turn node judged retryable: the same seat tries again on
+  // an unchanged turn count. Checked BEFORE `lastTurn`, which is either null
+  // (the opening turn failed) or a stale turn from an earlier exchange —
+  // neither says anything about the turn that just failed. This edge cannot
+  // loop: a failure the turn node will not retry — the consecutive-failure
+  // bound, or a turn that failed after its message was persisted — sets
+  // `state.error`, which the check above routes to finalize.
+  if (state.consecutiveTurnFailures > 0) return "turn";
   if (!state.lastTurn) return "finalize";
   // Terminal actions: accept (v1+v2), reject (v1), withdraw/decline (v2)
   if (isTerminalAction(state.lastTurn.action)) return "finalize";

--- a/packages/protocol/src/negotiations/negotiation.graph.turn.ts
+++ b/packages/protocol/src/negotiations/negotiation.graph.turn.ts
@@ -17,6 +17,7 @@ import { NEGOTIATION_QUESTION_GENERIC_COUNTERPARTY, NEGOTIATION_QUESTION_GENERIC
 import { buildIntentSnapshots } from "./negotiation.intent-snapshot-provenance.js";
 import { holdsNegotiationConversationLock } from "./negotiation.task-lock-policy.js";
 import { isNegotiationTurnCapReached } from "./negotiation.turn-cap.js";
+import { appendTurnFailure, turnFailureBoundReached, type NegotiationTurnFailure } from "./negotiation.turn-failure.js";
 import { expectedNegotiationSpeaker } from "./negotiation.expected-speaker.js";
 import { buildSeededAttribution } from './negotiation.attribution.js';
 import { askedChecklistTopics, buildAttributedDialogue, countNegotiationAskRounds, countPrincipalAskUserTurns, finalizeLog, initLog, memoryQueryText, negotiateCandidatesLog, resolveTaskAttribution, retrieveClientDm, retrieveMemory, screenNodeLog, turnLog, turnsFromMessages } from "./negotiation.graph.shared.js";
@@ -77,6 +78,24 @@ export async function turnNode(state: NegotiationState, deps: NegotiationGraphDe
   const agentStart = Date.now();
   traceEmitter?.({ type: "agent_start", name: agentName });
 
+  // Resolved before the try because a FAILED turn has to name its seat too:
+  // the whole point of the failure record is that the seat which cannot get a
+  // turn out of its agent is the first thing an investigation needs. Keys on
+  // initiatorUserId (rigid v2 stamp), never on parity or source/candidate
+  // position — under the conversation-scoped tie-break this run's source may
+  // hold the counterparty seat.
+  const actingSeat: NegotiationSeat =
+    (state.currentSpeaker === "source" ? state.sourceUser : state.candidateUser).id
+      === (state.initiatorUserId ?? state.sourceUser.id)
+      ? 'initiator'
+      : 'counterparty';
+  // Whether this attempt already put a turn into the shared conversation.
+  // Everything after that point — the ask_user park, the state flip — can
+  // still throw, and such a failure must NOT be retried: the turn is on the
+  // record, and running the seat again would persist a second one. Only a
+  // failure that produced nothing is a free retry.
+  let turnPersisted = false;
+
   try {
     const history: NegotiationTurn[] = turnsFromMessages(state.messages);
 
@@ -88,13 +107,8 @@ export async function turnNode(state: NegotiationState, deps: NegotiationGraphDe
     // Determine if this is the system agent's final allowed turn.
     const isFinalTurn = isNegotiationTurnCapReached(state.turnCount + 1, state.maxTurns);
 
-    // Seat attribution keys on initiatorUserId (rigid v2 stamp), never on
-    // parity or source/candidate position — under the conversation-scoped
-    // tie-break this run's source may hold the counterparty seat.
     const version = state.protocolVersion ?? 'v1';
-    const seat: NegotiationSeat = ownUser.id === (state.initiatorUserId ?? state.sourceUser.id)
-      ? 'initiator'
-      : 'counterparty';
+    const seat: NegotiationSeat = actingSeat;
 
     // ask_user availability (P3.2): flag on, full pause loop wired
     // (questioner + answer-window timer + an opportunity to resume
@@ -715,6 +729,7 @@ export async function turnNode(state: NegotiationState, deps: NegotiationGraphDe
       taskId: state.taskId,
       ...(state.continuationExecution ? { continuationExecution: state.continuationExecution } : {}),
     });
+    turnPersisted = true;
 
     // ─── ask_user pause (P3.2) ────────────────────────────────────────────
     // The negotiator consults its OWN client: persist the turn (done above),
@@ -838,6 +853,7 @@ export async function turnNode(state: NegotiationState, deps: NegotiationGraphDe
           taskId: state.taskId,
         }],
         turnCount: state.turnCount + 1,
+        consecutiveTurnFailures: 0,
         lastTurn: turn,
         status: 'input_required' as const,
         ...(nextChecklist.length > 0 && { checklist: nextChecklist }),
@@ -891,6 +907,9 @@ export async function turnNode(state: NegotiationState, deps: NegotiationGraphDe
         taskId: state.taskId,
       }],
       turnCount: state.turnCount + 1,
+      // This turn landed, so the failure run ends here: the bound counts
+      // CONSECUTIVE failures, not failures over the negotiation's life.
+      consecutiveTurnFailures: 0,
       currentSpeaker: (isSource ? "candidate" : "source") as "source" | "candidate",
       lastTurn: turn,
       memoryBySide: { [ownSide]: ownMemory },
@@ -914,13 +933,77 @@ export async function turnNode(state: NegotiationState, deps: NegotiationGraphDe
     // client, the call exceeded the turn budget, and the negotiation recorded
     // a withdrawal. The intent to ask became a rejection.
     //
-    // Leaving `lastTurn` untouched lets finalize see the session for what it
-    // is — unconcluded — so the opportunity stalls instead. A stall is
-    // retryable, and it is also what admits the post-stall park, which is the
-    // outcome an interrupted question actually wanted.
+    // A FAILED TURN IS ALSO NOT A TURN. Incrementing `turnCount` here spent a
+    // slice of the dialogue budget on an exchange that never happened, and
+    // finalize then reported an exhausted budget as if six turns of argument
+    // had failed to reach agreement — the observed shape being a negotiation
+    // "stalled after 6 turns" holding exactly one message. The count stays
+    // put; what advances instead is the consecutive-failure run, and the same
+    // seat retries.
+    //
+    // What the failure leaves behind is the record below. Before it, a failed
+    // turn wrote nothing at all — no message, no status, no metadata — so this
+    // class could only be investigated by timing arithmetic over the rows that
+    // did get written.
+    const failure: NegotiationTurnFailure = {
+      at: new Date().toISOString(),
+      seat: actingSeat,
+      turnIndex: state.turnCount,
+      error: errMsg,
+    };
+    const turnFailures = appendTurnFailure(state.turnFailures, failure);
+    const consecutiveTurnFailures = state.consecutiveTurnFailures + 1;
+    const boundReached = turnFailureBoundReached(consecutiveTurnFailures);
+    const retryable = !turnPersisted && !boundReached;
+
+    turnLog.warn('negotiation_turn_failed', {
+      taskId: state.taskId,
+      opportunityId: state.opportunityId || undefined,
+      seat: actingSeat,
+      turnIndex: state.turnCount,
+      consecutiveTurnFailures,
+      boundReached,
+      turnPersisted,
+      error: errMsg,
+    });
+    emitWide({
+      type: 'negotiation_turn_failed',
+      opportunityId: state.opportunityId,
+      negotiationConversationId: state.conversationId,
+      turnIndex: state.turnCount,
+      actor: state.currentSpeaker,
+      consecutiveTurnFailures,
+      boundReached,
+      error: errMsg,
+    });
+    // Durable trace, fail-open: the optional hook keeps existing fakes and
+    // wireups valid, and a metadata write that fails must not turn one failed
+    // turn into two.
+    if (state.taskId) {
+      await deps.database.setTaskFailedTurns?.(
+        state.taskId,
+        turnFailures as unknown as Array<Record<string, unknown>>,
+        state.continuationExecution,
+      ).catch((writeErr) => {
+        turnLog.error('Failed to persist the failed-turn trace', { taskId: state.taskId, error: writeErr });
+      });
+    }
+
+    // Below the bound the graph routes back into `turn` (see `routeAfterTurn`)
+    // and the same seat tries again on an unchanged turn count. At the bound
+    // the run ends: `error` is what routes to finalize, and it is set ONLY
+    // here, so every other consumer of `state.error` keeps its meaning.
+    if (retryable) return { turnFailures, consecutiveTurnFailures };
     return {
-      turnCount: state.turnCount + 1,
-      error: `Turn failed: ${errMsg}`,
+      turnFailures,
+      consecutiveTurnFailures,
+      // A turn that reached the conversation still counts, whatever failed
+      // after it: the message is the record, and an outcome that disowned it
+      // would be as untrue as the fake budget this work removes.
+      ...(turnPersisted ? { turnCount: state.turnCount + 1 } : {}),
+      error: turnPersisted
+        ? `Turn failed after its message was persisted: ${errMsg}`
+        : `Turn failed ${consecutiveTurnFailures}x consecutively: ${errMsg}`,
     };
   }
 }

--- a/packages/protocol/src/negotiations/negotiation.module.ts
+++ b/packages/protocol/src/negotiations/negotiation.module.ts
@@ -90,6 +90,8 @@ export {
   buildHermesNegotiationTurn,
 } from "./negotiation.hermes-contract.js";
 export { DEFAULT_NEGOTIATION_MAX_TURNS, isNegotiationTurnCapReached } from "./negotiation.turn-cap.js";
+export { MAX_CONSECUTIVE_TURN_FAILURES, appendTurnFailure, isTimeoutFailure, turnFailureBoundReached } from "./negotiation.turn-failure.js";
+export type { NegotiationTurnFailure } from "./negotiation.turn-failure.js";
 export { expectedNegotiationSpeaker } from "./negotiation.expected-speaker.js";
 export { negotiationScopeKey, readNegotiationMessages } from "./negotiation.scope.js";
 export {

--- a/packages/protocol/src/negotiations/negotiation.state.ts
+++ b/packages/protocol/src/negotiations/negotiation.state.ts
@@ -7,6 +7,7 @@ import type { NegotiatorMemoryEntry } from "./negotiation.memory.js";
 import { AskUserPayloadSchema, NEGOTIATION_ACTIONS, type NegotiationProtocolVersion } from "../shared/schemas/negotiation-state.schema.js";
 import { ChecklistDraftSchema } from "../shared/schemas/negotiation-checklist.schema.js";
 import type { ChecklistItem } from "./negotiation.checklist.contracts.js";
+import type { NegotiationTurnFailure } from "./negotiation.turn-failure.js";
 import type { NegotiationConsultationReason } from "./negotiation.consultation-policy.js";
 
 /**
@@ -72,7 +73,12 @@ export const NegotiationOutcomeSchema = z.object({
   })),
   reasoning: z.string(),
   turnCount: z.number(),
-  reason: z.enum(["turn_cap", "timeout", "screened_out"]).optional(),
+  /**
+   * Why an unconcluded negotiation ended. `agent_error` is the honest name for
+   * a run that stopped because the acting agent kept failing — distinct from
+   * `turn_cap`, which claims a dialogue happened and exhausted its budget.
+   */
+  reason: z.enum(["turn_cap", "timeout", "screened_out", "agent_error"]).optional(),
 });
 
 export type NegotiationOutcome = z.infer<typeof NegotiationOutcomeSchema>;
@@ -402,6 +408,27 @@ export const NegotiationGraphState = Annotation.Root({
   userAnswers: Annotation<NegotiationUserAnswer[]>({
     reducer: (curr, next) => next ?? curr,
     default: () => [],
+  }),
+
+  /**
+   * Failed turns recorded this session (most recent last, capped). A failed
+   * turn persists no message and no turn, so this channel — mirrored to
+   * `tasks.metadata.failedTurns` — is the only record that it happened.
+   */
+  turnFailures: Annotation<NegotiationTurnFailure[]>({
+    reducer: (curr, next) => next ?? curr,
+    default: () => [],
+  }),
+
+  /**
+   * Failed turns since the last turn that actually landed. Drives the retry
+   * edge out of the turn node and the error-stalled outcome at the bound; a
+   * successful turn resets it to zero, so it counts a RUN of failures rather
+   * than failures in total.
+   */
+  consecutiveTurnFailures: Annotation<number>({
+    reducer: (curr, next) => next ?? curr,
+    default: () => 0,
   }),
 
   outcome: Annotation<NegotiationOutcome | null>({

--- a/packages/protocol/src/negotiations/negotiation.turn-failure.ts
+++ b/packages/protocol/src/negotiations/negotiation.turn-failure.ts
@@ -1,0 +1,76 @@
+/**
+ * Failed negotiation turns: the durable trace and the bound that ends a run.
+ *
+ * A failed turn is not a decision (that rule shipped with the checklist
+ * negotiations) and it is not a TURN either. A provider timeout, a dropped
+ * connection or a throw in the park machinery says nothing about the match, so
+ * it must not spend the dialogue budget the two agents were given to reach an
+ * agreement — and it must leave something behind, because a failure that
+ * writes nothing can only be investigated by timing arithmetic over the rows
+ * that DID get written.
+ *
+ * What replaces the spent turn is a consecutive-failure count: the same seat
+ * retries, and a run that cannot get a turn out of its agent after
+ * {@link MAX_CONSECUTIVE_TURN_FAILURES} attempts ends error-stalled rather
+ * than running the budget down into a fake "out of turns" outcome. The bound
+ * is the terminator — the retry edge has no other exit.
+ */
+
+import type { NegotiationSeat } from "../shared/schemas/negotiation-state.schema.js";
+
+/**
+ * Consecutive failed turns tolerated before a negotiation ends error-stalled.
+ *
+ * Two, not more: the failures this bounds are correlated (a provider outage,
+ * an oversized prompt, a throw on data this negotiation carries), so a third
+ * attempt mostly buys latency. One retry is what turns the common case — a
+ * single tail-latency abort — into an ordinary turn.
+ */
+export const MAX_CONSECUTIVE_TURN_FAILURES = 2;
+
+/** How many failure records a task keeps. Diagnosis needs the tail, not a log. */
+export const MAX_RECORDED_TURN_FAILURES = 5;
+
+/** Longest error text kept per record; enough to identify the class. */
+const MAX_RECORDED_ERROR_LENGTH = 300;
+
+/** One failed turn, as recorded on the task. */
+export interface NegotiationTurnFailure {
+  /** ISO timestamp of the failure. */
+  at: string;
+  /** Seat whose turn failed — the acting side, not the initiator. */
+  seat: NegotiationSeat;
+  /** Turn index the failure happened AT; the count does not advance past it. */
+  turnIndex: number;
+  /** Error message, truncated. */
+  error: string;
+}
+
+/**
+ * Append a failure to the recorded trace, keeping the most recent
+ * {@link MAX_RECORDED_TURN_FAILURES}. The tail is what ended the run, so it is
+ * the half worth keeping when the cap bites.
+ */
+export function appendTurnFailure(
+  recorded: readonly NegotiationTurnFailure[],
+  failure: NegotiationTurnFailure,
+): NegotiationTurnFailure[] {
+  const next = [...recorded, { ...failure, error: failure.error.slice(0, MAX_RECORDED_ERROR_LENGTH) }];
+  return next.slice(-MAX_RECORDED_TURN_FAILURES);
+}
+
+/** Whether this many consecutive failures ends the negotiation. */
+export function turnFailureBoundReached(consecutiveFailures: number): boolean {
+  return consecutiveFailures >= MAX_CONSECUTIVE_TURN_FAILURES;
+}
+
+/**
+ * Whether a failure text is a timeout/abort.
+ *
+ * `AbortSignal.timeout` rejects with "The operation timed out." — which the
+ * previous `/timeout/i` test missed, so the one failure class the negotiator
+ * times out on was never classified as a timeout anywhere downstream.
+ */
+export function isTimeoutFailure(error: string | null | undefined): boolean {
+  return !!error && /timed\s*out|timeout|abort/i.test(error);
+}

--- a/packages/protocol/src/negotiations/tests/negotiation.turn-failure.spec.ts
+++ b/packages/protocol/src/negotiations/tests/negotiation.turn-failure.spec.ts
@@ -1,0 +1,260 @@
+import { describe, it, expect, beforeAll, afterAll, beforeEach, afterEach } from "bun:test";
+import { NegotiationGraphFactory } from "../negotiation.graph.js";
+import { NegotiationGraphState, type NegotiationTurn } from "../negotiation.state.js";
+import { IndexNegotiator, type NegotiationAgentInput } from "../negotiation.agent.js";
+import { NegotiationStallGapAuthor, type NegotiationStallGap, type StallGapAuthorInput } from "../negotiation.stall-gap.js";
+import { MAX_CONSECUTIVE_TURN_FAILURES } from "../negotiation.turn-failure.js";
+
+/**
+ * Failed turns: not a decision, not a turn, never silent.
+ *
+ * The incident this pins, observed on the sandbox minutes after the checklist
+ * negotiations shipped: a negotiation displayed "Stalled — agents ran out of
+ * turns. The dialogue hit its 6-turn budget without agreement." with exactly
+ * ONE message in the thread. The responder's model call had exceeded the
+ * per-turn abort ceiling; the failure spent a turn, wrote nothing, and
+ * finalize reported an exhausted budget for a dialogue that never happened.
+ *
+ * Pins:
+ * - a responder that throws every turn ends the negotiation `agent_error`
+ *   after the bound, with the outreach still the only message, the turn count
+ *   NOT run down to the cap, and a durable failure trace on the task,
+ * - a transient failure (throw once, succeed after) neither ends the
+ *   negotiation nor spends a turn,
+ * - a genuine out-of-turns stall is untouched: `turn_cap`, and the post-stall
+ *   park still runs,
+ * - an error-stalled run does NOT park: there is no dialogue to draw a gap
+ *   from, and the failure is ours rather than an information need of theirs.
+ */
+
+type FakeTurn = { senderId: string; taskId?: string; parts: Array<{ kind: string; data: NegotiationTurn }> };
+
+const outreachTurn: NegotiationTurn = {
+  action: "outreach",
+  assessment: { reasoning: "Their ML work fits the hire", suggestedRoles: { ownUser: "patient", otherUser: "agent" } },
+  message: "Hi — my client is hiring independent ML engineers.",
+};
+const counterTurn: NegotiationTurn = {
+  action: "counter",
+  assessment: { reasoning: "still apart", suggestedRoles: { ownUser: "peer", otherUser: "peer" } },
+  message: null,
+};
+
+/** The exact rejection `AbortSignal.timeout` produces when a turn overruns. */
+const TURN_TIMEOUT_ERROR = "The operation timed out.";
+
+function mkStubs(opts?: { failStateWriteAfterMessage?: boolean }) {
+  const createdMessages: FakeTurn[] = [];
+  const stateWrites: Array<{ state: string; statusMessage?: unknown }> = [];
+  const opportunityStatuses: string[] = [];
+  const failedTurnWrites: Array<Array<Record<string, unknown>>> = [];
+  const database = {
+    getOrCreateDM: async () => ({ id: "conv-1" }),
+    createTask: async (conversationId: string) => ({ id: "task-1", conversationId, state: "submitted" }),
+    updateOpportunityStatus: async (_id: string, status: string) => { opportunityStatuses.push(status); },
+    createMessage: async (p: FakeTurn) => {
+      createdMessages.push(p);
+      return { id: `msg-${createdMessages.length}`, senderId: p.senderId, parts: p.parts, createdAt: new Date() };
+    },
+    updateTaskState: async (_taskId: string, state: string, statusMessage?: unknown) => {
+      // Simulates a throw AFTER the turn reached the conversation — the shape
+      // the ask_user park machinery has (persist the turn, then park it).
+      if (opts?.failStateWriteAfterMessage && state === "working" && createdMessages.length > 0) {
+        throw new Error("park machinery exploded");
+      }
+      stateWrites.push({ state, statusMessage });
+    },
+    setTaskFailedTurns: async (_taskId: string, failedTurns: Array<Record<string, unknown>>) => { failedTurnWrites.push(failedTurns); },
+    createArtifact: async () => ({ id: "artifact-1" }),
+    setTaskTurnContext: async () => {},
+    getMessagesForConversation: async () => [],
+    getNegotiationMessages: async () => [],
+    getOpportunityUserAnswers: async () => [],
+    getNegotiationTaskForOpportunity: async () => null,
+    getLatestNegotiationTaskForConversation: async () => null,
+    getUserContext: async () => ({ text: "user ctx" }),
+  } as unknown as ConstructorParameters<typeof NegotiationGraphFactory>[0];
+
+  const dispatcher = {
+    hasExternalAgent: async () => false,
+    dispatch: async () => ({ handled: false, reason: "no_agent" }),
+  } as unknown as ConstructorParameters<typeof NegotiationGraphFactory>[1];
+
+  return { database, dispatcher, createdMessages, stateWrites, opportunityStatuses, failedTurnWrites };
+}
+
+async function runGraph(stubs: ReturnType<typeof mkStubs>, maxTurns = 6) {
+  const graph = new NegotiationGraphFactory(stubs.database, stubs.dispatcher).createGraph();
+  return graph.invoke({
+    sourceUser: { id: "u-src", intents: [{ id: "intent-src", title: "Hire ML", description: "Hire independent ML engineers", confidence: 1 }], profile: { name: "Alice", bio: "PM" } },
+    candidateUser: { id: "u-cand", intents: [], profile: { name: "Bob", bio: "ML engineer" } },
+    sourceIntentId: "intent-src",
+    indexContext: { networkId: "net-1", prompt: "" },
+    seedAssessment: { reasoning: "x", valencyRole: "peer" },
+    opportunityId: "opp-1",
+    maxTurns,
+  } as Partial<typeof NegotiationGraphState.State>);
+}
+
+/** Scripted seam: what each seat's agent does when asked for a turn. */
+let onInvoke: (input: NegotiationAgentInput) => Promise<NegotiationTurn> = async () => outreachTurn;
+let authorCalls: StallGapAuthorInput[] = [];
+let authorResult: NegotiationStallGap | null = null;
+
+describe("negotiation graph — failed turns", () => {
+  let origInvoke: typeof IndexNegotiator.prototype.invoke;
+  let origAuthor: typeof NegotiationStallGapAuthor.prototype.author;
+  const origScreenMode = process.env.NEGOTIATION_SCREEN_MODE;
+  const origVersion = process.env.NEGOTIATION_PROTOCOL_VERSION;
+
+  beforeAll(() => {
+    origInvoke = IndexNegotiator.prototype.invoke;
+    IndexNegotiator.prototype.invoke = function (input: NegotiationAgentInput) { return onInvoke(input); };
+    origAuthor = NegotiationStallGapAuthor.prototype.author;
+    NegotiationStallGapAuthor.prototype.author = async function (input: StallGapAuthorInput) {
+      authorCalls.push(input);
+      return authorResult;
+    };
+  });
+
+  afterAll(() => {
+    IndexNegotiator.prototype.invoke = origInvoke;
+    NegotiationStallGapAuthor.prototype.author = origAuthor;
+  });
+
+  beforeEach(() => {
+    authorCalls = [];
+    authorResult = null;
+    process.env.NEGOTIATION_SCREEN_MODE = "off";
+    process.env.NEGOTIATION_PROTOCOL_VERSION = "v2";
+  });
+
+  afterEach(() => {
+    if (origScreenMode === undefined) delete process.env.NEGOTIATION_SCREEN_MODE; else process.env.NEGOTIATION_SCREEN_MODE = origScreenMode;
+    if (origVersion === undefined) delete process.env.NEGOTIATION_PROTOCOL_VERSION; else process.env.NEGOTIATION_PROTOCOL_VERSION = origVersion;
+  });
+
+  it("ends error-stalled when the responder fails every turn, with the outreach still the only message", async () => {
+    const stubs = mkStubs();
+    let responderAttempts = 0;
+    onInvoke = async (input) => {
+      if (input.seat === "counterparty") {
+        responderAttempts += 1;
+        throw new Error(TURN_TIMEOUT_ERROR);
+      }
+      return outreachTurn;
+    };
+
+    const result = await runGraph(stubs);
+
+    // The responder was retried, and the bound — not the turn budget — is what
+    // ended the run.
+    expect(responderAttempts).toBe(MAX_CONSECUTIVE_TURN_FAILURES);
+    // One landed turn, so one message: the outreach. No park message, no
+    // synthesized decision.
+    expect(stubs.createdMessages).toHaveLength(1);
+    expect(stubs.createdMessages[0].parts[0].data.action).toBe("outreach");
+    expect(authorCalls).toHaveLength(0);
+
+    // The outcome tells the truth: an agent error, not an exhausted budget.
+    expect(result.outcome?.reason).toBe("agent_error");
+    expect(result.outcome?.turnCount).toBe(1);
+    expect(result.outcome?.hasOpportunity).toBe(false);
+
+    // Recoverable, never declined.
+    expect(stubs.opportunityStatuses[stubs.opportunityStatuses.length - 1]).toBe("stalled");
+    expect(stubs.opportunityStatuses).not.toContain("rejected");
+
+    // Durable trace: one record per failure, naming the seat that could not
+    // produce a turn and the error that stopped it.
+    const lastWrite = stubs.failedTurnWrites[stubs.failedTurnWrites.length - 1];
+    expect(stubs.failedTurnWrites).toHaveLength(MAX_CONSECUTIVE_TURN_FAILURES);
+    expect(lastWrite).toHaveLength(MAX_CONSECUTIVE_TURN_FAILURES);
+    expect(lastWrite[0]).toMatchObject({ seat: "counterparty", turnIndex: 1, error: TURN_TIMEOUT_ERROR });
+    expect(typeof lastWrite[0].at).toBe("string");
+
+    // …and the terminal task status says why the task is over.
+    const completion = stubs.stateWrites.find((w) => w.state === "completed");
+    expect(completion?.statusMessage).toMatchObject({
+      reason: "negotiation_agent_error",
+      consecutiveTurnFailures: MAX_CONSECUTIVE_TURN_FAILURES,
+      seat: "counterparty",
+      lastError: TURN_TIMEOUT_ERROR,
+    });
+  });
+
+  it("absorbs a transient failure: the negotiation continues and the failed turn spends no budget", async () => {
+    const stubs = mkStubs();
+    let failed = false;
+    let landedTurns = 0;
+    onInvoke = async (input) => {
+      if (input.seat === "counterparty" && !failed) {
+        failed = true;
+        throw new Error(TURN_TIMEOUT_ERROR);
+      }
+      landedTurns += 1;
+      return input.history.length === 0 ? outreachTurn : counterTurn;
+    };
+
+    const result = await runGraph(stubs, 3);
+
+    expect(failed).toBe(true);
+    // Three turns landed and were persisted — the failure took none of them.
+    expect(landedTurns).toBe(3);
+    expect(stubs.createdMessages).toHaveLength(3);
+    expect(result.outcome?.turnCount).toBe(3);
+    // It ran out of turns for real, so it says so.
+    expect(result.outcome?.reason).toBe("turn_cap");
+    // The failure is still recorded, even though it changed nothing.
+    expect(stubs.failedTurnWrites).toHaveLength(1);
+    expect(stubs.failedTurnWrites[0]).toHaveLength(1);
+  });
+
+  it("never retries a turn that already reached the conversation", async () => {
+    const stubs = mkStubs({ failStateWriteAfterMessage: true });
+    let invocations = 0;
+    onInvoke = async () => { invocations += 1; return outreachTurn; };
+
+    const result = await runGraph(stubs);
+
+    // One attempt, one message: a retry here would have persisted the same
+    // turn twice and handed the floor to a seat that had already spoken.
+    expect(invocations).toBe(1);
+    expect(stubs.createdMessages).toHaveLength(1);
+    // The turn is on the record, so it counts — and the run still ends
+    // honestly as an agent error rather than as a spent budget.
+    expect(result.outcome?.turnCount).toBe(1);
+    expect(result.outcome?.reason).toBe("agent_error");
+    expect(stubs.failedTurnWrites).toHaveLength(1);
+  });
+
+  it("leaves a genuine out-of-turns stall alone: turn_cap, and the park still runs", async () => {
+    const stubs = mkStubs();
+    authorResult = {
+      reason: "unresolved_owner_constraint",
+      question: {
+        title: "Timing",
+        prompt: "When could you realistically start?",
+        options: [
+          { label: "This quarter", description: "A retry pushes for an immediate start." },
+          { label: "Later this year", description: "A retry proposes a slower ramp-up." },
+        ],
+        multiSelect: false,
+      },
+    };
+    onInvoke = async (input) => (input.history.length === 0 ? outreachTurn : counterTurn);
+
+    const result = await runGraph(stubs, 2);
+
+    expect(result.outcome?.reason).toBe("turn_cap");
+    expect(result.outcome?.turnCount).toBe(2);
+    // Two turns plus the park message.
+    expect(stubs.createdMessages).toHaveLength(3);
+    expect(stubs.createdMessages[2].parts[0].data.action).toBe("ask_user");
+    expect(authorCalls[0]?.stallReason).toBe("turn_cap");
+    // Nothing failed, so nothing was recorded.
+    expect(stubs.failedTurnWrites).toHaveLength(0);
+    const completion = stubs.stateWrites.find((w) => w.state === "completed");
+    expect(completion?.statusMessage).toBeUndefined();
+  });
+});

--- a/packages/protocol/src/opportunities/negotiation-summary.builder.ts
+++ b/packages/protocol/src/opportunities/negotiation-summary.builder.ts
@@ -44,7 +44,11 @@ export function toDiscoveryNegotiation(r: NegotiationResolution): DiscoveryNegot
     ...(r.outcome.hasOpportunity && r.outcome.agreedRoles.length > 0
       ? { agreedRoles: r.outcome.agreedRoles.map((a) => ({ userId: a.userId, role: a.role as NegotiationRole })) }
       : {}),
-    ...(r.outcome.reason ? { reason: r.outcome.reason } : {}),
+    // `agent_error` deliberately does not cross into the discovery vocabulary:
+    // question generation reasons about why a DIALOGUE did not conclude, and a
+    // run that stopped on repeated agent failures has nothing to say about the
+    // match. It degrades to the unreasoned stall the digest already handles.
+    ...(r.outcome.reason && r.outcome.reason !== 'agent_error' ? { reason: r.outcome.reason } : {}),
   };
   return {
     counterpartyId: r.candidateUserId,

--- a/packages/protocol/src/opportunities/opportunity.actor.ts
+++ b/packages/protocol/src/opportunities/opportunity.actor.ts
@@ -13,6 +13,12 @@ export function normalizeOpportunityActorIntent(value: unknown): string | undefi
     normalized.length === 0
     || normalized.toLowerCase() === 'null'
     || normalized.toLowerCase() === 'undefined'
+    // Python's null literal, which evaluators do emit: a candidate actor was
+    // persisted with `intent: "None"` in dev and every downstream reader took
+    // it for a real binding — the counterparty seat was granted the ask_user
+    // consultation (whose park writes `recipientIntentId` straight at the
+    // intents table) on a signal that does not exist.
+    || normalized.toLowerCase() === 'none'
   ) {
     return undefined;
   }

--- a/packages/protocol/src/shared/interfaces/database.negotiation.ts
+++ b/packages/protocol/src/shared/interfaces/database.negotiation.ts
@@ -133,6 +133,21 @@ export interface NegotiationQueries {
   setTaskDeadlockShift?(taskId: string, deadlockShift: Record<string, unknown>, continuationExecution?: NegotiationContinuationExecution): Promise<void>;
 
   /**
+   * Replaces `metadata.failedTurns` with this session's capped failure trace,
+   * leaving other metadata keys intact. A failed turn persists no message and
+   * no turn, so without this write the failure leaves nothing behind at all
+   * and the class can only be reconstructed from timestamps.
+   *
+   * Replace rather than append: the graph holds the whole capped list in
+   * state, so a retried write is idempotent and no read-modify-write race
+   * exists. Optional so existing fakes/wireups remain valid; when absent the
+   * turn node logs the failure and proceeds.
+   * @param taskId - Task whose metadata to enrich
+   * @param failedTurns - NegotiationTurnFailure records (at, seat, turnIndex, error)
+   */
+  setTaskFailedTurns?(taskId: string, failedTurns: Array<Record<string, unknown>>, continuationExecution?: NegotiationContinuationExecution): Promise<void>;
+
+  /**
    * Returns the most-recently-created task whose metadata carries
    * `type: 'negotiation'` and `opportunityId: <id>`. Returns null if no
    * negotiation has been started for that opportunity yet.

--- a/packages/protocol/src/shared/schemas/negotiation-state.schema.ts
+++ b/packages/protocol/src/shared/schemas/negotiation-state.schema.ts
@@ -128,7 +128,8 @@ export const NegotiationOutcomeSchema = z.object({
   })),
   reasoning: z.string(),
   turnCount: z.number(),
-  reason: z.enum(["turn_cap", "timeout", "screened_out"]).optional(),
+  /** `agent_error`: the run stopped on repeated agent failures, not on a decision. */
+  reason: z.enum(["turn_cap", "timeout", "screened_out", "agent_error"]).optional(),
 });
 export type NegotiationOutcome = z.infer<typeof NegotiationOutcomeSchema>;
 

--- a/services/api/src/adapters/conversation.database.adapter.ts
+++ b/services/api/src/adapters/conversation.database.adapter.ts
@@ -1,4 +1,12 @@
-import type { NegotiationCounterpartyBinding } from '@indexnetwork/protocol';
+/**
+ * Locally aligned mirror of the protocol's `NegotiationCounterpartyBinding`.
+ * Adapters must not import from `@indexnetwork/protocol` (see the lint rule);
+ * structural compatibility is verified at the composition root via duck
+ * typing, which is why this is a mirror rather than an import.
+ */
+type NegotiationCounterpartyBinding =
+  | { kind: 'intent'; id: string }
+  | { kind: 'premise'; id: string };
 import { projectOwnerScreenDecision, readInitiatorUserId } from './negotiation-lifecycle.projection';
 import { buildHermesResponseMetadataSql, buildNegotiationParkMetadataSql } from './conversation-hermes-metadata.sql';
 import { readUserContext, schema, Artifact, ChatConversationMeta, ChatMessage, ChatMessageMeta, ChatScopeType, ChatSession, Conversation, ConversationParticipant, ConversationSession, ConversationSummary, CreateMessageInput, CreateSessionInput, Message, ResolvedParticipant, SYSTEM_AGENT_ID, Task, and, asc, count, db, desc, eq, gt, gte, inArray, isNull, lt, ne, opportunities, or, sql } from './database.shared';
@@ -3945,6 +3953,25 @@ export class ConversationDatabaseAdapter {
       if (continuationExecution) await assertContinuationExecutionEffect(tx as unknown as typeof db, continuationExecution);
       await tx.update(schema.tasks).set({
         metadata: sql`COALESCE(${schema.tasks.metadata}, '{}'::jsonb) || jsonb_build_object('deadlockShift', ${JSON.stringify(deadlockShift)}::jsonb)`,
+        updatedAt: new Date(),
+      }).where(eq(schema.tasks.id, taskId));
+    });
+  }
+
+  /**
+   * Replaces the task's `metadata.failedTurns` with the graph's capped
+   * failure trace, preserving other metadata keys. Sibling of
+   * {@link setTaskDeadlockShift}. Internal diagnostics only — no API surface
+   * projects this key.
+   *
+   * @param taskId - Task to update
+   * @param failedTurns - NegotiationTurnFailure records (at, seat, turnIndex, error)
+   */
+  async setTaskFailedTurns(taskId: string, failedTurns: Array<Record<string, unknown>>, continuationExecution?: ContinuationExecutionFence): Promise<void> {
+    await db.transaction(async (tx) => {
+      if (continuationExecution) await assertContinuationExecutionEffect(tx as unknown as typeof db, continuationExecution);
+      await tx.update(schema.tasks).set({
+        metadata: sql`COALESCE(${schema.tasks.metadata}, '{}'::jsonb) || jsonb_build_object('failedTurns', ${JSON.stringify(failedTurns)}::jsonb)`,
         updatedAt: new Date(),
       }).where(eq(schema.tasks.id, taskId));
     });


### PR DESCRIPTION
## The incident

A negotiation on the sandbox displayed **"Stalled — agents ran out of turns. The dialogue hit its 6-turn budget without agreement."** with exactly **one** message in the thread — the opening outreach. Task `dab7e0de`, opportunity `7a239460` (counterparty Zuri Boateng), created 19:51:43Z, outreach at 19:51:53Z, `completed` at 19:52:11Z.

The artifact says `turnCount: 2` with no `reason`, so the truth is narrower than the banner: the outreach landed, the responder's turn failed **once**, and the run ended. Two separate lies were on screen:

- the failed turn had **spent** a turn of the dialogue budget, and
- the banner claims a spent 6-turn budget **for every non-timeout stall**, `reason` or not — `ResolvedBanner` never looked at `turn_cap`.

## Root cause

Replaying that exact responder turn against the live negotiator model (real profiles, real seed assessment, the persisted outreach as history), with the abort ceiling lifted:

```
canAskUser=true   27.4s   15.8s   15.2s
canAskUser=false   9.9s   40.5s   18.1s
```

The shipped ceiling is `DEFAULT_TURN_TIMEOUT_MS = 15_000`, so **it sat at the median of the distribution**. Re-running at 15 s reproduces the failure exactly:

```
run=1 ms=10726 action=ask_user
run=2 ms=15004 THREW TimeoutError: The operation timed out.
```

That is the thrown error: `AbortSignal.timeout` firing on an ordinary turn. Its docstring sized it for a p90 of ~12 s and a p99 of ~20 s, which the prompt has since outgrown — checklist scoring, the client-DM excerpt, the ask-authoring rules. The ceiling also cuts *below* the machinery meant to absorb this: the runnable-level retry and the cross-vendor fallback share the same signal, so a budget spent by the first attempt left neither anywhere to run.

Nothing else in the turn path can produce this shape: memory retrieval, client-DM retrieval and the pre-contact cap all swallow their own errors, the checklist module has no throw sites, and the failure landed before `createMessage` (no message exists). Timing corroborates: 18.4 s from outreach to completion = a 15 s abort plus finalize.

**Why this seat.** Diffing the failing context against the healthy control born in the same batch (task `75c18601`, Maya Patel, 6 messages, clean decline): the only structural difference is `candidateIntentId`. The control's is absent; the failing one is the string **`"None"`**. `normalizeOpportunityActorIntent` filters `''`, `'null'`, `'undefined'` — not Python's `None` — so every reader took a phantom intent for a real binding, which granted that seat the `ask_user` consultation: the heaviest, slowest turn in the flow, on a signal that does not exist. Had the model actually asked, `captureNegotiationAskUserBinding` would have written `recipientIntentId: 'None'` at the intents table.

## The fixes

**1. Right-size the ceiling.** `DEFAULT_TURN_TIMEOUT_MS` 15 s → 45 s, with the measured distribution in the docstring, and `None` joins the null-like actor-intent sentinels.

**2. A failed turn is not a turn.** It no longer increments `turnCount`. The same seat retries; `MAX_CONSECUTIVE_TURN_FAILURES = 2` consecutive failures end the negotiation `agent_error` — the bound is the terminator, and the retry edge has no other exit. A landed turn resets the run, so the count is of *consecutive* failures. A turn that already reached the conversation is never retried (the ask_user park and the state flip can both throw after `createMessage`): it ends the run and still counts, because the message is the record.

**3. A failed turn is never silent.** Each failure writes `tasks.metadata.failedTurns` — `{at, seat, turnIndex, error}`, most recent 5 — and an error-stalled task carries a terminal `status_message` of `{reason: 'negotiation_agent_error', consecutiveTurnFailures, seat, lastError}`. This investigation had to be done with timing arithmetic; the next one can be done with one query.

**4. Finalize and the banner stop claiming a dialogue.** New outcome reason `agent_error`, distinct from `turn_cap`; the opportunity still ends `stalled` (recoverable, never declined). `ResolvedBanner` now says "Stalled — the agents hit an error … a fault on our side, not a verdict on the match", says "ran out of turns" only for `turn_cap`, and falls back to "the dialogue didn't conclude" when no reason was recorded. The inbox maps `agent_error` to the existing **Couldn't complete**.

Also fixed in passing: the stall-reason timeout test was `/timeout/i`, which never matched `"The operation timed out."` — the one failure the negotiator actually times out on.

## Deliberate choices

- **An error-stalled run does not park and does not enqueue the stalled-followup questioner.** Both ask the client to settle something the dialogue exposed; this run has no dialogue. The gap is ours, not theirs. Re-running remains the recovery, exactly as for any stall.
- **No Retry button.** There is no user-facing endpoint to re-run a negotiation today, and the handoff bounded the web work to copy + state mapping. The honest copy ships; a Retry affordance needs API surface and belongs in its own change.
- `agent_error` deliberately does not cross into the discovery-question vocabulary — it degrades to the unreasoned stall the digest already handles.
- Drive-by: the adapter now mirrors `NegotiationCounterpartyBinding` locally. #1455 added that import and it trips the adapter lint rule, which blocks any commit touching the file.

## Tests

- `negotiation.turn-failure.spec.ts` (new): the incident (responder throws every turn → `agent_error` after the bound, outreach still the only message, `turnCount: 1`, failure trace and terminal status message present, opportunity `stalled`, never `rejected`, no park); a transient failure (throw once, succeed after) spending no turn; no retry after a turn is persisted; a genuine `turn_cap` stall untouched, park included.
- `ResolvedBanner.test.tsx` (new) + a presentation case for `agent_error`.
- `packages/protocol`: 2293 pass / 0 fail (201 files), architecture suite green. `services/api`: typecheck + spec typecheck clean; suite failures are identical to the base commit (verified by reverting this diff and re-running). `apps/web`: 5 failures in 4 files, identical to the base commit; new tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
