### PR TITLE
feat(negotiations): an agent never consults a principal nobody is behind

### DIFF
--- a/packages/protocol/src/negotiations/negotiation.agent.ts
+++ b/packages/protocol/src/negotiations/negotiation.agent.ts
@@ -148,6 +148,40 @@ const PRE_CONTACT_ASK_USER_RULE = `
 - Use it when ONE fact you do not hold is what stands between you and the decision, and only {userName} holds it: how their own criteria bound this search, what they meant by a term in their own signal, whether a strong candidate just outside the literal wording is in scope. Ask about the SIGNAL's scope, not about this candidate — their answer has to hold for the next candidate too.
 - Do NOT use it when the evidence in front of you already decides: if this candidate plainly does not satisfy what {userName} asked for, pass, and pass silently. A contradiction is yours to judge; making {userName} confirm it spends their attention on a decision you could already make.`;
 
+/**
+ * The honest replacement for `ASK_USER_RULE` when the acting principal cannot
+ * be consulted (`ownUser.principalUnreachable`). Rendered instead of it, never
+ * beside it: the grant is withheld on the same condition, so the action is
+ * absent from both the prompt and the generation schema, and a rule describing
+ * a move the schema cannot express would only invite the agent to thrash
+ * against a refusal it never sees explained.
+ *
+ * It says what is true and nothing more: there is no channel here. It must
+ * NEVER say the principal is synthetic, seeded, or a test account. The
+ * counterparty's own user can read this negotiation's turns, and test framing
+ * leaking into a transcript would be both a disclosure and a lie about who
+ * they are talking to. "Cannot be consulted" is the whole truth the agent
+ * needs to act correctly.
+ *
+ * The second half is the anti-thrash half. Without it the seat treats the
+ * missing channel as a dead end and reaches for a terminal action, which
+ * inverts the verdict law: an unknown is not a conflict, and the first
+ * conversation is the cheaper next experiment.
+ */
+const PRINCIPAL_UNREACHABLE_RULE = `
+- YOU CANNOT CONSULT {userName} DURING THIS NEGOTIATION. No question can be put to them here and no answer can arrive, so every decision on this turn is yours to make on the record you already hold. That record — their signal and intents, their premises, their profile, and anything of theirs already quoted in your context — IS their knowledge for this negotiation. Read it as their answer instead of waiting for one.
+- Never stall, park, or defer for their input, and never route a question meant for {userName} to the other side's agent — that reaches the wrong party and settles nothing. If the fact you want belongs to the COUNTERPARTY, "question" is still the right action and is unaffected by any of this.`;
+
+/**
+ * Appended to `PRINCIPAL_UNREACHABLE_RULE` under the checklist protocol, where
+ * "a dimension that is {userName}'s own to settle" is vocabulary the prompt
+ * has actually established. Mirrors `ASK_USER_CHECKLIST_RULE`'s placement for
+ * the same reason: it names checklist fields, so it renders only where they
+ * exist.
+ */
+const PRINCIPAL_UNREACHABLE_CHECKLIST_RULE = `
+- A checklist dimension that would be {userName}'s own to settle is resolved from that record where the record settles it, and carried as an open unknown where it does not. An unknown is not a conflict: it never ends a negotiation on its own, "pass" stays reserved for a genuine conflict, and where the record leaves a question open the first conversation is the cheaper next experiment.`;
+
 /** v2 counterparty seat: receiving stance — acceptance is this seat's decision alone. */
 const V2_COUNTERPARTY_RULES = `- You hold the RECEIVING seat: the other side reached out to {userName}. Whether to accept is YOUR seat's decision alone.
 - Evaluate the initiator's arguments. Either:
@@ -337,7 +371,11 @@ export class IndexNegotiator {
     const version: NegotiationProtocolVersion = input.protocolVersion ?? "v1";
     const seat: NegotiationSeat = input.seat ?? (input.isDiscoverer ? "initiator" : "counterparty");
     const isFinalTurn = input.isFinalTurn ?? false;
-    const canAskUser = input.canAskUser === true && version === "v2" && !isFinalTurn;
+    // A principal nobody can reach has no consultation to grant. Defense in
+    // depth on top of the graph, which already withholds the grant on the same
+    // fact — mirroring the v2/final-turn guards on this same line.
+    const principalUnreachable = input.ownUser.principalUnreachable === true;
+    const canAskUser = input.canAskUser === true && version === "v2" && !isFinalTurn && !principalUnreachable;
     // Deadlock→bargaining stance (IND-428): v2 only — defense in depth on top
     // of the graph-side gating, mirroring the canAskUser guard above.
     const bargainingActive = input.bargaining != null && version === "v2";
@@ -401,7 +439,10 @@ export class IndexNegotiator {
           + (checklistActive ? ASK_USER_CHECKLIST_RULE : "")
           + (preContactConsult ? PRE_CONTACT_ASK_USER_RULE + stancePreContactConsultRule(stance) : "")
           + (clientDm.length > 0 ? ASK_USER_DM_GROUNDING_RULE : "")
-        : "");
+        : principalUnreachable && version === "v2"
+          ? PRINCIPAL_UNREACHABLE_RULE
+            + (checklistActive ? PRINCIPAL_UNREACHABLE_CHECKLIST_RULE : "")
+          : "");
     const finalTurnInstruction = input.isFinalTurn
       ? (version === "v2"
           ? (seat === "initiator"
@@ -530,6 +571,7 @@ ${stanceQuerySatisfiedRule(stance, otherName, userName)}`
           checklist: input.checklist ?? [],
           questionsSpent: input.questionsSpent ?? 0,
           ...(input.askedTopics ? { askedTopics: input.askedTopics } : {}),
+          ...(principalUnreachable ? { principalUnreachable: true } : {}),
         })
       : '';
 

--- a/packages/protocol/src/negotiations/negotiation.checklist.contracts.ts
+++ b/packages/protocol/src/negotiations/negotiation.checklist.contracts.ts
@@ -282,7 +282,13 @@ export type AskInadmissibility =
   /** This topic has already been asked in this negotiation. */
   | "repeat_topic"
   /** The principal's question budget for this negotiation is spent. */
-  | "budget_spent";
+  | "budget_spent"
+  /**
+   * This principal cannot be consulted at all — no answer can ever arrive, so
+   * no question may be put. Distinct from `budget_spent` on purpose: nothing
+   * was spent, and a trace that said otherwise would be a lie.
+   */
+  | "principal_unreachable";
 
 export type AskAdmissibility =
   | { admissible: true; dimension: ChecklistItem }
