### PR TITLE
feat(intent-agent): the agent takes the whole conversation — full chat ownership and verdicts through its judgment

### DIFF
--- a/docs/plans/2026-08-21-holistic-intent-agent.md
+++ b/docs/plans/2026-08-21-holistic-intent-agent.md
@@ -1,8 +1,9 @@
 # The holistic intent agent
 
-**Status:** phase 1 in progress on `feat/intent-agent`. Phase 1 ships the
-IntentAgent actor and collapses the DM ask→answer pipeline into it; the
-phases after it are listed at the end.
+**Status:** phase 1 shipped (#1477): the IntentAgent actor, with the DM
+ask→answer pipeline collapsed into it. Phase 2 shipped on
+`feat/agent-full-chat`: full chat ownership + verdicts through the agent
+(see "Phase 2 — shipped" below). Later phases are listed at the end.
 
 **Date:** 2026-08-21
 **Builds on:** [2026-08-18-conversational-questions](2026-08-18-conversational-questions.md)
@@ -242,20 +243,89 @@ the answer is durably heard rather than fail-open lost.
 
 Tables are left alone; no migration drops data.
 
-## Phase 2+
+## Phase 2 — shipped (full chat ownership + verdicts through the agent)
 
-- **Verdicts through the agent** — the accept/reject lane (#1471) becomes
-  agent judgment with the same proposal discipline.
+Built together because they are one seam: retiring the persona from intent
+scope orphans its verdict tools unless the agent absorbs them.
+
+**Ownership is unconditional.** For the negotiator persona + intent scope,
+EVERY user turn runs the IntentAgent on its serialized inbox — the
+`intentAgentOwnsTurn` parked-set gate is deleted, and the persona graph is
+never derived for this scope (`getNegotiatorGraphFactory` deleted from the
+chat service; the controller has no negotiator factory branch). With the
+persona gone from chat, its chat-side tool registrations for this scope —
+`answer_pending_question`, `accept_opportunity`/`reject_opportunity`,
+`remember`/`forget` — no longer exist; the HOSTS stay shared, and the MCP
+surface (`mcp.controller` toolDeps) still registers them unchanged. The
+controller's post-turn machinery (title, suggestions, done event, reflect
+queue) runs on the agent's response exactly as before.
+
+**The turn is two stages.** The acts stage (structured judgment) decides
+effects only — for a client message, `message_user` is structurally refused
+there (the validator rejects it; `wait` is the honest "nothing to execute").
+The reply stage then composes the conversational reply: a second model call
+under the same law plus a reply instruction, given the context and the
+just-executed acts. The reply persists as the assistant message inside the
+host and is ledgered as a `message_user` act with `stage: 'reply'`.
+Background events (`negotiation_needs_input`) skip the reply stage; the acts
+stage keeps `message_user` for authoring asks, exactly as phase 1.
+
+**Streaming: check-then-stream.** Tokens cross from the inbox worker to the
+waiting controller over Redis pub/sub on a channel keyed by the turn's
+message id (`intent-agent-reply.stream.ts`; hermetic in-process bus under
+test). The streaming tension — tokens reaching the client before the safety
+check completes — is resolved by CHECKING FIRST: the reply is generated to
+completion, passes `isSafeQuestionMessageProse` (fail → one retry → fixed
+fallback copy, failure ledgered on the act), is persisted, and only then is
+published as ordered sentence chunks. The latency cost is honest: the first
+token waits for the full reply generation plus the check — no earlier than
+phase 1's single emission, so nothing regressed, but not token-by-token
+model latency either. Chosen over buffer-and-flush-by-sentence because a
+mid-reply check failure there would need retraction semantics
+(`response_reset`) on a surface whose web client only consumes token/done —
+and no unchecked token may ever be persisted or shown. The transport is
+already incremental; a future incremental safety formulation can move the
+flush earlier without touching the SSE contract. The controller subscribes
+before enqueueing, relays chunks as SSE token events, and falls back to
+emitting the completed turn text if the channel delivered nothing (or only a
+prefix) — a turn is never lost to a dropped subscription, and the fixed
+failure copy still answers a failed/timed-out turn.
+
+**Verdicts execute only on the client's explicit word.** New acts
+`accept_opportunity`/`reject_opportunity` refer by number to a bounded
+active-match list now assembled into the turn context by the SAME reader the
+#1471 tools use (`readActionableCounterparties`; capped, newest kept,
+truncation logged). Execution reuses the #1471 lane via
+`passVerdictOnOpportunity` — the same
+`opportunityService.updateOpportunityStatus` write and failure
+classification the Radar card and MCP tools ride — and the outcome is
+ledgered verbatim. THE LAW lives in prompt v2
+(`INTENT_AGENT_SYSTEM_PROMPT_VERSION = 2`): explicit word → act; hedge →
+recommendation plus a settling question in the reply, never an act. The
+explicit/hedged boundary is judgment, so it is pinned in the live eval, not
+fenced in code; the structural fences (verdict acts only on user_message
+events, numbers only from the list, one verdict per match per turn) are in
+the validator.
+
+**Signal edits stay explicit.** The persona's chat edit rule was NOT
+inherited: there is no signal-edit act. The agent's reply directs the client
+to edit the signal directly (prompt rule 6). Deferred, not wired: absorbing
+the explicit intent-update host as an `update_signal` act.
+
+## Phase 3+
+
 - **Proactive contact** — the agent decides to open the conversation
   (new-match arrivals, expiring windows), with notification hanging off its
   `message_user` acts.
-- **Full chat ownership** — the agent takes every turn of the intent DM and
-  the persona graph retires from this scope; requires the inbox to carry
-  streaming turns.
+- **Incremental reply streaming** — an incremental safety formulation that
+  lets checked sentences flush before the reply completes.
 - **Cross-intent parallelism** — worker concurrency N with a per-intent
   advisory lock in the processor, if inbox latency ever warrants it.
 - **Question-block UI retirement** — once no legacy open blocks remain, the
   steps renderer and block parser leave the floor.
+- **Negotiator persona cleanup** — `createNegotiatorPersona` and the chat
+  persona module in the protocol package are now chat-dead (no api caller);
+  removing them is a protocol-major cleanup left for its own lane.
 - **MCP surface** — expose the dossier and the ledger to the user
   (`read`/curate), and route external-agent asks through the inbox.
 - **Dossier UI** — the disclosure boundary as a visible, editable list.

--- a/services/api/src/controllers/chat.controller.ts
+++ b/services/api/src/controllers/chat.controller.ts
@@ -13,8 +13,8 @@ import { userService } from "../services/user.service";
 import { isNegotiatorChatEnabled } from "../lib/negotiator-feature";
 import { negotiationReflectQueue } from "../queues/negotiations/reflect.queue";
 import { intentAgentQueue } from "../queues/intent-agent.queue";
-import { intentAgentOwnsTurn } from "../lib/intent-agent/intent-agent.host";
-import type { IntentAgentTurnResult } from "../lib/intent-agent/intent-agent.types";
+import { subscribeIntentAgentReply } from "../lib/intent-agent/intent-agent-reply.stream";
+import type { IntentAgentTurnResult, IntentAgentUserMessageEvent } from "../lib/intent-agent/intent-agent.types";
 import { SuggestionGenerator, ChatInterruptClassifier, NEGOTIATOR_PERSONA_ID, ONBOARDING_PERSONA_ID, SIGNAL_PERSONA_ID } from '@indexnetwork/protocol';
 import { createDoneEvent, createErrorEvent, createStatusEvent, createSteerOrQueueEvent, createTokenEvent, formatSSEEvent } from "../types/chat-streaming.types";
 import { emitChatInterrupt, onChatInterrupt } from '../lib/chat-interrupt.events';
@@ -26,10 +26,11 @@ const logger = log.controller.from("chat");
 
 /**
  * The orchestrator's event stream when it does not run: the signal's
- * IntentAgent owned this turn, so the response came from its serialized turn
- * instead of the persona graph. An empty stream rather than a branch around
- * the loop keeps one path through persistence, title, suggestions and `done`
- * — the turn differs only in where its text came from.
+ * IntentAgent owns every turn of this scope (phase 2 full chat ownership),
+ * so the response comes from its serialized turn instead of the persona
+ * graph. An empty stream rather than a branch around the loop keeps one path
+ * through persistence, title, suggestions and `done` — the turn differs only
+ * in where its text came from.
  */
 async function* emptyEventStream(): AsyncGenerator<never, void, unknown> {}
 
