### PR TITLE
feat(intent-agent): questions come with answers — option chips and a per-signal your-move badge

### DIFF
--- a/apps/web/src/components/DiscoverHome.tsx
+++ b/apps/web/src/components/DiscoverHome.tsx
@@ -23,6 +23,8 @@ interface HomeIntent {
   sourceType?: "file" | "link" | "integration" | "discovery_form" | "enrichment";
   waitingOpportunityCount?: number;
   pendingQuestionCount?: number;
+  /** The signal's agent is holding an unanswered question for the user. */
+  awaitingReply?: boolean;
   status?: string;
   warming?: boolean;
 }

--- a/apps/web/src/components/IntentList.tsx
+++ b/apps/web/src/components/IntentList.tsx
@@ -28,6 +28,12 @@ interface BaseIntent {
    */
   pendingQuestionCount?: number;
   /**
+   * The signal's agent asked something and is still waiting on an answer.
+   * Derived server-side from the signal's own chat, so it clears the moment
+   * the user replies there. Undefined/false renders nothing.
+   */
+  awaitingReply?: boolean;
+  /**
    * Lifecycle status (ACTIVE|PAUSED|FULFILLED|EXPIRED). A badge renders only for
    * non-default (non-ACTIVE) values; undefined or ACTIVE renders nothing — the
    * enum is vestigial today, so this is forward-looking. See EDG-53.
@@ -179,6 +185,19 @@ export default function IntentList<T extends BaseIntent>({
                         <span className="relative inline-flex h-1.5 w-1.5 rounded-full bg-emerald-500" />
                       </span>
                       live
+                    </div>
+                  )}
+
+                  {/* Your move — the agent is holding a question for this
+                      signal. Sits next to `live` because it is the same kind
+                      of fact: what this signal is doing right now. */}
+                  {intent.awaitingReply && (
+                    <div
+                      className="flex items-center gap-1.5 text-xs font-medium text-[#041729] font-ibm-plex-mono"
+                      title="Your agent asked you something on this signal"
+                    >
+                      <span className="inline-flex h-1.5 w-1.5 rounded-full bg-[#041729]" />
+                      your move
                     </div>
                   )}
 

--- a/apps/web/src/components/IntentNegotiatorChat.tsx
+++ b/apps/web/src/components/IntentNegotiatorChat.tsx
@@ -199,6 +199,15 @@ export default function IntentNegotiatorChat({
     inputRef.current?.focus();
   }, []);
 