@@ -301,6 +307,11 @@ export interface AskAdmissibilityInput {
   questionsSpent: number;
   /** Budget override; defaults to {@link QUESTION_BUDGET_PER_PRINCIPAL}. */
   budget?: number;
+  /**
+   * Whether THIS principal — the acting seat's, never the counterparty's — can
+   * be consulted at all. Absent/undefined means reachable.
+   */
+  principalUnreachable?: boolean;
 }
 
 /**
@@ -321,11 +332,18 @@ export interface AskAdmissibilityInput {
  * 4. **Unasked** — topic identity is the dimension, not the phrasing, so a
  *    re-ask reads as a repeat however it is worded.
  * 5. **Budget** — at most {@link QUESTION_BUDGET_PER_PRINCIPAL} per principal
- *    per negotiation, the turn-0 pre-contact consult included.
+ *    per negotiation, the turn-0 pre-contact consult included. A principal who
+ *    cannot be consulted at all is mechanically a budget of zero, and is
+ *    checked first so the refusal names that rather than a spent ration. It is
+ *    per-seat, like the budget it stands in for: the other principal's is
+ *    untouched.
  *
  * Order matters for the telemetry only; the conditions are conjunctive.
  */
 export function assessAskAdmissibility(input: AskAdmissibilityInput): AskAdmissibility {
+  if (input.principalUnreachable === true) {
+    return { admissible: false, reason: "principal_unreachable" };
+  }
   const budget = input.budget ?? QUESTION_BUDGET_PER_PRINCIPAL;
   if (input.questionsSpent >= budget) return { admissible: false, reason: "budget_spent" };
 
@@ -371,6 +389,12 @@ export interface ChecklistSectionInput {
    */
   askedTopics?: ReadonlyArray<{ dimension: string; answerhood?: Answerhood }>;
   budget?: number;
+  /**
+   * Whether this turn's client can be consulted at all. When true the budget
+   * line would be a fiction — there is no ration to spend — so an honest line
+   * about the missing channel replaces it.
+   */
+  principalUnreachable?: boolean;
 }
 
 /**
@@ -388,7 +412,11 @@ export function renderChecklistSection(input: ChecklistSectionInput): string {
   const askedTopics = (input.askedTopics ?? []).filter((topic) => topic.dimension.trim().length > 0);
   const asked = askedTopics.map((topic) => topic.dimension.trim());
   const declared = askedTopics.filter((topic) => topic.answerhood);
-  const budgetLine = `Questions your client has already been asked in THIS negotiation: ${spent} of ${budget}.`
+  const unreachable = input.principalUnreachable === true;
+  const budgetLine = unreachable
+    ? `Your client cannot be consulted in this negotiation: there is no channel to put a question to them and no answer can arrive. `
+      + `Score every dimension from the record you already hold, and carry as unknown whatever it does not settle.`
+    : `Questions your client has already been asked in THIS negotiation: ${spent} of ${budget}.`
     + (asked.length > 0 ? ` Topics already asked: ${asked.join("; ")} — never ask any of them again.` : "")
     + (declared.length > 0
       ? `\nAnswerhood you declared when you asked, and must score against now rather than re-reading the answer freely:\n`
@@ -402,8 +430,10 @@ export function renderChecklistSection(input: ChecklistSectionInput): string {
       + `No checklist exists for this negotiation. Write it now from the two intents alone: `
       + `${MIN_CHECKLIST_DIMENSIONS} to ${MAX_CHECKLIST_DIMENSIONS} dimensions, one of them the mutual want, `
       + `then score each. Fewer than ${MIN_CHECKLIST_DIMENSIONS} is not a checklist and will be discarded. `
-      + `At least one dimension must be something the record does not settle — score it unknown — and the best one `
-      + `is a thing only your client can answer.\n`
+      + `At least one dimension must be something the record does not settle — score it unknown`
+      + (unreachable
+        ? `.\n`
+        : ` — and the best one is a thing only your client can answer.\n`)
       + budgetLine;
   }
 

--- a/packages/protocol/src/negotiations/negotiation.graph.init.ts
+++ b/packages/protocol/src/negotiations/negotiation.graph.init.ts
@@ -20,7 +20,7 @@ import { isNegotiationTurnCapReached } from "./negotiation.turn-cap.js";
 import { expectedNegotiationSpeaker } from "./negotiation.expected-speaker.js";
 import { readNegotiationMessages } from "./negotiation.scope.js";
 import { buildSeededAttribution } from './negotiation.attribution.js';
-import { buildAttributedDialogue, finalizeLog, hasPriorAskUser, initLog, memoryQueryText, negotiateCandidatesLog, resolveTaskAttribution, retrieveMemory, screenNodeLog, turnLog, turnsFromMessages } from "./negotiation.graph.shared.js";
+import { buildAttributedDialogue, finalizeLog, hasPriorAskUser, initLog, memoryQueryText, negotiateCandidatesLog, resolvePrincipalUnreachable, resolveTaskAttribution, retrieveMemory, screenNodeLog, turnLog, turnsFromMessages } from "./negotiation.graph.shared.js";
 import type { NegotiationGraphDeps, NegotiationState } from "./negotiation.graph.shared.js";
 
 
@@ -266,10 +266,31 @@ export async function initNode(state: NegotiationState, deps: NegotiationGraphDe
         )
       : null;
 
+    // --- Principal reachability: resolved once, for both seats, here ---
+    // Init is the single choke point every negotiation passes through, whoever
+    // built the two contexts (ambient discovery, run-existing, chat, MCP), so
+    // stamping it here reaches all of them — and reaches the persisted
+    // `turnContext` too, since the turn node writes that from this state.
+    //
+    // Each seat is resolved independently: unreachability is a fact about one
+    // principal, never about the negotiation, and a seed-vs-real match must
+    // leave the real side's own consultation budget completely untouched.
+    // An explicit `true` from the caller wins over the lookup; anything else
+    // means reachable. Both seats unreachable — a seed-vs-seed match, which is
+    // the common shape in sandbox discovery — is a negotiation with zero
+    // consultations, decided by both agents from the record. That is the
+    // intended behaviour, not an error condition.
+    const [sourceUnreachable, candidateUnreachable] = await Promise.all([
+      resolvePrincipalUnreachable(deps, state.sourceUser),
+      resolvePrincipalUnreachable(deps, state.candidateUser),
+    ]);
+
     return {
       conversationId: conversation.id,
       taskId: task.id,
       currentSpeaker,
+      ...(sourceUnreachable ? { sourceUser: { ...state.sourceUser, principalUnreachable: true } } : {}),
+      ...(candidateUnreachable ? { candidateUser: { ...state.candidateUser, principalUnreachable: true } } : {}),
       turnCount: 0,
       maxTurns,
       isContinuation,

--- a/packages/protocol/src/negotiations/negotiation.graph.shared.ts
+++ b/packages/protocol/src/negotiations/negotiation.graph.shared.ts
@@ -179,6 +179,35 @@ export function countNegotiationAskRounds(
 }
 
 /**
+ * Whether one seat's principal can be consulted at all in this negotiation.
+ *
+ * A caller that already knows wins outright; otherwise the host is asked. The
+ * host owns the predicate — the protocol receives a boolean and never the
+ * address behind it, which is what keeps emails out of everything an LLM
+ * reads.
+ *
+ * Fails OPEN in every degenerate case (no host implementation, a rejected
+ * read): reachable. Wrongly silencing a real principal's own agent is the
+ * costlier of the two errors, and a legacy host must keep its behaviour.
+ */
+export async function resolvePrincipalUnreachable(
+  deps: NegotiationGraphDeps,
+  user: UserNegotiationContext,
+): Promise<boolean> {
+  if (user.principalUnreachable === true) return true;
+  if (!deps.database.isPrincipalUnreachable || !user.id) return false;
+  try {
+    return await deps.database.isPrincipalUnreachable(user.id) === true;
+  } catch (err) {
+    initLog.warn('Principal reachability lookup failed; treating principal as reachable', {
+      userId: user.id,
+      error: err instanceof Error ? err.message : String(err),
+    });
+    return false;
+  }
+}
+
+/**
  * P5.3 memory retrieval — never throws, never blocks a negotiation. The
  * injected fn already resolves [] when NEGOTIATOR_MEMORY_INJECT is off;
  * this wrapper adds the graph-side failure guard.

--- a/packages/protocol/src/negotiations/negotiation.graph.turn.ts
+++ b/packages/protocol/src/negotiations/negotiation.graph.turn.ts
@@ -22,7 +22,7 @@ import { expectedNegotiationSpeaker } from "./negotiation.expected-speaker.js";
 import { buildSeededAttribution } from './negotiation.attribution.js';
 import { askedChecklistTopics, buildAttributedDialogue, countNegotiationAskRounds, countPrincipalAskUserTurns, finalizeLog, initLog, memoryQueryText, negotiateCandidatesLog, resolveTaskAttribution, retrieveClientDm, retrieveMemory, screenNodeLog, turnLog, turnsFromMessages } from "./negotiation.graph.shared.js";
 import { configuredNegotiatorStance, stanceUsesChecklist } from "./negotiation.stance.contracts.js";
-import { assessAskAdmissibility, authorChecklist, checklistFromTurns, checklistVerdictState, configuredQuestionBudgetPerPrincipal, isChecklistAuthored, reconcileChecklist, ChecklistDraftSchema, type ChecklistItem } from "./negotiation.checklist.contracts.js";
+import { assessAskAdmissibility, authorChecklist, checklistFromTurns, checklistVerdictState, configuredQuestionBudgetPerPrincipal, isChecklistAuthored, reconcileChecklist, ChecklistDraftSchema, type AskInadmissibility, type ChecklistItem } from "./negotiation.checklist.contracts.js";
 import type { NegotiationGraphDeps, NegotiationState } from "./negotiation.graph.shared.js";
 
 
@@ -166,9 +166,17 @@ export async function turnNode(state: NegotiationState, deps: NegotiationGraphDe
     // pre-contact consult included. Under `advocate` the budget is 1, which is
     // exactly the legacy `hasPriorAskUser` ration expressed as a count.
     const questionBudget = configuredQuestionBudgetPerPrincipal();
+    // A principal nobody can reach cannot be consulted: no question can be put
+    // to them and no answer can ever arrive, so a park here would wait out the
+    // full consultation expiry for nothing and the authored question would rot
+    // unread. Mechanically a question budget of zero — and strictly per seat,
+    // read off the ACTING side's own context, so a match between a reachable
+    // and an unreachable principal leaves the reachable one's budget intact.
+    const principalUnreachable = ownUser.principalUnreachable === true;
     const askUserWiringAvailable =
       version === 'v2'
       && !isFinalTurn
+      && !principalUnreachable
       && configuredAskUserEnabled()
       && !!deps.questionerEnqueue
       && !!deps.timeoutQueue?.enqueueAskUserExpiry
@@ -589,6 +597,32 @@ export async function turnNode(state: NegotiationState, deps: NegotiationGraphDe
       }
     }
 
+    // An unreachable principal is refused BEFORE the generic coercion below so
+    // the trace names the condition that actually bound. The generic path logs
+    // only "unavailable", and the ask-admissibility rule further down is never
+    // reached once the action has been coerced — between them the record would
+    // have said nothing at all about why, or worse, blamed a spent budget.
+    if (turn.action === 'ask_user' && principalUnreachable) {
+      turnLog.info('negotiation_ask_inadmissible', {
+        taskId: state.taskId,
+        opportunityId: state.opportunityId || undefined,
+        seat,
+        reason: 'principal_unreachable' satisfies AskInadmissibility,
+        dimension: turn.askUser?.dimension,
+        questionsSpent,
+        questionBudget,
+      });
+      emitWide({
+        type: 'negotiation_ask_inadmissible',
+        opportunityId: state.opportunityId,
+        negotiationConversationId: state.conversationId,
+        turnIndex: state.turnCount,
+        actor: isSource ? 'source' : 'candidate',
+        reason: 'principal_unreachable',
+      });
+      turn = { ...turn, action: fallbackActionFor(version, seat, isFinalTurn) };
+    }
+
     // Safety net: off/shadow retain legacy behavior. In on, a spontaneous
     // ask_user is admissible only when the deterministic policy just
     // authorized it, so no unbounded pause can enter shared history.
@@ -628,6 +662,7 @@ export async function turnNode(state: NegotiationState, deps: NegotiationGraphDe
         answerhood: turn.askUser?.answerhood,
         askedDimensions,
         questionsSpent,
+        ...(principalUnreachable ? { principalUnreachable: true } : {}),
       });
       if (!admissibility.admissible) {
         turnLog.info('negotiation_ask_inadmissible', {

--- a/packages/protocol/src/negotiations/negotiation.state.ts
+++ b/packages/protocol/src/negotiations/negotiation.state.ts
@@ -83,11 +83,30 @@ export const NegotiationOutcomeSchema = z.object({
 
 export type NegotiationOutcome = z.infer<typeof NegotiationOutcomeSchema>;
 
-/** Context each agent receives about its user. */
+/**
+ * Context each agent receives about its user.
+ *
+ * Structurally duplicated by `shared/schemas/negotiation-state.schema.ts`,
+ * which is the declaration the package exports to hosts; the two must stay
+ * identical.
+ */
 export interface UserNegotiationContext {
   id: string;
   intents: Array<{ id: string; title: string; description: string; confidence: number }>;
   profile: { name?: string; bio?: string; location?: string; interests?: string[]; skills?: string[] };
+  /**
+   * Whether this principal can be consulted at all during the negotiation —
+   * true when no answer can ever arrive because nobody is behind the account
+   * (a seed persona today; a suspended or deleted account would qualify just
+   * as well, which is why the field names the operational truth rather than
+   * the cause). The API resolves it; the protocol only ever receives the
+   * boolean, never the address it was derived from — no email belongs in
+   * anything an LLM reads.
+   *
+   * Absent/undefined means reachable. Real users are the default, so every
+   * existing caller and every already-serialized state keeps working.
+   */
+  principalUnreachable?: boolean;
 }
 
 /** Seed assessment from the evaluator pre-filter. */

--- a/packages/protocol/src/negotiations/tests/negotiation.principal-unreachable.spec.ts
+++ b/packages/protocol/src/negotiations/tests/negotiation.principal-unreachable.spec.ts
@@ -1,0 +1,445 @@
+import { describe, it, expect, beforeAll, afterAll, beforeEach, afterEach } from "bun:test";
+
+import { NegotiationGraphFactory } from "../negotiation.graph.js";
+import { NegotiationGraphState } from "../negotiation.state.js";
+import { IndexNegotiator, type NegotiationAgentInput } from "../negotiation.agent.js";
+import { NegotiationStallGapAuthor } from "../negotiation.stall-gap.js";
+import { assessAskAdmissibility, renderChecklistSection, type ChecklistDraftItem, type ChecklistItem } from "../negotiation.checklist.contracts.js";
+import type { NegotiationTurn } from "../negotiation.state.js";
+import type { QuestionerEnqueuePayload } from "../../questions/question.input.js";
+
+/**
+ * An unreachable principal is never consulted.
+ *
+ * Some accounts have nobody behind them — seed personas today, and a suspended
+ * or deleted account would be the same operational fact. Their agent must not
+ * park on `ask_user`: no answer can arrive, so the negotiation would wait out
+ * the whole consultation expiry and the authored question would rot unread.
+ *
+ * What this pins:
+ *  - the ACTING seat's unreachability withholds the grant, so a scripted
+ *    ask_user is refused even when a dimension is unknown, pivotal and the
+ *    principal's own to settle,
+ *  - the refusal is traced as `principal_unreachable`, never as a spent budget
+ *    — nothing was spent,
+ *  - it is strictly per seat: the reachable side of the same negotiation still
+ *    asks, and spends its own budget doing so,
+ *  - two unreachable principals simply run a consultation-free negotiation.
+ *    That is the intended shape of a seed-vs-seed match, not an error,
+ *  - the prompt tells the agent the truth (no channel here) and never that its
+ *    principal is seeded or a test account — the counterparty's own user can
+ *    read these turns.
+ *
+ * Harness mirrors `negotiation.checklist-turn.spec.ts`: stubbed
+ * database/dispatcher, scripted agent turns, no live provider.
+ */
+
+type FakeMessage = {
+  id: string;
+  senderId: string;
+  role: "agent";
+  parts: unknown[];
+  createdAt: Date;
+};
+
+const dimension = (
+  name: string,
+  kind: ChecklistDraftItem["kind"],
+  result: ChecklistDraftItem["result"],
+  basis = "",
+): ChecklistDraftItem => ({ name, kind, result, basis });
+
+const CHECKLIST: ChecklistDraftItem[] = [
+  dimension("Mutual want", "mutual_want", "ok", "Alice's intent seeks an ML engineer; Bob's seeks applied ML work"),
+  dimension("Location", "fit", "unknown"),
+  dimension("Stage fit", "fit", "unknown"),
+];
+
+const ANSWERHOOD = { ok_when: "the client says remote is fine", conflict_when: "the client says Berlin only" };
+
+const QUESTION = {
+  title: "Location",
+  prompt: "Does this search have to stay in Berlin, or is remote in scope?",
+  options: [
+    { label: "Berlin only", description: "I will hold out for people already there." },
+    { label: "Remote is fine", description: "I will keep talking to strong people anywhere." },
+  ],
+  multiSelect: false,
+};
+
+const turn = (
+  action: string,
+  reasoning: string,
+  extra: Partial<NegotiationTurn> = {},
+): NegotiationTurn => ({
+  action,
+  assessment: { reasoning, suggestedRoles: { ownUser: "peer", otherUser: "peer" } },
+  message: null,
+  ...extra,
+} as NegotiationTurn);
+
+const askTurn = (checklist: ChecklistDraftItem[] = CHECKLIST) =>
+  turn("ask_user", "one unknown stands between me and the decision", {
+    askUser: {
+      reason: "unresolved_owner_constraint",
+      question: QUESTION,
+      dimension: "Location",
+      answerhood: ANSWERHOOD,
+    },
+    checklist,
+  } as Partial<NegotiationTurn>);
+
+function mkStubs(opts?: { unreachableUserIds?: string[] }) {
+  const createdMessages: Array<{ senderId: string; parts: Array<{ kind: string; data: NegotiationTurn }> }> = [];
+  const stateWrites: Array<{ taskId: string; state: string }> = [];
+  const unreachable = new Set(opts?.unreachableUserIds ?? []);
+  const reachabilityReads: string[] = [];
+
+  const database = {
+    getOrCreateDM: async () => ({ id: "conv-1" }),
+    createTask: async (conversationId: string) => ({ id: "task-new", conversationId, state: "submitted" }),
+    updateOpportunityStatus: async () => {},
+    createMessage: async (p: { senderId: string; parts: Array<{ kind: string; data: NegotiationTurn }> }) => {
+      createdMessages.push(p);
+      return { id: `msg-${createdMessages.length}`, senderId: p.senderId, parts: p.parts, createdAt: new Date() };
+    },
+    updateTaskState: async (taskId: string, state: string) => { stateWrites.push({ taskId, state }); },
+    createArtifact: async () => ({ id: "art-1" }),
+    setTaskTurnContext: async () => {},
+    captureNegotiationAskUserBinding: async (input: Record<string, unknown>) => ({
+      version: 2 as const,
+      settlementId: input.settlementId as string,
+      recipientUserId: input.recipientUserId as string,
+      recipientIntentId: input.recipientIntentId as string,
+      opportunityId: input.opportunityId as string,
+      networkId: input.networkId as string,
+      intentFingerprint: "fp-src",
+      opportunityStatus: "pending",
+      opportunityUpdatedAt: "2026-01-01T00:00:00.000Z",
+      counterpartyUserId: "u-cand",
+      counterpartyIntentId: "intent-cand",
+    }),
+    getMessagesForConversation: async () => [] as FakeMessage[],
+    getNegotiationMessages: async () => [] as FakeMessage[],
+    getOpportunityUserAnswers: async () => [],
+    getNegotiationTaskForOpportunity: async () => null,
+    getLatestNegotiationTaskForConversation: async () => null,
+    getTask: async () => null,
+    getUserContext: async () => ({ text: "Alice builds AI startups" }),
+    getTasksForUser: async () => [],
+    getArtifactsForTask: async () => [],
+    isPrincipalUnreachable: async (userId: string) => {
+      reachabilityReads.push(userId);
+      return unreachable.has(userId);
+    },
+  } as unknown as ConstructorParameters<typeof NegotiationGraphFactory>[0];
+
+  const dispatcher = {
+    hasExternalAgent: async () => false,
+    dispatch: async () => ({ handled: false, reason: "no_agent" }),
+  } as unknown as ConstructorParameters<typeof NegotiationGraphFactory>[1];
+
+  const timeoutQueue = {
+    enqueueTimeout: async () => "job-1",
+    cancelTimeout: async () => {},
+    enqueueAskUserExpiry: async () => "askuser-job-1",
+    cancelAskUserExpiry: async () => {},
+  } as unknown as ConstructorParameters<typeof NegotiationGraphFactory>[2];
+
+  const questionerEnqueues: QuestionerEnqueuePayload[] = [];
+  const questionerEnqueue = async (input: QuestionerEnqueuePayload) => { questionerEnqueues.push(input); };
+
+  return { database, dispatcher, timeoutQueue, questionerEnqueue, createdMessages, stateWrites, questionerEnqueues, reachabilityReads };
+}
+
+async function runGraph(stubs: ReturnType<typeof mkStubs>, input: Record<string, unknown> = {}) {
+  const graph = new NegotiationGraphFactory(
+    stubs.database, stubs.dispatcher, stubs.timeoutQueue, stubs.questionerEnqueue,
+  ).createGraph();
+  return graph.invoke({
+    sourceUser: { id: "u-src", intents: [{ id: "intent-src", title: "Hire an ML engineer", description: "Looking for applied ML depth", confidence: 1 }], profile: { name: "Alice", bio: "PM", skills: ["evals"] } },
+    candidateUser: { id: "u-cand", intents: [{ id: "intent-cand", title: "Join an AI product", description: "Wants applied ML work", confidence: 1 }], profile: { name: "Bob", bio: "ML engineer", skills: ["ml"] } },
+    sourceIntentId: "intent-src",
+    candidateIntentId: "intent-cand",
+    indexContext: { networkId: "net-1", prompt: "AI network" },
+    seedAssessment: { reasoning: "complementary", valencyRole: "peer" },
+    opportunityId: "opp-1",
+    maxTurns: 4,
+    ...input,
+  } as Partial<typeof NegotiationGraphState.State>);
+}
+
+/** Every action persisted to the shared record, in order. */
+function persistedActions(stubs: ReturnType<typeof mkStubs>) {
+  return stubs.createdMessages.map((message) => message.parts[0].data.action);
+}
+
+let agentInputs: NegotiationAgentInput[] = [];
+let agentScript: NegotiationTurn[] = [];
+
+describe("an unreachable principal is never consulted", () => {
+  let origAgentInvoke: typeof IndexNegotiator.prototype.invoke;
+  let origStallGapAuthor: typeof NegotiationStallGapAuthor.prototype.author;
+  const originals: Record<string, string | undefined> = {};
+
+  beforeAll(() => {
+    origAgentInvoke = IndexNegotiator.prototype.invoke;
+    IndexNegotiator.prototype.invoke = async function (input: NegotiationAgentInput) {
+      agentInputs.push(input);
+      const next = agentScript.shift();
+      if (!next) throw new Error("agent script exhausted");
+      return next;
+    };
+    origStallGapAuthor = NegotiationStallGapAuthor.prototype.author;
+    NegotiationStallGapAuthor.prototype.author = async function () { return null; };
+    for (const key of ["NEGOTIATION_ASK_USER_ENABLED", "NEGOTIATION_CONSULTATION_POLICY_MODE", "NEGOTIATION_PROTOCOL_VERSION", "NEGOTIATION_SCREEN_MODE", "NEGOTIATOR_STANCE"]) {
+      originals[key] = process.env[key];
+    }
+  });
+
+  afterAll(() => {
+    IndexNegotiator.prototype.invoke = origAgentInvoke;
+    NegotiationStallGapAuthor.prototype.author = origStallGapAuthor;
+  });
+
+  beforeEach(() => {
+    agentInputs = [];
+    agentScript = [];
+    // The dev configuration this ships into.
+    process.env.NEGOTIATION_ASK_USER_ENABLED = "true";
+    process.env.NEGOTIATION_CONSULTATION_POLICY_MODE = "on";
+    process.env.NEGOTIATION_PROTOCOL_VERSION = "v2";
+    process.env.NEGOTIATION_SCREEN_MODE = "off";
+    process.env.NEGOTIATOR_STANCE = "skeptic";
+  });
+
+  afterEach(() => {
+    for (const [key, value] of Object.entries(originals)) {
+      if (value === undefined) delete process.env[key]; else process.env[key] = value;
+    }
+  });
+
+  it("refuses the acting seat's ask even when the dimension is unknown, pivotal and the principal's own", async () => {
+    const stubs = mkStubs({ unreachableUserIds: ["u-src"] });
+    agentScript = [askTurn(), turn("decline", "not for me")];
+    await runGraph(stubs);
+
+    // The seat never sees the vocabulary, and the drafted ask never lands.
+    expect(agentInputs[0].canAskUser).not.toBe(true);
+    expect(agentInputs[0].ownUser.principalUnreachable).toBe(true);
+    // Refused, then carried by the opening rule into the outreach this turn
+    // was always going to be — the seat does not stall on the missing channel.
+    expect(persistedActions(stubs)[0]).toBe("outreach");
+    expect(persistedActions(stubs)).not.toContain("ask_user");
+    // Nothing parked, and nobody was asked anything.
+    expect(stubs.stateWrites.some((write) => write.state === "input_required")).toBe(false);
+    expect(stubs.questionerEnqueues).toHaveLength(0);
+  });
+
+  it("leaves the reachable seat of the same negotiation asking on its own budget", async () => {
+    const stubs = mkStubs({ unreachableUserIds: ["u-src"] });
+    agentScript = [
+      // The unreachable initiator opens instead of consulting.
+      turn("outreach", "opening", { message: "hi", checklist: CHECKLIST } as Partial<NegotiationTurn>),
+      // The reachable counterparty asks, and its ask is admitted.
+      askTurn(),
+    ];
+    await runGraph(stubs);
+
+    expect(agentInputs[0].ownUser.principalUnreachable).toBe(true);
+    expect(agentInputs[0].canAskUser).not.toBe(true);
+
+    expect(agentInputs[1].ownUser.id).toBe("u-cand");
+    expect(agentInputs[1].ownUser.principalUnreachable).toBeUndefined();
+    expect(agentInputs[1].canAskUser).toBe(true);
+
+    expect(persistedActions(stubs)).toEqual(["outreach", "ask_user"]);
+    expect(stubs.stateWrites.some((write) => write.state === "input_required")).toBe(true);
+    expect(stubs.questionerEnqueues).toHaveLength(1);
+  });
+
+  it("runs a seed-vs-seed match with zero consultations rather than failing it", async () => {
+    const stubs = mkStubs({ unreachableUserIds: ["u-src", "u-cand"] });
+    agentScript = [
+      askTurn(),
+      askTurn(),
+      turn("decline", "the record does not support it"),
+    ];
+    const result = await runGraph(stubs);
+
+    expect(agentInputs.every((input) => input.canAskUser !== true)).toBe(true);
+    expect(persistedActions(stubs)).not.toContain("ask_user");
+    expect(stubs.questionerEnqueues).toHaveLength(0);
+    // A consultation-free negotiation is a negotiation, not an error.
+    expect(result.error).toBeFalsy();
+  });
+
+  it("treats a host without the reachability port as every principal being reachable", async () => {
+    const stubs = mkStubs();
+    delete (stubs.database as unknown as Record<string, unknown>).isPrincipalUnreachable;
+    agentScript = [askTurn()];
+    await runGraph(stubs);
+
+    expect(agentInputs[0].ownUser.principalUnreachable).toBeUndefined();
+    expect(agentInputs[0].canAskUser).toBe(true);
+    expect(persistedActions(stubs)[0]).toBe("ask_user");
+  });
+});
+
+describe("the refusal names its own condition", () => {
+  const admissible = {
+    checklist: [
+      { name: "Location", kind: "fit", result: "unknown", basis: "" },
+    ] as ChecklistItem[],
+    dimension: "Location",
+    answerhood: ANSWERHOOD,
+    askedDimensions: [] as string[],
+    questionsSpent: 0,
+  };
+
+  it("refuses an unreachable principal's ask as `principal_unreachable`, not `budget_spent`", () => {
+    expect(assessAskAdmissibility({ ...admissible, principalUnreachable: true }))
+      .toEqual({ admissible: false, reason: "principal_unreachable" });
+  });
+
+  it("outranks every other refusal, because nothing was spent or repeated", () => {
+    const verdict = assessAskAdmissibility({
+      ...admissible,
+      principalUnreachable: true,
+      questionsSpent: 99,
+      askedDimensions: ["Location"],
+      dimension: "Nonexistent",
+    });
+    expect(verdict).toEqual({ admissible: false, reason: "principal_unreachable" });
+  });
+
+  it("changes nothing for a reachable principal", () => {
+    expect(assessAskAdmissibility(admissible).admissible).toBe(true);
+    expect(assessAskAdmissibility({ ...admissible, principalUnreachable: false }).admissible).toBe(true);
+  });
+});
+
+describe("the prompt tells the truth and only the truth", () => {
+  const checklist: ChecklistItem[] = [{ name: "Location", kind: "fit", result: "unknown", basis: "" }];
+
+  it("replaces the budget line with the missing channel", () => {
+    const rendered = renderChecklistSection({ checklist, questionsSpent: 0, principalUnreachable: true });
+    expect(rendered).toContain("cannot be consulted in this negotiation");
+    expect(rendered).not.toContain("Questions your client has already been asked");
+  });
+
+  it("never names the reason — a counterparty's user can read these turns", () => {
+    const rendered = renderChecklistSection({ checklist, questionsSpent: 0, principalUnreachable: true });
+    for (const leak of ["synthetic", "seed", "persona", "test account", "fake"]) {
+      expect(rendered.toLowerCase()).not.toContain(leak);
+    }
+  });
+
+  it("renders the budget line byte-for-byte as before for a reachable client", () => {
+    expect(renderChecklistSection({ checklist, questionsSpent: 1 }))
+      .toEqual(renderChecklistSection({ checklist, questionsSpent: 1, principalUnreachable: false }));
+  });
+});
+
+/**
+ * The prompt half, at the agent seam. `CapturingNegotiator` mirrors
+ * `negotiation.agent.ask-user.spec.ts`: the `callModel` seam, no live provider.
+ */
+class CapturingNegotiator extends IndexNegotiator {
+  calls = 0;
+  systemPrompts: string[] = [];
+  constructor(private outputs: unknown[]) {
+    super({ turnTimeoutMs: 1000 });
+  }
+  protected override async callModel(
+    _model: unknown,
+    chatMessages: Array<{ role: string; content: string }>,
+  ): Promise<unknown> {
+    this.systemPrompts.push(chatMessages[0].content);
+    const out = this.outputs[Math.min(this.calls, this.outputs.length - 1)];
+    this.calls += 1;
+    return out;
+  }
+}
+
+const agentBaseInput: NegotiationAgentInput = {
+  ownUser: { id: "u-init", intents: [], profile: { name: "Alice" } },
+  otherUser: { id: "u-cp", intents: [], profile: { name: "Bob" } },
+  indexContext: { networkId: "net-1", prompt: "" },
+  seedAssessment: { reasoning: "seed", valencyRole: "peer" },
+  history: [{ action: "counter", assessment: { reasoning: "r", suggestedRoles: { ownUser: "peer", otherUser: "peer" } }, message: null }],
+  seat: "initiator",
+  protocolVersion: "v2",
+};
+
+const counterOutput = {
+  action: "counter",
+  assessment: { reasoning: "ok", suggestedRoles: { ownUser: "peer", otherUser: "peer" } },
+  message: null,
+};
+
+describe("IndexNegotiator — the honest rule replaces the ask-user block", () => {
+  const stanceKey = "NEGOTIATOR_STANCE";
+  let originalStance: string | undefined;
+
+  beforeAll(() => { originalStance = process.env[stanceKey]; });
+  afterAll(() => {
+    if (originalStance === undefined) delete process.env[stanceKey];
+    else process.env[stanceKey] = originalStance;
+  });
+
+  async function unreachablePrompt(overrides: Partial<NegotiationAgentInput> = {}): Promise<string> {
+    const agent = new CapturingNegotiator([counterOutput]);
+    await agent.invoke({
+      ...agentBaseInput,
+      // The graph withholds the grant on the same fact; passing it anyway
+      // pins that the agent refuses it a second time rather than trusting it.
+      canAskUser: true,
+      ownUser: { ...agentBaseInput.ownUser, principalUnreachable: true },
+      ...overrides,
+    });
+    return agent.systemPrompts[0];
+  }
+
+  it("withholds the action from both the prompt and the generation schema", async () => {
+    const prompt = await unreachablePrompt();
+    expect(prompt).not.toContain('"ask_user"');
+    expect(prompt).not.toContain("AT MOST ONE client consultation");
+  });
+
+  it("says the one true thing: there is no channel here", async () => {
+    const prompt = await unreachablePrompt();
+    expect(prompt).toContain("YOU CANNOT CONSULT Alice DURING THIS NEGOTIATION");
+    expect(prompt).toContain("no answer can arrive");
+    // The record is the principal's knowledge — the anti-stall half.
+    expect(prompt).toContain("IS their knowledge for this negotiation");
+    expect(prompt).toContain("Never stall, park, or defer for their input");
+  });
+
+  it("keeps the counterparty channel open — `question` is unaffected", async () => {
+    const prompt = await unreachablePrompt();
+    expect(prompt).toContain('If the fact you want belongs to the COUNTERPARTY, "question" is still the right action');
+  });
+
+  it("never leaks why, in any wording a counterparty's user could read", async () => {
+    process.env[stanceKey] = "skeptic";
+    const prompt = (await unreachablePrompt({ checklist: [] })).toLowerCase();
+    for (const leak of ["synthetic", "seed persona", "test account", "fake", "not a real user", "simulated"]) {
+      expect(prompt).not.toContain(leak);
+    }
+  });
+
+  it("carries the verdict law under the checklist protocol, so an unknown never ends the negotiation", async () => {
+    process.env[stanceKey] = "skeptic";
+    const prompt = await unreachablePrompt();
+    expect(prompt).toContain("carried as an open unknown");
+    expect(prompt).toContain("An unknown is not a conflict");
+    expect(prompt).toContain("the cheaper next experiment");
+  });
+
+  it("says none of it to a reachable principal", async () => {
+    const agent = new CapturingNegotiator([counterOutput]);
+    await agent.invoke({ ...agentBaseInput, canAskUser: false });
+    expect(agent.systemPrompts[0]).not.toContain("YOU CANNOT CONSULT");
+  });
+});

--- a/packages/protocol/src/shared/interfaces/database.negotiation.ts
+++ b/packages/protocol/src/shared/interfaces/database.negotiation.ts
@@ -260,6 +260,19 @@ export type NegotiationGraphDatabase = Pick<
     parkGeneration?: string,
   ): Promise<{ id: string; conversationId: string; state: string }>;
 
