### PR TITLE
fix(negotiations): an answer beats staleness — drift is logged, never fatal

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -89,7 +89,7 @@
     },
     "packages/protocol": {
       "name": "@indexnetwork/protocol",
-      "version": "23.6.0",
+      "version": "23.6.1",
       "dependencies": {
         "@langchain/core": "1.1.48",
         "@langchain/langgraph": "1.3.2",

--- a/packages/protocol/CHANGELOG.md
+++ b/packages/protocol/CHANGELOG.md
@@ -20,6 +20,37 @@ went 6.7.1 → 8.0.2 with no 7.x in between because the whole 7.x line shipped a
 prereleases between the two promotions. To track every change, read `rc`; to
 pin a supported release, use `latest`.
 
+## 23.6.1 - 2026-08-20
+
+### Fixed
+
+- **An answer beats staleness — drift is logged, never fatal.** Observed live:
+  a client answered her own parked question ("Timing: This week") through the
+  new MCP answer lane, routing succeeded, consumption ran — and the settle
+  returned `lost`, because the signal had been edited twice since the park and
+  the revalidation fence required the world to look exactly as it did at park
+  time. The park became a zombie: still `input_required`, still rendered as
+  "waiting on YOUR answer" by every surface, structurally unanswerable. The
+  design law is explicit: signal edits cascade nothing, and a stale negotiation
+  is solved by ANSWERING its question — the user's answer is the freshest
+  commitment there is, and the resumed turn rebuilds its context from current
+  data anyway.
+
+  The settle's one fence is now two. Coherence stays hard: an answer that does
+  not belong to its park (settlement mismatch, wrong recipient, task no longer
+  parked, a dismiss/timeout settlement won the race) is still refused. Drift
+  stops losing: within a live opportunity and an active signal, the answer
+  settles and resumes regardless of what moved since the park.
+
+- **The unresumable tail is an explicit proposal, not a silent drop.** When
+  current reality genuinely cannot continue — terminal opportunity or archived
+  signal — the answer is still recorded as heard: settlement result and resume
+  outcome `recorded_unresumable` (additive), the block-consumption result
+  counts it in its own `recorded` array so a `skipped` count can never again
+  hide it, and the implementation retires the park and tells the client the
+  truth, proposing re-discovery under the updated signal — an offer, never an
+  automatic act.
+
 ## 23.6.0 - 2026-08-20
 
 ### Added

--- a/packages/protocol/package.json
+++ b/packages/protocol/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@indexnetwork/protocol",
-  "version": "23.6.0",
+  "version": "23.6.1",
   "type": "module",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",

--- a/packages/protocol/src/negotiations/negotiation.answer-consumption.ts
+++ b/packages/protocol/src/negotiations/negotiation.answer-consumption.ts
@@ -250,15 +250,24 @@ export interface InflightAnswerSettlementInput {
 
 /**
  * - `settled`: this call closed the exact `input_required` task and durably
- *   stored the answer for the continuation claim to read.
+ *   stored the answer for the continuation claim to read. Answers are
+ *   authoritative over staleness: the signal or opportunity having moved since
+ *   the park (drift) does not prevent this outcome — the resumed turn rebuilds
+ *   its context from current data.
  * - `already_settled`: an earlier delivery settled it; the stored settlement
  *   stands. Resuming is still correct — the continuation enqueue and claim are
  *   settlement-keyed and idempotent, so re-enqueueing recovers a lost job
  *   without a double resume.
- * - `lost`: the admission gate refused — the task is no longer
- *   `input_required` (answer-window expiry or another path won). No resume.
+ * - `recorded_unresumable`: the answer was durably recorded and the park
+ *   retired, but the negotiation genuinely cannot continue — the opportunity
+ *   is terminal or the recipient signal is archived. No resume; the caller
+ *   owes the client an honest explanation and a PROPOSAL of the next step,
+ *   never an automatic one.
+ * - `lost`: the coherence gate refused — this answer does not belong to this
+ *   park (the task is no longer `input_required`, or a dismiss/timeout
+ *   settlement won the race). No resume.
  */
-export type InflightAnswerSettlementResult = "settled" | "already_settled" | "lost";
+export type InflightAnswerSettlementResult = "settled" | "already_settled" | "recorded_unresumable" | "lost";
 
 export interface NegotiationAnswerConsumptionPorts {
   /** The same reads the negotiation graph resolves parks with. */
@@ -309,6 +318,8 @@ export function negotiationParkAnswerId(parkTaskId: string): string {
 export type NegotiationAnswerResumeOutcome =
   | "resumed_inflight"
   | "resumed_retry"
+  /** The answer was recorded and the park retired, but the negotiation cannot continue. */
+  | "recorded_unresumable"
   | "not_parked"
   | "no_negotiation"
   | "wrong_recipient";
@@ -356,6 +367,16 @@ export async function resumeParkedNegotiation(
         opportunityId: input.opportunityId,
       });
       return "not_parked";
+    }
+    if (settlement === "recorded_unresumable") {
+      // The answer was heard and durably recorded; the park is retired. There
+      // is nothing to enqueue — the negotiation is over, and the next step is
+      // a PROPOSAL the caller surfaces to the client, never an automatic act.
+      answerLog.info("negotiation_answer_recorded_unresumable", {
+        taskId: classification.taskId,
+        opportunityId: input.opportunityId,
+      });
+      return "recorded_unresumable";
     }
     // Settlement is durable; enqueue after it, never before — a crash between
     // the two is recovered by redelivery (`already_settled` → enqueue again).
@@ -423,6 +444,14 @@ export interface QuestionBlockAnswerConsumptionInput {
 
 export interface QuestionBlockAnswerConsumptionResult {
   resumed: Array<{ opportunityId: string; outcome: "resumed_inflight" | "resumed_retry" }>;
+  /**
+   * Answers that were heard and durably recorded on a park whose negotiation
+   * cannot continue (terminal opportunity / archived signal). Counted apart
+   * from `skipped` deliberately: nothing was skipped — the park was retired —
+   * and the caller owes the client the honest explanation plus the proposal
+   * of the next step.
+   */
+  recorded: Array<{ opportunityId: string; outcome: "recorded_unresumable" }>;
   skipped: Array<{
     opportunityId: string;
     outcome: "not_parked" | "no_negotiation" | "wrong_recipient" | "duplicate_route" | "failed";
@@ -450,6 +479,7 @@ export async function consumeQuestionBlockAnswers(
   const answeredAt = input.answeredAt ?? new Date().toISOString();
   const result: QuestionBlockAnswerConsumptionResult = {
     resumed: [],
+    recorded: [],
     skipped: [],
     unmatched: [],
     needsClarification: false,
@@ -481,6 +511,8 @@ export async function consumeQuestionBlockAnswers(
         });
         if (outcome === "resumed_inflight" || outcome === "resumed_retry") {
           result.resumed.push({ opportunityId, outcome });
+        } else if (outcome === "recorded_unresumable") {
+          result.recorded.push({ opportunityId, outcome });
         } else {
           result.skipped.push({ opportunityId, outcome });
         }

--- a/packages/protocol/src/negotiations/tests/negotiation.answer-consumption.spec.ts
+++ b/packages/protocol/src/negotiations/tests/negotiation.answer-consumption.spec.ts
@@ -301,6 +301,18 @@ describe("resumeParkedNegotiation", () => {
     expect(calls.inflightResumes).toHaveLength(0);
   });
 
+  it("reports an unresumable park as recorded, and enqueues nothing — the proposal is the caller's, not a resume", async () => {
+    const { ports, calls } = makePorts({
+      tasks: { [OPP_A]: inflightTask("task-1", OPP_A, "user-1") },
+      settleResult: "recorded_unresumable",
+    });
+    const outcome = await resumeParkedNegotiation(ports, { opportunityId: OPP_A, userId: "user-1", answerText: "yes" });
+    expect(outcome).toBe("recorded_unresumable");
+    expect(calls.settles).toHaveLength(1);
+    expect(calls.inflightResumes).toHaveLength(0);
+    expect(calls.retries).toHaveLength(0);
+  });
+
   it("resumes a post-stall park: record the answer under its deterministic id, then enqueue the retry", async () => {
     const { ports, calls } = makePorts({
       tasks: { [OPP_A]: completedTask("task-9", OPP_A) },
@@ -395,6 +407,22 @@ describe("consumeQuestionBlockAnswers", () => {
     expect(calls.settles).toHaveLength(1);
     expect(calls.settles[0]?.answer.freeText).toBe("first phrasing");
     expect(result.skipped).toContainEqual({ opportunityId: OPP_A, outcome: "duplicate_route" });
+  });
+
+  it("counts an unresumable answer in its own recorded array, never inside skipped", async () => {
+    const { ports } = makePorts({
+      tasks: { [OPP_C]: inflightTask("task-3", OPP_C, "user-1") },
+      settleResult: "recorded_unresumable",
+    });
+    const result = await consumeQuestionBlockAnswers(ports, {
+      block,
+      userId: "user-1",
+      answers: [{ ref: OPP_C, answerText: "Budget answer." }],
+    });
+    expect(result.recorded).toEqual([{ opportunityId: OPP_C, outcome: "recorded_unresumable" }]);
+    expect(result.resumed).toHaveLength(0);
+    expect(result.skipped).toHaveLength(0);
+    expect(result.needsClarification).toBe(false);
   });
 
   it("keeps consuming the rest of the reply when one negotiation fails", async () => {

--- a/services/api/src/adapters/questioner.adapter.ts
+++ b/services/api/src/adapters/questioner.adapter.ts
@@ -1,4 +1,3 @@
-import type { NegotiationCounterpartyBinding } from '@indexnetwork/protocol';
 /**
  * QuestionerAdapter — the negotiation-settlement core that survived the card
  * question retirement (docs/plans/2026-08-18-conversational-questions.md,
@@ -33,6 +32,7 @@ import { eq, and, sql, or, isNull, desc } from 'drizzle-orm/sql';
 
 import { intentNetworks, intents, networkMembers, networks, questions, opportunities } from '../schemas/database.schema';
 import { tasks } from '../schemas/conversation.schema';
+import { log } from '../lib/log';
 import type { DrizzleDB } from '../lib/drizzle/drizzle';
 import { computeIntentFingerprint } from '../lib/intent/intent.fingerprint';
 import { isValidNegotiationDetectionContract } from '../lib/question/negotiation-question.contract';
@@ -40,6 +40,8 @@ import { consultationExpiryReadiness } from '../lib/negotiation/consultation-exp
 import { claimContinuationExecution, completeContinuationExecution, heartbeatContinuationExecution, parkContinuationExecution, releaseContinuationExecution } from './negotiation-continuation.atomic';
 import type { ContinuationClaimResult, ContinuationExecutionFence, ContinuationReceipt } from './negotiation-continuation.atomic';
 
+
+const settleLogger = log.lib.from('questioner-adapter');
 
 class InflightConsultationPausePendingError extends Error {
   constructor() {
@@ -53,6 +55,11 @@ function isNonEmptyString(value: unknown): value is string {
 }
 
 // ─── Local adapter types (structurally aligned with protocol contracts) ───────
+
+/** Structural mirror of the protocol's `NegotiationCounterpartyBinding` (adapters may not import the protocol package). */
+type NegotiationCounterpartyBinding =
+  | { kind: 'intent'; id: string }
+  | { kind: 'premise'; id: string };
 
 /** Union of all question modes the adapter stores. */
 export type AdapterQuestionMode = 'intent' | 'negotiation' | 'negotiation_inflight' | 'chat' | 'pool_discovery';
@@ -132,7 +139,12 @@ interface AdapterNegotiationQuestionSettlement {
    * row. Card-path settlements keep the answer on the question row instead.
    */
   answer?: { selectedOptions: string[]; freeText?: string; answeredAt: string };
-  continuationStatus: 'requested' | 'completed';
+  /**
+   * 'unresumable' is a terminal record: the answer was heard on a park whose
+   * negotiation cannot continue (terminal opportunity / archived signal). No
+   * continuation was requested and none may ever claim it.
+   */
+  continuationStatus: 'requested' | 'completed' | 'unresumable';
   settledAt: string;
   completedAt?: string;
 }
@@ -282,6 +294,9 @@ function settlementIdForTask(taskId: string): string {
   return `negotiation-question-settlement-v1-${taskId}`;
 }
 
+/** Mirrors `NEGOTIATION_START_STATUSES` semantics (conversation.database.adapter): the statuses run-existing accepts an attempt from. */
+const RESUMABLE_OPPORTUNITY_STATUSES = new Set<string>(['latent', 'draft', 'pending', 'negotiating', 'stalled']);
+
 function parseAskUserBinding(value: unknown): {
   version: 2;
   settlementId: string;
@@ -355,7 +370,7 @@ function parseNegotiationQuestionSettlement(value: unknown): AdapterNegotiationQ
     || !isNonEmptyString(settlement.counterpartyUserId)
     || parseSettlementCounterpartyBinding(settlement) === null
     || (settlement.kind !== 'answer' && settlement.kind !== 'dismiss' && settlement.kind !== 'timeout')
-    || (settlement.continuationStatus !== 'requested' && settlement.continuationStatus !== 'completed')
+    || (settlement.continuationStatus !== 'requested' && settlement.continuationStatus !== 'completed' && settlement.continuationStatus !== 'unresumable')
     || !isNonEmptyString(settlement.settledAt)
     || Number.isNaN(Date.parse(settlement.settledAt))
     || (settlement.questionId !== undefined && !isNonEmptyString(settlement.questionId))
@@ -863,8 +878,11 @@ export class QuestionerAdapter {
    * Returns 'settled' when this call closed the task, 'already_settled' when
    * an earlier delivery stored an answer settlement for the same consult (the
    * settlement-keyed continuation enqueue is idempotent, so re-enqueueing is
-   * correct), and 'lost' when the admission gate refuses — the task is no
-   * longer `input_required`, or a dismiss/timeout settlement won the race.
+   * correct), 'recorded_unresumable' when the answer was durably recorded but
+   * the negotiation cannot continue (terminal opportunity / archived signal —
+   * the park retires, no continuation may claim it), and 'lost' when the
+   * coherence gate refuses — the task is no longer `input_required`, or a
+   * dismiss/timeout settlement won the race.
    */
   async settleInflightNegotiationAnswerFromDm(input: {
     taskId: string;
@@ -874,7 +892,7 @@ export class QuestionerAdapter {
     recipientIntentId: string;
     networkId: string;
     answer: { selectedOptions: string[]; freeText?: string; answeredAt: string };
-  }): Promise<'settled' | 'already_settled' | 'lost'> {
+  }): Promise<'settled' | 'already_settled' | 'recorded_unresumable' | 'lost'> {
     if (input.settlementId !== settlementIdForTask(input.taskId)) return 'lost';
     const candidate: AdapterNegotiationQuestionCandidate = {
       purpose: 'inflight_consultation',
@@ -900,7 +918,7 @@ export class QuestionerAdapter {
           && existingSettlement.settlementId === input.settlementId
           && existingSettlement.recipientUserId === input.recipientUserId
           && existingSettlement.opportunityId === input.opportunityId
-          ? 'already_settled'
+          ? (existingSettlement.continuationStatus === 'unresumable' ? 'recorded_unresumable' : 'already_settled')
           : 'lost';
       }
       const binding = parseAskUserBinding(
@@ -918,15 +936,55 @@ export class QuestionerAdapter {
         || binding.opportunityId !== input.opportunityId
         || binding.networkId !== input.networkId
       ) return 'lost';
-      // Same live revalidation as the card path: the stamped binding must
-      // still describe the current intent/opportunity, or the consult is
-      // stale and the answer must not resume it.
-      const current = await this.resolveNegotiationAdmission(candidate, tx as unknown as DrizzleDB);
-      if (
-        current?.intentFingerprint !== binding.intentFingerprint
-        || current.opportunityStatus !== binding.opportunityStatus
-        || current.opportunityUpdatedAt !== binding.opportunityUpdatedAt
-      ) return 'lost';
+      // Answers are authoritative over staleness; drift is logged, not fatal.
+      // The coherence checks above decide whether this answer belongs to this
+      // park; the world having moved since the park (signal edited,
+      // opportunity touched) never blocks it — the resumed turn re-reads
+      // current data. Only current reality gates: an opportunity run-existing
+      // would refuse (terminal status) or an archived/retired recipient signal
+      // makes the park genuinely unresumable.
+      const [opportunityRow] = await tx.select({
+        status: opportunities.status,
+        updatedAt: opportunities.updatedAt,
+      })
+        .from(opportunities)
+        .where(eq(opportunities.id, input.opportunityId))
+        .limit(1);
+      const [intentRow] = await tx.select({
+        archivedAt: intents.archivedAt,
+        status: intents.status,
+        payload: intents.payload,
+        summary: intents.summary,
+      })
+        .from(intents)
+        .where(and(
+          eq(intents.id, input.recipientIntentId),
+          eq(intents.userId, input.recipientUserId),
+        ))
+        .limit(1);
+      const resumable = opportunityRow !== undefined
+        && RESUMABLE_OPPORTUNITY_STATUSES.has(opportunityRow.status)
+        && intentRow !== undefined
+        && intentRow.archivedAt === null
+        && (intentRow.status === null || intentRow.status === 'ACTIVE');
+      if (resumable) {
+        const currentFingerprint = computeIntentFingerprint(intentRow.payload, intentRow.summary);
+        const currentUpdatedAt = opportunityRow.updatedAt.toISOString();
+        if (
+          currentFingerprint !== binding.intentFingerprint
+          || opportunityRow.status !== binding.opportunityStatus
+          || currentUpdatedAt !== binding.opportunityUpdatedAt
+        ) {
+          settleLogger.info('negotiation_answer_settled_despite_drift', {
+            taskId: input.taskId,
+            opportunityId: input.opportunityId,
+            recipientUserId: input.recipientUserId,
+            intentFingerprintMoved: currentFingerprint !== binding.intentFingerprint,
+            opportunityStatus: { bound: binding.opportunityStatus, current: opportunityRow.status },
+            opportunityUpdatedAt: { bound: binding.opportunityUpdatedAt, current: currentUpdatedAt },
+          });
+        }
+      }
 
       const durableSettlement: AdapterNegotiationQuestionSettlement = {
         version: 1,
@@ -948,13 +1006,16 @@ export class QuestionerAdapter {
           ...(input.answer.freeText !== undefined ? { freeText: input.answer.freeText } : {}),
           answeredAt: input.answer.answeredAt,
         },
-        continuationStatus: 'requested',
+        continuationStatus: resumable ? 'requested' : 'unresumable',
         settledAt: input.answer.answeredAt,
       };
       const [claimed] = await tx.update(tasks)
         .set({
           state: 'canceled',
-          statusMessage: { reason: 'ask_user_answered', settlementId: durableSettlement.settlementId },
+          statusMessage: {
+            reason: resumable ? 'ask_user_answered' : 'ask_user_answered_unresumable',
+            settlementId: durableSettlement.settlementId,
+          },
           metadata: sql`jsonb_set(COALESCE(${tasks.metadata}, '{}'::jsonb), '{questionSettlement}', ${JSON.stringify(durableSettlement)}::jsonb, true)`,
           statusTimestamp: new Date(),
           updatedAt: new Date(),
@@ -968,7 +1029,7 @@ export class QuestionerAdapter {
             .where(and(eq(questions.id, row.id), eq(questions.status, 'pending')));
         }
       }
-      return 'settled';
+      return resumable ? 'settled' : 'recorded_unresumable';
     });
   }
 

--- a/services/api/src/adapters/tests/negotiation-dm-answer.settlement.spec.ts
+++ b/services/api/src/adapters/tests/negotiation-dm-answer.settlement.spec.ts
@@ -213,6 +213,125 @@ describe('settleInflightNegotiationAnswerFromDm', () => {
     });
   });
 
+  test('drift never loses the answer: signal edited and opportunity moved since the park, still settled', async () => {
+    // The 2026-08-20 zombie park, inverted: the signal was edited (twice)
+    // after the park, so intentFingerprint / opportunityStatus /
+    // opportunityUpdatedAt all drifted off the stamped binding — and the
+    // recipient's own answer came back 'lost'. The design law: answers are
+    // authoritative over staleness; drift is logged, not fatal.
+    const fixture = await seedParkedConsult();
+    await db.update(intents)
+      .set({ payload: 'Find a design partner for a hardware pilot — now EU-based, Q4 start' })
+      .where(eq(intents.id, fixture.ownerIntentId));
+    await db.update(opportunities)
+      .set({ status: 'stalled', updatedAt: new Date() })
+      .where(eq(opportunities.id, fixture.opportunityId));
+
+    const result = await questionerAdapter.settleInflightNegotiationAnswerFromDm(
+      settleInput(fixture, 'Q4 works for me.'),
+    );
+    expect(result).toBe('settled');
+
+    const [task] = await db.select().from(tasks).where(eq(tasks.id, fixture.taskId));
+    expect(task.state).toBe('canceled');
+    expect(task.statusMessage).toMatchObject({ reason: 'ask_user_answered', settlementId: fixture.settlementId });
+    const settlement = (task.metadata as Record<string, unknown>).questionSettlement as Record<string, unknown>;
+    const binding = ((task.metadata as Record<string, unknown>).turnContext as Record<string, unknown>).askUserBinding as Record<string, unknown>;
+    // The settlement keeps recording the BINDING's provenance values — they
+    // describe the park that was answered, not the world after the drift.
+    expect(settlement).toMatchObject({
+      kind: 'answer',
+      continuationStatus: 'requested',
+      intentFingerprint: binding.intentFingerprint,
+      opportunityStatus: binding.opportunityStatus,
+      opportunityUpdatedAt: binding.opportunityUpdatedAt,
+      answer: { selectedOptions: [], freeText: 'Q4 works for me.' },
+    });
+  });
+
+  test('a terminal opportunity records the answer as heard and retires the park — no continuation', async () => {
+    const fixture = await seedParkedConsult();
+    await db.update(opportunities)
+      .set({ status: 'rejected', updatedAt: new Date() })
+      .where(eq(opportunities.id, fixture.opportunityId));
+
+    const result = await questionerAdapter.settleInflightNegotiationAnswerFromDm(
+      settleInput(fixture, 'Happy to proceed anyway.'),
+    );
+    expect(result).toBe('recorded_unresumable');
+
+    const [task] = await db.select().from(tasks).where(eq(tasks.id, fixture.taskId));
+    expect(task.state).toBe('canceled');
+    expect(task.statusMessage).toMatchObject({ reason: 'ask_user_answered_unresumable', settlementId: fixture.settlementId });
+    const settlement = (task.metadata as Record<string, unknown>).questionSettlement as Record<string, unknown>;
+    expect(settlement).toMatchObject({
+      kind: 'answer',
+      continuationStatus: 'unresumable',
+      answer: { selectedOptions: [], freeText: 'Happy to proceed anyway.' },
+    });
+
+    // No continuation may ever claim the unresumable record.
+    const claim = await questionerAdapter.claimNegotiationContinuationExecution({
+      taskId: fixture.taskId,
+      settlementId: fixture.settlementId,
+      opportunityId: fixture.opportunityId,
+      userId: fixture.ownerId,
+      recipientIntentId: fixture.ownerIntentId,
+      networkId: fixture.networkId,
+    });
+    expect(claim.status).toBe('invalid');
+
+    // Redelivery is idempotent and stays honest about the outcome.
+    const second = await questionerAdapter.settleInflightNegotiationAnswerFromDm(
+      settleInput(fixture, 'Happy to proceed anyway.'),
+    );
+    expect(second).toBe('recorded_unresumable');
+  });
+
+  test('an archived recipient signal records the answer as heard and retires the park', async () => {
+    const fixture = await seedParkedConsult();
+    await db.update(intents)
+      .set({ archivedAt: new Date() })
+      .where(eq(intents.id, fixture.ownerIntentId));
+
+    const result = await questionerAdapter.settleInflightNegotiationAnswerFromDm(
+      settleInput(fixture, 'Still interested.'),
+    );
+    expect(result).toBe('recorded_unresumable');
+
+    const [task] = await db.select().from(tasks).where(eq(tasks.id, fixture.taskId));
+    expect(task.state).toBe('canceled');
+    const settlement = (task.metadata as Record<string, unknown>).questionSettlement as Record<string, unknown>;
+    expect(settlement).toMatchObject({ kind: 'answer', continuationStatus: 'unresumable' });
+  });
+
+  test('coherence stays hard: a settlement id that is not the task\'s own refuses the answer', async () => {
+    const fixture = await seedParkedConsult();
+    const result = await questionerAdapter.settleInflightNegotiationAnswerFromDm({
+      ...settleInput(fixture, 'Mismatched key.'),
+      settlementId: 'negotiation-question-settlement-v1-some-other-task',
+    });
+    expect(result).toBe('lost');
+    const [task] = await db.select({ state: tasks.state }).from(tasks).where(eq(tasks.id, fixture.taskId));
+    expect(task.state).toBe('input_required');
+  });
+
+  test('coherence stays hard: a recipient the binding does not name refuses the answer', async () => {
+    const fixture = await seedParkedConsult();
+    const [stranger] = await db.insert(users).values({
+      email: `dm-answer-stranger-${randomUUID()}@test.local`, name: 'DM answer stranger',
+    }).returning({ id: users.id });
+    cleanup.users.push(stranger.id);
+
+    const result = await questionerAdapter.settleInflightNegotiationAnswerFromDm({
+      ...settleInput(fixture, 'Not my question.'),
+      recipientUserId: stranger.id,
+    });
+    expect(result).toBe('lost');
+    const [task] = await db.select({ state: tasks.state }).from(tasks).where(eq(tasks.id, fixture.taskId));
+    expect(task.state).toBe('input_required');
+  });
+
   test('a consult already settled by timeout refuses the answer', async () => {
     const fixture = await seedParkedConsult();
     // Simulate the expiry worker winning the race: kind 'timeout', task closed.

--- a/services/api/src/queues/question-message.queue.ts
+++ b/services/api/src/queues/question-message.queue.ts
@@ -117,6 +117,19 @@ export const QUESTION_ANSWER_CLARIFICATION_MESSAGE =
   + 'Could you say which question you are answering, or restate the answer together with it?';
 
 /**
+ * Server-owned copy for an answer that was heard on a park whose negotiation
+ * cannot continue (terminal opportunity / archived signal). Fixed copy, never
+ * model text — same rule as the close-out prose. It tells the truth about why
+ * nothing resumed and PROPOSES the next step in the owner's vocabulary:
+ * re-running discovery under the updated signal is offered, never performed.
+ */
+export const QUESTION_ANSWER_UNRESUMABLE_MESSAGE =
+  'I recorded your answer, but that negotiation cannot pick up where it left off — '
+  + 'the opportunity it was exploring has since closed, or the signal behind it is no longer active. '
+  + 'Nothing happens automatically from here: if this still matters to you, tell me and '
+  + 'I can propose re-running discovery under your updated signal.';
+
+/**
  * Singleton job id per scope: while a regeneration is queued for a signal,
  * further triggers coalesce into it instead of racing it. Dashes only —
  * BullMQ reserves colons for Redis key namespacing.
@@ -173,6 +186,8 @@ export interface QuestionMessageQueueDeps {
   publishRegenerationEvent?: (userId: string, event: { intentId: string; pending: boolean }) => Promise<void>;
   /** Notification seam; production enqueues onto the notification queue. */
   notify?: (data: QuestionMessageNotificationJobData) => Promise<unknown>;
+  /** Regeneration seam for the unresumable tail; production re-enters addRegenerateJob. */
+  enqueueRegeneration?: (data: QuestionMessageJobData) => Promise<unknown>;
 }
 
 export class QuestionMessageQueue {
@@ -624,10 +639,15 @@ export class QuestionMessageQueue {
       intentId,
       questionMessageId: data.questionMessageId,
       resumed: result.resumed.length,
+      recorded: result.recorded.length,
       skipped: result.skipped.length,
       unmatched: result.unmatched.length,
       needsClarification: result.needsClarification,
     });
+
+    if (result.recorded.length > 0) {
+      await this.settleUnresumableTail(data);
+    }
 
     if (result.needsClarification) {
       const chatSessions = this.deps?.chatSessions ?? (await import('../services/chat.service')).chatSessionService;
@@ -635,6 +655,44 @@ export class QuestionMessageQueue {
         sessionId,
         role: 'assistant',
         content: QUESTION_ANSWER_CLARIFICATION_MESSAGE,
+      });
+    }
+  }
+
+  /**
+   * The honest end of an answer whose negotiation cannot continue: tell the
+   * client the truth and propose the next step (fixed copy — the proposal is
+   * offered, never performed), then retire the now-dead question from the DM
+   * through the ordinary #1441 regeneration: the settled park has dropped out
+   * of the parked set, so the message shrinks or closes out.
+   *
+   * Best-effort by the same rule as notification: the answer is already
+   * durably recorded on the settlement, and a retry of this job would find
+   * the park already retired and never reach this tail again — throwing here
+   * could only lose the copy, not recover it.
+   */
+  private async settleUnresumableTail(data: QuestionAnswerJobData): Promise<void> {
+    try {
+      const chatSessions = this.deps?.chatSessions ?? (await import('../services/chat.service')).chatSessionService;
+      await chatSessions.addMessage({
+        sessionId: data.sessionId,
+        role: 'assistant',
+        content: QUESTION_ANSWER_UNRESUMABLE_MESSAGE,
+      });
+      const enqueueRegeneration = this.deps?.enqueueRegeneration
+        ?? ((target: QuestionMessageJobData) => this.addRegenerateJob(target));
+      await enqueueRegeneration({ userId: data.userId, intentId: data.intentId });
+      this.logger.info('question_answer_unresumable_settled', {
+        userId: data.userId,
+        intentId: data.intentId,
+        questionMessageId: data.questionMessageId,
+      });
+    } catch (err) {
+      this.logger.warn('question_answer_unresumable_tail_failed', {
+        userId: data.userId,
+        intentId: data.intentId,
+        questionMessageId: data.questionMessageId,
+        error: err instanceof Error ? err.message : String(err),
       });
     }
   }

--- a/services/api/src/queues/tests/question-message.queue.isolated.ts
+++ b/services/api/src/queues/tests/question-message.queue.isolated.ts
@@ -13,7 +13,7 @@ import { negotiationParkAnswerId, negotiationQuestionSettlementId, parseQuestion
 import type { NegotiationAnswerConsumptionPorts, QuestionBlockQuestion, QuestionerEnqueuePayload, RoutedAnswer } from '@indexnetwork/protocol';
 import { questionBlockFixture, questionMessageFixture, questionProseFixture } from '@indexnetwork/protocol/question-block/fixture';
 
-import { QUESTION_ANSWER_CLARIFICATION_MESSAGE, QUESTION_MESSAGE_CLOSED_BODY, QUEUE_NAME, QuestionMessageQueue, enqueueQuestionAnswerReply, parkedQuestionMessageTarget, questionMessageJobId, routeParkedQuestionEnqueue } from '../question-message.queue';
+import { QUESTION_ANSWER_CLARIFICATION_MESSAGE, QUESTION_ANSWER_UNRESUMABLE_MESSAGE, QUESTION_MESSAGE_CLOSED_BODY, QUEUE_NAME, QuestionMessageQueue, enqueueQuestionAnswerReply, parkedQuestionMessageTarget, questionMessageJobId, routeParkedQuestionEnqueue } from '../question-message.queue';
 import type { QuestionAnswerJobData } from '../question-message.queue';
 import type { QuestionMessageNotificationJobData } from '../notification.queue';
 import { QueueFactory } from '../../lib/bullmq/bullmq';
@@ -684,6 +684,8 @@ interface AnswerHarnessOptions {
   parks: Record<string, 'inflight' | 'post_stall'>;
   /** The router's verdict, or an Error for a payload that must never route. */
   routed: { addressesQuestions: boolean; answers: RoutedAnswer[] } | Error;
+  /** The settle's verdict; defaults to 'settled'. */
+  settleResult?: 'settled' | 'already_settled' | 'recorded_unresumable' | 'lost';
 }
 
 function buildAnswerHarness(options: AnswerHarnessOptions) {
@@ -695,6 +697,7 @@ function buildAnswerHarness(options: AnswerHarnessOptions) {
     stalledRetries: [] as Array<{ opportunityId: string; parkTaskId: string }>,
     delivered: [] as DeliveredMessage[],
     notified: [] as QuestionMessageNotificationJobData[],
+    regenerations: [] as Array<{ userId: string; intentId: string }>,
   };
   const taskIdFor = (opportunityId: string) => `task-${opportunityId}`;
   const ports: NegotiationAnswerConsumptionPorts = {
@@ -754,7 +757,7 @@ function buildAnswerHarness(options: AnswerHarnessOptions) {
         ...(input.answer.freeText !== undefined ? { freeText: input.answer.freeText } : {}),
         answeredAt: input.answer.answeredAt,
       });
-      return 'settled';
+      return options.settleResult ?? 'settled';
     },
     enqueueInflightResume: async (input) => {
       calls.inflightResumes.push({ opportunityId: input.opportunityId, settlementId: input.settlementId });
@@ -793,6 +796,9 @@ function buildAnswerHarness(options: AnswerHarnessOptions) {
     },
     notify: async (data) => {
       calls.notified.push(data);
+    },
+    enqueueRegeneration: async (data) => {
+      calls.regenerations.push(data);
     },
   });
   return { queue, calls };
@@ -914,6 +920,33 @@ describe('QuestionMessageQueue answer-consumption job', () => {
     expect(calls.routerInputs).toHaveLength(0);
     expect(calls.settled).toHaveLength(0);
     expect(calls.delivered).toHaveLength(0);
+  });
+
+  it('tells the truth and proposes — never resumes — when the answered park is unresumable', async () => {
+    const { queue, calls } = buildAnswerHarness({
+      parks: { [FIXTURE_PRIMARY_1]: 'inflight' },
+      routed: {
+        addressesQuestions: true,
+        answers: [{ ref: FIXTURE_PRIMARY_1, answerText: 'Happy to proceed anyway.' }],
+      },
+      settleResult: 'recorded_unresumable',
+    });
+
+    await queue.processJob('consume_question_answers', answerJob('Happy to proceed anyway.'));
+
+    // The answer was heard (settle ran), but nothing resumes automatically.
+    expect(calls.settled.map((settle) => settle.opportunityId)).toEqual([FIXTURE_PRIMARY_1]);
+    expect(calls.inflightResumes).toHaveLength(0);
+    expect(calls.stalledRetries).toHaveLength(0);
+    // The DM copy carries the honest explanation and the proposal, and the
+    // retired park's question is regenerated out of the message (#1441).
+    expect(calls.delivered).toEqual([{
+      sessionId: 'session-1',
+      role: 'assistant',
+      content: QUESTION_ANSWER_UNRESUMABLE_MESSAGE,
+    }]);
+    expect(calls.regenerations).toEqual([{ userId: USER_ID, intentId: INTENT_ID }]);
+    expect(calls.notified).toHaveLength(0);
   });
 
   it('never notifies for an answer-driven resume — the client is already in the conversation', async () => {


### PR DESCRIPTION
> "Intent update should always be explicit. Stale negs should be solved by question answering. When everything else is tried, the agent can propose resignaling with the updated intent."

## The broken flow

Tonight on the sandbox (task `aefff73b-d61f-4864-bfd8-859a8758ddcf`), a question parked at 20:20 ("Timing: This week") was answered by its own recipient at ~23:0x through the new MCP `answer_pending_question` lane. Every arrow up to the last one worked: the tool resolved the open question, routed the answer onto the right negotiation ref, consumption re-resolved the park, and the settle ran (`question_answer_consumed … resumed:0, skipped:1`).

**The broken arrow was the settle's revalidation fence.** One block returned `lost` for two very different reasons — "this answer does not belong to this park" (coherence) and "the world moved since the park" (drift). The signal had been edited twice since the park, so `intentFingerprint`/`opportunityStatus`/`opportunityUpdatedAt` no longer matched the stamped binding, and the fence threw the user's answer away. That is exactly what the design law forbids: the answer IS the freshest commitment there is, and the resumed turn rebuilds its context from current data anyway. The park became a zombie — still `input_required`, rendered as "waiting on YOUR answer" by every #1470/#1472/#1473 surface, structurally unanswerable until the 24h expiry. The same reply resumed the OTHER signal's park fine (`negotiation_answer_resumed_inflight, resumed:1`): the pipeline works; the fence was the defect.

## How each arrow is fixed

**Settle fence split** (`services/api/src/adapters/questioner.adapter.ts`, `settleInflightNegotiationAnswerFromDm`):
- *Coherence stays hard, byte-for-byte:* settlement-id derivation, task exists and is `input_required`, metadata type/opportunity/network match, binding present and matching, and the already-settled race handling are unchanged.
- *Drift stops losing:* the binding comparison against `resolveNegotiationAdmission` is replaced by a resumability check on current reality only — the opportunity is in a status run-existing would accept (mirrors `NEGOTIATION_START_STATUSES`: latent/draft/pending/negotiating/stalled) and the recipient signal is not archived. Within that, the answer settles and the resume enqueues no matter what moved, and the drift is logged honestly (`negotiation_answer_settled_despite_drift`, naming what moved). The settlement keeps recording the binding's counterparty/provenance values — they describe the park that was answered. `resolveNegotiationAdmission` itself is untouched; its other caller (`expireInflightQuestion`) keeps its semantics.

**The unresumable tail becomes an explicit proposal** (terminal opportunity / archived signal):
- The answer is still recorded as heard: the settlement is written with `kind: 'answer'` and a new `continuationStatus: 'unresumable'` — durable, inline answer included, and no continuation can ever claim it (the claim path refuses non-`requested` settlements). The task retires under `ask_user_answered_unresumable`, which resolves the park honestly — answer-triggered, i.e. an explicit human act, so law (1) is intact.
- The DM receives fixed server-owned copy (same rules as the #1441 close-out prose): the truth about why nothing resumed, plus the proposal — re-running discovery under the updated signal — offered, never performed. The retired park's question then leaves the DM through the ordinary #1441 regeneration (parked set shrinks → message shrinks or closes out). No automatic re-signal, no automatic re-discovery, no cascade.

**The result surface tells the truth** (`packages/protocol/src/negotiations/negotiation.answer-consumption.ts`, additive):
- `InflightAnswerSettlementResult` and `NegotiationAnswerResumeOutcome` gain `recorded_unresumable`; drift can no longer reach `lost`/`not_parked`.
- `consumeQuestionBlockAnswers` counts the tail in its own `recorded` array, and the consumption log line reports `resumed/recorded/skipped` distinctly — tonight's ambiguous `skipped:1` cannot recur.
- The MCP/persona answer-tool lane is enqueue-async (the tool returns before consumption runs), so the proposal copy for the unresumable case is delivered as the DM message above rather than as a synchronous tool result.

Protocol change is minimally additive: patch bump **23.6.0 → 23.6.1**, changelog entry in the existing style, `bun scripts/sync-lockfile-versions.ts` run (bun.lock updated), dist rebuilt before api tests.

## Test evidence

- `packages/protocol`: `bun test src/negotiations/tests/negotiation.answer-consumption.spec.ts` — **23 pass, 0 fail** (new: unresumable outcome enqueues nothing; `recorded` counted apart from `skipped`).
- `services/api`: `bun test ./src/adapters/tests/negotiation-dm-answer.settlement.spec.ts` (DB-backed) — **10 pass, 0 fail**. New specs: the incident inverted (signal edited + opportunity moved to `stalled` since the park → `settled`, settlement records the binding's values, drift logged); terminal opportunity → `recorded_unresumable`, park retired, continuation claim `invalid`, idempotent redelivery; archived signal → `recorded_unresumable`; coherence pins (foreign settlement id, recipient the binding does not name → `lost`, task untouched; timeout-settled and non-parked tasks unchanged).
- `services/api`: `bun test ./src/queues/tests/question-message.queue.isolated.ts` — **47 pass, 0 fail** (new: unresumable tail delivers `QUESTION_ANSWER_UNRESUMABLE_MESSAGE`, enqueues the retirement regeneration, resumes nothing, notifies nobody).
- `services/api` answer-path siblings (`open-question-consumption.settlement`, `negotiator-answer.host`, `answer-precedence` + wiring, `open-question-message`, `negotiation-question-routing.static`, `negotiation-stalled-retry.database`, `questioner.evidence`, `negotiation-listing-park.host`) — **71 pass, 0 fail** across 9 files.
- `packages/protocol` whole `src/negotiations/tests/` — 718 pass, 2 fail; both in `negotiator-discovery-query.spec.ts` (live-LLM eval), byte-identical to origin/dev and green when re-run in isolation — the known whole-dir flake.
- `services/api` full isolated suite — files=109 passed=1135 failed=4: `opportunity.service.rediscovery.isolated`, `opportunity.service.maintenance.isolated`, `tool.controller.isolated`, `archive-legacy-negotiations.isolated`. All four byte-identical to origin/dev (pre-existing, the known dev-red set); none touch this diff.
- `tsc --noEmit` clean in `services/api`; protocol `tsc` clean via the dist build.

Note: committing `questioner.adapter.ts` surfaced a latent pre-commit lint failure (the adapter's one `@indexnetwork/protocol` type import predates the adapter-layering eslint rule). Fixed the way the rule prescribes: the import is replaced by the local structural mirror of `NegotiationCounterpartyBinding`.

## Post-merge verification

Run on the root session after merge (deliberately not from this lane): re-run the settle against the real zombie park `aefff73b-d61f-4864-bfd8-859a8758ddcf` on the sandbox with the answer recorded earlier tonight. Opportunity `78a6b283` is `negotiating` (live), so after this fix the answer must settle and enqueue the resume. State the result on this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01N1FQ3gV1oWWXQHMGGroqcV
