### PR TITLE
fix(negotiations): a recovered negotiation is not an unmade one

### DIFF
--- a/apps/web/src/app/chat/[conversationId]/page.tsx
+++ b/apps/web/src/app/chat/[conversationId]/page.tsx
@@ -125,6 +125,13 @@ export default function NegotiationDetailPage() {
 
   const showOutcomeBanner = !resolvedVariant && effectiveOpportunityStatus === 'pending' && !!opportunityId;
 
+  // Whether this thread shows any agent message at all — the one fact that can
+  // falsify the `screened_out` banner's pre-contact copy, read from the same
+  // transcript the banner renders beneath. Conversation-wide on purpose: the
+  // claim is about what the reader can see above the banner, and every turn in
+  // the rail is visible regardless of which session produced it.
+  const contactMade = turns.length > 0;
+
   // IND-610: the owner-only outreach-gate card. A `screened_out` negotiation
   // with no turns is the one case where the transcript has nothing to show —
   // it dead-ended at "No messages in this negotiation" — yet a real decision
@@ -280,6 +287,7 @@ export default function NegotiationDetailPage() {
                         reason={outcomeReason}
                         turnCount={latestTaskTurnCount}
                         maxTurns={lifecycle?.maxTurns ?? null}
+                        contactMade={contactMade}
                         onLetGo={resolvedVariant === 'stalled' ? () => navigate('/negotiations') : undefined}
                       />
                     )}
@@ -316,6 +324,7 @@ export default function NegotiationDetailPage() {
                     reason={outcomeReason}
                     turnCount={latestTaskTurnCount}
                     maxTurns={lifecycle?.maxTurns ?? null}
+                    contactMade={contactMade}
                     onLetGo={resolvedVariant === 'stalled' ? () => navigate('/negotiations') : undefined}
                   />
                 )}

--- a/apps/web/src/components/__tests__/ResolvedBanner.test.tsx
+++ b/apps/web/src/components/__tests__/ResolvedBanner.test.tsx
@@ -13,6 +13,42 @@ import { describe, expect, it } from 'vitest';
 
 import ResolvedBanner from '../negotiations/ResolvedBanner';
 