+  /**
+   * Whether this principal can be consulted at all — true when no answer can
+   * ever arrive because nobody is behind the account. The host owns the
+   * predicate (today: the RFC 2606 `.test` domains the seed CLIs create their
+   * personas on), so the protocol receives a boolean and never the address it
+   * was derived from.
+   *
+   * Optional for backward-compatible hosts. A missing implementation, or a
+   * rejected read, means REACHABLE — real users are the default, and wrongly
+   * silencing a real principal's own agent is the costlier of the two errors.
+   */
+  isPrincipalUnreachable?(userId: string): Promise<boolean>;
+
   /** Persists a negotiation outcome artifact attached to a task. */
   createArtifact(data: { taskId: string; name?: string; parts: unknown[]; metadata?: Record<string, unknown> | null; continuationExecution?: NegotiationContinuationExecution }): Promise<{ id: string }>;
 

--- a/packages/protocol/src/shared/schemas/negotiation-state.schema.ts
+++ b/packages/protocol/src/shared/schemas/negotiation-state.schema.ts
@@ -135,11 +135,30 @@ export type NegotiationOutcome = z.infer<typeof NegotiationOutcomeSchema>;
 
 // ─── Pure interfaces ──────────────────────────────────────────────────────────
 
-/** Context each agent receives about its user. */
+/**
+ * Context each agent receives about its user.
+ *
+ * Structurally duplicated by the graph-internal declaration in
+ * `negotiations/negotiation.state.ts`; the two must stay identical, since the
+ * host imports this one and the graph passes the other.
+ */
 export interface UserNegotiationContext {
   id: string;
   intents: Array<{ id: string; title: string; description: string; confidence: number }>;
   profile: { name?: string; bio?: string; location?: string; interests?: string[]; skills?: string[] };
+  /**
+   * Whether this principal can be consulted at all during the negotiation —
+   * true when no answer can ever arrive because nobody is behind the account
+   * (a seed persona today; a suspended or deleted account would qualify just
+   * as well, which is why the field names the operational truth rather than
+   * the cause). The API resolves it; the protocol only ever receives the
+   * boolean, never the address it was derived from — no email belongs in
+   * anything an LLM reads.
+   *
+   * Absent/undefined means reachable. Real users are the default, so every
+   * existing caller and every already-serialized state keeps working.
+   */
+  principalUnreachable?: boolean;
 }
 
 /** Seed assessment from the evaluator pre-filter. */

