### PR TITLE
fix(negotiations): a person's row is their most alive pairing, not their newest

### DIFF
--- a/apps/web/src/components/__tests__/NegotiationsInbox.test.tsx
+++ b/apps/web/src/components/__tests__/NegotiationsInbox.test.tsx
@@ -28,6 +28,9 @@ function negotiation(
       parts: [{ kind: 'data', data: { action: input.action ?? 'counter' } }],
       senderId: input.senderId ?? `agent:${id}-peer`,
       createdAt: '2026-07-24T11:00:00.000Z',
+      // The message belongs to the represented session; without the task id
+      // the inbox (correctly) refuses to read it as that session's turn.
+      taskId: `${id}-task`,
     },
     metadata: null,
     via: [],

--- a/apps/web/src/lib/__tests__/negotiation-inbox.test.ts
+++ b/apps/web/src/lib/__tests__/negotiation-inbox.test.ts
@@ -18,6 +18,8 @@ function conversation(
     withMessage?: boolean;
     updatedAt?: string;
     screenDecision?: NonNullable<ConversationSummary['negotiation']>['screenDecision'];
+    /** Which task session produced the conversation's last message; defaults to the represented one. */
+    lastMessageTaskId?: string;
   } = {},
 ): ConversationSummary {
   const action = input.action ?? 'counter';
@@ -31,7 +33,7 @@ function conversation(
       parts: [{ kind: 'data', data: { action } }],
       senderId: input.senderId ?? `agent:${id}-peer`,
       createdAt: '2026-07-24T11:00:00.000Z',
-      taskId: `${id}-task`,
+      taskId: input.lastMessageTaskId ?? `${id}-task`,
     },
     metadata: null,
     via: [],
@@ -171,6 +173,97 @@ describe('negotiations inbox presentation', () => {
     ], 'viewer', NOW);
 
     expect(groups).toEqual({ yourMove: [], inProgress: [], resolved: [] });
+  });
+
+  // The API collapses a person's several task sessions into one represented
+  // `negotiation` by liveness (awaiting approval › parked › in progress ›
+  // resolved), so the row here only ever sees the most alive session. What the
+  // web must guarantee is that nothing from a *different* session with the
+  // same person — the conversation-wide last message — can caption or
+  // reclassify that row.
+  describe('person-row rollup (one row per counterparty)', () => {
+    it('keeps an awaiting-you row awaiting you when a later dead pairing left the last message', () => {
+      // Hye-jin ↔ Deniz: the represented session is the pending approval
+      // (outreach → accept); the conversation's newest message is a decline
+      // from a later session that was screened out.
+      const groups = deriveNegotiationInbox([
+        conversation('deniz', {
+          state: 'completed',
+          opportunityStatus: 'pending',
+          outcome: { hasOpportunity: true, reason: null },
+          action: 'decline',
+          lastMessageTaskId: 'deniz-later-task',
+          updatedAt: '2026-07-24T11:28:00.000Z',
+        }),
+      ], 'viewer', NOW);
+
+      expect(groups.inProgress).toEqual([]);
+      expect(groups.resolved).toEqual([]);
+      expect(groups.yourMove).toHaveLength(1);
+      const [row] = groups.yourMove;
+      expect(row.status).toBe('awaiting_review');
+      expect(row.lastAction).toBe('agents recommended moving forward');
+      expect(row.lastAction).not.toMatch(/did not/);
+      // The timestamp is the represented session's, not the dead one's.
+      expect(row.timeAgo).toBe('32m ago');
+      // …and the header counts it: "1 your move", matching Radar's "Awaiting you · 1".
+      expect(countNegotiationsRequiringAction([conversation('deniz', {
+        state: 'completed', opportunityStatus: 'pending', action: 'decline', lastMessageTaskId: 'deniz-later-task',
+      })], 'viewer')).toBe(1);
+    });
+
+    it('captions a live row from its own session, not from another session of the same person', () => {
+      const groups = deriveNegotiationInbox([
+        conversation('live', { state: 'working', opportunityStatus: 'negotiating', action: 'decline', lastMessageTaskId: 'live-earlier-task' }),
+        conversation('own', { state: 'working', opportunityStatus: 'negotiating', action: 'counter', senderId: 'agent:viewer' }),
+      ], 'viewer', NOW);
+
+      expect(groups.inProgress.map((item) => [item.conversationId, item.status, item.lastAction])).toEqual([
+        ['live', 'negotiating', 'agents exchanged a turn'],
+        ['own', 'negotiating', 'your agent countered'],
+      ]);
+    });
+
+    it('leaves an all-resolved person on their most recent resolved pairing', () => {
+      const groups = deriveNegotiationInbox([
+        conversation('deniz', {
+          state: 'completed',
+          opportunityStatus: 'rejected',
+          outcome: { hasOpportunity: false, reason: 'screened_out' },
+          action: 'accept',
+          lastMessageTaskId: 'deniz-earlier-task',
+        }),
+      ], 'viewer', NOW);
+
+      expect(groups.yourMove).toEqual([]);
+      expect(groups.resolved.map((item) => [item.status, item.lastAction])).toEqual([
+        ['no_match', 'agents did not find enough mutual value to continue'],
+      ]);
+    });
+  });
+
+  describe('header — "your move" counts what the viewer must act on', () => {
+    it('counts an opportunity pending the viewer\'s approval, exactly as the Radar\'s "Awaiting you" does', () => {
+      // No agent question is parked; the only thing awaiting the viewer is the
+      // owner-approval gate. That is a move of theirs.
+      const pendingApproval = conversation('approval', {
+        state: 'completed',
+        opportunityStatus: 'pending',
+        outcome: { hasOpportunity: true, reason: null },
+        action: 'accept',
+      });
+      expect(countNegotiationsRequiringAction([pendingApproval], 'viewer')).toBe(1);
+      expect(deriveNegotiationInbox([pendingApproval], 'viewer', NOW).yourMove[0]?.status).toBe('awaiting_review');
+    });
+
+    it('counts a parked question to the viewer and a pending approval as two moves, and nothing resolved', () => {
+      expect(countNegotiationsRequiringAction([
+        conversation('question', { state: 'input_required', action: 'ask_user', senderId: 'agent:viewer' }),
+        conversation('approval', { state: 'completed', opportunityStatus: 'pending', action: 'accept' }),
+        conversation('declined', { state: 'completed', opportunityStatus: 'rejected', action: 'decline', outcome: { hasOpportunity: false, reason: null } }),
+        conversation('their-question', { state: 'input_required', action: 'ask_user' }),
+      ], 'viewer')).toBe(2);
+    });
   });
 
   it('flattens groups into a last-updated ordering across groups', () => {

--- a/apps/web/src/lib/negotiation-inbox.ts
+++ b/apps/web/src/lib/negotiation-inbox.ts
@@ -67,6 +67,19 @@ function formatTimeAgo(timestamp: number, now: number): string {
   return `${months}mo ago`;
 }
 
+/**
+ * The summary line of a live row. `action` is the represented session's own
+ * last turn, or null when the conversation's last message belongs to another
+ * session with the same person (a later pairing that died, say). A null turn
+ * is then described from the row's state, so a dead session's "did not
+ * recommend proceeding" can never caption a row whose badge says the viewer
+ * is awaited.
+ */
+function describeLive(status: NegotiationInboxStatus, action: string | null, isOwnAgent: boolean): string {
+  if (action === null && status === 'awaiting_review') return 'agents recommended moving forward';
+  return describeAction(action, isOwnAgent);
+}
+
 function describeAction(action: string | null, isOwnAgent: boolean): string {
   const actor = isOwnAgent ? 'your agent' : 'their agent';
   switch (action) {
@@ -156,7 +169,18 @@ export function isVisibleNegotiationConversation(
   return Boolean(conversation.lastMessage) || Boolean(conversation.negotiation?.screenDecision);
 }
 
-/** Derive user-facing inbox groups without exposing raw task or opportunity states. */
+/**
+ * Derive user-facing inbox groups without exposing raw task or opportunity
+ * states.
+ *
+ * One row per A2A conversation, i.e. per counterparty person. The API already
+ * collapsed that person's several task sessions into `conversation.negotiation`
+ * by liveness (awaiting approval › parked › in progress › resolved, recency
+ * only within a tier — services/api negotiation-session-rollup.projection.ts),
+ * so a person with one live pairing and any number of dead ones is a live row
+ * here, and counts toward "your move". Earlier pairings with the same person
+ * are deliberately not summarised on the row; the transcript holds them.
+ */
 export function deriveNegotiationInbox(
   negotiations: ConversationSummary[],
   viewerUserId: string | undefined,
@@ -190,9 +214,12 @@ export function deriveNegotiationInbox(
       }];
     }
 
-    const lastTurn = readLastTurn(conversation.lastMessage.parts);
     const classification = classifyConversation(conversation, viewerUserId);
     const lifecycle = conversation.negotiation;
+    // The represented session is the most alive one with this person, not
+    // necessarily the one that produced the conversation's last message; its
+    // summary line and timestamp come from that session alone.
+    const lastTurn = sessionScopedLastTurn(conversation, lifecycle?.taskId);
     const sortTimestamp = new Date(
       lifecycle?.updatedAt
         ?? conversation.lastMessage.createdAt
@@ -210,7 +237,7 @@ export function deriveNegotiationInbox(
       signalCount: Math.max(lifecycle?.signalCount ?? 0, conversation.via.length),
       lastAction: classification.group === 'resolved'
         ? describeResolved(classification.status, reason)
-        : describeAction(lastTurn.action, conversation.lastMessage.senderId === ownAgentId),
+        : describeLive(classification.status, lastTurn.action, lastTurn.senderId === ownAgentId),
       timeAgo: formatTimeAgo(safeTimestamp, now),
       sortTimestamp: safeTimestamp,
       turnCount: lifecycle ? lifecycle.turnCount : null,

--- a/apps/web/src/services/conversation.ts
+++ b/apps/web/src/services/conversation.ts
@@ -78,7 +78,11 @@ export interface ConversationSummary {
   unreadCount: number;
   lastMessageAt: string | null;
   createdAt: string;
-  /** Latest task and opportunity lifecycle for A2A negotiation summaries. */
+  /**
+   * The task session that represents this A2A conversation to the viewer: the
+   * most alive session with that counterparty, newest only within a liveness
+   * tier. A pending approval is never shadowed by a later screened-out pairing.
+   */
   negotiation?: ConversationNegotiationLifecycle | null;
   negotiationOpportunities?: ConversationNegotiationOpportunity[];
 }

--- a/services/api/src/adapters/conversation.database.adapter.ts
+++ b/services/api/src/adapters/conversation.database.adapter.ts
@@ -7,7 +7,8 @@
 type NegotiationCounterpartyBinding =
   | { kind: 'intent'; id: string }
   | { kind: 'premise'; id: string };
-import { projectOwnerScreenDecision, readInitiatorUserId } from './negotiation-lifecycle.projection';
+import { projectOwnerScreenDecision } from './negotiation-lifecycle.projection';
+import { selectRepresentedNegotiationSession } from './negotiation-session-rollup.projection';
 import { buildHermesResponseMetadataSql, buildNegotiationParkMetadataSql } from './conversation-hermes-metadata.sql';
 import { readUserContext, schema, Artifact, ChatConversationMeta, ChatMessage, ChatMessageMeta, ChatScopeType, ChatSession, Conversation, ConversationParticipant, ConversationSession, ConversationSummary, CreateMessageInput, CreateSessionInput, Message, ResolvedParticipant, SYSTEM_AGENT_ID, Task, and, asc, count, db, desc, eq, gt, gte, inArray, isNull, lt, ne, opportunities, or, sql } from './database.shared';
 import { emitOpportunityLifecycleBestEffort, emitOpportunityTransitionBestEffort } from '../events/opportunity.event';
@@ -644,7 +645,6 @@ export class ConversationDatabaseAdapter {
       lastMessages,
       allMeta,
       unreadRows,
-      latestNegotiationTasks,
       negotiationTasks,
     ] = await Promise.all([
       db
@@ -726,49 +726,17 @@ export class ConversationDatabaseAdapter {
           ),
         ))
         .groupBy(schema.messages.conversationId),
-      includeNegotiationLifecycle
-        ? db
-          .selectDistinctOn([schema.tasks.conversationId], {
-            conversationId: schema.tasks.conversationId,
-            taskId: schema.tasks.id,
-            state: schema.tasks.state,
-            statusTimestamp: schema.tasks.statusTimestamp,
-            metadata: schema.tasks.metadata,
-            updatedAt: schema.tasks.updatedAt,
-            artifactParts: schema.artifacts.parts,
-            opportunityStatus: opportunities.status,
-            opportunityAcceptedBy: opportunities.acceptedBy,
-            currentTurnCount: sql<number>`(
-              SELECT count(*)::int
-              FROM ${schema.messages}
-              WHERE ${schema.messages.taskId} = ${schema.tasks.id}
-            )`,
-          })
-          .from(schema.tasks)
-          .leftJoin(
-            schema.artifacts,
-            and(
-              eq(schema.artifacts.taskId, schema.tasks.id),
-              eq(schema.artifacts.name, 'negotiation-outcome'),
-            ),
-          )
-          .leftJoin(opportunities, sql`${schema.tasks.metadata}->>'opportunityId' = ${opportunities.id}`)
-          .where(and(
-            inArray(schema.tasks.conversationId, ids),
-            sql`${schema.tasks.metadata}->>'type' = 'negotiation'`,
-            notArchivedNegotiationTaskWhere(),
-          ))
-          .orderBy(schema.tasks.conversationId, desc(schema.tasks.createdAt), desc(schema.tasks.id))
-        : Promise.resolve([]),
-      // All task rows are fetched in one batch so each viewer-visible
-      // opportunity can link to its own durable session. This intentionally
-      // avoids loading task history per rail row.
+      // All negotiation task rows are fetched in one batch: the represented
+      // session per conversation (`negotiation`) is chosen from them by
+      // liveness, and each viewer-visible opportunity links to its own durable
+      // session. This intentionally avoids loading task history per rail row.
       includeNegotiationLifecycle
         ? db
           .select({
             conversationId: schema.tasks.conversationId,
             taskId: schema.tasks.id,
             state: schema.tasks.state,
+            statusTimestamp: schema.tasks.statusTimestamp,
             metadata: schema.tasks.metadata,
             updatedAt: schema.tasks.updatedAt,
             createdAt: schema.tasks.createdAt,
@@ -931,24 +899,37 @@ export class ConversationDatabaseAdapter {
       viaByConv.set(metadataRow.conversationId, via);
     }
 
-    const negotiationByConv = new Map<string, NonNullable<ConversationSummary['negotiation']>>();
-    for (const row of latestNegotiationTasks) {
+    // One row per conversation. A durable A2A conversation carries a task
+    // session per opportunity the pair negotiated; the session that represents
+    // it to this viewer is the most alive one, not the newest one — see
+    // negotiation-session-rollup.projection.ts. A screened-out outreach gate
+    // is private to the client that initiated it and is never the represented
+    // session for the counterparty (the same module applies that rule before
+    // ranking).
+    const candidatesByConv = new Map<string, Array<typeof negotiationTasks[number] & {
+      metadata: Record<string, unknown>;
+      outcome: ReturnType<typeof readNegotiationOutcome>;
+    }>>();
+    for (const row of negotiationTasks) {
       const metadata = typeof row.metadata === 'object' && row.metadata !== null && !Array.isArray(row.metadata)
         ? row.metadata as Record<string, unknown>
         : {};
-      const outcome = readNegotiationOutcome(row.artifactParts);
+      const candidates = candidatesByConv.get(row.conversationId) ?? [];
+      candidates.push({ ...row, metadata, outcome: readNegotiationOutcome(row.artifactParts) });
+      candidatesByConv.set(row.conversationId, candidates);
+    }
+    const negotiationByConv = new Map<string, NonNullable<ConversationSummary['negotiation']>>();
+    for (const [conversationId, candidates] of candidatesByConv) {
+      const row = selectRepresentedNegotiationSession(candidates, viewerUserId);
+      if (!row) continue;
+      const { metadata, outcome } = row;
       const priorTurnCount = typeof metadata.priorTurnCount === 'number' && Number.isFinite(metadata.priorTurnCount)
         ? metadata.priorTurnCount
         : 0;
       const maxTurns = typeof metadata.maxTurns === 'number' && Number.isFinite(metadata.maxTurns)
         ? metadata.maxTurns
         : null;
-      // A screened-out outreach gate is private to the client that initiated
-      // it. Never project its lifecycle to the counterparty through the shared
-      // A2A conversation.
-      const initiatorUserId = readInitiatorUserId(metadata);
-      if (outcome?.reason === 'screened_out' && initiatorUserId !== viewerUserId) continue;
-      negotiationByConv.set(row.conversationId, {
+      negotiationByConv.set(conversationId, {
         taskId: row.taskId,
         state: row.state,
         statusTimestamp: row.statusTimestamp,

--- a/services/api/src/adapters/database.shared.ts
+++ b/services/api/src/adapters/database.shared.ts
@@ -722,11 +722,16 @@ export interface ConversationSummary {
   metadata: Record<string, unknown> | null;
   via: Array<{ intentId: string; opportunityId: string; title: string }>;
   unreadCount: number;
-  /** Present only when negotiation lifecycle projection was requested. */
+  /**
+   * Present only when negotiation lifecycle projection was requested. The one
+   * task session that represents this conversation to the viewer: the most
+   * alive visible session, newest first within a liveness tier — NOT simply
+   * the newest task (negotiation-session-rollup.projection.ts).
+   */
   negotiation?: NegotiationLifecycleSummary | null;
   /**
    * Viewer-scoped opportunities with an addressable negotiation task. Unlike
-   * `negotiation`, this is not limited to the conversation's latest task.
+   * `negotiation`, this is not limited to one session per conversation.
    */
   negotiationOpportunities?: Array<{
     intentId: string;

--- a/services/api/src/adapters/negotiation-session-rollup.projection.ts
+++ b/services/api/src/adapters/negotiation-session-rollup.projection.ts
@@ -1,0 +1,120 @@
+/**
+ * Which of a conversation's negotiation task sessions represents it to a viewer.
+ *
+ * One durable A2A conversation is one counterparty pair, and it accumulates a
+ * task session per opportunity the pair's agents have negotiated. The rail and
+ * the your-move badge read a single `negotiation` lifecycle per conversation,
+ * so the choice of session IS the row: its badge, its summary line, its
+ * timestamp, and whether it counts toward "your move".
+ *
+ * The choice is dominated by liveness, not recency. A viewer with one session
+ * awaiting their approval and any number of later screened-out ones has a live
+ * row; recency only breaks ties within the same liveness tier. Picking the
+ * newest task instead let a later rejection shadow an older pending approval:
+ * the rail read "No match" while the Radar for the same pair said "Awaiting
+ * you · 1", and the header read "0 your move".
+ *
+ * Pure and dependency-free so the rule is provable without a database.
+ */
+import { readInitiatorUserId } from './negotiation-lifecycle.projection';
+
+export type NegotiationSessionLiveness =
+  /** An opportunity awaits an owner's decision — the Radar's "Awaiting you". */
+  | 'awaiting_approval'
+  /** Parked `input_required`: a human was asked. Whose, the web decides from the session-scoped turn. */
+  | 'parked'
+  /** Agents are still exchanging turns, or the session has not started. */
+  | 'in_progress'
+  /** Accepted, declined, screened, stalled, expired, or failed. */
+  | 'resolved';
+
+const LIVENESS_RANK: Record<NegotiationSessionLiveness, number> = {
+  awaiting_approval: 0,
+  parked: 1,
+  in_progress: 2,
+  resolved: 3,
+};
+
+const TERMINAL_OPPORTUNITY_STATUSES = new Set(['accepted', 'rejected', 'stalled', 'expired']);
+const TERMINAL_TASK_STATES = new Set(['completed', 'failed', 'canceled', 'rejected', 'auth_required']);
+const STALL_REASONS = new Set(['turn_cap', 'timeout', 'agent_error']);
+
+export interface NegotiationSessionCandidate {
+  taskId: string;
+  state: string;
+  opportunityStatus: string | null;
+  outcome: { hasOpportunity: boolean; reason: string | null } | null;
+  metadata: Record<string, unknown>;
+  createdAt: Date | string;
+}
+
+/**
+ * Mirrors the precedence of the web's `deriveNegotiationPresentation`
+ * (apps/web/src/lib/negotiation-presentation.ts) at tier granularity: an
+ * opportunity's terminal status is authoritative over a stale task state, a
+ * pending opportunity is awaiting an owner regardless of the task that
+ * produced it, and a parked task is live until its opportunity closes.
+ *
+ * `awaiting_approval` ranks above `parked` deliberately. The server cannot see
+ * which side a parked task is waiting on (that needs the session's last turn),
+ * so if the two ever coexist for one pair, the pending approval — which is
+ * unambiguously the viewer's move — must be the one that represents the row.
+ */
+export function negotiationSessionLiveness(candidate: Pick<NegotiationSessionCandidate, 'state' | 'opportunityStatus' | 'outcome'>): NegotiationSessionLiveness {
+  const { state, opportunityStatus, outcome } = candidate;
+  if (opportunityStatus && TERMINAL_OPPORTUNITY_STATUSES.has(opportunityStatus)) return 'resolved';
+  if (outcome?.reason === 'agent_error') return 'resolved';
+  if (opportunityStatus === 'latent' || opportunityStatus === 'draft') return 'in_progress';
+  if (STALL_REASONS.has(outcome?.reason ?? '')) return 'resolved';
+  if (opportunityStatus === 'pending' || outcome?.hasOpportunity === true) return 'awaiting_approval';
+  if (state === 'input_required') return 'parked';
+  if (outcome?.hasOpportunity === false || TERMINAL_TASK_STATES.has(state)) return 'resolved';
+  return 'in_progress';
+}
+
+function timestampOf(value: Date | string): number {
+  const parsed = value instanceof Date ? value.getTime() : new Date(value).getTime();
+  return Number.isFinite(parsed) ? parsed : 0;
+}
+
+/**
+ * A screened-out outreach gate is private to the client that initiated it:
+ * it is never projected to the counterparty through the shared conversation,
+ * not even as the session that represents it.
+ */
+export function isNegotiationSessionVisibleTo(
+  candidate: Pick<NegotiationSessionCandidate, 'outcome' | 'metadata'>,
+  viewerUserId: string | null | undefined,
+): boolean {
+  if (candidate.outcome?.reason !== 'screened_out') return true;
+  return readInitiatorUserId(candidate.metadata) === viewerUserId;
+}
+
+/**
+ * Picks the session that represents a conversation to `viewerUserId`: the
+ * most alive visible session, newest-created first within a tier (ties on the
+ * same timestamp fall back to the larger task id, matching the previous
+ * `ORDER BY created_at DESC, id DESC`). Null when the viewer may see none.
+ */
+export function selectRepresentedNegotiationSession<T extends NegotiationSessionCandidate>(
+  candidates: readonly T[],
+  viewerUserId: string | null | undefined,
+): T | null {
+  let best: T | null = null;
+  let bestRank = Number.POSITIVE_INFINITY;
+  let bestCreatedAt = Number.NEGATIVE_INFINITY;
+  for (const candidate of candidates) {
+    if (!isNegotiationSessionVisibleTo(candidate, viewerUserId)) continue;
+    const rank = LIVENESS_RANK[negotiationSessionLiveness(candidate)];
+    const createdAt = timestampOf(candidate.createdAt);
+    const wins = best === null
+      || rank < bestRank
+      || (rank === bestRank && (createdAt > bestCreatedAt
+        || (createdAt === bestCreatedAt && candidate.taskId > best.taskId)));
+    if (!wins) continue;
+    best = candidate;
+    bestRank = rank;
+    bestCreatedAt = createdAt;
+  }
+  return best;
+}

--- a/services/api/src/adapters/tests/conversation.database.adapter.spec.ts
+++ b/services/api/src/adapters/tests/conversation.database.adapter.spec.ts
@@ -412,6 +412,96 @@ describe('ConversationDatabaseAdapter', () => {
         outcome: { hasOpportunity: true, reason: null },
       });
     }, 20000);
+
+    it('lets an older pending approval represent the pair over a newer screened-out pairing', async () => {
+      // Two opportunities between the same pair: outreach → accept (pending
+      // the owner's approval), then a later pairing the gate screened out.
+      // The represented session is the live one, for the owner who may see
+      // both AND for the counterparty who may not see the gate at all.
+      const suffix = `${Date.now()}-${crypto.randomUUID()}`;
+      const ownerId = `rollup-owner-${suffix}`;
+      const counterpartId = `rollup-counterpart-${suffix}`;
+      const pendingOpportunityId = `rollup-pending-${suffix}`;
+      const screenedOpportunityId = `rollup-screened-${suffix}`;
+      const conversation = await adapter.createConversation([
+        { participantId: `agent:${ownerId}`, participantType: 'agent' },
+        { participantId: `agent:${counterpartId}`, participantType: 'agent' },
+      ]);
+      createdIds.push(conversation.id);
+
+      await db.insert(schema.opportunities).values([
+        { id: pendingOpportunityId, status: 'pending' as const },
+        { id: screenedOpportunityId, status: 'rejected' as const },
+      ].map(({ id, status }) => ({
+        id,
+        detection: { source: 'manual', timestamp: new Date().toISOString() },
+        actors: [
+          { networkId: 'rollup-network', userId: ownerId, role: 'peer' },
+          { networkId: 'rollup-network', userId: counterpartId, role: 'peer' },
+        ],
+        interpretation: { category: 'test', reasoning: 'Rollup test.', confidence: 0.8 },
+        context: {},
+        confidence: '0.8',
+        status,
+      })));
+      createdOpportunityIds.push(pendingOpportunityId, screenedOpportunityId);
+
+      const pendingTask = await adapter.createTask(conversation.id, {
+        type: 'negotiation',
+        sourceUserId: ownerId,
+        candidateUserId: counterpartId,
+        initiatorUserId: ownerId,
+        opportunityId: pendingOpportunityId,
+        maxTurns: 6,
+      });
+      await adapter.createMessage({
+        conversationId: conversation.id,
+        senderId: `agent:${counterpartId}`,
+        role: 'agent',
+        taskId: pendingTask.id,
+        parts: [{ kind: 'data', data: { action: 'accept' } }],
+      });
+      await adapter.updateTaskState(pendingTask.id, 'completed');
+      await adapter.createArtifact({
+        taskId: pendingTask.id,
+        name: 'negotiation-outcome',
+        parts: [{ kind: 'data', data: { hasOpportunity: true, turnCount: 2 } }],
+      });
+
+      const screenedTask = await adapter.createTask(conversation.id, {
+        type: 'negotiation',
+        sourceUserId: ownerId,
+        candidateUserId: counterpartId,
+        initiatorUserId: ownerId,
+        opportunityId: screenedOpportunityId,
+        maxTurns: 6,
+      });
+      await adapter.updateTaskState(screenedTask.id, 'completed');
+      await adapter.createArtifact({
+        taskId: screenedTask.id,
+        name: 'negotiation-outcome',
+        parts: [{ kind: 'data', data: { hasOpportunity: false, reason: 'screened_out', turnCount: 0, reasoning: 'Not enough mutual value.' } }],
+      });
+      // Make the screened-out pairing unambiguously the newer task.
+      await db.update(schema.tasks).set({ createdAt: new Date(Date.now() + 60_000) }).where(eq(schema.tasks.id, screenedTask.id));
+
+      const ownerSummary = (await adapter.getConversationsForUser(`agent:${ownerId}`, ownerId, true))
+        .find((candidate) => candidate.id === conversation.id);
+      expect(ownerSummary?.negotiation).toMatchObject({
+        taskId: pendingTask.id,
+        opportunityId: pendingOpportunityId,
+        opportunityStatus: 'pending',
+        outcome: { hasOpportunity: true, reason: null },
+      });
+      // The conversation's last message is still that session's accept, so
+      // the web can caption the row from it.
+      expect(ownerSummary?.lastMessage?.taskId).toBe(pendingTask.id);
+
+      const counterpartSummary = (await adapter.getConversationsForUser(`agent:${counterpartId}`, counterpartId, true))
+        .find((candidate) => candidate.id === conversation.id);
+      expect(counterpartSummary?.negotiation?.taskId).toBe(pendingTask.id);
+      expect(JSON.stringify(counterpartSummary ?? {})).not.toContain('Not enough mutual value');
+    }, 30000);
   });
 
   describe('getLatestNegotiationTaskForConversation', () => {

--- a/services/api/src/adapters/tests/negotiation-session-rollup.projection.spec.ts
+++ b/services/api/src/adapters/tests/negotiation-session-rollup.projection.spec.ts
@@ -1,0 +1,110 @@
+/**
+ * Hermetic cover for the person-row rollup: which task session represents a
+ * counterparty conversation to a viewer. No database — the rule is pure, so
+ * "a live pairing is never shadowed by a later dead one" is proven on every
+ * run, not only in the DB-backed adapter spec.
+ */
+import { describe, expect, it } from 'bun:test';
+
+import { isNegotiationSessionVisibleTo, negotiationSessionLiveness, selectRepresentedNegotiationSession, type NegotiationSessionCandidate } from '../negotiation-session-rollup.projection';
+
+const VIEWER = 'user-viewer';
+const COUNTERPART = 'user-counterpart';
+
+function session(
+  taskId: string,
+  input: Partial<Omit<NegotiationSessionCandidate, 'taskId'>> & { initiatorUserId?: string } = {},
+): NegotiationSessionCandidate {
+  return {
+    taskId,
+    state: input.state ?? 'completed',
+    opportunityStatus: input.opportunityStatus ?? null,
+    outcome: input.outcome ?? null,
+    metadata: input.metadata ?? { type: 'negotiation', initiatorUserId: input.initiatorUserId ?? VIEWER },
+    createdAt: input.createdAt ?? '2026-08-20T15:00:00.000Z',
+  };
+}
+
+const PENDING_OLDER = session('pending-older', {
+  state: 'completed',
+  opportunityStatus: 'pending',
+  outcome: { hasOpportunity: true, reason: null },
+  createdAt: '2026-08-20T15:28:00.000Z',
+});
+const SCREENED_NEWER = session('screened-newer', {
+  state: 'completed',
+  opportunityStatus: 'rejected',
+  outcome: { hasOpportunity: false, reason: 'screened_out' },
+  createdAt: '2026-08-20T15:29:00.000Z',
+});
+const DECLINED_NEWER = session('declined-newer', {
+  state: 'completed',
+  opportunityStatus: 'rejected',
+  outcome: { hasOpportunity: false, reason: null },
+  createdAt: '2026-08-20T15:30:00.000Z',
+});
+const WORKING = session('working', { state: 'working', opportunityStatus: 'negotiating', createdAt: '2026-08-20T15:10:00.000Z' });
+
+describe('negotiationSessionLiveness', () => {
+  it.each([
+    ['pending opportunity, task completed', { state: 'completed', opportunityStatus: 'pending' }, 'awaiting_approval'],
+    ['agents agreed, opportunity not yet pending', { state: 'completed', opportunityStatus: 'negotiating', outcome: { hasOpportunity: true, reason: null } }, 'awaiting_approval'],
+    ['parked on a human', { state: 'input_required', opportunityStatus: 'negotiating' }, 'parked'],
+    ['working', { state: 'working', opportunityStatus: 'negotiating' }, 'in_progress'],
+    ['submitted, no opportunity row yet', { state: 'submitted', opportunityStatus: null }, 'in_progress'],
+    ['latent opportunity', { state: 'completed', opportunityStatus: 'latent' }, 'in_progress'],
+    ['screened out', { state: 'completed', opportunityStatus: 'rejected', outcome: { hasOpportunity: false, reason: 'screened_out' } }, 'resolved'],
+    ['declined', { state: 'completed', opportunityStatus: 'negotiating', outcome: { hasOpportunity: false, reason: null } }, 'resolved'],
+    ['accepted', { state: 'completed', opportunityStatus: 'accepted' }, 'resolved'],
+    ['stalled on turn cap', { state: 'completed', opportunityStatus: 'negotiating', outcome: { hasOpportunity: false, reason: 'turn_cap' } }, 'resolved'],
+    ['expired', { state: 'completed', opportunityStatus: 'expired' }, 'resolved'],
+    ['agent error', { state: 'failed', opportunityStatus: 'stalled', outcome: { hasOpportunity: false, reason: 'agent_error' } }, 'resolved'],
+    ['terminal opportunity beats a stale parked task', { state: 'input_required', opportunityStatus: 'rejected' }, 'resolved'],
+    ['terminal opportunity beats a stale pending-looking outcome', { state: 'completed', opportunityStatus: 'accepted', outcome: { hasOpportunity: true, reason: null } }, 'resolved'],
+  ] as const)('%s → %s', (_name, input, expected) => {
+    expect(negotiationSessionLiveness({ outcome: null, ...input })).toBe(expected);
+  });
+});
+
+describe('selectRepresentedNegotiationSession', () => {
+  it('lets an older pending approval represent the pair over a newer screened-out pairing', () => {
+    // Hye-jin ↔ Deniz on the sandbox: outreach → accept at 15:28, screened out
+    // at 15:29. The rail read "No match · 0 your move" while Radar said
+    // "Awaiting you · 1".
+    expect(selectRepresentedNegotiationSession([SCREENED_NEWER, PENDING_OLDER], VIEWER)?.taskId).toBe('pending-older');
+    expect(selectRepresentedNegotiationSession([PENDING_OLDER, SCREENED_NEWER], VIEWER)?.taskId).toBe('pending-older');
+  });
+
+  it('lets a live negotiation represent the pair over a newer declined one', () => {
+    expect(selectRepresentedNegotiationSession([DECLINED_NEWER, WORKING], VIEWER)?.taskId).toBe('working');
+  });
+
+  it('ranks a pending approval above a parked task, whichever is newer', () => {
+    const parkedNewer = session('parked-newer', { state: 'input_required', opportunityStatus: 'negotiating', createdAt: '2026-08-20T16:00:00.000Z' });
+    expect(selectRepresentedNegotiationSession([parkedNewer, PENDING_OLDER], VIEWER)?.taskId).toBe('pending-older');
+    expect(selectRepresentedNegotiationSession([parkedNewer, WORKING], VIEWER)?.taskId).toBe('parked-newer');
+  });
+
+  it('keeps recency as the tie-break within a tier (all resolved → newest created)', () => {
+    expect(selectRepresentedNegotiationSession([SCREENED_NEWER, DECLINED_NEWER], VIEWER)?.taskId).toBe('declined-newer');
+    const sameInstantA = session('a', { opportunityStatus: 'rejected', createdAt: '2026-08-20T15:00:00.000Z' });
+    const sameInstantB = session('b', { opportunityStatus: 'rejected', createdAt: '2026-08-20T15:00:00.000Z' });
+    expect(selectRepresentedNegotiationSession([sameInstantA, sameInstantB], VIEWER)?.taskId).toBe('b');
+    expect(selectRepresentedNegotiationSession([sameInstantB, sameInstantA], VIEWER)?.taskId).toBe('b');
+  });
+
+  it('never lets a screened-out gate represent the pair to the counterparty, and falls back to what they may see', () => {
+    expect(isNegotiationSessionVisibleTo(SCREENED_NEWER, VIEWER)).toBe(true);
+    expect(isNegotiationSessionVisibleTo(SCREENED_NEWER, COUNTERPART)).toBe(false);
+    expect(isNegotiationSessionVisibleTo(DECLINED_NEWER, COUNTERPART)).toBe(true);
+
+    expect(selectRepresentedNegotiationSession([SCREENED_NEWER], COUNTERPART)).toBeNull();
+    expect(selectRepresentedNegotiationSession([SCREENED_NEWER, DECLINED_NEWER], COUNTERPART)?.taskId).toBe('declined-newer');
+    // The initiator's own view is unchanged by the privacy rule.
+    expect(selectRepresentedNegotiationSession([SCREENED_NEWER], VIEWER)?.taskId).toBe('screened-newer');
+  });
+
+  it('returns null for no candidates', () => {
+    expect(selectRepresentedNegotiationSession([], VIEWER)).toBeNull();
+  });
+});


### PR DESCRIPTION
## The bug

The Negotiations page shows one row per counterparty person. That row is built from `conversation.negotiation`, which the API projected as the **newest-created** negotiation task in the pair's durable A2A conversation (`DISTINCT ON (conversation_id) … ORDER BY created_at DESC`).

Observed on the sandbox as Hye-jin Park ↔ Deniz Arslan:

- 15:28 — opportunity `d21a60dc…`: agents ran `outreach → accept`; opportunity `pending`, awaiting Hye-jin's approval. Radar: **Awaiting you · 1**.
- 15:29 — opportunity `ac5fcc3e…`: gate screened it out, `rejected`, zero messages.

The newer rejection shadowed the older pending approval: the single Deniz row read **"No match · agents did not find enough mutual value to continue"**, and the header read **"0 your move"**.

## Rule 1 — the represented session is chosen by liveness, recency only within a tier

The grouping happens server-side, so the pick moves to the API. New pure module `services/api/src/adapters/negotiation-session-rollup.projection.ts` (hermetic spec, no DB):

| tier | meaning | derived from |
|---|---|---|
| `awaiting_approval` | an opportunity awaits an owner's decision — the Radar's "Awaiting you" | `opportunityStatus === 'pending'` or `outcome.hasOpportunity === true` |
| `parked` | `input_required`, a human was asked (whose side, the web decides from the session-scoped turn) | task state |
| `in_progress` | agents still exchanging turns / not started | live task states, `latent`/`draft` |
| `resolved` | accepted, declined, screened, stalled, expired, failed | terminal opportunity status or task state, stall/error outcome reasons |

Within a tier: newest `createdAt`, then id — the previous ordering, so **all-resolved → most recent resolved** is unchanged. Precedence mirrors the web's `deriveNegotiationPresentation` at tier granularity (a terminal opportunity status beats a stale task state). `awaiting_approval` deliberately ranks above `parked`: the server cannot see which side a parked task waits on, and a pending approval is unambiguously the viewer's move — if both ever coexist for one pair, the row must not read "in progress".

Mechanically, the `DISTINCT ON` query is removed; the all-rows task query that already fed `negotiationOpportunities` now feeds the pick too (one query instead of two, same rows).

**Privacy rule moved, and slightly better**: "a screened-out gate is never projected to the counterparty" now lives in the same module (`isNegotiationSessionVisibleTo`) and filters *before* ranking. Before, a newest screened-out task for a non-initiator made `negotiation` null for the whole conversation, and the web then rendered the conversation's older visible pairing as a coarse "Not started"; now the counterparty falls back to the session they may see. The initiator's view and the zero-turn single-task cases (IND-610 specs) are unchanged. `screened_out` reasoning still never reaches a non-owner (asserted in the new DB-backed spec).

**How the row communicates the rest**: it doesn't — silently dropped, as the handoff allowed. The row opens the conversation, whose transcript holds the earlier pairings. The badge, summary line and "last activity" timestamp all come from the selected session; no count of other pairings is projected (that would be new API surface for a one-line aside).

### Web: the summary line can't be captioned by a dead session

`deriveNegotiationInbox` read `lastAction` from the **conversation-wide** last message (`readLastTurn(conversation.lastMessage.parts)`), while classification was already session-scoped. With the API now able to pick an older session, a later dead session's "did not recommend proceeding" could caption an awaiting-you row. The summary line now uses `sessionScopedLastTurn(conversation, negotiation.taskId)`; a live row whose session has no scoped turn is described from its state (`awaiting_review` → "agents recommended moving forward", otherwise the existing "agents exchanged a turn"). Timestamp comes from `negotiation.updatedAt` — the selected session's move, as before.

## Rule 2 — the header counts what the viewer must act on

**Chosen: include.** A pending owner approval already maps to `awaiting_review` → group `your_move` in `negotiation-presentation.ts`, so the header, the TopBar badge, and the DiscoverHome counts all count it — the same reality the Radar's `pending` → "Awaiting you" bucket counts. The observed "0 your move" was purely the rollup picking the wrong session. Rule 1 fixes it; rule 2 is now pinned by spec so the two surfaces can't drift:

- `countNegotiationsRequiringAction([pendingApproval]) === 1`, status `awaiting_review`
- parked question to the viewer + pending approval = 2; a declined pairing and a question parked on the *counterparty* don't count.

## Verified live on the sandbox

Ran `getConversationsForUser` for Hye-jin (`6c17f313…`) against the sandbox DB with this branch: the Deniz row now resolves to task `df02d258…` / opportunity `d21a60dc…`, `pending`, `hasOpportunity: true` (its `lastMessage.taskId` is that same session, so the row captions from the accept) — instead of the screened-out `ac5fcc3e…`. The three other rows (all-resolved people) are unchanged.

## Tests

- **API hermetic** `negotiation-session-rollup.projection.spec.ts` (20 tests): tier table; `[screened(newer), pending(older)] → pending`; `[declined(newer), working] → working`; pending beats parked either way; all-resolved → newest, same-instant id tie-break; counterparty never gets a screened-out session and falls back to the visible one.
- **API DB-backed** (`conversation.database.adapter.spec.ts`): two opportunities, pending (older, with accept message) + screened-out (newer, zero messages) → `negotiation.taskId` is the pending one for the owner **and** for the counterparty; `lastMessage.taskId` is the pending session; screen reasoning absent from the counterparty's summary. Passes against the test DB.
- **Web** (`negotiation-inbox.test.ts`): rollup — awaiting-you row stays awaiting-you with the caption/timestamp from its own session while another session left the last message; live row captioned from its own session; all-resolved unchanged. Header — pending approval counts; question+approval = 2.
- Existing #1444/#1449 family green: `negotiation-outline`, `negotiation-presentation`, `ChatSidebar`, `NegotiationsInbox`, `NegotiationActivity`, intent-page negotiator tests — 80/80.

### Pre-existing, not from this diff (verified by re-running against the HEAD adapter / HEAD inbox lib)

- `NegotiationsInbox.test.tsx › routes answer rows to /questions` was failing on `dev`: its fixture's `lastMessage` had no `taskId`, so the session-scoped classification (already in place) never matched. Fixed the fixture (`taskId: \`${id}-task\``) — the test now passes.
- Two DB-backed `conversation.database.adapter.spec.ts` tests fail on `dev` too and are untouched: `durable conversation sessions › maps all A2A task messages to one task session` (`hasPreviousSession`) and `negotiation conversation summaries › projects the latest task…` (`turnCount` expected 2, got 3 — `priorTurnCount + outcome.turnCount`). Both out of scope here; flagging for a follow-up.

## Boundaries

No protocol changes, no negotiation-graph changes, no flags. Screen/decline outcomes are untouched — presentation aggregation only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
