### PR TITLE
fix(negotiations): a turn that repeats a message is not a turn

### DIFF
--- a/apps/web/src/app/chat/[conversationId]/page.tsx
+++ b/apps/web/src/app/chat/[conversationId]/page.tsx
@@ -12,7 +12,7 @@ import ResolvedBanner, { type ResolvedBannerVariant } from '@/components/negotia
 import GateDecisionCard from '@/components/negotiations/GateDecisionCard';
 import { resolveGateDecision } from '@/components/negotiations/gate-decision';
 import { useTickingNow } from '@/components/negotiations/use-ticking-now';
-import { deriveSectionLabel, extractTurn, formatRelativeTime, groupTurnsBySession, viewerRoleLabel, type TranscriptTurn } from '@/components/negotiations/negotiation-turns';
+import { deriveSectionLabel, extractTurn, formatRelativeTime, groupTurnsBySession, terminalTurnAuthor, viewerRoleLabel, type TranscriptTurn } from '@/components/negotiations/negotiation-turns';
 
 // `agent_error` joins the stall reasons rather than the reject ones: a run
 // that stopped on repeated agent failures decided nothing, so it must never
@@ -131,6 +131,15 @@ export default function NegotiationDetailPage() {
   // claim is about what the reader can see above the banner, and every turn in
   // the rail is visible regardless of which session produced it.
   const contactMade = turns.length > 0;
+
+  // Who ended it, read from the same turns the banner renders above — and from
+  // the LATEST session's turns, because that is the negotiation the banner is
+  // scoped to (IND-566). An earlier task in this pair may well have ended the
+  // other way round.
+  const terminalAuthor = useMemo(
+    () => terminalTurnAuthor(latestSessionTurns, ownAgentId),
+    [latestSessionTurns, ownAgentId],
+  );
 
   // IND-610: the owner-only outreach-gate card. A `screened_out` negotiation
   // with no turns is the one case where the transcript has nothing to show —
@@ -288,6 +297,7 @@ export default function NegotiationDetailPage() {
                         turnCount={latestTaskTurnCount}
                         maxTurns={lifecycle?.maxTurns ?? null}
                         contactMade={contactMade}
+                        terminalAuthor={terminalAuthor}
                         onLetGo={resolvedVariant === 'stalled' ? () => navigate('/negotiations') : undefined}
                       />
                     )}
@@ -325,6 +335,7 @@ export default function NegotiationDetailPage() {
                     turnCount={latestTaskTurnCount}
                     maxTurns={lifecycle?.maxTurns ?? null}
                     contactMade={contactMade}
+                    terminalAuthor={terminalAuthor}
                     onLetGo={resolvedVariant === 'stalled' ? () => navigate('/negotiations') : undefined}
                   />
                 )}

--- a/apps/web/src/components/__tests__/ResolvedBanner.test.tsx
+++ b/apps/web/src/components/__tests__/ResolvedBanner.test.tsx
@@ -43,8 +43,51 @@ describe('ResolvedBanner — screened_out and what the thread can prove', () => 
   });
 
   it('leaves the other rejected reasons untouched by the guard', () => {
-    render(<ResolvedBanner variant="rejected" reason={null} turnCount={2} maxTurns={6} contactMade />);
+    // `terminalAuthor` is what the withdraw copy now hangs on; the #1458 guard
+    // is still the thing under test, which is that it touches only screened_out.
+    render(<ResolvedBanner variant="rejected" reason={null} turnCount={2} maxTurns={6} contactMade terminalAuthor="own" />);
     expect(screen.getByText(/Your agent withdrew after reviewing the opportunity/)).toBeInTheDocument();
+    expect(screen.getByText(/never learns the details/)).toBeInTheDocument();
+  });
+});
+
+/**
+ * Who ended it. The banner told an owner "Your agent withdrew after reviewing
+ * the opportunity (6 turns)" above a transcript whose final turn was the
+ * COUNTERPARTY's agent declining them — the exact inversion of what happened,
+ * and the only account of the exchange that owner ever gets.
+ */
+describe('ResolvedBanner — who actually ended it', () => {
+  it('says their agent declined when the counterparty authored the terminal turn', () => {
+    render(<ResolvedBanner variant="rejected" reason={null} turnCount={6} maxTurns={6} contactMade terminalAuthor="counterparty" />);
+    expect(screen.getByText(/Their agent declined \(6 turns\)/)).toBeInTheDocument();
+    expect(screen.queryByText(/Your agent withdrew/)).toBeNull();
+    // Nothing claims this side did the filtering, because it did not.
+    expect(screen.queryByText(/filtered out for you/)).toBeNull();
+    expect(screen.getByText('No opportunity')).toBeInTheDocument();
+    // The quiet-decline footnote is a claim about OUR decision reaching them.
+    expect(screen.queryByText(/declines are quiet by design/)).toBeNull();
+  });
+
+  it('keeps the withdrawal copy when this side authored the terminal turn', () => {
+    render(<ResolvedBanner variant="rejected" reason={null} turnCount={3} maxTurns={6} contactMade terminalAuthor="own" />);
+    expect(screen.getByText(/Your agent withdrew after reviewing the opportunity \(3 turns\)/)).toBeInTheDocument();
+    expect(screen.getByText('No opportunity — filtered out for you')).toBeInTheDocument();
+    expect(screen.getByText(/declines are quiet by design/)).toBeInTheDocument();
+  });
+
+  it('says something neutral when the transcript cannot name the author', () => {
+    render(<ResolvedBanner variant="rejected" reason={null} turnCount={4} maxTurns={6} contactMade />);
+    expect(screen.getByText(/After 4 turns, the agents ended this without a match/)).toBeInTheDocument();
+    // Never a guess in either direction.
+    expect(screen.queryByText(/Your agent withdrew/)).toBeNull();
+    expect(screen.queryByText(/Their agent declined/)).toBeNull();
+    expect(screen.getByText('No opportunity')).toBeInTheDocument();
+  });
+
+  it('lets the screened_out copy win over attribution — nothing was ever sent', () => {
+    render(<ResolvedBanner variant="rejected" reason="screened_out" turnCount={null} maxTurns={6} terminalAuthor={null} />);
+    expect(screen.getByText(/filtered out before either side reached out/)).toBeInTheDocument();
     expect(screen.getByText(/never learns the details/)).toBeInTheDocument();
   });
 });

--- a/apps/web/src/components/__tests__/negotiation-turns.test.ts
+++ b/apps/web/src/components/__tests__/negotiation-turns.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest';
 
