### PR TITLE
fix(negotiations): a question is open because its negotiation is parked, not because its message is newest

### DIFF
--- a/services/api/src/lib/question/answer-precedence.ts
+++ b/services/api/src/lib/question/answer-precedence.ts
@@ -29,10 +29,23 @@
  * answer falls through to the orchestrator — which, since #1466, is told an
  * open question exists in this scope and carries the tool to route an answer
  * explicitly. That is the long tail's lane, not a silent loss.
+ *
+ * What "open" means is NOT this module's judgment and no longer its code. It
+ * used to be: the gate anchored on the newest agent message and asked whether
+ * that message parsed as a question block. On 2026-08-20, 21:11, that
+ * predicate silently closed a question whose task had been `input_required`
+ * for fifty-one minutes — an edit-confirmation posted three minutes after the
+ * question had made it no longer the newest message — and the client's answer
+ * fell through to the orchestrator, which edited the signal from it. The
+ * second time that happened in one evening. Openness is now resolved from the
+ * PARKED SET by `readOpenQuestionsForIntent`, the same call the
+ * `answer_pending_question` host and the orchestrator's context enumeration
+ * make, so no two lanes can disagree about what is open.
  */
-import { classifyParkedNegotiation, parseQuestionMessage } from '@indexnetwork/protocol';
-import type { NegotiationAnswerConsumptionPorts, QuestionBlock, RoutedAnswer } from '@indexnetwork/protocol';
+import type { RoutedAnswer } from '@indexnetwork/protocol';
 
+import type { ParkedNegotiation } from '../../adapters/parked-negotiation.reader.adapter';
+import { readOpenQuestionsForIntent } from './open-question-message';
 import { QuestionAnswerRouter } from './question-answer.router';
 import { log } from '../log';
 
@@ -52,7 +65,8 @@ export const QUESTION_ANSWER_ACKNOWLEDGEMENT =
 /**
  * What the gate decided.
  *
- * - `no_open_question`: nothing is open in this scope (the common case). The
+ * - `no_open_question`: nothing is PARKED on this user's side for this signal
+ *   (the common case), or openness could not be resolved at all. The
  *   orchestrator path is untouched, byte for byte.
  * - `declined`: a question is open and the evaluator says this reply does not
  *   answer it. Falls through to the orchestrator, edit rule included.
@@ -68,8 +82,19 @@ export type AnswerPrecedence =
   | { status: 'unavailable'; questionMessageId: string }
   | {
     status: 'answered';
+    /**
+     * The delivered question-message's id, or the synthetic id of a derived
+     * block (`derivedQuestionMessageId`). Carried through to the
+     * consumption job, which uses it for logging only — routing is the refs
+     * inside the body.
+     */
     questionMessageId: string;
-    /** The block body as delivered — the message the client was answering. */
+    /**
+     * The block body the answer is consumed against: the message as delivered
+     * when one renders the park, else the body serialized from the parked set
+     * itself. Either way it carries the same negotiation refs, so consumption
+     * re-resolves the same parks and settles under the same settlement ids.
+     */
     questionMessageBody: string;
     /** The reply routed onto the block's negotiation refs; never empty. */
     routedAnswers: RoutedAnswer[];
@@ -78,44 +103,9 @@ export type AnswerPrecedence =
 /** Injectable seams; production resolves the real collaborators lazily. */
 export interface AnswerPrecedenceDeps {
   getSessionMessages?: (sessionId: string) => Promise<Array<{ id: string; role: string; content: string }>>;
-  answerPorts?: NegotiationAnswerConsumptionPorts;
+  /** This user's parked negotiations on this signal — the openness authority. */
+  readParkedNegotiations?: (userId: string, intentId: string) => Promise<ReadonlyArray<ParkedNegotiation>>;
   answerRouter?: Pick<QuestionAnswerRouter, 'route'>;
-}
-
-/**
- * The open question-message of a negotiator DM: the newest AGENT message,
- * when it carries a parseable question block. The still-parked half of the
- * predicate is checked separately below — it costs negotiation reads, and the
- * cheap half rules out every ordinary conversation first.
- */
-function openQuestionMessage(
-  messages: Array<{ id: string; role: string; content: string }>,
-): { id: string; content: string; block: QuestionBlock } | null {
-  const newestAgentMessage = [...messages].reverse().find((message) => message.role === 'assistant');
-  if (!newestAgentMessage) return null;
-  const parsed = parseQuestionMessage(newestAgentMessage.content);
-  if (!parsed) return null;
-  return { id: newestAgentMessage.id, content: newestAgentMessage.content, block: parsed.block };
-}
-
-/**
- * True while at least one negotiation the block references is still parked on
- * THIS user's side. A block whose parks all resolved is closed: its questions
- * are no longer answerable, so a reply to it is ordinary conversation and the
- * gate must not stand in the orchestrator's way.
- */
-async function referencesStillParked(
-  ports: NegotiationAnswerConsumptionPorts,
-  block: QuestionBlock,
-  userId: string,
-): Promise<boolean> {
-  for (const question of block.questions) {
-    for (const ref of [question.opportunityId, ...(question.alsoUnblocks ?? [])]) {
-      const classification = await classifyParkedNegotiation(ports.database, { opportunityId: ref, userId });
-      if (classification.kind === 'inflight' || classification.kind === 'post_stall') return true;
-    }
-  }
-  return false;
 }
 
 /**
@@ -132,21 +122,18 @@ export async function evaluateQuestionAnswerPrecedence(
   try {
     if (!input.replyText.trim()) return { status: 'no_open_question' };
 
-    const getSessionMessages = deps?.getSessionMessages
-      ?? (async (sessionId: string) => (await import('../../services/chat.service')).chatSessionService.getSessionMessages(sessionId));
-    const open = openQuestionMessage(await getSessionMessages(input.sessionId));
+    // Openness is the parked set, resolved once, by the same call every other
+    // answer lane makes. The parked read is also the cheap short-circuit: an
+    // ordinary conversational turn ends here, on one scoped indexed query,
+    // without reading a message.
+    const open = await readOpenQuestionsForIntent(input.userId, input.intentId, {
+      // The session is already resolved for this turn; the resolver must not
+      // look it up again, and must anchor on THIS conversation.
+      findSession: async () => ({ id: input.sessionId }),
+      ...(deps?.getSessionMessages ? { getSessionMessages: deps.getSessionMessages } : {}),
+      ...(deps?.readParkedNegotiations ? { readParkedNegotiations: deps.readParkedNegotiations } : {}),
+    });
     if (!open) return { status: 'no_open_question' };
-
-    const ports = deps?.answerPorts
-      ?? (await import('./negotiation-answer.ports')).negotiationAnswerConsumptionPorts();
-    if (!await referencesStillParked(ports, open.block, input.userId)) {
-      logger.info('question_answer_precedence_message_closed', {
-        userId: input.userId,
-        intentId: input.intentId,
-        questionMessageId: open.id,
-      });
-      return { status: 'no_open_question' };
-    }
 
     const router = deps?.answerRouter ?? new QuestionAnswerRouter();
     let routed;
@@ -159,10 +146,10 @@ export async function evaluateQuestionAnswerPrecedence(
       logger.warn('question_answer_precedence_evaluator_unavailable', {
         userId: input.userId,
         intentId: input.intentId,
-        questionMessageId: open.id,
+        questionMessageId: open.messageId,
         error: err instanceof Error ? err.message : String(err),
       });
-      return { status: 'unavailable', questionMessageId: open.id };
+      return { status: 'unavailable', questionMessageId: open.messageId };
     }
 
     // `addressesQuestions` with nothing extracted is not an answer this path
@@ -173,22 +160,26 @@ export async function evaluateQuestionAnswerPrecedence(
       logger.info('question_answer_precedence_declined', {
         userId: input.userId,
         intentId: input.intentId,
-        questionMessageId: open.id,
+        questionMessageId: open.messageId,
         addressesQuestions: routed.addressesQuestions,
       });
-      return { status: 'declined', questionMessageId: open.id };
+      return { status: 'declined', questionMessageId: open.messageId };
     }
 
     logger.info('question_answer_precedence_answered', {
       userId: input.userId,
       intentId: input.intentId,
-      questionMessageId: open.id,
+      questionMessageId: open.messageId,
+      // Delivered or derived: which one it was says whether the client was
+      // answering a message they can see or a park whose rendering never
+      // reached them. Both are answers; only one is also a delivery bug.
+      source: open.source,
       answers: routed.answers.length,
     });
     return {
       status: 'answered',
-      questionMessageId: open.id,
-      questionMessageBody: open.content,
+      questionMessageId: open.messageId,
+      questionMessageBody: open.body,
       routedAnswers: routed.answers,
     };
   } catch (err) {

--- a/services/api/src/lib/question/negotiator-answer.host.ts
+++ b/services/api/src/lib/question/negotiator-answer.host.ts
@@ -10,11 +10,21 @@
  * message that is also doing something else — plus the case where the
  * evaluator itself was unavailable.
  *
- * Nothing is re-implemented: this resolves the same open question-message the
- * gate anchors on, maps the number the model was shown onto that block's
- * negotiation ref, and enqueues consumption on the same serialized
- * question-message queue with the answer pre-routed. Every resume, settle and
- * retry below that is the #1432 spine, untouched.
+ * Nothing is re-implemented: this resolves the open questions through the SAME
+ * call the gate and the orchestrator's context enumeration make
+ * (`readOpenQuestionsForIntent`), maps the number the model was shown onto
+ * that block's negotiation ref, and enqueues consumption on the same
+ * serialized question-message queue with the answer pre-routed. Every resume,
+ * settle and retry below that is the #1432 spine, untouched.
+ *
+ * One call, not one rule written twice — that is load-bearing. On 2026-08-20
+ * the model was shown an open question and called this tool with `question: 1`
+ * while the host resolved nothing open and answered `no_open_question`, whose
+ * copy tells the client "the negotiations moved on". They had not: the task
+ * was `input_required` and stayed so for the rest of the window. Since
+ * openness is the parked set, `no_open_question` is now reachable only when
+ * the parks have genuinely resolved or expired — which is the only state that
+ * copy is true of.
  *
  * The tool never sees or emits an id. It is given positions, it returns
  * positions, and this module owns the mapping — the same rule that keeps the
@@ -55,7 +65,16 @@ export async function answerOpenQuestion(
     if (!answerText) return { status: 'error' };
 
     const open = await readOpenQuestionsForIntent(userId, input.intentId, deps);
+    // Nothing parked on this user's side for this signal. The only state in
+    // which telling the client the negotiations moved on is the truth.
     if (!open || open.questions.length === 0) return { status: 'no_open_question' };
+    if (!open.sessionId) {
+      // Parked, answerable, but the signal has no DM to consume the reply in —
+      // which cannot happen from a tool call made inside that very DM. Report
+      // the honest failure rather than the false close-out.
+      logger.warn('negotiator_answer_no_session', { userId, intentId: input.intentId });
+      return { status: 'error' };
+    }
 
     const question = open.questions.find((candidate) => candidate.position === input.question);
     if (!question) {
@@ -64,6 +83,7 @@ export async function answerOpenQuestion(
         intentId: input.intentId,
         question: input.question,
         open: open.questions.length,
+        source: open.source,
       });
       return { status: 'unknown_question', open: open.questions.length };
     }
@@ -92,6 +112,7 @@ export async function answerOpenQuestion(
       userId,
       intentId: input.intentId,
       questionMessageId: open.messageId,
+      source: open.source,
       opportunityId: question.opportunityId,
     });
     return { status: 'routed', label: question.label };

--- a/services/api/src/lib/question/open-question-message.ts
+++ b/services/api/src/lib/question/open-question-message.ts
@@ -1,27 +1,52 @@
 /**
- * The open question-message, per signal (conversational questions,
- * docs/plans/2026-08-18-conversational-questions.md).
+ * Openness, per signal: what this user is currently being asked
+ * (conversational questions, docs/plans/2026-08-18-conversational-questions.md).
  *
- * A question-message is OPEN while its block still references at least one
- * negotiation parked on this user's side: that is what makes it answerable,
- * and it is derived at read time from the parked set — there is no stored
- * read/unread or open/closed state anywhere in this design.
+ * A question is OPEN iff its negotiation is PARKED on this user's side for
+ * this signal — a mid-flight consult whose exact task sits `input_required`
+ * inside its answer window, or a post-stall park. Nothing about the DM's
+ * message order enters that predicate.
  *
- * Two surfaces need that predicate over the same parked set:
+ * That is a correction, and the incident behind it is exact. Openness used to
+ * mean "the NEWEST agent message in the DM parses as a question block". On
+ * 2026-08-20 a question was delivered at 20:21 and an edit-confirmation
+ * landed after it at 20:24; the question was still the durable ask — its task
+ * stayed `input_required` for the whole answer window — but it was no longer
+ * the newest message. At 21:11 the client answered it and EVERY lane resolved
+ * "nothing open": the precedence gate fell through, the orchestrator edited
+ * the signal instead, and the model's own `answer_pending_question` call was
+ * refused by the host with `no_open_question`. One intervening agent message
+ * had buried an ask that was still waiting, and the park outlived its own
+ * answerability.
  *
- * - the regeneration job's edit rule, which anchors on the newest message in
- *   the conversation (a client reply since means the message is no longer the
- *   one to rewrite), and
- * - the notification snapshot, which anchors on the newest AGENT message (a
- *   reply does not un-ask the question; only consumption and the regeneration
- *   that follows it do).
+ * The spine's doctrine already said which of the two is the record: the
+ * parked negotiation is the durable record, the DM message is its rendering.
+ * So openness is read from the parked set, and the question BLOCK is
+ * RECOVERED rather than located:
  *
- * The anchor differs, the openness test does not — so the test lives here
- * once and each caller hands it the message it anchors on.
+ * - the delivered question-message when one exists ANYWHERE in the DM (the
+ *   newest agent message that carries a block referencing a still-parked
+ *   negotiation — not the newest agent message), else
+ * - a block DERIVED from the parked turns themselves, through the same
+ *   dimension derivation the message author uses (`dimension-question.ts`),
+ *   so a park whose message was never delivered is still answerable.
+ *
+ * Every answerability lane resolves through {@link readOpenQuestionsForIntent}
+ * — the precedence gate, the `answer_pending_question` host, and the
+ * orchestrator's context enumeration — so the numbers the model is shown and
+ * the numbers the host resolves cannot disagree. They are the same call, not
+ * the same logic written twice.
+ *
+ * {@link readOpenQuestionMessages} stays anchored on the newest agent message
+ * on purpose: it is the NOTIFICATION snapshot, and a notification deep-links a
+ * message the client can actually open. A buried question is an answerability
+ * problem, not a notification one.
  */
