### PR TITLE
fix(opportunities): a won match is not the enricher's to expire

### DIFF
--- a/services/api/.test-isolated
+++ b/services/api/.test-isolated
@@ -117,3 +117,4 @@ src/lib/testing/tests/fixtures/isolated-import-target.isolated.ts
 src/adapters/tests/embedder.provider-free.isolated.ts
 src/queues/tests/question-message.queue.isolated.ts
 src/lib/question/tests/question-exhaustion.evaluator.isolated.ts
+src/controllers/tests/opportunity.reopen.controller.isolated.ts

--- a/services/api/src/adapters/opportunity.database.adapter.ts
+++ b/services/api/src/adapters/opportunity.database.adapter.ts
@@ -1,4 +1,4 @@
-import { schema, CreateOpportunityInput, OpportunityRow, UserIdentity, and, buildProfileFromUser, db, desc, eq, gte, inArray, isNotNull, isNull, lte, ne, normalizeEmbedding, notInArray, opportunities, or, sql, toOpportunityRow, traceAppOperation } from './database.shared';
+import { schema, CreateOpportunityInput, OpportunityRow, UserIdentity, and, buildProfileFromUser, db, desc, eq, gte, inArray, isNotNull, isNull, logger, lte, ne, normalizeEmbedding, notInArray, opportunities, or, sql, toOpportunityRow, traceAppOperation } from './database.shared';
 import { emitOpportunityLifecycleBestEffort, emitOpportunityTransitionBestEffort } from '../events/opportunity.event';
 import { computeIntentFingerprint } from '../lib/intent/intent.fingerprint';
 import { computeOutcomeCounterpartDedupKey, computeOutcomeIdempotencyKey, computeOutcomeSnapshotHash } from '../lib/opportunity/outcome-feedback.identity';
@@ -24,6 +24,14 @@ interface IntentScopedOpportunityPersistenceConflict {
 type IntentScopedOpportunityPersistenceResult =
   | { created: OpportunityRow; expired: OpportunityRow[] }
   | { conflict: IntentScopedOpportunityPersistenceConflict };
+
+/** Statuses a dead pairing may be reopened from — see {@link OpportunityDatabaseAdapter.reopenOpportunityForRerun}. */
+export const REOPENABLE_OPPORTUNITY_STATUSES = ['rejected', 'stalled', 'expired'] as const;
+
+export type ReopenOpportunityResult =
+  | { reopened: OpportunityRow }
+  | { conflict: 'active_negotiation'; taskId: string }
+  | { conflict: 'not_reopenable'; status: OpportunityRow['status'] };
 
 function opportunityTriggerForOwner(opportunity: OpportunityRow, ownerUserId: string): string | undefined {
   return opportunity.detection.triggeredBy
@@ -252,6 +260,80 @@ export function notificationSnapshotOpportunityWhere(userId: string) {
     sql`${opportunities.actors}::jsonb @> ${JSON.stringify([{ userId }])}::jsonb`,
     inArray(opportunities.status, ['latent', 'pending']),
   )!;
+}
+
+/**
+ * Statuses that enrichment-superseded expiry must never touch.
+ *
+ * `pending` means the agents already agreed and the row is waiting on its
+ * OWNER's approval — a won match. The protocol enricher's merge-candidate pool
+ * (DEFAULT_ENRICHER_EXCLUDE_STATUSES) omits `pending`, so a later sweep that
+ * re-finds the same pair hands the pending row back to us in `expireIds`;
+ * expiring it evaporates a match the human was about to approve.
+ *
+ * The invariant this pins: a `pending` opportunity leaves `pending` only by a
+ * human decision (accept/reject) or by its signal being archived — never by
+ * background churn. The intent-archive and removed-member cascades are
+ * deliberate human-caused paths and are unaffected.
+ */
+export const ENRICHMENT_EXPIRY_PROTECTED_STATUSES = ['pending'] as const;
+
+/**
+ * Expire the rows an enrichment merge superseded, skipping protected ones.
+ *
+ * A skipped row keeps its status AND its `updated_at` — an attempt CAS keyed to
+ * that timestamp must not lose its claim to a sweep that decided to leave the
+ * row alone. The newly created enriched row is still written, so dedup and
+ * suppression handle the duplicate on the read side as they always have.
+ *
+ * Runs inside the caller's transaction: the candidate statuses are read
+ * `FOR UPDATE`, so the skip decision cannot race a concurrent human decision.
+ *
+ * @param tx - The caller's open transaction
+ * @param expireIds - Rows the enricher marked superseded
+ * @param extraWhere - Extra predicate the caller scopes its expiry with
+ * @returns The rows actually expired
+ */
+async function expireEnrichmentSupersededIds(
+  tx: DrizzleTx,
+  expireIds: string[],
+  extraWhere?: ReturnType<typeof and>,
+): Promise<OpportunityRow[]> {
+  const expired: OpportunityRow[] = [];
+  if (expireIds.length === 0) return expired;
+
+  const candidates = await tx
+    .select({ id: opportunities.id, status: opportunities.status })
+    .from(opportunities)
+    .where(inArray(opportunities.id, expireIds))
+    // Deterministic lock order: two sweeps whose expire sets overlap queue up
+    // behind each other instead of deadlocking on a mirrored acquisition order.
+    .orderBy(opportunities.id)
+    .for('update');
+  const protectedIds = candidates
+    .filter((row) => (ENRICHMENT_EXPIRY_PROTECTED_STATUSES as readonly string[]).includes(row.status))
+    .map((row) => row.id);
+  if (protectedIds.length > 0) {
+    logger.info('enricher_skipped_pending', { opportunityIds: protectedIds });
+  }
+
+  const now = new Date();
+  for (const opportunityId of expireIds) {
+    if (protectedIds.includes(opportunityId)) continue;
+    const [row] = await tx
+      .update(opportunities)
+      .set({ status: 'expired', updatedAt: now })
+      .where(and(
+        eq(opportunities.id, opportunityId),
+        // Belt-and-braces: the FOR UPDATE read above already settled the skip,
+        // so this can only matter if that read is ever removed.
+        notInArray(opportunities.status, [...ENRICHMENT_EXPIRY_PROTECTED_STATUSES]),
+        ...(extraWhere ? [extraWhere] : []),
+      ))
+      .returning();
+    if (row) expired.push(toOpportunityRow(row));
+  }
+  return expired;
 }
 
 export class OpportunityDatabaseAdapter {
@@ -519,21 +601,7 @@ export class OpportunityDatabaseAdapter {
         throw new Error('OpportunityDatabaseAdapter.persistIntentScopedOpportunityIfNetworkEligible: no row returned');
       }
 
-      const expired: OpportunityRow[] = [];
-      if (expireIds.length > 0) {
-        const now = new Date();
-        for (const opportunityId of expireIds) {
-          const [row] = await tx
-            .update(opportunities)
-            .set({ status: 'expired', updatedAt: now })
-            .where(and(
-              eq(opportunities.id, opportunityId),
-              sameTrigger,
-            ))
-            .returning();
-          if (row) expired.push(toOpportunityRow(row));
-        }
-      }
+      const expired = await expireEnrichmentSupersededIds(tx, expireIds, sameTrigger);
       return { created: toOpportunityRow(inserted), expired };
     });
 
