### PR TITLE
fix(api): journal the persona-collapse migration so it actually runs

### DIFF
--- a/services/api/drizzle/meta/_journal.json
+++ b/services/api/drizzle/meta/_journal.json
@@ -995,6 +995,13 @@
       "when": 1786886087822,
       "tag": "0144_negotiation_round_and_brief",
       "breakpoints": true
+    },
+    {
+      "idx": 145,
+      "version": "7",
+      "when": 1786886087823,
+      "tag": "0145_collapse_chat_personas",
+      "breakpoints": true
     }
   ]
 }


### PR DESCRIPTION
## The problem

`services/api/drizzle/0145_collapse_chat_personas.sql` merged in #1495 without an entry in `services/api/drizzle/meta/_journal.json`. `drizzle-kit migrate` (the Railway `preDeployCommand`) applies migrations from the **journal**, not from the directory listing — so the persona collapse never ran on deploy.

Effect on `dev` right now: the API runs #1495's one-persona code while `conversations.persona` still holds `signal` / `negotiator` / `onboarding`, and `chat_session_scopes` still holds the `signal-intent` / `negotiator-intent` keys the code no longer writes.

## The fix

One journal entry for `0145`. The migration is re-runnable by construction — every statement is `WHERE`-scoped to the old values, so applying it where it was already run by hand is a no-op.

## Note on scope

`0142_drop_user_contexts` and `0143_drop_enrichment_tool_runs` are unjournaled too (both from the enrichment-removal work). They are **not** touched here: this PR restores only the migration whose absence is actively wrong on `dev`. Whether those two should be journaled or deleted is a separate question for their authors.

`0146_negotiation_round_size` arrives with #1496 and journals itself there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NGnB1RMoYqPaqaKS1TcUFQ