-import { parseQuestionMessage } from '@indexnetwork/protocol';
+import { QuestionBlockSchema, parseQuestionMessage, serializeQuestionMessage } from '@indexnetwork/protocol';
 import type { QuestionBlock, QuestionBlockQuestion } from '@indexnetwork/protocol';
 
+import type { ParkedNegotiation } from '../../adapters/parked-negotiation.reader.adapter';
+import { renderableQuestion } from './dimension-question';
 import { log } from '../log';
 
 const logger = log.lib.from('open-question-message');
@@ -125,7 +150,7 @@ export async function readOpenQuestionMessages(
   return open;
 }
 
-/** One question of a signal's open question-message, as the client sees it. */
+/** One question this signal currently has open, as the client sees it. */
 export interface OpenQuestionForIntent {
   /** 1-based position in the block — the number the orchestrator is shown. */
   position: number;
@@ -135,17 +160,74 @@ export interface OpenQuestionForIntent {
   opportunityId: string;
 }
 
-/** A signal's open question-message, resolved for one intent scope. */
+/** Where the open block came from — see the module header. */
+export type OpenQuestionSource = 'delivered' | 'derived';
+
+/** A signal's open questions, resolved for one intent scope. */
 export interface OpenQuestionsForIntent {
-  sessionId: string;
+  /**
+   * The signal's negotiator DM, when it exists. Null only for a park whose
+   * DM was never created — openness does not depend on the conversation, but
+   * consuming an answer through the queue does, so the caller must check.
+   */
+  sessionId: string | null;
+  /**
+   * The delivered question-message's id, or — for a derived block — a
+   * synthetic id that names no persisted message
+   * ({@link derivedQuestionMessageId}). Carried for logging and job payloads
+   * only; nothing downstream reads a message by it.
+   */
   messageId: string;
-  /** The message body as delivered — the block an answer is consumed against. */
+  /** The block body an answer is consumed against — delivered, or serialized here. */
   body: string;
+  /** The block itself, so a caller never re-parses `body` to route against it. */
+  block: QuestionBlock;
+  source: OpenQuestionSource;
   questions: OpenQuestionForIntent[];
 }
 
 /** Label cap for a question shown in the orchestrator's context. */
 const MAX_QUESTION_LABEL_CHARS = 80;
+
+/** Block-schema caps the derived block must respect (question-block.schema.ts). */
+const MAX_BLOCK_QUESTIONS = 20;
+const MAX_PROMPT_CHARS = 2000;
+const MAX_DIMENSION_CHARS = 60;
+
+/**
+ * Server-owned prose for a DERIVED block. Never rendered to the client — a
+ * derived block is not delivered, it is only the shape an answer is routed
+ * and consumed against — but the body is a real question-message body, so it
+ * carries real prose rather than a placeholder.
+ */
+export const DERIVED_QUESTION_MESSAGE_PROSE =
+  'Some of the conversations I am running on this signal are waiting on details only you can provide.';
+
+/**
+ * The prompt for a park with nothing renderable at all: no authored question
+ * (the safety gate stripped it, or no author was involved) and no dimension to
+ * derive one from — a policy-inferred consultation, or a pre-checklist
+ * post-stall gap.
+ *
+ * Fixed, server-owned copy. The alternative is dropping the park from the open
+ * set, and that is exactly the hole this module exists to close: a park with a
+ * live answer window must be answerable, and answering needs a question to
+ * route onto. A generic prompt bound to the right negotiation resumes the
+ * right negotiation; no prompt resumes nothing.
+ */
+export const UNRENDERABLE_PARK_PROMPT =
+  'One of the conversations I am running on this signal is parked on something only you can settle. '
+  + 'What should I take as your answer?';
+
+/**
+ * Synthetic id for a derived block, so payloads and logs can name it. It is
+ * deliberately not a uuid and deliberately not a message id: nothing may look
+ * it up, and a reader that tries will fail loudly rather than silently read
+ * the wrong message.
+ */
+export function derivedQuestionMessageId(intentId: string): string {
+  return `derived-question-message.${intentId}`;
+}
 
 function labelFor(question: QuestionBlockQuestion): string {
   const label = question.dimension?.trim() || question.prompt.trim();
@@ -154,25 +236,98 @@ function labelFor(question: QuestionBlockQuestion): string {
     : label;
 }
 
+/**
+ * Every question of the block, numbered as delivered — not only the ones whose
+ * negotiations are still parked. The numbers must line up with what the client
+ * is looking at, and a question whose parks resolved simply consumes to
+ * nothing.
+ */
+function enumerateQuestions(block: QuestionBlock): OpenQuestionForIntent[] {
+  return block.questions.map((question, index) => ({
+    position: index + 1,
+    label: labelFor(question),
+    opportunityId: question.opportunityId,
+  }));
+}
+
+/**
+ * The delivered rendering of the open ask: the newest AGENT message carrying a
+ * block that references a still-parked negotiation — searching BACK through
+ * the conversation, not just at its tail.
+ *
+ * Searching back is the fix. The newest agent message is a rendering detail:
+ * an edit-confirmation, a status line, or any other thing the negotiator says
+ * after asking pushes the question up the transcript without settling it.
+ */
+function deliveredQuestionMessage(
+  messages: Array<{ id: string; role: string; content: string }>,
+  parked: ReadonlyArray<{ opportunityId: string }>,
+): { id: string; content: string; block: QuestionBlock } | null {
+  for (let index = messages.length - 1; index >= 0; index -= 1) {
+    const message = messages[index];
+    if (!message || message.role !== 'assistant') continue;
+    const open = openQuestionBlock({ id: message.id, content: message.content }, parked);
+    if (open) return { id: message.id, content: message.content, block: open.block };
+  }
+  return null;
+}
+
+function clampPrompt(prompt: string): string {
+  const trimmed = prompt.trim();
+  return trimmed.length > MAX_PROMPT_CHARS ? trimmed.slice(0, MAX_PROMPT_CHARS).trimEnd() : trimmed;
+}
+
+/**
+ * The block a parked set makes on its own, when no delivered message renders
+ * it: one question per park, from the same material the message author would
+ * have used — the agent's park-time question, else one derived from the
+ * checklist dimension (`dimension-question.ts`), else the fixed prompt above.
+ *
+ * Null only when the block schema refuses the result, which would mean a park
+ * carrying something no message could have carried either. Openness is still
+ * real in that case; it is the recovery that failed, and the caller logs it.
+ */
+function deriveQuestionBlock(parked: ReadonlyArray<ParkedNegotiation>): QuestionBlock | null {
+  const questions = parked.slice(0, MAX_BLOCK_QUESTIONS).map((negotiation) => {
+    const question = renderableQuestion(negotiation);
+    const dimension = negotiation.dimension?.trim();
+    const options = question?.options ?? [];
+    return {
+      prompt: clampPrompt(question?.prompt || UNRENDERABLE_PARK_PROMPT) || UNRENDERABLE_PARK_PROMPT,
+      opportunityId: negotiation.opportunityId,
+      // Presentation only; routing is the ref. A dimension the block schema
+      // would reject is dropped rather than allowed to fail the whole block.
+      ...(dimension && dimension.length <= MAX_DIMENSION_CHARS ? { dimension } : {}),
+      // The block's options floor is two: a park-time question that carried
+      // one renders as a prompt with a reply arrow, exactly as it does today.
+      ...(options.length >= 2 ? { options: options.slice(0, 4) } : {}),
+    };
+  });
+  const block = QuestionBlockSchema.safeParse({ version: 1, questions });
+  return block.success ? block.data : null;
+}
+
 /** Injectable seams for {@link readOpenQuestionsForIntent}. */
 export interface OpenQuestionsForIntentDeps {
   findSession?: (userId: string, intentId: string) => Promise<{ id: string } | null>;
   getSessionMessages?: (sessionId: string) => Promise<Array<{ id: string; role: string; content: string }>>;
-  readParkedNegotiations?: (userId: string, intentId: string) => Promise<ReadonlyArray<{ opportunityId: string }>>;
+  readParkedNegotiations?: (userId: string, intentId: string) => Promise<ReadonlyArray<ParkedNegotiation>>;
 }
 
 /**
- * One signal's open question-message, resolved for the orchestrator's context
- * and for the `answer_pending_question` tool behind it (#1466).
+ * What this signal currently has open, for every lane that has to answer it:
+ * the precedence gate, the `answer_pending_question` host, and the
+ * orchestrator's context enumeration.
  *
- * Anchored on the newest AGENT message, like the notification snapshot rather
- * than the edit rule: the client having replied since does not un-ask the
- * question, and this is read on a turn where they just did reply.
+ * Parked first, deliberately: the parked read is the authority AND the cheap
+ * short-circuit — an indexed scoped query that rules out every ordinary
+ * conversation before a message is read. Null means nothing is parked on this
+ * user's side for this signal, which is the only thing that closes a question.
  *
- * Resolves null whenever there is nothing open — no DM, no block, or every
- * negotiation the block references has since resolved. Never throws: this
- * feeds a prompt section and a tool registration, and neither is worth failing
- * a chat turn over.
+ * Never throws: this feeds a prompt section, a tool registration and a chat
+ * turn, and none of them is worth failing over. A DM that cannot be read is
+ * degraded to the derived block rather than to "nothing open" — the park is
+ * the record, and losing the client's answer is the worse failure.
  */
 export async function readOpenQuestionsForIntent(
   userId: string,
@@ -181,39 +336,58 @@ export async function readOpenQuestionsForIntent(
 ): Promise<OpenQuestionsForIntent | null> {
   if (!userId || !intentId) return null;
   try {
-    const findSession = deps?.findSession
-      ?? (async (id: string, intent: string) => (await import('../../services/chat.service')).chatSessionService
-        .findNegotiatorIntentSession(id, intent));
-    const session = await findSession(userId, intentId);
-    if (!session) return null;
-
-    const getSessionMessages = deps?.getSessionMessages
-      ?? (async (sessionId: string) => (await import('../../services/chat.service')).chatSessionService
-        .getSessionMessages(sessionId));
-    const messages = await getSessionMessages(session.id);
-    const newestAgentMessage = [...messages].reverse().find((message) => message.role === 'assistant');
-    // Cheap first: no block, no parked-set read.
-    if (!newestAgentMessage || !parseQuestionMessage(newestAgentMessage.content)) return null;
-
     const readParkedNegotiations = deps?.readParkedNegotiations
       ?? (async (id: string, intent: string) => (await import('../../adapters/parked-negotiation.reader.adapter'))
         .parkedNegotiationReaderAdapter.readParkedNegotiations(id, intent));
     const parked = await readParkedNegotiations(userId, intentId);
-    const open = openQuestionBlock({ id: newestAgentMessage.id, content: newestAgentMessage.content }, parked);
-    if (!open) return null;
+    if (parked.length === 0) return null;
 
-    // Every question of the open block is listed, not only the still-parked
-    // ones: the numbers must line up with what the client is looking at, and a
-    // question whose parks resolved simply consumes to nothing.
+    const session = await (async () => {
+      try {
+        const findSession = deps?.findSession
+          ?? (async (id: string, intent: string) => (await import('../../services/chat.service')).chatSessionService
+            .findNegotiatorIntentSession(id, intent));
+        const found = await findSession(userId, intentId);
+        if (!found) return null;
+        const getSessionMessages = deps?.getSessionMessages
+          ?? (async (sessionId: string) => (await import('../../services/chat.service')).chatSessionService
+            .getSessionMessages(sessionId));
+        return { id: found.id, messages: await getSessionMessages(found.id) };
+      } catch (err) {
+        // The park stands whether or not its rendering can be read.
+        logger.warn('open_questions_dm_read_failed; falling back to the parked set', {
+          userId,
+          intentId,
+          error: err instanceof Error ? err.message : String(err),
+        });
+        return null;
+      }
+    })();
+
+    const delivered = session ? deliveredQuestionMessage(session.messages, parked) : null;
+    if (delivered) {
+      return {
+        sessionId: session!.id,
+        messageId: delivered.id,
+        body: delivered.content,
+        block: delivered.block,
+        source: 'delivered',
+        questions: enumerateQuestions(delivered.block),
+      };
+    }
+
+    const derived = deriveQuestionBlock(parked);
+    if (!derived) {
+      logger.warn('open_questions_parked_but_unrenderable', { userId, intentId, parked: parked.length });
+      return null;
+    }
     return {
-      sessionId: session.id,
-      messageId: open.id,
-      body: newestAgentMessage.content,
-      questions: open.block.questions.map((question, index) => ({
-        position: index + 1,
-        label: labelFor(question),
-        opportunityId: question.opportunityId,
-      })),
+      sessionId: session?.id ?? null,
+      messageId: derivedQuestionMessageId(intentId),
+      body: serializeQuestionMessage(DERIVED_QUESTION_MESSAGE_PROSE, derived),
+      block: derived,
+      source: 'derived',
+      questions: enumerateQuestions(derived),
     };
   } catch (err) {
     logger.warn('open_questions_for_intent_read_failed', {

--- a/services/api/src/lib/question/tests/answer-precedence.spec.ts
+++ b/services/api/src/lib/question/tests/answer-precedence.spec.ts
@@ -1,25 +1,38 @@
 /**
- * Answer precedence: while a question is open in a signal's negotiator DM,
- * the evaluator sees a free-text reply BEFORE the orchestrator does.
+ * Answer precedence: while a question is OPEN in a signal's scope, the
+ * evaluator sees a free-text reply BEFORE the orchestrator does.
  *
- * The incident this encodes (2026-08-20, sandbox): a negotiation parked on the
- * checklist dimension "Timing: This week" asked its client; three minutes
- * later the client replied "This month?"; the chat orchestrator's signal edit
- * rule consumed it and rewrote the intent, and the negotiation that asked was
- * never told. The evaluator was always capable of recognizing that reply — it
- * simply ran after the orchestrator had finished.
+ * Two incidents are encoded here, both from 2026-08-20 in the sandbox, both
+ * the same answer being eaten.
  *
- * The three outcomes under test are the whole contract: an answer never
- * reaches the orchestrator, a decline always does, and with no open question
- * nothing here runs at all.
+ * 20:24 — a negotiation parked on the checklist dimension "Timing: This week"
+ * asked its client; three minutes later the client replied; the chat
+ * orchestrator's signal edit rule consumed it and rewrote the intent, and the
+ * negotiation that asked was never told. That was the ORDER, and #1467 fixed
+ * it by running the evaluator first.
+ *
+ * 21:11 — the same question, the same answer, and the gate itself said
+ * "nothing open". An edit-confirmation had posted after the question, so the
+ * question was no longer the newest agent message, and openness was defined by
+ * message recency. The task had been `input_required` for fifty-one minutes.
+ * That is the PREDICATE, and it is what these specs now pin: open means
+ * parked, and the delivered message is searched for rather than required at
+ * the tail.
+ *
+ * The outcomes under test are the whole contract: an answer never reaches the
+ * orchestrator, a decline always does, an evaluator outage falls through
+ * without closing the question, and with nothing parked nothing here runs at
+ * all.
  */
 import { describe, expect, it } from 'bun:test';
 
-import { negotiationQuestionSettlementId, serializeQuestionMessage } from '@indexnetwork/protocol';
-import type { NegotiationAnswerConsumptionPorts, QuestionBlock } from '@indexnetwork/protocol';
+import { serializeQuestionMessage } from '@indexnetwork/protocol';
+import type { QuestionBlock } from '@indexnetwork/protocol';
 
+import type { ParkedNegotiation } from '../../../adapters/parked-negotiation.reader.adapter';
 import { evaluateQuestionAnswerPrecedence } from '../answer-precedence';
 import type { AnswerPrecedenceDeps } from '../answer-precedence';
+import { derivedQuestionMessageId } from '../open-question-message';
 
 const USER_ID = 'user-1';
 const INTENT_ID = 'intent-1';
@@ -40,6 +53,9 @@ const QUESTION_MESSAGE_BODY = serializeQuestionMessage(
   BLOCK,
 );
 
+/** The message that buried the question at 20:24 — an edit confirmation. */
+const EDIT_CONFIRMATION = 'Updated your signal: timing is now open to this month.';
+
 function sessionMessages(agentContent = QUESTION_MESSAGE_BODY) {
   return [
     { id: 'm1', role: 'user', content: 'Any news?' },
@@ -47,47 +63,30 @@ function sessionMessages(agentContent = QUESTION_MESSAGE_BODY) {
   ];
 }
 
-const TASK_ID = 'task-1';
-
 /**
- * Only `database` is reached from this module — the resume seams stay unused.
- * The mid-flight park shape `classifyParkedNegotiation` demands: an exact task
- * in `input_required` whose ask-user binding names this user, this opportunity
- * and the settlement id derived from the task itself.
+ * The park is the record: a mid-flight consult whose exact task is
+ * `input_required` and bound to this user and signal. The reader adapter is
+ * the set-wise mirror of `classifyParkedNegotiation` (the two are held
+ * together by the convergence contract test), so a park in this list means
+ * exactly what a live `input_required` task with a coherent ask-user binding
+ * means.
  */
-function ports(parked: boolean): NegotiationAnswerConsumptionPorts {
+function park(overrides: Partial<ParkedNegotiation> = {}): ParkedNegotiation {
   return {
-    database: {
-      getNegotiationTaskForOpportunity: async () => (parked
-        ? {
-          id: TASK_ID,
-          state: 'input_required',
-          metadata: {
-            type: 'negotiation',
-            opportunityId: PARKED_OPPORTUNITY,
-            turnContext: {
-              askUserBinding: {
-                settlementId: negotiationQuestionSettlementId(TASK_ID),
-                recipientUserId: USER_ID,
-                recipientIntentId: INTENT_ID,
-                networkId: 'network-1',
-                opportunityId: PARKED_OPPORTUNITY,
-              },
-            },
-          },
-        }
-        // No task at all: "no negotiation", which is not parked — the block is
-        // closed and the reply is ordinary conversation.
-        : null),
-      getNegotiationMessages: async () => [],
-    } as unknown as NegotiationAnswerConsumptionPorts['database'],
-  } as unknown as NegotiationAnswerConsumptionPorts;
+    opportunityId: PARKED_OPPORTUNITY,
+    kind: 'mid_flight',
+    dimension: 'Timing: This week',
+    dimensionKind: 'hard_constraint',
+    transcript: [],
+    parkedAt: new Date('2026-08-20T20:20:00Z'),
+    ...overrides,
+  };
 }
 
 function deps(overrides: Partial<AnswerPrecedenceDeps> = {}): AnswerPrecedenceDeps {
   return {
     getSessionMessages: async () => sessionMessages(),
-    answerPorts: ports(true),
+    readParkedNegotiations: async () => [park()],
     answerRouter: {
       route: async () => ({
         addressesQuestions: true,
@@ -107,9 +106,46 @@ describe('evaluateQuestionAnswerPrecedence', () => {
     expect(precedence.status).toBe('answered');
     if (precedence.status !== 'answered') throw new Error('unreachable');
     // The orchestrator never sees this reply, so the edit rule cannot run on
-    // it and the intent cannot be rewritten from it.
+    // it and the intent cannot be rewritten from it. The controller carries
+    // this routing straight into the consumption job (pinned in
+    // `answer-precedence.wiring.static.spec.ts`), so the queue consumes the
+    // decision the client was acknowledged for rather than re-deciding it.
     expect(precedence.questionMessageId).toBe('m2');
     expect(precedence.questionMessageBody).toBe(QUESTION_MESSAGE_BODY);
+    expect(precedence.routedAnswers).toEqual([{ ref: PARKED_OPPORTUNITY, answerText: 'This month.' }]);
+  });
+
+  it('takes the answer when a later agent message buried the question — 21:11', async () => {
+    // The 21:11 incident, exactly: question at 20:21, edit-confirmation at
+    // 20:24, reply at 21:11 while the task is still `input_required`. Under
+    // message recency this returned `no_open_question` and the reply fell
+    // through to the orchestrator, which edited the signal from it.
+    const precedence = await evaluateQuestionAnswerPrecedence(REPLY, deps({
+      getSessionMessages: async () => [
+        ...sessionMessages(),
+        { id: 'm3', role: 'assistant', content: EDIT_CONFIRMATION },
+      ],
+    }));
+
+    expect(precedence.status).toBe('answered');
+    if (precedence.status !== 'answered') throw new Error('unreachable');
+    // Answered against the block the client is actually looking at, recovered
+    // from where it sits in the DM rather than from the tail.
+    expect(precedence.questionMessageId).toBe('m2');
+    expect(precedence.questionMessageBody).toBe(QUESTION_MESSAGE_BODY);
+  });
+
+  it('takes the answer when the park has no delivered message at all', async () => {
+    // Regeneration had not landed, or its message was never written. The park
+    // is still the record, so the block is derived from it and the answer
+    // routes onto the same negotiation ref.
+    const precedence = await evaluateQuestionAnswerPrecedence(REPLY, deps({
+      getSessionMessages: async () => [{ id: 'm1', role: 'assistant', content: EDIT_CONFIRMATION }],
+    }));
+
+    expect(precedence.status).toBe('answered');
+    if (precedence.status !== 'answered') throw new Error('unreachable');
+    expect(precedence.questionMessageId).toBe(derivedQuestionMessageId(INTENT_ID));
     expect(precedence.routedAnswers).toEqual([{ ref: PARKED_OPPORTUNITY, answerText: 'This month.' }]);
   });
 
@@ -133,26 +169,31 @@ describe('evaluateQuestionAnswerPrecedence', () => {
     expect(precedence.status).toBe('declined');
   });
 
-  it('does not run at all when the DM has no question block', async () => {
+  it("does not run at all when nothing is parked on this user's side", async () => {
+    // The only thing that closes a question. The DM is not even read: the
+    // parked read is both the authority and the cheap short-circuit.
     let routed = false;
+    let sessionRead = false;
     const precedence = await evaluateQuestionAnswerPrecedence(REPLY, deps({
-      getSessionMessages: async () => sessionMessages('Here is what I found on the record.'),
+      readParkedNegotiations: async () => [],
+      getSessionMessages: async () => { sessionRead = true; return sessionMessages(); },
       answerRouter: { route: async () => { routed = true; throw new Error('must not route'); } },
     }));
 
     expect(precedence).toEqual({ status: 'no_open_question' });
     expect(routed).toBe(false);
+    expect(sessionRead).toBe(false);
   });
 
-  it('does not run when the block is there but every negotiation it references has resolved', async () => {
-    let routed = false;
+  it('does not run for a stale question-message whose negotiations have resolved', async () => {
+    // The other direction of the same predicate: the message is still sitting
+    // there, newest and parseable, but nothing is parked behind it. Answering
+    // it would resume nothing, so the reply is ordinary conversation.
     const precedence = await evaluateQuestionAnswerPrecedence(REPLY, deps({
-      answerPorts: ports(false),
-      answerRouter: { route: async () => { routed = true; throw new Error('must not route'); } },
+      readParkedNegotiations: async () => [],
     }));
 
     expect(precedence).toEqual({ status: 'no_open_question' });
-    expect(routed).toBe(false);
   });
 
   it('falls through, not closed, when the evaluator is unavailable', async () => {
@@ -163,19 +204,32 @@ describe('evaluateQuestionAnswerPrecedence', () => {
     expect(precedence).toEqual({ status: 'unavailable', questionMessageId: 'm2' });
   });
 
-  it('falls through when the session read itself fails', async () => {
+  it('still offers the reply to the evaluator when the DM read fails', async () => {
+    // A DM that cannot be read is a rendering failure, not a settled park. The
+    // block is derived from the parked set and the answer is still taken —
+    // losing the client's answer is the worse failure by a distance.
     const precedence = await evaluateQuestionAnswerPrecedence(REPLY, deps({
       getSessionMessages: async () => { throw new Error('db down'); },
+    }));
+
+    expect(precedence.status).toBe('answered');
+  });
+
+  it('falls through when the parked read itself fails', async () => {
+    // Openness is unknowable, so the turn proceeds as an ordinary one: the
+    // orchestrator still runs, and it carries the tool to route explicitly.
+    const precedence = await evaluateQuestionAnswerPrecedence(REPLY, deps({
+      readParkedNegotiations: async () => { throw new Error('db down'); },
     }));
 
     expect(precedence).toEqual({ status: 'no_open_question' });
   });
 
-  it('ignores an empty reply without touching the session', async () => {
+  it('ignores an empty reply without touching the parked set', async () => {
     let read = false;
     const precedence = await evaluateQuestionAnswerPrecedence(
       { ...REPLY, replyText: '   ' },
-      deps({ getSessionMessages: async () => { read = true; return sessionMessages(); } }),
+      deps({ readParkedNegotiations: async () => { read = true; return [park()]; } }),
     );
 
     expect(precedence).toEqual({ status: 'no_open_question' });

--- a/services/api/src/lib/question/tests/answer-precedence.wiring.static.spec.ts
+++ b/services/api/src/lib/question/tests/answer-precedence.wiring.static.spec.ts
@@ -14,6 +14,9 @@ import { readFileSync } from 'node:fs';
 
 const controller = readFileSync(new URL('../../../controllers/chat.controller.ts', import.meta.url), 'utf8');
 const composition = readFileSync(new URL('../../../controllers/mcp.controller.ts', import.meta.url), 'utf8');
+const gate = readFileSync(new URL('../answer-precedence.ts', import.meta.url), 'utf8');
+const host = readFileSync(new URL('../negotiator-answer.host.ts', import.meta.url), 'utf8');
+const chatService = readFileSync(new URL('../../../services/chat.service.ts', import.meta.url), 'utf8');
 
 describe('answer-precedence wiring', () => {
   it('evaluates precedence BEFORE the orchestrator stream, not after it', () => {
@@ -50,5 +53,26 @@ describe('answer-precedence wiring', () => {
 
   it('registers the long-tail routing tool at the composition root', () => {
     expect(composition).toContain('negotiatorAnswerTools: negotiatorAnswerToolsHost');
+  });
+
+  /**
+   * The second half of the 2026-08-20 incident was not an order problem: every
+   * lane agreed the reply was not an answer, because each one asked whether the
+   * newest agent message was a question block. One resolver is what makes them
+   * unable to disagree — so it is pinned as wiring, not left to convention.
+   */
+  it('resolves openness through the one shared resolver in every lane', () => {
+    for (const lane of [gate, host, chatService]) {
+      expect(lane).toContain('readOpenQuestionsForIntent');
+    }
+  });
+
+  it('never re-derives openness from the newest agent message', () => {
+    // The predicate that buried a live question. Neither lane may reintroduce
+    // it: openness is the parked set, and the delivered message is searched
+    // for rather than required at the tail.
+    for (const lane of [gate, host]) {
+      expect(lane).not.toContain("find((message) => message.role === 'assistant')");
+    }
   });
 });

--- a/services/api/src/lib/question/tests/negotiator-answer.host.spec.ts
+++ b/services/api/src/lib/question/tests/negotiator-answer.host.spec.ts
@@ -6,13 +6,23 @@
  * for the same reason the answer router does not see one: a ref the model
  * could name is a ref it could get wrong, and a misroute resumes the wrong
  * negotiation with the wrong fact.
+ *
+ * What these specs now also pin is the state the host may NOT report. On
+ * 2026-08-20 at 21:11 the model was shown an open question and called this
+ * tool with `question: 1`; the host resolved openness from the newest agent
+ * message, found an edit-confirmation there, and answered `no_open_question` —
+ * whose copy tells the client "the negotiations moved on". The task was
+ * `input_required` and stayed so. `no_open_question` is now reachable only
+ * when nothing is parked, which is the only state that copy is true of.
  */
 import { describe, expect, it } from 'bun:test';
 
 import { serializeQuestionMessage } from '@indexnetwork/protocol';
 import type { QuestionBlock } from '@indexnetwork/protocol';
 
+import type { ParkedNegotiation } from '../../../adapters/parked-negotiation.reader.adapter';
 import { answerOpenQuestion } from '../negotiator-answer.host';
+import { readOpenQuestionsForIntent } from '../open-question-message';
 
 const USER_ID = 'user-1';
 const INTENT_ID = 'intent-1';
@@ -28,7 +38,22 @@ const BLOCK: QuestionBlock = {
 };
 const BODY = serializeQuestionMessage('Two conversations are waiting on you.', BLOCK);
 
+/** The message that buries the question without settling it. */
+const EDIT_CONFIRMATION = 'Updated your signal: timing is now open to this month.';
+
+function park(opportunityId: string, dimension: string): ParkedNegotiation {
+  return {
+    opportunityId,
+    kind: 'mid_flight',
+    dimension,
+    dimensionKind: 'hard_constraint',
+    transcript: [],
+    parkedAt: new Date('2026-08-20T20:20:00Z'),
+  };
+}
+
 interface Enqueued {
+  sessionId: string;
   replyMessageId: string;
   precedence?: { questionMessageId: string; routedAnswers: Array<{ ref: string; answerText: string }> };
 }
@@ -40,7 +65,7 @@ function deps(overrides: Record<string, unknown> = {}) {
     deps: {
       findSession: async () => ({ id: 'session-1' }),
       getSessionMessages: async () => [{ id: 'm2', role: 'assistant', content: BODY }],
-      readParkedNegotiations: async () => [{ opportunityId: TIMING_OPPORTUNITY }],
+      readParkedNegotiations: async () => [park(TIMING_OPPORTUNITY, 'Timing: This week')],
       enqueueAnswer: (async (input: Enqueued) => { enqueued.push(input); return true; }) as never,
       ...overrides,
     },
@@ -48,7 +73,7 @@ function deps(overrides: Record<string, unknown> = {}) {
 }
 
 describe('answerOpenQuestion', () => {
-  it('maps the position the model was shown onto that question\'s negotiation ref', async () => {
+  it("maps the position the model was shown onto that question's negotiation ref", async () => {
     const { enqueued, deps: harness } = deps();
 
     const result = await answerOpenQuestion(USER_ID, {
@@ -68,6 +93,43 @@ describe('answerOpenQuestion', () => {
     expect(enqueued[0].replyMessageId).toBe(`tool-answer.${BUDGET_OPPORTUNITY}`);
   });
 
+  it('finds the question when a later agent message buried it — 21:11', async () => {
+    // The incident. The park is live; the question-message is two messages up.
+    // This call used to return `no_open_question`.
+    const { enqueued, deps: harness } = deps({
+      getSessionMessages: async () => [
+        { id: 'm2', role: 'assistant', content: BODY },
+        { id: 'm3', role: 'assistant', content: EDIT_CONFIRMATION },
+        { id: 'm4', role: 'user', content: 'this month' },
+      ],
+    });
+
+    const result = await answerOpenQuestion(USER_ID, { intentId: INTENT_ID, question: 1, answer: 'This month.' }, harness);
+
+    expect(result).toEqual({ status: 'routed', label: 'Timing: This week' });
+    expect(enqueued[0].precedence).toMatchObject({
+      questionMessageId: 'm2',
+      routedAnswers: [{ ref: TIMING_OPPORTUNITY, answerText: 'This month.' }],
+    });
+  });
+
+  it('routes against a derived block when the park has no delivered message', async () => {
+    const { enqueued, deps: harness } = deps({
+      getSessionMessages: async () => [{ id: 'm1', role: 'assistant', content: EDIT_CONFIRMATION }],
+    });
+
+    const result = await answerOpenQuestion(USER_ID, { intentId: INTENT_ID, question: 1, answer: 'This month.' }, harness);
+
+    // Same negotiation ref, so the same settlement resumes it: consumption
+    // re-resolves the park and keys on the task's own settlement id, which the
+    // block's shape never enters.
+    expect(result).toEqual({ status: 'routed', label: 'Timing: This week' });
+    expect(enqueued[0].precedence?.routedAnswers).toEqual([
+      { ref: TIMING_OPPORTUNITY, answerText: 'This month.' },
+    ]);
+    expect(enqueued[0].replyMessageId).toBe(`tool-answer.${TIMING_OPPORTUNITY}`);
+  });
+
   it('reports the open count rather than guessing when the position names nothing', async () => {
     const { enqueued, deps: harness } = deps();
 
@@ -77,7 +139,11 @@ describe('answerOpenQuestion', () => {
     expect(enqueued).toHaveLength(0);
   });
 
-  it('reports nothing open when the block\'s negotiations have all resolved', async () => {
+  it('reports nothing open ONLY when nothing is parked', async () => {
+    // The one state in which telling the client the negotiations moved on is
+    // the truth: the parks resolved or expired. The question-message may still
+    // be sitting in the DM — it is a stale rendering, and answering it would
+    // resume nothing.
     const { deps: harness } = deps({ readParkedNegotiations: async () => [] });
 
     const result = await answerOpenQuestion(USER_ID, { intentId: INTENT_ID, question: 1, answer: 'Yes.' }, harness);
@@ -85,12 +151,16 @@ describe('answerOpenQuestion', () => {
     expect(result).toEqual({ status: 'no_open_question' });
   });
 
-  it('reports nothing open when the signal has no DM at all', async () => {
+  it('reports an honest failure, not a close-out, when the signal has no DM', async () => {
+    // Previously `no_open_question` — which would tell a client with a LIVE
+    // park that their negotiations had moved on. They have not; the reply
+    // simply has no conversation to be consumed in, which cannot happen from a
+    // tool call made inside that very DM.
     const { deps: harness } = deps({ findSession: async () => null });
 
     const result = await answerOpenQuestion(USER_ID, { intentId: INTENT_ID, question: 1, answer: 'Yes.' }, harness);
 
-    expect(result).toEqual({ status: 'no_open_question' });
+    expect(result).toEqual({ status: 'error' });
   });
 
   it('never throws — a failed enqueue is reported, not raised', async () => {
@@ -106,12 +176,64 @@ describe('answerOpenQuestion', () => {
   it('refuses an empty answer without touching the conversation', async () => {
     let read = false;
     const { deps: harness } = deps({
-      findSession: async () => { read = true; return { id: 'session-1' }; },
+      readParkedNegotiations: async () => { read = true; return [park(TIMING_OPPORTUNITY, 'Timing: This week')]; },
     });
 
     const result = await answerOpenQuestion(USER_ID, { intentId: INTENT_ID, question: 1, answer: '  ' }, harness);
 
     expect(result).toEqual({ status: 'error' });
     expect(read).toBe(false);
+  });
+});
+
+/**
+ * The context the model is shown and the host that resolves its call are the
+ * SAME resolution, not two implementations of one rule.
+ *
+ * On 2026-08-20 they disagreed: the orchestrator's context listed an open
+ * question, the model called the tool with its number, and the host said
+ * nothing was open. Both read the DM; only one of them was looking at the
+ * right anchor. They now share `readOpenQuestionsForIntent` — the function
+ * `chat.service.ts` calls to build `openQuestions` and the one the host calls
+ * to resolve a position — so a divergence would have to be a divergence inside
+ * one function.
+ */
+describe('context enumeration and host resolution', () => {
+  it('agree on every position, buried question included', async () => {
+    const { enqueued, deps: harness } = deps({
+      getSessionMessages: async () => [
+        { id: 'm2', role: 'assistant', content: BODY },
+        { id: 'm3', role: 'assistant', content: EDIT_CONFIRMATION },
+      ],
+      readParkedNegotiations: async () => [
+        park(TIMING_OPPORTUNITY, 'Timing: This week'),
+        park(BUDGET_OPPORTUNITY, 'Budget'),
+      ],
+    });
+
+    // What the negotiator persona is given (chat.service.ts builds its
+    // `openQuestions` from exactly this call's `questions`).
+    const context = await readOpenQuestionsForIntent(USER_ID, INTENT_ID, harness);
+    expect(context?.questions.map((question) => question.label)).toEqual(['Timing: This week', 'Budget']);
+
+    // What the host does with the number the model reads off that context.
+    for (const question of context!.questions) {
+      const result = await answerOpenQuestion(USER_ID, {
+        intentId: INTENT_ID,
+        question: question.position,
+        answer: 'Answered.',
+      }, harness);
+      expect(result).toEqual({ status: 'routed', label: question.label });
+    }
+    expect(enqueued.map((job) => job.precedence?.routedAnswers[0]?.ref))
+      .toEqual([TIMING_OPPORTUNITY, BUDGET_OPPORTUNITY]);
+  });
+
+  it('close together: nothing in context, nothing routable', async () => {
+    const { deps: harness } = deps({ readParkedNegotiations: async () => [] });
+
+    expect(await readOpenQuestionsForIntent(USER_ID, INTENT_ID, harness)).toBeNull();
+    expect(await answerOpenQuestion(USER_ID, { intentId: INTENT_ID, question: 1, answer: 'Yes.' }, harness))
+      .toEqual({ status: 'no_open_question' });
   });
 });

--- a/services/api/src/lib/question/tests/open-question-consumption.settlement.spec.ts
+++ b/services/api/src/lib/question/tests/open-question-consumption.settlement.spec.ts
@@ -1,0 +1,130 @@
+/**
+ * One settlement, whichever shape the block arrived in.
+ *
+ * Openness is now the parked set, so the block an answer is consumed against
+ * may be the DELIVERED question-message or one DERIVED from the parked turns
+ * (`open-question-message.ts`). That is a new degree of freedom, and it must
+ * not become a new way to resume a negotiation twice — or to resume it under a
+ * different key and lose the idempotency the spine depends on.
+ *
+ * It does not, and this pins why: the block carries a negotiation REF and
+ * nothing else. Consumption re-resolves that ref to its current park and keys
+ * the settle on the task's own `negotiationQuestionSettlementId(taskId)`. The
+ * shape of the question the client answered never enters it.
+ */
+import { describe, expect, test } from 'bun:test';
+
+import { consumeQuestionBlockAnswers, negotiationQuestionSettlementId, serializeQuestionMessage } from '@indexnetwork/protocol';
+import type { InflightAnswerSettlementInput, NegotiationAnswerConsumptionPorts, QuestionBlock } from '@indexnetwork/protocol';
+
+import type { ParkedNegotiation } from '../../../adapters/parked-negotiation.reader.adapter';
+import { readOpenQuestionsForIntent } from '../open-question-message';
+
+const USER_ID = 'user-1';
+const INTENT_ID = 'intent-1';
+const OPPORTUNITY = '6d8b07ef-7fa8-4968-80d9-6af0ce364d27';
+const TASK_ID = 'task-1';
+const ANSWER = 'This month.';
+
+const DELIVERED_BLOCK: QuestionBlock = {
+  version: 1,
+  questions: [{ prompt: 'When could you meet?', opportunityId: OPPORTUNITY, dimension: 'Timing: This week' }],
+};
+const DELIVERED_BODY = serializeQuestionMessage('One conversation is waiting on you.', DELIVERED_BLOCK);
+
+const PARK: ParkedNegotiation = {
+  opportunityId: OPPORTUNITY,
+  kind: 'mid_flight',
+  dimension: 'Timing: This week',
+  dimensionKind: 'hard_constraint',
+  transcript: [],
+  parkedAt: new Date('2026-08-20T20:20:00Z'),
+};
+
+/** The mid-flight park shape `classifyParkedNegotiation` demands. */
+function ports() {
+  const settled: InflightAnswerSettlementInput[] = [];
+  const resumed: Array<{ taskId: string; settlementId: string }> = [];
+  return {
+    settled,
+    resumed,
+    ports: {
+      database: {
+        getNegotiationTaskForOpportunity: async () => ({
+          id: TASK_ID,
+          state: 'input_required',
+          metadata: {
+            type: 'negotiation',
+            opportunityId: OPPORTUNITY,
+            turnContext: {
+              askUserBinding: {
+                settlementId: negotiationQuestionSettlementId(TASK_ID),
+                recipientUserId: USER_ID,
+                recipientIntentId: INTENT_ID,
+                networkId: 'network-1',
+                opportunityId: OPPORTUNITY,
+              },
+            },
+          },
+        }),
+        getNegotiationMessages: async () => [],
+      },
+      settleInflightAnswer: async (input: InflightAnswerSettlementInput) => {
+        settled.push(input);
+        return 'settled' as const;
+      },
+      enqueueInflightResume: async (input: { taskId: string; settlementId: string }) => {
+        resumed.push({ taskId: input.taskId, settlementId: input.settlementId });
+      },
+      recordOpportunityAnswer: async () => {},
+      enqueueStalledRetry: async () => {},
+    } as unknown as NegotiationAnswerConsumptionPorts,
+  };
+}
+
+async function resolveBlock(messages: Array<{ id: string; role: string; content: string }>): Promise<QuestionBlock> {
+  const open = await readOpenQuestionsForIntent(USER_ID, INTENT_ID, {
+    findSession: async () => ({ id: 'session-1' }),
+    getSessionMessages: async () => messages,
+    readParkedNegotiations: async () => [PARK],
+  });
+  if (!open) throw new Error('expected the park to be open');
+  return open.block;
+}
+
+describe('answer consumption across delivered and derived blocks', () => {
+  test('both shapes settle the same park under the same settlement id', async () => {
+    // Delivered: the client answered the message they can see, buried or not.
+    const delivered = await resolveBlock([
+      { id: 'm2', role: 'assistant', content: DELIVERED_BODY },
+      { id: 'm3', role: 'assistant', content: 'Updated your signal.' },
+    ]);
+    // Derived: the park's rendering never reached the DM.
+    const derived = await resolveBlock([{ id: 'm1', role: 'assistant', content: 'Updated your signal.' }]);
+    expect(delivered.questions[0].prompt).not.toBe(derived.questions[0].prompt);
+
+    const first = ports();
+    await consumeQuestionBlockAnswers(first.ports, {
+      block: delivered,
+      userId: USER_ID,
+      answers: [{ ref: OPPORTUNITY, answerText: ANSWER }],
+      answeredAt: '2026-08-20T21:11:00.000Z',
+    });
+    const second = ports();
+    await consumeQuestionBlockAnswers(second.ports, {
+      block: derived,
+      userId: USER_ID,
+      answers: [{ ref: OPPORTUNITY, answerText: ANSWER }],
+      answeredAt: '2026-08-20T21:11:00.000Z',
+    });
+
+    // Identical settlements: the ref is the identity, the prompt is dressing.
+    expect(first.settled).toEqual(second.settled);
+    expect(first.settled[0]?.settlementId).toBe(negotiationQuestionSettlementId(TASK_ID));
+    expect(first.resumed).toEqual(second.resumed);
+    // So a delivered-shape delivery and a derived-shape delivery of the same
+    // answer are the SAME delivery twice — which the CAS on the parked task
+    // reports as `already_settled` and never resumes twice.
+    expect(first.resumed).toEqual([{ taskId: TASK_ID, settlementId: negotiationQuestionSettlementId(TASK_ID) }]);
+  });
+});

--- a/services/api/src/lib/question/tests/open-question-message.spec.ts
+++ b/services/api/src/lib/question/tests/open-question-message.spec.ts
@@ -1,9 +1,11 @@
 import { describe, expect, test } from 'bun:test';
 
 import { questionBlockFixture, questionMessageFixture, questionProseFixture } from '@indexnetwork/protocol/question-block/fixture';
-import { serializeQuestionMessage } from '@indexnetwork/protocol';
+import { parseQuestionMessage, serializeQuestionMessage } from '@indexnetwork/protocol';
+import type { QuestionBlock } from '@indexnetwork/protocol';
 
-import { openQuestionBlock, questionBlockRefs, readOpenQuestionMessages } from '../open-question-message';
+import type { ParkedNegotiation } from '../../../adapters/parked-negotiation.reader.adapter';
+import { UNRENDERABLE_PARK_PROMPT, derivedQuestionMessageId, openQuestionBlock, questionBlockRefs, readOpenQuestionMessages, readOpenQuestionsForIntent } from '../open-question-message';
 
 const PRIMARY = questionBlockFixture.questions[0].opportunityId;
 const ALSO_UNBLOCKS = questionBlockFixture.questions[0].alsoUnblocks![0];
@@ -121,5 +123,194 @@ describe('readOpenQuestionMessages', () => {
 
   test('an empty user id reads nothing', async () => {
     expect(await readOpenQuestionMessages('')).toEqual([]);
+  });
+});
+
+/**
+ * Openness = parked (the 2026-08-20 21:11 incident).
+ *
+ * The question was delivered at 20:21 and an edit-confirmation landed at
+ * 20:24, so the question stopped being the newest agent message. Its task
+ * stayed `input_required` until well past 21:11, when the client answered it —
+ * and every lane resolved "nothing open" off message recency. These pin the
+ * replacement predicate: the park is the record, the message is its rendering,
+ * and the rendering is RECOVERED (searched back for, or derived) rather than
+ * required to be at the tail.
+ */
+describe('readOpenQuestionsForIntent', () => {
+  const USER_ID = 'user-1';
+  const INTENT_ID = 'intent-1';
+  const TIMING = '6d8b07ef-7fa8-4968-80d9-6af0ce364d27';
+  const BUDGET = '7f3d2c1b-8a90-4e5f-b6c7-d8e9f0a1b2c3';
+
+  const DELIVERED_BLOCK: QuestionBlock = {
+    version: 1,
+    questions: [{
+      prompt: 'When could you meet?',
+      opportunityId: TIMING,
+      dimension: 'Timing: This week',
+    }],
+  };
+  const DELIVERED_BODY = serializeQuestionMessage('One conversation is waiting on you.', DELIVERED_BLOCK);
+  const EDIT_CONFIRMATION = 'Updated your signal to say you are open to remote.';
+
+  function park(overrides: Partial<ParkedNegotiation> = {}): ParkedNegotiation {
+    return {
+      opportunityId: TIMING,
+      kind: 'mid_flight',
+      transcript: [],
+      parkedAt: new Date('2026-08-20T20:20:00Z'),
+      ...overrides,
+    };
+  }
+
+  function resolve(input: {
+    parked?: ParkedNegotiation[];
+    messages?: Array<{ id: string; role: string; content: string }>;
+    session?: { id: string } | null;
+    onSessionRead?: () => void;
+  }) {
+    return readOpenQuestionsForIntent(USER_ID, INTENT_ID, {
+      readParkedNegotiations: async () => input.parked ?? [],
+      findSession: async () => {
+        input.onSessionRead?.();
+        return input.session === undefined ? { id: 'session-1' } : input.session;
+      },
+      getSessionMessages: async () => input.messages ?? [],
+    });
+  }
+
+  test('a question buried under later agent messages is still open — the incident', async () => {
+    const open = await resolve({
+      parked: [park()],
+      messages: [
+        { id: 'm1', role: 'user', content: 'How is it going?' },
+        { id: 'm2', role: 'assistant', content: DELIVERED_BODY },
+        { id: 'm3', role: 'assistant', content: EDIT_CONFIRMATION },
+        { id: 'm4', role: 'assistant', content: 'Still working on it.' },
+      ],
+    });
+
+    // Recovered from the delivered message, wherever it sits in the DM: the
+    // client is answering the block they can actually see.
+    expect(open?.source).toBe('delivered');
+    expect(open?.messageId).toBe('m2');
+    expect(open?.body).toBe(DELIVERED_BODY);
+    expect(open?.questions).toEqual([{ position: 1, label: 'Timing: This week', opportunityId: TIMING }]);
+  });
+
+  test('a park whose message was never delivered is open on a derived block', async () => {
+    const open = await resolve({
+      parked: [park({
+        dimension: 'Timing: This week',
+        dimensionKind: 'hard_constraint',
+        answerhood: { ok_when: 'a meeting inside this week works', conflict_when: 'nothing works before next month' },
+      })],
+      messages: [{ id: 'm1', role: 'assistant', content: EDIT_CONFIRMATION }],
+    });
+
+    expect(open?.source).toBe('derived');
+    expect(open?.messageId).toBe(derivedQuestionMessageId(INTENT_ID));
+    expect(open?.questions).toEqual([{ position: 1, label: 'Timing: This week', opportunityId: TIMING }]);
+    // Derived through the same derivation the message author uses, so the
+    // prompt names the dimension and the answerhood map becomes the options.
+    expect(open?.block.questions[0].prompt).toContain('Timing: This week');
+    expect(open?.block.questions[0].options).toEqual([
+      { label: 'a meeting inside this week works', description: expect.any(String) },
+      { label: 'nothing works before next month', description: expect.any(String) },
+    ]);
+    // The body is a real question-message body: consumption parses it.
+    expect(parseQuestionMessage(open!.body)?.block).toEqual(open!.block);
+  });
+
+  test('a park with neither an authored question nor a dimension is open on fixed copy', async () => {
+    // A policy-inferred consultation or a pre-checklist post-stall gap. There
+    // is nothing to render, and dropping it would put the park back outside
+    // every answer lane — the exact hole this module closes.
+    const open = await resolve({ parked: [park()], messages: [] });
+
+    expect(open?.source).toBe('derived');
+    expect(open?.block.questions[0].prompt).toBe(UNRENDERABLE_PARK_PROMPT);
+    expect(open?.block.questions[0].opportunityId).toBe(TIMING);
+  });
+
+  test('nothing parked is closed, even with a question-message sitting newest', async () => {
+    // The other direction, and it must hold just as hard: a delivered message
+    // whose parks have all resolved is a stale RENDERING. Answering it resumes
+    // nothing, so the reply is ordinary conversation.
+    let sessionRead = false;
+    const open = await resolve({
+      parked: [],
+      messages: [{ id: 'm2', role: 'assistant', content: DELIVERED_BODY }],
+      onSessionRead: () => { sessionRead = true; },
+    });
+
+    expect(open).toBeNull();
+    // And the parked read short-circuits before the DM is touched at all.
+    expect(sessionRead).toBe(false);
+  });
+
+  test('an expired ask window is closed', async () => {
+    // Expiry is a state change on the task, not a separate clock here: the
+    // expiry worker moves the exact task out of `input_required`, so the park
+    // leaves the parked set and the question closes with it.
+    expect(await resolve({ parked: [], messages: [{ id: 'm2', role: 'assistant', content: DELIVERED_BODY }] }))
+      .toBeNull();
+  });
+
+  test('a delivered block referencing only resolved negotiations does not shadow a live park', async () => {
+    const open = await resolve({
+      parked: [park({ opportunityId: BUDGET, dimension: 'Budget' })],
+      messages: [{ id: 'm2', role: 'assistant', content: DELIVERED_BODY }],
+    });
+
+    expect(open?.source).toBe('derived');
+    expect(open?.questions).toEqual([{ position: 1, label: 'Budget', opportunityId: BUDGET }]);
+  });
+
+  test('a DM that cannot be read degrades to the derived block, never to closed', async () => {
+    const open = await readOpenQuestionsForIntent(USER_ID, INTENT_ID, {
+      readParkedNegotiations: async () => [park({ dimension: 'Timing: This week' })],
+      findSession: async () => { throw new Error('db down'); },
+    });
+
+    expect(open?.source).toBe('derived');
+    expect(open?.sessionId).toBeNull();
+    expect(open?.questions).toHaveLength(1);
+  });
+
+  test('a signal with no DM is still open — the park does not need a conversation', async () => {
+    const open = await resolve({ parked: [park({ dimension: 'Budget' })], session: null });
+
+    expect(open?.source).toBe('derived');
+    expect(open?.sessionId).toBeNull();
+  });
+
+  test('every question of a delivered block is numbered as delivered', async () => {
+    // Only one of the two is still parked; both are listed, because the
+    // numbers must line up with what the client is looking at. Answering the
+    // resolved one simply consumes to nothing.
+    const twoQuestions = serializeQuestionMessage('Two conversations are waiting on you.', {
+      version: 1,
+      questions: [
+        DELIVERED_BLOCK.questions[0],
+        { prompt: 'What budget range works?', opportunityId: BUDGET, dimension: 'Budget' },
+      ],
+    });
+
+    const open = await resolve({
+      parked: [park({ opportunityId: BUDGET })],
+      messages: [{ id: 'm2', role: 'assistant', content: twoQuestions }],
+    });
+
+    expect(open?.questions).toEqual([
+      { position: 1, label: 'Timing: This week', opportunityId: TIMING },
+      { position: 2, label: 'Budget', opportunityId: BUDGET },
+    ]);
+  });
+
+  test('an empty scope reads nothing', async () => {
+    expect(await readOpenQuestionsForIntent('', INTENT_ID)).toBeNull();
+    expect(await readOpenQuestionsForIntent(USER_ID, '')).toBeNull();
   });
 });


### PR DESCRIPTION
A negotiation parked on this user's side is waiting for an answer for 24 hours. Tonight, twice, the answer arrived and had no route in — because "open" meant *the newest agent message in the DM parses as a question block*, and one intervening agent message closed a question that was still waiting.

## The incident (sandbox, DM `6d8b07ef…`, intent `34fa30bc…`, task `aefff73b…`)

| time | what landed |
|---|---|
| 20:20:37 | task `aefff73b` → `input_required`, ask-user binding names this user + signal |
| 20:21:29 | question-message delivered, block references opportunity `78a6b283` |
| 20:24:18 | an edit-confirmation posts **after** it — the question is no longer the newest agent message |
| 21:11:28 | the client replies "this month" |

Every lane resolved "nothing open" while the task sat `input_required`, mid-window:

- **the precedence gate** — `openQuestionMessage` anchored on the newest agent message, found the edit-confirmation, returned null, fell through silently (correct per its predicate);
- **the orchestrator** — saw an ordinary reply and edited the signal (legitimate from its view);
- **the host** — the model *did* call `answer_pending_question(question: 1)`, and the host answered `no_open_question`, whose copy tells the client "the negotiations moved on". False. The park outlived its own answerability.

One defect under all three: **openness was DM message recency.** The spine's own doctrine already said which of the two is the record — the parked negotiation is the durable record, the DM message is its rendering — and the rendering was being treated as the record.

## The fix: open = parked

A question is open iff its negotiation is parked on this user's side for this signal (`inflight` / `post_stall`, scoped `(userId, intentId)`), whatever the newest DM message is. The block an answer routes onto is **recovered**, not located:

1. the delivered question-message when one exists **anywhere** in the DM — searched back, not required at the tail;
2. else a block **derived** from the parked turns, through the same dimension derivation the message author uses (#1467);
3. else — a park with neither an authored question nor a dimension (policy-inferred consult, pre-checklist gap) — a fixed server-owned prompt bound to the right negotiation.

A live park is always answerable. Nothing parked is the only thing that closes a question.

**One call, three lanes.** `readOpenQuestionsForIntent` is now the single resolver for the precedence gate (`answer-precedence.ts`), the `answer_pending_question` host, and the orchestrator's context enumeration (`chat.service.ts`). The model and the host cannot disagree about what is open, because it is the same function — not the same rule written twice. A spec drives both from one dep set and asserts every position agrees; a static spec pins that no lane re-derives openness from the newest agent message.

**The false copy dies with the predicate.** `no_open_question` — and the "moved on" text behind it in the protocol tool — is now reachable only when nothing is parked, which is the only state it is true of. A live park with no DM at all reports `error` (honest failure) rather than the close-out.

**Settlement is unaffected by block shape.** The block carries a negotiation ref and nothing else; consumption re-resolves that ref and keys on the task's own `negotiationQuestionSettlementId(taskId)`. A new spec runs the same answer through a delivered-shape block and a derived-shape block and asserts identical settlements and resumes — so the new degree of freedom cannot become a second way to resume a negotiation.

**Cost.** The parked read is both the authority and the cheap short-circuit: an ordinary conversational turn now ends on one scoped indexed query *before* any message is read (it used to read the DM first). A DM that cannot be read degrades to the derived block, never to "nothing open" — losing the client's answer is the worse failure.

## Tests

`bun test src/lib/question/tests` — 92 pass, 0 fail, 10 files.

- **Resolver** (`open-question-message.spec.ts`): buried under N agent messages → open, block from the delivered message; no delivered message → open, block derived from the dimension (options from the answerhood map); park with nothing renderable → open on fixed copy; **nothing parked → closed even with a question-message sitting newest** (stale rendering, pinned in that direction too); expired ask window → closed; a delivered block whose refs all resolved does not shadow a live park; DM read failure → derived, not closed.
- **The incident as a spec** (`answer-precedence.spec.ts`): question delivered, edit-confirmation after it, then the reply → `answered`, anchored on the buried message, routed onto the park's ref. The controller carries that routing into the consumption job and swaps the orchestrator for an empty stream (pinned in `answer-precedence.wiring.static.spec.ts`), so the edit rule never runs and the intent is untouched.
- **Host** (`negotiator-answer.host.spec.ts`): a live park is always found (buried or derived); `no_open_question` only when nothing is parked; context enumeration and host resolution proven to come from the same call.
- **Settlement** (`open-question-consumption.settlement.spec.ts`): delivered and derived blocks settle the same park under the same settlement id.
- Existing #1467 suites stay green, including the wiring order pin. The answer-precedence fixtures moved from `answerPorts` + message-recency setups to park-backed ones, because that is precisely what the module now reads; each case kept its original assertion.

`bun run typecheck`, `typecheck:specs`, and `eslint src/lib/question` are clean. The full api suite has its usual pre-existing DB-backed failures (tool controller, MCP factory, CLI credentials, conversation adapter, opportunity service) — none in the question or chat lanes, none touched by this diff.

## Verification

**Mechanical, read-only, against the sandbox DB (done):**

- task `aefff73b-d61f-4864-bfd8-859a8758ddcf` is **still** `input_required`, not archived, binding `recipientUserId=6c17f313…` / `recipientIntentId=34fa30bc…`, settlement `negotiation-question-settlement-v1-aefff73b-…`;
- the parked-negotiation reader's exact mid-flight predicate (participant binding + ask-user binding + not archived + intent ownership) returns this task for that pair — so the new resolver reads it as open;
- the DM's message order is the incident verbatim: block at 20:21:29, agent messages at 20:24:18 and 21:11:28 after it, and the block references the parked opportunity `78a6b283…` — so the search-back recovers the delivered message the client is looking at.

**Awaiting the human half (needs the fix deployed):** replying to the still-buried question in DM `6d8b07ef` should route to task `aefff73b`, resume it, and leave `intents.payload` untouched. The evaluator's judgment of the reply is a model call, so only a live run proves that last step end to end.

## Boundaries

`services/api/src/lib/question/**` only. No protocol changes, no flags, no schema, no controller change (the gate's signature is unchanged). Re-delivery UX — bumping the question back to the bottom of the DM — stays out of scope; openness no longer depends on it.

One known gap left deliberately outside the boundary: on the `unavailable` path (evaluator outage) the controller enqueues consumption without routing, and the queue's own fallback still anchors on the newest agent message, so a buried question enqueues nothing there. That turn does reach the orchestrator, which now carries a working tool lane, so the answer still has a route in. Closing it properly means letting `enqueueQuestionAnswerReply` take a resolved block without routed answers — a small follow-up in `question-message.queue.ts`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01K6eFTJ3h2q2NW1qr9E3aS2
