### PR TITLE
feat(negotiations): a seed persona someone is logged in as is reachable

### DIFF
--- a/services/api/src/adapters/conversation.database.adapter.ts
+++ b/services/api/src/adapters/conversation.database.adapter.ts
@@ -27,7 +27,7 @@ import { consultationActorSetMatchesBinding, externalConsultationCoordinatesFor 
 import { authorizeNegotiationMutationInTransaction } from '../lib/agent/negotiation-runtime-authority';
 import { isDedicatedHermesNegotiationAudience, type NegotiationCredentialPrincipal } from '../lib/agent/hermes-credential';
 import { digestHermesRunId, issueHermesRunCapability, parseHermesRunCapabilityBinding, verifyHermesRunCapability, type HermesRunOutcome } from '../lib/agent/hermes-negotiation-run';
-import { isSyntheticUserEmail } from '../lib/users/synthetic';
+import { resolvePrincipalUnreachable } from '../lib/users/synthetic';
 
 /**
  * In-transaction read of ONE negotiation's turn history, for the locked floor
@@ -1640,16 +1640,43 @@ export class ConversationDatabaseAdapter {
   }
 
   /**
+   * Whether the user holds a session Better Auth still honours — a `sessions`
+   * row with `expires_at` in the future. This is the `ACTIVE_SESSION_RULE`
+   * read (`unexpired`, nothing stricter) behind seed-persona reachability:
+   * sign-in writes the row, sign-out deletes it, expiry retires it.
+   *
+   * The bound is a client `Date`, not SQL `now()`. `sessions.expires_at` is a
+   * timestamp WITHOUT time zone holding UTC wall-clock (that is what the
+   * driver writes for a `Date`), so comparing it to `now()` would make
+   * Postgres read the naive column in the connection's local zone and shift
+   * every session by the server's UTC offset — east of UTC, a live session
+   * reads as expired. Binding a `Date` round-trips through the same
+   * serialization the row was written with.
+   */
+  async hasActiveSession(userId: string): Promise<boolean> {
+    const [row] = await db
+      .select({ id: schema.sessions.id })
+      .from(schema.sessions)
+      .where(and(
+        eq(schema.sessions.userId, userId),
+        gt(schema.sessions.expiresAt, new Date()),
+      ))
+      .limit(1);
+    return row !== undefined;
+  }
+
+  /**
    * Whether this principal can be consulted at all — the host half of the
    * negotiation graph's `isPrincipalUnreachable` port.
    *
-   * The predicate lives in `lib/users/synthetic`; this is the DB read behind
-   * it. The graph receives only the boolean, which is what keeps addresses out
-   * of negotiation context and out of every prompt built from it.
+   * The rule lives in `lib/users/synthetic` and this adapter is its reader:
+   * a seed persona nobody is signed in as is unreachable; a real user, or a
+   * seed persona someone is currently driving, is not. The graph receives only
+   * the boolean, which is what keeps addresses out of negotiation context and
+   * out of every prompt built from it.
    */
   async isPrincipalUnreachable(userId: string): Promise<boolean> {
-    const user = await this.getUser(userId);
-    return isSyntheticUserEmail(user?.email);
+    return resolvePrincipalUnreachable(userId, this);
   }
 
   /**

--- a/services/api/src/adapters/tests/conversation.database.adapter.spec.ts
+++ b/services/api/src/adapters/tests/conversation.database.adapter.spec.ts
@@ -290,6 +290,43 @@ describe('ConversationDatabaseAdapter', () => {
     }, 10000);
   });
 
+  describe('isPrincipalUnreachable', () => {
+    it('treats a seed persona as unreachable only while nobody holds an unexpired session', async () => {
+      const run = crypto.randomUUID();
+      const seedId = `reach-seed-${run}`;
+      const realId = `reach-real-${run}`;
+      await db.insert(schema.users).values([
+        { id: seedId, email: `${seedId}@index-network.test`, name: 'Seed Persona' },
+        { id: realId, email: `${realId}@example.org`, name: 'Real Person' },
+      ]);
+      createdUserIds.push(seedId, realId);
+
+      // Nobody signed in: the #1459 default.
+      expect(await adapter.isPrincipalUnreachable(seedId)).toBe(true);
+      expect(await adapter.isPrincipalUnreachable(realId)).toBe(false);
+
+      // An expired session is no one at the keyboard.
+      const sessionId = `reach-session-${run}`;
+      await db.insert(schema.sessions).values({
+        id: sessionId,
+        token: `reach-token-${run}`,
+        userId: seedId,
+        expiresAt: new Date(Date.now() - 60_000),
+      });
+      expect(await adapter.isPrincipalUnreachable(seedId)).toBe(true);
+
+      // An unexpired session is someone driving the persona.
+      await db.update(schema.sessions)
+        .set({ expiresAt: new Date(Date.now() + 60 * 60_000) })
+        .where(eq(schema.sessions.id, sessionId));
+      expect(await adapter.isPrincipalUnreachable(seedId)).toBe(false);
+
+      // Sign-out deletes the row; the persona goes quiet again.
+      await db.delete(schema.sessions).where(eq(schema.sessions.id, sessionId));
+      expect(await adapter.isPrincipalUnreachable(seedId)).toBe(true);
+    }, 30000);
+  });
+
   describe('getOpportunityLifecyclesForNegotiations', () => {
     it('omits unrelated opportunities and projects only owner-scoped lifecycle evidence', async () => {
       const suffix = `${Date.now()}-${crypto.randomUUID()}`;

--- a/services/api/src/lib/users/synthetic.ts
+++ b/services/api/src/lib/users/synthetic.ts
@@ -15,11 +15,37 @@
  * suspended or deleted account, say), and stated without leaking test framing
  * into anything a counterparty's user might read.
  *
+ * A seed persona is only unreachable while nobody is behind it. The moment a
+ * tester signs in as one, there IS someone to answer — the question routes to
+ * whoever is driving the account — so an inhabited seed is reachable, and the
+ * rule is:
+ *
+ *     unreachable(user) = isSyntheticUserEmail(user.email)
+ *                         AND NOT hasActiveSession(user.id)
+ *
+ * "Active session" is {@link ACTIVE_SESSION_RULE}: any row in `sessions` for
+ * the user whose `expires_at` is still in the future. Better Auth issues
+ * seven-day sessions and refreshes `expires_at` on use, and sign-out deletes
+ * the row, so an unexpired session means "someone set this persona up to be
+ * driven this week and has not left" — which is exactly the population whose
+ * questions deserve to land. A tester who signed in yesterday still wants the
+ * question today; no recency window tighter than the session's own lifetime
+ * is applied.
+ *
  * This is the single definition. Every consumer goes through it.
  */
 import { log } from '../log';
 
 const logger = log.lib.from('users/synthetic');
+
+/**
+ * The one liveness rule a seed persona's session must satisfy to count as
+ * inhabited. Stated as a constant so the choice is named, not scattered:
+ * `unexpired` means `sessions.expires_at > now()` and nothing stricter.
+ * Readers implementing {@link SyntheticPrincipalReader.hasActiveSession}
+ * encode this exact predicate.
+ */
+export const ACTIVE_SESSION_RULE = 'unexpired' as const;
 
 /**
  * Whether this address belongs to a seed persona: true iff the domain's final
@@ -38,34 +64,61 @@ export function isSyntheticUserEmail(email: string | null | undefined): boolean 
   return domain.split('.').at(-1) === 'test';
 }
 
-/** The narrow read {@link resolvePrincipalUnreachable} needs. */
+/** The narrow reads {@link resolvePrincipalUnreachable} needs. */
 export interface SyntheticPrincipalReader {
   getUser(userId: string): Promise<{ email: string | null } | null>;
+  /**
+   * Whether the user holds a session satisfying {@link ACTIVE_SESSION_RULE}.
+   * Only ever consulted for seed personas; real users never reach it.
+   */
+  hasActiveSession(userId: string): Promise<boolean>;
 }
 
 /**
  * Whether this principal can be consulted at all during a negotiation.
  *
- * Fails OPEN — an unresolvable user, a missing email, or a failed read all
- * report *reachable*. Real users are the default, and the cost of the two
- * errors is not symmetric: wrongly calling a real principal unreachable would
- * silently stop their own agent from ever asking them anything, while wrongly
- * calling a seed persona reachable only restores today's behaviour.
+ * Two reads, two populations, two opposite failure directions — both correct:
+ *
+ * - The user read fails OPEN. An unresolvable user, a missing email, or a
+ *   failed read all report *reachable*. Real users are the default, and
+ *   wrongly calling a real principal unreachable would silently stop their
+ *   own agent from ever asking them anything, while wrongly calling a seed
+ *   persona reachable only restores pre-#1459 behaviour.
+ * - The session read fails CLOSED, and is only made for `.test` users. A seed
+ *   persona whose session read fails reports *unreachable*: wrongly asking a
+ *   persona nobody inhabits rots a question in a DM no one opens, while
+ *   wrongly silencing an inhabited persona merely restores yesterday's
+ *   behaviour. Real users short-circuit before the sessions table is touched,
+ *   so the common path costs one read and a sessions outage cannot affect a
+ *   real principal.
  */
 export async function resolvePrincipalUnreachable(
   userId: string,
   reader?: SyntheticPrincipalReader,
 ): Promise<boolean> {
+  const resolved = reader
+    ?? (await import('../../adapters/database.adapter')).conversationDatabaseAdapter;
+
+  let synthetic: boolean;
   try {
-    const resolved = reader
-      ?? (await import('../../adapters/database.adapter')).conversationDatabaseAdapter;
     const user = await resolved.getUser(userId);
-    return isSyntheticUserEmail(user?.email);
+    synthetic = isSyntheticUserEmail(user?.email);
   } catch (err) {
     logger.warn('Principal reachability read failed; treating principal as reachable', {
       userId,
       error: err instanceof Error ? err.message : String(err),
     });
     return false;
+  }
+  if (!synthetic) return false;
+
+  try {
+    return !(await resolved.hasActiveSession(userId));
+  } catch (err) {
+    logger.warn('Seed-persona session read failed; treating principal as unreachable', {
+      userId,
+      error: err instanceof Error ? err.message : String(err),
+    });
+    return true;
   }
 }

--- a/services/api/src/lib/users/tests/synthetic.spec.ts
+++ b/services/api/src/lib/users/tests/synthetic.spec.ts
@@ -35,20 +35,55 @@ describe('isSyntheticUserEmail', () => {
 });
 
 describe('resolvePrincipalUnreachable', () => {
-  it('resolves the principal through the reader', async () => {
-    const reader = { getUser: async () => ({ email: 'seed-tester-3@index-network.test' }) };
+  const neverConsulted = async (): Promise<boolean> => {
+    throw new Error('sessions table consulted for a real user');
+  };
+
+  it('reports an uninhabited seed persona as unreachable', async () => {
+    const reader = {
+      getUser: async () => ({ email: 'seed-tester-3@index-network.test' }),
+      hasActiveSession: async () => false,
+    };
     expect(await resolvePrincipalUnreachable('user-seed', reader)).toBe(true);
   });
 
-  it('reports a real user as reachable', async () => {
-    const reader = { getUser: async () => ({ email: 'real@index.network' }) };
+  it('reports a seed persona someone is signed in as reachable', async () => {
+    const consulted: string[] = [];
+    const reader = {
+      getUser: async () => ({ email: 'seed-tester-3@index-network.test' }),
+      hasActiveSession: async (userId: string) => { consulted.push(userId); return true; },
+    };
+    expect(await resolvePrincipalUnreachable('user-seed', reader)).toBe(false);
+    expect(consulted).toEqual(['user-seed']);
+  });
+
+  it('reports a real user as reachable without ever touching sessions', async () => {
+    const reader = {
+      getUser: async () => ({ email: 'real@index.network' }),
+      hasActiveSession: neverConsulted,
+    };
     expect(await resolvePrincipalUnreachable('user-real', reader)).toBe(false);
   });
 
-  it('fails open when the user is missing or the read throws', async () => {
-    expect(await resolvePrincipalUnreachable('gone', { getUser: async () => null })).toBe(false);
+  it('fails open when the user is missing or the user read throws', async () => {
+    expect(await resolvePrincipalUnreachable('gone', {
+      getUser: async () => null,
+      hasActiveSession: neverConsulted,
+    })).toBe(false);
     expect(await resolvePrincipalUnreachable('boom', {
       getUser: async () => { throw new Error('db down'); },
+      hasActiveSession: neverConsulted,
     })).toBe(false);
+  });
+
+  it('fails CLOSED when a seed persona\'s session read throws — the opposite direction, deliberately', async () => {
+    // A seed persona is unreachable by default (#1459). If we cannot tell
+    // whether someone is behind it, asking anyway risks a question rotting in
+    // a DM nobody opens; staying silent merely restores yesterday's behaviour.
+    const reader = {
+      getUser: async () => ({ email: 'seed-tester-3@index-network.test' }),
+      hasActiveSession: async () => { throw new Error('sessions down'); },
+    };
+    expect(await resolvePrincipalUnreachable('user-seed', reader)).toBe(true);
   });
 });


### PR DESCRIPTION
#1459 taught the negotiator that a seed persona has nobody behind it, so its agent must not park on `ask_user`. That is true exactly while nobody is behind it — and the rule had no way to notice when someone was.

Negotiation `703741e6` in the sandbox is the bill for that. Mira's agent wanted to know what Hye-jin means by "studio operations experience": unknown, client-authoritative, unasked, budget untouched, and pivotal enough that Mira later declined over it. A five-for-five admissible ask. Yanek was logged in as Hye-jin at that moment, able to answer in one line. The `.test` TLD rule refused anyway, and the barred agent degenerated into a copy-loop.

## The change

One line of meaning, in the single definition:

```
unreachable(user) = isSyntheticUserEmail(user.email) AND NOT hasActiveSession(user.id)
```

It lands in `lib/users/synthetic`, so every consumer inherits it without being rewired. All four sites already resolved through the two shared functions — verified, not rewired:

| path | resolves through | after |
|---|---|---|
| graph init-node stamp | `ConversationDatabaseAdapter.isPrincipalUnreachable` | inherits |
| timeout fallback | same adapter method via `NegotiationGraphDatabase` | inherits |
| external consultation + pickup re-stamp | `resolvePrincipalUnreachable` | inherits |
| park-path question fence | `resolvePrincipalUnreachable` | inherits |

No reachability rule exists anywhere outside those two functions — a sweep of `services/api/src` finds `.test` only in the seed CLIs themselves, and `apps/web/src` has no seed or test-account gating at all, so nothing stands between an inhabited persona's question and their UI.

The protocol port and the graph are untouched. No flags, no schema, no protocol changes. Uninhabited seeds behave exactly as #1459 built them, and the prompt fragments, refusal reasons and specs still hold for them.

## Why "unexpired", and why it is a named constant

`ACTIVE_SESSION_RULE = 'unexpired'`: a row in `sessions` with `expires_at > now`, and nothing stricter. Better Auth issues seven-day sessions, refreshes `expires_at` on use, and deletes the row on sign-out, so the row's own lifetime already carries the meaning we want — *someone set this persona up to be driven this week and has not left*. A tester who signed in yesterday still wants the question today; a recency window tighter than the session's lifetime would silence them and buy nothing. Sign-out and expiry both return the persona to silence on their own.

## Two reads, two opposite fail directions, both correct

- **The user read fails OPEN**, unchanged from #1459. A missing user, a missing email, a failed read → *reachable*. Wrongly silencing a real principal's own agent is the costlier error.
- **The session read fails CLOSED**, and is only ever reached by a `.test` user. A seed persona whose session read throws → *unreachable*. Wrongly asking a persona nobody inhabits rots a question in a DM no one opens; wrongly silencing an inhabited persona merely restores yesterday's behaviour.

Real users short-circuit before the sessions table is touched, so the common path costs one read and a sessions outage cannot reach a real principal. Both directions are documented at the function and asserted in the specs.

## A timezone bug the adapter spec caught

The first implementation compared `expires_at` against SQL `now()`. `sessions.expires_at` is a `timestamp` **without** time zone holding UTC wall-clock, so Postgres reads the naive column in the connection's zone and shifts every session by the server's UTC offset. Against the local test database (`Europe/Istanbul`) a live seven-day session read as expired and the inhabited persona stayed silenced — the exact bug this PR exists to fix, reintroduced one layer down. Neon runs `GMT`, so the sandbox would not have shown it; it would have waited for a differently-configured environment. The bound is now a client `Date`, which round-trips through the same serialization the row was written with, matching the convention already used for naive columns elsewhere in the adapters.

## Live evidence — the incident pair, real sandbox data

`protocol_sandbox` still holds the accounts from `703741e6`. Hye-jin has five unexpired sessions from the session in question (`expires_at` 2026-08-27, written 15:14–15:19 UTC today); Mira has none.

Running the production code against that live database — the graph's own `resolvePrincipalUnreachable` given the real api adapter as its port, and `routeParkedQuestionEnqueue` with production reachability resolution:

```
=== Hye-jin Park  (sandbox-person-96@index-network.test, SIGNED IN)
  graph init-node stamp : {"id":"6c17f313-…","intents":[],"profile":{}}
  principalUnreachable  : ABSENT -> ask_user granted
  question fence        : handled=true regenerateJobs=[{"userId":"6c17f313-…","intentId":"live-check-intent"}]

=== Mira Kovač    (mira.kovac@sandbox.test, uninhabited)
  graph init-node stamp : {"id":"f1000000-…","intents":[],"profile":{},"principalUnreachable":true}
  principalUnreachable  : PRESENT -> ask_user withheld
  question fence        : handled=true regenerateJobs=[]
                          log: question_message_principal_unreachable
```

The inhabited seat carries no `principalUnreachable` stamp — the grant is present — and its question now clears the fence into her own scope, where before it was dropped. The uninhabited seat is refused exactly as #1459 left it. Both from one negotiation's two seats, resolved live.

I did not drive a fresh negotiation to a rendered question card: `703741e6` is `completed`, the sandbox holds no parked task to re-run, and the copy-loop lane is in flight in the same code. This is the fallback the task allows — the grant shown present at the choke point, the fence shown passing, and no seed-specific filter anywhere in the delivery spine. The remaining unproven link is the LLM actually choosing to draft the ask, which is the other lane's problem.

## Tests

`bun test` in `services/api`: **1695 pass, 18 fail**. All 18 are pre-existing on `dev` — verified by reverting only the two source files to `dev` and re-running: the same 18 fail, plus exactly the 2 new specs asserting the new behaviour, which go red→green with the implementation restored. (Two of the 18 are the known DB-backed conversation adapter failures; the rest are the CLI-credential, MCP-factory, ToolController and maintenance-graph suites, none of which touch this path.)

New coverage:
- `synthetic.spec.ts` — `.test` + unexpired session → reachable; `.test` + expired/absent session → unreachable; `.test` + throwing session read → **unreachable** (the documented asymmetry); real user → reachable with a `hasActiveSession` stub that throws if consulted, proving the short-circuit.
- `conversation.database.adapter.spec.ts` — one seed persona walked through all four states against the real database: no session, expired session, unexpired session, session deleted.
- #1459's specs stay green, including the protocol's 16-test `negotiation.principal-unreachable.spec.ts` and the queue fence and consultation suites.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
