### PR TITLE
Document #1481's removals under protocol 24.0.0

### DIFF
--- a/packages/protocol/CHANGELOG.md
+++ b/packages/protocol/CHANGELOG.md
@@ -24,6 +24,44 @@ pin a supported release, use `latest`.
 
 ### Removed
 
+- **BREAKING: every environment feature gate is gone, and what each environment
+  was running became the code's behaviour.** No accessor in this package reads
+  `process.env` for a behaviour decision any more; configuration narrows to
+  credentials, endpoints, and the model/log values the host supplies.
+
+  Off the barrel: `configuredAskUserEnabled`, `askUserAnswerWindowMs`,
+  `discoveryEvaluatorMinScore`, `negotiationConsultationPolicyMode`,
+  `negotiationEvidenceQuestionsMode`, `poolQuestionsRanking`,
+  `poolQuestionsMiningMode`, `poolQuestionsMode`, `poolQuestionsPushMode`,
+  `poolQuestionsStampNewborn`, `poolQuestionsVisitTrigger`,
+  `POOL_VISIT_MINING_DEBOUNCE_MS`, `isIntroducerDiscoveryEnabled`,
+  `runIntroducerDiscovery`, `selectContactsForDiscovery`,
+  `shouldRunIntroducerDiscovery`, `IntroducerDiscoveryDatabase`,
+  `IntroducerDiscoveryQueue`, `INTRODUCER_DISCOVERY_SOURCE`,
+  `ContactWithIntents`, `MAX_CONTACTS_PER_CYCLE`, `MAX_CANDIDATES_PER_CONTACT`.
+  The five `poolQuestions*` accessors had no callers at all — they read
+  variables retired with the card question generators.
+
+  Behaviour now fixed in code: negotiations stamp protocol `v2`; `ask_user` and
+  the deterministic consultation policy are on; deadlock-shift is on; the
+  negotiator drafts in the `skeptic` stance (`advocate` and `evaluator`, and the
+  `stance*` predicates that distinguished them, are gone); negotiators receive
+  only each participant's exact opportunity-bound signal; HyDE generates under
+  `frame-v1`; candidate evaluation runs in parallel; retrieval floor is `0.20`
+  and the evaluator score floor is `40`; the two question miners are pinned to
+  `shadow`.
+
+- **BREAKING: profile matching is removed — discovery is intent-to-intent only.**
+  Premise-to-premise, context-to-context and context-to-intent strategies are
+  gone, along with the `profileCorpus` hint on the embedder interface. Premises
+  remain as an entity; they are no longer a matching corpus.
+
+- **BREAKING: introducer discovery is removed** — the queue, the maintenance-graph
+  node, and the on-behalf-of persistence path (`onBehalfOfUserId` is off the
+  opportunity graph state; nothing assigned it once the queue was gone). The
+  `introducer_discovery` opportunity source value is kept as read-only history:
+  nothing stamps it, and rows created before this release still carry it.
+
 - **BREAKING: the negotiation outreach screen gate is gone.** `NegotiationScreener`
   is off the barrel, and the graph is now `init → turn* → finalize` — every
   negotiation that reaches `init` proceeds to its first turn. The gate was one


### PR DESCRIPTION
`packages/protocol/CHANGELOG.md`'s `24.0.0` entry documented only the screen-gate removal from #1482. #1481 removed a larger surface from the same package in the same release window and shipped no changelog entry and no version bump, so the `rc` stream carried a changed export surface under `23.6.4` — the same gap `23.6.3` was cut to correct.

This documents, under the `24.0.0` heading that will actually carry them to `latest`:

- **Every env feature gate**, with the 22 barrel exports that went and the behaviour now fixed in code (v2 protocol, ask_user + consultation policy on, deadlock shift on, `skeptic` stance, exact-signal-only context, `frame-v1` HyDE, parallel evaluation, retrieval floor `0.20`, evaluator floor `40`, miners pinned to `shadow`).
- **Profile matching removed** — discovery is intent-to-intent only.
- **Introducer discovery removed**, with `introducer_discovery` kept as read-only history.

Export list derived by diffing `packages/protocol/src/index.ts` between `05e38b3ce` (pre-#1481) and `5b1878732`, not written from memory. No code change; `bun run check:lockfile-versions` passes and `package.json` is already `24.0.0`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0111CW7gUfHYLgZ3pruYsbuT