+describe('ResolvedBanner — screened_out and what the thread can prove', () => {
+  // The pre-contact copy was observed rendering directly beneath a two-hour-old
+  // outreach: an error-stalled negotiation was re-screened on recovery, passed,
+  // and flipped to `rejected`. The screen fix stops new rows from reaching that
+  // state; the rows already in that state are still rendered by this component,
+  // so the copy may not assert a history the thread contradicts.
+  it('keeps the pre-contact copy when nothing was ever sent', () => {
+    render(<ResolvedBanner variant="rejected" reason="screened_out" turnCount={null} maxTurns={6} contactMade={false} />);
+    expect(screen.getByText('No opportunity — filtered out for you')).toBeInTheDocument();
+    expect(screen.getByText(/filtered out before either side reached out/)).toBeInTheDocument();
+    expect(screen.getByText(/never learns the details/)).toBeInTheDocument();
+  });
+
+  it('defaults to the pre-contact copy when the caller supplies no thread context', () => {
+    render(<ResolvedBanner variant="rejected" reason="screened_out" turnCount={null} maxTurns={6} />);
+    expect(screen.getByText(/filtered out before either side reached out/)).toBeInTheDocument();
+  });
+
+  it('drops every pre-contact claim when the thread holds messages', () => {
+    render(<ResolvedBanner variant="rejected" reason="screened_out" turnCount={1} maxTurns={6} contactMade />);
+    // Nothing is claimed about who reached out, who was notified, or what the
+    // counterparty knows — only that it ended without agreement.
+    expect(screen.getByText('This negotiation ended without agreement.')).toBeInTheDocument();
+    expect(screen.queryByText(/before either side reached out/)).toBeNull();
+    expect(screen.queryByText(/neither of you was notified/)).toBeNull();
+    expect(screen.queryByText(/never learns the details/)).toBeNull();
+    expect(screen.queryByText(/filtered out for you/)).toBeNull();
+  });
+
+  it('leaves the other rejected reasons untouched by the guard', () => {
+    render(<ResolvedBanner variant="rejected" reason={null} turnCount={2} maxTurns={6} contactMade />);
+    expect(screen.getByText(/Your agent withdrew after reviewing the opportunity/)).toBeInTheDocument();
+    expect(screen.getByText(/never learns the details/)).toBeInTheDocument();
+  });
+});
+
 describe('ResolvedBanner — stalled variants', () => {
   it('claims a spent turn budget only for turn_cap', () => {
     render(<ResolvedBanner variant="stalled" reason="turn_cap" turnCount={6} maxTurns={6} />);

--- a/apps/web/src/components/negotiations/ResolvedBanner.tsx
+++ b/apps/web/src/components/negotiations/ResolvedBanner.tsx
@@ -6,6 +6,23 @@ interface ResolvedBannerProps {
   reason: string | null;
   turnCount: number | null;
   maxTurns: number | null;
+  /**
+   * Whether the thread this banner renders into holds any agent message.
+   *
+   * The `screened_out` copy makes three claims about history — nobody reached
+   * out, nobody was notified, the other side never learns the details — that the
+   * banner cannot verify from an outcome label alone. It was observed rendering
+   * all three directly beneath a two-hour-old outreach, because a negotiation
+   * recovered from an error stall was re-screened after contact. The outcome is
+   * the wrong place to fix that (bad rows already exist and keep their terminal
+   * state), so the copy is gated on what the reader can see instead: with
+   * messages above it, the banner drops every pre-contact claim and says only
+   * what is still true — the negotiation ended without agreement.
+   *
+   * Omitted (undefined) means "no thread context", which reads as no contact
+   * and preserves the existing copy for callers that render without a transcript.
+   */
+  contactMade?: boolean;
   /** Stalled only: route to the user's agent to answer the open question. */
   onRevive?: () => void;
   /** Stalled only: leave the transcript. */
@@ -17,11 +34,16 @@ interface ResolvedBannerProps {
  * filtering done for you, with hedged, reason-based phrasing — a screened-out
  * thread never names who screened, so the counterparty learns nothing.
  */
-export function ResolvedBanner({ variant, reason, turnCount, maxTurns, onRevive, onLetGo }: ResolvedBannerProps) {
+export function ResolvedBanner({ variant, reason, turnCount, maxTurns, contactMade = false, onRevive, onLetGo }: ResolvedBannerProps) {
   if (variant === 'rejected') {
+    const screenedOutBeforeContact = reason === 'screened_out' && !contactMade;
     let body: string;
-    if (reason === 'screened_out') {
+    if (screenedOutBeforeContact) {
       body = 'This connection was filtered out before either side reached out, so neither of you was notified.';
+    } else if (reason === 'screened_out') {
+      // Contact exists, so no claim is made about who reached out, who was
+      // notified, or what the other side knows — only that it ended here.
+      body = 'This negotiation ended without agreement.';
     } else if (!reason) {
       // Agent voluntarily withdrew — the candidate didn’t match this opportunity’s query.
       body = `Your agent withdrew after reviewing the opportunity${turnCount != null && turnCount > 0 ? ` (${turnCount} ${turnCount === 1 ? 'turn' : 'turns'})` : ''} — the candidate didn’t align with what you’re looking for. You were never notified while this played out.`;
@@ -31,12 +53,25 @@ export function ResolvedBanner({ variant, reason, turnCount, maxTurns, onRevive,
     return (
       <div className="mt-4 rounded-lg border border-red-200 bg-red-50 px-4 py-4">
         <h3 className="font-ibm-plex-mono text-[13px] font-bold text-[#041729]">
-          No opportunity — filtered out for you
+          {/*
+            "filtered out for you" says the connection was screened before it
+            reached anyone. Above a thread with messages in it, only the verdict
+            survives — the account of how it was reached does not.
+          */}
+          {reason === 'screened_out' && contactMade ? 'No opportunity' : 'No opportunity — filtered out for you'}
         </h3>
         <p className="mt-1 text-[13px] text-[#3D3D3D]">{body}</p>
-        <p className="mt-2.5 font-ibm-plex-mono text-[11px] text-gray-400">
-          The other side never learns the details — declines are quiet by design.
-        </p>
+        {/*
+          The quiet-decline footnote is a claim about the counterparty's
+          knowledge. It holds for every end reached without contact, and for a
+          decline the agents never sent — but not above a visible outreach the
+          counterparty demonstrably received.
+        */}
+        {!(reason === 'screened_out' && contactMade) && (
+          <p className="mt-2.5 font-ibm-plex-mono text-[11px] text-gray-400">
+            The other side never learns the details — declines are quiet by design.
+          </p>
+        )}
       </div>
     );
   }

--- a/bun.lock
+++ b/bun.lock
@@ -89,7 +89,7 @@
     },
     "packages/protocol": {
       "name": "@indexnetwork/protocol",
-      "version": "23.1.0",
+      "version": "23.1.1",
       "dependencies": {
         "@langchain/core": "1.1.48",
         "@langchain/langgraph": "1.3.2",

--- a/docs/domain/negotiation.md
+++ b/docs/domain/negotiation.md
@@ -83,7 +83,15 @@ Each turn produces a structured assessment:
 
 ### Screen gate (shadow / enforce)
 
-Between init and the first turn, **fresh negotiations only** (continuations skip it) pass through an outreach gate: one structured LLM call from the reaching client's perspective deciding `reach_out | pass` — is this match worth the client's name before any turn is exchanged? Inputs: the client's intents + discovery query, the counterparty's `user_contexts` paragraph + active intents, and the seed assessment.
+Between init and the first turn, **pre-contact runs only** pass through an outreach gate: one structured LLM call from the reaching client's perspective deciding `reach_out | pass` — is this match worth the client's name before any turn is exchanged? Inputs: the client's intents + discovery query, the counterparty's `user_contexts` paragraph + active intents, and the seed assessment.
+
+**Pre-contact is the whole eligibility rule**, and it is scoped to the negotiation, not to the conversation:
+
+- A **new opportunity reusing an existing `dm_pair`** is screened (IND-563). It has sent nothing of its own; the pair's earlier matches reach the gate as labelled context so a stale rehash is caught before the counterparty is re-engaged.
+- A negotiation that has **already spoken** is never screened. The gate's question is whether to make first contact, and once a turn of this negotiation is on the counterparty's thread that question is settled. Re-asking it let an infrastructure recovery — `negotiation-run-existing` on an error-stalled run, the documented recovery path — end a live negotiation as `screened_out` hours after its outreach landed, with the counterparty never given the chance to answer.
+- An **exact `ask_user` resume** (`continuationExecution`) is never re-screened: it is the same negotiation resumed mid-flight after the client answered.
+
+Contact means a **persisted turn**, nothing weaker. A screen decision is task metadata, so a continuation whose only prior activity is a screen has still sent nothing. An `ask_user` park is persisted but is not contact either — it asks the client's own principal, so an all-`ask_user` history is still pre-contact (the same reading the pre-contact consult resume applies). The same predicate gates the IND-564 opening-`withdraw` guard and the `screened_out` label in finalize: an outcome claiming nothing was ever sent can never be recorded for a negotiation whose own messages say otherwise.
 
 Controlled by `NEGOTIATION_SCREEN_MODE`:
 

--- a/packages/protocol/CHANGELOG.md
+++ b/packages/protocol/CHANGELOG.md
@@ -20,6 +20,32 @@ went 6.7.1 → 8.0.2 with no 7.x in between because the whole 7.x line shipped a
 prereleases between the two promotions. To track every change, read `rc`; to
 pin a supported release, use `latest`.
 
+## 23.1.1 - 2026-08-19
+
+### Fixed
+
+- **A negotiation that has already spoken is no longer re-screened.** The outreach
+  gate asks whether to make first contact, and `routeAfterInit` ran it on every
+  continuation that was not an exact `ask_user` resume. An error-stalled negotiation
+  recovered through `negotiation-run-existing` — the documented recovery path — was
+  therefore re-screened two hours after its outreach landed; the gate passed, and an
+  infrastructure failure plus its own recovery turned into a terminal `rejected`
+  the counterparty was never given the chance to answer. Eligibility is now
+  pre-contact, scoped to the negotiation (new `negotiationHasMadeContact`): a new
+  opportunity reusing an existing `dm_pair` is still screened (IND-563), a
+  screen-only or all-`ask_user` history is still pre-contact, and a persisted turn
+  addressed to the counterparty ends the question for good.
+- **A first-turn `withdraw` on a contacted continuation persists as a real
+  retraction.** The IND-564 guard read `outreachOpened`, which is per-task, so a
+  continuation of a negotiation whose outreach was sent in an earlier session was
+  treated as never-contacted and routed to the quiet `screened_out` outcome. The
+  guard now applies only where nothing was ever sent; a withdraw against a message
+  the counterparty received is recorded as the move it is.
+- **`screened_out` can no longer be stamped on a negotiation whose messages
+  contradict it.** `finalizeNode` gates both routes to the label — the screen-node
+  block and the opening-turn refusal — on the same pre-contact predicate, so the one
+  outcome that claims nothing was ever sent is unfalsifiable at the point of record.
+
 ## 23.1.0 - 2026-08-19
 
 ### Fixed

--- a/packages/protocol/package.json
+++ b/packages/protocol/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@indexnetwork/protocol",
-  "version": "23.1.0",
+  "version": "23.1.1",
   "type": "module",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",

--- a/packages/protocol/src/negotiations/negotiation.graph.finalize.ts
+++ b/packages/protocol/src/negotiations/negotiation.graph.finalize.ts
@@ -9,7 +9,7 @@ import type { NegotiationTurnPayload } from "../shared/interfaces/agent-dispatch
 import { type NegotiationTurn, type NegotiationOutcome } from "./negotiation.state.js";
 import { allowedActionsFor, askUserAnswerWindowMs, configuredAskUserEnabled, configuredProtocolVersion, fallbackActionFor, isRejectLikeAction, isTerminalAction, negotiationAskRoundsCap, readProtocolVersion, rejectActionFor } from "./negotiation.protocol.js";
 import { assessConsultationEligibility, consultationPromptFor, negotiationConsultationPolicyMode, type NegotiationConsultationReason } from "./negotiation.consultation-policy.js";
-import { blocksNegotiationBeforeFirstTurn, type ScreenDecision, type ScreenDecisionRecord } from "./negotiation.screen.js";
+import { blocksNegotiationBeforeFirstTurn, negotiationHasMadeContact, type ScreenDecision, type ScreenDecisionRecord } from "./negotiation.screen.js";
 import { configuredScreenMode } from "./negotiation.screen.contracts.js";
 import { assessDeadlock, configuredDeadlockShiftEnabled, configuredDeadlockThreshold, type DeadlockAssessment, type DeadlockShiftRecord } from "./negotiation.deadlock.js";
 import type { NegotiationSeat, NegotiationProtocolVersion } from "../shared/schemas/negotiation-state.schema.js";
@@ -101,8 +101,21 @@ export async function finalizeNode(state: NegotiationState, deps: NegotiationGra
   //    withdrawing TURN is the reason.
   // They are collapsed into `screenedOut` for status/lifecycle purposes but
   // must stay separate when attributing `outcome.reasoning` below.
-  const blockedByScreenNode = blocksNegotiationBeforeFirstTurn(state.screenDecision, state.turnCount);
-  const refusedAtOpeningTurn = state.firstTurnScreenedOut === true;
+  //
+  // The invariant behind both routes, asserted where the label is actually
+  // stamped: `screened_out` is a claim that NOTHING was ever sent. It is the
+  // only outcome that tells the owner the counterparty was never involved and
+  // never notified, so it may not be applied to a negotiation whose own
+  // messages contradict it. The routing gate and the opening-withdraw guard
+  // each keep this true upstream; gating both routes here makes it
+  // unfalsifiable at the point of record, whatever path reached this node —
+  // including the reasoning attribution below, which must not surface a
+  // "did not reach out" rationale for a negotiation that did. A negotiation
+  // that has spoken falls through to the honest ends (a stall, an error, a
+  // turn cap).
+  const contactMade = negotiationHasMadeContact(history);
+  const blockedByScreenNode = !contactMade && blocksNegotiationBeforeFirstTurn(state.screenDecision, state.turnCount);
+  const refusedAtOpeningTurn = !contactMade && state.firstTurnScreenedOut === true;
   const screenedOut = blockedByScreenNode || refusedAtOpeningTurn;
   // The run ended because the acting agent kept failing, not because the two
   // sides ran out of things to say.

--- a/packages/protocol/src/negotiations/negotiation.graph.ts
+++ b/packages/protocol/src/negotiations/negotiation.graph.ts
@@ -15,13 +15,14 @@ import { NegotiationGraphState } from "./negotiation.state.js";
 import { IndexNegotiator } from "./negotiation.agent.js";
 import { NegotiationStallGapAuthor } from "./negotiation.stall-gap.js";
 import { blocksNegotiationBeforeFirstTurn, NegotiationScreener } from "./negotiation.screen.js";
-import { configuredScreenMode } from "./negotiation.screen.contracts.js";
+import { configuredScreenMode, negotiationHasMadeContact } from "./negotiation.screen.contracts.js";
 import { isTerminalAction } from "./negotiation.protocol.js";
 import { isNegotiationTurnCapReached } from "./negotiation.turn-cap.js";
 import type { QuestionerEnqueueFn } from "../questions/question.module.js";
 import type { ReflectEnqueueFn } from "./negotiation.reflect.js";
 import type { NegotiatorMemoryRetrieveFn } from "./negotiation.memory.js";
 import type { NegotiatorClientDmRetrieveFn } from "./negotiation.client-dm.js";
+import { turnsFromMessages } from "./negotiation.graph.shared.js";
 import type { NegotiationGraphDeps, NegotiationState } from "./negotiation.graph.shared.js";
 import { initNode } from "./negotiation.graph.init.js";
 import { screenNode } from "./negotiation.graph.screen.js";
@@ -87,13 +88,28 @@ export class NegotiationGraphFactory {
 /** After init: fail closed, run the outreach gate, or go straight to the first turn. */
 export function routeAfterInit(state: NegotiationState): string {
   if (state.error) return "finalize";
-  // Screen gate: fresh negotiations only (continuations already passed
-  // the gate when the dialogue opened); off disables the node entirely.
-  // IND-563: regular continuations (new opportunity, existing dm_pair)
-  // also run through the screen gate so stale matches are caught before
-  // re-engaging the counterparty. Exact ask_user resumes
-  // (continuationExecution) are mid-flight and must never be re-screened.
-  if (configuredScreenMode() !== "off" && !state.continuationExecution) return "screen";
+  // Screen gate: PRE-CONTACT runs only; off disables the node entirely.
+  //
+  // IND-563: a new opportunity reusing an existing dm_pair still runs the gate
+  // — it has sent nothing of its own, so stale matches are caught before the
+  // counterparty is re-engaged. Its scope is what makes that safe: init seeds
+  // `messages` from THIS negotiation's turns, so the pair's earlier matches do
+  // not read as contact here.
+  //
+  // Exact ask_user resumes (continuationExecution) are mid-flight and must
+  // never be re-screened.
+  //
+  // A negotiation that has already spoken is not screened at all. The gate
+  // decides whether to make first contact; once contact exists the question is
+  // settled, and asking it again lets an infrastructure recovery
+  // (`negotiation-run-existing` on an error-stalled run) end a live negotiation
+  // as `screened_out` — the counterparty never answering an outreach it had
+  // already received.
+  if (
+    configuredScreenMode() !== "off"
+    && !state.continuationExecution
+    && !negotiationHasMadeContact(turnsFromMessages(state.messages))
+  ) return "screen";
   return "turn";
 }
 

--- a/packages/protocol/src/negotiations/negotiation.graph.turn.ts
+++ b/packages/protocol/src/negotiations/negotiation.graph.turn.ts
@@ -9,7 +9,7 @@ import type { NegotiationTurnPayload } from "../shared/interfaces/agent-dispatch
 import { type NegotiationTurn, type NegotiationOutcome } from "./negotiation.state.js";
 import { allowedActionsFor, askUserAnswerWindowMs, configuredAskUserEnabled, configuredProtocolVersion, fallbackActionFor, isRejectLikeAction, isTerminalAction, negotiationAskRoundsCap, readProtocolVersion } from "./negotiation.protocol.js";
 import { assessConsultationEligibility, consultationPromptFor, countOpenPreContactConsults, isPreContactConsultResume, MAX_OPEN_PRE_CONTACT_CONSULTS_PER_INTENT, negotiationConsultationPolicyMode, PRE_CONTACT_CONSULT_MARKER, type NegotiationConsultationReason } from "./negotiation.consultation-policy.js";
-import { blocksNegotiationBeforeFirstTurn, type ScreenDecision, type ScreenDecisionRecord } from "./negotiation.screen.js";
+import { blocksNegotiationBeforeFirstTurn, negotiationHasMadeContact, type ScreenDecision, type ScreenDecisionRecord } from "./negotiation.screen.js";
 import { configuredScreenMode } from "./negotiation.screen.contracts.js";
 import { assessDeadlock, configuredDeadlockShiftEnabled, configuredDeadlockThreshold, type DeadlockAssessment, type DeadlockShiftRecord } from "./negotiation.deadlock.js";
 import type { NegotiationSeat, NegotiationProtocolVersion } from "../shared/schemas/negotiation-state.schema.js";
@@ -128,6 +128,12 @@ export async function turnNode(state: NegotiationState, deps: NegotiationGraphDe
     // resume re-enters holding nothing but its own `ask_user` turn.
     const isFreshOpeningTurn = state.turnCount === 0 && !state.isContinuation;
     const isPreContactResume = state.turnCount === 0 && isPreContactConsultResume(history);
+    // Has this negotiation ever addressed the counterparty — in this task or an
+    // earlier one? `outreachOpened` alone answers only for THIS task, which is
+    // exactly the blind spot that let a recovered stall be re-labelled as
+    // never-contacted; `history` carries the negotiation's own prior turns
+    // across every session it has run.
+    const contactMade = state.outreachOpened || negotiationHasMadeContact(history);
     // Pre-contact consultation (the turn-0 third verdict). The initiator may
     // consult its client BEFORE deciding whether to reach out, so the seat's
     // opening vocabulary stops being binary. Everything downstream is the
@@ -446,7 +452,15 @@ export async function turnNode(state: NegotiationState, deps: NegotiationGraphDe
     // lands on. This is also what makes an UNANSWERED pre-contact consult
     // resolve to today's behavior — the expiry worker resumes through exactly
     // this path.
-    if (turn.action === 'withdraw' && !state.outreachOpened && (!state.continuationExecution || isPreContactResume)) {
+    //
+    // The whole guard is scoped to a negotiation that has never spoken.
+    // `outreachOpened` is per-TASK, so on a continuation of a CONTACTED
+    // negotiation (an error-stalled run recovered through run-existing) it
+    // reads false while an outreach sits on the counterparty's thread. A
+    // withdraw there is a real move against a real message and must persist as
+    // one — routing it here would relabel a live negotiation as never-contacted
+    // and end it quietly under `screened_out`.
+    if (turn.action === 'withdraw' && !contactMade && (!state.continuationExecution || isPreContactResume)) {
       turnLog.info('negotiation_opening_withdraw_screened_out', {
         taskId: state.taskId,
         opportunityId: state.opportunityId || undefined,

--- a/packages/protocol/src/negotiations/negotiation.screen.contracts.ts
+++ b/packages/protocol/src/negotiations/negotiation.screen.contracts.ts
@@ -83,3 +83,40 @@ export function blocksNegotiationBeforeFirstTurn(
     turnCount === 0
   );
 }
+
+/**
+ * Whether a negotiation has already made contact — the fact the outreach gate
+ * exists to decide, and therefore the fact that makes re-deciding it a
+ * category error.
+ *
+ * The screen asks one question: "should we make first contact?". Once an agent
+ * message for this negotiation is on the counterparty's thread, that question
+ * has been answered by the world, and a `pass` here would end a negotiation the
+ * counterparty was never given a chance to answer — while the outreach it
+ * denies sits visibly above the notice saying no contact was ever made. This
+ * was observed live: an error-stalled negotiation recovered through
+ * `negotiation-run-existing` re-screened, passed, and flipped to `rejected`
+ * with `screened_out` two hours after its outreach landed.
+ *
+ * Contact is a PERSISTED TURN, not a screen decision: a screen record is task
+ * metadata, so a continuation whose only prior activity is a screen has still
+ * sent nothing and is still genuinely pre-contact.
+ *
+ * `ask_user` is the one persisted turn that is not contact. It parks the
+ * negotiation to ask the client's OWN principal a question before deciding to
+ * reach out; nothing was ever addressed to the counterparty. This is the same
+ * reading `isPreContactConsultResume` already applies to an all-`ask_user`
+ * history, and keeping the two in step is what lets a pre-contact consult
+ * resume still resolve as the opening decision it is.
+ *
+ * Scope matters as much as the predicate: callers pass THIS negotiation's turns
+ * (`readNegotiationMessages`), never the pair's whole DM. A new match reusing an
+ * established `dm_pair` conversation has made no contact of its own and must
+ * still be screened (IND-563) — the pair's earlier dialogue reaches the gate as
+ * labelled context instead.
+ */
+export function negotiationHasMadeContact(
+  turns: readonly { action: string }[],
+): boolean {
+  return turns.some((turn) => turn.action !== "ask_user");
+}

--- a/packages/protocol/src/negotiations/negotiation.screen.ts
+++ b/packages/protocol/src/negotiations/negotiation.screen.ts
@@ -12,6 +12,7 @@ export {
   configuredScreenMode,
   ScreenDecisionSchema,
   blocksNegotiationBeforeFirstTurn,
+  negotiationHasMadeContact,
 } from "./negotiation.screen.contracts.js";
 export type {
   NegotiationScreenMode,

--- a/packages/protocol/src/negotiations/tests/negotiation.continuation-screen.spec.ts
+++ b/packages/protocol/src/negotiations/tests/negotiation.continuation-screen.spec.ts
@@ -6,16 +6,25 @@ import { NegotiationScreener, type NegotiationScreenerInput, type ScreenDecision
 import type { NegotiationTurn } from "../negotiation.state.js";
 
 /**
- * IND-563 — the outreach screen runs on continuations, with two guarantees not
- * covered by the fresh-run routing suite (negotiation.screen-routing.spec.ts):
+ * IND-563 — which continuations the outreach screen may decide, with three
+ * guarantees not covered by the fresh-run routing suite
+ * (negotiation.screen-routing.spec.ts):
  *
- * 1. A regular continuation (a new opportunity reusing an existing dm_pair
- *    conversation) forwards its prior dialogue to the screener, so the gate
- *    judges the NEW signal on its own merits.
+ * 1. A new opportunity reusing an existing dm_pair conversation IS screened,
+ *    and the pair's earlier dialogue reaches the screener as context, so the
+ *    gate judges the NEW signal on its own merits.
  * 2. An EXACT ask_user resume (continuationExecution present) is NEVER
  *    re-screened — the successor task is the same logical negotiation resumed
  *    mid-flight after the client answered, and re-screening it in enforce mode
  *    could wrongly kill it.
+ * 3. A continuation of a negotiation that has ALREADY SPOKEN is never screened
+ *    either. The gate's question is whether to make first contact; a run-existing
+ *    recovery of an error-stalled negotiation has an outreach on the
+ *    counterparty's thread, so the question is settled and re-asking it can only
+ *    end a live negotiation as `screened_out`.
+ *
+ * The distinction between 1 and 3 is scope, not chronology: `getNegotiationMessages`
+ * answers for THIS negotiation, `getMessagesForConversation` for the pair.
  */
 
 type FakeMessage = {
@@ -99,7 +108,17 @@ const EXACT_CONTINUATION_EXECUTION = {
   leaseExpiresAt: new Date(Date.now() + 60_000).toISOString(),
 };
 
-function mkStubs(opts?: { priorMessages?: FakeMessage[]; exact?: boolean }) {
+function mkStubs(opts?: {
+  /** The pair's whole shared DM — context, possibly from other matches. */
+  priorMessages?: FakeMessage[];
+  /**
+   * THIS negotiation's own turns. Defaults to the whole DM (a same-match
+   * re-run); pass `[]` to model a NEW match in a DM that already holds
+   * concluded negotiations for other matches.
+   */
+  negotiationMessages?: FakeMessage[];
+  exact?: boolean;
+}) {
   const createdMessages: Array<{ senderId: string; parts: Array<{ kind: string; data: NegotiationTurn }> }> = [];
   const tasksById = new Map<string, Record<string, unknown>>();
   if (opts?.exact) {
@@ -121,7 +140,7 @@ function mkStubs(opts?: { priorMessages?: FakeMessage[]; exact?: boolean }) {
     getNegotiationTaskForOpportunity: async () => null,
     getOpportunityUserAnswers: async () => [],
     getMessagesForConversation: async () => opts?.priorMessages ?? [],
-    getNegotiationMessages: async () => opts?.priorMessages ?? [],
+    getNegotiationMessages: async () => opts?.negotiationMessages ?? opts?.priorMessages ?? [],
     getLatestNegotiationTaskForConversation: async () => null,
     getUserContext: async () => ({ text: "Bob builds ML systems." }),
     getTask: async (id: string) => tasksById.get(id) ?? null,
@@ -203,25 +222,38 @@ describe("negotiation graph — screen on continuations (IND-563)", () => {
     if (origVersion === undefined) delete process.env.NEGOTIATION_PROTOCOL_VERSION; else process.env.NEGOTIATION_PROTOCOL_VERSION = origVersion;
   });
 
-  it("regular continuation forwards prior dialogue to the screener", async () => {
+  it("a NEW match in an established DM forwards the pair's dialogue to the screener as context", async () => {
     process.env.NEGOTIATION_SCREEN_MODE = "shadow";
-    const stubs = mkStubs({ priorMessages: [priorMsg("u-src", "outreach", 0), priorMsg("u-cand", "decline", 1)] });
+    const stubs = mkStubs({
+      priorMessages: [priorMsg("u-src", "outreach", 0), priorMsg("u-cand", "decline", 1)],
+      negotiationMessages: [],
+    });
 
     await runGraph(stubs);
 
     expect(screenerInputs.length).toBe(1);
-    expect(screenerInputs[0].isContinuation).toBe(true);
-    expect(screenerInputs[0].priorDialogue?.map((t) => t.action)).toEqual(["outreach", "decline"]);
+    // This negotiation has not spoken, so it is not a continuation of one; the
+    // settled match reaches the gate through the attributed channel.
+    expect(screenerInputs[0].isContinuation).toBe(false);
+    const attributed = screenerInputs[0].priorDialogueAttributed;
+    expect(attributed).toBeDefined();
+    expect([
+      ...attributed!.unattributed,
+      ...attributed!.earlier.flatMap((g) => g.turns),
+    ].map((t) => t.action)).toEqual(["outreach", "decline"]);
   }, 30_000);
 
-  it("enforce: a continuation `pass` is screened out — no NEW message in the shared thread", async () => {
+  it("enforce: a NEW match that rehashes a settled decline is screened out — no NEW message in the shared thread", async () => {
     process.env.NEGOTIATION_SCREEN_MODE = "enforce";
     screenerResult = {
       decision: "pass",
       reasoning: "the new signal rehashes a settled decline",
       evidence: { counterpartyPremiseFit: "weak", intentAlignment: "none" },
     };
-    const stubs = mkStubs({ priorMessages: [priorMsg("u-src", "outreach", 0), priorMsg("u-cand", "decline", 1)] });
+    const stubs = mkStubs({
+      priorMessages: [priorMsg("u-src", "outreach", 0), priorMsg("u-cand", "decline", 1)],
+      negotiationMessages: [],
+    });
 
     const result = await runGraph(stubs);
 
@@ -229,6 +261,48 @@ describe("negotiation graph — screen on continuations (IND-563)", () => {
     // Zero NEW turns persisted — the counterparty is never re-engaged.
     expect(stubs.createdMessages.length).toBe(0);
     expect(result.outcome?.hasOpportunity).toBe(false);
+    expect(result.outcome?.reason).toBe("screened_out");
+  }, 30_000);
+
+  it("a contacted negotiation re-run through run-existing is never re-screened — the responder takes the turn", async () => {
+    // The observed incident: the initiator's outreach landed, the run failed
+    // on infrastructure, and the documented recovery (`negotiation-run-existing`)
+    // produced a continuation with one prior turn. Re-screening it ended the
+    // negotiation as `screened_out` — beneath the very outreach that falsifies
+    // the claim, and before the responder had ever spoken.
+    process.env.NEGOTIATION_SCREEN_MODE = "enforce";
+    screenerResult = {
+      decision: "pass",
+      reasoning: "a defensible PRE-contact judgment, applied after contact",
+      evidence: { counterpartyPremiseFit: "weak", intentAlignment: "none" },
+    };
+    const stubs = mkStubs({ priorMessages: [priorMsg("u-src", "outreach", 0)] });
+
+    const result = await runGraph(stubs);
+
+    expect(screenerInputs.length).toBe(0);
+    // The seat that owed a turn — the responder, who had never spoken — takes one.
+    expect(stubs.createdMessages.length).toBeGreaterThanOrEqual(1);
+    expect(stubs.createdMessages[0].senderId).toBe("agent:u-cand");
+    expect(result.outcome?.reason).not.toBe("screened_out");
+  }, 30_000);
+
+  it("a continuation whose only prior activity is a consult park is still pre-contact — it may re-screen", async () => {
+    // `ask_user` is persisted, but it is a question to the client's OWN
+    // principal: nothing was ever addressed to the counterparty, so the
+    // opening decision is still open and the gate may still make it.
+    process.env.NEGOTIATION_SCREEN_MODE = "enforce";
+    screenerResult = {
+      decision: "pass",
+      reasoning: "the client's answer settled it against reaching out",
+      evidence: { counterpartyPremiseFit: "weak", intentAlignment: "none" },
+    };
+    const stubs = mkStubs({ priorMessages: [priorMsg("u-src", "ask_user", 0)] });
+
+    const result = await runGraph(stubs);
+
+    expect(screenerInputs.length).toBe(1);
+    expect(stubs.createdMessages.length).toBe(0);
     expect(result.outcome?.reason).toBe("screened_out");
   }, 30_000);
 

--- a/packages/protocol/src/negotiations/tests/negotiation.continuation-withdraw.spec.ts
+++ b/packages/protocol/src/negotiations/tests/negotiation.continuation-withdraw.spec.ts
@@ -9,17 +9,24 @@ import type { NegotiationTurn } from "../negotiation.state.js";
 /**
  * IND-564 — never emit `withdraw` as an opening move.
  *
- * `withdraw` retracts an outreach the initiator made. In a continuation whose
- * first (and only) initiator move is `withdraw` — retracting an outreach never
- * made in the current task — persisting it would drop a spurious "connection
- * withdrawn" message into the shared dm_pair thread. The graph maps such a move
- * to the quiet screen-out outcome instead:
+ * `withdraw` retracts an outreach. Emitted before one exists, it would drop a
+ * spurious "connection withdrawn" message into the shared dm_pair thread for a
+ * connection the counterparty was never offered, so the graph maps it to the
+ * quiet screen-out outcome instead:
  *  - no message persisted into the shared conversation,
  *  - turnCount stays 0,
  *  - the opportunity is quietly `rejected` with reason `screened_out`.
  *
- * `withdraw` remains legal AFTER the initiator actually opened `outreach` in
- * the SAME task; prior-task (seeded) turns never count as that outreach.
+ * The guard's subject is an outreach that was never MADE, not one this task did
+ * not make. `outreachOpened` alone answers only for the current task, and a
+ * continuation of a CONTACTED negotiation — an error-stalled run recovered
+ * through `negotiation-run-existing` — has an outreach on the counterparty's
+ * thread from an earlier session. A withdraw there retracts a real message and
+ * persists as the real move it is; routing it to `screened_out` would tell the
+ * owner no contact was ever made, directly above the message that was.
+ *
+ * `withdraw` is therefore legal after an in-task `outreach` OR after any turn
+ * this negotiation persisted in an earlier session.
  */
 
 type FakeMessage = {
@@ -131,10 +138,12 @@ describe("negotiation graph — opening-move withdraw guard (IND-564)", () => {
     IndexNegotiator.prototype.invoke = origInvoke;
   });
 
-  it("continuation + first-turn withdraw ⇒ no message persisted, opportunity quietly rejected", async () => {
+  it("continuation of a CONTACTED negotiation + first-turn withdraw ⇒ a real retraction, not a screen-out", async () => {
     // Prior dialogue from an EARLIER task (seeded): u-src outreached, u-cand
     // countered. Last speaker is u-cand ⇒ u-src (the initiator) speaks first
-    // in this continuation and immediately withdraws.
+    // in this continuation and immediately withdraws. There IS an outreach to
+    // retract — it is on the counterparty's thread — so the withdraw is a move,
+    // not a spurious message, and the negotiation ended in the open.
     const stubs = mkStubs([priorMsg("u-src", "outreach", 0), priorMsg("u-cand", "counter", 1)]);
     agentScript = [{
       action: "withdraw",
@@ -144,15 +153,36 @@ describe("negotiation graph — opening-move withdraw guard (IND-564)", () => {
 
     const result = await runGraph(stubs);
 
-    // The withdraw never lands in the shared dm_pair conversation.
-    expect(stubs.createdMessages.length).toBe(0);
-    // Quiet screen-out outcome: rejected, reason screened_out, zero turns.
+    expect(stubs.createdMessages.length).toBe(1);
+    expect(stubs.createdMessages[0].parts[0].data.action).toBe("withdraw");
+    // A negotiation the counterparty already heard from can never be recorded
+    // as one where neither side reached out.
     expect(result.outcome?.hasOpportunity).toBe(false);
+    expect(result.outcome?.reason).not.toBe("screened_out");
+    // Reject-like, so the opportunity still ends `rejected` — openly.
+    expect(stubs.statusUpdates).toEqual([
+      { opportunityId: "opp-1", status: "negotiating" },
+      { opportunityId: "opp-1", status: "rejected" },
+    ]);
+  }, 30_000);
+
+  it("continuation whose only prior turn is a consult park + withdraw ⇒ still the quiet screen-out", async () => {
+    // An `ask_user` park is persisted, but it was addressed to the client's own
+    // principal: no outreach exists to retract, so the guard still applies and
+    // nothing lands in the shared thread.
+    const stubs = mkStubs([priorMsg("u-src", "ask_user", 0)]);
+    agentScript = [{
+      action: "withdraw",
+      assessment: { reasoning: "the client's answer settled it against reaching out", suggestedRoles: { ownUser: "peer", otherUser: "peer" } },
+      message: "not proceeding",
+    }];
+
+    const result = await runGraph(stubs);
+
+    expect(stubs.createdMessages.length).toBe(0);
     expect(result.outcome?.reason).toBe("screened_out");
     expect(result.outcome?.turnCount).toBe(0);
-    // The screen-out reasoning falls back to the blocked turn's reasoning.
-    expect(result.outcome?.reasoning).toContain("poor fit");
-    // Opportunity quietly rejected (init flipped it to negotiating first).
+    expect(result.outcome?.reasoning).toContain("settled it against reaching out");
     expect(stubs.statusUpdates).toEqual([
       { opportunityId: "opp-1", status: "negotiating" },
       { opportunityId: "opp-1", status: "rejected" },

--- a/packages/protocol/src/negotiations/tests/negotiation.screen-routing.spec.ts
+++ b/packages/protocol/src/negotiations/tests/negotiation.screen-routing.spec.ts
@@ -357,30 +357,64 @@ describe("negotiation graph — screen node routing (IND-398)", () => {
     expect(result.outcome?.reason).not.toBe("screened_out");
   });
 
-  it("enforce (P2.2): a regular continuation `pass` screens out — zero new messages, rejected (IND-563)", async () => {
+  it("enforce (P2.2): a NEW match in an established DM can still be screened out — zero new messages, rejected (IND-563)", async () => {
     process.env.NEGOTIATION_SCREEN_MODE = "enforce";
     screenerResult = {
       decision: "pass",
       reasoning: "stale premise; not worth reaching out again",
       evidence: { counterpartyPremiseFit: "weak", intentAlignment: "none" },
     };
+    // The pair has talked before, on a DIFFERENT concluded match. This
+    // negotiation has sent nothing of its own, which is what keeps it a
+    // pre-contact run the gate may still decide.
     const stubs = mkStubs({
       priorMessages: [priorMsg("u-src", "propose", 0), priorMsg("u-cand", "counter", 1)],
+      negotiationMessages: [],
     });
 
-    const result = await runGraph(stubs, { opportunityId: "opp-1" });
+    const result = await runGraph(stubs, { opportunityId: "opp-fresh" });
 
-    // IND-563: the continuation is screened and, on a genuine enforce `pass`,
+    // IND-563: the new match is screened and, on a genuine enforce `pass`,
     // blocked before any turn — no NEW message lands in the shared thread.
     expect(screenerInputs.length).toBe(1);
-    expect(screenerInputs[0].isContinuation).toBe(true);
+    // Not a continuation: the pair's history belongs to another match, and
+    // reaches the gate as labelled context rather than as this negotiation's
+    // own dialogue.
+    expect(screenerInputs[0].isContinuation).toBe(false);
     expect(stubs.createdMessages.length).toBe(0);
     expect(result.outcome?.hasOpportunity).toBe(false);
     expect(result.outcome?.reason).toBe("screened_out");
     expect(stubs.statusUpdates).toEqual([
-      { opportunityId: "opp-1", status: "negotiating" },
-      { opportunityId: "opp-1", status: "rejected" },
+      { opportunityId: "opp-fresh", status: "negotiating" },
+      { opportunityId: "opp-fresh", status: "rejected" },
     ]);
+  });
+
+  it("enforce: a negotiation that has already spoken is NOT re-screened — the gate never runs", async () => {
+    // The incident shape: an error-stalled negotiation whose outreach is
+    // already on the counterparty's thread, recovered through
+    // `negotiation-run-existing`. The gate decides whether to make FIRST
+    // contact; here contact exists, so re-asking it could only end a live
+    // negotiation the counterparty was never given the chance to answer.
+    process.env.NEGOTIATION_SCREEN_MODE = "enforce";
+    screenerResult = {
+      decision: "pass",
+      reasoning: "would wrongly kill a negotiation the counterparty can still answer",
+      evidence: { counterpartyPremiseFit: "weak", intentAlignment: "none" },
+    };
+    const stubs = mkStubs({
+      priorMessages: [priorMsg("u-src", "outreach", 0)],
+      negotiationMessages: [priorMsg("u-src", "outreach", 0)],
+    });
+
+    const result = await runGraph(stubs, { opportunityId: "opp-1" });
+
+    expect(screenerInputs.length).toBe(0);
+    expect(stubs.screenWrites.length).toBe(0);
+    // The responder — who had never spoken — takes a real turn instead.
+    expect(stubs.createdMessages.length).toBeGreaterThanOrEqual(1);
+    expect(result.outcome?.reason).not.toBe("screened_out");
+    expect(stubs.statusUpdates.some((u) => u.status === "rejected")).toBe(false);
   });
 
   it("emits a negotiation_screen trace event when an opportunityId is present", async () => {

--- a/packages/protocol/src/negotiations/tests/negotiation.screen.spec.ts
+++ b/packages/protocol/src/negotiations/tests/negotiation.screen.spec.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeEach, afterAll } from "bun:test";
-import { NegotiationScreener, ScreenDecisionSchema, configuredScreenMode, NEGOTIATION_SCREEN_MODES, type NegotiationScreenerInput } from "../negotiation.screen.js";
+import { NegotiationScreener, ScreenDecisionSchema, configuredScreenMode, negotiationHasMadeContact, NEGOTIATION_SCREEN_MODES, type NegotiationScreenerInput } from "../negotiation.screen.js";
 
 /**
  * IND-398 — screener unit behavior.
@@ -219,5 +219,30 @@ describe("NegotiationScreener.invoke", () => {
 
     const user = screener.capturedMessages.find((m) => m.role === "user")!.content;
     expect(user).not.toContain("Prior dialogue with");
+  });
+});
+
+describe("negotiationHasMadeContact", () => {
+  // The predicate that decides whether the outreach gate still has a question
+  // to answer, and whether `screened_out` — a claim that nothing was ever
+  // sent — may be recorded.
+  it("is false before anything is persisted", () => {
+    expect(negotiationHasMadeContact([])).toBe(false);
+  });
+
+  it("is true once any turn addressed to the counterparty exists", () => {
+    expect(negotiationHasMadeContact([{ action: "outreach" }])).toBe(true);
+    expect(negotiationHasMadeContact([{ action: "propose" }, { action: "counter" }])).toBe(true);
+    // Even a decline is contact: the counterparty spoke, so both sides did.
+    expect(negotiationHasMadeContact([{ action: "outreach" }, { action: "decline" }])).toBe(true);
+  });
+
+  it("does not count an ask_user park — that question went to the client, not the counterparty", () => {
+    expect(negotiationHasMadeContact([{ action: "ask_user" }])).toBe(false);
+    expect(negotiationHasMadeContact([{ action: "ask_user" }, { action: "ask_user" }])).toBe(false);
+  });
+
+  it("counts contact made either side of a park", () => {
+    expect(negotiationHasMadeContact([{ action: "ask_user" }, { action: "outreach" }])).toBe(true);
   });
 });


### PR DESCRIPTION
## The incident

An error-stalled negotiation on the sandbox (the #1456 incident thread — conversation `3c5fde1c-ef92-4513-9e7e-34a4d4213bba`, opportunity `7a239460-7f09-4545-a20c-e355aab095e6`, counterparty Zuri Boateng) was recovered with `negotiation-run-existing`, the documented recovery path. The continuation task (`52beecf8-…`, `isContinuation: true`, `priorTurnCount: 1`) re-ran the **pre-contact screen** two hours after the initiator's outreach was already sitting in the counterparty's conversation. The screen decided `pass` in enforce mode (`turnsAdded: 0`), the opportunity went `stalled → rejected`, and the web banner rendered — directly beneath the visible outreach:

> **No opportunity — filtered out for you.** This connection was filtered out before either side reached out, so neither of you was notified. *The other side never learns the details.*

Every clause is falsified by the message above it. An infrastructure failure plus its own recovery path had silently become a terminal rejection the counterparty was never given the chance to answer.

## 1. A contacted negotiation is never re-screened (`packages/protocol`)

The screen asks one question: *should we make first contact?* Once contact exists, the question is settled, and re-asking it can only produce the above. Eligibility is now **pre-contact**, expressed once as `negotiationHasMadeContact` and gating three places:

- **`routeAfterInit`** — the gate is skipped entirely for a negotiation that has spoken. A new opportunity reusing an existing `dm_pair` is **still screened** (IND-563): it has sent nothing of its own, and the pair's earlier matches reach the gate as labelled context rather than as contact. Exact `ask_user` resumes stay exempt as before.
- **The IND-564 opening-`withdraw` guard** — it read `outreachOpened`, which is *per-task*. On a continuation whose outreach was sent in an earlier session it read false, so a first-turn `withdraw` was routed to the same quiet `screened_out`: a second path to the same lie. The guard now applies only where nothing was ever sent; a withdraw against a message the counterparty received persists as the real move it is, and ends the opportunity as an open `rejected`.
- **`finalizeNode`** — both routes to the label are gated on the same predicate, so the one outcome that claims nothing was ever sent cannot be recorded for a negotiation whose own messages contradict it, whatever path reached the node.

### The predicate, and the documented edge

**Contact is a persisted turn, nothing weaker**, and it is read from *this negotiation's* messages (`readNegotiationMessages`), never the pair's whole DM — that scope is what keeps IND-563 intact.

- A continuation whose **only prior activity is a screen** has still sent nothing (a screen record is task metadata) → **still pre-contact, may re-screen.**
- An **`ask_user` park** is persisted, but it asks the client's own principal; nothing was addressed to the counterparty. An all-`ask_user` history is therefore **still pre-contact** — the same reading `isPreContactConsultResume` already applies, which is what keeps the pre-contact consult resume resolving as the opening decision it is.

### Two existing specs asserted the bug

`negotiation.screen-routing.spec.ts` and `negotiation.continuation-screen.spec.ts` each had a test named for the IND-563 guarantee ("a regular continuation `pass` screens out") whose fixture returned the prior dialogue from `getNegotiationMessages` — which scopes to *this* negotiation. That is a same-match re-run, i.e. exactly the incident shape, not the "new opportunity, existing dm_pair" case the tests describe. Their fixtures now separate the two reads (`negotiationMessages` vs `priorMessages`), and the IND-563 guarantee is asserted on the shape it actually names.

## 2. The banner cannot claim a history it cannot prove (`apps/web`)

Fixed independently, because rows already in this state keep their terminal status and are still rendered. `ResolvedBanner` takes `contactMade` — read from the same transcript it renders beneath (`turns.length > 0`, the signal `resolveGateDecision` already uses). With messages in the thread, the `screened_out` copy drops every pre-contact claim (who reached out, who was notified, what the other side learns) and says only *"This negotiation ended without agreement."*; the heading loses "filtered out for you" and the quiet-decline footnote does not render. No new outcome vocabulary — a presentation guard on what the reader can see. Omitting the prop preserves today's copy.

## 3. The observed row — manual, not a migration

**No data repair ships in this PR.** Historical rows keep their wrong terminal state (`rejected` + `screened_out`); only the banner guard protects their presentation. A migration would have to encode "which rows are wrong" as *outcome says screened_out AND messages exist* — which is precisely the presentation guard, applied irreversibly to data, across every environment the migration runs in.

For the one observed row, the targeted manual statement (sandbox, `protocol_sandbox`) restores the pre-incident status so the recovery path can be re-run — now correctly handing the turn to the responder:

```sql
-- before: status = 'rejected'   after: status = 'stalled' (its state before the re-screen)
UPDATE opportunities
   SET status = 'stalled', updated_at = now()
 WHERE id = '7a239460-7f09-4545-a20c-e355aab095e6'
   AND status = 'rejected';
```

The negotiation-outcome artifact keeps `reason: 'screened_out'`; the banner guard is what makes its rendering honest either way. **Not executed** — say the word and I'll run it.

## Tests

**Protocol** (`bun test src/negotiations/tests` — 596 pass; the 2 failures are the pre-existing live-LLM `discoveryQuery` evals, unchanged from baseline):

- a contacted negotiation re-run through run-existing → gate never runs, **the responder (who had never spoken) takes a real turn**, outcome is never `screened_out`;
- a new match in an established DM → gate still runs, enforce `pass` still screens out with zero new messages;
- a consult-park-only continuation → still pre-contact, may re-screen, still lands on `screened_out`;
- a first-turn `withdraw` on a **contacted** continuation → persists as a real retraction, `rejected` in the open; on a **park-only** continuation → still the quiet screen-out;
- `negotiationHasMadeContact` unit-pinned, including `ask_user` on either side of contact.

**Web** (`vitest` — `ResolvedBanner.test.tsx`, 8 pass): pre-contact copy with an empty thread and by default; every pre-contact claim gone when messages exist — the "never learns the details" line asserted absent above a visible outreach; other rejected reasons untouched.

**Also run:** full `packages/protocol` suite and `services/api` `bun run test`. The failures there (chat/premise/HyDE module-mock resolution in protocol; MCP auth, CLI credentials, legacy park chronology in api) are pre-existing — verified by re-running `services/api` against a `dist` rebuilt from the base commit's protocol sources: identical failures. `apps/web`'s 5 unrelated suite failures likewise touch none of the changed files.

## Scope

Screen gate routing + the two collapse paths to `screened_out`, and the one banner component. No stance or prompt changes, no checklist changes, no flags. `docs/domain/negotiation.md` records the pre-contact rule; protocol bumped to 23.1.1 with a CHANGELOG entry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)