### PR TITLE
fix(negotiations): a premise-matched counterparty is premise-bound — the stamp stops borrowing the recipient's intent

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -89,7 +89,7 @@
     },
     "packages/protocol": {
       "name": "@indexnetwork/protocol",
-      "version": "23.6.1",
+      "version": "23.6.2",
       "dependencies": {
         "@langchain/core": "1.1.48",
         "@langchain/langgraph": "1.3.2",

--- a/packages/protocol/CHANGELOG.md
+++ b/packages/protocol/CHANGELOG.md
@@ -20,6 +20,32 @@ went 6.7.1 → 8.0.2 with no 7.x in between because the whole 7.x line shipped a
 prereleases between the two promotions. To track every change, read `rc`; to
 pin a supported release, use `latest`.
 
+## 23.6.2 - 2026-08-21
+
+### Fixed
+
+- **A premise-matched counterparty is premise-bound — two wrongs stopped
+  agreeing.** A premise-matched opportunity actor carries BOTH keys: `premise`
+  is its own fact, `intent` names the intent it matched AGAINST — the
+  recipient's. Two sites independently preferred `intent` whenever the key
+  existed, and their mistakes agreed with each other: the api's ask-user
+  capture stamped every premise-matched park's `counterpartyBinding` with the
+  recipient's own intent (so the claim's counterparty-liveness check could
+  never pass — observed live as `admission:"invalid"` after #1474/#1475 had
+  already made settle and claim drift-tolerant), and this package's
+  `resolveOpportunityActorBinding` resolved a dual-key actor to that same
+  wrong intent binding — so the re-drive's continuation revalidation
+  (`opportunityActorMatchesBinding` in `negotiateExistingOpportunity`) would
+  have accepted the mis-stamp and refused a corrected premise stamp as
+  `stale_continuation`, one gate after the claim.
+
+  Both flips ship together, mirror-identical: a present `premise` is the
+  binding, `intent` binds only in its absence. Mirror consequence, intended:
+  a dual-key actor no longer matches an intent-kind binding naming its
+  matched-against intent — the gate stops accepting mis-stamped settlements,
+  which already fail the claim's liveness check earlier, so nothing that
+  works today breaks.
+
 ## 23.6.1 - 2026-08-20
 
 ### Fixed

--- a/packages/protocol/package.json
+++ b/packages/protocol/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@indexnetwork/protocol",
-  "version": "23.6.1",
+  "version": "23.6.2",
   "type": "module",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",

--- a/packages/protocol/src/opportunities/opportunity.actor.ts
+++ b/packages/protocol/src/opportunities/opportunity.actor.ts
@@ -46,10 +46,13 @@ export function resolveOpportunityActorBinding(actor: {
   intent?: unknown;
   premise?: unknown;
 }): NegotiationCounterpartyBinding | undefined {
-  const intent = resolveOpportunityActorIntent(actor);
-  if (intent !== undefined) return { kind: 'intent', id: intent };
+  // A premise-matched actor's `intent` key names the intent it matched
+  // against (the recipient's), never its own material — so a present
+  // `premise` is the binding, and `intent` binds only in its absence.
   const premise = normalizeOpportunityActorIntent(actor.premise);
-  return premise === undefined ? undefined : { kind: 'premise', id: premise };
+  if (premise !== undefined) return { kind: 'premise', id: premise };
+  const intent = resolveOpportunityActorIntent(actor);
+  return intent === undefined ? undefined : { kind: 'intent', id: intent };
 }
 
 /** Whether an actor still carries the exact binding a parked negotiation pinned. */

--- a/packages/protocol/src/opportunities/tests/opportunity.actor-binding.spec.ts
+++ b/packages/protocol/src/opportunities/tests/opportunity.actor-binding.spec.ts
@@ -23,11 +23,13 @@ describe("resolveOpportunityActorBinding", () => {
     expect(resolveOpportunityActorBinding({ premise: "p-1" })).toEqual({ kind: "premise", id: "p-1" });
   });
 
-  it("prefers the intent when an actor somehow carries both", () => {
-    // Intent is the stronger claim: it is what the person stated they want,
-    // where a premise is what the system inferred about them.
-    expect(resolveOpportunityActorBinding({ intent: "i-1", premise: "p-1" }))
-      .toEqual({ kind: "intent", id: "i-1" });
+  it("prefers the premise when an actor carries both keys", () => {
+    // A premise-matched actor's `intent` key names the intent it matched
+    // against (the recipient's), never its own material. The enricher emits
+    // both keys for premise matches, so intent-first resolution bound the
+    // counterparty to the recipient's own signal.
+    expect(resolveOpportunityActorBinding({ intent: "i-recipient", premise: "p-own" }))
+      .toEqual({ kind: "premise", id: "p-own" });
   });
 
   it("returns undefined for an actor bound by neither", () => {
@@ -52,5 +54,31 @@ describe("opportunityActorMatchesBinding", () => {
   it("refuses an actor that lost its binding, or a park that carries none", () => {
     expect(opportunityActorMatchesBinding({}, { kind: "intent", id: "i-1" })).toBe(false);
     expect(opportunityActorMatchesBinding({ intent: "i-1" }, undefined)).toBe(false);
+  });
+
+  it("matches a dual-key premise-matched actor against its own premise", () => {
+    // The incident shape: a premise-matched counterparty carries both keys —
+    // `premise` is its own fact, `intent` the recipient's intent it matched
+    // against. A correctly stamped premise-kind park must pass this gate.
+    expect(opportunityActorMatchesBinding(
+      { intent: "i-recipient", premise: "p-own" },
+      { kind: "premise", id: "p-own" },
+    )).toBe(true);
+  });
+
+  it("no longer matches a dual-key actor against its matched-against intent", () => {
+    // Deliberate mirror of the premise-first flip: an intent-kind binding
+    // naming the recipient's intent is the MIS-stamp this fix eliminates, and
+    // the gate stops agreeing with it. Nothing that works today breaks —
+    // such parks already fail the claim's counterparty-liveness check first.
+    expect(opportunityActorMatchesBinding(
+      { intent: "i-recipient", premise: "p-own" },
+      { kind: "intent", id: "i-recipient" },
+    )).toBe(false);
+  });
+
+  it("keeps an intent-only actor matching its own intent binding", () => {
+    expect(opportunityActorMatchesBinding({ intent: "i-own" }, { kind: "intent", id: "i-own" })).toBe(true);
+    expect(opportunityActorMatchesBinding({ intent: "i-own" }, { kind: "premise", id: "i-own" })).toBe(false);
   });
 });

--- a/services/api/src/adapters/conversation.database.adapter.ts
+++ b/services/api/src/adapters/conversation.database.adapter.ts
@@ -3879,9 +3879,12 @@ export class ConversationDatabaseAdapter {
         throw new Error('Ask-user opportunity actor binding is ambiguous');
       }
       const counterpartyUserId = counterparties[0].userId!;
-      const counterpartyBinding: NegotiationCounterpartyBinding = typeof counterparties[0].intent === 'string'
-        ? { kind: 'intent', id: counterparties[0].intent }
-        : { kind: 'premise', id: counterparties[0].premise! };
+      // A premise-matched actor's `intent` key names the intent it matched
+      // against (the recipient's), never its own material — so a present
+      // `premise` is the binding, and `intent` binds only in its absence.
+      const counterpartyBinding: NegotiationCounterpartyBinding = typeof counterparties[0].premise === 'string'
+        ? { kind: 'premise', id: counterparties[0].premise }
+        : { kind: 'intent', id: counterparties[0].intent! };
       const members = await tx.select({ userId: schema.networkMembers.userId }).from(schema.networkMembers)
         .innerJoin(schema.networks, and(
           eq(schema.networks.id, schema.networkMembers.networkId),

--- a/services/api/src/adapters/tests/negotiation-counterparty-binding.capture.spec.ts
+++ b/services/api/src/adapters/tests/negotiation-counterparty-binding.capture.spec.ts
@@ -1,0 +1,250 @@
+/**
+ * The counterparty-binding stamp (capture time) and the resume it must survive.
+ *
+ * #1474 made the settle survive drift; #1475 made the claim and expiry survive
+ * drift. The live re-drive STILL refused — correctly — because the park's
+ * stored coordinates were wrong at the source: a premise-matched counterparty
+ * actor carries BOTH keys (`premise` is its own fact, `intent` names the
+ * intent it matched AGAINST — the recipient's), and the capture's intent-first
+ * preference stamped every such park with the recipient's own intent. The
+ * claim's counterparty-liveness check ("intent owned by the counterparty")
+ * can never pass for that stamp. This spec pins the corrected stamp at its
+ * source and then runs the whole chain the three lanes fixed: correct stamp →
+ * drift → drift-tolerant settle → drift-tolerant claim → successor minted.
+ */
+import { afterAll, describe, expect, setDefaultTimeout, test } from 'bun:test';
+import { randomUUID } from 'crypto';
+import { eq, inArray } from 'drizzle-orm';
+
+import db from '../../lib/drizzle/drizzle';
+import { questionerAdapter } from '../questioner.adapter.instance';
+import { ConversationDatabaseAdapter } from '../conversation.database.adapter';
+import { intents, intentNetworks, networks, networkMembers, opportunities, premises, premiseNetworks, users } from '../../schemas/database.schema';
+import { conversations, messages, tasks } from '../../schemas/conversation.schema';
+
+setDefaultTimeout(30_000);
+
+const conversationAdapter = new ConversationDatabaseAdapter();
+
+const cleanup = {
+  users: [] as string[],
+  networks: [] as string[],
+  intents: [] as string[],
+  premises: [] as string[],
+  opportunities: [] as string[],
+  conversations: [] as string[],
+};
+
+afterAll(async () => {
+  if (cleanup.conversations.length > 0) {
+    await db.delete(messages).where(inArray(messages.conversationId, cleanup.conversations));
+    await db.delete(tasks).where(inArray(tasks.conversationId, cleanup.conversations));
+    await db.delete(conversations).where(inArray(conversations.id, cleanup.conversations));
+  }
+  if (cleanup.opportunities.length > 0) await db.delete(opportunities).where(inArray(opportunities.id, cleanup.opportunities));
+  if (cleanup.premises.length > 0) {
+    await db.delete(premiseNetworks).where(inArray(premiseNetworks.premiseId, cleanup.premises));
+    await db.delete(premises).where(inArray(premises.id, cleanup.premises));
+  }
+  if (cleanup.intents.length > 0) {
+    await db.delete(intentNetworks).where(inArray(intentNetworks.intentId, cleanup.intents));
+    await db.delete(intents).where(inArray(intents.id, cleanup.intents));
+  }
+  if (cleanup.networks.length > 0) {
+    await db.delete(networkMembers).where(inArray(networkMembers.networkId, cleanup.networks));
+    await db.delete(networks).where(inArray(networks.id, cleanup.networks));
+  }
+  if (cleanup.users.length > 0) await db.delete(users).where(inArray(users.id, cleanup.users));
+});
+
+/**
+ * Seeds the incident's world: recipient bound by intent, counterparty matched
+ * by premise discovery — so its actor carries BOTH the recipient's intent id
+ * (the intent it matched against, mirroring real enricher output) and its own
+ * premise, which is a real row owned by the counterparty and assigned to the
+ * network. `counterpartyShape: 'intent'` seeds the other kind instead: a
+ * counterparty with only its own stated intent.
+ */
+async function seedWorkingNegotiation(counterpartyShape: 'premise' | 'intent') {
+  const [recipient, counterparty] = await db.insert(users).values([
+    { email: `binding-stamp-recipient-${randomUUID()}@test.local`, name: 'Binding stamp recipient' },
+    { email: `binding-stamp-counterparty-${randomUUID()}@test.local`, name: 'Binding stamp counterparty' },
+  ]).returning({ id: users.id });
+  cleanup.users.push(recipient.id, counterparty.id);
+  const [network] = await db.insert(networks).values({
+    title: `Binding stamp ${randomUUID()}`,
+    description: 'counterparty binding stamp fixture',
+    isPersonal: false,
+  }).returning({ id: networks.id });
+  cleanup.networks.push(network.id);
+  await db.insert(networkMembers).values([
+    { networkId: network.id, userId: recipient.id, permissions: ['member'] },
+    { networkId: network.id, userId: counterparty.id, permissions: ['member'] },
+  ]);
+  const [recipientIntent] = await db.insert(intents).values({
+    userId: recipient.id, payload: 'Find a manufacturing partner for a sensor line', status: 'ACTIVE',
+  }).returning({ id: intents.id });
+  cleanup.intents.push(recipientIntent.id);
+  await db.insert(intentNetworks).values([{ intentId: recipientIntent.id, networkId: network.id }]);
+
+  let counterpartyPremiseId: string | undefined;
+  let counterpartyIntentId: string | undefined;
+  if (counterpartyShape === 'premise') {
+    const [premise] = await db.insert(premises).values({
+      userId: counterparty.id,
+      assertion: { text: 'Runs a contract manufacturing line for industrial sensors' } as never,
+      provenance: { kind: 'test' } as never,
+      validity: { status: 'valid' } as never,
+      status: 'ACTIVE',
+    }).returning({ id: premises.id });
+    cleanup.premises.push(premise.id);
+    await db.insert(premiseNetworks).values([{ premiseId: premise.id, networkId: network.id }]);
+    counterpartyPremiseId = premise.id;
+  } else {
+    const [counterpartyIntent] = await db.insert(intents).values({
+      userId: counterparty.id, payload: 'Offer contract manufacturing', status: 'ACTIVE',
+    }).returning({ id: intents.id });
+    cleanup.intents.push(counterpartyIntent.id);
+    await db.insert(intentNetworks).values([{ intentId: counterpartyIntent.id, networkId: network.id }]);
+    counterpartyIntentId = counterpartyIntent.id;
+  }
+
+  const counterpartyActor = counterpartyShape === 'premise'
+    // The incident shape: `intent` is the RECIPIENT'S intent (matched
+    // against), `premise` is the counterparty's own fact.
+    ? { userId: counterparty.id, intent: recipientIntent.id, premise: counterpartyPremiseId, networkId: network.id, role: 'agent' }
+    : { userId: counterparty.id, intent: counterpartyIntentId, networkId: network.id, role: 'peer' };
+  const [opportunity] = await db.insert(opportunities).values({
+    detection: { kind: 'test', summary: 'binding stamp' } as never,
+    actors: [
+      { userId: recipient.id, intent: recipientIntent.id, networkId: network.id, role: 'patient' },
+      counterpartyActor,
+    ] as never,
+    interpretation: { reasoning: 'fixture', category: 'test' } as never,
+    context: { networkId: network.id } as never,
+    confidence: '0.9',
+    status: 'negotiating',
+  }).returning();
+  cleanup.opportunities.push(opportunity.id);
+
+  const conversation = await conversationAdapter.createConversation([
+    { participantId: `agent:${recipient.id}`, participantType: 'agent' },
+    { participantId: `agent:${counterparty.id}`, participantType: 'agent' },
+  ]);
+  cleanup.conversations.push(conversation.id);
+  const task = await conversationAdapter.createTask(conversation.id, {
+    type: 'negotiation',
+    opportunityId: opportunity.id,
+    networkId: network.id,
+    sourceUserId: counterparty.id,
+    candidateUserId: recipient.id,
+    candidateIntentId: recipientIntent.id,
+  });
+  // The capture accepts only an in-flight turn.
+  await db.update(tasks).set({ state: 'working' }).where(eq(tasks.id, task.id));
+
+  return {
+    recipientId: recipient.id,
+    recipientIntentId: recipientIntent.id,
+    counterpartyId: counterparty.id,
+    counterpartyPremiseId,
+    counterpartyIntentId,
+    networkId: network.id,
+    opportunityId: opportunity.id,
+    taskId: task.id,
+    settlementId: `negotiation-question-settlement-v1-${task.id}`,
+  };
+}
+
+type Fixture = Awaited<ReturnType<typeof seedWorkingNegotiation>>;
+
+async function captureBinding(fixture: Fixture) {
+  return conversationAdapter.captureNegotiationAskUserBinding({
+    taskId: fixture.taskId,
+    turnContext: { fixture: 'binding-stamp' },
+    settlementId: fixture.settlementId,
+    recipientUserId: fixture.recipientId,
+    recipientIntentId: fixture.recipientIntentId,
+    opportunityId: fixture.opportunityId,
+    networkId: fixture.networkId,
+  });
+}
+
+async function parkSettleAndClaim(fixture: Fixture, freeText: string) {
+  // The real pause parks the task after the capture armed the timeout.
+  await db.update(tasks).set({ state: 'input_required' }).where(eq(tasks.id, fixture.taskId));
+  const settled = await questionerAdapter.settleInflightNegotiationAnswerFromDm({
+    taskId: fixture.taskId,
+    settlementId: fixture.settlementId,
+    opportunityId: fixture.opportunityId,
+    recipientUserId: fixture.recipientId,
+    recipientIntentId: fixture.recipientIntentId,
+    networkId: fixture.networkId,
+    answer: { selectedOptions: [], freeText, answeredAt: new Date().toISOString() },
+  });
+  const claim = await questionerAdapter.claimNegotiationContinuationExecution({
+    taskId: fixture.taskId,
+    settlementId: fixture.settlementId,
+    opportunityId: fixture.opportunityId,
+    userId: fixture.recipientId,
+    recipientIntentId: fixture.recipientIntentId,
+    networkId: fixture.networkId,
+  });
+  return { settled, claim };
+}
+
+describe('captureNegotiationAskUserBinding counterparty stamp', () => {
+  test('a premise-matched counterparty is premise-bound, even when its actor also names the matched-against intent', async () => {
+    const fixture = await seedWorkingNegotiation('premise');
+    const binding = await captureBinding(fixture);
+    expect(binding.counterpartyUserId).toBe(fixture.counterpartyId);
+    expect(binding.counterpartyBinding).toEqual({ kind: 'premise', id: fixture.counterpartyPremiseId! });
+    const [task] = await db.select({ metadata: tasks.metadata }).from(tasks).where(eq(tasks.id, fixture.taskId));
+    const turnContext = (task.metadata as Record<string, unknown>).turnContext as Record<string, unknown>;
+    expect((turnContext.askUserBinding as Record<string, unknown>).counterpartyBinding)
+      .toEqual({ kind: 'premise', id: fixture.counterpartyPremiseId! });
+  });
+
+  test('the incident end-to-end, inverted: correct stamp → drift → DM settle → claim mints the successor', async () => {
+    const fixture = await seedWorkingNegotiation('premise');
+    const binding = await captureBinding(fixture);
+    expect(binding.counterpartyBinding).toEqual({ kind: 'premise', id: fixture.counterpartyPremiseId! });
+
+    // The 2026-08-20 incident's drift, on a correctly stamped park: signal
+    // edited AND opportunity moved within the resumable set after the park.
+    await db.update(intents)
+      .set({ payload: 'Find a manufacturing partner for a sensor line — now EU-based, Q4 start' })
+      .where(eq(intents.id, fixture.recipientIntentId));
+    await db.update(opportunities)
+      .set({ status: 'stalled', updatedAt: new Date(Date.now() + 1000) })
+      .where(eq(opportunities.id, fixture.opportunityId));
+
+    const { settled, claim } = await parkSettleAndClaim(fixture, 'Q4 works; EU preferred.');
+    expect(settled).toBe('settled');
+    expect(claim.status).toBe('claimed');
+    if (claim.status !== 'claimed') return;
+    expect(claim.execution.counterpartyBinding).toEqual({ kind: 'premise', id: fixture.counterpartyPremiseId! });
+    expect(claim.execution.consultation).toMatchObject({
+      kind: 'answer',
+      recipientUserId: fixture.recipientId,
+      freeText: 'Q4 works; EU preferred.',
+    });
+    const [successor] = await db.select().from(tasks).where(eq(tasks.id, claim.execution.successorTaskId));
+    expect(successor.metadata).toMatchObject({
+      resumeFromTaskId: fixture.taskId,
+      continuationSettlementId: fixture.settlementId,
+    });
+  });
+
+  test('an intent-only counterparty still stamps its own intent and the claim still passes', async () => {
+    const fixture = await seedWorkingNegotiation('intent');
+    const binding = await captureBinding(fixture);
+    expect(binding.counterpartyBinding).toEqual({ kind: 'intent', id: fixture.counterpartyIntentId! });
+
+    const { settled, claim } = await parkSettleAndClaim(fixture, 'Ready when you are.');
+    expect(settled).toBe('settled');
+    expect(claim.status).toBe('claimed');
+    if (claim.status !== 'claimed') return;
+    expect(claim.execution.counterpartyBinding).toEqual({ kind: 'intent', id: fixture.counterpartyIntentId! });
+  });
+});


### PR DESCRIPTION
## The flow, four arrows

A client answers her parked question; the answer must resume the negotiation. #1474 fixed the first arrow: the DM **settle** survives world drift (answers beat staleness). #1475 fixed the second: the **claim and expiry** survive the same drift. Tonight's live re-drive of the real park `aefff73b-d61f-4864-bfd8-859a8758ddcf` STILL refused — `RunExistingJob: Exact negotiation continuation skipped {admission:"invalid"}` — and this time the refusal was *correct*: the park's stored coordinates are wrong at the source.

**Third arrow — the stamp.** A premise-matched counterparty actor carries BOTH keys: `premise` is its own fact; `intent` names the intent it matched AGAINST — the recipient's. `captureNegotiationAskUserBinding` preferred `intent` whenever the key existed, so every premise-matched park's `counterpartyBinding` was stamped `{kind:'intent', id:<the recipient's own intent>}`. The claim's counterparty-liveness check ("intent owned by the counterparty user") can never pass for that stamp. Dev runs mostly premise matches, so most real parks are mis-stamped.

**Fourth arrow — the matcher that agreed with the stamp.** The stop-and-report sweep found the same intent-first preference in protocol: `resolveOpportunityActorBinding` resolves a dual-key actor to that same wrong intent binding. Its sole consumer, `opportunityActorMatchesBinding`, is the continuation revalidation gate in `negotiateExistingOpportunity` — the gate every exact re-drive passes through AFTER the claim. It would have *accepted* the mis-stamp and *refused* a corrected premise stamp as `stale_continuation`, one gate after the claim. Fixing only the stamp would have moved the broken arrow, not removed it.

## The broken lines, exactly

- `services/api/src/adapters/conversation.database.adapter.ts:3882-3884` — `captureNegotiationAskUserBinding`:
  ```ts
  const counterpartyBinding: NegotiationCounterpartyBinding = typeof counterparties[0].intent === 'string'
    ? { kind: 'intent', id: counterparties[0].intent }
    : { kind: 'premise', id: counterparties[0].premise! };
  ```
- `packages/protocol/src/opportunities/opportunity.actor.ts:44-53` — `resolveOpportunityActorBinding`:
  ```ts
  const intent = resolveOpportunityActorIntent(actor);
  if (intent !== undefined) return { kind: 'intent', id: intent };
  ```

Both flips ship together, mirror-identical: a present `premise` is the binding; `intent` binds only in its absence. One comment at each site states the constraint the code can't show. The deliberate mirror — a dual-key actor no longer matches an intent-kind binding naming its matched-against intent — is pinned in the protocol spec with a comment saying so; such parks already fail the claim's liveness check earlier, so nothing that works today breaks.

Protocol ceremony: 23.6.1 → 23.6.2, changelog entry naming the two wrongs that agreed, lockfile synced via `bun scripts/sync-lockfile-versions.ts`, dist rebuilt before api tests.

## Test evidence

New `services/api/src/adapters/tests/negotiation-counterparty-binding.capture.spec.ts` (harness style of `negotiation-continuation.atomic.spec.ts`; stamps via the capture, never by hand):

1. **Premise-matched capture** — counterparty actor carries BOTH `intent` (= recipient's intent, mirroring real enricher output) and `premise` (real premises row owned by the counterparty, assigned via premise_networks); capture on a `working` task returns and persists `{kind:'premise', id:<premise>}`.
2. **The incident end-to-end, inverted** — correct stamp → drift (recipient signal edited, opportunity `negotiating`→`stalled`, updatedAt touched) → DM settle (`settled`) → claim (`claimed`, successor minted with `resumeFromTaskId`/`continuationSettlementId`, execution carries the premise binding). The run logs both `negotiation_answer_settled_despite_drift` and `negotiation_continuation_claimed_despite_drift` — the full three-fix chain in one spec.
3. **Intent-only counterparty unchanged** — stamps `{kind:'intent', id:<its own intent>}` and the claim still passes.

Extended `packages/protocol/src/opportunities/tests/opportunity.actor-binding.spec.ts`: dual-key actor resolves premise-first; matches its own premise binding; **no longer** matches the matched-against intent binding (deliberate mirror, commented); intent-only actor unchanged both ways.

Commands and counts:

- `cd services/api && NODE_ENV=test API_TEST_REQUIRE_DATABASE=1 bun test src/adapters/tests/negotiation-counterparty-binding.capture.spec.ts src/adapters/tests/negotiation-continuation.atomic.spec.ts src/adapters/tests/negotiation-dm-answer.settlement.spec.ts` → **23 pass, 0 fail** across the three files (the run's single reported fail is the preload's isolated-suite fan-out hook, see baseline below).
- `cd packages/protocol && bun test src/opportunities/tests/opportunity.actor-binding.spec.ts` → **10 pass, 0 fail**.
- `cd packages/protocol && bun test src/opportunities/tests/opportunity.existing-negotiation.spec.ts` → **4 pass, 0 fail**.
- `cd services/api && bun run typecheck` → clean. Protocol `tsc` build → clean.

## Pre-existing failures (baselined, not touched)

Baselined against origin/dev (`6a62be5d79`) in a detached worktree — no stash:

- The 4 known dev-red api isolated files: `opportunity.service.rediscovery.isolated.ts`, `opportunity.service.maintenance.isolated.ts`, `tool.controller.isolated.ts`, `archive-legacy-negotiations.isolated.ts` (isolated fan-out: files=109 passed=1135 skipped=41 failed=4 — identical on this branch).
- `conversation.database.adapter.spec.ts` → 27 pass, 2 own fails (task-session mapping, summary projection) — the known dev-red pair.
- Protocol whole-dir run: 94 fails across 16 files on this branch vs **114 fails across 20 files on origin/dev** — this branch's failing set is a strict subset of the baseline's, same files, same per-file counts (whole-dir mock/env contamination class; every affected file passes or is unchanged in isolation, and none touches this diff).

## Known follow-up (out of this lane, reported for a next handoff)

Same root, adjacent flow, untouched here: `negotiateExistingOpportunity` stamps `candidateIntentId = resolveOpportunityActorIntent(candidateActor)` (`opportunity.existing-negotiation.ts:126`) — for a dual-key premise-matched candidate that is the recipient's intent id — and init writes it into task metadata `participantBindings` (`negotiation.graph.init.ts:189-192`). The api external-claim consultation flow then derives its counterparty binding from those bindings as always-intent (`externalConsultationCoordinatesFor`, `services/api/src/lib/negotiation/consultation.ts:130`), so external-consultation parks for premise-matched counterparties are mis-stamped the same way and their claims will fail the counterparty-liveness check identically. `consultation-expiry.ts:64-74` already documents participantBindings as intent-only.

## Post-merge step

The root session performs a single disclosed sandbox data repair of park `aefff73b` (rewrite its stored `counterpartyBinding` to `{kind:'premise', id:'cc977cb5…'}`) and re-drives it as the live verification. No migrations or backfills ship here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01N1FQ3gV1oWWXQHMGGroqcV
