### PR TITLE
fix(negotiations): a task's first turn can park

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -89,7 +89,7 @@
     },
     "packages/protocol": {
       "name": "@indexnetwork/protocol",
-      "version": "23.3.0",
+      "version": "23.3.1",
       "dependencies": {
         "@langchain/core": "1.1.48",
         "@langchain/langgraph": "1.3.2",

--- a/packages/protocol/CHANGELOG.md
+++ b/packages/protocol/CHANGELOG.md
@@ -20,6 +20,38 @@ went 6.7.1 → 8.0.2 with no 7.x in between because the whole 7.x line shipped a
 prereleases between the two promotions. To track every change, read `rc`; to
 pin a supported release, use `latest`.
 
+## 23.3.1 - 2026-08-20
+
+### Fixed
+
+- **A task's FIRST turn can park.** The first `ask_user` this system ever fired —
+  produced by 23.3.0's conclusion floor, on the first turn of a resumed
+  session — died at the park with "Ask-user material binding is no longer
+  valid", and the negotiation stalled. The binding capture locks the task row
+  `state = 'working'` and refuses anything else; the graph announced `working`
+  only at the END of a completed turn, so on a task's first turn the row still
+  held its creation state (`submitted`) and no first-turn park could bind. The
+  turn was already on the record when it threw, which makes the failure
+  unretryable — so the whole opportunity ended as `agent_error`.
+
+  The turn node now announces `working` before the capture rather than only
+  after the turn, carrying the same continuation-execution fence as every other
+  state write. The fence in the adapter is unchanged: `working` is the true
+  precondition for a settlement coordinate, and what was wrong was the
+  sequencing, not the check. The flip sits at the park rather than at the top of
+  the turn deliberately — a task that dies before putting anything on the record
+  stays reclaimable under the watchdog's ten-minute `submitted` rule instead of
+  disappearing under the twelve-hour `working` one — and the end-of-turn flip
+  stays for every path that does not park.
+
+  Latent since the turn-0 pre-contact consult shipped and never once hit,
+  because no first-turn ask was ever drafted; the conclusion floor made them
+  routine, a run-existing continuation's turn 0 being the common case. The
+  twenty-five specs covering this loop all missed it because their database
+  stubs accepted any task state at capture time — the new spec's stub asserts
+  the state exactly as the adapter does, on the agent-drafted ask, the
+  floor-guaranteed one, the pre-contact consult and a later-turn ask alike.
+
 ## 23.3.0 - 2026-08-20
 
 ### Changed

--- a/packages/protocol/package.json
+++ b/packages/protocol/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@indexnetwork/protocol",
-  "version": "23.3.0",
+  "version": "23.3.1",
   "type": "module",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",

--- a/packages/protocol/src/negotiations/negotiation.graph.turn.ts
+++ b/packages/protocol/src/negotiations/negotiation.graph.turn.ts
@@ -1376,6 +1376,26 @@ export async function turnNode(state: NegotiationState, deps: NegotiationGraphDe
           }
         : undefined;
 
+      // The task is WORKING before the binding is captured. The capture locks
+      // the task row `state = 'working'` and refuses anything else — a fence on
+      // the coordinate the timeout/answer paths later settle against — while
+      // the graph only ever announced `working` at the END of a completed turn,
+      // below. On a task's FIRST turn the row therefore still held its creation
+      // state (`submitted`), and every first-turn park died on
+      // "Ask-user material binding is no longer valid": the turn was already on
+      // the record, so the failure was not even retryable and the negotiation
+      // stalled. Latent since the pre-contact consult shipped; the conclusion
+      // floor made first-turn asks routine, and a run-existing continuation's
+      // turn 0 is the common one.
+      //
+      // Announced HERE rather than at the top of the turn deliberately. A task
+      // that dies before putting anything on the record is reclaimed by the
+      // watchdog's ten-minute `submitted` rule; flipping at turn start would
+      // hide such a task under the twelve-hour `working` rule instead. At this
+      // point the turn IS on the record, so `working` is simply true — and the
+      // end-of-turn flip below stays for every path that does not park.
+      await deps.database.updateTaskState(state.taskId, 'working', undefined, state.continuationExecution);
+
       const askUserBinding = await deps.database.captureNegotiationAskUserBinding({
         taskId: state.taskId,
         settlementId,

--- a/packages/protocol/src/negotiations/tests/negotiation.first-turn-park.spec.ts
+++ b/packages/protocol/src/negotiations/tests/negotiation.first-turn-park.spec.ts
@@ -1,0 +1,372 @@
+import { describe, it, expect, beforeAll, afterAll, beforeEach, afterEach } from "bun:test";
+
+import { NegotiationGraphFactory } from "../negotiation.graph.js";
+import { NegotiationGraphState } from "../negotiation.state.js";
+import { IndexNegotiator, type NegotiationAgentInput } from "../negotiation.agent.js";
+import { NegotiationStallGapAuthor } from "../negotiation.stall-gap.js";
+import type { ChecklistDraftItem } from "../negotiation.checklist.contracts.js";
+import type { NegotiationTurn } from "../negotiation.state.js";
+import type { QuestionerEnqueuePayload } from "../../questions/question.input.js";
+
+/**
+ * A task's FIRST turn can park.
+ *
+ * The ask-user binding capture locks the task row `state = 'working'` and
+ * refuses anything else — the integrity fence that makes the captured marker
+ * the only settlement coordinate the timeout/answer paths accept. But the graph
+ * announced `working` only at the END of a completed turn, so on a task's first
+ * turn the row still held its creation state (`submitted`) and the park died on
+ * "Ask-user material binding is no longer valid" — after the turn was already on
+ * the record, which makes the failure unretryable and stalls the opportunity.
+ *
+ * Latent since the turn-0 pre-contact consult shipped (#1455) and never hit,
+ * because no first-turn ask was ever drafted. The conclusion floor (#1464) made
+ * first-turn asks routine and the first one in this system's history died here.
+ *
+ * What this file pins is the sequencing, and the stub is the regression net:
+ * `captureNegotiationAskUserBinding` here ASSERTS the task's state exactly as
+ * the api adapter does, so a park that binds against a non-working task fails
+ * the spec instead of passing it — which is why the twenty-five specs that
+ * already cover this loop all missed the bug.
+ *
+ * Harness mirrors `negotiation.conclude-floor.spec.ts`: stubbed database and
+ * dispatcher, scripted agent turns, no live provider.
+ */
+
+type FakeMessage = {
+  id: string;
+  senderId: string;
+  role: "agent";
+  parts: unknown[];
+  createdAt: Date;
+};
+
+const dimension = (
+  name: string,
+  kind: ChecklistDraftItem["kind"],
+  result: ChecklistDraftItem["result"],
+  basis = "",
+): ChecklistDraftItem => ({ name, kind, result, basis });
+
+/** Two dimensions scored, one open and the client's own to settle. */
+const OPEN_CHECKLIST: ChecklistDraftItem[] = [
+  dimension("Mutual want", "mutual_want", "ok", "Alice's intent seeks an ML engineer; Bob's seeks applied ML work"),
+  dimension("Studio operations experience", "fit", "unknown"),
+  dimension("Stage fit", "fit", "ok", "Bob's intent names early-stage product work"),
+];
+
+const QUESTION = {
+  title: "Studio operations",
+  prompt: "Does the studio side have to be hands-on, or is adjacent tooling work in scope?",
+  options: [
+    { label: "Hands-on only", description: "I want someone who has run one." },
+    { label: "Adjacent tooling is fine", description: "Building for studios counts." },
+  ],
+  multiSelect: false,
+};
+
+const turn = (
+  action: string,
+  reasoning: string,
+  extra: Partial<NegotiationTurn> = {},
+): NegotiationTurn => ({
+  action,
+  assessment: { reasoning, suggestedRoles: { ownUser: "peer", otherUser: "peer" } },
+  message: null,
+  ...extra,
+} as NegotiationTurn);
+
+const said = (
+  action: string,
+  message: string,
+  checklist: ChecklistDraftItem[] = OPEN_CHECKLIST,
+) => turn(action, `${action} turn`, { message, checklist } as Partial<NegotiationTurn>);
+
+/**
+ * Built per use, never shared: the graph rewrites `turn.action` in place on the
+ * object the agent returned, so a module-level fixture handed to two tests is
+ * silently rewritten by the first one.
+ */
+const askTurn = (checklist: ChecklistDraftItem[] = OPEN_CHECKLIST): NegotiationTurn =>
+  turn("ask_user", "one unknown stands between me and a verdict", {
+    askUser: {
+      reason: "unresolved_owner_constraint",
+      question: QUESTION,
+      dimension: "Studio operations experience",
+    },
+    checklist,
+  } as Partial<NegotiationTurn>);
+
+const OPENING = "Alice is hiring an ML engineer with studio operations experience.";
+
+/** A persisted message row, as the graph's own readers expect to find one. */
+const turnMsg = (userId: string, data: NegotiationTurn, index: number): FakeMessage => ({
+  id: `prior-${index}`,
+  senderId: `agent:${userId}`,
+  role: "agent",
+  parts: [{ kind: "data", data }],
+  createdAt: new Date(Date.now() + index),
+});
+
+/** The prior session this negotiation is resumed from — one outreach, on the record. */
+const priorSession = (): FakeMessage[] => [turnMsg("u-src", said("outreach", OPENING), 0)];
+
+function mkStubs(opts?: {
+  priorMessages?: FakeMessage[];
+  /** Fail the capture for a reason that is NOT the task state, to pin the failure path. */
+  bindingAmbiguous?: boolean;
+}) {
+  const createdMessages: Array<{ senderId: string; parts: Array<{ kind: string; data: NegotiationTurn }> }> = [];
+  const stateWrites: Array<{ taskId: string; state: string }> = [];
+  const opportunityStatuses: string[] = [];
+  const failedTurns: Array<Record<string, unknown>> = [];
+  /** The task rows this run touches, and the state each is actually in. */
+  const taskStates = new Map<string, string>();
+  /** The state each binding capture found the task in — the whole point of this file. */
+  const captureStates: string[] = [];
+
+  const database = {
+    getOrCreateDM: async () => ({ id: "conv-1" }),
+    createTask: async (conversationId: string) => {
+      // Tasks are created `submitted`; nothing else sets them working.
+      taskStates.set("task-new", "submitted");
+      return { id: "task-new", conversationId, state: "submitted" };
+    },
+    updateOpportunityStatus: async (_id: string, status: string) => { opportunityStatuses.push(status); },
+    createMessage: async (p: { senderId: string; parts: Array<{ kind: string; data: NegotiationTurn }> }) => {
+      createdMessages.push(p);
+      return { id: `msg-${createdMessages.length}`, senderId: p.senderId, parts: p.parts, createdAt: new Date() };
+    },
+    updateTaskState: async (taskId: string, state: string) => {
+      taskStates.set(taskId, state);
+      stateWrites.push({ taskId, state });
+    },
+    createArtifact: async () => ({ id: "art-1" }),
+    setTaskTurnContext: async () => {},
+    setTaskFailedTurns: async (_taskId: string, failures: Array<Record<string, unknown>>) => {
+      failedTurns.splice(0, failedTurns.length, ...failures);
+    },
+    captureNegotiationAskUserBinding: async (input: Record<string, unknown>) => {
+      const observed = taskStates.get(input.taskId as string) ?? "missing";
+      captureStates.push(observed);
+      // THE FENCE, as the api adapter enforces it: the capture selects the task
+      // row `FOR UPDATE` with `state = 'working'` and throws when it finds no
+      // such row. A stub that skips this check is why the loop's existing specs
+      // never saw a first-turn park fail.
+      if (observed !== "working") throw new Error("Ask-user material binding is no longer valid");
+      if (opts?.bindingAmbiguous) throw new Error("Ask-user opportunity actor binding is ambiguous");
+      return {
+        version: 2 as const,
+        settlementId: input.settlementId as string,
+        recipientUserId: input.recipientUserId as string,
+        recipientIntentId: input.recipientIntentId as string,
+        opportunityId: input.opportunityId as string,
+        networkId: input.networkId as string,
+        intentFingerprint: "fp-src",
+        opportunityStatus: "pending",
+        opportunityUpdatedAt: "2026-01-01T00:00:00.000Z",
+        counterpartyUserId: "u-cand",
+        counterpartyIntentId: "intent-cand",
+      };
+    },
+    getMessagesForConversation: async () => opts?.priorMessages ?? [],
+    getNegotiationMessages: async () => opts?.priorMessages ?? [],
+    getOpportunityUserAnswers: async () => [],
+    getNegotiationTaskForOpportunity: async () => null,
+    getLatestNegotiationTaskForConversation: async () => null,
+    getTask: async () => null,
+    getUserContext: async () => ({ text: "Alice builds AI startups" }),
+    getTasksForUser: async () => [],
+    getArtifactsForTask: async () => [],
+  } as unknown as ConstructorParameters<typeof NegotiationGraphFactory>[0];
+
+  const dispatcher = {
+    hasExternalAgent: async () => false,
+    dispatch: async () => ({ handled: false, reason: "no_agent" }),
+  } as unknown as ConstructorParameters<typeof NegotiationGraphFactory>[1];
+
+  const timeoutQueue = {
+    enqueueTimeout: async () => "job-1",
+    cancelTimeout: async () => {},
+    enqueueAskUserExpiry: async () => "askuser-job-1",
+    cancelAskUserExpiry: async () => {},
+  } as unknown as ConstructorParameters<typeof NegotiationGraphFactory>[2];
+
+  const questionerEnqueues: QuestionerEnqueuePayload[] = [];
+  const questionerEnqueue = async (input: QuestionerEnqueuePayload) => { questionerEnqueues.push(input); };
+
+  return {
+    database, dispatcher, timeoutQueue, questionerEnqueue,
+    createdMessages, stateWrites, questionerEnqueues, opportunityStatuses,
+    captureStates, failedTurns,
+  };
+}
+
+async function runGraph(stubs: ReturnType<typeof mkStubs>, input: Record<string, unknown> = {}) {
+  const graph = new NegotiationGraphFactory(
+    stubs.database, stubs.dispatcher, stubs.timeoutQueue, stubs.questionerEnqueue,
+  ).createGraph();
+  return graph.invoke({
+    sourceUser: {
+      id: "u-src",
+      intents: [{ id: "intent-src", title: "Hire an ML engineer", description: "Looking for applied ML depth", confidence: 1 }],
+      profile: { name: "Alice", bio: "PM", skills: ["evals"] },
+    },
+    candidateUser: {
+      id: "u-cand",
+      intents: [{ id: "intent-cand", title: "Join an AI product", description: "Wants applied ML work", confidence: 1 }],
+      profile: { name: "Bob", bio: "ML engineer", skills: ["ml"] },
+    },
+    sourceIntentId: "intent-src",
+    candidateIntentId: "intent-cand",
+    indexContext: { networkId: "net-1", prompt: "AI network" },
+    seedAssessment: { reasoning: "complementary", valencyRole: "peer" },
+    opportunityId: "opp-1",
+    maxTurns: 6,
+    ...input,
+  } as Partial<typeof NegotiationGraphState.State>);
+}
+
+const persistedActions = (stubs: ReturnType<typeof mkStubs>) =>
+  stubs.createdMessages.map((message) => message.parts[0].data.action);
+
+const persistedTurns = (stubs: ReturnType<typeof mkStubs>) =>
+  stubs.createdMessages.map((message) => message.parts[0].data);
+
+const states = (stubs: ReturnType<typeof mkStubs>) => stubs.stateWrites.map((write) => write.state);
+
+let agentInputs: NegotiationAgentInput[] = [];
+let agentScript: NegotiationTurn[] = [];
+
+describe("a first-turn ask parks", () => {
+  let origAgentInvoke: typeof IndexNegotiator.prototype.invoke;
+  let origStallGapAuthor: typeof NegotiationStallGapAuthor.prototype.author;
+  const originals: Record<string, string | undefined> = {};
+
+  beforeAll(() => {
+    origAgentInvoke = IndexNegotiator.prototype.invoke;
+    IndexNegotiator.prototype.invoke = async function (input: NegotiationAgentInput) {
+      agentInputs.push(input);
+      const next = agentScript.shift();
+      if (!next) throw new Error("agent script exhausted");
+      return next;
+    };
+    origStallGapAuthor = NegotiationStallGapAuthor.prototype.author;
+    NegotiationStallGapAuthor.prototype.author = async function () { return null; };
+    for (const key of ["NEGOTIATION_ASK_USER_ENABLED", "NEGOTIATION_CONSULTATION_POLICY_MODE", "NEGOTIATION_PROTOCOL_VERSION", "NEGOTIATION_SCREEN_MODE", "NEGOTIATOR_STANCE"]) {
+      originals[key] = process.env[key];
+    }
+  });
+
+  afterAll(() => {
+    IndexNegotiator.prototype.invoke = origAgentInvoke;
+    NegotiationStallGapAuthor.prototype.author = origStallGapAuthor;
+  });
+
+  beforeEach(() => {
+    agentInputs = [];
+    agentScript = [];
+    // The dev configuration this ships into.
+    process.env.NEGOTIATION_ASK_USER_ENABLED = "true";
+    process.env.NEGOTIATION_CONSULTATION_POLICY_MODE = "on";
+    process.env.NEGOTIATION_PROTOCOL_VERSION = "v2";
+    process.env.NEGOTIATION_SCREEN_MODE = "off";
+    process.env.NEGOTIATOR_STANCE = "skeptic";
+  });
+
+  afterEach(() => {
+    for (const [key, value] of Object.entries(originals)) {
+      if (value === undefined) delete process.env[key]; else process.env[key] = value;
+    }
+  });
+
+  // THE DECISIVE SPEC — the live shape, turn 0 of a resumed session.
+  it("binds against a working task when the agent asks on its very first turn", async () => {
+    const stubs = mkStubs({ priorMessages: priorSession() });
+    agentScript = [askTurn()];
+
+    await runGraph(stubs);
+
+    // The capture found the task WORKING — before this fix it found `submitted`
+    // and the park threw.
+    expect(stubs.captureStates).toEqual(["working"]);
+    // And the flip came before the capture, not after the turn.
+    expect(states(stubs)).toEqual(["working", "input_required"]);
+    expect(persistedActions(stubs)).toEqual(["ask_user"]);
+    expect(stubs.questionerEnqueues).toHaveLength(1);
+    expect(stubs.questionerEnqueues[0].negotiation.taskId).toBe("task-new");
+    // Nothing was concluded on the client's behalf.
+    expect(stubs.opportunityStatuses).not.toContain("rejected");
+  });
+
+  it("binds against a working task when the conclusion floor fires the ask itself on turn 0", async () => {
+    const stubs = mkStubs({ priorMessages: priorSession() });
+    // The observed shape: the resumed session's first turn concludes over an
+    // open dimension, is refused, concludes again — and the graph asks.
+    agentScript = [
+      turn("accept", "good enough to meet on", { checklist: OPEN_CHECKLIST } as Partial<NegotiationTurn>),
+      turn("accept", "still good enough", { checklist: OPEN_CHECKLIST } as Partial<NegotiationTurn>),
+    ];
+
+    await runGraph(stubs);
+
+    expect(stubs.captureStates).toEqual(["working"]);
+    expect(states(stubs)).toEqual(["working", "input_required"]);
+    expect(persistedActions(stubs)).toEqual(["ask_user"]);
+    const parked = persistedTurns(stubs)[0];
+    expect(parked.askUser).toEqual({
+      reason: "unresolved_owner_constraint",
+      dimension: "Studio operations experience",
+      guaranteed: true,
+    });
+    expect(stubs.questionerEnqueues).toHaveLength(1);
+    expect(stubs.opportunityStatuses).not.toContain("accepted");
+  });
+
+  it("binds against a working task for the turn-0 pre-contact consult", async () => {
+    // No prior turns at all: the initiator consults its client BEFORE reaching
+    // out, on a task whose first turn this also is.
+    const stubs = mkStubs();
+    agentScript = [askTurn([])];
+
+    await runGraph(stubs);
+
+    expect(stubs.captureStates).toEqual(["working"]);
+    expect(states(stubs)).toEqual(["working", "input_required"]);
+    expect(persistedActions(stubs)).toEqual(["ask_user"]);
+    expect(stubs.questionerEnqueues[0].negotiation.recipientUserId).toBe("u-src");
+  });
+
+  it("leaves a later-turn ask exactly as it was — the end-of-turn flip still runs", async () => {
+    const stubs = mkStubs();
+    agentScript = [said("outreach", OPENING), askTurn()];
+
+    await runGraph(stubs);
+
+    expect(persistedActions(stubs)).toEqual(["outreach", "ask_user"]);
+    expect(stubs.captureStates).toEqual(["working"]);
+    // The completed outreach turn's own flip, then the park's — same state
+    // twice is a no-op update, and the second one is what the fence reads.
+    expect(states(stubs)).toEqual(["working", "working", "input_required"]);
+    expect(stubs.questionerEnqueues).toHaveLength(1);
+  });
+
+  it("still fails the turn when the binding is genuinely invalid", async () => {
+    // The fence is not loosened, only sequenced: a capture that fails for a
+    // real reason still ends the turn as a failure rather than crashing the
+    // graph or parking a negotiation nothing can settle.
+    const stubs = mkStubs({ priorMessages: priorSession(), bindingAmbiguous: true });
+    agentScript = [askTurn()];
+
+    await runGraph(stubs);
+
+    expect(stubs.captureStates).toEqual(["working"]);
+    // No park state after the flip: the turn reached the record and then
+    // failed, and finalize closed the task out as it does for any failed turn.
+    expect(states(stubs)).toEqual(["working", "completed"]);
+    expect(persistedActions(stubs)).toEqual(["ask_user"]);
+    expect(stubs.questionerEnqueues).toHaveLength(0);
+    expect(stubs.failedTurns).toHaveLength(1);
+    expect(stubs.failedTurns[0].error).toBe("Ask-user opportunity actor binding is ambiguous");
+  });
+});


### PR DESCRIPTION
## The bug, observed live

The first `ask_user` in this system's history — fired by #1464's conclusion floor on the first turn of a resumed session (Hye-jin ↔ Mira, dimension "Studio Operations Experience") — died at the park:

```
error: "Ask-user material binding is no longer valid"
→ turnPersisted:true, consecutiveTurnFailures:1 → outcome agent_error → opportunity stalled
```

`captureNegotiationAskUserBinding` selects the task row `FOR UPDATE` with `eq(tasks.state,'working')` and throws when it finds no such row — the integrity fence that makes the captured marker the only settlement coordinate the timeout/answer paths accept. The graph only ever announced `working` at the END of a completed turn (`negotiation.graph.turn.ts:1516`, after the ask-park branch has already returned), so on a task's FIRST turn the row still held its creation state (`submitted`) and no first-turn park could bind. The turn was already on the record when the capture threw, so the failure was not even retryable: the whole opportunity ended as `agent_error`.

Latent since the turn-0 pre-contact consult shipped (#1455) and never once hit, because no first-turn ask was ever drafted — sessions opened with outreach. #1464 made first-turn asks routine, and a run-existing continuation's turn 0 is the common case.

## The fix

One line in `turnNode`: announce `working` immediately before the binding capture, carrying the same `state.continuationExecution` fence as every other state write, so a zombie duplicate execution still cannot write.

The adapter is untouched. `working` is the true precondition for a settlement coordinate — what was wrong was the sequencing, not the check. `updateTaskState` is an unconditional row update, so the same state twice is a harmless no-op and the end-of-turn flip stays for every path that does not park.

**Why at the park rather than at the top of the turn.** The watchdog reclaims a stale `submitted` task after ten minutes (on `createdAt`) but a stale `working` one only after twelve hours (on `updatedAt`). Flipping at turn start would hide a task that dies before putting anything on the record under the twelve-hour rule. At the park the turn IS on the record, so `working` is simply true there.

Scope check: `captureNegotiationAskUserBinding` has exactly one caller, so the screen path and the post-stall park are unaffected; the `waiting_for_agent` dispatch branch sets its own state and is untouched.

## Tests

New `negotiation.first-turn-park.spec.ts` (scripted harness, no live provider). The regression net is the stub: its `captureNegotiationAskUserBinding` asserts the task's state exactly as the adapter does — which is why the twenty-five specs already covering this loop all passed through the bug.

- a FIRST-turn agent-drafted ask parks: capture sees `working`, state sequence `working → input_required`, questioner enqueued
- a FIRST-turn floor-guaranteed ask (scripted dodge over an unknown dimension) parks the same way
- the turn-0 pre-contact consult parks (the #1455 latent case)
- a later-turn ask is unchanged — `working` (end of the outreach turn), `working` (park), `input_required`
- a capture that fails for a REAL reason still ends the turn as a failure rather than crashing or parking something nothing can settle

All 5 fail without the fix. Protocol negotiation suite: 655 pass, 2 fail — both the known live-LLM judgment flakes in `negotiator-discovery-query.spec.ts`, unrelated to task state. `tsc` clean via `build:package:protocol`.

Protocol patch bump to 23.3.1 + changelog + lockfile sync. No api changes, no flags.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NuyBfDZheSvypY3NHSWZc8