### PR TITLE
Persona identity + create_intent scope rule

### DIFF
--- a/apps/web/src/components/ChatContent.tsx
+++ b/apps/web/src/components/ChatContent.tsx
@@ -1080,7 +1080,7 @@ export default function ChatContent({
               <span className="flex h-7 w-7 items-center justify-center rounded-lg bg-[#041729] text-lg leading-none text-white">+</span>
               <span>
                 <span className="block text-sm font-medium text-[#041729]">Who are you trying to meet?</span>
-                <span className="block text-xs text-gray-500">Let your Signal Agent guide you through a new signal.</span>
+                <span className="block text-xs text-gray-500">A few questions to make what you’re looking for legible.</span>
               </span>
             </button>
           <div className="mt-8">

--- a/apps/web/src/components/ChatContent.tsx
+++ b/apps/web/src/components/ChatContent.tsx
@@ -726,7 +726,7 @@ export default function ChatContent({
         </p>
         <p className="mt-1 text-sm text-gray-600">
           {startsSignal
-            ? "Its messages are preserved. Continue in a separate Signal Agent chat."
+            ? "Its messages are preserved. Continue in a separate chat with your agent."
             : "This chat is unchanged. Start a new chat to continue safely."}
         </p>
         <Button
@@ -740,7 +740,7 @@ export default function ChatContent({
             navigate("/");
           }}
         >
-          {startsSignal ? "Start a Signal Agent chat" : "Start a new chat"}
+          {startsSignal ? "Start a chat with your agent" : "Start a new chat"}
         </Button>
       </div>
     );

--- a/apps/web/src/contexts/AIChatContext.tsx
+++ b/apps/web/src/contexts/AIChatContext.tsx
@@ -310,13 +310,13 @@ function mergeDebugMetaIntoTraceEvents(
 }
 
 const SAFE_TURN_BLOCK_MESSAGES: Readonly<Record<string, string>> = {
-  WEB_SIGNAL_PERSONA_REQUIRED: "Start a new Signal Agent chat to continue.",
-  WEB_SIGNAL_SESSION_REQUIRED: "This earlier chat is read-only. Start a new Signal Agent chat to continue.",
-  WEB_SIGNAL_AGENT_DISABLED: "Signal Agent is not available right now.",
+  WEB_SIGNAL_PERSONA_REQUIRED: "Start a new chat with your agent to continue.",
+  WEB_SIGNAL_SESSION_REQUIRED: "This earlier chat is read-only. Start a new chat with your agent to continue.",
+  WEB_SIGNAL_AGENT_DISABLED: "Your agent is not available right now.",
   WEB_SIGNAL_PERSONA_FORBIDDEN: "This chat can only be continued in the web app.",
   CHAT_PERSONA_MISMATCH: "This request does not match the chat that was opened.",
   CHAT_PERSONA_UNSUPPORTED: "This chat cannot be continued safely.",
-  CHAT_SCOPE_REQUIRES_NEW_SESSION: "Start a separate Signal Agent chat for that focus.",
+  CHAT_SCOPE_REQUIRES_NEW_SESSION: "Start a separate chat with your agent for that focus.",
 };
 
 /** Parse only known policy denials and never render server-controlled detail text. */

--- a/apps/web/tests/ai-chat-context-signal.test.tsx
+++ b/apps/web/tests/ai-chat-context-signal.test.tsx
@@ -394,7 +394,7 @@ describe('AIChatContext Signal persona transport and ownership', () => {
   });
 
   test.each([
-    ['WEB_SIGNAL_AGENT_DISABLED', 'Signal Agent is not available right now.'],
+    ['WEB_SIGNAL_AGENT_DISABLED', 'Your agent is not available right now.'],
     ['CHAT_PERSONA_MISMATCH', 'This request does not match the chat that was opened.'],
     ['CHAT_PERSONA_UNSUPPORTED', 'This chat cannot be continued safely.'],
   ])('maps %s to product-safe state without trusting server detail', async (code, safeMessage) => {

--- a/packages/protocol/src/agents/agent.module.ts
+++ b/packages/protocol/src/agents/agent.module.ts
@@ -13,20 +13,20 @@ export { ChatTitleGenerator } from "../chat/chat.title.generator.js";
 export { createChatTools } from "../chat/chat.tools.js";
 export { createNegotiatorPersona, NEGOTIATOR_PERSONA_ID } from "../chat/negotiator.persona.js";
 export {
+  createOnboardingPersona,
   createOnboardingTools,
   filterOnboardingTools,
   narrowOnboardingTools,
-  ONBOARDING_PERSONA,
   ONBOARDING_PERSONA_ID,
   ONBOARDING_PROFILE_KICKOFF,
   ONBOARDING_TOOL_NAMES,
 } from "../chat/onboarding.persona.js";
 export {
+  createSignalPersona,
   createSignalTools,
   filterSignalTools,
   narrowSignalTools,
   SIGNAL_NEW_SIGNAL_KICKOFF,
-  SIGNAL_PERSONA,
   SIGNAL_PERSONA_ID,
   SIGNAL_TOOL_NAMES,
 } from "../chat/signal.persona.js";

--- a/packages/protocol/src/chat/agent-identity.prompt.ts
+++ b/packages/protocol/src/chat/agent-identity.prompt.ts
@@ -1,0 +1,41 @@
+// ═══════════════════════════════════════════════════════════════════════════════
+// PERSONA SELF-IDENTIFICATION
+// ═══════════════════════════════════════════════════════════════════════════════
+//
+// Every chat persona is the same thing to the user: their own agent. The app
+// says so everywhere — the intent page column, the chat placeholder, /agents,
+// /agent/memory. A persona that introduces itself by its toolset ("Signal
+// Agent", "Onboarding Agent") tells the user they are talking to something
+// else. The name comes from the user's `type='personal'` agent row, the same
+// row the negotiator persona already reads.
+
+/** Identity of the user's personal agent, as the persona should introduce it. */
+export interface AgentIdentityOptions {
+  /**
+   * Display name from the user's `type='personal'` agent row. Absent only if
+   * the row is somehow missing — `ensureNegotiatorAgent` runs at auth, so
+   * every user has one from signup.
+   */
+  agentName?: string;
+}
+
+/**
+ * Builds a persona's opening self-identification sentence.
+ *
+ * The nameless fallback stays generic on purpose: reintroducing a product noun
+ * there would recreate exactly the mismatch this helper exists to remove.
+ *
+ * @param input - The agent's name, the user it works for, and the persona's role
+ * @returns One sentence, e.g. `You are Ada's Agent, the private signals and profile assistant for Ada.`
+ */
+export function buildAgentSelfIntroduction(input: {
+  agentName?: string;
+  userName: string;
+  /** Role phrase, without a leading article-free verb — e.g. "the restricted setup assistant". */
+  role: string;
+}): string {
+  const name = input.agentName?.trim();
+  return name
+    ? `You are ${name}, ${input.role} for ${input.userName}.`
+    : `You are ${input.userName}'s personal agent, ${input.role}.`;
+}

--- a/packages/protocol/src/chat/onboarding.persona.ts
+++ b/packages/protocol/src/chat/onboarding.persona.ts
@@ -6,7 +6,7 @@ import { resolveChatContext } from "../shared/agent/tool.helpers.js";
 import { deriveAllowedNetworkIds, scopeFromNetworkId } from "../shared/agent/tool.scope.js";
 import type { ChatPersonaConfig } from "./chat.persona.js";
 import { narrowSignalTools } from "./signal.persona.js";
-import { buildOnboardingSystemContent } from "./onboarding.prompt.js";
+import { buildOnboardingSystemContent, type OnboardingPromptOptions } from "./onboarding.prompt.js";
 
 /** Public kickoff marker used by the restricted web profile phase. */
 export { ONBOARDING_PROFILE_KICKOFF } from "./onboarding.prompt.js";
@@ -98,12 +98,24 @@ export async function createOnboardingTools(
   );
 }
 
-/** Restricted web onboarding persona on the persona-neutral chat runtime. */
-export const ONBOARDING_PERSONA: ChatPersonaConfig = {
-  id: ONBOARDING_PERSONA_ID,
-  buildSystemContent: (ctx, iterCtx) => buildOnboardingSystemContent(ctx, iterCtx),
-  createTools: (deps, preResolvedContext) => createOnboardingTools(deps, preResolvedContext),
-  loopBehaviors: {
-    hallucinationRecovery: true,
-  },
-};
+/** Identity this persona introduces itself with. */
+export type OnboardingPersonaOptions = OnboardingPromptOptions;
+
+/**
+ * Creates the restricted web onboarding persona on the persona-neutral chat
+ * runtime. A factory, not a singleton, because the persona introduces itself
+ * as the user's own agent — named from their `type='personal'` agent row,
+ * which `ensureNegotiatorAgent` writes at auth, before onboarding ever runs.
+ *
+ * @param opts - Identity from the user's `type='personal'` agent row
+ */
+export function createOnboardingPersona(opts: OnboardingPersonaOptions = {}): ChatPersonaConfig {
+  return {
+    id: ONBOARDING_PERSONA_ID,
+    buildSystemContent: (ctx, iterCtx) => buildOnboardingSystemContent(ctx, opts, iterCtx),
+    createTools: (deps, preResolvedContext) => createOnboardingTools(deps, preResolvedContext),
+    loopBehaviors: {
+      hallucinationRecovery: true,
+    },
+  };
+}

--- a/packages/protocol/src/chat/onboarding.prompt.ts
+++ b/packages/protocol/src/chat/onboarding.prompt.ts
@@ -1,4 +1,5 @@
 import type { ResolvedToolContext } from "../shared/agent/tool.factory.js";
+import { buildAgentSelfIntroduction, type AgentIdentityOptions } from "./agent-identity.prompt.js";
 import type { IterationContext } from "./chat.prompt.modules.js";
 import { buildSignalIntakeGuidance, getSignalIntakeStage } from "./signal.prompt.js";
 
@@ -19,9 +20,20 @@ The durable profile approval marker is absent. Work only on the approved profile
 Do not start signal-intake questions during this profile phase. Do not call create_intent or complete_onboarding here.`;
 }
 
-/** Builds the restricted, server-selected web onboarding prompt. */
+/** Identity injected into the onboarding prompt, from the user's personal agent row. */
+export type OnboardingPromptOptions = AgentIdentityOptions;
+
+/**
+ * Builds the restricted, server-selected web onboarding prompt.
+ *
+ * @param ctx - Resolved user and scope context
+ * @param opts - Identity from the user's `type='personal'` agent row
+ * @param iterCtx - Agent-loop iteration context
+ * @returns The complete onboarding-persona system prompt
+ */
 export function buildOnboardingSystemContent(
   ctx: ResolvedToolContext,
+  opts: OnboardingPromptOptions = {},
   iterCtx?: IterationContext,
 ): string {
   const userContext = JSON.stringify(ctx.user, null, 2);
@@ -41,7 +53,11 @@ export function buildOnboardingSystemContent(
 The profile phase is durably complete. Do not call profile preview/confirmation tools again unless the user explicitly corrects a profile fact. During guided intake, create_intent is proposal-only. The browser confirms the proposal, then invokes complete_onboarding with the exact created intent ID before navigation. Never call complete_onboarding before the proposal has been persisted by the browser.`
     : buildProfileGuidance(ctx);
 
-  return `You are Onboarding Agent, the restricted setup assistant for ${ctx.userName}.
+  return `${buildAgentSelfIntroduction({
+    ...(opts.agentName ? { agentName: opts.agentName } : {}),
+    userName: ctx.userName,
+    role: "the restricted setup assistant",
+  })}
 
 Your only job is to collect an explicitly approved profile and guide the user's first signal. You cannot import Gmail or contacts, discover or act on opportunities, negotiate, choose or join communities, change memberships, administer agents or networks, or perform arbitrary orchestration.
 

--- a/packages/protocol/src/chat/signal.persona.ts
+++ b/packages/protocol/src/chat/signal.persona.ts
@@ -6,7 +6,7 @@ import { error, resolveChatContext, success } from "../shared/agent/tool.helpers
 import type { SystemDatabase, UserDatabase } from "../shared/interfaces/database.interface.js";
 import { deriveAllowedNetworkIds, focusedIntentId, focusedNetworkId, scopeFromNetworkId } from "../shared/agent/tool.scope.js";
 import type { ChatPersonaConfig } from "./chat.persona.js";
-import { buildSignalSystemContent } from "./signal.prompt.js";
+import { buildSignalSystemContent, type SignalPromptOptions } from "./signal.prompt.js";
 
 /** Public kickoff marker used by New Signal surfaces to enter guided intake. */
 export { SIGNAL_NEW_SIGNAL_KICKOFF } from "./signal.prompt.js";
@@ -395,14 +395,28 @@ export async function createSignalTools(
   return narrowSignalTools(allowed, { context: resolvedContext, userDb, systemDb });
 }
 
-/** Restricted Signal Agent persona on the persona-neutral chat runtime. */
-export const SIGNAL_PERSONA: ChatPersonaConfig = {
-  id: SIGNAL_PERSONA_ID,
-  buildSystemContent: (ctx, iterCtx) => buildSignalSystemContent(ctx, iterCtx),
-  createTools: (deps, preResolvedContext) => createSignalTools(deps, preResolvedContext),
-  loopBehaviors: {
-    // Direct discovery is absent, so its create-intent retry callback must stay off.
-    // create_intent can legitimately return proposal cards; retain recovery/stripping.
-    hallucinationRecovery: true,
-  },
-};
+/** Identity this persona introduces itself with. */
+export type SignalPersonaOptions = SignalPromptOptions;
+
+/**
+ * Creates the restricted signals persona on the persona-neutral chat runtime.
+ *
+ * A factory rather than a static singleton for the same reason the negotiator
+ * is one: the persona's identity comes from the user's `type='personal'` agent
+ * row, so it can only be bound per session. Capabilities, allowlist and tool
+ * narrowing are identity-independent and unchanged.
+ *
+ * @param opts - Identity from the user's `type='personal'` agent row
+ */
+export function createSignalPersona(opts: SignalPersonaOptions = {}): ChatPersonaConfig {
+  return {
+    id: SIGNAL_PERSONA_ID,
+    buildSystemContent: (ctx, iterCtx) => buildSignalSystemContent(ctx, opts, iterCtx),
+    createTools: (deps, preResolvedContext) => createSignalTools(deps, preResolvedContext),
+    loopBehaviors: {
+      // Direct discovery is absent, so its create-intent retry callback must stay off.
+      // create_intent can legitimately return proposal cards; retain recovery/stripping.
+      hallucinationRecovery: true,
+    },
+  };
+}

--- a/packages/protocol/src/chat/signal.prompt.ts
+++ b/packages/protocol/src/chat/signal.prompt.ts
@@ -1,5 +1,6 @@
 import type { ResolvedToolContext } from "../shared/agent/tool.factory.js";
 import { focusedIntentId } from "../shared/agent/tool.scope.js";
+import { buildAgentSelfIntroduction, type AgentIdentityOptions } from "./agent-identity.prompt.js";
 import type { IterationContext } from "./chat.prompt.modules.js";
 
 /** Stable user-message marker for opening the guided New Signal intake. */
@@ -44,7 +45,7 @@ export type SignalIntakeStage = "interview" | "complete";
  * plain conversation, so the only tool-call marker left is `create_intent`
  * (the synthesis step), which completes the intake.
  *
- * @param iterCtx - Current Signal Agent iteration context
+ * @param iterCtx - Current signals-persona iteration context
  * @returns The intake stage, or null for ordinary Signal chats
  */
 export function getSignalIntakeStage(iterCtx?: IterationContext): SignalIntakeStage | null {
@@ -81,19 +82,24 @@ Skip a question when the user has already answered it unprompted. When you have 
 The browser is showing the proposed signal before it is saved. If the user gives feedback on that draft, use it to revise the signal and call \`create_intent\` again with the revised description. This produces a replacement proposal only; never persist or auto-approve either draft. Pass the newest tool-produced \`\`\`intent_proposal\`\`\` block through verbatim and tell the user to review it. If the user has no feedback, briefly confirm that they can approve, edit, or skip the visible draft.`;
 }
 
+/** Identity injected into the signals prompt, from the user's personal agent row. */
+export type SignalPromptOptions = AgentIdentityOptions;
+
 /**
- * Builds the restricted Signal Agent system prompt.
+ * Builds the restricted signals-and-profile system prompt.
  *
- * Signal manages the user's signals and profile knowledge. Matching,
+ * This persona manages the user's signals and profile knowledge. Matching,
  * opportunities, negotiations, administration, imports, and membership changes
- * are deliberately outside this persona and are not advertised here.
+ * are deliberately outside it and are not advertised here.
  *
  * @param ctx - Resolved user and scope context
+ * @param opts - Identity from the user's `type='personal'` agent row
  * @param iterCtx - Agent-loop iteration context used for the New Signal kickoff
- * @returns The complete Signal Agent system prompt
+ * @returns The complete signals-persona system prompt
  */
 export function buildSignalSystemContent(
   ctx: ResolvedToolContext,
+  opts: SignalPromptOptions = {},
   iterCtx?: IterationContext,
 ): string {
   const userContext = JSON.stringify(ctx.user, null, 2);
@@ -111,7 +117,11 @@ export function buildSignalSystemContent(
     2,
   );
 
-  return `You are Signal Agent, the private signals and profile assistant for ${ctx.userName}.
+  return `${buildAgentSelfIntroduction({
+    ...(opts.agentName ? { agentName: opts.agentName } : {}),
+    userName: ctx.userName,
+    role: "the private signals and profile assistant",
+  })}
 
 Your role is deliberately narrow: ${scopedIntentId ? "help the user inspect and refine this selected signal (intent)" : "help the user capture, inspect, refine, archive, and place their signals (intents)"}, and keep the profile knowledge and premises behind those signals accurate. You may explain the communities and memberships the user already has, but you do not discover opportunities, inspect or act on opportunities, negotiate, manage contacts or imports, administer agents or communities, or change memberships. Matching happens separately in the background after signals change.
 

--- a/packages/protocol/src/chat/tests/onboarding.persona.spec.ts
+++ b/packages/protocol/src/chat/tests/onboarding.persona.spec.ts
@@ -3,7 +3,7 @@ config({ path: ".env.test", override: true });
 
 import { describe, expect, it } from "bun:test";
 
-import { ONBOARDING_PERSONA, ONBOARDING_PERSONA_ID, ONBOARDING_TOOL_NAMES, filterOnboardingTools, narrowOnboardingTools } from "../onboarding.persona.js";
+import { createOnboardingPersona, ONBOARDING_PERSONA_ID, ONBOARDING_TOOL_NAMES, filterOnboardingTools, narrowOnboardingTools } from "../onboarding.persona.js";
 import { buildOnboardingSystemContent } from "../onboarding.prompt.js";
 import { SIGNAL_NEW_SIGNAL_KICKOFF } from "../signal.prompt.js";
 import type { ChatTools, ResolvedToolContext } from "../../shared/agent/tool.factory.js";
@@ -73,13 +73,29 @@ function makeContext(onboarding: Record<string, unknown> = {}): ResolvedToolCont
   } as unknown as ResolvedToolContext;
 }
 
-describe("ONBOARDING_PERSONA", () => {
+describe("createOnboardingPersona", () => {
   it("uses a first-class persisted persona with proposal recovery", () => {
+    const persona = createOnboardingPersona({ agentName: "Alice's Agent" });
     expect(ONBOARDING_PERSONA_ID).toBe("onboarding");
-    expect(ONBOARDING_PERSONA.id).toBe(ONBOARDING_PERSONA_ID);
-    expect(ONBOARDING_PERSONA.loopBehaviors).toEqual({
+    expect(persona.id).toBe(ONBOARDING_PERSONA_ID);
+    expect(persona.loopBehaviors).toEqual({
       hallucinationRecovery: true,
     });
+  });
+
+  it("introduces itself as the user's own agent, never a product noun", () => {
+    const ctx = makeContext();
+    const named = createOnboardingPersona({ agentName: "Alice's Agent" })
+      .buildSystemContent(ctx, { iteration: 1 } as never);
+    expect(named).toContain("You are Alice's Agent, the restricted setup assistant for Alice.");
+    expect(named).not.toContain("Onboarding Agent");
+
+    // ensureNegotiatorAgent runs at auth, so a nameless row is the unexpected
+    // case — it still must not reintroduce a product noun.
+    const nameless = createOnboardingPersona()
+      .buildSystemContent(ctx, { iteration: 1 } as never);
+    expect(nameless).toContain("You are Alice's personal agent, the restricted setup assistant.");
+    expect(nameless).not.toContain("Onboarding Agent");
   });
 
   it("pins the exact positive allowlist and excludes every forbidden family", () => {
@@ -120,7 +136,7 @@ describe("ONBOARDING_PERSONA", () => {
 
 describe("buildOnboardingSystemContent", () => {
   it("runs the approved profile flow during the profile phase", () => {
-    const prompt = buildOnboardingSystemContent(makeContext(), {
+    const prompt = buildOnboardingSystemContent(makeContext(), {}, {
       currentMessage: "onboarding-profile-kickoff",
       recentTools: [],
       ctx: makeContext(),
@@ -135,7 +151,7 @@ describe("buildOnboardingSystemContent", () => {
       profileConfirmedAt: "2026-07-01T00:00:00.000Z",
       currentStep: "first_signal",
     });
-    const prompt = buildOnboardingSystemContent(ctx, {
+    const prompt = buildOnboardingSystemContent(ctx, {}, {
       currentMessage: SIGNAL_NEW_SIGNAL_KICKOFF,
       recentTools: [],
       ctx,

--- a/packages/protocol/src/chat/tests/signal.persona.spec.ts
+++ b/packages/protocol/src/chat/tests/signal.persona.spec.ts
@@ -3,7 +3,7 @@ config({ path: ".env.test", override: true });
 
 import { describe, expect, it, mock } from "bun:test";
 
-import { SIGNAL_PERSONA, SIGNAL_PERSONA_ID, SIGNAL_TOOL_NAMES, filterSignalTools, narrowSignalTools } from "../signal.persona.js";
+import { createSignalPersona, SIGNAL_PERSONA_ID, SIGNAL_TOOL_NAMES, filterSignalTools, narrowSignalTools } from "../signal.persona.js";
 import { buildSignalSystemContent, getSignalIntakeStage, isSignalNewSignalFeedback, isSignalNewSignalKickoff, SIGNAL_NEW_SIGNAL_KICKOFF } from "../signal.prompt.js";
 import type { ChatTools, ResolvedToolContext } from "../../shared/agent/tool.factory.js";
 import type { SystemDatabase, UserDatabase } from "../../shared/interfaces/database.interface.js";
@@ -199,22 +199,23 @@ function parsed(result: unknown) {
   };
 }
 
-describe("SIGNAL_PERSONA", () => {
+describe("createSignalPersona", () => {
   it("uses the canonical persisted persona id", () => {
     expect(SIGNAL_PERSONA_ID).toBe("signal");
-    expect(SIGNAL_PERSONA.id).toBe(SIGNAL_PERSONA_ID);
+    expect(createSignalPersona({ agentName: "Alice's Agent" }).id).toBe(SIGNAL_PERSONA_ID);
   });
 
   it("retains proposal recovery", () => {
-    expect(SIGNAL_PERSONA.loopBehaviors).toEqual({
+    expect(createSignalPersona().loopBehaviors).toEqual({
       hallucinationRecovery: true,
     });
   });
 
-  it("uses the Signal-specific prompt builder", () => {
+  it("uses the signals prompt builder bound to the agent identity", () => {
     const ctx = makeContext();
-    expect(SIGNAL_PERSONA.buildSystemContent(ctx, { iteration: 1 } as never)).toBe(
-      buildSignalSystemContent(ctx),
+    const persona = createSignalPersona({ agentName: "Alice's Agent" });
+    expect(persona.buildSystemContent(ctx, { iteration: 1 } as never)).toBe(
+      buildSignalSystemContent(ctx, { agentName: "Alice's Agent" }),
     );
   });
 });
@@ -248,8 +249,8 @@ describe("guided New Signal intake", () => {
     ]))).toBe("complete");
   });
 
-  it("instructs the live Signal Agent to interview in plain conversation", () => {
-    const prompt = buildSignalSystemContent(context, iteration());
+  it("instructs the live persona to interview in plain conversation", () => {
+    const prompt = buildSignalSystemContent(context, {}, iteration());
     expect(prompt).toContain("NEW SIGNAL INTAKE (ACTIVE)");
     expect(prompt).toContain("plain conversation");
     expect(prompt).not.toContain("ask_user_question");
@@ -264,7 +265,7 @@ describe("guided New Signal intake", () => {
     // The profile legitimately shapes WHICH questions get asked. It may not
     // put a background into the signal the user never stated: when an answer
     // leaves the signal vague, the agent asks rather than filling the gap.
-    const prompt = buildSignalSystemContent(context, iteration());
+    const prompt = buildSignalSystemContent(context, {}, iteration());
 
     expect(prompt).toContain("use it to decide WHICH questions to ask");
     expect(prompt).toContain("the signal itself is written from this conversation's answers");
@@ -275,8 +276,8 @@ describe("guided New Signal intake", () => {
     expect(prompt).not.toContain("combine the answers with the preloaded identity/profile context");
   });
 
-  it("asks the Signal Agent to return a replacement proposal when preview feedback arrives", () => {
-    const complete = buildSignalSystemContent(context, {
+  it("asks the persona to return a replacement proposal when preview feedback arrives", () => {
+    const complete = buildSignalSystemContent(context, {}, {
       ...iteration(),
       currentMessage: "new-signal-preview-feedback: Make the location Berlin-specific.",
       recentTools: [],
@@ -288,7 +289,7 @@ describe("guided New Signal intake", () => {
   });
 });
 
-describe("Signal Agent tool boundary", () => {
+describe("signals persona tool boundary", () => {
   it("pins the exact positive allowlist", () => {
     expect(SIGNAL_TOOL_NAMES).toEqual(EXPECTED_SIGNAL_TOOLS);
   });
@@ -539,10 +540,22 @@ describe("Signal Agent tool boundary", () => {
 });
 
 describe("buildSignalSystemContent", () => {
-  const prompt = buildSignalSystemContent(makeContext());
+  const prompt = buildSignalSystemContent(makeContext(), { agentName: "Alice's Agent" });
+
+  it("introduces itself as the user's own agent, never a product noun", () => {
+    // The app calls this the user's Personal Agent everywhere else; a persona
+    // named after its toolset tells the user they reached something else.
+    expect(prompt).toContain("You are Alice's Agent, the private signals and profile assistant for Alice.");
+    expect(prompt).not.toContain("Signal Agent");
+  });
+
+  it("falls back to a generic self-description when the agent row has no name", () => {
+    const nameless = buildSignalSystemContent(makeContext());
+    expect(nameless).toContain("You are Alice's personal agent, the private signals and profile assistant.");
+    expect(nameless).not.toContain("Signal Agent");
+  });
 
   it("identifies the restricted role and grounds writes", () => {
-    expect(prompt).toContain("You are Signal Agent");
     expect(prompt).toContain("Read before writing");
     expect(prompt).toContain("latest explicit request");
     expect(prompt).toContain("Matching happens separately in the background");
@@ -564,7 +577,7 @@ describe("buildSignalSystemContent", () => {
 
   it("intent scope advertises only refinement and suppresses new-signal intake", () => {
     const intentContext = makeContext({ scopeType: "intent", scopeId: INTENT_ID });
-    const scopedPrompt = buildSignalSystemContent(intentContext, {
+    const scopedPrompt = buildSignalSystemContent(intentContext, {}, {
       currentMessage: SIGNAL_NEW_SIGNAL_KICKOFF,
       recentTools: [],
       ctx: intentContext,

--- a/packages/protocol/src/index.ts
+++ b/packages/protocol/src/index.ts
@@ -116,11 +116,11 @@ export { type ChatPersonaConfig } from "./agents/agent.module.js";
 export { NEGOTIATOR_PERSONA_ID, createNegotiatorPersona } from "./agents/agent.module.js";
 export {
   SIGNAL_PERSONA_ID,
-  SIGNAL_PERSONA,
+  createSignalPersona,
 } from "./agents/agent.module.js";
 export {
   ONBOARDING_PERSONA_ID,
-  ONBOARDING_PERSONA,
+  createOnboardingPersona,
 } from "./agents/agent.module.js";
 export { RadarGraphFactory } from "./opportunities/opportunity.module.js";
 export { HydeGraphFactory } from "./discovery/index.js";

--- a/packages/protocol/src/mcp/mcp.server.ts
+++ b/packages/protocol/src/mcp/mcp.server.ts
@@ -15,7 +15,7 @@ import { McpResolvedIdentitySchema } from '../shared/schemas/mcp-auth.schema.js'
 import { CANONICAL_GUIDANCE_SUMMARY } from '../shared/agent/canonical-guidance.js';
 import type { ToolDeps, ResolvedToolContext, RawToolDefinition } from '../shared/agent/tool.helpers.js';
 import { resolveChatContext } from '../shared/agent/tool.helpers.js';
-import { deriveAllowedNetworkIds, scopeFromNetworkId } from '../shared/agent/tool.scope.js';
+import { deriveAllowedNetworkIds, isToolAllowedInScope, scopeFromNetworkId } from '../shared/agent/tool.scope.js';
 import { createToolRegistry } from '../shared/agent/tool.registry.js';
 import type { ToolRegistryDeps } from '../shared/agent/tool.registry.js';
 import { bindOwnerApprovalProvenance } from '../opportunities/opportunity.owner-provenance.js';
@@ -647,7 +647,12 @@ export function createMcpServer(
           // Do not use cached registration metadata handlers here: tool handlers
           // close over userDb/systemDb when the registry is created. The MCP
           // surface profile keeps the tools/call lookup identical to tools/list.
-          const requestRegistry = createToolRegistry(requestDeps, { surface: 'mcp' });
+          const requestRegistry = createToolRegistry(requestDeps, {
+            surface: 'mcp',
+            // Same scope exclusion tools/list applies, from the same rule: a
+            // tool this scope makes impossible is absent, not merely refused.
+            scope: context,
+          });
           const requestTool = requestRegistry.get(toolName);
 
           if (!requestTool) {
@@ -728,7 +733,12 @@ export function createMcpServer(
     const visibleNames = new Set(
       capabilityPolicy.visibleToolNames(
         resolved.subject,
-        toolMetadata.map((tool) => tool.name),
+        // The static metadata is scope-free (it is cached across principals),
+        // so the focused scope is applied here — an intent-scoped session must
+        // not advertise a tool it cannot call.
+        toolMetadata
+          .filter((tool) => isToolAllowedInScope(tool.name, resolved.context))
+          .map((tool) => tool.name),
       ),
     );
 

--- a/packages/protocol/src/mcp/tests/mcp.server.spec.ts
+++ b/packages/protocol/src/mcp/tests/mcp.server.spec.ts
@@ -14,6 +14,8 @@ import { MCP_INSTRUCTIONS, sanitizeMcpResult, buildMcpOnboardingMessage, ONBOARD
 import { CANONICAL_GUIDANCE_SUMMARY, CANONICAL_GUIDANCE_TOPICS } from "../../shared/agent/canonical-guidance.js";
 import type { ResolvedToolContext } from "../../shared/agent/tool.helpers.js";
 import { ToolRuntimeError } from "../../shared/agent/tool.runtime.js";
+import { createToolRegistry, type ToolRegistryDeps } from "../../shared/agent/tool.registry.js";
+import { isToolAllowedInScope } from "../../shared/agent/tool.scope.js";
 
 describe("MCP_INSTRUCTIONS", () => {
   test("fits within the 4500 character context budget", () => {
@@ -293,6 +295,51 @@ describe('getMcpToolMetadataCacheKey', () => {
     const base = getMcpToolMetadataCacheKey(baseDeps);
     const withContacts = { ...baseDeps, contactService: {} } as Parameters<typeof getMcpToolMetadataCacheKey>[0];
     expect(getMcpToolMetadataCacheKey(withContacts)).toBe(base);
+  });
+});
+
+/**
+ * Intent-scoped MCP sessions. Scoped API keys hydrate scopeType/scopeId into
+ * the resolved context, so an MCP session can be pinned to one signal — and a
+ * session pinned to one signal exists to refine it. `create_intent` must be
+ * absent from what such a session is offered, not merely refused once the
+ * model calls it.
+ */
+describe("intent-scoped MCP tool surface", () => {
+  // Registration only DEFINES tools; a permissive deep proxy satisfies the
+  // nested dep reads that happen while wiring.
+  function makeDeps(): ToolRegistryDeps {
+    const deep: unknown = new Proxy(function () {} as object, {
+      get: () => deep,
+      apply: () => deep,
+    });
+    return deep as ToolRegistryDeps;
+  }
+
+  const intentScope = { scopeType: "intent" as const, scopeId: "11111111-1111-4111-8111-111111111111" };
+
+  test("the MCP registry omits create_intent under an intent scope", () => {
+    const registry = createToolRegistry(makeDeps(), { surface: "mcp", scope: intentScope });
+    expect(registry.get("create_intent")).toBeUndefined();
+    expect(registry.get("update_intent")).toBeDefined();
+  });
+
+  test("an unscoped MCP registry still offers create_intent", () => {
+    const registry = createToolRegistry(makeDeps(), { surface: "mcp" });
+    expect(registry.get("create_intent")).toBeDefined();
+  });
+
+  test("tools/list applies the same rule to the cached static metadata", () => {
+    // The metadata cache is scope-free (shared across principals), so
+    // tools/list filters it through this predicate before the capability
+    // policy runs. Same rule, same exclusion as the registry above.
+    expect(isToolAllowedInScope("create_intent", intentScope)).toBe(false);
+    expect(isToolAllowedInScope("update_intent", intentScope)).toBe(true);
+    expect(isToolAllowedInScope("create_intent", {})).toBe(true);
+    expect(isToolAllowedInScope("create_intent", {
+      scopeType: "network",
+      scopeId: "22222222-2222-4222-8222-222222222222",
+    })).toBe(true);
   });
 });
 

--- a/packages/protocol/src/shared/agent/tests/tool.factory.spec.ts
+++ b/packages/protocol/src/shared/agent/tests/tool.factory.spec.ts
@@ -218,6 +218,7 @@ mock.module("../../../opportunities/opportunity.presentation.js", () => ({
 
 import { describe, test, expect, beforeAll } from "bun:test";
 import { createChatTools, type ToolContext } from "../tool.factory.js";
+import { createToolRegistry, type ToolRegistryDeps } from "../tool.registry.js";
 import type { ChatGraphCompositeDatabase, SystemDatabase } from "../../interfaces/database.interface.js";
 import type { ActiveIntent, IndexMemberDetails, IndexedIntentDetails } from "../../interfaces/database.interface.js";
 import type { Embedder } from "../../interfaces/embedder.interface.js";
@@ -457,6 +458,39 @@ describe("createChatTools", () => {
 
     expect(names).not.toContain("create_intent");
     expect(names).toContain("update_intent");
+  });
+});
+
+// The chat factory is one of two surfaces that build a toolset. The shared
+// registry behind MCP and the REST Tool API is the other, and an intent scope
+// reaches it too — so the exclusion above has to hold there as well, from the
+// same rule rather than from each call site remembering it.
+describe("createToolRegistry intent-scope exclusions", () => {
+  // Registration only DEFINES tools; a permissive deep proxy satisfies the
+  // nested dep reads that happen while wiring.
+  function makeRegistryDeps(): ToolRegistryDeps {
+    const deep: unknown = new Proxy(function () {} as object, {
+      get: () => deep,
+      apply: () => deep,
+    });
+    return deep as ToolRegistryDeps;
+  }
+
+  const intentScope = { scopeType: "intent" as const, scopeId: "11111111-1111-4111-8111-111111111111" };
+  const networkScope = { scopeType: "network" as const, scopeId: "22222222-2222-4222-8222-222222222222" };
+
+  test("an intent-scoped registry does not advertise create_intent", () => {
+    for (const surface of ["rest", "mcp"] as const) {
+      const registry = createToolRegistry(makeRegistryDeps(), { surface, scope: intentScope });
+      expect(registry.get("create_intent"), `${surface} surface must omit create_intent`).toBeUndefined();
+      expect(registry.get("update_intent"), `${surface} surface keeps update_intent`).toBeDefined();
+    }
+  });
+
+  test("unscoped and network-scoped registries keep create_intent", () => {
+    expect(createToolRegistry(makeRegistryDeps()).get("create_intent")).toBeDefined();
+    expect(createToolRegistry(makeRegistryDeps(), { scope: networkScope }).get("create_intent")).toBeDefined();
+    expect(createToolRegistry(makeRegistryDeps(), { scope: {} }).get("create_intent")).toBeDefined();
   });
 });
 

--- a/packages/protocol/src/shared/agent/tool.factory.ts
+++ b/packages/protocol/src/shared/agent/tool.factory.ts
@@ -15,7 +15,7 @@ import { protocolLogger } from "../observability/protocol.logger.js";
 import type { QuestionerEnqueueFn } from "../../questions/question.module.js";
 
 import { type ToolContext, type ResolvedToolContext, type ToolDeps, resolveChatContext, error, redactSensitiveFields } from "./tool.helpers.js";
-import { deriveAllowedNetworkIds, focusedIntentId, scopeFromNetworkId } from "./tool.scope.js";
+import { deriveAllowedNetworkIds, filterToolsForScope, scopeFromNetworkId } from "./tool.scope.js";
 import { invokeToolRuntime, toolRuntimeErrorToResult } from "./tool.runtime.js";
 import { createEnrichmentTools } from "../../enrichment/enrichment.tools.js";
 import { createOpportunityTools } from "../../opportunities/opportunity.module.js";
@@ -243,11 +243,10 @@ export async function createChatTools(
   const profileTools = createEnrichmentTools(defineTool, toolDeps);
   const intentTools = Intents.createTools(defineTool, toolDeps);
   // An intent-scoped conversation exists to refine its selected signal. Keep
-  // creation out of the model-visible registry; the update handler separately
+  // creation out of the model-visible registry — the same rule the shared tool
+  // registry applies for MCP/REST callers. The update handler separately
   // clamps writes to the exact scoped intent as a runtime backstop.
-  const intentToolsForChat = focusedIntentId(resolvedContext)
-    ? intentTools.filter((candidate) => (candidate as { name: string }).name !== "create_intent")
-    : intentTools;
+  const intentToolsForChat = filterToolsForScope(intentTools, resolvedContext);
   const networkTools = Networks.createTools(defineTool, toolDeps);
   const opportunityTools = createOpportunityTools(defineTool, toolDeps);
   const utilityTools = createUtilityTools(defineTool, toolDeps);

--- a/packages/protocol/src/shared/agent/tool.registry.ts
+++ b/packages/protocol/src/shared/agent/tool.registry.ts
@@ -14,6 +14,7 @@ import { createNegotiationAnswerTools, createNegotiationTools } from '../../nego
 import { createChatTools } from '../../chat/chat.tools.js';
 import { createPremiseTools } from '../../premises/premise.tools.js';
 import type { OpportunityOwnerApprovalDeps } from '../../opportunities/opportunity.tools.port.js';
+import { isToolAllowedInScope, type ToolScopeEnvelope } from './tool.scope.js';
 import { protocolLogger } from '../observability/protocol.logger.js';
 import { requestContext } from '../observability/request-context.js';
 
@@ -28,6 +29,15 @@ export interface CreateToolRegistryOptions {
    * (IND-373/598).
    */
   surface?: ToolSurface;
+  /**
+   * The caller's focused scope. Tools a scope makes impossible are left out of
+   * the registry entirely, so they are neither listed nor callable — the same
+   * exclusion the chat tool factory applies. Omit for an unscoped caller.
+   *
+   * MCP contexts reach this through scoped API keys and through the chat
+   * scope envelope, so the rule cannot live at one call site.
+   */
+  scope?: ToolScopeEnvelope;
 }
 
 /**
@@ -120,6 +130,18 @@ export function createToolRegistry(deps: ToolRegistryDeps, options: CreateToolRe
     createChatTools(dt, deps);
   }
 
+
+  // Scope exclusions are applied after composition so every domain is covered
+  // by one rule rather than each createTools() call remembering it. The
+  // handlers still refuse independently at runtime — those refusals document
+  // the invariant and cover callers that build a registry without a scope.
+  if (options.scope) {
+    for (const toolName of [...registry.keys()]) {
+      if (!isToolAllowedInScope(toolName, options.scope)) {
+        registry.delete(toolName);
+      }
+    }
+  }
 
   logger.verbose('Tool registry created', { toolCount: registry.size, surface: options.surface ?? 'rest' });
   return registry;

--- a/packages/protocol/src/shared/agent/tool.scope.ts
+++ b/packages/protocol/src/shared/agent/tool.scope.ts
@@ -63,6 +63,41 @@ export function focusedNetworkLabel(scope: ToolScopeEnvelope & { indexName?: str
   return scope.indexName ?? focusedNetworkId(scope) ?? 'this network';
 }
 
+/**
+ * Tools an intent-scoped session must never advertise.
+ *
+ * A session pinned to one signal exists to refine that signal, so creating a
+ * DIFFERENT one there is not a capability the caller has. Both surfaces that
+ * build a toolset — the chat tool factory and the shared tool registry behind
+ * MCP/REST — apply this from here, so neither has to remember the rule. The
+ * runtime handlers still refuse independently; those refusals document the
+ * invariant and cover any caller that builds a toolset without a scope.
+ */
+const INTENT_SCOPED_TOOL_EXCLUSIONS: ReadonlySet<string> = new Set(['create_intent']);
+
+/**
+ * Returns whether a tool may be offered at all under the given focused scope.
+ *
+ * @param toolName - Registry name of the tool
+ * @param scope - The caller's focused scope envelope
+ */
+export function isToolAllowedInScope(toolName: string, scope: ToolScopeEnvelope): boolean {
+  return !(focusedIntentId(scope) && INTENT_SCOPED_TOOL_EXCLUSIONS.has(toolName));
+}
+
+/**
+ * Filters a toolset down to what the focused scope allows.
+ *
+ * @param tools - Tools carrying their registry names
+ * @param scope - The caller's focused scope envelope
+ */
+export function filterToolsForScope<T extends { name: string }>(
+  tools: readonly T[],
+  scope: ToolScopeEnvelope,
+): T[] {
+  return tools.filter((candidate) => isToolAllowedInScope(candidate.name, scope));
+}
+
 export function deriveAllowedNetworkIds(input: DeriveNetworkScopeInput): string[] {
   if (!hasNetworkScope(input)) {
     return uniqueNetworkIds(input.memberships.map((membership) => membership.networkId));

--- a/services/api/src/controllers/chat.controller.ts
+++ b/services/api/src/controllers/chat.controller.ts
@@ -452,7 +452,7 @@ export class ChatController {
         if (sessionPersona === SIGNAL_PERSONA_ID) {
           return Response.json(
             {
-              error: 'Start a separate Signal Agent chat for that focus.',
+              error: 'Start a separate chat with your agent for that focus.',
               code: 'CHAT_SCOPE_REQUIRES_NEW_SESSION',
               action: { type: 'start_signal_session', href: '/' },
             },

--- a/services/api/src/controllers/chat.controller.ts
+++ b/services/api/src/controllers/chat.controller.ts
@@ -484,12 +484,22 @@ export class ChatController {
     // untouched.
     const agentOwnsTurn = sessionPersona === NEGOTIATOR_PERSONA_ID
       && effectiveScope?.scopeType === 'intent';
+    // The personas that DO run a graph introduce themselves as the client's
+    // own agent, named from the same `type='personal'` row the IntentAgent
+    // belongs to. A missing row is not fatal: the prompt falls back to a
+    // generic self-description rather than a product noun, so the signal and
+    // onboarding chats keep working.
+    const personaNeedsIdentity = !agentOwnsTurn
+      && (sessionPersona === SIGNAL_PERSONA_ID || sessionPersona === ONBOARDING_PERSONA_ID);
+    const identityAgent = personaNeedsIdentity
+      ? await resolveNegotiatorAgent(user.id).catch(() => null)
+      : null;
     const factory = agentOwnsTurn
       ? null
       : sessionPersona === ONBOARDING_PERSONA_ID
-        ? chatSessionService.getOnboardingGraphFactory()
+        ? chatSessionService.getOnboardingGraphFactory(identityAgent)
         : sessionPersona === SIGNAL_PERSONA_ID
-          ? chatSessionService.getSignalGraphFactory()
+          ? chatSessionService.getSignalGraphFactory(identityAgent)
           : null;
     if (!factory && !agentOwnsTurn) {
       return Response.json(

--- a/services/api/src/controllers/mcp.controller.ts
+++ b/services/api/src/controllers/mcp.controller.ts
@@ -46,7 +46,7 @@ import { negotiatorVerdictToolsHost } from '../lib/agent/negotiator-verdict.host
 import { resolveProtocolBaseUrl } from '../lib/protocol-url';
 import { isHermesNegotiatorAudience } from '../lib/agent/hermes-credential';
 
-import { Intents, EnrichmentGraphFactory, OpportunityGraphFactory, HydeGraphFactory, Networks, NegotiationGraphFactory, HydeGenerator, LensInferrer, createMcpServer, ChatGraphFactory, PremiseGraphFactory, SIGNAL_PERSONA, SIGNAL_PERSONA_ID, McpApiKeyMetadataSchema, CANONICAL_MCP_CAPABILITY_POLICY_OPTIONS } from '@indexnetwork/protocol';
+import { Intents, EnrichmentGraphFactory, OpportunityGraphFactory, HydeGraphFactory, Networks, NegotiationGraphFactory, HydeGenerator, LensInferrer, createMcpServer, ChatGraphFactory, PremiseGraphFactory, createSignalPersona, SIGNAL_PERSONA_ID, McpApiKeyMetadataSchema, CANONICAL_MCP_CAPABILITY_POLICY_OPTIONS } from '@indexnetwork/protocol';
 import type { HydeGraphDatabase, PremiseGraphDatabase, ToolDeps, McpAuthResolver, ScopedDepsFactory, Embedder, ChatGraphCompositeDatabase, McpAuthInput, McpResolvedIdentity, OpportunityOwnerApprovalAuthority, McpAuthorizationObserver } from '@indexnetwork/protocol';
 
 import { API_URL, JWT_AUDIENCE } from '../lib/betterauth/betterauth';
@@ -157,7 +157,11 @@ const chatSessionReader = {
  * persona-neutral runtime and all injected deps. There is no default persona —
  * the retired orchestrator used to be it.
  */
-export const chatFactory = new ChatGraphFactory(chatDatabaseAdapter, embedderAdapter, scraperAdapter, chatSessionReader, protocolDeps, SIGNAL_PERSONA);
+// The runtime has no default persona; this base factory just carries the deps.
+// Every chat surface derives a sibling factory bound to the client's own agent
+// identity (`ChatSessionService.get*GraphFactory`), so the nameless persona
+// here never drives a turn.
+export const chatFactory = new ChatGraphFactory(chatDatabaseAdapter, embedderAdapter, scraperAdapter, chatSessionReader, protocolDeps, createSignalPersona());
 
 // ═══════════════════════════════════════════════════════════════════════════════
 // GRAPH COMPILATION (lazy, cached)

--- a/services/api/src/controllers/tests/chat.signal.spec.ts
+++ b/services/api/src/controllers/tests/chat.signal.spec.ts
@@ -9,6 +9,7 @@ import { ChatController } from '../chat.controller';
 import { AuthGuard, SessionOnlyGuard, type AuthenticatedUser } from '../../guards/auth.guard';
 import { recordRequestAuthContext } from '../../lib/request-auth-context';
 import { RouteRegistry } from '../../lib/router/router.decorators';
+import { agentService } from '../../services/agent.service';
 import { chatSessionService } from '../../services/chat.service';
 import { fileService } from '../../services/file.service';
 import { userService } from '../../services/user.service';
@@ -140,6 +141,24 @@ describe('Signal Agent web chat routing (IND-449)', () => {
     );
     expect(getSignalFactorySpy).toHaveBeenCalledTimes(1);
     expect(signalInputs).toHaveLength(1);
+  });
+
+  test('the signals persona is named from the user own personal agent row', async () => {
+    // Every persona introduces itself as the user's agent, so the restricted
+    // surfaces read the same `type='personal'` row the negotiator does.
+    const agentSpy = spyOn(agentService, 'getNegotiatorAgent')
+      .mockResolvedValue({ id: 'agent-1', name: "Signal User's Agent" } as never);
+
+    await stream(controller, { message: 'Draft a signal', persona: 'signal' }, 'web');
+    expect(getSignalFactorySpy).toHaveBeenLastCalledWith(
+      expect.objectContaining({ name: "Signal User's Agent" }),
+    );
+
+    // A missing row is not fatal here: the prompt falls back to a generic
+    // self-description rather than failing the turn or naming a product.
+    agentSpy.mockResolvedValue(null as never);
+    await stream(controller, { message: 'Draft another', persona: 'signal' }, 'web');
+    expect(getSignalFactorySpy).toHaveBeenLastCalledWith(null);
   });
 
   test('persisted Signal persona is inherited when the followup omits persona', async () => {

--- a/services/api/src/services/chat.service.ts
+++ b/services/api/src/services/chat.service.ts
@@ -1,7 +1,7 @@
 import { log } from '../lib/log';
 import { conversationDatabaseAdapter, ConversationDatabaseAdapter, ChatDatabaseAdapter } from '../adapters/database.adapter';
 import type { ChatPersonaId, ChatScopeType } from '../adapters/database.shared';
-import { ChatGraphFactory, ChatTitleGenerator, NEGOTIATOR_PERSONA_ID, ONBOARDING_PERSONA, ONBOARDING_PERSONA_ID, SIGNAL_PERSONA_ID } from '@indexnetwork/protocol';
+import { ChatGraphFactory, ChatTitleGenerator, NEGOTIATOR_PERSONA_ID, ONBOARDING_PERSONA_ID, SIGNAL_PERSONA_ID, createOnboardingPersona, createSignalPersona } from '@indexnetwork/protocol';
 import type { ChatGraphCompositeDatabase } from '@indexnetwork/protocol';
 import { getCheckpointer } from '../adapters/checkpointer.adapter';
 import type { PostgresSaver } from '@langchain/langgraph-checkpoint-postgres';
@@ -65,6 +65,16 @@ function generateSnowflakeId(): string {
   const random = Math.floor(Math.random() * 4194304); // 2^22
   const snowflake = BigInt(timestamp) * BigInt(4194304) + BigInt(random);
   return snowflake.toString();
+}
+
+/**
+ * Narrows a personal agent row to the identity a persona introduces itself
+ * with. An absent or blank name yields `{}` so the prompt uses its generic
+ * fallback rather than a product noun.
+ */
+function personaIdentity(agent?: { name?: string | null } | null): { agentName?: string } {
+  const agentName = agent?.name?.trim();
+  return agentName ? { agentName } : {};
 }
 
 /**
@@ -746,18 +756,28 @@ export class ChatSessionService {
   }
 
   /**
-   * Derive the restricted Signal Agent graph factory while sharing the
+   * Derive the restricted signals graph factory while sharing the
    * persona-neutral runtime and all injected dependencies.
    *
-   * @returns A Signal-persona sibling factory
+   * Like the negotiator, this persona introduces itself as the client's own
+   * agent, so it is bound per session to their `type='personal'` agent row.
+   * A missing row leaves the name absent and the prompt falls back to a
+   * generic self-description — the chat surface still works.
+   *
+   * @param agent - Identity from the user's `type='personal'` agent row
+   * @returns A signals-persona sibling factory
    */
-  getSignalGraphFactory(): ChatGraphFactory {
-    return this.factory;
+  getSignalGraphFactory(agent?: { name?: string | null } | null): ChatGraphFactory {
+    return this.factory.withPersona(createSignalPersona(personaIdentity(agent)));
   }
 
-  /** Derive the restricted onboarding graph factory from the shared runtime. */
-  getOnboardingGraphFactory(): ChatGraphFactory {
-    return this.factory.withPersona(ONBOARDING_PERSONA);
+  /**
+   * Derive the restricted onboarding graph factory from the shared runtime.
+   *
+   * @param agent - Identity from the user's `type='personal'` agent row
+   */
+  getOnboardingGraphFactory(agent?: { name?: string | null } | null): ChatGraphFactory {
+    return this.factory.withPersona(createOnboardingPersona(personaIdentity(agent)));
   }
 
   // The negotiator-persona graph factory retired with phase 2 of the

--- a/services/api/src/services/chat.service.ts
+++ b/services/api/src/services/chat.service.ts
@@ -149,7 +149,7 @@ export class ChatSessionService {
         ok: false,
         status: 409,
         code: 'WEB_SIGNAL_SESSION_REQUIRED',
-        error: 'This earlier chat is read-only. Start a new Signal Agent chat to continue.',
+        error: 'This earlier chat is read-only. Start a new chat with your agent to continue.',
         action: { type: 'start_signal_session', href: '/' },
       };
     }
@@ -235,7 +235,7 @@ export class ChatSessionService {
           ok: false,
           status: 403,
           code: 'WEB_SIGNAL_PERSONA_FORBIDDEN',
-          error: 'Signal Agent chats can only be started in the web app.',
+          error: 'Chats with your agent can only be started in the web app.',
         };
       }
       return { ok: true, persona: SIGNAL_PERSONA_ID };
@@ -250,7 +250,7 @@ export class ChatSessionService {
         ok: false,
         status: 409,
         code: 'WEB_SIGNAL_PERSONA_REQUIRED',
-        error: 'Start a new Signal Agent chat to continue.',
+        error: 'Start a new chat with your agent to continue.',
         action: { type: 'start_signal_session', href: '/' },
       };
     }

--- a/services/api/src/services/tests/chat.service.isolated.ts
+++ b/services/api/src/services/tests/chat.service.isolated.ts
@@ -32,7 +32,9 @@ mock.module("@indexnetwork/protocol", () => {
     },
     SIGNAL_PERSONA_ID: "signal",
     NEGOTIATOR_PERSONA_ID: "negotiator",
-    SIGNAL_PERSONA: { id: "signal" },
+    ONBOARDING_PERSONA_ID: "onboarding",
+    createSignalPersona: mock((opts?: { agentName?: string }) => ({ id: "signal", ...opts })),
+    createOnboardingPersona: mock((opts?: { agentName?: string }) => ({ id: "onboarding", ...opts })),
     createNegotiatorPersona: mock(() => ({ id: "negotiator" })),
   };
 });

--- a/services/api/src/services/tool.service.ts
+++ b/services/api/src/services/tool.service.ts
@@ -138,8 +138,10 @@ export class ToolService {
 
     const toolDeps = this.buildToolDeps(database, userDb, systemDb, graphs);
 
-    // Build registry and look up tool
-    const registry = createToolRegistry(toolDeps);
+    // Build registry and look up tool. The resolved context carries the
+    // caller's focused scope, so tools that scope makes impossible are absent
+    // from the registry rather than refused after the model calls them.
+    const registry = createToolRegistry(toolDeps, { scope: context });
     const tool = registry.get(toolName);
     if (!tool) {
       const available = Array.from(registry.keys()).sort();


### PR DESCRIPTION
Three passes, one problem: the chat personas named themselves after their toolset instead of after the user's agent, the "no creating signals inside a signal's chat" rule was enforced on one surface but not the other, and the user-facing copy still said "Signal Agent" in nine places.

Rebased onto `614948236e` (#1478, full chat ownership). That PR removed the negotiator persona factory from the chat controller — the intent DM now runs the IntentAgent and derives no persona graph — so only the signal and onboarding personas take an identity here. Both conflicts were in the factory-selection block and the `chat.service` import; resolved in favour of dev's structure, with the identity threading added on top.

## Pass 1 — every persona introduces itself as the user's agent

Three personas identified themselves three ways: the negotiator from the user's `type='personal'` agent row, Signal as "Signal Agent", onboarding as "Onboarding Agent" — while the UI calls all of it the user's Personal Agent (intent-page column, chat placeholder, `/agents`, and `/agent/memory`, titled "Personal Agent memory" next to an `/agent` that said "Signal Agent").

- `SIGNAL_PERSONA` and `ONBOARDING_PERSONA` become `createSignalPersona({ agentName })` / `createOnboardingPersona({ agentName })`, mirroring `createNegotiatorPersona`.
- `getSignalGraphFactory` / `getOnboardingGraphFactory` take the agent row and `withPersona()` it; the chat controller resolves it for the personas that still run a graph.
- A shared `buildAgentSelfIntroduction` renders the opening sentence. Nameless row → `You are <user>'s personal agent, …` rather than a product noun. Not fatal on these surfaces, so signal and onboarding keep working.
- Composition root: the base `chatFactory` now carries a nameless signals persona. It never drives a turn — every surface derives a sibling factory bound to the client's identity.

Unchanged on purpose: capabilities, allowlists, tool narrowing, `SIGNAL_PERSONA_ID`/`ONBOARDING_PERSONA_ID`, the persisted `conversations.persona` values, `SIGNAL_TOOL_NAMES`, `ensureNegotiatorAgent`.

## Pass 2 — `create_intent` only when there is no intent scope

The rule was enforced three times on the chat surface (`tool.factory.ts` filter, the Signal wrapper, the shared handler) and zero times on the registry path. `createToolRegistry` had no scope filtering, and MCP contexts can be intent-scoped — so an intent-scoped session advertised `create_intent` and only failed once the model called it.

- `isToolAllowedInScope` / `filterToolsForScope` now sit next to `focusedIntentId`.
- `tool.factory.ts` uses them instead of its inline filter; `createToolRegistry` gains a `scope` option and applies them after composition, so no domain has to remember the rule.
- MCP `tools/call` passes the resolved context as scope; `tools/list` applies the same predicate to its static metadata (cached across principals, so it cannot carry a scope of its own). The REST tool service passes its context too.
- The runtime refusals stay as backstops — cheap, and they document the invariant for callers that build a toolset without a scope.

Out of scope, deliberately: Signal keeps `create_intent` in unscoped chats, and onboarding keeps it for the guided first signal.

## Pass 3 — finish the rename

Nine strings still said "Signal Agent": the four policy-denial messages the web app renders (`AIChatContext.tsx`), the four API errors behind them (`chat.service.ts`, `chat.controller.ts`), and the new-signal card on the home chat. Only human-readable text changes — every error code (`WEB_SIGNAL_PERSONA_REQUIRED`, `WEB_SIGNAL_SESSION_REQUIRED`, `WEB_SIGNAL_AGENT_DISABLED`, `CHAT_SCOPE_REQUIRES_NEW_SESSION`, `WEB_SIGNAL_PERSONA_FORBIDDEN`) is contract and keeps its name, as do persona ids and `conversations.persona` values.

These are error paths where the agent row may not be resolved, so none of them thread an `agentName`; they use the same generic "your agent" the prompt falls back to.

**One of them was a factual bug, not a naming one.** `ChatContent.tsx:1083` promised "Let your Signal Agent guide you through a new signal", but its `onClick` is `navigate("/i/new")` — the deterministic intake funnel (`FastSignalIntake`: a precomputed first question, a planned follow-up, a client-side community picker, then synthesis). No agent is involved at any point. It now reads "A few questions to make what you're looking for legible." — the register of that page's own headline, and accurate about what the flow is.

Left alone as non-user-facing: the JSDoc in `signal.persona.ts`, the retired-env-var warning at `startup.env.ts:298`, and the comment at `fast-intake-feature.ts:5`.

## Tests

- New: intent-scoped registry omits `create_intent` on both surfaces (`tool.factory.spec.ts`); MCP registry + tools/list predicate (`mcp.server.spec.ts`); the signals persona is named from the user's own agent row, and a missing row is not fatal (`chat.signal.spec.ts`); named and nameless self-introduction for both personas.
- Updated: `signal.persona.spec.ts`, `onboarding.persona.spec.ts`, `chat.service.isolated.ts` for the factory signatures; `ai-chat-context-signal.test.tsx` for the renamed denial message.
- `packages/protocol`: 2477 pass / 0 fail across 213 files (per-file runner).
- `services/api`: 1829 pass / 17 fail. `apps/web`: 463 pass / 9 fail.
- Both failure sets are pre-existing and were verified, not assumed: `614948236e`'s tree checked out in place, protocol rebuilt, identical suites re-run, failure sets diffed. Zero delta on both. (Same check was run against `ace821c6` before the rebase, also zero delta.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ReNYmeeAAPvuWrFQLFbHF4