+  // A chip is a canned reply, not a new answer channel: its text is sent
+  // through the ordinary send path, so the agent's next turn cannot tell it
+  // from something the user typed.
+  const handleOptionSelect = useCallback(async (option: string) => {
+    if (isLoading || !ready) return;
+    setInput("");
+    await sendMessage(option);
+  }, [isLoading, ready, sendMessage]);
+
   const handleSend = useCallback(async () => {
     const text = input.trim();
     if (!text || isLoading || !ready) return;
@@ -301,6 +310,13 @@ export default function IntentNegotiatorChat({
 
             {messages.map((msg, messageIndex) => {
               const previousMessage = messageIndex > 0 ? messages[messageIndex - 1] : undefined;
+              // Chips belong to an unanswered question only. Any later message
+              // — the user's typed answer, their tapped chip, the agent's next
+              // word — is that answer, so message order is the whole rule and
+              // there is no "answered" state to keep.
+              const options = messageIndex === messages.length - 1 && !msg.isStreaming
+                ? msg.options ?? []
+                : [];
               const startsSession = previousMessage !== undefined
                 && previousMessage.conversationSessionId !== msg.conversationSessionId;
               return (
@@ -345,6 +361,21 @@ export default function IntentNegotiatorChat({
                         intentProposalStatusMap={proposalStatusMap}
                         onQuestionQuote={handleQuestionQuote}
                       />
+                      {options.length > 0 && (
+                        <div className="mt-2 flex flex-wrap gap-1.5" data-testid="negotiator-chat-options">
+                          {options.map((option) => (
+                            <button
+                              key={option}
+                              type="button"
+                              onClick={() => void handleOptionSelect(option)}
+                              disabled={isLoading || !ready}
+                              className="rounded-full border border-[#E9E9E9] bg-[#FCFCFC] px-3 py-1 text-xs font-ibm-plex-mono text-gray-700 transition-colors hover:border-[#4091BB] hover:text-[#041729] disabled:cursor-not-allowed disabled:opacity-50"
+                            >
+                              {option}
+                            </button>
+                          ))}
+                        </div>
+                      )}
                     </div>
                   )}
                 </Fragment>

--- a/apps/web/src/components/__tests__/IntentNegotiatorChatOptions.test.tsx
+++ b/apps/web/src/components/__tests__/IntentNegotiatorChatOptions.test.tsx
@@ -1,0 +1,97 @@
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const sendMessage = vi.fn(async () => {});
+const chatState = {
+  messages: [] as Array<Record<string, unknown>>,
+  isLoading: false,
+  sendMessage,
+  stopStream: vi.fn(),
+  loadSession: vi.fn(async () => true),
+  loadPreviousMessages: vi.fn(async () => {}),
+  hasPreviousSession: false,
+  isLoadingPreviousMessages: false,
+  clearChat: vi.fn(),
+  sessionId: 'session-1',
+};
+
+vi.mock('@/contexts/AIChatContext', () => ({ useAIChat: () => chatState }));
+vi.mock('@/contexts/ConversationContext', () => ({
+  useConversation: () => ({ subscribeQuestionRegeneration: () => () => {} }),
+}));
+vi.mock('@/lib/api', () => ({
+  apiClient: {
+    post: vi.fn(async () => ({
+      session: { id: 'session-1' },
+      created: false,
+      agent: { id: 'agent-1', name: 'Ada', description: null },
+    })),
+    patch: vi.fn(async () => ({})),
+  },
+}));
+vi.mock('@/components/chat/AssistantMessageContent', () => ({
+  default: ({ content }: { content: string }) => <p>{content}</p>,
+}));
+
+import IntentNegotiatorChat from '../IntentNegotiatorChat';
+
+function agentMessage(overrides: Record<string, unknown> = {}) {
+  return {
+    id: 'msg-agent',
+    role: 'assistant',
+    content: 'What should I push hardest on?',
+    timestamp: new Date('2026-08-21T10:00:00.000Z'),
+    options: ['Hiring speed', 'Comp banding'],
+    ...overrides,
+  };
+}
+
+function renderChat() {
+  return render(
+    <IntentNegotiatorChat
+      intentId="intent-1"
+      opportunityStatusMap={{}}
+      opportunityActionLoading={{}}
+      onOpportunityAction={() => {}}
+      onUnavailable={() => {}}
+    />,
+  );
+}
+
+/**
+ * Option chips are canned replies: they render under an unanswered agent
+ * question and, when tapped, go out through the ordinary send path — the same
+ * one typing uses. Nothing about them is a separate answer channel.
+ */
+describe('IntentNegotiatorChat option chips', () => {
+  beforeEach(() => {
+    sendMessage.mockClear();
+    chatState.isLoading = false;
+    chatState.messages = [agentMessage()];
+  });
+
+  it('sends the tapped chip as an ordinary user message', async () => {
+    renderChat();
+    const chip = await screen.findByRole('button', { name: 'Hiring speed' });
+    await userEvent.click(chip);
+    await waitFor(() => expect(sendMessage).toHaveBeenCalledWith('Hiring speed'));
+  });
+
+  it('drops the chips once anything answers the question', async () => {
+    chatState.messages = [
+      agentMessage(),
+      { id: 'msg-user', role: 'user', content: 'Hiring speed', timestamp: new Date('2026-08-21T10:01:00.000Z') },
+    ];
+    renderChat();
+    await screen.findByText('Hiring speed');
+    expect(screen.queryByRole('button', { name: 'Hiring speed' })).toBeNull();
+  });
+
+  it('renders nothing extra for a message that offered no chips', async () => {
+    chatState.messages = [agentMessage({ options: undefined })];
+    renderChat();
+    await screen.findByText('What should I push hardest on?');
+    expect(screen.queryByTestId('negotiator-chat-options')).toBeNull();
+  });
+});

--- a/apps/web/src/components/__tests__/IntentSignalCards.test.tsx
+++ b/apps/web/src/components/__tests__/IntentSignalCards.test.tsx
@@ -1,0 +1,26 @@
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+
+import IntentList from '../IntentList';
+
+const baseIntent = {
+  id: 'intent-1',
+  payload: 'Find a hiring partner in Berlin',
+  createdAt: '2026-08-20T10:00:00.000Z',
+};
+
+/**
+ * The per-signal your-move badge. It reads one derived server flag and says
+ * nothing on its own: no flag, no badge, and no zero state.
+ */
+describe('IntentList your-move badge', () => {
+  it('marks a signal whose agent is holding a question', () => {
+    render(<IntentList intents={[{ ...baseIntent, awaitingReply: true }]} />);
+    expect(screen.getByText('your move')).toBeTruthy();
+  });
+
+  it('says nothing when the agent is not waiting on the owner', () => {
+    render(<IntentList intents={[baseIntent, { ...baseIntent, id: 'intent-2', awaitingReply: false }]} />);
+    expect(screen.queryByText('your move')).toBeNull();
+  });
+});

--- a/apps/web/src/contexts/AIChatContext.tsx
+++ b/apps/web/src/contexts/AIChatContext.tsx
@@ -148,6 +148,12 @@ interface ChatMessage {
   wasInterrupted?: boolean;
   /** Durable timeline session that supplied this persisted message. */
   conversationSessionId?: string | null;
+  /**
+   * Canned replies the agent offered under a question — tap one and its exact
+   * text is sent as an ordinary user message. Nothing else reads them, so a
+   * chip is a shortcut for typing and never a separate answer channel.
+   */
+  options?: string[];
 }
 
 export type ChatScope =
@@ -1055,11 +1061,18 @@ export function AIChatProvider({ children }: { children: React.ReactNode }) {
                           msg.decisionQuestions && msg.decisionQuestions.length > 0
                             ? msg.decisionQuestions
                             : fromDone;
+                        // Chips ride the done event only so this turn shows
+                        // them without a reload; the persisted message carries
+                        // the same list for every later read.
+                        const options = Array.isArray(event.options)
+                          ? (event.options as string[])
+                          : undefined;
                         return {
                           ...msg,
                           content: finalContent,
                           isStreaming: false,
                           ...(decisionQuestions ? { decisionQuestions } : {}),
+                          ...(options && options.length > 0 ? { options } : {}),
                         };
                       }),
                     );
@@ -1359,6 +1372,7 @@ export function AIChatProvider({ children }: { children: React.ReactNode }) {
           decisionQuestions?: Question[] | null;
           decisionQuestionsSubmitted?: boolean | null;
           interrupted?: boolean | null;
+          options?: string[] | null;
           debugMeta?: {
             tools?: Array<{
               name: string;
@@ -1404,6 +1418,7 @@ export function AIChatProvider({ children }: { children: React.ReactNode }) {
           : {}),
         ...(m.decisionQuestionsSubmitted ? { decisionQuestionsSubmitted: true } : {}),
         ...(m.interrupted ? { wasInterrupted: true } : {}),
+        ...(Array.isArray(m.options) && m.options.length > 0 ? { options: m.options } : {}),
         conversationSessionId: data.sessionId,
       }));
 
@@ -1448,6 +1463,7 @@ export function AIChatProvider({ children }: { children: React.ReactNode }) {
           decisionQuestions?: Question[] | null;
           decisionQuestionsSubmitted?: boolean | null;
           interrupted?: boolean | null;
+          options?: string[] | null;
           debugMeta?: {
             tools?: Array<{
               name: string;
@@ -1480,6 +1496,7 @@ export function AIChatProvider({ children }: { children: React.ReactNode }) {
           : {}),
         ...(message.decisionQuestionsSubmitted ? { decisionQuestionsSubmitted: true } : {}),
         ...(message.interrupted ? { wasInterrupted: true } : {}),
+        ...(Array.isArray(message.options) && message.options.length > 0 ? { options: message.options } : {}),
         conversationSessionId: data.sessionId,
       }));
       setMessages((current) => {

--- a/services/api/src/adapters/conversation.database.adapter.ts
+++ b/services/api/src/adapters/conversation.database.adapter.ts
@@ -5361,6 +5361,7 @@ export class ConversationDatabaseAdapter {
     if (data.subgraphResults) msgMeta.subgraphResults = data.subgraphResults;
     if (data.tokenCount !== undefined) msgMeta.tokenCount = data.tokenCount;
     if (data.interrupted) msgMeta.interrupted = true;
+    if (data.options?.length) msgMeta.options = data.options;
 
     await this.insertMessageWithConversationSession({
       id: data.id,
@@ -5591,6 +5592,7 @@ export class ConversationDatabaseAdapter {
         subgraphResults: (meta.subgraphResults as Record<string, unknown>) ?? null,
         tokenCount: typeof meta.tokenCount === 'number' ? meta.tokenCount : null,
         interrupted: meta.interrupted ?? null,
+        options: Array.isArray(meta.options) ? meta.options.filter((o): o is string => typeof o === 'string') : null,
         createdAt: msg.createdAt,
       };
     });

--- a/services/api/src/adapters/database.shared.ts
+++ b/services/api/src/adapters/database.shared.ts
@@ -184,6 +184,13 @@ export interface IntentListRow {
   waitingOpportunityCount: number;
   /** True while a fresh intent has not completed its first discovery run. */
   warming: boolean;
+  /**
+   * The signal's agent asked its owner something and is still waiting: the
+   * newest message in the signal's DM is an agent question offering canned
+   * replies. Derived per read from the conversation itself — answering (by
+   * typing or by tapping a chip) is what clears it.
+   */
+  awaitingReply: boolean;
   discoveryProgress?: {
     status: 'queued' | 'running' | 'retrying' | 'completed' | 'failed' | 'blocked' | 'unknown';
     attempt: number;
@@ -418,6 +425,12 @@ export interface ChatMessage {
   subgraphResults: Record<string, unknown> | null;
   tokenCount: number | null;
   interrupted?: boolean | null;
+  /**
+   * Canned replies the client may tap instead of typing. Present only on an
+   * agent question that offered them; tapping one sends its text as an
+   * ordinary user message, so nothing else reads this.
+   */
+  options?: string[] | null;
   createdAt: Date;
 }
 
@@ -455,6 +468,8 @@ export interface ChatMessageMeta {
    * conversational-questions edit rule). Absent on messages never edited.
    */
   regeneratedAt?: string;
+  /** Canned replies offered under an agent question (2-4 short strings). */
+  options?: string[];
   [key: string]: unknown;
 }
 
@@ -479,6 +494,8 @@ export interface CreateMessageInput {
   subgraphResults?: Record<string, unknown>;
   tokenCount?: number;
   interrupted?: boolean;
+  /** Canned replies for an agent question; stored in messages.metadata. */
+  options?: string[];
 }
 
 /**

--- a/services/api/src/adapters/intent.database.adapter.ts
+++ b/services/api/src/adapters/intent.database.adapter.ts
@@ -6,6 +6,9 @@ import { canApplyExpectedIntentUpdate, computeIntentFingerprint } from '../lib/i
 import { intentProposalAnalysisSchema, mapProposalAnalysisToIntent } from '../lib/intent/intent-proposal';
 
 
+/** Scope type of the per-signal DM the personal agent speaks into. */
+const NEGOTIATOR_INTENT_SCOPE_TYPE = 'negotiator-intent';
+
 export class IntentDatabaseAdapter {
   /**
    * Retrieve a single user_context row (global when networkId is null), or null.
@@ -598,18 +601,20 @@ export class IntentDatabaseAdapter {
   /**
    * Enrich a page of intent list rows with their registered networks, the
    * per-intent counts the UI surfaces (pending questions, waiting
-   * opportunities), and the fresh-intent discovery state. Runs three grouped
-   * queries in parallel and joins in memory, so it stays O(1) round-trips
-   * regardless of page size.
+   * opportunities), the fresh-intent discovery state, and whether the signal's
+   * own agent is holding an unanswered question. Runs the grouped queries in
+   * parallel and joins in memory, so it stays O(1) round-trips regardless of
+   * page size.
    *
    * @param rows - The paginated base intent rows to enrich.
    * @param userId - Owner, used to scope the waiting-opportunity actor match.
-   * @returns The rows with `networks`, `pendingQuestionCount`, and
-   *   `waitingOpportunityCount` populated (empty/zero when none), plus a
-   *   deduplicated total of waiting opportunities across the page's signals.
+   * @returns The rows with `networks`, `pendingQuestionCount`,
+   *   `waitingOpportunityCount` and `awaitingReply` populated (empty/zero/false
+   *   when none), plus a deduplicated total of waiting opportunities across
+   *   the page's signals.
    */
   private async attachIntentExtras(
-    rows: (Omit<IntentListRow, 'networks' | 'pendingQuestionCount' | 'waitingOpportunityCount' | 'warming'> & {
+    rows: (Omit<IntentListRow, 'networks' | 'pendingQuestionCount' | 'waitingOpportunityCount' | 'warming' | 'awaitingReply'> & {
       /** Stamped by the from-intent queue on first successful discovery (IND-482). */
       firstDiscoverySucceededAt: Date | null;
     })[],
@@ -619,10 +624,11 @@ export class IntentDatabaseAdapter {
     if (rows.length === 0) return { rows: [], totalWaitingOpportunities: 0 };
     const intentIds = rows.map(r => r.id);
     const warmingCutoff = new Date(Date.now() - 24 * 60 * 60 * 1000);
-    const [networks, countResult, progress] = await Promise.all([
+    const [networks, countResult, progress, awaitingReply] = await Promise.all([
       this.networksByIntent(intentIds),
       this.countsByIntent(intentIds, userId),
       includeDiscoveryProgress ? this.discoveryProgressByIntent(intentIds, userId) : Promise.resolve(new Map()),
+      this.awaitingReplyByIntent(intentIds, userId),
     ]);
     return {
       rows: rows.map(({ firstDiscoverySucceededAt, ...r }) => ({
@@ -630,6 +636,7 @@ export class IntentDatabaseAdapter {
         networks: networks.get(r.id) ?? [],
         pendingQuestionCount: countResult.byIntent.get(r.id)?.questions ?? 0,
         waitingOpportunityCount: countResult.byIntent.get(r.id)?.opportunities ?? 0,
+        awaitingReply: awaitingReply.has(r.id),
         warming: r.createdAt > warmingCutoff
           && firstDiscoverySucceededAt == null,
         ...(includeDiscoveryProgress ? { discoveryProgress: progress.get(r.id) ?? {
@@ -643,6 +650,52 @@ export class IntentDatabaseAdapter {
       })),
       totalWaitingOpportunities: countResult.totalWaitingOpportunities,
     };
+  }
+
+  /**
+   * The signals whose agent is waiting on the owner: the newest message in the
+   * signal's ('negotiator-intent', intentId) DM is agent-authored AND offered
+   * canned replies, so it is a question nobody has answered yet. A later
+   * message of any kind — the owner's typed answer or their tapped chip, both
+   * ordinary user messages — makes the newest row theirs and clears the flag.
+   *
+   * Derived, never stored: there is no "answered" bit to drift out of sync,
+   * and one DISTINCT ON read covers the whole page.
+   *
+   * @param intentIds - The page's signals
+   * @param userId - Owner, scoping the DM lookup
+   * @returns The subset of ids whose DM is waiting on an answer
+   */
+  private async awaitingReplyByIntent(intentIds: string[], userId: string): Promise<Set<string>> {
+    const waiting = new Set<string>();
+    if (intentIds.length === 0) return waiting;
+    const rows = await db
+      .selectDistinctOn([schema.chatSessionScopes.scopeId], {
+        intentId: schema.chatSessionScopes.scopeId,
+        role: schema.messages.role,
+        metadata: schema.messages.metadata,
+      })
+      .from(schema.chatSessionScopes)
+      .innerJoin(
+        schema.messages,
+        eq(schema.messages.conversationId, schema.chatSessionScopes.conversationId),
+      )
+      .where(and(
+        eq(schema.chatSessionScopes.userId, userId),
+        eq(schema.chatSessionScopes.scopeType, NEGOTIATOR_INTENT_SCOPE_TYPE),
+        inArray(schema.chatSessionScopes.scopeId, intentIds),
+      ))
+      .orderBy(
+        schema.chatSessionScopes.scopeId,
+        desc(schema.messages.createdAt),
+        desc(schema.messages.id),
+      );
+    for (const row of rows) {
+      if (row.role !== 'agent') continue;
+      const options = (row.metadata as { options?: unknown } | null)?.options;
+      if (Array.isArray(options) && options.length > 0) waiting.add(row.intentId);
+    }
+    return waiting;
   }
 
   private async discoveryProgressByIntent(intentIds: string[], userId: string): Promise<Map<string, NonNullable<IntentListRow['discoveryProgress']>>> {

--- a/services/api/src/adapters/tests/intent.awaiting-reply.spec.ts
+++ b/services/api/src/adapters/tests/intent.awaiting-reply.spec.ts
@@ -1,0 +1,138 @@
+/**
+ * Canned replies and the your-move badge, against the real database.
+ *
+ * Two derived reads, one fact. An agent question carries its options in the
+ * message's own metadata (no new table, no new column), and a signal is
+ * "your move" exactly while the newest message in its ('negotiator-intent',
+ * intentId) DM is such a question. Nothing records that it was answered:
+ * the owner's reply — typed or tapped — is a newer message, and that is what
+ * clears the badge.
+ */
+import { config } from 'dotenv';
+config({ path: '.env.test', override: true });
+
+import { afterAll as bunAfterAll, beforeAll as bunBeforeAll, describe, expect, test } from 'bun:test';
+import { eq } from 'drizzle-orm/sql';
+
+import { conversationDatabaseAdapter, intentDatabaseAdapter, UserDatabaseAdapter } from '../database.adapter';
+import { chatSessionService } from '../../services/chat.service';
+import db from '../../lib/drizzle/drizzle';
+import { withMinimumDatabaseHookBudget } from '../../lib/testing/database-test-budget';
+import { intents } from '../../schemas/database.schema';
+
+const EMAIL = 'test-intent-awaiting-reply@example.com';
+const OTHER_EMAIL = 'test-intent-awaiting-reply-other@example.com';
+const beforeAll = withMinimumDatabaseHookBudget(bunBeforeAll, 30_000);
+const afterAll = withMinimumDatabaseHookBudget(bunAfterAll, 30_000);
+
+describe('agent question options and the per-signal your-move flag', () => {
+  const users = new UserDatabaseAdapter();
+  let userId: string;
+  let otherUserId: string;
+  const sessionIds = new Set<string>();
+
+  async function createIntent(ownerId: string): Promise<string> {
+    const id = crypto.randomUUID();
+    await db.insert(intents).values({
+      id,
+      userId: ownerId,
+      payload: 'Find a hiring partner',
+      summary: 'Find a hiring partner',
+      status: 'ACTIVE',
+    });
+    return id;
+  }
+
+  async function pinnedSession(ownerId: string, forIntentId: string): Promise<string> {
+    const resolved = await chatSessionService.resolveNegotiatorIntentSession(ownerId, forIntentId);
+    if ('error' in resolved) throw new Error(resolved.error);
+    sessionIds.add(resolved.session.id);
+    return resolved.session.id;
+  }
+
+  async function awaitingReplyFor(ownerId: string, forIntentId: string): Promise<boolean> {
+    const { rows } = await intentDatabaseAdapter.listIntents(ownerId, { page: 1, limit: 100, archived: false });
+    const row = rows.find((candidate) => candidate.id === forIntentId);
+    expect(row).toBeDefined();
+    return row!.awaitingReply;
+  }
+
+  async function resetUser(email: string): Promise<string> {
+    const existing = await users.findByEmail(email);
+    if (existing) {
+      await db.delete(intents).where(eq(intents.userId, existing.id));
+      await users.deleteById(existing.id);
+    }
+    return (await users.create({ email, name: 'Awaiting Reply User' })).id;
+  }
+
+  beforeAll(async () => {
+    userId = await resetUser(EMAIL);
+    otherUserId = await resetUser(OTHER_EMAIL);
+  });
+
+  afterAll(async () => {
+    for (const id of sessionIds) await conversationDatabaseAdapter.deleteChatSession(id).catch(() => {});
+    for (const id of [userId, otherUserId]) {
+      await db.delete(intents).where(eq(intents.userId, id)).catch(() => {});
+      await users.deleteById(id).catch(() => {});
+    }
+  });
+
+  test('an agent question keeps its options, and the signal reads as your move until the owner answers', async () => {
+    const intentId = await createIntent(userId);
+    const sessionId = await pinnedSession(userId, intentId);
+    expect(await awaitingReplyFor(userId, intentId)).toBe(false);
+
+    const options = ['Hiring speed', 'Comp banding', 'Team shape'];
+    await chatSessionService.addMessage({
+      sessionId,
+      role: 'assistant',
+      content: 'What should I push hardest on when I talk to her?',
+      options,
+    });
+
+    // The chips survive the round trip on the message itself.
+    const history = await chatSessionService.getConversationSessionHistory(sessionId);
+    const asked = history.messages[history.messages.length - 1]!;
+    expect(asked.role).toBe('assistant');
+    expect(asked.options).toEqual(options);
+
+    expect(await awaitingReplyFor(userId, intentId)).toBe(true);
+
+    // A tapped chip is an ordinary user message — and that is what answers.
+    await chatSessionService.addMessage({ sessionId, role: 'user', content: 'Hiring speed' });
+    expect(await awaitingReplyFor(userId, intentId)).toBe(false);
+  });
+
+  test('an agent message that merely reports never claims the owner move', async () => {
+    const intentId = await createIntent(userId);
+    const sessionId = await pinnedSession(userId, intentId);
+
+    await chatSessionService.addMessage({
+      sessionId,
+      role: 'assistant',
+      content: 'I passed your timing along; nothing needs you right now.',
+    });
+
+    const history = await chatSessionService.getConversationSessionHistory(sessionId);
+    expect(history.messages[history.messages.length - 1]!.options).toBeNull();
+    expect(await awaitingReplyFor(userId, intentId)).toBe(false);
+  });
+
+  test('another owner\'s waiting question never lands on this owner\'s signals', async () => {
+    const foreignIntentId = await createIntent(otherUserId);
+    const foreignSessionId = await pinnedSession(otherUserId, foreignIntentId);
+    await chatSessionService.addMessage({
+      sessionId: foreignSessionId,
+      role: 'assistant',
+      content: 'Which of these matters more to you?',
+      options: ['Speed', 'Reach'],
+    });
+
+    expect(await awaitingReplyFor(otherUserId, foreignIntentId)).toBe(true);
+    const { rows } = await intentDatabaseAdapter.listIntents(userId, { page: 1, limit: 100, archived: false });
+    expect(rows.some((row) => row.id === foreignIntentId)).toBe(false);
+    expect(rows.every((row) => row.awaitingReply === false)).toBe(true);
+  });
+});

--- a/services/api/src/controllers/chat.controller.ts
+++ b/services/api/src/controllers/chat.controller.ts
@@ -590,6 +590,8 @@ export class ChatController {
           let agentTurn: IntentAgentTurnResult | null = null;
           let agentUserMessageId: string | null = null;
           let agentAssistantMessageId: string | undefined;
+          /** Canned replies the agent attached to its delivered message. */
+          let agentReplyOptions: string[] | undefined;
 
           if (agentOwnsTurn && effectiveScope) {
             // The conversation is the agent's memory, so the client's message
@@ -635,7 +637,13 @@ export class ChatController {
               });
               fullResponse = agentTurn.messages.join('\n\n');
               for (const act of agentTurn.acts) {
-                if (act.tool === 'message_user') agentAssistantMessageId = act.messageId;
+                if (act.tool !== 'message_user') continue;
+                agentAssistantMessageId = act.messageId;
+                // The chips belong to the last message the turn delivered —
+                // the same one `agentAssistantMessageId` names. They are
+                // already persisted on it; the done event only spares the
+                // client a reload to see them.
+                agentReplyOptions = act.options;
               }
               // Dropped-subscription fallback: whatever the channel did not
               // deliver of the completed turn is emitted as one token event.
@@ -873,6 +881,7 @@ export class ChatController {
                     title: sessionTitle,
                     suggestions,
                     ...(decisionQuestions !== undefined ? { decisionQuestions } : {}),
+                    ...(agentReplyOptions ? { options: agentReplyOptions } : {}),
                   }),
                 ),
               ),

--- a/services/api/src/lib/intent-agent/intent-agent.host.ts
+++ b/services/api/src/lib/intent-agent/intent-agent.host.ts
@@ -22,6 +22,7 @@ import type { NegotiatorVerdictResult } from '../agent/negotiator-verdict.host';
 import { assembleIntentAgentContext } from './intent-agent.context';
 import type { IntentAgentContextDeps, IntentAgentTurnContext } from './intent-agent.context';
 import { IntentAgentTurn } from './intent-agent.turn';
+import type { IntentAgentReply } from './intent-agent.turn';
 import type { IntentAgentDecidedAct, IntentAgentEvent, IntentAgentExecutedAct, IntentAgentInboxEvent, IntentAgentReplyFallbackReason, IntentAgentTurnResult, IntentAgentUserMessageEvent } from './intent-agent.types';
 import { log } from '../log';
 
@@ -56,7 +57,7 @@ export interface IntentAgentChatSessions {
     | { session: { id: string } }
     | { error: string; status: 400 | 403 | 404 | 500 }
   >;
-  addMessage(params: { sessionId: string; role: 'user' | 'assistant' | 'system'; content: string }): Promise<string>;
+  addMessage(params: { sessionId: string; role: 'user' | 'assistant' | 'system'; content: string; options?: string[] }): Promise<string>;
 }
 
 /** Injectable seams; production resolves the real collaborators lazily. */
@@ -161,6 +162,7 @@ async function deliverMessage(
   event: IntentAgentInboxEvent,
   text: string,
   deps?: IntentAgentHostDeps,
+  options?: string[],
 ): Promise<{ sessionId: string; messageId: string } | null> {
   const chatSessions = await resolveChatSessions(deps);
   const resolved = await chatSessions.resolveNegotiatorIntentSession(event.userId, event.intentId);
@@ -180,6 +182,7 @@ async function deliverMessage(
     sessionId: resolved.session.id,
     role: 'assistant',
     content: text,
+    ...(options ? { options } : {}),
   });
   return { sessionId: resolved.session.id, messageId };
 }
@@ -201,9 +204,14 @@ export async function executeIntentAgentActs(
   for (const act of decided) {
     switch (act.tool) {
       case 'message_user': {
-        const delivered = await deliverMessage(event, act.text, deps);
+        const delivered = await deliverMessage(event, act.text, deps, act.options);
         if (!delivered) break;
-        const executed: IntentAgentExecutedAct = { tool: 'message_user', text: act.text, ...delivered };
+        const executed: IntentAgentExecutedAct = {
+          tool: 'message_user',
+          text: act.text,
+          ...(act.options ? { options: act.options } : {}),
+          ...delivered,
+        };
         await appendLedger(event, executed, deps);
         result.acts.push(executed);
         result.messages.push(act.text);
@@ -308,15 +316,15 @@ async function runReplyStage(
   result: IntentAgentTurnResult,
   deps?: IntentAgentHostDeps,
 ): Promise<void> {
-  let text: string | null = null;
+  let composed: IntentAgentReply | null = null;
   let fallback: IntentAgentReplyFallbackReason | undefined;
   if (!turn.reply) {
     // An injected judgment seam without a reply seam cannot compose one.
     fallback = 'model_error';
   } else {
     try {
-      text = await turn.reply(context, result.acts);
-      if (text === null) fallback = 'safety_check_failed';
+      composed = await turn.reply(context, result.acts);
+      if (composed === null) fallback = 'safety_check_failed';
     } catch (err) {
       logger.error('intent_agent_reply_stage_failed', {
         userId: event.userId,
@@ -334,12 +342,14 @@ async function runReplyStage(
     });
   }
 
-  const content = text ?? INTENT_AGENT_REPLY_FALLBACK;
-  const delivered = await deliverMessage(event, content, deps);
+  const content = composed?.text ?? INTENT_AGENT_REPLY_FALLBACK;
+  const options = composed?.options;
+  const delivered = await deliverMessage(event, content, deps, options);
   if (!delivered) return;
   const executed: IntentAgentExecutedAct = {
     tool: 'message_user',
     text: content,
+    ...(options ? { options } : {}),
     ...delivered,
     stage: 'reply',
     ...(fallback ? { fallback } : {}),

--- a/services/api/src/lib/intent-agent/intent-agent.prompt.ts
+++ b/services/api/src/lib/intent-agent/intent-agent.prompt.ts
@@ -20,10 +20,16 @@
  * row is never fatal: the nameless form is byte-identical to version 2's
  * opener, because this loop negotiates unattended and must not fail a turn
  * over a display name.
+ *
+ * Version 4 (options): a question — asked from either stage — MAY carry 2-4
+ * candidate answers. They are canned replies and nothing else: tapping one
+ * sends its exact text as an ordinary client message, so the law about them
+ * is only about wording, never about routing. There is deliberately no
+ * "other" option, because typing has always been available.
  */
 import { buildAgentSelfIntroduction, type AgentIdentityOptions } from '@indexnetwork/protocol';
 
-export const INTENT_AGENT_SYSTEM_PROMPT_VERSION = 3;
+export const INTENT_AGENT_SYSTEM_PROMPT_VERSION = 4;
 
 /**
  * The role phrase the self-introduction is built around. It names the client
@@ -46,7 +52,7 @@ export function buildIntentAgentSystemPrompt(identity: AgentIdentityOptions = {}
   return `${introduction} You conduct negotiations on their behalf, and you hold the WHOLE conversation with them about this signal: every message they send here comes to you, whether it is an answer, an instruction, a question, or small talk. You have just been woken by an event; decide what to do, then act through your tools.
 
 Your tools, each of which is recorded in your ledger:
-- message_user: say something to your client in this signal's conversation. Plain prose, their language, no markup blocks. Available only when a negotiation event woke you — when your client themselves wrote to you, your reply is composed in a separate step after your acts, so do not use this tool then.
+- message_user: say something to your client in this signal's conversation. Plain prose, their language, no markup blocks. Available only when a negotiation event woke you — when your client themselves wrote to you, your reply is composed in a separate step after your acts, so do not use this tool then. When the message ASKS them something, you may also give an \`options\` list: 2-4 short, concrete, mutually distinct candidate answers in their language, each a few words. They are a shortcut for typing, nothing more — your client can always answer in their own words, so never offer an "other", "something else" or "let me type" option. A message that merely reports gets no options; a question you cannot reduce to a few clean candidates gets none either.
 - answer_negotiation: resolve what a waiting negotiation asked for, using your client's words or a dossier fact. This is the only way a negotiation moves again.
 - accept_opportunity / reject_opportunity: execute your client's verdict on one of the listed matches. See the verdict law below — this fires ONLY on their explicit word.
 - note_dossier: record a fact your client stated, in a form useful at the negotiation table.
@@ -87,5 +93,6 @@ export const INTENT_AGENT_REPLY_INSTRUCTION = `You have already decided and exec
 - If an act failed or a match had already moved on, say so honestly and propose the next step; propose only.
 - If you executed nothing, just answer them: their status question from the listed state, their hedge with your recommendation and the question that would settle it, their small talk briefly and warmly.
 - No markup blocks, no lists of internal state, no identifiers, no scores, no counterparty details beyond the match list. One coherent reply, a few sentences unless more is genuinely needed.
+- If your reply asks your client something, you may also give an \`options\` list: 2-4 short, concrete, mutually distinct candidate answers in their language, each a few words. They are a shortcut for typing — your client can always answer in their own words — so never offer an "other" or "something else" option. A reply that does not ask, or asks something you cannot reduce to a few clean candidates, gets no options.
 
-Write the reply text only.`;
+Write the reply prose in \`reply\`; leave \`options\` out unless the reply asks.`;

--- a/services/api/src/lib/intent-agent/intent-agent.turn.ts
+++ b/services/api/src/lib/intent-agent/intent-agent.turn.ts
@@ -31,6 +31,40 @@ const logger = log.lib.from('intent-agent.turn');
 const MAX_TURN_CHARS = 500;
 const MAX_TRANSCRIPT_TURNS = 6;
 const MAX_DM_CHARS = 1000;
+const MAX_OPTION_CHARS = 60;
+const MIN_OPTIONS = 2;
+const MAX_OPTIONS = 4;
+
+/**
+ * Canned replies, normalized. Options are a shortcut for typing and nothing
+ * more, so a malformed set is DROPPED rather than rejected: the question
+ * still reads fine as prose, and refusing the whole round trip over chip
+ * wording would trade a convenience for a lost turn. Blank, over-long,
+ * duplicate and leak-tripping candidates go — a chip is delivered prose and
+ * passes the same identifier gate the message does; fewer than two survivors
+ * means no chips at all (one chip is not a choice), and more than four are
+ * cut to the first four.
+ *
+ * @param raw - Whatever the model emitted for `options`
+ * @returns 2-4 distinct short strings, or undefined for "no chips"
+ */
+export function normalizeMessageOptions(raw: unknown): string[] | undefined {
+  if (!Array.isArray(raw)) return undefined;
+  const seen = new Set<string>();
+  const options: string[] = [];
+  for (const candidate of raw) {
+    if (typeof candidate !== 'string') continue;
+    const text = candidate.trim();
+    if (!text || text.length > MAX_OPTION_CHARS) continue;
+    if (!isSafeQuestionMessageProse(text)) continue;
+    const key = text.toLowerCase();
+    if (seen.has(key)) continue;
+    seen.add(key);
+    options.push(text);
+    if (options.length === MAX_OPTIONS) break;
+  }
+  return options.length >= MIN_OPTIONS ? options : undefined;
+}
 
 // Optional fields are `.nullable().optional()`: the OpenAI structured-output
 // schema translation refuses optional-without-nullable, and the validator
@@ -40,6 +74,8 @@ const DecidedActsSchema = z.object({
     act: z.enum(['message_user', 'answer_negotiation', 'accept_opportunity', 'reject_opportunity', 'note_dossier', 'retire_dossier', 'wait']),
     /** message_user: the message. note_dossier: the fact. */
     text: z.string().max(4000).nullable().optional(),
+    /** message_user: 2-4 short canned replies, when the message asks. */
+    options: z.array(z.string().max(MAX_OPTION_CHARS)).max(8).nullable().optional(),
     /** answer_negotiation: 1-based number from the waiting list. */
     negotiation: z.number().int().min(1).nullable().optional(),
     /** answer_negotiation: the answer, restated so it stands alone. */
@@ -52,6 +88,23 @@ const DecidedActsSchema = z.object({
     reason: z.string().max(500).nullable().optional(),
   })).min(1).max(6),
 });
+
+/**
+ * The reply stage's shape (phase 2 + options): the prose plus, when the reply
+ * asks the client something, the same 2-4 canned replies the acts stage may
+ * attach. Structured rather than plain text ONLY so the chips can travel with
+ * the words that earned them — `reply` is the delivered prose, unchanged.
+ */
+const ReplySchema = z.object({
+  reply: z.string().max(4000),
+  options: z.array(z.string().max(MAX_OPTION_CHARS)).max(8).nullable().optional(),
+});
+
+/** A composed reply: the prose the client reads, plus optional chips. */
+export interface IntentAgentReply {
+  text: string;
+  options?: string[];
+}
 
 function truncate(text: string, max: number): string {
   const trimmed = text.trim();
@@ -244,7 +297,8 @@ export class IntentAgentTurn {
           if (context.event.kind === 'user_message') return null;
           const text = act.text?.trim();
           if (!text || !isSafeQuestionMessageProse(text)) return null;
-          decided.push({ tool: 'message_user', text });
+          const options = normalizeMessageOptions(act.options);
+          decided.push({ tool: 'message_user', text, ...(options ? { options } : {}) });
           break;
         }
         case 'accept_opportunity':
@@ -308,16 +362,22 @@ export class IntentAgentTurn {
    * Model errors propagate — the caller distinguishes a provider outage
    * (fallback, reason 'model_error') from refused prose.
    */
-  async reply(context: IntentAgentTurnContext, executed: IntentAgentExecutedAct[]): Promise<string | null> {
+  async reply(context: IntentAgentTurnContext, executed: IntentAgentExecutedAct[]): Promise<IntentAgentReply | null> {
     const userMessage = renderIntentAgentReplyStage(context, executed);
     const system = `${systemPrompt(context)}\n\n${INTENT_AGENT_REPLY_INSTRUCTION}`;
     for (let attempt = 0; attempt < 2; attempt++) {
-      const raw = (await this.callReplyModel([
+      const parsed = ReplySchema.safeParse(await this.callReplyModel([
         { role: 'system', content: system },
         { role: 'user', content: userMessage },
-      ])).trim();
-      if (raw && isSafeQuestionMessageProse(raw)) return raw;
-      logger.warn('intent_agent_reply_rejected', { attempt: attempt + 1, empty: !raw });
+      ]));
+      if (parsed.success) {
+        const text = parsed.data.reply.trim();
+        if (text && isSafeQuestionMessageProse(text)) {
+          const options = normalizeMessageOptions(parsed.data.options);
+          return { text, ...(options ? { options } : {}) };
+        }
+      }
+      logger.warn('intent_agent_reply_rejected', { attempt: attempt + 1, malformed: !parsed.success });
     }
     return null;
   }
@@ -333,12 +393,11 @@ export class IntentAgentTurn {
       .invoke(messages);
   }
 
-  /** Raw plain-text round trip for the reply stage; same seam discipline. */
-  protected async callReplyModel(messages: Array<{ role: string; content: string }>): Promise<string> {
-    const response = await this.buildModel().invoke(messages);
-    return typeof response.content === 'string'
-      ? response.content
-      : response.content.map((part) => (typeof part === 'string' ? part : 'text' in part ? part.text : '')).join('');
+  /** Raw round trip for the reply stage; same seam discipline. */
+  protected async callReplyModel(messages: Array<{ role: string; content: string }>): Promise<unknown> {
+    return this.buildModel()
+      .withStructuredOutput(ReplySchema, { name: 'intent_agent_reply' })
+      .invoke(messages);
   }
 
   private buildModel(): ChatOpenAI {

--- a/services/api/src/lib/intent-agent/intent-agent.types.ts
+++ b/services/api/src/lib/intent-agent/intent-agent.types.ts
@@ -51,7 +51,17 @@ export type IntentAgentEvent = IntentAgentInboxEvent | IntentAgentAnswerToolEven
 // ─── Decided acts (model output, ids already resolved from indices) ─────────
 
 export type IntentAgentDecidedAct =
-  | { tool: 'message_user'; text: string }
+  | {
+    tool: 'message_user';
+    text: string;
+    /**
+     * Canned replies for a question, 2-4 short strings. Purely a shortcut:
+     * tapping one sends that exact text as an ordinary client message, so
+     * there is no answer machinery behind them. Absent when the message
+     * merely reports. Normalized (and dropped) by the turn's validator.
+     */
+    options?: string[];
+  }
   | { tool: 'answer_negotiation'; opportunityId: string; answer: string }
   | { tool: 'note_dossier'; text: string }
   | { tool: 'retire_dossier'; entryId: string }
@@ -82,6 +92,8 @@ export type IntentAgentExecutedAct =
   | {
     tool: 'message_user';
     text: string;
+    /** The canned replies delivered with this message, when it asked. */
+    options?: string[];
     sessionId: string;
     messageId: string;
     /**

--- a/services/api/src/lib/intent-agent/tests/intent-agent.identity.spec.ts
+++ b/services/api/src/lib/intent-agent/tests/intent-agent.identity.spec.ts
@@ -75,9 +75,9 @@ class CapturingTurn extends IntentAgentTurn {
     this.systems.push(messages.find((message) => message.role === 'system')!.content);
     return { acts: [{ act: 'wait', reason: 'nothing to do' }] };
   }
-  protected override async callReplyModel(messages: Array<{ role: string; content: string }>): Promise<string> {
+  protected override async callReplyModel(messages: Array<{ role: string; content: string }>): Promise<unknown> {
     this.systems.push(messages.find((message) => message.role === 'system')!.content);
-    return 'Nothing needs you right now.';
+    return { reply: 'Nothing needs you right now.' };
   }
 }
 
@@ -103,7 +103,7 @@ describe('buildIntentAgentSystemPrompt', () => {
     const firstSentence = (prompt: string) => prompt.slice(0, prompt.indexOf('You conduct negotiations'));
     expect(named.slice(firstSentence(named).length)).toBe(nameless.slice(firstSentence(nameless).length));
     // The version constant exists to make a prompt change loud.
-    expect(INTENT_AGENT_SYSTEM_PROMPT_VERSION).toBe(3);
+    expect(INTENT_AGENT_SYSTEM_PROMPT_VERSION).toBe(4);
   });
 });
 

--- a/services/api/src/lib/intent-agent/tests/intent-agent.loop.capture.spec.ts
+++ b/services/api/src/lib/intent-agent/tests/intent-agent.loop.capture.spec.ts
@@ -35,7 +35,7 @@ function scriptedTurn(
   return {
     decide: async (context: IntentAgentTurnContext) => script(context),
     // Phase 2: a client-message turn ends with the streaming reply stage.
-    ...(reply !== undefined ? { reply: async () => reply } : {}),
+    ...(reply !== undefined ? { reply: async () => ({ text: reply }) } : {}),
   };
 }
 

--- a/services/api/src/lib/intent-agent/tests/intent-agent.turn.spec.ts
+++ b/services/api/src/lib/intent-agent/tests/intent-agent.turn.spec.ts
@@ -79,13 +79,13 @@ class ScriptedModelTurn extends IntentAgentTurn {
 /** A turn whose reply-stage round trips are scripted. */
 class ScriptedReplyTurn extends IntentAgentTurn {
   replyCalls = 0;
-  constructor(private readonly replies: string[]) {
+  constructor(private readonly replies: Array<string | { reply: string; options?: unknown }>) {
     super({ model: 'test-model' });
   }
-  protected override async callReplyModel(): Promise<string> {
+  protected override async callReplyModel(): Promise<unknown> {
     const output = this.replies[this.replyCalls];
     this.replyCalls += 1;
-    return output ?? '';
+    return typeof output === 'string' ? { reply: output } : output ?? { reply: '' };
   }
 }
 
@@ -355,9 +355,9 @@ describe('IntentAgentTurn.reply', () => {
       `Your opportunity_id is ${OPP_A}.`,
       'Sent your timing along; one match is waiting on your decision.',
     ]);
-    expect(await leaky.reply(context({ event: USER_MESSAGE }), [])).toBe(
-      'Sent your timing along; one match is waiting on your decision.',
-    );
+    expect(await leaky.reply(context({ event: USER_MESSAGE }), [])).toEqual({
+      text: 'Sent your timing along; one match is waiting on your decision.',
+    });
     expect(leaky.replyCalls).toBe(2);
 
     const hopeless = new ScriptedReplyTurn([
@@ -371,6 +371,24 @@ describe('IntentAgentTurn.reply', () => {
   it('an empty reply counts as refused prose, not a message', async () => {
     const empty = new ScriptedReplyTurn(['', '   ']);
     expect(await empty.reply(context({ event: USER_MESSAGE }), [])).toBeNull();
+  });
+
+  it('carries the reply\'s canned replies through, normalized', async () => {
+    const asking = new ScriptedReplyTurn([{
+      reply: 'Which of these should I push hardest on?',
+      options: ['  Hiring speed  ', 'hiring speed', 'Comp banding', '', 'Team shape', 'A fourth one too', 'Cut me'],
+    }]);
+    expect(await asking.reply(context({ event: USER_MESSAGE }), [])).toEqual({
+      text: 'Which of these should I push hardest on?',
+      options: ['Hiring speed', 'Comp banding', 'Team shape', 'A fourth one too'],
+    });
+  });
+
+  it('drops a chip set too thin to be a choice — the prose still stands', async () => {
+    const thin = new ScriptedReplyTurn([{ reply: 'How soon do you want to start?', options: ['Q4'] }]);
+    expect(await thin.reply(context({ event: USER_MESSAGE }), [])).toEqual({
+      text: 'How soon do you want to start?',
+    });
   });
 });
 
@@ -402,7 +420,8 @@ describe('runIntentAgentTurn reply stage', () => {
       ...(overrides.withReplySeam === false ? {} : {
         reply: async (turnContext: IntentAgentTurnContext) => {
           replyCalls += 1;
-          return overrides.reply ? overrides.reply(turnContext) : 'All quiet on this signal.';
+          const composed = overrides.reply ? await overrides.reply(turnContext) : 'All quiet on this signal.';
+          return typeof composed === 'string' ? { text: composed } : composed;
         },
       }),
     } as never;

--- a/services/api/src/lib/intent-agent/tests/intent-agent.verdict.capture.spec.ts
+++ b/services/api/src/lib/intent-agent/tests/intent-agent.verdict.capture.spec.ts
@@ -69,7 +69,7 @@ describe('IntentAgent verdict acts over the real #1471 lane', () => {
               reason: 'Client: reject the manufacturing match.',
             }];
           },
-          reply: async () => replyText,
+          reply: async () => ({ text: replyText }),
         },
       },
     );
@@ -121,7 +121,7 @@ describe('IntentAgent verdict acts over the real #1471 lane', () => {
           // The agent decided from stale knowledge (an id no longer listed);
           // the lane refuses the write and the act records why.
           decide: async () => [{ tool: 'accept_opportunity' as const, opportunityId: fixture.opportunityId }],
-          reply: async () => 'That match had already closed before your word reached it — nothing was decided.',
+          reply: async () => ({ text: 'That match had already closed before your word reached it — nothing was decided.' }),
         },
       },
     );

--- a/services/api/src/queues/tests/intent-agent.queue.isolated.ts
+++ b/services/api/src/queues/tests/intent-agent.queue.isolated.ts
@@ -50,7 +50,7 @@ function buildQueue(script: (context: IntentAgentTurnContext) => IntentAgentDeci
         return script(context);
       },
       // Phase 2: client-message turns end with the reply stage.
-      reply: async () => 'Right here.',
+      reply: async () => ({ text: 'Right here.' }),
     },
     chatSessions: {
       resolveNegotiatorIntentSession: async () => ({ session: { id: 'session-1' } }),

--- a/services/api/src/services/chat.service.ts
+++ b/services/api/src/services/chat.service.ts
@@ -586,6 +586,8 @@ export class ChatSessionService {
     subgraphResults?: Record<string, unknown>;
     tokenCount?: number;
     interrupted?: boolean;
+    /** Canned replies rendered as chips under an agent question. */
+    options?: string[];
   }): Promise<string> {
     logger.verbose('Adding message', {
       sessionId: params.sessionId,
@@ -604,6 +606,7 @@ export class ChatSessionService {
       subgraphResults: params.subgraphResults,
       tokenCount: params.tokenCount,
       interrupted: params.interrupted,
+      options: params.options,
     });
 
     // Update session timestamp

--- a/services/api/src/types/chat-streaming.types.ts
+++ b/services/api/src/types/chat-streaming.types.ts
@@ -198,6 +198,12 @@ export interface DoneEvent extends ChatStreamEventBase {
   opportunityCards?: OpportunityCardPayload[];
   /** Decision questions to render, harvested from any tool result carrying `questions`. */
   decisionQuestions?: Question[];
+  /**
+   * Canned replies offered under this reply, when the agent asked something.
+   * The persisted message carries the same list; this only saves the client a
+   * reload to see the chips on the turn that produced them.
+   */
+  options?: string[];
 }
 
 /**
@@ -717,6 +723,7 @@ export interface CreateDoneEventOptions {
   suggestions?: ChatSuggestion[];
   opportunityCards?: OpportunityCardPayload[];
   decisionQuestions?: Question[];
+  options?: string[];
 }
 
 /**


### PR DESCRIPTION
The agent asks in prose today, and nothing on the signal list tells the user a question is waiting. Both halves of that are one fact, so they ship together.

## Options are canned replies, not answer machinery

A `message_user` act — from either stage of a turn — may carry 2–4 short candidate answers. Tapping one sends its **exact text through the ordinary chat send path**, so the agent's next turn cannot tell a chip from something the user typed. No new endpoint, no answer schema, no state machine, and deliberately no "other" option: typing was always available.

- Chips travel on the message's own `metadata` jsonb — no new table, no new column, no migration.
- The turn's validator **drops** a malformed set rather than rejecting the round trip: blank, over-long, duplicate and identifier-leaking candidates go (chips pass the same `isSafeQuestionMessageProse` gate the prose does), and fewer than two survivors means no chips at all.
- The reply stage becomes structured (`{ reply, options }`) only so the chips can travel with the words that earned them. The delivered prose and its check-then-stream discipline are unchanged; the `done` event carries the chips purely to spare the client a reload.
- Chips disappear once anything follows the question — derived from message order, no new client state.

## The your-move badge

One derived read, `awaitingReply` on the intent-list row: the newest message in the signal's `('negotiator-intent', intentId)` DM is an agent question offering chips. Nothing records that it was answered — the user's reply, typed or tapped, is simply a newer message. One `DISTINCT ON` per intent-list page, alongside the existing grouped counts.

The aggregate `N your move` counter is negotiation-conversation-based and has no per-intent mapping (`via` is always empty on A2A conversations), so this takes the handoff's stated fallback rather than inventing a parallel derivation from it.

## Scope

api + web only; `packages/protocol` untouched (the api keeps its own copy of the chat-streaming types). No feature flags — this ships on.

## Verification

- New: `intent.awaiting-reply.spec.ts` (real DB — options round-trip on the message, badge on/off across an answer, never crosses owners), chip normalization cases in `intent-agent.turn.spec.ts`, and web component tests for the chip send path and the badge.
- `services/api`: full suite green except a stable pre-existing set (MCP factory, CLI credentials, ToolController, ConversationController session history, two `conversation.database.adapter` projections). The two adapter failures were confirmed pre-existing by re-running the spec against the unmodified file on `HEAD`.
- `apps/web`: 474 pass; the 3 failures (`negotiation-presence`, `chat-sidebar-unread`) are pre-existing and untouched by this diff.
- Not exercised against a running local stack: the stack listening on :3000/:3001 is the main checkout, not this worktree.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CWeSbzWcbqydsXCpYobd8X