@@ -691,6 +759,69 @@ export class OpportunityDatabaseAdapter {
       expectedUpdatedAt,
       fallbackStatus,
     ));
+  }
+
+  /**
+   * Reopen a dead pairing so the negotiation can be re-run.
+   *
+   * Terminal-only by design: `pending` (awaiting the owner's approval) and
+   * `accepted` (already connected) are live or won matches, never reopenable —
+   * reopening one would throw away a decision, not recover from a dead end.
+   *
+   * `updated_at` is written as `date_trunc('milliseconds', now())` and NOT with
+   * a bare `now()`. The attempt CAS in
+   * `createNegotiationTaskForAttemptInTransaction` compares this timestamp with
+   * a JS `Date` read back from the row, which carries milliseconds only; a
+   * microsecond-precision write makes the equality fail and the queued re-run
+   * dies as "stale or already claimed".
+   *
+   * Serializes on the shared negotiation-attempt lock, so a reopen racing a
+   * live claim observes the committed winner and reports the conflict instead
+   * of yanking a running negotiation back to `stalled`.
+   *
+   * @param id - Opportunity ID
+   * @returns The reopened row, a conflict describing why it was refused, or
+   *   `null` when no such opportunity exists
+   */
+  async reopenOpportunityForRerun(id: string): Promise<ReopenOpportunityResult | null> {
+    const result = await db.transaction(async (tx): Promise<ReopenOpportunityResult | null> => {
+      await acquireNegotiationAttemptLock(tx, id);
+
+      const [opportunity] = await tx
+        .select({ status: opportunities.status })
+        .from(opportunities)
+        .where(eq(opportunities.id, id))
+        .for('update');
+      if (!opportunity) return null;
+      if (!(REOPENABLE_OPPORTUNITY_STATUSES as readonly string[]).includes(opportunity.status)) {
+        return { conflict: 'not_reopenable', status: opportunity.status };
+      }
+
+      const [activeTask] = await tx
+        .select({ id: schema.tasks.id })
+        .from(schema.tasks)
+        .where(qualifyingActiveNegotiationTaskWhere(id))
+        .limit(1);
+      if (activeTask) return { conflict: 'active_negotiation', taskId: activeTask.id };
+
+      const [row] = await tx
+        .update(opportunities)
+        .set({
+          status: 'stalled',
+          acceptedBy: null,
+          updatedAt: sql`date_trunc('milliseconds', now())`,
+        })
+        .where(and(
+          eq(opportunities.id, id),
+          inArray(opportunities.status, [...REOPENABLE_OPPORTUNITY_STATUSES]),
+        ))
+        .returning();
+      return row ? { reopened: toOpportunityRow(row) } : null;
+    });
+    if (result && 'reopened' in result) {
+      emitOpportunityTransitionBestEffort(result.reopened);
+    }
+    return result;
   }
 
   async getOpportunity(id: string): Promise<OpportunityRow | null> {
@@ -1260,16 +1391,7 @@ export class OpportunityDatabaseAdapter {
         .returning();
       if (!inserted) throw new Error('OpportunityDatabaseAdapter.createOpportunityAndExpireIds: no row returned');
       const created = toOpportunityRow(inserted);
-      const expired: OpportunityRow[] = [];
-      const now = new Date();
-      for (const id of expireIds) {
-        const [row] = await tx
-          .update(opportunities)
-          .set({ status: 'expired', updatedAt: now })
-          .where(eq(opportunities.id, id))
-          .returning();
-        if (row) expired.push(toOpportunityRow(row));
-      }
+      const expired = await expireEnrichmentSupersededIds(tx, expireIds);
       return { created, expired };
     }),
     );
@@ -1352,16 +1474,7 @@ export class OpportunityDatabaseAdapter {
         .returning();
       if (!inserted) throw new Error('OpportunityDatabaseAdapter.createOpportunityAndExpireIdsIfNetworkEligible: no row returned');
 
-      const expired: OpportunityRow[] = [];
-      const now = new Date();
-      for (const opportunityId of expireIds) {
-        const [row] = await tx
-          .update(opportunities)
-          .set({ status: 'expired', updatedAt: now })
-          .where(eq(opportunities.id, opportunityId))
-          .returning();
-        if (row) expired.push(toOpportunityRow(row));
-      }
+      const expired = await expireEnrichmentSupersededIds(tx, expireIds);
       return { created: toOpportunityRow(inserted), expired };
     });
     if (result) emitOpportunityLifecycleBestEffort(result.created);

