### PR TITLE
Run opportunity discovery for different signals side by side

### DIFF
--- a/services/api/.test-isolated
+++ b/services/api/.test-isolated
@@ -19,6 +19,7 @@ src/controllers/tests/opportunity.controller.isolated.ts
 src/queues/tests/enrichment.queue.jobs.isolated.ts
 src/queues/tests/expiration.queue.isolated.ts
 src/queues/tests/from-enrichment.queue.isolated.ts
+src/queues/tests/from-intent.queue.concurrency.isolated.ts
 src/queues/tests/from-intent.queue.isolated.ts
 src/queues/tests/hyde.queue.isolated.ts
 src/queues/tests/intent.queue.isolated.ts

--- a/services/api/src/queues/opportunity/discovery.intent-lock.ts
+++ b/services/api/src/queues/opportunity/discovery.intent-lock.ts
@@ -1,0 +1,79 @@
+/**
+ * Same-intent overlap guard for intent-triggered discovery.
+ *
+ * Enqueue-time BullMQ deduplication (the IND-419 tier-1 debounce) only covers
+ * jobs that are still waiting: once job A for intent X is active, a second
+ * enqueue for X is admitted and — now that the from-intent worker runs several
+ * jobs at once — would start alongside A. Persistence already tolerates that
+ * overlap (pair dedup IND-166, the `final_atomic_conflict` re-check, the
+ * intent-scoped atomic create+expire), so this guard is not a correctness gate;
+ * it stops two runs spending LLM and embedder budget on the same intent at the
+ * same time. It is the cheapest correct shape: a short-TTL Redis lock keyed by
+ * intentId (`SET NX PX` + holder-checked release), with an in-process map in the
+ * hermetic test baseline so worker specs exercise the real acquire→defer path
+ * without Redis.
+ */
+import { useHermeticRedis } from '../../lib/bullmq/bullmq';
+
+export interface IntentDiscoveryLock {
+  /** True when this caller now holds the intent's lock for `ttlMs`. */
+  tryAcquire(intentId: string, token: string, ttlMs: number): Promise<boolean>;
+  /** Releases only when `token` is the current holder; a lapsed lock is a no-op. */
+  release(intentId: string, token: string): Promise<void>;
+}
+
+const LOCK_KEY_PREFIX = 'opportunity:from-intent:running:';
+
+const RELEASE_LUA = `
+-- from-intent lock release: only the holder may delete.
+if redis.call('GET', KEYS[1]) ~= ARGV[1] then return 0 end
+return redis.call('DEL', KEYS[1])
+`;
+
+interface RedisLockClient {
+  set(key: string, value: string, mode: 'PX', ttlMs: number, condition: 'NX'): Promise<unknown>;
+  eval(script: string, numberOfKeys: number, ...args: Array<string | number>): Promise<unknown>;
+}
+
+export class RedisIntentDiscoveryLock implements IntentDiscoveryLock {
+  constructor(private readonly getClient: () => Promise<RedisLockClient>) {}
+
+  async tryAcquire(intentId: string, token: string, ttlMs: number): Promise<boolean> {
+    const redis = await this.getClient();
+    return await redis.set(LOCK_KEY_PREFIX + intentId, token, 'PX', ttlMs, 'NX') === 'OK';
+  }
+
+  async release(intentId: string, token: string): Promise<void> {
+    const redis = await this.getClient();
+    await redis.eval(RELEASE_LUA, 1, LOCK_KEY_PREFIX + intentId, token);
+  }
+}
+
+/**
+ * Module-wide (not per-instance) so it models Redis faithfully: every
+ * FromIntentQueue instance in a process sees the same locks.
+ */
+const hermeticLocks = new Map<string, { token: string; expiresAt: number }>();
+
+export class InMemoryIntentDiscoveryLock implements IntentDiscoveryLock {
+  async tryAcquire(intentId: string, token: string, ttlMs: number): Promise<boolean> {
+    const existing = hermeticLocks.get(intentId);
+    if (existing && existing.expiresAt > Date.now()) return false;
+    hermeticLocks.set(intentId, { token, expiresAt: Date.now() + ttlMs });
+    return true;
+  }
+
+  async release(intentId: string, token: string): Promise<void> {
+    if (hermeticLocks.get(intentId)?.token === token) hermeticLocks.delete(intentId);
+  }
+}
+
+export function createIntentDiscoveryLock(): IntentDiscoveryLock {
+  if (useHermeticRedis()) return new InMemoryIntentDiscoveryLock();
+  // Lazy so importing the queue module never constructs the cache adapter's
+  // Redis singletons (same pattern as intent-agent-reply.stream).
+  return new RedisIntentDiscoveryLock(async () => {
+    const { getRedisClient } = await import('../../adapters/cache.adapter');
+    return getRedisClient();
+  });
+}

