### PR TITLE
feat(protocol): discovery evaluates the whole pool and floors matches at 10

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -89,7 +89,7 @@
     },
     "packages/protocol": {
       "name": "@indexnetwork/protocol",
-      "version": "26.0.0",
+      "version": "27.0.0",
       "dependencies": {
         "@langchain/core": "1.1.48",
         "@langchain/langgraph": "1.3.2",

--- a/packages/protocol/CHANGELOG.md
+++ b/packages/protocol/CHANGELOG.md
@@ -20,6 +20,37 @@ went 6.7.1 → 8.0.2 with no 7.x in between because the whole 7.x line shipped a
 prereleases between the two promotions. To track every change, read `rc`; to
 pin a supported release, use `latest`.
 
+## 27.0.0 - 2026-08-22
+
+### Changed
+
+- **Discovery evaluates its whole candidate pool and surfaces at least 10
+  matches when the pool allows it.** Retrieval limits were raised
+  (`LIMIT_PER_STRATEGY` 30→80, `PER_INDEX_LIMIT` 80→160) and the intent path
+  re-runs its search with no similarity floor once when the deduped pool has
+  fewer than `DISCOVERY_MIN_MATCHES` (10) distinct users. Evaluation now
+  scores the entire pool (capped at 80 by rank) in one parallel round instead
+  of batching 25 at a time with an early stop on the first passing batch —
+  pass rate does not track similarity rank, so batching was stranding real
+  matches behind an over-scored head cluster. Every passing candidate is
+  returned uncapped; when fewer than 10 pass, the run fills the rest with the
+  best-scored rejected candidates (tiebroken by similarity), persisted with
+  their real score. `rankingNode` no longer defaults to a 20-item limit —
+  only a caller-supplied `options.limit` cuts the list now.
+- `not_accepted` evaluator verdicts now carry the model's actors under
+  `returnAll` (previously always `[]`) so a rejected candidate can be used as
+  a fill; guard drops (`incomplete_actors`, `unsupported_claim`) still carry
+  none and are never fills.
+
+### Removed
+
+- **BREAKING: the `continue_discovery` operation mode is gone**, along with
+  the batched-evaluation continuation it existed for: `remainingCandidates`
+  (state field and graph output), the `evaluation_bound` trace entry, and
+  `'evaluation_bound_reached'` / `unevaluatedCandidates` on
+  `OpportunityDiscoverySummary`. Evaluation no longer batches or stops early,
+  so there is nothing left to page into.
+
 ## 26.0.0 - 2026-08-22
 
 ### Changed

--- a/packages/protocol/package.json
+++ b/packages/protocol/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@indexnetwork/protocol",
-  "version": "26.0.0",
+  "version": "27.0.0",
   "type": "module",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",

--- a/packages/protocol/src/internal/opportunities/discovery.env.ts
+++ b/packages/protocol/src/internal/opportunities/discovery.env.ts
@@ -12,6 +12,14 @@ export const DISCOVERY_MIN_SIMILARITY = 0.20;
 /** Floor an evaluator score must clear for the opportunity to be accepted. */
 export const DISCOVERY_EVALUATOR_MIN_SCORE = 40;
 
+/**
+ * Minimum opportunities a discovery run tries to surface when the pool
+ * allows it. When fewer than this many candidates pass evaluation, the run
+ * fills the rest with the best-scored rejected candidates (their real, low
+ * score is persisted so they stay distinguishable downstream).
+ */
+export const DISCOVERY_MIN_MATCHES = 10;
+
 function validateThreshold(name: string, value: number, max: number): number {
   if (!Number.isFinite(value) || value < 0 || value > max) {
     throw new Error(`${name} must be a finite decimal between 0 and ${max} (inclusive)`);

--- a/packages/protocol/src/internal/opportunities/opportunity.evaluator.ts
+++ b/packages/protocol/src/internal/opportunities/opportunity.evaluator.ts
@@ -117,7 +117,7 @@ Match patterns to consider:
 Output:
 - A list of verdicts with EXACTLY ONE verdict for EVERY candidate entity (never omit a candidate).
 - Each verdict has candidateId (the candidate USER ID), accepted, reasoning, score, and actors.
-- EVERY verdict — accepted or not — must include exactly the source and that candidate as actors, with roles. A rejected candidate may still be surfaced downstream when nothing better exists, so its actors matter as much as an accepted verdict's.
+- EVERY verdict — accepted or not — must include exactly the source and that candidate as actors, with roles.
 - Rejected candidates still require a verdict: set accepted=false and score below the appropriate threshold.
 - A verdict score is 0-100:
   - 90-100: Must Meet — candidate's PRIMARY role directly matches what the discoverer seeks.

--- a/packages/protocol/src/internal/opportunities/opportunity.evaluator.ts
+++ b/packages/protocol/src/internal/opportunities/opportunity.evaluator.ts
@@ -117,7 +117,7 @@ Match patterns to consider:
 Output:
 - A list of verdicts with EXACTLY ONE verdict for EVERY candidate entity (never omit a candidate).
 - Each verdict has candidateId (the candidate USER ID), accepted, reasoning, score, and actors.
-- accepted=true verdicts must include exactly the source and that candidate as actors. accepted=false verdicts may use an empty actor list.
+- EVERY verdict — accepted or not — must include exactly the source and that candidate as actors, with roles. A rejected candidate may still be surfaced downstream when nothing better exists, so its actors matter as much as an accepted verdict's.
 - Rejected candidates still require a verdict: set accepted=false and score below the appropriate threshold.
 - A verdict score is 0-100:
   - 90-100: Must Meet — candidate's PRIMARY role directly matches what the discoverer seeks.
@@ -240,7 +240,7 @@ const EvaluatorVerdictSchema = z.object({
   accepted: z.boolean().describe('Whether this candidate is a qualifying opportunity'),
   score: z.number().min(0).max(100),
   reasoning: z.string(),
-  actors: z.array(ActorSchema).describe('Accepted verdicts include source and candidate actors; rejected verdicts may use an empty list'),
+  actors: z.array(ActorSchema).describe('Every verdict — accepted or not — includes exactly the source and candidate actors'),
 });
 
 const entityBundleResponseFormat = z.object({
@@ -267,8 +267,10 @@ export interface EvaluatorRejection {
 export type EvaluatedOpportunityWithActors = z.infer<typeof _OpportunityWithActorsSchema> & {
   /**
    * Set only on diagnostic entries returned under `returnAll`. These carry the
-   * evaluator's real score and reasoning so the trace can say what happened, and
-   * they hold no actors — they must never be persisted.
+   * evaluator's real score and reasoning so the trace can say what happened.
+   * A `not_accepted` entry keeps the model's actors — the caller may surface
+   * it as a fill when too few candidates pass. `incomplete_actors` and
+   * `unsupported_claim` entries hold no actors and must never be persisted.
    */
   rejection?: EvaluatorRejection;
 };
@@ -628,13 +630,16 @@ ${renderOpportunityEvidenceForPrompt(e.evidence ?? [])}`;
         const filtered = introGuard.filter((op) => op.score >= minScore);
         // `returnAll` callers trace every candidate, so they need the dropped
         // verdicts too: without them a rejected candidate is indistinguishable
-        // from one the evaluator never answered for.
+        // from one the evaluator never answered for. `not_accepted` verdicts
+        // keep the model's actors — the caller may surface them as a fill when
+        // too few candidates pass. Guard drops (incomplete_actors,
+        // unsupported_claim) never carry actors: they are not persistable.
         const rejections: EvaluatedOpportunityWithActors[] = triaged
           .filter((entry) => entry.reason !== undefined)
           .map((entry) => ({
             reasoning: entry.reasoning,
             score: entry.verdict.score,
-            actors: [],
+            actors: entry.reason === 'not_accepted' ? entry.verdict.actors : [],
             rejection: { candidateId: entry.verdict.candidateId, reason: entry.reason! },
           }));
         invokeEntityBundleLog.verbose('Done', {

--- a/packages/protocol/src/internal/opportunities/opportunity.graph.discovery.ts
+++ b/packages/protocol/src/internal/opportunities/opportunity.graph.discovery.ts
@@ -13,14 +13,15 @@ import { timed } from '../shared/observability/performance.js';
 import { withCandidateEvidence } from './opportunity.evidence.js';
 import { buildDiscovererContext, discoveryLog, type OpportunityGraphDeps, type OpportunityState } from "./opportunity.graph.shared.js";
 import { collectHydeResults, computeLensStats, mergeStrategyCandidates, runQueryHydeDiscovery, toLensEmbeddings, type DiscoveryStrategyContext } from "./opportunity.graph.discovery-strategies.js";
+import { DISCOVERY_MIN_MATCHES } from './discovery.env.js';
 
 /** Trace entries accumulate in the order the frontend renders them. */
 type TraceEntry = { node: string; detail?: string; data?: Record<string, unknown> };
 
 // Search limits - fixed values for candidate retrieval
 // (The options.limit controls final output, not search pool)
-const LIMIT_PER_STRATEGY = 30;
-const PER_INDEX_LIMIT = 80;
+const LIMIT_PER_STRATEGY = 80;
+const PER_INDEX_LIMIT = 160;
 
 /**
  * Node 3: Discovery
@@ -296,28 +297,47 @@ async function discoverFromIntent(
   }
 
   const lensEmbeddings = toLensEmbeddings(hydeEmbeddings, lenses);
-  const allCandidates: CandidateMatch[] = [];
-  await Promise.all(
-    state.targetNetworks.map(async (targetIndex) => {
-      const results = await deps.embedder.searchWithHydeEmbeddings(lensEmbeddings, {
-        indexScope: [targetIndex.networkId],
-        excludeUserId: discoveryUserId,
-        limitPerStrategy: ctx.limitPerStrategy,
-        limit: ctx.perIndexLimit,
-        minScore: deps.retrievalMinSimilarity,
-      });
-      allCandidates.push(...collectHydeResults(results, targetIndex.networkId));
-    })
-  );
+
+  const searchAllNetworks = async (minScore: number): Promise<CandidateMatch[]> => {
+    const found: CandidateMatch[] = [];
+    await Promise.all(
+      state.targetNetworks.map(async (targetIndex) => {
+        const results = await deps.embedder.searchWithHydeEmbeddings(lensEmbeddings, {
+          indexScope: [targetIndex.networkId],
+          excludeUserId: discoveryUserId,
+          limitPerStrategy: ctx.limitPerStrategy,
+          limit: ctx.perIndexLimit,
+          minScore,
+        });
+        found.push(...collectHydeResults(results, targetIndex.networkId));
+      })
+    );
+    return found;
+  };
+
   const byUserAndIndex = new Map<string, CandidateMatch>();
-  for (const c of allCandidates) {
-    const key = `${c.candidateUserId}:${c.networkId}:intent:${c.candidateIntentId}`;
-    if (!byUserAndIndex.has(key) || c.similarity > (byUserAndIndex.get(key)?.similarity ?? 0)) {
-      byUserAndIndex.set(key, c);
+  const mergeIntoPool = (found: CandidateMatch[]) => {
+    for (const c of found) {
+      const key = `${c.candidateUserId}:${c.networkId}:intent:${c.candidateIntentId}`;
+      if (!byUserAndIndex.has(key) || c.similarity > (byUserAndIndex.get(key)?.similarity ?? 0)) {
+        byUserAndIndex.set(key, c);
+      }
     }
+  };
+
+  mergeIntoPool(await searchAllNetworks(deps.retrievalMinSimilarity));
+
+  // The similarity floor can be what keeps a small network under the match
+  // floor, not a genuine lack of members. Re-run without it once when the
+  // deduped pool doesn't have enough distinct users yet.
+  const distinctUsers = new Set(Array.from(byUserAndIndex.values()).map((c) => c.candidateUserId)).size;
+  const toppedUp = distinctUsers < DISCOVERY_MIN_MATCHES;
+  if (toppedUp) {
+    mergeIntoPool(await searchAllNetworks(0));
   }
+
   const candidates = Array.from(byUserAndIndex.values());
-  discoveryLog.verbose('Intent-path discovery complete', { candidatesFound: candidates.length });
+  discoveryLog.verbose('Intent-path discovery complete', { candidatesFound: candidates.length, toppedUp });
   const usedLenses = Object.keys(hydeEmbeddings);
 
   // Build trace with individual candidate similarity scores
@@ -343,6 +363,7 @@ async function discoverFromIntent(
       lenses: usedLenses,
       candidateCount: candidates.length,
       byLens: computeLensStats(candidates),
+      toppedUp,
       durationMs: Date.now() - startTime,
       model: getModelName("hydeGenerator"),
     },

--- a/packages/protocol/src/internal/opportunities/opportunity.graph.evaluation.ts
+++ b/packages/protocol/src/internal/opportunities/opportunity.graph.evaluation.ts
@@ -15,7 +15,7 @@ import { requestContext } from '../shared/observability/request-context.js';
 import { getAbortSignalConfig } from '../shared/agent/model-signal.js';
 import type { OpportunityEvidence } from '../../protocol/schemas/network-assignment.schema.js';
 import { mergeOpportunityEvidence } from './opportunity.evidence.js';
-import { DISCOVERY_EVALUATOR_MIN_SCORE } from './discovery.env.js';
+import { DISCOVERY_EVALUATOR_MIN_SCORE, DISCOVERY_MIN_MATCHES } from './discovery.env.js';
 import { buildEvaluatorEvidenceKey, buildNetworkContexts, evaluationLog, networkMembershipPairKey, rankingLog, REJECTION_COOLDOWN_MS, REJECTION_COOLDOWN_SIMILARITY_PENALTY, safeOpportunityGraphError, type OpportunityGraphDeps, type OpportunityState } from "./opportunity.graph.shared.js";
 
 /** Pairwise verdict shape the evaluator returns, before actors are resolved. */
@@ -30,20 +30,13 @@ type PairwiseOpportunity = {
 /** Graph trace entry shape. */
 type TraceEntry = { node: string; detail?: string; data?: Record<string, unknown> };
 
-/** Batch size for one evaluator call. Larger batches time out. */
-const EVAL_BATCH_SIZE = 25;
-
 /**
- * How many batches one discovery run may evaluate.
- *
- * Candidates are taken strictly by rank, so a degenerate head cluster — many
- * candidates the retriever scored alike — used to consume the only batch and
- * strand the genuine matches behind it, reported as `evaluator_rejected_all`.
- * When a batch yields no passes we continue into the tail, bounded so a run can
- * never fan out unboundedly. Whatever is left after the bound is reported as
- * never-evaluated rather than as rejected.
+ * Every candidate in the pool is evaluated — no early stop, no similarity
+ * cutoff (pass rate does not track similarity; see the discovery match-floor
+ * PR). This still bounds the pool by rank so a run can never fan out
+ * unboundedly against a very large network.
  */
-const MAX_EVAL_BATCHES_PER_RUN = 3;
+const MAX_EVALUATION_POOL = 80;
 
 /**
  * Node 3: Evaluation (Entity bundle)
@@ -73,7 +66,6 @@ export async function evaluationNode(state: OpportunityState, deps: OpportunityG
       return {
         candidates: [],
         evaluatedOpportunities: [],
-        remainingCandidates: [],
         error: 'Failed to validate candidate network memberships.',
         agentTimings: [],
       };
@@ -87,7 +79,7 @@ export async function evaluationNode(state: OpportunityState, deps: OpportunityG
       });
     }
     if (eligibleCandidates.length === 0) {
-      return { candidates: [], evaluatedOpportunities: [], remainingCandidates: [], agentTimings: [] };
+      return { candidates: [], evaluatedOpportunities: [], agentTimings: [] };
     }
 
     if (dedupedCandidates.length < sortedCandidates.length) {
@@ -99,28 +91,13 @@ export async function evaluationNode(state: OpportunityState, deps: OpportunityG
     }
 
     const pool = await applyRejectionCooldown(eligibleCandidates, discoveryUserId, deps);
-
-    // Early termination: if search was query-driven and no query-sourced candidates remain,
-    // clear remaining to prevent pointless pagination through non-query leftovers
-    const isQueryDriven = !!state.searchQuery?.trim();
-    let loggedEarlyTermination = false;
-    const remainingAfter = (consumed: number): CandidateMatch[] => {
-      const rest = pool.slice(consumed);
-      const queryRest = rest.filter(
-        (c) => c.discoverySource === 'query' || c.discoverySource == null,
-      );
-      if (isQueryDriven && rest.length > 0 && queryRest.length === 0) {
-        if (!loggedEarlyTermination) {
-          loggedEarlyTermination = true;
-          evaluationLog.info(
-            "Early termination: no query-sourced candidates remain",
-            { droppedCandidates: rest.length },
-          );
-        }
-        return [];
-      }
-      return rest;
-    };
+    const boundedPool = pool.slice(0, MAX_EVALUATION_POOL);
+    if (boundedPool.length < pool.length) {
+      evaluationLog.info('Evaluation pool bounded by rank', {
+        pool: pool.length,
+        evaluated: boundedPool.length,
+      });
+    }
 
     const agentTimingsAccum: DebugMetaAgent[] = [];
 
@@ -154,80 +131,30 @@ export async function evaluationNode(state: OpportunityState, deps: OpportunityG
         ? (deps.evaluatorAgent as OpportunityEvaluator)
         : new OpportunityEvaluator();
 
-      const traceEntries: TraceEntry[] = [];
-      const passedOpportunities: EvaluatedOpportunity[] = [];
-      let remaining: CandidateMatch[] = [];
-      let consumed = 0;
-      let batchesRun = 0;
-
-      // Bounded batch continuation: a batch that passes nothing does not end the
-      // run while ranked-lower candidates are still waiting. Candidates arrive by
-      // rank, so a head cluster the retriever over-scored would otherwise strand
-      // every genuine match behind it.
-      while (batchesRun < MAX_EVAL_BATCHES_PER_RUN && consumed < pool.length) {
-        const batch = pool.slice(consumed, consumed + EVAL_BATCH_SIZE);
-        const batchNumber = batchesRun + 1;
-        if (batchNumber > 1) {
-          evaluationLog.info('No candidate passed; continuing into the next batch', {
-            batchNumber,
-            evaluating: batch.length,
-            alreadyEvaluated: consumed,
-          });
-        }
-        const batchResult = await evaluateCandidateBatch({
-          batch,
-          batchNumber,
-          sourceEntity,
-          state,
-          deps,
-          discoveryUserId,
-          minScore,
-          evaluator,
-          evaluatorSignalConfig,
-          agentTimingsAccum,
-        });
-        consumed += batch.length;
-        batchesRun += 1;
-        traceEntries.push(...batchResult.trace);
-        passedOpportunities.push(...batchResult.passed);
-        remaining = remainingAfter(consumed);
-        if (batchResult.passed.length > 0) break;
-        if (remaining.length === 0) break;
-      }
-
-      // A run that ends on the bound with candidates left must say so. Reporting
-      // it as "the evaluator rejected everything" hides an unevaluated tail.
-      if (passedOpportunities.length === 0 && remaining.length > 0) {
-        evaluationLog.info('Evaluation bound reached with candidates still unevaluated', {
-          batchesRun,
-          evaluated: consumed,
-          unevaluated: remaining.length,
-        });
-        traceEntries.push({
-          node: "evaluation_bound",
-          detail: `${remaining.length} candidate(s) never evaluated — stopped after ${batchesRun} batch(es) of ${EVAL_BATCH_SIZE}`,
-          data: {
-            unevaluatedCandidates: remaining.length,
-            evaluatedCandidates: consumed,
-            batchesRun,
-            maxBatches: MAX_EVAL_BATCHES_PER_RUN,
-            batchSize: EVAL_BATCH_SIZE,
-          },
-        });
-      }
+      const { passed, filled, trace: traceEntries } = await evaluateCandidatePool({
+        pool: boundedPool,
+        sourceEntity,
+        state,
+        deps,
+        discoveryUserId,
+        minScore,
+        evaluator,
+        evaluatorSignalConfig,
+        agentTimingsAccum,
+      });
 
       evaluationLog.verbose('Evaluation complete', {
-        batchesRun,
-        evaluatedCandidates: consumed,
-        passed: passedOpportunities.length,
-        unevaluated: remaining.length,
+        evaluatedCandidates: boundedPool.length,
+        passed: passed.length,
+        filled: filled.length,
       });
 
       return {
         candidates: eligibleCandidates,
-        // Only opportunities that passed the threshold reach downstream nodes
-        evaluatedOpportunities: passedOpportunities,
-        remainingCandidates: remaining,
+        // Every passing opportunity reaches downstream nodes, uncapped; filled
+        // candidates (best-scored rejects) top the run up to the match floor
+        // when too few passed.
+        evaluatedOpportunities: [...passed, ...filled],
         trace: traceEntries,
         agentTimings: agentTimingsAccum,
       };
@@ -252,10 +179,9 @@ export async function evaluationNode(state: OpportunityState, deps: OpportunityG
   });
 }
 
-/** Everything one evaluator batch needs, resolved once per run by {@link evaluationNode}. */
-interface CandidateBatchArgs {
-  batch: CandidateMatch[];
-  batchNumber: number;
+/** Everything the evaluation round needs, resolved once per run by {@link evaluationNode}. */
+interface CandidatePoolArgs {
+  pool: CandidateMatch[];
   sourceEntity: EvaluatorEntity;
   state: OpportunityState;
   deps: OpportunityGraphDeps;
@@ -266,21 +192,34 @@ interface CandidateBatchArgs {
   agentTimingsAccum: DebugMetaAgent[];
 }
 
+/** An {@link EvaluatedOpportunity} plus the retrieval similarity behind it, for fill-tiebreaking. */
+type ScoredOpportunity = EvaluatedOpportunity & { _similarity: number };
+
+function stripSimilarity(o: ScoredOpportunity): EvaluatedOpportunity {
+  const { _similarity: _drop, ...rest } = o;
+  return rest;
+}
+
 /**
- * Evaluate one batch of candidates: hydrate entities, invoke the evaluator, map
- * verdicts onto opportunities, and emit this batch's slice of the trace.
+ * Evaluate the whole candidate pool in one parallel round: hydrate entities,
+ * invoke the evaluator once per candidate, map verdicts onto opportunities,
+ * and emit the trace. Every passing opportunity is returned uncapped; when
+ * fewer than {@link DISCOVERY_MIN_MATCHES} pass, the best-scored non-passing
+ * verdicts (evaluator rejects and below-threshold accepts — never guard
+ * drops) fill the rest, tiebroken by retrieval similarity.
  */
-async function evaluateCandidateBatch(
-  args: CandidateBatchArgs,
-): Promise<{ passed: EvaluatedOpportunity[]; trace: TraceEntry[] }> {
+async function evaluateCandidatePool(
+  args: CandidatePoolArgs,
+): Promise<{ passed: EvaluatedOpportunity[]; filled: EvaluatedOpportunity[]; trace: TraceEntry[] }> {
   const {
-    batch, batchNumber, sourceEntity, state, deps, discoveryUserId,
+    pool, sourceEntity, state, deps, discoveryUserId,
     minScore, evaluator, evaluatorSignalConfig, agentTimingsAccum,
   } = args;
-  const batchStart = Date.now();
+  const evalStart = Date.now();
   const traceEntries: TraceEntry[] = [];
 
-  const candidateEntities = await buildCandidateEntities(batch, deps);
+  const candidateEntities = await buildCandidateEntities(pool, deps);
+  const similarityByUserId = new Map(pool.map((c) => [c.candidateUserId, c.similarity]));
 
   const userIdToIndexId = new Map<string, Id<'networks'>>();
   const evidenceByEntityKey = new Map<string, OpportunityEvidence[]>();
@@ -309,7 +248,7 @@ async function evaluateCandidateBatch(
 
   const networkContexts = await buildNetworkContexts([sourceEntity, ...candidateEntities], deps.database);
 
-  // One evaluator call per candidate, fired in parallel.
+  // One evaluator call per candidate, fired in parallel — the whole pool, one round.
   const evaluatorVerdicts: PairwiseOpportunity[] = await evaluateInParallel({
     evaluator, sourceEntity, candidateEntities, state, discoveryUserId,
     networkContexts, minScore, evaluatorSignalConfig, agentTimingsAccum, traceEntries,
@@ -321,15 +260,12 @@ async function evaluateCandidateBatch(
   const rejections = evaluatorVerdicts.filter((op) => op.rejection !== undefined);
   const pairwiseOpportunities = evaluatorVerdicts.filter((op) => op.rejection === undefined);
 
-  const evaluatedOpportunities: EvaluatedOpportunity[] = pairwiseOpportunities.map((op) => ({
-    reasoning: op.reasoning,
-    score: op.score,
-    evidence: mergeOpportunityEvidence(...op.actors.map(evidenceForActor)),
-    actors: op.actors.map((a) => {
+  function mapActors(actors: PairwiseOpportunity['actors']): EvaluatedOpportunity['actors'] {
+    return actors.map((a) => {
       const isSource = a.userId === discoveryUserId;
       if (isSource) {
         // Source actor inherits the counterpart's networkId (shared match context)
-        const counterpart = op.actors.find((other) => other.userId !== a.userId);
+        const counterpart = actors.find((other) => other.userId !== a.userId);
         const counterpartIndexId = counterpart
           ? userIdToIndexId.get(counterpart.userId) ?? (candidateEntities.find((e) => e.userId === counterpart.userId)?.networkId as Id<'networks'>)
           : undefined;
@@ -346,33 +282,73 @@ async function evaluateCandidateBatch(
         intentId: a.intentId as Id<'intents'> | undefined,
         networkId: userIdToIndexId.get(a.userId) ?? (candidateEntities.find((e) => e.userId === a.userId)?.networkId as Id<'networks'>),
       };
-    }),
-  }));
+    });
+  }
 
+  function toScoredOpportunity(op: PairwiseOpportunity, candidateUserId: string): ScoredOpportunity {
+    return {
+      reasoning: op.reasoning,
+      score: op.score,
+      evidence: mergeOpportunityEvidence(...op.actors.map(evidenceForActor)),
+      actors: mapActors(op.actors),
+      _similarity: similarityByUserId.get(candidateUserId) ?? 0,
+    };
+  }
+
+  const evaluatedOpportunities: ScoredOpportunity[] = pairwiseOpportunities.map((op) => {
+    const candidateUserId = op.actors.find((a) => a.userId !== discoveryUserId)?.userId ?? '';
+    return toScoredOpportunity(op, candidateUserId);
+  });
   const passed = evaluatedOpportunities.filter((o) => o.score >= minScore);
-  evaluationLog.verbose('Batch evaluated', {
-    batchNumber,
+
+  // Rejected-but-fillable pool for the match floor: accepted verdicts that
+  // didn't clear minScore, plus the evaluator's own `not_accepted` rejections
+  // (which now carry actors — see opportunity.evaluator.ts). Guard drops
+  // (`incomplete_actors`, `unsupported_claim`) are never fills — they hold no
+  // usable actors and were never a real verdict on the pairing.
+  const belowScore = evaluatedOpportunities.filter((o) => o.score < minScore);
+  const notAcceptedRejections = rejections
+    .filter((op) => op.rejection!.reason === 'not_accepted')
+    .map((op) => {
+      const candidateId = op.rejection!.candidateId;
+      const actorIds = new Set(op.actors.map((a) => a.userId));
+      const hasUsableActors = actorIds.size === 2 && actorIds.has(discoveryUserId) && actorIds.has(candidateId);
+      const actors = hasUsableActors ? op.actors : [
+        { userId: discoveryUserId, role: 'peer' as const, intentId: state.resolvedTriggerIntentId ?? sourceEntity.intents?.[0]?.intentId ?? null },
+        { userId: candidateId, role: 'peer' as const, intentId: candidateEntities.find((e) => e.userId === candidateId)?.intents?.[0]?.intentId ?? null },
+      ];
+      return toScoredOpportunity({ ...op, actors }, candidateId);
+    });
+  const fillPool = [...belowScore, ...notAcceptedRejections]
+    .sort((a, b) => (b.score - a.score) || (b._similarity - a._similarity));
+  const needed = Math.max(0, DISCOVERY_MIN_MATCHES - passed.length);
+  const filled = fillPool.slice(0, needed);
+  const filledCandidateIds = new Set(
+    filled.map((o) => o.actors.find((a) => a.userId !== discoveryUserId)?.userId),
+  );
+
+  evaluationLog.verbose('Pool evaluated', {
     evaluatedCount: evaluatedOpportunities.length,
     rejectedCount: rejections.length,
     passed: passed.length,
+    filled: filled.length,
   });
 
-  // Threshold filter trace: how many candidates in this batch were above/below similarity threshold
-  const aboveThreshold = batch.filter(
+  // Threshold filter trace: how many candidates in the pool were above/below the retrieval similarity threshold.
+  const aboveThreshold = pool.filter(
     (candidate) => candidate.similarity >= deps.retrievalMinSimilarity,
   ).length;
-  const belowThreshold = batch.length - aboveThreshold;
+  const belowThreshold = pool.length - aboveThreshold;
   traceEntries.push({
     node: "threshold_filter",
-    detail: `${aboveThreshold} above ${deps.retrievalMinSimilarity}, ${belowThreshold} below (batch ${batchNumber} of ${batch.length})`,
+    detail: `${aboveThreshold} above ${deps.retrievalMinSimilarity}, ${belowThreshold} below (pool of ${pool.length})`,
     data: {
       aboveThreshold,
       belowThreshold,
       minScore: deps.retrievalMinSimilarity,
       retrievalMinSimilarity: deps.retrievalMinSimilarity,
       evaluatorMinScore: minScore,
-      batchSize: batch.length,
-      batchNumber,
+      poolSize: pool.length,
     },
   });
 
@@ -396,15 +372,18 @@ async function evaluateCandidateBatch(
 
   traceEntries.push({
     node: "evaluation",
-    detail: `Evaluated ${candidateEntities.length} candidate(s) → ${passed.length} passed (min score ${minScore})`,
+    detail: filled.length > 0
+      ? `Evaluated ${candidateEntities.length} candidate(s) → ${passed.length} passed, ${filled.length} filled to reach the ${DISCOVERY_MIN_MATCHES}-match floor (min score ${minScore})`
+      : `Evaluated ${candidateEntities.length} candidate(s) → ${passed.length} passed (min score ${minScore})`,
     data: {
-      inputCandidates: batch.length,
+      inputCandidates: pool.length,
       returnedFromEvaluator: evaluatedOpportunities.length,
       rejectedByEvaluator: rejections.length,
       passedCount: passed.length,
+      filledCount: filled.length,
+      matchFloor: DISCOVERY_MIN_MATCHES,
       minScore,
-      batchNumber,
-      durationMs: Date.now() - batchStart,
+      durationMs: Date.now() - evalStart,
       model: getModelName("opportunityEvaluator"),
     },
   });
@@ -418,7 +397,6 @@ async function evaluateCandidateBatch(
       detail: `${guardDropped.length} accepted verdict(s) dropped by evaluator guards`,
       data: {
         droppedCount: guardDropped.length,
-        batchNumber,
         drops: guardDropped.map((op) => ({
           candidateUserId: op.rejection!.candidateId,
           reason: op.rejection!.reason,
@@ -435,11 +413,14 @@ async function evaluateCandidateBatch(
     const rejected = rejectedByUserId.get(entity.userId);
     const score = evaluated?.score ?? rejected?.score;
     const didPass = evaluated !== undefined && evaluated.score >= minScore;
+    const isFilled = filledCandidateIds.has(entity.userId);
     const status = didPass
       ? '✓ passed'
-      : score !== undefined
-        ? `✗ score ${score}`
-        : '✗ no verdict';
+      : isFilled
+        ? `~ filled (score ${score})`
+        : score !== undefined
+          ? `✗ score ${score}`
+          : '✗ no verdict';
 
     traceEntries.push({
       node: "candidate",
@@ -450,11 +431,11 @@ async function evaluateCandidateBatch(
         bio: entity.profile?.bio,
         score: score,
         passed: didPass,
+        filled: isFilled,
         reasoning: evaluated?.reasoning
           ?? rejected?.reasoning
           ?? 'Evaluator returned no verdict for this candidate',
         rejectionReason: rejected?.reason,
-        batchNumber,
         matchedVia: entity.matchedVia,
         ragScore: entity.ragScore,
         model: getModelName("opportunityEvaluator"),
@@ -470,7 +451,7 @@ async function evaluateCandidateBatch(
     });
   }
 
-  return { passed, trace: traceEntries };
+  return { passed: passed.map(stripSimilarity), filled: filled.map(stripSimilarity), trace: traceEntries };
 }
 /** Dedup by userId — when same similarity, prefer index with highest relevancyScore. */
 function dedupeCandidatesByUser(sortedCandidates: CandidateMatch[], state: OpportunityState): CandidateMatch[] {
@@ -521,7 +502,7 @@ async function filterToActiveMemberships(
  *
  * Candidates with a recently rejected or stalled opportunity receive a
  * similarity penalty so they are ranked lower (and often pushed out of
- * the evaluation batch). This prevents cross-query re-surfacing of
+ * the evaluation pool). This prevents cross-query re-surfacing of
  * false-positive matches that were already caught downstream.
  * The persist-node dedup is still the hard gate; this is a soft guard
  * that reduces evaluator cost and LLM false-positive rate.
@@ -721,8 +702,7 @@ export async function rankingNode(state: OpportunityState) {
 
     try {
       const sorted = [...state.evaluatedOpportunities].sort((a, b) => b.score - a.score);
-      const limit = state.options.limit ?? 20;
-      const ranked = sorted.slice(0, limit);
+      const ranked = state.options.limit != null ? sorted.slice(0, state.options.limit) : sorted;
 
       const actorSetKey = (opp: EvaluatedOpportunity) =>
         opp.actors

--- a/packages/protocol/src/internal/opportunities/opportunity.graph.modes.ts
+++ b/packages/protocol/src/internal/opportunities/opportunity.graph.modes.ts
@@ -634,7 +634,6 @@ function introductionState(request: IntroductionRequest): OpportunityState {
     suggestedIntentDescription: undefined,
     hydeEmbeddings: {},
     candidates: [],
-    remainingCandidates: [],
     discoveryId: null,
     evaluatedCandidates: [],
     evaluatedOpportunities: [],

--- a/packages/protocol/src/internal/opportunities/opportunity.graph.shared.ts
+++ b/packages/protocol/src/internal/opportunities/opportunity.graph.shared.ts
@@ -41,7 +41,12 @@ export type OpportunityEvaluatorLike = {
     reasoning: string;
     score: number;
     actors: Array<{ userId: string; role: 'agent' | 'patient' | 'peer'; intentId?: string | null; evidenceKey?: string | null }>;
-    /** Diagnostic-only entry under `returnAll` — carries no actors, never persisted. */
+    /**
+     * Diagnostic-only entry under `returnAll`, never itself persisted. A
+     * `not_accepted` rejection carries the model's actors (or a fallback pair)
+     * so the caller can surface it as a fill when too few candidates pass;
+     * `incomplete_actors`/`unsupported_claim` guard drops carry no actors.
+     */
     rejection?: { candidateId: string; reason: 'not_accepted' | 'incomplete_actors' | 'unsupported_claim' };
   }>>;
 };

--- a/packages/protocol/src/internal/opportunities/opportunity.graph.ts
+++ b/packages/protocol/src/internal/opportunities/opportunity.graph.ts
@@ -170,7 +170,6 @@ export class OpportunityGraphFactory {
       // Conditional routing: early exit if no indexed intents
       .addConditionalEdges('prep', shouldContinueAfterPrep, {
         scope: 'scope',
-        evaluation: 'evaluation',
         [END]: END,
       })
 
@@ -213,13 +212,6 @@ function shouldContinueAfterPrep(state: OpportunityState): string {
   if (state.error) {
     routingLog.verbose('Error in prep - ending early');
     return END;
-  }
-  // Continuation mode: skip scope/resolve/discovery, go straight to evaluation
-  if (state.operationMode === 'continue_discovery') {
-    routingLog.verbose('Continue discovery → skipping to evaluation', {
-      candidatesLoaded: state.candidates.length,
-    });
-    return 'evaluation';
   }
   routingLog.verbose('Continuing to scope');
   return 'scope';

--- a/packages/protocol/src/internal/opportunities/opportunity.state.ts
+++ b/packages/protocol/src/internal/opportunities/opportunity.state.ts
@@ -199,7 +199,6 @@ export const OpportunityGraphState = Annotation.Root({
    * Operation mode controls graph flow:
    * - 'create': Existing discover pipeline (Prep → Scope → Discovery → Evaluation → Ranking → Persist)
    * - 'create_introduction': Introduction path (validation → evaluation → persist) for chat-driven intros
-   * - 'continue_discovery': Pagination path (Prep → Evaluation → Ranking → Persist) using pre-loaded candidates
    * - 'read': List opportunities filtered by userId and optionally networkId (fast path)
    * - 'update': Change opportunity status (accept, reject, etc.)
    * - 'delete': Expire/archive an opportunity
@@ -211,7 +210,7 @@ export const OpportunityGraphState = Annotation.Root({
    *
    * Defaults to 'create' for backward compatibility.
    */
-  operationMode: Annotation<'create' | 'create_introduction' | 'continue_discovery' | 'read' | 'update' | 'delete' | 'send' | 'negotiate_existing' | 'approve_introduction'>({
+  operationMode: Annotation<'create' | 'create_introduction' | 'read' | 'update' | 'delete' | 'send' | 'negotiate_existing' | 'approve_introduction'>({
     reducer: (curr, next) => next ?? curr,
     default: () => 'create' as const,
   }),
@@ -334,12 +333,6 @@ export const OpportunityGraphState = Annotation.Root({
 
   /** Candidate matches from semantic search (from discovery) */
   candidates: Annotation<CandidateMatch[]>({
-    reducer: (curr, next) => next ?? curr,
-    default: () => [],
-  }),
-
-  /** Candidates not yet evaluated (for pagination -- cached in Redis by caller). */
-  remainingCandidates: Annotation<CandidateMatch[]>({
     reducer: (curr, next) => next ?? curr,
     default: () => [],
   }),

--- a/packages/protocol/src/internal/opportunities/tests/opportunity.evaluator.spec.ts
+++ b/packages/protocol/src/internal/opportunities/tests/opportunity.evaluator.spec.ts
@@ -149,6 +149,43 @@ describe('OpportunityEvaluator', () => {
       expect(scoreFiltered).toHaveLength(0);
     });
 
+    it('keeps the model\'s actors on a not_accepted rejection under returnAll, unlike a guard drop', async () => {
+      const mockEntityBundleModel = {
+        invoke: async () => ({
+          verdicts: [
+            {
+              candidateId: 'user-2', accepted: false,
+              reasoning: 'Complementary-role mismatch.',
+              score: 15,
+              actors: [
+                { userId: 'user-1', role: 'peer', intentId: null },
+                { userId: 'user-2', role: 'peer', intentId: null },
+              ],
+            },
+          ],
+        }),
+      } as unknown as Runnable;
+      const evaluatorWithMock = new OpportunityEvaluator({ entityBundleModel: mockEntityBundleModel });
+      const input: EvaluatorInput = {
+        discovererId: 'user-1',
+        entities: [
+          { userId: 'user-1', profile: { name: 'Alice' }, networkId: 'idx-1' },
+          { userId: 'user-2', profile: { name: 'Bob' }, networkId: 'idx-1' },
+        ],
+      };
+
+      const returnAll = await evaluatorWithMock.invokeEntityBundle(input, { minScore: 70, returnAll: true });
+
+      expect(returnAll).toHaveLength(1);
+      expect(returnAll[0].rejection).toEqual({ candidateId: 'user-2', reason: 'not_accepted' });
+      // Unlike a guard drop, a not_accepted rejection keeps its actors — the
+      // caller may surface it as a fill when too few candidates pass.
+      expect(returnAll[0].actors).toEqual([
+        { userId: 'user-1', role: 'peer', intentId: null, evidenceKey: undefined },
+        { userId: 'user-2', role: 'peer', intentId: null, evidenceKey: undefined },
+      ]);
+    });
+
     it('retries once then fails closed when a batch omits a candidate verdict', async () => {
       let calls = 0;
       const mockEntityBundleModel = {

--- a/packages/protocol/src/internal/opportunities/tests/opportunity.graph.dedup.spec.ts
+++ b/packages/protocol/src/internal/opportunities/tests/opportunity.graph.dedup.spec.ts
@@ -225,22 +225,6 @@ const ownedIntentInput = {
   options: { initialStatus: 'latent' as const },
 };
 
-const continuationInput = {
-  userId: USER_A,
-  operationMode: 'continue_discovery' as const,
-  searchQuery: 'co-founder',
-  candidates: [{
-    candidateUserId: USER_B,
-    candidateIntentId: 'intent-bob' as Id<'intents'>,
-    networkId: NET_ID,
-    similarity: 0.9,
-    lens: 'mirror',
-    candidatePayload: 'Looking to join a startup',
-    candidateSummary: 'Potential co-founder',
-  }],
-  options: {},
-};
-
 // ---------------------------------------------------------------------------
 // Tests
 // ---------------------------------------------------------------------------
@@ -400,7 +384,7 @@ describe('opportunity graph — continuation negotiation lifecycle', () => {
         negotiationInputs.push(input);
         if (input.opportunityId) observedTaskBoundaries.push(input.opportunityId);
       }),
-    }).invoke(continuationInput);
+    }).invoke(discoveryInput);
 
     expect(negotiationInputs).toHaveLength(1);
     expect(negotiationInputs[0].opportunityId).toBe('opp-continuation-new');
@@ -436,7 +420,7 @@ describe('opportunity graph — continuation negotiation lifecycle', () => {
 
     const result = await buildGraph(db, undefined, {
       negotiationGraph: resolvedNegotiationGraph(() => { negotiationInvocations += 1; }),
-    }).invoke(continuationInput);
+    }).invoke(discoveryInput);
 
     expect(negotiationInvocations).toBe(0);
     expect(compensationInvocations).toBe(0);
@@ -466,7 +450,7 @@ describe('opportunity graph — continuation negotiation lifecycle', () => {
     };
 
     await buildGraph(db, undefined, { negotiationGraph: failingNegotiationGraph })
-      .invoke(continuationInput);
+      .invoke(discoveryInput);
 
     expect(compensationCalls).toEqual([
       ['opp-init-failure', persistedBoundary, 'draft'],
@@ -498,7 +482,7 @@ describe('opportunity graph — continuation negotiation lifecycle', () => {
 
     await buildGraph(db, undefined, {
       negotiationGraph: resolvedNegotiationGraph(() => { negotiationInvocations += 1; }),
-    }).invoke(continuationInput);
+    }).invoke(discoveryInput);
 
     expect(negotiationInvocations).toBe(0);
     expect(compensationCalls).toEqual([

--- a/packages/protocol/src/internal/opportunities/tests/opportunity.graph.spec.ts
+++ b/packages/protocol/src/internal/opportunities/tests/opportunity.graph.spec.ts
@@ -502,7 +502,10 @@ describe('Opportunity Graph', () => {
 
       expect(searchSpy.mock.calls[0]?.[1]?.minScore).toBe(0.42);
       expect(evaluatorCalls[0]?.minScore).toBe(63);
-      expect(result.opportunities).toEqual([]);
+      // Below the evaluator threshold, so it never "passed" — but the pool has
+      // nothing else, so it fills the match floor with its own real score.
+      expect(result.opportunities).toHaveLength(1);
+      expect(parseFloat(result.opportunities[0].confidence)).toBeCloseTo(0.62, 5);
       expect(result.trace).toContainEqual(expect.objectContaining({
         node: 'threshold_filter',
         detail: expect.stringContaining('above 0.42'),
@@ -582,6 +585,60 @@ describe('Opportunity Graph', () => {
       expect(result.candidates.length).toBeGreaterThanOrEqual(1);
     });
 
+    test('tops up retrieval with no similarity floor when the pool has fewer than the match floor of users', async () => {
+      const { compiledGraph, mockEmbedder } = createMockGraph();
+      const firstPass = Array.from({ length: 3 }, (_, i) => ({
+        type: 'intent' as const,
+        id: `intent-first-${i}`,
+        userId: `${String(i).padStart(8, '0')}-0000-4000-8000-000000000000`,
+        score: 0.9 - i * 0.01,
+        matchedVia: 'mirror' as const,
+        networkId: 'idx-1',
+      }));
+      const toppedUp = Array.from({ length: 12 }, (_, i) => ({
+        type: 'intent' as const,
+        id: `intent-top-${i}`,
+        userId: `${String(i + 100).padStart(8, '0')}-0000-4000-8000-000000000000`,
+        score: 0.1,
+        matchedVia: 'mirror' as const,
+        networkId: 'idx-1',
+      }));
+      const searchSpy = spyOn(mockEmbedder, 'searchWithHydeEmbeddings').mockImplementation(
+        async (_lensEmbeddings, opts) => (opts?.minScore === 0 ? toppedUp : firstPass),
+      );
+
+      const result = (await compiledGraph.invoke({
+        userId: 'a0000000-0000-4000-8000-000000000001' as Id<'users'>,
+        searchQuery: 'co-founder',
+        options: {},
+      } as OpportunityGraphInvokeInput)) as OpportunityGraphInvokeResult;
+
+      expect(searchSpy).toHaveBeenCalledTimes(2);
+      expect(searchSpy.mock.calls[1]?.[1]?.minScore).toBe(0);
+      const distinctUsers = new Set(result.candidates.map((c) => c.candidateUserId));
+      expect(distinctUsers.size).toBeGreaterThanOrEqual(10);
+    });
+
+    test('does not top up retrieval when the first pass already has enough distinct users', async () => {
+      const { compiledGraph, mockEmbedder } = createMockGraph();
+      const candidates = Array.from({ length: 12 }, (_, i) => ({
+        type: 'intent' as const,
+        id: `intent-${i}`,
+        userId: `${String(i).padStart(8, '0')}-0000-4000-8000-000000000000`,
+        score: 0.9 - i * 0.01,
+        matchedVia: 'mirror' as const,
+        networkId: 'idx-1',
+      }));
+      const searchSpy = spyOn(mockEmbedder, 'searchWithHydeEmbeddings').mockResolvedValue(candidates);
+
+      await compiledGraph.invoke({
+        userId: 'a0000000-0000-4000-8000-000000000001' as Id<'users'>,
+        searchQuery: 'co-founder',
+        options: {},
+      } as OpportunityGraphInvokeInput);
+
+      expect(searchSpy).toHaveBeenCalledTimes(1);
+    });
   });
 
   describe('Evaluation node: userId dedup', () => {
@@ -706,41 +763,7 @@ describe('Opportunity Graph', () => {
     });
   });
 
-  describe('Evaluation node: batching and continuation', () => {
-    // Evaluation fans a batch out into one call per candidate, so the batch
-    // boundary shows up as a call COUNT (25 per batch) rather than as one call
-    // carrying 25 entities.
-
-    test('when search is query-driven and remaining candidates have no query-sourced entries, remainingCandidates is empty', async () => {
-      // 5 query candidates come through HyDE search → tagged 'query'
-      // With EVAL_BATCH_SIZE=25, all 5 fit in one batch → remaining = 0
-      const queryCandidates = Array.from({ length: 5 }, (_, i) => ({
-        type: 'intent' as const,
-        id: `intent-query-${i}`,
-        userId: `${String(i + 1).padStart(8, '0')}-0000-4000-8000-0000000000a0`,
-        score: 0.9 - i * 0.01,
-        matchedVia: 'Painters' as const,
-        networkId: 'idx-1',
-      }));
-
-      const { compiledGraph, mockEmbedder } = createMockGraph({
-        evaluatorResult: [],
-        thresholdOverrides: { evaluatorMinScore: 50 },
-      });
-
-      // HyDE search returns query candidates (tagged 'query' in discovery node)
-      spyOn(mockEmbedder, 'searchWithHydeEmbeddings').mockResolvedValue(queryCandidates);
-
-      const result = (await compiledGraph.invoke({
-        userId: 'a0000000-0000-4000-8000-000000000001' as Id<'users'>,
-        searchQuery: 'painters',
-        options: {},
-      } as OpportunityGraphInvokeInput)) as OpportunityGraphInvokeResult;
-
-      // All query candidates consumed in one batch → remainingCandidates is empty
-      expect(result.remainingCandidates.length).toBe(0);
-    });
-
+  describe('Evaluation node: whole-pool evaluation and the match floor', () => {
     /** Distinct HyDE candidates, ranked by descending score. */
     const rankedCandidates = (count: number) =>
       Array.from({ length: count }, (_, i) => ({
@@ -752,106 +775,172 @@ describe('Opportunity Graph', () => {
         networkId: 'idx-1',
       }));
 
-    const passingVerdict = (candidateUserId: string) => ({
+    const SOURCE_USER_ID = 'a0000000-0000-4000-8000-000000000001';
+
+    const passingVerdict = (candidateUserId: string, score = 80) => ({
       reasoning: 'The candidate funds the stage and sector the source user is raising for.',
-      score: 80,
+      score,
       actors: [
-        { userId: 'a0000000-0000-4000-8000-000000000001', role: 'patient' as const, intentId: null },
+        { userId: SOURCE_USER_ID, role: 'patient' as const, intentId: null },
         { userId: candidateUserId, role: 'agent' as const, intentId: null },
       ],
     });
 
+    /** A `not_accepted` verdict — carries actors, same as the real evaluator now does. */
+    const rejectedVerdict = (candidateUserId: string, score: number) => ({
+      reasoning: 'Complementary-role mismatch.',
+      score,
+      actors: [
+        { userId: SOURCE_USER_ID, role: 'peer' as const, intentId: null },
+        { userId: candidateUserId, role: 'peer' as const, intentId: null },
+      ],
+      rejection: { candidateId: candidateUserId, reason: 'not_accepted' as const },
+    });
+
+    /** A guard-dropped verdict — never carries actors, never a fill candidate. */
+    const guardDroppedVerdict = (
+      candidateUserId: string,
+      score: number,
+      reason: 'incomplete_actors' | 'unsupported_claim',
+    ) => ({
+      reasoning: 'Guard dropped this verdict.',
+      score,
+      actors: [],
+      rejection: { candidateId: candidateUserId, reason },
+    });
+
     /** Records the candidate ids handed to each evaluator call. */
-    const batchRecordingEvaluator = (
-      seenBatches: string[][],
-      verdictsFor: (candidateIds: string[]) => EvaluatedOpportunityWithActors[],
+    const recordingEvaluator = (
+      seenCalls: string[][],
+      verdictFor: (candidateId: string) => EvaluatedOpportunityWithActors[],
     ): OpportunityEvaluatorLike => ({
       invokeEntityBundle: async (input) => {
         const candidateIds = input.entities.slice(1).map((e) => e.userId);
-        seenBatches.push(candidateIds);
-        return verdictsFor(candidateIds);
+        seenCalls.push(candidateIds);
+        return candidateIds.flatMap(verdictFor);
       },
     });
 
-    test('evaluates the next batch when a batch passes nothing, so tail passers are still found', async () => {
-      // 30 candidates: the top 25 (one full batch) fail, a passer sits at rank 28.
+    test('evaluates every candidate in one round — a passer deep in the tail is still found', async () => {
+      // 30 candidates, one passer at rank 27 — no batch boundary to strand it behind.
       const candidates = rankedCandidates(30);
       const passerId = candidates[27].userId;
-      const seenBatches: string[][] = [];
+      const seenCalls: string[][] = [];
       const { compiledGraph, mockEmbedder } = createMockGraph({
-        evaluator: batchRecordingEvaluator(seenBatches, (ids) =>
-          ids.includes(passerId) ? [passingVerdict(passerId)] : [],
+        evaluator: recordingEvaluator(seenCalls, (id) =>
+          id === passerId ? [passingVerdict(id)] : [rejectedVerdict(id, 20)],
         ),
         thresholdOverrides: { evaluatorMinScore: 50 },
       });
       spyOn(mockEmbedder, 'searchWithHydeEmbeddings').mockResolvedValue(candidates);
 
       const result = (await compiledGraph.invoke({
-        userId: 'a0000000-0000-4000-8000-000000000001' as Id<'users'>,
+        userId: SOURCE_USER_ID as Id<'users'>,
         searchQuery: 'painters',
         options: {},
       } as OpportunityGraphInvokeInput)) as OpportunityGraphInvokeResult;
 
-      // One call per candidate: 25 in the first batch, 5 in the second.
-      expect(seenBatches).toHaveLength(30);
-      expect(seenBatches.flat()).toContain(passerId);
-      expect(result.evaluatedOpportunities).toHaveLength(1);
-      expect(result.remainingCandidates).toEqual([]);
+      // One round, every candidate evaluated — no batching.
+      expect(seenCalls).toHaveLength(30);
+      expect(seenCalls.flat()).toContain(passerId);
+      const passerActor = result.opportunities.flatMap((o) => o.actors).find((a) => a.userId === passerId);
+      expect(passerActor).toBeDefined();
     });
 
-    test('stops as soon as a batch passes, leaving the rest for pagination', async () => {
-      const candidates = rankedCandidates(30);
-      const passerId = candidates[3].userId;
-      const seenBatches: string[][] = [];
+    test('surfaces every passing candidate uncapped — more than the old 20-item ranking default', async () => {
+      const candidates = rankedCandidates(25);
+      const seenCalls: string[][] = [];
       const { compiledGraph, mockEmbedder } = createMockGraph({
-        evaluator: batchRecordingEvaluator(seenBatches, (ids) =>
-          ids.includes(passerId) ? [passingVerdict(passerId)] : [],
+        evaluator: recordingEvaluator(seenCalls, (id) => [passingVerdict(id, 90)]),
+        thresholdOverrides: { evaluatorMinScore: 50 },
+      });
+      spyOn(mockEmbedder, 'searchWithHydeEmbeddings').mockResolvedValue(candidates);
+
+      const result = (await compiledGraph.invoke({
+        userId: SOURCE_USER_ID as Id<'users'>,
+        searchQuery: 'painters',
+        options: {},
+      } as OpportunityGraphInvokeInput)) as OpportunityGraphInvokeResult;
+
+      expect(result.opportunities).toHaveLength(25);
+    });
+
+    test('fills below the match floor with the best-scored rejects, tiebroken by similarity', async () => {
+      // 15 candidates ranked by similarity; only the top 3 pass.
+      const candidates = rankedCandidates(15);
+      const passerIds = new Set(candidates.slice(0, 3).map((c) => c.userId));
+      // Rejects get varied scores so the top 7 by score are deterministic.
+      const rejectScoreByIndex = new Map(candidates.slice(3).map((c, i) => [c.userId, 49 - i]));
+      const seenCalls: string[][] = [];
+      const { compiledGraph, mockEmbedder } = createMockGraph({
+        evaluator: recordingEvaluator(seenCalls, (id) =>
+          passerIds.has(id) ? [passingVerdict(id, 90)] : [rejectedVerdict(id, rejectScoreByIndex.get(id)!)],
         ),
         thresholdOverrides: { evaluatorMinScore: 50 },
       });
       spyOn(mockEmbedder, 'searchWithHydeEmbeddings').mockResolvedValue(candidates);
 
       const result = (await compiledGraph.invoke({
-        userId: 'a0000000-0000-4000-8000-000000000001' as Id<'users'>,
+        userId: SOURCE_USER_ID as Id<'users'>,
         searchQuery: 'painters',
         options: {},
       } as OpportunityGraphInvokeInput)) as OpportunityGraphInvokeResult;
 
-      // The first batch passes, so the second never runs: 25 calls, not 30.
-      expect(seenBatches).toHaveLength(25);
-      expect(result.evaluatedOpportunities).toHaveLength(1);
-      // The 5 query-sourced candidates behind the batch stay available for pagination.
-      expect(result.remainingCandidates.length).toBe(5);
+      // 3 passed + 7 fills = 10, the match floor.
+      expect(result.opportunities).toHaveLength(10);
+      const counterpartIds = result.opportunities.map(
+        (o) => o.actors.find((a) => a.userId !== SOURCE_USER_ID)!.userId,
+      );
+      // The 7 fills are the top 7 rejects by score (ranks 3..9 of the reject pool).
+      const expectedFillIds = candidates.slice(3, 10).map((c) => c.userId);
+      for (const id of expectedFillIds) expect(counterpartIds).toContain(id);
+      // A fill's persisted confidence is its real (low) score, not the passing threshold.
+      const fillOpp = result.opportunities.find(
+        (o) => o.actors.find((a) => a.userId === expectedFillIds[0]),
+      );
+      expect(parseFloat(fillOpp?.confidence ?? 'NaN')).toBeCloseTo(rejectScoreByIndex.get(expectedFillIds[0])! / 100, 5);
     });
 
-    test('stops at the batch bound and reports the stranded tail honestly', async () => {
-      // 80 candidates, every one rejected: 3 batches of 25 run, 5 are never evaluated.
-      const candidates = rankedCandidates(80);
-      const seenBatches: string[][] = [];
+    test('never pads past the pool — a small rejected pool stays small', async () => {
+      const candidates = rankedCandidates(4);
       const { compiledGraph, mockEmbedder } = createMockGraph({
-        evaluator: batchRecordingEvaluator(seenBatches, () => []),
+        evaluator: recordingEvaluator([], (id) => [rejectedVerdict(id, 10)]),
         thresholdOverrides: { evaluatorMinScore: 50 },
       });
       spyOn(mockEmbedder, 'searchWithHydeEmbeddings').mockResolvedValue(candidates);
 
       const result = (await compiledGraph.invoke({
-        userId: 'a0000000-0000-4000-8000-000000000001' as Id<'users'>,
+        userId: SOURCE_USER_ID as Id<'users'>,
         searchQuery: 'painters',
         options: {},
       } as OpportunityGraphInvokeInput)) as OpportunityGraphInvokeResult;
 
-      expect(seenBatches).toHaveLength(75);
-      expect(seenBatches.every((call) => call.length === 1)).toBe(true);
-      expect(result.evaluatedOpportunities).toEqual([]);
-      expect(result.remainingCandidates.length).toBe(5);
-      expect(result.trace).toContainEqual(expect.objectContaining({
-        node: 'evaluation_bound',
-        data: expect.objectContaining({
-          unevaluatedCandidates: 5,
-          evaluatedCandidates: 75,
-          batchesRun: 3,
+      expect(result.opportunities).toHaveLength(4);
+    });
+
+    test('guard-dropped verdicts never fill, even when the floor is unmet', async () => {
+      const candidates = rankedCandidates(5);
+      const [passer, ...rest] = candidates;
+      const { compiledGraph, mockEmbedder } = createMockGraph({
+        evaluator: recordingEvaluator([], (id) => {
+          if (id === passer.userId) return [passingVerdict(id, 90)];
+          return [guardDroppedVerdict(id, 95, 'unsupported_claim')];
         }),
-      }));
+        thresholdOverrides: { evaluatorMinScore: 50 },
+      });
+      spyOn(mockEmbedder, 'searchWithHydeEmbeddings').mockResolvedValue(candidates);
+
+      const result = (await compiledGraph.invoke({
+        userId: SOURCE_USER_ID as Id<'users'>,
+        searchQuery: 'painters',
+        options: {},
+      } as OpportunityGraphInvokeInput)) as OpportunityGraphInvokeResult;
+
+      // Only the single passer — guard drops (even with a higher score) never fill.
+      expect(result.opportunities).toHaveLength(1);
+      const counterpartId = result.opportunities[0].actors.find((a) => a.userId !== SOURCE_USER_ID)?.userId;
+      expect(counterpartId).toBe(passer.userId);
+      void rest;
     });
   });
 
@@ -878,7 +967,7 @@ describe('Opportunity Graph', () => {
       } as OpportunityGraphInvokeInput)) as OpportunityGraphInvokeResult;
     };
 
-    test('reports the model\'s own rejection with its score and reasoning', async () => {
+    test('reports the model\'s own rejection with its score and reasoning, and fills the floor with it', async () => {
       const result = await runWith(diagnosticEvaluator([{
         reasoning: 'Same-side match: both are seeking investment rather than offering it.',
         score: 12,
@@ -886,13 +975,17 @@ describe('Opportunity Graph', () => {
         rejection: { candidateId: CANDIDATE_ID, reason: 'not_accepted' },
       }]));
 
-      expect(result.evaluatedOpportunities).toEqual([]);
+      // The pool has exactly one candidate; with nothing passing, it fills the
+      // match floor with its own real (low) score rather than vanishing.
+      expect(result.evaluatedOpportunities).toHaveLength(1);
+      expect(result.evaluatedOpportunities[0].score).toBe(12);
       expect(result.trace).toContainEqual(expect.objectContaining({
         node: 'candidate',
         data: expect.objectContaining({
           userId: CANDIDATE_ID,
           score: 12,
           passed: false,
+          filled: true,
           rejectionReason: 'not_accepted',
           reasoning: 'Same-side match: both are seeking investment rather than offering it.',
         }),
@@ -1009,7 +1102,6 @@ describe('Opportunity Graph', () => {
       expect(evaluatorSpy).not.toHaveBeenCalled();
       expect(result.candidates).toEqual([]);
       expect(result.evaluatedOpportunities).toEqual([]);
-      expect(result.remainingCandidates).toEqual([]);
       expect(result.opportunities).toEqual([]);
     });
 
@@ -2950,6 +3042,10 @@ async function runDirectConnectionEval(): Promise<{ opportunities: Array<{ reaso
     const durationMs = Date.now() - start;
     totalDurationMs += durationMs;
     const opportunities = raw
+      // `rejection === undefined` is the persistable signal now — a not_accepted
+      // rejection carries real actors too (for the discovery match floor), so
+      // actor presence alone no longer distinguishes an accepted verdict.
+      .filter(op => op.rejection === undefined)
       .map(op => {
         const candidate = op.actors.find(a => a.userId !== DISCOVERER_ID);
         if (!candidate?.userId) return null;

--- a/services/api/src/queues/opportunity/discovery.shared.ts
+++ b/services/api/src/queues/opportunity/discovery.shared.ts
@@ -77,7 +77,6 @@ export type OpportunityDiscoveryCompletionReason =
   | 'created_or_reactivated'
   | 'no_search_candidates'
   | 'evaluator_rejected_all'
-  | 'evaluation_bound_reached'
   | 'same_trigger_duplicate_suppressed'
   | 'pair_active_negotiation_suppressed'
   | 'final_atomic_conflict'
@@ -88,8 +87,6 @@ export interface OpportunityDiscoverySummary {
   evaluatedCount: number;
   opportunitiesCreated: number;
   completionReason: OpportunityDiscoveryCompletionReason;
-  /** Candidates retrieved but never handed to the evaluator (batch bound reached). */
-  unevaluatedCandidates: number;
   sameTriggerDuplicateSuppressions: number;
   pairActiveNegotiationSuppressions: number;
   crossTriggerAllowedCount: number;
@@ -98,7 +95,6 @@ export interface OpportunityDiscoverySummary {
 
 interface OpportunityDiscoveryResultShape {
   candidates?: unknown[];
-  remainingCandidates?: unknown[];
   evaluatedOpportunities?: unknown[];
   opportunities?: unknown[];
   persistenceOutcome?: {
@@ -115,7 +111,6 @@ export function summarizeOpportunityDiscoveryResult(
   result: OpportunityDiscoveryResultShape,
 ): OpportunityDiscoverySummary {
   const candidates = Array.isArray(result.candidates) ? result.candidates : [];
-  const unevaluatedCandidates = Array.isArray(result.remainingCandidates) ? result.remainingCandidates.length : 0;
   const opportunities = Array.isArray(result.opportunities) ? result.opportunities : [];
   const persistence = result.persistenceOutcome;
   const evaluatedCount = persistence?.evaluatedCount
@@ -129,8 +124,7 @@ export function summarizeOpportunityDiscoveryResult(
     : candidates.length === 0
       ? 'no_search_candidates'
       : evaluatedCount === 0
-        // A zero-output run with candidates still queued is a bound, not a verdict.
-        ? (unevaluatedCandidates > 0 ? 'evaluation_bound_reached' : 'evaluator_rejected_all')
+        ? 'evaluator_rejected_all'
         : finalAtomicConflictCount > 0
           ? 'final_atomic_conflict'
           : pairActiveNegotiationSuppressions > 0
@@ -144,7 +138,6 @@ export function summarizeOpportunityDiscoveryResult(
     evaluatedCount,
     opportunitiesCreated: opportunities.length,
     completionReason,
-    unevaluatedCandidates,
     sameTriggerDuplicateSuppressions,
     pairActiveNegotiationSuppressions,
     crossTriggerAllowedCount,

--- a/services/api/src/queues/tests/from-intent.queue.isolated.ts
+++ b/services/api/src/queues/tests/from-intent.queue.isolated.ts
@@ -90,7 +90,6 @@ const discoverySummary = (overrides: Partial<OpportunityDiscoverySummary> = {}):
   evaluatedCount: 0,
   opportunitiesCreated: 0,
   completionReason: 'created_or_reactivated',
-  unevaluatedCandidates: 0,
   sameTriggerDuplicateSuppressions: 0,
   pairActiveNegotiationSuppressions: 0,
   crossTriggerAllowedCount: 0,
@@ -528,18 +527,6 @@ describe('FromIntentQueue', () => {
 
       expect(evaluatorZero.completionReason).toBe('evaluator_rejected_all');
       expect(persistenceDedupZero.completionReason).toBe('same_trigger_duplicate_suppressed');
-    });
-
-    it('reports a stranded tail as a bound, not as an evaluator rejection', () => {
-      const bounded = summarizeOpportunityDiscoveryResult({
-        candidates: [{}, {}],
-        remainingCandidates: [{}],
-        evaluatedOpportunities: [],
-        opportunities: [],
-      });
-
-      expect(bounded.completionReason).toBe('evaluation_bound_reached');
-      expect(bounded.unevaluatedCandidates).toBe(1);
     });
   });
 


### PR DESCRIPTION
## Summary

Intent-triggered discovery often persisted fewer than 10 opportunities. Traced cause: retrieval capped the pool (30/strategy, 80/index), evaluation batched 25 candidates at a time and stopped as soon as one batch passed ≥1, and ranking defaulted to a 20-item cap. Live data (811 prod runs) showed pass rate does not track similarity rank (flat 41–47% from 0.40–1.0 similarity), so batching by rank stranded real matches behind an over-scored head cluster.

- **Retrieval** (`opportunity.graph.discovery.ts`): `LIMIT_PER_STRATEGY` 30→80, `PER_INDEX_LIMIT` 80→160. The intent path re-runs its search once with `minScore: 0` when the deduped pool has fewer than `DISCOVERY_MIN_MATCHES` (10) distinct users, so the 0.20 similarity floor can't be what keeps a small network under the match floor.
- **Evaluation** (`opportunity.graph.evaluation.ts`): the whole deduped, membership-filtered pool (capped at 80 by rank) is evaluated in **one** parallel round — no more 25-candidate batches, no early stop, no `evaluation_bound`/`remainingCandidates`/`continue_discovery` pagination path. Every passing candidate is returned uncapped. When fewer than 10 pass, the run fills the rest with the best-scored rejected candidates (tiebroken by similarity), persisted with their real (low) score so they stay distinguishable downstream — no new flag/field, `confidence` is just the real score.
- **Evaluator** (`opportunity.evaluator.ts`): `not_accepted` verdicts now carry the model's actors under `returnAll` (previously always `[]`) so a rejected candidate can become a fill. Guard drops (`incomplete_actors`, `unsupported_claim`) still carry none and are never fills.
- **Ranking**: dropped the `?? 20` default limit — only a caller-supplied `options.limit` cuts the list now (the intent trigger already passes none).

**Public-surface break**: `continue_discovery` operation mode removed from the `OpportunityGraphOptions`/state union — protocol bumps to `27.0.0` (rebased onto `dev` after #1489 took `26.0.0` for an unrelated intent-graph break; `CHANGELOG.md` entry moved under its own `27.0.0` heading above `26.0.0`, `bun.lock` workspace version re-synced). `services/api`'s `OpportunityDiscoverySummary` drops `unevaluatedCandidates`/`evaluation_bound_reached` (nothing consumed them beyond diagnostics).

## Evaluator prompt A/B (actors-on-every-verdict clause)

The first version of the "every verdict must include actors" prompt line carried an explanatory clause ("...so its actors matter as much as an accepted verdict's"). A reviewer flagged a pass-rate drop vs. the pre-change baseline (5/25 evaluated passed on Olivia Hardie's intent, similarity ranks 11/12/13/16/25, scores 75–85) against a first post-change run that only passed 2/49. Re-ran Olivia's intent (`d3eed0da-32dd-470d-baef-ebc75c1aa247`) 3× with the explanatory clause and 3× with it trimmed to just the mechanical instruction:

| Prompt | Run | Passed (of pool) | Named-5 hits (Sher / Apestegui / Akula / Mastick / Vasquez) |
|---|---|---|---|
| with clause | 1 | 2/49 | 0/5 (only non-named passers) |
| with clause | 2 | 4/49 | 4/5 |
| with clause | 3 | 4/49 | 2/5 |
| trimmed | 4 | 7/49 | 4/5 (Sher scored 60, still not_accepted) |
| trimmed | 5 | 6/48 | 3/5 (Vasquez guard-dropped as `unsupported_claim`, unrelated to this clause) |
| trimmed | 6 | 7/49 | 3/5 (Sher passed at 75 this time) |

Avg total passed: **3.3 with the clause → 6.7 trimmed** — clearly closer to (and here exceeding) the 5-pass baseline. Kept the trimmed version (`opportunity.evaluator.ts`): `"EVERY verdict — accepted or not — must include exactly the source and that candidate as actors, with roles."` with no explanatory tail. LLM output has inherent run-to-run variance (this is a live model on live data, not a fixture), so this isn't a controlled experiment, but the direction and magnitude across 3-vs-3 runs is consistent enough to act on.

## Live check (sandbox DB, Edge City network, ~49 other members with intents)

Two intent-triggered runs via a scratch harness invoking the graph directly:

| Intent | Pool | Evaluator calls | Wall-clock | Passed | Filled | Persisted (rerun, dedup'd) |
|---|---|---|---|---|---|---|
| Olivia Hardie | 49 | 49 (one round) | 31.7s | 2 | 8 | 7 |
| Grace Dessert | 47 | 47 (one round) | 28.7s | 1 | 9 | 6 |

Both runs evaluated the entire pool in a single round (no batching), reached the 10-match floor before persist-time dedup, and fills were selected by score first, similarity as tiebreak (verified against the printed per-candidate trace). Persisted counts are below 10 because these intents already had opportunities from earlier exploration in this sandbox — expected, since re-runs still dedupe against existing opportunities.

Expected production cost: up to 80 evaluator calls per intent (~3x prior average, same wall-clock since parallel) and more negotiations per intent.

## Test plan

- [x] `bun run architecture:check` (protocol) — passes
- [x] `npx tsc --noEmit` (protocol, api) — clean
- [x] `bun run test` (protocol, excludes live-model specs) — 2287 pass / 0 fail
- [x] `bun test src/internal/opportunities/tests/` (protocol, includes live specs) — clean except 2 tests that are pre-existing failures unrelated to this diff, confirmed by running the identical tests against a stashed pre-change checkout (both fail there too — a `requestContext` singleton not configured when this spec file runs standalone, not something this PR touches)
- [x] `bun test` (services/api) — clean except a pre-existing, diff-unrelated set of 14 isolated-test files failing on module-mock resolution (`conversationDatabaseAdapter`/`embedderAdapter` not found — infra issue, confirmed unrelated by inspection)
- [x] `bun run check:subtree-parity` — passes
- [x] Unit specs added/updated: whole-pool evaluation (no batching), uncapped passes, floor-fill by score/similarity, no fill beyond pool size, guard-dropped verdicts never fill, retrieval top-up only under the match-floor threshold, evaluator keeps actors on `not_accepted` under `returnAll`
- [x] Live sandbox check against two real intents (see above), plus the 6-run prompt A/B above
- [x] Rebased onto `origin/dev` (post-#1489); CI green (`check`, `lint`, `typecheck`, `test`, `protocol-source-tests`, `protocol-architecture`, `provider-free-security`), PR is `MERGEABLE`/`CLEAN`

Do not merge — root session merges after explicit approval.

Claude-Session: https://claude.ai/code/session_01HsKQjrwMEjFbLycTRe2tTk
