### PR TITLE
feat(negotiations): the owner's verdict needs a lane in their own DM

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -89,7 +89,7 @@
     },
     "packages/protocol": {
       "name": "@indexnetwork/protocol",
-      "version": "23.4.0",
+      "version": "23.5.0",
       "dependencies": {
         "@langchain/core": "1.1.48",
         "@langchain/langgraph": "1.3.2",

--- a/packages/protocol/CHANGELOG.md
+++ b/packages/protocol/CHANGELOG.md
@@ -20,6 +20,79 @@ went 6.7.1 → 8.0.2 with no 7.x in between because the whole 7.x line shipped a
 prereleases between the two promotions. To track every change, read `rc`; to
 pin a supported release, use `latest`.
 
+## 23.5.0 - 2026-08-20
+
+### Added
+
+- **The owner's verdict has a lane in their own DM.** Observed live: in the
+  negotiator DM for one signal, a client told their agent to reject the
+  counterparty — a pairing parked `input_required`. The agent could not comply.
+  The owner makes exactly three kinds of decision in that room. They ANSWER a
+  question a parked negotiation asked, which `answer_pending_question` gave a
+  lane. They EDIT the signal, which `update_intent` always covered.
+  And they pass a VERDICT on a counterparty, which had no lever at all. So on
+  "reject them" the persona's whole repertoire was to say something back, or to
+  edit the signal instead; the pairing stayed parked and the counterparty
+  stayed live.
+
+  `update_opportunity` is in the negotiator toolset and cannot substitute for
+  either half of this. `admitOpportunityUpdate` blocks a `negotiating` pairing
+  outright, and the IND-593 owner-approval boundary fails closed on the chat
+  surface by design — `createChatTools` binds
+  `{ surface: 'chat', sessionAuthenticated: false }`, and a mediated surface is
+  denied `untrusted_provenance`. The verdict levers that exist are the Radar
+  card's Skip and Start-Chat and the REST endpoints behind them, none of which
+  the client's own agent can reach.
+
+  So `createNegotiatorVerdictTools` adds `reject_opportunity` and
+  `accept_opportunity` to the negotiator persona, on the same pattern
+  `answer_pending_question` set. Appended AFTER the allowlist filter and only in
+  an intent-pinned session with `negotiatorVerdictTools` injected, so they never
+  enter the shared chat-tool registry and the orchestrator and MCP tool listing
+  cannot see them. `NegotiatorVerdictToolsHost` is the whole surface the package
+  knows; the composition root owns everything behind it.
+
+- **Numbered refs, never ids.** The prompt renders this signal's actionable
+  counterparties as `N. {name} — {state}`, and the tool takes the number. The
+  schema offers no place to put an id and no result string carries one. The rule
+  is `answer_pending_question`'s, for a sharper reason: a ref the model can name
+  is a ref it can get wrong, and a wrong ref here declines the wrong person.
+  The host owns the mapping, and a successful result names WHO the write landed
+  on — so the confirmation the client reads comes from the write rather than
+  from the model's belief about which counterparty it picked.
+
+- **An optional `reason`, in the client's own words.** Capped at 500 characters,
+  omitted entirely when they gave none. The tool description and the prompt both
+  say it is never to be inferred or written for them.
+
+### Changed
+
+- **The pinned-signal prompt gains a verdict section, and only where the tools
+  exist.** `NegotiatorPromptOptions.actionableCounterparties` renders
+  `## Verdicts {userName} can pass here` plus two tool-reference rows. It says
+  the tool call IS the decision — not the sentence about it, and not an edit of
+  the signal; that a verdict the client did not pass must never be passed for
+  them; that `update_opportunity` is not this lever; and that an accept is one
+  side of two and never a connection. Rendered only in an intent-pinned session
+  with a non-empty list, since that is the only place the tools are registered.
+  Absent or empty leaves the prompt byte-identical to 23.4.0.
+
+- **Result copy is honest at every status.** `executed` names the counterparty
+  and forbids also editing the signal; `none_actionable` forbids implying a
+  decision was recorded; `unknown_counterparty` states plainly that nothing was
+  decided and re-lists the current set; `already_decided` says whose move it is;
+  `error` forbids describing the pairing as decided. A host that throws is
+  caught and reported as `error` rather than costing the client their turn.
+
+- **Execution is the path the Radar card already takes, and nothing more.** The
+  host behind the seam runs the SAME owner status update the Skip page calls
+  through `PATCH /opportunities/:id/status`, intent-scoped. No new task-state
+  transition is invented, and the retirement of a dismissed pairing's open
+  question is not re-invoked: `OpportunityEvents.onTransition` already fires the
+  exhaustion evaluator on every committed opportunity status write, owner reject
+  included, so a rejected pairing's question dies with it because that arrow was
+  already there.
+
 ## 23.4.0 - 2026-08-20
 
 ### Added

--- a/packages/protocol/package.json
+++ b/packages/protocol/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@indexnetwork/protocol",
-  "version": "23.4.0",
+  "version": "23.5.0",
   "type": "module",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",

--- a/packages/protocol/src/chat/negotiator.persona.ts
+++ b/packages/protocol/src/chat/negotiator.persona.ts
@@ -2,7 +2,7 @@ import { createChatTools, type ChatTools, type ToolContext, type ResolvedToolCon
 import { focusedIntentId, type ToolScopeEnvelope } from "../shared/agent/tool.scope.js";
 import type { ChatPersonaConfig } from "./chat.persona.js";
 import { buildNegotiatorSystemContent, type NegotiatorPromptOptions } from "./negotiator.prompt.js";
-import { createNegotiatorAnswerTools, createNegotiatorMemoryTools } from "./negotiator.tools.js";
+import { createNegotiatorAnswerTools, createNegotiatorMemoryTools, createNegotiatorVerdictTools } from "./negotiator.tools.js";
 
 // ═══════════════════════════════════════════════════════════════════════════════
 // NEGOTIATOR PERSONA (P4.1)
@@ -145,6 +145,18 @@ export async function createNegotiatorTools(
   if (deps.negotiatorAnswerTools && pinnedIntentId) {
     extra.push(...createNegotiatorAnswerTools({
       host: deps.negotiatorAnswerTools,
+      userId: deps.userId,
+      intentId: pinnedIntentId,
+    }));
+  }
+  // #1471: `reject_opportunity`/`accept_opportunity` are the owner's VERDICT
+  // lane. Same conditionality and same reason as the answer tool: the
+  // counterparties they act on are ONE signal's, listed and numbered in the
+  // pinned prompt, so a number outside a pinned session names nothing — and a
+  // verdict that names nothing must never reach a write.
+  if (deps.negotiatorVerdictTools && pinnedIntentId) {
+    extra.push(...createNegotiatorVerdictTools({
+      host: deps.negotiatorVerdictTools,
       userId: deps.userId,
       intentId: pinnedIntentId,
     }));

--- a/packages/protocol/src/chat/negotiator.prompt.ts
+++ b/packages/protocol/src/chat/negotiator.prompt.ts
@@ -57,6 +57,17 @@ export interface NegotiatorPromptOptions {
    * Absent/empty → the prompt is byte-identical to before.
    */
   openQuestions?: string[];
+  /**
+   * This signal's ACTIONABLE counterparties — the pairings the client can still
+   * pass a verdict on — one short line each ("Camille Dubois — your agents are
+   * still negotiating"), in a stable order. Rendered as the verdict section,
+   * and the numbers the model is shown here are exactly the numbers
+   * `reject_opportunity` / `accept_opportunity` take.
+   *
+   * Only meaningful in an intent-pinned session, where those tools are
+   * registered. Absent/empty → the prompt is byte-identical to before.
+   */
+  actionableCounterparties?: string[];
 }
 
 /**
@@ -117,6 +128,33 @@ ${list}
 }
 
 /**
+ * Renders the verdict section for an intent-pinned session (#1471).
+ *
+ * The owner has three kinds of decision here — answer, edit, VERDICT — and
+ * until this existed the third had no lane. On 2026-08-20 a client told their
+ * agent to reject a counterparty and the agent had nothing in its toolset that
+ * could do it; the levers were the Radar card and the endpoints behind it.
+ *
+ * The numbers are the whole interface. The model never sees an opportunity id
+ * and never emits one: it reads a position off this list and the host maps it,
+ * because a ref the model can name is a ref it can get wrong, and a wrong ref
+ * here declines the wrong person.
+ */
+function buildVerdictSection(userName: string, counterparties: string[]): string {
+  const list = counterparties.map((label, index) => `${index + 1}. ${label}`).join("\n");
+  return `
+## Verdicts ${userName} can pass here
+These are this signal's counterparties ${userName} can still decide on, numbered:
+${list}
+- When they decide on one — decline it or accept it, however they phrase it — call reject_opportunity or accept_opportunity with that number. That call is the decision. Saying it back to them is not, and neither is editing their signal.
+- Never pass a verdict they did not pass. Not on your own read of a match, not on a hesitation, not on silence. If which counterparty they mean is unclear, ask before you call.
+- Pass their reason only if they gave one, in their own words. Never write one for them.
+- update_opportunity is not this lever. It refuses a pairing whose agents are mid-negotiation outright, and it does not carry an owner verdict from chat — these two tools do.
+- Accepting is one side of two. It does not connect them — the counterparty has to accept too. Say it that way.
+- Never tell them a match is declined or accepted without a successful tool result for it.`;
+}
+
+/**
  * Renders the remember/forget guidance section (P5.4). Only rendered when the
  * memory tools are actually registered, so the model is never told about
  * capabilities it does not have.
@@ -171,6 +209,14 @@ export function buildNegotiatorSystemContent(
   const answerToolRow = pinnedIntentId && opts.openQuestions?.length
     ? "\n| **answer_pending_question** | question, answer | Route what the client just said to one of the open questions above — the only thing that resumes a parked negotiation |"
     : "";
+  // Same conditionality, same reason: the verdict tools are registered only in
+  // a pinned session, so the numbered counterparties only mean something there.
+  const verdictSection = pinnedIntentId && opts.actionableCounterparties?.length
+    ? buildVerdictSection(ctx.userName, opts.actionableCounterparties)
+    : "";
+  const verdictToolRows = pinnedIntentId && opts.actionableCounterparties?.length
+    ? "\n| **reject_opportunity** | counterparty, reason? | Decline one of the counterparties above, on the client's explicit verdict — the only thing that declines a match |\n| **accept_opportunity** | counterparty, reason? | Accept one of them, on the client's explicit verdict — one side of a two-party decision |"
+    : "";
   const memorySection = renderNegotiatorChatMemorySection(opts.memory ?? []);
   const memoryToolsSection = opts.memoryToolsEnabled ? buildMemoryToolsSection() : "";
   const memoryToolsRows = opts.memoryToolsEnabled
@@ -208,7 +254,7 @@ ${signalGuidance}
 - **Handle memberships**: list the communities they belong to and join or leave communities when they ask.
 - **Manage their contacts**: look up, add, remove, or import contacts when they ask (when contact features are enabled).
 - **Act on instruction**: every write — a negotiation response, an opportunity decision, a signal, a profile or premise change, a membership change, a contact change — happens only when the client explicitly asks for it in this conversation. Never write anything the client did not just ask for.
-${pinnedSignalSection}${openQuestionsSection}${memorySection}${memoryToolsSection}
+${pinnedSignalSection}${openQuestionsSection}${verdictSection}${memorySection}${memoryToolsSection}
 ## What you cannot do here
 - **No direct discovery.** You cannot run matching or search for people yourself. Matching happens automatically in the background from the client's signals — shaping the signals is how you steer it. ${matchVisibility}
 - **No community administration.** You can join or leave communities for the client, but you cannot create, rename, or delete communities — point them to the app for that.
@@ -244,7 +290,7 @@ ${profileContext}
 | **read_networks** / **read_network_memberships** | — | The client's communities and memberships |
 | **create_network_membership** / **delete_network_membership** | networkId | Join/leave a community on instruction |
 | **list_contacts** / **search_contacts** / **remove_contact** | ... | The client's contacts |
-| **scrape_url** | url, objective | Read a link the client pasted (e.g. before drafting a signal from it) |${answerToolRow}${memoryToolsRows}
+| **scrape_url** | url, objective | Read a link the client pasted (e.g. before drafting a signal from it) |${answerToolRow}${verdictToolRows}${memoryToolsRows}
 
 ## Grounding rules
 - **Never fabricate.** Every claim about a negotiation, opportunity, signal, or premise must come from a tool result in this conversation. If you have not looked it up this turn, look it up before answering. Only the client's identity and profile above are preloaded.

--- a/packages/protocol/src/chat/negotiator.tools.ts
+++ b/packages/protocol/src/chat/negotiator.tools.ts
@@ -2,6 +2,7 @@ import { tool } from "@langchain/core/tools";
 import { z } from "zod";
 import type { NegotiatorMemoryToolsHost, NegotiatorMemoryToolView } from "../shared/interfaces/negotiator-memory.interface.js";
 import type { NegotiatorAnswerToolsHost } from "../shared/interfaces/negotiator-answer.interface.js";
+import type { NegotiatorVerdictInput, NegotiatorVerdictResult, NegotiatorVerdictToolsHost } from "../shared/interfaces/negotiator-verdict.interface.js";
 import { protocolLogger } from "../shared/observability/protocol.logger.js";
 
 // ═══════════════════════════════════════════════════════════════════════════════
@@ -265,4 +266,157 @@ export function createNegotiatorAnswerTools(opts: {
   );
 
   return [answerPendingQuestion];
+}
+
+// ═══════════════════════════════════════════════════════════════════════════════
+// OWNER VERDICT TOOLS (#1471)
+// ═══════════════════════════════════════════════════════════════════════════════
+//
+// The owner's three decisions in their signal's DM are ANSWER, EDIT, and
+// VERDICT. Answer got a lane in #1466 and edit always had one; verdict had
+// none. On 2026-08-20 a client told their agent, in the DM of a parked
+// pairing, to reject the counterparty — and the agent's whole toolset held no
+// lever that could do it. The verdict levers were the Radar card's Skip and
+// Start-Chat, and the REST endpoints behind them. `update_opportunity` is in
+// the toolset and cannot substitute: its admission blocks `negotiating`
+// outright, and the IND-593 owner-approval boundary fails closed on the chat
+// surface. So the persona's only available move on "reject them" was to say
+// something, or to edit the signal instead.
+//
+// Positions, never ids — the same rule `answer_pending_question` follows, and
+// for a sharper reason: a ref the model can name is a ref it can get wrong,
+// and a wrong ref here rejects the wrong person. The model is shown a numbered
+// list of this signal's actionable counterparties and hands back a number; the
+// host owns the mapping and reports back WHO it acted on, so the confirmation
+// the client reads names the person the write actually landed on.
+//
+// Registered only in intent-pinned negotiator sessions with the host injected:
+// the counterparties are one signal's, so a number with no signal behind it
+// would decide nothing — or something.
+
+const verdictLogger = protocolLogger("NegotiatorVerdictTools");
+
+const VerdictSchema = z.object({
+  counterparty: z
+    .number()
+    .int()
+    .min(1)
+    .describe("Which counterparty the client is deciding on, by the number shown in your context."),
+  reason: z
+    .string()
+    .min(1)
+    .max(500)
+    .optional()
+    .describe(
+      "Why, in the client's OWN words, if they gave a reason. For the record only. Leave it out entirely when they did not say — never infer one, never write one for them.",
+    ),
+});
+
+/** One verdict's copy, per host status. Kept together so both tools stay honest in the same way. */
+function describeVerdict(
+  verdict: "rejected" | "accepted",
+  result: NegotiatorVerdictResult,
+): Record<string, unknown> {
+  switch (result.status) {
+    case "executed":
+      return verdict === "rejected"
+        ? {
+          status: "executed",
+          counterparty: result.counterparty,
+          message:
+            `Done — you have declined the ${result.counterparty} pairing, and they will not be contacted further about it. Confirm that to the client in one short sentence, naming ${result.counterparty}. Do NOT also edit their signal: a verdict on one match is not a change to what they are looking for.`,
+        }
+        : {
+          status: "executed",
+          counterparty: result.counterparty,
+          message:
+            `Done — you have accepted the ${result.counterparty} pairing on the client's behalf. That is one side of it: the connection is made when ${result.counterparty} accepts too, so tell the client plainly that it is now waiting on them. Do NOT also edit their signal.`,
+        };
+    case "none_actionable":
+      return {
+        status: "none_actionable",
+        message:
+          "There is no counterparty left to decide on for this signal — they have concluded or expired. Tell the client that plainly rather than implying a decision was recorded.",
+      };
+    case "unknown_counterparty":
+      return {
+        status: "unknown_counterparty",
+        count: result.count,
+        actionable: result.actionable,
+        message:
+          "That number does not name a counterparty of this signal. Nothing was decided. Re-read the list above and call this again with the right number, or ask the client which of them they meant.",
+      };
+    case "already_decided":
+      return {
+        status: "already_decided",
+        counterparty: result.counterparty,
+        message:
+          `The client has already acted on the ${result.counterparty} pairing, so nothing changed just now. Say so plainly — for an accept, it is ${result.counterparty}'s move next, not theirs.`,
+      };
+    case "error":
+      return {
+        status: "error",
+        message:
+          `Could not record that ${verdict === "rejected" ? "rejection" : "acceptance"}. Tell the client honestly that it did not go through, and do not describe the pairing as ${verdict}.`,
+      };
+  }
+}
+
+/**
+ * Creates the negotiator persona's `reject_opportunity` / `accept_opportunity`
+ * tools, bound to the acting client and the signal this session is pinned to.
+ */
+export function createNegotiatorVerdictTools(opts: {
+  host: NegotiatorVerdictToolsHost;
+  userId: string;
+  intentId: string;
+}) {
+  const { host, userId, intentId } = opts;
+
+  const run = async (
+    verdict: "rejected" | "accepted",
+    toolName: string,
+    execute: (input: NegotiatorVerdictInput) => Promise<NegotiatorVerdictResult>,
+    query: z.infer<typeof VerdictSchema>,
+  ) => {
+    verdictLogger.info("Tool invoked", { toolName, userId, counterparty: query.counterparty });
+    try {
+      const result = await execute({
+        intentId,
+        counterparty: query.counterparty,
+        ...(query.reason ? { reason: query.reason } : {}),
+      });
+      return JSON.stringify(describeVerdict(verdict, result));
+    } catch (err) {
+      verdictLogger.error("Tool failed", {
+        toolName,
+        error: err instanceof Error ? err.message : String(err),
+      });
+      return JSON.stringify(describeVerdict(verdict, { status: "error" }));
+    }
+  };
+
+  const rejectOpportunity = tool(
+    async (query: z.infer<typeof VerdictSchema>) =>
+      run("rejected", "reject_opportunity", (input) => host.rejectOpportunity(userId, input), query),
+    {
+      name: "reject_opportunity",
+      description:
+        "Decline one of this signal's counterparties, because the client just told you to. This is the ONLY thing that actually declines a match — saying it, or editing their signal, does not. Use it whenever they pass that verdict on a specific counterparty, however they phrase it ('not this one', 'pass', 'tell them no'). Never on your own judgment, and never on a match they have not decided about.",
+      schema: VerdictSchema,
+    },
+  );
+
+  const acceptOpportunity = tool(
+    async (query: z.infer<typeof VerdictSchema>) =>
+      run("accepted", "accept_opportunity", (input) => host.acceptOpportunity(userId, input), query),
+    {
+      name: "accept_opportunity",
+      description:
+        "Accept one of this signal's counterparties on the client's explicit instruction. This is the ONLY thing that records their acceptance. It is one side of a two-party decision — the connection is made when the counterparty accepts too, so never tell the client they are connected on the strength of this alone. Never on your own judgment.",
+      schema: VerdictSchema,
+    },
+  );
+
+  return [rejectOpportunity, acceptOpportunity];
 }

--- a/packages/protocol/src/chat/tests/negotiator.verdict-tools.spec.ts
+++ b/packages/protocol/src/chat/tests/negotiator.verdict-tools.spec.ts
@@ -1,0 +1,253 @@
+/**
+ * #1471 — the negotiator's `reject_opportunity` / `accept_opportunity` tools
+ * and the numbered counterparty list they act on.
+ *
+ * The owner's three decisions in their signal's DM are ANSWER, EDIT and
+ * VERDICT. The first two had lanes; the third had none, so on 2026-08-20 a
+ * client who told their agent to reject a counterparty got words back and
+ * nothing else. What is pinned here is that the verdict is now an explicit
+ * act, that the model reaches it by POSITION and never by id, and that every
+ * result — including the ones where nothing happened — is copy the persona
+ * can only repeat honestly.
+ */
+import { describe, expect, it } from "bun:test";
+
+import { createNegotiatorVerdictTools } from "../negotiator.tools.js";
+import { buildNegotiatorSystemContent } from "../negotiator.prompt.js";
+import type { NegotiatorVerdictInput, NegotiatorVerdictResult, NegotiatorVerdictToolsHost } from "../../shared/interfaces/negotiator-verdict.interface.js";
+import type { ResolvedToolContext } from "../../shared/agent/tool.factory.js";
+
+const AGENT_OPTS = { agentName: "Alice's Negotiator" };
+const OPPORTUNITY_ID = "eba8e028-1c4d-4f7a-9b3e-5d6a7c8e9f01";
+
+function makeCtx(overrides: Partial<ResolvedToolContext> = {}): ResolvedToolContext {
+  return {
+    userId: "user-1",
+    userName: "Alice Test",
+    userEmail: "alice@example.com",
+    user: { id: "user-1", name: "Alice Test", email: "alice@example.com" },
+    userProfile: null,
+    userNetworks: [],
+    isOwner: false,
+    isOnboarding: false,
+    hasName: true,
+    ...overrides,
+  } as unknown as ResolvedToolContext;
+}
+
+const pinnedCtx = makeCtx({ scopeType: "intent", scopeId: "intent-42" } as Partial<ResolvedToolContext>);
+
+type Call = { tool: "reject" | "accept"; userId: string; input: NegotiatorVerdictInput };
+
+function makeHost(result: NegotiatorVerdictResult): { host: NegotiatorVerdictToolsHost; calls: Call[] } {
+  const calls: Call[] = [];
+  return {
+    calls,
+    host: {
+      rejectOpportunity: async (userId, input) => { calls.push({ tool: "reject", userId, input }); return result; },
+      acceptOpportunity: async (userId, input) => { calls.push({ tool: "accept", userId, input }); return result; },
+    },
+  };
+}
+
+const tools = (host: NegotiatorVerdictToolsHost) =>
+  createNegotiatorVerdictTools({ host, userId: "user-1", intentId: "intent-42" });
+
+const invoke = async (tool: { invoke: (input: unknown) => Promise<unknown> }, input: unknown) =>
+  JSON.parse(String(await tool.invoke(input))) as Record<string, unknown>;
+
+describe("createNegotiatorVerdictTools", () => {
+  it("registers exactly the two verdict tools", () => {
+    const { host } = makeHost({ status: "executed", counterparty: "Camille Dubois" });
+    expect(tools(host).map((t) => t.name)).toEqual(["reject_opportunity", "accept_opportunity"]);
+  });
+
+  it("routes a position and the client's own reason to the host, bound to the pinned signal", async () => {
+    const { host, calls } = makeHost({ status: "executed", counterparty: "Camille Dubois" });
+    const [reject] = tools(host);
+
+    const result = await invoke(reject as never, { counterparty: 1, reason: "Wrong stage for me." });
+
+    expect(calls).toEqual([{
+      tool: "reject",
+      userId: "user-1",
+      input: { intentId: "intent-42", counterparty: 1, reason: "Wrong stage for me." },
+    }]);
+    expect(result.status).toBe("executed");
+    // The confirmation names who the WRITE landed on, not who the model believed it picked.
+    expect(result.counterparty).toBe("Camille Dubois");
+    expect(String(result.message)).toContain("Camille Dubois");
+    expect(String(result.message)).toContain("will not be contacted further");
+    // A verdict on one match is not an edit of the signal.
+    expect(String(result.message)).toContain("Do NOT also edit their signal");
+  });
+
+  it("omits the reason entirely when the client gave none — never an invented one", async () => {
+    const { host, calls } = makeHost({ status: "executed", counterparty: "Camille Dubois" });
+    const [reject] = tools(host);
+
+    await invoke(reject as never, { counterparty: 2 });
+
+    expect(calls[0].input).toEqual({ intentId: "intent-42", counterparty: 2 });
+    expect("reason" in calls[0].input).toBe(false);
+  });
+
+  it("tells the client an accept is one side of two, never a connection", async () => {
+    const { host, calls } = makeHost({ status: "executed", counterparty: "Camille Dubois" });
+    const [, accept] = tools(host);
+
+    const result = await invoke(accept as never, { counterparty: 1 });
+
+    expect(calls[0].tool).toBe("accept");
+    expect(String(result.message)).toContain("waiting on them");
+    expect(String(result.message)).not.toContain("connected");
+  });
+
+  it("hands back the current list when the number names no counterparty, and says nothing was decided", async () => {
+    const { host } = makeHost({
+      status: "unknown_counterparty",
+      count: 2,
+      actionable: ["Camille Dubois — parked, waiting on you", "Ilya Roth — waiting on your decision"],
+    });
+    const [reject] = tools(host);
+
+    const result = await invoke(reject as never, { counterparty: 7 });
+
+    expect(result).toMatchObject({ status: "unknown_counterparty", count: 2 });
+    expect(result.actionable).toEqual([
+      "Camille Dubois — parked, waiting on you",
+      "Ilya Roth — waiting on your decision",
+    ]);
+    expect(String(result.message)).toContain("Nothing was decided");
+  });
+
+  it("does not let an empty scope read as a recorded decision", async () => {
+    const { host } = makeHost({ status: "none_actionable" });
+    const [reject] = tools(host);
+
+    const result = await invoke(reject as never, { counterparty: 1 });
+
+    expect(result.status).toBe("none_actionable");
+    expect(String(result.message)).toContain("rather than implying a decision was recorded");
+  });
+
+  it("says whose move it is when the client already acted", async () => {
+    const { host } = makeHost({ status: "already_decided", counterparty: "Camille Dubois" });
+    const [, accept] = tools(host);
+
+    const result = await invoke(accept as never, { counterparty: 1 });
+
+    expect(result).toMatchObject({ status: "already_decided", counterparty: "Camille Dubois" });
+    expect(String(result.message)).toContain("nothing changed just now");
+  });
+
+  it("forbids describing the pairing as decided when the write failed", async () => {
+    const { host } = makeHost({ status: "error" });
+    const [reject, accept] = tools(host);
+
+    const rejected = await invoke(reject as never, { counterparty: 1 });
+    const accepted = await invoke(accept as never, { counterparty: 1 });
+
+    expect(rejected.status).toBe("error");
+    expect(String(rejected.message)).toContain("do not describe the pairing as rejected");
+    expect(String(accepted.message)).toContain("do not describe the pairing as accepted");
+  });
+
+  it("never throws when the host does — the client keeps their turn", async () => {
+    const host: NegotiatorVerdictToolsHost = {
+      rejectOpportunity: async () => { throw new Error("database unavailable"); },
+      acceptOpportunity: async () => { throw new Error("database unavailable"); },
+    };
+    const [reject] = tools(host);
+
+    expect((await invoke(reject as never, { counterparty: 1 })).status).toBe("error");
+  });
+
+  it("exposes no id to the model — not in the schema, not in any result string", async () => {
+    const statuses: NegotiatorVerdictResult[] = [
+      { status: "executed", counterparty: "Camille Dubois" },
+      { status: "none_actionable" },
+      { status: "unknown_counterparty", count: 1, actionable: ["Camille Dubois — parked, waiting on you"] },
+      { status: "already_decided", counterparty: "Camille Dubois" },
+      { status: "error" },
+    ];
+    for (const status of statuses) {
+      const { host } = makeHost(status);
+      for (const tool of tools(host)) {
+        const raw = String(await (tool as never as { invoke: (i: unknown) => Promise<unknown> })
+          .invoke({ counterparty: 1 }));
+        expect(raw).not.toContain(OPPORTUNITY_ID);
+        expect(raw).not.toMatch(/[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}/i);
+        expect(raw.toLowerCase()).not.toContain("opportunityid");
+      }
+    }
+    // The schema itself offers no place to put one.
+    const { host } = makeHost({ status: "executed", counterparty: "Camille Dubois" });
+    for (const tool of tools(host)) {
+      expect(Object.keys((tool.schema as unknown as { shape: Record<string, unknown> }).shape).sort())
+        .toEqual(["counterparty", "reason"]);
+    }
+  });
+});
+
+describe("buildNegotiatorSystemContent — verdicts in a pinned signal", () => {
+  const COUNTERPARTIES = [
+    "Camille Dubois — parked, waiting on you",
+    "Ilya Roth — waiting on your decision",
+  ];
+
+  it("numbers each counterparty with the number the tools take", () => {
+    const prompt = buildNegotiatorSystemContent(pinnedCtx, {
+      ...AGENT_OPTS,
+      actionableCounterparties: COUNTERPARTIES,
+    });
+
+    expect(prompt).toContain("## Verdicts Alice Test can pass here");
+    expect(prompt).toContain("1. Camille Dubois — parked, waiting on you");
+    expect(prompt).toContain("2. Ilya Roth — waiting on your decision");
+    expect(prompt).toContain("reject_opportunity");
+    expect(prompt).toContain("accept_opportunity");
+  });
+
+  it("makes the tool call the decision, not the sentence about it", () => {
+    const prompt = buildNegotiatorSystemContent(pinnedCtx, {
+      ...AGENT_OPTS,
+      actionableCounterparties: COUNTERPARTIES,
+    });
+
+    expect(prompt).toContain("That call is the decision.");
+    expect(prompt).toContain("Never pass a verdict they did not pass");
+    expect(prompt).toContain("Pass their reason only if they gave one");
+    expect(prompt).toContain("Accepting is one side of two");
+    expect(prompt).toContain("update_opportunity is not this lever");
+  });
+
+  it("says nothing about the tools when no counterparty is actionable — the prompt is unchanged", () => {
+    const withNone = buildNegotiatorSystemContent(pinnedCtx, AGENT_OPTS);
+    const withEmpty = buildNegotiatorSystemContent(pinnedCtx, { ...AGENT_OPTS, actionableCounterparties: [] });
+
+    expect(withNone).not.toContain("reject_opportunity");
+    expect(withNone).not.toContain("Verdicts Alice Test can pass here");
+    expect(withEmpty).toBe(withNone);
+  });
+
+  it("says nothing about the tools outside a pinned signal — they are not registered there", () => {
+    const unscoped = buildNegotiatorSystemContent(makeCtx(), {
+      ...AGENT_OPTS,
+      actionableCounterparties: COUNTERPARTIES,
+    });
+
+    expect(unscoped).not.toContain("reject_opportunity");
+    expect(unscoped).not.toContain("Verdicts Alice Test can pass here");
+  });
+
+  it("carries no opportunity id into the prompt", () => {
+    const prompt = buildNegotiatorSystemContent(pinnedCtx, {
+      ...AGENT_OPTS,
+      actionableCounterparties: COUNTERPARTIES,
+    });
+    const verdictSection = prompt.slice(prompt.indexOf("## Verdicts"));
+
+    expect(verdictSection).not.toMatch(/[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}/i);
+  });
+});

--- a/packages/protocol/src/shared/agent/tool.helpers.ts
+++ b/packages/protocol/src/shared/agent/tool.helpers.ts
@@ -23,6 +23,7 @@ import type { AgentDispatcher } from "../interfaces/agent-dispatcher.interface.j
 import type { DeliveryLedger } from "../interfaces/delivery-ledger.interface.js";
 import type { NegotiatorMemoryToolsHost } from "../interfaces/negotiator-memory.interface.js";
 import type { NegotiatorAnswerToolsHost } from "../interfaces/negotiator-answer.interface.js";
+import type { NegotiatorVerdictToolsHost } from "../interfaces/negotiator-verdict.interface.js";
 import type { QuestionerEnqueueFn } from "../../questions/question.input.js";
 import type { EnrichmentRunQueue, EnrichmentRunStore } from "../interfaces/enrichment-run.interface.js";
 import type { McpActivityCaller } from "./activity-projection.js";
@@ -183,6 +184,14 @@ interface ToolContextBindings {
    * intent-scoped session (the question lives in one signal's DM).
    */
   negotiatorAnswerTools?: NegotiatorAnswerToolsHost;
+  /**
+   * Host bridge for the negotiator persona's `reject_opportunity` /
+   * `accept_opportunity` tools — the owner's VERDICT lane, which had no lever
+   * in chat at all before #1471. Injected by the composition root; consumed
+   * exclusively by the negotiator persona's toolset, and only in an
+   * intent-scoped session (the counterparties are one signal's).
+   */
+  negotiatorVerdictTools?: NegotiatorVerdictToolsHost;
   /**
    * Resolve a user's global user_context paragraph (profile-replacing identity
    * text), generating it on demand when absent. Mirrors `ToolDeps.getUserContextText`

--- a/packages/protocol/src/shared/interfaces/negotiator-verdict.interface.ts
+++ b/packages/protocol/src/shared/interfaces/negotiator-verdict.interface.ts
@@ -1,0 +1,81 @@
+/**
+ * Host bridge for the negotiator persona's `reject_opportunity` and
+ * `accept_opportunity` tools.
+ *
+ * The owner has exactly three kinds of decision in their signal's DM: they can
+ * ANSWER a question the negotiation asked, they can EDIT the signal, and they
+ * can pass a VERDICT on a counterparty. The first two had lanes —
+ * `answer_pending_question` (#1466) and `update_intent`. The third had none.
+ * On 2026-08-20, in the DM for a parked pairing, the client told their agent to
+ * reject the counterparty and the agent could not comply: the only verdict
+ * levers in the product were the Radar card's Skip/Start-Chat and the REST
+ * endpoints behind them, both out of the chat agent's reach. `update_opportunity`
+ * is in the toolset but cannot serve — its admission blocks `negotiating`
+ * outright, and the IND-593 owner-approval boundary fails closed on the chat
+ * surface by design.
+ *
+ * Positions, never ids. The prompt lists this signal's actionable
+ * counterparties, numbered; the tool takes the number; the host owns the
+ * mapping onto the opportunity. A ref the model could name is a ref it could
+ * get wrong, and here a wrong ref rejects the wrong person — the one failure
+ * this seam exists to make impossible.
+ *
+ * Everything behind the seam — enumerating the scope's actionable pairings,
+ * resolving the number, and executing the SAME owner accept/reject the Radar's
+ * card executes — lives on the host. The protocol package only ever sees this
+ * surface, and only the negotiator persona's toolset receives it.
+ */
+
+/**
+ * What the host did with one verdict.
+ *
+ * - `executed`: the verdict is recorded. `counterparty` is who it landed on,
+ *   so the model's confirmation to the client names a person the host actually
+ *   acted on rather than the one the model believed it had picked.
+ * - `none_actionable`: this signal has no counterparty left to decide on —
+ *   they concluded, expired, or were never here.
+ * - `unknown_counterparty`: the number does not name one. `actionable` carries
+ *   the current list so the model can re-read it rather than guess again, and
+ *   `count` is how many there are.
+ * - `already_decided`: the client (or their agent) already acted on this
+ *   pairing; for an accept that means the other side must move next.
+ * - `error`: the host could not execute it. The client must be told honestly.
+ */
+export type NegotiatorVerdictResult =
+  | { status: "executed"; counterparty: string }
+  | { status: "none_actionable" }
+  | { status: "unknown_counterparty"; count: number; actionable: string[] }
+  | { status: "already_decided"; counterparty: string }
+  | { status: "error" };
+
+/** One verdict the client passed, as the tools hand it to the host. */
+export interface NegotiatorVerdictInput {
+  /** The pinned signal whose counterparties are in scope. */
+  intentId: string;
+  /** 1-based position, exactly as the prompt listed it. */
+  counterparty: number;
+  /**
+   * The client's own words for why, when they gave one. For the record only —
+   * never invented, never inferred, and never required.
+   */
+  reason?: string;
+}
+
+export interface NegotiatorVerdictToolsHost {
+  /**
+   * Decline one counterparty of this signal on the client's instruction: the
+   * same owner-reject the Radar card's Skip performs, including whatever the
+   * pairing's live negotiation and open question do in its wake.
+   *
+   * @param userId - The acting client; the host scopes every read and write to them.
+   */
+  rejectOpportunity(userId: string, input: NegotiatorVerdictInput): Promise<NegotiatorVerdictResult>;
+
+  /**
+   * Accept one counterparty of this signal on the client's instruction: the
+   * same owner-accept the Radar card performs. Two-party semantics are
+   * unchanged — the client's accept is one side's, and the connection is made
+   * only when the other side accepts too.
+   */
+  acceptOpportunity(userId: string, input: NegotiatorVerdictInput): Promise<NegotiatorVerdictResult>;
+}

--- a/services/api/src/controllers/mcp.controller.ts
+++ b/services/api/src/controllers/mcp.controller.ts
@@ -41,6 +41,7 @@ import { negotiatorClientDmRetrieve } from '../adapters/negotiator-client-dm.ret
 import { negotiatorMemoryWriteService } from '../services/negotiator-memory.service';
 import { isNegotiatorMemoryWriteEnabled } from '../lib/negotiator-feature';
 import { negotiatorAnswerToolsHost } from '../lib/question/negotiator-answer.host';
+import { negotiatorVerdictToolsHost } from '../lib/agent/negotiator-verdict.host';
 import { resolveProtocolBaseUrl } from '../lib/protocol-url';
 import { isHermesNegotiatorAudience } from '../lib/agent/hermes-credential';
 
@@ -120,6 +121,11 @@ const protocolDeps = {
   // gate declined. Registered only in intent-pinned negotiator sessions; the
   // orchestrator registry never sees it.
   negotiatorAnswerTools: negotiatorAnswerToolsHost,
+  // #1471: host bridge for the negotiator persona's `reject_opportunity` /
+  // `accept_opportunity` tools — the owner's VERDICT lane, which had no lever
+  // in chat before. Registered only in intent-pinned negotiator sessions; the
+  // orchestrator registry never sees it.
+  negotiatorVerdictTools: negotiatorVerdictToolsHost,
   ...(isNegotiatorMemoryWriteEnabled() && {
     negotiatorMemoryTools: {
       remember: async (userId: string, input: { kind: 'disclosure_rule' | 'playbook' | 'threshold'; content: string; sessionId?: string }) =>

--- a/services/api/src/lib/agent/negotiator-verdict.host.ts
+++ b/services/api/src/lib/agent/negotiator-verdict.host.ts
@@ -1,0 +1,284 @@
+/**
+ * Host bridge behind the negotiator persona's `reject_opportunity` and
+ * `accept_opportunity` tools (#1471) — the owner's VERDICT lane.
+ *
+ * The owner makes three kinds of decision in their signal's DM. They ANSWER a
+ * question a parked negotiation asked (#1466 gave that a lane). They EDIT the
+ * signal (`update_intent` always had one). And they pass a VERDICT on a
+ * counterparty — which had no lane at all. On 2026-08-20, in the DM of a
+ * pairing parked on `input_required`, a client told their agent to reject the
+ * counterparty. The agent could not: every verdict lever in the product was
+ * the Radar card's Skip/Start-Chat and the REST endpoints behind them, and
+ * `update_opportunity` — which is in the toolset — refuses a `negotiating`
+ * pairing outright and fails the IND-593 owner-approval boundary on the chat
+ * surface by design.
+ *
+ * Nothing is re-implemented here. The reject is the SAME
+ * `opportunityService.updateOpportunityStatus(id, 'rejected', userId, …)` the
+ * Radar's Skip page calls through `PATCH /opportunities/:id/status`, and the
+ * accept is that call with `'accepted'`. Everything that hangs off an owner
+ * verdict therefore happens exactly as it already does: the outcome hooks, the
+ * DM resolution on accept, the contact memberships, and — via
+ * `OpportunityEvents.onTransition` (main.ts) → `evaluateOpportunityTransition`
+ * — the question-message regeneration that retires a dismissed pairing's open
+ * question. A rejected pairing's question dies with it because that arrow
+ * already exists on every status transition; this module deliberately does not
+ * reach into it.
+ *
+ * Positions, never ids. The prompt lists this signal's actionable
+ * counterparties, numbered; the tool hands back a number; this module owns the
+ * mapping. A ref the model could name is a ref it could get wrong, and here a
+ * wrong ref declines the wrong person — so the model is never given one, and
+ * the successful result names WHO was acted on so the confirmation the client
+ * reads comes from the write rather than from the model's belief about it.
+ */
+import type { OpportunityStatus } from '@indexnetwork/protocol';
+
+import { opportunityService } from '../../services/opportunity.service';
+import { log } from '../log';
+
+const logger = log.lib.from('negotiator-verdict.host');
+
+/**
+ * Statuses a client can still pass a verdict on: the match is live and
+ * undecided by them. `latent`/`draft` are pre-delivery, and `accepted` /
+ * `rejected` / `expired` are already decided — a verdict on any of those would
+ * be a decision the client has no reason to believe they are making.
+ */
+export const ACTIONABLE_VERDICT_STATUSES: OpportunityStatus[] = ['pending', 'negotiating', 'stalled'];
+
+/** How each actionable status reads to the client, in one clause. */
+const STATE_LINE: Record<string, string> = {
+  pending: 'waiting on your decision',
+  negotiating: 'your agents are still negotiating',
+  stalled: 'parked, waiting on you',
+};
+
+/** One numbered counterparty, as both the prompt and the mapping see it. */
+export interface ActionableCounterparty {
+  /** 1-based, exactly as the prompt renders it and the tool names it. */
+  position: number;
+  opportunityId: string;
+  /** Who the client would be deciding about. */
+  name: string;
+  status: string;
+  /** The prompt line: name + one-line state. */
+  label: string;
+}
+
+/** Structural slice of what the opportunity list returns for this purpose. */
+interface ListedOpportunity {
+  id: string;
+  status: string;
+  createdAt: Date | string;
+  counterpartName?: string;
+  actors?: Array<{ userId: string; role?: string }>;
+}
+
+/** Injectable seams; production resolves the real service. */
+export interface NegotiatorVerdictHostDeps {
+  listOpportunities?: (
+    userId: string,
+    options: { statuses: OpportunityStatus[]; scopeType: 'intent'; scopeId: string },
+  ) => Promise<unknown[]>;
+  updateStatus?: (
+    opportunityId: string,
+    status: OpportunityStatus,
+    userId: string,
+    options: { scopeType: 'intent'; scopeId: string },
+  ) => Promise<unknown>;
+}
+
+/** Mirrors the protocol's `NegotiatorVerdictResult`; structural by design. */
+export type NegotiatorVerdictResult =
+  | { status: 'executed'; counterparty: string }
+  | { status: 'none_actionable' }
+  | { status: 'unknown_counterparty'; count: number; actionable: string[] }
+  | { status: 'already_decided'; counterparty: string }
+  | { status: 'error' };
+
+export interface NegotiatorVerdictInput {
+  intentId: string;
+  counterparty: number;
+  reason?: string;
+}
+
+const asTime = (value: Date | string): number => {
+  const ms = value instanceof Date ? value.getTime() : Date.parse(value);
+  return Number.isFinite(ms) ? ms : 0;
+};
+
+/**
+ * This signal's actionable counterparties, numbered — the single ordering both
+ * the prompt and the mapping read, so the number the client's agent was shown
+ * is the number this module resolves.
+ *
+ * The order is OLDEST FIRST, deliberately. The list is rendered when the turn
+ * starts and resolved when the tool fires, and in between a fresh match can
+ * appear: ascending order appends it at the end instead of renumbering
+ * everything above it, so a new arrival mid-turn cannot slide a different
+ * person under the number the client's agent already read. (A pairing
+ * CONCLUDING mid-turn still shifts what follows it; the write then lands on a
+ * neighbour of the intended one, which is why the executed result names who it
+ * hit and the persona is told to confirm by name.)
+ *
+ * Introducer rows are excluded: an introducer is not a party to the pairing,
+ * and accept/reject is the parties' decision.
+ *
+ * Never throws — the prompt path treats an unreadable list as "no verdicts to
+ * offer", which is strictly better than losing the turn.
+ */
+export async function readActionableCounterparties(
+  userId: string,
+  intentId: string,
+  deps?: NegotiatorVerdictHostDeps,
+): Promise<ActionableCounterparty[]> {
+  try {
+    const list = deps?.listOpportunities
+      ?? ((uid: string, options: { statuses: OpportunityStatus[]; scopeType: 'intent'; scopeId: string }) =>
+        opportunityService.getOpportunitiesForUser(uid, options));
+    const rows = (await list(userId, {
+      statuses: ACTIONABLE_VERDICT_STATUSES,
+      scopeType: 'intent',
+      scopeId: intentId,
+    })) as ListedOpportunity[];
+
+    return rows
+      .filter((row) => {
+        if (!row?.id || !ACTIONABLE_VERDICT_STATUSES.includes(row.status as OpportunityStatus)) return false;
+        const own = row.actors?.find((actor) => actor.userId === userId);
+        return !own || own.role !== 'introducer';
+      })
+      .sort((a, b) => asTime(a.createdAt) - asTime(b.createdAt) || a.id.localeCompare(b.id))
+      .map((row, index) => {
+        const name = row.counterpartName?.trim() || 'An unnamed match';
+        const state = STATE_LINE[row.status] ?? row.status;
+        return {
+          position: index + 1,
+          opportunityId: row.id,
+          name,
+          status: row.status,
+          label: `${name} — ${state}`,
+        };
+      });
+  } catch (err) {
+    logger.error('negotiator_verdict_enumeration_failed', {
+      userId,
+      intentId,
+      error: err instanceof Error ? err.message : String(err),
+    });
+    return [];
+  }
+}
+
+/**
+ * Execute one verdict on the number the client's agent named.
+ *
+ * Never throws — a tool that throws costs the client their turn, and the
+ * honest failure the model is told to report is strictly better than that.
+ */
+async function passVerdict(
+  userId: string,
+  input: NegotiatorVerdictInput,
+  target: 'rejected' | 'accepted',
+  deps?: NegotiatorVerdictHostDeps,
+): Promise<NegotiatorVerdictResult> {
+  try {
+    const actionable = await readActionableCounterparties(userId, input.intentId, deps);
+    if (actionable.length === 0) return { status: 'none_actionable' };
+
+    const relist = () => ({
+      status: 'unknown_counterparty' as const,
+      count: actionable.length,
+      actionable: actionable.map((candidate) => candidate.label),
+    });
+
+    const chosen = actionable.find((candidate) => candidate.position === input.counterparty);
+    if (!chosen) {
+      logger.info('negotiator_verdict_unknown_counterparty', {
+        userId,
+        intentId: input.intentId,
+        counterparty: input.counterparty,
+        actionable: actionable.length,
+      });
+      return relist();
+    }
+
+    // The Radar's Skip/Start-Chat path, called exactly as the REST controller
+    // calls it. The intent scope is not decoration: it re-checks that the
+    // pairing really belongs to the signal this DM is pinned to, and it keeps
+    // the accept from cascading onto sibling opportunities — the same
+    // narrowing the intent-scoped Radar applies.
+    //
+    // `actionProvenance` is deliberately NOT passed. That field marks a verified
+    // first-party owner CLICK for outcome capture (IND-434); a verdict spoken to
+    // an agent is a real owner decision but a model-mediated one, and a
+    // misheard "not this one" must not become a mined preference label.
+    const update = deps?.updateStatus
+      ?? ((opportunityId: string, status: OpportunityStatus, uid: string, options: { scopeType: 'intent'; scopeId: string }) =>
+        opportunityService.updateOpportunityStatus(opportunityId, status, uid, options));
+    const result = await update(chosen.opportunityId, target, userId, {
+      scopeType: 'intent',
+      scopeId: input.intentId,
+    }) as { error?: string; status?: number } | null;
+
+    if (result && typeof result === 'object' && 'error' in result && result.error) {
+      // 409 is the self-accept guard: this client already committed, so it is
+      // the other side's move. 403/404 means the pairing left the actionable
+      // set between the list being rendered and this call — nothing was
+      // decided, and re-listing is more use to the client than an error.
+      if (result.status === 409) return { status: 'already_decided', counterparty: chosen.name };
+      if (result.status === 403 || result.status === 404) return relist();
+      logger.error('negotiator_verdict_rejected_by_service', {
+        userId,
+        intentId: input.intentId,
+        opportunityId: chosen.opportunityId,
+        target,
+        serviceStatus: result.status,
+        error: result.error,
+      });
+      return { status: 'error' };
+    }
+
+    logger.info('negotiator_verdict_executed', {
+      userId,
+      intentId: input.intentId,
+      opportunityId: chosen.opportunityId,
+      target,
+      // The client's own words, when they gave any. There is no column for a
+      // verdict reason on the owner path, and inventing one would be a new
+      // write this lane has no mandate for — so the log is the record.
+      ...(input.reason ? { reason: input.reason } : {}),
+    });
+    return { status: 'executed', counterparty: chosen.name };
+  } catch (err) {
+    logger.error('negotiator_verdict_failed', {
+      userId,
+      intentId: input.intentId,
+      counterparty: input.counterparty,
+      target,
+      error: err instanceof Error ? err.message : String(err),
+    });
+    return { status: 'error' };
+  }
+}
+
+/** Decline one counterparty on the client's instruction — the Radar Skip path. */
+export const rejectOpportunity = (
+  userId: string,
+  input: NegotiatorVerdictInput,
+  deps?: NegotiatorVerdictHostDeps,
+): Promise<NegotiatorVerdictResult> => passVerdict(userId, input, 'rejected', deps);
+
+/** Accept one counterparty on the client's instruction — one side of two. */
+export const acceptOpportunity = (
+  userId: string,
+  input: NegotiatorVerdictInput,
+  deps?: NegotiatorVerdictHostDeps,
+): Promise<NegotiatorVerdictResult> => passVerdict(userId, input, 'accepted', deps);
+
+/** The host object the composition root injects into the negotiator toolset. */
+export const negotiatorVerdictToolsHost = {
+  rejectOpportunity: (userId: string, input: NegotiatorVerdictInput) => rejectOpportunity(userId, input),
+  acceptOpportunity: (userId: string, input: NegotiatorVerdictInput) => acceptOpportunity(userId, input),
+};

--- a/services/api/src/lib/agent/tests/negotiator-verdict.host.spec.ts
+++ b/services/api/src/lib/agent/tests/negotiator-verdict.host.spec.ts
@@ -1,0 +1,255 @@
+/**
+ * The host behind `reject_opportunity` / `accept_opportunity` (#1471):
+ * position → opportunity, then the SAME owner accept/reject the Radar card
+ * performs.
+ *
+ * The tool is given numbers and never an id, so this module owns the mapping —
+ * and a wrong mapping here is not a misroute, it is declining the wrong
+ * person. Hence the ordering is pinned as hard as the writes are.
+ */
+import { describe, expect, it } from 'bun:test';
+
+import { ACTIONABLE_VERDICT_STATUSES, acceptOpportunity, readActionableCounterparties, rejectOpportunity } from '../negotiator-verdict.host';
+
+const USER_ID = 'user-1';
+const INTENT_ID = 'intent-1';
+const CAMILLE = 'eba8e028-1c4d-4f7a-9b3e-5d6a7c8e9f01';
+const ILYA = '7f3d2c1b-8a90-4e5f-b6c7-d8e9f0a1b2c3';
+const FRESH = 'aa11bb22-cc33-4d44-8e55-ff6677889900';
+
+const row = (over: Record<string, unknown>) => ({
+  id: CAMILLE,
+  status: 'stalled',
+  createdAt: new Date('2026-08-01T00:00:00Z'),
+  counterpartName: 'Camille Dubois',
+  actors: [{ userId: USER_ID, role: 'peer' }, { userId: 'user-2', role: 'peer' }],
+  ...over,
+});
+
+const CAMILLE_ROW = row({});
+const ILYA_ROW = row({
+  id: ILYA,
+  status: 'pending',
+  createdAt: new Date('2026-08-05T00:00:00Z'),
+  counterpartName: 'Ilya Roth',
+});
+
+interface Written {
+  opportunityId: string;
+  status: string;
+  userId: string;
+  options: { scopeType: string; scopeId: string };
+}
+
+function harness(over: Record<string, unknown> = {}) {
+  const listed: Array<{ userId: string; options: Record<string, unknown> }> = [];
+  const written: Written[] = [];
+  return {
+    listed,
+    written,
+    deps: {
+      listOpportunities: (async (userId: string, options: Record<string, unknown>) => {
+        listed.push({ userId, options });
+        return [CAMILLE_ROW, ILYA_ROW];
+      }) as never,
+      updateStatus: (async (
+        opportunityId: string,
+        status: string,
+        userId: string,
+        options: { scopeType: string; scopeId: string },
+      ) => {
+        written.push({ opportunityId, status, userId, options });
+        return { opportunity: { id: opportunityId, status } };
+      }) as never,
+      ...over,
+    },
+  };
+}
+
+describe('readActionableCounterparties', () => {
+  it('scopes the read to this client, this signal, and the statuses still open to a verdict', async () => {
+    const { listed, deps } = harness();
+
+    await readActionableCounterparties(USER_ID, INTENT_ID, deps);
+
+    expect(listed).toEqual([{
+      userId: USER_ID,
+      options: { statuses: ACTIONABLE_VERDICT_STATUSES, scopeType: 'intent', scopeId: INTENT_ID },
+    }]);
+    expect(ACTIONABLE_VERDICT_STATUSES).toEqual(['pending', 'negotiating', 'stalled']);
+  });
+
+  it('numbers oldest first and labels each with name plus one-line state', async () => {
+    const { deps } = harness();
+
+    const actionable = await readActionableCounterparties(USER_ID, INTENT_ID, deps);
+
+    expect(actionable).toEqual([
+      {
+        position: 1,
+        opportunityId: CAMILLE,
+        name: 'Camille Dubois',
+        status: 'stalled',
+        label: 'Camille Dubois — parked, waiting on you',
+      },
+      {
+        position: 2,
+        opportunityId: ILYA,
+        name: 'Ilya Roth',
+        status: 'pending',
+        label: 'Ilya Roth — waiting on your decision',
+      },
+    ]);
+  });
+
+  it('appends a match that arrives mid-turn instead of renumbering the ones already read', async () => {
+    const fresh = row({
+      id: FRESH,
+      status: 'negotiating',
+      createdAt: new Date('2026-08-19T00:00:00Z'),
+      counterpartName: 'Nora Vance',
+    });
+    const { deps } = harness({
+      listOpportunities: (async () => [fresh, ILYA_ROW, CAMILLE_ROW]) as never,
+    });
+
+    const actionable = await readActionableCounterparties(USER_ID, INTENT_ID, deps);
+
+    expect(actionable.map((c) => c.name)).toEqual(['Camille Dubois', 'Ilya Roth', 'Nora Vance']);
+    expect(actionable[2].label).toBe('Nora Vance — your agents are still negotiating');
+  });
+
+  it('excludes a pairing the client only introduced — a verdict is the parties\' to pass', async () => {
+    const { deps } = harness({
+      listOpportunities: (async () => [
+        row({ actors: [{ userId: USER_ID, role: 'introducer' }, { userId: 'user-2', role: 'peer' }] }),
+        ILYA_ROW,
+      ]) as never,
+    });
+
+    const actionable = await readActionableCounterparties(USER_ID, INTENT_ID, deps);
+
+    expect(actionable.map((c) => c.opportunityId)).toEqual([ILYA]);
+  });
+
+  it('offers no verdicts rather than losing the turn when the read fails', async () => {
+    const { deps } = harness({
+      listOpportunities: (async () => { throw new Error('database unavailable'); }) as never,
+    });
+
+    expect(await readActionableCounterparties(USER_ID, INTENT_ID, deps)).toEqual([]);
+  });
+});
+
+describe('rejectOpportunity', () => {
+  it('sends the number the model was shown down the Radar Skip path, intent-scoped', async () => {
+    const { written, deps } = harness();
+
+    const result = await rejectOpportunity(USER_ID, { intentId: INTENT_ID, counterparty: 1 }, deps);
+
+    expect(result).toEqual({ status: 'executed', counterparty: 'Camille Dubois' });
+    expect(written).toEqual([{
+      opportunityId: CAMILLE,
+      status: 'rejected',
+      userId: USER_ID,
+      options: { scopeType: 'intent', scopeId: INTENT_ID },
+    }]);
+  });
+
+  it('resolves position 2 to the second counterparty, not the first', async () => {
+    const { written, deps } = harness();
+
+    const result = await rejectOpportunity(
+      USER_ID,
+      { intentId: INTENT_ID, counterparty: 2, reason: 'Wrong stage for me.' },
+      deps,
+    );
+
+    expect(result).toEqual({ status: 'executed', counterparty: 'Ilya Roth' });
+    expect(written[0].opportunityId).toBe(ILYA);
+  });
+
+  it('writes nothing and re-lists when the number names no counterparty', async () => {
+    const { written, deps } = harness();
+
+    const result = await rejectOpportunity(USER_ID, { intentId: INTENT_ID, counterparty: 5 }, deps);
+
+    expect(result).toEqual({
+      status: 'unknown_counterparty',
+      count: 2,
+      actionable: ['Camille Dubois — parked, waiting on you', 'Ilya Roth — waiting on your decision'],
+    });
+    expect(written).toHaveLength(0);
+  });
+
+  it('writes nothing when the signal has nothing actionable left', async () => {
+    const { written, deps } = harness({ listOpportunities: (async () => []) as never });
+
+    const result = await rejectOpportunity(USER_ID, { intentId: INTENT_ID, counterparty: 1 }, deps);
+
+    expect(result).toEqual({ status: 'none_actionable' });
+    expect(written).toHaveLength(0);
+  });
+
+  it('re-lists rather than erroring when the pairing left the set between render and call', async () => {
+    const { deps } = harness({
+      updateStatus: (async () => ({ error: 'Opportunity not found', status: 404 })) as never,
+    });
+
+    const result = await rejectOpportunity(USER_ID, { intentId: INTENT_ID, counterparty: 1 }, deps);
+
+    expect(result).toMatchObject({ status: 'unknown_counterparty', count: 2 });
+  });
+
+  it('reports a service refusal honestly instead of claiming the decision landed', async () => {
+    const { deps } = harness({
+      updateStatus: (async () => ({ error: 'Not authorized to update this opportunity', status: 403 })) as never,
+    });
+    const { deps: broken } = harness({
+      updateStatus: (async () => ({ error: 'Boom', status: 500 })) as never,
+    });
+
+    expect(await rejectOpportunity(USER_ID, { intentId: INTENT_ID, counterparty: 1 }, deps))
+      .toMatchObject({ status: 'unknown_counterparty' });
+    expect(await rejectOpportunity(USER_ID, { intentId: INTENT_ID, counterparty: 1 }, broken))
+      .toEqual({ status: 'error' });
+  });
+
+  it('never throws — a failed write is reported, not raised', async () => {
+    const { deps } = harness({
+      updateStatus: (async () => { throw new Error('connection reset'); }) as never,
+    });
+
+    expect(await rejectOpportunity(USER_ID, { intentId: INTENT_ID, counterparty: 1 }, deps))
+      .toEqual({ status: 'error' });
+  });
+});
+
+describe('acceptOpportunity', () => {
+  it('takes the same owner path with the accepted status', async () => {
+    const { written, deps } = harness();
+
+    const result = await acceptOpportunity(USER_ID, { intentId: INTENT_ID, counterparty: 1 }, deps);
+
+    expect(result).toEqual({ status: 'executed', counterparty: 'Camille Dubois' });
+    expect(written).toEqual([{
+      opportunityId: CAMILLE,
+      status: 'accepted',
+      userId: USER_ID,
+      options: { scopeType: 'intent', scopeId: INTENT_ID },
+    }]);
+  });
+
+  it('names whose move it is when the client already committed', async () => {
+    const { deps } = harness({
+      updateStatus: (async () => ({
+        error: 'You have already acted on this opportunity. The other party must accept.',
+        status: 409,
+      })) as never,
+    });
+
+    const result = await acceptOpportunity(USER_ID, { intentId: INTENT_ID, counterparty: 1 }, deps);
+
+    expect(result).toEqual({ status: 'already_decided', counterparty: 'Camille Dubois' });
+  });
+});

--- a/services/api/src/lib/agent/tests/negotiator-verdict.wiring.static.spec.ts
+++ b/services/api/src/lib/agent/tests/negotiator-verdict.wiring.static.spec.ts
@@ -1,0 +1,78 @@
+/**
+ * Static invariants of the owner-verdict WIRING (#1471).
+ *
+ * The mapping and the writes are unit-tested in `negotiator-verdict.host.spec.ts`.
+ * What this pins is what no unit test can reach.
+ *
+ * Two things, both load-bearing:
+ *
+ * 1. The verdict reaches the model ONLY through the pinned-signal path — the
+ *    composition root injects the host, the persona registers the tools only
+ *    with a pinned intent, and the prompt gets its numbered list from the same
+ *    reader the host maps against. Break any link and the tools either vanish
+ *    (back to the 2026-08-20 gap, where "reject them" had no lever) or come
+ *    back with numbers pointing at a different list than the host resolves.
+ *
+ * 2. A rejected pairing's open question retires because
+ *    `OpportunityEvents.onTransition` runs the exhaustion evaluator on EVERY
+ *    committed status transition — owner reject included. That arrow already
+ *    existed; this lane relies on it rather than re-invoking retirement, which
+ *    is why it touches nothing under `lib/question/`. If that wiring is ever
+ *    cut, a declined pairing keeps asking its client about itself.
+ */
+import { describe, expect, it } from 'bun:test';
+import { readFileSync } from 'node:fs';
+
+const read = (relative: string) => readFileSync(new URL(relative, import.meta.url), 'utf8');
+
+const composition = read('../../../controllers/mcp.controller.ts');
+const chatService = read('../../../services/chat.service.ts');
+const main = read('../../../main.ts');
+const persona = read('../../../../../../packages/protocol/src/chat/negotiator.persona.ts');
+const host = read('../negotiator-verdict.host.ts');
+
+describe('owner-verdict wiring', () => {
+  it('registers the verdict host at the composition root, ungated', () => {
+    expect(composition).toContain('negotiatorVerdictTools: negotiatorVerdictToolsHost');
+    // No flag: a verdict lever that is sometimes absent is a lever the client
+    // cannot rely on, and the persona would silently fall back to words.
+    expect(composition).not.toMatch(/isNegotiatorVerdict\w*Enabled/);
+  });
+
+  it('registers the tools only in an intent-pinned session with the host injected', () => {
+    expect(persona).toContain('if (deps.negotiatorVerdictTools && pinnedIntentId) {');
+    expect(persona).toContain('createNegotiatorVerdictTools({');
+  });
+
+  it('feeds the prompt from the same reader the host maps against', () => {
+    // One ordering, two consumers. A second enumeration would be a second
+    // order, and the number the client's agent read would resolve elsewhere.
+    expect(chatService).toContain("import { readActionableCounterparties } from '../lib/agent/negotiator-verdict.host'");
+    expect(chatService).toContain('await readActionableCounterparties(userId, pinnedIntent.intentId)');
+    expect(chatService).toContain('actionableCounterparties: actionableCounterparties.map((counterparty) => counterparty.label)');
+    expect(host).toContain('export async function readActionableCounterparties');
+  });
+
+  it('offers verdicts only for a pinned signal', () => {
+    expect(chatService).toContain('const actionableCounterparties = pinnedIntent?.intentId');
+  });
+
+  it('executes the verdict through the same owner status path the Radar card uses', () => {
+    expect(host).toContain('opportunityService.updateOpportunityStatus(opportunityId, status, uid, options)');
+    // Never the MCP `update_opportunity` lane: its admission refuses a
+    // `negotiating` pairing outright and its owner-approval boundary fails
+    // closed on the chat surface.
+    expect(host).not.toContain('admitOpportunityUpdate');
+    expect(host).not.toContain('ownerApprovalProof');
+    // Outcome capture stays reserved for a verified first-party click: the
+    // field is discussed in a comment and never passed.
+    expect(host).not.toMatch(/actionProvenance\s*:/);
+  });
+
+  it('retires a dismissed pairing\'s question through the transition hook that already exists', () => {
+    expect(main).toContain('OpportunityEvents.onTransition');
+    expect(main).toContain('evaluateOpportunityTransition({ opportunityId: opportunity.id, status: opportunity.status })');
+    // This lane calls that machinery, it does not reimplement or edit it.
+    expect(host).not.toContain('lib/question');
+  });
+});

--- a/services/api/src/services/chat.service.ts
+++ b/services/api/src/services/chat.service.ts
@@ -6,6 +6,7 @@ import type { ChatGraphCompositeDatabase } from '@indexnetwork/protocol';
 import { getCheckpointer } from '../adapters/checkpointer.adapter';
 import { negotiatorMemoryRetrievalAdapter } from '../adapters/negotiator-memory.retrieval.adapter';
 import { readOpenQuestionsForIntent } from '../lib/question/open-question-message';
+import { readActionableCounterparties } from '../lib/agent/negotiator-verdict.host';
 import { isNegotiatorMemoryWriteEnabled } from '../lib/negotiator-feature';
 import type { PostgresSaver } from '@langchain/langgraph-checkpoint-postgres';
 
@@ -793,6 +794,15 @@ export class ChatSessionService {
     const openQuestions = pinnedIntent?.intentId
       ? (await readOpenQuestionsForIntent(userId, pinnedIntent.intentId))?.questions ?? []
       : [];
+    // #1471: the counterparties of this signal the client can still pass a
+    // verdict on. Without them the persona has numbers for nothing and the
+    // verdict tools are unreachable — which was the whole gap: told to reject
+    // a match, the agent's only moves were to say so, or to edit the signal.
+    // Never throws (the reader swallows its own failures); empty → the prompt
+    // is byte-identical to before.
+    const actionableCounterparties = pinnedIntent?.intentId
+      ? await readActionableCounterparties(userId, pinnedIntent.intentId)
+      : [];
     return this.factory.withPersona(
       createNegotiatorPersona({
         agentName: agent.name,
@@ -805,6 +815,9 @@ export class ChatSessionService {
         ...(isNegotiatorMemoryWriteEnabled() ? { memoryToolsEnabled: true } : {}),
         ...(openQuestions.length > 0
           ? { openQuestions: openQuestions.map((question) => question.label) }
+          : {}),
+        ...(actionableCounterparties.length > 0
+          ? { actionableCounterparties: actionableCounterparties.map((counterparty) => counterparty.label) }
           : {}),
       }),
     );


### PR DESCRIPTION
## The gap

In the negotiator DM for one signal, a client told their agent to reject the counterparty (parked `input_required`). The agent could not comply.

The owner has exactly three kinds of decision in that room:

| decision | lane |
|---|---|
| **answer** a question a parked negotiation asked | `answer_pending_question` (#1467) |
| **edit** the signal | `update_intent` |
| **verdict** on a counterparty | *none* |

So on "reject them", the persona's whole repertoire was to say something back, or to edit the signal instead. The pairing stayed parked and the counterparty stayed live.

`update_opportunity` is in the negotiator toolset and cannot substitute:

- `admitOpportunityUpdate` blocks a `negotiating` pairing outright (`BLOCKED_UPDATE_STATUSES`), and
- the IND-593 owner-approval boundary fails closed on the chat surface — `tool.factory.ts` binds `{ surface: 'chat', sessionAuthenticated: false }`, and `attestOwnerInteraction` denies that with `untrusted_provenance`.

The verdict levers that exist are the Radar card's Skip / Start-Chat and the REST endpoints behind them. None is reachable from the client's own agent.

## The tools

Registered **only** in intent-pinned negotiator sessions with the host injected, appended after the allowlist filter — never in the shared chat-tool registry, so the orchestrator and the MCP tool listing never see them.

| tool | args | what it does |
|---|---|---|
| `reject_opportunity` | `counterparty` (int ≥1), `reason?` (≤500 chars) | Declines one of this signal's counterparties on the client's explicit verdict |
| `accept_opportunity` | `counterparty` (int ≥1), `reason?` (≤500 chars) | Accepts one, on the client's explicit verdict — one side of two |

**Numbered refs only.** The model never sees or emits an opportunity id; the schema has no place to put one, and no result string carries one (pinned by a spec that greps every result of every status for a UUID). A ref the model can name is a ref it can get wrong, and a wrong ref here declines the wrong person.

### Context-listing format (verbatim — for the floor-page lane to mirror)

Section heading, rendered only in a pinned session with a non-empty list:

```
## Verdicts {userName} can pass here
These are this signal's counterparties {userName} can still decide on, numbered:
1. Camille Dubois — parked, waiting on you
2. Ilya Roth — waiting on your decision
3. Nora Vance — your agents are still negotiating
```

The label is `{counterpartName} — {state}`, with the state clause fixed per status:

| status | state clause |
|---|---|
| `pending` | `waiting on your decision` |
| `negotiating` | `your agents are still negotiating` |
| `stalled` | `parked, waiting on you` |

Missing name → `An unnamed match`.

### Result vocabulary

`executed` (carries `counterparty`) · `none_actionable` · `unknown_counterparty` (carries `count` + the re-listed `actionable` labels) · `already_decided` (carries `counterparty`) · `error`.

Copy follows #1467's honesty style: the success names **who the write landed on** and forbids also editing the signal; an accept is described as one side of two and never as a connection; an unknown number says plainly that nothing was decided and re-lists; a failure forbids describing the pairing as decided.

## The host

`services/api/src/lib/agent/negotiator-verdict.host.ts` — outside the fenced `lib/question/**` tree.

- **Enumerates** the scope's actionable pairings via `opportunityService.getOpportunitiesForUser(userId, { statuses: ['pending','negotiating','stalled'], scopeType: 'intent', scopeId })`. Rows where the client's own actor is `introducer` are excluded — a verdict is the parties' to pass.
- **Executes** through the SAME call the Radar's Skip page makes (`opportunitiesService.updateStatus(id, "rejected")` → `PATCH /opportunities/:id/status` → `opportunityService.updateOpportunityStatus`), with `'rejected'` / `'accepted'` and the intent scope. Nothing about the transition is reinvented: the outcome hooks, the DM resolution on accept, the contact memberships, and the sibling-accept narrowing all behave exactly as the intent-scoped Radar makes them behave. No new task-state transitions were invented — owner reject flips status and lets the existing hooks run, which is precisely what Skip does today.
- **Maps** with one enumeration serving both the prompt render and the tool call, so the number the client's agent read is the number the host resolves. Ordered **oldest-first** on purpose: a match arriving between the prompt render and the tool call appends at the end instead of renumbering the list already shown.
- Service refusals are read, not swallowed: `409` (self-accept guard) → `already_decided`; `403`/`404` (pairing left the set mid-turn) → `unknown_counterparty` with the current list; anything else → honest `error`. Never throws.

### Question retirement — no fenced file touched

A rejected pairing's open question retires through machinery that **already fires on this path**: `main.ts` wires `OpportunityEvents.onTransition` → `evaluateOpportunityTransition`, and the adapter emits that hook from every opportunity status UPDATE — the evaluator's own header names "owner accept/reject" among its triggers. So the retirement is invoked by taking the owner path, not by reaching into `lib/question/**`. A static spec pins that arrow so a future refactor that cuts it is caught here rather than by a declined pairing that keeps asking its client about itself.

No `TODO(owner-verdict)` was needed.

## Tests

- `packages/protocol/src/chat/tests/negotiator.verdict-tools.spec.ts` — 15 tests: schema shape, numbered mapping through a stubbed host, honesty copy per result status, reason omitted when unstated, and no id in any model-visible string or in the schema.
- `services/api/src/lib/agent/tests/negotiator-verdict.host.spec.ts` — 14 tests: scoped enumeration, oldest-first ordering incl. the mid-turn-arrival case, introducer exclusion, position→id mapping, reject/accept reaching the owner path with the right status and scope, and every no-write path (unknown number, empty scope, 403/404/409/500, throw).
- `services/api/src/lib/agent/tests/negotiator-verdict.wiring.static.spec.ts` — 6 tests: ungated registration at the composition root, pinned-only tool registration, one shared enumeration behind prompt and host, the owner path rather than the MCP admission lane, and the transition→retirement arrow.

Existing suites green: `packages/protocol/src/chat/tests/negotiator.*` (46 pass), `services/api/src/lib/question/tests/` + `src/lib/agent/tests/` (99 + 27 pass), `services/api/src/services/tests/` (165 pass). The 11 protocol whole-dir failures (`ChatSummarizer`, `SuggestionGenerator`, chat-graph streaming) and the 17 api failures reproduce identically on `origin/dev` with this diff's api files reverted — pre-existing, unrelated.

## Boundaries

- **`fix/open-means-parked` (#1470)** — no file under `services/api/src/lib/question/**` is touched. Retirement is reached through the already-wired transition hook, as above.
- **`fix/dimension-authority`** — nothing under `packages/protocol/src/negotiations/**` or the shared checklist schemas. The protocol footprint is `chat/` + `shared/interfaces/` + one field on `shared/agent/tool.helpers.ts` (the #1467 footprint exactly).
- Rebased onto `origin/dev` after #1469 landed; protocol bumped **23.4.0 → 23.5.0** and `bun scripts/sync-lockfile-versions.ts` run.
- No flags, no migrations, no web changes.

## Flagged for review

This deliberately does not traverse the IND-593 owner-approval boundary, whose implementation comment names the chat orchestrator as a mediated surface that must fail closed. The gap it closes is real and these tools are materially narrower than `update_opportunity` — negotiator-persona-only, intent-pinned, id-free, absent from the shared and MCP registries, and prompted to fire only on the client's explicit verdict — but it is still a model executing an owner decision, and the boundary's owner should say whether that narrowing is enough.

Two conservative choices follow from it:

- **`actionProvenance` is withheld.** That field marks a verified first-party owner *click* for outcome capture (IND-434). A verdict spoken to an agent is a real owner decision but a mediated one, and a misheard "not this one" must not become a mined preference label.
- **A verdict reason has no column** on the owner path, and inventing a write for it is outside this lane's mandate. The structured `negotiator_verdict_executed` log is its only record for now.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011Ss8vpbtdoxof2yj9MHmvj