@@ -203,6 +204,10 @@ export class ChatController {
 
   constructor(
     private readonly suggestionGenerator: () => Pick<SuggestionGenerator, 'generate'> = getSuggestionGenerator,
+    /** Seam for tests; production awaits the serialized inbox turn. */
+    private readonly runIntentAgentUserTurn: (
+      event: IntentAgentUserMessageEvent,
+    ) => Promise<IntentAgentTurnResult> = (event) => intentAgentQueue.runUserMessageTurn(event),
   ) {}
   /**
    * SSE streaming endpoint for chat messages with context support.
@@ -292,10 +297,6 @@ export class ChatController {
     const requestedScope = normalizeChatScope(body);
     if (requestedScope instanceof Response) return requestedScope;
 
-    // Captured by validateScope when an intent scope validates — used to pin
-    // the signal by name in the negotiator prompt (P4.2) without re-fetching.
-    let pinnedIntentLabel: string | undefined;
-
     const validateScope = async (scope: ChatScope | undefined) => {
       if (!scope) return undefined;
       if (scope.scopeType === 'network') {
@@ -309,7 +310,6 @@ export class ChatController {
       if (!validation.ok) {
         return Response.json({ error: validation.error }, { status: validation.status });
       }
-      pinnedIntentLabel = validation.title;
       return undefined;
     };
 
@@ -476,23 +476,22 @@ export class ChatController {
     }
 
     const sessionId = currentSessionId;
-    const factory = sessionPersona === ONBOARDING_PERSONA_ID
-      ? chatSessionService.getOnboardingGraphFactory()
-      : sessionPersona === SIGNAL_PERSONA_ID
-        ? chatSessionService.getSignalGraphFactory()
-        : sessionPersona === NEGOTIATOR_PERSONA_ID && negotiatorAgent
-        ? await chatSessionService.getNegotiatorGraphFactory(
-            negotiatorAgent,
-            user.id,
-            effectiveScope?.scopeType === 'intent'
-              ? {
-                intentId: effectiveScope.scopeId,
-                ...(pinnedIntentLabel ? { label: pinnedIntentLabel } : {}),
-              }
-              : undefined,
-          )
-        : null;
-    if (!factory) {
+    // ─── Phase 2 (full chat ownership): the negotiator intent DM runs no
+    // persona graph at all — EVERY turn is the signal's IntentAgent's,
+    // decided and executed on its serialized inbox. Negotiator sessions are
+    // intent-scoped by construction (enforced above), so no negotiator
+    // persona factory is derived; other personas and network scope are
+    // untouched.
+    const agentOwnsTurn = sessionPersona === NEGOTIATOR_PERSONA_ID
+      && effectiveScope?.scopeType === 'intent';
+    const factory = agentOwnsTurn
+      ? null
+      : sessionPersona === ONBOARDING_PERSONA_ID
+        ? chatSessionService.getOnboardingGraphFactory()
+        : sessionPersona === SIGNAL_PERSONA_ID
+          ? chatSessionService.getSignalGraphFactory()
+          : null;
+    if (!factory && !agentOwnsTurn) {
       return Response.json(
         { error: 'This chat cannot be continued safely.', code: 'CHAT_PERSONA_UNSUPPORTED' },
         { status: 409 },
@@ -524,6 +523,7 @@ export class ChatController {
     const trustedOrigins = (process.env.TRUSTED_ORIGINS ?? "").split(",").map(o => o.trim()).filter(Boolean);
     const originUrl = rawOrigin && trustedOrigins.includes(rawOrigin) ? rawOrigin : undefined;
     const suggestionGenerator = this.suggestionGenerator;
+    const runIntentAgentUserTurn = this.runIntentAgentUserTurn;
 
     const stream = new ReadableStream({
       start(controller) {
@@ -567,23 +567,19 @@ export class ChatController {
           let debugMeta: { graph: string; iterations: number; tools: unknown[]; llm?: unknown; orchestratorNegotiations?: unknown} | undefined;
           let decisionQuestions: import("@indexnetwork/protocol").Question[] | undefined;
 
-          // ─── The IntentAgent's turn (holistic intent-agent collapse) ─────
-          // While a negotiation is parked awaiting this client on this
-          // signal, the turn belongs to the signal's IntentAgent: the message
-          // is persisted, its event runs on the agent's serialized inbox, and
-          // whatever the agent said back is emitted as the response. The
-          // persona graph does not run — so no tool, and in particular not
-          // the signal edit rule, can consume an answer before the agent
-          // judges it (the 2026-08-20 incident's fix, kept by construction:
-          // the agent turn sits exactly where the precedence gate sat).
-          // While nothing is parked, the persona streams byte-identically to
-          // before.
+          // ─── The IntentAgent's turn (phase 2: full chat ownership) ──────
+          // EVERY turn of a negotiator intent-scoped DM belongs to the
+          // signal's IntentAgent: the message is persisted, its event runs
+          // on the agent's serialized inbox, and the agent's reply streams
+          // back over the turn's Redis channel as token events. The persona
+          // graph never runs for this scope — the 2026-08-20 incident's fix
+          // is now unconditional, and the client talks to one mind. If the
+          // channel yields nothing (or only a prefix) but the turn
+          // completes, the completed text is emitted as a token event — a
+          // turn is never lost to a dropped subscription.
           let agentTurn: IntentAgentTurnResult | null = null;
           let agentUserMessageId: string | null = null;
           let agentAssistantMessageId: string | undefined;
-          const agentOwnsTurn =
-            sessionPersona === NEGOTIATOR_PERSONA_ID && effectiveScope?.scopeType === 'intent'
-            && await intentAgentOwnsTurn(user.id, effectiveScope.scopeId);
 
           if (agentOwnsTurn && effectiveScope) {
             // The conversation is the agent's memory, so the client's message
@@ -595,8 +591,31 @@ export class ChatController {
               role: 'user',
               content: messageContent,
             });
+            // Subscribe BEFORE enqueueing so no chunk can be published into
+            // an unwatched channel. Everything on the channel was checked
+            // and persisted by the host before publishing.
+            let streamedText = '';
+            let lastSeq = 0;
+            let unsubscribeReply: (() => void) | null = null;
             try {
-              agentTurn = await intentAgentQueue.runUserMessageTurn({
+              unsubscribeReply = await subscribeIntentAgentReply(agentUserMessageId, (chunk) => {
+                if (chunk.seq <= lastSeq) return;
+                lastSeq = chunk.seq;
+                streamedText += chunk.content;
+                try {
+                  controller.enqueue(
+                    encoder.encode(formatSSEEvent(createTokenEvent(sessionId, chunk.content))),
+                  );
+                } catch {
+                  // Stream may have already closed.
+                }
+              });
+            } catch (subscribeErr) {
+              // Degraded to the fallback emission below, never a lost turn.
+              logger.warn('Intent-agent reply subscription failed', { sessionId, error: subscribeErr });
+            }
+            try {
+              agentTurn = await runIntentAgentUserTurn({
                 kind: 'user_message',
                 userId: user.id,
                 intentId: effectiveScope.scopeId,
@@ -608,11 +627,26 @@ export class ChatController {
               for (const act of agentTurn.acts) {
                 if (act.tool === 'message_user') agentAssistantMessageId = act.messageId;
               }
+              // Dropped-subscription fallback: whatever the channel did not
+              // deliver of the completed turn is emitted as one token event.
+              // The host publishes chunks whose concatenation IS the joined
+              // messages, so a healthy stream leaves no remainder.
+              if (fullResponse && fullResponse !== streamedText) {
+                const remainder = fullResponse.startsWith(streamedText)
+                  ? fullResponse.slice(streamedText.length)
+                  : null;
+                if (remainder) {
+                  controller.enqueue(
+                    encoder.encode(formatSSEEvent(createTokenEvent(sessionId, remainder))),
+                  );
+                }
+                // A non-prefix divergence emits nothing more: the done
+                // event's response is authoritative for the final text.
+              }
             } catch (agentErr) {
               // The event is durable on the inbox and retries in the
               // background; the client hears honest fixed copy rather than
-              // losing the turn — or having it silently re-decided by the
-              // persona.
+              // losing the turn.
               logger.error('Intent-agent turn failed; replying with fixed copy', { sessionId, error: agentErr });
               fullResponse = INTENT_AGENT_TURN_FAILURE_REPLY;
               try {
@@ -624,16 +658,22 @@ export class ChatController {
               } catch (persistErr) {
                 logger.error('Failed to persist intent-agent failure copy', { sessionId, error: persistErr });
               }
-            }
-            if (fullResponse) {
-              controller.enqueue(
-                encoder.encode(formatSSEEvent(createTokenEvent(sessionId, fullResponse))),
-              );
+              try {
+                controller.enqueue(
+                  encoder.encode(formatSSEEvent(createTokenEvent(sessionId, fullResponse))),
+                );
+              } catch {
+                // Stream may have already closed.
+              }
+            } finally {
+              unsubscribeReply?.();
             }
           }
 
-          // Use context-aware streaming to load previous messages
-          const orchestratorEvents = agentOwnsTurn
+          // Use context-aware streaming to load previous messages. An
+          // agent-owned turn has no factory (checked above): its stream is
+          // empty so one path runs persistence, title, suggestions and done.
+          const orchestratorEvents = !factory || agentOwnsTurn
             ? emptyEventStream()
             : factory.streamChatEventsWithContext(
               {

--- a/services/api/src/controllers/tests/chat.negotiator.isolated.ts
+++ b/services/api/src/controllers/tests/chat.negotiator.isolated.ts
@@ -8,8 +8,11 @@
  *   persona='negotiator', title = the signal)
  * - negotiator sessions are excluded from the default /chat/sessions listing,
  *   and ?persona=negotiator no longer selects them
- * - streaming a negotiator session runs on the negotiator persona factory
- *   (client-scoped, loop behaviors off) and persists the turn
+ * - streaming a negotiator session runs the signal's IntentAgent on its
+ *   serialized inbox (phase 2 full chat ownership) — the persona graph is
+ *   never derived for this scope — relays the turn's streamed reply chunks
+ *   as token events, falls back to the completed text on a silent channel,
+ *   and answers a failed turn with fixed honest copy
  * - network scope and persona/session mismatches are rejected; conversations
  *   preserved from the removed unscoped DM are read-only
  *
@@ -29,6 +32,9 @@ import type { ChatGraphFactory, ChatPersonaConfig } from "@indexnetwork/protocol
 import db from "../../lib/drizzle/drizzle";
 import { agents, chatSessionScopes, conversationParticipants, conversations, intents } from "../../schemas/database.schema";
 import type { AuthenticatedUser } from "../../guards/auth.guard";
+import { INTENT_AGENT_TURN_FAILURE_REPLY } from "../chat.controller";
+import { publishIntentAgentReplyChunk } from "../../lib/intent-agent/intent-agent-reply.stream";
+import type { IntentAgentTurnResult, IntentAgentUserMessageEvent } from "../../lib/intent-agent/intent-agent.types";
 
 const EMAIL = "test-chat-negotiator@example.com";
 
@@ -59,6 +65,18 @@ describe("Negotiator chat persona (IND-402)", () => {
       yield { type: "response_complete", response: "Here is the record." };
     },
   } as unknown as ChatGraphFactory;
+
+  /** Events the controller handed to the IntentAgent seam. */
+  const agentTurnEvents: IntentAgentUserMessageEvent[] = [];
+  /** Scripted per test; the default echoes an empty turn. */
+  let scriptedAgentTurn: (event: IntentAgentUserMessageEvent) => Promise<IntentAgentTurnResult> =
+    async () => ({ acts: [], messages: [] });
+
+  /** Parse the SSE body into its JSON events. */
+  const sseEvents = (body: string): Array<Record<string, unknown>> => body
+    .split("\n")
+    .filter((line) => line.startsWith("data: "))
+    .map((line) => JSON.parse(line.slice("data: ".length)) as Record<string, unknown>);
 
   const mockUser = (): AuthenticatedUser => ({
     id: testUserId,
@@ -104,7 +122,13 @@ describe("Negotiator chat persona (IND-402)", () => {
     testIntentId = intent.id;
 
     chatSessionService.setFactory(stubFactory);
-    controller = new ChatController(() => ({ generate: async () => [] }) as never);
+    controller = new ChatController(
+      () => ({ generate: async () => [] }) as never,
+      (event) => {
+        agentTurnEvents.push(event);
+        return scriptedAgentTurn(event);
+      },
+    );
   }, 30_000);
 
   afterAll(async () => {
@@ -273,10 +297,18 @@ describe("Negotiator chat persona (IND-402)", () => {
     process.env.NEGOTIATOR_CHAT_ENABLED = 'true';
   }, 60000);
 
-  test("streaming persona=negotiator with intent scope resolves the pinned session and seeds the scope + prompt pin", async () => {
+  // Phase 2 (full chat ownership): every intent-scoped negotiator turn runs
+  // the IntentAgent on its serialized inbox; the persona graph — and with it
+  // the persona's chat tool registrations — is never derived for this scope.
+  test("streaming persona=negotiator with intent scope runs the IntentAgent, never the persona factory", async () => {
     process.env.NEGOTIATOR_CHAT_ENABLED = 'true';
     capturedPersonas.length = 0;
     capturedStreamInputs.length = 0;
+    agentTurnEvents.length = 0;
+    scriptedAgentTurn = async (event) => ({
+      acts: [{ tool: 'message_user', text: 'One match is waiting on you.', sessionId: event.sessionId, messageId: 'assistant-1', stage: 'reply' }],
+      messages: ['One match is waiting on you.'],
+    });
 
     const res = await controller.messageStream(
       streamReq({
@@ -288,42 +320,44 @@ describe("Negotiator chat persona (IND-402)", () => {
       mockUser(),
     );
     expect(res.status).toBe(200);
-    await res.text();
+    const body = await res.text();
 
     const pinned = (await conversationDatabaseAdapter.getNegotiatorIntentChatSession(testUserId, testIntentId))!;
     expect(res.headers.get("X-Session-Id")).toBe(pinned.id);
 
-    // Negotiator persona factory with the intent scope threaded to the graph.
-    expect(capturedPersonas.length).toBe(1);
-    expect(capturedPersonas[0].id).toBe("negotiator");
-    expect(capturedStreamInputs.length).toBe(1);
-    expect(capturedStreamInputs[0].scopeType).toBe("intent");
-    expect(capturedStreamInputs[0].scopeId).toBe(testIntentId);
+    // Ownership is unconditional: the agent got the turn, the persona did not.
+    expect(capturedPersonas.length).toBe(0);
+    expect(capturedStreamInputs.length).toBe(0);
+    expect(agentTurnEvents).toHaveLength(1);
+    expect(agentTurnEvents[0]).toMatchObject({
+      kind: 'user_message',
+      userId: testUserId,
+      intentId: testIntentId,
+      sessionId: pinned.id,
+      text: "What's happening with this signal?",
+    });
 
-    // The prompt pins the signal (id + human-readable label) when built with
-    // an intent-scoped context.
-    const prompt = capturedPersonas[0].buildSystemContent(
-      {
-        userId: testUserId,
-        userName: "Test Negotiator User",
-        userEmail: EMAIL,
-        user: { id: testUserId },
-        userProfile: null,
-        userNetworks: [],
-        scopeType: "intent",
-        scopeId: testIntentId,
-      } as never,
-      { iteration: 1 } as never,
-    );
-    expect(prompt).toContain("## Pinned signal");
-    expect(prompt).toContain(testIntentId);
-    expect(prompt).toContain(INTENT_PAYLOAD);
+    // The client's message was persisted BEFORE the turn (the agent's memory).
+    const messages = await chatSessionService.getSessionMessages(pinned.id);
+    expect(messages.some((m) => m.role === 'user' && m.content === "What's happening with this signal?")).toBe(true);
+
+    // The silent channel fell back to the completed reply in one token event,
+    // and the done event carries the authoritative text.
+    const events = sseEvents(body);
+    const tokens = events.filter((e) => e.type === 'token');
+    expect(tokens.map((e) => e.content)).toEqual(['One match is waiting on you.']);
+    const done = events.find((e) => e.type === 'done') as { response: string } | undefined;
+    expect(done?.response).toBe('One match is waiting on you.');
   }, 60000);
 
-  test("streaming the pinned session by sessionId alone inherits the intent scope and negotiator persona", async () => {
+  test("streaming the pinned session by sessionId alone routes to the same agent turn", async () => {
     process.env.NEGOTIATOR_CHAT_ENABLED = 'true';
     capturedPersonas.length = 0;
-    capturedStreamInputs.length = 0;
+    agentTurnEvents.length = 0;
+    scriptedAgentTurn = async (event) => ({
+      acts: [{ tool: 'message_user', text: 'Still on it.', sessionId: event.sessionId, messageId: 'assistant-2', stage: 'reply' }],
+      messages: ['Still on it.'],
+    });
 
     const pinned = (await conversationDatabaseAdapter.getNegotiatorIntentChatSession(testUserId, testIntentId))!;
     const res = await controller.messageStream(
@@ -333,10 +367,57 @@ describe("Negotiator chat persona (IND-402)", () => {
     expect(res.status).toBe(200);
     await res.text();
 
-    expect(capturedPersonas.length).toBe(1);
-    expect(capturedPersonas[0].id).toBe("negotiator");
-    expect(capturedStreamInputs[0].scopeType).toBe("intent");
-    expect(capturedStreamInputs[0].scopeId).toBe(testIntentId);
+    expect(capturedPersonas.length).toBe(0);
+    expect(agentTurnEvents).toHaveLength(1);
+    expect(agentTurnEvents[0]).toMatchObject({ intentId: testIntentId, sessionId: pinned.id });
+  }, 60000);
+
+  test("reply chunks published on the turn's channel relay as ordered token events, with no duplicate remainder", async () => {
+    process.env.NEGOTIATOR_CHAT_ENABLED = 'true';
+    agentTurnEvents.length = 0;
+    scriptedAgentTurn = async (event) => {
+      // The host's shape: chunks published (post-check, post-persist) before
+      // the job resolves, concatenating to exactly the joined messages.
+      await publishIntentAgentReplyChunk(event.messageId, { seq: 1, content: 'Declined that match. ' });
+      await publishIntentAgentReplyChunk(event.messageId, { seq: 2, content: 'Nothing else needs you.' });
+      return {
+        acts: [{ tool: 'message_user', text: 'Declined that match. Nothing else needs you.', sessionId: event.sessionId, messageId: 'assistant-3', stage: 'reply' }],
+        messages: ['Declined that match. Nothing else needs you.'],
+      };
+    };
+
+    const pinned = (await conversationDatabaseAdapter.getNegotiatorIntentChatSession(testUserId, testIntentId))!;
+    const res = await controller.messageStream(
+      streamReq({ message: "reject the manufacturing match", sessionId: pinned.id }),
+      mockUser(),
+    );
+    expect(res.status).toBe(200);
+    const events = sseEvents(await res.text());
+
+    const tokens = events.filter((e) => e.type === 'token').map((e) => e.content);
+    expect(tokens).toEqual(['Declined that match. ', 'Nothing else needs you.']);
+    const done = events.find((e) => e.type === 'done') as { response: string } | undefined;
+    expect(done?.response).toBe('Declined that match. Nothing else needs you.');
+  }, 60000);
+
+  test("a failed agent turn answers with the fixed honest copy and persists it", async () => {
+    process.env.NEGOTIATOR_CHAT_ENABLED = 'true';
+    scriptedAgentTurn = async () => {
+      throw new Error('turn timed out');
+    };
+
+    const pinned = (await conversationDatabaseAdapter.getNegotiatorIntentChatSession(testUserId, testIntentId))!;
+    const res = await controller.messageStream(
+      streamReq({ message: "hello?", sessionId: pinned.id }),
+      mockUser(),
+    );
+    expect(res.status).toBe(200);
+    const events = sseEvents(await res.text());
+
+    const tokens = events.filter((e) => e.type === 'token').map((e) => e.content);
+    expect(tokens).toEqual([INTENT_AGENT_TURN_FAILURE_REPLY]);
+    const messages = await chatSessionService.getSessionMessages(pinned.id);
+    expect(messages.at(-1)).toMatchObject({ role: 'assistant', content: INTENT_AGENT_TURN_FAILURE_REPLY });
   }, 60000);
 
   // ── Conversations preserved from the removed unscoped DM ──────────────

--- a/services/api/src/lib/agent/negotiator-verdict.host.ts
+++ b/services/api/src/lib/agent/negotiator-verdict.host.ts
@@ -103,6 +103,13 @@ export interface NegotiatorVerdictInput {
   reason?: string;
 }
 
+/** Verdict named by opportunity id — the IntentAgent's lane (phase 2). */
+export interface NegotiatorVerdictByIdInput {
+  intentId: string;
+  opportunityId: string;
+  reason?: string;
+}
+
 const asTime = (value: Date | string): number => {
   const ms = value instanceof Date ? value.getTime() : Date.parse(value);
   return Number.isFinite(ms) ? ms : 0;
@@ -172,6 +179,70 @@ export async function readActionableCounterparties(
 }
 
 /**
+ * Execute one verdict on a counterparty already resolved from the actionable
+ * list. Shared by the position lane (persona/MCP tools) and the id lane (the
+ * IntentAgent's acts) so there is exactly one write path and one honest
+ * classification of its failures.
+ */
+async function executeVerdictOn(
+  userId: string,
+  intentId: string,
+  chosen: ActionableCounterparty,
+  target: 'rejected' | 'accepted',
+  relist: () => Extract<NegotiatorVerdictResult, { status: 'unknown_counterparty' }>,
+  deps?: NegotiatorVerdictHostDeps,
+  reason?: string,
+): Promise<NegotiatorVerdictResult> {
+    // The Radar's Skip/Start-Chat path, called exactly as the REST controller
+    // calls it. The intent scope is not decoration: it re-checks that the
+    // pairing really belongs to the signal this DM is pinned to, and it keeps
+    // the accept from cascading onto sibling opportunities — the same
+    // narrowing the intent-scoped Radar applies.
+    //
+    // `actionProvenance` is deliberately NOT passed. That field marks a verified
+    // first-party owner CLICK for outcome capture (IND-434); a verdict spoken to
+    // an agent is a real owner decision but a model-mediated one, and a
+    // misheard "not this one" must not become a mined preference label.
+    const update = deps?.updateStatus
+      ?? ((opportunityId: string, status: OpportunityStatus, uid: string, options: { scopeType: 'intent'; scopeId: string }) =>
+        opportunityService.updateOpportunityStatus(opportunityId, status, uid, options));
+  const result = await update(chosen.opportunityId, target, userId, {
+    scopeType: 'intent',
+    scopeId: intentId,
+  }) as { error?: string; status?: number } | null;
+
+  if (result && typeof result === 'object' && 'error' in result && result.error) {
+    // 409 is the self-accept guard: this client already committed, so it is
+    // the other side's move. 403/404 means the pairing left the actionable
+    // set between the list being rendered and this call — nothing was
+    // decided, and re-listing is more use to the client than an error.
+    if (result.status === 409) return { status: 'already_decided', counterparty: chosen.name };
+    if (result.status === 403 || result.status === 404) return relist();
+    logger.error('negotiator_verdict_rejected_by_service', {
+      userId,
+      intentId,
+      opportunityId: chosen.opportunityId,
+      target,
+      serviceStatus: result.status,
+      error: result.error,
+    });
+    return { status: 'error' };
+  }
+
+  logger.info('negotiator_verdict_executed', {
+    userId,
+    intentId,
+    opportunityId: chosen.opportunityId,
+    target,
+    // The client's own words, when they gave any. There is no column for a
+    // verdict reason on the owner path, and inventing one would be a new
+    // write this lane has no mandate for — so the log is the record.
+    ...(reason ? { reason } : {}),
+  });
+  return { status: 'executed', counterparty: chosen.name };
+}
+
+/**
  * Execute one verdict on the number the client's agent named.
  *
  * Never throws — a tool that throws costs the client their turn, and the
@@ -204,58 +275,63 @@ async function passVerdict(
       return relist();
     }
 
-    // The Radar's Skip/Start-Chat path, called exactly as the REST controller
-    // calls it. The intent scope is not decoration: it re-checks that the
-    // pairing really belongs to the signal this DM is pinned to, and it keeps
-    // the accept from cascading onto sibling opportunities — the same
-    // narrowing the intent-scoped Radar applies.
-    //
-    // `actionProvenance` is deliberately NOT passed. That field marks a verified
-    // first-party owner CLICK for outcome capture (IND-434); a verdict spoken to
-    // an agent is a real owner decision but a model-mediated one, and a
-    // misheard "not this one" must not become a mined preference label.
-    const update = deps?.updateStatus
-      ?? ((opportunityId: string, status: OpportunityStatus, uid: string, options: { scopeType: 'intent'; scopeId: string }) =>
-        opportunityService.updateOpportunityStatus(opportunityId, status, uid, options));
-    const result = await update(chosen.opportunityId, target, userId, {
-      scopeType: 'intent',
-      scopeId: input.intentId,
-    }) as { error?: string; status?: number } | null;
-
-    if (result && typeof result === 'object' && 'error' in result && result.error) {
-      // 409 is the self-accept guard: this client already committed, so it is
-      // the other side's move. 403/404 means the pairing left the actionable
-      // set between the list being rendered and this call — nothing was
-      // decided, and re-listing is more use to the client than an error.
-      if (result.status === 409) return { status: 'already_decided', counterparty: chosen.name };
-      if (result.status === 403 || result.status === 404) return relist();
-      logger.error('negotiator_verdict_rejected_by_service', {
-        userId,
-        intentId: input.intentId,
-        opportunityId: chosen.opportunityId,
-        target,
-        serviceStatus: result.status,
-        error: result.error,
-      });
-      return { status: 'error' };
-    }
-
-    logger.info('negotiator_verdict_executed', {
-      userId,
-      intentId: input.intentId,
-      opportunityId: chosen.opportunityId,
-      target,
-      // The client's own words, when they gave any. There is no column for a
-      // verdict reason on the owner path, and inventing one would be a new
-      // write this lane has no mandate for — so the log is the record.
-      ...(input.reason ? { reason: input.reason } : {}),
-    });
-    return { status: 'executed', counterparty: chosen.name };
+    return await executeVerdictOn(userId, input.intentId, chosen, target, relist, deps, input.reason);
   } catch (err) {
     logger.error('negotiator_verdict_failed', {
       userId,
       intentId: input.intentId,
       counterparty: input.counterparty,
+      target,
+      error: err instanceof Error ? err.message : String(err),
+    });
+    return { status: 'error' };
+  }
+}
+
+/**
+ * Execute one verdict on an opportunity the caller already holds the id of —
+ * the IntentAgent's lane (phase 2). The agent's context numbered THIS list
+ * (the same reader) and its validator resolved the number to the id, so the
+ * id re-checks membership here rather than trusting the earlier read: an
+ * opportunity that left the actionable set between context assembly and this
+ * call gets a re-list, exactly as a stale position does on the tool lane.
+ *
+ * Never throws — the act's outcome is ledgered either way, and an honest
+ * failure beats a lost turn.
+ */
+export async function passVerdictOnOpportunity(
+  userId: string,
+  input: NegotiatorVerdictByIdInput,
+  target: 'rejected' | 'accepted',
+  deps?: NegotiatorVerdictHostDeps,
+): Promise<NegotiatorVerdictResult> {
+  try {
+    const actionable = await readActionableCounterparties(userId, input.intentId, deps);
+    if (actionable.length === 0) return { status: 'none_actionable' };
+
+    const relist = () => ({
+      status: 'unknown_counterparty' as const,
+      count: actionable.length,
+      actionable: actionable.map((candidate) => candidate.label),
+    });
+
+    const chosen = actionable.find((candidate) => candidate.opportunityId === input.opportunityId);
+    if (!chosen) {
+      logger.info('negotiator_verdict_opportunity_left_actionable_set', {
+        userId,
+        intentId: input.intentId,
+        opportunityId: input.opportunityId,
+        actionable: actionable.length,
+      });
+      return relist();
+    }
+
+    return await executeVerdictOn(userId, input.intentId, chosen, target, relist, deps, input.reason);
+  } catch (err) {
+    logger.error('negotiator_verdict_failed', {
+      userId,
+      intentId: input.intentId,
+      opportunityId: input.opportunityId,
       target,
       error: err instanceof Error ? err.message : String(err),
     });

--- a/services/api/src/lib/agent/tests/negotiator-verdict.wiring.static.spec.ts
+++ b/services/api/src/lib/agent/tests/negotiator-verdict.wiring.static.spec.ts
@@ -26,7 +26,8 @@ import { readFileSync } from 'node:fs';
 const read = (relative: string) => readFileSync(new URL(relative, import.meta.url), 'utf8');
 
 const composition = read('../../../controllers/mcp.controller.ts');
-const chatService = read('../../../services/chat.service.ts');
+const agentContext = read('../../intent-agent/intent-agent.context.ts');
+const agentHost = read('../../intent-agent/intent-agent.host.ts');
 const main = read('../../../main.ts');
 const persona = read('../../../../../../packages/protocol/src/chat/negotiator.persona.ts');
 const host = read('../negotiator-verdict.host.ts');
@@ -39,22 +40,26 @@ describe('owner-verdict wiring', () => {
     expect(composition).not.toMatch(/isNegotiatorVerdict\w*Enabled/);
   });
 
-  it('registers the tools only in an intent-pinned session with the host injected', () => {
+  it('keeps the MCP surface registered on the shared host — the persona registration is chat-dead, not the lane', () => {
+    // Phase 2 retired the negotiator persona from chat, and with it the
+    // persona-side tool registration; the claude.ai connector's path is a
+    // DIFFERENT registration (McpToolDeps) and must keep working.
+    expect(composition).toContain('negotiatorVerdictTools: protocolDeps.negotiatorVerdictTools');
+    // The protocol persona module still gates on a pinned intent; it simply
+    // has no chat caller any more (cleanup deferred to a protocol lane).
     expect(persona).toContain('if (deps.negotiatorVerdictTools && pinnedIntentId) {');
-    expect(persona).toContain('createNegotiatorVerdictTools({');
   });
 
-  it('feeds the prompt from the same reader the host maps against', () => {
+  it('feeds the agent context from the same reader the host maps against', () => {
     // One ordering, two consumers. A second enumeration would be a second
     // order, and the number the client's agent read would resolve elsewhere.
-    expect(chatService).toContain("import { readActionableCounterparties } from '../lib/agent/negotiator-verdict.host'");
-    expect(chatService).toContain('await readActionableCounterparties(userId, pinnedIntent.intentId)');
-    expect(chatService).toContain('actionableCounterparties: actionableCounterparties.map((counterparty) => counterparty.label)');
+    // Phase 2 (full chat ownership) moved the chat consumer from the retired
+    // persona prompt into the IntentAgent's turn context — same reader, and
+    // the acts execute back through this host's id-keyed lane.
+    expect(agentContext).toContain('.readActionableCounterparties(id, intent)');
+    expect(agentHost).toContain('passVerdictOnOpportunity(userId, input, target');
     expect(host).toContain('export async function readActionableCounterparties');
-  });
-
-  it('offers verdicts only for a pinned signal', () => {
-    expect(chatService).toContain('const actionableCounterparties = pinnedIntent?.intentId');
+    expect(host).toContain('export async function passVerdictOnOpportunity');
   });
 
   it('executes the verdict through the same owner status path the Radar card uses', () => {

--- a/services/api/src/lib/intent-agent/intent-agent-reply.stream.ts
+++ b/services/api/src/lib/intent-agent/intent-agent-reply.stream.ts
@@ -1,0 +1,127 @@
+/**
+ * Token transport for the IntentAgent's streaming reply stage (phase 2 of
+ * docs/plans/2026-08-21-holistic-intent-agent.md).
+ *
+ * The turn runs on the inbox worker — serialization stays THE inbox — so the
+ * reply's chunks cross back to the waiting chat controller over Redis
+ * pub/sub, on a channel keyed by the same message id that keys the inbox
+ * job (prior art: `lib/conversation-events.ts` publishes conversation events
+ * on user-scoped channels the same way). The controller subscribes BEFORE
+ * enqueueing and forwards chunks as SSE token events; if the subscription
+ * yields nothing but the job completes, it falls back to emitting the
+ * completed reply in one token event — a turn is never lost to a dropped
+ * channel, because the channel is a latency optimization and the job result
+ * is the truth.
+ *
+ * Chunks are published only AFTER the reply passed the prose-safety check
+ * and was persisted (check-then-stream — see intent-agent.turn.ts `reply`):
+ * nothing unchecked ever crosses this transport.
+ *
+ * In hermetic test mode (the same `useHermeticRedis()` guard the queue
+ * factory applies) the transport is an in-process emitter, so controller and
+ * worker specs exercise the real subscribe→publish→relay path without Redis.
+ */
+import { EventEmitter } from 'events';
+
+import { useHermeticRedis } from '../bullmq/bullmq';
+import { log } from '../log';
+
+const logger = log.lib.from('intent-agent-reply.stream');
+
+/** One ordered slice of the checked reply. `seq` starts at 1 per turn. */
+export interface IntentAgentReplyChunk {
+  seq: number;
+  content: string;
+}
+
+export function intentAgentReplyChannel(messageId: string): string {
+  return `intent-agent:reply:${messageId}`;
+}
+
+const hermeticBus = new EventEmitter();
+hermeticBus.setMaxListeners(200);
+
+/**
+ * Publish one chunk toward whichever controller is streaming this turn.
+ * Never throws — the job result is the durable truth and a publish failure
+ * must not fail the turn; the controller's fallback covers the gap.
+ */
+export async function publishIntentAgentReplyChunk(
+  messageId: string,
+  chunk: IntentAgentReplyChunk,
+): Promise<void> {
+  const channel = intentAgentReplyChannel(messageId);
+  try {
+    if (useHermeticRedis()) {
+      hermeticBus.emit(channel, JSON.stringify(chunk));
+      return;
+    }
+    const { getRedisClient } = await import('../../adapters/cache.adapter');
+    await getRedisClient().publish(channel, JSON.stringify(chunk));
+  } catch (err) {
+    logger.warn('intent_agent_reply_publish_failed', {
+      messageId,
+      seq: chunk.seq,
+      error: err instanceof Error ? err.message : String(err),
+    });
+  }
+}
+
+/**
+ * Subscribe to a turn's reply chunks. Resolves once the subscription is
+ * established (subscribe BEFORE enqueueing the turn); the returned cleanup
+ * is idempotent and must run in the stream's finally. Malformed payloads are
+ * dropped — the fallback path owns completeness, this path owns latency.
+ */
+export async function subscribeIntentAgentReply(
+  messageId: string,
+  onChunk: (chunk: IntentAgentReplyChunk) => void,
+): Promise<() => void> {
+  const channel = intentAgentReplyChannel(messageId);
+  const handle = (data: string) => {
+    try {
+      const parsed = JSON.parse(data) as IntentAgentReplyChunk;
+      if (typeof parsed?.seq === 'number' && typeof parsed?.content === 'string') onChunk(parsed);
+    } catch {
+      // Malformed chunk: drop; the job-result fallback delivers the reply.
+    }
+  };
+
+  if (useHermeticRedis()) {
+    hermeticBus.on(channel, handle);
+    return () => hermeticBus.off(channel, handle);
+  }
+
+  const { createRedisClient } = await import('../../adapters/cache.adapter');
+  const subscriber = createRedisClient();
+  let cancelled = false;
+  subscriber.on('message', (incoming: string, data: string) => {
+    if (!cancelled && incoming === channel) handle(data);
+  });
+  try {
+    await subscriber.subscribe(channel);
+  } catch (err) {
+    // A failed subscribe is a degraded turn, not a lost one: the caller's
+    // fallback emits the completed reply from the job result.
+    logger.warn('intent_agent_reply_subscribe_failed', {
+      messageId,
+      error: err instanceof Error ? err.message : String(err),
+    });
+  }
+  return () => {
+    if (cancelled) return;
+    cancelled = true;
+    subscriber.unsubscribe(channel).then(() => subscriber.disconnect()).catch(() => subscriber.disconnect());
+  };
+}
+
+/**
+ * Split a checked reply into sentence-sized chunks for progressive rendering.
+ * Purely presentational: the text is already complete, checked, and
+ * persisted when this runs (check-then-stream), so the split can never
+ * change what the client ultimately reads.
+ */
+export function chunkReplyText(text: string): string[] {
+  const chunks = text.match(/[^.!?\n]*[.!?\n]+[)"'”’]*\s*|[^.!?\n]+$/g);
+  return chunks && chunks.length > 0 ? chunks : [text];
+}

--- a/services/api/src/lib/intent-agent/intent-agent.context.ts
+++ b/services/api/src/lib/intent-agent/intent-agent.context.ts
@@ -8,6 +8,7 @@
  * conduct. Nothing here is cached or carried between turns.
  */
 import type { ParkedNegotiation } from '../../adapters/parked-negotiation.reader.adapter';
+import type { ActionableCounterparty } from '../agent/negotiator-verdict.host';
 import type { IntentDossierEntryRow } from '../../adapters/intent-dossier.adapter';
 import type { IntentAgentLedgerRow } from '../../adapters/intent-agent-ledger.adapter';
 import type { IntentAgentInboxEvent } from './intent-agent.types';
@@ -15,6 +16,13 @@ import type { IntentAgentInboxEvent } from './intent-agent.types';
 /** How much conversation memory a turn reads. */
 const MAX_DM_MESSAGES = 20;
 const MAX_LEDGER_ACTS = 20;
+/**
+ * How many active matches a turn sees. Bounded so a prolific signal cannot
+ * flood the prompt; the newest matches are kept because they are the ones a
+ * verdict or a status question is most likely about, and what is dropped is
+ * logged so the truncation is never silent.
+ */
+const MAX_OPPORTUNITIES = 12;
 
 export interface IntentAgentTurnContext {
   event: IntentAgentInboxEvent;
@@ -24,6 +32,14 @@ export interface IntentAgentTurnContext {
   parked: ParkedNegotiation[];
   /** Active dossier entries, oldest first — the numbered list. */
   dossier: IntentDossierEntryRow[];
+  /**
+   * This signal's active matches (statuses a verdict can still land on),
+   * oldest first — the numbered list verdict acts refer to. Served by the
+   * SAME reader the #1471 verdict tools use, so the state the agent reasons
+   * over is the state the verdict host would act on. Bounded to
+   * MAX_OPPORTUNITIES, keeping the newest.
+   */
+  opportunities: ActionableCounterparty[];
   /** Recent DM transcript, oldest first. */
   recentDm: Array<{ role: string; content: string }>;
   /** The agent's own recent acts, newest first. */
@@ -34,6 +50,7 @@ export interface IntentAgentTurnContext {
 export interface IntentAgentContextDeps {
   readParkedNegotiations?: (userId: string, intentId: string) => Promise<ParkedNegotiation[]>;
   readDossier?: (userId: string, intentId: string) => Promise<IntentDossierEntryRow[]>;
+  readOpportunities?: (userId: string, intentId: string) => Promise<ActionableCounterparty[]>;
   readLedger?: (userId: string, intentId: string, limit: number) => Promise<IntentAgentLedgerRow[]>;
   findSession?: (userId: string, intentId: string) => Promise<{ id: string } | null>;
   getSessionMessages?: (sessionId: string) => Promise<Array<{ role: string; content: string }>>;
@@ -52,6 +69,11 @@ export async function assembleIntentAgentContext(
   const readDossier = deps?.readDossier
     ?? (async (id: string, intent: string) => (await import('../../adapters/intent-dossier.adapter'))
       .intentDossierAdapter.readActiveEntries(id, intent));
+  // The verdict reader never throws (an unreadable list reads as "no
+  // verdicts to offer") — the same degradation the persona prompt used.
+  const readOpportunities = deps?.readOpportunities
+    ?? (async (id: string, intent: string) => (await import('../agent/negotiator-verdict.host'))
+      .readActionableCounterparties(id, intent));
   const readLedger = deps?.readLedger
     ?? (async (id: string, intent: string, limit: number) => (await import('../../adapters/intent-agent-ledger.adapter'))
       .intentAgentLedgerAdapter.readRecent(id, intent, limit));
@@ -61,12 +83,27 @@ export async function assembleIntentAgentContext(
     return intent?.payload ?? null;
   });
 
-  const [parked, dossier, recentActs, signalText] = await Promise.all([
+  const [parked, dossier, allOpportunities, recentActs, signalText] = await Promise.all([
     readParked(userId, intentId),
     readDossier(userId, intentId),
+    readOpportunities(userId, intentId),
     readLedger(userId, intentId, MAX_LEDGER_ACTS),
     getIntentText(intentId).catch(() => null),
   ]);
+
+  // Bounded, keeping the newest (the reader lists oldest first). The agent's
+  // numbers are context-relative — its validator resolves them to ids — so
+  // truncation renumbers nothing anywhere else.
+  const opportunities = allOpportunities.slice(-MAX_OPPORTUNITIES);
+  if (allOpportunities.length > opportunities.length) {
+    const { log } = await import('../log');
+    log.lib.from('intent-agent.context').warn('intent_agent_context_opportunities_truncated', {
+      userId,
+      intentId,
+      total: allOpportunities.length,
+      kept: opportunities.length,
+    });
+  }
 
   // The DM may not exist yet (a park can fire before the client ever opened
   // this signal's conversation). The transcript read degrades to empty; the
@@ -93,5 +130,5 @@ export async function assembleIntentAgentContext(
     }
   })();
 
-  return { event, signalText, parked: [...parked], dossier, recentDm, recentActs };
+  return { event, signalText, parked: [...parked], dossier, opportunities, recentDm, recentActs };
 }

--- a/services/api/src/lib/intent-agent/intent-agent.host.ts
+++ b/services/api/src/lib/intent-agent/intent-agent.host.ts
@@ -17,37 +17,15 @@
 import { resumeParkedNegotiation } from '@indexnetwork/protocol';
 import type { NegotiationAnswerConsumptionPorts } from '@indexnetwork/protocol';
 
+import { chunkReplyText, publishIntentAgentReplyChunk } from './intent-agent-reply.stream';
+import type { NegotiatorVerdictResult } from '../agent/negotiator-verdict.host';
 import { assembleIntentAgentContext } from './intent-agent.context';
 import type { IntentAgentContextDeps, IntentAgentTurnContext } from './intent-agent.context';
 import { IntentAgentTurn } from './intent-agent.turn';
-import type { IntentAgentDecidedAct, IntentAgentEvent, IntentAgentExecutedAct, IntentAgentInboxEvent, IntentAgentTurnResult } from './intent-agent.types';
+import type { IntentAgentDecidedAct, IntentAgentEvent, IntentAgentExecutedAct, IntentAgentInboxEvent, IntentAgentReplyFallbackReason, IntentAgentTurnResult, IntentAgentUserMessageEvent } from './intent-agent.types';
 import { log } from '../log';
 
 const logger = log.lib.from('intent-agent.host');
-
-/**
- * Whether the signal's IntentAgent owns a DM turn: true while a negotiation
- * is parked awaiting this client on this signal
- * (docs/plans/2026-08-21-holistic-intent-agent.md, "Answer side"). A cheap
- * honest read, not judgment — whether a message ANSWERS anything is the
- * agent's call, made inside its serialized turn. Never throws: an unreadable
- * parked set falls through to the persona, exactly as the retired
- * answer-precedence gate failed open.
- */
-export async function intentAgentOwnsTurn(userId: string, intentId: string): Promise<boolean> {
-  try {
-    const { parkedNegotiationReaderAdapter } = await import('../../adapters/parked-negotiation.reader.adapter');
-    const parked = await parkedNegotiationReaderAdapter.readParkedNegotiations(userId, intentId);
-    return parked.length > 0;
-  } catch (err) {
-    logger.error('intent_agent_turn_ownership_read_failed; falling through to the persona', {
-      userId,
-      intentId,
-      error: err instanceof Error ? err.message : String(err),
-    });
-    return false;
-  }
-}
 
 /**
  * Fixed honest copy for an answer heard on a park whose negotiation cannot
@@ -62,12 +40,15 @@ export const INTENT_AGENT_UNRESUMABLE_MESSAGE =
   + 'I can propose re-running discovery under your updated signal.';
 
 /**
- * Backstop reply for the impossible case rule 8 forbids: the client spoke
- * and the agent's acts delivered nothing back. Code-owned copy — the prompt
- * carries the judgment; this only refuses silence.
+ * Fixed honest copy delivered when the reply stage could not produce prose
+ * that passes the safety gate (fail → one retry → this), or the reply model
+ * call itself failed. Server-owned, never model text: the acts the turn
+ * executed are durable either way, so the copy says that instead of
+ * pretending nothing happened. The failure is ledgered on the act.
  */
-export const INTENT_AGENT_SILENT_TURN_REPLY =
-  'Noted — I have taken that in. Nothing on this signal needs your attention right now.';
+export const INTENT_AGENT_REPLY_FALLBACK =
+  'I acted on your message and everything I did is recorded, but I could not compose a clean reply just now. '
+  + 'Ask me where things stand and I will lay it out.';
 
 /** Structural slice of ChatSessionService the executor needs. */
 export interface IntentAgentChatSessions {
@@ -81,8 +62,16 @@ export interface IntentAgentChatSessions {
 /** Injectable seams; production resolves the real collaborators lazily. */
 export interface IntentAgentHostDeps {
   context?: IntentAgentContextDeps;
-  turn?: Pick<IntentAgentTurn, 'decide'>;
+  turn?: Pick<IntentAgentTurn, 'decide'> & Partial<Pick<IntentAgentTurn, 'reply'>>;
   chatSessions?: IntentAgentChatSessions;
+  /** The #1471 verdict lane, by opportunity id; production is the shared host. */
+  verdict?: (
+    userId: string,
+    input: { intentId: string; opportunityId: string; reason?: string },
+    target: 'accepted' | 'rejected',
+  ) => Promise<NegotiatorVerdictResult>;
+  /** Reply-chunk publisher; production is the Redis transport. */
+  publishReplyChunk?: typeof publishIntentAgentReplyChunk;
   dossier?: {
     addEntry(input: { userId: string; intentId: string; text: string; source: 'user_message' | 'answer' | 'agent_note' }): Promise<string>;
     retireEntry(input: { userId: string; entryId: string }): Promise<boolean>;
@@ -235,6 +224,31 @@ export async function executeIntentAgentActs(
         result.acts.push(executed);
         break;
       }
+      case 'accept_opportunity':
+      case 'reject_opportunity': {
+        // The client's explicit word, executing through the SAME #1471 host
+        // the persona tools and the MCP surface call — one write path, one
+        // classification. Nothing here re-decides explicitness: that law is
+        // the prompt's, pinned by the live eval.
+        const verdict = deps?.verdict
+          ?? (async (userId: string, input: { intentId: string; opportunityId: string; reason?: string }, target: 'accepted' | 'rejected') =>
+            (await import('../agent/negotiator-verdict.host')).passVerdictOnOpportunity(userId, input, target, undefined));
+        const outcome = await verdict(
+          event.userId,
+          { intentId: event.intentId, opportunityId: act.opportunityId, ...(act.reason ? { reason: act.reason } : {}) },
+          act.tool === 'accept_opportunity' ? 'accepted' : 'rejected',
+        );
+        const executed: IntentAgentExecutedAct = {
+          tool: act.tool,
+          opportunityId: act.opportunityId,
+          outcome: outcome.status,
+          ...('counterparty' in outcome ? { counterparty: outcome.counterparty } : {}),
+          ...(act.reason ? { reason: act.reason } : {}),
+        };
+        await appendLedger(event, executed, deps);
+        result.acts.push(executed);
+        break;
+      }
       case 'note_dossier': {
         const dossier = await resolveDossier(deps);
         const entryId = await dossier.addEntry({
@@ -265,14 +279,9 @@ export async function executeIntentAgentActs(
     }
   }
 
-  // Rule 8's backstop: the client spoke, so the client hears back. Code-owned
-  // copy, not ledgered as an agent act — the agent's decision (whatever it
-  // was) is already on the ledger above.
-  if (event.kind === 'user_message' && result.messages.length === 0) {
-    const delivered = await deliverMessage(event, INTENT_AGENT_SILENT_TURN_REPLY, deps);
-    if (delivered) result.messages.push(INTENT_AGENT_SILENT_TURN_REPLY);
-  }
-
+  // Phase 2: a client message is always followed by the reply stage
+  // (runIntentAgentTurn), which guarantees the client hears back — the old
+  // rule-8 backstop's job, now owned by the stage that composes the reply.
   return result;
 }
 
@@ -283,8 +292,94 @@ function getDefaultTurn(): IntentAgentTurn {
 }
 
 /**
+ * The reply stage (phase 2): a client-message turn always ends with the
+ * agent's conversational reply — composed by a second model call over the
+ * same context plus the just-executed acts, checked (isSafeQuestionMessage-
+ * Prose, fail → one retry inside `reply`) BEFORE it is persisted or a single
+ * chunk leaves the host. A reply the model could not produce safely becomes
+ * the fixed fallback copy, and the failure is ledgered on the act — never a
+ * thrown error: the acts already executed, and re-running them to retry
+ * prose would trade a wording problem for duplicate effects.
+ */
+async function runReplyStage(
+  event: IntentAgentUserMessageEvent,
+  context: IntentAgentTurnContext,
+  turn: NonNullable<IntentAgentHostDeps['turn']>,
+  result: IntentAgentTurnResult,
+  deps?: IntentAgentHostDeps,
+): Promise<void> {
+  let text: string | null = null;
+  let fallback: IntentAgentReplyFallbackReason | undefined;
+  if (!turn.reply) {
+    // An injected judgment seam without a reply seam cannot compose one.
+    fallback = 'model_error';
+  } else {
+    try {
+      text = await turn.reply(context, result.acts);
+      if (text === null) fallback = 'safety_check_failed';
+    } catch (err) {
+      logger.error('intent_agent_reply_stage_failed', {
+        userId: event.userId,
+        intentId: event.intentId,
+        error: err instanceof Error ? err.message : String(err),
+      });
+      fallback = 'model_error';
+    }
+  }
+  if (fallback) {
+    logger.warn('intent_agent_reply_fell_back', {
+      userId: event.userId,
+      intentId: event.intentId,
+      reason: fallback,
+    });
+  }
+
+  const content = text ?? INTENT_AGENT_REPLY_FALLBACK;
+  const delivered = await deliverMessage(event, content, deps);
+  if (!delivered) return;
+  const executed: IntentAgentExecutedAct = {
+    tool: 'message_user',
+    text: content,
+    ...delivered,
+    stage: 'reply',
+    ...(fallback ? { fallback } : {}),
+  };
+  await appendLedger(event, executed, deps);
+  result.acts.push(executed);
+  result.messages.push(content);
+}
+
+/**
+ * Stream a completed client-message turn's delivered messages to whichever
+ * controller is waiting, as ordered chunks on the turn's channel. Runs only
+ * AFTER everything is checked and persisted (check-then-stream); joining the
+ * chunks reproduces `result.messages.join('\n\n')` exactly, so the
+ * controller's fallback and the stream can never disagree about the text.
+ */
+async function publishTurnMessages(
+  event: IntentAgentUserMessageEvent,
+  result: IntentAgentTurnResult,
+  deps?: IntentAgentHostDeps,
+): Promise<void> {
+  if (result.messages.length === 0) return;
+  const publish = deps?.publishReplyChunk ?? publishIntentAgentReplyChunk;
+  let seq = 0;
+  for (const [index, message] of result.messages.entries()) {
+    const prefixed = index > 0 ? `\n\n${message}` : message;
+    for (const content of chunkReplyText(prefixed)) {
+      seq += 1;
+      await publish(event.messageId, { seq, content });
+    }
+  }
+}
+
+/**
  * The loop, whole: event → assemble context → one judgment → execute the
- * acts. This is what the inbox worker runs, one event at a time per intent.
+ * acts — and, for a client message, the streaming reply stage (phase 2).
+ * Background events (`negotiation_needs_input`) skip the reply stage: no
+ * client is waiting, and the acts stage keeps `message_user` for authoring
+ * asks exactly as phase 1. This is what the inbox worker runs, one event at
+ * a time per intent.
  */
 export async function runIntentAgentTurn(
   event: IntentAgentInboxEvent,
@@ -299,5 +394,10 @@ export async function runIntentAgentTurn(
     event: event.kind,
     acts: decided.map((act) => act.tool),
   });
-  return executeIntentAgentActs(event, decided, deps);
+  const result = await executeIntentAgentActs(event, decided, deps);
+  if (event.kind === 'user_message') {
+    await runReplyStage(event, context, turn, result, deps);
+    await publishTurnMessages(event, result, deps);
+  }
+  return result;
 }

--- a/services/api/src/lib/intent-agent/intent-agent.prompt.ts
+++ b/services/api/src/lib/intent-agent/intent-agent.prompt.ts
@@ -5,18 +5,25 @@
  * here. Code executes what the agent decides, refuses the impossible, and
  * records everything — it never re-decides. Change the law by shipping a new
  * version of this constant, never by branching around it.
+ *
+ * Version 2 (phase 2, full chat ownership): the agent holds EVERY turn of
+ * the signal's conversation, not just the parked ones; the verdict lane
+ * (accept/reject, #1471) becomes agent judgment under the explicit-word law;
+ * and the conversational reply moved to a second, streaming stage with its
+ * own instruction (`INTENT_AGENT_REPLY_INSTRUCTION`).
  */
 
-export const INTENT_AGENT_SYSTEM_PROMPT_VERSION = 1;
+export const INTENT_AGENT_SYSTEM_PROMPT_VERSION = 2;
 
-export const INTENT_AGENT_SYSTEM_PROMPT = `You are your client's personal agent for ONE signal — one thing they are trying to find or make happen. You conduct negotiations on their behalf, and you hold one conversation with them about this signal. You have just been woken by an event; decide what to do, then act through your tools.
+export const INTENT_AGENT_SYSTEM_PROMPT = `You are your client's personal agent for ONE signal — one thing they are trying to find or make happen. You conduct negotiations on their behalf, and you hold the WHOLE conversation with them about this signal: every message they send here comes to you, whether it is an answer, an instruction, a question, or small talk. You have just been woken by an event; decide what to do, then act through your tools.
 
 Your tools, each of which is recorded in your ledger:
-- message_user: say something to your client in this signal's conversation. Plain prose, their language, no markup blocks.
+- message_user: say something to your client in this signal's conversation. Plain prose, their language, no markup blocks. Available only when a negotiation event woke you — when your client themselves wrote to you, your reply is composed in a separate step after your acts, so do not use this tool then.
 - answer_negotiation: resolve what a waiting negotiation asked for, using your client's words or a dossier fact. This is the only way a negotiation moves again.
+- accept_opportunity / reject_opportunity: execute your client's verdict on one of the listed matches. See the verdict law below — this fires ONLY on their explicit word.
 - note_dossier: record a fact your client stated, in a form useful at the negotiation table.
 - retire_dossier: retire a dossier entry your client has contradicted or withdrawn.
-- wait: nothing needs doing. Choosing wait is a real decision and is recorded.
+- wait: nothing needs doing. Choosing wait is a real decision and is recorded. When your client wrote to you and none of the other tools apply — small talk, a status question, a request you can answer in words — wait IS the right decision: your reply is composed afterwards either way.
 
 The law you operate under:
 
@@ -26,14 +33,30 @@ The law you operate under:
 
 3. An explicit answer from your client always beats staleness. If they answer something you asked — even late, even obliquely, even folded into another thought — take it as the answer and resolve the negotiation that was waiting. Do not second-guess an answer because circumstances changed since you asked.
 
-4. Everything you may use at the negotiation table must be in the dossier. When your client tells you something negotiations may rely on, note it. When you answer a negotiation, the answer becomes a dossier fact automatically. What is not in the dossier stays in this room.
+4. Everything you may use at the negotiation table must be in the dossier. When your client tells you something negotiations may rely on — even in passing, even mid-sentence — note it. When you answer a negotiation, the answer becomes a dossier fact automatically. What is not in the dossier stays in this room.
 
-5. You propose, your client disposes. Never act on their behalf beyond what your tools do; never promise a counterparty anything your client has not said. When a negotiation cannot continue, say so honestly and propose the next step — re-running discovery under their updated signal, for instance — but only propose it.
+5. THE VERDICT LAW. accept_opportunity and reject_opportunity execute a real decision about a real person, and only your client may make it. Fire one ONLY when their message explicitly renders the verdict on an identifiable listed match — "reject it", "let's go with them", "accept the second one", "pass on the designer". A hedge, a lean, or a musing — "maybe we should pass?", "I'm not sure about this one", "they seem weak" — is NOT a verdict: never act on it. Instead, give your recommendation in your reply and ask the question that would settle it. When in any doubt, it is not explicit. You propose, your client disposes.
 
-6. Never reveal or invent counterparty identity, internal identifiers, scores, or system machinery. Speak about negotiations in terms of what they need from your client.
+6. Beyond your tools, act on nothing. Never promise a counterparty anything your client has not said. When a negotiation cannot continue, say so honestly and propose the next step — re-running discovery under their updated signal, for instance — but only propose it. When your client asks to change the signal itself, tell them honestly that you do not edit it from this conversation and point them to editing the signal directly.
 
-7. When your client's message is ordinary conversation, reply to it honestly and briefly from what you know about this signal. When they ask what is happening, tell them plainly: what is waiting, what you are doing about it.
+7. Never reveal or invent counterparty identity beyond what the match list shows, internal identifiers, scores, or system machinery. Speak about negotiations in terms of what they need from your client.
 
-8. Always leave your client with a reply when they spoke to you: answering a negotiation silently is abandonment — acknowledge what you did with their words.
+8. When your client asks what is happening, tell them plainly from the listed state: which matches are live, what is waiting on them, what you are doing about it. Ordinary conversation gets an honest, brief reply from what you know about this signal — nothing more is required of it.
 
-You will be shown the waiting negotiations and dossier entries as numbered lists. Refer to them ONLY by those numbers. Never invent a number that is not listed.`;
+You will be shown the waiting negotiations, the dossier entries, and your client's active matches as numbered lists. Refer to them ONLY by those numbers. Never invent a number that is not listed.`;
+
+/**
+ * The reply stage's addendum (phase 2). Appended to the system prompt for the
+ * second model call of a client-message turn — the streaming conversational
+ * reply, composed AFTER the acts executed. The delivered text must pass the
+ * same identifier-leak gate the acts-stage prose passes
+ * (`isSafeQuestionMessageProse`); fail → one retry → fixed fallback copy.
+ */
+export const INTENT_AGENT_REPLY_INSTRUCTION = `You have already decided and executed this turn's acts; they are listed below with their outcomes. Now write the one thing left: your reply to your client, in plain prose.
+
+- Acknowledge what you actually did this turn — an answered negotiation, a recorded fact, an executed verdict — in their language, without naming tools or machinery.
+- If an act failed or a match had already moved on, say so honestly and propose the next step; propose only.
+- If you executed nothing, just answer them: their status question from the listed state, their hedge with your recommendation and the question that would settle it, their small talk briefly and warmly.
+- No markup blocks, no lists of internal state, no identifiers, no scores, no counterparty details beyond the match list. One coherent reply, a few sentences unless more is genuinely needed.
+
+Write the reply text only.`;

--- a/services/api/src/lib/intent-agent/intent-agent.turn.ts
+++ b/services/api/src/lib/intent-agent/intent-agent.turn.ts
@@ -21,9 +21,9 @@ import { z } from 'zod';
 import { getModelName } from '@indexnetwork/protocol';
 
 import { isSafeQuestionMessageProse } from '../question/negotiation-question.contract';
-import { INTENT_AGENT_SYSTEM_PROMPT } from './intent-agent.prompt';
+import { INTENT_AGENT_REPLY_INSTRUCTION, INTENT_AGENT_SYSTEM_PROMPT } from './intent-agent.prompt';
 import type { IntentAgentTurnContext } from './intent-agent.context';
-import type { IntentAgentDecidedAct } from './intent-agent.types';
+import type { IntentAgentDecidedAct, IntentAgentExecutedAct } from './intent-agent.types';
 import { log } from '../log';
 
 const logger = log.lib.from('intent-agent.turn');
@@ -37,16 +37,18 @@ const MAX_DM_CHARS = 1000;
 // below treats null and absent alike.
 const DecidedActsSchema = z.object({
   acts: z.array(z.object({
-    act: z.enum(['message_user', 'answer_negotiation', 'note_dossier', 'retire_dossier', 'wait']),
+    act: z.enum(['message_user', 'answer_negotiation', 'accept_opportunity', 'reject_opportunity', 'note_dossier', 'retire_dossier', 'wait']),
     /** message_user: the message. note_dossier: the fact. */
     text: z.string().max(4000).nullable().optional(),
     /** answer_negotiation: 1-based number from the waiting list. */
     negotiation: z.number().int().min(1).nullable().optional(),
     /** answer_negotiation: the answer, restated so it stands alone. */
     answer: z.string().max(4000).nullable().optional(),
+    /** accept/reject_opportunity: 1-based number from the matches list. */
+    opportunity: z.number().int().min(1).nullable().optional(),
     /** retire_dossier: 1-based number from the dossier list. */
     entry: z.number().int().min(1).nullable().optional(),
-    /** wait: why nothing needs doing. */
+    /** wait: why nothing needs doing. accept/reject: the client's words. */
     reason: z.string().max(500).nullable().optional(),
   })).min(1).max(6),
 });
@@ -83,6 +85,14 @@ function renderDossier(context: IntentAgentTurnContext): string {
   return `Dossier — the facts you may use at the negotiation table (refer by number):\n${lines.join('\n')}`;
 }
 
+function renderOpportunities(context: IntentAgentTurnContext): string {
+  if (context.opportunities.length === 0) return 'Active matches on this signal: none right now.';
+  const lines = context.opportunities.map((opportunity, index) =>
+    `${index + 1}. ${opportunity.label}`);
+  return `Your client's active matches on this signal (refer by number; a verdict acts on exactly one of these):
+${lines.join('\n')}`;
+}
+
 function renderLedger(context: IntentAgentTurnContext): string {
   if (context.recentActs.length === 0) return '';
   const lines = context.recentActs.slice(0, 10).map((row) => {
@@ -107,7 +117,7 @@ function renderDm(context: IntentAgentTurnContext): string {
 function renderEvent(context: IntentAgentTurnContext): string {
   const { event } = context;
   if (event.kind === 'user_message') {
-    return `THE EVENT: your client just wrote to you:\n"${truncate(event.text, 4000)}"\n\nDecide what to do with it. If it answers something a negotiation is waiting on, resolve that negotiation with it. Either way, reply to your client.`;
+    return `THE EVENT: your client just wrote to you:\n"${truncate(event.text, 4000)}"\n\nDecide what to do with it. If it answers something a negotiation is waiting on, resolve that negotiation with it. If it explicitly renders a verdict on a listed match, execute the verdict — and remember the verdict law: a hedge is not a verdict. If it states a fact worth keeping, note it. If none of your tools apply, wait — your reply to your client is composed in a separate step after these acts, so do not use message_user here.`;
   }
   const position = context.parked.findIndex((parked) => parked.opportunityId === event.opportunityId);
   const which = position >= 0
@@ -123,6 +133,8 @@ export function renderIntentAgentTurn(context: IntentAgentTurnContext): string {
     '',
     renderParked(context),
     '',
+    renderOpportunities(context),
+    '',
     renderDossier(context),
     renderLedger(context),
     '',
@@ -130,6 +142,40 @@ export function renderIntentAgentTurn(context: IntentAgentTurnContext): string {
     '',
     renderEvent(context),
   ].join('\n');
+}
+
+/** Compact prose record of the acts the turn just executed, for the reply. */
+function renderExecutedAct(act: IntentAgentExecutedAct): string {
+  switch (act.tool) {
+    case 'message_user':
+      return `- You sent your client a message: ${act.text}`;
+    case 'answer_negotiation':
+      return `- You resolved a waiting negotiation with the answer "${act.answer}" (outcome: ${act.outcome}).`;
+    case 'accept_opportunity':
+    case 'reject_opportunity': {
+      const verb = act.tool === 'accept_opportunity' ? 'ACCEPTED' : 'REJECTED';
+      return act.outcome === 'executed'
+        ? `- You executed your client's verdict: ${verb} ${act.counterparty ?? 'the match'}.`
+        : `- You tried to execute your client's verdict (${verb.toLowerCase()}) but it did not land: ${act.outcome === 'already_decided' ? 'they had already committed on this match — it is the other side\'s move now' : act.outcome === 'unknown_counterparty' || act.outcome === 'none_actionable' ? 'that match is no longer open to a verdict' : 'the write failed'}. Tell your client honestly.`;
+    }
+    case 'note_dossier':
+      return `- You noted a fact for the negotiation table: ${act.text}`;
+    case 'retire_dossier':
+      return act.retired ? '- You retired an outdated dossier entry.' : '- You tried to retire a dossier entry that was already gone.';
+    case 'wait':
+      return `- You decided nothing needed doing${act.reason ? ` (${act.reason})` : ''}.`;
+  }
+}
+
+/** What the reply stage sees, rendered; exported for the live eval's transparency. */
+export function renderIntentAgentReplyStage(
+  context: IntentAgentTurnContext,
+  executed: IntentAgentExecutedAct[],
+): string {
+  const acts = executed.length === 0
+    ? 'You executed no acts this turn.'
+    : `The acts you just executed for this turn:\n${executed.map(renderExecutedAct).join('\n')}`;
+  return `${renderIntentAgentTurn(context)}\n\n${acts}\n\nNow write your reply to your client.`;
 }
 
 export interface IntentAgentTurnConfig {
@@ -177,13 +223,36 @@ export class IntentAgentTurn {
     if (acts.some((act) => act.act === 'wait') && acts.length > 1) return null;
 
     const answered = new Set<number>();
+    const judged = new Set<number>();
     const decided: IntentAgentDecidedAct[] = [];
     for (const act of acts) {
       switch (act.act) {
         case 'message_user': {
+          // Phase 2: when the client themselves wrote, the reply is the
+          // dedicated streaming stage's — an acts-stage message would race
+          // it and double-speak. Structural, not judgment: rejected here so
+          // the retry re-decides without it.
+          if (context.event.kind === 'user_message') return null;
           const text = act.text?.trim();
           if (!text || !isSafeQuestionMessageProse(text)) return null;
           decided.push({ tool: 'message_user', text });
+          break;
+        }
+        case 'accept_opportunity':
+        case 'reject_opportunity': {
+          // A verdict exists only as the client's explicit word — an event
+          // with no client message cannot carry one. Whether the word WAS
+          // explicit is the prompt's law (pinned by the live eval); this
+          // only refuses the structurally impossible.
+          if (context.event.kind !== 'user_message') return null;
+          if (!act.opportunity || act.opportunity > context.opportunities.length) return null;
+          if (judged.has(act.opportunity)) return null;
+          judged.add(act.opportunity);
+          decided.push({
+            tool: act.act,
+            opportunityId: context.opportunities[act.opportunity - 1]!.opportunityId,
+            ...(act.reason?.trim() ? { reason: act.reason.trim() } : {}),
+          });
           break;
         }
         case 'answer_negotiation': {
@@ -218,15 +287,56 @@ export class IntentAgentTurn {
   }
 
   /**
+   * The reply stage (phase 2): the streaming conversational reply for a
+   * client-message turn, composed AFTER the acts executed. One plain-text
+   * call under the same law plus the reply instruction; the returned prose
+   * must pass the identifier-leak gate before anyone sees it — fail → one
+   * retry → null, and the caller delivers the fixed fallback copy. This is
+   * the honest resolution of the streaming tension: the check runs on the
+   * COMPLETED reply, and the transport streams it only afterwards
+   * (check-then-stream) — no unchecked token ever leaves the host.
+   *
+   * Model errors propagate — the caller distinguishes a provider outage
+   * (fallback, reason 'model_error') from refused prose.
+   */
+  async reply(context: IntentAgentTurnContext, executed: IntentAgentExecutedAct[]): Promise<string | null> {
+    const userMessage = renderIntentAgentReplyStage(context, executed);
+    const system = `${INTENT_AGENT_SYSTEM_PROMPT}\n\n${INTENT_AGENT_REPLY_INSTRUCTION}`;
+    for (let attempt = 0; attempt < 2; attempt++) {
+      const raw = (await this.callReplyModel([
+        { role: 'system', content: system },
+        { role: 'user', content: userMessage },
+      ])).trim();
+      if (raw && isSafeQuestionMessageProse(raw)) return raw;
+      logger.warn('intent_agent_reply_rejected', { attempt: attempt + 1, empty: !raw });
+    }
+    return null;
+  }
+
+  /**
    * Raw structured-model round trip. A seam so tests drive the
    * validate → retry loop without a live provider — the model is constructed
    * here, not in the constructor, so tests never need a key.
    */
   protected async callModel(messages: Array<{ role: string; content: string }>): Promise<unknown> {
+    return this.buildModel()
+      .withStructuredOutput(DecidedActsSchema, { name: 'intent_agent_acts' })
+      .invoke(messages);
+  }
+
+  /** Raw plain-text round trip for the reply stage; same seam discipline. */
+  protected async callReplyModel(messages: Array<{ role: string; content: string }>): Promise<string> {
+    const response = await this.buildModel().invoke(messages);
+    return typeof response.content === 'string'
+      ? response.content
+      : response.content.map((part) => (typeof part === 'string' ? part : 'text' in part ? part.text : '')).join('');
+  }
+
+  private buildModel(): ChatOpenAI {
     const apiKey = process.env.OPENROUTER_API_KEY;
     if (!apiKey?.trim()) throw new Error('IntentAgentTurn: OPENROUTER_API_KEY is required');
     const timeoutEnv = Number.parseInt(process.env.OPENROUTER_REQUEST_TIMEOUT_MS ?? '', 10);
-    const model = new ChatOpenAI({
+    return new ChatOpenAI({
       model: this.modelName,
       configuration: {
         baseURL: process.env.OPENROUTER_BASE_URL ?? 'https://openrouter.ai/api/v1',
@@ -237,8 +347,5 @@ export class IntentAgentTurn {
       timeout: Number.isFinite(timeoutEnv) && timeoutEnv > 0 ? timeoutEnv : 60_000,
       maxRetries: 1,
     });
-    return model
-      .withStructuredOutput(DecidedActsSchema, { name: 'intent_agent_acts' })
-      .invoke(messages);
   }
 }

--- a/services/api/src/lib/intent-agent/intent-agent.types.ts
+++ b/services/api/src/lib/intent-agent/intent-agent.types.ts
@@ -55,6 +55,14 @@ export type IntentAgentDecidedAct =
   | { tool: 'answer_negotiation'; opportunityId: string; answer: string }
   | { tool: 'note_dossier'; text: string }
   | { tool: 'retire_dossier'; entryId: string }
+  /**
+   * The client's explicit verdict on a counterparty (phase 2). Decided only
+   * for user_message events — a verdict without the client's word behind it
+   * is structurally impossible — and only in the client's explicit words
+   * (the prompt's law; hedges become proposals in the reply, never acts).
+   */
+  | { tool: 'accept_opportunity'; opportunityId: string; reason?: string }
+  | { tool: 'reject_opportunity'; opportunityId: string; reason?: string }
   | { tool: 'wait'; reason?: string };
 
 // ─── Executed acts (decision + durable effects) ─────────────────────────────
@@ -67,8 +75,24 @@ export type NegotiationAnswerOutcome =
   | 'no_negotiation'
   | 'wrong_recipient';
 
+/** Why a reply-stage delivery fell back to the fixed server-owned copy. */
+export type IntentAgentReplyFallbackReason = 'safety_check_failed' | 'model_error';
+
 export type IntentAgentExecutedAct =
-  | { tool: 'message_user'; text: string; sessionId: string; messageId: string }
+  | {
+    tool: 'message_user';
+    text: string;
+    sessionId: string;
+    messageId: string;
+    /**
+     * 'reply' marks the streaming reply stage's delivery (phase 2); absent
+     * for acts-stage messages (background-event asks). `fallback` records
+     * that the model's reply was refused and the fixed copy delivered
+     * instead — the ledgered failure the spec demands.
+     */
+    stage?: 'reply';
+    fallback?: IntentAgentReplyFallbackReason;
+  }
   | {
     tool: 'answer_negotiation';
     opportunityId: string;
@@ -81,6 +105,15 @@ export type IntentAgentExecutedAct =
   }
   | { tool: 'note_dossier'; text: string; entryId: string }
   | { tool: 'retire_dossier'; entryId: string; retired: boolean }
+  | {
+    /** The #1471 verdict lane's outcome, verbatim from the shared host. */
+    tool: 'accept_opportunity' | 'reject_opportunity';
+    opportunityId: string;
+    outcome: 'executed' | 'none_actionable' | 'unknown_counterparty' | 'already_decided' | 'error';
+    /** Who the write actually landed on, when it landed. */
+    counterparty?: string;
+    reason?: string;
+  }
   | { tool: 'wait'; reason?: string };
 
 /** One completed turn: what the agent did, plus what the client should see. */

--- a/services/api/src/lib/intent-agent/tests/intent-agent-reply.stream.spec.ts
+++ b/services/api/src/lib/intent-agent/tests/intent-agent-reply.stream.spec.ts
@@ -1,0 +1,78 @@
+/**
+ * The reply transport's contract (phase 2 of
+ * docs/plans/2026-08-21-holistic-intent-agent.md): chunks published on a
+ * turn's channel reach a subscriber established beforehand, in order;
+ * malformed payloads are dropped rather than crashing the relay (the
+ * job-result fallback owns completeness); and the sentence chunker
+ * reassembles losslessly — the streamed text can never differ from the
+ * checked, persisted reply it was cut from.
+ *
+ * Runs against the hermetic in-process bus (the same `useHermeticRedis()`
+ * guard the queue factory applies), which is exactly what the controller and
+ * worker use under test — so this is the relay the controller spec's
+ * SSE-level test rides on, pinned one level down.
+ */
+import { describe, expect, it } from 'bun:test';
+
+import { chunkReplyText, intentAgentReplyChannel, publishIntentAgentReplyChunk, subscribeIntentAgentReply } from '../intent-agent-reply.stream';
+import type { IntentAgentReplyChunk } from '../intent-agent-reply.stream';
+
+describe('intent-agent reply transport (hermetic bus)', () => {
+  it('delivers published chunks to an established subscriber, in publish order', async () => {
+    const received: IntentAgentReplyChunk[] = [];
+    const unsubscribe = await subscribeIntentAgentReply('message-1', (chunk) => received.push(chunk));
+
+    await publishIntentAgentReplyChunk('message-1', { seq: 1, content: 'First. ' });
+    await publishIntentAgentReplyChunk('message-1', { seq: 2, content: 'Second.' });
+    // A different turn's channel must not leak in.
+    await publishIntentAgentReplyChunk('message-2', { seq: 1, content: 'Other turn.' });
+
+    unsubscribe();
+    // After cleanup nothing more arrives.
+    await publishIntentAgentReplyChunk('message-1', { seq: 3, content: 'Late.' });
+
+    expect(received).toEqual([
+      { seq: 1, content: 'First. ' },
+      { seq: 2, content: 'Second.' },
+    ]);
+  });
+
+  it('drops payloads that are not chunks instead of crashing the relay', async () => {
+    const received: IntentAgentReplyChunk[] = [];
+    const unsubscribe = await subscribeIntentAgentReply('message-3', (chunk) => received.push(chunk));
+
+    // A misshapen payload (no content) and a well-formed one: only the
+    // well-formed chunk reaches the handler — the job-result fallback owns
+    // completeness, so dropping is the honest move.
+    await publishIntentAgentReplyChunk('message-3', { seq: 1 } as IntentAgentReplyChunk);
+    await publishIntentAgentReplyChunk('message-3', { seq: 2, content: 'Real.' });
+
+    unsubscribe();
+    expect(received).toEqual([{ seq: 2, content: 'Real.' }]);
+  });
+
+  it('keys channels by message id', () => {
+    expect(intentAgentReplyChannel('abc')).toBe('intent-agent:reply:abc');
+  });
+});
+
+describe('chunkReplyText', () => {
+  it('cuts on sentence boundaries and reassembles losslessly', () => {
+    const text = 'Done — I declined that match. Nothing else needs you right now! Want my read on the other one?';
+    const chunks = chunkReplyText(text);
+    expect(chunks.length).toBeGreaterThan(1);
+    expect(chunks.join('')).toBe(text);
+  });
+
+  it('is lossless on text with no sentence punctuation, newlines, and separators', () => {
+    for (const text of [
+      'no punctuation at all',
+      'line one\nline two\n',
+      '\n\nSecond message after a separator.',
+      'Trailing space. ',
+      '…',
+    ]) {
+      expect(chunkReplyText(text).join('')).toBe(text);
+    }
+  });
+});

--- a/services/api/src/lib/intent-agent/tests/intent-agent.judgment.llm.spec.ts
+++ b/services/api/src/lib/intent-agent/tests/intent-agent.judgment.llm.spec.ts
@@ -1,13 +1,19 @@
 /**
- * Live-LLM judgment eval for the IntentAgent's prompt
- * (docs/plans/2026-08-21-holistic-intent-agent.md): given a parked ask about
- * timing and a client reply "actually this month works", the agent must
- * ANSWER the negotiation — not merely chat back. This is the behavioral leg
- * of the collapse: the judgment the answer-precedence gate + router pipeline
- * used to make in stages is now one prompt's call, and this pins that the
- * prompt makes it.
+ * Live-LLM judgment evals for the IntentAgent's prompt, version 2
+ * (docs/plans/2026-08-21-holistic-intent-agent.md, phase 2):
  *
- * Paid, live round trip — gated exactly like the other live-model api specs
+ * - the phase-1 regression: a timing reply on a parked ask still ANSWERS the
+ *   negotiation rather than becoming chat;
+ * - small talk stays conversation — no acts fire;
+ * - an explicit verdict ("reject the second one") executes the verdict act
+ *   on the right listed match;
+ * - a hedged verdict must NOT fire an act — this is THE pin for the verdict
+ *   law, and it lives here deliberately: whether the client's word was
+ *   explicit IS judgment, the prompt's to make, so a deterministic harness
+ *   cannot fence it without re-deciding (the mocked specs pin the plumbing
+ *   instead).
+ *
+ * Paid, live round trips — gated exactly like the other live-model api specs
  * (embedder.adapter.spec.ts): RUN_PAID_INTEGRATION_TESTS=1 plus a real
  * OPENROUTER_API_KEY, skipped with a log otherwise. The protocol live-LLM
  * flake policy applies: re-run in isolation before blaming a diff.
@@ -52,12 +58,48 @@ const CONTEXT: IntentAgentTurnContext = {
     parkedAt: new Date('2026-08-20T20:20:00Z'),
   }],
   dossier: [],
+  opportunities: [{
+    position: 1,
+    opportunityId: OPPORTUNITY,
+    name: 'A fractional CFO candidate',
+    status: 'stalled',
+    label: 'A fractional CFO candidate — parked, waiting on you',
+  }],
   recentDm: [
     { role: 'assistant', content: 'One of the conversations on this signal is waiting on timing: when could you start the engagement? Does next week work?' },
     { role: 'user', content: 'actually this month works' },
   ],
   recentActs: [],
 };
+
+const CFO_MATCH = '5b1f36cc-93b2-4d0f-9a75-2f4f3f0a1c11';
+const COO_MATCH = '9c2e47dd-a4c3-4e10-8b86-3a5e4f1b2d22';
+
+/** A quiet signal: two live matches, nothing parked, nothing waiting. */
+function conversationContext(text: string): IntentAgentTurnContext {
+  return {
+    event: {
+      kind: 'user_message',
+      userId: 'user-1',
+      intentId: 'intent-1',
+      sessionId: 'session-1',
+      messageId: 'reply-2',
+      text,
+    },
+    signalText: 'Find a fractional CFO for a seed-stage startup',
+    parked: [],
+    dossier: [],
+    opportunities: [
+      { position: 1, opportunityId: CFO_MATCH, name: 'A fractional CFO with fintech exits', status: 'negotiating', label: 'A fractional CFO with fintech exits — your agents are still negotiating' },
+      { position: 2, opportunityId: COO_MATCH, name: 'A part-time COO candidate', status: 'pending', label: 'A part-time COO candidate — waiting on your decision' },
+    ],
+    recentDm: [
+      { role: 'assistant', content: 'Two matches are live on this signal: a fractional CFO your agents are still negotiating with, and a part-time COO candidate waiting on your decision.' },
+      { role: 'user', content: text },
+    ],
+    recentActs: [],
+  };
+}
 
 describe('IntentAgent judgment (live model)', () => {
   test('a timing reply answers the parked negotiation instead of becoming chat', async () => {
@@ -80,5 +122,54 @@ describe('IntentAgent judgment (live model)', () => {
         expect(act.text.toLowerCase()).not.toContain('when could you start');
       }
     }
+  });
+
+  test('small talk stays conversation — no acts fire', async () => {
+    if (process.env.RUN_PAID_INTEGRATION_TESTS !== '1' || !process.env.OPENROUTER_API_KEY) {
+      console.log('Skipping live intent-agent judgment eval (set RUN_PAID_INTEGRATION_TESTS=1 with OPENROUTER_API_KEY)');
+      return;
+    }
+
+    const decided = await new IntentAgentTurn().decide(
+      conversationContext('thanks for the update — appreciate you keeping on top of this!'),
+    );
+
+    // Nothing to execute: no answer, no verdict, no dossier write. The reply
+    // stage speaks; the acts stage waits.
+    expect(decided.every((act) => act.tool === 'wait')).toBe(true);
+  });
+
+  test('an explicit verdict executes on the match the client named', async () => {
+    if (process.env.RUN_PAID_INTEGRATION_TESTS !== '1' || !process.env.OPENROUTER_API_KEY) {
+      console.log('Skipping live intent-agent judgment eval (set RUN_PAID_INTEGRATION_TESTS=1 with OPENROUTER_API_KEY)');
+      return;
+    }
+
+    const decided = await new IntentAgentTurn().decide(
+      conversationContext('Reject the second one — the COO profile is not what we need right now.'),
+    );
+
+    const verdicts = decided.filter((act) => act.tool === 'accept_opportunity' || act.tool === 'reject_opportunity');
+    expect(verdicts).toEqual([expect.objectContaining({ tool: 'reject_opportunity', opportunityId: COO_MATCH })]);
+  });
+
+  test('a hedged verdict fires no act — the agent may only propose in its reply', async () => {
+    if (process.env.RUN_PAID_INTEGRATION_TESTS !== '1' || !process.env.OPENROUTER_API_KEY) {
+      console.log('Skipping live intent-agent judgment eval (set RUN_PAID_INTEGRATION_TESTS=1 with OPENROUTER_API_KEY)');
+      return;
+    }
+
+    const context = conversationContext("I'm not sure about the COO candidate… maybe we should pass?");
+    const turn = new IntentAgentTurn();
+    const decided = await turn.decide(context);
+
+    // THE VERDICT LAW, live: a hedge must never reach a write.
+    expect(decided.some((act) => act.tool === 'accept_opportunity' || act.tool === 'reject_opportunity')).toBe(false);
+
+    // And the proposal path is deliverable: the reply stage produces prose
+    // that passes the safety gate (a null here would mean fixed fallback
+    // copy where a recommendation belongs).
+    const reply = await turn.reply(context, []);
+    expect(reply).not.toBeNull();
   });
 });

--- a/services/api/src/lib/intent-agent/tests/intent-agent.loop.capture.spec.ts
+++ b/services/api/src/lib/intent-agent/tests/intent-agent.loop.capture.spec.ts
@@ -28,8 +28,15 @@ const cleanup = newParkFixtureCleanup();
 afterAll(() => cleanupParkFixtures(cleanup));
 
 /** A deterministic judgment seam: the loop runs everything else for real. */
-function scriptedTurn(script: (context: IntentAgentTurnContext) => IntentAgentDecidedAct[]) {
-  return { decide: async (context: IntentAgentTurnContext) => script(context) };
+function scriptedTurn(
+  script: (context: IntentAgentTurnContext) => IntentAgentDecidedAct[],
+  reply?: string,
+) {
+  return {
+    decide: async (context: IntentAgentTurnContext) => script(context),
+    // Phase 2: a client-message turn ends with the streaming reply stage.
+    ...(reply !== undefined ? { reply: async () => reply } : {}),
+  };
 }
 
 describe('IntentAgent loop over the real settle/claim substrate', () => {
@@ -69,6 +76,8 @@ describe('IntentAgent loop over the real settle/claim substrate', () => {
     // ── Turn 2: the client replies; the agent answers the negotiation. ──
     const replyId = await chatSessionService.addMessage({ sessionId: session!.id, role: 'user', content: 'Q4 works; EU preferred.' });
     const ackText = 'Thanks — I have taken Q4 with an EU preference back to that conversation.';
+    // Phase 2: the acknowledgment is the reply STAGE's, not an acts-stage
+    // message_user — the acts decide effects, the reply speaks.
     const turn2 = await runIntentAgentTurn(
       { kind: 'user_message', userId: fixture.recipientId, intentId: fixture.recipientIntentId, sessionId: session!.id, messageId: replyId, text: 'Q4 works; EU preferred.' },
       {
@@ -77,9 +86,8 @@ describe('IntentAgent loop over the real settle/claim substrate', () => {
           expect(waiting).toBeDefined();
           return [
             { tool: 'answer_negotiation', opportunityId: waiting!.opportunityId, answer: 'Q4 works; EU preferred.' },
-            { tool: 'message_user', text: ackText },
           ];
-        }),
+        }, ackText),
       },
     );
 
@@ -116,10 +124,12 @@ describe('IntentAgent loop over the real settle/claim substrate', () => {
       continuationSettlementId: fixture.settlementId,
     });
 
-    // The client heard back, and both acts are on the ledger.
+    // The client heard back — the reply-stage delivery — and both acts are
+    // on the ledger, the reply marked with its stage.
     expect(turn2.messages).toEqual([ackText]);
     const ledgerAfterAnswer = await intentAgentLedgerAdapter.readRecent(fixture.recipientId, fixture.recipientIntentId);
     expect(ledgerAfterAnswer.map((row) => row.act.tool)).toEqual(['message_user', 'answer_negotiation', 'message_user']);
+    expect(ledgerAfterAnswer[0]!.act).toMatchObject({ stage: 'reply', text: ackText });
   });
 
   test('answer-from-knowledge: a dossier fact answers the park without asking — the duplicate-question kill', async () => {

--- a/services/api/src/lib/intent-agent/tests/intent-agent.turn.spec.ts
+++ b/services/api/src/lib/intent-agent/tests/intent-agent.turn.spec.ts
@@ -15,7 +15,7 @@ import { describe, expect, it } from 'bun:test';
 
 import { IntentAgentTurn } from '../intent-agent.turn';
 import type { IntentAgentTurnContext } from '../intent-agent.context';
-import { INTENT_AGENT_SILENT_TURN_REPLY, INTENT_AGENT_UNRESUMABLE_MESSAGE, executeIntentAgentActs } from '../intent-agent.host';
+import { INTENT_AGENT_REPLY_FALLBACK, INTENT_AGENT_UNRESUMABLE_MESSAGE, executeIntentAgentActs, runIntentAgentTurn } from '../intent-agent.host';
 import type { IntentAgentHostDeps } from '../intent-agent.host';
 import type { IntentAgentInboxEvent } from '../intent-agent.types';
 import type { ParkedNegotiation } from '../../../adapters/parked-negotiation.reader.adapter';
@@ -52,6 +52,10 @@ function context(overrides: Partial<IntentAgentTurnContext> = {}): IntentAgentTu
     dossier: [
       { id: 'entry-1', text: 'Timing: Q4 works.', source: 'user_message', createdAt: new Date(2000) },
     ],
+    opportunities: [
+      { position: 1, opportunityId: OPP_A, name: 'Camille Dubois', status: 'stalled', label: 'Camille Dubois — parked, waiting on you' },
+      { position: 2, opportunityId: OPP_B, name: 'Ilya Roth', status: 'pending', label: 'Ilya Roth — waiting on your decision' },
+    ],
     recentDm: [],
     recentActs: [],
     ...overrides,
@@ -69,6 +73,19 @@ class ScriptedModelTurn extends IntentAgentTurn {
     this.calls += 1;
     if (output instanceof Error) throw output;
     return output;
+  }
+}
+
+/** A turn whose reply-stage round trips are scripted. */
+class ScriptedReplyTurn extends IntentAgentTurn {
+  replyCalls = 0;
+  constructor(private readonly replies: string[]) {
+    super({ model: 'test-model' });
+  }
+  protected override async callReplyModel(): Promise<string> {
+    const output = this.replies[this.replyCalls];
+    this.replyCalls += 1;
+    return output ?? '';
   }
 }
 
@@ -135,6 +152,50 @@ describe('IntentAgentTurn.decide', () => {
     expect(await turn.decide(context())).toEqual([
       { tool: 'message_user', text: 'One conversation needs your timing.' },
     ]);
+  });
+
+  it('an acts-stage message_user is refused for a client-message turn — the reply stage speaks there', async () => {
+    // Phase 2 (full chat ownership): the client's reply is the streaming
+    // reply stage's; an acts-stage message would double-speak.
+    const turn = new ScriptedModelTurn([
+      { acts: [{ act: 'message_user', text: 'Right away.' }] },
+      { acts: [{ act: 'wait', reason: 'Nothing to execute; the reply handles it.' }] },
+    ]);
+    expect(await turn.decide(context({ event: USER_MESSAGE }))).toEqual([
+      { tool: 'wait', reason: 'Nothing to execute; the reply handles it.' },
+    ]);
+  });
+
+  it('maps a verdict number onto the matches list — and refuses one outside it or doubled', async () => {
+    const turn = new ScriptedModelTurn([{
+      acts: [{ act: 'reject_opportunity', opportunity: 2, reason: 'Client said reject the second one.' }],
+    }]);
+    expect(await turn.decide(context({ event: USER_MESSAGE }))).toEqual([
+      { tool: 'reject_opportunity', opportunityId: OPP_B, reason: 'Client said reject the second one.' },
+    ]);
+
+    const outside = new ScriptedModelTurn([
+      { acts: [{ act: 'accept_opportunity', opportunity: 3 }] },
+      { acts: [{ act: 'accept_opportunity', opportunity: 9 }] },
+    ]);
+    await expect(outside.decide(context({ event: USER_MESSAGE }))).rejects.toThrow('no valid act list');
+
+    const doubled = new ScriptedModelTurn([
+      { acts: [{ act: 'accept_opportunity', opportunity: 1 }, { act: 'reject_opportunity', opportunity: 1 }] },
+      { acts: [{ act: 'wait' }] },
+    ]);
+    expect(await doubled.decide(context({ event: USER_MESSAGE }))).toEqual([{ tool: 'wait' }]);
+  });
+
+  it('a verdict act without a client message behind it is structurally impossible', async () => {
+    // A background event carries no client word, so no verdict can exist —
+    // the explicitness of the word itself is the prompt's law, pinned in the
+    // live eval (there is no code fence for judgment).
+    const turn = new ScriptedModelTurn([
+      { acts: [{ act: 'reject_opportunity', opportunity: 1 }] },
+      { acts: [{ act: 'reject_opportunity', opportunity: 2 }] },
+    ]);
+    await expect(turn.decide(context())).rejects.toThrow('no valid act list');
   });
 
   it('a model outage propagates — the inbox retry owns recovery, never a guess', async () => {
@@ -251,15 +312,31 @@ describe('executeIntentAgentActs', () => {
     expect(harness.delivered).toEqual([INTENT_AGENT_UNRESUMABLE_MESSAGE]);
   });
 
-  it('rule 8 backstop: a client message that produced no reply gets the fixed copy, unledgered', async () => {
+  // The rule-8 silent-turn backstop left with phase 2: a client message is
+  // always followed by the reply stage (see the runIntentAgentTurn suite
+  // below), which owns the never-silent guarantee now.
+  it('a verdict act executes through the injected #1471 lane and ledgers the outcome verbatim', async () => {
     const harness = hostDeps();
+    const passed: Array<{ input: Record<string, unknown>; target: string }> = [];
+    harness.deps.verdict = async (_userId, input, target) => {
+      passed.push({ input, target });
+      return { status: 'executed', counterparty: 'Ilya Roth' };
+    };
     const result = await executeIntentAgentActs(USER_MESSAGE, [
-      { tool: 'note_dossier', text: 'Prefers EU manufacturing.' },
+      { tool: 'reject_opportunity', opportunityId: OPP_B, reason: 'reject the second one' },
     ], harness.deps);
-    expect(result.messages).toEqual([INTENT_AGENT_SILENT_TURN_REPLY]);
-    // The backstop is the executor's copy, not an agent act — only the
-    // decided act is on the ledger.
-    expect(harness.ledgered.map((act) => act.tool)).toEqual(['note_dossier']);
+    expect(passed).toEqual([{
+      input: { intentId: 'intent-1', opportunityId: OPP_B, reason: 'reject the second one' },
+      target: 'rejected',
+    }]);
+    expect(result.acts).toEqual([{
+      tool: 'reject_opportunity',
+      opportunityId: OPP_B,
+      outcome: 'executed',
+      counterparty: 'Ilya Roth',
+      reason: 'reject the second one',
+    }]);
+    expect(harness.ledgered.map((act) => act.tool)).toEqual(['reject_opportunity']);
   });
 
   it('a needs_input turn with no message stays silent — the backstop is for a client who spoke', async () => {
@@ -269,5 +346,122 @@ describe('executeIntentAgentActs', () => {
     ], harness.deps);
     expect(result.messages).toEqual([]);
     expect(harness.delivered).toEqual([]);
+  });
+});
+
+describe('IntentAgentTurn.reply', () => {
+  it('returns checked prose — an identifier leak is retried once, then refused', async () => {
+    const leaky = new ScriptedReplyTurn([
+      `Your opportunity_id is ${OPP_A}.`,
+      'Sent your timing along; one match is waiting on your decision.',
+    ]);
+    expect(await leaky.reply(context({ event: USER_MESSAGE }), [])).toBe(
+      'Sent your timing along; one match is waiting on your decision.',
+    );
+    expect(leaky.replyCalls).toBe(2);
+
+    const hopeless = new ScriptedReplyTurn([
+      `The opportunity_id is ${OPP_A}.`,
+      `Still the opportunity_id: ${OPP_B}.`,
+    ]);
+    expect(await hopeless.reply(context({ event: USER_MESSAGE }), [])).toBeNull();
+    expect(hopeless.replyCalls).toBe(2);
+  });
+
+  it('an empty reply counts as refused prose, not a message', async () => {
+    const empty = new ScriptedReplyTurn(['', '   ']);
+    expect(await empty.reply(context({ event: USER_MESSAGE }), [])).toBeNull();
+  });
+});
+
+/**
+ * The reply stage in the loop: a client-message turn always ends with a
+ * delivered reply — checked model prose when possible, the fixed fallback
+ * copy (failure ledgered) when not — and its chunks are published only after
+ * delivery (check-then-stream). Background events skip the stage entirely.
+ */
+describe('runIntentAgentTurn reply stage', () => {
+  function loopDeps(overrides: {
+    reply?: (context: IntentAgentTurnContext) => Promise<string | null>;
+    withReplySeam?: boolean;
+  } = {}) {
+    const harness = hostDeps();
+    const published: Array<{ messageId: string; seq: number; content: string }> = [];
+    let replyCalls = 0;
+    harness.deps.context = {
+      readParkedNegotiations: async () => [],
+      readDossier: async () => [],
+      readOpportunities: async () => [],
+      readLedger: async () => [],
+      findSession: async () => ({ id: 'session-1' }),
+      getSessionMessages: async () => [],
+      getIntentText: async () => 'Find a manufacturing partner',
+    };
+    harness.deps.turn = {
+      decide: async () => [{ tool: 'wait' as const, reason: 'Nothing to execute.' }],
+      ...(overrides.withReplySeam === false ? {} : {
+        reply: async (turnContext: IntentAgentTurnContext) => {
+          replyCalls += 1;
+          return overrides.reply ? overrides.reply(turnContext) : 'All quiet on this signal.';
+        },
+      }),
+    } as never;
+    harness.deps.publishReplyChunk = async (messageId, chunk) => {
+      published.push({ messageId, ...chunk });
+    };
+    return { harness, published, replyCalls: () => replyCalls };
+  }
+
+  it('delivers the checked reply, ledgers it with its stage, and publishes chunks whose join is the delivered text', async () => {
+    const { harness, published } = loopDeps({
+      reply: async () => 'I sent your timing along. One match is still waiting on your decision — want my read?',
+    });
+    const result = await runIntentAgentTurn(USER_MESSAGE, harness.deps);
+
+    const replyText = 'I sent your timing along. One match is still waiting on your decision — want my read?';
+    expect(result.messages).toEqual([replyText]);
+    expect(harness.delivered).toEqual([replyText]);
+    const replyAct = harness.ledgered.find((act) => act.stage === 'reply');
+    expect(replyAct).toMatchObject({ tool: 'message_user', text: replyText });
+    expect(replyAct!.fallback).toBeUndefined();
+
+    // Check-then-stream: publication happens after delivery, in order, and
+    // reassembles exactly.
+    expect(published.length).toBeGreaterThan(1);
+    expect(published.map((chunk) => chunk.seq)).toEqual(published.map((_, index) => index + 1));
+    expect(published.every((chunk) => chunk.messageId === USER_MESSAGE.messageId)).toBe(true);
+    expect(published.map((chunk) => chunk.content).join('')).toBe(replyText);
+  });
+
+  it('a reply refused by the safety gate twice delivers the fixed copy and ledgers the failure', async () => {
+    const { harness, published } = loopDeps({ reply: async () => null });
+    const result = await runIntentAgentTurn(USER_MESSAGE, harness.deps);
+
+    expect(result.messages).toEqual([INTENT_AGENT_REPLY_FALLBACK]);
+    const replyAct = harness.ledgered.find((act) => act.stage === 'reply');
+    expect(replyAct).toMatchObject({ fallback: 'safety_check_failed', text: INTENT_AGENT_REPLY_FALLBACK });
+    expect(published.map((chunk) => chunk.content).join('')).toBe(INTENT_AGENT_REPLY_FALLBACK);
+  });
+
+  it('a reply-stage model failure falls back instead of retrying the whole turn — the acts already executed', async () => {
+    const { harness } = loopDeps({
+      reply: async () => {
+        throw new Error('provider down');
+      },
+    });
+    const result = await runIntentAgentTurn(USER_MESSAGE, harness.deps);
+
+    expect(result.messages).toEqual([INTENT_AGENT_REPLY_FALLBACK]);
+    expect(harness.ledgered.find((act) => act.stage === 'reply')).toMatchObject({ fallback: 'model_error' });
+  });
+
+  it('background events skip the reply stage — no client is waiting', async () => {
+    const { harness, published, replyCalls } = loopDeps();
+    const result = await runIntentAgentTurn(NEEDS_INPUT, harness.deps);
+
+    expect(replyCalls()).toBe(0);
+    expect(result.messages).toEqual([]);
+    expect(published).toEqual([]);
+    expect(harness.ledgered.map((act) => act.tool)).toEqual(['wait']);
   });
 });

--- a/services/api/src/lib/intent-agent/tests/intent-agent.verdict.capture.spec.ts
+++ b/services/api/src/lib/intent-agent/tests/intent-agent.verdict.capture.spec.ts
@@ -1,0 +1,135 @@
+/**
+ * Verdict acts over the REAL #1471 lane (phase 2 of
+ * docs/plans/2026-08-21-holistic-intent-agent.md): the model is the only
+ * thing mocked — context assembly reads the production actionable list, the
+ * act executes through `passVerdictOnOpportunity` → the SAME
+ * `opportunityService.updateOpportunityStatus` the Radar card calls, the DB
+ * status transitions, and the ledger records the outcome.
+ *
+ * What is deliberately NOT pinned here: that a hedged message produces no
+ * verdict act. Whether the client's word was explicit IS judgment — the
+ * prompt's law — and a deterministic harness cannot fence it without
+ * re-deciding; the live eval (intent-agent.judgment.llm.spec.ts) pins it.
+ * This spec pins the plumbing: what the agent decides is what the lane
+ * executes, and nothing fires that was not decided.
+ */
+import { afterAll, describe, expect, setDefaultTimeout, test } from 'bun:test';
+import { eq } from 'drizzle-orm';
+
+import db from '../../../lib/drizzle/drizzle';
+import { opportunities } from '../../../schemas/database.schema';
+import { intentAgentLedgerAdapter } from '../../../adapters/intent-agent-ledger.adapter';
+import { chatSessionService } from '../../../services/chat.service';
+import { cleanupParkFixtures, newParkFixtureCleanup, seedWorkingNegotiation } from '../../../adapters/tests/fixtures/negotiation-park.fixture';
+import { runIntentAgentTurn } from '../intent-agent.host';
+import type { IntentAgentDecidedAct } from '../intent-agent.types';
+import type { IntentAgentTurnContext } from '../intent-agent.context';
+
+setDefaultTimeout(60_000);
+
+const cleanup = newParkFixtureCleanup();
+
+afterAll(() => cleanupParkFixtures(cleanup));
+
+describe('IntentAgent verdict acts over the real #1471 lane', () => {
+  test('an explicit reject decided by the agent transitions the opportunity and ledgers the outcome', async () => {
+    const fixture = await seedWorkingNegotiation(cleanup, 'intent');
+
+    // The client's DM and their message — the turn's event.
+    const resolved = await chatSessionService.resolveNegotiatorIntentSession(fixture.recipientId, fixture.recipientIntentId);
+    if ('error' in resolved) throw new Error(resolved.error);
+    cleanup.conversations.push(resolved.session.id);
+    const messageId = await chatSessionService.addMessage({
+      sessionId: resolved.session.id,
+      role: 'user',
+      content: 'Reject the manufacturing match — we are going another way.',
+    });
+
+    const replyText = 'Done — I declined that match on your word. Nothing else on this signal needs you right now.';
+    const turn = await runIntentAgentTurn(
+      {
+        kind: 'user_message',
+        userId: fixture.recipientId,
+        intentId: fixture.recipientIntentId,
+        sessionId: resolved.session.id,
+        messageId,
+        text: 'Reject the manufacturing match — we are going another way.',
+      },
+      {
+        turn: {
+          decide: async (context: IntentAgentTurnContext): Promise<IntentAgentDecidedAct[]> => {
+            // Context assembly served the PRODUCTION actionable list: the
+            // fixture's negotiating pairing is numbered and id-mapped.
+            const listed = context.opportunities.find((o) => o.opportunityId === fixture.opportunityId);
+            expect(listed).toBeDefined();
+            expect(listed!.status).toBe('negotiating');
+            return [{
+              tool: 'reject_opportunity',
+              opportunityId: listed!.opportunityId,
+              reason: 'Client: reject the manufacturing match.',
+            }];
+          },
+          reply: async () => replyText,
+        },
+      },
+    );
+
+    // The REAL write ran: the same transition the Radar's Skip performs.
+    const [row] = await db.select({ status: opportunities.status })
+      .from(opportunities).where(eq(opportunities.id, fixture.opportunityId));
+    expect(row!.status).toBe('rejected');
+
+    // The act reports the executed outcome, naming who the write landed on.
+    const verdictAct = turn.acts.find((act) => act.tool === 'reject_opportunity');
+    expect(verdictAct).toMatchObject({
+      opportunityId: fixture.opportunityId,
+      outcome: 'executed',
+    });
+
+    // The client heard the reply-stage acknowledgment, and both the verdict
+    // and the reply are on the ledger.
+    expect(turn.messages).toEqual([replyText]);
+    const ledger = await intentAgentLedgerAdapter.readRecent(fixture.recipientId, fixture.recipientIntentId);
+    expect(ledger.map((rowLedger) => rowLedger.act.tool)).toEqual(['message_user', 'reject_opportunity']);
+    expect(ledger[1]!.act).toMatchObject({ tool: 'reject_opportunity', outcome: 'executed' });
+    expect(ledger[1]!.event).toMatchObject({ kind: 'user_message', intentId: fixture.recipientIntentId });
+  });
+
+  test('a verdict on an opportunity that left the actionable set executes nothing and reports honestly', async () => {
+    const fixture = await seedWorkingNegotiation(cleanup, 'intent');
+    // Concluded before the agent's act lands: the actionable set moved on.
+    await db.update(opportunities).set({ status: 'expired' }).where(eq(opportunities.id, fixture.opportunityId));
+
+    const resolved = await chatSessionService.resolveNegotiatorIntentSession(fixture.recipientId, fixture.recipientIntentId);
+    if ('error' in resolved) throw new Error(resolved.error);
+    cleanup.conversations.push(resolved.session.id);
+    const messageId = await chatSessionService.addMessage({
+      sessionId: resolved.session.id, role: 'user', content: 'Accept them.',
+    });
+
+    const turn = await runIntentAgentTurn(
+      {
+        kind: 'user_message',
+        userId: fixture.recipientId,
+        intentId: fixture.recipientIntentId,
+        sessionId: resolved.session.id,
+        messageId,
+        text: 'Accept them.',
+      },
+      {
+        turn: {
+          // The agent decided from stale knowledge (an id no longer listed);
+          // the lane refuses the write and the act records why.
+          decide: async () => [{ tool: 'accept_opportunity' as const, opportunityId: fixture.opportunityId }],
+          reply: async () => 'That match had already closed before your word reached it — nothing was decided.',
+        },
+      },
+    );
+
+    const [row] = await db.select({ status: opportunities.status })
+      .from(opportunities).where(eq(opportunities.id, fixture.opportunityId));
+    expect(row!.status).toBe('expired');
+    const verdictAct = turn.acts.find((act) => act.tool === 'accept_opportunity');
+    expect(verdictAct).toMatchObject({ outcome: 'none_actionable' });
+  });
+});

--- a/services/api/src/lib/intent-agent/tests/intent-agent.wiring.static.spec.ts
+++ b/services/api/src/lib/intent-agent/tests/intent-agent.wiring.static.spec.ts
@@ -13,16 +13,37 @@ import { join } from 'path';
 const read = (relative: string) => readFileSync(join(__dirname, '../../../..', relative), 'utf8');
 
 describe('intent-agent wiring', () => {
-  it('the chat controller routes the owned turn through the serialized inbox, before the persona stream', () => {
+  it('the chat controller routes every intent-scoped negotiator turn through the serialized inbox — ownership is unconditional', () => {
     const controller = read('src/controllers/chat.controller.ts');
-    expect(controller).toContain('intentAgentOwnsTurn');
+    // Phase 2 (full chat ownership): the parked-set ownership gate is gone —
+    // the agent owns the turn because the scope is its, not because
+    // something happens to be parked.
+    expect(controller).not.toContain('intentAgentOwnsTurn');
     expect(controller).toContain('runUserMessageTurn');
+    // The reply streams over the turn's channel, subscribed before enqueue.
+    expect(controller.indexOf('subscribeIntentAgentReply(')).toBeGreaterThan(0);
+    expect(controller.indexOf('subscribeIntentAgentReply(')).toBeLessThan(controller.indexOf('runIntentAgentUserTurn({'));
     // Order: the agent turn is decided before the orchestrator stream is
     // even constructed — no persona tool can consume an answer first.
     expect(controller.indexOf('runUserMessageTurn')).toBeLessThan(controller.indexOf('streamChatEventsWithContext'));
     // The replaced gate machinery is gone, not dormant.
     expect(controller).not.toContain('evaluateQuestionAnswerPrecedence');
     expect(controller).not.toContain('enqueueQuestionAnswerReply');
+  });
+
+  it('the negotiator persona graph is retired from chat — no factory derivation, no persona tool registrations for this scope', () => {
+    const controller = read('src/controllers/chat.controller.ts');
+    const service = read('src/services/chat.service.ts');
+    // Phase 2: intent-scope negotiator turns never invoke the persona
+    // factory; the persona's chat-side tool registrations (answer, verdict,
+    // memory) died with it. The MCP surface registers the shared hosts
+    // through its own toolDeps and is deliberately untouched.
+    expect(controller).not.toContain('getNegotiatorGraphFactory');
+    expect(service).not.toContain('getNegotiatorGraphFactory');
+    expect(service).not.toContain('createNegotiatorPersona');
+    const mcp = read('src/controllers/mcp.controller.ts');
+    expect(mcp).toContain('negotiatorAnswerTools');
+    expect(mcp).toContain('negotiatorVerdictTools');
   });
 
   it('every park wakes the agent through the one enqueue seam, behind the principal fence', () => {

--- a/services/api/src/queues/tests/intent-agent.queue.isolated.ts
+++ b/services/api/src/queues/tests/intent-agent.queue.isolated.ts
@@ -29,6 +29,7 @@ function buildQueue(script: (context: IntentAgentTurnContext) => IntentAgentDeci
     context: {
       readParkedNegotiations: async () => [],
       readDossier: async () => [],
+      readOpportunities: async () => [],
       readLedger: async () => [],
       findSession: async () => null,
       getSessionMessages: async () => [],
@@ -48,6 +49,8 @@ function buildQueue(script: (context: IntentAgentTurnContext) => IntentAgentDeci
         spans.push(span);
         return script(context);
       },
+      // Phase 2: client-message turns end with the reply stage.
+      reply: async () => 'Right here.',
     },
     chatSessions: {
       resolveNegotiatorIntentSession: async () => ({ session: { id: 'session-1' } }),
@@ -111,8 +114,10 @@ describe('IntentAgentQueue serialization', () => {
     });
   });
 
-  it('runUserMessageTurn returns what the agent did, messages included', async () => {
-    await withQueue(buildQueue(() => [{ tool: 'message_user', text: 'Right here.' }]), async ({ queue, delivered }) => {
+  it('runUserMessageTurn returns what the agent did, the reply-stage message included', async () => {
+    // Phase 2: the reply is the streaming stage's delivery, not an
+    // acts-stage message_user.
+    await withQueue(buildQueue(() => [{ tool: 'wait', reason: 'Only conversation.' }]), async ({ queue, delivered }) => {
       const result = await queue.runUserMessageTurn({
         kind: 'user_message',
         userId: 'user-1',
@@ -124,7 +129,8 @@ describe('IntentAgentQueue serialization', () => {
 
       expect(result.messages).toEqual(['Right here.']);
       expect(result.acts).toEqual([
-        { tool: 'message_user', text: 'Right here.', sessionId: 'session-1', messageId: 'message-1' },
+        { tool: 'wait', reason: 'Only conversation.' },
+        { tool: 'message_user', text: 'Right here.', sessionId: 'session-1', messageId: 'message-1', stage: 'reply' },
       ]);
       expect(delivered).toEqual(['Right here.']);
     });

--- a/services/api/src/services/chat.service.ts
+++ b/services/api/src/services/chat.service.ts
@@ -1,13 +1,9 @@
 import { log } from '../lib/log';
 import { conversationDatabaseAdapter, ConversationDatabaseAdapter, ChatDatabaseAdapter } from '../adapters/database.adapter';
 import type { ChatPersonaId, ChatScopeType } from '../adapters/database.shared';
-import { ChatGraphFactory, ChatTitleGenerator, NEGOTIATOR_PERSONA_ID, ONBOARDING_PERSONA, ONBOARDING_PERSONA_ID, SIGNAL_PERSONA_ID, createNegotiatorPersona } from '@indexnetwork/protocol';
+import { ChatGraphFactory, ChatTitleGenerator, NEGOTIATOR_PERSONA_ID, ONBOARDING_PERSONA, ONBOARDING_PERSONA_ID, SIGNAL_PERSONA_ID } from '@indexnetwork/protocol';
 import type { ChatGraphCompositeDatabase } from '@indexnetwork/protocol';
 import { getCheckpointer } from '../adapters/checkpointer.adapter';
-import { negotiatorMemoryRetrievalAdapter } from '../adapters/negotiator-memory.retrieval.adapter';
-import { readOpenQuestionsForIntent } from '../lib/question/open-question-message';
-import { readActionableCounterparties } from '../lib/agent/negotiator-verdict.host';
-import { isNegotiatorMemoryWriteEnabled } from '../lib/negotiator-feature';
 import type { PostgresSaver } from '@langchain/langgraph-checkpoint-postgres';
 
 const logger = log.service.from("ChatSessionService");
@@ -764,64 +760,13 @@ export class ChatSessionService {
     return this.factory.withPersona(ONBOARDING_PERSONA);
   }
 
-  /**
-   * Derive a negotiator-persona graph factory bound to the client's personal
-   * negotiator agent identity. Shares all dependencies with the orchestrator
-   * factory; only prompt/toolset/loop behaviors differ.
-   *
-   * @param agent - Identity from the user's `type='personal'` agent row
-   * @param pinnedIntent - The pinned signal for intent-scoped sessions (P4.2):
-   *                       its id, and its label for the prompt's pinned signal
-   *                       section. The id also resolves the signal's OPEN
-   *                       questions (#1466) — what the client's own agent is
-   *                       currently waiting on them for.
-   */
-  async getNegotiatorGraphFactory(
-    agent: { name: string; description?: string | null },
-    userId: string,
-    pinnedIntent?: { intentId?: string; label?: string },
-  ): Promise<ChatGraphFactory> {
-    // P5.3: the client's accumulated negotiator memories inform the DM
-    // persona (gated on NEGOTIATOR_MEMORY_INJECT; [] → byte-identical
-    // prompt). The adapter never throws — the catch is belt and braces so a
-    // memory failure can never take down the chat surface.
-    const memory = await negotiatorMemoryRetrievalAdapter.retrieveForChat(userId).catch(() => []);
-    // #1466: the questions this signal's DM currently has open. Without them
-    // the persona could not tell that a message answering one WAS an answer —
-    // its only move on such a message was to edit the signal, which is what it
-    // did on 2026-08-20. Never throws (the reader swallows its own failures);
-    // absent → the prompt is byte-identical to before.
-    const openQuestions = pinnedIntent?.intentId
-      ? (await readOpenQuestionsForIntent(userId, pinnedIntent.intentId))?.questions ?? []
-      : [];
-    // #1471: the counterparties of this signal the client can still pass a
-    // verdict on. Without them the persona has numbers for nothing and the
-    // verdict tools are unreachable — which was the whole gap: told to reject
-    // a match, the agent's only moves were to say so, or to edit the signal.
-    // Never throws (the reader swallows its own failures); empty → the prompt
-    // is byte-identical to before.
-    const actionableCounterparties = pinnedIntent?.intentId
-      ? await readActionableCounterparties(userId, pinnedIntent.intentId)
-      : [];
-    return this.factory.withPersona(
-      createNegotiatorPersona({
-        agentName: agent.name,
-        ...(agent.description?.trim() ? { agentDescription: agent.description } : {}),
-        ...(pinnedIntent?.label?.trim() ? { pinnedIntentLabel: pinnedIntent.label.trim() } : {}),
-        ...(memory.length > 0 ? { memory } : {}),
-        // P5.4: the remember/forget tools are registered by the composition
-        // root under the same flag — the prompt advertises them only when
-        // they actually exist for this session.
-        ...(isNegotiatorMemoryWriteEnabled() ? { memoryToolsEnabled: true } : {}),
-        ...(openQuestions.length > 0
-          ? { openQuestions: openQuestions.map((question) => question.label) }
-          : {}),
-        ...(actionableCounterparties.length > 0
-          ? { actionableCounterparties: actionableCounterparties.map((counterparty) => counterparty.label) }
-          : {}),
-      }),
-    );
-  }
+  // The negotiator-persona graph factory retired with phase 2 of the
+  // holistic intent-agent (full chat ownership): every turn of the
+  // negotiator intent DM runs the IntentAgent on its serialized inbox, so no
+  // persona graph — and none of the persona's chat tool registrations
+  // (answer_pending_question, accept/reject_opportunity, remember/forget) —
+  // exists for this scope any more. The hosts those tools called stay
+  // shared: the MCP surface (mcp.controller toolDeps) still registers them.
 
   /**
    * Verify that a message belongs to a session owned by the given user.


### PR DESCRIPTION
Phase 2 of docs/plans/2026-08-21-holistic-intent-agent.md — "Full chat ownership" + "Verdicts through the agent", built together because they are one seam: retiring the persona from intent scope orphans its verdict tools unless the agent absorbs them.

## The direction

The personal agent is an actual agent: it holds the whole conversation with its client, conducts negotiations, asks when it needs to — and the client's explicit word is the only thing that executes anything. Prompts carry judgment, code carries effects; explicit over automatic; the agent proposes, the client disposes.

## The seam closed: two minds → one

Phase 1 left the client talking to two minds — the IntentAgent while something was parked (`intentAgentOwnsTurn`), the persona graph otherwise, so the agent never heard casual context and could not `note_dossier` from chat. Now, for `sessionPersona === negotiator && scopeType === 'intent'`, EVERY user turn runs the IntentAgent on its serialized inbox. Negotiator sessions are intent-scoped by construction (new ones require the pin; unscoped legacy rows are read-only), so the persona graph is never derived for this scope at all. Other personas and network scope are byte-identical. Post-turn machinery (title, suggestions, done event, reflect queue) runs on the agent's response exactly as before.

The turn is now two stages:

- **Acts stage** (structured judgment, as phase 1) decides effects — answer_negotiation, note_dossier, retire_dossier, the new verdicts, wait. For a client message, `message_user` is structurally refused here (the validator rejects it; `wait` is the honest "nothing to execute"); background events keep it for authoring asks, exactly as phase 1.
- **Reply stage** (new) composes the conversational reply: a second model call under the same law plus a reply instruction, over the context plus the just-executed acts. The reply persists in the host and is ledgered as `message_user` with `stage: 'reply'`. Background events skip the stage — no client is waiting.

## Streaming design and the safety-check choice

Tokens cross from the inbox worker to the waiting controller over Redis pub/sub, on a channel keyed by the turn's message id (`intent-agent-reply.stream.ts`; the same in-process hermetic guard the queue factory uses under test). The controller subscribes BEFORE enqueueing, relays chunks as SSE `token` events (monotonic seq), and falls back to emitting whatever the channel did not deliver of the completed turn as one token event — a turn is never lost to a dropped subscription. `runUserMessageTurn` keeps its timeout semantics and the fixed failure copy stays. No SSE framing changes: the surface emits only more `token` events plus the same `done`.

**The tension resolved: check-then-stream.** The reply is generated to completion, passes `isSafeQuestionMessageProse` (fail → one retry → fixed fallback copy, with the failure ledgered on the act as `fallback: 'safety_check_failed' | 'model_error'`), is persisted — and only then is published as ordered sentence chunks. Latency cost, stated honestly: the first token waits for full generation plus the check, i.e. no earlier than phase 1's single emission (nothing regressed), but not token-by-token model latency either. Chosen over buffer-and-flush-by-sentence because a mid-reply check failure there would need retraction semantics (`response_reset`) on a surface whose web client consumes only token/done — and because no unchecked token may ever be persisted or shown. The transport is already incremental; an incremental safety formulation can move the flush earlier later without touching the SSE contract (listed in the design doc's Phase 3+).

Steer/interrupt: unchanged semantics. A steer during an agent-owned turn cannot stop the serialized inbox turn (the message is already durable and being judged); the stream stops emitting, the interrupted-turn guard cannot double-persist (the agent path persisted the user message before the turn and its assistant messages inside it), and the steer message lands as its own next serialized turn.

## Verdicts: the client's word executes, the agent's opinion proposes

New acts `accept_opportunity` / `reject_opportunity`, referring by 1-based number to a bounded active-match list now assembled into the turn context by the SAME reader the #1471 tools use (`readActionableCounterparties`; cap 12, newest kept, truncation logged — numbers are context-relative and resolved to ids by the validator, so the cap renumbers nothing). Execution reuses the #1471 lane through a new id-keyed entry (`passVerdictOnOpportunity`) that shares the position lane's exact write (`opportunityService.updateOpportunityStatus`) and failure classification — nothing reimplemented; an id that left the actionable set between context assembly and the act re-lists honestly. Outcomes are ledgered verbatim.

THE LAW is prompt v2's (`INTENT_AGENT_SYSTEM_PROMPT_VERSION = 2`): a verdict fires ONLY on the client's explicit word; a hedge gets a recommendation and the question that would settle it, never an act. The explicit/hedged boundary is judgment, so it is pinned in the live eval (a deterministic harness cannot fence it without re-deciding — said in a comment where the mocked spec pins the plumbing). Structural fences in the validator: verdict acts only on `user_message` events, only listed numbers, one verdict per match per turn.

Signal edits stay explicit: no signal-edit act was added. The prompt directs the client honestly to edit the signal itself. The persona's `update_intent` was a shared-registry chat tool, not a dedicated explicit-update host wired for absorption — so `update_signal` is deferred, not invented.

## Deleted (shipped, not flagged)

- `intentAgentOwnsTurn` and its parked-set read — ownership is unconditional.
- The persona-graph invocation for negotiator intent scope: `chatSessionService.getNegotiatorGraphFactory` (prompt assembly, memory retrieval, open-question and counterparty prompt seeding) and the controller's negotiator factory branch.
- With it, the persona's chat-side tool registrations for this scope — `answer_pending_question`, `accept_opportunity`/`reject_opportunity`, `remember`/`forget` — no longer exist: the api no longer constructs the negotiator persona, so `createNegotiatorTools` has no chat caller. The hosts stay shared.
- The rule-8 silent-turn backstop (`INTENT_AGENT_SILENT_TURN_REPLY`) — the reply stage owns the never-silent guarantee now, with `INTENT_AGENT_REPLY_FALLBACK` as its ledgered fixed copy.
- Specs pinning the old seam were updated with one-line comments citing the direction (chat.negotiator.isolated streaming tests, wiring static pins, queue isolated user-message shape, loop capture turn 2).

## MCP surface: verified untouched

The claude.ai connector registers the verdict/answer hosts through a DIFFERENT path: `mcp.controller.ts` builds `McpToolDeps` with `negotiatorAnswerTools`/`negotiatorVerdictTools` from the module-level hosts (lines ~680) into `createMcpServer` — no persona involved. Verified by (1) reading that toolDeps wiring before touching anything; (2) leaving the hosts and the protocol MCP tool modules byte-untouched (the only host change is the additive id-keyed entry); (3) a new static pin asserting `mcp.controller.ts` retains both registrations; (4) running the protocol suites that cover the MCP verdict tools and capability policy: `bun test src/opportunities/tests/opportunity.verdict.tools.spec.ts src/mcp/tests/mcp.authorization-policy.spec.ts src/chat/tests/negotiator.verdict-tools.spec.ts` → 61 pass, 0 fail.

## Test evidence

All in `services/api` unless noted (`NODE_ENV=test bun test …`):

- `src/lib/intent-agent/tests/ + src/queues/tests/intent-agent.queue.isolated.ts + src/lib/agent/tests/negotiator-verdict.host.spec.ts` → **57 pass, 0 fail** (turn validation incl. verdict mapping/bans 21, loop over real settle/claim substrate 2, verdicts over the real #1471 lane DB-backed 2, reply transport + chunker 5, wiring static pins 5, live-eval file skipped-gate 4, queue serialization/dedup/reply shape 4, verdict host 14).
- `src/controllers/tests/chat.negotiator.isolated.ts` → **17 pass, 0 fail** — includes: agent runs / persona never derived (both entry paths), worker→pub/sub→SSE relay in order with no duplicate remainder, silent-channel fallback delivers the completed reply, failed turn delivers and persists the fixed copy.
- `src/services/tests/chat.service.isolated.ts` → **42 pass**, `src/controllers/tests/chat.controller.isolated.ts` → **26 pass**, `chat.signal.spec.ts` → **18 pass**, `chat.controller.decisionQuestions.spec.ts` → **3 pass** (each run isolated, per the manifest).
- **Live-LLM evals (paid gate), actually run**: `RUN_PAID_INTEGRATION_TESTS=1 bun test src/lib/intent-agent/tests/intent-agent.judgment.llm.spec.ts` → **4 pass, 0 fail** (9.9s): phase-1 "actually this month works" answers the park under prompt v2; small talk fires no acts; "Reject the second one" executes on the right match; a hedged verdict fires no act and the reply stage produces safe deliverable prose.
- Full api baseline: `bun run test` → see baselined failures below.
- `bunx tsc --noEmit` clean.

## Baselined failures (pre-existing, per the #1462 method — no `git stash`)

Full `bun run test` on this branch: **1828 pass, 4 skip, 17 fail** (1849 tests, 209 files). Every failing file was re-run against the base commit (`git checkout b8ea9d1fa0 -- services/api/src`, run, restore — the working tree was fully committed, so nothing was stashed) with **identical** per-file counts, i.e. all 17 are pre-existing on dev on this machine:

- `src/adapters/tests/clicredential.adapter.spec.ts` ×4 (known list)
- `src/adapters/tests/conversation.database.adapter.spec.ts` ×2 (known list)
- `src/adapters/tests/negotiation-scope.static.spec.ts` ×1 (known list)
- `src/controllers/tests/conversation.controller.spec.ts` ×2, `src/controllers/tests/tool.controller.contract.spec.ts` ×2, `src/adapters/tests/archive-legacy-negotiations.isolated.ts` ×1, `tests/maintenance-introducer-discovery.spec.ts` ×1, `tests/mcp.spec.ts` ×4 (update_opportunity owner-approval flows) — beyond the handoff's known list but verified base-identical.

The one whole-suite run before the verdict-wiring spec update showed 2 additional failures in `negotiator-verdict.wiring.static.spec.ts` — those pinned the retired persona-prompt seeding and were updated in this PR (commit `7592500944`), not baselined. Running incompatible isolated files in a single bun process also cross-contaminates (the manifest's reason for `scripts/test-isolated.sh`); all such files pass in isolation. The protocol live-LLM whole-dir flake policy applies as usual.

## Deferred

- `update_signal` act — no existing dedicated explicit-intent-update host is wired into the persona toolset to absorb; the reply directs the client to the signal's own edit affordance.
- Incremental reply streaming (checked-sentence flush) — needs an incremental safety formulation; transport already supports it.
- Protocol cleanup: `createNegotiatorPersona`/`createNegotiatorTools` and the negotiator chat persona module are now chat-dead (no api caller); removal is a protocol-major cleanup for its own lane. Protocol was NOT touched in this PR (still 23.6.2).
- Context enrichment option noted, not wired: the persona's negotiator-memory / client-DM retrieval adapters are cheap drop-ins for context assembly if conversation quality wants them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01N1FQ3gV1oWWXQHMGGroqcV
