### PR TITLE
fix(negotiations): an answer to an open question is not a change of signal

### DIFF
--- a/packages/protocol/src/chat/negotiator.persona.ts
+++ b/packages/protocol/src/chat/negotiator.persona.ts
@@ -2,7 +2,7 @@ import { createChatTools, type ChatTools, type ToolContext, type ResolvedToolCon
 import { focusedIntentId, type ToolScopeEnvelope } from "../shared/agent/tool.scope.js";
 import type { ChatPersonaConfig } from "./chat.persona.js";
 import { buildNegotiatorSystemContent, type NegotiatorPromptOptions } from "./negotiator.prompt.js";
-import { createNegotiatorMemoryTools } from "./negotiator.tools.js";
+import { createNegotiatorAnswerTools, createNegotiatorMemoryTools } from "./negotiator.tools.js";
 
 // ═══════════════════════════════════════════════════════════════════════════════
 // NEGOTIATOR PERSONA (P4.1)
@@ -128,15 +128,28 @@ export async function createNegotiatorTools(
   // AFTER the allowlist filter, and only when the composition root injected
   // the host bridge (i.e. negotiator memory writes are enabled). They never
   // enter the shared registry, so the orchestrator cannot see them.
+  const extra: ChatTools = [];
   if (deps.negotiatorMemoryTools) {
-    const memoryTools = createNegotiatorMemoryTools({
+    extra.push(...createNegotiatorMemoryTools({
       host: deps.negotiatorMemoryTools,
       userId: deps.userId,
       ...(deps.sessionId ? { sessionId: deps.sessionId } : {}),
-    });
-    return [...contextFiltered, ...memoryTools] as ChatTools;
+    }));
   }
-  return contextFiltered;
+  // #1466: `answer_pending_question` is the long-tail lane for a reply the
+  // deterministic precedence gate declined. Registered only in an
+  // intent-pinned session — an open question lives in one signal's DM, so a
+  // question number with no signal behind it would route nowhere — and only
+  // when the composition root injected the host.
+  const pinnedIntentId = focusedIntentId(toolScope);
+  if (deps.negotiatorAnswerTools && pinnedIntentId) {
+    extra.push(...createNegotiatorAnswerTools({
+      host: deps.negotiatorAnswerTools,
+      userId: deps.userId,
+      intentId: pinnedIntentId,
+    }));
+  }
+  return (extra.length > 0 ? [...contextFiltered, ...extra] : contextFiltered) as ChatTools;
 }
 
 /**

--- a/packages/protocol/src/chat/negotiator.prompt.ts
+++ b/packages/protocol/src/chat/negotiator.prompt.ts
@@ -46,6 +46,17 @@ export interface NegotiatorPromptOptions {
    * tool-reference rows; false/absent → prompt unchanged.
    */
   memoryToolsEnabled?: boolean;
+  /**
+   * The questions currently OPEN in this signal's DM, in the order the
+   * question-message lists them — one label per question (its checklist
+   * dimension, or a short form of its prompt). Rendered as the open-question
+   * section, and the numbers the model is shown here are exactly the numbers
+   * `answer_pending_question` takes.
+   *
+   * Only meaningful in an intent-pinned session, where the tool is registered.
+   * Absent/empty → the prompt is byte-identical to before.
+   */
+  openQuestions?: string[];
 }
 
 /**
@@ -58,7 +69,7 @@ function buildPinnedSignalSection(intentId: string, label?: string): string {
   return `
 ## Pinned signal
 This conversation was opened from one of the client's signals (intent id: ${intentId}${labelLine}). Treat it as the working focus of this chat:
-- When one of your negotiations for this signal parks needing the client's input, the open questions appear here as your own question message. Work through them conversationally; the client's replies are routed back to the parked negotiations automatically.
+- When one of your negotiations for this signal parks needing the client's input, the open questions appear here as your own question message. Work through them conversationally; a reply that plainly answers one is routed back to the parked negotiation before you ever see it.
 - Matches for this signal are already visible in the adjacent Radar. Do not repeat them or bulk-list them in chat. When the client explicitly references a match, use its opportunity and negotiation records to explain it or act on it; update_opportunity remains available only for their explicit instruction.
 - When summarizing negotiations, always state the scope: say “for this signal” for the default pinned view, or “across all your signals” when the client explicitly asks for full history. Separate CURRENT items (active or waiting on you) from CONCLUDED AGENT NEGOTIATIONS. If there are zero current items, say that plainly before mentioning concluded history. A concluded agent negotiation is not a completed connection. Never imply an ongoing negotiation that the same-turn list_negotiations result does not show.
 - When the client restates or sharpens what they want here, propose an update to this signal (update_intent) or a new premise — on their confirmation — so background matching reflects it.
@@ -79,6 +90,30 @@ When one of your negotiations parks needing the client's input, a question messa
 - When the client asks what needs their attention, point them at their signals' conversations and summarize what is waiting there in plain language.
 - When the client asks why something is being asked, explain the question's context from the record it came from (the negotiation, opportunity, or signal behind it) — look it up, don't guess.
 - Never pressure the client to answer; a parked negotiation keeps until they do.`;
+}
+
+/**
+ * Renders the open-question section for an intent-pinned session (#1466).
+ *
+ * The client's own agent is waiting on them for a named thing, and until this
+ * existed the persona had no way to know it — so a message that answered the
+ * question looked like nothing but a chance to sharpen the signal, and got
+ * treated as one.
+ *
+ * Only the LONG TAIL reaches this prompt at all: a reply that plainly answers
+ * an open question is routed by the answer evaluator before this persona runs.
+ * What is left is oblique, late, or mixed — which is exactly the material that
+ * needs the routing to be an explicit act.
+ */
+function buildOpenQuestionsSection(userName: string, openQuestions: string[]): string {
+  const list = openQuestions.map((label, index) => `${index + 1}. “${label}”`).join("\n");
+  return `
+## An open question is waiting on ${userName}
+One or more of your negotiations for this signal are parked until ${userName} answers. What is waiting, in the order your question message lists it:
+${list}
+- If their message answers one of these — even obliquely, even late, even folded into something else — call answer_pending_question with that number and what they said. It is the only thing that resumes the negotiation.
+- An answer is not a change of signal. While a question above is open, do NOT update this signal on the strength of a message that answers it: route the answer first. If they are genuinely doing both, say back what you understood as each and get their confirmation before you change the signal.
+- Never pressure them to answer, and never claim a negotiation resumed without a successful tool result for it.`;
 }
 
 /**
@@ -127,6 +162,15 @@ export function buildNegotiatorSystemContent(
   const pinnedSignalSection = pinnedIntentId
     ? buildPinnedSignalSection(pinnedIntentId, opts.pinnedIntentLabel)
     : buildQuestionInboxSection();
+  // Only in a pinned session: the tool that acts on this section is registered
+  // there and nowhere else, so naming open questions anywhere else would
+  // describe a capability the model does not have.
+  const openQuestionsSection = pinnedIntentId && opts.openQuestions?.length
+    ? buildOpenQuestionsSection(ctx.userName, opts.openQuestions)
+    : "";
+  const answerToolRow = pinnedIntentId && opts.openQuestions?.length
+    ? "\n| **answer_pending_question** | question, answer | Route what the client just said to one of the open questions above — the only thing that resumes a parked negotiation |"
+    : "";
   const memorySection = renderNegotiatorChatMemorySection(opts.memory ?? []);
   const memoryToolsSection = opts.memoryToolsEnabled ? buildMemoryToolsSection() : "";
   const memoryToolsRows = opts.memoryToolsEnabled
@@ -164,7 +208,7 @@ ${signalGuidance}
 - **Handle memberships**: list the communities they belong to and join or leave communities when they ask.
 - **Manage their contacts**: look up, add, remove, or import contacts when they ask (when contact features are enabled).
 - **Act on instruction**: every write — a negotiation response, an opportunity decision, a signal, a profile or premise change, a membership change, a contact change — happens only when the client explicitly asks for it in this conversation. Never write anything the client did not just ask for.
-${pinnedSignalSection}${memorySection}${memoryToolsSection}
+${pinnedSignalSection}${openQuestionsSection}${memorySection}${memoryToolsSection}
 ## What you cannot do here
 - **No direct discovery.** You cannot run matching or search for people yourself. Matching happens automatically in the background from the client's signals — shaping the signals is how you steer it. ${matchVisibility}
 - **No community administration.** You can join or leave communities for the client, but you cannot create, rename, or delete communities — point them to the app for that.
@@ -200,7 +244,7 @@ ${profileContext}
 | **read_networks** / **read_network_memberships** | — | The client's communities and memberships |
 | **create_network_membership** / **delete_network_membership** | networkId | Join/leave a community on instruction |
 | **list_contacts** / **search_contacts** / **remove_contact** | ... | The client's contacts |
-| **scrape_url** | url, objective | Read a link the client pasted (e.g. before drafting a signal from it) |${memoryToolsRows}
+| **scrape_url** | url, objective | Read a link the client pasted (e.g. before drafting a signal from it) |${answerToolRow}${memoryToolsRows}
 
 ## Grounding rules
 - **Never fabricate.** Every claim about a negotiation, opportunity, signal, or premise must come from a tool result in this conversation. If you have not looked it up this turn, look it up before answering. Only the client's identity and profile above are preloaded.

--- a/packages/protocol/src/chat/negotiator.tools.ts
+++ b/packages/protocol/src/chat/negotiator.tools.ts
@@ -1,6 +1,7 @@
 import { tool } from "@langchain/core/tools";
 import { z } from "zod";
 import type { NegotiatorMemoryToolsHost, NegotiatorMemoryToolView } from "../shared/interfaces/negotiator-memory.interface.js";
+import type { NegotiatorAnswerToolsHost } from "../shared/interfaces/negotiator-answer.interface.js";
 import { protocolLogger } from "../shared/observability/protocol.logger.js";
 
 // ═══════════════════════════════════════════════════════════════════════════════
@@ -158,4 +159,110 @@ export function createNegotiatorMemoryTools(opts: {
   );
 
   return [remember, forget];
+}
+
+// ═══════════════════════════════════════════════════════════════════════════════
+// ANSWER ROUTING TOOL (#1466)
+// ═══════════════════════════════════════════════════════════════════════════════
+//
+// `answer_pending_question` is the LONG TAIL of answer routing, not its spine.
+// The spine is deterministic and upstream of this persona entirely: while a
+// signal's DM has an open question, a free-text reply is offered to the answer
+// evaluator before the orchestrator runs, and an accepted answer never reaches
+// a model with tools at all. What reaches here is what the evaluator declined
+// — an oblique answer, a late one, or one folded into a message that is also
+// doing something else.
+//
+// It exists because before it the persona had exactly one thing it could do
+// with such a message: edit the client's signal. On 2026-08-20 it did, to a
+// two-word reply that was answering a parked negotiation's question.
+//
+// Registered only when the composition root injects the host AND the session
+// is pinned to a signal: an open question lives in one signal's DM, and a
+// number with no scope behind it would route nowhere.
+
+const answerLogger = protocolLogger("NegotiatorAnswerTools");
+
+const AnswerPendingQuestionSchema = z.object({
+  question: z
+    .number()
+    .int()
+    .min(1)
+    .describe("Which open question is being answered, by the number shown in your context."),
+  answer: z
+    .string()
+    .min(1)
+    .max(4000)
+    .describe(
+      "What the client said in answer to it, in their own words, restated only enough to stand alone. Never add a preference, constraint, or detail they did not state.",
+    ),
+});
+
+/**
+ * Creates the negotiator persona's `answer_pending_question` tool, bound to
+ * the acting client and the signal this session is pinned to.
+ */
+export function createNegotiatorAnswerTools(opts: {
+  host: NegotiatorAnswerToolsHost;
+  userId: string;
+  intentId: string;
+}) {
+  const { host, userId, intentId } = opts;
+
+  const answerPendingQuestion = tool(
+    async (query: z.infer<typeof AnswerPendingQuestionSchema>) => {
+      answerLogger.info("Tool invoked", { toolName: "answer_pending_question", userId, question: query.question });
+      try {
+        const result = await host.answerOpenQuestion(userId, {
+          intentId,
+          question: query.question,
+          answer: query.answer,
+        });
+        switch (result.status) {
+          case "routed":
+            return JSON.stringify({
+              status: "routed",
+              question: result.label,
+              message:
+                "The answer is on its way to the negotiation that was waiting on it. Confirm to the client in one short sentence what you took as their answer, and do not also change their signal on the strength of it.",
+            });
+          case "no_open_question":
+            return JSON.stringify({
+              status: "no_open_question",
+              message:
+                "Nothing is waiting on the client for this signal any more — the negotiations moved on. Tell them that plainly rather than implying their answer was recorded.",
+            });
+          case "unknown_question":
+            return JSON.stringify({
+              status: "unknown_question",
+              open: result.open,
+              message:
+                "That number does not name an open question. Re-read the open questions in your context and call this again with the right one, or ask the client which they meant.",
+            });
+          case "error":
+            return JSON.stringify({
+              status: "error",
+              message: "Could not route that answer. Tell the client honestly that it did not go through.",
+            });
+        }
+      } catch (err) {
+        answerLogger.error("Tool failed", {
+          toolName: "answer_pending_question",
+          error: err instanceof Error ? err.message : String(err),
+        });
+        return JSON.stringify({
+          status: "error",
+          message: "Could not route that answer. Tell the client honestly that it did not go through.",
+        });
+      }
+    },
+    {
+      name: "answer_pending_question",
+      description:
+        "Route what the client just said to one of the open questions waiting on them for this signal, resuming the negotiation that was parked on it. Use it whenever their message answers one — even obliquely, even mixed with something else. This is the ONLY thing that resumes a parked negotiation; editing their signal does not.",
+      schema: AnswerPendingQuestionSchema,
+    },
+  );
+
+  return [answerPendingQuestion];
 }

