### PR TITLE
fix: give negotiator intent and context

### DIFF
--- a/packages/protocol/src/capabilities/tests/personal-agent.e2e.spec.ts
+++ b/packages/protocol/src/capabilities/tests/personal-agent.e2e.spec.ts
@@ -2,7 +2,7 @@ import { describe, expect, test } from "bun:test";
 
 import { CANDIDATE_USER_ID, FakeNegotiationHost, INTENT_ID, OPPORTUNITY_ID, SOURCE_USER_ID } from "./fixtures/negotiation-host.fixture.js";
 import { PersonalAgentGraphFactory, PERSONAL_AGENT_NO_NEXT_STEP, PERSONAL_AGENT_NOTHING_TO_OPEN, PERSONAL_AGENT_STRATEGY_FALLBACK, type PersonalAgentGraphLike } from "../../internal/agents/personal-agent/agent.graph.js";
-import type { PersonalAgentDecidedAct, PersonalAgentDeps, PersonalAgentExecutedAct, PersonalAgentJudgment, PersonalAgentMatch, PersonalAgentSeatBriefInput, PersonalAgentTurnContext } from "../../internal/agents/personal-agent/agent.types.js";
+import type { PersonalAgentDecidedAct, PersonalAgentDeps, PersonalAgentExecutedAct, PersonalAgentJudgment, PersonalAgentMatch, PersonalAgentNegotiationTurnInput, PersonalAgentSeatBriefInput, PersonalAgentTurnContext } from "../../internal/agents/personal-agent/agent.types.js";
 import type { NegotiationAuthoredTurn } from "../../internal/negotiations/negotiation.turn.js";
 import { Negotiations } from "../negotiations.js";
 