-import { deriveSectionLabel, extractTurn, formatRelativeTime, formatSectionDate, groupTurnsBySession, outcomeChipVariant, roleChipLabel, roleLabel, verbFor, viewerRoleLabel, type TranscriptTurn } from '@/components/negotiations/negotiation-turns';
+import { deriveSectionLabel, extractTurn, formatRelativeTime, formatSectionDate, groupTurnsBySession, outcomeChipVariant, roleChipLabel, roleLabel, terminalTurnAuthor, verbFor, viewerRoleLabel, type TranscriptTurn } from '@/components/negotiations/negotiation-turns';
 import type { ConversationMessage } from '@/services/conversation';
 
 function message(parts: unknown[], overrides: Partial<ConversationMessage> = {}): ConversationMessage {
@@ -107,6 +107,43 @@ describe('viewerRoleLabel', () => {
 
   it('returns null when no turn suggested roles', () => {
     expect(viewerRoleLabel([{ ...turns[0], suggestedRoles: null }], 'agent:own')).toBeNull();
+  });
+});
+
+describe('terminalTurnAuthor', () => {
+  const turn = (senderId: string, action: string): TranscriptTurn =>
+    ({ id: action, sessionId: null, senderId, createdAt: '', action, text: 't', suggestedRoles: null });
+
+  it('names the counterparty when their agent authored the decline', () => {
+    expect(terminalTurnAuthor([
+      turn('agent:own', 'outreach'),
+      turn('agent:other', 'decline'),
+    ], 'agent:own')).toBe('counterparty');
+  });
+
+  it('names this side when our own agent withdrew', () => {
+    expect(terminalTurnAuthor([
+      turn('agent:other', 'outreach'),
+      turn('agent:own', 'withdraw'),
+    ], 'agent:own')).toBe('own');
+  });
+
+  it('reads the LAST terminal turn, not the first', () => {
+    expect(terminalTurnAuthor([
+      turn('agent:own', 'withdraw'),
+      turn('agent:other', 'reject'),
+    ], 'agent:own')).toBe('counterparty');
+  });
+
+  it('settles nothing when no turn ended the negotiation', () => {
+    expect(terminalTurnAuthor([
+      turn('agent:own', 'outreach'),
+      turn('agent:other', 'question'),
+    ], 'agent:own')).toBeNull();
+  });
+
+  it('settles nothing without a viewer agent id — a guess is worse than silence', () => {
+    expect(terminalTurnAuthor([turn('agent:other', 'decline')], null)).toBeNull();
   });
 });
 

--- a/apps/web/src/components/negotiations/ResolvedBanner.tsx
+++ b/apps/web/src/components/negotiations/ResolvedBanner.tsx
@@ -1,3 +1,5 @@
+import type { TerminalTurnAuthor } from './negotiation-turns';
+
 export type ResolvedBannerVariant = 'rejected' | 'stalled';
 
 interface ResolvedBannerProps {
@@ -23,6 +25,20 @@ interface ResolvedBannerProps {
    * and preserves the existing copy for callers that render without a transcript.
    */
   contactMade?: boolean;
+  /**
+   * Who authored the turn that ended this negotiation, derived from the
+   * transcript rendered above (`terminalTurnAuthor`).
+   *
+   * The outcome label cannot supply it — `rejected` says a negotiation ended
+   * against the match, never which agent decided that — and this banner is the
+   * only account the owner gets of what happened. It was observed telling an
+   * owner "your agent withdrew after reviewing the opportunity" above a
+   * transcript whose final turn was the COUNTERPARTY's agent declining them.
+   *
+   * Omitted/null means the transcript settles nothing, and the copy says
+   * nothing: neutral wording, never a guess about who walked away.
+   */
+  terminalAuthor?: TerminalTurnAuthor | null;
   /** Stalled only: route to the user's agent to answer the open question. */
   onRevive?: () => void;
   /** Stalled only: leave the transcript. */
@@ -34,9 +50,12 @@ interface ResolvedBannerProps {
  * filtering done for you, with hedged, reason-based phrasing — a screened-out
  * thread never names who screened, so the counterparty learns nothing.
  */
-export function ResolvedBanner({ variant, reason, turnCount, maxTurns, contactMade = false, onRevive, onLetGo }: ResolvedBannerProps) {
+export function ResolvedBanner({ variant, reason, turnCount, maxTurns, contactMade = false, terminalAuthor = null, onRevive, onLetGo }: ResolvedBannerProps) {
   if (variant === 'rejected') {
     const screenedOutBeforeContact = reason === 'screened_out' && !contactMade;
+    const turnsSuffix = turnCount != null && turnCount > 0
+      ? ` (${turnCount} ${turnCount === 1 ? 'turn' : 'turns'})`
+      : '';
     let body: string;
     if (screenedOutBeforeContact) {
       body = 'This connection was filtered out before either side reached out, so neither of you was notified.';
@@ -44,30 +63,45 @@ export function ResolvedBanner({ variant, reason, turnCount, maxTurns, contactMa
       // Contact exists, so no claim is made about who reached out, who was
       // notified, or what the other side knows — only that it ended here.
       body = 'This negotiation ended without agreement.';
-    } else if (!reason) {
-      // Agent voluntarily withdrew — the candidate didn’t match this opportunity’s query.
-      body = `Your agent withdrew after reviewing the opportunity${turnCount != null && turnCount > 0 ? ` (${turnCount} ${turnCount === 1 ? 'turn' : 'turns'})` : ''} — the candidate didn’t align with what you’re looking for. You were never notified while this played out.`;
+    } else if (terminalAuthor === 'counterparty') {
+      // Their agent ended it. Saying "your agent withdrew" here — which is what
+      // this banner did — reverses who decided and who was decided about, and
+      // it is the owner's only account of the exchange.
+      body = `Their agent declined${turnsSuffix} — the two agents didn’t find enough mutual value.`;
+    } else if (terminalAuthor === 'own') {
+      // Our own agent walked away: the original copy, now stated only where the
+      // transcript actually shows this side authoring the terminal turn.
+      body = `Your agent withdrew after reviewing the opportunity${turnsSuffix} — the candidate didn’t align with what you’re looking for. You were never notified while this played out.`;
     } else {
-      body = `${turnCount != null && turnCount > 0 ? `After ${turnCount} ${turnCount === 1 ? 'turn' : 'turns'}, the` : 'The'} agents couldn’t justify this connection, so it was quietly set aside. You were never notified while this played out.`;
+      // The transcript does not say who ended it, so neither does the copy.
+      body = `${turnCount != null && turnCount > 0 ? `After ${turnCount} ${turnCount === 1 ? 'turn' : 'turns'}, the` : 'The'} agents ended this without a match.`;
     }
+    // "filtered out for you" and the quiet-decline footnote are both claims
+    // about a decision THIS side made. Above a decline the counterparty
+    // authored — or an ending nobody can attribute — neither is ours to make.
+    const ownDecision = reason !== 'screened_out' && terminalAuthor === 'own';
+    const showQuietFootnote = screenedOutBeforeContact || ownDecision;
     return (
       <div className="mt-4 rounded-lg border border-red-200 bg-red-50 px-4 py-4">
         <h3 className="font-ibm-plex-mono text-[13px] font-bold text-[#041729]">
           {/*
-            "filtered out for you" says the connection was screened before it
-            reached anyone. Above a thread with messages in it, only the verdict
-            survives — the account of how it was reached does not.
+            "filtered out for you" says this side did the filtering. It survives
+            only where that is demonstrably true: a connection screened before it
+            reached anyone, or our own agent's withdrawal. Above a thread whose
+            terminal turn came from the counterparty — or from nobody the
+            transcript can name — only the verdict survives.
           */}
-          {reason === 'screened_out' && contactMade ? 'No opportunity' : 'No opportunity — filtered out for you'}
+          {screenedOutBeforeContact || ownDecision ? 'No opportunity — filtered out for you' : 'No opportunity'}
         </h3>
         <p className="mt-1 text-[13px] text-[#3D3D3D]">{body}</p>
         {/*
           The quiet-decline footnote is a claim about the counterparty's
-          knowledge. It holds for every end reached without contact, and for a
-          decline the agents never sent — but not above a visible outreach the
-          counterparty demonstrably received.
+          knowledge: that OUR side's decision never reached them. It holds for
+          an end reached without contact, and for our own agent's withdrawal —
+          but not above a visible outreach the counterparty demonstrably
+          received, and not when THEY are the side that declined.
         */}
-        {!(reason === 'screened_out' && contactMade) && (
+        {showQuietFootnote && (
           <p className="mt-2.5 font-ibm-plex-mono text-[11px] text-gray-400">
             The other side never learns the details — declines are quiet by design.
           </p>

--- a/apps/web/src/components/negotiations/negotiation-turns.ts
+++ b/apps/web/src/components/negotiations/negotiation-turns.ts
@@ -92,6 +92,44 @@ export function extractTurn(message: ConversationMessage): TranscriptTurn | null
 }
 
 /**
+ * Actions that END a negotiation against the match. `accept` is deliberately
+ * absent: an accepted negotiation renders the opportunity banner, never the
+ * resolved one.
+ */
+const TERMINAL_REJECT_ACTIONS = new Set(['decline', 'reject', 'withdraw']);
+
+/** Who authored the turn that ended a negotiation, from the viewer's side. */
+export type TerminalTurnAuthor = 'own' | 'counterparty';
+
+/**
+ * The author of the terminal turn, read from the transcript the banner renders
+ * above — the only place the fact exists on the client.
+ *
+ * The outcome label does not carry it. `opportunityStatus: 'rejected'` says a
+ * negotiation ended against the match and nothing about which agent decided
+ * that, which is how a counterparty's decline came to be shown to the other
+ * owner as "your agent withdrew after reviewing the opportunity": their agent
+ * had done no such thing — it had been declined.
+ *
+ * Returns null when the transcript settles nothing (no terminal turn visible,
+ * or no viewer agent id to compare against). The caller must say something
+ * neutral there rather than guess: a guess is what this exists to remove.
+ */
+export function terminalTurnAuthor(
+  turns: TranscriptTurn[],
+  ownAgentId: string | null,
+): TerminalTurnAuthor | null {
+  if (!ownAgentId) return null;
+  for (let i = turns.length - 1; i >= 0; i -= 1) {
+    const turn = turns[i];
+    if (turn.action && TERMINAL_REJECT_ACTIONS.has(turn.action)) {
+      return turn.senderId === ownAgentId ? 'own' : 'counterparty';
+    }
+  }
+  return null;
+}
+
+/**
  * Role-suggestion chip label, viewer-first: "you → Helper · Dan → Seeker".
  * suggestedRoles is recorded from the sending agent's perspective, so the
  * mapping flips when the counterpart's agent authored the turn.

--- a/bun.lock
+++ b/bun.lock
@@ -89,7 +89,7 @@
     },
     "packages/protocol": {
       "name": "@indexnetwork/protocol",
-      "version": "23.1.1",
+      "version": "23.2.0",
       "dependencies": {
         "@langchain/core": "1.1.48",
         "@langchain/langgraph": "1.3.2",

--- a/packages/protocol/CHANGELOG.md
+++ b/packages/protocol/CHANGELOG.md
@@ -20,6 +20,56 @@ went 6.7.1 → 8.0.2 with no 7.x in between because the whole 7.x line shipped a
 prereleases between the two promotions. To track every change, read `rc`; to
 pin a supported release, use `latest`.
 
+## 23.2.0 - 2026-08-20
+
+### Fixed
+
+- **No turn may repeat a message already on the record.** A counterparty asked what
+  a phrase in the client's own signal meant; the answering agent could not consult
+  its (unreachable) principal and its record did not settle the phrase, so with no
+  legal move left it copied the question back word for word. Both models then
+  locked — reproducing text already in context is close to deterministic — and the
+  negotiation spent its remaining turns exchanging two byte-identical messages
+  before one side declined citing "repeated lack of clarity … despite five
+  inquiries". The turn node now compares each drafted message against every
+  message already in the negotiation: an exact repeat is never persisted, the turn
+  is re-issued ONCE with the repeated text quoted back and an instruction to
+  contribute or conclude, and a second repeat ends the run as the new
+  `outcome.reason: "repetition"` — never as a decline, because nobody decided
+  anything. Terminal turns are exempt (a turn that ends the negotiation cannot
+  loop, and refusing one would turn a successful accept into a stall);
+  message-less turns have nothing to duplicate. Deadlock detection (IND-428)
+  could not cover this: its four-turn threshold arrives one turn before a
+  six-turn cap, after the loop has already consumed the negotiation.
+- **The unreachable-principal rule gains the move the corner actually needed.**
+  `PRINCIPAL_UNREACHABLE_RULE` said never stall and never route the client's
+  question to the other side, but named no move for the case that occurred: the
+  COUNTERPARTY asks something client-authoritative that the record does not
+  settle. The rule now says to state the limit of the record — "X's signal says
+  Y; it does not specify further" is a complete answer — and to let the
+  counterparty score that dimension unknown, never repeating or mirroring their
+  question and never inventing an answer the record does not hold.
+- **A decline needs a conflict.** The verdict law ("an unknown is not a reason to
+  end anything; pass stays reserved for conflict") was prompt-only, and the prompt
+  lost. A drafted `decline`/`reject` over an authored checklist that holds no
+  `conflict` dimension is now refused — logged as `negotiation_decline_inadmissible`
+  with the unknowns that stood in for one — and coerced to the conservative
+  non-terminal fallback, its terminal message dropped with the action it belonged
+  to. On the final turn, where the seat's vocabulary is accept-or-decline, the
+  decline stands but the violation is recorded rather than manufactured silently.
+  Assessing stances only; fails open on an unauthored checklist; `advocate` is
+  untouched.
+
+### Added
+
+- `NegotiationOutcome.reason` gains `"repetition"`, and `NegotiationAgentInput`
+  gains `antiEcho` (the repeated text, quoted back on a re-issue).
+- `assessDeclineAdmissibility` in the checklist contracts: the verdict law as a
+  pure function, beside `assessAskAdmissibility`.
+- Machine-fault reasons (`agent_error`, `repetition`) are filtered out of the
+  discovery vocabulary by an allow-list rather than a deny-list, so a new
+  negotiation reason can never silently cross that boundary.
+
 ## 23.1.1 - 2026-08-19
 
 ### Fixed

--- a/packages/protocol/package.json
+++ b/packages/protocol/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@indexnetwork/protocol",
-  "version": "23.1.1",
+  "version": "23.2.0",
   "type": "module",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",

--- a/packages/protocol/src/negotiations/negotiation.agent.ts
+++ b/packages/protocol/src/negotiations/negotiation.agent.ts
@@ -170,7 +170,8 @@ const PRE_CONTACT_ASK_USER_RULE = `
  */
 const PRINCIPAL_UNREACHABLE_RULE = `
 - YOU CANNOT CONSULT {userName} DURING THIS NEGOTIATION. No question can be put to them here and no answer can arrive, so every decision on this turn is yours to make on the record you already hold. That record — their signal and intents, their premises, their profile, and anything of theirs already quoted in your context — IS their knowledge for this negotiation. Read it as their answer instead of waiting for one.
-- Never stall, park, or defer for their input, and never route a question meant for {userName} to the other side's agent — that reaches the wrong party and settles nothing. If the fact you want belongs to the COUNTERPARTY, "question" is still the right action and is unaffected by any of this.`;
+- Never stall, park, or defer for their input, and never route a question meant for {userName} to the other side's agent — that reaches the wrong party and settles nothing. If the fact you want belongs to the COUNTERPARTY, "question" is still the right action and is unaffected by any of this.
+- WHEN THE COUNTERPARTY ASKS YOU SOMETHING ONLY {userName} COULD SETTLE AND YOUR RECORD DOES NOT SETTLE IT, answer with the limit of the record: "{userName}'s signal says X; it does not specify further" is a COMPLETE and honest answer, and the other side is free to treat that dimension as unknown. Say what the record does hold before you say what it does not. Never repeat, mirror, or hand their question back to them, and never invent an answer the record does not hold — an unanswerable question is answered by naming its limit, not by returning it.`;
 
 /**
  * Appended to `PRINCIPAL_UNREACHABLE_RULE` under the checklist protocol, where
@@ -180,7 +181,8 @@ const PRINCIPAL_UNREACHABLE_RULE = `
  * exist.
  */
 const PRINCIPAL_UNREACHABLE_CHECKLIST_RULE = `
-- A checklist dimension that would be {userName}'s own to settle is resolved from that record where the record settles it, and carried as an open unknown where it does not. An unknown is not a conflict: it never ends a negotiation on its own, "pass" stays reserved for a genuine conflict, and where the record leaves a question open the first conversation is the cheaper next experiment.`;
+- A checklist dimension that would be {userName}'s own to settle is resolved from that record where the record settles it, and carried as an open unknown where it does not. An unknown is not a conflict: it never ends a negotiation on its own, "pass" stays reserved for a genuine conflict, and where the record leaves a question open the first conversation is the cheaper next experiment.
+- If the counterparty asks about such a dimension, name it as an open unknown to them in plain words — what {userName}'s record does say, and that it does not go further — and let them score it unknown on their own checklist. That is a real contribution to the exchange; echoing their question back is not.`;
 
 /** v2 counterparty seat: receiving stance — acceptance is this seat's decision alone. */
 const V2_COUNTERPARTY_RULES = `- You hold the RECEIVING seat: the other side reached out to {userName}. Whether to accept is YOUR seat's decision alone.
@@ -190,6 +192,16 @@ const V2_COUNTERPARTY_RULES = `- You hold the RECEIVING seat: the other side rea
   - "counter" if you have specific objections but see potential
   - "question" if you need a specific clarification from the initiator
 - Never use "outreach" — you are responding, not reaching out.`;
+
+/**
+ * The anti-echo re-issue instruction: the message a refused draft repeated.
+ * Shared by the graph (which detects the repeat) and the prompt (which quotes
+ * it back), so neither side has to describe the other's shape.
+ */
+export interface NegotiationAntiEcho {
+  /** The exact message text the refused draft reproduced. */
+  repeatedMessage: string;
+}
 
 export interface NegotiationAgentInput {
   ownUser: UserNegotiationContext;
@@ -285,6 +297,17 @@ export interface NegotiationAgentInput {
    * falls back to the flat continuation history (byte-identical to before).
    */
   priorDialogue?: AttributedPriorDialogue;
+  /**
+   * A re-issue of THIS turn after the graph refused the previous draft for
+   * repeating a message already on the record, word for word (the copy-loop
+   * guard in `negotiation.graph.turn.ts`). Carries the repeated text so the
+   * instruction can quote it back and demand something else.
+   *
+   * Set by the graph only, and only once per turn: a second repeat ends the
+   * negotiation rather than asking a third time. Absent → the prompt is
+   * byte-identical to before.
+   */
+  antiEcho?: NegotiationAntiEcho;
   /**
    * Durable caller-owned execution identity. Timeout workers reuse this exact
    * value across delivery retries; it is forwarded as model-run metadata for
@@ -585,6 +608,20 @@ ${stanceQuerySatisfiedRule(stance, otherName, userName)}`
 
     const intentsLabel = input.discoveryQuery ? 'Background intents (secondary to discovery query)' : 'Intents';
 
+    // ─── Anti-echo re-issue (copy-loop guard) ─────────────────────────────
+    // Placed LAST in the user message, after the closing instruction, because
+    // the closing instruction is what the model acts on and this supersedes it
+    // for this one draft. It quotes the repeated text verbatim: the failure it
+    // corrects is a copy, so the correction has to name the thing not to copy.
+    //
+    // What it does NOT do is tell the agent how the negotiation should end. It
+    // offers the honest moves — contribute, or conclude — and leaves the choice
+    // where it belongs, because a re-issue that pushed toward a verdict would
+    // manufacture exactly the false decline this whole guard exists to prevent.
+    const antiEchoInstruction = input.antiEcho
+      ? `\n\nSTOP — YOUR PREVIOUS DRAFT FOR THIS TURN REPEATED A MESSAGE ALREADY IN THIS NEGOTIATION, WORD FOR WORD:\n"""\n${input.antiEcho.repeatedMessage}\n"""\nThat text is already on the record. Sending it again says nothing, moves nothing, and is not a turn. Do not repeat it, mirror it, or hand it back — and if it was the counterparty's question, do not ask it back at them.\nDraft something the record does not already hold. Answer from what you know; where you cannot answer, say plainly what your side's record does say and that it does not go further, and let them judge it; or make a concrete proposal; or, if this match genuinely does not work, conclude it and say why. Never end a negotiation merely because something stayed unknown.`
+      : '';
+
     const userMessage = `YOUR USER (${userName}):
 Bio: ${input.ownUser.profile.bio ?? "N/A"}
 Skills: ${input.ownUser.profile.skills?.join(", ") ?? "N/A"}
@@ -615,7 +652,7 @@ ${preContactResume
             ? `This is the opening turn and nothing has been sent yet. You hold THREE verdicts here: ask ${userName} the one open thing only they can settle, make the outreach case, or let the match pass. Score the checklist first — if a dimension is unknown and theirs to settle, asking now costs the counterparty nothing and buys a better opening.`
             : "This is the opening turn. Make the outreach case.")
         : "This is the opening turn. Propose the connection case.")
-    : "Evaluate the latest arguments and respond."}`;
+    : "Evaluate the latest arguments and respond."}${antiEchoInstruction}`;
 
     const chatMessages = [
       { role: "system", content: systemPrompt },

--- a/packages/protocol/src/negotiations/negotiation.checklist.contracts.ts
+++ b/packages/protocol/src/negotiations/negotiation.checklist.contracts.ts
@@ -368,6 +368,60 @@ export function assessAskAdmissibility(input: AskAdmissibilityInput): AskAdmissi
   return { admissible: true, dimension: item };
 }
 
+// ─── Decline admissibility: the verdict law, mechanically (plan §6) ──────────
+
+/**
+ * Why a drafted decline was refused. One condition today, named rather than
+ * implied so the telemetry says which law bound — the same discipline
+ * {@link AskInadmissibility} follows.
+ */
+export type DeclineInadmissibility =
+  /** The checklist holds no `conflict` dimension: nothing was decided against. */
+  | "no_conflict_dimension";
+
+export type DeclineAdmissibility =
+  | { admissible: true }
+  | { admissible: false; reason: DeclineInadmissibility; unknowns: string[] };
+
+export interface DeclineAdmissibilityInput {
+  /** The reconciled checklist this turn is deciding on. */
+  checklist: readonly ChecklistItem[];
+}
+
+/**
+ * The verdict law, in the half a machine can check: **an unknown is not a
+ * reason to end anything; a decline needs a conflict.**
+ *
+ * Elimination by Aspects (plan §6) makes one conflicting dimension decisive on
+ * its own — and says nothing else is. A checklist carrying only `ok`s and
+ * `unknown`s has therefore found nothing to decide against: the honest moves
+ * there are to answer the unknown from the record, to carry it, or to let the
+ * first conversation settle it. Ending the negotiation on it is the model
+ * mistaking "I could not find out" for "this does not work", which is exactly
+ * what was observed in dev — a decline citing "repeated lack of clarity"
+ * against a counterparty whose agent had never been able to answer.
+ *
+ * The check is deliberately narrow. It reads the checklist and nothing else:
+ * not the reasoning, not the message, not the transcript. Whether a conflict
+ * is REAL stays the agent's judgment and the basis discipline's problem; all
+ * this refuses is a terminal verdict with no conflict behind it at all.
+ *
+ * Fails OPEN on an unauthored checklist — see {@link isChecklistAuthored} —
+ * for the same reason ask admissibility does: with no frozen dimensions there
+ * is no law to have violated, and a failed authoring pass must not stand
+ * between an agent and an honest verdict.
+ */
+export function assessDeclineAdmissibility(input: DeclineAdmissibilityInput): DeclineAdmissibility {
+  if (!isChecklistAuthored(input.checklist)) return { admissible: true };
+  const verdict = checklistVerdictState(input.checklist);
+  if (verdict.conflicts.length > 0) return { admissible: true };
+  return {
+    admissible: false,
+    reason: "no_conflict_dimension",
+    unknowns: verdict.unknowns.map((item) => item.name),
+  };
+}
+
 // ─── Prompt rendering ────────────────────────────────────────────────────────
 
 const KIND_LABEL: Record<ChecklistKind, string> = {

--- a/packages/protocol/src/negotiations/negotiation.graph.finalize.ts
+++ b/packages/protocol/src/negotiations/negotiation.graph.finalize.ts
@@ -126,11 +126,20 @@ export async function finalizeNode(state: NegotiationState, deps: NegotiationGra
   // resets the run to zero. An init-time error (`busy`, an invalid
   // continuation) carries no failures, so it keeps today's outcome.
   const errorStalled = !screenedOut && !!state.error && state.consecutiveTurnFailures > 0;
+  // The copy-loop guard ended the run (`negotiation.graph.turn.ts`): a drafted
+  // turn repeated a message already on the record, and so did its one anti-echo
+  // re-issue. Kept distinct from every neighbouring end because it is a
+  // different fact from each of them — the agents did not run out of turns
+  // (nothing was spent), the run did not error (a turn came back, it just said
+  // nothing new), and nobody declined. `lastTurn` here is the last turn that
+  // actually landed, which is why the reject-like mapping below must never see
+  // this run as a decision: the repeated draft was never persisted.
+  const repetitionStalled = !screenedOut && !errorStalled && state.repetitionStalled === true;
   // Failed turns no longer advance `turnCount`, so an error-stalled run is
   // normally nowhere near the cap. The guard is explicit anyway: "ran out of
   // turns" is a claim about a dialogue, and this is the outcome where the
   // dialogue is precisely what did not happen.
-  const atCap = !screenedOut && !errorStalled && isNegotiationTurnCapReached(state.turnCount, state.maxTurns) && !isTerminalAction(lastTurn?.action);
+  const atCap = !screenedOut && !errorStalled && !repetitionStalled && isNegotiationTurnCapReached(state.turnCount, state.maxTurns) && !isTerminalAction(lastTurn?.action);
 
   let agreedRoles: NegotiationOutcome["agreedRoles"] = [];
   if (hasOpportunity && history.length >= 2) {
@@ -167,9 +176,11 @@ export async function finalizeNode(state: NegotiationState, deps: NegotiationGra
       ? { reason: "screened_out" as const }
       : errorStalled
         ? { reason: "agent_error" as const }
-        : atCap
-          ? { reason: "turn_cap" as const }
-          : {}),
+        : repetitionStalled
+          ? { reason: "repetition" as const }
+          : atCap
+            ? { reason: "turn_cap" as const }
+            : {}),
   };
 
   // Unconcluded end: no opportunity, no explicit reject, and turns actually
@@ -181,6 +192,10 @@ export async function finalizeNode(state: NegotiationState, deps: NegotiationGra
   // no dialogue to have exposed anything — the gap is ours, not theirs, and
   // asking them about it would dress an outage up as an information need. The
   // opportunity still ends `stalled`, so re-running remains the recovery.
+  // A repetition stall stays UNCONCLUDED, unlike an error stall. The exchange
+  // happened and exposed a real gap — in the observed case a question about the
+  // client's own signal that nobody on either side could answer — so the park
+  // that carries that gap back to the client is exactly the right recovery.
   const endedUnconcluded = !hasOpportunity && !screenedOut && !errorStalled
     && !isRejectLikeAction(lastTurn?.action) && state.turnCount > 0;
   const stallReason: NegotiationStallReason = atCap
@@ -380,7 +395,7 @@ export async function finalizeNode(state: NegotiationState, deps: NegotiationGra
       isContinuation: state.isContinuation,
       turnsAdded: state.turnCount,
       priorTurnCount: state.priorTurnCount,
-      outcome: hasOpportunity ? 'accepted' : screenedOut ? 'screened_out' : errorStalled ? 'agent_error' : (atCap ? 'turn_cap' : (lastTurn?.action ?? 'unknown')),
+      outcome: hasOpportunity ? 'accepted' : screenedOut ? 'screened_out' : errorStalled ? 'agent_error' : repetitionStalled ? 'repetition' : (atCap ? 'turn_cap' : (lastTurn?.action ?? 'unknown')),
       opportunityId: state.opportunityId || undefined,
     });
 
@@ -388,11 +403,16 @@ export async function finalizeNode(state: NegotiationState, deps: NegotiationGra
       // screened_out → 'rejected': quiet terminal status (hidden from
       // default lists), never 'stalled' — with zero turns the generic
       // mapping would misfile the client's own gate decision.
+      // `repetitionStalled` outranks the reject-like mapping: the last turn that
+      // LANDED may well be a `question` or a `counter`, but if the guard ended
+      // the run then no decision was reached and the row may not read as one.
       const nextStatus = lastTurn?.action === 'accept'
         ? 'pending'
-        : (screenedOut || isRejectLikeAction(lastTurn?.action))
-          ? 'rejected'
-          : 'stalled';
+        : repetitionStalled
+          ? 'stalled'
+          : (screenedOut || isRejectLikeAction(lastTurn?.action))
+            ? 'rejected'
+            : 'stalled';
       await deps.database.updateOpportunityStatus(state.opportunityId, nextStatus, undefined, state.continuationExecution).catch((err) => {
         finalizeLog.error("Failed to update opportunity status", { opportunityId: state.opportunityId, nextStatus, error: err });
       });

--- a/packages/protocol/src/negotiations/negotiation.graph.ts
+++ b/packages/protocol/src/negotiations/negotiation.graph.ts
@@ -123,6 +123,12 @@ export function routeAfterTurn(state: NegotiationState): string {
   if (state.status === 'waiting_for_agent') return "finalize";
   if (state.status === 'input_required') return "finalize";
   if (state.error) return "finalize";
+  // The copy-loop guard ended the run: an agent repeated a message already on
+  // the record and repeated it again when re-issued. Nothing was persisted and
+  // the turn count did not move, so there is nothing to route back to — and
+  // unlike a failed turn this is not retryable, because the same seat facing
+  // the same record produces the same copy.
+  if (state.repetitionStalled) return "finalize";
   // A failed turn the turn node judged retryable: the same seat tries again on
   // an unchanged turn count. Checked BEFORE `lastTurn`, which is either null
   // (the opening turn failed) or a stale turn from an earlier exchange —

--- a/packages/protocol/src/negotiations/negotiation.graph.turn.ts
+++ b/packages/protocol/src/negotiations/negotiation.graph.turn.ts
@@ -22,7 +22,7 @@ import { expectedNegotiationSpeaker } from "./negotiation.expected-speaker.js";
 import { buildSeededAttribution } from './negotiation.attribution.js';
 import { askedChecklistTopics, buildAttributedDialogue, countNegotiationAskRounds, countPrincipalAskUserTurns, finalizeLog, initLog, memoryQueryText, negotiateCandidatesLog, resolveTaskAttribution, retrieveClientDm, retrieveMemory, screenNodeLog, turnLog, turnsFromMessages } from "./negotiation.graph.shared.js";
 import { configuredNegotiatorStance, stanceUsesChecklist } from "./negotiation.stance.contracts.js";
-import { assessAskAdmissibility, authorChecklist, checklistFromTurns, checklistVerdictState, configuredQuestionBudgetPerPrincipal, isChecklistAuthored, reconcileChecklist, ChecklistDraftSchema, type AskInadmissibility, type ChecklistItem } from "./negotiation.checklist.contracts.js";
+import { assessAskAdmissibility, assessDeclineAdmissibility, authorChecklist, checklistFromTurns, checklistVerdictState, configuredQuestionBudgetPerPrincipal, isChecklistAuthored, reconcileChecklist, ChecklistDraftSchema, type AskInadmissibility, type ChecklistItem } from "./negotiation.checklist.contracts.js";
 import type { NegotiationGraphDeps, NegotiationState } from "./negotiation.graph.shared.js";
 
 
@@ -258,6 +258,98 @@ export async function turnNode(state: NegotiationState, deps: NegotiationGraphDe
         : {}),
     };
 
+    // The in-process draft, as a callable rather than a straight-line branch:
+    // the copy-loop guard below re-issues THIS turn once, and a re-issue has to
+    // be the same draft under one added instruction, not a different prompt
+    // assembled twice. The A2H excerpt is memoized across both calls — one read
+    // per turn, whatever the guard does.
+    //
+    // The re-issue always runs here, even when the refused draft came from an
+    // externally dispatched personal agent. Re-dispatching would reopen the
+    // whole dispatch contract mid-turn (a `waiting` result would suspend the
+    // graph holding a discarded draft, a timeout would end the turn with
+    // nothing), and the in-process negotiator is the one seat that is always
+    // available. What the external agent's draft cost it is one turn, not the
+    // negotiation.
+    let clientDmForPrompt: Awaited<ReturnType<typeof retrieveClientDm>> | null = null;
+    const draftFromSystemAgent = async (antiEcho?: { repeatedMessage: string }): Promise<NegotiationTurn> => {
+      const agentPriorDialogue = buildAttributedDialogue(state);
+
+      // ─── A2H: the acting user's own negotiator DM for this signal ──────
+      // Retrieved HERE, in the system-agent draft, rather than beside
+      // `ownMemory` above. Two reasons, and the first is the constraint:
+      //
+      // 1. `payload` is built and dispatched before this point, so the
+      //    excerpt cannot reach an external agent by a later edit — the
+      //    value does not exist in that scope. Memory is safe to forward
+      //    (distilled standing rules); a verbatim excerpt of the client's
+      //    private thread with their own negotiator is not, and an external
+      //    registered agent can hold the personal-agent seat.
+      // 2. A dispatched turn never reads it, so it never pays for the query.
+      //
+      // Read on EVERY turn under the checklist protocol, not only the turns
+      // where the agent may ask. This was gated on `askUserAvailable` — the DM
+      // was present exactly when the agent might ask something, on the theory
+      // that knowing what the client already said changes what it asks. But
+      // the answers matter most AFTER they are given: on a turn with the grant
+      // spent, the negotiator argued the client's case having never read a word
+      // the client wrote about this signal.
+      //
+      // That is also what plan §2 requires. The commitment store is the
+      // client's own intents, premises, and ANSWERS; a dimension may be scored
+      // from them. An answer the negotiator cannot see cannot score anything,
+      // so the same question stays open and gets asked again.
+      //
+      // Still in-process only, for the reason above: the excerpt is never
+      // forwarded to `NegotiationTurnPayload`, so an external agent holding the
+      // personal-agent seat cannot receive the client's private thread.
+      //
+      // What stays gated is the FEATURE, not the turn. `configuredAskUserEnabled()`
+      // is the A2H kill switch: flipped off, no A2H read is issued at all and
+      // the prompt is the pre-A2H one. v2-only for the same reason — a v1
+      // negotiation has no A2H vocabulary, so its prompt stays byte-identical.
+      // Dropped from the gate are the per-turn conditions that used to ride
+      // along inside `askUserAvailable`: final turn, budget spent, ask-rounds
+      // cap, pre-contact bound. Those decide whether the agent may ASK, not
+      // whether it may know what its client already said.
+      if (clientDmForPrompt === null) {
+        clientDmForPrompt = version === 'v2' && configuredAskUserEnabled() && ownIntentId
+          ? await retrieveClientDm(deps, ownUser.id, ownIntentId)
+          : [];
+      }
+      const clientDm = clientDmForPrompt;
+      return deps.systemAgent.invoke({
+        ownUser,
+        otherUser,
+        indexContext: state.indexContext,
+        seedAssessment: state.seedAssessment,
+        history,
+        isFinalTurn,
+        isDiscoverer: isSource,
+        seat,
+        protocolVersion: version,
+        ...(state.discoveryQuery && isSource && { discoveryQuery: state.discoveryQuery }),
+        isContinuation: state.isContinuation,
+        ...(agentPriorDialogue && { priorDialogue: agentPriorDialogue }),
+        ...(state.userAnswers.length > 0 && { userAnswers: state.userAnswers }),
+        ...(askUserAvailable && { canAskUser: true }),
+        ...(checklistActive
+          ? {
+              checklist: frozenChecklist,
+              questionsSpent,
+              ...(askedTopics.length > 0 && { askedTopics }),
+            }
+          : {}),
+        ...(bargainingMode && { bargaining: { consecutiveNonConvergent: deadlock!.consecutiveNonConvergent } }),
+        ...(ownMemory.length > 0 && { memory: ownMemory }),
+        ...(clientDm.length > 0 && { clientDm }),
+        ...(state.privateConsultation?.recipientUserId === ownUser.id
+          ? { privateConsultation: state.privateConsultation }
+          : {}),
+        ...(antiEcho ? { antiEcho } : {}),
+      });
+    };
+
     const scope = { action: 'manage:negotiations', scopeType: 'network', scopeId: state.indexContext.networkId };
 
     const dispatchResult = await deps.dispatcher.dispatch(ownUser.id, scope, payload, { timeoutMs: state.timeoutMs });
@@ -306,77 +398,7 @@ export async function turnNode(state: NegotiationState, deps: NegotiationGraphDe
       return { status: 'waiting_for_agent' as const };
     } else {
       // No personal agent or timeout — run system agent
-      const agentPriorDialogue = buildAttributedDialogue(state);
-
-      // ─── A2H: the acting user's own negotiator DM for this signal ──────
-      // Retrieved HERE, inside the system-agent branch, rather than beside
-      // `ownMemory` above. Two reasons, and the first is the constraint:
-      //
-      // 1. `payload` is built and dispatched before this point, so the
-      //    excerpt cannot reach an external agent by a later edit — the
-      //    value does not exist in that scope. Memory is safe to forward
-      //    (distilled standing rules); a verbatim excerpt of the client's
-      //    private thread with their own negotiator is not, and an external
-      //    registered agent can hold the personal-agent seat.
-      // 2. A dispatched turn never reads it, so it never pays for the query.
-      //
-      // Read on EVERY turn under the checklist protocol, not only the turns
-      // where the agent may ask. This was gated on `askUserAvailable` — the DM
-      // was present exactly when the agent might ask something, on the theory
-      // that knowing what the client already said changes what it asks. But
-      // the answers matter most AFTER they are given: on a turn with the grant
-      // spent, the negotiator argued the client's case having never read a word
-      // the client wrote about this signal.
-      //
-      // That is also what plan §2 requires. The commitment store is the
-      // client's own intents, premises, and ANSWERS; a dimension may be scored
-      // from them. An answer the negotiator cannot see cannot score anything,
-      // so the same question stays open and gets asked again.
-      //
-      // Still in-process only, for the reason above: the excerpt is never
-      // forwarded to `NegotiationTurnPayload`, so an external agent holding the
-      // personal-agent seat cannot receive the client's private thread.
-      //
-      // What stays gated is the FEATURE, not the turn. `configuredAskUserEnabled()`
-      // is the A2H kill switch: flipped off, no A2H read is issued at all and
-      // the prompt is the pre-A2H one. v2-only for the same reason — a v1
-      // negotiation has no A2H vocabulary, so its prompt stays byte-identical.
-      // Dropped from the gate are the per-turn conditions that used to ride
-      // along inside `askUserAvailable`: final turn, budget spent, ask-rounds
-      // cap, pre-contact bound. Those decide whether the agent may ASK, not
-      // whether it may know what its client already said.
-      const clientDm = version === 'v2' && configuredAskUserEnabled() && ownIntentId
-        ? await retrieveClientDm(deps, ownUser.id, ownIntentId)
-        : [];
-      turn = await deps.systemAgent.invoke({
-        ownUser,
-        otherUser,
-        indexContext: state.indexContext,
-        seedAssessment: state.seedAssessment,
-        history,
-        isFinalTurn,
-        isDiscoverer: isSource,
-        seat,
-        protocolVersion: version,
-        ...(state.discoveryQuery && isSource && { discoveryQuery: state.discoveryQuery }),
-        isContinuation: state.isContinuation,
-        ...(agentPriorDialogue && { priorDialogue: agentPriorDialogue }),
-        ...(state.userAnswers.length > 0 && { userAnswers: state.userAnswers }),
-        ...(askUserAvailable && { canAskUser: true }),
-        ...(checklistActive
-          ? {
-              checklist: frozenChecklist,
-              questionsSpent,
-              ...(askedTopics.length > 0 && { askedTopics }),
-            }
-          : {}),
-        ...(bargainingMode && { bargaining: { consecutiveNonConvergent: deadlock!.consecutiveNonConvergent } }),
-        ...(ownMemory.length > 0 && { memory: ownMemory }),
-        ...(clientDm.length > 0 && { clientDm }),
-        ...(state.privateConsultation?.recipientUserId === ownUser.id
-          ? { privateConsultation: state.privateConsultation }
-          : {}),
-      });
+      turn = await draftFromSystemAgent();
     }
 
     traceEmitter?.({ type: "agent_end", name: agentName, durationMs: Date.now() - agentStart, summary: `${turn.action}` });
@@ -395,39 +417,60 @@ export async function turnNode(state: NegotiationState, deps: NegotiationGraphDe
     // The reconciled list is stamped back onto the turn, so the message record
     // IS the checklist's store — no new table, and a continuation recovers it
     // from the same messages it recovers the dialogue from.
-    let nextChecklist: ChecklistItem[] = frozenChecklist;
-    if (checklistActive) {
-      const parsedDraft = ChecklistDraftSchema.safeParse(turn.checklist ?? []);
+    //
+    // A function rather than a straight-line block because the copy-loop guard
+    // below can replace the drafted turn with a re-issued one, and a re-issue
+    // arrives carrying its OWN raw checklist draft. Persisting that unreconciled
+    // would let `checklistFromTurns` read it back as the frozen dimensions on
+    // the next turn — the freeze, defeated by the very guard meant to protect
+    // the exchange. Whatever is persisted has been through here.
+    const applyChecklistDiscipline = (
+      draftTurn: NegotiationTurn,
+      opts?: { reissue?: boolean },
+    ): { turn: NegotiationTurn; checklist: ChecklistItem[] } => {
+      if (!checklistActive) return { turn: draftTurn, checklist: frozenChecklist };
+      let next = draftTurn;
+      const parsedDraft = ChecklistDraftSchema.safeParse(draftTurn.checklist ?? []);
       const draft = parsedDraft.success ? parsedDraft.data : [];
       if (!parsedDraft.success) {
         turnLog.warn('Checklist draft failed schema validation; keeping the frozen scores', {
           taskId: state.taskId,
           seat,
           handledExternally: dispatchResult.handled,
+          ...(opts?.reissue && { reissue: true }),
         });
       }
-      nextChecklist = isChecklistAuthored(frozenChecklist)
+      const reconciled = isChecklistAuthored(frozenChecklist)
         ? reconcileChecklist(frozenChecklist, draft)
         : (authorChecklist(draft) ?? []);
-      if (nextChecklist.length > 0) {
-        turn = { ...turn, checklist: nextChecklist };
-      } else if (turn.checklist) {
+      if (reconciled.length > 0) {
+        next = { ...next, checklist: reconciled };
+      } else if (next.checklist) {
         // An authoring that produced nothing usable must not leave the raw
         // draft on the turn: `checklistFromTurns` would read it back as the
         // frozen dimensions on the next turn, which is exactly the freeze this
         // path declined to grant.
-        const { checklist: _unusable, ...rest } = turn;
-        turn = rest;
+        const { checklist: _unusable, ...rest } = next;
+        next = rest;
       }
       if (!isChecklistAuthored(frozenChecklist)) {
         turnLog.info('negotiation_checklist_authored', {
           taskId: state.taskId,
           opportunityId: state.opportunityId || undefined,
           seat,
-          dimensions: nextChecklist.length,
-          authored: nextChecklist.length > 0,
+          dimensions: reconciled.length,
+          authored: reconciled.length > 0,
+          ...(opts?.reissue && { reissue: true }),
         });
       }
+      return { turn: next, checklist: reconciled };
+    };
+
+    let nextChecklist: ChecklistItem[] = frozenChecklist;
+    {
+      const disciplined = applyChecklistDiscipline(turn);
+      turn = disciplined.turn;
+      nextChecklist = disciplined.checklist;
     }
 
     // Whether the ask on the table is the AGENT's own move, captured before the
@@ -686,6 +729,81 @@ export async function turnNode(state: NegotiationState, deps: NegotiationGraphDe
       }
     }
 
+    // ─── Decline verdict law, mechanically (checklist plan §6) ────────────
+    // "An unknown is not a reason to end anything; pass stays reserved for
+    // conflict." That law was prompt-only, and the prompt lost: observed in dev
+    // as a decline citing "repeated lack of clarity … despite five inquiries"
+    // over a checklist that held unknowns and no conflict at all. Nothing had
+    // been decided against — the counterparty simply could not answer, because
+    // the fact was its own unreachable principal's.
+    //
+    // Scoped like every other checklist rule: the assessing stances only, an
+    // authored checklist only (fails open — same rationale as ask
+    // admissibility), and read from `nextChecklist`, the reconciled scores this
+    // very turn is deciding on rather than the ones it inherited.
+    //
+    // `withdraw` is deliberately NOT covered. The initiator's turn-0 refusal is
+    // screen semantics — it decides whether to make contact at all, on evidence
+    // that predates any checklist — and the opening-withdraw guard above has
+    // already returned by this point. Governing in-flight declines is what this
+    // is for.
+    //
+    // A function for the same reason the checklist discipline is one: the
+    // copy-loop guard below can replace the drafted turn, and a re-issued
+    // decline is as bound by the verdict law as the first one was.
+    const enforceDeclineVerdictLaw = (
+      candidate: NegotiationTurn,
+      checklist: ChecklistItem[],
+      opts?: { reissue?: boolean },
+    ): NegotiationTurn => {
+      if (
+        !checklistActive
+        || (candidate.action !== 'decline' && candidate.action !== 'reject')
+        || !isChecklistAuthored(checklist)
+      ) return candidate;
+      const declineAdmissibility = assessDeclineAdmissibility({ checklist });
+      if (declineAdmissibility.admissible) return candidate;
+      // The final turn is the one place the law cannot simply be enforced: the
+      // seat's vocabulary there is accept-or-decline, so refusing the decline
+      // would either manufacture an accept nobody chose or emit an action the
+      // seat's schema does not carry. The cap wins — but not quietly. The
+      // violation is logged and traced with the unknowns that stood in for a
+      // conflict, so "the turn budget forced a verdict" is a readable fact
+      // about the row rather than something an investigation has to
+      // reconstruct from the checklist.
+      turnLog.info('negotiation_decline_inadmissible', {
+        taskId: state.taskId,
+        opportunityId: state.opportunityId || undefined,
+        seat,
+        reason: declineAdmissibility.reason,
+        unknowns: declineAdmissibility.unknowns,
+        turnIndex: state.turnCount,
+        isFinalTurn,
+        coerced: !isFinalTurn,
+        ...(opts?.reissue && { reissue: true }),
+      });
+      emitWide({
+        type: 'negotiation_decline_inadmissible',
+        opportunityId: state.opportunityId,
+        negotiationConversationId: state.conversationId,
+        turnIndex: state.turnCount,
+        actor: isSource ? 'source' : 'candidate',
+        reason: declineAdmissibility.reason,
+        unknowns: declineAdmissibility.unknowns,
+        isFinalTurn,
+        coerced: !isFinalTurn,
+      });
+      if (isFinalTurn) return candidate;
+      // The message is dropped with the action it belonged to. It was written
+      // to end the negotiation; carried onto a `counter` it would announce a
+      // decline the record does not contain, which is the same class of
+      // dishonesty as the decline itself. The reasoning stays — it is the
+      // trace of what the agent tried to do.
+      return { ...candidate, action: fallbackActionFor(version, seat, isFinalTurn), message: null };
+    };
+
+    turn = enforceDeclineVerdictLaw(turn, nextChecklist);
+
     // ─── Deadlock shift record (IND-428) ───────────────────────────────
     // Applied-stance analytics: recorded once per session, on the first
     // turn actually drafted in the bargaining stance (the system agent —
@@ -750,23 +868,165 @@ export async function turnNode(state: NegotiationState, deps: NegotiationGraphDe
     // have: it sees the question at the DB boundary with no idea who the
     // counterparty is or what the evaluator wrote, so it cannot tell that a
     // well-formed question is naming them or paraphrasing it.
-    if (turn.askUser?.question) {
+    //
+    // A function, like the two gates above, so the copy-loop guard's re-issued
+    // turn faces it as well: "a rejected question must not survive in the
+    // shared record" is a property of what gets PERSISTED, not of one draft.
+    const enforceAuthoredQuestionSafety = (candidate: NegotiationTurn): NegotiationTurn => {
+      if (!candidate.askUser?.question) return candidate;
       const counterpartyName = otherUser.profile?.name?.trim();
       const seedReasoning = state.seedAssessment?.reasoning?.trim();
-      const safeAuthoredQuestion = isSafeAuthoredNegotiationQuestion(turn.askUser.question, {
+      const safeAuthoredQuestion = isSafeAuthoredNegotiationQuestion(candidate.askUser.question, {
         ...(counterpartyName ? { forbiddenIdentifiers: [counterpartyName] } : {}),
         ...(seedReasoning ? { forbiddenSourceText: [seedReasoning] } : {}),
       });
-      if (!safeAuthoredQuestion) {
-        turnLog.warn('Dropping unsafe authored ask_user question; consultation continues without it', {
+      if (safeAuthoredQuestion) return candidate;
+      turnLog.warn('Dropping unsafe authored ask_user question; consultation continues without it', {
+        taskId: state.taskId,
+        opportunityId: state.opportunityId || undefined,
+        seat,
+        handledExternally: dispatchResult.handled,
+      });
+      const { question: _rejected, ...askUserWithoutQuestion } = candidate.askUser;
+      return { ...candidate, askUser: askUserWithoutQuestion };
+    };
+
+    turn = enforceAuthoredQuestionSafety(turn);
+
+    // ─── The copy-loop guard: no turn may repeat a message on the record ──
+    // Observed live: a counterparty asked what a phrase in the client's signal
+    // meant; the answering agent could not consult its own (unreachable)
+    // principal and its record did not settle the phrase, so with no good move
+    // it copied the question back verbatim. From there both models locked —
+    // reproducing text already in context is close to deterministic — and the
+    // negotiation spent its remaining turns exchanging two byte-identical
+    // messages before one side declined citing "repeated lack of clarity".
+    //
+    // The comparison is exact text, not similarity: it is the failure that was
+    // actually observed (identical `parts` objects, identical md5 over the
+    // message), and an exact match cannot be a false positive — no legitimate
+    // turn advances a negotiation by re-sending a message already in it. Two
+    // agents making the same POINT in different words is a real exchange and
+    // must stay untouched, which a similarity threshold could not promise.
+    //
+    // Messages only, and non-terminal turns only.
+    //
+    // `null`/absent messages cover `ask_user` and every turn that carries
+    // reasoning alone; there is nothing on the record for those to duplicate.
+    //
+    // TERMINAL turns are exempt on principle, not convenience: this guard
+    // exists to stop a LOOP, and a turn that ends the negotiation cannot loop.
+    // The cost of covering them would be paid in the wrong direction — an
+    // `accept` that happens to close by restating the outreach it is accepting
+    // would be refused, and a successful match would end as a stall. Refusing a
+    // terminal turn destroys the outcome; letting a cosmetic repeat through
+    // costs a duplicated line in a transcript that is already over.
+    //
+    // Deadlock detection (IND-428) does not cover this and cannot: it needs
+    // four consecutive non-convergent turns, which on a six-turn cap arrives
+    // one turn before the end — after the loop has already consumed the
+    // negotiation. This runs on the first repeat, before it is persisted.
+    const priorMessages = new Set(
+      history
+        .map((prior) => (typeof prior.message === 'string' ? prior.message.trim() : ''))
+        .filter((message) => message.length > 0),
+    );
+    const repeatsPriorMessage = (candidate: NegotiationTurn): string | null => {
+      if (isTerminalAction(candidate.action)) return null;
+      const message = typeof candidate.message === 'string' ? candidate.message.trim() : '';
+      return message.length > 0 && priorMessages.has(message) ? message : null;
+    };
+
+    const repeatedMessage = repeatsPriorMessage(turn);
+    if (repeatedMessage) {
+      turnLog.warn('negotiation_turn_repetition', {
+        taskId: state.taskId,
+        opportunityId: state.opportunityId || undefined,
+        seat,
+        turnIndex: state.turnCount,
+        action: turn.action,
+        attempt: 'draft',
+        handledExternally: dispatchResult.handled,
+      });
+      emitWide({
+        type: 'negotiation_turn_repetition',
+        opportunityId: state.opportunityId,
+        negotiationConversationId: state.conversationId,
+        turnIndex: state.turnCount,
+        actor: isSource ? 'source' : 'candidate',
+        attempt: 'draft',
+      });
+
+      // The duplicate is discarded — never persisted — and the turn is re-issued
+      // ONCE, told what it repeated. Coercion is deterministic on purpose: the
+      // agent gets one chance to contribute something new, and if it cannot, the
+      // negotiation ends honestly rather than filling its remaining turns with
+      // copies and calling the result a decision.
+      const reissued = applyChecklistDiscipline(
+        await draftFromSystemAgent({ repeatedMessage }),
+        { reissue: true },
+      );
+      let retryTurn = reissued.turn;
+
+      // The re-issue inherits this turn's seat vocabulary, and nothing else it
+      // could have earned earlier in the node. An out-of-seat action is coerced
+      // exactly as a dispatched one is; `ask_user` is refused outright, because
+      // the consultation decision — grant, policy admission, admissibility —
+      // was already taken above for this turn, and re-running it from here
+      // would let a repeated message become a park that skipped every one of
+      // those gates. Its `askUser` payload goes with it: no other action may
+      // carry one into the record.
+      if (version === 'v2' && !allowedActionsFor(version, seat, isFinalTurn, { askUser: false }).includes(retryTurn.action)) {
+        turnLog.warn('Anti-echo re-issue returned an action this turn cannot take, coercing to conservative fallback', {
+          taskId: state.taskId,
+          seat,
+          action: retryTurn.action,
+          isFinalTurn,
+        });
+        const { askUser: _refused, ...rest } = retryTurn;
+        retryTurn = { ...rest, action: fallbackActionFor(version, seat, isFinalTurn) };
+      }
+      // The gates the first draft passed, applied to what would replace it.
+      retryTurn = enforceDeclineVerdictLaw(retryTurn, reissued.checklist, { reissue: true });
+      retryTurn = enforceAuthoredQuestionSafety(retryTurn);
+
+      const repeatedAgain = repeatsPriorMessage(retryTurn);
+      if (repeatedAgain) {
+        // Twice is not a slip. Nothing is persisted, the turn count does not
+        // move, and the negotiation ends as what it is: stalled on repetition.
+        // NOT a decline — no side decided anything, and finalize must not be
+        // able to read a verdict out of this. That is why it travels as its own
+        // channel rather than as `error`, which means the agent produced no
+        // turn at all.
+        turnLog.error('negotiation_repetition_stalled', {
           taskId: state.taskId,
           opportunityId: state.opportunityId || undefined,
           seat,
-          handledExternally: dispatchResult.handled,
+          turnIndex: state.turnCount,
+          action: retryTurn.action,
         });
-        const { question: _rejected, ...askUserWithoutQuestion } = turn.askUser;
-        turn = { ...turn, askUser: askUserWithoutQuestion };
+        emitWide({
+          type: 'negotiation_turn_repetition',
+          opportunityId: state.opportunityId,
+          negotiationConversationId: state.conversationId,
+          turnIndex: state.turnCount,
+          actor: isSource ? 'source' : 'candidate',
+          attempt: 'reissue',
+          stalled: true,
+        });
+        traceEmitter?.({ type: "agent_end", name: agentName, durationMs: Date.now() - agentStart, summary: "repetition_stalled" });
+        return { repetitionStalled: true };
       }
+
+      turnLog.info('negotiation_turn_repetition_recovered', {
+        taskId: state.taskId,
+        opportunityId: state.opportunityId || undefined,
+        seat,
+        turnIndex: state.turnCount,
+        action: retryTurn.action,
+      });
+      turn = retryTurn;
+      nextChecklist = reissued.checklist;
     }
 
     const parts = [{ kind: "data" as const, data: turn }];

--- a/packages/protocol/src/negotiations/negotiation.state.ts
+++ b/packages/protocol/src/negotiations/negotiation.state.ts
@@ -77,8 +77,11 @@ export const NegotiationOutcomeSchema = z.object({
    * Why an unconcluded negotiation ended. `agent_error` is the honest name for
    * a run that stopped because the acting agent kept failing — distinct from
    * `turn_cap`, which claims a dialogue happened and exhausted its budget.
+   * `repetition` is the honest name for a run the copy-loop guard ended: an
+   * agent reproduced a message already on the record and did it again when
+   * re-issued, so nothing was decided and no verdict may be implied.
    */
-  reason: z.enum(["turn_cap", "timeout", "screened_out", "agent_error"]).optional(),
+  reason: z.enum(["turn_cap", "timeout", "screened_out", "agent_error", "repetition"]).optional(),
 });
 
 export type NegotiationOutcome = z.infer<typeof NegotiationOutcomeSchema>;
@@ -448,6 +451,20 @@ export const NegotiationGraphState = Annotation.Root({
   consecutiveTurnFailures: Annotation<number>({
     reducer: (curr, next) => next ?? curr,
     default: () => 0,
+  }),
+
+  /**
+   * The copy-loop guard ended this run: a drafted turn repeated a message
+   * already on the record, and the single anti-echo re-issue repeated it too.
+   *
+   * A channel rather than `error` because the two are different facts and the
+   * outcome must not confuse them — `error` means the agent could not produce
+   * a turn at all, this means it produced one that said nothing new. Routes to
+   * finalize, where it becomes `reason: "repetition"`.
+   */
+  repetitionStalled: Annotation<boolean>({
+    reducer: (curr, next) => next ?? curr,
+    default: () => false,
   }),
 
   outcome: Annotation<NegotiationOutcome | null>({

--- a/packages/protocol/src/negotiations/tests/negotiation.copy-loop.spec.ts
+++ b/packages/protocol/src/negotiations/tests/negotiation.copy-loop.spec.ts
@@ -1,0 +1,555 @@
+import { describe, it, expect, beforeAll, afterAll, beforeEach, afterEach } from "bun:test";
+
+import { NegotiationGraphFactory } from "../negotiation.graph.js";
+import { NegotiationGraphState } from "../negotiation.state.js";
+import { IndexNegotiator, type NegotiationAgentInput } from "../negotiation.agent.js";
+import { NegotiationStallGapAuthor } from "../negotiation.stall-gap.js";
+import { assessDeclineAdmissibility, type ChecklistDraftItem, type ChecklistItem } from "../negotiation.checklist.contracts.js";
+import type { NegotiationTurn } from "../negotiation.state.js";
+import type { QuestionerEnqueuePayload } from "../../questions/question.input.js";
+
+/**
+ * The copy loop, and the two rules that let it happen.
+ *
+ * Observed live on the sandbox: a counterparty asked what a phrase in the
+ * client's own signal meant. The answering agent could not consult its
+ * principal (unreachable) and its record did not settle the phrase, so with no
+ * legal move left it copied the question back word for word. Both models then
+ * locked — reproducing text already in context is close to deterministic — and
+ * turns 2/4 and 3/5 of that negotiation were byte-identical pairs. It ended on
+ * a decline citing "repeated lack of clarity ... despite five inquiries",
+ * against a checklist that held unknowns and not one conflict.
+ *
+ * What this pins:
+ *  - a drafted turn that repeats a message already on the record is never
+ *    persisted; the turn is re-issued once, told what it repeated,
+ *  - a second repeat ends the negotiation as `repetition` — not a decline,
+ *    because nobody decided anything — and the transcript holds no
+ *    byte-identical pair,
+ *  - distinct messages flow through untouched,
+ *  - the prompt gives the corner its missing legal move: state what the record
+ *    does and does not hold,
+ *  - a decline needs a conflict. An unknown never ends a negotiation, and where
+ *    the turn cap forces a verdict the violation is at least recorded.
+ *
+ * Harness mirrors `negotiation.checklist-turn.spec.ts`: stubbed
+ * database/dispatcher, scripted agent turns, no live provider.
+ */
+
+type FakeMessage = {
+  id: string;
+  senderId: string;
+  role: "agent";
+  parts: unknown[];
+  createdAt: Date;
+};
+
+const dimension = (
+  name: string,
+  kind: ChecklistDraftItem["kind"],
+  result: ChecklistDraftItem["result"],
+  basis = "",
+): ChecklistDraftItem => ({ name, kind, result, basis });
+
+/** Three dimensions, one scored, two open — and nothing in conflict. */
+const OPEN_CHECKLIST: ChecklistDraftItem[] = [
+  dimension("Mutual want", "mutual_want", "ok", "Alice's intent seeks an ML engineer; Bob's seeks applied ML work"),
+  dimension("Studio operations", "fit", "unknown"),
+  dimension("Stage fit", "fit", "unknown"),
+];
+
+/** The same three, with one dimension genuinely in conflict. */
+const CONFLICTED_CHECKLIST: ChecklistDraftItem[] = [
+  dimension("Mutual want", "mutual_want", "ok", "Alice's intent seeks an ML engineer; Bob's seeks applied ML work"),
+  dimension("Studio operations", "fit", "conflict", "Bob's profile states he has never worked in a studio"),
+  dimension("Stage fit", "fit", "unknown"),
+];
+
+const turn = (
+  action: string,
+  reasoning: string,
+  extra: Partial<NegotiationTurn> = {},
+): NegotiationTurn => ({
+  action,
+  assessment: { reasoning, suggestedRoles: { ownUser: "peer", otherUser: "peer" } },
+  message: null,
+  ...extra,
+} as NegotiationTurn);
+
+const said = (
+  action: string,
+  message: string,
+  checklist: ChecklistDraftItem[] = OPEN_CHECKLIST,
+) => turn(action, `${action} turn`, { message, checklist } as Partial<NegotiationTurn>);
+
+const OPENING = "Alice is hiring an ML engineer with studio operations experience.";
+const THE_QUESTION = "What do you mean by studio operations experience?";
+const THE_HONEST_ANSWER = "Alice's signal says studio operations experience; it does not specify further.";
+
+function mkStubs(opts?: { priorMessages?: FakeMessage[] }) {
+  const createdMessages: Array<{ senderId: string; parts: Array<{ kind: string; data: NegotiationTurn }> }> = [];
+  const stateWrites: Array<{ taskId: string; state: string }> = [];
+  const opportunityStatuses: string[] = [];
+
+  const database = {
+    getOrCreateDM: async () => ({ id: "conv-1" }),
+    createTask: async (conversationId: string) => ({ id: "task-new", conversationId, state: "submitted" }),
+    updateOpportunityStatus: async (_id: string, status: string) => { opportunityStatuses.push(status); },
+    createMessage: async (p: { senderId: string; parts: Array<{ kind: string; data: NegotiationTurn }> }) => {
+      createdMessages.push(p);
+      return { id: `msg-${createdMessages.length}`, senderId: p.senderId, parts: p.parts, createdAt: new Date() };
+    },
+    updateTaskState: async (taskId: string, state: string) => { stateWrites.push({ taskId, state }); },
+    createArtifact: async () => ({ id: "art-1" }),
+    setTaskTurnContext: async () => {},
+    captureNegotiationAskUserBinding: async (input: Record<string, unknown>) => ({
+      version: 2 as const,
+      settlementId: input.settlementId as string,
+      recipientUserId: input.recipientUserId as string,
+      recipientIntentId: input.recipientIntentId as string,
+      opportunityId: input.opportunityId as string,
+      networkId: input.networkId as string,
+      intentFingerprint: "fp-src",
+      opportunityStatus: "pending",
+      opportunityUpdatedAt: "2026-01-01T00:00:00.000Z",
+      counterpartyUserId: "u-cand",
+      counterpartyIntentId: "intent-cand",
+    }),
+    getMessagesForConversation: async () => opts?.priorMessages ?? [],
+    getNegotiationMessages: async () => opts?.priorMessages ?? [],
+    getOpportunityUserAnswers: async () => [],
+    getNegotiationTaskForOpportunity: async () => null,
+    getLatestNegotiationTaskForConversation: async () => null,
+    getTask: async () => null,
+    getUserContext: async () => ({ text: "Alice builds AI startups" }),
+    getTasksForUser: async () => [],
+    getArtifactsForTask: async () => [],
+  } as unknown as ConstructorParameters<typeof NegotiationGraphFactory>[0];
+
+  const dispatcher = {
+    hasExternalAgent: async () => false,
+    dispatch: async () => ({ handled: false, reason: "no_agent" }),
+  } as unknown as ConstructorParameters<typeof NegotiationGraphFactory>[1];
+
+  const timeoutQueue = {
+    enqueueTimeout: async () => "job-1",
+    cancelTimeout: async () => {},
+    enqueueAskUserExpiry: async () => "askuser-job-1",
+    cancelAskUserExpiry: async () => {},
+  } as unknown as ConstructorParameters<typeof NegotiationGraphFactory>[2];
+
+  const questionerEnqueues: QuestionerEnqueuePayload[] = [];
+  const questionerEnqueue = async (input: QuestionerEnqueuePayload) => { questionerEnqueues.push(input); };
+
+  return { database, dispatcher, timeoutQueue, questionerEnqueue, createdMessages, stateWrites, questionerEnqueues, opportunityStatuses };
+}
+
+async function runGraph(stubs: ReturnType<typeof mkStubs>, input: Record<string, unknown> = {}) {
+  const graph = new NegotiationGraphFactory(
+    stubs.database, stubs.dispatcher, stubs.timeoutQueue, stubs.questionerEnqueue,
+  ).createGraph();
+  return graph.invoke({
+    sourceUser: { id: "u-src", intents: [{ id: "intent-src", title: "Hire an ML engineer", description: "Looking for applied ML depth", confidence: 1 }], profile: { name: "Alice", bio: "PM", skills: ["evals"] } },
+    candidateUser: { id: "u-cand", intents: [{ id: "intent-cand", title: "Join an AI product", description: "Wants applied ML work", confidence: 1 }], profile: { name: "Bob", bio: "ML engineer", skills: ["ml"] } },
+    sourceIntentId: "intent-src",
+    candidateIntentId: "intent-cand",
+    indexContext: { networkId: "net-1", prompt: "AI network" },
+    seedAssessment: { reasoning: "complementary", valencyRole: "peer" },
+    opportunityId: "opp-1",
+    maxTurns: 6,
+    ...input,
+  } as Partial<typeof NegotiationGraphState.State>);
+}
+
+/** Every action persisted to the shared record, in order. */
+function persistedActions(stubs: ReturnType<typeof mkStubs>) {
+  return stubs.createdMessages.map((message) => message.parts[0].data.action);
+}
+
+/** Every message persisted to the shared record, in order. */
+function persistedMessages(stubs: ReturnType<typeof mkStubs>) {
+  return stubs.createdMessages.map((message) => message.parts[0].data.message ?? null);
+}
+
+/** The failure exactly as the DB proved it: two turns with the same text. */
+function hasIdenticalMessagePair(stubs: ReturnType<typeof mkStubs>): boolean {
+  const messages = persistedMessages(stubs).filter((message): message is string => typeof message === "string" && message.trim().length > 0);
+  return new Set(messages.map((message) => message.trim())).size !== messages.length;
+}
+
+let agentInputs: NegotiationAgentInput[] = [];
+let agentScript: NegotiationTurn[] = [];
+
+describe("the copy loop at the turn seam", () => {
+  let origAgentInvoke: typeof IndexNegotiator.prototype.invoke;
+  let origStallGapAuthor: typeof NegotiationStallGapAuthor.prototype.author;
+  const originals: Record<string, string | undefined> = {};
+
+  beforeAll(() => {
+    origAgentInvoke = IndexNegotiator.prototype.invoke;
+    IndexNegotiator.prototype.invoke = async function (input: NegotiationAgentInput) {
+      agentInputs.push(input);
+      const next = agentScript.shift();
+      if (!next) throw new Error("agent script exhausted");
+      return next;
+    };
+    origStallGapAuthor = NegotiationStallGapAuthor.prototype.author;
+    NegotiationStallGapAuthor.prototype.author = async function () { return null; };
+    for (const key of ["NEGOTIATION_ASK_USER_ENABLED", "NEGOTIATION_CONSULTATION_POLICY_MODE", "NEGOTIATION_PROTOCOL_VERSION", "NEGOTIATION_SCREEN_MODE", "NEGOTIATOR_STANCE"]) {
+      originals[key] = process.env[key];
+    }
+  });
+
+  afterAll(() => {
+    IndexNegotiator.prototype.invoke = origAgentInvoke;
+    NegotiationStallGapAuthor.prototype.author = origStallGapAuthor;
+  });
+
+  beforeEach(() => {
+    agentInputs = [];
+    agentScript = [];
+    // The dev configuration this ships into.
+    process.env.NEGOTIATION_ASK_USER_ENABLED = "true";
+    process.env.NEGOTIATION_CONSULTATION_POLICY_MODE = "on";
+    process.env.NEGOTIATION_PROTOCOL_VERSION = "v2";
+    process.env.NEGOTIATION_SCREEN_MODE = "off";
+    process.env.NEGOTIATOR_STANCE = "skeptic";
+  });
+
+  afterEach(() => {
+    for (const [key, value] of Object.entries(originals)) {
+      if (value === undefined) delete process.env[key]; else process.env[key] = value;
+    }
+  });
+
+  it("discards a duplicate draft and re-issues the turn once, telling it what it repeated", async () => {
+    const stubs = mkStubs();
+    agentScript = [
+      said("outreach", OPENING),
+      said("question", THE_QUESTION),
+      // The observed failure: the initiator hands the question back verbatim.
+      said("question", THE_QUESTION),
+      // The re-issue, which is what actually lands.
+      said("counter", THE_HONEST_ANSWER),
+      turn("accept", "the record is enough to meet on"),
+    ];
+    await runGraph(stubs);
+
+    // The duplicate never reached the conversation; the re-issue did.
+    expect(persistedMessages(stubs)).toEqual([OPENING, THE_QUESTION, THE_HONEST_ANSWER, null]);
+    expect(persistedActions(stubs)).toEqual(["outreach", "question", "counter", "accept"]);
+    expect(hasIdenticalMessagePair(stubs)).toBe(false);
+
+    // Exactly one extra draft, and it was told what to stop repeating.
+    expect(agentInputs).toHaveLength(5);
+    expect(agentInputs[2].antiEcho).toBeUndefined();
+    expect(agentInputs[3].antiEcho).toEqual({ repeatedMessage: THE_QUESTION });
+    // The re-issue is still the SAME turn: same seat, same history, no extra
+    // turn spent on it.
+    expect(agentInputs[3].seat).toBe(agentInputs[2].seat);
+    expect(agentInputs[3].history).toHaveLength(agentInputs[2].history.length);
+  });
+
+  it("ends the negotiation as `repetition` when the re-issue repeats too, and never as a decline", async () => {
+    const stubs = mkStubs();
+    agentScript = [
+      said("outreach", OPENING),
+      said("question", THE_QUESTION),
+      said("question", THE_QUESTION),
+      // Told not to echo, it echoes anyway. Twice is not a slip.
+      said("question", THE_QUESTION),
+    ];
+    const result = await runGraph(stubs);
+
+    // Nothing after the counterparty's question was persisted, and the record
+    // holds no byte-identical pair — the shape the DB proved on the live row.
+    expect(persistedMessages(stubs)).toEqual([OPENING, THE_QUESTION]);
+    expect(hasIdenticalMessagePair(stubs)).toBe(false);
+
+    // The honest outcome: nobody decided anything.
+    expect(result.outcome?.reason).toBe("repetition");
+    expect(result.outcome?.hasOpportunity).toBe(false);
+    // The failed turn is not counted as one — the two turns that landed are.
+    expect(result.outcome?.turnCount).toBe(2);
+    // And the opportunity is stalled, never rejected: a stall is retryable and
+    // says nothing about the match; `rejected` would be a verdict nobody gave.
+    expect(stubs.opportunityStatuses.at(-1)).toBe("stalled");
+  });
+
+  it("leaves distinct messages completely alone", async () => {
+    const stubs = mkStubs();
+    agentScript = [
+      said("outreach", OPENING),
+      said("question", THE_QUESTION),
+      said("counter", THE_HONEST_ANSWER),
+      turn("accept", "good enough to meet on"),
+    ];
+    await runGraph(stubs);
+
+    expect(persistedActions(stubs)).toEqual(["outreach", "question", "counter", "accept"]);
+    // One draft per turn: no re-issue was triggered, and no turn saw an
+    // anti-echo instruction.
+    expect(agentInputs).toHaveLength(4);
+    expect(agentInputs.every((input) => input.antiEcho === undefined)).toBe(true);
+  });
+
+  it("exempts a TERMINAL turn — the guard stops loops, and a turn that ends the negotiation cannot loop", async () => {
+    const stubs = mkStubs();
+    agentScript = [
+      said("outreach", OPENING),
+      // An accept that closes by restating the outreach it is accepting. Under
+      // a guard that covered terminal turns this would be refused and a
+      // successful match would end as a stall — the guard destroying exactly
+      // the outcome it exists to protect.
+      said("accept", OPENING),
+    ];
+    const result = await runGraph(stubs);
+
+    expect(persistedActions(stubs)).toEqual(["outreach", "accept"]);
+    expect(result.outcome?.hasOpportunity).toBe(true);
+    // No re-issue was attempted.
+    expect(agentInputs).toHaveLength(2);
+  });
+
+  it("exempts turns that carry no message — there is nothing on the record for them to duplicate", async () => {
+    const stubs = mkStubs();
+    agentScript = [
+      said("outreach", OPENING),
+      // Two message-less turns in a row are not a copy loop; they are two
+      // agents reasoning without addressing each other's text.
+      turn("counter", "not yet convinced", { checklist: OPEN_CHECKLIST } as Partial<NegotiationTurn>),
+      turn("counter", "not yet convinced", { checklist: OPEN_CHECKLIST } as Partial<NegotiationTurn>),
+      turn("accept", "convinced"),
+    ];
+    await runGraph(stubs);
+
+    expect(persistedActions(stubs)).toEqual(["outreach", "counter", "counter", "accept"]);
+    expect(agentInputs).toHaveLength(4);
+  });
+});
+
+describe("a decline needs a conflict — the verdict law, mechanically", () => {
+  const authored: ChecklistItem[] = OPEN_CHECKLIST as ChecklistItem[];
+
+  it("refuses a decline over a checklist that holds only unknowns, and names them", () => {
+    expect(assessDeclineAdmissibility({ checklist: authored })).toEqual({
+      admissible: false,
+      reason: "no_conflict_dimension",
+      unknowns: ["Studio operations", "Stage fit"],
+    });
+  });
+
+  it("admits a decline that has a conflict behind it", () => {
+    expect(assessDeclineAdmissibility({ checklist: CONFLICTED_CHECKLIST as ChecklistItem[] }))
+      .toEqual({ admissible: true });
+  });
+
+  it("fails open on an unauthored checklist — there is no law to have violated", () => {
+    expect(assessDeclineAdmissibility({ checklist: [] })).toEqual({ admissible: true });
+    // Too few dimensions, and no mutual want: not an authored checklist.
+    expect(assessDeclineAdmissibility({
+      checklist: [dimension("Stage fit", "fit", "unknown")] as ChecklistItem[],
+    })).toEqual({ admissible: true });
+  });
+});
+
+describe("the verdict law at the turn seam", () => {
+  let origAgentInvoke: typeof IndexNegotiator.prototype.invoke;
+  let origStallGapAuthor: typeof NegotiationStallGapAuthor.prototype.author;
+  const originals: Record<string, string | undefined> = {};
+
+  beforeAll(() => {
+    origAgentInvoke = IndexNegotiator.prototype.invoke;
+    IndexNegotiator.prototype.invoke = async function (input: NegotiationAgentInput) {
+      agentInputs.push(input);
+      const next = agentScript.shift();
+      if (!next) throw new Error("agent script exhausted");
+      return next;
+    };
+    origStallGapAuthor = NegotiationStallGapAuthor.prototype.author;
+    NegotiationStallGapAuthor.prototype.author = async function () { return null; };
+    for (const key of ["NEGOTIATION_ASK_USER_ENABLED", "NEGOTIATION_CONSULTATION_POLICY_MODE", "NEGOTIATION_PROTOCOL_VERSION", "NEGOTIATION_SCREEN_MODE", "NEGOTIATOR_STANCE"]) {
+      originals[key] = process.env[key];
+    }
+  });
+
+  afterAll(() => {
+    IndexNegotiator.prototype.invoke = origAgentInvoke;
+    NegotiationStallGapAuthor.prototype.author = origStallGapAuthor;
+  });
+
+  beforeEach(() => {
+    agentInputs = [];
+    agentScript = [];
+    process.env.NEGOTIATION_ASK_USER_ENABLED = "true";
+    process.env.NEGOTIATION_CONSULTATION_POLICY_MODE = "on";
+    process.env.NEGOTIATION_PROTOCOL_VERSION = "v2";
+    process.env.NEGOTIATION_SCREEN_MODE = "off";
+    process.env.NEGOTIATOR_STANCE = "skeptic";
+  });
+
+  afterEach(() => {
+    for (const [key, value] of Object.entries(originals)) {
+      if (value === undefined) delete process.env[key]; else process.env[key] = value;
+    }
+  });
+
+  it("refuses a mid-flight decline that has no conflict behind it, and keeps the dialogue open", async () => {
+    const stubs = mkStubs();
+    agentScript = [
+      said("outreach", OPENING),
+      // The observed decline: "repeated lack of clarity", over unknowns.
+      said("decline", "I have asked repeatedly and nothing was clarified."),
+      said("counter", "one more angle"),
+      turn("accept", "settled"),
+    ];
+    await runGraph(stubs);
+
+    // Coerced to the conservative non-terminal fallback, and the message that
+    // was written to end the negotiation does not travel on it.
+    expect(persistedActions(stubs)).toEqual(["outreach", "counter", "counter", "accept"]);
+    expect(persistedMessages(stubs)[1]).toBeNull();
+    // The negotiation did not end there.
+    expect(stubs.opportunityStatuses.at(-1)).toBe("pending");
+  });
+
+  it("admits the decline the moment a dimension is actually in conflict", async () => {
+    const stubs = mkStubs();
+    agentScript = [
+      said("outreach", OPENING),
+      said("decline", "Bob has never worked in a studio; this is not the person.", CONFLICTED_CHECKLIST),
+    ];
+    await runGraph(stubs);
+
+    expect(persistedActions(stubs)).toEqual(["outreach", "decline"]);
+    expect(persistedMessages(stubs)[1]).toBe("Bob has never worked in a studio; this is not the person.");
+    expect(stubs.opportunityStatuses.at(-1)).toBe("rejected");
+  });
+
+  it("lets the final turn's forced verdict stand — the cap wins, and the row still says a decline landed", async () => {
+    const stubs = mkStubs();
+    agentScript = [
+      said("outreach", OPENING),
+      // maxTurns 2 makes this the final turn: the seat's only moves are accept
+      // and decline, so refusing the decline could only manufacture an accept.
+      said("decline", "nothing was ever clarified"),
+    ];
+    const result = await runGraph(stubs, { maxTurns: 2 });
+
+    expect(persistedActions(stubs)).toEqual(["outreach", "decline"]);
+    expect(result.outcome?.hasOpportunity).toBe(false);
+    expect(stubs.opportunityStatuses.at(-1)).toBe("rejected");
+  }, 10_000);
+
+  it("leaves `advocate` untouched — no checklist, no law", async () => {
+    process.env.NEGOTIATOR_STANCE = "advocate";
+    const stubs = mkStubs();
+    agentScript = [
+      said("outreach", OPENING),
+      said("decline", "not a fit"),
+    ];
+    await runGraph(stubs);
+
+    expect(persistedActions(stubs)).toEqual(["outreach", "decline"]);
+    expect(stubs.opportunityStatuses.at(-1)).toBe("rejected");
+  });
+});
+
+/**
+ * The prompt half, at the agent seam. `CapturingNegotiator` mirrors
+ * `negotiation.principal-unreachable.spec.ts`: the `callModel` seam, no live
+ * provider.
+ */
+class CapturingNegotiator extends IndexNegotiator {
+  calls = 0;
+  systemPrompts: string[] = [];
+  userMessages: string[] = [];
+  constructor(private outputs: unknown[]) {
+    super({ turnTimeoutMs: 1000 });
+  }
+  protected override async callModel(
+    _model: unknown,
+    chatMessages: Array<{ role: string; content: string }>,
+  ): Promise<unknown> {
+    this.systemPrompts.push(chatMessages[0].content);
+    this.userMessages.push(chatMessages[1].content);
+    const out = this.outputs[Math.min(this.calls, this.outputs.length - 1)];
+    this.calls += 1;
+    return out;
+  }
+}
+
+const counterOutput = {
+  action: "counter",
+  assessment: { reasoning: "ok", suggestedRoles: { ownUser: "peer", otherUser: "peer" } },
+  message: null,
+};
+
+const agentBaseInput: NegotiationAgentInput = {
+  ownUser: { id: "u-init", intents: [], profile: { name: "Alice" } },
+  otherUser: { id: "u-cp", intents: [], profile: { name: "Bob" } },
+  indexContext: { networkId: "net-1", prompt: "" },
+  seedAssessment: { reasoning: "seed", valencyRole: "peer" },
+  history: [{
+    action: "question",
+    assessment: { reasoning: "need to know", suggestedRoles: { ownUser: "peer", otherUser: "peer" } },
+    message: THE_QUESTION,
+  }],
+  seat: "initiator",
+  protocolVersion: "v2",
+};
+
+describe("the prompt gives the corner its missing move", () => {
+  const stanceKey = "NEGOTIATOR_STANCE";
+  let originalStance: string | undefined;
+
+  beforeAll(() => { originalStance = process.env[stanceKey]; });
+  afterAll(() => {
+    if (originalStance === undefined) delete process.env[stanceKey];
+    else process.env[stanceKey] = originalStance;
+  });
+
+  async function promptFor(overrides: Partial<NegotiationAgentInput> = {}) {
+    const agent = new CapturingNegotiator([counterOutput]);
+    await agent.invoke({ ...agentBaseInput, ...overrides });
+    return { system: agent.systemPrompts[0], user: agent.userMessages[0] };
+  }
+
+  it("tells an unreachable principal's agent to state the limit of the record instead of echoing", async () => {
+    process.env[stanceKey] = "skeptic";
+    const { system } = await promptFor({
+      ownUser: { ...agentBaseInput.ownUser, principalUnreachable: true },
+    });
+    // The exact corner the live failure hit: the counterparty asked something
+    // only the client could settle, and the record does not settle it.
+    expect(system).toContain("WHEN THE COUNTERPARTY ASKS YOU SOMETHING ONLY Alice COULD SETTLE AND YOUR RECORD DOES NOT SETTLE IT");
+    expect(system).toContain("is a COMPLETE and honest answer");
+    expect(system).toContain("Never repeat, mirror, or hand their question back to them");
+    // Under the checklist protocol the same move is stated in checklist terms.
+    expect(system).toContain("name it as an open unknown to them in plain words");
+  });
+
+  it("never renders the rule for a reachable principal", async () => {
+    process.env[stanceKey] = "skeptic";
+    const { system } = await promptFor({ canAskUser: false });
+    expect(system).not.toContain("YOU CANNOT CONSULT");
+    expect(system).not.toContain("WHEN THE COUNTERPARTY ASKS YOU SOMETHING ONLY");
+  });
+
+  it("quotes the repeated text back on a re-issue, and offers moves rather than a verdict", async () => {
+    process.env[stanceKey] = "skeptic";
+    const { user } = await promptFor({ antiEcho: { repeatedMessage: THE_QUESTION } });
+    expect(user).toContain("REPEATED A MESSAGE ALREADY IN THIS NEGOTIATION, WORD FOR WORD");
+    expect(user).toContain(THE_QUESTION);
+    expect(user).toContain("do not ask it back at them");
+    // The re-issue must not push toward ending it — that would manufacture the
+    // false decline the guard exists to prevent.
+    expect(user).toContain("Never end a negotiation merely because something stayed unknown.");
+  });
+
+  it("says nothing about echoing on an ordinary turn", async () => {
+    process.env[stanceKey] = "skeptic";
+    const { user } = await promptFor();
+    expect(user).not.toContain("WORD FOR WORD");
+  });
+});

--- a/packages/protocol/src/negotiations/tests/negotiation.principal-unreachable.spec.ts
+++ b/packages/protocol/src/negotiations/tests/negotiation.principal-unreachable.spec.ts
@@ -55,6 +55,18 @@ const CHECKLIST: ChecklistDraftItem[] = [
   dimension("Stage fit", "fit", "unknown"),
 ];
 
+/**
+ * The same dimensions with one genuinely in conflict. A decline needs one —
+ * the verdict law is enforced at the turn node now, so a scripted decline over
+ * an unknowns-only checklist would be refused as inadmissible and the script
+ * would never reach its end.
+ */
+const CONFLICTED_CHECKLIST: ChecklistDraftItem[] = [
+  dimension("Mutual want", "mutual_want", "ok", "Alice's intent seeks an ML engineer; Bob's seeks applied ML work"),
+  dimension("Location", "fit", "conflict", "Bob's profile places him in Lisbon; the signal asks for Berlin"),
+  dimension("Stage fit", "fit", "unknown"),
+];
+
 const ANSWERHOOD = { ok_when: "the client says remote is fine", conflict_when: "the client says Berlin only" };
 
 const QUESTION = {
@@ -263,7 +275,7 @@ describe("an unreachable principal is never consulted", () => {
     agentScript = [
       askTurn(),
       askTurn(),
-      turn("decline", "the record does not support it"),
+      turn("decline", "the record puts Bob in the wrong city", { checklist: CONFLICTED_CHECKLIST } as Partial<NegotiationTurn>),
     ];
     const result = await runGraph(stubs);
 

--- a/packages/protocol/src/opportunities/negotiation-summary.builder.ts
+++ b/packages/protocol/src/opportunities/negotiation-summary.builder.ts
@@ -24,6 +24,18 @@ export interface NegotiationResolution {
 }
 
 /**
+ * The negotiation's outcome reason, narrowed to the discovery vocabulary.
+ *
+ * Written as an allow-list rather than a deny-list so a new negotiation reason
+ * cannot silently cross the boundary: anything discovery does not declare —
+ * `agent_error`, `repetition`, whatever comes next — is dropped, and the caller
+ * degrades to the unreasoned stall the digest already handles.
+ */
+function discoveryOutcomeReason(reason: NegotiationOutcome["reason"]): DiscoveryOutcome["reason"] | undefined {
+  return reason === "turn_cap" || reason === "timeout" || reason === "screened_out" ? reason : undefined;
+}
+
+/**
  * Convert one negotiation resolution to `DiscoveryNegotiation`.
  *
  * @param r - The raw resolution from the negotiate node.
@@ -44,11 +56,13 @@ export function toDiscoveryNegotiation(r: NegotiationResolution): DiscoveryNegot
     ...(r.outcome.hasOpportunity && r.outcome.agreedRoles.length > 0
       ? { agreedRoles: r.outcome.agreedRoles.map((a) => ({ userId: a.userId, role: a.role as NegotiationRole })) }
       : {}),
-    // `agent_error` deliberately does not cross into the discovery vocabulary:
-    // question generation reasons about why a DIALOGUE did not conclude, and a
-    // run that stopped on repeated agent failures has nothing to say about the
-    // match. It degrades to the unreasoned stall the digest already handles.
-    ...(r.outcome.reason && r.outcome.reason !== 'agent_error' ? { reason: r.outcome.reason } : {}),
+    // `agent_error` and `repetition` deliberately do not cross into the
+    // discovery vocabulary: question generation reasons about why a DIALOGUE
+    // did not conclude, and a run that stopped on repeated agent failures — or
+    // on an agent reproducing a message already on the record — has nothing to
+    // say about the match. Both degrade to the unreasoned stall the digest
+    // already handles.
+    ...(discoveryOutcomeReason(r.outcome.reason) ? { reason: discoveryOutcomeReason(r.outcome.reason) } : {}),
   };
   return {
     counterpartyId: r.candidateUserId,

--- a/packages/protocol/src/shared/schemas/negotiation-state.schema.ts
+++ b/packages/protocol/src/shared/schemas/negotiation-state.schema.ts
@@ -128,8 +128,12 @@ export const NegotiationOutcomeSchema = z.object({
   })),
   reasoning: z.string(),
   turnCount: z.number(),
-  /** `agent_error`: the run stopped on repeated agent failures, not on a decision. */
-  reason: z.enum(["turn_cap", "timeout", "screened_out", "agent_error"]).optional(),
+  /**
+   * `agent_error`: the run stopped on repeated agent failures, not on a decision.
+   * `repetition`: the run stopped because an agent kept reproducing a message
+   * already on the record — likewise not a decision.
+   */
+  reason: z.enum(["turn_cap", "timeout", "screened_out", "agent_error", "repetition"]).optional(),
 });
 export type NegotiationOutcome = z.infer<typeof NegotiationOutcomeSchema>;
 


### PR DESCRIPTION
## The bug, as the database recorded it

Conversation `d92544ed-506c-4845-96f7-9604e82d5ddc`, task `703741e6-db7a-473f-82a2-67df5f21c48a` (Hye-jin Park ↔ Mira Kovač, 6 turns, outcome decline).

1. Hye-jin's agent opens.
2. Mira's agent asks what "studio operations experience" means — a phrase from Hye-jin's own signal, and a question only Hye-jin could settle.
3. Hye-jin's principal is unreachable (#1459), so `ask_user` is withheld, and her premises do not elaborate the phrase. With no legal move left, her agent **copies Mira's question back verbatim**.
4. Both models lock. Turns 2 and 4 are byte-identical whole part objects (same md5 over `parts::text`); turns 3 and 5 likewise. No model was meaningfully consulted for turns 4–5.
5. Mira's agent declines, citing "repeated lack of clarity … despite five inquiries" — over a checklist holding unknowns and **not one conflict**.
6. Hye-jin is shown: *"Your agent withdrew after reviewing the opportunity (6 turns) — the candidate didn't align with what you're looking for."* Her agent did not withdraw. It was declined.

Same disease in `e069822d-…` (partial lock) and `879de91b-…` (full lock). Deadlock detection (IND-428, 4 consecutive non-convergent) fires at turn 5 of a 6-turn cap — structurally too late.

Four things had to be true at once, so all four are fixed.

## 1. No turn may repeat a message on the record

`negotiation.graph.turn.ts` compares each drafted message against every message already in this negotiation. On an exact match the draft is **discarded, never persisted**, and the turn is re-issued **once** with the repeated text quoted back plus an instruction to contribute something the record does not hold — or to conclude. A second repeat ends the run as `outcome.reason: "repetition"`, with the opportunity `stalled`.

- **Never a decline.** Nobody decided anything, so it travels as its own state channel rather than as `error` (which means the agent produced no turn at all) and outranks the reject-like status mapping in finalize.
- **Exact text, not similarity.** Two agents making the same point in different words is a real exchange; only a byte-identical repeat is refused, and that cannot be a false positive.
- **Terminal turns are exempt on principle.** The guard stops *loops*, and a turn that ends the negotiation cannot loop. Covering them would refuse an `accept` that closes by restating the outreach it accepts — destroying the outcome the guard exists to protect. (Pinned by a test; this is also what three existing constant-stub fixtures were quietly relying on.)
- The re-issue runs through the in-process negotiator even when the refused draft came from a dispatched agent: re-dispatching would reopen the dispatch contract mid-turn (a `waiting` result would suspend the graph holding a discarded draft). It faces every gate the first draft did — checklist reconcile, seat vocabulary, the verdict law, the authored-question safety gate — which is why those three are now closures rather than straight-line blocks.

## 2. The unreachable-principal rule gains its missing legal move

`PRINCIPAL_UNREACHABLE_RULE` said never stall and never route the client's question to the other side, but named no move for the case that actually occurred. It now says: state the limit of the record — *"{userName}'s signal says X; it does not specify further"* is a complete, honest answer — and let the counterparty score that dimension unknown. Never mirror their question; never invent an answer. The checklist sibling says the same in checklist terms.

## 3. The verdict law, mechanically

New `assessDeclineAdmissibility` in the checklist contracts. A drafted `decline`/`reject` over an authored checklist with no `conflict` dimension is refused, logged as `negotiation_decline_inadmissible` naming the unknowns that stood in for one, and coerced to the conservative non-terminal fallback — with the terminal message dropped, since a message written to end the negotiation must not travel on a `counter`.

**Final-turn decision:** the decline **stands**, and the violation is logged and traced with `isFinalTurn: true, coerced: false`. The seat's final vocabulary is accept-or-decline, so refusing there could only manufacture an accept nobody chose or emit an action the schema does not carry. The cap wins — but not silently, which is the part that was missing.

Scoped to assessing stances, fails open on an unauthored checklist (same rationale as ask admissibility), `advocate` untouched, and turn-0 screen semantics (`withdraw`) explicitly out of scope.

## 4. The banner says who actually ended it

`terminalTurnAuthor` reads the sender of the last terminal turn from the transcript the banner renders above — the only place that fact exists on the client, since `rejected` says a negotiation ended and nothing about who decided.

- counterparty-authored → *"Their agent declined (N turns) — the two agents didn't find enough mutual value."*
- own-authored → the existing withdrawal copy, unchanged.
- indeterminate → *"After N turns, the agents ended this without a match."* Never a guess.

"No opportunity — filtered out for you" and the quiet-decline footnote are claims about a decision **this** side made, so they now render only where that is demonstrably true. The #1458 pre-contact guard is intact and its specs stay green (one existing case now passes `terminalAuthor="own"`, which is the fact its copy always depended on).

## Tests

New `negotiation.copy-loop.spec.ts` (scripted agent, no live provider): re-issued once with the anti-echo instruction and the second draft persisting; a double repeat stalling as `repetition` with no byte-identical pair in the transcript and the opportunity `stalled`; distinct messages untouched; message-less and terminal turns exempt; the verdict law as a contract and at the turn seam (mid-flight refusal, conflict admits, final-turn stands, `advocate` untouched); the prompt's record-limit move rendering only for an unreachable principal, and the anti-echo instruction quoting the repeated text.

Banner + `terminalTurnAuthor` specs in `apps/web`. `negotiation.principal-unreachable.spec.ts`'s seed-vs-seed fixture now declines over a conflict — its claim is about consultations, not verdicts.

Suites: protocol negotiations 628/630 (the 2 failures are the known live-LLM `negotiator-discovery-query` flake — 4/4 in isolation); protocol opportunities 935/938 (known whole-dir presenter flake — 162/162 in isolation); web 477 pass with the same 4 failures the clean baseline has (`negotiation-presence`, `topbar`, `chat-sidebar-unread`). API `tsc --noEmit` and spec typecheck clean; eslint 0 errors.

## Notes

- Protocol `23.1.1 → 23.2.0`. `NegotiationOutcome.reason` gains `"repetition"`; the discovery vocabulary now filters machine-fault reasons through an allow-list, so a future reason cannot silently cross that boundary.
- No flags. Ships on by default.
- **Scope limit:** the guard lives in the graph's turn node, covering in-process and locally-dispatched turns. Turns submitted through the polling/respond API are not re-issued by it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