--- a/services/api/src/adapters/tests/enricher-pending-guard.database.spec.ts
+++ b/services/api/src/adapters/tests/enricher-pending-guard.database.spec.ts
@@ -1,0 +1,154 @@
+/**
+ * Pending is sacred: the enricher may not expire a won match.
+ *
+ * `pending` means the agents already agreed and the row is waiting on its
+ * OWNER's approval. The protocol enricher's merge-candidate pool
+ * (DEFAULT_ENRICHER_EXCLUDE_STATUSES) omits `pending`, so a background sweep
+ * that re-finds the same pair hands the pending row back to the api in
+ * `expireIds` — and, before this guard, the api expired it, evaporating a match
+ * the human was about to approve.
+ *
+ * The invariant pinned here: a `pending` opportunity leaves `pending` only by a
+ * human decision (accept/reject) or by its signal being archived — never by
+ * background churn. The intent-archive and removed-member cascades are
+ * deliberate human-caused paths and stay, so this spec pins both sides.
+ */
+import { afterAll, describe, expect, setDefaultTimeout, test } from 'bun:test';
+import { readFileSync } from 'node:fs';
+import { randomUUID } from 'crypto';
+import { eq, inArray } from 'drizzle-orm';
+
+import db from '../../lib/drizzle/drizzle';
+import { OpportunityDatabaseAdapter, ENRICHMENT_EXPIRY_PROTECTED_STATUSES } from '../opportunity.database.adapter';
+import { opportunities } from '../../schemas/database.schema';
+
+setDefaultTimeout(30_000);
+
+const adapter = new OpportunityDatabaseAdapter();
+const createdOpportunityIds: string[] = [];
+
+afterAll(async () => {
+  if (createdOpportunityIds.length > 0) {
+    await db.delete(opportunities).where(inArray(opportunities.id, createdOpportunityIds));
+  }
+});
+
+const PAIR = [randomUUID(), randomUUID()];
+const NETWORK_ID = randomUUID();
+
+async function seedOpportunity(
+  status: typeof opportunities.$inferSelect['status'],
+  intentId = randomUUID(),
+) {
+  const [opportunity] = await db.insert(opportunities).values({
+    detection: { source: 'opportunity_graph', triggeredBy: intentId } as never,
+    actors: [
+      { userId: PAIR[0], networkId: NETWORK_ID, role: 'patient', intent: intentId },
+      { userId: PAIR[1], networkId: NETWORK_ID, role: 'agent' },
+    ] as never,
+    interpretation: { reasoning: 'pending-guard fixture', category: 'collaboration' } as never,
+    context: { networkId: NETWORK_ID } as never,
+    confidence: '0.8',
+    status,
+  }).returning();
+  createdOpportunityIds.push(opportunity.id);
+  return opportunity;
+}
+
+/** The merged row a sweep writes when it re-finds the same pair. */
+function enrichedCandidate() {
+  return {
+    detection: { source: 'opportunity_graph', triggeredBy: randomUUID() },
+    actors: [
+      { userId: PAIR[0], networkId: NETWORK_ID, role: 'patient' },
+      { userId: PAIR[1], networkId: NETWORK_ID, role: 'agent' },
+    ],
+    interpretation: { reasoning: 'later sweep re-found this pair', category: 'collaboration' },
+    context: { networkId: NETWORK_ID },
+    confidence: '0.82',
+    status: 'pending' as const,
+  } as never;
+}
+
+async function readRow(id: string) {
+  const [row] = await db.select().from(opportunities).where(eq(opportunities.id, id));
+  return row;
+}
+
+describe('enricher expiry — pending is sacred', () => {
+  test('a pending prior row survives a merge sweep untouched, and the new row is still written', async () => {
+    const won = await seedOpportunity('pending');
+
+    const result = await adapter.createOpportunityAndExpireIds(enrichedCandidate(), [won.id]);
+    createdOpportunityIds.push(result.created.id);
+
+    // The won match is exactly as the sweep found it — status AND updatedAt, so
+    // an attempt CAS keyed to that timestamp keeps its claim.
+    const after = await readRow(won.id);
+    expect(after.status).toBe('pending');
+    expect(after.updatedAt.getTime()).toBe(won.updatedAt.getTime());
+
+    // Nothing was expired, and the enriched candidate still exists for dedup
+    // and suppression to handle on the read side.
+    expect(result.expired).toHaveLength(0);
+    expect(result.created.id).not.toBe(won.id);
+  });
+
+  test.each(['rejected', 'stalled', 'latent', 'draft'] as const)(
+    'a %s prior row still merges and expires — the guard narrowed nothing else',
+    async (status) => {
+      const prior = await seedOpportunity(status);
+
+      const result = await adapter.createOpportunityAndExpireIds(enrichedCandidate(), [prior.id]);
+      createdOpportunityIds.push(result.created.id);
+
+      expect(result.expired.map((row) => row.id)).toEqual([prior.id]);
+      expect((await readRow(prior.id)).status).toBe('expired');
+    },
+  );
+
+  test('a mixed expire set expires the dead rows and keeps only the pending one', async () => {
+    const won = await seedOpportunity('pending');
+    const dead = await seedOpportunity('stalled');
+
+    const result = await adapter.createOpportunityAndExpireIds(enrichedCandidate(), [won.id, dead.id]);
+    createdOpportunityIds.push(result.created.id);
+
+    expect(result.expired.map((row) => row.id)).toEqual([dead.id]);
+    expect((await readRow(won.id)).status).toBe('pending');
+    expect((await readRow(dead.id)).status).toBe('expired');
+  });
+
+  test('the deliberate human-caused cascade still expires a pending row', async () => {
+    // Archiving the signal behind a match is a human decision, not background
+    // churn — the invariant names it as a way out of `pending`.
+    const intentId = randomUUID();
+    const won = await seedOpportunity('pending', intentId);
+
+    expect(await adapter.expireOpportunitiesByIntent(intentId)).toBeGreaterThan(0);
+    expect((await readRow(won.id)).status).toBe('expired');
+  });
+});
+
+describe('enricher expiry — every merge path routes through the guard', () => {
+  const source = readFileSync('src/adapters/opportunity.database.adapter.ts', 'utf8');
+
+  test('pending is the protected status', () => {
+    expect([...ENRICHMENT_EXPIRY_PROTECTED_STATUSES]).toEqual(['pending']);
+  });
+
+  test("no merge path writes status: 'expired' outside the shared guarded helper", () => {
+    // The three enrichment-superseded expiry paths — createOpportunityAndExpireIds,
+    // createOpportunityAndExpireIdsIfNetworkEligible and
+    // persistIntentScopedOpportunityIfNetworkEligible — must all delegate, or a
+    // sweep regains a way to expire a won match. The bulk writers
+    // (expireOpportunitiesByIntent / ForRemovedMember / expireStaleOpportunities)
+    // are deliberate non-enrichment paths and keep their own writes.
+    const guardedCalls = source.match(/expireEnrichmentSupersededIds\(tx,/g) ?? [];
+    expect(guardedCalls).toHaveLength(3);
+
+    const expiredWrites = source.match(/\.set\(\{ status: 'expired'/g) ?? [];
+    // One inside the helper, plus the three bulk writers.
+    expect(expiredWrites).toHaveLength(4);
+  });
+});

--- a/services/api/src/adapters/tests/opportunity-reopen.database.spec.ts
+++ b/services/api/src/adapters/tests/opportunity-reopen.database.spec.ts
@@ -1,0 +1,148 @@
+/**
+ * Reopening a dead pairing (POST /api/opportunities/:id/reopen).
+ *
+ * Pins the write against the real database: which statuses may be reopened,
+ * that a live negotiation task blocks the reopen with its task id, and — the
+ * part that broke by hand on 2026-08-19 — that `updated_at` lands on a whole
+ * millisecond. The attempt CAS in
+ * `createNegotiationTaskForAttemptInTransaction` compares that column with a JS
+ * `Date`, which carries milliseconds only; a bare `now()` writes microseconds
+ * and the queued re-run dies as "stale or already claimed". The last test
+ * closes that loop by actually claiming the attempt after a reopen.
+ */
+import { afterAll, describe, expect, setDefaultTimeout, test } from 'bun:test';
+import { randomUUID } from 'crypto';
+import { eq, inArray, sql } from 'drizzle-orm';
+
+import db from '../../lib/drizzle/drizzle';
+import { OpportunityDatabaseAdapter, REOPENABLE_OPPORTUNITY_STATUSES } from '../opportunity.database.adapter';
+import { ConversationDatabaseAdapter } from '../conversation.database.adapter';
+import { opportunities } from '../../schemas/database.schema';
+import { conversations, messages, tasks } from '../../schemas/conversation.schema';
+
+setDefaultTimeout(30_000);
+
+const adapter = new OpportunityDatabaseAdapter();
+const conversationAdapter = new ConversationDatabaseAdapter();
+
+const createdOpportunityIds: string[] = [];
+const createdConversationIds: string[] = [];
+
+afterAll(async () => {
+  if (createdConversationIds.length > 0) {
+    await db.delete(messages).where(inArray(messages.conversationId, createdConversationIds));
+    await db.delete(tasks).where(inArray(tasks.conversationId, createdConversationIds));
+    await db.delete(conversations).where(inArray(conversations.id, createdConversationIds));
+  }
+  if (createdOpportunityIds.length > 0) {
+    await db.delete(opportunities).where(inArray(opportunities.id, createdOpportunityIds));
+  }
+});
+
+async function seedOpportunity(status: typeof opportunities.$inferSelect['status']) {
+  const [opportunity] = await db.insert(opportunities).values({
+    detection: { source: 'opportunity_graph' } as never,
+    actors: [
+      { userId: randomUUID(), networkId: randomUUID(), role: 'patient' },
+      { userId: randomUUID(), networkId: randomUUID(), role: 'agent' },
+    ] as never,
+    interpretation: { reasoning: 'reopen fixture', category: 'collaboration' } as never,
+    context: {} as never,
+    confidence: '0.8',
+    status,
+  }).returning();
+  createdOpportunityIds.push(opportunity.id);
+  return opportunity;
+}
+
+async function createConversation(): Promise<string> {
+  const [conversation] = await db.insert(conversations).values({}).returning();
+  createdConversationIds.push(conversation.id);
+  return conversation.id;
+}
+
+async function readRow(id: string) {
+  const [row] = await db.select().from(opportunities).where(eq(opportunities.id, id));
+  return row;
+}
+
+/** The database's own view of the precision actually stored. */
+async function updatedAtIsWholeMilliseconds(id: string): Promise<boolean> {
+  const result = await db.execute(sql`
+    SELECT date_part('microseconds', updated_at)::int % 1000 = 0 AS whole
+    FROM opportunities WHERE id = ${id}
+  `);
+  const rows = (result as unknown as { rows?: Array<{ whole: boolean }> }).rows
+    ?? (result as unknown as Array<{ whole: boolean }>);
+  return rows[0].whole;
+}
+
+describe('reopenOpportunityForRerun', () => {
+  test.each([...REOPENABLE_OPPORTUNITY_STATUSES])(
+    'a %s match reopens to stalled with a millisecond-truncated updated_at',
+    async (status) => {
+      const opportunity = await seedOpportunity(status);
+
+      const result = await adapter.reopenOpportunityForRerun(opportunity.id);
+
+      expect(result).toBeTruthy();
+      expect(result && 'reopened' in result && result.reopened.status).toBe('stalled');
+      expect((await readRow(opportunity.id)).status).toBe('stalled');
+      expect(await updatedAtIsWholeMilliseconds(opportunity.id)).toBe(true);
+    },
+  );
+
+  test.each(['pending', 'accepted', 'negotiating', 'latent', 'draft'] as const)(
+    'a %s match is refused — a live or won match is not reopenable',
+    async (status) => {
+      const opportunity = await seedOpportunity(status);
+
+      const result = await adapter.reopenOpportunityForRerun(opportunity.id);
+
+      expect(result).toEqual({ conflict: 'not_reopenable', status });
+      const after = await readRow(opportunity.id);
+      expect(after.status).toBe(status);
+      expect(after.updatedAt.getTime()).toBe(opportunity.updatedAt.getTime());
+    },
+  );
+
+  test('a live negotiation task blocks the reopen and names the task', async () => {
+    const opportunity = await seedOpportunity('stalled');
+    const conversationId = await createConversation();
+    const task = await conversationAdapter.createTask(conversationId, {
+      type: 'negotiation',
+      opportunityId: opportunity.id,
+      intentSnapshots: [],
+    });
+    await db.update(tasks).set({ state: 'working' }).where(eq(tasks.id, task.id));
+
+    const result = await adapter.reopenOpportunityForRerun(opportunity.id);
+
+    expect(result).toEqual({ conflict: 'active_negotiation', taskId: task.id });
+    expect((await readRow(opportunity.id)).updatedAt.getTime())
+      .toBe(opportunity.updatedAt.getTime());
+  });
+
+  test('an unknown opportunity answers null', async () => {
+    expect(await adapter.reopenOpportunityForRerun(randomUUID())).toBeNull();
+  });
+
+  test('the reopened row can immediately claim a fresh negotiation attempt', async () => {
+    // The load-bearing end of the millisecond truncation: the re-run reads the
+    // row it just reopened and claims an attempt against its exact updated_at.
+    const opportunity = await seedOpportunity('rejected');
+    await adapter.reopenOpportunityForRerun(opportunity.id);
+    const reopened = await readRow(opportunity.id);
+
+    const attempt = await conversationAdapter.createNegotiationTaskForAttempt({
+      conversationId: await createConversation(),
+      opportunityId: reopened.id,
+      expectedStatus: reopened.status,
+      expectedUpdatedAt: reopened.updatedAt,
+      metadata: { type: 'negotiation', opportunityId: reopened.id, intentSnapshots: [] },
+    });
+
+    expect(attempt).not.toBeNull();
+    expect((await readRow(opportunity.id)).status).toBe('negotiating');
+  });
+});

--- a/services/api/src/controllers/opportunity.controller.ts
+++ b/services/api/src/controllers/opportunity.controller.ts
@@ -278,6 +278,48 @@ export class OpportunityController {
   }
 
   /**
+   * POST /opportunities/:id/reopen — reopen a dead pairing and queue its
+   * negotiation re-run. Accepts a full UUID or short ID prefix.
+   *
+   * Terminal-only: `rejected`, `stalled`, or `expired`. A `pending` match is
+   * waiting on its owner's decision and an `accepted` one already connected —
+   * both answer 409, as does a match that still has a live negotiation task
+   * (the response then carries that task's `taskId`).
+   *
+   * @param req - Incoming request (body is ignored; the agent network scope is read from it).
+   * @param user - Authenticated user; must be an actor on the opportunity.
+   * @param params - Route params; `id` is the opportunity ID.
+   * @returns 202 `{ opportunityId, status: 'stalled', enqueued: true }`, or a
+   *   structured error (403 for non-actors, 404 unknown, 409 not reopenable).
+   */
+  @Post('/:id/reopen')
+  @UseGuards(RateLimit('write'), AuthGuard)
+  async reopen(req: Request, user: AuthenticatedUser, params?: RouteParams) {
+    const id = params?.id;
+    if (!id) {
+      return Response.json({ error: 'Missing opportunity id' }, { status: 400 });
+    }
+
+    const resolved = await opportunityService.resolveId(id, user.id);
+    if ('error' in resolved) {
+      return Response.json({ error: resolved.error }, { status: resolved.status });
+    }
+
+    const { networkScopeId } = await withAgentScope(req, user);
+    const result = await opportunityService.reopenOpportunity(resolved.id, user.id, {
+      ...(networkScopeId ? { networkScopeId } : {}),
+    });
+    if ('error' in result) {
+      return Response.json(
+        result.taskId ? { error: result.error, taskId: result.taskId } : { error: result.error },
+        { status: result.status },
+      );
+    }
+    logger.info('Opportunity reopened', { userId: user.id, opportunityId: resolved.id });
+    return Response.json(result, { status: 202 });
+  }
+
+  /**
    * POST /opportunities/:id/owner-approvals — issue a single-use owner-approval
    * proof for a pending MCP-agent interaction challenge (IND-593).
    *

--- a/services/api/src/controllers/tests/opportunity.reopen.controller.isolated.ts
+++ b/services/api/src/controllers/tests/opportunity.reopen.controller.isolated.ts
@@ -1,0 +1,103 @@
+/**
+ * Wire contract for POST /api/opportunities/:id/reopen.
+ *
+ * The floor page wires its Reopen button straight to these codes and this body,
+ * so they are pinned here against the controller with a stubbed service: 202
+ * `{ opportunityId, status: 'stalled', enqueued: true }` on success, 403 for a
+ * non-actor, and 409 (carrying `taskId` when a negotiation is in flight) for a
+ * match that is not a dead end. The behaviour behind them lives in
+ * `src/services/tests/opportunity.service.reopen.spec.ts`.
+ */
+import { config } from 'dotenv';
+config({ path: '.env.test', override: true });
+
+import { afterAll, beforeAll, describe, expect, mock, test } from 'bun:test';
+
+import type { AuthenticatedUser } from '../../guards/auth.guard';
+import { RouteRegistry } from '../../lib/router/router.decorators';
+
+const OPP_ID = '11111111-1111-4111-8111-111111111111';
+
+const reopenOpportunity = mock(async (..._args: unknown[]) => ({}) as unknown);
+const resolveId = mock(async () => ({ id: OPP_ID }) as unknown);
+
+mock.module('../../queues/notification.queue', () => ({
+  queueOpportunityNotification: async () => ({ id: 'mock-job' }),
+}));
+mock.module('../../services/opportunity.service', () => ({
+  opportunityService: { resolveId, reopenOpportunity },
+}));
+
+let OpportunityControllerClass: typeof import('../opportunity.controller').OpportunityController;
+
+beforeAll(async () => {
+  OpportunityControllerClass = (await import('../opportunity.controller')).OpportunityController;
+});
+
+afterAll(() => {
+  mock.restore();
+});
+
+const user: AuthenticatedUser = { id: 'user-actor-1', email: 'actor@example.com', name: 'Actor' };
+
+function request() {
+  return new Request(`http://localhost/api/opportunities/${OPP_ID}/reopen`, { method: 'POST' });
+}
+
+async function callReopen() {
+  const response = await new OpportunityControllerClass().reopen(request(), user, { id: OPP_ID });
+  return { response, body: await response.json() as Record<string, unknown> };
+}
+
+describe('POST /api/opportunities/:id/reopen', () => {
+  test('the route is registered on the opportunity controller', async () => {
+    const { OpportunityController } = await import('../opportunity.controller');
+    const routes = RouteRegistry.getRoutes(OpportunityController);
+    expect(routes.some((route) => route.method === 'POST' && route.path === '/:id/reopen')).toBe(true);
+  });
+
+  test('202 with the enqueued payload the floor page reads', async () => {
+    reopenOpportunity.mockResolvedValueOnce({ opportunityId: OPP_ID, status: 'stalled', enqueued: true });
+
+    const { response, body } = await callReopen();
+
+    expect(response.status).toBe(202);
+    expect(body).toEqual({ opportunityId: OPP_ID, status: 'stalled', enqueued: true });
+  });
+
+  test('403 for a non-actor', async () => {
+    reopenOpportunity.mockResolvedValueOnce({ error: 'Not authorized to reopen this opportunity', status: 403 });
+
+    const { response, body } = await callReopen();
+
+    expect(response.status).toBe(403);
+    expect(body).toEqual({ error: 'Not authorized to reopen this opportunity' });
+  });
+
+  test('409 carries the live task id', async () => {
+    reopenOpportunity.mockResolvedValueOnce({
+      error: 'This match already has a negotiation in flight',
+      status: 409,
+      taskId: 'task-live-1',
+    });
+
+    const { response, body } = await callReopen();
+
+    expect(response.status).toBe(409);
+    expect(body).toEqual({ error: 'This match already has a negotiation in flight', taskId: 'task-live-1' });
+  });
+
+  test('409 without a task id for a pending match', async () => {
+    reopenOpportunity.mockResolvedValueOnce({
+      error: 'Only a rejected, stalled, or expired match can be reopened (this one is pending)',
+      status: 409,
+    });
+
+    const { response, body } = await callReopen();
+
+    expect(response.status).toBe(409);
+    expect(body).toEqual({
+      error: 'Only a rejected, stalled, or expired match can be reopened (this one is pending)',
+    });
+  });
+});

--- a/services/api/src/services/opportunity.service.ts
+++ b/services/api/src/services/opportunity.service.ts
@@ -4,6 +4,9 @@ import { RadarGraphFactory, MaintenanceGraphFactory, type MaintenanceGraphDataba
 import type { OpportunityControllerDatabase, RadarGraphDatabase, CreateOpportunityData, Opportunity, OpportunityActor, OpportunityStatus, Embedder, OpportunityCache } from '@indexnetwork/protocol';
 
 import { ChatDatabaseAdapter, chatDatabaseAdapter, conversationDatabaseAdapter } from '../adapters/database.adapter';
+// Imported from the owning adapter rather than the barrel: the reopen write is
+// api-local, and specs that stub the barrel should not have to know about it.
+import { OpportunityDatabaseAdapter, type ReopenOpportunityResult } from '../adapters/opportunity.database.adapter';
 import { EmbedderAdapter } from '../adapters/embedder.adapter';
 import { RedisCacheAdapter } from '../adapters/cache.adapter';
 import { outcomeFeedbackRecorder, type OutcomeFeedbackRecorderLike, type PreparedOutcomeCapture, type OwnerActionProvenance } from '../lib/opportunity/outcome-feedback.recorder';
@@ -13,6 +16,7 @@ import type { OutcomeOutbox } from '@indexnetwork/protocol';
 const logger = log.service.from("OpportunityService");
 const startChatLogger = log.service.from("OpportunityService.startChat");
 const updateStatusLogger = log.service.from("OpportunityService.updateOpportunityStatus");
+const reopenLogger = log.service.from("OpportunityService.reopenOpportunity");
 
 /**
  * Lifecycle statuses surfaced in the default opportunity list (when no explicit
@@ -223,6 +227,25 @@ interface OpportunityPresentationDeps {
   gatherContext?: typeof gatherPresenterContext;
 }
 
+/**
+ * Reopen seam. The reopen write is api-local (it lives on
+ * `OpportunityDatabaseAdapter`, not on the protocol database port), so the
+ * service reaches it through this narrow port rather than through `this.db`.
+ */
+export interface OpportunityReopenDatabase {
+  reopenOpportunityForRerun(id: string): Promise<ReopenOpportunityResult | null>;
+}
+
+/** Enqueue seam for the re-run job, so specs can assert the enqueue without Redis. */
+export interface NegotiationRerunQueue {
+  addJob(data: { opportunityId: string; userId: string }): Promise<unknown>;
+}
+
+export interface OpportunityReopenDeps {
+  database?: OpportunityReopenDatabase;
+  queue?: NegotiationRerunQueue;
+}
+
 export class OpportunityService {
   private db: OpportunityControllerDatabase;
   private cache: OpportunityCache;
@@ -238,6 +261,10 @@ export class OpportunityService {
   private maintenanceGraph: ReturnType<MaintenanceGraphFactory['createGraph']> | null = null;
   /** Event emitter for opportunity lifecycle; subscribe via onOpportunityEvent. */
   private readonly events = new OpportunityServiceEvents();
+  /** api-local reopen write; see {@link OpportunityService.reopenOpportunity}. */
+  private readonly reopenDb: OpportunityReopenDatabase;
+  /** Injected only by specs; production resolves the real queue lazily. */
+  private readonly rerunQueue: NegotiationRerunQueue | null;
 
   constructor(
     database?: OpportunityControllerDatabase,
@@ -245,6 +272,7 @@ export class OpportunityService {
     outcomeRecorder: OutcomeFeedbackRecorderLike = outcomeFeedbackRecorder,
     presentation: OpportunityPresentationDeps = {},
     askingFirstTasks: AskingFirstTaskReader = conversationDatabaseAdapter,
+    reopen: OpportunityReopenDeps = {},
   ) {
     this.db = database ?? (new ChatDatabaseAdapter() as OpportunityControllerDatabase);
     this.cache = cache ?? new RedisCacheAdapter();
@@ -255,6 +283,15 @@ export class OpportunityService {
     this.deliveryCache = new RedisCacheAdapter();
     this.outcomeRecorder = outcomeRecorder;
     this.askingFirstTasks = askingFirstTasks;
+    this.reopenDb = reopen.database ?? new OpportunityDatabaseAdapter();
+    this.rerunQueue = reopen.queue ?? null;
+  }
+
+  /** The re-run queue, imported lazily so loading the service never opens Redis. */
+  private async getRerunQueue(): Promise<NegotiationRerunQueue> {
+    if (this.rerunQueue) return this.rerunQueue;
+    const { negotiationRunExistingQueue } = await import('../queues/negotiations/run-existing.queue');
+    return negotiationRunExistingQueue;
   }
 
   private getPresenter(): OpportunityPresenter {
@@ -951,6 +988,79 @@ export class OpportunityService {
       counterpartUserId: counterpart.userId,
       opportunity: sanitizeOpportunityForResponse(updated),
     };
+  }
+
+
+  /**
+   * Reopen a dead pairing and queue its negotiation re-run.
+   *
+   * The user's lever for a match that died on a bad turn: it resets the
+   * opportunity to `stalled` and enqueues negotiate-existing, which is exactly
+   * the recovery that was being done by hand with SQL. Only an actor on the
+   * opportunity may pull it, and only from a terminal status — a `pending` row
+   * is awaiting its owner's decision and an `accepted` one already connected,
+   * so neither is a dead end to recover from.
+   *
+   * A re-run that the screen then vetoes (dev runs `NEGOTIATION_SCREEN_MODE`
+   * `enforce`) is a correct outcome, not a failure of this call.
+   *
+   * @param opportunityId - Resolved opportunity ID
+   * @param userId - The calling user, who must be an actor
+   * @param options - Network clamp derived from a network-scoped API-key principal
+   * @returns The 202 payload, or a structured error
+   */
+  async reopenOpportunity(
+    opportunityId: string,
+    userId: string,
+    options?: Pick<IntentScopeOptions, 'networkScopeId'>,
+  ): Promise<
+    | { opportunityId: string; status: 'stalled'; enqueued: true }
+    | { error: string; status: number; taskId?: string }
+  > {
+    const opp = await this.db.getOpportunity(opportunityId);
+    if (!opp) return { error: 'Opportunity not found', status: 404 };
+    if (!opp.actors.some((actor) => actor.userId === userId)) {
+      return { error: 'Not authorized to reopen this opportunity', status: 403 };
+    }
+    // A network-scoped agent principal may not reach out of its network, and
+    // learns nothing about what is outside it — same 404 as the sibling writes.
+    if (!matchesAgentNetworkScope(opp, userId, options?.networkScopeId)) {
+      return { error: 'Opportunity not found', status: 404 };
+    }
+
+    const result = await this.reopenDb.reopenOpportunityForRerun(opportunityId);
+    if (!result) return { error: 'Opportunity not found', status: 404 };
+    if ('conflict' in result) {
+      if (result.conflict === 'active_negotiation') {
+        return {
+          error: 'This match already has a negotiation in flight',
+          status: 409,
+          taskId: result.taskId,
+        };
+      }
+      return {
+        error: `Only a rejected, stalled, or expired match can be reopened (this one is ${result.status})`,
+        status: 409,
+      };
+    }
+
+    try {
+      const queue = await this.getRerunQueue();
+      await queue.addJob({ opportunityId, userId });
+    } catch (err) {
+      // The row is now `stalled`, which is itself reopenable — so a retry of
+      // this same call re-queues cleanly. Say so rather than reporting success
+      // for a re-run that was never queued.
+      reopenLogger.error('Reopen flipped the status but the re-run could not be queued', {
+        opportunityId,
+        userId,
+        error: err,
+      });
+      return { error: 'Match reopened, but the negotiation run could not be queued — retry', status: 500 };
+    }
+
+    reopenLogger.info('Opportunity reopened for re-run', { opportunityId, userId });
+    return { opportunityId, status: 'stalled', enqueued: true };
   }
 
 

--- a/services/api/src/services/tests/opportunity.service.reopen.spec.ts
+++ b/services/api/src/services/tests/opportunity.service.reopen.spec.ts
@@ -1,0 +1,146 @@
+/**
+ * OpportunityService.reopenOpportunity — the user's lever to re-run a dead
+ * pairing (POST /api/opportunities/:id/reopen).
+ *
+ * Exercised with a stubbed database and a stubbed re-run queue, so the
+ * authorization rule, the reopenable-status rule, and the enqueue are pinned
+ * without Postgres or Redis. The write itself (status flip and its
+ * millisecond-truncated `updated_at`) is pinned against the real database in
+ * `src/adapters/tests/opportunity-reopen.database.spec.ts`.
+ */
+
+import { config } from 'dotenv';
+config({ path: '.env.test', override: true });
+
+import { describe, it, expect, mock } from 'bun:test';
+import type { Opportunity, OpportunityControllerDatabase } from '@indexnetwork/protocol';
+import { OpportunityService, type NegotiationRerunQueue, type OpportunityReopenDatabase } from '../opportunity.service';
+import type { ReopenOpportunityResult } from '../../adapters/opportunity.database.adapter';
+
+const ACTOR_ID = 'user-actor-001';
+const PEER_ID = 'user-peer-002';
+const STRANGER_ID = 'user-stranger-003';
+const OPP_ID = 'opp-reopen-001';
+
+function makeOpportunity(overrides: Partial<Opportunity> = {}): Opportunity {
+  return {
+    id: OPP_ID,
+    detection: { source: 'opportunity_graph', timestamp: new Date().toISOString() },
+    actors: [
+      { networkId: 'idx-1', userId: ACTOR_ID, role: 'patient' },
+      { networkId: 'idx-1', userId: PEER_ID, role: 'agent' },
+    ],
+    interpretation: { category: 'collaboration', reasoning: 'Strong match.', confidence: 0.85, signals: [] },
+    context: { networkId: 'idx-1' },
+    confidence: '0.85',
+    status: 'rejected',
+    createdAt: new Date(),
+    updatedAt: new Date(),
+    expiresAt: null,
+    ...overrides,
+  };
+}
+
+function makeService(
+  opp: Opportunity | null,
+  reopenResult: ReopenOpportunityResult | null,
+  queueOverride?: NegotiationRerunQueue,
+) {
+  const db = {
+    getOpportunity: mock(async () => opp),
+  } as unknown as OpportunityControllerDatabase;
+  const reopenDb: OpportunityReopenDatabase = {
+    reopenOpportunityForRerun: mock(async () => reopenResult),
+  };
+  const queue: NegotiationRerunQueue = queueOverride ?? { addJob: mock(async () => ({ id: 'job-1' })) };
+  const service = new OpportunityService(db, undefined, undefined, {}, undefined, {
+    database: reopenDb,
+    queue,
+  });
+  return { service, db, reopenDb, queue };
+}
+
+describe('OpportunityService.reopenOpportunity', () => {
+  it('reopens for an actor and enqueues the re-run', async () => {
+    const opp = makeOpportunity({ status: 'rejected' });
+    const { service, reopenDb, queue } = makeService(opp, {
+      reopened: { ...opp, status: 'stalled' } as never,
+    });
+
+    const result = await service.reopenOpportunity(OPP_ID, ACTOR_ID);
+
+    expect(result).toEqual({ opportunityId: OPP_ID, status: 'stalled', enqueued: true });
+    expect(reopenDb.reopenOpportunityForRerun).toHaveBeenCalledWith(OPP_ID);
+    expect(queue.addJob).toHaveBeenCalledWith({ opportunityId: OPP_ID, userId: ACTOR_ID });
+  });
+
+  it('refuses a non-actor with 403 and never touches the row or the queue', async () => {
+    const { service, reopenDb, queue } = makeService(makeOpportunity(), null);
+
+    const result = await service.reopenOpportunity(OPP_ID, STRANGER_ID);
+
+    expect(result).toEqual({ error: 'Not authorized to reopen this opportunity', status: 403 });
+    expect(reopenDb.reopenOpportunityForRerun).not.toHaveBeenCalled();
+    expect(queue.addJob).not.toHaveBeenCalled();
+  });
+
+  it('answers 409 with the task id while a negotiation is in flight', async () => {
+    const { service, queue } = makeService(makeOpportunity({ status: 'stalled' }), {
+      conflict: 'active_negotiation',
+      taskId: 'task-live-1',
+    });
+
+    const result = await service.reopenOpportunity(OPP_ID, ACTOR_ID);
+
+    expect(result).toMatchObject({ status: 409, taskId: 'task-live-1' });
+    expect(queue.addJob).not.toHaveBeenCalled();
+  });
+
+  it.each(['pending', 'accepted'] as const)(
+    'answers 409 for a %s match — a live or won match is not a dead end to recover from',
+    async (status) => {
+      const { service, queue } = makeService(makeOpportunity({ status }), {
+        conflict: 'not_reopenable',
+        status,
+      });
+
+      const result = await service.reopenOpportunity(OPP_ID, ACTOR_ID);
+
+      expect(result).toMatchObject({ status: 409 });
+      expect('error' in result && result.error).toContain(status);
+      expect(queue.addJob).not.toHaveBeenCalled();
+    },
+  );
+
+  it('404s a network-scoped agent principal reaching outside its network', async () => {
+    const { service, reopenDb } = makeService(makeOpportunity(), null);
+
+    const result = await service.reopenOpportunity(OPP_ID, ACTOR_ID, { networkScopeId: 'idx-other' });
+
+    expect(result).toEqual({ error: 'Opportunity not found', status: 404 });
+    expect(reopenDb.reopenOpportunityForRerun).not.toHaveBeenCalled();
+  });
+
+  it('404s an unknown opportunity before any authorization work', async () => {
+    const { service, reopenDb } = makeService(null, null);
+
+    const result = await service.reopenOpportunity(OPP_ID, ACTOR_ID);
+
+    expect(result).toEqual({ error: 'Opportunity not found', status: 404 });
+    expect(reopenDb.reopenOpportunityForRerun).not.toHaveBeenCalled();
+  });
+
+  it('reports the failed enqueue instead of claiming a run that was never queued', async () => {
+    const opp = makeOpportunity({ status: 'expired' });
+    const { service } = makeService(
+      opp,
+      { reopened: { ...opp, status: 'stalled' } as never },
+      { addJob: mock(async () => { throw new Error('redis down'); }) },
+    );
+
+    const result = await service.reopenOpportunity(OPP_ID, ACTOR_ID);
+
+    expect(result).toMatchObject({ status: 500 });
+    expect('error' in result && result.error).toContain('retry');
+  });
+});


### PR DESCRIPTION
Two fixes from the two-month funnel audit: the top-ranked silent match-killer, and the missing user lever. `services/api` only — no protocol changes, no flags, no migrations.

## 1. Pending is sacred — the enricher may not expire a won match

**The flow that was broken.** Agents agree → the opportunity goes `pending` → it sits waiting for the OWNER's approval, which is the won state. A later background sweep re-finds the same pair (shared intent ids, or reasoning cosine ≥ 0.7) → `enrichOrCreate` treats the pending row as a merge candidate, because `DEFAULT_ENRICHER_EXCLUDE_STATUSES = ['accepted','negotiating','expired']` omits `pending` → the api writes the merged row and stamps the old one `expired`. **The match the human was about to approve evaporates.** Observed live at ~3h lifetime on the sandbox (the Deniz card), and plausibly erasing won matches on dev for weeks.

**Where the fix goes, and why here.** The api never passes `excludeStatuses` — `persistOpportunities` calls `enrichOrCreate` inside protocol with protocol-owned options, so there is no api-side seam to narrow that pool without editing protocol. The guard therefore lives at the write, which is the stronger place anyway: it holds regardless of what any future caller feeds into `expireIds`.

All three enrichment-superseded expiry paths in `opportunity.database.adapter.ts` — `createOpportunityAndExpireIds`, `createOpportunityAndExpireIdsIfNetworkEligible`, `persistIntentScopedOpportunityIfNetworkEligible` — now share one helper that:

- reads the candidate rows `FOR UPDATE` inside the caller's transaction (ordered by id, so overlapping sweeps queue instead of deadlocking), so the skip decision cannot race a concurrent human decision;
- skips any `pending` row and logs `enricher_skipped_pending` with the ids;
- leaves the skipped row's `updated_at` untouched as well as its status — an attempt CAS keyed to that timestamp must not lose its claim to a sweep that decided to leave the row alone;
- still writes the new enriched row, so dedup/suppression handle the duplicate on the read side exactly as before.

Nothing else narrowed: `rejected`, `stalled`, `latent` and `draft` prior rows merge and expire as they do today.

**Invariant, stated and pinned by spec:** a `pending` opportunity leaves `pending` only by a human decision (accept/reject) or by its signal being archived — never by background churn. The intent-archive and premise-retraction/removed-member cascades are deliberate human-caused paths and stay; the spec pins that side too, by proving `expireOpportunitiesByIntent` still expires a pending row.

**Adjacent path deliberately not touched:** `expireStaleOpportunities` (the `expires_at` TTL sweep) can still expire a `pending` row. That is a different mechanism — a deadline set when the row was created, not enrichment churn — and is out of this PR's scope. Flagging it as the next thing to look at if won matches still go missing.

## 2. `POST /api/opportunities/:id/reopen` — the user's lever to re-run a dead pairing

Productizes the manual recovery done by hand four times this week (SQL status reset + `negotiationRunExistingQueue.addJob`).

**Endpoint path and response shape, verbatim** (the floor-page lane wires its Reopen buttons to these):

```
POST /api/opportunities/:id/reopen

202 → { "opportunityId": "<uuid>", "status": "stalled", "enqueued": true }
403 → { "error": "Not authorized to reopen this opportunity" }
404 → { "error": "Opportunity not found" }
409 → { "error": "This match already has a negotiation in flight", "taskId": "<task-uuid>" }
409 → { "error": "Only a rejected, stalled, or expired match can be reopened (this one is pending)" }
500 → { "error": "Match reopened, but the negotiation run could not be queued — retry" }
```

`:id` accepts a full UUID or a short prefix (`resolveId`, same as the sibling routes). The body is ignored.

- **Auth:** the session user must be an actor on the opportunity, and a network-scoped API-key principal is clamped to its network (404, same as `updateStatus`/`startChat`).
- **Precondition:** status ∈ {`rejected`, `stalled`, `expired`} AND no active negotiation task (`working`/`submitted`/`waiting_for_agent`/`claimed` fresh, or `input_required` within the ask-user window) → otherwise 409 with the task id. `pending` and `accepted` are refused: a live or won match is not a dead end to recover from.
- **Action, one transaction,** serialized on the shared negotiation-attempt advisory lock so a reopen racing a live claim sees the committed winner instead of yanking a running negotiation back: `UPDATE opportunities SET status='stalled', updated_at=date_trunc('milliseconds', now()) WHERE id=$1 AND status=ANY(terminal)`, then `negotiationRunExistingQueue.addJob({ opportunityId, userId: caller })`.
- **`date_trunc('milliseconds', …)` is load-bearing.** The attempt CAS in `createNegotiationTaskForAttemptInTransaction` compares `updated_at` against a millisecond-truncated JS `Date`; a bare `now()` writes microseconds and the queued re-run dies with "stale or already claimed" (hit live on 2026-08-19). The spec asserts `date_part('microseconds', updated_at)::int % 1000 = 0` and then actually claims an attempt against the reopened row — flipping the write back to `now()` fails four tests.
- A second call while the run is active gets the 409.

**Expected, not a bug:** with `NEGOTIATION_SCREEN_MODE=off` (local) a never-contacted pair goes straight to outreach; under `enforce` (dev) the screen may still veto the re-run per #1458's screen-only-prior-activity rule. That is the screen doing its job.

## Tests

- `enricher-pending-guard.database.spec.ts` (real DB): a pending prior row survives a merge sweep with status AND `updated_at` unchanged and nothing expired, while the new row is still written; `rejected`/`stalled`/`latent`/`draft` still merge and expire; a mixed expire set keeps only the pending row; the human-caused intent-archive cascade still expires a pending row. Plus a source-level check that all three merge paths route through the guard, so a fourth path cannot quietly regain the ability to expire a won match.
- `opportunity-reopen.database.spec.ts` (real DB): each reopenable status flips to `stalled` with a whole-millisecond `updated_at`; `pending`/`accepted`/`negotiating`/`latent`/`draft` are refused untouched; a live task blocks with its id; unknown id → null; and the reopened row immediately claims a fresh negotiation attempt.
- `opportunity.service.reopen.spec.ts`: actor → enqueued, non-actor → 403 with no write and no enqueue, out-of-network agent principal → 404, conflicts → 409, failed enqueue reported rather than claimed as success.
- `opportunity.reopen.controller.isolated.ts`: the wire contract above — status codes and bodies — plus route registration.

**Baseline:** the api suite has 23 pre-existing failures (mcp owner-proof, maintenance introducer discovery, conversation adapter/controller, cli credential, tool controller, question-message author, and 4 isolated files). Verified by the #1462 method — restoring dev's `services/api` sources in this worktree and re-running the same file set produces the identical 23. New specs: 33 pass. `typecheck`, `typecheck:specs`, and lint on the touched files are clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01E5StKjzeh9PZWT9Vz29kZc