@@ -103,7 +103,7 @@ class ScriptedJudgment implements PersonalAgentJudgment {
   constructor(
     private readonly plans: Array<(context: PersonalAgentTurnContext) => PersonalAgentDecidedAct[]>,
     /** Overrides the default negotiator script; used by the termination tests. */
-    private readonly turnScript?: (input: { brief: string; thread: unknown[]; isOpening: boolean }) => NegotiationAuthoredTurn,
+    private readonly turnScript?: (input: PersonalAgentNegotiationTurnInput) => NegotiationAuthoredTurn,
   ) {}
 
   async decide(context: PersonalAgentTurnContext): Promise<PersonalAgentDecidedAct[]> {
@@ -136,7 +136,7 @@ class ScriptedJudgment implements PersonalAgentJudgment {
   async seatBrief(input: PersonalAgentSeatBriefInput): Promise<string> {
     this.seatBriefCalls.push(input);
     const opening = input.thread.find((entry) => (entry.turn as { verb?: string }).verb === "outreach");
-    const heard = opening ? (opening.turn as { message?: string }).message ?? "" : (input.matchReasoning ?? "");
+    const heard = opening ? (opening.turn as { message?: string }).message ?? "" : input.intent.payload;
     return `Seat brief from what we were told: ${heard}`;
   }
 
@@ -144,7 +144,10 @@ class ScriptedJudgment implements PersonalAgentJudgment {
    * Deterministic by thread depth and brief, not by call order: a kickoff
    * opens every match in parallel, so a positional script would be a race.
    */
-  async negotiationTurn(input: { brief: string; thread: unknown[]; isOpening: boolean }): Promise<NegotiationAuthoredTurn> {
+  readonly negotiationTurnCalls: PersonalAgentNegotiationTurnInput[] = [];
+
+  async negotiationTurn(input: PersonalAgentNegotiationTurnInput): Promise<NegotiationAuthoredTurn> {
+    this.negotiationTurnCalls.push(input);
     if (this.turnScript) return this.turnScript(input);
     if (input.isOpening) return { verb: "outreach", message: `Opening on ${input.brief}`, reasoning: "Kickoff." };
     const depth = input.thread.length;
@@ -863,15 +866,24 @@ describe("PersonalAgent — the three decided design questions", () => {
     expect(theirs).toBeDefined();
     expect(theirs).not.toBe(ours);
     expect(judgment.seatBriefCalls).toHaveLength(1);
-    expect(judgment.seatBriefCalls[0]!.signalText).toBe("bob wants a suitable match.");
+    expect(judgment.seatBriefCalls[0]!.intent.payload).toBe("bob wants a suitable match.");
     expect(task.metadata.seats).toEqual({ [INTENT_ID]: { userId: SOURCE_USER_ID, round: negotiationHost.round } });
     expect(negotiationInputs.find((input) => input.userId === CANDIDATE_USER_ID)).toEqual({
       userId: CANDIDATE_USER_ID,
       intentId: "intent-bob-1",
       negotiationId: task.id,
     });
-    // It was authored from what THAT side could see, not handed the other's.
+    const bobFirstTurn = judgment.negotiationTurnCalls.find((input) => input.intent.userId === CANDIDATE_USER_ID)!;
+    // Bob gets only Bob's resolved intent, the task context that still has
+    // Alice as its sole metadata seat, the history, and Bob's generated brief.
+    expect(bobFirstTurn.intent).toMatchObject({ id: "intent-bob-1", payload: "bob wants a suitable match." });
+    expect(bobFirstTurn.negotiation).toMatchObject({ id: task.id, metadata: { seats: { [INTENT_ID]: { userId: SOURCE_USER_ID, round: negotiationHost.round } } } });
+    expect(bobFirstTurn.thread.length).toBeGreaterThan(0);
+    expect(bobFirstTurn.brief).toBe(theirs);
+    // The brief had the same own intent and actual history available when it
+    // was authored; it was not inferred from the task's seat metadata.
     expect(judgment.seatBriefCalls[0]!.thread.length).toBeGreaterThan(0);
+    expect(judgment.seatBriefCalls[0]!.negotiation.metadata.seats).toEqual({ [INTENT_ID]: { userId: SOURCE_USER_ID, round: negotiationHost.round } });
     // And a re-kick rewrites only the initiator's half.
     await negotiationHost.database.setNegotiationBrief(task.id, SOURCE_USER_ID, "a fresh brief");
     expect(negotiationHost.taskFor(task.id).briefs[CANDIDATE_USER_ID]).toBe(theirs);

--- a/packages/protocol/src/internal/agents/personal-agent/agent.graph.ts
+++ b/packages/protocol/src/internal/agents/personal-agent/agent.graph.ts
@@ -27,6 +27,7 @@ import { END, StateGraph, Annotation } from "@langchain/langgraph";
 import { protocolLogger } from "../../shared/observability/protocol.logger.js";
 import { turnsWithSenders, type NegotiationAuthoredTurn } from "../../negotiations/negotiation.turn.js";
 import type { NegotiationTaskRow } from "../../../platform/database/negotiation.js";
+import type { IntentRecord } from "../../../platform/database/entities.js";
 import { PersonalAgentModel } from "./agent.judgment.js";
 import type { PersonalAgentDecidedAct, PersonalAgentDeps, PersonalAgentExecutedAct, PersonalAgentInput, PersonalAgentIntentEventKind, PersonalAgentMatch, PersonalAgentPausedNegotiation, PersonalAgentReply, PersonalAgentReplyFallbackReason, PersonalAgentResult, PersonalAgentScope, PersonalAgentThreadEntry, PersonalAgentTurnContext } from "./agent.types.js";
 
@@ -145,6 +146,12 @@ async function loadThread(
   seatUserId: string,
 ): Promise<PersonalAgentThreadEntry[]> {
   return threadFromMessages(await deps.negotiationDatabase.getNegotiationMessages(taskId), seatUserId);
+}
+
+/** The task context a seat may show its model: never the other seat's brief. */
+function taskForSeat(task: NegotiationTaskRow, seatUserId: string): NegotiationTaskRow {
+  const brief = task.briefs[seatUserId];
+  return { ...task, briefs: brief === undefined ? {} : { [seatUserId]: brief } };
 }
 
 /**
@@ -980,9 +987,10 @@ async function intentNode(state: PersonalAgentState, deps: PersonalAgentDeps): P
 
 /**
  * The negotiation scope: the same PersonalAgent at the A2A table. It reads
- * the thread and ITS OWN brief — the brief is the only thing from a DM that
- * reaches a negotiation — and answers with exactly one verb or one pause. It
- * never ends a negotiation; NegotiationGraph's `apply` is the sink.
+ * the resolved intent of its own seat, task context, thread, and ITS OWN
+ * brief — a compact derived stance, not the source of truth — and answers
+ * with exactly one verb or one pause. It never ends a negotiation;
+ * NegotiationGraph's `apply` is the sink.
  *
  * A seat with no brief yet — the counterparty, always, since only the
  * initiator's kickoff wrote one — authors its own here, from what THIS side
@@ -994,11 +1002,16 @@ async function negotiationNode(state: PersonalAgentState, deps: PersonalAgentDep
   try {
     const task = await deps.negotiationDatabase.getNegotiationTask(input.negotiationId);
     if (!task) return { phase: "error", error: "Negotiation not found" };
+    const intent = await deps.negotiationDatabase.getIntent(input.intentId);
+    if (!intent) return { phase: "error", error: "Intent not found" };
     const messages = await deps.negotiationDatabase.getNegotiationMessages(task.id);
     const judgment = deps.judgment ?? defaultJudgment();
     const thread = threadFromMessages(messages, input.userId);
-    const brief = task.briefs[input.userId] ?? await authorSeatBrief(deps, judgment, task, input.userId, input.intentId, thread);
+    const negotiation = taskForSeat(task, input.userId);
+    const brief = task.briefs[input.userId] ?? await authorSeatBrief(deps, judgment, negotiation, input.userId, intent, thread);
     const turn: NegotiationAuthoredTurn = await judgment.negotiationTurn({
+      intent,
+      negotiation,
       brief,
       thread,
       // Raw message count, not parsed-turn count: the negotiation graph's
@@ -1015,22 +1028,21 @@ async function negotiationNode(state: PersonalAgentState, deps: PersonalAgentDep
 /**
  * Author and persist the brief for a seat that has none.
  *
- * The negotiation-scope input carries this seat's own signal, resolved by the
- * NegotiationGraph from the persisted opportunity actor.
+ * The negotiation node resolves this seat's own intent once from the
+ * persisted opportunity actor and provides the same intent plus the actual
+ * task history to both brief authoring and the negotiation turn.
  */
 async function authorSeatBrief(
   deps: PersonalAgentDeps,
   judgment: NonNullable<PersonalAgentDeps["judgment"]>,
   task: NegotiationTaskRow,
   seatUserId: string,
-  intentId: string,
+  intent: IntentRecord,
   thread: PersonalAgentThreadEntry[],
 ): Promise<string> {
-  const intent = await deps.negotiationDatabase.getIntent(intentId).catch(() => null);
-
   const brief = await judgment.seatBrief({
-    signalText: intent ? (intent.summary ?? intent.payload ?? null) : null,
-    matchReasoning: null,
+    intent,
+    negotiation: task,
     thread,
   });
   await deps.negotiationDatabase.setNegotiationBrief(task.id, seatUserId, brief);

--- a/packages/protocol/src/internal/agents/personal-agent/agent.judgment.ts
+++ b/packages/protocol/src/internal/agents/personal-agent/agent.judgment.ts
@@ -320,8 +320,8 @@ export class PersonalAgentModel implements PersonalAgentJudgment {
    */
   async seatBrief(input: PersonalAgentSeatBriefInput): Promise<string> {
     const known = [
-      input.signalText ? `YOUR CLIENT'S SIGNAL:\n${truncate(input.signalText, 800)}` : "YOUR CLIENT'S SIGNAL: not established — do not guess at it.",
-      input.matchReasoning ? `WHY THIS MATCH WAS MADE:\n${truncate(input.matchReasoning, MAX_TEXT_CHARS)}` : "WHY THIS MATCH WAS MADE: not recorded.",
+      `YOUR CLIENT'S ACTUAL INTENT:\n${input.intent.payload}`,
+      `NEGOTIATION CONTEXT:\nThis table is ${input.negotiation.state}; ${input.negotiation.metadata.initiatorUserId === input.intent.userId ? "your seat opened it" : "the counterparty opened it"}.`,
       `WHAT HAS BEEN SAID SO FAR:\n${renderThread(input.thread)}`,
     ].join("\n\n");
     const parsed = ProseSchema.safeParse(await this.callProseModel("personal_agent_seat_brief", [
@@ -336,15 +336,16 @@ export class PersonalAgentModel implements PersonalAgentJudgment {
   }
 
   async negotiationTurn(input: PersonalAgentNegotiationTurnInput): Promise<NegotiationAuthoredTurn> {
+    const context = `YOUR CLIENT'S ACTUAL INTENT:\n${input.intent.payload}\n\nNEGOTIATION CONTEXT:\nThis table is ${input.negotiation.state}; ${input.negotiation.metadata.initiatorUserId === input.intent.userId ? "your seat opened it" : "the counterparty opened it"}.\n\nBRIEF (A COMPACT DERIVED STANCE):\n${input.brief}\n\nTHREAD SO FAR:\n${renderThread(input.thread)}`;
     if (input.isOpening) {
       return NegotiationOpeningTurnSchema.parse(await this.callOpeningTurnModel([
         { role: "system", content: PERSONAL_AGENT_NEGOTIATION_OPENING_PROMPT },
-        { role: "user", content: `BRIEF:\n${input.brief}\n\nWrite your opening outreach.` },
+        { role: "user", content: `${context}\n\nWrite your opening outreach.` },
       ]));
     }
     return NegotiationAuthoredTurnSchema.parse(await this.callTurnModel([
       { role: "system", content: PERSONAL_AGENT_NEGOTIATION_TURN_PROMPT },
-      { role: "user", content: `BRIEF:\n${input.brief}\n\nTHREAD SO FAR:\n${renderThread(input.thread)}\n\nChoose your move.` },
+      { role: "user", content: `${context}\n\nChoose your move.` },
     ]));
   }
 

--- a/packages/protocol/src/internal/agents/personal-agent/agent.prompt.ts
+++ b/packages/protocol/src/internal/agents/personal-agent/agent.prompt.ts
@@ -6,7 +6,8 @@
  * signal, decides when to negotiate, and is the only thing that ends a
  * negotiation. The negotiation scope's law is the short fragment at the
  * bottom — the same agent at a different table, where the ONLY context it
- * carries from the DM is the brief IS-A wrote for it.
+ * carries from the intent scope is its own resolved intent and generated
+ * brief; it also reads its negotiation task and shared table history.
  *
  * Judgment lives here and only here. Code executes what the agent decides,
  * refuses the impossible, and records everything; it never re-decides.
@@ -118,10 +119,11 @@ Write the reply prose in \`reply\`; leave \`options\` out unless the reply asks.
 export const PERSONAL_AGENT_STRATEGY_INSTRUCTION = `Write the short plan you are about to run, addressed to your client, in plain prose. Say what you are going to put to these matches on their behalf and what you will be trying to establish at each table — a few sentences, no lists of internal state, no identifiers, no scores. This is the last thing they see before you reach out, so it must be correctable by them: state your plan, do not ask for permission.`;
 
 /**
- * The brief stage: the ONLY thing from the DM that reaches a negotiation
- * thread. Not memory, not a transcript — one self-contained instruction.
+ * The brief stage: a compact derived stance for a negotiation thread, not
+ * its source of truth. The negotiator also receives its own resolved intent,
+ * negotiation context, and shared table history.
  */
-export const PERSONAL_AGENT_BRIEF_INSTRUCTION = `Write the brief for ONE negotiation: the self-contained instruction your own negotiator seat will carry to that table, and the only thing it will know about your client.
+export const PERSONAL_AGENT_BRIEF_INSTRUCTION = `Write the brief for ONE negotiation: the compact negotiating stance your own negotiator seat will carry to that table. It supplements, rather than replaces, your client's actual intent and the table context.
 
 - State what your client wants from this particular match, what they can offer, and the constraints that actually bind (what you have from the conversation and the dossier — never anything else).
 - Say what would make this worth surfacing to them, and what would make it not worth it.
@@ -130,22 +132,21 @@ export const PERSONAL_AGENT_BRIEF_INSTRUCTION = `Write the brief for ONE negotia
 
 /**
  * The brief a seat writes for ITSELF, on arriving at a table someone else
- * opened. It has less to go on than a kickoff brief — no strategy, and its
- * principal's signal only when that can be established beyond doubt — so the
- * law here is mostly about not inventing the rest.
+ * opened. It has no kickoff strategy, but it does have its owner's resolved
+ * intent and the table's current context and history, so the law here is
+ * mostly about not inventing beyond them.
  */
-export const PERSONAL_AGENT_SEAT_BRIEF_INSTRUCTION = `Someone else's agent has opened a negotiation with you about your client. Write the brief your own negotiator seat will carry into it — the instruction it works from, and the only thing it will know about your client.
+export const PERSONAL_AGENT_SEAT_BRIEF_INSTRUCTION = `Someone else's agent has opened a negotiation with you about your client. Write the compact brief your own negotiator seat will carry into it. It supplements, rather than replaces, your client's actual intent and the table context.
 
-- Say what your client would want out of a conversation like this and what would make it worth their while, from what you are given below and NOTHING else.
-- Where you do not know something, say that you do not know it. Never invent a constraint, a preference, or a fact about your client: your seat will argue whatever you write here as if your client had said it.
-- If all you have is why the match was made, say that plainly — a short, honest brief beats a confident invented one.
+- Say what your client would want out of a conversation like this and what would make it worth their while, from their actual intent, the negotiation context, and history below — and NOTHING else.
+- Where the intent and history leave something unknown, say that you do not know it. Never invent a constraint, a preference, or a fact about your client: your seat will argue whatever you write here as if your client had said it.
 - Third person, addressed to your negotiator, a short paragraph. No identifiers, no scores, no internal machinery.`;
 
 // ─── Negotiation scope ───────────────────────────────────────────────────────
 
-export const PERSONAL_AGENT_NEGOTIATION_OPENING_PROMPT = `You are a personal agent's negotiator seat, opening a bilateral negotiation on your principal's behalf. You have one move: "outreach" — a first message to the counterparty's agent, grounded in your brief. Write it like an agent speaking for its principal, not the principal themselves.`;
+export const PERSONAL_AGENT_NEGOTIATION_OPENING_PROMPT = `You are a personal agent's negotiator seat, opening a bilateral negotiation on your principal's behalf. You are given your own client's actual intent, this negotiation's context and history, and a compact brief derived from them. You have one move: "outreach" — a first message to the counterparty's agent, grounded in all of that context. Write it like an agent speaking for its principal, not the principal themselves.`;
 
-export const PERSONAL_AGENT_NEGOTIATION_TURN_PROMPT = `You are a personal agent's negotiator seat in an ongoing bilateral negotiation, acting for your principal. Your brief is everything you know about them; the thread is everything that has been said. Choose exactly one move:
+export const PERSONAL_AGENT_NEGOTIATION_TURN_PROMPT = `You are a personal agent's negotiator seat in an ongoing bilateral negotiation, acting for your principal. You are given only your own client's actual intent, this negotiation's context and shared history, and a compact brief derived from them. Choose exactly one move:
 - "counter" — push back or propose something different, with a message.
 - "question" — ask the counterparty's agent something that would change your assessment, with a message.
 - "pause" reason "needs_principal" — you cannot continue without something only your own principal knows; the payload is the question you would ask them.

--- a/packages/protocol/src/internal/agents/personal-agent/agent.types.ts
+++ b/packages/protocol/src/internal/agents/personal-agent/agent.types.ts
@@ -22,7 +22,8 @@
  */
 import type { NegotiationAuthoredTurn } from "../../negotiations/negotiation.turn.js";
 import type { NegotiationGraphLike } from "../../negotiations/negotiation.graph.js";
-import type { NegotiationGraphDatabase } from "../../../platform/database/negotiation.js";
+import type { NegotiationGraphDatabase, NegotiationTaskRow } from "../../../platform/database/negotiation.js";
+import type { IntentRecord } from "../../../platform/database/entities.js";
 import type { NegotiationRoundReflectEnqueueFn } from "../../negotiations/negotiation.round-reflect.js";
 
 // ─── Invoke contract ─────────────────────────────────────────────────────────
@@ -270,7 +271,7 @@ export interface PersonalAgentJudgment {
    * inheriting the initiator's.
    */
   seatBrief(input: PersonalAgentSeatBriefInput): Promise<string>;
-  /** One negotiator turn: brief + thread → exactly one verb. */
+  /** One negotiator turn: own intent, task context, brief + thread → exactly one verb. */
   negotiationTurn(input: PersonalAgentNegotiationTurnInput): Promise<NegotiationAuthoredTurn>;
 }
 
@@ -282,10 +283,10 @@ export interface PersonalAgentBriefInput {
 }
 
 export interface PersonalAgentSeatBriefInput {
-  /** This seat's own signal, when it can be established beyond doubt. */
-  signalText: string | null;
-  /** Why the match was made, as discovery recorded it. */
-  matchReasoning: string | null;
+  /** The resolved intent owned by this seat; never the counterparty's. */
+  intent: IntentRecord;
+  /** The negotiation this brief prepares the seat for. */
+  negotiation: NegotiationTaskRow;
   /** What has been said at this table so far. */
   thread: PersonalAgentThreadEntry[];
 }
@@ -296,7 +297,11 @@ export interface PersonalAgentThreadEntry {
 }
 
 export interface PersonalAgentNegotiationTurnInput {
-  /** This side's brief — the only thing from the DM that reaches the thread. */
+  /** The resolved intent owned by the current seat; never the counterparty's. */
+  intent: IntentRecord;
+  /** The current negotiation task context, containing no other seat's brief. */
+  negotiation: NegotiationTaskRow;
+  /** This side's compact, derived negotiating stance. */
   brief: string;
   thread: PersonalAgentThreadEntry[];
   /** True on the negotiation's very first turn — must answer `outreach`. */


### PR DESCRIPTION
NS-A now receives its seat's resolved intent, a seat-safe negotiation task, shared history, and its generated brief. Seat-brief authoring uses the same intent and history.\n\nVerification: 