--- a/packages/protocol/src/chat/tests/negotiator.answer-tools.spec.ts
+++ b/packages/protocol/src/chat/tests/negotiator.answer-tools.spec.ts
@@ -1,0 +1,150 @@
+/**
+ * #1466 — the negotiator's `answer_pending_question` tool and the open-question
+ * section it acts on.
+ *
+ * This is the LONG TAIL of answer routing, not its spine: a reply that plainly
+ * answers an open question is routed by the answer evaluator before this
+ * persona runs at all. What is pinned here is that the persona can route an
+ * oblique or late one EXPLICITLY — and that it is told, in the same breath,
+ * not to rewrite the client's signal from a message that answers a question.
+ * That substitution is what happened on 2026-08-20, when the persona's only
+ * available move on such a message was to edit the signal.
+ *
+ * The tool sees positions, never ids: the mapping onto negotiation refs lives
+ * on the host, for the same reason the answer router never sees one.
+ */
+import { describe, expect, it } from "bun:test";
+
+import { createNegotiatorAnswerTools } from "../negotiator.tools.js";
+import { buildNegotiatorSystemContent } from "../negotiator.prompt.js";
+import type { NegotiatorAnswerRoutingResult, NegotiatorAnswerToolsHost } from "../../shared/interfaces/negotiator-answer.interface.js";
+import type { ResolvedToolContext } from "../../shared/agent/tool.factory.js";
+
+const AGENT_OPTS = { agentName: "Alice's Negotiator" };
+
+function makeCtx(overrides: Partial<ResolvedToolContext> = {}): ResolvedToolContext {
+  return {
+    userId: "user-1",
+    userName: "Alice Test",
+    userEmail: "alice@example.com",
+    user: { id: "user-1", name: "Alice Test", email: "alice@example.com" },
+    userProfile: null,
+    userNetworks: [],
+    isOwner: false,
+    isOnboarding: false,
+    hasName: true,
+    ...overrides,
+  } as unknown as ResolvedToolContext;
+}
+
+const pinnedCtx = makeCtx({ scopeType: "intent", scopeId: "intent-42" } as Partial<ResolvedToolContext>);
+
+function makeHost(result: NegotiatorAnswerRoutingResult): {
+  host: NegotiatorAnswerToolsHost;
+  calls: Array<{ userId: string; input: { intentId: string; question: number; answer: string } }>;
+} {
+  const calls: Array<{ userId: string; input: { intentId: string; question: number; answer: string } }> = [];
+  return {
+    calls,
+    host: {
+      answerOpenQuestion: async (userId, input) => {
+        calls.push({ userId, input });
+        return result;
+      },
+    },
+  };
+}
+
+const invoke = async (tool: { invoke: (input: unknown) => Promise<unknown> }, input: unknown) =>
+  JSON.parse(String(await tool.invoke(input))) as Record<string, unknown>;
+
+describe("createNegotiatorAnswerTools", () => {
+  it("routes a position and the client's own words to the host, bound to the pinned signal", async () => {
+    const { host, calls } = makeHost({ status: "routed", label: "Timing: This week" });
+    const [answer] = createNegotiatorAnswerTools({ host, userId: "user-1", intentId: "intent-42" });
+
+    const result = await invoke(answer as never, { question: 1, answer: "This month." });
+
+    expect(calls).toEqual([{
+      userId: "user-1",
+      input: { intentId: "intent-42", question: 1, answer: "This month." },
+    }]);
+    expect(result.status).toBe("routed");
+    expect(result.question).toBe("Timing: This week");
+    // The confirmation it is told to give must not become a signal edit.
+    expect(String(result.message)).toContain("do not also change their signal");
+  });
+
+  it("tells the client honestly when nothing is open any more", async () => {
+    const { host } = makeHost({ status: "no_open_question" });
+    const [answer] = createNegotiatorAnswerTools({ host, userId: "user-1", intentId: "intent-42" });
+
+    const result = await invoke(answer as never, { question: 1, answer: "This month." });
+
+    expect(result.status).toBe("no_open_question");
+    expect(String(result.message)).toContain("rather than implying their answer was recorded");
+  });
+
+  it("hands back the open count when the position names no open question", async () => {
+    const { host } = makeHost({ status: "unknown_question", open: 2 });
+    const [answer] = createNegotiatorAnswerTools({ host, userId: "user-1", intentId: "intent-42" });
+
+    const result = await invoke(answer as never, { question: 7, answer: "Yes." });
+
+    expect(result).toMatchObject({ status: "unknown_question", open: 2 });
+  });
+
+  it("never throws when the host does — the client keeps their turn", async () => {
+    const host: NegotiatorAnswerToolsHost = {
+      answerOpenQuestion: async () => { throw new Error("queue unavailable"); },
+    };
+    const [answer] = createNegotiatorAnswerTools({ host, userId: "user-1", intentId: "intent-42" });
+
+    const result = await invoke(answer as never, { question: 1, answer: "This month." });
+
+    expect(result.status).toBe("error");
+  });
+});
+
+describe("buildNegotiatorSystemContent — open questions in a pinned signal", () => {
+  it("names each open question by the number the tool takes", () => {
+    const prompt = buildNegotiatorSystemContent(pinnedCtx, {
+      ...AGENT_OPTS,
+      openQuestions: ["Timing: This week", "Budget"],
+    });
+
+    expect(prompt).toContain("## An open question is waiting on Alice Test");
+    expect(prompt).toContain("1. “Timing: This week”");
+    expect(prompt).toContain("2. “Budget”");
+    expect(prompt).toContain("answer_pending_question");
+  });
+
+  it("forbids editing the signal from a message that answers an open question", () => {
+    const prompt = buildNegotiatorSystemContent(pinnedCtx, {
+      ...AGENT_OPTS,
+      openQuestions: ["Timing: This week"],
+    });
+
+    expect(prompt).toContain("An answer is not a change of signal");
+    expect(prompt).toContain("route the answer first");
+  });
+
+  it("says nothing about the tool when no question is open — the prompt is unchanged", () => {
+    const withNone = buildNegotiatorSystemContent(pinnedCtx, AGENT_OPTS);
+    const withEmpty = buildNegotiatorSystemContent(pinnedCtx, { ...AGENT_OPTS, openQuestions: [] });
+
+    expect(withNone).not.toContain("answer_pending_question");
+    expect(withNone).not.toContain("An open question is waiting");
+    expect(withEmpty).toBe(withNone);
+  });
+
+  it("says nothing about the tool outside a pinned signal — the tool is not registered there", () => {
+    const unscoped = buildNegotiatorSystemContent(makeCtx(), {
+      ...AGENT_OPTS,
+      openQuestions: ["Timing: This week"],
+    });
+
+    expect(unscoped).not.toContain("answer_pending_question");
+    expect(unscoped).toContain("## Open questions");
+  });
+});

--- a/packages/protocol/src/chat/tests/negotiator.persona.spec.ts
+++ b/packages/protocol/src/chat/tests/negotiator.persona.spec.ts
@@ -147,7 +147,7 @@ describe("buildNegotiatorSystemContent — pinned signal (intent scope)", () => 
     }
     // Question guidance is conversational now: parked negotiations surface as
     // the negotiator's own question message; no record/answer tools remain.
-    expect(prompt).toContain("routed back to the parked negotiations automatically");
+    expect(prompt).toContain("routed back to the parked negotiation before you ever see it");
   });
 
   it("includes the human-readable label when provided", () => {
@@ -194,7 +194,7 @@ describe("buildNegotiatorSystemContent — open questions (DM)", () => {
     const prompt = buildNegotiatorSystemContent(scopedCtx, AGENT_OPTS);
     expect(prompt).not.toContain("## Open questions");
     expect(prompt).toContain("## Pinned signal");
-    expect(prompt).toContain("routed back to the parked negotiations automatically");
+    expect(prompt).toContain("routed back to the parked negotiation before you ever see it");
   });
 });
 

--- a/packages/protocol/src/shared/agent/tool.helpers.ts
+++ b/packages/protocol/src/shared/agent/tool.helpers.ts
@@ -22,6 +22,7 @@ import type { NegotiationTimeoutQueue } from "../interfaces/negotiation-events.i
 import type { AgentDispatcher } from "../interfaces/agent-dispatcher.interface.js";
 import type { DeliveryLedger } from "../interfaces/delivery-ledger.interface.js";
 import type { NegotiatorMemoryToolsHost } from "../interfaces/negotiator-memory.interface.js";
+import type { NegotiatorAnswerToolsHost } from "../interfaces/negotiator-answer.interface.js";
 import type { QuestionerEnqueueFn } from "../../questions/question.input.js";
 import type { EnrichmentRunQueue, EnrichmentRunStore } from "../interfaces/enrichment-run.interface.js";
 import type { McpActivityCaller } from "./activity-projection.js";