--- a/services/api/src/queues/opportunity/discovery.shared.ts
+++ b/services/api/src/queues/opportunity/discovery.shared.ts
@@ -7,6 +7,19 @@ import type { OpportunityGraphDatabase, HydeGraphDatabase, Embedder, HydeCache, 
 
 import { negotiationRunExistingQueue } from '../negotiations/run-existing.queue';
 
+/**
+ * Worker concurrency shared by the from-intent and from-enrichment discovery
+ * queues. The factory default (1) serialized every user's scan behind every
+ * other user's, which is what made a second onboarding look stalled. 4 lets a
+ * handful of signals scan side by side; it stays low because one scan already
+ * fans its evaluator out in parallel (one LLM call per candidate) on top of
+ * HyDE and embedder calls, so worker concurrency multiplies provider load —
+ * raise it only after checking LLM/embedder rate limits. The intent-agent
+ * queue deliberately keeps 1 (agent turns for one conversation must not
+ * interleave) and is not covered by this constant.
+ */
+export const DISCOVERY_WORKER_CONCURRENCY = 4;
+
 /** Graph DB shape the opportunity/HyDE graphs require — every `from-*` queue casts its ChatDatabaseAdapter to this. */
 export type OpportunityGraphDb = OpportunityGraphDatabase & HydeGraphDatabase;
 

--- a/services/api/src/queues/opportunity/from-enrichment.queue.ts
+++ b/services/api/src/queues/opportunity/from-enrichment.queue.ts
@@ -3,7 +3,7 @@ import { log } from '../../lib/log';
 import { QueueFactory } from '../../lib/bullmq/bullmq';
 import type { NegotiationGraphLike, AgentDispatcher } from '@indexnetwork/protocol';
 
-import { createOpportunityGraphDb, runOpportunityDiscovery, type OpportunityGraphDb } from './discovery.shared';
+import { createOpportunityGraphDb, runOpportunityDiscovery, DISCOVERY_WORKER_CONCURRENCY, type OpportunityGraphDb } from './discovery.shared';
 import { buildEnrichmentDiscoveryTrigger } from './discovery-trigger.builders';
 
 export const QUEUE_NAME = 'opportunity-from-enrichment';
@@ -112,7 +112,11 @@ export class FromEnrichmentQueue {
       this.queueLogger.info('Processing job', { jobId: job.id });
       await this.processJob(job.name, job.data);
     };
-    this.worker = QueueFactory.createWorker<FromEnrichmentJobData>(QUEUE_NAME, processor);
+    this.worker = QueueFactory.createWorker<FromEnrichmentJobData>(QUEUE_NAME, processor, {
+      // Profile scans for different users run side by side; rationale for the
+      // number lives with the constant.
+      concurrency: DISCOVERY_WORKER_CONCURRENCY,
+    });
   }
 
   async close(): Promise<void> {

--- a/services/api/src/queues/opportunity/from-intent.queue.ts
+++ b/services/api/src/queues/opportunity/from-intent.queue.ts
@@ -6,12 +6,22 @@ import { QueueFactory } from '../../lib/bullmq/bullmq';
 import { ChatDatabaseAdapter } from '../../adapters/database.adapter';
 import type { NegotiationGraphLike, AgentDispatcher } from '@indexnetwork/protocol';
 
-import { createOpportunityGraphDb, runOpportunityDiscovery, type OpportunityGraphDb } from './discovery.shared';
+import { createOpportunityGraphDb, runOpportunityDiscovery, DISCOVERY_WORKER_CONCURRENCY, type OpportunityGraphDb } from './discovery.shared';
 import { buildIntentDiscoveryTrigger, type FromIntentGraphInvokeOptions } from './discovery-trigger.builders';
 export type { FromIntentGraphInvokeOptions } from './discovery-trigger.builders';
+import { createIntentDiscoveryLock, type IntentDiscoveryLock } from './discovery.intent-lock';
 import { maybeRunNegotiationEvidenceShadow } from '../pool/negotiation-evidence.shadow';
 
 export const QUEUE_NAME = 'opportunity-from-intent';
+
+/**
+ * Same-intent overlap guard (see discovery.intent-lock.ts). The lock outlives
+ * any plausible scan so it never lapses mid-run, yet a worker that dies
+ * without releasing only blocks that intent's next run for this long.
+ */
+export const SAME_INTENT_LOCK_TTL_MS = 10 * 60 * 1000;
+/** How long a job that found its intent already running waits before re-checking. */
+export const SAME_INTENT_DEFER_DELAY_MS = 30 * 1000;
 
 export interface FromIntentJobData {
   intentId: string;
@@ -31,6 +41,10 @@ export interface FromIntentDeps {
   invokeOpportunityGraph?: (opts: FromIntentGraphInvokeOptions) => Promise<void>;
   negotiationGraph?: NegotiationGraphLike;
   agentDispatcher?: Pick<AgentDispatcher, 'hasExternalAgent'>;
+  /** Same-intent overlap guard; defaults to Redis (in-process map under the hermetic test baseline). */
+  intentLock?: IntentDiscoveryLock;
+  /** Test hook: shortens the re-check delay of a deferred same-intent job. */
+  sameIntentDeferDelayMs?: number;
 }
 
 export class FromIntentQueue {
@@ -42,6 +56,8 @@ export class FromIntentQueue {
   private readonly queueLogger = log.queue.from('FromIntentQueue');
   private readonly database: FromIntentDatabase | ChatDatabaseAdapter;
   private readonly graphDb: OpportunityGraphDb;
+  private readonly intentLock: IntentDiscoveryLock;
+  private readonly sameIntentDeferDelayMs: number;
   private deps: FromIntentDeps | undefined;
   private worker: ReturnType<typeof QueueFactory.createWorker<FromIntentJobData>> | null = null;
 
@@ -49,6 +65,8 @@ export class FromIntentQueue {
     this.deps = deps;
     this.database = deps?.database ?? new ChatDatabaseAdapter();
     this.graphDb = createOpportunityGraphDb(this.database);
+    this.intentLock = deps?.intentLock ?? createIntentDiscoveryLock();
+    this.sameIntentDeferDelayMs = deps?.sameIntentDeferDelayMs ?? SAME_INTENT_DEFER_DELAY_MS;
   }
 
   setRuntimeDeps(runtimeDeps: Pick<FromIntentDeps, 'negotiationGraph' | 'agentDispatcher'>): void {
@@ -67,6 +85,13 @@ export class FromIntentQueue {
     },
   ): Promise<Job<FromIntentJobData>> {
     await this.recordProgress(data, 'queued', 0);
+    return this.enqueueDiscover(data, options);
+  }
+
+  private enqueueDiscover(
+    data: FromIntentJobData,
+    options?: Parameters<FromIntentQueue['addJob']>[1],
+  ): Promise<Job<FromIntentJobData>> {
     return this.queue.add('discover_opportunities', data, {
       attempts: 3,
       backoff: { type: 'exponential', delay: 1000 },
@@ -243,19 +268,83 @@ export class FromIntentQueue {
       .sort();
   }
 
+  /**
+   * Same-intent overlap guard around the processor. With worker concurrency
+   * above 1, a second job for an intent whose scan is still running would
+   * otherwise start alongside it; enqueue-time dedup cannot see active jobs.
+   * Returns a release function when this job owns the intent, or null when
+   * another run already holds it. Fails open: the lock only saves provider
+   * budget (persistence tolerates overlap), so a Redis hiccup must not fail a
+   * scan.
+   */
+  private async acquireIntentLock(data: FromIntentJobData): Promise<(() => Promise<void>) | null> {
+    const token = crypto.randomUUID();
+    try {
+      if (!(await this.intentLock.tryAcquire(data.intentId, token, SAME_INTENT_LOCK_TTL_MS))) return null;
+    } catch (error) {
+      this.queueLogger.warn('Same-intent lock unavailable; running unguarded', {
+        intentId: data.intentId,
+        error: error instanceof Error ? error.message : String(error),
+      });
+      return async () => {};
+    }
+    return async () => {
+      try {
+        await this.intentLock.release(data.intentId, token);
+      } catch (error) {
+        this.queueLogger.warn('Same-intent lock release failed; TTL will clear it', {
+          intentId: data.intentId,
+          error: error instanceof Error ? error.message : String(error),
+        });
+      }
+    };
+  }
+
+  /**
+   * A job that found its intent already running is re-added as a fresh delayed
+   * job rather than dropped: it may carry a newer trigger (an edit, a resume)
+   * than the run in flight read. No custom jobId — the original id is still
+   * occupied by this job — and no progress write: the running job's lifecycle
+   * writes for this intent are the authoritative ones.
+   */
+  private async deferOverlappingJob(job: Job<FromIntentJobData>): Promise<void> {
+    this.queueLogger.info('Discovery already running for intent; deferring job', {
+      event: 'intent_discovery_overlap_deferred',
+      jobId: job.id,
+      intentId: job.data.intentId,
+      userId: job.data.userId,
+      retryInMs: this.sameIntentDeferDelayMs,
+    });
+    await this.enqueueDiscover(job.data, {
+      priority: job.opts?.priority,
+      delay: this.sameIntentDeferDelayMs,
+    });
+  }
+
   startWorker(): void {
     if (this.worker) return;
     const processor = async (job: Job<FromIntentJobData>) => {
       this.queueLogger.info('Processing job', { jobId: job.id });
+      const release = await this.acquireIntentLock(job.data);
+      if (!release) {
+        await this.deferOverlappingJob(job);
+        return;
+      }
       try {
         await this.processJob(job.name, job.data, job.attemptsMade + 1);
       } catch (error) {
         const attempt = job.attemptsMade + 1;
         await this.recordProgress(job.data, 'failed', attempt);
         throw error;
+      } finally {
+        await release();
       }
     };
-    this.worker = QueueFactory.createWorker<FromIntentJobData>(QUEUE_NAME, processor);
+    this.worker = QueueFactory.createWorker<FromIntentJobData>(QUEUE_NAME, processor, {
+      // Scans for different signals run side by side; same-intent runs are
+      // serialized by the lock above. Rationale for the number lives with it.
+      concurrency: DISCOVERY_WORKER_CONCURRENCY,
+    });
   }
 
   async close(): Promise<void> {

--- a/services/api/src/queues/tests/from-enrichment.queue.isolated.ts
+++ b/services/api/src/queues/tests/from-enrichment.queue.isolated.ts
@@ -37,6 +37,7 @@ import { buildEnrichmentDiscoveryTrigger } from '../opportunity/discovery-trigge
 import type { FromEnrichmentJobData } from '../opportunity/from-enrichment.queue';
 
 const { FromEnrichmentQueue, QUEUE_NAME } = await import('../opportunity/from-enrichment.queue');
+const { DISCOVERY_WORKER_CONCURRENCY } = await import('../opportunity/discovery.shared');
 
 describe('FromEnrichmentQueue', () => {
   describe('constructor and static', () => {
@@ -125,6 +126,17 @@ describe('FromEnrichmentQueue', () => {
       queue.startWorker();
       queue.startWorker();
       expect(mockCreateWorker).toHaveBeenCalledTimes(1);
+    });
+
+    it('runs profile scans for different users side by side instead of one at a time', () => {
+      const queue = new FromEnrichmentQueue();
+      queue.startWorker();
+      expect(DISCOVERY_WORKER_CONCURRENCY).toBeGreaterThan(1);
+      expect(mockCreateWorker).toHaveBeenLastCalledWith(
+        QUEUE_NAME,
+        expect.any(Function),
+        expect.objectContaining({ concurrency: DISCOVERY_WORKER_CONCURRENCY }),
+      );
     });
 
     it('processor invokes processJob when worker runs a job', async () => {

--- a/services/api/src/queues/tests/from-intent.queue.concurrency.isolated.ts
+++ b/services/api/src/queues/tests/from-intent.queue.concurrency.isolated.ts
@@ -1,0 +1,132 @@
+/**
+ * FromIntentQueue worker concurrency and the same-intent overlap guard.
+ *
+ * Unlike from-intent.queue.isolated.ts this keeps the real QueueFactory (the
+ * hermetic in-memory broker under the test baseline) so jobs travel
+ * add → worker → processor → lock exactly as in production; only the DB,
+ * embedder, and the discovery graph are stood in for.
+ */
+import { config } from 'dotenv';
+config({ path: '.env.test', override: true });
+
+import { afterAll, describe, expect, it, mock } from 'bun:test';
+
+mock.module('../../adapters/database.adapter', () => ({
+  ChatDatabaseAdapter: class ChatDatabaseAdapter {},
+  chatDatabaseAdapter: {},
+}));
+mock.module('../../adapters/embedder.adapter', () => ({
+  EmbedderAdapter: class EmbedderAdapter {},
+  embedderAdapter: {},
+}));
+mock.module('../negotiations/run-existing.queue', () => ({
+  negotiationRunExistingQueue: { addJob: async () => ({ id: 'neg-1' }) },
+}));
+mock.module('../pool/negotiation-evidence.shadow', () => ({
+  maybeRunNegotiationEvidenceShadow: async () => {},
+}));
+mock.module('../questioner/recovery.shared', () => ({
+  maybeEnqueueIntentRecovery: async () => {},
+}));
+
+afterAll(() => {
+  mock.restore();
+});
+
+import type { FromIntentDatabase, FromIntentGraphInvokeOptions } from '../opportunity/from-intent.queue';
+
+const { FromIntentQueue } = await import('../opportunity/from-intent.queue');
+const { DISCOVERY_WORKER_CONCURRENCY } = await import('../opportunity/discovery.shared');
+
+const database: FromIntentDatabase = {
+  getIntentForIndexing: async (id: string) => ({ id, payload: 'P', userId: 'u1', sourceType: null, sourceId: null }),
+  getNetworkIdsForIntent: async () => ['idx1'],
+  getAssignmentNetworkMembershipsForUser: async () => [{ networkId: 'idx1', isPersonal: false }],
+  markIntentFirstDiscoverySucceeded: async () => {},
+  recordIntentDiscoveryProgress: async () => {},
+};
+
+/**
+ * A graph stand-in that parks every invocation on a gate so the test controls
+ * when each scan "finishes", and records how many scans were in flight at once.
+ */
+function gatedGraph() {
+  let active = 0;
+  let peakActive = 0;
+  const started: string[] = [];
+  const releases: Array<() => void> = [];
+  const invoke = async (opts: FromIntentGraphInvokeOptions) => {
+    active += 1;
+    peakActive = Math.max(peakActive, active);
+    started.push(opts.triggerIntentId ?? '?');
+    await new Promise<void>((resolve) => releases.push(resolve));
+    active -= 1;
+  };
+  const waitForStarted = async (count: number) => {
+    for (let index = 0; index < 200 && started.length < count; index += 1) await Bun.sleep(5);
+    return started.length;
+  };
+  return {
+    invoke,
+    started,
+    releases,
+    waitForStarted,
+    peak: () => peakActive,
+    releaseAll: () => { for (const release of releases.splice(0)) release(); },
+  };
+}
+
+describe('FromIntentQueue worker concurrency', () => {
+  it('runs jobs for different intents side by side', async () => {
+    expect(DISCOVERY_WORKER_CONCURRENCY).toBeGreaterThan(1);
+    const graph = gatedGraph();
+    const queue = new FromIntentQueue({ database, invokeOpportunityGraph: graph.invoke });
+    queue.startWorker();
+
+    await queue.addJob({ intentId: 'intent-a', userId: 'u1' });
+    await queue.addJob({ intentId: 'intent-b', userId: 'u1' });
+
+    expect(await graph.waitForStarted(2)).toBe(2);
+    // Both scans are parked on the gate at the same time: no serialization.
+    expect(graph.peak()).toBe(2);
+    graph.releaseAll();
+    await Bun.sleep(10);
+    await queue.close();
+  });
+
+  it('defers a second job for an intent whose scan is still running, then runs it', async () => {
+    const graph = gatedGraph();
+    const queue = new FromIntentQueue({
+      database,
+      invokeOpportunityGraph: graph.invoke,
+      sameIntentDeferDelayMs: 10,
+    });
+    queue.startWorker();
+
+    const first = await queue.addJob({ intentId: 'intent-same', userId: 'u1' });
+    expect(await graph.waitForStarted(1)).toBe(1);
+    // Arrives while the first scan is in flight; worker concurrency would
+    // otherwise start it immediately.
+    const second = await queue.addJob({ intentId: 'intent-same', userId: 'u1' });
+    expect(second.id).not.toBe(first.id);
+
+    // The guard trips: the second job finishes without scanning and a delayed
+    // re-check is queued in its place.
+    await Bun.sleep(30);
+    expect(graph.started).toEqual(['intent-same']);
+    expect(graph.peak()).toBe(1);
+    expect(await second.getState()).toBe('completed');
+    const counts = await queue.queue.getJobCounts('delayed', 'waiting', 'active');
+    expect(counts.delayed + counts.waiting + counts.active).toBeGreaterThanOrEqual(1);
+
+    // Once the first scan releases the lock, the deferred job gets its turn —
+    // and never overlapped with the first.
+    graph.releaseAll();
+    expect(await graph.waitForStarted(2)).toBe(2);
+    expect(graph.started).toEqual(['intent-same', 'intent-same']);
+    expect(graph.peak()).toBe(1);
+    graph.releaseAll();
+    await Bun.sleep(10);
+    await queue.close();
+  });
+});

--- a/services/api/src/queues/tests/from-intent.queue.isolated.ts
+++ b/services/api/src/queues/tests/from-intent.queue.isolated.ts
@@ -16,6 +16,8 @@ mock.module('../../lib/bullmq/bullmq', () => ({
     createWorker: mockCreateWorker,
     createQueueEvents: () => ({ on: () => {}, close: async () => {} }),
   },
+  // The same-intent lock picks its in-process implementation off this guard.
+  useHermeticRedis: () => true,
 }));
 mock.module('../../adapters/database.adapter', () => ({
   ChatDatabaseAdapter: class ChatDatabaseAdapter {},
@@ -66,7 +68,7 @@ import type { FromIntentJobData, FromIntentDatabase, FromIntentDeps, FromIntentG
 import { buildIntentDiscoveryTrigger } from '../opportunity/discovery-trigger.builders';
 
 const { FromIntentQueue, QUEUE_NAME } = await import('../opportunity/from-intent.queue');
-const { summarizeOpportunityDiscoveryResult } = await import('../opportunity/discovery.shared');
+const { summarizeOpportunityDiscoveryResult, DISCOVERY_WORKER_CONCURRENCY } = await import('../opportunity/discovery.shared');
 
 type FromIntentDatabaseOverrides = Partial<FromIntentDatabase> & Pick<FromIntentDatabase, 'getIntentForIndexing'>;
 
@@ -547,6 +549,17 @@ describe('FromIntentQueue', () => {
       queue.startWorker();
       queue.startWorker();
       expect(mockCreateWorker).toHaveBeenCalledTimes(1);
+    });
+
+    it('runs scans for different signals side by side instead of one at a time', () => {
+      const queue = new FromIntentQueue();
+      queue.startWorker();
+      expect(DISCOVERY_WORKER_CONCURRENCY).toBeGreaterThan(1);
+      expect(mockCreateWorker).toHaveBeenLastCalledWith(
+        QUEUE_NAME,
+        expect.any(Function),
+        expect.objectContaining({ concurrency: DISCOVERY_WORKER_CONCURRENCY }),
+      );
     });
 
     it('processor invokes processJob when worker runs a job', async () => {


### PR DESCRIPTION
## Why

With two users onboarding, Maya's discovery scan finished after ~4½ min and Daniel's only started afterwards, so his UI looked stalled. The serialization was never a design choice: `opportunity-from-intent` and `opportunity-from-enrichment` created their workers with no options and inherited the `QueueFactory` default concurrency of 1. (Per-scan latency is a separate worktree, `perf/funnel-signal-latency`, and is not touched here.)

## What changed

**Concurrency: 4** (`DISCOVERY_WORKER_CONCURRENCY` in `discovery.shared.ts`, used by both `from-intent` and `from-enrichment`).
Rationale: 4 lets a handful of signals scan at the same time — enough that one onboarding no longer queues behind another — while staying low because one scan already fans its evaluator out in parallel (one LLM call per candidate in `evaluateInParallel`) on top of HyDE and embedder calls, so worker concurrency is a multiplier on provider load. Raise only after checking LLM/embedder rate limits. The intent-agent queue keeps concurrency 1 on purpose (agent turns for one conversation must not interleave) and is untouched.

**Same-intent overlap guard** (`discovery.intent-lock.ts`, wired in `FromIntentQueue.startWorker`).
Enqueue-time BullMQ dedup only covers waiting jobs (and no production caller passes `deduplication` today), so once job A for intent X is active a second job for X could start alongside it. The guard is a short-TTL Redis lock keyed by `intentId` (`SET NX PX` + holder-checked Lua release; in-process map under the hermetic test baseline):

- **When it trips:** the second job logs `intent_discovery_overlap_deferred` and is re-added as a *fresh delayed job* (30 s, `SAME_INTENT_DEFER_DELAY_MS`) rather than dropped — it may carry a newer trigger (edit, resume) than the run in flight read. The re-add carries the original priority, no custom `jobId` (that id is still occupied), and writes no progress row; the running job's lifecycle writes for the intent remain authoritative. The deferred job re-checks the lock each time it fires and runs as soon as the first run releases.
- **Lock TTL** is 10 min (`SAME_INTENT_LOCK_TTL_MS`): outlives any plausible scan so it never lapses mid-run; if a worker dies without releasing, that intent's next run is deferred for at most that long.
- **Fails open:** a Redis error on acquire/release logs a warning and the scan proceeds unguarded — persistence already tolerates overlap (pair dedup IND-166, `final_atomic_conflict` re-check, intent-scoped atomic create+expire), so the lock only saves provider budget.

**Out-of-order completion check:** `recordIntentDiscoveryProgress` upserts by `intentId` and `markIntentFirstDiscoverySucceeded` updates by `intentId` (null-guarded), so jobs for different intents of the same user completing in any order touch disjoint rows; same-intent runs are serialized by the lock. No change needed.

## Tests

- New `from-intent.queue.concurrency.isolated.ts` (registered in `.test-isolated`): uses the real hermetic BullMQ double end-to-end — two jobs for different intents are in flight together; two jobs for the same intent do not overlap, the second is deferred and then runs after the first releases.
- `from-intent.queue.isolated.ts` / `from-enrichment.queue.isolated.ts`: assert the worker is created with `concurrency: DISCOVERY_WORKER_CONCURRENCY` (bullmq mock now also exports `useHermeticRedis`, which the lock module reads).
- Ran in isolation: the three specs above + `bullmq.spec.ts` all pass; `tsc --noEmit` and `tsc -p tsconfig.spec.json` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011iYcKr2Ku5fUD3QuCFn8xg
