### PR TITLE
The IntentAgent knows its own name

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -89,7 +89,7 @@
     },
     "packages/protocol": {
       "name": "@indexnetwork/protocol",
-      "version": "23.6.3",
+      "version": "23.6.4",
       "dependencies": {
         "@langchain/core": "1.1.48",
         "@langchain/langgraph": "1.3.2",

--- a/packages/protocol/CHANGELOG.md
+++ b/packages/protocol/CHANGELOG.md
@@ -20,6 +20,25 @@ went 6.7.1 → 8.0.2 with no 7.x in between because the whole 7.x line shipped a
 prereleases between the two promotions. To track every change, read `rc`; to
 pin a supported release, use `latest`.
 
+## 23.6.4 - 2026-08-21
+
+### Added
+
+- **`buildAgentSelfIntroduction` is now actually exported.** 23.6.3's entry
+  named it as part of the new surface, but it was only reachable from inside
+  the package — the three chat personas import it directly. It is now on the
+  barrel (`buildAgentSelfIntroduction`, `AgentIdentityOptions`), which is what
+  makes that claim true for consumers.
+
+### Changed
+
+- **`buildAgentSelfIntroduction`'s `userName` is optional.** Additive: every
+  existing caller passes it and gets the same sentence. Absent, the builder
+  emits `You are <name>, <role>.` or, with no name either, `You are <role>.` —
+  the form a surface needs when its role phrase already says whose agent this
+  is and it never resolves a client display name. The API's IntentAgent loop
+  is the first such caller.
+
 ## 23.6.3 - 2026-08-21
 
 ### Added

--- a/packages/protocol/package.json
+++ b/packages/protocol/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@indexnetwork/protocol",
-  "version": "23.6.3",
+  "version": "23.6.4",
   "type": "module",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",

--- a/packages/protocol/src/agents/agent.module.ts
+++ b/packages/protocol/src/agents/agent.module.ts
@@ -3,6 +3,8 @@
  *
  * Anything outside this capability imports from here and nowhere else.
  */
+export { buildAgentSelfIntroduction } from "../chat/agent-identity.prompt.js";
+export type { AgentIdentityOptions } from "../chat/agent-identity.prompt.js";
 export type { DebugMetaAgent } from "../chat/chat-streaming.types.js";
 export { ChatGraphFactory } from "../chat/chat.graph.js";
 export { ChatInterruptClassifier } from "../chat/chat.interrupt.classifier.js";

--- a/packages/protocol/src/chat/agent-identity.prompt.ts
+++ b/packages/protocol/src/chat/agent-identity.prompt.ts
@@ -25,17 +25,26 @@ export interface AgentIdentityOptions {
  * The nameless fallback stays generic on purpose: reintroducing a product noun
  * there would recreate exactly the mismatch this helper exists to remove.
  *
+ * `userName` is optional because not every surface names its client. The chat
+ * personas run inside a resolved tool context and always have it; the
+ * IntentAgent's unattended loop speaks of "your client" from end to end and
+ * never resolves a display name, so it supplies a role phrase that already
+ * says whose agent this is and omits the name rather than reading the user
+ * row for one word.
+ *
  * @param input - The agent's name, the user it works for, and the persona's role
  * @returns One sentence, e.g. `You are Ada's Agent, the private signals and profile assistant for Ada.`
  */
 export function buildAgentSelfIntroduction(input: {
   agentName?: string;
-  userName: string;
+  userName?: string;
   /** Role phrase, without a leading article-free verb — e.g. "the restricted setup assistant". */
   role: string;
 }): string {
   const name = input.agentName?.trim();
-  return name
-    ? `You are ${name}, ${input.role} for ${input.userName}.`
-    : `You are ${input.userName}'s personal agent, ${input.role}.`;
+  const client = input.userName?.trim();
+  if (name) {
+    return client ? `You are ${name}, ${input.role} for ${client}.` : `You are ${name}, ${input.role}.`;
+  }
+  return client ? `You are ${client}'s personal agent, ${input.role}.` : `You are ${input.role}.`;
 }

--- a/packages/protocol/src/chat/tests/agent-identity.prompt.spec.ts
+++ b/packages/protocol/src/chat/tests/agent-identity.prompt.spec.ts
@@ -1,0 +1,47 @@
+/**
+ * The one sentence every surface that speaks AS the user's own agent opens
+ * with. Two axes, four forms: the agent may or may not have a name on its
+ * `type='personal'` row, and the surface may or may not name the client.
+ * Neither absence may reintroduce a product noun, and neither may throw —
+ * the unattended IntentAgent loop builds this sentence on every turn.
+ */
+import { describe, expect, it } from "bun:test";
+
+import { buildAgentSelfIntroduction } from "../agent-identity.prompt.js";
+
+describe("buildAgentSelfIntroduction", () => {
+  it("names both parties when the surface knows both", () => {
+    expect(buildAgentSelfIntroduction({
+      agentName: "Ada's Agent",
+      userName: "Ada",
+      role: "the private signals and profile assistant",
+    })).toBe("You are Ada's Agent, the private signals and profile assistant for Ada.");
+  });
+
+  it("falls back to the client's possessive — never a product noun — when the row is nameless", () => {
+    expect(buildAgentSelfIntroduction({
+      userName: "Ada",
+      role: "the restricted setup assistant",
+    })).toBe("You are Ada's personal agent, the restricted setup assistant.");
+    expect(buildAgentSelfIntroduction({
+      agentName: "   ",
+      userName: "Ada",
+      role: "the restricted setup assistant",
+    })).toBe("You are Ada's personal agent, the restricted setup assistant.");
+  });
+
+  it("states the name alone on a surface that never names its client", () => {
+    // The IntentAgent's law speaks of "your client" from end to end, so its
+    // role phrase already carries the relationship and no userName is read.
+    expect(buildAgentSelfIntroduction({
+      agentName: "Ada's Agent",
+      role: "your client's personal agent for ONE signal",
+    })).toBe("You are Ada's Agent, your client's personal agent for ONE signal.");
+  });
+
+  it("degrades to the bare role when neither party is named", () => {
+    expect(buildAgentSelfIntroduction({
+      role: "your client's personal agent for ONE signal",
+    })).toBe("You are your client's personal agent for ONE signal.");
+  });
+});

--- a/packages/protocol/src/index.ts
+++ b/packages/protocol/src/index.ts
@@ -114,6 +114,9 @@ export { DEFAULT_NETWORK_ASSIGNMENT_THRESHOLD, resolveAssignmentNetworkScope, bu
 export { ChatGraphFactory } from "./agents/agent.module.js";
 export { type ChatPersonaConfig } from "./agents/agent.module.js";
 export { NEGOTIATOR_PERSONA_ID, createNegotiatorPersona } from "./agents/agent.module.js";
+// The shared self-identification helper: every surface that speaks AS the
+// user's own agent introduces itself through this one sentence builder.
+export { buildAgentSelfIntroduction, type AgentIdentityOptions } from "./agents/agent.module.js";
 export {
   SIGNAL_PERSONA_ID,
   createSignalPersona,

--- a/services/api/src/lib/intent-agent/intent-agent.context.ts
+++ b/services/api/src/lib/intent-agent/intent-agent.context.ts
@@ -26,6 +26,14 @@ const MAX_OPPORTUNITIES = 12;
 
 export interface IntentAgentTurnContext {
   event: IntentAgentInboxEvent;
+  /**
+   * The agent's own display name, from the client's `type='personal'` agent
+   * row — the SAME row the chat personas introduce themselves from, and the
+   * same name the DM surface addresses it by ("Message {agentName}…").
+   * Absent when the row is missing or nameless; the law falls back to its
+   * generic opener rather than failing an unattended turn over a name.
+   */
+  agentName?: string;
   /** The signal's own text; null when unreadable. */
   signalText: string | null;
   /** The waiting negotiations, oldest park first — the numbered list. */
@@ -48,6 +56,7 @@ export interface IntentAgentTurnContext {
 
 /** Injectable seams; production resolves the real collaborators lazily. */
 export interface IntentAgentContextDeps {
+  readAgentName?: (userId: string) => Promise<string | null>;
   readParkedNegotiations?: (userId: string, intentId: string) => Promise<ParkedNegotiation[]>;
   readDossier?: (userId: string, intentId: string) => Promise<IntentDossierEntryRow[]>;
   readOpportunities?: (userId: string, intentId: string) => Promise<ActionableCounterparty[]>;
@@ -77,18 +86,26 @@ export async function assembleIntentAgentContext(
   const readLedger = deps?.readLedger
     ?? (async (id: string, intent: string, limit: number) => (await import('../../adapters/intent-agent-ledger.adapter'))
       .intentAgentLedgerAdapter.readRecent(id, intent, limit));
+  // Identity, read beside the rest of the turn's state. `ensureNegotiatorAgent`
+  // runs at auth so the row is always there — but this loop negotiates
+  // unattended, so an unreadable name degrades to the generic opener rather
+  // than throwing a turn away.
+  const readAgentName = deps?.readAgentName
+    ?? (async (id: string) => (await import('../../services/agent.service'))
+      .agentService.getNegotiatorAgent(id).then((agent) => agent?.name ?? null));
   const getIntentText = deps?.getIntentText ?? (async (id: string) => {
     const { chatDatabaseAdapter } = await import('../../adapters/database.adapter');
     const intent = await chatDatabaseAdapter.getIntentForIndexing(id);
     return intent?.payload ?? null;
   });
 
-  const [parked, dossier, allOpportunities, recentActs, signalText] = await Promise.all([
+  const [parked, dossier, allOpportunities, recentActs, signalText, agentName] = await Promise.all([
     readParked(userId, intentId),
     readDossier(userId, intentId),
     readOpportunities(userId, intentId),
     readLedger(userId, intentId, MAX_LEDGER_ACTS),
     getIntentText(intentId).catch(() => null),
+    readAgentName(userId).catch(() => null),
   ]);
 
   // Bounded, keeping the newest (the reader lists oldest first). The agent's
@@ -130,5 +147,15 @@ export async function assembleIntentAgentContext(
     }
   })();
 
-  return { event, signalText, parked: [...parked], dossier, opportunities, recentDm, recentActs };
+  const name = agentName?.trim();
+  return {
+    event,
+    ...(name ? { agentName: name } : {}),
+    signalText,
+    parked: [...parked],
+    dossier,
+    opportunities,
+    recentDm,
+    recentActs,
+  };
 }

--- a/services/api/src/lib/intent-agent/intent-agent.prompt.ts
+++ b/services/api/src/lib/intent-agent/intent-agent.prompt.ts
@@ -1,21 +1,49 @@
 /**
  * The IntentAgent's law (docs/plans/2026-08-21-holistic-intent-agent.md).
  *
- * A versioned constant, not scattered strings: judgment lives here, and only
+ * One versioned law, not scattered strings: judgment lives here, and only
  * here. Code executes what the agent decides, refuses the impossible, and
  * records everything — it never re-decides. Change the law by shipping a new
- * version of this constant, never by branching around it.
+ * version of it, never by branching around it.
  *
  * Version 2 (phase 2, full chat ownership): the agent holds EVERY turn of
  * the signal's conversation, not just the parked ones; the verdict lane
  * (accept/reject, #1471) becomes agent judgment under the explicit-word law;
  * and the conversational reply moved to a second, streaming stage with its
  * own instruction (`INTENT_AGENT_REPLY_INSTRUCTION`).
+ *
+ * Version 3 (identity): the agent knows its own name. The UI on this exact
+ * surface addresses it by the name on the user's `type='personal'` agent row
+ * ("Message {agentName}…", "your direct line to {agentName}"), so the law is
+ * a BUILDER, not a constant — the opener is where identity belongs, and a
+ * name arriving as context data would not be a self-conception. A missing
+ * row is never fatal: the nameless form is byte-identical to version 2's
+ * opener, because this loop negotiates unattended and must not fail a turn
+ * over a display name.
  */
+import { buildAgentSelfIntroduction, type AgentIdentityOptions } from '@indexnetwork/protocol';
 
-export const INTENT_AGENT_SYSTEM_PROMPT_VERSION = 2;
+export const INTENT_AGENT_SYSTEM_PROMPT_VERSION = 3;
 
-export const INTENT_AGENT_SYSTEM_PROMPT = `You are your client's personal agent for ONE signal — one thing they are trying to find or make happen. You conduct negotiations on their behalf, and you hold the WHOLE conversation with them about this signal: every message they send here comes to you, whether it is an answer, an instruction, a question, or small talk. You have just been woken by an event; decide what to do, then act through your tools.
+/**
+ * The role phrase the self-introduction is built around. It names the client
+ * relationship itself, which is why this surface passes no `userName`: the
+ * whole law speaks of "your client" and never of a display name.
+ */
+const INTENT_AGENT_ROLE = "your client's personal agent for ONE signal — one thing they are trying to find or make happen";
+
+/**
+ * The law, bound to one agent's identity.
+ *
+ * @param identity - Name from the client's `type='personal'` agent row; absent falls back to the generic opener
+ * @returns The system prompt for both stages of one turn
+ */
+export function buildIntentAgentSystemPrompt(identity: AgentIdentityOptions = {}): string {
+  const introduction = buildAgentSelfIntroduction({
+    ...(identity.agentName ? { agentName: identity.agentName } : {}),
+    role: INTENT_AGENT_ROLE,
+  });
+  return `${introduction} You conduct negotiations on their behalf, and you hold the WHOLE conversation with them about this signal: every message they send here comes to you, whether it is an answer, an instruction, a question, or small talk. You have just been woken by an event; decide what to do, then act through your tools.
 
 Your tools, each of which is recorded in your ledger:
 - message_user: say something to your client in this signal's conversation. Plain prose, their language, no markup blocks. Available only when a negotiation event woke you — when your client themselves wrote to you, your reply is composed in a separate step after your acts, so do not use this tool then.
@@ -44,6 +72,7 @@ The law you operate under:
 8. When your client asks what is happening, tell them plainly from the listed state: which matches are live, what is waiting on them, what you are doing about it. Ordinary conversation gets an honest, brief reply from what you know about this signal — nothing more is required of it.
 
 You will be shown the waiting negotiations, the dossier entries, and your client's active matches as numbered lists. Refer to them ONLY by those numbers. Never invent a number that is not listed.`;
+}
 
 /**
  * The reply stage's addendum (phase 2). Appended to the system prompt for the

--- a/services/api/src/lib/intent-agent/intent-agent.turn.ts
+++ b/services/api/src/lib/intent-agent/intent-agent.turn.ts
@@ -21,7 +21,7 @@ import { z } from 'zod';
 import { getModelName } from '@indexnetwork/protocol';
 
 import { isSafeQuestionMessageProse } from '../question/negotiation-question.contract';
-import { INTENT_AGENT_REPLY_INSTRUCTION, INTENT_AGENT_SYSTEM_PROMPT } from './intent-agent.prompt';
+import { INTENT_AGENT_REPLY_INSTRUCTION, buildIntentAgentSystemPrompt } from './intent-agent.prompt';
 import type { IntentAgentTurnContext } from './intent-agent.context';
 import type { IntentAgentDecidedAct, IntentAgentExecutedAct } from './intent-agent.types';
 import { log } from '../log';
@@ -126,6 +126,15 @@ function renderEvent(context: IntentAgentTurnContext): string {
   return `THE EVENT: ${which} just paused because it needs your client's input.\n\nDecide: if the dossier or the conversation already contains what it needs, answer it directly without asking. Otherwise ask your client in your own words. If it is no longer waiting, wait.`;
 }
 
+/**
+ * The law this turn runs under, bound to the agent's own name. Both stages
+ * of a turn build it from the SAME context, so the acts stage and the reply
+ * stage are unmistakably the same agent to the client.
+ */
+function systemPrompt(context: IntentAgentTurnContext): string {
+  return buildIntentAgentSystemPrompt(context.agentName ? { agentName: context.agentName } : {});
+}
+
 /** What judgment sees, rendered; exported for the live eval's transparency. */
 export function renderIntentAgentTurn(context: IntentAgentTurnContext): string {
   return [
@@ -199,7 +208,7 @@ export class IntentAgentTurn {
     const userMessage = renderIntentAgentTurn(context);
     for (let attempt = 0; attempt < 2; attempt++) {
       const raw = await this.callModel([
-        { role: 'system', content: INTENT_AGENT_SYSTEM_PROMPT },
+        { role: 'system', content: systemPrompt(context) },
         { role: 'user', content: userMessage },
       ]);
       const decided = this.validate(raw, context);
@@ -301,7 +310,7 @@ export class IntentAgentTurn {
    */
   async reply(context: IntentAgentTurnContext, executed: IntentAgentExecutedAct[]): Promise<string | null> {
     const userMessage = renderIntentAgentReplyStage(context, executed);
-    const system = `${INTENT_AGENT_SYSTEM_PROMPT}\n\n${INTENT_AGENT_REPLY_INSTRUCTION}`;
+    const system = `${systemPrompt(context)}\n\n${INTENT_AGENT_REPLY_INSTRUCTION}`;
     for (let attempt = 0; attempt < 2; attempt++) {
       const raw = (await this.callReplyModel([
         { role: 'system', content: system },

--- a/services/api/src/lib/intent-agent/tests/intent-agent.identity.spec.ts
+++ b/services/api/src/lib/intent-agent/tests/intent-agent.identity.spec.ts
@@ -1,0 +1,150 @@
+/**
+ * The IntentAgent knows its own name.
+ *
+ * The DM surface addresses this agent by the name on the client's
+ * `type='personal'` agent row — the placeholder is `Message ${agentName}…`
+ * and the header says "your direct line to {agentName} about this signal".
+ * Between #1478 (which retired the named negotiator persona from this scope)
+ * and this change, the law opened namelessly, so the client called the agent
+ * something the agent had never heard.
+ *
+ * Two things are pinned here: the name reaches BOTH stages of a turn from
+ * the one context, and a missing row is never fatal — it degrades to the
+ * generic opener, because this loop conducts negotiations unattended.
+ */
+import { describe, expect, it } from 'bun:test';
+
+import { assembleIntentAgentContext } from '../intent-agent.context';
+import type { IntentAgentContextDeps, IntentAgentTurnContext } from '../intent-agent.context';
+import { INTENT_AGENT_SYSTEM_PROMPT_VERSION, buildIntentAgentSystemPrompt } from '../intent-agent.prompt';
+import { IntentAgentTurn } from '../intent-agent.turn';
+import type { IntentAgentInboxEvent } from '../intent-agent.types';
+
+const NEEDS_INPUT: IntentAgentInboxEvent = {
+  kind: 'negotiation_needs_input',
+  userId: 'user-1',
+  intentId: 'intent-1',
+  opportunityId: '11111111-1111-4111-8111-111111111111',
+  taskId: 'task-1',
+};
+
+const USER_MESSAGE: IntentAgentInboxEvent = {
+  kind: 'user_message',
+  userId: 'user-1',
+  intentId: 'intent-1',
+  sessionId: 'session-1',
+  messageId: 'reply-1',
+  text: 'Q4 works.',
+};
+
+function context(overrides: Partial<IntentAgentTurnContext> = {}): IntentAgentTurnContext {
+  return {
+    event: NEEDS_INPUT,
+    signalText: 'Find a manufacturing partner',
+    parked: [],
+    dossier: [],
+    opportunities: [],
+    recentDm: [],
+    recentActs: [],
+    ...overrides,
+  };
+}
+
+/** Every collaborator injected: the assembly runs with no database at all. */
+function contextDeps(overrides: Partial<IntentAgentContextDeps> = {}): IntentAgentContextDeps {
+  return {
+    readAgentName: async () => 'Ada\'s Agent',
+    readParkedNegotiations: async () => [],
+    readDossier: async () => [],
+    readOpportunities: async () => [],
+    readLedger: async () => [],
+    findSession: async () => null,
+    getSessionMessages: async () => [],
+    getIntentText: async () => 'Find a manufacturing partner',
+    ...overrides,
+  };
+}
+
+/** A turn that records the system prompt each stage actually sent. */
+class CapturingTurn extends IntentAgentTurn {
+  systems: string[] = [];
+  constructor() {
+    super({ model: 'test-model' });
+  }
+  protected override async callModel(messages: Array<{ role: string; content: string }>): Promise<unknown> {
+    this.systems.push(messages.find((message) => message.role === 'system')!.content);
+    return { acts: [{ act: 'wait', reason: 'nothing to do' }] };
+  }
+  protected override async callReplyModel(messages: Array<{ role: string; content: string }>): Promise<string> {
+    this.systems.push(messages.find((message) => message.role === 'system')!.content);
+    return 'Nothing needs you right now.';
+  }
+}
+
+describe('buildIntentAgentSystemPrompt', () => {
+  it('opens in the agent\'s own name — identity is the self-conception, not a context field', () => {
+    const prompt = buildIntentAgentSystemPrompt({ agentName: 'Ada\'s Agent' });
+    expect(prompt.startsWith(
+      'You are Ada\'s Agent, your client\'s personal agent for ONE signal — one thing they are trying to find or make happen.',
+    )).toBe(true);
+  });
+
+  it('falls back to the nameless opener, unchanged from version 2, when the row has no name', () => {
+    // Byte-identical to the pre-identity opener: a missing agent row must
+    // cost the client nothing but the name.
+    const opener = 'You are your client\'s personal agent for ONE signal — one thing they are trying to find or make happen.';
+    expect(buildIntentAgentSystemPrompt().startsWith(opener)).toBe(true);
+    expect(buildIntentAgentSystemPrompt({}).startsWith(opener)).toBe(true);
+  });
+
+  it('changes nothing else about the law — the identity is one sentence', () => {
+    const named = buildIntentAgentSystemPrompt({ agentName: 'Ada\'s Agent' });
+    const nameless = buildIntentAgentSystemPrompt();
+    const firstSentence = (prompt: string) => prompt.slice(0, prompt.indexOf('You conduct negotiations'));
+    expect(named.slice(firstSentence(named).length)).toBe(nameless.slice(firstSentence(nameless).length));
+    // The version constant exists to make a prompt change loud.
+    expect(INTENT_AGENT_SYSTEM_PROMPT_VERSION).toBe(3);
+  });
+});
+
+describe('the turn carries one identity through both stages', () => {
+  it('names the agent to the acts stage and to the reply stage alike', async () => {
+    const turn = new CapturingTurn();
+    const bound = context({ event: USER_MESSAGE, agentName: 'Ada\'s Agent' });
+    await turn.decide(bound);
+    await turn.reply(bound, []);
+    expect(turn.systems).toHaveLength(2);
+    for (const system of turn.systems) {
+      expect(system.startsWith('You are Ada\'s Agent, ')).toBe(true);
+    }
+  });
+
+  it('speaks generically when the context carries no name — a turn is never lost to one', async () => {
+    const turn = new CapturingTurn();
+    await turn.decide(context());
+    expect(turn.systems[0]!.startsWith('You are your client\'s personal agent')).toBe(true);
+  });
+});
+
+describe('context assembly resolves the identity', () => {
+  it('reads the name from the personal agent row, trimmed', async () => {
+    const assembled = await assembleIntentAgentContext(
+      NEEDS_INPUT,
+      contextDeps({ readAgentName: async () => '  Ada\'s Agent  ' }),
+    );
+    expect(assembled.agentName).toBe('Ada\'s Agent');
+  });
+
+  it('leaves the name absent — never throws — when the row is missing, nameless, or unreadable', async () => {
+    for (const readAgentName of [
+      async () => null,
+      async () => '   ',
+      async () => { throw new Error('agent row unreadable'); },
+    ] satisfies Array<IntentAgentContextDeps['readAgentName']>) {
+      const assembled = await assembleIntentAgentContext(NEEDS_INPUT, contextDeps({ readAgentName }));
+      expect(assembled.agentName).toBeUndefined();
+      // The rest of the turn is untouched by a name that did not resolve.
+      expect(assembled.signalText).toBe('Find a manufacturing partner');
+    }
+  });
+});


### PR DESCRIPTION
The DM on an intent page addresses the agent by name — the composer renders
``Message ${agentName}…`` (`IntentNegotiatorChat.tsx:233`) and the header says
"This is your direct line to {agentName} about this signal" (`:283`) — while the
agent's own law opened *"You are your client's personal agent for ONE signal."*
The client had a name for it; it had none for itself.

That is a regression from #1478. The intent DM used to run the negotiator
persona, whose prompt opened "You are ${agentName}, the personal negotiator agent
working for ${userName}" from the user's `type='personal'` agent row. Full chat
ownership retired `getNegotiatorGraphFactory`, and the only named
self-introduction went with it.

## The shape

`INTENT_AGENT_SYSTEM_PROMPT` becomes `buildIntentAgentSystemPrompt`. Identity
belongs in the opener; a name arriving in the per-turn context block would be
data about the agent rather than the agent's self-conception, which is the whole
point. Nothing upstream depended on the constant being identical across users —
one importer, no snapshot assertion, no cache keyed on it, and the OpenRouter
call sets no `cache_control` breakpoints — so the cost side of that trade-off is
empty. `INTENT_AGENT_SYSTEM_PROMPT_VERSION` → 3.

`assembleIntentAgentContext` resolves the name beside the other per-turn reads,
through `agentService.getNegotiatorAgent` — the same row the chat personas were
bound to in #1479. Both stages of a turn build the prompt from that one context,
so the acts stage and the reply stage are unmistakably the same agent to the
client.

A missing, nameless, or unreadable row is **never fatal**: this loop conducts
negotiations unattended and must not lose a turn over a display name. The
nameless opener is byte-identical to version 2's, so that path costs nothing but
the name — matching the call #1479 made for signal and onboarding.

`buildAgentSelfIntroduction` is reused rather than reimplemented. Its `userName`
becomes optional (additive; every existing caller passes it and gets the same
sentence) because this law speaks of "your client" from end to end and never
resolves a display name for anything else — its role phrase already carries the
relationship. The helper also reaches the protocol barrel, which 23.6.3's
changelog already claimed it did; 23.6.4 makes that true.

Out of scope and untouched: the UI strings, persona ids, `conversations.persona`
values, the acts ledger schema, and anything about *what* the agent does. No
feature flag.

## Verification

Baselines re-derived on `bc65abbbd1`'s tree in place (not carried over from
memory — web was 3, not the 9 recorded at `614948236e`), protocol dist rebuilt
for each, identical suites run after the rebase onto `origin/dev`:

| suite | baseline | after | failure set |
|---|---|---|---|
| api | 17 fail / 1829 pass | 17 fail / 1836 pass | identical |
| web | 3 fail / 469 pass | 3 fail / 469 pass | identical |
| protocol | 94 fail / 2529 pass | 94 fail / 2533 pass | identical |

`tsc --noEmit` clean, `eslint` clean on the changed files (0 errors repo-wide).

🤖 Generated with [Claude Code](https://claude.com/claude-code)