@@ -174,6 +175,14 @@ interface ToolContextBindings {
    * orchestrator registry never sees these tools.
    */
   negotiatorMemoryTools?: NegotiatorMemoryToolsHost;
+  /**
+   * Host bridge for the negotiator persona's `answer_pending_question` tool —
+   * the long-tail lane of answer routing, for replies the deterministic
+   * precedence gate declined. Injected by the composition root; consumed
+   * exclusively by the negotiator persona's toolset, and only in an
+   * intent-scoped session (the question lives in one signal's DM).
+   */
+  negotiatorAnswerTools?: NegotiatorAnswerToolsHost;
   /**
    * Resolve a user's global user_context paragraph (profile-replacing identity
    * text), generating it on demand when absent. Mirrors `ToolDeps.getUserContextText`

--- a/packages/protocol/src/shared/interfaces/negotiator-answer.interface.ts
+++ b/packages/protocol/src/shared/interfaces/negotiator-answer.interface.ts
@@ -1,0 +1,50 @@
+/**
+ * Host bridge for the negotiator persona's `answer_pending_question` tool.
+ *
+ * The deterministic path is the one that matters: while a signal's DM has an
+ * open question, a free-text reply is offered to the answer evaluator BEFORE
+ * this persona runs at all, and an accepted answer never reaches it. This tool
+ * is the LONG TAIL of that arrow — the client answers obliquely, or three
+ * turns later, or mixes an answer into a message that is also asking for
+ * something else. In those cases the evaluator declines and the conversation
+ * lands here, where routing an answer must be an explicit act rather than a
+ * side effect of editing the client's signal.
+ *
+ * Everything behind the seam — resolving the DM, re-checking that the question
+ * is still open, mapping the number the model was shown onto the negotiation
+ * ref, and enqueueing consumption on the serialized question-message queue —
+ * lives on the host. The protocol package only ever sees this surface, and
+ * only the negotiator persona's toolset receives it.
+ */
+
+/**
+ * What the host did with one routing attempt.
+ *
+ * - `routed`: the answer is on its way to the negotiation it unparks.
+ * - `no_open_question`: nothing is open in this scope any more — the parks
+ *   resolved, or another answer already settled them.
+ * - `unknown_question`: the number does not name a question that is open.
+ *   `open` is how many there are, so the model can re-read its own context
+ *   rather than guess again.
+ * - `error`: the host could not route it. The client must be told honestly.
+ */
+export type NegotiatorAnswerRoutingResult =
+  | { status: "routed"; label: string }
+  | { status: "no_open_question" }
+  | { status: "unknown_question"; open: number }
+  | { status: "error" };
+
+export interface NegotiatorAnswerToolsHost {
+  /**
+   * Route what the client just said to one open question of this signal's DM.
+   *
+   * @param userId - The acting client; the host scopes every read to them.
+   * @param input.intentId - The pinned signal whose DM holds the question.
+   * @param input.question - 1-based position, exactly as the prompt listed it.
+   * @param input.answer - What the client said, in their own words.
+   */
+  answerOpenQuestion(
+    userId: string,
+    input: { intentId: string; question: number; answer: string },
+  ): Promise<NegotiatorAnswerRoutingResult>;
+}

--- a/services/api/src/adapters/parked-negotiation.reader.adapter.ts
+++ b/services/api/src/adapters/parked-negotiation.reader.adapter.ts
@@ -86,8 +86,27 @@ export interface ParkedNegotiation {
    */
   dimension?: string;
   /**
+   * The dimension's checklist kind, recovered from the checklist the park turn
+   * itself persisted (the turn record is the checklist's only store). Absent
+   * when the ask named no dimension, or when the turn carried no checklist —
+   * a pre-checklist turn or an external agent's.
+   */
+  dimensionKind?: 'mutual_want' | 'hard_constraint' | 'fit';
+  /**
+   * What the ask declared would score the dimension `ok` and what would score
+   * it `conflict` (checklist plan §3). Absent for asks that declared none —
+   * every pre-checklist ask, and the conclusion floor's own guaranteed ask,
+   * which names a dimension but has no author behind it.
+   */
+  answerhood?: { ok_when: string; conflict_when: string };
+  /**
    * The negotiator-authored question persisted at park time. Absent only when
-   * the mid-flight safety gate stripped it from the turn.
+   * the mid-flight safety gate stripped it from the turn — or when no author
+   * was involved at all, which is the conclusion floor's guaranteed ask: the
+   * graph fires it from a dimension the agent scored unknown, so the park
+   * carries `dimension` and no `question`. The question-message author derives
+   * a renderable question from the dimension in exactly that case
+   * (`lib/question/dimension-question.ts`).
    */
   question?: ParkedNegotiationQuestion;
   /** The negotiation's turns, oldest first, ending in the park turn. */
@@ -100,7 +119,8 @@ interface RawTurn {
   action?: unknown;
   assessment?: { reasoning?: unknown };
   message?: unknown;
-  askUser?: { reason?: unknown; question?: unknown; dimension?: unknown };
+  askUser?: { reason?: unknown; question?: unknown; dimension?: unknown; answerhood?: unknown };
+  checklist?: unknown;
 }
 
 /** The `data` payload of an A2A turn message, or null for non-turn parts. */
@@ -131,6 +151,42 @@ function questionFrom(value: unknown): ParkedNegotiationQuestion | undefined {
     options,
     ...(typeof question.multiSelect === 'boolean' ? { multiSelect: question.multiSelect } : {}),
   };
+}
+
+/** The ask's answerhood map, or undefined when it declared none. */
+function answerhoodFrom(value: unknown): { ok_when: string; conflict_when: string } | undefined {
+  if (!value || typeof value !== 'object') return undefined;
+  const map = value as Record<string, unknown>;
+  if (typeof map.ok_when !== 'string' || typeof map.conflict_when !== 'string') return undefined;
+  const ok = map.ok_when.trim();
+  const conflict = map.conflict_when.trim();
+  return ok && conflict ? { ok_when: ok, conflict_when: conflict } : undefined;
+}
+
+const CHECKLIST_KINDS = new Set(['mutual_want', 'hard_constraint', 'fit']);
+
+/** Same normalization the protocol's `dimensionKey` uses; adapters may not import it. */
+function dimensionKey(name: string): string {
+  return name.trim().toLowerCase().replace(/\s+/g, ' ');
+}
+
+/**
+ * The kind of the named dimension, read off the checklist the park turn itself
+ * persisted. Matched by normalized name for the same reason the graph does:
+ * the ask spells the dimension in its own words and the checklist holds the
+ * authored one.
+ */
+function dimensionKindFrom(checklist: unknown, dimension: string): ParkedNegotiation['dimensionKind'] {
+  if (!Array.isArray(checklist)) return undefined;
+  const key = dimensionKey(dimension);
+  for (const entry of checklist) {
+    const item = entry as Record<string, unknown> | null;
+    if (!item || typeof item.name !== 'string' || typeof item.kind !== 'string') continue;
+    if (dimensionKey(item.name) === key && CHECKLIST_KINDS.has(item.kind)) {
+      return item.kind as ParkedNegotiation['dimensionKind'];
+    }
+  }
+  return undefined;
 }
 
 interface NegotiationRecord {
@@ -282,13 +338,18 @@ export class ParkedNegotiationReaderAdapter {
   ): ParkedNegotiation {
     const askUser = record.lastTurn?.action === 'ask_user' ? record.lastTurn.askUser : undefined;
     const question = questionFrom(askUser?.question);
+    const dimension = typeof askUser?.dimension === 'string' && askUser.dimension.trim().length > 0
+      ? askUser.dimension.trim()
+      : undefined;
+    const dimensionKind = dimension ? dimensionKindFrom(record.lastTurn?.checklist, dimension) : undefined;
+    const answerhood = answerhoodFrom(askUser?.answerhood);
     return {
       opportunityId,
       kind,
       ...(typeof askUser?.reason === 'string' ? { reason: askUser.reason } : {}),
-      ...(typeof askUser?.dimension === 'string' && askUser.dimension.trim().length > 0
-        ? { dimension: askUser.dimension.trim() }
-        : {}),
+      ...(dimension ? { dimension } : {}),
+      ...(dimensionKind ? { dimensionKind } : {}),
+      ...(answerhood ? { answerhood } : {}),
       ...(question ? { question } : {}),
       transcript: record.turns,
       parkedAt: record.lastCreatedAt ?? new Date(0),

--- a/services/api/src/adapters/tests/parked-negotiation.classifier-convergence.spec.ts
+++ b/services/api/src/adapters/tests/parked-negotiation.classifier-convergence.spec.ts
@@ -186,6 +186,36 @@ function preContactParkTurn() {
   };
 }
 
+/**
+ * A CONCLUSION-FLOOR park (#1464): the graph fired the ask, not the agent, so
+ * the turn carries the checklist dimension it fired on and its answerhood map
+ * — and no authored question at all. The checklist rides on the same turn,
+ * which is the only place the dimension's kind is stored.
+ */
+function floorFiredParkTurn() {
+  return {
+    action: 'ask_user',
+    message: null,
+    assessment: {
+      reasoning: NEGOTIATION_PARK_REASONING,
+      suggestedRoles: { ownUser: 'peer', otherUser: 'peer' },
+    },
+    askUser: {
+      reason: 'unresolved_owner_constraint',
+      dimension: 'Timing: This week',
+      answerhood: {
+        ok_when: 'a meeting inside the next two weeks works',
+        conflict_when: 'nothing before next quarter is possible',
+      },
+      guaranteed: true,
+    },
+    checklist: [
+      { name: 'Timing: This week', kind: 'hard_constraint', result: 'unknown', basis: '' },
+      { name: 'Mutual interest', kind: 'mutual_want', result: 'ok', basis: 'Both signals say so.' },
+    ],
+  };
+}
+
 function ordinaryTurn() {
   return {
     action: 'counter',
@@ -369,5 +399,35 @@ describe('parked-set reader ⇄ classifyParkedNegotiation convergence', () => {
 
     expect(classification.kind).toBe('not_parked');
     expect(parkedSet.some((parked) => parked.opportunityId === negotiation.opportunityId)).toBe(false);
+  });
+
+  test('floor-fired park: the reader carries the dimension, its kind, and the answerhood the ask declared', async () => {
+    // The park that made the 2026-08-20 incident possible. It has no authored
+    // question, so what the client is asked has to be written from the
+    // dimension — and that needs all three fields off the persisted turn. Two
+    // of them (kind, answerhood) had no reader at all before this.
+    const fixture = await seedParticipants();
+    const negotiation = await seedNegotiation(fixture, 'stalled');
+    await appendTurn(negotiation.conversationId, negotiation.taskId, `agent:${fixture.counterpartyId}`, ordinaryTurn());
+    await appendTurn(negotiation.conversationId, negotiation.taskId, `agent:${fixture.ownerId}`, floorFiredParkTurn());
+    await db.update(tasks).set({ state: 'completed' }).where(eq(tasks.id, negotiation.taskId));
+
+    const classification = await classifyParkedNegotiation(chatDatabaseAdapter, {
+      opportunityId: negotiation.opportunityId,
+      userId: fixture.ownerId,
+    });
+    const parkedSet = await reader.readParkedNegotiations(fixture.ownerId, fixture.ownerIntentId);
+    const entry = parkedSet.find((parked) => parked.opportunityId === negotiation.opportunityId);
+
+    expect(classification.kind).toBe('post_stall');
+    expect(entry?.kind).toBe('post_stall');
+    expect(entry?.question).toBeUndefined();
+    expect(entry?.dimension).toBe('Timing: This week');
+    // Read off the checklist the same turn persisted, matched by name.
+    expect(entry?.dimensionKind).toBe('hard_constraint');
+    expect(entry?.answerhood).toEqual({
+      ok_when: 'a meeting inside the next two weeks works',
+      conflict_when: 'nothing before next quarter is possible',
+    });
   });
 });

--- a/services/api/src/controllers/chat.controller.ts
+++ b/services/api/src/controllers/chat.controller.ts
@@ -13,14 +13,25 @@ import { userService } from "../services/user.service";
 import { isNegotiatorChatEnabled } from "../lib/negotiator-feature";
 import { negotiationReflectQueue } from "../queues/negotiations/reflect.queue";
 import { enqueueQuestionAnswerReply, questionMessageQueue } from "../queues/question-message.queue";
+import { QUESTION_ANSWER_ACKNOWLEDGEMENT, evaluateQuestionAnswerPrecedence } from "../lib/question/answer-precedence";
+import type { AnswerPrecedence } from "../lib/question/answer-precedence";
 import { SuggestionGenerator, ChatInterruptClassifier, NEGOTIATOR_PERSONA_ID, ONBOARDING_PERSONA_ID, SIGNAL_PERSONA_ID } from '@indexnetwork/protocol';
-import { createDoneEvent, createErrorEvent, createStatusEvent, createSteerOrQueueEvent, formatSSEEvent } from "../types/chat-streaming.types";
+import { createDoneEvent, createErrorEvent, createStatusEvent, createSteerOrQueueEvent, createTokenEvent, formatSSEEvent } from "../types/chat-streaming.types";
 import { emitChatInterrupt, onChatInterrupt } from '../lib/chat-interrupt.events';
 
 type RouteParams = Record<string, string>;
 type ChatScope = { scopeType: 'network' | 'intent'; scopeId: string };
 
 const logger = log.controller.from("chat");
+
+/**
+ * The orchestrator's event stream when it does not run: the answer-precedence
+ * gate accepted this reply as an answer to the scope's open question, so the
+ * turn is already decided. An empty stream rather than a branch around the
+ * loop keeps one path through persistence, title, suggestions and `done` —
+ * the turn differs only in where its text came from.
+ */
+async function* emptyEventStream(): AsyncGenerator<never, void, unknown> {}
 
 function normalizeChatScope(input: {
   scopeType?: 'network' | 'intent' | null;
@@ -462,8 +473,11 @@ export class ChatController {
         ? await chatSessionService.getNegotiatorGraphFactory(
             negotiatorAgent,
             user.id,
-            effectiveScope?.scopeType === 'intent' && pinnedIntentLabel
-              ? { label: pinnedIntentLabel }
+            effectiveScope?.scopeType === 'intent'
+              ? {
+                intentId: effectiveScope.scopeId,
+                ...(pinnedIntentLabel ? { label: pinnedIntentLabel } : {}),
+              }
               : undefined,
           )
         : null;
@@ -542,21 +556,60 @@ export class ChatController {
           let debugMeta: { graph: string; iterations: number; tools: unknown[]; llm?: unknown; orchestratorNegotiations?: unknown} | undefined;
           let decisionQuestions: import("@indexnetwork/protocol").Question[] | undefined;
 
-          // Use context-aware streaming to load previous messages
+          // ─── Answer precedence (#1466) ───────────────────────────────────
+          // While this signal's DM has an OPEN question, the reply is offered
+          // to the answer evaluator BEFORE the orchestrator runs — before any
+          // tool, and so before the signal edit rule can rewrite the intent
+          // from it. An accepted answer never reaches the orchestrator; it is
+          // acknowledged in server-owned copy and consumed on the serialized
+          // question-message queue. Anything else (no open question, the
+          // evaluator declines, the evaluator is unavailable) falls through to
+          // the ordinary flow below, unchanged.
+          //
+          // The order is the fix. Both consumers already existed and both were
+          // behaving correctly on 2026-08-20 when "This month?" — an answer to
+          // a parked negotiation's timing question — was consumed by the edit
+          // rule instead, because the orchestrator simply ran first.
+          const answerPrecedence: AnswerPrecedence =
+            sessionPersona === NEGOTIATOR_PERSONA_ID && effectiveScope?.scopeType === 'intent'
+              ? await evaluateQuestionAnswerPrecedence({
+                  userId: user.id,
+                  intentId: effectiveScope.scopeId,
+                  sessionId,
+                  replyText: messageContent,
+                })
+              : { status: 'no_open_question' };
 
-          for await (const event of factory.streamChatEventsWithContext(
-            {
-              userId: user.id,
-              message: messageContent,
-              sessionId,
-              maxContextMessages: 20,
-              ...(effectiveScope ? { scopeType: effectiveScope.scopeType, scopeId: effectiveScope.scopeId } : {}),
-              prefillMessages: body.prefillMessages,
-              runId,
-            },
-            checkpointer,
-            streamAbortController.signal,
-          )) {
+          if (answerPrecedence.status === 'answered') {
+            // The answer IS the turn. The response is server-owned copy, not
+            // model text — the same rule the close-out and clarification
+            // messages follow — and it is emitted as one token event so the
+            // rest of this handler (persistence, title, suggestions, done)
+            // runs byte-identically to an ordinary turn.
+            fullResponse = QUESTION_ANSWER_ACKNOWLEDGEMENT;
+            controller.enqueue(
+              encoder.encode(formatSSEEvent(createTokenEvent(sessionId, fullResponse))),
+            );
+          }
+
+          // Use context-aware streaming to load previous messages
+          const orchestratorEvents = answerPrecedence.status === 'answered'
+            ? emptyEventStream()
+            : factory.streamChatEventsWithContext(
+              {
+                userId: user.id,
+                message: messageContent,
+                sessionId,
+                maxContextMessages: 20,
+                ...(effectiveScope ? { scopeType: effectiveScope.scopeType, scopeId: effectiveScope.scopeId } : {}),
+                prefillMessages: body.prefillMessages,
+                runId,
+              },
+              checkpointer,
+              streamAbortController.signal,
+            );
+
+          for await (const event of orchestratorEvents) {
             if (streamInterruptedBySteer) break;
             if (event) {
               // response_complete is an internal event carrying the agent's
@@ -599,12 +652,28 @@ export class ChatController {
             }
           }
 
-          // A user message in the signal's negotiator DM may be an answer to
-          // the open question-message. Detection runs after the reply is
-          // persisted and BEFORE the assistant response is, so the newest
-          // agent message is still the one the client was answering; the
-          // serialized question-message queue owns everything after that.
+          // Consumption, enqueued once the reply has a persisted id (it keys
+          // the job's redelivery dedup). The serialized question-message queue
+          // owns everything after that — resuming each parked negotiation the
+          // answer unparks, and the clarifying follow-up if any ref no longer
+          // routes.
+          //
+          // Two statuses reach it, for different reasons:
+          // - `answered`: the gate's own routing is carried through, so the
+          //   job consumes the decision the client was just acknowledged for
+          //   rather than re-deciding it.
+          // - `unavailable`: the evaluator could not decide, so the job is
+          //   enqueued the way it always was — no routing attached — and the
+          //   queue's retry policy covers the outage. This turn also went to
+          //   the orchestrator, which can route the same reply through its
+          //   tool; both land in the same settlement-keyed, idempotent
+          //   consumption, so the duplicate is harmless and the recovery is
+          //   worth more than the tidiness.
+          //
+          // A reply the gate DECLINED has nothing to consume: that judgment is
+          // the same one the job would make, and it already ran.
           const detectQuestionAnswerReply = async (replyMessageId: string) => {
+            if (answerPrecedence.status !== 'answered' && answerPrecedence.status !== 'unavailable') return;
             if (sessionPersona !== NEGOTIATOR_PERSONA_ID || effectiveScope?.scopeType !== 'intent') return;
             await enqueueQuestionAnswerReply({
               userId: user.id,
@@ -612,6 +681,15 @@ export class ChatController {
               sessionId,
               replyText: messageContent,
               replyMessageId,
+              ...(answerPrecedence.status === 'answered'
+                ? {
+                  precedence: {
+                    questionMessageId: answerPrecedence.questionMessageId,
+                    questionMessageBody: answerPrecedence.questionMessageBody,
+                    routedAnswers: answerPrecedence.routedAnswers,
+                  },
+                }
+                : {}),
             });
           };
 

--- a/services/api/src/controllers/mcp.controller.ts
+++ b/services/api/src/controllers/mcp.controller.ts
@@ -40,6 +40,7 @@ import { negotiatorMemoryRetrieve } from '../adapters/negotiator-memory.retrieva
 import { negotiatorClientDmRetrieve } from '../adapters/negotiator-client-dm.retrieval.adapter';
 import { negotiatorMemoryWriteService } from '../services/negotiator-memory.service';
 import { isNegotiatorMemoryWriteEnabled } from '../lib/negotiator-feature';
+import { negotiatorAnswerToolsHost } from '../lib/question/negotiator-answer.host';
 import { resolveProtocolBaseUrl } from '../lib/protocol-url';
 import { isHermesNegotiatorAudience } from '../lib/agent/hermes-credential';
 
@@ -114,6 +115,11 @@ const protocolDeps = {
   // memory tools. Injected only while memory writes are enabled — when the
   // flag is off the tools are simply not registered. Consumed exclusively by
   // createNegotiatorTools; the orchestrator registry never sees these tools.
+  // #1466: host bridge for the negotiator persona's `answer_pending_question`
+  // tool — the long-tail lane for a reply the deterministic answer-precedence
+  // gate declined. Registered only in intent-pinned negotiator sessions; the
+  // orchestrator registry never sees it.
+  negotiatorAnswerTools: negotiatorAnswerToolsHost,
   ...(isNegotiatorMemoryWriteEnabled() && {
     negotiatorMemoryTools: {
       remember: async (userId: string, input: { kind: 'disclosure_rule' | 'playbook' | 'threshold'; content: string; sessionId?: string }) =>

--- a/services/api/src/lib/question/answer-precedence.ts
+++ b/services/api/src/lib/question/answer-precedence.ts
@@ -1,0 +1,203 @@
+/**
+ * Answer precedence: a free-text reply in a signal's negotiator DM is offered
+ * to the answer evaluator BEFORE the chat orchestrator sees it, whenever that
+ * DM has an open question.
+ *
+ * Why it is an order and not a preference. Both consumers of a DM reply
+ * already existed: the answer spine (route the reply onto the open question
+ * block, resume the parked negotiations) and the chat orchestrator (converse,
+ * and edit the signal when the client sharpens it). They ran in the wrong
+ * order — the orchestrator streamed first, tools and all, and the answer
+ * detection fired only after it had finished. On 2026-08-20 a negotiation
+ * parked on "Timing: This week" asked its client, the client replied
+ * "This month?" three minutes later, and the orchestrator's signal edit rule
+ * consumed it: the intent was rewritten, and the negotiation that asked is
+ * still parked. Nothing about that was a bug in either consumer. It was the
+ * order.
+ *
+ * So: while a question is open in this scope, the evaluator gets the reply
+ * first, deterministically. Only a reply it DECLINES falls through to the
+ * orchestrator, which then behaves exactly as it does today — including the
+ * edit rule. With no open question nothing here runs at all.
+ *
+ * The judgment itself is not rebuilt: `QuestionAnswerRouter` already decides
+ * whether text answers an open question and extracts what it answers (#1432).
+ * This module owns only the ORDER and the fall-through rule.
+ *
+ * Fail-open, deliberately. A provider outage must not turn an ordinary
+ * conversational turn into a canned refusal, so an evaluator that cannot
+ * answer falls through to the orchestrator — which, since #1466, is told an
+ * open question exists in this scope and carries the tool to route an answer
+ * explicitly. That is the long tail's lane, not a silent loss.
+ */
+import { classifyParkedNegotiation, parseQuestionMessage } from '@indexnetwork/protocol';
+import type { NegotiationAnswerConsumptionPorts, QuestionBlock, RoutedAnswer } from '@indexnetwork/protocol';
+
+import { QuestionAnswerRouter } from './question-answer.router';
+import { log } from '../log';
+
+const logger = log.lib.from('question-answer.precedence');
+
+/**
+ * Server-owned acknowledgement for a reply the evaluator took as an answer.
+ * Fixed copy, never model text — the same rule the close-out and clarification
+ * messages follow. An accepted answer does not reach the orchestrator, so this
+ * is what the client sees while the serialized consumption job resumes the
+ * negotiations the answer unparks.
+ */
+export const QUESTION_ANSWER_ACKNOWLEDGEMENT =
+  'Got it — I have taken that as your answer and sent it back to the conversations that were waiting on it. '
+  + 'I will let you know here when they move.';
+
+/**
+ * What the gate decided.
+ *
+ * - `no_open_question`: nothing is open in this scope (the common case). The
+ *   orchestrator path is untouched, byte for byte.
+ * - `declined`: a question is open and the evaluator says this reply does not
+ *   answer it. Falls through to the orchestrator, edit rule included.
+ * - `unavailable`: a question is open and the evaluator could not decide (a
+ *   model failure). Falls through, with the open question named in the
+ *   orchestrator's context.
+ * - `answered`: the reply answers the open question. The orchestrator is
+ *   skipped and the routed answers are consumed.
+ */
+export type AnswerPrecedence =
+  | { status: 'no_open_question' }
+  | { status: 'declined'; questionMessageId: string }
+  | { status: 'unavailable'; questionMessageId: string }
+  | {
+    status: 'answered';
+    questionMessageId: string;
+    /** The block body as delivered — the message the client was answering. */
+    questionMessageBody: string;
+    /** The reply routed onto the block's negotiation refs; never empty. */
+    routedAnswers: RoutedAnswer[];
+  };
+
+/** Injectable seams; production resolves the real collaborators lazily. */
+export interface AnswerPrecedenceDeps {
+  getSessionMessages?: (sessionId: string) => Promise<Array<{ id: string; role: string; content: string }>>;
+  answerPorts?: NegotiationAnswerConsumptionPorts;
+  answerRouter?: Pick<QuestionAnswerRouter, 'route'>;
+}
+
+/**
+ * The open question-message of a negotiator DM: the newest AGENT message,
+ * when it carries a parseable question block. The still-parked half of the
+ * predicate is checked separately below — it costs negotiation reads, and the
+ * cheap half rules out every ordinary conversation first.
+ */
+function openQuestionMessage(
+  messages: Array<{ id: string; role: string; content: string }>,
+): { id: string; content: string; block: QuestionBlock } | null {
+  const newestAgentMessage = [...messages].reverse().find((message) => message.role === 'assistant');
+  if (!newestAgentMessage) return null;
+  const parsed = parseQuestionMessage(newestAgentMessage.content);
+  if (!parsed) return null;
+  return { id: newestAgentMessage.id, content: newestAgentMessage.content, block: parsed.block };
+}
+
+/**
+ * True while at least one negotiation the block references is still parked on
+ * THIS user's side. A block whose parks all resolved is closed: its questions
+ * are no longer answerable, so a reply to it is ordinary conversation and the
+ * gate must not stand in the orchestrator's way.
+ */
+async function referencesStillParked(
+  ports: NegotiationAnswerConsumptionPorts,
+  block: QuestionBlock,
+  userId: string,
+): Promise<boolean> {
+  for (const question of block.questions) {
+    for (const ref of [question.opportunityId, ...(question.alsoUnblocks ?? [])]) {
+      const classification = await classifyParkedNegotiation(ports.database, { opportunityId: ref, userId });
+      if (classification.kind === 'inflight' || classification.kind === 'post_stall') return true;
+    }
+  }
+  return false;
+}
+
+/**
+ * Decide, before the orchestrator runs, whether this reply is an answer to the
+ * scope's open question.
+ *
+ * Never throws: every failure resolves to a fall-through status, because the
+ * alternative — failing a chat turn — is worse than asking the client again.
+ */
+export async function evaluateQuestionAnswerPrecedence(
+  input: { userId: string; intentId: string; sessionId: string; replyText: string },
+  deps?: AnswerPrecedenceDeps,
+): Promise<AnswerPrecedence> {
+  try {
+    if (!input.replyText.trim()) return { status: 'no_open_question' };
+
+    const getSessionMessages = deps?.getSessionMessages
+      ?? (async (sessionId: string) => (await import('../../services/chat.service')).chatSessionService.getSessionMessages(sessionId));
+    const open = openQuestionMessage(await getSessionMessages(input.sessionId));
+    if (!open) return { status: 'no_open_question' };
+
+    const ports = deps?.answerPorts
+      ?? (await import('./negotiation-answer.ports')).negotiationAnswerConsumptionPorts();
+    if (!await referencesStillParked(ports, open.block, input.userId)) {
+      logger.info('question_answer_precedence_message_closed', {
+        userId: input.userId,
+        intentId: input.intentId,
+        questionMessageId: open.id,
+      });
+      return { status: 'no_open_question' };
+    }
+
+    const router = deps?.answerRouter ?? new QuestionAnswerRouter();
+    let routed;
+    try {
+      routed = await router.route({ block: open.block, replyText: input.replyText });
+    } catch (err) {
+      // The evaluator is the only judge here and it did not answer. Falling
+      // through is the honest move: the orchestrator can see the open question
+      // and route explicitly, and the client's turn still gets a reply.
+      logger.warn('question_answer_precedence_evaluator_unavailable', {
+        userId: input.userId,
+        intentId: input.intentId,
+        questionMessageId: open.id,
+        error: err instanceof Error ? err.message : String(err),
+      });
+      return { status: 'unavailable', questionMessageId: open.id };
+    }
+
+    // `addressesQuestions` with nothing extracted is not an answer this path
+    // can consume — consumption would resume nothing and ask again. It is
+    // exactly the oblique case the orchestrator's tool exists for, so it falls
+    // through rather than burning the turn on a clarifying follow-up.
+    if (!routed.addressesQuestions || routed.answers.length === 0) {
+      logger.info('question_answer_precedence_declined', {
+        userId: input.userId,
+        intentId: input.intentId,
+        questionMessageId: open.id,
+        addressesQuestions: routed.addressesQuestions,
+      });
+      return { status: 'declined', questionMessageId: open.id };
+    }
+
+    logger.info('question_answer_precedence_answered', {
+      userId: input.userId,
+      intentId: input.intentId,
+      questionMessageId: open.id,
+      answers: routed.answers.length,
+    });
+    return {
+      status: 'answered',
+      questionMessageId: open.id,
+      questionMessageBody: open.content,
+      routedAnswers: routed.answers,
+    };
+  } catch (err) {
+    logger.error('question_answer_precedence_failed; falling through to the orchestrator', {
+      userId: input.userId,
+      intentId: input.intentId,
+      sessionId: input.sessionId,
+      error: err instanceof Error ? err.message : String(err),
+    });
+    return { status: 'no_open_question' };
+  }
+}

--- a/services/api/src/lib/question/dimension-question.ts
+++ b/services/api/src/lib/question/dimension-question.ts
@@ -1,0 +1,178 @@
+/**
+ * Deriving a renderable question from the checklist dimension a park is about
+ * (conversational questions × the conclusion floor, #1464).
+ *
+ * A park used to carry a question because an agent wrote one. The conclusion
+ * floor changed that: when an agent drafts a verdict while a dimension it
+ * itself scored `unknown` is still askable, the GRAPH fires the ask on its
+ * behalf — and a graph-fired ask has no author, so it parks with
+ * `askUser.dimension` (plus the answerhood map when the agent declared one)
+ * and no `askUser.question`.
+ *
+ * Downstream, that absence used to degrade the whole delivery shape: the
+ * question-message author's deterministic composition renders park-time
+ * questions verbatim, so a park with none contributed nothing, and the block
+ * lost the one thing that makes answering structural. Live on 2026-08-20 the
+ * first floor-fired ask ever delivered reached its client as PROSE — a
+ * "we need to know…" paragraph with nothing bound to it — and the client's
+ * answer three minutes later was consumed by the chat orchestrator's signal
+ * edit rule instead of the negotiation that was starving for it.
+ *
+ * So the question is DERIVED here, deterministically, from material the
+ * client's own side already holds: the dimension its agent authored, the kind
+ * it filed the dimension under, and the answerhood map it declared before
+ * asking. No model call — an arrow that matters must not be a model's choice.
+ * What comes out is the same `title/prompt/options` shape a park-time question
+ * has, so every consumer downstream (the author's model grounding, its block
+ * mapping, its deterministic fallback) treats it exactly like one.
+ *
+ * The derived prompt still faces `isSafeQuestionMessagePrompt`: the dimension
+ * name is agent-written text and this is the first surface that renders it as
+ * a question rather than a label. A rejected derivation resolves to
+ * `undefined` — today's behaviour, one park with nothing renderable — rather
+ * than shipping unchecked text into the client's DM.
+ */
+import type { ParkedNegotiation, ParkedNegotiationQuestion } from '../../adapters/parked-negotiation.reader.adapter';
+import { isSafeQuestionMessagePrompt } from './negotiation-question.contract';
+
+/**
+ * Title cap, mirroring the protocol's `StructuredQuestionSchema.title` (≤12
+ * chars, the noun of the decision domain). Nothing here is validated against
+ * that schema — the block carries no title — but a derived question that
+ * could not be persisted as an authored one is a derivation that drifted, and
+ * the sibling ask-generation lane hit exactly this cap from the other side.
+ */
+export const MAX_DERIVED_TITLE_CHARS = 12;
+
+/** Block prompts cap at 2000; the renderer-facing question shape caps at 400. */
+const MAX_DERIVED_PROMPT_CHARS = 400;
+
+/** Option label/description caps, from the block schema. */
+const MAX_OPTION_LABEL_CHARS = 120;
+const MAX_OPTION_DESCRIPTION_CHARS = 280;
+
+/** Last-resort title when the dimension name yields no usable leading noun. */
+const FALLBACK_TITLE = 'Detail';
+
+/**
+ * How each checklist kind reads to the person being asked. The kind is the
+ * agent's own filing of what sort of fact this is, and saying it out loud is
+ * what stops the derived question from reading as a generic "any thoughts?".
+ */
+const KIND_PHRASE: Record<NonNullable<ParkedNegotiation['dimensionKind']>, string> = {
+  mutual_want: 'something you would have to actually want',
+  hard_constraint: 'a constraint I cannot work around on my own',
+  fit: 'a question of how well this actually fits you',
+};
+
+function clamp(text: string, max: number): string {
+  const trimmed = text.trim();
+  if (trimmed.length <= max) return trimmed;
+  const cut = trimmed.slice(0, max);
+  const lastSpace = cut.lastIndexOf(' ');
+  return (lastSpace > max * 0.5 ? cut.slice(0, lastSpace) : cut).trimEnd();
+}
+
+/**
+ * The decision-domain noun of a dimension name: "Timing: This week" → "Timing",
+ * "Stage fit (pre-seed)" → "Stage fit". Dimension names are ≤60 chars and
+ * frequently qualified; the title is the part before the first qualifier,
+ * clamped to the cap.
+ */
+export function titleFromDimension(name: string): string {
+  const lead = name.split(/[:—–(\-|/]/)[0] ?? '';
+  const title = clamp(lead, MAX_DERIVED_TITLE_CHARS) || clamp(name, MAX_DERIVED_TITLE_CHARS);
+  return title || FALLBACK_TITLE;
+}
+
+/**
+ * The two answers the ask itself declared would settle the dimension, as
+ * decision options: the LABEL is the answer, the DESCRIPTION is what the
+ * negotiation does with it — the same contract park-time options carry, so the
+ * client is choosing a consequence rather than a phrasing.
+ *
+ * Returns `[]` without an answerhood map. The block's options are optional and
+ * two is its floor, so a park whose ask declared nothing renders as a prompt
+ * with a reply arrow — still a block, still structurally bound.
+ */
+function optionsFromAnswerhood(
+  answerhood: ParkedNegotiation['answerhood'],
+  title: string,
+): ParkedNegotiationQuestion['options'] {
+  if (!answerhood) return [];
+  // The answerhood map never passed the park-time authored-question gate —
+  // that gate covers `askUser.question` only — and these labels are the first
+  // thing to render it to the client. Either half tripping drops BOTH options,
+  // not the question: a block with a prompt and no options is still bound to
+  // its negotiation, which is the property that matters here.
+  if (!isSafeQuestionMessagePrompt(answerhood.ok_when) || !isSafeQuestionMessagePrompt(answerhood.conflict_when)) {
+    return [];
+  }
+  return [
+    {
+      label: clamp(answerhood.ok_when, MAX_OPTION_LABEL_CHARS),
+      description: clamp(
+        `That settles ${title.toLowerCase()} and I carry the negotiation forward on it.`,
+        MAX_OPTION_DESCRIPTION_CHARS,
+      ),
+    },
+    {
+      label: clamp(answerhood.conflict_when, MAX_OPTION_LABEL_CHARS),
+      description: clamp(
+        `That marks ${title.toLowerCase()} as a conflict and I stop pressing it there.`,
+        MAX_OPTION_DESCRIPTION_CHARS,
+      ),
+    },
+  ];
+}
+
+/**
+ * The prompt: the dimension named, what kind of fact the agent filed it under,
+ * and the ask. The answerhood map is NOT spliced in here — it is written from
+ * the agent's point of view ("they can meet inside two weeks") and reads
+ * wrongly in second person; it belongs on the options, where each half is a
+ * choice the client makes rather than a sentence about them.
+ */
+function promptFromDimension(name: string, kind: ParkedNegotiation['dimensionKind']): string {
+  const kindClause = kind ? ` — ${KIND_PHRASE[kind]}` : '';
+  const prompt = `${clamp(name, 120)}${kindClause}. One of your negotiations is parked on this until you tell me where you land. What should I take as your answer?`;
+  return clamp(prompt, MAX_DERIVED_PROMPT_CHARS);
+}
+
+/**
+ * The renderable question for one park: the agent's own, when it authored one,
+ * otherwise one derived from the dimension. `undefined` only when there is
+ * neither — a park with no question and no dimension, which is what a
+ * policy-inferred consultation and a pre-checklist post-stall gap look like.
+ * That case is unchanged: nothing renderable, left for a later regeneration.
+ */
+export function renderableQuestion(parked: ParkedNegotiation): ParkedNegotiationQuestion | undefined {
+  if (parked.question) return parked.question;
+  return deriveQuestionFromDimension(parked);
+}
+
+/**
+ * Derives the question a floor-fired park never had. Exported for the specs
+ * and for callers that need to distinguish derived from authored; ordinary
+ * consumers want {@link renderableQuestion}.
+ */
+export function deriveQuestionFromDimension(parked: ParkedNegotiation): ParkedNegotiationQuestion | undefined {
+  const name = parked.dimension?.trim();
+  if (!name) return undefined;
+
+  const title = titleFromDimension(name);
+  const prompt = promptFromDimension(name, parked.dimensionKind);
+  // The dimension name is agent-written and this is the first surface to
+  // render it as a question. A prompt that trips the gate is dropped whole:
+  // the park falls back to having nothing renderable, which is exactly where
+  // it stood before this module existed.
+  if (!isSafeQuestionMessagePrompt(prompt)) return undefined;
+
+  const options = optionsFromAnswerhood(parked.answerhood, title);
+  return {
+    title,
+    prompt,
+    options,
+    multiSelect: false,
+  };
+}

--- a/services/api/src/lib/question/negotiator-answer.host.ts
+++ b/services/api/src/lib/question/negotiator-answer.host.ts
@@ -1,0 +1,114 @@
+/**
+ * Host bridge behind the negotiator persona's `answer_pending_question` tool
+ * (#1466) — the long-tail lane of answer routing.
+ *
+ * The deterministic lane is upstream and does not involve a model with tools:
+ * while a signal's DM has an open question, a free-text reply is offered to
+ * the answer evaluator BEFORE the orchestrator runs, and an accepted answer
+ * never reaches it (`answer-precedence.ts`). What arrives here is what the
+ * evaluator declined — an oblique answer, a late one, or one folded into a
+ * message that is also doing something else — plus the case where the
+ * evaluator itself was unavailable.
+ *
+ * Nothing is re-implemented: this resolves the same open question-message the
+ * gate anchors on, maps the number the model was shown onto that block's
+ * negotiation ref, and enqueues consumption on the same serialized
+ * question-message queue with the answer pre-routed. Every resume, settle and
+ * retry below that is the #1432 spine, untouched.
+ *
+ * The tool never sees or emits an id. It is given positions, it returns
+ * positions, and this module owns the mapping — the same rule that keeps the
+ * answer router from minting a ref that would resume the wrong negotiation.
+ */
+import { readOpenQuestionsForIntent } from './open-question-message';
+import type { OpenQuestionsForIntentDeps } from './open-question-message';
+import { enqueueQuestionAnswerReply } from '../../queues/question-message.queue';
+import { log } from '../log';
+
+const logger = log.lib.from('negotiator-answer.host');
+
+/** Mirrors the protocol's `NegotiatorAnswerRoutingResult`; structural by design. */
+export type NegotiatorAnswerRoutingResult =
+  | { status: 'routed'; label: string }
+  | { status: 'no_open_question' }
+  | { status: 'unknown_question'; open: number }
+  | { status: 'error' };
+
+/** Injectable seams; production resolves the real collaborators. */
+export interface NegotiatorAnswerHostDeps extends OpenQuestionsForIntentDeps {
+  enqueueAnswer?: typeof enqueueQuestionAnswerReply;
+}
+
+/**
+ * Route one answer the orchestrator extracted onto the open question it names.
+ *
+ * Never throws — a tool that throws costs the client their turn, and the
+ * honest failure the model is told to report is strictly better than that.
+ */
+export async function answerOpenQuestion(
+  userId: string,
+  input: { intentId: string; question: number; answer: string },
+  deps?: NegotiatorAnswerHostDeps,
+): Promise<NegotiatorAnswerRoutingResult> {
+  try {
+    const answerText = input.answer.trim();
+    if (!answerText) return { status: 'error' };
+
+    const open = await readOpenQuestionsForIntent(userId, input.intentId, deps);
+    if (!open || open.questions.length === 0) return { status: 'no_open_question' };
+
+    const question = open.questions.find((candidate) => candidate.position === input.question);
+    if (!question) {
+      logger.info('negotiator_answer_unknown_question', {
+        userId,
+        intentId: input.intentId,
+        question: input.question,
+        open: open.questions.length,
+      });
+      return { status: 'unknown_question', open: open.questions.length };
+    }
+
+    const enqueueAnswer = deps?.enqueueAnswer ?? enqueueQuestionAnswerReply;
+    const enqueued = await enqueueAnswer({
+      userId,
+      intentId: input.intentId,
+      sessionId: open.sessionId,
+      replyText: answerText,
+      // No persisted reply id here: the tool fires mid-turn, before the
+      // client's message has one. Keying on the negotiation instead makes two
+      // tool calls for the same question in one turn coalesce, which is the
+      // only duplication this path can produce — and everything below the
+      // enqueue is settlement-keyed and idempotent anyway.
+      replyMessageId: `tool-answer.${question.opportunityId}`,
+      precedence: {
+        questionMessageId: open.messageId,
+        questionMessageBody: open.body,
+        routedAnswers: [{ ref: question.opportunityId, answerText }],
+      },
+    });
+    if (!enqueued) return { status: 'error' };
+
+    logger.info('negotiator_answer_routed', {
+      userId,
+      intentId: input.intentId,
+      questionMessageId: open.messageId,
+      opportunityId: question.opportunityId,
+    });
+    return { status: 'routed', label: question.label };
+  } catch (err) {
+    logger.error('negotiator_answer_route_failed', {
+      userId,
+      intentId: input.intentId,
+      error: err instanceof Error ? err.message : String(err),
+    });
+    return { status: 'error' };
+  }
+}
+
+/** The host object the composition root injects into the negotiator toolset. */
+export const negotiatorAnswerToolsHost = {
+  answerOpenQuestion: (
+    userId: string,
+    input: { intentId: string; question: number; answer: string },
+  ) => answerOpenQuestion(userId, input),
+};

--- a/services/api/src/lib/question/open-question-message.ts
+++ b/services/api/src/lib/question/open-question-message.ts
@@ -124,3 +124,103 @@ export async function readOpenQuestionMessages(
   }
   return open;
 }
+
+/** One question of a signal's open question-message, as the client sees it. */
+export interface OpenQuestionForIntent {
+  /** 1-based position in the block — the number the orchestrator is shown. */
+  position: number;
+  /** The step's label: its checklist dimension, else a short form of the prompt. */
+  label: string;
+  /** The negotiation this question unparks; the answer's routing identity. */
+  opportunityId: string;
+}
+
+/** A signal's open question-message, resolved for one intent scope. */
+export interface OpenQuestionsForIntent {
+  sessionId: string;
+  messageId: string;
+  /** The message body as delivered — the block an answer is consumed against. */
+  body: string;
+  questions: OpenQuestionForIntent[];
+}
+
+/** Label cap for a question shown in the orchestrator's context. */
+const MAX_QUESTION_LABEL_CHARS = 80;
+
+function labelFor(question: QuestionBlockQuestion): string {
+  const label = question.dimension?.trim() || question.prompt.trim();
+  return label.length > MAX_QUESTION_LABEL_CHARS
+    ? `${label.slice(0, MAX_QUESTION_LABEL_CHARS).trimEnd()}…`
+    : label;
+}
+
+/** Injectable seams for {@link readOpenQuestionsForIntent}. */
+export interface OpenQuestionsForIntentDeps {
+  findSession?: (userId: string, intentId: string) => Promise<{ id: string } | null>;
+  getSessionMessages?: (sessionId: string) => Promise<Array<{ id: string; role: string; content: string }>>;
+  readParkedNegotiations?: (userId: string, intentId: string) => Promise<ReadonlyArray<{ opportunityId: string }>>;
+}
+
+/**
+ * One signal's open question-message, resolved for the orchestrator's context
+ * and for the `answer_pending_question` tool behind it (#1466).
+ *
+ * Anchored on the newest AGENT message, like the notification snapshot rather
+ * than the edit rule: the client having replied since does not un-ask the
+ * question, and this is read on a turn where they just did reply.
+ *
+ * Resolves null whenever there is nothing open — no DM, no block, or every
+ * negotiation the block references has since resolved. Never throws: this
+ * feeds a prompt section and a tool registration, and neither is worth failing
+ * a chat turn over.
+ */
+export async function readOpenQuestionsForIntent(
+  userId: string,
+  intentId: string,
+  deps?: OpenQuestionsForIntentDeps,
+): Promise<OpenQuestionsForIntent | null> {
+  if (!userId || !intentId) return null;
+  try {
+    const findSession = deps?.findSession
+      ?? (async (id: string, intent: string) => (await import('../../services/chat.service')).chatSessionService
+        .findNegotiatorIntentSession(id, intent));
+    const session = await findSession(userId, intentId);
+    if (!session) return null;
+
+    const getSessionMessages = deps?.getSessionMessages
+      ?? (async (sessionId: string) => (await import('../../services/chat.service')).chatSessionService
+        .getSessionMessages(sessionId));
+    const messages = await getSessionMessages(session.id);
+    const newestAgentMessage = [...messages].reverse().find((message) => message.role === 'assistant');
+    // Cheap first: no block, no parked-set read.
+    if (!newestAgentMessage || !parseQuestionMessage(newestAgentMessage.content)) return null;
+
+    const readParkedNegotiations = deps?.readParkedNegotiations
+      ?? (async (id: string, intent: string) => (await import('../../adapters/parked-negotiation.reader.adapter'))
+        .parkedNegotiationReaderAdapter.readParkedNegotiations(id, intent));
+    const parked = await readParkedNegotiations(userId, intentId);
+    const open = openQuestionBlock({ id: newestAgentMessage.id, content: newestAgentMessage.content }, parked);
+    if (!open) return null;
+
+    // Every question of the open block is listed, not only the still-parked
+    // ones: the numbers must line up with what the client is looking at, and a
+    // question whose parks resolved simply consumes to nothing.
+    return {
+      sessionId: session.id,
+      messageId: open.id,
+      body: newestAgentMessage.content,
+      questions: open.block.questions.map((question, index) => ({
+        position: index + 1,
+        label: labelFor(question),
+        opportunityId: question.opportunityId,
+      })),
+    };
+  } catch (err) {
+    logger.warn('open_questions_for_intent_read_failed', {
+      userId,
+      intentId,
+      error: err instanceof Error ? err.message : String(err),
+    });
+    return null;
+  }
+}

--- a/services/api/src/lib/question/question-message.author.ts
+++ b/services/api/src/lib/question/question-message.author.ts
@@ -18,6 +18,15 @@
  * park-time questions (each already passed the identifier-aware safety gate
  * before it persisted) under fixed server-owned prose. Only a parked set with
  * no renderable question at all resolves to null — then there is no message.
+ *
+ * A park fired by the conclusion floor (#1464) has NO authored question: the
+ * graph, not an agent, decided to ask, and what it carries is the checklist
+ * dimension it fired on. Such a park gets its question DERIVED from that
+ * dimension (`dimension-question.ts`) before anything here reads one, so it
+ * travels this module as an ordinary parked question does and reaches the
+ * client as a real question block. Without that, the deterministic
+ * composition had nothing to render for it and the whole message degraded to
+ * prose — the delivery shape that made the 2026-08-20 incident possible.
  */
 import { ChatOpenAI } from '@langchain/openai';
 import { z } from 'zod';
@@ -28,6 +37,7 @@ import { QuestionBlockSchema } from '@indexnetwork/protocol';
 import type { ParkedNegotiation } from '../../adapters/parked-negotiation.reader.adapter';
 import type { NegotiatorClientDmMessage } from '../../adapters/negotiator-client-dm.retrieval.adapter';
 import { isSafeQuestionMessageProse, isSafeQuestionMessagePrompt } from './negotiation-question.contract';
+import { deriveQuestionFromDimension } from './dimension-question';
 import { log } from '../log';
 
 const logger = log.lib.from('question-message.author');
@@ -73,12 +83,35 @@ const AuthoredOutputSchema = z.object({
   })).min(1).max(20),
 });
 
+/**
+ * A parked negotiation with its RENDERABLE question resolved: the one its
+ * agent authored at park time, or — for a conclusion-floor ask, which has no
+ * author — one derived deterministically from the dimension the graph fired
+ * on (`dimension-question.ts`).
+ *
+ * Resolved once, at the top of `author`, so every path below reads one field:
+ * the model grounding, the block mapping, and the deterministic composition
+ * all treat a derived question exactly as they treat an authored one. That
+ * equality is the point — it is what makes a floor-fired park deliver as a
+ * real question block instead of degrading to prose.
+ */
+interface RenderableParked extends ParkedNegotiation {
+  /** True when `question` was derived from the dimension rather than authored. */
+  questionDerived?: boolean;
+}
+
+function withRenderableQuestion(parked: ParkedNegotiation): RenderableParked {
+  if (parked.question) return parked;
+  const derived = deriveQuestionFromDimension(parked);
+  return derived ? { ...parked, question: derived, questionDerived: true } : parked;
+}
+
 function truncate(text: string, max: number): string {
   const trimmed = text.trim();
   return trimmed.length > max ? `${trimmed.slice(0, max)}…` : trimmed;
 }
 
-function renderParkedNegotiation(parked: ParkedNegotiation, index: number): string {
+function renderParkedNegotiation(parked: RenderableParked, index: number): string {
   const lines = [`Parked negotiation ${index}:`];
   if (parked.reason) lines.push(`- Pause category: ${parked.reason}`);
   if (parked.dimension) lines.push(`- Checklist dimension it is stuck on: ${parked.dimension}`);
@@ -86,8 +119,13 @@ function renderParkedNegotiation(parked: ParkedNegotiation, index: number): stri
     const options = parked.question.options
       .map((option) => `${option.label} (${option.description})`)
       .join('; ');
-    lines.push(`- Question authored at park time: [${parked.question.title}] ${parked.question.prompt}`);
-    lines.push(`- Its decision options: ${options}`);
+    // A derived question is labelled as such: it was written from the
+    // dimension, not by the agent that ran this negotiation, so "preserve its
+    // substance" applies to the dimension it names rather than to its wording.
+    lines.push(parked.questionDerived
+      ? `- Question derived from the dimension (no author): [${parked.question.title}] ${parked.question.prompt}`
+      : `- Question authored at park time: [${parked.question.title}] ${parked.question.prompt}`);
+    if (options) lines.push(`- Its decision options: ${options}`);
   } else {
     lines.push('- No question was authored at park time; derive the gap from the transcript.');
   }
@@ -139,9 +177,15 @@ export class QuestionMessageAuthor {
   async author(input: QuestionMessageAuthorInput): Promise<AuthoredQuestionMessage | null> {
     if (input.parked.length === 0) return null;
 
+    // Resolve every park's renderable question BEFORE anything reads one: a
+    // floor-fired park carries a dimension and no author, and deriving here
+    // is what keeps it a question block on both the model path and the
+    // deterministic fallback.
+    const parked = input.parked.map(withRenderableQuestion);
+
     const userMessage = [
       input.signalText ? `The client's signal: ${truncate(input.signalText, 800)}\n` : '',
-      input.parked.map(renderParkedNegotiation).join('\n\n'),
+      parked.map(renderParkedNegotiation).join('\n\n'),
       renderClientDm(input.clientDm),
       '\n\nWrite the message: the prose preamble and the questions with their "unblocks" indices.',
     ].join('\n');
@@ -155,7 +199,7 @@ export class QuestionMessageAuthor {
           { role: 'system', content: SYSTEM_PROMPT },
           { role: 'user', content: userMessage },
         ]);
-        const authored = this.validate(raw, input.parked);
+        const authored = this.validate(raw, parked);
         if (authored) return authored;
         logger.warn('Question-message model output rejected', { attempt: attempt + 1 });
       }
@@ -164,11 +208,11 @@ export class QuestionMessageAuthor {
         error: err instanceof Error ? err.message : String(err),
       });
     }
-    return this.compose(input.parked);
+    return this.compose(parked);
   }
 
   /** Schema + coverage + safety validation of one model round trip. */
-  private validate(raw: unknown, parked: ParkedNegotiation[]): AuthoredQuestionMessage | null {
+  private validate(raw: unknown, parked: RenderableParked[]): AuthoredQuestionMessage | null {
     const parsed = AuthoredOutputSchema.safeParse(raw);
     if (!parsed.success) return null;
 
@@ -212,11 +256,13 @@ export class QuestionMessageAuthor {
   }
 
   /**
-   * Deterministic composition: fixed prose over the park-time questions,
-   * verbatim. Negotiations whose park-time question was stripped as unsafe
-   * have nothing renderable and are left for a later regeneration.
+   * Deterministic composition: fixed prose over each park's renderable
+   * question, verbatim — the one its agent authored, or the one derived from
+   * its dimension. Negotiations with neither (an authored question stripped as
+   * unsafe, or a park naming no dimension at all) have nothing renderable and
+   * are left for a later regeneration.
    */
-  private compose(parked: ParkedNegotiation[]): AuthoredQuestionMessage | null {
+  private compose(parked: RenderableParked[]): AuthoredQuestionMessage | null {
     const questions = parked.flatMap((negotiation) =>
       negotiation.question
         ? [{

--- a/services/api/src/lib/question/tests/answer-precedence.spec.ts
+++ b/services/api/src/lib/question/tests/answer-precedence.spec.ts
@@ -1,0 +1,184 @@
+/**
+ * Answer precedence: while a question is open in a signal's negotiator DM,
+ * the evaluator sees a free-text reply BEFORE the orchestrator does.
+ *
+ * The incident this encodes (2026-08-20, sandbox): a negotiation parked on the
+ * checklist dimension "Timing: This week" asked its client; three minutes
+ * later the client replied "This month?"; the chat orchestrator's signal edit
+ * rule consumed it and rewrote the intent, and the negotiation that asked was
+ * never told. The evaluator was always capable of recognizing that reply — it
+ * simply ran after the orchestrator had finished.
+ *
+ * The three outcomes under test are the whole contract: an answer never
+ * reaches the orchestrator, a decline always does, and with no open question
+ * nothing here runs at all.
+ */
+import { describe, expect, it } from 'bun:test';
+
+import { negotiationQuestionSettlementId, serializeQuestionMessage } from '@indexnetwork/protocol';
+import type { NegotiationAnswerConsumptionPorts, QuestionBlock } from '@indexnetwork/protocol';
+
+import { evaluateQuestionAnswerPrecedence } from '../answer-precedence';
+import type { AnswerPrecedenceDeps } from '../answer-precedence';
+
+const USER_ID = 'user-1';
+const INTENT_ID = 'intent-1';
+const SESSION_ID = 'session-1';
+const PARKED_OPPORTUNITY = '6d8b07ef-7fa8-4968-80d9-6af0ce364d27';
+
+const BLOCK: QuestionBlock = {
+  version: 1,
+  questions: [{
+    prompt: 'Timing: This week — a constraint I cannot work around on my own. Where do you land?',
+    opportunityId: PARKED_OPPORTUNITY,
+    dimension: 'Timing: This week',
+  }],
+};
+
+const QUESTION_MESSAGE_BODY = serializeQuestionMessage(
+  'One of the conversations I am running on this signal is waiting on you.',
+  BLOCK,
+);
+
+function sessionMessages(agentContent = QUESTION_MESSAGE_BODY) {
+  return [
+    { id: 'm1', role: 'user', content: 'Any news?' },
+    { id: 'm2', role: 'assistant', content: agentContent },
+  ];
+}
+
+const TASK_ID = 'task-1';
+
+/**
+ * Only `database` is reached from this module — the resume seams stay unused.
+ * The mid-flight park shape `classifyParkedNegotiation` demands: an exact task
+ * in `input_required` whose ask-user binding names this user, this opportunity
+ * and the settlement id derived from the task itself.
+ */
+function ports(parked: boolean): NegotiationAnswerConsumptionPorts {
+  return {
+    database: {
+      getNegotiationTaskForOpportunity: async () => (parked
+        ? {
+          id: TASK_ID,
+          state: 'input_required',
+          metadata: {
+            type: 'negotiation',
+            opportunityId: PARKED_OPPORTUNITY,
+            turnContext: {
+              askUserBinding: {
+                settlementId: negotiationQuestionSettlementId(TASK_ID),
+                recipientUserId: USER_ID,
+                recipientIntentId: INTENT_ID,
+                networkId: 'network-1',
+                opportunityId: PARKED_OPPORTUNITY,
+              },
+            },
+          },
+        }
+        // No task at all: "no negotiation", which is not parked — the block is
+        // closed and the reply is ordinary conversation.
+        : null),
+      getNegotiationMessages: async () => [],
+    } as unknown as NegotiationAnswerConsumptionPorts['database'],
+  } as unknown as NegotiationAnswerConsumptionPorts;
+}
+
+function deps(overrides: Partial<AnswerPrecedenceDeps> = {}): AnswerPrecedenceDeps {
+  return {
+    getSessionMessages: async () => sessionMessages(),
+    answerPorts: ports(true),
+    answerRouter: {
+      route: async () => ({
+        addressesQuestions: true,
+        answers: [{ ref: PARKED_OPPORTUNITY, answerText: 'This month.' }],
+      }),
+    },
+    ...overrides,
+  };
+}
+
+const REPLY = { userId: USER_ID, intentId: INTENT_ID, sessionId: SESSION_ID, replyText: 'This month?' };
+
+describe('evaluateQuestionAnswerPrecedence', () => {
+  it('takes a reply that answers the open question — the incident, as a spec', async () => {
+    const precedence = await evaluateQuestionAnswerPrecedence(REPLY, deps());
+
+    expect(precedence.status).toBe('answered');
+    if (precedence.status !== 'answered') throw new Error('unreachable');
+    // The orchestrator never sees this reply, so the edit rule cannot run on
+    // it and the intent cannot be rewritten from it.
+    expect(precedence.questionMessageId).toBe('m2');
+    expect(precedence.questionMessageBody).toBe(QUESTION_MESSAGE_BODY);
+    expect(precedence.routedAnswers).toEqual([{ ref: PARKED_OPPORTUNITY, answerText: 'This month.' }]);
+  });
+
+  it('falls through when the evaluator declines the reply', async () => {
+    const precedence = await evaluateQuestionAnswerPrecedence(
+      { ...REPLY, replyText: "what's my radar look like?" },
+      deps({ answerRouter: { route: async () => ({ addressesQuestions: false, answers: [] }) } }),
+    );
+
+    expect(precedence).toEqual({ status: 'declined', questionMessageId: 'm2' });
+  });
+
+  it('falls through when the evaluator addresses the question but extracts nothing', async () => {
+    // The oblique long tail: the orchestrator's tool is the lane for it, not a
+    // consumption that would resume nothing and then ask again.
+    const precedence = await evaluateQuestionAnswerPrecedence(
+      REPLY,
+      deps({ answerRouter: { route: async () => ({ addressesQuestions: true, answers: [] }) } }),
+    );
+
+    expect(precedence.status).toBe('declined');
+  });
+
+  it('does not run at all when the DM has no question block', async () => {
+    let routed = false;
+    const precedence = await evaluateQuestionAnswerPrecedence(REPLY, deps({
+      getSessionMessages: async () => sessionMessages('Here is what I found on the record.'),
+      answerRouter: { route: async () => { routed = true; throw new Error('must not route'); } },
+    }));
+
+    expect(precedence).toEqual({ status: 'no_open_question' });
+    expect(routed).toBe(false);
+  });
+
+  it('does not run when the block is there but every negotiation it references has resolved', async () => {
+    let routed = false;
+    const precedence = await evaluateQuestionAnswerPrecedence(REPLY, deps({
+      answerPorts: ports(false),
+      answerRouter: { route: async () => { routed = true; throw new Error('must not route'); } },
+    }));
+
+    expect(precedence).toEqual({ status: 'no_open_question' });
+    expect(routed).toBe(false);
+  });
+
+  it('falls through, not closed, when the evaluator is unavailable', async () => {
+    const precedence = await evaluateQuestionAnswerPrecedence(REPLY, deps({
+      answerRouter: { route: async () => { throw new Error('provider down'); } },
+    }));
+
+    expect(precedence).toEqual({ status: 'unavailable', questionMessageId: 'm2' });
+  });
+
+  it('falls through when the session read itself fails', async () => {
+    const precedence = await evaluateQuestionAnswerPrecedence(REPLY, deps({
+      getSessionMessages: async () => { throw new Error('db down'); },
+    }));
+
+    expect(precedence).toEqual({ status: 'no_open_question' });
+  });
+
+  it('ignores an empty reply without touching the session', async () => {
+    let read = false;
+    const precedence = await evaluateQuestionAnswerPrecedence(
+      { ...REPLY, replyText: '   ' },
+      deps({ getSessionMessages: async () => { read = true; return sessionMessages(); } }),
+    );
+
+    expect(precedence).toEqual({ status: 'no_open_question' });
+    expect(read).toBe(false);
+  });
+});

--- a/services/api/src/lib/question/tests/answer-precedence.wiring.static.spec.ts
+++ b/services/api/src/lib/question/tests/answer-precedence.wiring.static.spec.ts
@@ -1,0 +1,54 @@
+/**
+ * Static invariants of the answer-precedence WIRING (#1466).
+ *
+ * The precedence decision itself is unit-tested in `answer-precedence.spec.ts`.
+ * What this pins is the thing that unit test cannot reach: the ORDER inside
+ * the chat controller's SSE handler, which is the whole fix. The 2026-08-20
+ * incident was not a wrong decision by any component — it was the orchestrator
+ * running first. A refactor that moves this evaluation back below the stream,
+ * or that lets an accepted answer reach the orchestrator anyway, reopens the
+ * incident while every unit test still passes.
+ */
+import { describe, expect, it } from 'bun:test';
+import { readFileSync } from 'node:fs';
+
+const controller = readFileSync(new URL('../../../controllers/chat.controller.ts', import.meta.url), 'utf8');
+const composition = readFileSync(new URL('../../../controllers/mcp.controller.ts', import.meta.url), 'utf8');
+
+describe('answer-precedence wiring', () => {
+  it('evaluates precedence BEFORE the orchestrator stream, not after it', () => {
+    const evaluated = controller.indexOf('evaluateQuestionAnswerPrecedence');
+    const streamed = controller.indexOf('factory.streamChatEventsWithContext');
+    const persisted = controller.indexOf('await chatSessionService.addMessage');
+
+    expect(evaluated).toBeGreaterThan(-1);
+    expect(streamed).toBeGreaterThan(-1);
+    expect(evaluated).toBeLessThan(streamed);
+    // And before anything is written, so a decision can still change the turn.
+    expect(evaluated).toBeLessThan(persisted);
+  });
+
+  it('runs the orchestrator only for a reply the evaluator did not take as an answer', () => {
+    // An accepted answer swaps the orchestrator's event stream for an empty
+    // one: no tool runs, so the signal edit rule cannot fire on it.
+    expect(controller).toContain("answerPrecedence.status === 'answered'");
+    expect(controller).toContain('emptyEventStream()');
+  });
+
+  it('gates the precedence check on the negotiator DM of one signal', () => {
+    expect(controller).toContain("sessionPersona === NEGOTIATOR_PERSONA_ID && effectiveScope?.scopeType === 'intent'");
+  });
+
+  it('never enqueues consumption for a reply the evaluator declined', () => {
+    // The queue would only re-run the same evaluator on the same text and
+    // reach the same verdict. `unavailable` is the exception on purpose: no
+    // verdict was reached, so the job is enqueued unrouted and the queue's
+    // retry covers the outage.
+    expect(controller).toContain("if (answerPrecedence.status !== 'answered' && answerPrecedence.status !== 'unavailable') return;");
+    expect(controller).toContain('precedence: {');
+  });
+
+  it('registers the long-tail routing tool at the composition root', () => {
+    expect(composition).toContain('negotiatorAnswerTools: negotiatorAnswerToolsHost');
+  });
+});

--- a/services/api/src/lib/question/tests/dimension-question.spec.ts
+++ b/services/api/src/lib/question/tests/dimension-question.spec.ts
@@ -1,0 +1,122 @@
+/**
+ * Deriving a question from the dimension a floor-fired park names (#1464 →
+ * #1466). No model call: the derivation is deterministic, because an arrow
+ * that matters must not be a model's choice.
+ */
+import { describe, expect, it } from 'bun:test';
+
+import { MAX_DERIVED_TITLE_CHARS, deriveQuestionFromDimension, renderableQuestion, titleFromDimension } from '../dimension-question';
+import type { ParkedNegotiation } from '../../../adapters/parked-negotiation.reader.adapter';
+
+const OPPORTUNITY = '6d8b07ef-7fa8-4968-80d9-6af0ce364d27';
+
+function parked(overrides: Partial<ParkedNegotiation> = {}): ParkedNegotiation {
+  return {
+    opportunityId: OPPORTUNITY,
+    kind: 'mid_flight',
+    dimension: 'Timing: This week',
+    dimensionKind: 'hard_constraint',
+    answerhood: {
+      ok_when: 'a meeting inside the next two weeks works',
+      conflict_when: 'nothing before next quarter is possible',
+    },
+    transcript: [],
+    parkedAt: new Date(0),
+    ...overrides,
+  };
+}
+
+describe('titleFromDimension', () => {
+  it('takes the decision-domain noun and respects the title cap', () => {
+    expect(titleFromDimension('Timing: This week')).toBe('Timing');
+    expect(titleFromDimension('Stage fit (pre-seed)')).toBe('Stage fit');
+    expect(titleFromDimension('Compensation expectations alignment').length)
+      .toBeLessThanOrEqual(MAX_DERIVED_TITLE_CHARS);
+  });
+
+  it('never resolves empty', () => {
+    expect(titleFromDimension(':::').length).toBeGreaterThan(0);
+  });
+});
+
+describe('deriveQuestionFromDimension', () => {
+  it('names the dimension and what kind of fact it is, and ends in a question', () => {
+    const question = deriveQuestionFromDimension(parked())!;
+
+    expect(question.title).toBe('Timing');
+    expect(question.prompt).toContain('Timing: This week');
+    expect(question.prompt).toContain('a constraint I cannot work around on my own');
+    expect(question.prompt.trimEnd().endsWith('?')).toBe(true);
+    expect(question.prompt.length).toBeLessThanOrEqual(400);
+  });
+
+  it('turns the declared answerhood into the two options, each with its consequence', () => {
+    const question = deriveQuestionFromDimension(parked())!;
+
+    expect(question.options).toEqual([
+      {
+        label: 'a meeting inside the next two weeks works',
+        description: 'That settles timing and I carry the negotiation forward on it.',
+      },
+      {
+        label: 'nothing before next quarter is possible',
+        description: 'That marks timing as a conflict and I stop pressing it there.',
+      },
+    ]);
+  });
+
+  it('still derives a question when the ask declared no answerhood', () => {
+    const question = deriveQuestionFromDimension(parked({ answerhood: undefined }))!;
+
+    expect(question.prompt).toContain('Timing: This week');
+    expect(question.options).toEqual([]);
+  });
+
+  it('omits the kind clause when the checklist did not carry the dimension', () => {
+    const question = deriveQuestionFromDimension(parked({ dimensionKind: undefined }))!;
+
+    expect(question.prompt).toContain('Timing: This week');
+    expect(question.prompt).not.toContain('constraint I cannot work around');
+  });
+
+  it('derives nothing at all when the park names no dimension', () => {
+    expect(deriveQuestionFromDimension(parked({ dimension: undefined }))).toBeUndefined();
+  });
+
+  it('drops the whole derivation when the dimension name would leak into a prompt', () => {
+    // The dimension name is agent-written, and this is the first surface that
+    // renders it as a question rather than as a label.
+    expect(deriveQuestionFromDimension(parked({ dimension: 'Whether to share the seed assessment' })))
+      .toBeUndefined();
+  });
+
+  it('drops only the options when an answerhood half would leak', () => {
+    const question = deriveQuestionFromDimension(parked({
+      answerhood: { ok_when: 'Bianca is available on Thursday', conflict_when: 'she is not' },
+    }))!;
+
+    // The block still binds to its negotiation, which is the property that
+    // matters; only the selectable answers are withheld.
+    expect(question.prompt).toContain('Timing: This week');
+    expect(question.options).toEqual([]);
+  });
+});
+
+describe('renderableQuestion', () => {
+  it('prefers the question the agent actually authored', () => {
+    const authored = {
+      title: 'Budget',
+      prompt: 'What budget range works?',
+      options: [
+        { label: 'Under 10k', description: 'I propose the smaller engagement.' },
+        { label: 'Above 10k', description: 'I keep the full scope on the table.' },
+      ],
+    };
+
+    expect(renderableQuestion(parked({ question: authored }))).toBe(authored);
+  });
+
+  it('falls back to the derived one when there is no author', () => {
+    expect(renderableQuestion(parked())?.title).toBe('Timing');
+  });
+});

--- a/services/api/src/lib/question/tests/negotiator-answer.host.spec.ts
+++ b/services/api/src/lib/question/tests/negotiator-answer.host.spec.ts
@@ -1,0 +1,117 @@
+/**
+ * The host behind `answer_pending_question` (#1466): position → negotiation
+ * ref, then the same consumption path every other answer takes.
+ *
+ * The tool is given numbers and never an id — this module owns the mapping,
+ * for the same reason the answer router does not see one: a ref the model
+ * could name is a ref it could get wrong, and a misroute resumes the wrong
+ * negotiation with the wrong fact.
+ */
+import { describe, expect, it } from 'bun:test';
+
+import { serializeQuestionMessage } from '@indexnetwork/protocol';
+import type { QuestionBlock } from '@indexnetwork/protocol';
+
+import { answerOpenQuestion } from '../negotiator-answer.host';
+
+const USER_ID = 'user-1';
+const INTENT_ID = 'intent-1';
+const TIMING_OPPORTUNITY = '6d8b07ef-7fa8-4968-80d9-6af0ce364d27';
+const BUDGET_OPPORTUNITY = '7f3d2c1b-8a90-4e5f-b6c7-d8e9f0a1b2c3';
+
+const BLOCK: QuestionBlock = {
+  version: 1,
+  questions: [
+    { prompt: 'When could you meet?', opportunityId: TIMING_OPPORTUNITY, dimension: 'Timing: This week' },
+    { prompt: 'What budget range works?', opportunityId: BUDGET_OPPORTUNITY, dimension: 'Budget' },
+  ],
+};
+const BODY = serializeQuestionMessage('Two conversations are waiting on you.', BLOCK);
+
+interface Enqueued {
+  replyMessageId: string;
+  precedence?: { questionMessageId: string; routedAnswers: Array<{ ref: string; answerText: string }> };
+}
+
+function deps(overrides: Record<string, unknown> = {}) {
+  const enqueued: Enqueued[] = [];
+  return {
+    enqueued,
+    deps: {
+      findSession: async () => ({ id: 'session-1' }),
+      getSessionMessages: async () => [{ id: 'm2', role: 'assistant', content: BODY }],
+      readParkedNegotiations: async () => [{ opportunityId: TIMING_OPPORTUNITY }],
+      enqueueAnswer: (async (input: Enqueued) => { enqueued.push(input); return true; }) as never,
+      ...overrides,
+    },
+  };
+}
+
+describe('answerOpenQuestion', () => {
+  it('maps the position the model was shown onto that question\'s negotiation ref', async () => {
+    const { enqueued, deps: harness } = deps();
+
+    const result = await answerOpenQuestion(USER_ID, {
+      intentId: INTENT_ID,
+      question: 2,
+      answer: 'Up to twenty thousand.',
+    }, harness);
+
+    expect(result).toEqual({ status: 'routed', label: 'Budget' });
+    expect(enqueued).toHaveLength(1);
+    expect(enqueued[0].precedence).toMatchObject({
+      questionMessageId: 'm2',
+      routedAnswers: [{ ref: BUDGET_OPPORTUNITY, answerText: 'Up to twenty thousand.' }],
+    });
+    // Two tool calls for the same question in one turn coalesce on this id;
+    // everything below the enqueue is settlement-keyed and idempotent.
+    expect(enqueued[0].replyMessageId).toBe(`tool-answer.${BUDGET_OPPORTUNITY}`);
+  });
+
+  it('reports the open count rather than guessing when the position names nothing', async () => {
+    const { enqueued, deps: harness } = deps();
+
+    const result = await answerOpenQuestion(USER_ID, { intentId: INTENT_ID, question: 5, answer: 'Yes.' }, harness);
+
+    expect(result).toEqual({ status: 'unknown_question', open: 2 });
+    expect(enqueued).toHaveLength(0);
+  });
+
+  it('reports nothing open when the block\'s negotiations have all resolved', async () => {
+    const { deps: harness } = deps({ readParkedNegotiations: async () => [] });
+
+    const result = await answerOpenQuestion(USER_ID, { intentId: INTENT_ID, question: 1, answer: 'Yes.' }, harness);
+
+    expect(result).toEqual({ status: 'no_open_question' });
+  });
+
+  it('reports nothing open when the signal has no DM at all', async () => {
+    const { deps: harness } = deps({ findSession: async () => null });
+
+    const result = await answerOpenQuestion(USER_ID, { intentId: INTENT_ID, question: 1, answer: 'Yes.' }, harness);
+
+    expect(result).toEqual({ status: 'no_open_question' });
+  });
+
+  it('never throws — a failed enqueue is reported, not raised', async () => {
+    const { deps: harness } = deps({
+      enqueueAnswer: (async () => { throw new Error('queue unavailable'); }) as never,
+    });
+
+    const result = await answerOpenQuestion(USER_ID, { intentId: INTENT_ID, question: 1, answer: 'Yes.' }, harness);
+
+    expect(result).toEqual({ status: 'error' });
+  });
+
+  it('refuses an empty answer without touching the conversation', async () => {
+    let read = false;
+    const { deps: harness } = deps({
+      findSession: async () => { read = true; return { id: 'session-1' }; },
+    });
+
+    const result = await answerOpenQuestion(USER_ID, { intentId: INTENT_ID, question: 1, answer: '  ' }, harness);
+
+    expect(result).toEqual({ status: 'error' });
+    expect(read).toBe(false);
+  });
+});

--- a/services/api/src/lib/question/tests/question-message.author.spec.ts
+++ b/services/api/src/lib/question/tests/question-message.author.spec.ts
@@ -69,15 +69,20 @@ describe('QuestionMessageAuthor', () => {
 
     expect(result).not.toBeNull();
     expect(result!.prose).toBe(VALID_OUTPUT.prose);
+    // Options ride from the PRIMARY park's own question, verbatim — merged
+    // parks inherit the primary's, for the same reason the block's identity is
+    // the primary's ref.
     expect(result!.questions).toEqual([
       {
         prompt: 'What equity range are you prepared to offer?',
         opportunityId: OPPORTUNITY_A,
         alsoUnblocks: [OPPORTUNITY_B],
+        options: parked(OPPORTUNITY_A).question!.options,
       },
       {
         prompt: 'Can you be on-site one week per month?',
         opportunityId: OPPORTUNITY_C,
+        options: parked(OPPORTUNITY_C).question!.options,
       },
     ]);
     expect(author.calls).toBe(1);
@@ -152,5 +157,100 @@ describe('QuestionMessageAuthor', () => {
 
     expect(result).toBeNull();
     expect(author.calls).toBe(0);
+  });
+});
+
+// ─── Floor-fired parks: a dimension with no author still delivers a block ────
+//
+// The conclusion floor (#1464) fires an ask the agent did not draft, so the
+// park carries `dimension` (+ the answerhood map when the agent declared one)
+// and NO `question`. Before derivation such a park contributed nothing to the
+// deterministic composition, and a message with no renderable question at all
+// resolved to null — which is how the first floor-fired ask ever delivered
+// reached its client as prose with nothing bound to it (2026-08-20).
+
+function floorFiredParked(opportunityId: string, withAnswerhood = true): ParkedNegotiation {
+  return {
+    opportunityId,
+    kind: 'mid_flight',
+    reason: 'unresolved_owner_constraint',
+    dimension: 'Timing: This week',
+    dimensionKind: 'hard_constraint',
+    ...(withAnswerhood
+      ? {
+        answerhood: {
+          ok_when: 'a meeting inside the next two weeks works',
+          conflict_when: 'nothing before next quarter is possible',
+        },
+      }
+      : {}),
+    transcript: [{ action: 'ask_user', reasoning: 'Parked on an askable unknown.' }],
+    parkedAt: new Date(0),
+  };
+}
+
+describe('QuestionMessageAuthor — floor-fired parks (no authored question)', () => {
+  it('composes a bound question block from the dimension when the model is unavailable', async () => {
+    const author = new StubbedAuthor([new Error('provider down')]);
+    const result = await author.author(input([floorFiredParked(OPPORTUNITY_A)]));
+
+    expect(result).not.toBeNull();
+    expect(result!.prose).toBe(QUESTION_MESSAGE_FALLBACK_PROSE);
+    expect(result!.questions).toHaveLength(1);
+    const [question] = result!.questions;
+    // Bound to the negotiation it unparks — the block's whole routing contract.
+    expect(question.opportunityId).toBe(OPPORTUNITY_A);
+    expect(question.dimension).toBe('Timing: This week');
+    expect(question.prompt).toContain('Timing: This week');
+    // The two answers the ask itself declared, as selectable options.
+    expect(question.options).toEqual([
+      {
+        label: 'a meeting inside the next two weeks works',
+        description: 'That settles timing and I carry the negotiation forward on it.',
+      },
+      {
+        label: 'nothing before next quarter is possible',
+        description: 'That marks timing as a conflict and I stop pressing it there.',
+      },
+    ]);
+  });
+
+  it('keeps the derived options on the model path too', async () => {
+    const modelled = {
+      prose: 'I paused one conversation on a detail only you can settle.',
+      questions: [{ prompt: 'Could you meet within the next two weeks?', unblocks: [0] }],
+    };
+    const author = new StubbedAuthor([modelled]);
+    const result = await author.author(input([floorFiredParked(OPPORTUNITY_A)]));
+
+    expect(result!.prose).toBe(modelled.prose);
+    expect(result!.questions[0].prompt).toBe('Could you meet within the next two weeks?');
+    expect(result!.questions[0].options).toHaveLength(2);
+    expect(result!.questions[0].dimension).toBe('Timing: This week');
+  });
+
+  it('still delivers a block when the ask declared no answerhood — prompt only, no options', async () => {
+    const author = new StubbedAuthor([new Error('provider down')]);
+    const result = await author.author(input([floorFiredParked(OPPORTUNITY_A, false)]));
+
+    expect(result!.questions).toHaveLength(1);
+    expect(result!.questions[0].opportunityId).toBe(OPPORTUNITY_A);
+    expect(result!.questions[0].options).toBeUndefined();
+  });
+
+  it('mixes authored and derived questions in one block', async () => {
+    const author = new StubbedAuthor([new Error('provider down')]);
+    const result = await author.author(input([parked(OPPORTUNITY_A), floorFiredParked(OPPORTUNITY_B)]));
+
+    expect(result!.questions.map((question) => question.opportunityId))
+      .toEqual([OPPORTUNITY_A, OPPORTUNITY_B]);
+  });
+
+  it('falls back to prose-only behaviour when the park names no dimension either', async () => {
+    // Unchanged from before derivation: nothing renderable, no message.
+    const author = new StubbedAuthor([new Error('provider down')]);
+    const result = await author.author(input([parked(OPPORTUNITY_A, false)]));
+
+    expect(result).toBeNull();
   });
 });

--- a/services/api/src/queues/question-message.queue.ts
+++ b/services/api/src/queues/question-message.queue.ts
@@ -43,7 +43,7 @@
 import { Job } from 'bullmq';
 
 import { classifyParkedNegotiation, consumeQuestionBlockAnswers, parseQuestionMessage, serializeQuestionMessage } from '@indexnetwork/protocol';
-import type { NegotiationAnswerConsumptionPorts, QuestionBlock, QuestionerEnqueuePayload } from '@indexnetwork/protocol';
+import type { NegotiationAnswerConsumptionPorts, QuestionBlock, QuestionerEnqueuePayload, RoutedAnswer } from '@indexnetwork/protocol';
 
 import { log } from '../lib/log';
 import { openQuestionBlock, questionBlockRefs } from '../lib/question/open-question-message';
@@ -82,6 +82,18 @@ export interface QuestionAnswerJobData {
   questionMessageBody: string;
   /** ISO timestamp of the reply; fixed at enqueue so retries are stable. */
   repliedAt: string;
+  /**
+   * The reply already routed onto the block's refs by the answer-precedence
+   * gate (`lib/question/answer-precedence.ts`), which had to run the evaluator
+   * before the chat turn to decide whether the orchestrator got this message
+   * at all. Carried so the job consumes that decision instead of re-running
+   * the same model call against the same text and possibly disagreeing with
+   * the routing the client was already acknowledged for.
+   *
+   * Absent for a job enqueued without a precedence decision, which routes here
+   * exactly as it always did.
+   */
+  routedAnswers?: RoutedAnswer[];
 }
 
 /**
@@ -587,9 +599,13 @@ export class QuestionMessageQueue {
 
     // Routing is interpretive (an LLM maps text onto refs) and has no safe
     // fallback; a hard routing failure throws so the queue's retry policy
-    // covers a transient model outage.
-    const router = this.deps?.answerRouter ?? new QuestionAnswerRouter();
-    const routed = await router.route({ block, replyText: data.replyText });
+    // covers a transient model outage. A payload that already carries the
+    // precedence gate's routing skips the call entirely — that decision is
+    // what kept this reply away from the orchestrator, so re-deciding it here
+    // could only contradict what the client was already told.
+    const routed = data.routedAnswers
+      ? { addressesQuestions: data.routedAnswers.length > 0, answers: data.routedAnswers }
+      : await (this.deps?.answerRouter ?? new QuestionAnswerRouter()).route({ block, replyText: data.replyText });
     if (!routed.addressesQuestions) {
       // Ordinary conversation in a DM with an open question-message. The
       // negotiator's chat reply handles it; consumption stays silent.
@@ -703,11 +719,16 @@ export interface QuestionAnswerReplyDetectionDeps {
  * ('negotiator-intent', intentId) session, check whether the conversation has
  * an open question-message — the newest AGENT message, when it carries a
  * parseable question block — and if so enqueue consumption of the reply
- * against it. Runs after the reply is persisted and BEFORE the negotiator's
- * streamed response is, so "newest agent message" is still the message the
- * client was answering. The still-parked half of the open-message predicate
- * is deliberately left to the serialized job: it is authoritative there, and
- * a block whose parks all resolved simply consumes to nothing.
+ * against it. The still-parked half of the open-message predicate is
+ * deliberately left to the serialized job: it is authoritative there, and a
+ * block whose parks all resolved simply consumes to nothing.
+ *
+ * `precedence` is what the answer-precedence gate already resolved BEFORE the
+ * chat turn ran (`lib/question/answer-precedence.ts`): the open message it
+ * anchored on and the routing it accepted. When present, this function is a
+ * plain enqueue of that decision — no second anchor read, no second routing
+ * call. Without it the function re-derives the anchor itself, exactly as it
+ * did when detection ran after the stream.
  *
  * Returns whether a consumption job was enqueued. Never throws — reply
  * detection must not break the chat turn.
@@ -719,11 +740,38 @@ export async function enqueueQuestionAnswerReply(
     sessionId: string;
     replyText: string;
     replyMessageId: string;
+    /** The precedence gate's accepted decision, when one was taken. */
+    precedence?: {
+      questionMessageId: string;
+      questionMessageBody: string;
+      routedAnswers: RoutedAnswer[];
+    };
   },
   deps?: QuestionAnswerReplyDetectionDeps,
 ): Promise<boolean> {
   const detectionLogger = log.lib.from('question-answer.reply-detection');
   try {
+    const addConsumeAnswerJob = deps?.addConsumeAnswerJob
+      ?? ((data: QuestionAnswerJobData) => questionMessageQueue.addConsumeAnswerJob(data));
+    const base = {
+      userId: input.userId,
+      intentId: input.intentId,
+      sessionId: input.sessionId,
+      replyText: input.replyText,
+      replyMessageId: input.replyMessageId,
+      repliedAt: new Date().toISOString(),
+    };
+
+    if (input.precedence) {
+      await addConsumeAnswerJob({
+        ...base,
+        questionMessageId: input.precedence.questionMessageId,
+        questionMessageBody: input.precedence.questionMessageBody,
+        routedAnswers: input.precedence.routedAnswers,
+      });
+      return true;
+    }
+
     const getSessionMessages = deps?.getSessionMessages
       ?? (async (sessionId: string) => (await import('../services/chat.service')).chatSessionService.getSessionMessages(sessionId));
     const messages = await getSessionMessages(input.sessionId);
@@ -732,17 +780,10 @@ export async function enqueueQuestionAnswerReply(
     const parsed = parseQuestionMessage(newestAgentMessage.content);
     if (!parsed) return false;
 
-    const addConsumeAnswerJob = deps?.addConsumeAnswerJob
-      ?? ((data: QuestionAnswerJobData) => questionMessageQueue.addConsumeAnswerJob(data));
     await addConsumeAnswerJob({
-      userId: input.userId,
-      intentId: input.intentId,
-      sessionId: input.sessionId,
-      replyText: input.replyText,
-      replyMessageId: input.replyMessageId,
+      ...base,
       questionMessageId: newestAgentMessage.id,
       questionMessageBody: newestAgentMessage.content,
-      repliedAt: new Date().toISOString(),
     });
     return true;
   } catch (err) {

--- a/services/api/src/queues/tests/question-message.queue.isolated.ts
+++ b/services/api/src/queues/tests/question-message.queue.isolated.ts
@@ -682,7 +682,8 @@ const PARK_REASONING = "Negotiation parked pending the client's answer.";
 interface AnswerHarnessOptions {
   /** Which refs currently hold a live park, and of which flavour. */
   parks: Record<string, 'inflight' | 'post_stall'>;
-  routed: { addressesQuestions: boolean; answers: RoutedAnswer[] };
+  /** The router's verdict, or an Error for a payload that must never route. */
+  routed: { addressesQuestions: boolean; answers: RoutedAnswer[] } | Error;
 }
 
 function buildAnswerHarness(options: AnswerHarnessOptions) {
@@ -774,6 +775,7 @@ function buildAnswerHarness(options: AnswerHarnessOptions) {
     answerRouter: {
       route: async (input) => {
         calls.routerInputs.push({ replyText: input.replyText });
+        if (options.routed instanceof Error) throw options.routed;
         return options.routed;
       },
     },
@@ -810,6 +812,23 @@ function answerJob(replyText: string): QuestionAnswerJobData {
 }
 
 describe('QuestionMessageQueue answer-consumption job', () => {
+  it('consumes the precedence gate\'s routing without calling the router again', async () => {
+    const { queue, calls } = buildAnswerHarness({
+      parks: { [FIXTURE_PRIMARY_1]: 'inflight' },
+      // Any router call here would be a second, contradictable judgment of a
+      // reply the gate already accepted — the harness makes one fail the test.
+      routed: new Error('the router must not run for a pre-routed payload'),
+    });
+
+    await queue.processJob('consume_question_answers', {
+      ...answerJob('This month.'),
+      routedAnswers: [{ ref: FIXTURE_PRIMARY_1, answerText: 'This month.' }],
+    });
+
+    expect(calls.routerInputs).toHaveLength(0);
+    expect(calls.inflightResumes.map((resume) => resume.opportunityId)).toEqual([FIXTURE_PRIMARY_1]);
+  });
+
   it('routes a reply onto an inflight park and resumes the primary and every alsoUnblocks ref', async () => {
     const { queue, calls } = buildAnswerHarness({
       parks: { [FIXTURE_PRIMARY_1]: 'inflight', [FIXTURE_ALSO_1]: 'inflight' },
@@ -921,6 +940,31 @@ describe('enqueueQuestionAnswerReply detection', () => {
     replyText: 'March works.',
     replyMessageId: 'reply-1',
   };
+
+  it('enqueues the precedence gate\'s own decision without re-anchoring or re-routing', async () => {
+    // The gate ran the evaluator BEFORE the chat turn to decide the
+    // orchestrator would not see this reply. Re-deriving either half here
+    // could only contradict what the client was already acknowledged for.
+    const enqueued: QuestionAnswerJobData[] = [];
+    const result = await enqueueQuestionAnswerReply({
+      ...reply,
+      precedence: {
+        questionMessageId: 'm2',
+        questionMessageBody: questionMessageFixture,
+        routedAnswers: [{ ref: FIXTURE_PRIMARY_1, answerText: 'March works.' }],
+      },
+    }, {
+      getSessionMessages: async () => { throw new Error('must not re-read the session'); },
+      addConsumeAnswerJob: async (data) => { enqueued.push(data); },
+    });
+
+    expect(result).toBe(true);
+    expect(enqueued[0]).toMatchObject({
+      questionMessageId: 'm2',
+      questionMessageBody: questionMessageFixture,
+      routedAnswers: [{ ref: FIXTURE_PRIMARY_1, answerText: 'March works.' }],
+    });
+  });
 
   it('enqueues consumption when the newest agent message carries a question block', async () => {
     const enqueued: QuestionAnswerJobData[] = [];

--- a/services/api/src/services/chat.service.ts
+++ b/services/api/src/services/chat.service.ts
@@ -5,6 +5,7 @@ import { ChatGraphFactory, ChatTitleGenerator, NEGOTIATOR_PERSONA_ID, ONBOARDING
 import type { ChatGraphCompositeDatabase } from '@indexnetwork/protocol';
 import { getCheckpointer } from '../adapters/checkpointer.adapter';
 import { negotiatorMemoryRetrievalAdapter } from '../adapters/negotiator-memory.retrieval.adapter';
+import { readOpenQuestionsForIntent } from '../lib/question/open-question-message';
 import { isNegotiatorMemoryWriteEnabled } from '../lib/negotiator-feature';
 import type { PostgresSaver } from '@langchain/langgraph-checkpoint-postgres';
 
@@ -768,20 +769,30 @@ export class ChatSessionService {
    * factory; only prompt/toolset/loop behaviors differ.
    *
    * @param agent - Identity from the user's `type='personal'` agent row
-   * @param pinnedIntent - Optional pinned-signal label for intent-scoped
-   *                       sessions (P4.2); rendered in the prompt's pinned
-   *                       signal section
+   * @param pinnedIntent - The pinned signal for intent-scoped sessions (P4.2):
+   *                       its id, and its label for the prompt's pinned signal
+   *                       section. The id also resolves the signal's OPEN
+   *                       questions (#1466) — what the client's own agent is
+   *                       currently waiting on them for.
    */
   async getNegotiatorGraphFactory(
     agent: { name: string; description?: string | null },
     userId: string,
-    pinnedIntent?: { label?: string },
+    pinnedIntent?: { intentId?: string; label?: string },
   ): Promise<ChatGraphFactory> {
     // P5.3: the client's accumulated negotiator memories inform the DM
     // persona (gated on NEGOTIATOR_MEMORY_INJECT; [] → byte-identical
     // prompt). The adapter never throws — the catch is belt and braces so a
     // memory failure can never take down the chat surface.
     const memory = await negotiatorMemoryRetrievalAdapter.retrieveForChat(userId).catch(() => []);
+    // #1466: the questions this signal's DM currently has open. Without them
+    // the persona could not tell that a message answering one WAS an answer —
+    // its only move on such a message was to edit the signal, which is what it
+    // did on 2026-08-20. Never throws (the reader swallows its own failures);
+    // absent → the prompt is byte-identical to before.
+    const openQuestions = pinnedIntent?.intentId
+      ? (await readOpenQuestionsForIntent(userId, pinnedIntent.intentId))?.questions ?? []
+      : [];
     return this.factory.withPersona(
       createNegotiatorPersona({
         agentName: agent.name,
@@ -792,6 +803,9 @@ export class ChatSessionService {
         // root under the same flag — the prompt advertises them only when
         // they actually exist for this session.
         ...(isNegotiatorMemoryWriteEnabled() ? { memoryToolsEnabled: true } : {}),
+        ...(openQuestions.length > 0
+          ? { openQuestions: openQuestions.map((question) => question.label) }
+          : {}),
       }),
     );
   }


### PR DESCRIPTION
## The incident, from the record

Sandbox, 2026-08-20, DM conversation `6d8b07ef`, intent `34fa30bc`, task `aefff73b` (still `input_required` as of writing).

| time (UTC) | what happened |
|---|---|
| 20:21:22 | the conclusion floor fires an ask on `Timing: This week` — `askUser: { reason, dimension, guaranteed: true }`, no authored question, **no answerhood** |
| 20:21:29 | the question-message lands in the DM |
| 20:24:14 | **`update_intent` rewrites the signal** |
| 20:24:17 | the client's reply `"This month?"` is persisted |
| 20:24:18 | "OK. I've updated your signal to reflect that you're looking to connect this month." |

Two things that record settles.

**The delivery shape was not the defect.** The brief called the delivered question prose; it wasn't. The message carried a well-formed block:

```
{ "version": 1, "questions": [ { "prompt": "Does your intent to connect 'this week' still hold, or has your availability changed?",
                                 "opportunityId": "78a6b283-…", "dimension": "Timing: This week" } ] }
```

Bound ref, dimension label, model-authored prompt written off the dimension. What it had no options — the floor declares no answerhood, by construction — so it rendered as a prompt with a reply arrow.

**The defect was the order.** `update_intent` fired at 20:24:14 — *three seconds before the client's reply was even on the record* (20:24:17) and four before the confirmation. The orchestrator streamed first, tools and all; answer detection only started after the whole stream. And the rewrite was not even what the agent claimed: the payload is now `"Connect with individuals for friendship and shared humanity in San Francisco or Birmingham"` — the timing constraint is gone entirely, not set to "this month". `opportunities.metadata.userAnswers` is `null`; nothing was ever routed.

So fix 2 is the incident fix. Fix 1 is narrower than the brief assumed but still real, and fix 3 is the fallback — details below.

## 1. A floor-fired park's question is derived from its dimension

`services/api/src/lib/question/dimension-question.ts` (new).

A conclusion-floor ask has no author, so the park carries `dimension` and no `question`. The author's model path happened to cope (it reads `dimension` off the parked turn), but the **deterministic composition** did not: it renders park-time questions verbatim, so a floor-fired park contributed nothing, and a message with no renderable question at all resolves to `null` — no message delivered. On the incident's exact payload, one rejected model round trip and the client would have been told nothing at all.

The question is now derived, with no model call: title from the dimension's decision-domain noun (capped at 12, mirroring `StructuredQuestionSchema.title` — the cap the sibling `fix/ask-generation-schema-seam` lane hit from the other side), prompt from name + checklist kind, options from `answerhood.ok_when` / `conflict_when` when the ask declared them, labelled with what the negotiation does with each. Bound to the same `opportunityId` every authored question binds to. Derived text still faces `isSafeQuestionMessagePrompt` — the dimension name is agent-written and this is the first surface rendering it as a question; a trip drops the derivation, and a trip in an answerhood half drops only the options, never the binding.

**In practice a floor ask will usually have no options**, because the floor declares no answerhood. That is the incident's real shape and it is left as-is: inventing two choices from a dimension name would be inventing semantics. Options appear when an agent-drafted ask named a dimension with answerhood and had its question stripped by the safety gate.

`ParkedNegotiation` gains `dimensionKind` (matched by normalized name against the checklist the park turn itself persisted — its only store) and `answerhood`. Neither had a reader before.

## 2. Deterministic precedence for free text while a question is open

`services/api/src/lib/question/answer-precedence.ts` (new), wired in `chat.controller.ts` **before** `factory.streamChatEventsWithContext`.

With an open question in the DM's `(userId, intentId)` scope, the reply goes to the answer evaluator (`QuestionAnswerRouter` — the existing judgment, not a new one) first:

- **answered** → the orchestrator does not run at all. Its event stream is swapped for an empty one, so no tool fires and the edit rule cannot reach this message. The turn's text is server-owned copy (same rule as the close-out and clarification messages) and consumption is enqueued on the serialized question-message queue **carrying the gate's routing**, so the job consumes the decision the client was just acknowledged for instead of re-deciding it.
- **declined** → falls through to the orchestrator, byte for byte as today. No consumption job: that verdict is the one the job would have reached, and it already ran.
- **evaluator unavailable** → falls through to the orchestrator *and* enqueues consumption unrouted, so the queue's retry still covers a provider outage the way it did before. Both lanes end in the same settlement-keyed idempotent consumption.
- **no open question** → nothing here runs; the cheap parse-first guard means an ordinary DM never touches the negotiation tables.

Cost: on a turn where a question *is* open, one evaluator round trip before the orchestrator starts. Nowhere else.

## 3. The orchestrator's long-tail tool

`answer_pending_question` — for the oblique answer, the late one, the one folded into a message that is also asking for something else. The orchestrator's context now names what is open in this scope, numbered, and the tool takes those numbers; the mapping onto negotiation refs lives on the host (`negotiator-answer.host.ts`), so the model never sees or emits an id. Routing reuses the same consumption path as everything above.

**The brief said to reuse the MCP `answer_pending_question`. There isn't one** — it was retired with the card question surface (`tests/mcp.spec.ts`: "does not list the retired question tools"). So this is built over `consumeQuestionBlockAnswers` directly, which is where that tool pointed anyway.

Specs for 1 and 2 pass with this tool absent, as required.

## Flagged: the edit rule's confirmation bar

**Inside question scope** the bar is deterministic and comes free from fix 2: the orchestrator cannot see a message the evaluator took as an answer, so the edit rule cannot rewrite the signal from one. Belt-and-braces, the prompt also carries it in words: *"An answer is not a change of signal. While a question above is open, do NOT update this signal on the strength of a message that answers it: route the answer first."*

**Outside question scope I did not add one, and that is a decision, not an omission.** A global "short or ambiguous messages need an explicit confirm" bar is a blunt heuristic that misfires on legitimate short instructions ("make it remote-only", "drop Birmingham"), and it is precisely the model-judgment-shaped gate this week's lesson says not to lean on. The prompt already requires confirmation before a signal update, and the record shows that when the client *was* asked ("Would you like me to update your signal to…?" at 20:19:38) the flow worked. Reverse it if you disagree — it is one prompt line plus a guard.

Worth noting separately, because this PR does not fix it: at 20:24:18 the agent told the client it had set "this month" while the payload it wrote has **no timing at all**. That is an honesty gap in the edit path, not a routing one.

## Boundary deviation

The brief said `services/api` + `apps/web` only, no protocol changes. Fix 3 could not be done that way: the chat orchestrator, its persona, prompt and tool registry all live in `packages/protocol/src/chat/`. So this touches four protocol files — `chat/negotiator.{persona,prompt,tools}.ts`, `shared/agent/tool.helpers.ts` — plus one new interface. **No schema files, nothing under `negotiations/` or `questions/`**, so `fix/ask-generation-schema-seam` stays disjoint. Fixes 1 and 2 are entirely inside `services/api`. `apps/web` is untouched — blocks already render.

## Tests

New: `dimension-question.spec.ts` (11), `answer-precedence.spec.ts` (8, the incident as a spec), `negotiator-answer.host.spec.ts` (6), `answer-precedence.wiring.static.spec.ts` (5 — pins the *order* inside the controller, which no unit test can reach and which is the whole fix), `negotiator.answer-tools.spec.ts` (8). Extended: the author spec (floor-fired parks, authored/derived mixes), the queue isolated spec (pre-routed payload skips the router), and the classifier-convergence spec — a real floor-fired park persisted to Postgres, proving the reader recovers dimension, kind and answerhood off the turn.

Also fixes one **pre-existing** failure on `dev`: `QuestionMessageAuthor > maps model output indices to opportunity refs` had a stale expectation predating the block's `options` field.

Full-suite diff against `dev`, timings stripped: `services/api` — identical failure set minus that one; `packages/protocol` — identical (94), the only delta being a live-LLM eval flake.

## Live verification — NOT done, and it cannot be from here

The brief asks for the still-parked question to be answered on sandbox after the fix. That needs the fix deployed, and this worktree session neither merges nor deploys. What I did verify against `protocol_sandbox` (read-only) is the table at the top and the current state: task `aefff73b` is still `input_required`, `userAnswers` is still `null`, the intent still carries the rewritten payload.

One thing to know before trying it: the DM's question-message is **no longer the newest agent message** — the edit confirmation is — so by the open-question predicate nothing is open in that scope today. A regeneration has to re-deliver the question-message first (any park trigger or opportunity transition on that signal will do it). Then answering in the DM should route, resume `aefff73b`, and leave `intents.payload` untouched.
