### PR TITLE
fix: bind negotiation seats to actor intents

### DIFF
--- a/packages/protocol/src/capabilities/tests/fixtures/negotiation-host.fixture.ts
+++ b/packages/protocol/src/capabilities/tests/fixtures/negotiation-host.fixture.ts
@@ -82,8 +82,12 @@ export class FakeNegotiationHost {
 
   readonly database: NegotiationGraphDatabase = {
     getOpportunity: async (id: string) => (this.opportunities.get(id) as never) ?? null,
-    getIntent: async (intentId: string) =>
-      intentId === INTENT_ID ? ({ id: INTENT_ID, userId: SOURCE_USER_ID, payload: "Alice wants a technical co-founder." } as never) : null,
+    getIntent: async (intentId: string) => {
+      const actor = [...this.opportunities.values()]
+        .flatMap((opportunity) => opportunity.actors)
+        .find((candidate) => candidate.intent === intentId);
+      return actor ? ({ id: intentId, userId: actor.userId, payload: `${actor.userId} wants a suitable match.` } as never) : null;
+    },
     getUserContext: async () => null as never,
     openNegotiationTask: async (input) => {
       const existing = [...this.tasks.values()].find((task) =>

--- a/packages/protocol/src/capabilities/tests/personal-agent.e2e.spec.ts
+++ b/packages/protocol/src/capabilities/tests/personal-agent.e2e.spec.ts
@@ -173,12 +173,14 @@ function buildCycle(judgment: ScriptedJudgment, counterparties: string[]) {
   const negotiationHost = new FakeNegotiationHost(counterparties);
   const principal = new FakePrincipalHost(negotiationHost);
   const wakes: Array<{ userId: string; intentId: string }> = [];
+  const negotiationInputs: Array<{ userId: string; intentId: string; negotiationId: string }> = [];
   let agent: PersonalAgentGraphLike;
   const negotiations = new Negotiations({
     database: negotiationHost.database,
     reflectEnqueue: async (job) => { negotiationHost.enqueueReflect(job); },
     author: {
       authorTurn: async ({ negotiationId, userId, intentId }) => {
+        negotiationInputs.push({ negotiationId, userId, intentId });
         const result = await agent.invoke({ userId, intentId, negotiationId });
         if (!result.turn) throw new Error(result.error ?? "PersonalAgent produced no negotiation turn");
         return result.turn;
@@ -199,7 +201,7 @@ function buildCycle(judgment: ScriptedJudgment, counterparties: string[]) {
     judgment,
   }).createGraph();
   const judgmentMatches = () => judgment.decideCalls.at(-1)?.matches ?? [];
-  return { agent, negotiationHost, principal, wakes, judgmentMatches };
+  return { agent, negotiationHost, principal, wakes, judgmentMatches, negotiationInputs };
 }
 
 const userMessage = (text: string) => ({
@@ -847,7 +849,7 @@ describe("PersonalAgent — round-5 regressions", () => {
 describe("PersonalAgent — the three decided design questions", () => {
   test("D18: each seat negotiates from its OWN brief, authored by its own agent", async () => {
     const judgment = new ScriptedJudgment([() => [{ tool: "kickoff", reasoning: "Reaching out." }]]);
-    const { agent, negotiationHost } = buildCycle(judgment, [CANDIDATE_USER_ID]);
+    const { agent, negotiationHost, negotiationInputs } = buildCycle(judgment, [CANDIDATE_USER_ID]);
 
     await agent.invoke({ userId: SOURCE_USER_ID, intentId: INTENT_ID, event: "matches_ready" });
 
@@ -861,6 +863,13 @@ describe("PersonalAgent — the three decided design questions", () => {
     expect(theirs).toBeDefined();
     expect(theirs).not.toBe(ours);
     expect(judgment.seatBriefCalls).toHaveLength(1);
+    expect(judgment.seatBriefCalls[0]!.signalText).toBe("bob wants a suitable match.");
+    expect(task.metadata.seats).toEqual({ [INTENT_ID]: { userId: SOURCE_USER_ID, round: negotiationHost.round } });
+    expect(negotiationInputs.find((input) => input.userId === CANDIDATE_USER_ID)).toEqual({
+      userId: CANDIDATE_USER_ID,
+      intentId: "intent-bob-1",
+      negotiationId: task.id,
+    });
     // It was authored from what THAT side could see, not handed the other's.
     expect(judgment.seatBriefCalls[0]!.thread.length).toBeGreaterThan(0);
     // And a re-kick rewrites only the initiator's half.

--- a/packages/protocol/src/internal/agents/personal-agent/agent.graph.ts
+++ b/packages/protocol/src/internal/agents/personal-agent/agent.graph.ts
@@ -997,7 +997,7 @@ async function negotiationNode(state: PersonalAgentState, deps: PersonalAgentDep
     const messages = await deps.negotiationDatabase.getNegotiationMessages(task.id);
     const judgment = deps.judgment ?? defaultJudgment();
     const thread = threadFromMessages(messages, input.userId);
-    const brief = task.briefs[input.userId] ?? await authorSeatBrief(deps, judgment, task, input.userId, thread);
+    const brief = task.briefs[input.userId] ?? await authorSeatBrief(deps, judgment, task, input.userId, input.intentId, thread);
     const turn: NegotiationAuthoredTurn = await judgment.negotiationTurn({
       brief,
       thread,
@@ -1015,36 +1015,22 @@ async function negotiationNode(state: PersonalAgentState, deps: PersonalAgentDep
 /**
  * Author and persist the brief for a seat that has none.
  *
- * The seat's own signal is used when it can be established BEYOND DOUBT: a
- * premise-matched actor's `intent` field names the intent it matched AGAINST,
- * not one it owns, so an actor carrying this negotiation's own `intentId` is
- * ambiguous and is treated as unknown rather than guessed at. Without it the
- * brief is written from what this side can see honestly — why the match
- * exists, and whatever has been said so far — which is still its own
- * instructions rather than the counterparty's.
+ * The negotiation-scope input carries this seat's own signal, resolved by the
+ * NegotiationGraph from the persisted opportunity actor.
  */
 async function authorSeatBrief(
   deps: PersonalAgentDeps,
   judgment: NonNullable<PersonalAgentDeps["judgment"]>,
   task: NegotiationTaskRow,
   seatUserId: string,
+  intentId: string,
   thread: PersonalAgentThreadEntry[],
 ): Promise<string> {
-  const opportunity = await deps.negotiationDatabase.getOpportunity(task.metadata.opportunityId).catch(() => null);
-  // The seat's OWN binding, recorded when its own kickoff opened or re-kicked
-  // this negotiation. Never inferred from the opportunity's actor rows: a
-  // premise-matched actor's `intent` names the intent it matched AGAINST, so
-  // it cannot be trusted to name the seat's own signal. A seat that has not
-  // kicked off here yet simply has no signal to show, and the brief says so.
-  const seatIntentId = Object.entries(task.metadata.seats)
-    .find(([, binding]) => binding.userId === seatUserId)?.[0] ?? null;
-  const intent = seatIntentId ? await deps.negotiationDatabase.getIntent(seatIntentId).catch(() => null) : null;
+  const intent = await deps.negotiationDatabase.getIntent(intentId).catch(() => null);
 
   const brief = await judgment.seatBrief({
     signalText: intent ? (intent.summary ?? intent.payload ?? null) : null,
-    matchReasoning: typeof (opportunity as { reasoning?: unknown } | null)?.reasoning === "string"
-      ? (opportunity as unknown as { reasoning: string }).reasoning
-      : null,
+    matchReasoning: null,
     thread,
   });
   await deps.negotiationDatabase.setNegotiationBrief(task.id, seatUserId, brief);

--- a/packages/protocol/src/internal/agents/personal-agent/agent.types.ts
+++ b/packages/protocol/src/internal/agents/personal-agent/agent.types.ts
@@ -48,14 +48,8 @@ export type PersonalAgentInput =
   | { userId: string; intentId: string; event: "matches_ready" }
   /** Every negotiation of `(intentId, round)` has paused. */
   | { userId: string; intentId: string; event: "all_paused"; round: number }
-  /**
-   * One negotiator turn for the given seat. `intentId` is the SPEAKING seat's
-   * own signal and is absent when that seat has not bound one — it appears
-   * only once that seat's own kickoff has opened or re-kicked this
-   * negotiation (D21), and it is never guessed from the opportunity's actor
-   * rows. The routing key is `negotiationId`.
-   */
-  | { userId: string; intentId?: string; negotiationId: string };
+  /** One negotiator turn for the given seat and its own signal. */
+  | { userId: string; intentId: string; negotiationId: string };
 
 export type PersonalAgentScope = "global" | "intent" | "negotiation";
 

--- a/packages/protocol/src/internal/negotiations/negotiation.graph.ts
+++ b/packages/protocol/src/internal/negotiations/negotiation.graph.ts
@@ -295,17 +295,17 @@ async function turnNode(state: NegotiationState, deps: NegotiationGraphDeps): Pr
     // it because history is non-empty).
     const isOpening = messages.length === 0;
 
+    const opportunity = await deps.database.getOpportunity(task.metadata.opportunityId);
+    const actor = opportunity?.actors.find((candidate) => candidate.userId === speakerId && candidate.role !== "introducer");
+    if (!actor?.intent) return { task, turns, phase: "error", error: "Speaking opportunity actor has no intent" };
+
     // Every turn is authored in-process, synchronously, within this invoke:
     // the author is the speaking seat's own PersonalAgent in negotiation
     // scope, which reads the thread and the brief and answers with one verb.
     const authored = await deps.author.authorTurn({
       negotiationId: task.id,
       userId: speakerId,
-      // The SPEAKING seat's own signal, when it has bound one. A seat that has
-      // not kicked this negotiation off yet has no binding, and guessing one
-      // from the opportunity's actor rows is exactly the premise-matched
-      // ambiguity that field cannot be trusted for.
-      ...(seatIntentOf(meta, speakerId) ? { intentId: seatIntentOf(meta, speakerId)! } : {}),
+      intentId: actor.intent,
     });
     const turn: NegotiationTurn = isOpening ? NegotiationOpeningTurnSchema.parse(authored) : authored;
 
@@ -423,11 +423,6 @@ async function applyNode(state: NegotiationState, deps: NegotiationGraphDeps): P
   } catch (err) {
     return { phase: "error", error: err instanceof Error ? err.message : String(err) };
   }
-}
-
-/** The signal a seat has bound to this negotiation, if it has bound one. */
-export function seatIntentOf(meta: NegotiationTaskMetadata, userId: string): string | undefined {
-  return Object.entries(meta.seats).find(([, binding]) => binding.userId === userId)?.[0];
 }
 
 /**

--- a/packages/protocol/src/internal/negotiations/negotiation.turn-author.ts
+++ b/packages/protocol/src/internal/negotiations/negotiation.turn-author.ts
@@ -21,12 +21,8 @@ export interface NegotiationTurnAuthorInput {
   negotiationId: string;
   /** The seat speaking — the graph's computed next speaker. */
   userId: string;
-  /**
-   * The SPEAKING seat's own signal, when it has bound one. Absent for a seat
-   * that has not kicked this negotiation off yet — its signal is not
-   * guessable from the opportunity's actor rows.
-   */
-  intentId?: string;
+  /** The speaking seat's own persisted opportunity-actor signal. */
+  intentId: string;
 }
 
 export interface NegotiationTurnAuthor {


### PR DESCRIPTION
## Summary
- resolve each negotiation turn's required signal from its speaking opportunity actor
- pass the required intent through PersonalAgent negotiation scope into brief construction
- cover the counterparty's first turn without a seat binding

## Verification
- bun test packages/protocol/src/capabilities/tests/personal-agent.e2e.spec.ts
- bun run --cwd packages/protocol build