### PR TITLE
fix(discovery): honest retrieval scores and a second evaluation batch

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -89,7 +89,7 @@
     },
     "packages/protocol": {
       "name": "@indexnetwork/protocol",
-      "version": "23.0.0",
+      "version": "23.1.0",
       "dependencies": {
         "@langchain/core": "1.1.48",
         "@langchain/langgraph": "1.3.2",

--- a/packages/protocol/CHANGELOG.md
+++ b/packages/protocol/CHANGELOG.md
@@ -20,6 +20,38 @@ went 6.7.1 → 8.0.2 with no 7.x in between because the whole 7.x line shipped a
 prereleases between the two promotions. To track every change, read `rc`; to
 pin a supported release, use `latest`.
 
+## 23.1.0 - 2026-08-19
+
+### Fixed
+
+- **Retrieval scores no longer clamp at a flat ceiling.** The multi-signal bonus in
+  `mergeStrategyCandidates` was added to the raw similarity and then clamped
+  (`Math.min(raw + boost, 1)`), so candidates found by enough strategies all landed
+  on exactly 1.0. Candidates enter evaluation strictly by rank, so a head cluster of
+  identical maxima crowded genuine matches out of the only evaluated batch. The bonus
+  now consumes the headroom above the raw score (new internal
+  `opportunities/opportunity.similarity.ts`): strictly monotone in the raw score,
+  and 1.0 is reachable only by a vector that actually scored 1.0.
+- **Evaluation continues past a batch that passes nothing.** `remainingCandidates`
+  was written and never read — there was no second batch, so a run whose top-ranked
+  candidates all failed reported `evaluator_rejected_all` while the real matches sat
+  unevaluated behind them. The evaluation node now walks up to
+  `MAX_EVAL_BATCHES_PER_RUN` (3) batches of 25 while no candidate passes, and stops
+  as soon as one does.
+- **A stranded tail is reported as a bound, not as a rejection.** When the batch bound
+  is reached with candidates left, the trace carries an `evaluation_bound` node with
+  the never-evaluated count.
+
+### Changed
+
+- **`invokeEntityBundle` under `returnAll: true` now returns dropped verdicts too**,
+  tagged with `rejection: { candidateId, reason }` (`not_accepted` |
+  `incomplete_actors` | `unsupported_claim`) and carrying no actors. Previously a
+  candidate the model explicitly rejected, and one whose accepted verdict a guard
+  dropped, were both indistinguishable from silence, and the discovery trace labelled
+  every one of them "No evaluation returned for this candidate". Callers that
+  persist must filter on `rejection === undefined`; `returnAll: false` is unchanged.
+
 ## 23.0.0 - 2026-08-19
 
 ### Added

--- a/packages/protocol/package.json
+++ b/packages/protocol/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@indexnetwork/protocol",
-  "version": "23.0.0",
+  "version": "23.1.0",
   "type": "module",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",

--- a/packages/protocol/src/opportunities/opportunity.evaluator.ts
+++ b/packages/protocol/src/opportunities/opportunity.evaluator.ts
@@ -248,7 +248,30 @@ const entityBundleResponseFormat = z.object({
 });
 
 export type EvaluatorActor = z.infer<typeof ActorSchema>;
-export type EvaluatedOpportunityWithActors = z.infer<typeof _OpportunityWithActorsSchema>;
+
+/**
+ * Why a candidate produced no persistable opportunity.
+ * - `not_accepted` — the model judged the pairing not viable and said so, with a score.
+ * - `incomplete_actors` — accepted, but the actor set was unusable (never persistable).
+ * - `unsupported_claim` — accepted, but the reasoning asserted an affiliation or
+ *   presence the evidence does not support; the claim guard rejects it outright.
+ */
+export type EvaluatorRejectionReason = 'not_accepted' | 'incomplete_actors' | 'unsupported_claim';
+
+/** A verdict the guards dropped, carried for diagnostics under `returnAll`. */
+export interface EvaluatorRejection {
+  candidateId: string;
+  reason: EvaluatorRejectionReason;
+}
+
+export type EvaluatedOpportunityWithActors = z.infer<typeof _OpportunityWithActorsSchema> & {
+  /**
+   * Set only on diagnostic entries returned under `returnAll`. These carry the
+   * evaluator's real score and reasoning so the trace can say what happened, and
+   * they hold no actors — they must never be persisted.
+   */
+  rejection?: EvaluatorRejection;
+};
 type EvaluatorVerdict = z.infer<typeof EvaluatorVerdictSchema>;
 export type EvaluatorOutputBundle = z.infer<typeof entityBundleResponseFormat>;
 
@@ -289,6 +312,21 @@ function reconcileEvaluatorVerdicts(
   }
   if (seen.size !== expected.size) throw new EvaluatorIncompleteError();
   return verdicts;
+}
+
+/**
+ * The single place that decides whether a verdict can become an opportunity.
+ * Returns `undefined` when the verdict is persistable, otherwise why it is not.
+ */
+function verdictRejectionReason(
+  verdict: EvaluatorVerdict,
+  introductionMode: boolean,
+): EvaluatorRejectionReason | undefined {
+  if (!verdict.accepted) return 'not_accepted';
+  if (verdict.actors.length < 2) return 'incomplete_actors';
+  if (introductionMode && verdict.actors.length !== 2) return 'incomplete_actors';
+  if (hasUnsupportedOpportunityClaim(stripUuids(verdict.reasoning))) return 'unsupported_claim';
+  return undefined;
 }
 
 function isEvaluatorOutputError(error: unknown): boolean {
@@ -572,28 +610,43 @@ ${renderOpportunityEvidenceForPrompt(e.evidence ?? [])}`;
           input.discovererId,
           input.introductionMode ?? false,
         );
-        const accepted = verdicts
-          .filter((verdict) => verdict.accepted)
-          .map((verdict) => ({
-            reasoning: stripUuids(verdict.reasoning),
-            score: verdict.score,
-            actors: verdict.actors,
-          }))
-          .filter((op): op is EvaluatedOpportunityWithActors => op.actors.length >= 2);
         // Persistence safety is deterministic and precedes every score/returnAll
         // path. Network/context placement is not typed support provenance, so an
         // unsupported affiliation or presence claim rejects the whole result.
-        const claimSafe = accepted.filter((op) => !hasUnsupportedOpportunityClaim(op.reasoning));
-        const introGuard = input.introductionMode ? claimSafe.filter((op) => op.actors.length === 2) : claimSafe;
+        const triaged = verdicts.map((verdict) => ({
+          verdict,
+          reasoning: stripUuids(verdict.reasoning),
+          reason: verdictRejectionReason(verdict, input.introductionMode ?? false),
+        }));
+        const introGuard = triaged
+          .filter((entry) => entry.reason === undefined)
+          .map((entry) => ({
+            reasoning: entry.reasoning,
+            score: entry.verdict.score,
+            actors: entry.verdict.actors,
+          }));
         const filtered = introGuard.filter((op) => op.score >= minScore);
+        // `returnAll` callers trace every candidate, so they need the dropped
+        // verdicts too: without them a rejected candidate is indistinguishable
+        // from one the evaluator never answered for.
+        const rejections: EvaluatedOpportunityWithActors[] = triaged
+          .filter((entry) => entry.reason !== undefined)
+          .map((entry) => ({
+            reasoning: entry.reasoning,
+            score: entry.verdict.score,
+            actors: [],
+            rejection: { candidateId: entry.verdict.candidateId, reason: entry.reason! },
+          }));
         invokeEntityBundleLog.verbose('Done', {
           total: verdicts.length,
-          afterClaimGuard: claimSafe.length,
-          afterIntroGuard: introGuard.length,
+          persistable: introGuard.length,
+          rejectedByModel: rejections.filter((op) => op.rejection?.reason === 'not_accepted').length,
+          droppedUnsupportedClaim: rejections.filter((op) => op.rejection?.reason === 'unsupported_claim').length,
+          droppedIncompleteActors: rejections.filter((op) => op.rejection?.reason === 'incomplete_actors').length,
           accepted: filtered.length,
           returnAll,
         });
-        return returnAll ? introGuard : filtered;
+        return returnAll ? [...introGuard, ...rejections] : filtered;
       } catch (error) {
         if (!isEvaluatorOutputError(error)) throw error;
         incompleteReason = error instanceof Error ? error.message : 'invalid output';

--- a/packages/protocol/src/opportunities/opportunity.graph.discovery-strategies.ts
+++ b/packages/protocol/src/opportunities/opportunity.graph.discovery-strategies.ts
@@ -14,6 +14,7 @@ import { getModelName } from '../shared/agent/model.config.js';
 import { selectHydeDocumentsForGeneration, getHydeGenerationMode } from '../discovery/index.js';
 import { mergeOpportunityEvidence, withCandidateEvidence, withMatchedStrategies } from './opportunity.evidence.js';
 import { discoveryProfileMatchingEnabled, discoveryProfileSource, discoveryIntentMatchingEnabled } from './discovery.env.js';
+import { withMultiSignalBonus } from './opportunity.similarity.js';
 import { buildDiscovererContext, discoveryLog, getSourcePremiseDiscoveryLimit, PREMISE_MATCH_LIMIT_PER_SOURCE, type OpportunityGraphDeps, type OpportunityState } from "./opportunity.graph.shared.js";
 
 /** Corpus gating passed through to the embedder on every HyDE search. */
@@ -442,11 +443,17 @@ export function runAuxiliaryStrategies(
   ]);
 }
 
+/** Bonus fraction per additional strategy that surfaced the same candidate. */
+const MULTI_STRATEGY_BONUS_PER_STRATEGY = 0.05;
+/** Ceiling on the total multi-strategy bonus fraction. */
+const MULTI_STRATEGY_BONUS_MAX = 0.15;
+
 /**
  * Merge candidates from multiple strategies. Deduplicates by userId + networkId + entityId,
  * keeps the highest similarity, tracks which strategies found each candidate,
- * and applies a multi-strategy boost (+0.05 per additional strategy, boost capped at 0.15,
- * final similarity capped at 1.0).
+ * and applies a multi-strategy boost (+5% of the headroom above the raw score per
+ * additional strategy, capped at 15%). The boost consumes headroom rather than being
+ * added and clamped, so it can never manufacture a tie at 1.0.
  */
 export function mergeStrategyCandidates(...groups: CandidateMatch[][]): CandidateMatch[] {
   const merged = new Map<string, CandidateMatch & { _strategies: Set<string> }>();
@@ -470,10 +477,12 @@ export function mergeStrategyCandidates(...groups: CandidateMatch[][]): Candidat
   }
   return Array.from(merged.values()).map(({ _strategies, ...c }) => {
     const matchedStrategies = Array.from(_strategies);
-    const boost = Math.min((_strategies.size - 1) * 0.05, 0.15);
     return {
       ...c,
-      similarity: Math.min(c.similarity + boost, 1.0),
+      similarity: withMultiSignalBonus(c.similarity, _strategies.size, {
+        perSignal: MULTI_STRATEGY_BONUS_PER_STRATEGY,
+        maxBonus: MULTI_STRATEGY_BONUS_MAX,
+      }),
       matchedStrategies,
       evidence: withMatchedStrategies(mergeOpportunityEvidence(c.evidence), matchedStrategies),
     };

--- a/packages/protocol/src/opportunities/opportunity.graph.evaluation.ts
+++ b/packages/protocol/src/opportunities/opportunity.graph.evaluation.ts
@@ -8,7 +8,7 @@
 import type { Id } from '../shared/interfaces/database.interface.js';
 import type { DebugMetaAgent } from '../agents/agent.module.js';
 import type { CandidateMatch, EvaluatedOpportunity } from './opportunity.state.js';
-import { OpportunityEvaluator, type EvaluatedOpportunityWithActors, type EvaluatorEntity, type EvaluatorInput } from "./opportunity.evaluator.js";
+import { OpportunityEvaluator, type EvaluatedOpportunityWithActors, type EvaluatorEntity, type EvaluatorInput, type EvaluatorRejection } from "./opportunity.evaluator.js";
 import { getModelName } from '../shared/agent/model.config.js';
 import { timed } from '../shared/observability/performance.js';
 import { requestContext } from '../shared/observability/request-context.js';
@@ -23,10 +23,27 @@ type PairwiseOpportunity = {
   reasoning: string;
   score: number;
   actors: Array<{ userId: string; role: 'agent' | 'patient' | 'peer'; intentId?: string | null; evidenceKey?: string | null }>;
+  /** Diagnostic-only entry: the evaluator answered, but nothing persistable came of it. */
+  rejection?: EvaluatorRejection;
 };
+
+/** Graph trace entry shape. */
+type TraceEntry = { node: string; detail?: string; data?: Record<string, unknown> };
 
 /** Batch size for one evaluator call. Larger batches time out. */
 const EVAL_BATCH_SIZE = 25;
+
+/**
+ * How many batches one discovery run may evaluate.
+ *
+ * Candidates are taken strictly by rank, so a degenerate head cluster — many
+ * candidates the retriever scored alike — used to consume the only batch and
+ * strand the genuine matches behind it, reported as `evaluator_rejected_all`.
+ * When a batch yields no passes we continue into the tail, bounded so a run can
+ * never fan out unboundedly. Whatever is left after the bound is reported as
+ * never-evaluated rather than as rejected.
+ */
+const MAX_EVAL_BATCHES_PER_RUN = 3;
 
 /**
  * Node 3: Evaluation (Entity bundle)
@@ -81,36 +98,29 @@ export async function evaluationNode(state: OpportunityState, deps: OpportunityG
       });
     }
 
-    const eligibleCandidatesAfterCooldown = await applyRejectionCooldown(eligibleCandidates, discoveryUserId, deps);
-
-    const batchToEvaluate = eligibleCandidatesAfterCooldown.slice(0, EVAL_BATCH_SIZE);
-    const remaining = eligibleCandidatesAfterCooldown.slice(EVAL_BATCH_SIZE);
+    const pool = await applyRejectionCooldown(eligibleCandidates, discoveryUserId, deps);
 
     // Early termination: if search was query-driven and no query-sourced candidates remain,
     // clear remaining to prevent pointless pagination through non-query leftovers
     const isQueryDriven = !!state.searchQuery?.trim();
-    const queryRemaining = remaining.filter(
-      (c) => c.discoverySource === 'query' || c.discoverySource == null,
-    );
-    const effectiveRemaining =
-      isQueryDriven && queryRemaining.length === 0 ? [] : remaining;
-
-    if (isQueryDriven && remaining.length > 0 && queryRemaining.length === 0) {
-      evaluationLog.info(
-        "Early termination: no query-sourced candidates remain",
-        {
-          droppedCandidates: remaining.length,
-        },
+    let loggedEarlyTermination = false;
+    const remainingAfter = (consumed: number): CandidateMatch[] => {
+      const rest = pool.slice(consumed);
+      const queryRest = rest.filter(
+        (c) => c.discoverySource === 'query' || c.discoverySource == null,
       );
-    }
-
-    if (effectiveRemaining.length > 0) {
-      evaluationLog.verbose('Batched candidates for evaluation', {
-        evaluating: batchToEvaluate.length,
-        remaining: effectiveRemaining.length,
-        total: sortedCandidates.length,
-      });
-    }
+      if (isQueryDriven && rest.length > 0 && queryRest.length === 0) {
+        if (!loggedEarlyTermination) {
+          loggedEarlyTermination = true;
+          evaluationLog.info(
+            "Early termination: no query-sourced candidates remain",
+            { droppedCandidates: rest.length },
+          );
+        }
+        return [];
+      }
+      return rest;
+    };
 
     const agentTimingsAccum: DebugMetaAgent[] = [];
 
@@ -135,33 +145,6 @@ export async function evaluationNode(state: OpportunityState, deps: OpportunityG
         matchedVia: undefined,
       };
 
-      const candidateEntities = await buildCandidateEntities(batchToEvaluate, deps);
-
-      const userIdToIndexId = new Map<string, Id<'networks'>>();
-      const evidenceByEntityKey = new Map<string, OpportunityEvidence[]>();
-      const entityKeysByUserId = new Map<string, string[]>();
-      for (const e of candidateEntities) {
-        if (!userIdToIndexId.has(e.userId)) userIdToIndexId.set(e.userId, e.networkId as Id<'networks'>);
-        if (e.evidenceKey) {
-          evidenceByEntityKey.set(
-            e.evidenceKey,
-            mergeOpportunityEvidence(evidenceByEntityKey.get(e.evidenceKey), e.evidence),
-          );
-          entityKeysByUserId.set(e.userId, [...(entityKeysByUserId.get(e.userId) ?? []), e.evidenceKey]);
-        }
-      }
-
-      function evidenceForActor(actor: { userId: string; intentId?: string | null; evidenceKey?: string | null }): OpportunityEvidence[] | undefined {
-        if (actor.evidenceKey) return evidenceByEntityKey.get(actor.evidenceKey);
-        const keys = entityKeysByUserId.get(actor.userId) ?? [];
-        const intentKey = actor.intentId ? keys.find((key) => key.endsWith(`:${actor.intentId}`)) : undefined;
-        if (intentKey) return evidenceByEntityKey.get(intentKey);
-        // Avoid leaking unrelated resource evidence when the evaluator collapsed multiple
-        // candidates for the same user into a profile-only actor.
-        if (keys.length === 1) return evidenceByEntityKey.get(keys[0]);
-        return undefined;
-      }
-
       const minScore = state.targetUserId
         ? DISCOVERY_EVALUATOR_MIN_SCORE_DEFAULT
         : deps.evaluatorMinScore;
@@ -172,143 +155,82 @@ export async function evaluationNode(state: OpportunityState, deps: OpportunityG
         : new OpportunityEvaluator();
 
       const runParallel = process.env.RUN_OPPORTUNITY_EVAL_IN_PARALLEL === 'true';
-      const networkContexts = await buildNetworkContexts([sourceEntity, ...candidateEntities], deps.database);
 
-      // Declare trace entries early so both parallel and serial paths can push error entries
-      const traceEntries: Array<{ node: string; detail?: string; data?: Record<string, unknown> }> = [];
+      const traceEntries: TraceEntry[] = [];
+      const passedOpportunities: EvaluatedOpportunity[] = [];
+      let remaining: CandidateMatch[] = [];
+      let consumed = 0;
+      let batchesRun = 0;
 
-      const pairwiseOpportunities: PairwiseOpportunity[] = runParallel
-        ? await evaluateInParallel({
-            evaluator, sourceEntity, candidateEntities, state, discoveryUserId,
-            networkContexts, minScore, evaluatorSignalConfig, agentTimingsAccum, traceEntries,
-          })
-        : splitBundledVerdicts(
-            await evaluateBundled({
-              evaluator, sourceEntity, candidateEntities, state, discoveryUserId,
-              networkContexts, minScore, evaluatorSignalConfig, agentTimingsAccum,
-            }),
-            state,
-            candidateEntities,
-          );
-
-      const evaluatedOpportunities: EvaluatedOpportunity[] = pairwiseOpportunities.map((op) => ({
-        reasoning: op.reasoning,
-        score: op.score,
-        evidence: mergeOpportunityEvidence(...op.actors.map(evidenceForActor)),
-        actors: op.actors.map((a) => {
-          const isSource = a.userId === discoveryUserId;
-          if (isSource) {
-            // Source actor inherits the counterpart's networkId (shared match context)
-            const counterpart = op.actors.find((other) => other.userId !== a.userId);
-            const counterpartIndexId = counterpart
-              ? userIdToIndexId.get(counterpart.userId) ?? (candidateEntities.find((e) => e.userId === counterpart.userId)?.networkId as Id<'networks'>)
-              : undefined;
-            return {
-              userId: a.userId as Id<'users'>,
-              role: a.role,
-              intentId: a.intentId as Id<'intents'> | undefined,
-              networkId: counterpartIndexId ?? userIdToIndexId.get(a.userId) ?? ('' as Id<'networks'>),
-            };
-          }
-          return {
-            userId: a.userId as Id<'users'>,
-            role: a.role,
-            intentId: a.intentId as Id<'intents'> | undefined,
-            networkId: userIdToIndexId.get(a.userId) ?? (candidateEntities.find((e) => e.userId === a.userId)?.networkId as Id<'networks'>),
-          };
-        }),
-      }));
-
-      const passed = evaluatedOpportunities.filter((o) => o.score >= minScore);
-      evaluationLog.verbose('Evaluation complete', {
-        evaluatedCount: evaluatedOpportunities.length,
-        passed: passed.length,
-      });
-
-      // Threshold filter trace: how many candidates in this batch were above/below similarity threshold
-      const aboveThreshold = batchToEvaluate.filter(
-        (candidate) => candidate.similarity >= deps.retrievalMinSimilarity,
-      ).length;
-      const belowThreshold = batchToEvaluate.length - aboveThreshold;
-      traceEntries.push({
-        node: "threshold_filter",
-        detail: `${aboveThreshold} above ${deps.retrievalMinSimilarity}, ${belowThreshold} below (batch of ${batchToEvaluate.length})`,
-        data: {
-          aboveThreshold,
-          belowThreshold,
-          minScore: deps.retrievalMinSimilarity,
-          retrievalMinSimilarity: deps.retrievalMinSimilarity,
-          evaluatorMinScore: minScore,
-          batchSize: batchToEvaluate.length,
-        },
-      });
-
-      // Create a map of evaluated candidates by userId for quick lookup.
-      // Use discoveryUserId (which accounts for onBehalfOfUserId in introducer flow)
-      // rather than state.userId (which is the introducer, not present in pairwise actors).
-      const evaluatedByUserId = new Map<string, { score: number; reasoning: string }>();
-      for (const opp of evaluatedOpportunities) {
-        const candidateActor = opp.actors.find(a => a.userId !== discoveryUserId);
-        if (candidateActor) {
-          evaluatedByUserId.set(candidateActor.userId, { score: opp.score, reasoning: opp.reasoning });
+      // Bounded batch continuation: a batch that passes nothing does not end the
+      // run while ranked-lower candidates are still waiting. Candidates arrive by
+      // rank, so a head cluster the retriever over-scored would otherwise strand
+      // every genuine match behind it.
+      while (batchesRun < MAX_EVAL_BATCHES_PER_RUN && consumed < pool.length) {
+        const batch = pool.slice(consumed, consumed + EVAL_BATCH_SIZE);
+        const batchNumber = batchesRun + 1;
+        if (batchNumber > 1) {
+          evaluationLog.info('No candidate passed; continuing into the next batch', {
+            batchNumber,
+            evaluating: batch.length,
+            alreadyEvaluated: consumed,
+          });
         }
+        const batchResult = await evaluateCandidateBatch({
+          batch,
+          batchNumber,
+          sourceEntity,
+          state,
+          deps,
+          discoveryUserId,
+          minScore,
+          evaluator,
+          runParallel,
+          evaluatorSignalConfig,
+          agentTimingsAccum,
+        });
+        consumed += batch.length;
+        batchesRun += 1;
+        traceEntries.push(...batchResult.trace);
+        passedOpportunities.push(...batchResult.passed);
+        remaining = remainingAfter(consumed);
+        if (batchResult.passed.length > 0) break;
+        if (remaining.length === 0) break;
       }
 
-      traceEntries.push({
-        node: "evaluation",
-        detail: `Evaluated ${candidateEntities.length} candidate(s) → ${passed.length} passed (min score ${minScore})`,
-        data: {
-          inputCandidates: batchToEvaluate.length,
-          returnedFromEvaluator: evaluatedOpportunities.length,
-          passedCount: passed.length,
-          minScore,
-          remaining: effectiveRemaining.length,
-          batchNumber: 1,
-          durationMs: Date.now() - startTime,
-          model: getModelName("opportunityEvaluator"),
-        },
-      });
-
-      // Individual candidate entries - show ALL candidates that went to evaluator
-      for (const entity of candidateEntities) {
-        const candidateName = entity.profile?.name || entity.userId.slice(0, 8);
-        const evaluated = evaluatedByUserId.get(entity.userId);
-        const score = evaluated?.score;
-        const didPass = score !== undefined && score >= minScore;
-        const status = score !== undefined
-          ? (didPass ? '✓ passed' : `✗ score ${score}`)
-          : '✗ not scored';
-
+      // A run that ends on the bound with candidates left must say so. Reporting
+      // it as "the evaluator rejected everything" hides an unevaluated tail.
+      if (passedOpportunities.length === 0 && remaining.length > 0) {
+        evaluationLog.info('Evaluation bound reached with candidates still unevaluated', {
+          batchesRun,
+          evaluated: consumed,
+          unevaluated: remaining.length,
+        });
         traceEntries.push({
-          node: "candidate",
-          detail: `${candidateName}: ${status}`,
+          node: "evaluation_bound",
+          detail: `${remaining.length} candidate(s) never evaluated — stopped after ${batchesRun} batch(es) of ${EVAL_BATCH_SIZE}`,
           data: {
-            userId: entity.userId,
-            name: candidateName,
-            bio: entity.profile?.bio,
-            score: score,
-            passed: didPass,
-            reasoning: evaluated?.reasoning || 'No evaluation returned for this candidate',
-            matchedVia: entity.matchedVia,
-            ragScore: entity.ragScore,
-            model: getModelName("opportunityEvaluator"),
-            intents: entity.intents?.map((i: { intentId?: string; payload?: string; summary?: string }) => ({
-              intentId: i.intentId,
-              summary: (i.summary || i.payload || '').slice(0, 100),
-            })),
-            profile: entity.profile ? {
-              name: entity.profile.name,
-              location: entity.profile.location,
-            } : undefined,
+            unevaluatedCandidates: remaining.length,
+            evaluatedCandidates: consumed,
+            batchesRun,
+            maxBatches: MAX_EVAL_BATCHES_PER_RUN,
+            batchSize: EVAL_BATCH_SIZE,
           },
         });
       }
 
+      evaluationLog.verbose('Evaluation complete', {
+        batchesRun,
+        evaluatedCandidates: consumed,
+        passed: passedOpportunities.length,
+        unevaluated: remaining.length,
+      });
+
       return {
         candidates: eligibleCandidates,
-        // Only pass opportunities that passed the threshold to downstream nodes
-        evaluatedOpportunities: evaluatedOpportunities.filter((o) => o.score >= minScore),
-        remainingCandidates: effectiveRemaining,
+        // Only opportunities that passed the threshold reach downstream nodes
+        evaluatedOpportunities: passedOpportunities,
+        remainingCandidates: remaining,
         trace: traceEntries,
         agentTimings: agentTimingsAccum,
       };
@@ -333,6 +255,237 @@ export async function evaluationNode(state: OpportunityState, deps: OpportunityG
   });
 }
 
+/** Everything one evaluator batch needs, resolved once per run by {@link evaluationNode}. */
+interface CandidateBatchArgs {
+  batch: CandidateMatch[];
+  batchNumber: number;
+  sourceEntity: EvaluatorEntity;
+  state: OpportunityState;
+  deps: OpportunityGraphDeps;
+  discoveryUserId: string;
+  minScore: number;
+  evaluator: OpportunityEvaluator;
+  runParallel: boolean;
+  evaluatorSignalConfig: ReturnType<typeof getAbortSignalConfig>;
+  agentTimingsAccum: DebugMetaAgent[];
+}
+
+/**
+ * Evaluate one batch of candidates: hydrate entities, invoke the evaluator, map
+ * verdicts onto opportunities, and emit this batch's slice of the trace.
+ */
+async function evaluateCandidateBatch(
+  args: CandidateBatchArgs,
+): Promise<{ passed: EvaluatedOpportunity[]; trace: TraceEntry[] }> {
+  const {
+    batch, batchNumber, sourceEntity, state, deps, discoveryUserId,
+    minScore, evaluator, runParallel, evaluatorSignalConfig, agentTimingsAccum,
+  } = args;
+  const batchStart = Date.now();
+  const traceEntries: TraceEntry[] = [];
+
+  const candidateEntities = await buildCandidateEntities(batch, deps);
+
+  const userIdToIndexId = new Map<string, Id<'networks'>>();
+  const evidenceByEntityKey = new Map<string, OpportunityEvidence[]>();
+  const entityKeysByUserId = new Map<string, string[]>();
+  for (const e of candidateEntities) {
+    if (!userIdToIndexId.has(e.userId)) userIdToIndexId.set(e.userId, e.networkId as Id<'networks'>);
+    if (e.evidenceKey) {
+      evidenceByEntityKey.set(
+        e.evidenceKey,
+        mergeOpportunityEvidence(evidenceByEntityKey.get(e.evidenceKey), e.evidence),
+      );
+      entityKeysByUserId.set(e.userId, [...(entityKeysByUserId.get(e.userId) ?? []), e.evidenceKey]);
+    }
+  }
+
+  function evidenceForActor(actor: { userId: string; intentId?: string | null; evidenceKey?: string | null }): OpportunityEvidence[] | undefined {
+    if (actor.evidenceKey) return evidenceByEntityKey.get(actor.evidenceKey);
+    const keys = entityKeysByUserId.get(actor.userId) ?? [];
+    const intentKey = actor.intentId ? keys.find((key) => key.endsWith(`:${actor.intentId}`)) : undefined;
+    if (intentKey) return evidenceByEntityKey.get(intentKey);
+    // Avoid leaking unrelated resource evidence when the evaluator collapsed multiple
+    // candidates for the same user into a profile-only actor.
+    if (keys.length === 1) return evidenceByEntityKey.get(keys[0]);
+    return undefined;
+  }
+
+  const networkContexts = await buildNetworkContexts([sourceEntity, ...candidateEntities], deps.database);
+
+  const evaluatorVerdicts: PairwiseOpportunity[] = runParallel
+    ? await evaluateInParallel({
+        evaluator, sourceEntity, candidateEntities, state, discoveryUserId,
+        networkContexts, minScore, evaluatorSignalConfig, agentTimingsAccum, traceEntries,
+      })
+    : splitBundledVerdicts(
+        await evaluateBundled({
+          evaluator, sourceEntity, candidateEntities, state, discoveryUserId,
+          networkContexts, minScore, evaluatorSignalConfig, agentTimingsAccum,
+        }),
+        state,
+        candidateEntities,
+      );
+
+  // Verdicts the evaluator answered but nothing persistable came of. They carry the
+  // real score and reasoning, so the per-candidate trace can say what happened
+  // instead of claiming the candidate was never evaluated.
+  const rejections = evaluatorVerdicts.filter((op) => op.rejection !== undefined);
+  const pairwiseOpportunities = evaluatorVerdicts.filter((op) => op.rejection === undefined);
+
+  const evaluatedOpportunities: EvaluatedOpportunity[] = pairwiseOpportunities.map((op) => ({
+    reasoning: op.reasoning,
+    score: op.score,
+    evidence: mergeOpportunityEvidence(...op.actors.map(evidenceForActor)),
+    actors: op.actors.map((a) => {
+      const isSource = a.userId === discoveryUserId;
+      if (isSource) {
+        // Source actor inherits the counterpart's networkId (shared match context)
+        const counterpart = op.actors.find((other) => other.userId !== a.userId);
+        const counterpartIndexId = counterpart
+          ? userIdToIndexId.get(counterpart.userId) ?? (candidateEntities.find((e) => e.userId === counterpart.userId)?.networkId as Id<'networks'>)
+          : undefined;
+        return {
+          userId: a.userId as Id<'users'>,
+          role: a.role,
+          intentId: a.intentId as Id<'intents'> | undefined,
+          networkId: counterpartIndexId ?? userIdToIndexId.get(a.userId) ?? ('' as Id<'networks'>),
+        };
+      }
+      return {
+        userId: a.userId as Id<'users'>,
+        role: a.role,
+        intentId: a.intentId as Id<'intents'> | undefined,
+        networkId: userIdToIndexId.get(a.userId) ?? (candidateEntities.find((e) => e.userId === a.userId)?.networkId as Id<'networks'>),
+      };
+    }),
+  }));
+
+  const passed = evaluatedOpportunities.filter((o) => o.score >= minScore);
+  evaluationLog.verbose('Batch evaluated', {
+    batchNumber,
+    evaluatedCount: evaluatedOpportunities.length,
+    rejectedCount: rejections.length,
+    passed: passed.length,
+  });
+
+  // Threshold filter trace: how many candidates in this batch were above/below similarity threshold
+  const aboveThreshold = batch.filter(
+    (candidate) => candidate.similarity >= deps.retrievalMinSimilarity,
+  ).length;
+  const belowThreshold = batch.length - aboveThreshold;
+  traceEntries.push({
+    node: "threshold_filter",
+    detail: `${aboveThreshold} above ${deps.retrievalMinSimilarity}, ${belowThreshold} below (batch ${batchNumber} of ${batch.length})`,
+    data: {
+      aboveThreshold,
+      belowThreshold,
+      minScore: deps.retrievalMinSimilarity,
+      retrievalMinSimilarity: deps.retrievalMinSimilarity,
+      evaluatorMinScore: minScore,
+      batchSize: batch.length,
+      batchNumber,
+    },
+  });
+
+  // Create a map of evaluated candidates by userId for quick lookup.
+  // Use discoveryUserId (which accounts for onBehalfOfUserId in introducer flow)
+  // rather than state.userId (which is the introducer, not present in pairwise actors).
+  const evaluatedByUserId = new Map<string, { score: number; reasoning: string }>();
+  for (const opp of evaluatedOpportunities) {
+    const candidateActor = opp.actors.find(a => a.userId !== discoveryUserId);
+    if (candidateActor) {
+      evaluatedByUserId.set(candidateActor.userId, { score: opp.score, reasoning: opp.reasoning });
+    }
+  }
+  const rejectedByUserId = new Map<string, { score: number; reasoning: string; reason: EvaluatorRejection['reason'] }>();
+  for (const op of rejections) {
+    const rejection = op.rejection!;
+    rejectedByUserId.set(rejection.candidateId, {
+      score: op.score,
+      reasoning: op.reasoning,
+      reason: rejection.reason,
+    });
+  }
+
+  traceEntries.push({
+    node: "evaluation",
+    detail: `Evaluated ${candidateEntities.length} candidate(s) → ${passed.length} passed (min score ${minScore})`,
+    data: {
+      inputCandidates: batch.length,
+      returnedFromEvaluator: evaluatedOpportunities.length,
+      rejectedByEvaluator: rejections.length,
+      passedCount: passed.length,
+      minScore,
+      batchNumber,
+      durationMs: Date.now() - batchStart,
+      model: getModelName("opportunityEvaluator"),
+    },
+  });
+
+  // Guard drops are not model judgements — surface them so they cannot look like
+  // an evaluator that simply had nothing to say.
+  const guardDropped = rejections.filter((op) => op.rejection!.reason !== 'not_accepted');
+  if (guardDropped.length > 0) {
+    traceEntries.push({
+      node: "evaluation_dropped",
+      detail: `${guardDropped.length} accepted verdict(s) dropped by evaluator guards`,
+      data: {
+        droppedCount: guardDropped.length,
+        batchNumber,
+        drops: guardDropped.map((op) => ({
+          candidateUserId: op.rejection!.candidateId,
+          reason: op.rejection!.reason,
+          score: op.score,
+        })),
+      },
+    });
+  }
+
+  // Individual candidate entries - show ALL candidates that went to evaluator
+  for (const entity of candidateEntities) {
+    const candidateName = entity.profile?.name || entity.userId.slice(0, 8);
+    const evaluated = evaluatedByUserId.get(entity.userId);
+    const rejected = rejectedByUserId.get(entity.userId);
+    const score = evaluated?.score ?? rejected?.score;
+    const didPass = evaluated !== undefined && evaluated.score >= minScore;
+    const status = didPass
+      ? '✓ passed'
+      : score !== undefined
+        ? `✗ score ${score}`
+        : '✗ no verdict';
+
+    traceEntries.push({
+      node: "candidate",
+      detail: `${candidateName}: ${status}`,
+      data: {
+        userId: entity.userId,
+        name: candidateName,
+        bio: entity.profile?.bio,
+        score: score,
+        passed: didPass,
+        reasoning: evaluated?.reasoning
+          ?? rejected?.reasoning
+          ?? 'Evaluator returned no verdict for this candidate',
+        rejectionReason: rejected?.reason,
+        batchNumber,
+        matchedVia: entity.matchedVia,
+        ragScore: entity.ragScore,
+        model: getModelName("opportunityEvaluator"),
+        intents: entity.intents?.map((i: { intentId?: string; payload?: string; summary?: string }) => ({
+          intentId: i.intentId,
+          summary: (i.summary || i.payload || '').slice(0, 100),
+        })),
+        profile: entity.profile ? {
+          name: entity.profile.name,
+          location: entity.profile.location,
+        } : undefined,
+      },
+    });
+  }
+
+  return { passed, trace: traceEntries };
+}
 /** Dedup by userId — when same similarity, prefer index with highest relevancyScore. */
 function dedupeCandidatesByUser(sortedCandidates: CandidateMatch[], state: OpportunityState): CandidateMatch[] {
   const bestByUser = new Map<string, CandidateMatch>();

--- a/packages/protocol/src/opportunities/opportunity.graph.shared.ts
+++ b/packages/protocol/src/opportunities/opportunity.graph.shared.ts
@@ -43,6 +43,8 @@ export type OpportunityEvaluatorLike = {
     reasoning: string;
     score: number;
     actors: Array<{ userId: string; role: 'agent' | 'patient' | 'peer'; intentId?: string | null; evidenceKey?: string | null }>;
+    /** Diagnostic-only entry under `returnAll` — carries no actors, never persisted. */
+    rejection?: { candidateId: string; reason: 'not_accepted' | 'incomplete_actors' | 'unsupported_claim' };
   }>>;
 };
 

--- a/packages/protocol/src/opportunities/opportunity.similarity.ts
+++ b/packages/protocol/src/opportunities/opportunity.similarity.ts
@@ -1,0 +1,53 @@
+/**
+ * Retrieval score calibration.
+ *
+ * A candidate's `similarity` must stay an honest, cosine-derived value. Retrieval
+ * awards a bonus when more than one signal (HyDE lens, or discovery strategy)
+ * surfaced the same candidate, and that bonus used to be *added* to the raw score
+ * and then clamped: `Math.min(raw + bonus, 1)`. Any candidate with enough
+ * overlapping signals landed on exactly 1.0, so dozens of unrelated candidates tied
+ * at the top of the ranking and monopolised the by-rank evaluation batch.
+ *
+ * The bonus is applied to the headroom above the raw score instead. That keeps it
+ * strictly monotone in the raw score and strictly below 1.0 unless the vector itself
+ * scored 1.0 — a flat ceiling of identical maxima across different documents is
+ * impossible by construction.
+ */
+
+/** Default bonus per additional distinct signal that surfaced the same candidate. */
+export const MULTI_SIGNAL_BONUS_PER_SIGNAL = 0.1;
+
+/** Default ceiling on the total multi-signal bonus fraction. */
+export const MULTI_SIGNAL_BONUS_MAX = 0.3;
+
+/**
+ * Clamp a raw vector score into [0, 1].
+ * pgvector's `1 - (a <=> b)` can return values a float epsilon outside the range,
+ * and a non-finite score (bad parse, missing column) must not poison the ranking.
+ */
+export function normalizeSimilarity(raw: number): number {
+  if (!Number.isFinite(raw)) return 0;
+  if (raw <= 0) return 0;
+  return raw >= 1 ? 1 : raw;
+}
+
+/**
+ * Combine a raw similarity with a bounded bonus for multi-signal agreement.
+ *
+ * `distinctSignals` is the number of *distinct* signals (lenses, strategies) that
+ * surfaced this candidate — not the number of matched rows. The same lens hitting
+ * three of a user's premises is one signal, not three.
+ */
+export function withMultiSignalBonus(
+  raw: number,
+  distinctSignals: number,
+  options: { perSignal?: number; maxBonus?: number } = {},
+): number {
+  const base = normalizeSimilarity(raw);
+  const extraSignals = Math.max(0, Math.floor(distinctSignals) - 1);
+  if (extraSignals === 0 || base >= 1) return base;
+  const perSignal = options.perSignal ?? MULTI_SIGNAL_BONUS_PER_SIGNAL;
+  const maxBonus = options.maxBonus ?? MULTI_SIGNAL_BONUS_MAX;
+  const bonus = Math.min(extraSignals * perSignal, maxBonus);
+  return base + (1 - base) * bonus;
+}

--- a/packages/protocol/src/opportunities/tests/opportunity.evaluator.spec.ts
+++ b/packages/protocol/src/opportunities/tests/opportunity.evaluator.spec.ts
@@ -133,8 +133,15 @@ describe('OpportunityEvaluator', () => {
         minScore: 70,
         returnAll: true,
       });
-      expect(returnAll).toHaveLength(1);
-      expect(returnAll[0].reasoning).toContain('privacy tools');
+      const persistable = returnAll.filter((op) => op.rejection === undefined);
+      expect(persistable).toHaveLength(1);
+      expect(persistable[0].reasoning).toContain('privacy tools');
+      // The claim-guard drop is reported, not swallowed: `returnAll` callers trace
+      // every candidate and must be able to say why this one produced nothing.
+      const dropped = returnAll.filter((op) => op.rejection !== undefined);
+      expect(dropped).toHaveLength(1);
+      expect(dropped[0].rejection).toEqual({ candidateId: 'user-2', reason: 'unsupported_claim' });
+      expect(dropped[0].actors).toEqual([]);
 
       const scoreFiltered = await evaluatorWithMock.invokeEntityBundle(input, {
         minScore: 70,

--- a/packages/protocol/src/opportunities/tests/opportunity.graph.spec.ts
+++ b/packages/protocol/src/opportunities/tests/opportunity.graph.spec.ts
@@ -7,7 +7,7 @@
 import { config } from "dotenv";
 config({ path: '.env.test', override: true });
 
-import { afterAll, afterEach, beforeAll, describe, test, it, expect, mock, spyOn } from 'bun:test';
+import { afterAll, afterEach, beforeAll, beforeEach, describe, test, it, expect, mock, spyOn } from 'bun:test';
 import type { Runnable } from '@langchain/core/runnables';
 import { OpportunityGraphFactory, type OpportunityEvaluatorLike, type OpportunityGraphThresholdOverrides, buildDiscovererContext, buildPrioritizedNegotiationIntents } from '../opportunity.graph.js';
 import type { Id } from '../../shared/interfaces/database.interface.js';
@@ -1259,7 +1259,20 @@ describe('Opportunity Graph', () => {
     });
   });
 
-  describe('Evaluation node: early termination', () => {
+  describe('Evaluation node: batching and continuation', () => {
+    // Batch boundaries are asserted on the bundled path, where one evaluator call
+    // is one batch. The parallel path fans a batch out into one call per candidate;
+    // the last test in this block covers continuation there.
+    let previousParallelEvaluation: string | undefined;
+    beforeEach(() => {
+      previousParallelEvaluation = process.env.RUN_OPPORTUNITY_EVAL_IN_PARALLEL;
+      process.env.RUN_OPPORTUNITY_EVAL_IN_PARALLEL = 'false';
+    });
+    afterEach(() => {
+      if (previousParallelEvaluation === undefined) delete process.env.RUN_OPPORTUNITY_EVAL_IN_PARALLEL;
+      else process.env.RUN_OPPORTUNITY_EVAL_IN_PARALLEL = previousParallelEvaluation;
+    });
+
     test('when search is query-driven and remaining candidates have no query-sourced entries, remainingCandidates is empty', async () => {
       // 5 query candidates come through HyDE search → tagged 'query'
       // With EVAL_BATCH_SIZE=25, all 5 fit in one batch → remaining = 0
@@ -1290,23 +1303,50 @@ describe('Opportunity Graph', () => {
       expect(result.remainingCandidates.length).toBe(0);
     });
 
-    test('when remaining candidates still have query-sourced entries, remainingCandidates is preserved', async () => {
-      // Create 30 query candidates — after batch of 25, 5 remain with discoverySource='query'
-      const allQueryCandidates = Array.from({ length: 30 }, (_, i) => ({
+    /** Distinct HyDE candidates, ranked by descending score. */
+    const rankedCandidates = (count: number) =>
+      Array.from({ length: count }, (_, i) => ({
         type: 'intent' as const,
         id: `intent-q-${i}`,
         userId: `${String(i).padStart(8, '0')}-0000-4000-8000-000000000000`,
-        score: 0.95 - i * 0.01,
+        score: 0.99 - i * 0.005,
         matchedVia: 'Painters' as const,
         networkId: 'idx-1',
       }));
 
+    const passingVerdict = (candidateUserId: string) => ({
+      reasoning: 'The candidate funds the stage and sector the source user is raising for.',
+      score: 80,
+      actors: [
+        { userId: 'a0000000-0000-4000-8000-000000000001', role: 'patient' as const, intentId: null },
+        { userId: candidateUserId, role: 'agent' as const, intentId: null },
+      ],
+    });
+
+    /** Records the candidate ids handed to each evaluator batch. */
+    const batchRecordingEvaluator = (
+      seenBatches: string[][],
+      verdictsFor: (candidateIds: string[]) => EvaluatedOpportunityWithActors[],
+    ): OpportunityEvaluatorLike => ({
+      invokeEntityBundle: async (input) => {
+        const candidateIds = input.entities.slice(1).map((e) => e.userId);
+        seenBatches.push(candidateIds);
+        return verdictsFor(candidateIds);
+      },
+    });
+
+    test('evaluates the next batch when a batch passes nothing, so tail passers are still found', async () => {
+      // 30 candidates: the top 25 (one full batch) fail, a passer sits at rank 28.
+      const candidates = rankedCandidates(30);
+      const passerId = candidates[27].userId;
+      const seenBatches: string[][] = [];
       const { compiledGraph, mockEmbedder } = createMockGraph({
-        evaluatorResult: [],
+        evaluator: batchRecordingEvaluator(seenBatches, (ids) =>
+          ids.includes(passerId) ? [passingVerdict(passerId)] : [],
+        ),
         thresholdOverrides: { evaluatorMinScore: 50 },
       });
-
-      spyOn(mockEmbedder, 'searchWithHydeEmbeddings').mockResolvedValue(allQueryCandidates);
+      spyOn(mockEmbedder, 'searchWithHydeEmbeddings').mockResolvedValue(candidates);
 
       const result = (await compiledGraph.invoke({
         userId: 'a0000000-0000-4000-8000-000000000001' as Id<'users'>,
@@ -1314,8 +1354,169 @@ describe('Opportunity Graph', () => {
         options: {},
       } as OpportunityGraphInvokeInput)) as OpportunityGraphInvokeResult;
 
-      // 5 query-sourced candidates remain — pagination should be preserved
+      expect(seenBatches.map((batch) => batch.length)).toEqual([25, 5]);
+      expect(seenBatches[1]).toContain(passerId);
+      expect(result.evaluatedOpportunities).toHaveLength(1);
+      expect(result.remainingCandidates).toEqual([]);
+    });
+
+    test('stops as soon as a batch passes, leaving the rest for pagination', async () => {
+      const candidates = rankedCandidates(30);
+      const passerId = candidates[3].userId;
+      const seenBatches: string[][] = [];
+      const { compiledGraph, mockEmbedder } = createMockGraph({
+        evaluator: batchRecordingEvaluator(seenBatches, (ids) =>
+          ids.includes(passerId) ? [passingVerdict(passerId)] : [],
+        ),
+        thresholdOverrides: { evaluatorMinScore: 50 },
+      });
+      spyOn(mockEmbedder, 'searchWithHydeEmbeddings').mockResolvedValue(candidates);
+
+      const result = (await compiledGraph.invoke({
+        userId: 'a0000000-0000-4000-8000-000000000001' as Id<'users'>,
+        searchQuery: 'painters',
+        options: {},
+      } as OpportunityGraphInvokeInput)) as OpportunityGraphInvokeResult;
+
+      expect(seenBatches).toHaveLength(1);
+      expect(result.evaluatedOpportunities).toHaveLength(1);
+      // The 5 query-sourced candidates behind the batch stay available for pagination.
       expect(result.remainingCandidates.length).toBe(5);
+    });
+
+    test('stops at the batch bound and reports the stranded tail honestly', async () => {
+      // 80 candidates, every one rejected: 3 batches of 25 run, 5 are never evaluated.
+      const candidates = rankedCandidates(80);
+      const seenBatches: string[][] = [];
+      const { compiledGraph, mockEmbedder } = createMockGraph({
+        evaluator: batchRecordingEvaluator(seenBatches, () => []),
+        thresholdOverrides: { evaluatorMinScore: 50 },
+      });
+      spyOn(mockEmbedder, 'searchWithHydeEmbeddings').mockResolvedValue(candidates);
+
+      const result = (await compiledGraph.invoke({
+        userId: 'a0000000-0000-4000-8000-000000000001' as Id<'users'>,
+        searchQuery: 'painters',
+        options: {},
+      } as OpportunityGraphInvokeInput)) as OpportunityGraphInvokeResult;
+
+      expect(seenBatches.map((batch) => batch.length)).toEqual([25, 25, 25]);
+      expect(result.evaluatedOpportunities).toEqual([]);
+      expect(result.remainingCandidates.length).toBe(5);
+      expect(result.trace).toContainEqual(expect.objectContaining({
+        node: 'evaluation_bound',
+        data: expect.objectContaining({
+          unevaluatedCandidates: 5,
+          evaluatedCandidates: 75,
+          batchesRun: 3,
+        }),
+      }));
+    });
+
+    test('continues into the tail on the parallel evaluation path too', async () => {
+      process.env.RUN_OPPORTUNITY_EVAL_IN_PARALLEL = 'true';
+      const candidates = rankedCandidates(30);
+      const passerId = candidates[27].userId;
+      const seenBatches: string[][] = [];
+      const { compiledGraph, mockEmbedder } = createMockGraph({
+        evaluator: batchRecordingEvaluator(seenBatches, (ids) =>
+          ids.includes(passerId) ? [passingVerdict(passerId)] : [],
+        ),
+        thresholdOverrides: { evaluatorMinScore: 50 },
+      });
+      spyOn(mockEmbedder, 'searchWithHydeEmbeddings').mockResolvedValue(candidates);
+
+      const result = (await compiledGraph.invoke({
+        userId: 'a0000000-0000-4000-8000-000000000001' as Id<'users'>,
+        searchQuery: 'painters',
+        options: {},
+      } as OpportunityGraphInvokeInput)) as OpportunityGraphInvokeResult;
+
+      // One call per candidate here, so assert on coverage rather than batch shape.
+      const evaluated = new Set(seenBatches.flat());
+      expect(evaluated.size).toBe(30);
+      expect(evaluated.has(passerId)).toBe(true);
+      expect(result.evaluatedOpportunities).toHaveLength(1);
+      expect(result.remainingCandidates).toEqual([]);
+    });
+  });
+
+  /**
+   * An evaluator that returns nothing for a candidate is ambiguous on its own:
+   * the model may have judged the pairing unviable, or a deterministic guard may
+   * have dropped an accepted verdict. The trace has to distinguish them.
+   */
+  describe('Evaluation node: verdict diagnostics', () => {
+    const CANDIDATE_ID = 'b0000000-0000-4000-8000-000000000002';
+
+    const diagnosticEvaluator = (
+      entries: EvaluatedOpportunityWithActors[],
+    ): OpportunityEvaluatorLike => ({
+      invokeEntityBundle: async () => entries,
+    });
+
+    const runWith = async (evaluator: OpportunityEvaluatorLike) => {
+      const { compiledGraph } = createMockGraph({ evaluator, thresholdOverrides: { evaluatorMinScore: 50 } });
+      return (await compiledGraph.invoke({
+        userId: 'a0000000-0000-4000-8000-000000000001' as Id<'users'>,
+        searchQuery: 'co-founder',
+        options: {},
+      } as OpportunityGraphInvokeInput)) as OpportunityGraphInvokeResult;
+    };
+
+    test('reports the model\'s own rejection with its score and reasoning', async () => {
+      const result = await runWith(diagnosticEvaluator([{
+        reasoning: 'Same-side match: both are seeking investment rather than offering it.',
+        score: 12,
+        actors: [],
+        rejection: { candidateId: CANDIDATE_ID, reason: 'not_accepted' },
+      }]));
+
+      expect(result.evaluatedOpportunities).toEqual([]);
+      expect(result.trace).toContainEqual(expect.objectContaining({
+        node: 'candidate',
+        data: expect.objectContaining({
+          userId: CANDIDATE_ID,
+          score: 12,
+          passed: false,
+          rejectionReason: 'not_accepted',
+          reasoning: 'Same-side match: both are seeking investment rather than offering it.',
+        }),
+      }));
+    });
+
+    test('surfaces a guard drop instead of letting it look like silence', async () => {
+      const result = await runWith(diagnosticEvaluator([{
+        reasoning: 'Both will be at the same event.',
+        score: 88,
+        actors: [],
+        rejection: { candidateId: CANDIDATE_ID, reason: 'unsupported_claim' },
+      }]));
+
+      expect(result.evaluatedOpportunities).toEqual([]);
+      expect(result.trace).toContainEqual(expect.objectContaining({
+        node: 'evaluation_dropped',
+        data: expect.objectContaining({
+          droppedCount: 1,
+          drops: [{ candidateUserId: CANDIDATE_ID, reason: 'unsupported_claim', score: 88 }],
+        }),
+      }));
+      // A high-scoring guard drop must never reach persistence.
+      expect(result.opportunities).toEqual([]);
+    });
+
+    test('says "no verdict" only when the evaluator really returned nothing', async () => {
+      const result = await runWith(diagnosticEvaluator([]));
+
+      expect(result.trace).toContainEqual(expect.objectContaining({
+        node: 'candidate',
+        detail: expect.stringContaining('✗ no verdict'),
+        data: expect.objectContaining({
+          userId: CANDIDATE_ID,
+          score: undefined,
+          reasoning: 'Evaluator returned no verdict for this candidate',
+        }),
+      }));
     });
   });
 

--- a/packages/protocol/src/opportunities/tests/opportunity.similarity.spec.ts
+++ b/packages/protocol/src/opportunities/tests/opportunity.similarity.spec.ts
@@ -1,0 +1,122 @@
+/**
+ * Retrieval score calibration.
+ *
+ * The property that matters: retrieval scores stay honest cosine-derived values.
+ * A multi-signal bonus may reorder candidates, but it must never manufacture a
+ * flat ceiling — a head cluster of identical maxima across unrelated documents is
+ * what starved evaluation of every genuine match behind it.
+ */
+import { describe, expect, it } from 'bun:test';
+import { MULTI_SIGNAL_BONUS_MAX, normalizeSimilarity, withMultiSignalBonus } from '../opportunity.similarity.js';
+import { mergeStrategyCandidates } from '../opportunity.graph.discovery-strategies.js';
+import type { CandidateMatch } from '../opportunity.state.js';
+import type { Id } from '../../shared/interfaces/database.interface.js';
+
+describe('normalizeSimilarity', () => {
+  it('passes honest cosine values through unchanged', () => {
+    expect(normalizeSimilarity(0.42)).toBe(0.42);
+    expect(normalizeSimilarity(0)).toBe(0);
+    expect(normalizeSimilarity(1)).toBe(1);
+  });
+
+  it('clamps the float epsilon pgvector can return outside [0, 1]', () => {
+    expect(normalizeSimilarity(1.0000000000000002)).toBe(1);
+    expect(normalizeSimilarity(-0.03)).toBe(0);
+  });
+
+  it('treats an unparseable score as no similarity rather than poisoning the ranking', () => {
+    expect(normalizeSimilarity(Number.NaN)).toBe(0);
+    // A non-finite score is garbage, not a perfect match — it must not top the ranking.
+    expect(normalizeSimilarity(Number.POSITIVE_INFINITY)).toBe(0);
+  });
+});
+
+describe('withMultiSignalBonus', () => {
+  it('is a no-op for a single signal', () => {
+    expect(withMultiSignalBonus(0.55, 1)).toBe(0.55);
+    expect(withMultiSignalBonus(0.55, 0)).toBe(0.55);
+  });
+
+  it('rewards additional distinct signals without reaching 1', () => {
+    const one = withMultiSignalBonus(0.6, 1);
+    const two = withMultiSignalBonus(0.6, 2);
+    const four = withMultiSignalBonus(0.6, 4);
+    expect(two).toBeGreaterThan(one);
+    expect(four).toBeGreaterThan(two);
+    expect(four).toBeLessThan(1);
+  });
+
+  it('caps the bonus so agreement cannot outweigh the vector', () => {
+    const capped = withMultiSignalBonus(0.5, 12);
+    expect(capped).toBeCloseTo(0.5 + 0.5 * MULTI_SIGNAL_BONUS_MAX, 12);
+  });
+
+  it('only ever returns 1 when the raw score is already 1', () => {
+    expect(withMultiSignalBonus(1, 6)).toBe(1);
+    for (const raw of [0.99, 0.995, 0.999, 0.9999]) {
+      expect(withMultiSignalBonus(raw, 8)).toBeLessThan(1);
+    }
+  });
+
+  it('is strictly monotone in the raw score at any signal count', () => {
+    for (const signals of [1, 2, 3, 5, 10]) {
+      let previous = -1;
+      for (let raw = 0; raw <= 1.0001; raw += 0.01) {
+        const score = withMultiSignalBonus(Math.min(raw, 1), signals);
+        expect(score).toBeGreaterThan(previous);
+        previous = score;
+      }
+    }
+  });
+
+  it('keeps distinct documents distinct — no flat ceiling', () => {
+    // Thirty candidates with distinct raw scores, each surfaced by every signal.
+    const raws = Array.from({ length: 30 }, (_, i) => 0.70 + i * 0.01);
+    const scores = raws.map((raw) => withMultiSignalBonus(raw, 6));
+    expect(new Set(scores).size).toBe(raws.length);
+    const max = Math.max(...scores);
+    expect(scores.filter((s) => s === max)).toHaveLength(1);
+  });
+});
+
+describe('mergeStrategyCandidates', () => {
+  const candidate = (
+    userId: string,
+    similarity: number,
+    discoverySource: CandidateMatch['discoverySource'],
+  ): CandidateMatch => ({
+    candidateUserId: userId as Id<'users'>,
+    candidateIntentId: `${userId}-intent` as Id<'intents'>,
+    networkId: 'idx-1' as Id<'networks'>,
+    similarity,
+    lens: 'lens',
+    discoverySource,
+  });
+
+  it('never ties candidates at the ceiling, however many strategies agree', () => {
+    const raws = [0.99, 0.97, 0.95, 0.93];
+    const merged = mergeStrategyCandidates(
+      raws.map((s, i) => candidate(`u${i}`, s, 'query')),
+      raws.map((s, i) => candidate(`u${i}`, s, 'premise-similarity')),
+      raws.map((s, i) => candidate(`u${i}`, s, 'context-to-intent')),
+      raws.map((s, i) => candidate(`u${i}`, s, 'context-similarity')),
+    );
+
+    expect(merged).toHaveLength(raws.length);
+    for (const c of merged) expect(c.similarity).toBeLessThan(1);
+    expect(new Set(merged.map((c) => c.similarity)).size).toBe(raws.length);
+    // Merging must not reorder candidates that agree on the same strategy set.
+    expect(merged.map((c) => c.candidateUserId)).toEqual(['u0', 'u1', 'u2', 'u3']);
+  });
+
+  it('still ranks multi-strategy agreement above a lone match', () => {
+    const merged = mergeStrategyCandidates(
+      [candidate('agreed', 0.60, 'query'), candidate('alone', 0.62, 'query')],
+      [candidate('agreed', 0.58, 'premise-similarity')],
+      [candidate('agreed', 0.57, 'context-to-intent')],
+    );
+    const byUser = Object.fromEntries(merged.map((c) => [c.candidateUserId, c.similarity]));
+    expect(byUser.agreed).toBeGreaterThan(byUser.alone);
+    expect(byUser.alone).toBe(0.62);
+  });
+});

--- a/services/api/src/adapters/embedder.adapter.ts
+++ b/services/api/src/adapters/embedder.adapter.ts
@@ -5,6 +5,7 @@
 
 import OpenAI from 'openai';
 import { and, eq, inArray, isNotNull, isNull, ne, or, sql } from 'drizzle-orm/sql';
+import { withMultiSignalBonus } from '../lib/embedding/similarity.calibration';
 import { OPENROUTER_EMBEDDING_BASE_URL, OPENROUTER_EMBEDDING_DIMENSIONS, OPENROUTER_EMBEDDING_MODEL } from '../lib/embedding/embedding.config';
 import { embeddingConfigurationFingerprint } from '../lib/embedding/embedding.identity';
 import { traceAppOperation } from '../lib/sentry-performance';
@@ -94,6 +95,39 @@ export function planHydeCorpusSearches(
     userContexts,
     preferred,
   };
+}
+
+/**
+ * Collapse HyDE matches to one candidate per user, scored honestly.
+ *
+ * The retained score is the user's best raw cosine similarity plus a bounded
+ * bonus for each ADDITIONAL DISTINCT lens that surfaced them. Counting matched
+ * rows instead of lenses (one lens hitting three of a user's premises counted as
+ * three signals) saturated the old additive bonus, so unrelated candidates all
+ * landed on exactly 1.0 and monopolised the by-rank evaluation batch.
+ */
+export function mergeAndRankHydeCandidates(
+  candidates: HydeCandidate[],
+  limit: number,
+): HydeCandidate[] {
+  const byUser = new Map<string, HydeCandidate[]>();
+  for (const c of candidates) {
+    const existing = byUser.get(c.userId) ?? [];
+    existing.push(c);
+    byUser.set(c.userId, existing);
+  }
+
+  const scored = Array.from(byUser.entries()).map(([, matches]) => {
+    const bestMatch = matches.reduce((a, b) => (a.score > b.score ? a : b));
+    const lenses = [...new Set(matches.map((m) => m.matchedVia))];
+    return {
+      ...bestMatch,
+      score: withMultiSignalBonus(bestMatch.score, lenses.length),
+      matchedLenses: lenses.length > 1 ? lenses : undefined,
+    };
+  });
+
+  return scored.sort((a, b) => b.score - a.score).slice(0, limit);
 }
 
 // ─────────────────────────────────────────────────────────────────────────────
@@ -464,25 +498,7 @@ export class EmbedderAdapter {
     candidates: HydeCandidate[],
     limit: number
   ): HydeCandidate[] {
-    const byUser = new Map<string, HydeCandidate[]>();
-    for (const c of candidates) {
-      const existing = byUser.get(c.userId) ?? [];
-      existing.push(c);
-      byUser.set(c.userId, existing);
-    }
-
-    const scored = Array.from(byUser.entries()).map(([, matches]) => {
-      const bestMatch = matches.reduce((a, b) => (a.score > b.score ? a : b));
-      const lensBonus = (matches.length - 1) * 0.1;
-      const lenses = [...new Set(matches.map((m) => m.matchedVia))];
-      return {
-        ...bestMatch,
-        score: Math.min(bestMatch.score + lensBonus, 1),
-        matchedLenses: lenses.length > 1 ? lenses : undefined,
-      };
-    });
-
-    return scored.sort((a, b) => b.score - a.score).slice(0, limit);
+    return mergeAndRankHydeCandidates(candidates, limit);
   }
 
   // ─────────────────────────────────────────────────────────────────────────

--- a/services/api/src/adapters/tests/embedder.adapter.merge-ranking.spec.ts
+++ b/services/api/src/adapters/tests/embedder.adapter.merge-ranking.spec.ts
@@ -1,0 +1,82 @@
+/**
+ * HyDE candidate merge scoring. Pure — no database.
+ *
+ * The retrieval score a candidate carries into evaluation is the number the
+ * evaluation batch is cut by, so it has to stay an honest cosine value. The
+ * regression this pins: a per-matched-row bonus that saturated at 1.0, tying
+ * dozens of unrelated candidates at the top of the ranking.
+ */
+import { describe, expect, it } from 'bun:test';
+import { mergeAndRankHydeCandidates, type HydeCandidate } from '../embedder.adapter.js';
+
+const match = (
+  userId: string,
+  score: number,
+  matchedVia: string,
+  id = `${userId}-${matchedVia}`,
+): HydeCandidate => ({
+  type: 'premise',
+  id,
+  userId,
+  score,
+  matchedVia,
+  networkId: 'idx-1',
+});
+
+describe('mergeAndRankHydeCandidates', () => {
+  it('keeps a single-lens candidate on its raw cosine score', () => {
+    const [merged] = mergeAndRankHydeCandidates([match('u1', 0.63, 'lens-a')], 10);
+    expect(merged.score).toBe(0.63);
+    expect(merged.matchedLenses).toBeUndefined();
+  });
+
+  it('counts distinct lenses, not matched rows', () => {
+    // One lens hitting five of a user's premises is one signal, not five.
+    const manyRowsOneLens = mergeAndRankHydeCandidates(
+      Array.from({ length: 5 }, (_, i) => match('u1', 0.6 - i * 0.01, 'lens-a', `p${i}`)),
+      10,
+    );
+    expect(manyRowsOneLens[0].score).toBe(0.6);
+    expect(manyRowsOneLens[0].matchedLenses).toBeUndefined();
+
+    const twoLenses = mergeAndRankHydeCandidates(
+      [match('u1', 0.6, 'lens-a'), match('u1', 0.5, 'lens-b')],
+      10,
+    );
+    expect(twoLenses[0].score).toBeGreaterThan(0.6);
+    expect(twoLenses[0].matchedLenses).toEqual(['lens-a', 'lens-b']);
+  });
+
+  it('cannot manufacture a flat ceiling out of unrelated candidates', () => {
+    // Thirty users, each surfaced by three lenses across several premises —
+    // the exact shape that used to score every one of them exactly 1.0.
+    const candidates = Array.from({ length: 30 }, (_, i) => {
+      const raw = 0.55 + i * 0.005;
+      return ['lens-a', 'lens-b', 'lens-c'].flatMap((lens, l) => [
+        match(`u${i}`, raw - l * 0.02, lens, `u${i}-${lens}-1`),
+        match(`u${i}`, raw - l * 0.02 - 0.01, lens, `u${i}-${lens}-2`),
+      ]);
+    }).flat();
+
+    const merged = mergeAndRankHydeCandidates(candidates, 100);
+
+    expect(merged).toHaveLength(30);
+    for (const c of merged) expect(c.score).toBeLessThan(1);
+    const max = Math.max(...merged.map((c) => c.score));
+    expect(merged.filter((c) => c.score === max)).toHaveLength(1);
+    expect(new Set(merged.map((c) => c.score)).size).toBe(30);
+  });
+
+  it('preserves the raw ranking when every candidate has the same lens count', () => {
+    const candidates = [0.9, 0.8, 0.7].flatMap((raw, i) => [
+      match(`u${i}`, raw, 'lens-a'),
+      match(`u${i}`, raw - 0.05, 'lens-b'),
+    ]);
+    expect(mergeAndRankHydeCandidates(candidates, 10).map((c) => c.userId)).toEqual(['u0', 'u1', 'u2']);
+  });
+
+  it('clamps a score pgvector returned just outside [0, 1]', () => {
+    const [merged] = mergeAndRankHydeCandidates([match('u1', 1.0000000000000002, 'lens-a')], 10);
+    expect(merged.score).toBe(1);
+  });
+});

--- a/services/api/src/lib/embedding/similarity.calibration.ts
+++ b/services/api/src/lib/embedding/similarity.calibration.ts
@@ -1,0 +1,55 @@
+/**
+ * Retrieval score calibration for pgvector search results.
+ *
+ * A candidate's score must stay an honest cosine-derived value. Retrieval awards a
+ * bonus when more than one signal (HyDE lens here, discovery strategy in the
+ * protocol graph) surfaced the same candidate, and that bonus used to be *added*
+ * to the raw score and then clamped: `Math.min(raw + bonus, 1)`. Any candidate with
+ * enough overlapping signals landed on exactly 1.0, so unrelated candidates tied at
+ * the top of the ranking and monopolised the by-rank evaluation batch.
+ *
+ * The bonus consumes the headroom above the raw score instead. That keeps it
+ * strictly monotone in the raw score and strictly below 1.0 unless the vector
+ * itself scored 1.0 — a flat ceiling is impossible by construction.
+ *
+ * Deliberately duplicated from the protocol's `opportunity.similarity.ts`: adapters
+ * may not import from `@indexnetwork/protocol`. Keep the two in step.
+ */
+
+/** Default bonus per additional distinct signal that surfaced the same candidate. */
+export const MULTI_SIGNAL_BONUS_PER_SIGNAL = 0.1;
+
+/** Default ceiling on the total multi-signal bonus fraction. */
+export const MULTI_SIGNAL_BONUS_MAX = 0.3;
+
+/**
+ * Clamp a raw vector score into [0, 1].
+ * pgvector's `1 - (a <=> b)` can return values a float epsilon outside the range,
+ * and a non-finite score (bad parse, missing column) must not poison the ranking.
+ */
+export function normalizeSimilarity(raw: number): number {
+  if (!Number.isFinite(raw)) return 0;
+  if (raw <= 0) return 0;
+  return raw >= 1 ? 1 : raw;
+}
+
+/**
+ * Combine a raw similarity with a bounded bonus for multi-signal agreement.
+ *
+ * `distinctSignals` is the number of *distinct* signals (lenses, strategies) that
+ * surfaced this candidate — not the number of matched rows. The same lens hitting
+ * three of a user's premises is one signal, not three.
+ */
+export function withMultiSignalBonus(
+  raw: number,
+  distinctSignals: number,
+  options: { perSignal?: number; maxBonus?: number } = {},
+): number {
+  const base = normalizeSimilarity(raw);
+  const extraSignals = Math.max(0, Math.floor(distinctSignals) - 1);
+  if (extraSignals === 0 || base >= 1) return base;
+  const perSignal = options.perSignal ?? MULTI_SIGNAL_BONUS_PER_SIGNAL;
+  const maxBonus = options.maxBonus ?? MULTI_SIGNAL_BONUS_MAX;
+  const bonus = Math.min(extraSignals * perSignal, maxBonus);
+  return base + (1 - base) * bonus;
+}

--- a/services/api/src/lib/embedding/tests/similarity.calibration.spec.ts
+++ b/services/api/src/lib/embedding/tests/similarity.calibration.spec.ts
@@ -1,0 +1,43 @@
+/**
+ * These assertions deliberately mirror the protocol's
+ * `opportunity.similarity.spec.ts`. The two implementations are duplicated across
+ * the adapter boundary, so pinning the same numbers on both sides makes drift a
+ * test failure rather than a silent divergence in retrieval scores.
+ */
+import { describe, expect, it } from 'bun:test';
+import { MULTI_SIGNAL_BONUS_MAX, normalizeSimilarity, withMultiSignalBonus } from '../similarity.calibration';
+
+describe('normalizeSimilarity', () => {
+  it('passes honest cosine values through and clamps the rest', () => {
+    expect(normalizeSimilarity(0.42)).toBe(0.42);
+    expect(normalizeSimilarity(1.0000000000000002)).toBe(1);
+    expect(normalizeSimilarity(-0.03)).toBe(0);
+    expect(normalizeSimilarity(Number.NaN)).toBe(0);
+  });
+});
+
+describe('withMultiSignalBonus', () => {
+  it('is a no-op for a single signal', () => {
+    expect(withMultiSignalBonus(0.55, 1)).toBe(0.55);
+  });
+
+  it('caps the bonus at a fraction of the headroom', () => {
+    expect(withMultiSignalBonus(0.5, 12)).toBeCloseTo(0.5 + 0.5 * MULTI_SIGNAL_BONUS_MAX, 12);
+  });
+
+  it('only ever returns 1 when the raw score is already 1', () => {
+    expect(withMultiSignalBonus(1, 6)).toBe(1);
+    for (const raw of [0.99, 0.995, 0.999, 0.9999]) {
+      expect(withMultiSignalBonus(raw, 8)).toBeLessThan(1);
+    }
+  });
+
+  it('is strictly monotone in the raw score', () => {
+    let previous = -1;
+    for (let raw = 0; raw <= 1.0001; raw += 0.01) {
+      const score = withMultiSignalBonus(Math.min(raw, 1), 5);
+      expect(score).toBeGreaterThan(previous);
+      previous = score;
+    }
+  });
+});

--- a/services/api/src/queues/opportunity/discovery.shared.ts
+++ b/services/api/src/queues/opportunity/discovery.shared.ts
@@ -64,6 +64,7 @@ export type OpportunityDiscoveryCompletionReason =
   | 'created_or_reactivated'
   | 'no_search_candidates'
   | 'evaluator_rejected_all'
+  | 'evaluation_bound_reached'
   | 'same_trigger_duplicate_suppressed'
   | 'pair_active_negotiation_suppressed'
   | 'final_atomic_conflict'
@@ -74,6 +75,8 @@ export interface OpportunityDiscoverySummary {
   evaluatedCount: number;
   opportunitiesCreated: number;
   completionReason: OpportunityDiscoveryCompletionReason;
+  /** Candidates retrieved but never handed to the evaluator (batch bound reached). */
+  unevaluatedCandidates: number;
   sameTriggerDuplicateSuppressions: number;
   pairActiveNegotiationSuppressions: number;
   crossTriggerAllowedCount: number;
@@ -82,6 +85,7 @@ export interface OpportunityDiscoverySummary {
 
 interface OpportunityDiscoveryResultShape {
   candidates?: unknown[];
+  remainingCandidates?: unknown[];
   evaluatedOpportunities?: unknown[];
   opportunities?: unknown[];
   persistenceOutcome?: {
@@ -98,6 +102,7 @@ export function summarizeOpportunityDiscoveryResult(
   result: OpportunityDiscoveryResultShape,
 ): OpportunityDiscoverySummary {
   const candidates = Array.isArray(result.candidates) ? result.candidates : [];
+  const unevaluatedCandidates = Array.isArray(result.remainingCandidates) ? result.remainingCandidates.length : 0;
   const opportunities = Array.isArray(result.opportunities) ? result.opportunities : [];
   const persistence = result.persistenceOutcome;
   const evaluatedCount = persistence?.evaluatedCount
@@ -111,7 +116,8 @@ export function summarizeOpportunityDiscoveryResult(
     : candidates.length === 0
       ? 'no_search_candidates'
       : evaluatedCount === 0
-        ? 'evaluator_rejected_all'
+        // A zero-output run with candidates still queued is a bound, not a verdict.
+        ? (unevaluatedCandidates > 0 ? 'evaluation_bound_reached' : 'evaluator_rejected_all')
         : finalAtomicConflictCount > 0
           ? 'final_atomic_conflict'
           : pairActiveNegotiationSuppressions > 0
@@ -125,6 +131,7 @@ export function summarizeOpportunityDiscoveryResult(
     evaluatedCount,
     opportunitiesCreated: opportunities.length,
     completionReason,
+    unevaluatedCandidates,
     sameTriggerDuplicateSuppressions,
     pairActiveNegotiationSuppressions,
     crossTriggerAllowedCount,

--- a/services/api/src/queues/tests/from-intent.queue.isolated.ts
+++ b/services/api/src/queues/tests/from-intent.queue.isolated.ts
@@ -88,6 +88,7 @@ const discoverySummary = (overrides: Partial<OpportunityDiscoverySummary> = {}):
   evaluatedCount: 0,
   opportunitiesCreated: 0,
   completionReason: 'created_or_reactivated',
+  unevaluatedCandidates: 0,
   sameTriggerDuplicateSuppressions: 0,
   pairActiveNegotiationSuppressions: 0,
   crossTriggerAllowedCount: 0,
@@ -525,6 +526,18 @@ describe('FromIntentQueue', () => {
 
       expect(evaluatorZero.completionReason).toBe('evaluator_rejected_all');
       expect(persistenceDedupZero.completionReason).toBe('same_trigger_duplicate_suppressed');
+    });
+
+    it('reports a stranded tail as a bound, not as an evaluator rejection', () => {
+      const bounded = summarizeOpportunityDiscoveryResult({
+        candidates: [{}, {}],
+        remainingCandidates: [{}],
+        evaluatedOpportunities: [],
+        opportunities: [],
+      });
+
+      expect(bounded.completionReason).toBe('evaluation_bound_reached');
+      expect(bounded.unevaluatedCandidates).toBe(1);
     });
   });
 


### PR DESCRIPTION
An intent with real matches in the pool showed an empty radar. Traced live against the sandbox: intent `9c82a44f` ("Secure funding from early-stage investors"), 47 candidates found, 0 evaluated opportunities, `evaluator_rejected_all`. Three independent faults compound.

**This affects dev too.** Both the score calibration and the stranded tail are environment-independent — the sandbox seed personas just made the degenerate cluster loud enough to see.

## 1. Retrieval scores clamped at a flat ceiling

The multi-signal bonus was added to the raw cosine similarity and then clamped (`Math.min(raw + boost, 1)`), and the HyDE merge counted matched **rows** rather than distinct lenses — so a user matched by three lenses across several premises saturated. In the failing run ~30 unrelated candidates (healthcare SaaS in Austin, bookkeeping in Accra, VP Eng in Madrid) all scored exactly `1.0` against a "founders who raised in Turkey" lens whose own reported `avgSimilarity` was 0.82. Their premise embeddings are distinct in the DB — this was score math, not duplicate data.

The bonus now consumes the headroom above the raw score (`base + (1 - base) * bonus`) and counts distinct signals. It stays strictly monotone in the raw score, and 1.0 is reachable only by a vector that actually scored 1.0 — a flat ceiling is impossible by construction.

## 2. The head cluster monopolised the only evaluated batch

Candidates are taken strictly by rank, `EVAL_BATCH_SIZE` is 25, and `remainingCandidates` was a dead letter: annotated in state, written by the evaluation node, read by nothing. There was no batch 2. The 22 stranded candidates included the genuine investor-lens matches (avg 0.554).

Evaluation now continues into the tail while no candidate passes, bounded by `MAX_EVAL_BATCHES_PER_RUN = 3` (75 candidates), and stops as soon as a batch passes something. No flag; the bound is a named constant. Worst case for a zero-result run is 3× the evaluator calls it used to make — that is the deliberate trade for not stranding matches.

## 3. A stranded tail is now reported as a bound, not a rejection

When the bound is reached with candidates left, the trace carries an `evaluation_bound` node with the never-evaluated count, and the completion reason is `evaluation_bound_reached` rather than `evaluator_rejected_all`. `OpportunityDiscoverySummary` gains `unevaluatedCandidates`.

## 4. The mislabel that hid all of this

Per-candidate trace reasoning read "No evaluation returned for this candidate" whenever `invokeEntityBundle` resolved to `[]` under `returnAll: true`. It was neither of the two options the diagnosis proposed. `returnAll` returned only **accepted** verdicts, so an explicit model rejection (which carries a score and reasoning) and a guard-dropped accepted verdict both vanished into the same empty array. The failing run had 25 clean empties, zero `Parallel eval failed` warnings and zero `evaluation_errors` nodes — the evaluator had answered every time, and the answers were thrown away.

`returnAll` now also returns the dropped verdicts, tagged `rejection: { candidateId, reason }` (`not_accepted` | `incomplete_actors` | `unsupported_claim`) and carrying no actors. The trace shows the model's real score and reasoning; guard drops surface as their own `evaluation_dropped` node. Callers that persist filter on `rejection === undefined`. `returnAll: false` is unchanged.

## Tests

- `opportunity.similarity.spec.ts` — normalization and bonus properties: monotone in the raw score at every signal count, capped, never 1.0 unless raw is 1.0, 30 distinct documents stay 30 distinct scores with exactly one maximum. Plus `mergeStrategyCandidates` end-to-end.
- `embedder.adapter.merge-ranking.spec.ts` — the HyDE merge (extracted as a pure function): distinct lenses not rows, and the exact 30-user × 3-lens × 2-premise shape that used to score everyone 1.0.
- `opportunity.graph.spec.ts` — batch continuation: 30 candidates with the passer at rank 28 → both batches run, passer found, nothing left over; passer in batch 1 → one batch, tail preserved for pagination; 80 all-failing → stops at 3 batches with `evaluation_bound` recording 5 stranded; and continuation on the parallel path.
- `opportunity.graph.spec.ts` — verdict diagnostics: a model rejection shows its own score and reasoning, a guard drop emits `evaluation_dropped` and never reaches persistence, and "no verdict" appears only when the evaluator really returned nothing.
- `from-intent.queue.isolated.ts` — a stranded tail summarises as `evaluation_bound_reached`.

## Notes

The calibration helper is duplicated in `services/api/src/lib/embedding/similarity.calibration.ts` because the adapter boundary rule forbids adapters importing from `@indexnetwork/protocol`. Both copies are pinned to the same numbers by mirrored specs, so drift fails a test.

Protocol bumped to 23.1.0 (behaviour change under `returnAll`, optional field added to `EvaluatedOpportunityWithActors`).

Boundaries respected: nothing under `negotiations/`, stances, or intents was touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)