--- a/services/api/src/adapters/conversation.database.adapter.ts
+++ b/services/api/src/adapters/conversation.database.adapter.ts
@@ -26,6 +26,7 @@ import { consultationActorSetMatchesBinding, externalConsultationCoordinatesFor 
 import { authorizeNegotiationMutationInTransaction } from '../lib/agent/negotiation-runtime-authority';
 import { isDedicatedHermesNegotiationAudience, type NegotiationCredentialPrincipal } from '../lib/agent/hermes-credential';
 import { digestHermesRunId, issueHermesRunCapability, parseHermesRunCapabilityBinding, verifyHermesRunCapability, type HermesRunOutcome } from '../lib/agent/hermes-negotiation-run';
+import { isSyntheticUserEmail } from '../lib/users/synthetic';
 
 /**
  * In-transaction read of ONE negotiation's turn history, for the locked floor
@@ -1655,6 +1656,19 @@ export class ConversationDatabaseAdapter {
       .where(eq(schema.users.id, userId))
       .limit(1);
     return row ?? null;
+  }
+
+  /**
+   * Whether this principal can be consulted at all — the host half of the
+   * negotiation graph's `isPrincipalUnreachable` port.
+   *
+   * The predicate lives in `lib/users/synthetic`; this is the DB read behind
+   * it. The graph receives only the boolean, which is what keeps addresses out
+   * of negotiation context and out of every prompt built from it.
+   */
+  async isPrincipalUnreachable(userId: string): Promise<boolean> {
+    const user = await this.getUser(userId);
+    return isSyntheticUserEmail(user?.email);
   }
 
   /**

--- a/services/api/src/lib/negotiation/consultation.ts
+++ b/services/api/src/lib/negotiation/consultation.ts
@@ -56,6 +56,13 @@ export type ExternalConsultationEligibilityInput = {
     questionerEnabled: boolean;
     expiryEnabled: boolean;
   };
+  /**
+   * Whether the RECIPIENT principal — `userId`'s own user, the one this
+   * consultation would put a question to — can be consulted at all. Callers
+   * compute it (they hold the database); this boundary stays pure and never
+   * sees the address it was derived from. Absent/undefined means reachable.
+   */
+  recipientPrincipalUnreachable?: boolean;
 };
 
 export type ExternalConsultationEligibility = {
@@ -210,7 +217,11 @@ export function assessExternalConsultationEligibility(
     && input.task.claimedByAgentId === input.agentId
     && metadata.type === 'negotiation'
     && Boolean(coordinates && seat);
+  // Structural, not policy: a principal nobody can reach has no consultation
+  // to advertise or admit, whatever the policy mode says. Every mode composes
+  // `eligible` from `structuralEligible`, so refusing here refuses everywhere.
   const structuralEligible = protocolVersion === 'v2'
+    && input.recipientPrincipalUnreachable !== true
     && !isOpeningTurn
     && !isFinalTurn
     && counterpartyTurn

--- a/services/api/src/lib/negotiation/tests/consultation.spec.ts
+++ b/services/api/src/lib/negotiation/tests/consultation.spec.ts
@@ -312,6 +312,32 @@ describe('external owner consultation eligibility', () => {
     expect(payload.context).not.toHaveProperty('disclosureSubject');
     expect(payload.context).not.toHaveProperty('draftQuestion');
   });
+
+  // An unreachable principal — a seed persona today — has nobody who could
+  // ever answer. Refused structurally, so no policy mode can admit it and the
+  // pickup path never advertises the move either.
+  it.each(['off', 'shadow', 'on'] as const)(
+    'refuses an unreachable recipient in %s mode',
+    (policyMode) => {
+      const eligible = assessExternalConsultationEligibility(fixture({ policyMode }));
+      expect(eligible.structuralEligible).toBe(true);
+
+      const refused = assessExternalConsultationEligibility(fixture({
+        policyMode,
+        recipientPrincipalUnreachable: true,
+      }));
+      expect(refused.structuralEligible).toBe(false);
+      expect(refused.eligible).toBe(false);
+    },
+  );
+
+  it('leaves a reachable recipient exactly as before', () => {
+    const stated = assessExternalConsultationEligibility(fixture({
+      policyMode: 'on',
+      recipientPrincipalUnreachable: false,
+    }));
+    expect(stated).toEqual(assessExternalConsultationEligibility(fixture({ policyMode: 'on' })));
+  });
 });
 
 describe('consultation claim and layering source invariants', () => {

--- a/services/api/src/lib/users/synthetic.ts
+++ b/services/api/src/lib/users/synthetic.ts
@@ -1,0 +1,71 @@
+/**
+ * Synthetic principals — seed-persona accounts with nobody behind them.
+ *
+ * The seed CLIs (`src/cli/db-seed.ts`, `db-seed-sandbox.ts`, `test-data.ts`,
+ * `sandbox-personas.ts`) create every persona on a `.test` email domain, which
+ * RFC 2606 reserves for exactly this: `.test` is permanently unresolvable in
+ * the public DNS, so no address under it can ever belong to a deliverable
+ * mailbox and no real user can hold one. That makes the TLD a safe durable
+ * marker by construction — no `users.is_synthetic` column, and no feature flag.
+ *
+ * The operational fact this establishes is *unreachability*: a principal whose
+ * agent asks them something will never receive an answer. Consumers therefore
+ * speak of an "unreachable principal" rather than a synthetic one — the same
+ * truth, stated in terms that would still hold if the reason changed (a
+ * suspended or deleted account, say), and stated without leaking test framing
+ * into anything a counterparty's user might read.
+ *
+ * This is the single definition. Every consumer goes through it.
+ */
+import { log } from '../log';
+
+const logger = log.lib.from('users/synthetic');
+
+/**
+ * Whether this address belongs to a seed persona: true iff the domain's final
+ * label is exactly `test`, case-insensitively, with an optional FQDN trailing
+ * dot tolerated.
+ *
+ * The final label is the whole test. `test@test.example.com` is a real address
+ * at a real domain whose `test` label is not final, and must stay reachable.
+ */
+export function isSyntheticUserEmail(email: string | null | undefined): boolean {
+  if (typeof email !== 'string') return false;
+  const at = email.lastIndexOf('@');
+  if (at < 0) return false;
+  const domain = email.slice(at + 1).trim().toLowerCase().replace(/\.$/, '');
+  if (domain.length === 0) return false;
+  return domain.split('.').at(-1) === 'test';
+}
+
+/** The narrow read {@link resolvePrincipalUnreachable} needs. */
+export interface SyntheticPrincipalReader {
+  getUser(userId: string): Promise<{ email: string | null } | null>;
+}
+
+/**
+ * Whether this principal can be consulted at all during a negotiation.
+ *
+ * Fails OPEN — an unresolvable user, a missing email, or a failed read all
+ * report *reachable*. Real users are the default, and the cost of the two
+ * errors is not symmetric: wrongly calling a real principal unreachable would
+ * silently stop their own agent from ever asking them anything, while wrongly
+ * calling a seed persona reachable only restores today's behaviour.
+ */
+export async function resolvePrincipalUnreachable(
+  userId: string,
+  reader?: SyntheticPrincipalReader,
+): Promise<boolean> {
+  try {
+    const resolved = reader
+      ?? (await import('../../adapters/database.adapter')).conversationDatabaseAdapter;
+    const user = await resolved.getUser(userId);
+    return isSyntheticUserEmail(user?.email);
+  } catch (err) {
+    logger.warn('Principal reachability read failed; treating principal as reachable', {
+      userId,
+      error: err instanceof Error ? err.message : String(err),
+    });
+    return false;
+  }
+}

--- a/services/api/src/lib/users/tests/synthetic.spec.ts
+++ b/services/api/src/lib/users/tests/synthetic.spec.ts
@@ -1,0 +1,54 @@
+import { describe, expect, it } from 'bun:test';
+
+import { isSyntheticUserEmail, resolvePrincipalUnreachable } from '../synthetic';
+
+describe('isSyntheticUserEmail', () => {
+  it('recognizes every domain the seed CLIs own', () => {
+    expect(isSyntheticUserEmail('seed-tester-1@index-network.test')).toBe(true);
+    expect(isSyntheticUserEmail('sandbox-person-01@index-network.test')).toBe(true);
+    expect(isSyntheticUserEmail('persona@sandbox.test')).toBe(true);
+  });
+
+  it('reads the final label case-insensitively and tolerates an FQDN dot', () => {
+    expect(isSyntheticUserEmail('Seed@Index-Network.TEST')).toBe(true);
+    expect(isSyntheticUserEmail('seed@index-network.Test')).toBe(true);
+    expect(isSyntheticUserEmail('seed@index-network.test.')).toBe(true);
+    expect(isSyntheticUserEmail('  seed@index-network.test  '.trim())).toBe(true);
+  });
+
+  it('leaves real users alone', () => {
+    expect(isSyntheticUserEmail('someone@index.network')).toBe(false);
+    expect(isSyntheticUserEmail('someone@gmail.com')).toBe(false);
+    // `test` is a label here, but not the FINAL one: a real domain, a real mailbox.
+    expect(isSyntheticUserEmail('test@test.example.com')).toBe(false);
+    expect(isSyntheticUserEmail('test@testing.com')).toBe(false);
+    expect(isSyntheticUserEmail('test.user@example.org')).toBe(false);
+  });
+
+  it('treats anything that is not an address as reachable', () => {
+    expect(isSyntheticUserEmail(null)).toBe(false);
+    expect(isSyntheticUserEmail(undefined)).toBe(false);
+    expect(isSyntheticUserEmail('')).toBe(false);
+    expect(isSyntheticUserEmail('not-an-address')).toBe(false);
+    expect(isSyntheticUserEmail('trailing@')).toBe(false);
+  });
+});
+
+describe('resolvePrincipalUnreachable', () => {
+  it('resolves the principal through the reader', async () => {
+    const reader = { getUser: async () => ({ email: 'seed-tester-3@index-network.test' }) };
+    expect(await resolvePrincipalUnreachable('user-seed', reader)).toBe(true);
+  });
+
+  it('reports a real user as reachable', async () => {
+    const reader = { getUser: async () => ({ email: 'real@index.network' }) };
+    expect(await resolvePrincipalUnreachable('user-real', reader)).toBe(false);
+  });
+
+  it('fails open when the user is missing or the read throws', async () => {
+    expect(await resolvePrincipalUnreachable('gone', { getUser: async () => null })).toBe(false);
+    expect(await resolvePrincipalUnreachable('boom', {
+      getUser: async () => { throw new Error('db down'); },
+    })).toBe(false);
+  });
+});

--- a/services/api/src/queues/negotiations/timeout.shared.ts
+++ b/services/api/src/queues/negotiations/timeout.shared.ts
@@ -26,6 +26,39 @@ export function negotiationMessagesFor(
 
 type NegotiationSeat = 'initiator' | 'counterparty';
 
+/**
+ * The acting seat's minimal context for a timeout fallback turn.
+ *
+ * These invocations bypass the negotiation graph, so nothing has stamped
+ * reachability for them — the fallback has to ask the host itself, or a seed
+ * persona's agent would consult a principal here that the graph refuses to
+ * consult everywhere else. Only the ACTING side is resolved: it is the only
+ * one whose consultation the prompt can grant, and the counterparty's context
+ * on this path carries no more than an id either way.
+ *
+ * Fails OPEN, like every other reader of this port: a host without the method,
+ * or a read that rejects, means reachable.
+ */
+async function actingUserContext(
+  database: Pick<NegotiationGraphDatabase, 'isPrincipalUnreachable'>,
+  userId: string,
+  logger: TimeoutLogger,
+): Promise<UserNegotiationContext> {
+  const base: UserNegotiationContext = { id: userId, intents: [], profile: {} };
+  if (!database.isPrincipalUnreachable) return base;
+  try {
+    return await database.isPrincipalUnreachable(userId)
+      ? { ...base, principalUnreachable: true }
+      : base;
+  } catch (err) {
+    logger.warn('Principal reachability lookup failed; treating principal as reachable', {
+      userId,
+      error: err instanceof Error ? err.message : String(err),
+    });
+    return base;
+  }
+}
+
 export type TimeoutNegotiatorInvoke = (input: {
   ownUser: UserNegotiationContext;
   otherUser: UserNegotiationContext;
@@ -214,7 +247,7 @@ export async function runResumableTimeoutFallback(params: {
       executionId: execution.executionId,
     });
     const turn = await invokeNegotiator({
-      ownUser: { id: activeUserId, intents: [], profile: {} },
+      ownUser: await actingUserContext(database, activeUserId, logger),
       otherUser: { id: otherUserId, intents: [], profile: {} },
       indexContext: { networkId: '', prompt: '' },
       seedAssessment: { reasoning: seedReasoning, valencyRole: 'peer' },
@@ -392,7 +425,7 @@ export async function runTimeoutFallback(params: {
   }).filter(Boolean);
 
   // Run AI agent for the timed-out turn
-  const ownUserCtx: UserNegotiationContext = { id: activeUserId, intents: [], profile: {} };
+  const ownUserCtx: UserNegotiationContext = await actingUserContext(database, activeUserId, logger);
   const otherUserCtx: UserNegotiationContext = { id: otherUserId, intents: [], profile: {} };
   const seedAssessment: SeedAssessment = { reasoning: seedReasoning, valencyRole: 'peer' };
 

--- a/services/api/src/queues/question-message.queue.ts
+++ b/services/api/src/queues/question-message.queue.ts
@@ -53,6 +53,7 @@ import { QuestionAnswerRouter } from '../lib/question/question-answer.router';
 import type { ParkedNegotiationReaderAdapter } from '../adapters/parked-negotiation.reader.adapter';
 import type { NegotiatorClientDmRetrieveFn } from '../adapters/negotiator-client-dm.retrieval.adapter';
 import type { QuestionMessageNotificationJobData } from './notification.queue';
+import { resolvePrincipalUnreachable } from '../lib/users/synthetic';
 
 export const QUEUE_NAME = 'question-message-queue';
 
@@ -652,12 +653,43 @@ export function parkedQuestionMessageTarget(input: QuestionerEnqueuePayload): Qu
  * hand the QuestionerAgent, enqueue the regeneration job for the parked
  * side's scope instead and report the payload as handled. Everything else
  * returns false and flows to the questioner unchanged.
+ *
+ * The last fence for an unreachable principal, and deliberately the widest:
+ * every park-path question — inflight consultation and stalled follow-up
+ * alike, from the graph or from the external-agent path — funnels through
+ * here on its way to being authored. The admission rules upstream should have
+ * refused already; this catches whatever they miss and whatever calls in
+ * later. A question addressed to a principal nobody is behind can only rot
+ * unread in a DM no one opens, so it is dropped rather than written. The
+ * payload still reports as handled: it was a park payload, correctly routed
+ * and correctly declined — not something a retired generator should hear about.
  */
-export async function routeParkedQuestionEnqueue(input: QuestionerEnqueuePayload): Promise<boolean> {
+export async function routeParkedQuestionEnqueue(
+  input: QuestionerEnqueuePayload,
+  deps?: ParkedQuestionRoutingDeps,
+): Promise<boolean> {
   const target = parkedQuestionMessageTarget(input);
   if (!target) return false;
-  await questionMessageQueue.addRegenerateJob(target);
+  const principalUnreachable = deps?.principalUnreachable ?? resolvePrincipalUnreachable;
+  if (await principalUnreachable(target.userId)) {
+    log.queue.from('QuestionMessageQueue').info('question_message_principal_unreachable', {
+      userId: target.userId,
+      intentId: target.intentId,
+      mode: input.mode,
+      purpose: input.purpose,
+    });
+    return true;
+  }
+  const addRegenerateJob = deps?.addRegenerateJob
+    ?? ((data: QuestionMessageJobData) => questionMessageQueue.addRegenerateJob(data));
+  await addRegenerateJob(target);
   return true;
+}
+
+/** Injectable seams for {@link routeParkedQuestionEnqueue}; production uses the real collaborators. */
+export interface ParkedQuestionRoutingDeps {
+  principalUnreachable?: (userId: string) => Promise<boolean>;
+  addRegenerateJob?: (data: QuestionMessageJobData) => Promise<unknown>;
 }
 
 /** Injectable seams for {@link enqueueQuestionAnswerReply}; production uses the real collaborators. */

--- a/services/api/src/queues/tests/question-message.queue.isolated.ts
+++ b/services/api/src/queues/tests/question-message.queue.isolated.ts
@@ -13,7 +13,7 @@ import { negotiationParkAnswerId, negotiationQuestionSettlementId, parseQuestion
 import type { NegotiationAnswerConsumptionPorts, QuestionBlockQuestion, QuestionerEnqueuePayload, RoutedAnswer } from '@indexnetwork/protocol';
 import { questionBlockFixture, questionMessageFixture, questionProseFixture } from '@indexnetwork/protocol/question-block/fixture';
 
-import { QUESTION_ANSWER_CLARIFICATION_MESSAGE, QUESTION_MESSAGE_CLOSED_BODY, QUEUE_NAME, QuestionMessageQueue, enqueueQuestionAnswerReply, parkedQuestionMessageTarget, questionMessageJobId } from '../question-message.queue';
+import { QUESTION_ANSWER_CLARIFICATION_MESSAGE, QUESTION_MESSAGE_CLOSED_BODY, QUEUE_NAME, QuestionMessageQueue, enqueueQuestionAnswerReply, parkedQuestionMessageTarget, questionMessageJobId, routeParkedQuestionEnqueue } from '../question-message.queue';
 import type { QuestionAnswerJobData } from '../question-message.queue';
 import type { QuestionMessageNotificationJobData } from '../notification.queue';
 import { QueueFactory } from '../../lib/bullmq/bullmq';
@@ -609,6 +609,49 @@ describe('park-path trigger routing', () => {
   it('keys the singleton job per (user, intent) scope without colons', () => {
     expect(questionMessageJobId(USER_ID, INTENT_ID)).toBe(`question-message.${USER_ID}.${INTENT_ID}`);
     expect(questionMessageJobId(USER_ID, INTENT_ID)).not.toContain(':');
+  });
+
+  // The last fence for a principal nobody is behind. The admission rules in
+  // the graph and in the external-consultation path refuse first; this catches
+  // whatever they miss and whatever calls in later, because a question
+  // addressed to such a principal can only rot unread.
+  it('refuses to author a question for an unreachable principal', async () => {
+    const jobs: Array<{ userId: string; intentId: string }> = [];
+    const asked: string[] = [];
+    const routed = await routeParkedQuestionEnqueue(inflightPayload, {
+      principalUnreachable: async (userId) => { asked.push(userId); return true; },
+      addRegenerateJob: async (data) => { jobs.push(data); },
+    });
+
+    // Handled — a park payload, correctly routed and correctly declined.
+    expect(routed).toBe(true);
+    expect(asked).toEqual([USER_ID]);
+    expect(jobs).toEqual([]);
+  });
+
+  it('fences the post-stall family the same way', async () => {
+    const jobs: Array<{ userId: string; intentId: string }> = [];
+    const stalled = {
+      ...inflightPayload,
+      mode: 'negotiation',
+      purpose: 'stalled_followup',
+      negotiation: { ...inflightPayload.negotiation!, purpose: 'stalled_followup' },
+    } as unknown as QuestionerEnqueuePayload;
+
+    expect(await routeParkedQuestionEnqueue(stalled, {
+      principalUnreachable: async () => true,
+      addRegenerateJob: async (data) => { jobs.push(data); },
+    })).toBe(true);
+    expect(jobs).toEqual([]);
+  });
+
+  it('routes a reachable principal to the regeneration job unchanged', async () => {
+    const jobs: Array<{ userId: string; intentId: string }> = [];
+    expect(await routeParkedQuestionEnqueue(inflightPayload, {
+      principalUnreachable: async () => false,
+      addRegenerateJob: async (data) => { jobs.push(data); },
+    })).toBe(true);
+    expect(jobs).toEqual([{ userId: USER_ID, intentId: INTENT_ID }]);
   });
 });
 

--- a/services/api/src/services/negotiation-polling.service.ts
+++ b/services/api/src/services/negotiation-polling.service.ts
@@ -15,6 +15,7 @@ import { AMBIENT_PARK_WINDOW_MS, allowedActionsFor, askUserAnswerWindowMs, confi
 import { NegotiationPollingAuthorization } from '../lib/agent/negotiation-polling-authorization';
 import { parkedQuestionEnqueue } from '../queues/parked-question.enqueue';
 import { assessExternalConsultationEligibility, buildExternalConsultationQuestionerPayload, type ExternalConsultationPersistedTurn } from '../lib/negotiation/consultation';
+import { resolvePrincipalUnreachable } from '../lib/users/synthetic';
 import { isDedicatedHermesNegotiationAudience, type NegotiationCredentialPrincipal } from '../lib/agent/hermes-credential';
 import type { AtomicHermesResponseInput, AtomicHermesResponseResult, HermesRunMutationAuthority } from '../adapters/conversation.database.adapter';
 import { remainingDeadlineDelayMs } from '../lib/negotiation/timeout-execution';
@@ -448,6 +449,10 @@ export class NegotiationPollingService {
     const persistedTurns = this.persistedTurns(messages);
     const questionerEnqueue = parkedQuestionEnqueue();
     const policyMode = negotiationConsultationPolicyMode();
+    // The recipient here is the claiming owner themselves. A principal nobody
+    // can reach has no consultation to admit: the park would wait out the full
+    // expiry and the authored question would never be read.
+    const recipientPrincipalUnreachable = await resolvePrincipalUnreachable(userId);
     const eligibility = assessExternalConsultationEligibility({
       task: {
         id: task.id,
@@ -459,6 +464,7 @@ export class NegotiationPollingService {
       userId,
       agentId,
       policyMode,
+      ...(recipientPrincipalUnreachable ? { recipientPrincipalUnreachable: true } : {}),
       wiring: {
         askUserEnabled: configuredAskUserEnabled(),
         questionerEnabled: Boolean(questionerEnqueue),
@@ -1086,14 +1092,25 @@ export class NegotiationPollingService {
     // urgency signal rather than the old claimedAt + 6h which was wildly wrong.
     const deadline = new Date(parkStartTime.getTime() + AMBIENT_PARK_WINDOW_MS);
 
+    // Never advertise a consultation to an agent whose principal cannot be
+    // reached — the same fact the admission path refuses on, applied one step
+    // earlier so the seat is not offered a move it would be denied.
+    const pickupPrincipalUnreachable = await resolvePrincipalUnreachable(userId);
+
     // Project persisted source/candidate context into own/other perspective
     // for the claiming user. Null when the task was parked before turn
     // context persistence was added (pre-migration tasks).
     let context: PickupResult['context'] = null;
     if (meta.turnContext) {
       const isSource = meta.sourceUserId === userId;
-      const ownUser = isSource ? meta.turnContext.sourceUser : meta.turnContext.candidateUser;
+      const persistedOwnUser = isSource ? meta.turnContext.sourceUser : meta.turnContext.candidateUser;
       const otherUser = isSource ? meta.turnContext.candidateUser : meta.turnContext.sourceUser;
+      // Re-stamped from the live read rather than trusted from the record: a
+      // task parked before reachability was persisted carries nothing, and the
+      // external agent holding this seat must not be told it can consult.
+      const ownUser = pickupPrincipalUnreachable
+        ? { ...persistedOwnUser, principalUnreachable: true }
+        : persistedOwnUser;
       context = {
         ownUser,
         otherUser,
@@ -1122,6 +1139,7 @@ export class NegotiationPollingService {
       userId,
       agentId: task.claimedByAgentId ?? '',
       policyMode: negotiationConsultationPolicyMode(),
+      ...(pickupPrincipalUnreachable ? { recipientPrincipalUnreachable: true } : {}),
       wiring: {
         askUserEnabled: configuredAskUserEnabled(),
         questionerEnabled: Boolean(questionerEnqueue),


### PR DESCRIPTION
## The problem

Seed personas have no one to answer them. Their negotiator could still park on `ask_user`, so the negotiation waited out the full consultation expiry for an answer that was never coming, and the authored question rotted in a DM nobody opens. That also made the question flow untestable single-player: half the asks in a test negotiation landed on an account with no human behind it.

The real tester's own agent is untouched — it keeps asking exactly as it does now.

## The marker

No `users.is_synthetic` column, no migration, no flag. The seed CLIs (`db-seed.ts`, `db-seed-sandbox.ts`, `test-data.ts`, `sandbox-personas.ts`) already create every persona on an RFC 2606 `.test` domain, which is permanently unresolvable in the public DNS — no address under it can belong to a deliverable mailbox. `services/api/src/lib/users/synthetic.ts` owns that predicate as the single definition; every consumer goes through it.

What it establishes is *unreachability*, and that is what the code says throughout: the same operational truth, stated in terms that would still hold for a suspended or deleted account.

## Where it is enforced

The API resolves the predicate and threads a boolean. The protocol never receives the address — no email belongs in anything an LLM reads, and `UserNegotiationContext` stays email-free.

- **One stamp, one choke point.** The two contexts are built inside `packages/protocol/src/opportunities/**`, not in the API as the handoff assumed, so threading at construction would have meant touching an out-of-scope surface and missing future callers. The negotiation graph's **init node** is the point every path flows through instead — ambient discovery, run-existing, chat and MCP alike — and because the turn node writes `turnContext` from that state, the external-agent pickup path inherits it. The host supplies the fact through a new optional `isPrincipalUnreachable(userId)` on `NegotiationGraphDatabase`; the API implements it on `ConversationDatabaseAdapter`.
- **Turn node** withholds the `ask_user` grant for the acting seat.
- **Ask admissibility** gains a distinct `principal_unreachable` refusal, checked before the budget, so a trace never claims a ration was spent when nothing was.
- **External consultation** (`assessExternalConsultationEligibility`) is structurally ineligible, so no policy mode can admit it and pickup never advertises the move.
- **Park-path question route** declines to author, as the last fence for anything the four rules above miss.
- **Timeout fallback turns** bypass the graph, so they resolve the acting seat themselves.

All of it is **per seat**: a match between a reachable and an unreachable principal leaves the reachable side's own question budget completely intact.

## The prompt

When the acting principal cannot be reached, the ask-user instruction block is replaced by an honest one: there is no channel here, the record already in context IS the principal's knowledge, a checklist dimension of theirs resolves from that record or is carried as an open unknown — and an unknown still never ends a negotiation (`pass` stays reserved for conflict; the first conversation is the cheaper next experiment). The checklist section's budget line, which would be a fiction, is replaced too.

It never says the principal is synthetic, seeded, or a test account. The counterparty's own user can read these turns, and that framing would be both a disclosure and a lie about who they are talking to. "Cannot be consulted" is the whole truth the agent needs.

## The seed-vs-seed edge

Two unreachable principals simply negotiate with zero consultations, both agents deciding from the record. That is the intended shape of a sandbox discovery match, not an error — asserted as such.

## Safety

**dev's real users are unaffected**: the predicate is `.test`-TLD-only, and every absent value means reachable — a legacy host without the port, an old serialized state, a failed read. Wrongly silencing a real principal's agent is the costlier of the two errors, so every reader fails open. Ships on by default per the no-new-feature-flags rule.

## Tests

- Predicate unit spec: seed domains and case/FQDN variants → true; `index.network`, `gmail.com`, `test@test.example.com` (label not final) → false; missing/failed reads → reachable.
- Protocol graph spec (16 tests): the acting seat's ask refused with an unknown, pivotal, principal-authoritative dimension on the table; the reachable seat of the *same* negotiation still asks and parks; seed-vs-seed completes with zero consultations; a host without the port behaves exactly as before; the refusal outranks and outnames `budget_spent`; the prompt says the true thing and leaks none of the reason.
- External path: refused in `off`/`shadow`/`on`; a reachable recipient is byte-identical to before.
- Questioner fence: both park families declined, reachable principals routed unchanged.

`bun test src/negotiations` in protocol is clean; the API isolated suite has the same 4 pre-existing failing files before and after this branch (verified against the base by reverting the API diff).

🤖 Generated with [Claude Code](https://claude.com/claude-code)