### PR TITLE
refactor(protocol)!: make PersonalAgent intent turns chat-first

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -89,7 +89,7 @@
     },
     "packages/protocol": {
       "name": "@indexnetwork/protocol",
-      "version": "33.0.0",
+      "version": "34.0.0",
       "dependencies": {
         "@langchain/core": "1.1.48",
         "@langchain/langgraph": "1.3.2",
@@ -106,7 +106,7 @@
     },
     "services/api": {
       "name": "@indexnetwork/api",
-      "version": "0.97.0",
+      "version": "0.97.1",
       "dependencies": {
         "@aws-sdk/client-s3": "^3.939.0",
         "@aws-sdk/s3-request-presigner": "^3.983.0",

--- a/docs/plans/2026-08-23-personal-agent-and-negotiation-graphs.md
+++ b/docs/plans/2026-08-23-personal-agent-and-negotiation-graphs.md
@@ -49,7 +49,7 @@ acceptance is not owner approval.
 - **Brief** — the per-negotiation, **per-seat** context an IS-A writes for its
   OWN seat. Not memory. The only thing from a DM that reaches a negotiation
   thread. The initiator's kickoff writes its own; the counterparty's agent
-  writes its own at its first turn (D18/D51).
+  writes its own at its first turn (D51).
 - **Strategy** — IS-A's plan for a round of negotiations, written in the DM
   before kickoff, visible to and correctable by the principal.
 - **Round** — one kickoff and the negotiations it started, ending when all of
@@ -61,8 +61,8 @@ acceptance is not owner approval.
 discovery persists matches for intent I          (all of them — no cap)
         │  event: matches_ready
         ▼
-IS-A ── (may ask first) ── strategy in DM ── brief × N in parallel ── kickoff
-                                        (up to MAX_MATCHES; the rest next round)
+IS-A ── conversational tool loop ── strategy in DM ── brief × N in parallel ── kickoff
+                                          (up to MAX_MATCHES; the rest next round)
         ▲                                                     │
         │                                                     │  negotiator turns flow A↔B
         │                                                     │  until every negotiation of
@@ -70,9 +70,8 @@ IS-A ── (may ask first) ── strategy in DM ── brief × N in parallel 
         │                                                     ▼
         └────────────────── reflect ◄────── all paused ───────┘
                       │
-              phase 1 · ASK    questions for the principal, merged across negotiations
-                      │        k = 0 → ACT; else post in DM, wait until all answered
-              phase 2 · ACT    reject / promote to pending / re-kick the rest with new briefs
+              The same conversational loop may ask, act, or do both in
+              context order. Each completed tool result informs the next choice.
 ```
 
 The negotiator never ends a negotiation. IS-A is the only terminator, and it
@@ -83,15 +82,14 @@ learns of it on its next reflect turn, if one triggers.
 
 ### Kickoff
 
-1. `matches_ready(I)` arrives. IS-A takes a DM turn. It may ask the principal
-   before reaching out; if it asks, kickoff waits for the answers and the
-   turn re-enters here.
+1. `matches_ready(I)` arrives. IS-A takes a normal DM turn and chooses whether
+   kickoff is useful in the current context.
 2. IS-A writes the **strategy** into the DM.
 3. IS-A derives one **brief** per match — intent, DM so far, strategy — in
    parallel, a few at a time. That brief is for IS-A's OWN seat; the
-   counterparty's agent writes its own (D18/D51).
+   counterparty's agent writes its own (D51).
 4. IS-A kicks off **every eligible match it was shown** — the same list the
-   prompt rendered, capped at `MAX_MATCHES` (D19/D52). No per-match selection
+   prompt rendered, capped at `MAX_MATCHES` (D52). No per-match selection
    by the agent: the negotiator filters by negotiating, and IS-A judges at
    reflect where it has turns to judge on. Matches over the cap, ones awaiting
    introducer approval, ones already the principal's to decide (`pending`) and
@@ -135,20 +133,15 @@ so an early first pause cannot dedupe away the round's real reflect.
 
 ### Reflect
 
-**Phase 1 — ASK.** Input: every paused negotiation **of the signal** (not just
-of the round — a negotiation a later kickoff left behind must stay decidable),
-with its reason, plus the payload of the pauses OUR OWN seat made, plus the
-DM. A counterparty's payload is theirs to hand to their own principal. IS-A composes the questions the principal must answer
-before anything is decided — `needs_principal` payloads merged and deduped
-across negotiations (one answer often serves several) plus its own gaps. If
-there are none, go to ACT. Otherwise post them in the DM and wait.
+Input is every paused negotiation **of the signal** (not just of the round — a
+negotiation a later kickoff left behind must stay decidable), with its reason,
+the payload of pauses OUR OWN seat made, and the DM. A counterparty's payload
+is theirs to hand to their own principal. IS-A uses that context in the same
+conversational tool loop as any other event. It can ask about a missing fact,
+act on an independent resolved matter, or do both; an executed result is shown
+before it chooses again.
 
-Answers are ordinary DM messages. On each, IS-A judges "all answered?" and
-keeps asking or clarifying until yes. The principal may say "go with what you
-have"; IS-A may then act, and may re-kick a subset when the unanswered
-questions concern only the others.
-
-**Phase 2 — ACT.** Only with the answers in hand:
+When appropriate, the available effects include:
 
 - `reject` — opportunity `rejected`, negotiation closed.
 - `promote` — opportunity `pending`; the principal sees it on the Radar.
@@ -156,8 +149,7 @@ questions concern only the others.
   DM + this negotiation's thread + the answers), in parallel, then kick all
   off together. Round counter bumps.
 
-Verdicts are never executed in phase 1: an answer to a knowledge question may
-change them. "Questions first" is ordering in code, not a prompt rule.
+Questions are ordinary `message_user` prose, not a privileged phase or tool.
 
 ## The two graphs
 
@@ -172,21 +164,19 @@ One LangGraph, one persona, one agent loop (today's persona-neutral
 | Input | Scope | What runs |
 |---|---|---|
 | `{ userId }` | global | deferred — graph-level input error for now |
-| `{ userId, intentId, event: user_message }` | IS-A | DM turn; includes "are my open questions answered? → ACT" |
-| `{ userId, intentId, event: matches_ready }` | IS-A | kickoff turn (may ask → strategy → briefs → open all) |
-| `{ userId, intentId, event: all_paused }` | IS-A | reflect phase 1 (→ phase 2 when nothing to ask) |
+| `{ userId, intentId, event: user_message }` | IS-A | conversational DM turn |
+| `{ userId, intentId, event: matches_ready }` | IS-A | conversational turn with new-match context |
+| `{ userId, intentId, event: all_paused }` | IS-A | conversational turn with paused-negotiation context |
 | `{ userId, negotiationId, intentId? }` | negotiator | one turn: read thread + its OWN brief → one verb or one pause. `intentId` is the speaking seat's signal when it has bound one (D21) |
 
 Scope decides: which conversation is read and written (the signal DM vs the
-negotiation thread), the prompt fragment, the verb set, and who the reply
-goes to (principal vs counterparty). `matches_ready` and `all_paused` are the
-same node — "look at the state, maybe ask, else act" — differing only in what
-ACT does.
+negotiation thread), the prompt fragment, the verb set, and who the reply goes
+to (principal vs counterparty). All intent events enter the same sequential
+conversation loop; background events are context, not a separate workflow state.
 
-IS-A verbs: `message_user` (with optional canned-reply options), `ask`
-(questions that block ACT), `kickoff`, `reject`, `promote`, `note_dossier` /
-`retire_dossier`, `accept_opportunity` on the principal's explicit word
-(unchanged from phase 2 of the IntentAgent plan). Verbs are tools; effects go
+IS-A verbs: `message_user` (with optional canned-reply options, including
+questions), `kickoff`, `reject`, `promote`, `note_dossier` / `retire_dossier`,
+`accept_opportunity` on the principal's explicit word. Verbs are tools; effects go
 through the domain graphs: kickoff/reject/promote/turns → NegotiationGraph;
 accept → the opportunity path.
 
@@ -202,7 +192,7 @@ dossier and reply stream become ports the host implements.
 | `{ negotiationId, brief, byUserId }` | resume with new context for ONE named seat |
 | `{ negotiationId, turn, byUserId }` | apply a submitted turn — from AgentGraph or an external agent, same verbs, same validation → continue or pause. `byUserId` is the submitting seat; `apply` rejects a turn whose `byUserId` is not the speaker it computed |
 | `{ negotiationId, pause: counterparty_silent \| open_failed }` | a timeout fired, or an open failed and left a live task |
-| `{ negotiationId, verdict: pending \| reject, reasoning, byUserId }` | resolve — the only terminal write on the negotiation, from IS-A ACT. `byUserId` is the authenticated resolving seat, which scopes the private outcome reasoning. It also closes the negotiation behind an owner verdict on the opportunity, and never writes over an already-terminal opportunity status (D23) |
+| `{ negotiationId, verdict: pending \| reject, reasoning, byUserId }` | resolve — the only terminal write on the negotiation, chosen by the agent. `byUserId` is the authenticated resolving seat, which scopes the private outcome reasoning. It also closes the negotiation behind an owner verdict on the opportunity, and never writes over an already-terminal opportunity status (D23) |
 | `{ negotiationId }` | read |
 
 `reasoning` is recorded on the outcome artifact and travels with the opportunity status — it is what the Radar card / closed card render. It is private to the resolving side: never persisted as a message into the A2A thread. A reject reason may contain principal-private material; the counterparty only ever sees that the negotiation closed.
@@ -316,7 +306,7 @@ Each step states its breaks in the PR and bumps the protocol major.
 Every solo design call taken while building this plan, with the alternative
 rejected. D1-D14 (the NegotiationGraph rewrite and the persona collapse) live
 in [2026-08-24-overnight-decisions.md](2026-08-24-overnight-decisions.md);
-D15+ below are the AgentGraph step's. D18-D20 in that log are three design
+D15+ below are the AgentGraph step's. D18-D20 in the overnight log are three design
 questions review rounds 2-5 raised and I first deferred; the owner's standing
 rule is that a legitimate design question gets DECIDED with the alternatives
 written down, not handed back, so they are decided there and implemented here
@@ -341,29 +331,31 @@ Alternative rejected: passing the already-loaded `{ brief, thread, isOpening }`
 `{ userId, intentId, negotiationId }` input and gives the graph two ways to
 know a thread.
 
-### D17. `wait` is deleted; an empty act list is the answer
-Chose: a turn that decides nothing returns no acts. The ledger already records
-what woke the turn.
-Alternative rejected: keeping `wait` as an explicit ledgered non-act — one
-more verb for a state the empty list already expresses.
+### D17. Intent scope is a sequential conversational tool loop
+Chose: each turn selects one tool, sees its durable result, then selects the
+next move or a natural `message_user` response. Questions are normal prose and
+may accompany independent work.
+Alternative rejected: a precomputed batch followed by a separate narration
+call — it hid tool outcomes from the next decision and imposed an unnecessary
+conversation policy.
 
-### D18. "Questions block ACT" is enforced in the validator, for every event
-Chose: any `ask` in a decided act list drops the `kickoff`/`promote`/`reject`
-acts beside it, on user_message turns as well as reflect turns.
-Alternative rejected: leaving it to the prompt — the plan says ordering in
-code, not a prompt rule, and the case it protects (an answer that changes the
-verdict) is exactly the one a model is most likely to get wrong.
+### D18. Irreversible calls are bounded within one assembled turn
+Chose: at most one kickoff, one promote/reject verdict per negotiation, and
+one acceptance per opportunity can execute against a turn's snapshot.
+Repeated choices are refused without a write or ledger entry, and a
+non-durable refusal observation lets the agent choose again from changed context.
+Alternative rejected: trusting a static snapshot after an irreversible write
+— it can re-round the same matches or resolve a negotiation twice.
 
-### D19. Kickoff runs last in a turn and re-reads the match list
-Chose: every other act executes in the model's order, then kickoff.
-Alternative rejected: strict model order — a promote or reject moves the
-opportunity's status, and a kickoff reading the turn's stale list would
-re-open the match it had just resolved.
+### D19. Kickoff follows the model's sequential choice
+Chose: kickoff executes when selected and reads the turn's bounded targets;
+the per-turn guard prevents a second kickoff from reusing that snapshot.
+Alternative rejected: graph-level reordering behind a precomputed batch.
 
 ### D20. A kickoff that opens nothing leaves the round unstamped
 Chose: no stamp, no reflect enqueue, `opened: 0` on the ledgered act.
 Alternative rejected: stamping zero — a stamped empty round is instantly
-"all paused", so reflect fires, ACT kicks off again, and the loop never ends.
+"all paused", so reflect fires, the agent kicks off again, and the loop never ends.
 
 ### D21. A capped negotiation is never re-kickable — read from its OWN state
 **Restated after review; the first version of this decision was wrong.**
@@ -399,7 +391,7 @@ mechanisms.
 
 ### D22. A pause payload stays scoped to the seat that paused
 Chose: reflect sees the full payload of OUR seat's pauses (the
-`needs_principal` questions ASK merges) and only the reason for the
+`needs_principal` questions the agent may surface) and only the reason for the
 counterparty's. The shared thread carries everything else.
 Alternative rejected: exposing every payload of the round — the counterparty's
 `needs_principal` question is for THEIR principal, and their
@@ -488,13 +480,9 @@ Chose: the validator drops the offending act and keeps the rest, exactly as
 `normalizeMessageOptions` drops a malformed chip, and returns `null` — the
 retry-then-throw path — only for output that did not parse at all.
 
-The first version also returned `null` when everything dropped, which on a
-client-message turn is the common case: a model that answers with nothing but
-an acts-stage `message_user` had every act dropped, was retried against an
-identical prompt with no feedback, produced the same output, and threw — so the
-client got the failure copy instead of the reply the reply stage writes anyway.
-An emptied list is a turn that decided nothing, and deciding nothing is a real
-answer.
+The pre-chat-first version also treated an empty batch as a retryable failure.
+The sequential loop instead requires a single valid next choice and uses an
+honest terminal fallback only when it cannot safely continue after an effect.
 
 Alternative rejected: refusing the whole round trip on any impossible act (the
 first shipped behaviour) — it discards the client's actual request, a verdict
@@ -668,13 +656,13 @@ queued reflect runs against an empty round and wakes the agent with "every
 negotiation of this round has paused" and nothing listed, inviting a kickoff
 that strands the round holding the actual work.
 
-### D44. The reply stage never throws — the whole stage, not just the model call
-Chose: the delivery and the ledger append inside the reply stage are guarded
-too, the way `recordKickoff` already guards its ledger.
-Alternative rejected: guarding only the model call (the shipped shape) — the
-acts are already executed and the reply may already be on the principal's
-screen, so a database blip after delivery failed the job and the retry
-re-decided and re-executed every verdict and kickoff on top of it.
+### D44. Durable effects terminate safely on later failure
+Chose: after any delivered principal message or durable tool result, a later
+failure ends the turn with an honest fallback rather than retrying the inbox
+job. Delivery and ledger writes are guarded where their effects have landed.
+Alternative rejected: retrying after a later model or database failure — a
+strategy or verdict may already be visible or durable, and replaying it can
+duplicate work.
 
 ### D45. A failed wake is kept, and its slot is not reused
 Chose: `matches_ready` jobs keep failed records, and a slot only accepts a new
@@ -741,7 +729,7 @@ BUNDLED validator bounds the index, and `judgment` is a documented swap seam,
 so a host or fixture implementation would throw mid-turn and abandon (then
 retry) every act already executed above it.
 
-### D51. One brief per SEAT, authored by that seat's own agent (log D18)
+### D51. One brief per SEAT, authored by that seat's own agent (overnight log D18)
 Chose: `brief` stops being one column read by whoever speaks. It is keyed by
 the seat's userId, the initiator's kickoff writes only its own, and a seat that
 arrives without one authors it at its first turn — `negotiationNode` already
@@ -764,7 +752,7 @@ counterparty's principal, so it would invent them. Migration 0148 drops
 `brief` for `briefs` with no backfill: a seat without one authors it, which is
 the new mechanism recovering in-flight rows rather than a migration guessing.
 
-### D52. Kickoff opens exactly the matches the agent decided from (log D19)
+### D52. Kickoff opens exactly the matches the agent decided from (overnight log D19)
 Chose: at most `MAX_MATCHES` (12) — the same cap `assembleContext` uses for
 the prompt — with the opens running three at a time. The agent decided from
 twelve, so it opens those twelve; the rest wait for the next round, which is
@@ -792,8 +780,10 @@ first replica.
 Chose: one policy for the whole kickoff region. Before the bump a failure is
 safe to retry, so it propagates. After it, the turn has done irreversible,
 principal-visible work — a strategy message and a new round — so every failure
-below is logged, ledgered and carried past: the compensation, the round read,
-the size stamp (retried three times first) and the reflect enqueue. A round
+below is logged, ledgered and carried past. Open failures also remain explicit
+in the accumulated kickoff result so the next conversational choice cannot
+mistake a compensated task for a successful open. The compensation, round read,
+size stamp (retried three times first) and reflect enqueue do not throw. A round
 left unsettled by one of them is recovered by the interrupted-round repair
 (D53), which exists for exactly that.
 Alternative rejected: letting the stamp or the compensation throw so a queue
@@ -804,7 +794,7 @@ the two halves of that contradiction; this states one policy for the region.
 
 ### D55. A negotiation binds a signal PER SEAT (log D21)
 Chose: `metadata.intentId` / `metadata.round` become `metadata.seats`, one
-binding per seat keyed by intent id (`{ userId, round }`) — the shape D18
+binding per seat keyed by intent id (`{ userId, round }`) — the shape D51
 already established for briefs. A kickoff binds its own seat and touches no
 other's, so a re-kick from either side can neither overwrite the other's brief
 nor leave the task in neither round: both were guard-able bugs and are now
@@ -843,15 +833,24 @@ to the principal as fact, which is the exact leak the gate exists for. If a
 future change widens it, widen it for every delivered surface at once, not
 here.
 
-### D57. A background turn never ends in silence
-Chose: an intent-scope turn on `matches_ready` or `all_paused` that produced
-no acts at all delivers one fixed line saying so.
-The doc's node is "look at the state, maybe ask, else act" — deciding NEITHER
-is not a state that contract has, but a model can return an empty act list.
-There is no reply stage behind a background event, so the turn would end
-silently; on reflect it would also consume the round's one retained job, and
-nothing would ever wake that signal again. The line keeps the loop reachable:
-the principal's next message is an ordinary turn that can ask or act.
-Alternative rejected: treating an empty list as a failure and retrying — the
-retry runs an identical prompt (D30), so it fails the same way and loses the
-wake instead of ending it honestly.
+### D57. A background turn has an explicit conversational terminal response
+Chose: every intent event, including `matches_ready` and `all_paused`, ends
+with the model's `message_user` response or an honest bounded-loop fallback.
+The terminal choice is tracked independently from earlier strategy messages,
+so a kickoff cannot hide exhaustion. This keeps the principal informed when a
+background wake has no further safe move.
+Alternative rejected: ending after effects merely because a background event
+has no separate narration phase.
+
+### D58. Awaited turns have an execution deadline, not only a controller wait
+Chose: a user-message job gets seventy seconds from its BullMQ enqueue
+timestamp, leaving twenty seconds inside the controller's ninety-second wait;
+an already-stale job is unrecoverable and never invokes the graph. Background
+jobs get a fresh seventy-second budget. The worker installs the remaining
+budget in request context, choice/prose calls add a fifteen-second per-call
+bound, and the intent loop checks cancellation before each new action. A
+kickoff checks again before strategy delivery and the round bump; after the
+bump its existing compensation and settlement region still finishes.
+Alternative rejected: timing out only the waiting controller — the serialized
+worker could continue mutating state or retry after the client had already
+received fixed failure copy.

--- a/packages/protocol/CHANGELOG.md
+++ b/packages/protocol/CHANGELOG.md
@@ -20,6 +20,43 @@ went 6.7.1 → 8.0.2 with no 7.x in between because the whole 7.x line shipped a
 prereleases between the two promotions. To track every change, read `rc`; to
 pin a supported release, use `latest`.
 
+## 34.0.0 - 2026-08-24
+
+### Breaking
+
+- **PersonalAgent intent turns use one sequential judgment choice at a time.**
+  `PersonalAgentJudgment.decide(context)` and
+  `PersonalAgentJudgment.reply(context, executed)` are replaced by
+  `next(context, executed, nonDurable?)`. Each call returns one
+  `PersonalAgentDecidedAct`; completed effects and refused irreversible calls
+  inform the next choice before the turn ends with `message_user`.
+- **The dedicated `ask` act is removed.** Questions are ordinary
+  `message_user` responses, so an unresolved question about one matter no
+  longer blocks an independent action on another. `PersonalAgentDecidedAct`
+  and `PersonalAgentExecutedAct` no longer include `ask`, and executed
+  `message_user` acts no longer carry reply-stage `stage` or `fallback`
+  fields.
+- **Executed kickoff results gain required attempt accounting.** Every
+  `PersonalAgentExecutedAct` with `tool: 'kickoff'` now includes `attempted`
+  and `failed` alongside `opened`.
+- **The separate reply-stage API is deleted.** Removed root exports:
+  `PERSONAL_AGENT_REPLY_FALLBACK`, `renderPersonalAgentReplyStage`,
+  `validateDecidedActs`, `PersonalAgentReply`, and
+  `PersonalAgentReplyFallbackReason`. Use the singular `validateDecidedAct`
+  for one choice.
+
+### Added
+
+- `PersonalAgentNonDurableObservation`, the feedback shape for an
+  irreversible tool choice refused before any write or ledger entry.
+
+### Changed
+
+- Intent-scope events now share one bounded, result-informed conversational
+  tool loop. Repeated irreversible calls are refused against the turn's
+  snapshot, and a failure after durable work or tool-budget exhaustion ends
+  with honest terminal copy instead of retrying earlier effects.
+
 ## 33.0.0 - 2026-08-24
 
 ### Breaking

--- a/packages/protocol/package.json
+++ b/packages/protocol/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@indexnetwork/protocol",
-  "version": "33.0.0",
+  "version": "34.0.0",
   "type": "module",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",

--- a/packages/protocol/src/capabilities/tests/personal-agent.e2e.spec.ts
+++ b/packages/protocol/src/capabilities/tests/personal-agent.e2e.spec.ts
@@ -1,15 +1,19 @@
 import { describe, expect, test } from "bun:test";
+import { AsyncLocalStorage } from "async_hooks";
 
 import { CANDIDATE_USER_ID, FakeNegotiationHost, INTENT_ID, OPPORTUNITY_ID, SOURCE_USER_ID } from "./fixtures/negotiation-host.fixture.js";
-import { PersonalAgentGraphFactory, PERSONAL_AGENT_NO_NEXT_STEP, PERSONAL_AGENT_NOTHING_TO_OPEN, PERSONAL_AGENT_STRATEGY_FALLBACK, type PersonalAgentGraphLike } from "../../internal/agents/personal-agent/agent.graph.js";
-import type { PersonalAgentDecidedAct, PersonalAgentDeps, PersonalAgentExecutedAct, PersonalAgentJudgment, PersonalAgentMatch, PersonalAgentNegotiationTurnInput, PersonalAgentSeatBriefInput, PersonalAgentTurnContext } from "../../internal/agents/personal-agent/agent.types.js";
+import { PersonalAgentGraphFactory, PERSONAL_AGENT_NOTHING_TO_OPEN, PERSONAL_AGENT_POST_ACTION_FAILURE, PERSONAL_AGENT_STRATEGY_FALLBACK, PERSONAL_AGENT_TOOL_BUDGET_EXHAUSTED, type PersonalAgentGraphLike } from "../../internal/agents/personal-agent/agent.graph.js";
+import type { PersonalAgentDecidedAct, PersonalAgentDeps, PersonalAgentExecutedAct, PersonalAgentJudgment, PersonalAgentMatch, PersonalAgentNegotiationTurnInput, PersonalAgentNonDurableObservation, PersonalAgentSeatBriefInput, PersonalAgentTurnContext } from "../../internal/agents/personal-agent/agent.types.js";
 import type { NegotiationAuthoredTurn } from "../../internal/negotiations/negotiation.turn.js";
 import { Negotiations } from "../negotiations.js";
+import { requestContext, setRequestContextStore } from "../../internal/shared/observability/request-context.js";
+
+setRequestContextStore(new AsyncLocalStorage());
 
 /**
  * The whole cycle, end to end: matches_ready → kickoff (strategy + a brief per
- * match, in parallel) → negotiator turns → all paused → reflect ASK → the
- * principal's answers → reflect ACT (promote / reject / re-kick).
+ * match, in parallel) → negotiator turns → all paused → further conversational
+ * turns that can act and respond in the order the current context warrants.
  *
  * Both real graphs run: the PersonalAgent's negotiation scope IS the
  * NegotiationGraph's turn author, so a kickoff genuinely self-plays every
@@ -29,6 +33,7 @@ class FakePrincipalHost {
   readonly ledgerRows: Array<{ event: Record<string, unknown>; act: Record<string, unknown> }> = [];
   readonly publishedChunks: Array<{ messageId: string; seq: number; content: string }> = [];
   readonly accepted: Array<{ opportunityId: string; reason?: string }> = [];
+  readonly retireCalls: string[] = [];
   private messageCounter = 0;
 
   constructor(private readonly negotiations: FakeNegotiationHost) {}
@@ -51,6 +56,7 @@ class FakePrincipalHost {
       return id;
     },
     retireEntry: async ({ entryId }) => {
+      this.retireCalls.push(entryId);
       const index = this.dossierEntries.findIndex((entry) => entry.id === entryId);
       if (index < 0) return false;
       this.dossierEntries.splice(index, 1);
@@ -97,32 +103,52 @@ class FakePrincipalHost {
 /** Scripted judgment: the ONE model seam, driven by the turn's own shape. */
 class ScriptedJudgment implements PersonalAgentJudgment {
   readonly decideCalls: PersonalAgentTurnContext[] = [];
-  readonly briefCalls: Array<{ opportunityId: string; strategy: string }> = [];
+  readonly strategyCalls: PersonalAgentTurnContext[] = [];
+  readonly briefCalls: Array<{ opportunityId: string; strategy: string; dossier: string[] }> = [];
   private cursor = 0;
+  private activeContext: PersonalAgentTurnContext | null = null;
+  private activePlan: PersonalAgentDecidedAct[] = [];
 
   constructor(
     private readonly plans: Array<(context: PersonalAgentTurnContext) => PersonalAgentDecidedAct[]>,
     /** Overrides the default negotiator script; used by the termination tests. */
     private readonly turnScript?: (input: PersonalAgentNegotiationTurnInput) => NegotiationAuthoredTurn,
+    /** Optional next-choice behavior once a turn's scripted actions are spent. */
+    private readonly afterActs?: (
+      context: PersonalAgentTurnContext,
+      executed: PersonalAgentExecutedAct[],
+      nonDurable: PersonalAgentNonDurableObservation[],
+    ) => PersonalAgentDecidedAct | Promise<PersonalAgentDecidedAct>,
   ) {}
 
-  async decide(context: PersonalAgentTurnContext): Promise<PersonalAgentDecidedAct[]> {
-    this.decideCalls.push(context);
-    const plan = this.plans[this.cursor];
-    this.cursor += 1;
-    return plan ? plan(context) : [];
+  async next(
+    context: PersonalAgentTurnContext,
+    executed: PersonalAgentExecutedAct[],
+    nonDurable: PersonalAgentNonDurableObservation[] = [],
+  ): Promise<PersonalAgentDecidedAct> {
+    if (context !== this.activeContext) {
+      this.activeContext = context;
+      if (executed.length === 0) {
+        this.decideCalls.push(context);
+        this.activePlan = this.plans[this.cursor++]?.(context) ?? [];
+      }
+    }
+    return this.activePlan.shift()
+      ?? await this.afterActs?.(context, executed, nonDurable)
+      ?? { tool: "message_user", text: `Here is where things stand after ${executed.length} act(s).` };
   }
 
-  async reply(_context: PersonalAgentTurnContext, executed: PersonalAgentExecutedAct[]): Promise<{ text: string }> {
-    return { text: `Here is where things stand after ${executed.length} act(s).` };
-  }
-
-  async strategy(): Promise<string> {
+  async strategy(context: PersonalAgentTurnContext): Promise<string> {
+    this.strategyCalls.push(context);
     return "I will put your constraints to each of them and find out who can actually move.";
   }
 
-  async brief(_context: PersonalAgentTurnContext, input: { match: PersonalAgentMatch; strategy: string }): Promise<string> {
-    this.briefCalls.push({ opportunityId: input.match.opportunityId, strategy: input.strategy });
+  async brief(context: PersonalAgentTurnContext, input: { match: PersonalAgentMatch; strategy: string }): Promise<string> {
+    this.briefCalls.push({
+      opportunityId: input.match.opportunityId,
+      strategy: input.strategy,
+      dossier: context.dossier.map((entry) => entry.text),
+    });
     return `Brief for ${input.match.opportunityId}: ${input.strategy}`;
   }
 
@@ -131,7 +157,7 @@ class ScriptedJudgment implements PersonalAgentJudgment {
   /**
    * The counterparty's own brief, authored at its first turn. It is written
    * from what THIS side can see — here, whatever the opening turn said — and
-   * never from the initiator's, which is the whole point of D18.
+   * never from the initiator's, which is the whole point of D51.
    */
   async seatBrief(input: PersonalAgentSeatBriefInput): Promise<string> {
     this.seatBriefCalls.push(input);
@@ -216,22 +242,402 @@ const userMessage = (text: string) => ({
   text,
 });
 
-describe("PersonalAgent — the whole cycle", () => {
-  test("matches_ready → ask → kickoff → all paused → reflect ASK → answers → ACT", async () => {
+describe("PersonalAgent — chat-first intent turns", () => {
+  test("acts on one resolved matter and asks about another in the same turn", async () => {
+    const judgment = new ScriptedJudgment([() => [
+      { tool: "note_dossier", text: "Can start in three weeks." },
+      { tool: "message_user", text: "I noted the timing. What compensation range should I use?" },
+    ]]);
+    const { agent, principal } = buildCycle(judgment, [CANDIDATE_USER_ID]);
+
+    const result = await agent.invoke(userMessage("I can start in three weeks."));
+
+    expect(result.acts.map((act) => act.tool)).toEqual(["note_dossier", "message_user"]);
+    expect(principal.dossierEntries.map((entry) => entry.text)).toEqual(["Can start in three weeks."]);
+    expect(result.messages).toEqual(["I noted the timing. What compensation range should I use?"]);
+  });
+
+  test("can ask naturally without fabricating work", async () => {
+    const judgment = new ScriptedJudgment([() => [
+      { tool: "message_user", text: "What timing would work for you?" },
+    ]]);
+    const { agent } = buildCycle(judgment, [CANDIDATE_USER_ID]);
+
+    const result = await agent.invoke({ userId: SOURCE_USER_ID, intentId: INTENT_ID, event: "matches_ready" });
+
+    expect(result.acts.map((act) => act.tool)).toEqual(["message_user"]);
+    expect(result.messages).toEqual(["What timing would work for you?"]);
+  });
+
+  test("answers a plain conversation without fabricated work", async () => {
+    const judgment = new ScriptedJudgment([() => [
+      { tool: "message_user", text: "I am here and keeping an eye on this signal." },
+    ]]);
+    const { agent } = buildCycle(judgment, [CANDIDATE_USER_ID]);
+
+    const result = await agent.invoke(userMessage("Thanks."));
+
+    expect(result.acts.map((act) => act.tool)).toEqual(["message_user"]);
+    expect(result.messages).toEqual(["I am here and keeping an eye on this signal."]);
+  });
+
+  test("uses the actual executed tool result before choosing the response", async () => {
+    const judgment = new ScriptedJudgment(
+      [() => [{ tool: "note_dossier", text: "Prefers remote." }]],
+      undefined,
+      (_context, executed) => {
+        const note = executed.find((act) => act.tool === "note_dossier");
+        return note?.entryId === "dossier-1"
+          ? { tool: "message_user", text: "I saved your remote preference for the negotiation table." }
+          : { tool: "message_user", text: "I could not save that preference." };
+      },
+    );
+    const { agent } = buildCycle(judgment, [CANDIDATE_USER_ID]);
+
+    const result = await agent.invoke(userMessage("Remote is important."));
+
+    expect(result.acts.map((act) => act.tool)).toEqual(["note_dossier", "message_user"]);
+    expect(result.messages).toEqual(["I saved your remote preference for the negotiation table."]);
+  });
+
+  test("refreshes the dossier after note_dossier before kickoff strategy and briefs", async () => {
+    const judgment = new ScriptedJudgment(
+      [() => [{ tool: "note_dossier", text: "Only remote roles." }]],
+      undefined,
+      (context, executed) => {
+        if (!executed.some((act) => act.tool === "kickoff")) {
+          return context.dossier.some((entry) => entry.text === "Only remote roles.")
+            ? { tool: "kickoff", reasoning: "Reach out with the new constraint." }
+            : { tool: "message_user", text: "The new dossier fact was missing." };
+        }
+        return { tool: "message_user", text: "I noted remote-only and used it in the outreach." };
+      },
+    );
+    const { agent } = buildCycle(judgment, [CANDIDATE_USER_ID]);
+
+    await agent.invoke(userMessage("Only remote roles, please."));
+
+    expect(judgment.strategyCalls).toHaveLength(1);
+    expect(judgment.strategyCalls[0]!.dossier.map((entry) => entry.text)).toEqual(["Only remote roles."]);
+    expect(judgment.briefCalls[0]!.dossier).toEqual(["Only remote roles."]);
+  });
+
+  test("refreshes the dossier after retire_dossier before kickoff strategy and briefs", async () => {
+    const judgment = new ScriptedJudgment(
+      [() => [{ tool: "retire_dossier", entryId: "dossier-old" }]],
+      undefined,
+      (context, executed) => {
+        if (!executed.some((act) => act.tool === "kickoff")) {
+          return context.dossier.length === 0
+            ? { tool: "kickoff", reasoning: "Reach out without the withdrawn constraint." }
+            : { tool: "message_user", text: "The retired dossier fact was still present." };
+        }
+        return { tool: "message_user", text: "I retired that constraint before reaching out." };
+      },
+    );
+    const { agent, principal } = buildCycle(judgment, [CANDIDATE_USER_ID]);
+    principal.dossierEntries.push({
+      id: "dossier-old", text: "Must be in London.", source: "user_message", createdAt: new Date(),
+    });
+
+    await agent.invoke(userMessage("London is no longer required."));
+
+    expect(judgment.strategyCalls).toHaveLength(1);
+    expect(judgment.strategyCalls[0]!.dossier).toEqual([]);
+    expect(judgment.briefCalls[0]!.dossier).toEqual([]);
+  });
+
+  test("does not retire an entry outside the assembled dossier snapshot", async () => {
+    const hiddenEntry = {
+      id: "dossier-hidden", text: "Still active but hidden from this snapshot.", source: "user_message", createdAt: new Date(),
+    };
+    const judgment = new ScriptedJudgment(
+      [() => [{ tool: "retire_dossier", entryId: hiddenEntry.id }]],
+      undefined,
+      (_context, executed) => executed.some((act) => act.tool === "retire_dossier" && !act.retired)
+        ? { tool: "message_user", text: "I could not retire an entry that was not available in this turn." }
+        : { tool: "message_user", text: "I did not see the retirement failure." },
+    );
+    const { agent, principal } = buildCycle(judgment, [CANDIDATE_USER_ID]);
+    principal.dossierEntries.push(hiddenEntry);
+    principal.dossier.readActiveEntries = async () => [];
+
+    const result = await agent.invoke(userMessage("Remove the hidden dossier fact."));
+
+    expect(principal.retireCalls).toEqual([]);
+    expect(principal.dossierEntries).toEqual([hiddenEntry]);
+    expect(result.acts[0]).toMatchObject({ tool: "retire_dossier", entryId: hiddenEntry.id, retired: false });
+    expect(result.messages).toEqual(["I could not retire an entry that was not available in this turn."]);
+  });
+
+  test("executes an explicit bounded acceptance once and recovers from a repeated call", async () => {
+    const judgment = new ScriptedJudgment(
+      [() => [
+        { tool: "accept_opportunity", opportunityId: OPPORTUNITY_ID, reason: "Client chose the first match." },
+        { tool: "accept_opportunity", opportunityId: OPPORTUNITY_ID, reason: "Duplicate." },
+      ]],
+      undefined,
+      (_context, _executed, nonDurable) => nonDurable.some((observation) =>
+        observation.tool === "accept_opportunity" && observation.opportunityId === OPPORTUNITY_ID)
+        ? { tool: "message_user", text: "I accepted the first match once." }
+        : { tool: "message_user", text: "I did not see the refused duplicate acceptance." },
+    );
+    const { agent, principal } = buildCycle(judgment, [CANDIDATE_USER_ID]);
+
+    const result = await agent.invoke(userMessage("Let's go with the first one."));
+
+    expect(principal.accepted).toEqual([{ opportunityId: OPPORTUNITY_ID, reason: "Client chose the first match." }]);
+    expect(result.acts.filter((act) => act.tool === "accept_opportunity")).toHaveLength(1);
+    expect(principal.ledgerRows.filter((row) => row.act.tool === "accept_opportunity")).toHaveLength(1);
+    expect(result.messages).toEqual(["I accepted the first match once."]);
+  });
+
+  test("does not accept an older match outside the bounded match snapshot", async () => {
+    const counterparties = Array.from({ length: 13 }, (_, index) => `candidate-${index + 1}`);
+    const judgment = new ScriptedJudgment(
+      [() => [{ tool: "accept_opportunity", opportunityId: OPPORTUNITY_ID, reason: "Injected hidden id." }]],
+      undefined,
+      (_context, executed) => executed.some((act) =>
+        act.tool === "accept_opportunity" && act.outcome === "not_available")
+        ? { tool: "message_user", text: "I could not accept a match outside this turn's available list." }
+        : { tool: "message_user", text: "I did not see the acceptance failure." },
+    );
+    const { agent, principal } = buildCycle(judgment, counterparties);
+
+    const result = await agent.invoke(userMessage("Accept the hidden older match."));
+
+    expect(principal.accepted).toEqual([]);
+    expect(result.acts[0]).toMatchObject({
+      tool: "accept_opportunity", opportunityId: OPPORTUNITY_ID, outcome: "not_available",
+    });
+    expect(result.messages).toEqual(["I could not accept a match outside this turn's available list."]);
+  });
+
+  test("refuses background acceptance and lets the agent recover without calling the host", async () => {
+    const judgment = new ScriptedJudgment(
+      [() => [{ tool: "accept_opportunity", opportunityId: OPPORTUNITY_ID }]],
+      undefined,
+      (_context, _executed, nonDurable) => nonDurable.some((observation) =>
+        observation.tool === "accept_opportunity" && observation.opportunityId === OPPORTUNITY_ID)
+        ? { tool: "message_user", text: "I need your explicit verdict before accepting that match." }
+        : { tool: "message_user", text: "I did not see the refused background acceptance." },
+    );
+    const { agent, principal } = buildCycle(judgment, [CANDIDATE_USER_ID]);
+
+    const result = await agent.invoke({
+      userId: SOURCE_USER_ID, intentId: INTENT_ID, event: "matches_ready",
+    });
+
+    expect(principal.accepted).toEqual([]);
+    expect(result.acts.map((act) => act.tool)).toEqual(["message_user"]);
+    expect(result.messages).toEqual(["I need your explicit verdict before accepting that match."]);
+  });
+
+  test("does not accept a match from hedge text", async () => {
+    const judgment = new ScriptedJudgment([() => [
+      { tool: "message_user", text: "It sounds promising. What would settle it for you?" },
+    ]]);
+    const { agent, principal } = buildCycle(judgment, [CANDIDATE_USER_ID]);
+
+    const result = await agent.invoke(userMessage("Maybe the first one? I'm not sure."));
+
+    expect(principal.accepted).toEqual([]);
+    expect(result.acts.map((act) => act.tool)).toEqual(["message_user"]);
+  });
+
+  test("does not start the chosen tool after the request signal aborts", async () => {
+    const controller = new AbortController();
+    const judgment = new ScriptedJudgment([() => {
+      controller.abort(new DOMException("deadline", "TimeoutError"));
+      return [{ tool: "note_dossier", text: "Must not be written." }];
+    }]);
+    const { agent, principal } = buildCycle(judgment, [CANDIDATE_USER_ID]);
+
+    const result = await requestContext.run(
+      { abortSignal: controller.signal },
+      () => agent.invoke(userMessage("Remember this.")),
+    );
+
+    expect(result.error).toBeDefined();
+    expect(result.acts).toEqual([]);
+    expect(principal.dossierEntries).toEqual([]);
+    expect(principal.ledgerRows).toEqual([]);
+  });
+
+  test("does not deliver strategy or bump the round when the deadline expires during strategy generation", async () => {
+    const controller = new AbortController();
+    const judgment = new ScriptedJudgment([() => [{ tool: "kickoff", reasoning: "Reach out." }]]);
+    judgment.strategy = async () => {
+      controller.abort(new DOMException("deadline", "TimeoutError"));
+      return "This strategy must not be delivered.";
+    };
+    const { agent, negotiationHost, principal } = buildCycle(judgment, [CANDIDATE_USER_ID]);
+
+    const result = await requestContext.run(
+      { abortSignal: controller.signal },
+      () => agent.invoke({ userId: SOURCE_USER_ID, intentId: INTENT_ID, event: "matches_ready" }),
+    );
+
+    expect(result.error).toBeDefined();
+    expect(result.acts).toEqual([]);
+    expect(principal.dmMessages).toEqual([]);
+    expect(principal.ledgerRows).toEqual([]);
+    expect(negotiationHost.round).toBe(1);
+  });
+
+  test("does not message, ledger, or wake when an empty kickoff expires during lifecycle reads", async () => {
+    const controller = new AbortController();
+    const judgment = new ScriptedJudgment([() => [{ tool: "kickoff", reasoning: "Check for work." }]]);
+    const { agent, negotiationHost, principal, wakes } = buildCycle(judgment, []);
+    const readLifecycle = negotiationHost.database.getIntentNegotiationRound;
+    negotiationHost.database.getIntentNegotiationRound = async (intentId) => {
+      const lifecycle = await readLifecycle.call(negotiationHost.database, intentId);
+      controller.abort(new DOMException("deadline", "TimeoutError"));
+      return lifecycle;
+    };
+
+    const result = await requestContext.run(
+      { abortSignal: controller.signal },
+      () => agent.invoke({ userId: SOURCE_USER_ID, intentId: INTENT_ID, event: "matches_ready" }),
+    );
+
+    expect(result.error).toBeDefined();
+    expect(result.acts).toEqual([]);
+    expect(principal.dmMessages).toEqual([]);
+    expect(principal.ledgerRows).toEqual([]);
+    expect(wakes).toEqual([]);
+  });
+
+  test("finishes compensation and settlement when the deadline aborts after the round bump", async () => {
+    const controller = new AbortController();
+    const judgment = new ScriptedJudgment([() => [{ tool: "kickoff", reasoning: "Reach out." }]]);
+    const { agent, negotiationHost, principal } = buildCycle(judgment, [CANDIDATE_USER_ID]);
+    const createMessage = negotiationHost.database.createNegotiationMessage;
+    let rejectedOpening = false;
+    negotiationHost.database.createNegotiationMessage = async (input) => {
+      if (!rejectedOpening) {
+        rejectedOpening = true;
+        controller.abort(new DOMException("deadline", "TimeoutError"));
+        return null;
+      }
+      return createMessage.call(negotiationHost.database, input);
+    };
+
+    const result = await requestContext.run(
+      { abortSignal: controller.signal },
+      () => agent.invoke({ userId: SOURCE_USER_ID, intentId: INTENT_ID, event: "matches_ready" }),
+    );
+
+    const task = [...negotiationHost.tasks.values()][0]!;
+    expect(result.error).toBeUndefined();
+    expect(task.state).toBe("paused");
+    expect(task.metadata.pause?.reason).toBe("open_failed");
+    expect(negotiationHost.roundSize).toBe(1);
+    expect(principal.dmMessages.at(-1)?.content).toBe(PERSONAL_AGENT_POST_ACTION_FAILURE);
+  });
+
+  test("refuses a repeated kickoff without opening a second round or strategy", async () => {
+    const judgment = new ScriptedJudgment(
+      [() => [
+        { tool: "kickoff", reasoning: "First outreach." },
+        { tool: "kickoff", reasoning: "Try it again." },
+      ]],
+      undefined,
+      (_context, _executed, nonDurable) => nonDurable.some((observation) =>
+        observation.kind === "irreversible_tool_refused" && observation.tool === "kickoff")
+        ? { tool: "message_user", text: "The first outreach is underway; the repeated kickoff was refused." }
+        : { tool: "message_user", text: "I did not see the refused kickoff." },
+    );
+    const { agent, negotiationHost, principal } = buildCycle(judgment, [CANDIDATE_USER_ID]);
+
+    const result = await agent.invoke({ userId: SOURCE_USER_ID, intentId: INTENT_ID, event: "matches_ready" });
+
+    expect(result.acts.filter((act) => act.tool === "kickoff")).toHaveLength(1);
+    expect(result.messages.at(-1)).toBe("The first outreach is underway; the repeated kickoff was refused.");
+    expect(negotiationHost.round).toBe(2);
+    expect(principal.dmMessages.filter((message) => message.content.includes("find out who can actually move"))).toHaveLength(1);
+    expect(principal.ledgerRows.filter((row) => row.act.tool === "kickoff")).toHaveLength(1);
+  });
+
+  test("refuses a repeated terminal verdict for the same negotiation", async () => {
     const judgment = new ScriptedJudgment([
-      // 1. matches_ready: ask before speaking on the principal's behalf.
-      () => [{ tool: "ask", text: "Before I reach out — what is your timeline?" }],
+      () => [
+        { tool: "kickoff", reasoning: "Open it." },
+        { tool: "message_user", text: "The negotiation is open." },
+      ],
+      (context) => {
+        const negotiationId = context.paused[0]!.negotiationId;
+        return [
+          { tool: "reject", negotiationId, reasoning: "Not a fit." },
+          { tool: "promote", negotiationId, reasoning: "Actually promote it." },
+        ];
+      },
+    ], undefined, (context, _executed, nonDurable) => {
+      const negotiationId = context.paused[0]!.negotiationId;
+      return nonDurable.some((observation) =>
+        observation.kind === "irreversible_tool_refused"
+        && observation.tool === "promote"
+        && observation.negotiationId === negotiationId)
+        ? { tool: "message_user", text: "I closed that negotiation as not a fit; the conflicting verdict was refused." }
+        : { tool: "message_user", text: "I did not see the refused verdict." };
+    });
+    const { agent, negotiationHost, principal } = buildCycle(judgment, [CANDIDATE_USER_ID]);
+
+    await agent.invoke({ userId: SOURCE_USER_ID, intentId: INTENT_ID, event: "matches_ready" });
+    const result = await agent.invoke({ userId: SOURCE_USER_ID, intentId: INTENT_ID, event: "all_paused", round: negotiationHost.round });
+
+    expect(result.acts.map((act) => act.tool)).toEqual(["reject", "message_user"]);
+    expect(result.messages).toEqual(["I closed that negotiation as not a fit; the conflicting verdict was refused."]);
+    expect(negotiationHost.opportunityStatusUpdates.filter((update) => update.status === "rejected")).toHaveLength(1);
+    expect(negotiationHost.opportunityStatusUpdates.filter((update) => update.status === "pending")).toHaveLength(0);
+    expect(principal.ledgerRows.filter((row) => row.act.tool === "reject")).toHaveLength(1);
+    expect(principal.ledgerRows.filter((row) => row.act.tool === "promote")).toHaveLength(0);
+  });
+
+  test("delivers the dedicated exhaustion response after kickoff's strategy", async () => {
+    const judgment = new ScriptedJudgment([() => [
+      { tool: "kickoff", reasoning: "Open it." },
+      ...Array.from({ length: 7 }, (_, index): PersonalAgentDecidedAct => ({ tool: "note_dossier", text: `Fact ${index + 1}.` })),
+    ]]);
+    const { agent, principal } = buildCycle(judgment, [CANDIDATE_USER_ID]);
+
+    const result = await agent.invoke({ userId: SOURCE_USER_ID, intentId: INTENT_ID, event: "matches_ready" });
+
+    expect(result.messages.at(-1)).toBe(PERSONAL_AGENT_TOOL_BUDGET_EXHAUSTED);
+    expect(principal.dmMessages.at(-1)?.content).toBe(PERSONAL_AGENT_TOOL_BUDGET_EXHAUSTED);
+    expect(result.acts.filter((act) => act.tool === "kickoff")).toHaveLength(1);
+  });
+
+  test("a strategy message makes a later round-bump failure non-retryable", async () => {
+    const judgment = new ScriptedJudgment([() => [{ tool: "kickoff", reasoning: "Open it." }]]);
+    const { agent, negotiationHost, principal } = buildCycle(judgment, [CANDIDATE_USER_ID]);
+    negotiationHost.database.bumpIntentNegotiationRound = async () => { throw new Error("round bump failed"); };
+
+    const result = await agent.invoke({ userId: SOURCE_USER_ID, intentId: INTENT_ID, event: "matches_ready" });
+
+    expect(result.error).toBeUndefined();
+    expect(principal.dmMessages.filter((message) => message.content.includes("find out who can actually move"))).toHaveLength(1);
+    expect(principal.dmMessages.at(-1)?.content).toBe(PERSONAL_AGENT_POST_ACTION_FAILURE);
+    expect(negotiationHost.round).toBe(1);
+  });
+});
+
+describe("PersonalAgent — the whole cycle", () => {
+  test("matches_ready → conversation → kickoff → all_paused → further conversation and actions", async () => {
+    const judgment = new ScriptedJudgment([
+      // 1. matches_ready: the agent asks for the missing timing.
+      () => [{ tool: "message_user", text: "Before I reach out — what is your timeline?" }],
       // 2. their answer: note it, then kick every match off.
       () => [
         { tool: "note_dossier", text: "Wants to start within a month." },
         { tool: "kickoff", reasoning: "Timeline is settled; reaching out to all three." },
       ],
-      // 3. all_paused (reflect phase 1): merge what the tables need into one ask.
+      // 3. all_paused: ask what one table still needs.
       (context) => {
         expect(context.paused).toHaveLength(3);
-        return [{ tool: "ask", text: "One of them needs your earliest start date — what should I say?" }];
+        return [{ tool: "message_user", text: "One of them needs your earliest start date — what should I say?" }];
       },
-      // 4. their answer (reflect phase 2 ACT): promote, reject, re-kick the rest.
+      // 4. their answer: promote, reject, and re-kick the rest.
       (context) => {
         const byOpportunity = new Map(context.paused.map((paused) => [paused.opportunityId, paused.negotiationId]));
         return [
@@ -245,7 +651,7 @@ describe("PersonalAgent — the whole cycle", () => {
 
     // ── 1. matches_ready: it asks, and reaches out to no one ──────────────
     const asked = await agent.invoke({ userId: SOURCE_USER_ID, intentId: INTENT_ID, event: "matches_ready" });
-    expect(asked.acts.map((act) => act.tool)).toEqual(["ask"]);
+    expect(asked.acts.map((act) => act.tool)).toEqual(["message_user"]);
     expect(negotiationHost.tasks.size).toBe(0);
     expect(principal.dmMessages.at(-1)?.content).toContain("what is your timeline");
 
@@ -255,7 +661,7 @@ describe("PersonalAgent — the whole cycle", () => {
       "note_dossier",
       "message_user", // the strategy, written into the DM before anyone is contacted
       "kickoff",
-      "message_user", // the reply stage
+      "message_user", // the model's natural terminal response
     ]);
     // One brief per match, all derived from the same strategy.
     expect(judgment.briefCalls.map((call) => call.opportunityId).sort())
@@ -277,24 +683,24 @@ describe("PersonalAgent — the whole cycle", () => {
     // duplicate a real effect — which also means a broken one records nothing
     // and says nothing, so it is asserted rather than assumed.
     expect(principal.ledgerRows.map((row) => row.act.tool))
-      .toEqual(["ask", "note_dossier", "message_user", "kickoff", "message_user"]);
+      .toEqual(["message_user", "note_dossier", "message_user", "kickoff", "message_user"]);
     // The principal's reply streamed back as ordered chunks.
     expect(principal.publishedChunks.map((chunk) => chunk.seq)).toEqual([1, 2, 3]);
 
-    // ── 3. reflect phase 1: it asks, and decides nothing ──────────────────
+    // ── 3. reflect: it asks, and decides nothing ──────────────────────────
     const reflectAsk = await agent.invoke({ userId: SOURCE_USER_ID, intentId: INTENT_ID, event: "all_paused", round });
-    expect(reflectAsk.acts.map((act) => act.tool)).toEqual(["ask"]);
+    expect(reflectAsk.acts.map((act) => act.tool)).toEqual(["message_user"]);
     expect(negotiationHost.opportunityStatusUpdates.filter((update) => update.status === "pending")).toHaveLength(0);
     expect(negotiationHost.opportunityStatusUpdates.filter((update) => update.status === "rejected")).toHaveLength(0);
 
-    // ── 4. reflect phase 2: promote, reject, re-kick ──────────────────────
+    // ── 4. next turn: promote, reject, re-kick ────────────────────────────
     const acted = await agent.invoke(userMessage("I could start in three weeks."));
     expect(acted.acts.map((act) => act.tool)).toEqual([
       "promote",
       "reject",
       "message_user", // the new round's strategy
       "kickoff",
-      "message_user", // the reply stage
+      "message_user", // the model's natural terminal response
     ]);
     expect(negotiationHost.opportunities.get(SECOND_OPPORTUNITY_ID)!.status).toBe("pending");
     expect(negotiationHost.opportunities.get(THIRD_OPPORTUNITY_ID)!.status).toBe("rejected");
@@ -314,7 +720,7 @@ describe("PersonalAgent — the whole cycle", () => {
         const ours = context.paused.find((paused) => paused.opportunityId === OPPORTUNITY_ID)!;
         const theirs = context.paused.find((paused) => paused.opportunityId === THIRD_OPPORTUNITY_ID)!;
         // Our own seat's needs_principal question is exactly what reflect
-        // merges into its ASK.
+        // asks naturally about the independent unresolved matter.
         expect(ours.pausedByUs).toBe(true);
         expect(ours.payload).toEqual({ question: "What is the earliest you could start?" });
         // Their agent's recommendation is theirs to hand to their principal.
@@ -341,12 +747,14 @@ describe("PersonalAgent — the whole cycle", () => {
 
     const result = await agent.invoke({ userId: SOURCE_USER_ID, intentId: INTENT_ID, event: "matches_ready" });
     // The act names the round it actually looked at, not a placeholder.
-    // A background turn has no reply stage, so a kickoff with nothing to open
-    // must still SAY so — silence there ends the cycle with the principal
+    // A background turn still tells the principal when a kickoff has nothing to open;
+    // silence there ends the cycle with the principal
     // never told (the reflect job is retained and nothing is active).
-    expect(result.acts.map((act) => act.tool)).toEqual(["message_user", "kickoff"]);
-    expect(result.acts.at(-1)).toEqual({ tool: "kickoff", round: negotiationHost.round, opened: 0, reasoning: "Nothing to open." });
-    expect(result.messages).toHaveLength(1);
+    expect(result.acts.map((act) => act.tool)).toEqual(["message_user", "kickoff", "message_user"]);
+    expect(result.acts.find((act) => act.tool === "kickoff")).toEqual({
+      tool: "kickoff", round: negotiationHost.round, opened: 0, attempted: 0, failed: 0, reasoning: "Nothing to open.",
+    });
+    expect(result.messages).toHaveLength(2);
     expect(negotiationHost.roundSize).toBeNull();
     expect(negotiationHost.kickoffStartedAt).toBeNull(); // no round was ever begun
     expect(negotiationHost.reflectJobs).toEqual([]);
@@ -407,14 +815,16 @@ describe("PersonalAgent — termination and retry safety", () => {
     const briefCallsBefore = judgment.briefCalls.length;
     const acted = await agent.invoke({ userId: SOURCE_USER_ID, intentId: INTENT_ID, event: "all_paused", round: firstRound + 1 });
 
-    expect(acted.acts.map((act) => act.tool)).toEqual(["message_user", "kickoff"]);
-    expect(acted.acts.at(-1)).toEqual({ tool: "kickoff", round: firstRound + 1, opened: 0, reasoning: "Send them out." });
+    expect(acted.acts.map((act) => act.tool)).toEqual(["message_user", "kickoff", "message_user"]);
+    expect(acted.acts.find((act) => act.tool === "kickoff")).toEqual({
+      tool: "kickoff", round: firstRound + 1, opened: 0, attempted: 0, failed: 0, reasoning: "Send them out.",
+    });
     expect(negotiationHost.round).toBe(firstRound + 1); // no further bump
     expect(negotiationHost.tasks.size).toBe(2); // nothing re-opened
-    // No second STRATEGY and no model spend — the only thing added to the DM
-    // is the honest "nothing to open" line.
-    expect(principal.dmMessages).toHaveLength(strategyMessagesBefore + 1);
-    expect(principal.dmMessages.at(-1)!.content).toBe(PERSONAL_AGENT_NOTHING_TO_OPEN);
+    // No second STRATEGY and no extra brief spend — the turn adds the honest
+    // "nothing to open" line and its natural terminal response.
+    expect(principal.dmMessages).toHaveLength(strategyMessagesBefore + 2);
+    expect(principal.dmMessages.at(-2)!.content).toBe(PERSONAL_AGENT_NOTHING_TO_OPEN);
     expect(judgment.briefCalls).toHaveLength(briefCallsBefore); // no model spend
     expect(negotiationHost.reflectJobs).toHaveLength(reflectJobsBefore); // the loop ends here
   });
@@ -456,7 +866,7 @@ describe("PersonalAgent — termination and retry safety", () => {
     // The repair opened nothing, so it claims nothing: the one act reported is
     // the round this turn actually opened.
     expect(retried.acts.filter((act) => act.tool === "kickoff")).toEqual([
-      { tool: "kickoff", round: round + 1, opened: 1, reasoning: "Reaching out." },
+      { tool: "kickoff", round: round + 1, opened: 1, attempted: 1, failed: 0, reasoning: "Reaching out." },
     ]);
     expect(negotiationHost.roundSize).toBe(1);      // the stranded round is settled
     // The negotiation is RESUMED into the new round, never duplicated — the
@@ -497,8 +907,8 @@ describe("PersonalAgent — kickoff safety at the edges", () => {
 
     const result = await agent.invoke({ userId: SOURCE_USER_ID, intentId: INTENT_ID, event: "matches_ready" });
 
-    expect(result.acts.map((act) => act.tool)).toEqual(["message_user", "kickoff"]);
-    expect(principal.dmMessages).toHaveLength(1);            // the strategy was written
+    expect(result.acts.map((act) => act.tool)).toEqual(["message_user", "kickoff", "message_user"]);
+    expect(principal.dmMessages).toHaveLength(2);            // strategy, then natural terminal response
     expect(judgment.briefCalls).toHaveLength(1);             // a brief was derived
     expect(negotiationHost.round).toBe(5);                   // a NEW round, not a stamp of the stale one
     expect(negotiationHost.roundSize).toBe(1);
@@ -586,7 +996,7 @@ describe("PersonalAgent — what a turn may open, and what it may claim", () => 
     expect(negotiationHost.opportunityStatusUpdates.map((update) => update.id)).toEqual([OPPORTUNITY_ID]);
     // No brief was spent on it either.
     expect(judgment.briefCalls.map((call) => call.opportunityId)).toEqual([OPPORTUNITY_ID]);
-    expect(principal.dmMessages).toHaveLength(1); // strategy only
+    expect(principal.dmMessages).toHaveLength(2); // strategy, then natural terminal response
   });
 
   test("an open that failed AFTER outreach is not labelled 'nothing has been said'", async () => {
@@ -646,7 +1056,7 @@ describe("PersonalAgent — what a turn may open, and what it may claim", () => 
     expect(judgment.briefCalls.length).toBe(briefsBefore + 1);
     expect(principal.dmMessages.length).toBeGreaterThan(messagesBefore);
     expect(acted.acts.filter((act) => act.tool === "kickoff")).toEqual([
-      { tool: "kickoff", round: stranded + 1, opened: 1, reasoning: "They said go ahead." },
+      { tool: "kickoff", round: stranded + 1, opened: 1, attempted: 1, failed: 0, reasoning: "They said go ahead." },
     ]);
     expect(negotiationHost.roundSize).toBe(1);
   });
@@ -721,26 +1131,30 @@ describe("PersonalAgent — round-4 regressions", () => {
 
     const acted = await agent.invoke({ userId: SOURCE_USER_ID, intentId: INTENT_ID, event: "matches_ready" });
 
-    expect(acted.acts.map((act) => act.tool)).toEqual(["message_user", "kickoff"]);
-    expect(acted.acts.at(-1)).toEqual({ tool: "kickoff", round: stranded, opened: 0, reasoning: "Nothing left to open." });
+    expect(acted.acts.map((act) => act.tool)).toEqual(["message_user", "kickoff", "message_user"]);
+    expect(acted.acts.find((act) => act.tool === "kickoff")).toEqual({
+      tool: "kickoff", round: stranded, opened: 0, attempted: 0, failed: 0, reasoning: "Nothing left to open.",
+    });
     expect(negotiationHost.round).toBe(stranded);              // no bump
     expect(negotiationHost.roundSize).toBe(1);                 // settled all the same
     expect(negotiationHost.reflectJobs.map((job) => job.round)).toEqual([stranded]);
   });
 
-  test("a reply-stage failure never retries the turn's already-executed acts", async () => {
-    // The acts are durable and the reply may already be on the principal's
-    // screen; a thrown error here fails the job, and the retry re-decides and
-    // re-executes every verdict and kickoff on top of it.
-    const judgment = new ScriptedJudgment([() => [{ tool: "note_dossier", text: "Can start in a week." }]]);
+  test("a model failure after durable work ends with a ledgered fallback instead of retrying", async () => {
+    const judgment = new ScriptedJudgment(
+      [() => [{ tool: "note_dossier", text: "Can start in a week." }]],
+      undefined,
+      async () => { throw new Error("model unavailable after note"); },
+    );
     const { agent, principal } = buildCycle(judgment, [CANDIDATE_USER_ID]);
-    principal.conversation.addMessage = async () => { throw new Error("write failed"); };
 
     const result = await agent.invoke(userMessage("I can start in a week."));
 
     expect(result.error).toBeUndefined();
-    expect(result.acts.map((act) => act.tool)).toEqual(["note_dossier"]);
+    expect(result.acts.map((act) => act.tool)).toEqual(["note_dossier", "message_user"]);
     expect(principal.dossierEntries).toHaveLength(1);
+    expect(principal.dmMessages.at(-1)?.content).toBe(PERSONAL_AGENT_POST_ACTION_FAILURE);
+    expect(principal.ledgerRows.at(-1)?.act.tool).toBe("message_user");
   });
 
   test("an unapproved introduction is filtered before a brief is spent on it", async () => {
@@ -797,13 +1211,14 @@ describe("PersonalAgent — round-5 regressions", () => {
     // Reflecting on the LATER round must still see the one left behind.
     const acted = await agent.invoke({ userId: SOURCE_USER_ID, intentId: INTENT_ID, event: "all_paused", round: cappedRound + 1 });
 
-    expect(acted.acts).toEqual([{
+    expect(acted.acts[0]).toEqual({
       tool: "reject",
       negotiationId: capped.id,
       opportunityId: OPPORTUNITY_ID,
       reasoning: "Went nowhere.",
       outcome: "resolved",
-    }]);
+    });
+    expect(acted.acts[1]).toMatchObject({ tool: "message_user" });
     expect(negotiationHost.opportunities.get(OPPORTUNITY_ID)!.status).toBe("rejected");
   });
 
@@ -843,14 +1258,14 @@ describe("PersonalAgent — round-5 regressions", () => {
     const result = await agent.invoke({ userId: SOURCE_USER_ID, intentId: INTENT_ID, event: "all_paused", round: 1 });
 
     expect(result.error).toBeUndefined();
-    expect(result.acts.map((act) => act.tool)).toEqual(["note_dossier", "reject"]);
-    expect(result.acts.at(-1)).toMatchObject({ outcome: "error" });
+    expect(result.acts.map((act) => act.tool)).toEqual(["note_dossier", "reject", "message_user"]);
+    expect(result.acts[1]).toMatchObject({ outcome: "error" });
     expect(principal.dossierEntries).toHaveLength(1); // the earlier act stands
   });
 });
 
 describe("PersonalAgent — the three decided design questions", () => {
-  test("D18: each seat negotiates from its OWN brief, authored by its own agent", async () => {
+  test("D51: each seat negotiates from its OWN brief, authored by its own agent", async () => {
     const judgment = new ScriptedJudgment([() => [{ tool: "kickoff", reasoning: "Reaching out." }]]);
     const { agent, negotiationHost, negotiationInputs } = buildCycle(judgment, [CANDIDATE_USER_ID]);
 
@@ -889,7 +1304,7 @@ describe("PersonalAgent — the three decided design questions", () => {
     expect(negotiationHost.taskFor(task.id).briefs[CANDIDATE_USER_ID]).toBe(theirs);
   });
 
-  test("D18: a seat authors its brief once, then reuses it", async () => {
+  test("D51: a seat authors its brief once, then reuses it", async () => {
     const judgment = new ScriptedJudgment(
       [() => [{ tool: "kickoff", reasoning: "Reaching out." }], () => [{ tool: "kickoff", reasoning: "Again." }]],
       (input) => (input.isOpening
@@ -909,7 +1324,7 @@ describe("PersonalAgent — the three decided design questions", () => {
     expect([...negotiationHost.tasks.values()][0]!.briefs[CANDIDATE_USER_ID]).toBe(authored);
   });
 
-  test("D19: kickoff opens exactly the matches the agent decided from, and the rest wait", async () => {
+  test("D52: kickoff opens exactly the matches the agent decided from, and the rest wait", async () => {
     // Fifteen matches; the prompt showed twelve, so twelve are opened. The
     // other three are not lost and — crucially — do not trigger another wake,
     // or a large signal would kick off over and over inside one round.
@@ -957,7 +1372,9 @@ describe("PersonalAgent — the three decided design questions", () => {
     expect(concurrent.error).toBeUndefined();
     expect(negotiationHost.round).toBe(stranded);      // no bump
     expect(negotiationHost.roundSize).toBeNull();      // and NOT settled out from under it
-    expect(concurrent.acts.at(-1)).toEqual({ tool: "kickoff", round: stranded, opened: 0, reasoning: "Concurrent turn." });
+    expect(concurrent.acts.find((act) => act.tool === "kickoff")).toEqual({
+      tool: "kickoff", round: stranded, opened: 0, attempted: 0, failed: 0, reasoning: "Concurrent turn.",
+    });
 
     // Past the bound the same round reads as abandoned, and is repaired.
     failStamp = false;
@@ -979,7 +1396,7 @@ describe("PersonalAgent — round-6: per-seat binding and the kickoff region", (
    * seat's slot and stamped its own round over the first seat's — so one side
    * argued the other's constraints and the task belonged to neither round.
    */
-  test("D18/D21: a second seat's kickoff binds its own signal and never touches the first's", async () => {
+  test("D51/D55: a second seat's kickoff binds its own signal and never touches the first's", async () => {
     const judgment = new ScriptedJudgment([() => [{ tool: "kickoff", reasoning: "Alice reaching out." }]]);
     const { agent, negotiationHost } = buildCycle(judgment, [CANDIDATE_USER_ID]);
     // Bob's agent opened this negotiation first, for Bob's own signal.
@@ -1011,22 +1428,20 @@ describe("PersonalAgent — round-6: per-seat binding and the kickoff region", (
     expect(await negotiationHost.database.getNegotiationTasksForIntentRound(INTENT_ID, negotiationHost.round)).toHaveLength(1);
   });
 
-  test("a background turn that decides nothing still says so — no silent end", async () => {
-    // The doc's node is "look, maybe ask, else act"; deciding NEITHER is not a
-    // state that contract has, but the model can return an empty act list. On
-    // a background event there is no reply stage, so silence there ends the
-    // signal — and for reflect it also consumes the round's one retained job.
+  test("a background turn can reply naturally without fabricating work", async () => {
+    // The scripted seam's empty plan falls through to a normal terminal
+    // response, just as the production loop requires the model to choose.
     const judgment = new ScriptedJudgment([() => [], () => []]);
     const { agent, principal } = buildCycle(judgment, [CANDIDATE_USER_ID]);
 
     const reflected = await agent.invoke({ userId: SOURCE_USER_ID, intentId: INTENT_ID, event: "all_paused", round: 1 });
     expect(reflected.acts.map((act) => act.tool)).toEqual(["message_user"]);
-    expect(principal.dmMessages.at(-1)!.content).toBe(PERSONAL_AGENT_NO_NEXT_STEP);
+    expect(principal.dmMessages.at(-1)!.content).toBe("Here is where things stand after 0 act(s).");
 
-    // A principal-message turn is unaffected: its reply stage speaks anyway.
+    // Client messages use the same conversational terminal response.
     const replied = await agent.invoke(userMessage("What is happening?"));
     expect(replied.acts.map((act) => act.tool)).toEqual(["message_user"]);
-    expect(replied.acts[0]).toMatchObject({ stage: "reply" });
+    expect(replied.messages).toEqual(["Here is where things stand after 0 act(s)."]);
   });
 
   test("D21: a negotiation the counterparty opened is still decidable by BOTH agents", async () => {
@@ -1064,7 +1479,7 @@ describe("PersonalAgent — round-6: per-seat binding and the kickoff region", (
     expect(judgment.decideCalls.at(-1)!.paused.map((paused) => paused.negotiationId)).toEqual([task.id]);
   });
 
-  test("D19: the agent is shown exactly what a kickoff would open", async () => {
+  test("D52: the agent is shown exactly what a kickoff would open", async () => {
     // Shown one list and opening another meant the agent was offered matches
     // a kickoff would skip and opened matches it had never been shown.
     const judgment = new ScriptedJudgment([(context) => {
@@ -1084,27 +1499,48 @@ describe("PersonalAgent — round-6: per-seat binding and the kickoff region", (
   });
 
   test("D22: a failed open is recorded and never leaves the round unsettleable", async () => {
-    const judgment = new ScriptedJudgment([() => [{ tool: "kickoff", reasoning: "Reaching out." }]]);
+    const judgment = new ScriptedJudgment(
+      [() => [{ tool: "kickoff", reasoning: "Reaching out." }]],
+      undefined,
+      (_context, executed) => {
+        const kickoff = executed.find((act) => act.tool === "kickoff");
+        return kickoff?.attempted === 2 && kickoff.failed === 1 && kickoff.opened === 2
+          ? { tool: "message_user", text: "I reached one match, but the other failed to open this round." }
+          : { tool: "message_user", text: "I did not receive the partial kickoff result." };
+      },
+    );
     const { agent, negotiationHost, principal } = buildCycle(judgment, [CANDIDATE_USER_ID, "carol"]);
-    // The brief for the second match never generates: no invoke ran, so there
-    // is no task for the compensation to find and the match would otherwise
-    // vanish from the turn entirely.
-    const brief = judgment.brief.bind(judgment);
-    judgment.brief = async (context, input) => {
-      if (input.match.opportunityId === SECOND_OPPORTUNITY_ID) throw new Error("brief model down");
-      return brief(context, input);
+    // The second task is created before its opening turn fails, then paused by
+    // compensation. It therefore counts in `opened` (the settled round size),
+    // making the separate attempted/failed result essential to an honest reply.
+    const createMessage = negotiationHost.database.createNegotiationMessage;
+    let failedSecondOpening = false;
+    negotiationHost.database.createNegotiationMessage = async (input) => {
+      const opportunityId = negotiationHost.tasks.get(input.taskId)?.metadata.opportunityId;
+      if (!failedSecondOpening && opportunityId === SECOND_OPPORTUNITY_ID) {
+        failedSecondOpening = true;
+        return null;
+      }
+      return createMessage.call(negotiationHost.database, input);
     };
 
     const acted = await agent.invoke({ userId: SOURCE_USER_ID, intentId: INTENT_ID, event: "matches_ready" });
 
     expect(acted.error).toBeUndefined();
-    expect(negotiationHost.tasks.size).toBe(1);
-    // The round still settles on what DID open, so it can still reflect.
-    expect(negotiationHost.roundSize).toBe(1);
+    expect(acted.acts.find((act) => act.tool === "kickoff")).toMatchObject({
+      opened: 2, attempted: 2, failed: 1,
+    });
+    expect(acted.messages.at(-1)).toBe("I reached one match, but the other failed to open this round.");
+    expect(negotiationHost.tasks.size).toBe(2);
+    // The round settles both the successful and compensated task, so it can reflect.
+    expect(negotiationHost.roundSize).toBe(2);
     expect(negotiationHost.reflectJobs).toHaveLength(1);
     // And the loss is on the record, not silent.
     expect(principal.ledgerRows.some((row) => typeof row.act.reasoning === "string"
       && row.act.reasoning.includes("Could not open 1 of 2"))).toBe(true);
+    expect(principal.ledgerRows.filter((row) => row.act.tool === "kickoff").at(-1)?.act).toMatchObject({
+      opened: 2, attempted: 2, failed: 1,
+    });
   });
 
   test("D22: after the round bump nothing throws — the strategy is never re-sent", async () => {
@@ -1118,9 +1554,9 @@ describe("PersonalAgent — round-6: per-seat binding and the kickoff region", (
     const acted = await agent.invoke({ userId: SOURCE_USER_ID, intentId: INTENT_ID, event: "matches_ready" });
 
     expect(acted.error).toBeUndefined();
-    expect(acted.acts.map((act) => act.tool)).toEqual(["message_user", "kickoff"]);
+    expect(acted.acts.map((act) => act.tool)).toEqual(["message_user", "kickoff", "message_user"]);
     expect(negotiationHost.tasks.size).toBe(1);
-    expect(principal.dmMessages).toHaveLength(1); // one strategy, never two
+    expect(principal.dmMessages).toHaveLength(2); // one strategy, then one natural terminal response
   });
 
   test("F3: a strategy the prose gate keeps refusing falls back instead of losing the wake", async () => {

--- a/packages/protocol/src/index.ts
+++ b/packages/protocol/src/index.ts
@@ -247,9 +247,9 @@ export type {
  * host implements the ports (signal DM, dossier, act ledger, reply
  * transport, the owner's accept path) and wires ONE graph.
  */
-export { PersonalAgentGraphFactory, PERSONAL_AGENT_REPLY_FALLBACK, chunkReplyText } from "./internal/agents/personal-agent/agent.graph.js";
+export { PersonalAgentGraphFactory, chunkReplyText } from "./internal/agents/personal-agent/agent.graph.js";
 export type { PersonalAgentGraphLike } from "./internal/agents/personal-agent/agent.graph.js";
-export { PersonalAgentModel, renderPersonalAgentTurn, renderPersonalAgentReplyStage, normalizeMessageOptions, validateDecidedActs } from "./internal/agents/personal-agent/agent.judgment.js";
+export { PersonalAgentModel, renderPersonalAgentTurn, normalizeMessageOptions, validateDecidedAct } from "./internal/agents/personal-agent/agent.judgment.js";
 export { buildPersonalAgentSystemPrompt, isSafeAgentMessageProse, PERSONAL_AGENT_SYSTEM_PROMPT_VERSION } from "./internal/agents/personal-agent/agent.prompt.js";
 export type {
   PersonalAgentInput,
@@ -259,8 +259,7 @@ export type {
   PersonalAgentDeps,
   PersonalAgentDecidedAct,
   PersonalAgentExecutedAct,
-  PersonalAgentReply,
-  PersonalAgentReplyFallbackReason,
+  PersonalAgentNonDurableObservation,
   PersonalAgentJudgment,
   PersonalAgentTurnContext,
   PersonalAgentThreadEntry,

--- a/packages/protocol/src/internal/agents/personal-agent/agent.graph.ts
+++ b/packages/protocol/src/internal/agents/personal-agent/agent.graph.ts
@@ -5,31 +5,30 @@
  * The cycle this graph runs:
  *
  *   discovery persists matches ──► matches_ready ──► kickoff
- *     (may ask first) → strategy into the DM → one brief per match in
+ *     → strategy into the DM → one brief per match in
  *     parallel → open ALL of them. No selection at kickoff: the negotiator
  *     filters by negotiating, IS-A judges at reflect where it has turns to
  *     judge on.
  *
- *   every negotiation of the round paused ──► all_paused ──► reflect
- *     phase 1 ASK: the questions the principal must answer, merged across
- *     negotiations. If there are none, phase 2 ACT: reject / promote /
- *     re-kick the rest with fresh briefs. Verdicts NEVER execute in phase 1.
+ *   every negotiation of the round paused ──► all_paused ──► reflect,
+ *     where the agent can continue the conversation and take any supported
+ *     action in the order the current context warrants.
  *
- *   the principal wrote ──► user_message ──► a DM turn that can also ACT,
+ *   the principal wrote ──► user_message ──► a conversational tool turn,
  *     because answers to the reflect questions arrive as ordinary messages.
  *
- * `matches_ready` and `all_paused` are ONE node — "look at the state, maybe
- * ask, else act" — differing only in what ACT does. Judgment lives in the
+ * All intent events share one conversation loop. Judgment lives in the
  * prompt; this file is effects, and every effect leaves a ledger row.
  */
 import { END, StateGraph, Annotation } from "@langchain/langgraph";
 
 import { protocolLogger } from "../../shared/observability/protocol.logger.js";
+import { requestContext } from "../../shared/observability/request-context.js";
 import { turnsWithSenders, type NegotiationAuthoredTurn } from "../../negotiations/negotiation.turn.js";
 import type { NegotiationTaskRow } from "../../../platform/database/negotiation.js";
 import type { IntentRecord } from "../../../platform/database/entities.js";
 import { PersonalAgentModel } from "./agent.judgment.js";
-import type { PersonalAgentDecidedAct, PersonalAgentDeps, PersonalAgentExecutedAct, PersonalAgentInput, PersonalAgentIntentEventKind, PersonalAgentMatch, PersonalAgentPausedNegotiation, PersonalAgentReply, PersonalAgentReplyFallbackReason, PersonalAgentResult, PersonalAgentScope, PersonalAgentThreadEntry, PersonalAgentTurnContext } from "./agent.types.js";
+import type { PersonalAgentDecidedAct, PersonalAgentDeps, PersonalAgentExecutedAct, PersonalAgentInput, PersonalAgentIntentEventKind, PersonalAgentMatch, PersonalAgentNonDurableObservation, PersonalAgentPausedNegotiation, PersonalAgentResult, PersonalAgentScope, PersonalAgentThreadEntry, PersonalAgentTurnContext } from "./agent.types.js";
 
 const logger = protocolLogger("PersonalAgentGraph");
 
@@ -39,7 +38,7 @@ const MAX_LEDGER_ACTS = 20;
 /**
  * How many matches a turn sees, newest kept — a prolific signal must not
  * flood the prompt, and kickoff opens exactly the set the agent decided from
- * (D19). What is over the cap waits for the next round, which is what rounds
+ * (D52). What is over the cap waits for the next round, which is what rounds
  * are for.
  */
 const MAX_MATCHES = 12;
@@ -91,15 +90,8 @@ async function mapWithConcurrency<T, R>(
  */
 const NOT_KICKOFF_ELIGIBLE_STATUSES = new Set(["pending"]);
 
-/**
- * Fixed honest copy delivered when the reply stage could not produce prose
- * that passes the safety gate, or the reply model call itself failed.
- * Server-owned, never model text: the acts the turn executed are durable
- * either way, so the copy says that instead of pretending nothing happened.
- */
-export const PERSONAL_AGENT_REPLY_FALLBACK =
-  "I acted on your message and everything I did is recorded, but I could not compose a clean reply just now. "
-  + "Ask me where things stand and I will lay it out.";
+/** Bounded tool steps keep a faulty model from holding a serialized inbox forever. */
+const MAX_INTENT_TOOL_STEPS = 8;
 
 // ─── State ───────────────────────────────────────────────────────────────────
 
@@ -310,14 +302,70 @@ async function deliverMessage(
 
 interface TurnAccumulator {
   acts: PersonalAgentExecutedAct[];
+  nonDurable: PersonalAgentNonDurableObservation[];
   messages: string[];
+  /** The model explicitly selected the natural terminal response. */
+  finalMessageChosen: boolean;
+}
+
+/**
+ * The model sees completed tool results, but context remains a snapshot for
+ * one serialized turn. Do not let that snapshot turn one kickoff into several
+ * rounds or call an irreversible target twice. Even an error outcome can be
+ * uncertain, so it still consumes that target's one call for this snapshot.
+ */
+function isRepeatedIrreversibleAct(
+  act: PersonalAgentDecidedAct,
+  executed: PersonalAgentExecutedAct[],
+): boolean {
+  if (act.tool === "kickoff") return executed.some((entry) => entry.tool === "kickoff");
+  if (act.tool === "promote" || act.tool === "reject") {
+    return executed.some((entry) =>
+      (entry.tool === "promote" || entry.tool === "reject")
+      && entry.negotiationId === act.negotiationId);
+  }
+  if (act.tool === "accept_opportunity") {
+    return executed.some((entry) => entry.tool === "accept_opportunity" && entry.opportunityId === act.opportunityId);
+  }
+  return false;
+}
+
+function refusedIrreversibleObservation(act: PersonalAgentDecidedAct): PersonalAgentNonDurableObservation {
+  if (act.tool === "kickoff") {
+    return {
+      kind: "irreversible_tool_refused",
+      tool: "kickoff",
+      reason: "A kickoff already executed against this turn's snapshot. Choose a different next step.",
+    };
+  }
+  if (act.tool === "promote" || act.tool === "reject") {
+    return {
+      kind: "irreversible_tool_refused",
+      tool: act.tool,
+      negotiationId: act.negotiationId,
+      reason: "A terminal verdict already executed for this negotiation against this turn's snapshot. Choose a different next step.",
+    };
+  }
+  if (act.tool === "accept_opportunity") {
+    return {
+      kind: "irreversible_tool_refused",
+      tool: "accept_opportunity",
+      opportunityId: act.opportunityId,
+      reason: "An acceptance already executed for this match against this turn's snapshot. Choose a different next step.",
+    };
+  }
+  throw new Error("Only repeated irreversible acts can be refused here");
+}
+
+function throwIfIntentAborted(): void {
+  requestContext.getStore()?.abortSignal?.throwIfAborted();
 }
 
 async function say(
   deps: PersonalAgentDeps,
   context: PersonalAgentTurnContext,
   accumulator: TurnAccumulator,
-  tool: "message_user" | "ask",
+  tool: "message_user",
   text: string,
   options?: string[],
 ): Promise<void> {
@@ -354,10 +402,32 @@ async function ledgerOrLog(
   }
 }
 
+/** Record a terminal recovery even if its DM delivery itself is unavailable. */
+async function ledgerTerminalFallback(
+  deps: PersonalAgentDeps,
+  context: PersonalAgentTurnContext,
+  text: string,
+  cause: unknown,
+): Promise<void> {
+  try {
+    await deps.ledger.append({
+      userId: context.userId,
+      intentId: context.intentId,
+      event: { kind: context.event, ...(context.round !== undefined ? { round: context.round } : {}) },
+      act: {
+        tool: "terminal_fallback",
+        text,
+        cause: cause instanceof Error ? cause.message : String(cause),
+      },
+    });
+  } catch (ledgerError) {
+    logger.error("Failed to ledger terminal fallback", { intentId: context.intentId, error: ledgerError });
+  }
+}
+
 /**
  * Fixed, server-owned copy for a kickoff that has no one to reach out to.
- * A background turn has no reply stage behind it, so without this the
- * principal is told nothing at all and — with no negotiation left active and
+ * Without this, the principal is told nothing at all and — with no negotiation left active and
  * the round's reflect job retained forever — nothing can wake the agent for
  * this signal again.
  */
@@ -365,20 +435,15 @@ export const PERSONAL_AGENT_NOTHING_TO_OPEN =
   "There is nothing new for me to put to anyone on this signal right now — what I have is either "
   + "waiting on your decision or has run as far as it can. Tell me if you want me to change tack.";
 
-/**
- * Fixed, server-owned copy for a background turn that decided nothing at all.
- *
- * The doc's node is "look at the state, maybe ask, else act" — deciding
- * NEITHER is not a state that contract has. It is reachable anyway (the model
- * can return an empty act list), and on a background event there is no reply
- * stage behind it, so the turn would end in silence: for reflect that also
- * consumes the round's one retained job, and the signal is never heard from
- * again. Saying this keeps the loop reachable — the principal's next message
- * is an ordinary `user_message` turn that can ask or act.
- */
-export const PERSONAL_AGENT_NO_NEXT_STEP =
-  "I looked at where this signal stands and I do not have a next step for it right now. "
-  + "Tell me how you would like to proceed and I will pick it up.";
+/** Honest terminal response when the bounded loop has already done work. */
+export const PERSONAL_AGENT_TOOL_BUDGET_EXHAUSTED =
+  "I reached my turn limit before I could safely choose another step. "
+  + "I have recorded what happened; please tell me how you want to continue.";
+
+/** Honest terminal response when a later model choice fails after durable work. */
+export const PERSONAL_AGENT_POST_ACTION_FAILURE =
+  "I completed some work, but I could not safely continue this turn after that. "
+  + "I have recorded what happened; please tell me how you want to proceed.";
 
 export const PERSONAL_AGENT_NO_MATCHES_YET =
   "Nothing has come up for this signal yet. I will pick it up as soon as it does.";
@@ -393,7 +458,7 @@ export const PERSONAL_AGENT_STRATEGY_FALLBACK =
   + "this once — ask me what I am putting to them and I will lay it out.";
 
 /**
- * Kickoff / re-kick: the ACT both event turns can reach.
+ * Kickoff / re-kick: one tool available in every intent event.
  *
  * Strategy into the DM first (the principal sees and can correct the plan),
  * then ONE BRIEF PER MATCH IN PARALLEL, then every match opened together.
@@ -448,14 +513,17 @@ async function runKickoff(
   }
 
   if (matches.length === 0) {
-    // Say so. A background turn has no reply stage, and with nothing active
+    throwIfIntentAborted();
+    // Say so. With nothing active
     // and the reflect job retained forever, silence here ends the cycle for
     // this signal with the principal never told.
     if (context.event !== "user_message") {
       await say(deps, context, accumulator, "message_user",
         context.matches.length === 0 ? PERSONAL_AGENT_NO_MATCHES_YET : PERSONAL_AGENT_NOTHING_TO_OPEN);
     }
-    await recordKickoff(deps, context, accumulator, { tool: "kickoff", round: lifecycle.round, opened: 0, reasoning });
+    await recordKickoff(deps, context, accumulator, {
+      tool: "kickoff", round: lifecycle.round, opened: 0, attempted: 0, failed: 0, reasoning,
+    });
     // Runs on this path too: it is the authoritative recovery for a batch the
     // inbox could not coalesce, and a turn with nothing to open is exactly
     // when a batch that landed mid-turn would otherwise be waited on forever.
@@ -467,15 +535,24 @@ async function runKickoff(
   // retry and propagates. The strategy itself falls back rather than throwing
   // — losing a whole wake because the prose gate disliked one sentence, three
   // times over an identical prompt, is not a trade worth making.
-  const strategy = await strategyOrFallback(judgment, context);
+  const kickoffContext: PersonalAgentTurnContext = {
+    ...context,
+    dossier: await deps.dossier.readActiveEntries(context.userId, context.intentId),
+  };
+  const strategy = await strategyOrFallback(judgment, kickoffContext);
+  throwIfIntentAborted();
   await say(deps, context, accumulator, "message_user", strategy);
 
+  throwIfIntentAborted();
   const round = await deps.negotiationDatabase.bumpIntentNegotiationRound(context.intentId);
   // ─── from here down, nothing throws (D54) ───────────────────────────────
+  // There are deliberately no cancellation gates below the bump. This
+  // kickoff is already underway: abort-aware brief/open calls reject into the
+  // settled results so compensation and round settlement can still finish.
   const threadByOpportunity = new Map(context.paused.map((paused) => [paused.opportunityId, paused.thread]));
 
   const opens = await mapWithConcurrency(matches, KICKOFF_CONCURRENCY, async (match) => {
-    const brief = await judgment.brief(context, {
+    const brief = await judgment.brief(kickoffContext, {
       match,
       strategy,
       thread: threadByOpportunity.get(match.opportunityId) ?? [],
@@ -506,13 +583,17 @@ async function runKickoff(
       tool: "kickoff",
       round,
       opened: 0,
+      attempted: matches.length,
+      failed: failed.length,
       reasoning: `Could not open ${failed.length} of ${matches.length} match(es) this round.`,
     });
   }
 
   const opened = await settleRound(deps, context, round, { triggerReflect: true });
   if (opened === 0 && repairedRound !== null) await triggerRoundReflect(deps, context, repairedRound);
-  await recordKickoff(deps, context, accumulator, { tool: "kickoff", round, opened, reasoning });
+  await recordKickoff(deps, context, accumulator, {
+    tool: "kickoff", round, opened, attempted: matches.length, failed: failed.length, reasoning,
+  });
   if (opened > 0) await wakeForNewMatches(deps, context);
 }
 
@@ -739,8 +820,7 @@ async function spentItsTurnBudget(deps: PersonalAgentDeps, match: PersonalAgentM
 }
 
 /**
- * Execute one decided act. Kickoff is not handled here — it runs last, after
- * every verdict, so it reads statuses the verdicts already moved.
+ * Execute one decided act. Kickoff uses its own multi-stage runner.
  */
 async function executeAct(
   deps: PersonalAgentDeps,
@@ -750,7 +830,6 @@ async function executeAct(
 ): Promise<void> {
   switch (act.tool) {
     case "message_user":
-    case "ask":
       await say(deps, context, accumulator, act.tool, act.text, act.options);
       return;
     case "promote":
@@ -794,6 +873,25 @@ async function executeAct(
       return;
     }
     case "accept_opportunity": {
+      // `judgment` is injectable, so production's numbered-reference
+      // validator is not the effects boundary. The host may read the signal's
+      // wider match set; never let an injected id reach a hidden match that
+      // was outside this turn's bounded snapshot.
+      if (!context.matches.some((match) => match.opportunityId === act.opportunityId)) {
+        logger.warn("Decided acceptance on a match this turn cannot see", {
+          intentId: context.intentId,
+          opportunityId: act.opportunityId,
+        });
+        const missing: PersonalAgentExecutedAct = {
+          tool: "accept_opportunity",
+          opportunityId: act.opportunityId,
+          outcome: "not_available",
+          ...(act.reason ? { reason: act.reason } : {}),
+        };
+        await ledgerOrLog(deps, context, missing);
+        accumulator.acts.push(missing);
+        return;
+      }
       // The principal's own explicit word, executing through the host's
       // untouched owner path. Nothing here re-decides explicitness: that law
       // is the prompt's.
@@ -826,6 +924,23 @@ async function executeAct(
       return;
     }
     case "retire_dossier": {
+      // As with verdict and acceptance ids, the documented judgment seam can
+      // bypass the numbered-reference validator. Retire only an entry in the
+      // active dossier snapshot the model was given.
+      if (!context.dossier.some((entry) => entry.id === act.entryId)) {
+        logger.warn("Decided retirement of a dossier entry this turn cannot see", {
+          intentId: context.intentId,
+          entryId: act.entryId,
+        });
+        const missing: PersonalAgentExecutedAct = {
+          tool: "retire_dossier",
+          entryId: act.entryId,
+          retired: false,
+        };
+        await ledgerOrLog(deps, context, missing);
+        accumulator.acts.push(missing);
+        return;
+      }
       const retired = await deps.dossier.retireEntry({ userId: context.userId, entryId: act.entryId });
       const executed: PersonalAgentExecutedAct = { tool: "retire_dossier", entryId: act.entryId, retired };
       await ledgerOrLog(deps, context, executed);
@@ -833,67 +948,6 @@ async function executeAct(
       return;
     }
   }
-}
-
-/**
- * The reply stage: a principal-message turn always ends with the agent's
- * conversational reply — a second model call over the same context plus the
- * just-executed acts, checked BEFORE it is persisted or a chunk leaves the
- * host. A reply the model could not produce safely becomes the fixed
- * fallback copy, and the failure is ledgered on the act — never a thrown
- * error: the acts already executed, and re-running them to retry prose would
- * trade a wording problem for duplicate effects.
- */
-async function runReplyStage(
-  deps: PersonalAgentDeps,
-  context: PersonalAgentTurnContext,
-  accumulator: TurnAccumulator,
-): Promise<void> {
-  const judgment = deps.judgment ?? defaultJudgment();
-  let composed: PersonalAgentReply | null = null;
-  let fallback: PersonalAgentReplyFallbackReason | undefined;
-  try {
-    composed = await judgment.reply(context, accumulator.acts);
-    if (composed === null) fallback = "safety_check_failed";
-  } catch (err) {
-    logger.error("PersonalAgent reply stage failed", {
-      userId: context.userId,
-      intentId: context.intentId,
-      error: err instanceof Error ? err.message : String(err),
-    });
-    fallback = "model_error";
-  }
-
-  const content = composed?.text ?? PERSONAL_AGENT_REPLY_FALLBACK;
-  const options = composed?.options;
-  // Everything below is guarded, because the file's contract for this stage —
-  // "never a thrown error" — has to be true of the whole stage, not just the
-  // model call. The turn's acts are already executed and durable; letting a
-  // delivery or ledger blip out of here fails the job, and the retry
-  // re-decides and re-executes every verdict and kickoff on top of a reply
-  // the principal may already be reading.
-  let delivered: { sessionId: string; messageId: string } | null = null;
-  try {
-    delivered = await deliverMessage(deps, context, content, options);
-  } catch (err) {
-    logger.error("Failed to deliver a turn's reply", {
-      userId: context.userId,
-      intentId: context.intentId,
-      error: err instanceof Error ? err.message : String(err),
-    });
-  }
-  if (!delivered) return;
-  const executed: PersonalAgentExecutedAct = {
-    tool: "message_user",
-    text: content,
-    ...(options ? { options } : {}),
-    ...delivered,
-    stage: "reply",
-    ...(fallback ? { fallback } : {}),
-  };
-  await ledgerOrLog(deps, context, executed);
-  accumulator.acts.push(executed);
-  accumulator.messages.push(content);
 }
 
 /**
@@ -942,45 +996,91 @@ async function publishTurnMessages(
 
 async function intentNode(state: PersonalAgentState, deps: PersonalAgentDeps): Promise<Partial<PersonalAgentState>> {
   const input = state.input as Extract<PersonalAgentInput, { event: PersonalAgentIntentEventKind }>;
+  let context: PersonalAgentTurnContext | null = null;
+  let accumulator: TurnAccumulator | null = null;
   try {
-    const context = await assembleContext(deps, input);
+    context = await assembleContext(deps, input);
     const judgment = deps.judgment ?? defaultJudgment();
-    const decided = await judgment.decide(context);
-    logger.info("PersonalAgent turn decided", {
-      userId: context.userId,
-      intentId: context.intentId,
-      event: context.event,
-      acts: decided.map((act) => act.tool),
-    });
-
-    const accumulator: TurnAccumulator = { acts: [], messages: [] };
-    // Kickoff runs last, after every verdict — it re-reads the match list, and
-    // a match this turn promoted or rejected must not be re-opened.
-    const kickoff = decided.find((act): act is Extract<PersonalAgentDecidedAct, { tool: "kickoff" }> => act.tool === "kickoff");
-    for (const act of decided) {
-      if (act.tool === "kickoff") continue;
-      await executeAct(deps, context, accumulator, act);
+    accumulator = { acts: [], nonDurable: [], messages: [], finalMessageChosen: false };
+    for (let step = 0; step < MAX_INTENT_TOOL_STEPS; step++) {
+      const act = await judgment.next(context, accumulator.acts, accumulator.nonDurable);
+      throwIfIntentAborted();
+      logger.info("PersonalAgent chose tool", { intentId: context.intentId, event: context.event, step, tool: act.tool });
+      if (act.tool === "accept_opportunity" && context.event !== "user_message") {
+        logger.warn("PersonalAgent refused acceptance without a client message", {
+          intentId: context.intentId,
+          event: context.event,
+        });
+        accumulator.nonDurable.push({
+          kind: "irreversible_tool_refused",
+          tool: "accept_opportunity",
+          opportunityId: act.opportunityId,
+          reason: "Acceptance requires an explicit verdict in a client message. Choose a different next step.",
+        });
+        continue;
+      }
+      if (isRepeatedIrreversibleAct(act, accumulator.acts)) {
+        logger.warn("PersonalAgent repeated an irreversible tool in one turn", {
+          intentId: context.intentId,
+          event: context.event,
+          tool: act.tool,
+        });
+        accumulator.nonDurable.push(refusedIrreversibleObservation(act));
+        continue;
+      }
+      if (act.tool === "message_user") {
+        accumulator.finalMessageChosen = true;
+        await executeAct(deps, context, accumulator, act);
+        break;
+      }
+      if (act.tool === "kickoff") await runKickoff(deps, context, accumulator, act.reasoning);
+      else {
+        await executeAct(deps, context, accumulator, act);
+        if (act.tool === "note_dossier" || act.tool === "retire_dossier") {
+          context = {
+            ...context,
+            dossier: await deps.dossier.readActiveEntries(context.userId, context.intentId),
+          };
+        }
+      }
     }
-    if (kickoff) await runKickoff(deps, context, accumulator, kickoff.reasoning);
-
-    // A background event has no reply stage behind it, so a turn that decided
-    // nothing would end in silence — and for reflect, silently consume the
-    // round's one retained job. Never the empty end of a cycle.
-    if (context.event !== "user_message" && accumulator.acts.length === 0) {
-      logger.warn("A background turn decided nothing", { intentId: context.intentId, event: context.event });
-      await say(deps, context, accumulator, "message_user", PERSONAL_AGENT_NO_NEXT_STEP);
+    if (!accumulator.finalMessageChosen) {
+      if (accumulator.acts.length === 0) throwIfIntentAborted();
+      logger.warn("PersonalAgent exhausted its intent tool budget", { intentId: context.intentId, event: context.event });
+      await say(deps, context, accumulator, "message_user", PERSONAL_AGENT_TOOL_BUDGET_EXHAUSTED);
     }
-
-    if (context.event === "user_message") {
-      await runReplyStage(deps, context, accumulator);
-      await publishTurnMessages(deps, input.event === "user_message" ? input.messageId : "", accumulator.messages);
-    }
+    if (input.event === "user_message") await publishTurnMessages(deps, input.messageId, accumulator.messages);
 
     return {
       phase: "done",
       result: { scope: "intent", acts: accumulator.acts, messages: accumulator.messages },
     };
   } catch (err) {
+    // An outer queue retry repeats the entire turn. Once a durable tool has
+    // completed, a later invalid model choice must therefore terminate this
+    // turn rather than replaying its earlier effects.
+    const durableEffectExecuted = (accumulator?.acts.length ?? 0) > 0;
+    if (context && accumulator && durableEffectExecuted) {
+      logger.error("PersonalAgent failed after a durable effect; ending turn without retry", {
+        intentId: context.intentId,
+        event: context.event,
+        error: err,
+      });
+      try {
+        await say(deps, context, accumulator, "message_user", PERSONAL_AGENT_POST_ACTION_FAILURE);
+      } catch (fallbackError) {
+        logger.error("PersonalAgent terminal fallback could not be delivered", {
+          intentId: context.intentId,
+          error: fallbackError,
+        });
+        await ledgerTerminalFallback(deps, context, PERSONAL_AGENT_POST_ACTION_FAILURE, err);
+      }
+      if (input.event === "user_message") await publishTurnMessages(deps, input.messageId, accumulator.messages);
+      return {
+        phase: "done",
+        result: { scope: "intent", acts: accumulator.acts, messages: accumulator.messages },
+      };
+    }
     return { phase: "error", error: err instanceof Error ? err.message : String(err) };
   }
 }
@@ -994,7 +1094,7 @@ async function intentNode(state: PersonalAgentState, deps: PersonalAgentDeps): P
  *
  * A seat with no brief yet — the counterparty, always, since only the
  * initiator's kickoff wrote one — authors its own here, from what THIS side
- * knows, and persists it. That is the whole of D18: the counterparty's agent
+ * knows, and persists it. That is the whole of D51: the counterparty's agent
  * arrives with its own instructions rather than the initiator's.
  */
 async function negotiationNode(state: PersonalAgentState, deps: PersonalAgentDeps): Promise<Partial<PersonalAgentState>> {

--- a/packages/protocol/src/internal/agents/personal-agent/agent.judgment.ts
+++ b/packages/protocol/src/internal/agents/personal-agent/agent.judgment.ts
@@ -19,8 +19,8 @@ import { createStructuredModel } from "../../shared/agent/model.config.js";
 import { invokeWithAbortSignal } from "../../shared/agent/model-signal.js";
 import { protocolLogger } from "../../shared/observability/protocol.logger.js";
 import { NegotiationAuthoredTurnSchema, NegotiationOpeningTurnSchema, type NegotiationAuthoredTurn, type NegotiationTurn } from "../../negotiations/negotiation.turn.js";
-import { buildPersonalAgentSystemPrompt, isSafeAgentMessageProse, personalAgentEventInstruction, PERSONAL_AGENT_BRIEF_INSTRUCTION, PERSONAL_AGENT_NEGOTIATION_OPENING_PROMPT, PERSONAL_AGENT_NEGOTIATION_TURN_PROMPT, PERSONAL_AGENT_REPLY_INSTRUCTION, PERSONAL_AGENT_SEAT_BRIEF_INSTRUCTION, PERSONAL_AGENT_STRATEGY_INSTRUCTION } from "./agent.prompt.js";
-import type { PersonalAgentBriefInput, PersonalAgentSeatBriefInput, PersonalAgentDecidedAct, PersonalAgentExecutedAct, PersonalAgentJudgment, PersonalAgentNegotiationTurnInput, PersonalAgentReply, PersonalAgentThreadEntry, PersonalAgentTurnContext } from "./agent.types.js";
+import { buildPersonalAgentSystemPrompt, isSafeAgentMessageProse, personalAgentEventInstruction, PERSONAL_AGENT_BRIEF_INSTRUCTION, PERSONAL_AGENT_NEGOTIATION_OPENING_PROMPT, PERSONAL_AGENT_NEGOTIATION_TURN_PROMPT, PERSONAL_AGENT_SEAT_BRIEF_INSTRUCTION, PERSONAL_AGENT_STRATEGY_INSTRUCTION } from "./agent.prompt.js";
+import type { PersonalAgentBriefInput, PersonalAgentSeatBriefInput, PersonalAgentDecidedAct, PersonalAgentExecutedAct, PersonalAgentJudgment, PersonalAgentNegotiationTurnInput, PersonalAgentNonDurableObservation, PersonalAgentThreadEntry, PersonalAgentTurnContext } from "./agent.types.js";
 
 const logger = protocolLogger("PersonalAgent:Judgment");
 
@@ -32,6 +32,7 @@ const logger = protocolLogger("PersonalAgent:Judgment");
  * is still running.
  */
 const NEGOTIATION_TURN_TIMEOUT_MS = 20_000;
+export const PERSONAL_AGENT_MODEL_TIMEOUT_MS = 15_000;
 
 const MAX_TEXT_CHARS = 500;
 const MAX_DM_CHARS = 1000;
@@ -155,14 +156,15 @@ export function renderPersonalAgentTurn(context: PersonalAgentTurnContext): stri
   ].join("\n");
 }
 
-/** Compact prose record of the acts the turn just executed, for the reply. */
+/** Compact prose record of the acts the agent just executed, for its next choice. */
 function renderExecutedAct(act: PersonalAgentExecutedAct): string {
   switch (act.tool) {
     case "message_user":
-    case "ask":
       return `- You wrote to your client: ${act.text}`;
     case "kickoff":
-      return `- You opened or re-opened ${act.opened} negotiation(s) for this signal: ${act.reasoning}`;
+      return act.failed > 0
+        ? `- You attempted to open or re-open ${act.attempted} match(es); ${act.failed} failed to open. The round settled with ${act.opened} negotiation task(s): ${act.reasoning}`
+        : `- You attempted to open or re-open ${act.attempted} match(es); none failed to open. The round settled with ${act.opened} negotiation task(s): ${act.reasoning}`;
     case "promote":
       return act.outcome === "resolved"
         ? `- You ended a negotiation and put the match in your client's decision queue: ${act.reasoning}`
@@ -174,7 +176,9 @@ function renderExecutedAct(act: PersonalAgentExecutedAct): string {
     case "note_dossier":
       return `- You noted a fact for the negotiation table: ${act.text}`;
     case "retire_dossier":
-      return act.retired ? "- You retired an outdated dossier entry." : "- You tried to retire a dossier entry that was already gone.";
+      return act.retired
+        ? "- You retired an outdated dossier entry."
+        : "- You tried to retire a dossier entry, but it was not available in this turn and no entry changed.";
     case "accept_opportunity":
       return act.outcome === "executed"
         ? `- You executed your client's verdict: ACCEPTED ${act.counterparty ?? "the match"}.`
@@ -182,22 +186,40 @@ function renderExecutedAct(act: PersonalAgentExecutedAct): string {
   }
 }
 
-/** What the reply stage sees, rendered; exported for the live eval's transparency. */
-export function renderPersonalAgentReplyStage(
+function renderNonDurableObservations(
+  context: PersonalAgentTurnContext,
+  observations: PersonalAgentNonDurableObservation[],
+): string {
+  if (observations.length === 0) return "";
+  const lines = observations.map((observation) => {
+    if (observation.tool === "kickoff") return `- Refused kickoff: ${observation.reason}`;
+    if (observation.tool === "accept_opportunity") {
+      const position = context.matches.findIndex((match) => match.opportunityId === observation.opportunityId);
+      const match = position >= 0 ? `match ${position + 1}` : "a match";
+      return `- Refused accept_opportunity for ${match}: ${observation.reason}`;
+    }
+    const position = context.paused.findIndex((paused) => paused.negotiationId === observation.negotiationId);
+    const negotiation = position >= 0 ? `negotiation ${position + 1}` : "a negotiation";
+    return `- Refused ${observation.tool} for ${negotiation}: ${observation.reason}`;
+  });
+  return `\n\nNON-DURABLE REFUSALS (these calls did not execute and changed no state):\n${lines.join("\n")}`;
+}
+
+function renderExecutedResults(
   context: PersonalAgentTurnContext,
   executed: PersonalAgentExecutedAct[],
+  nonDurable: PersonalAgentNonDurableObservation[],
 ): string {
   const acts = executed.length === 0
     ? "You executed no acts this turn."
     : `The acts you just executed for this turn:\n${executed.map(renderExecutedAct).join("\n")}`;
-  // The reply stage has been observed fabricating outreach ("I've reached out
-  // to ...") on a turn that executed nothing, when the client's own words read
-  // like an answer. Spelled out in context rather than trusted to the general
-  // reply law alone: this is the one shape that invites that story.
-  const nothingHappened = executed.length === 0
+  // A client message that caused no action can invite fabricated outreach.
+  // State the constraint only for that event: a background wake has no client
+  // message, so claiming one would give the model false context.
+  const nothingHappened = executed.length === 0 && context.event === "user_message"
     ? "\n\nYour client just wrote to you and you decided nothing needed doing this turn. You sent NOTHING, contacted NO ONE, and moved NO negotiation forward. If their message reads as an answer to a question, it is NOT resolved — whatever it might have answered stands exactly as it did before they wrote. Tell your client the truth about what did and did not happen."
     : "";
-  return `${renderPersonalAgentTurn(context)}\n\n${acts}${nothingHappened}\n\nNow write your reply to your client.`;
+  return `${renderPersonalAgentTurn(context)}\n\n${acts}${nothingHappened}${renderNonDurableObservations(context, nonDurable)}\n\nChoose the next single tool call. If the conversation is complete for now, use message_user for your natural reply.`;
 }
 
 // ─── Schemas ─────────────────────────────────────────────────────────────────
@@ -205,12 +227,11 @@ export function renderPersonalAgentReplyStage(
 // Optional fields are `.nullable().optional()`: the structured-output schema
 // translation refuses optional-without-nullable, and the validator below
 // treats null and absent alike.
-const DecidedActsSchema = z.object({
-  acts: z.array(z.object({
-    act: z.enum(["message_user", "ask", "kickoff", "promote", "reject", "note_dossier", "retire_dossier", "accept_opportunity"]),
-    /** message_user / ask: the prose. note_dossier: the fact. */
+const DecidedActSchema = z.object({
+    act: z.enum(["message_user", "kickoff", "promote", "reject", "note_dossier", "retire_dossier", "accept_opportunity"]),
+    /** message_user: the prose. note_dossier: the fact. */
     text: z.string().max(4000).nullable().optional(),
-    /** message_user / ask: 2-4 short canned replies. */
+    /** message_user: 2-4 short canned replies. */
     options: z.array(z.string().max(MAX_OPTION_CHARS)).max(8).nullable().optional(),
     /** promote / reject: 1-based number from the paused list. */
     negotiation: z.number().int().min(1).nullable().optional(),
@@ -222,12 +243,6 @@ const DecidedActsSchema = z.object({
     reasoning: z.string().max(2000).nullable().optional(),
     /** accept_opportunity: the client's own words. */
     reason: z.string().max(500).nullable().optional(),
-  })).max(8),
-});
-
-const ReplySchema = z.object({
-  reply: z.string().max(4000),
-  options: z.array(z.string().max(MAX_OPTION_CHARS)).max(8).nullable().optional(),
 });
 
 const ProseSchema = z.object({ text: z.string().min(1).max(4000) });
@@ -235,50 +250,23 @@ const ProseSchema = z.object({ text: z.string().min(1).max(4000) });
 // ─── Production judgment ─────────────────────────────────────────────────────
 
 export class PersonalAgentModel implements PersonalAgentJudgment {
-  /**
-   * One judgment: context in, decided acts out (numbers already resolved to
-   * ids). Validate → retry once → throw; a turn that cannot be judged must
-   * not be guessed.
-   */
-  async decide(context: PersonalAgentTurnContext): Promise<PersonalAgentDecidedAct[]> {
-    const userMessage = renderPersonalAgentTurn(context);
+  /** One ReAct-style choice: results and refused calls are visible before the next call. */
+  async next(
+    context: PersonalAgentTurnContext,
+    executed: PersonalAgentExecutedAct[],
+    nonDurable: PersonalAgentNonDurableObservation[] = [],
+  ): Promise<PersonalAgentDecidedAct> {
+    const userMessage = renderExecutedResults(context, executed, nonDurable);
     for (let attempt = 0; attempt < 2; attempt++) {
       const raw = await this.callActsModel([
         { role: "system", content: this.systemPrompt(context) },
         { role: "user", content: userMessage },
       ]);
-      const decided = validateDecidedActs(raw, context);
+      const decided = validateDecidedAct(raw, context);
       if (decided) return decided;
-      logger.warn("Personal-agent acts rejected", { attempt: attempt + 1, event: context.event });
+      logger.warn("Personal-agent choice rejected", { attempt: attempt + 1, event: context.event });
     }
-    throw new Error("PersonalAgent turn produced no valid act list");
-  }
-
-  /**
-   * The reply stage: the conversational reply for a client-message turn,
-   * composed AFTER the acts executed. The returned prose must pass the
-   * identifier-leak gate before anyone sees it — fail → one retry → null, and
-   * the caller delivers the fixed fallback copy. Check-then-stream: the
-   * transport only sees a completed, checked reply.
-   */
-  async reply(context: PersonalAgentTurnContext, executed: PersonalAgentExecutedAct[]): Promise<PersonalAgentReply | null> {
-    const userMessage = renderPersonalAgentReplyStage(context, executed);
-    const system = `${this.systemPrompt(context)}\n\n${PERSONAL_AGENT_REPLY_INSTRUCTION}`;
-    for (let attempt = 0; attempt < 2; attempt++) {
-      const parsed = ReplySchema.safeParse(await this.callReplyModel([
-        { role: "system", content: system },
-        { role: "user", content: userMessage },
-      ]));
-      if (parsed.success) {
-        const text = parsed.data.reply.trim();
-        if (text && isSafeAgentMessageProse(text)) {
-          const options = normalizeMessageOptions(parsed.data.options);
-          return { text, ...(options ? { options } : {}) };
-        }
-      }
-      logger.warn("Personal-agent reply rejected", { attempt: attempt + 1, malformed: !parsed.success });
-    }
-    return null;
+    throw new Error("PersonalAgent turn produced no valid tool choice");
   }
 
   async strategy(context: PersonalAgentTurnContext): Promise<string> {
@@ -359,15 +347,27 @@ export class PersonalAgentModel implements PersonalAgentJudgment {
    * needs a provider key.
    */
   protected async callActsModel(messages: Array<{ role: string; content: string }>): Promise<unknown> {
-    return createStructuredModel("chat", DecidedActsSchema, { name: "personal_agent_acts" }).invoke(messages);
-  }
-
-  protected async callReplyModel(messages: Array<{ role: string; content: string }>): Promise<unknown> {
-    return createStructuredModel("chat", ReplySchema, { name: "personal_agent_reply" }).invoke(messages);
+    return invokeWithAbortSignal(
+      this.createChoiceModel(),
+      messages,
+      AbortSignal.timeout(PERSONAL_AGENT_MODEL_TIMEOUT_MS),
+    );
   }
 
   protected async callProseModel(name: string, messages: Array<{ role: string; content: string }>): Promise<unknown> {
-    return createStructuredModel("chat", ProseSchema, { name }).invoke(messages);
+    return invokeWithAbortSignal(
+      this.createProseModel(name),
+      messages,
+      AbortSignal.timeout(PERSONAL_AGENT_MODEL_TIMEOUT_MS),
+    );
+  }
+
+  protected createChoiceModel(): ReturnType<typeof createStructuredModel> {
+    return createStructuredModel("chat", DecidedActSchema, { name: "personal_agent_choice" });
+  }
+
+  protected createProseModel(name: string): ReturnType<typeof createStructuredModel> {
+    return createStructuredModel("chat", ProseSchema, { name });
   }
 
   protected async callOpeningTurnModel(messages: Array<{ role: string; content: string }>): Promise<unknown> {
@@ -399,101 +399,60 @@ export class PersonalAgentModel implements PersonalAgentJudgment {
  * identifier-leak gate, a verdict on a turn that cannot carry one — and
  * nothing here re-decides.
  *
- * The ONE ordering rule the design demands lives here rather than in the
- * prompt: a turn that asks executes nothing, because the answer may change
- * what the right decision is.
+ * Sequencing is conversational: the graph supplies each executed result to
+ * the next model choice, while this validator keeps references bounded.
  */
-export function validateDecidedActs(
+export function validateDecidedAct(
   raw: unknown,
   context: PersonalAgentTurnContext,
-): PersonalAgentDecidedAct[] | null {
-  const parsed = DecidedActsSchema.safeParse(raw);
+): PersonalAgentDecidedAct | null {
+  const parsed = DecidedActSchema.safeParse(raw);
   if (!parsed.success) return null;
-
-  const judged = new Set<number>();
-  const decided: PersonalAgentDecidedAct[] = [];
-  let kickedOff = false;
-  let dropped = 0;
-  // One impossible act DROPS, exactly as a malformed chip drops: refusing the
-  // whole round trip over it would discard the client's real requests too, and
-  // the retry sees an identical prompt with no feedback, so it usually makes
-  // the same mistake twice and the turn dies. Only a list with nothing valid
-  // left in it is worth re-deciding.
-  const drop = (): void => { dropped += 1; };
-  for (const act of parsed.data.acts) {
+  const act = parsed.data;
+  // This is a single-choice loop: an impossible choice returns null and gets
+  // one model retry; valid choices pass through without being re-decided.
     switch (act.act) {
       case "message_user":
-      case "ask": {
-        // On a client-message turn the reply is the dedicated stage's — an
-        // acts-stage message would race it and double-speak. Structural, not
-        // judgment: dropped, and the reply stage says whatever it wanted to say.
-        if (context.event === "user_message") { drop(); break; }
+      {
         const text = act.text?.trim();
-        if (!text || !isSafeAgentMessageProse(text)) { drop(); break; }
+        if (!text || !isSafeAgentMessageProse(text)) return null;
         const options = normalizeMessageOptions(act.options);
-        decided.push({ tool: act.act, text, ...(options ? { options } : {}) });
-        break;
+        return { tool: "message_user", text, ...(options ? { options } : {}) };
       }
       case "kickoff": {
-        if (kickedOff) { drop(); break; }
-        kickedOff = true;
-        decided.push({ tool: "kickoff", reasoning: act.reasoning?.trim() || "Reaching out to this signal's matches." });
-        break;
+        return { tool: "kickoff", reasoning: act.reasoning?.trim() || "Reaching out to this signal's matches." };
       }
       case "promote":
       case "reject": {
-        if (!act.negotiation || act.negotiation > context.paused.length) { drop(); break; }
-        if (judged.has(act.negotiation)) { drop(); break; }
-        judged.add(act.negotiation);
-        decided.push({
+        if (!act.negotiation || act.negotiation > context.paused.length) return null;
+        return {
           tool: act.act,
           negotiationId: context.paused[act.negotiation - 1]!.negotiationId,
           reasoning: act.reasoning?.trim() || (act.act === "promote" ? "Worth surfacing." : "Not a match."),
-        });
-        break;
+        };
       }
       case "accept_opportunity": {
         // A verdict exists only as the client's explicit word — an event with
         // no client message cannot carry one. Whether the word WAS explicit
         // is the prompt's law; this refuses only the structurally impossible.
-        if (context.event !== "user_message") { drop(); break; }
-        if (!act.opportunity || act.opportunity > context.matches.length) { drop(); break; }
-        decided.push({
+        if (context.event !== "user_message") return null;
+        if (!act.opportunity || act.opportunity > context.matches.length) return null;
+        return {
           tool: "accept_opportunity",
           opportunityId: context.matches[act.opportunity - 1]!.opportunityId,
           ...(act.reason?.trim() ? { reason: act.reason.trim() } : {}),
-        });
-        break;
+        };
       }
       case "note_dossier": {
         const text = act.text?.trim();
-        if (!text) { drop(); break; }
-        decided.push({ tool: "note_dossier", text });
-        break;
+        if (!text) return null;
+        return { tool: "note_dossier", text };
       }
       case "retire_dossier": {
-        if (!act.entry || act.entry > context.dossier.length) { drop(); break; }
-        decided.push({ tool: "retire_dossier", entryId: context.dossier[act.entry - 1]!.id });
-        break;
+        if (!act.entry || act.entry > context.dossier.length) return null;
+        return { tool: "retire_dossier", entryId: context.dossier[act.entry - 1]!.id };
       }
     }
-  }
-
-  // An emptied list is still an answer. Re-deciding it would retry an
-  // identical prompt with no feedback — the model produces the same output,
-  // the turn throws, and on a client-message turn the client gets the failure
-  // copy instead of the reply the stage would have written anyway. `null` is
-  // reserved for output that did not parse at all.
-  if (dropped > 0) {
-    logger.warn("Personal-agent acts partially dropped", { event: context.event, dropped, kept: decided.length });
-  }
-
-  // Questions block acting. Ordering in code, not a prompt rule: an answer to
-  // a knowledge question may change every verdict below it.
-  if (decided.some((act) => act.tool === "ask")) {
-    return decided.filter((act) => act.tool !== "kickoff" && act.tool !== "promote" && act.tool !== "reject");
-  }
-  return decided;
 }
 
 /** Re-exported for the graph's own thread rendering of a negotiator turn. */

--- a/packages/protocol/src/internal/agents/personal-agent/agent.prompt.ts
+++ b/packages/protocol/src/internal/agents/personal-agent/agent.prompt.ts
@@ -16,7 +16,7 @@ import { buildAgentSelfIntroduction, type AgentIdentityOptions } from "../../cha
 import { hasUnsupportedOpportunityClaim } from "../../shared/utils/claim-safety.js";
 import type { PersonalAgentIntentEventKind } from "./agent.types.js";
 
-export const PERSONAL_AGENT_SYSTEM_PROMPT_VERSION = 5;
+export const PERSONAL_AGENT_SYSTEM_PROMPT_VERSION = 6;
 
 const INTERNAL_OR_PRIVATE_PATTERN = /\b(?:[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}|(?:task|intent|network|opportunity|user|match)[_-]?id|private transcript|raw transcript|assessment(?:\.reasoning)?|seed assessment|evaluator reasoning|match reason|matchReason|internal metadata|counterparty profile)\b/i;
 
@@ -55,8 +55,7 @@ export function buildPersonalAgentSystemPrompt(identity: AgentIdentityOptions = 
   return `${introduction} You decide when to reach out to this signal's matches, you run those negotiations through your negotiator seat at each table, and you hold the WHOLE conversation with your client about this signal: every message they send here comes to you, whether it is an answer, an instruction, a question, or small talk. You have just been woken by an event; decide what to do, then act through your tools.
 
 Your tools, each of which is recorded in your ledger:
-- message_user: say something to your client. Plain prose, their language, no markup blocks. Use it to REPORT — what you are about to do, what you decided, where things stand. Available only when a background event woke you; when your client themselves wrote to you, your reply is composed in a separate step after your acts, so do not use this tool then.
-- ask: put questions to your client that you need answered BEFORE you can decide anything. Asking blocks acting: a turn that asks executes no verdicts and starts no negotiations, because their answer may change what the right decision is. Merge what several negotiations need into one message and never ask the same thing twice — one answer often serves several tables. When your message asks something you can reduce to a few clean candidates, give an \`options\` list: 2-4 short, concrete, mutually distinct candidate answers in their language. They are a shortcut for typing, nothing more, so never offer an "other", "something else" or "let me type" option.
+- message_user: say something to your client. This is your normal conversational response on every event, whether it reports an action, answers a question, or asks for information. When it asks something you can reduce to a few clean candidates, give an \`options\` list: 2-4 short, concrete, mutually distinct candidate answers in their language. They are a shortcut for typing, nothing more, so never offer an "other", "something else" or "let me type" option.
 - kickoff: open every undecided match of this signal — or re-open the ones still running — with a fresh brief each. You write a short strategy into the conversation first and your client sees it. There is no selection here: you reach out to all of them and judge later, when the tables have given you something to judge on.
 - promote: this negotiation has converged into something your client should see. The match moves to their decision queue. This ENDS the negotiation.
 - reject: this negotiation is not a match. The match is dismissed. This ENDS the negotiation.
@@ -64,13 +63,13 @@ Your tools, each of which is recorded in your ledger:
 - note_dossier: record a fact your client stated, in a form useful at the negotiation table.
 - retire_dossier: retire a dossier entry your client has contradicted or withdrawn.
 
-If nothing needs doing, decide nothing — an empty act list is a real answer and is recorded as such.
+Choose one tool at a time. After every non-message tool, you will see its actual result before choosing again. Finish the turn with message_user; never fabricate work in that response.
 
 The law you operate under:
 
 1. The conversation is your memory. Read it before deciding. Never ask your client for something they already told you — if a table needs a fact the conversation or the dossier already contains, use it. If you are unsure the fact still holds, confirm it in one short question; do not re-ask it from scratch.
 
-2. Questions come before decisions, never beside them. When you ask, ask in your own words, grounded in what actually stalled: name the thing the negotiation needs, not the machinery behind it. When your client has answered — even late, even obliquely, even folded into another thought — take it as the answer and decide. They may also tell you to go with what you have; that is an answer too, and you then act on what you know, re-opening only the tables whose open questions you can now speak to.
+2. Ask in your own words, grounded in what actually stalled: name the thing the negotiation needs, not the machinery behind it. An unresolved question about one matter does not prevent you from acting on another matter that is resolved. When your client has answered — even late, even obliquely, even folded into another thought — take it as the answer and decide. They may also tell you to go with what you have; that is an answer too, and you then act on what you know, re-opening only the tables whose open questions you can now speak to.
 
 3. You are the only one who ends a negotiation. Your negotiator seats never accept, decline or withdraw — they reach out, push back, ask, or pause. A table that paused recommending "reject" is a recommendation, not a decision: it is yours to make, from the whole picture rather than one table's view.
 
@@ -91,29 +90,13 @@ You will be shown the paused negotiations, the dossier entries, and your client'
 export function personalAgentEventInstruction(event: PersonalAgentIntentEventKind): string {
   switch (event) {
     case "user_message":
-      return `Decide what to do with it. If it answers what you were waiting on, decide now — promote, reject, or kick the rest off again with what you have learned. If it explicitly renders a verdict on a listed match, execute it, and remember the verdict law: a hedge is not a verdict. If it states a fact worth keeping, note it. Your reply to your client is composed in a separate step after these acts, so do not use message_user or ask here — if you need something from them, simply say so in that reply.`;
+      return `Your client just wrote. Converse naturally: if it answers what you were waiting on, decide what follows; if it explicitly renders a verdict on a listed match, execute it; if it states a fact worth keeping, note it. Finish with an honest message_user response. A hedge is not a verdict.`;
     case "matches_ready":
-      return `THE EVENT: discovery has just found matches for this signal, and nothing has been reached out to yet. Decide: if there is something you must know from your client before speaking on their behalf, ask it now and reach out to no one this turn. Otherwise use kickoff — you will write a short strategy into the conversation, then a brief for each match, then open them all.`;
+      return `THE EVENT: discovery has just found matches for this signal. Decide what can usefully happen now. You may kickoff resolved work and still use message_user to ask about a separate unresolved matter.`;
     case "all_paused":
-      return `THE EVENT: every negotiation of this round has paused; they are listed above with what each is waiting on. This is your moment to reflect. FIRST, decide whether there is anything you must ask your client before deciding — merge what the tables need into one message, drop what the conversation or the dossier already answers, and if you ask, act on nothing this turn. If there is nothing left to ask, decide: promote the tables worth their attention, reject the ones that are not, and use kickoff to send the rest back out with what you now know.`;
+      return `THE EVENT: every negotiation of this round has paused; they are listed above with what each is waiting on. Reflect on each independently: promote or reject the tables you can resolve, re-kick those you can advance, and ask your client about what remains unresolved in your final message_user response.`;
   }
 }
-
-/**
- * The reply stage's addendum. Appended to the system prompt for the second
- * model call of a client-message turn — the conversational reply, composed
- * AFTER the acts executed. The delivered text passes the same prose gate the
- * acts-stage prose passes; fail → one retry → fixed fallback copy.
- */
-export const PERSONAL_AGENT_REPLY_INSTRUCTION = `You have already decided and executed this turn's acts; they are listed below with their outcomes. Now write the one thing left: your reply to your client, in plain prose.
-
-- Acknowledge what you actually did this turn — a negotiation you ended, a round you sent back out, a recorded fact, an executed verdict — in their language, without naming tools or machinery.
-- If an act failed or a match had already moved on, say so honestly and propose the next step; propose only.
-- If you executed nothing, just answer them: their status question from the listed state, their hedge with your recommendation and the question that would settle it, their small talk briefly and warmly. Never claim to have sent a message, contacted someone, or moved a negotiation forward unless that act is listed above — a turn where you decided nothing needed doing did not reach anyone, and saying otherwise is a lie your client cannot see through. If their message read as an answer to a question, and you did not act on it, tell them so plainly rather than implying it was handled.
-- No markup blocks, no lists of internal state, no identifiers, no scores, no counterparty details beyond the match list. One coherent reply, a few sentences unless more is genuinely needed.
-- If your reply asks your client something, you may also give an \`options\` list: 2-4 short, concrete, mutually distinct candidate answers in their language, each a few words. They are a shortcut for typing — your client can always answer in their own words — so never offer an "other" or "something else" option.
-
-Write the reply prose in \`reply\`; leave \`options\` out unless the reply asks.`;
 
 /** The strategy stage: the plan the principal reads before anyone is contacted. */
 export const PERSONAL_AGENT_STRATEGY_INSTRUCTION = `Write the short plan you are about to run, addressed to your client, in plain prose. Say what you are going to put to these matches on their behalf and what you will be trying to establish at each table — a few sentences, no lists of internal state, no identifiers, no scores. This is the last thing they see before you reach out, so it must be correctable by them: state your plan, do not ask for permission.`;

--- a/packages/protocol/src/internal/agents/personal-agent/agent.types.ts
+++ b/packages/protocol/src/internal/agents/personal-agent/agent.types.ts
@@ -68,14 +68,11 @@ export interface PersonalAgentResult {
 // ─── Decided acts (model output, positions already resolved to ids) ──────────
 
 /**
- * `wait` is gone: a turn that decides nothing simply decides nothing, and
- * reflect is ask-or-act rather than ask-or-act-or-wait. `ask` is the verb
- * that BLOCKS acting — a turn that asks does not also execute verdicts, so
- * an answer to a knowledge question can still change them.
+ * One model choice is one tool call. `message_user` is the natural terminal
+ * response, including a question when more information is needed.
  */
 export type PersonalAgentDecidedAct =
   | { tool: "message_user"; text: string; options?: string[] }
-  | { tool: "ask"; text: string; options?: string[] }
   /** Open (or re-open) every undecided match of this signal with fresh briefs. */
   | { tool: "kickoff"; reasoning: string }
   /** Terminal writes IS-A owns: opportunity → `pending` / `rejected`. */
@@ -88,25 +85,23 @@ export type PersonalAgentDecidedAct =
 
 // ─── Executed acts (decision + durable effects) ──────────────────────────────
 
-/** Why a reply-stage delivery fell back to the fixed server-owned copy. */
-export type PersonalAgentReplyFallbackReason = "safety_check_failed" | "model_error";
-
 export type PersonalAgentExecutedAct =
   | {
-    tool: "message_user" | "ask";
+    tool: "message_user";
     text: string;
     options?: string[];
     sessionId: string;
     messageId: string;
-    /** 'reply' marks the streaming reply stage's delivery. */
-    stage?: "reply";
-    fallback?: PersonalAgentReplyFallbackReason;
   }
   | {
     tool: "kickoff";
     round: number;
-    /** How many negotiations this kickoff actually opened or resumed. */
+    /** How many negotiation tasks the round settled with; preserves the round-size semantics. */
     opened: number;
+    /** How many matches this kickoff tried to open or resume. */
+    attempted: number;
+    /** How many of those attempts failed before or during negotiation opening. */
+    failed: number;
     reasoning: string;
   }
   | {
@@ -124,6 +119,30 @@ export type PersonalAgentExecutedAct =
     outcome: string;
     counterparty?: string;
     reason?: string;
+  };
+
+/**
+ * Feedback from the turn runner about a tool choice it refused before any
+ * write. This helps the next choice recover without pretending that the call
+ * executed or recording it in the act ledger.
+ */
+export type PersonalAgentNonDurableObservation =
+  | {
+    kind: "irreversible_tool_refused";
+    tool: "kickoff";
+    reason: string;
+  }
+  | {
+    kind: "irreversible_tool_refused";
+    tool: "promote" | "reject";
+    negotiationId: string;
+    reason: string;
+  }
+  | {
+    kind: "irreversible_tool_refused";
+    tool: "accept_opportunity";
+    opportunityId: string;
+    reason: string;
   };
 
 // ─── Host ports ──────────────────────────────────────────────────────────────
@@ -178,7 +197,7 @@ export interface PersonalAgentConversationPort {
   }): Promise<string>;
 }
 
-/** Token transport for the streaming reply stage. */
+/** Token transport for completed conversational messages. */
 export interface PersonalAgentReplyStreamPort {
   publish(messageId: string, chunk: { seq: number; content: string }): Promise<void>;
 }
@@ -246,21 +265,17 @@ export interface PersonalAgentDeps {
 
 // ─── Judgment seam ───────────────────────────────────────────────────────────
 
-/** A composed reply: the prose the principal reads, plus optional chips. */
-export interface PersonalAgentReply {
-  text: string;
-  options?: string[];
-}
-
 /**
  * Everything the agent asks a model for. One interface so a host, a test or
  * an eval can drive the whole cycle without a provider.
  */
 export interface PersonalAgentJudgment {
-  /** One intent-scope turn: context in, decided acts out. */
-  decide(context: PersonalAgentTurnContext): Promise<PersonalAgentDecidedAct[]>;
-  /** The conversational reply for a principal-message turn, after the acts ran. */
-  reply(context: PersonalAgentTurnContext, executed: PersonalAgentExecutedAct[]): Promise<PersonalAgentReply | null>;
+  /** One intent-scope choice. Durable results and refused calls inform the next choice. */
+  next(
+    context: PersonalAgentTurnContext,
+    executed: PersonalAgentExecutedAct[],
+    nonDurable?: PersonalAgentNonDurableObservation[],
+  ): Promise<PersonalAgentDecidedAct>;
   /** The plan for a round, written into the DM before any negotiation opens. */
   strategy(context: PersonalAgentTurnContext): Promise<string>;
   /** One negotiation's brief. Called once per match, in parallel. */

--- a/packages/protocol/src/internal/agents/personal-agent/tests/agent.judgment.spec.ts
+++ b/packages/protocol/src/internal/agents/personal-agent/tests/agent.judgment.spec.ts
@@ -1,86 +1,158 @@
 import { describe, expect, test } from "bun:test";
 
-import { validateDecidedActs } from "../agent.judgment.js";
-import type { PersonalAgentTurnContext } from "../agent.types.js";
+import { PersonalAgentModel, PERSONAL_AGENT_MODEL_TIMEOUT_MS, validateDecidedAct } from "../agent.judgment.js";
+import type { PersonalAgentExecutedAct, PersonalAgentNonDurableObservation, PersonalAgentTurnContext } from "../agent.types.js";
 
-/**
- * The validator refuses the impossible and re-decides nothing. What it must
- * NOT do is throw away a whole round trip over one impossible act: the retry
- * sees an identical prompt with no feedback, usually repeats the mistake, and
- * the client's real request — a verdict they asked for in words — silently
- * never happens. One bad act drops, exactly as a malformed chip drops.
- */
+class CapturingPersonalAgentModel extends PersonalAgentModel {
+  lastMessages: Array<{ role: string; content: string }> = [];
+
+  protected override async callActsModel(messages: Array<{ role: string; content: string }>): Promise<unknown> {
+    this.lastMessages = messages;
+    return { act: "message_user", text: "I chose a different next step." };
+  }
+}
+
+class SignalCapturingPersonalAgentModel extends PersonalAgentModel {
+  choiceSignal?: AbortSignal;
+  proseSignal?: AbortSignal;
+
+  protected override createChoiceModel() {
+    return {
+      invoke: async (_input: unknown, config?: { signal?: AbortSignal }) => {
+        this.choiceSignal = config?.signal;
+        return { act: "message_user", text: "Done." };
+      },
+    } as never;
+  }
+
+  protected override createProseModel() {
+    return {
+      invoke: async (_input: unknown, config?: { signal?: AbortSignal }) => {
+        this.proseSignal = config?.signal;
+        return { text: "A concise strategy." };
+      },
+    } as never;
+  }
+}
+
 function context(overrides: Partial<PersonalAgentTurnContext> = {}): PersonalAgentTurnContext {
   return {
-    userId: "alice",
-    intentId: "intent-1",
-    event: "user_message",
-    message: { text: "reject the second one", sessionId: "dm-1", messageId: "m-1" },
+    userId: "alice", intentId: "intent-1", event: "user_message",
+    message: { text: "hello", sessionId: "dm-1", messageId: "m-1" },
     signalText: "Looking for a technical co-founder.",
     matches: [{ opportunityId: "opportunity-1", label: "A match", status: "negotiating" }],
-    paused: [
-      { negotiationId: "task-1", opportunityId: "opportunity-1", reason: "ready_for_verdict", pausedByUs: true, thread: [] },
-      { negotiationId: "task-2", opportunityId: "opportunity-2", reason: "needs_principal", pausedByUs: true, thread: [] },
-    ],
-    dossier: [],
-    recentDm: [],
-    recentActs: [],
-    ...overrides,
+    kickoffTargets: [], knownMatchIds: [],
+    paused: [{ negotiationId: "task-1", opportunityId: "opportunity-1", reason: "ready_for_verdict", pausedByUs: true, thread: [] }],
+    dossier: [], recentDm: [], recentActs: [], ...overrides,
   };
 }
 
-describe("validateDecidedActs", () => {
-  test("an acts-stage message on a client-message turn drops; the client's verdict still executes", () => {
-    const decided = validateDecidedActs({
-      acts: [
-        { act: "message_user", text: "On it." },
-        { act: "reject", negotiation: 2, reasoning: "They asked me to." },
-      ],
-    }, context());
-
-    expect(decided).toEqual([{ tool: "reject", negotiationId: "task-2", reasoning: "They asked me to." }]);
+describe("validateDecidedAct", () => {
+  test("allows a normal conversational response on a client-message turn", () => {
+    expect(validateDecidedAct({ act: "message_user", text: "What timing works for you?" }, context()))
+      .toEqual({ tool: "message_user", text: "What timing works for you?" });
   });
 
-  test("a number outside the list drops, and its siblings survive", () => {
-    const decided = validateDecidedActs({
-      acts: [
-        { act: "promote", negotiation: 9, reasoning: "Out of range." },
-        { act: "note_dossier", text: "Can start in three weeks." },
-      ],
-    }, context({ event: "all_paused", round: 2 }));
-
-    expect(decided).toEqual([{ tool: "note_dossier", text: "Can start in three weeks." }]);
+  test("keeps references bounded to the state the model was shown", () => {
+    expect(validateDecidedAct({ act: "reject", negotiation: 2 }, context())).toBeNull();
   });
 
-  test("a list where nothing survives is an empty turn, not a retry", () => {
-    // The client-message turn's reply stage writes the reply either way, so a
-    // model that answered with nothing but an acts-stage message has decided
-    // nothing — not failed. Re-deciding it would retry an identical prompt,
-    // get the same output, throw, and hand the client the failure copy.
-    expect(validateDecidedActs({ acts: [{ act: "message_user", text: "hi" }] }, context())).toEqual([]);
+  test("accepts only a bounded user-message verdict and rejects background acceptance", () => {
+    expect(validateDecidedAct({ act: "accept_opportunity", opportunity: 1 }, context()))
+      .toEqual({ tool: "accept_opportunity", opportunityId: "opportunity-1" });
+    expect(validateDecidedAct(
+      { act: "accept_opportunity", opportunity: 1 },
+      context({ event: "matches_ready", message: undefined }),
+    )).toBeNull();
+  });
+});
+
+describe("PersonalAgentModel", () => {
+  test("renders refused irreversible calls as non-durable observations", async () => {
+    const model = new CapturingPersonalAgentModel();
+    const observation: PersonalAgentNonDurableObservation = {
+      kind: "irreversible_tool_refused",
+      tool: "kickoff",
+      reason: "A kickoff already executed against this turn's snapshot. Choose a different next step.",
+    };
+
+    await model.next(context(), [], [observation]);
+
+    const prompt = model.lastMessages.find((message) => message.role === "user")?.content;
+    expect(prompt).toContain("NON-DURABLE REFUSALS (these calls did not execute and changed no state)");
+    expect(prompt).toContain("Refused kickoff: A kickoff already executed against this turn's snapshot.");
   });
 
-  test("output that does not parse at all is still refused", () => {
-    expect(validateDecidedActs({ acts: [{ act: "not_a_tool" }] }, context())).toBeNull();
-    expect(validateDecidedActs({ nope: true }, context())).toBeNull();
+  test("renders a refused verdict by bounded list position, never raw negotiation id", async () => {
+    const model = new CapturingPersonalAgentModel();
+    const negotiationId = "aeb2e65d-0c7b-4a0d-909c-d3868d1cb091";
+    const turn = context({
+      paused: [{
+        negotiationId,
+        opportunityId: "opportunity-1",
+        reason: "ready_for_verdict",
+        pausedByUs: true,
+        thread: [],
+      }],
+    });
+    const observation: PersonalAgentNonDurableObservation = {
+      kind: "irreversible_tool_refused",
+      tool: "promote",
+      negotiationId,
+      reason: "A terminal verdict already executed for this negotiation against this turn's snapshot.",
+    };
+
+    await model.next(turn, [], [observation]);
+
+    const prompt = model.lastMessages.find((message) => message.role === "user")?.content;
+    expect(prompt).toContain("Refused promote for negotiation 1");
+    expect(prompt).not.toContain(negotiationId);
   });
 
-  test("an empty act list is a real answer — the turn decided nothing", () => {
-    expect(validateDecidedActs({ acts: [] }, context())).toEqual([]);
+  test("renders a refused acceptance by bounded match position, never raw opportunity id", async () => {
+    const model = new CapturingPersonalAgentModel();
+    const opportunityId = "5d8e06ce-6d99-4212-a8ec-3a5451950127";
+    const turn = context({ matches: [{ opportunityId, label: "First match", status: "pending" }] });
+    const observation: PersonalAgentNonDurableObservation = {
+      kind: "irreversible_tool_refused",
+      tool: "accept_opportunity",
+      opportunityId,
+      reason: "An acceptance already executed for this match against this turn's snapshot.",
+    };
+
+    await model.next(turn, [], [observation]);
+
+    const prompt = model.lastMessages.find((message) => message.role === "user")?.content;
+    expect(prompt).toContain("Refused accept_opportunity for match 1");
+    expect(prompt).not.toContain(opportunityId);
   });
 
-  test("asking still blocks acting, after the drops", () => {
-    const decided = validateDecidedActs({
-      acts: [
-        { act: "ask", text: "How soon could you start?" },
-        { act: "promote", negotiation: 1, reasoning: "Converged." },
-        { act: "note_dossier", text: "Prefers remote." },
-      ],
-    }, context({ event: "all_paused", round: 2 }));
+  test("renders partial kickoff failures explicitly for the next choice", async () => {
+    const model = new CapturingPersonalAgentModel();
+    const kickoff: PersonalAgentExecutedAct = {
+      tool: "kickoff",
+      round: 2,
+      opened: 2,
+      attempted: 2,
+      failed: 1,
+      reasoning: "Reaching out.",
+    };
 
-    expect(decided).toEqual([
-      { tool: "ask", text: "How soon could you start?" },
-      { tool: "note_dossier", text: "Prefers remote." },
-    ]);
+    await model.next(context(), [kickoff]);
+
+    const prompt = model.lastMessages.find((message) => message.role === "user")?.content;
+    expect(prompt).toContain("attempted to open or re-open 2 match(es); 1 failed to open");
+    expect(prompt).toContain("round settled with 2 negotiation task(s)");
+  });
+
+  test("passes a 15-second abort signal to choice and prose model calls", async () => {
+    const model = new SignalCapturingPersonalAgentModel();
+
+    await model.next(context(), []);
+    await model.strategy(context());
+
+    expect(PERSONAL_AGENT_MODEL_TIMEOUT_MS).toBe(15_000);
+    expect(model.choiceSignal).toBeInstanceOf(AbortSignal);
+    expect(model.proseSignal).toBeInstanceOf(AbortSignal);
   });
 });

--- a/services/api/CHANGELOG.md
+++ b/services/api/CHANGELOG.md
@@ -9,6 +9,15 @@ section before promoting to `main`).
 
 ## [Unreleased]
 
+### Fixed
+- Give PersonalAgent user-message jobs an enqueue-relative 70-second execution
+  deadline inside the controller's 90-second wait, with the same fresh budget
+  for background turns. A user-message deadline failure before durable work
+  lands is unrecoverable, so BullMQ cannot hide post-timeout work behind a
+  retry; a background deadline failure remains retryable so a persisted wake
+  cannot be stranded. Once durable work has started, the graph finishes
+  through its existing honest terminal response or kickoff compensation path.
+
 ### Removed
 - **Breaking:** remove the retired `negotiation-run-existing` queue and
   `POST /api/opportunities/:id/reopen`. The old endpoint only enqueued that

--- a/services/api/package.json
+++ b/services/api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@indexnetwork/api",
-  "version": "0.97.0",
+  "version": "0.97.1",
   "license": "MIT",
   "private": true,
   "scripts": {

--- a/services/api/src/controllers/tests/chat.negotiator.isolated.ts
+++ b/services/api/src/controllers/tests/chat.negotiator.isolated.ts
@@ -262,7 +262,7 @@ describe("Signal DM (intent-scoped PersonalAgent chat)", () => {
     capturedStreamInputs.length = 0;
     agentTurnEvents.length = 0;
     scriptedAgentTurn = async (event) => ({
-      acts: [{ tool: 'message_user', text: 'One match is waiting on you.', sessionId: event.sessionId, messageId: 'assistant-1', stage: 'reply' }],
+      acts: [{ tool: 'message_user', text: 'One match is waiting on you.', sessionId: event.sessionId, messageId: 'assistant-1' }],
       messages: ['One match is waiting on you.'],
     });
 
@@ -309,7 +309,7 @@ describe("Signal DM (intent-scoped PersonalAgent chat)", () => {
     capturedPersonas.length = 0;
     agentTurnEvents.length = 0;
     scriptedAgentTurn = async (event) => ({
-      acts: [{ tool: 'message_user', text: 'Still on it.', sessionId: event.sessionId, messageId: 'assistant-2', stage: 'reply' }],
+      acts: [{ tool: 'message_user', text: 'Still on it.', sessionId: event.sessionId, messageId: 'assistant-2' }],
       messages: ['Still on it.'],
     });
 
@@ -334,7 +334,7 @@ describe("Signal DM (intent-scoped PersonalAgent chat)", () => {
       await publishPersonalAgentReplyChunk(event.messageId, { seq: 1, content: 'Declined that match. ' });
       await publishPersonalAgentReplyChunk(event.messageId, { seq: 2, content: 'Nothing else needs you.' });
       return {
-        acts: [{ tool: 'message_user', text: 'Declined that match. Nothing else needs you.', sessionId: event.sessionId, messageId: 'assistant-3', stage: 'reply' }],
+        acts: [{ tool: 'message_user', text: 'Declined that match. Nothing else needs you.', sessionId: event.sessionId, messageId: 'assistant-3' }],
         messages: ['Declined that match. Nothing else needs you.'],
       };
     };

--- a/services/api/src/lib/agent/personal-agent-reply.stream.ts
+++ b/services/api/src/lib/agent/personal-agent-reply.stream.ts
@@ -1,5 +1,5 @@
 /**
- * Token transport for the PersonalAgent's streaming reply stage.
+ * Token transport for the PersonalAgent's completed conversational messages.
  *
  * The turn runs on the inbox worker — serialization stays THE inbox — so the
  * reply's chunks cross back to the waiting chat controller over Redis
@@ -12,9 +12,8 @@
  * channel, because the channel is a latency optimization and the job result
  * is the truth.
  *
- * Chunks are published only AFTER the reply passed the prose-safety check
- * and was persisted (check-then-stream — see the protocol reply stage):
- * nothing unchecked ever crosses this transport.
+ * Chunks are published only after each message passed its prose-safety check
+ * and was persisted; nothing unchecked crosses this transport.
  *
  * In hermetic test mode (the same `useHermeticRedis()` guard the queue
  * factory applies) the transport is an in-process emitter, so controller and
@@ -27,7 +26,7 @@ import { log } from '../log';
 
 const logger = log.lib.from('personal-agent-reply.stream');
 
-/** One ordered slice of the checked reply. `seq` starts at 1 per turn. */
+/** One ordered slice of a checked message. `seq` starts at 1 per turn. */
 export interface PersonalAgentReplyChunk {
   seq: number;
   content: string;

--- a/services/api/src/lib/bullmq/bullmq.hermetic.ts
+++ b/services/api/src/lib/bullmq/bullmq.hermetic.ts
@@ -1,3 +1,4 @@
+import { UnrecoverableError } from 'bullmq';
 import type { Job, JobsOptions, Processor, Queue, QueueEvents, Worker } from 'bullmq';
 
 interface ListenerMap {
@@ -335,7 +336,7 @@ function processRecord(broker: Broker, worker: WorkerRecord, record: JobRecord):
       const failure = error instanceof Error ? error : new Error(String(error));
       record.job.attemptsMade += 1;
       const attempts = Number(record.job.opts.attempts ?? 1);
-      if (record.job.attemptsMade < attempts) {
+      if (!(failure instanceof UnrecoverableError) && record.job.attemptsMade < attempts) {
         record.state = 'waiting';
       } else {
         record.state = 'failed';

--- a/services/api/src/queues/personal-agent.queue.ts
+++ b/services/api/src/queues/personal-agent.queue.ts
@@ -16,9 +16,9 @@
  *   completion: reflect must fire exactly once per round, or the agent acts
  *   twice on the same moment.
  */
-import { Job } from 'bullmq';
+import { Job, UnrecoverableError } from 'bullmq';
 import type { QueueEvents } from 'bullmq';
-import { negotiationRoundReflectJobId } from '@indexnetwork/protocol';
+import { negotiationRoundReflectJobId, requestContext } from '@indexnetwork/protocol';
 import type { NegotiationRoundReflectJobData, PersonalAgentInput, PersonalAgentResult } from '@indexnetwork/protocol';
 
 import { QueueFactory } from '../lib/bullmq/bullmq';
@@ -29,10 +29,13 @@ export const QUEUE_NAME = 'personal-agent-queue';
 
 /**
  * How long the chat controller waits for an awaited `user_message` turn
- * before answering with fixed copy and leaving the event to retry in the
- * background. Covers one queued turn ahead plus one model call.
+ * before answering with fixed copy. The worker's 70-second enqueue-relative
+ * deadline leaves twenty seconds inside this response boundary.
  */
 export const PERSONAL_AGENT_TURN_WAIT_MS = 90_000;
+
+/** Leave the controller twenty seconds to finish its own 90-second response path. */
+export const PERSONAL_AGENT_EXECUTION_BUDGET_MS = 70_000;
 
 /** What the agent is woken with — the graph's own intent-scope input shapes. */
 export type PersonalAgentEvent = Extract<PersonalAgentInput, { event: string }>;
@@ -157,9 +160,9 @@ export class PersonalAgentQueue {
   /**
    * The chat controller's lane: enqueue the principal's message and wait for
    * the serialized turn, returning what the agent did so the controller can
-   * emit its messages as the turn's response. Throws on turn failure or
-   * timeout — the caller answers with fixed copy while the event retries in
-   * the background, so the message is durably heard either way.
+   * emit its messages as the turn's response. Throws on turn failure or wait
+   * timeout; the worker's enqueue-relative deadline prevents a stale user
+   * turn from mutating state after the controller has already answered.
    */
   async runUserMessageTurn(
     event: PersonalAgentUserMessageEvent,
@@ -182,12 +185,45 @@ export class PersonalAgentQueue {
     return result;
   }
 
+  /** Apply the queue-time/user deadline or a fresh, retryable background budget to one invocation. */
+  async processJob(job: Job<PersonalAgentEvent>): Promise<PersonalAgentResult> {
+    const isUserMessage = job.data.event === 'user_message';
+    const remaining = isUserMessage
+      ? job.timestamp + PERSONAL_AGENT_EXECUTION_BUDGET_MS - Date.now()
+      : PERSONAL_AGENT_EXECUTION_BUDGET_MS;
+    if (remaining <= 0) {
+      throw new UnrecoverableError('PersonalAgent user-message execution deadline expired before pickup');
+    }
+
+    const deadlineSignal = AbortSignal.timeout(remaining);
+    const existing = requestContext.getStore() ?? {};
+    const abortSignal = existing.abortSignal
+      ? AbortSignal.any([existing.abortSignal, deadlineSignal])
+      : deadlineSignal;
+    try {
+      return await requestContext.run(
+        { ...existing, abortSignal },
+        () => this.processEvent(job.data),
+      );
+    } catch (error) {
+      // A user-message retry could mutate state after the controller has
+      // already returned its timeout response, so its deadline is terminal.
+      // Background wakes have no waiting caller and are the only path back to
+      // persisted matches/paused rounds; their pre-effect expiry must retain
+      // the queue's ordinary retry policy instead of stranding that work.
+      if (isUserMessage && deadlineSignal.aborted) {
+        throw new UnrecoverableError('PersonalAgent execution deadline expired');
+      }
+      throw error;
+    }
+  }
+
   /** Start the BullMQ worker. Idempotent; call from the protocol server only. */
   startWorker(): void {
     if (this.worker) return;
     const processor = async (job: Job<PersonalAgentEvent>) => {
       this.logger.info('Processing event', { jobId: job.id, jobName: job.name });
-      return this.processEvent(job.data);
+      return this.processJob(job);
     };
     this.worker = QueueFactory.createWorker<PersonalAgentEvent>(QUEUE_NAME, processor);
   }

--- a/services/api/src/queues/tests/personal-agent.queue.isolated.ts
+++ b/services/api/src/queues/tests/personal-agent.queue.isolated.ts
@@ -6,9 +6,14 @@
  * overlap. Hermetic BullMQ double, no Redis, no database, no model.
  */
 import { describe, expect, it } from 'bun:test';
+import { requestContext, setRequestContextStore } from '@indexnetwork/protocol';
 import type { PersonalAgentInput, PersonalAgentResult } from '@indexnetwork/protocol';
+import { UnrecoverableError } from 'bullmq';
 
-import { PersonalAgentQueue } from '../personal-agent.queue';
+import { requestContext as hostRequestContext } from '../../lib/request-context';
+import { PERSONAL_AGENT_EXECUTION_BUDGET_MS, PersonalAgentQueue } from '../personal-agent.queue';
+
+setRequestContextStore(hostRequestContext);
 
 const sleep = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms));
 
@@ -180,7 +185,7 @@ describe('PersonalAgentQueue serialization', () => {
   it('runUserMessageTurn returns what the agent did', async () => {
     const result: PersonalAgentResult = {
       scope: 'intent',
-      acts: [{ tool: 'message_user', text: 'Right here.', sessionId: 'session-1', messageId: 'message-1', stage: 'reply' }],
+      acts: [{ tool: 'message_user', text: 'Right here.', sessionId: 'session-1', messageId: 'message-1' }],
       messages: ['Right here.'],
     };
     await withQueue(buildQueue(() => result), async ({ queue }) => {
@@ -194,11 +199,120 @@ describe('PersonalAgentQueue serialization', () => {
   });
 
   it('a graph-level error fails the turn — the awaited lane rejects and the job stays retryable', async () => {
-    await withQueue(buildQueue(() => ({ scope: 'intent', acts: [], messages: [], error: 'provider down' })), async ({ queue }) => {
+    await withQueue(buildQueue(() => ({ scope: 'intent', acts: [], messages: [], error: 'provider down' })), async ({ queue, invocations }) => {
       await expect(queue.runUserMessageTurn({
         userId: 'user-1', intentId: 'intent-1', event: 'user_message',
         sessionId: 'session-1', messageId: 'reply-3', text: 'hello',
       }, { timeoutMs: 500 })).rejects.toThrow();
+      expect(invocations()).toBe(3);
     });
+  });
+
+  it('a stale queued user message is unrecoverable and never invokes the graph', async () => {
+    const built = buildQueue(() => idle);
+    try {
+      const job = await built.queue.addUserMessageEvent({
+        userId: 'user-1', intentId: 'intent-1', event: 'user_message',
+        sessionId: 'session-1', messageId: 'reply-stale', text: 'hello',
+      });
+      job.timestamp = Date.now() - PERSONAL_AGENT_EXECUTION_BUDGET_MS - 1;
+      built.queue.startWorker();
+
+      await expect(job.waitUntilFinished(undefined as never, 1_000)).rejects.toBeInstanceOf(UnrecoverableError);
+      expect(built.invocations()).toBe(0);
+      expect(job.attemptsMade).toBe(1);
+    } finally {
+      await built.queue.close();
+    }
+  });
+
+  it('a deadline abort that fails invocation becomes unrecoverable', async () => {
+    const queue = new PersonalAgentQueue(async () => {
+      const signal = requestContext.getStore()?.abortSignal;
+      await new Promise<void>((resolve) => signal?.addEventListener('abort', () => resolve(), { once: true }));
+      throw new Error('model aborted');
+    });
+    try {
+      const job = await queue.addUserMessageEvent({
+        userId: 'user-1', intentId: 'intent-1', event: 'user_message',
+        sessionId: 'session-1', messageId: 'reply-deadline', text: 'hello',
+      });
+      job.timestamp = Date.now() - PERSONAL_AGENT_EXECUTION_BUDGET_MS + 25;
+
+      await expect(queue.processJob(job)).rejects.toBeInstanceOf(UnrecoverableError);
+    } finally {
+      await queue.close();
+    }
+  });
+
+  it('a background job gets a fresh execution-relative budget and preserves request context', async () => {
+    let captured: ReturnType<typeof requestContext.getStore>;
+    const queue = new PersonalAgentQueue(async () => {
+      captured = requestContext.getStore();
+      return idle;
+    });
+    try {
+      const job = await queue.addMatchesReadyEvent({ userId: 'user-1', intentId: 'intent-background' });
+      job.timestamp = Date.now() - PERSONAL_AGENT_EXECUTION_BUDGET_MS * 2;
+
+      const result = await hostRequestContext.run(
+        { originUrl: 'https://queue.example.test' },
+        () => queue.processJob(job),
+      );
+
+      expect(result).toEqual(idle);
+      expect(captured?.originUrl).toBe('https://queue.example.test');
+      expect(captured?.abortSignal).toBeInstanceOf(AbortSignal);
+      expect(captured?.abortSignal?.aborted).toBe(false);
+    } finally {
+      await queue.close();
+    }
+  });
+
+  it('a background deadline failure stays retryable instead of becoming unrecoverable', async () => {
+    const timeoutDescriptor = Object.getOwnPropertyDescriptor(AbortSignal, 'timeout')!;
+    const deadline = new AbortController();
+    Object.defineProperty(AbortSignal, 'timeout', {
+      configurable: true,
+      value: () => deadline.signal,
+    });
+    const queue = new PersonalAgentQueue(async () => {
+      const signal = requestContext.getStore()?.abortSignal;
+      await new Promise<void>((resolve) => signal?.addEventListener('abort', () => resolve(), { once: true }));
+      throw new Error('background model aborted');
+    });
+    try {
+      const job = await queue.addMatchesReadyEvent({ userId: 'user-1', intentId: 'intent-background-deadline' });
+      const processing = queue.processJob(job);
+      deadline.abort(new DOMException('deadline', 'TimeoutError'));
+
+      await expect(processing).rejects.toThrow('background model aborted');
+      await expect(processing).rejects.not.toBeInstanceOf(UnrecoverableError);
+    } finally {
+      Object.defineProperty(AbortSignal, 'timeout', timeoutDescriptor);
+      await queue.close();
+    }
+  });
+
+  it('preserves inherited cancellation separately from the queue deadline', async () => {
+    const inherited = new AbortController();
+    const queue = new PersonalAgentQueue(async () => {
+      const signal = requestContext.getStore()?.abortSignal;
+      await new Promise<void>((resolve) => signal?.addEventListener('abort', () => resolve(), { once: true }));
+      throw new Error('caller cancelled');
+    });
+    try {
+      const job = await queue.addMatchesReadyEvent({ userId: 'user-1', intentId: 'intent-cancelled' });
+      const processing = hostRequestContext.run(
+        { abortSignal: inherited.signal },
+        () => queue.processJob(job),
+      );
+      inherited.abort(new DOMException('caller cancelled', 'AbortError'));
+
+      await expect(processing).rejects.toThrow('caller cancelled');
+      await expect(processing).rejects.not.toBeInstanceOf(UnrecoverableError);
+    } finally {
+      await queue.close();
+    }
   });
 });


### PR DESCRIPTION
## Summary
- replace IS-A's batched ASK/ACT decision plus separate reply stage with a bounded sequential conversational tool loop
- feed each durable result and refused irreversible call into the next choice, allowing independent actions and questions in context order
- preserve retry safety with snapshot-scoped effect fences, honest terminal recovery, and queue/model deadlines that distinguish awaited user turns from retryable background wakes
- preserve the speaking seat's resolved intent and seat-safe negotiation task context from the latest `dev`
- update the canonical AgentGraph design record and regression coverage

## Breaking protocol changes
- replace `PersonalAgentJudgment.decide` / `.reply` with `next(context, executed, nonDurable?)`
- remove the `ask` act; questions are ordinary `message_user` responses
- remove `PERSONAL_AGENT_REPLY_FALLBACK`, `renderPersonalAgentReplyStage`, `validateDecidedActs`, `PersonalAgentReply`, and `PersonalAgentReplyFallbackReason`; use `validateDecidedAct` and `PersonalAgentNonDurableObservation`
- add required `attempted` and `failed` fields to executed kickoff acts

`@indexnetwork/protocol` is bumped to 34.0.0. `@indexnetwork/api` is bumped to 0.97.1 for the queue deadline behavior.

## Verification
- rebased onto `origin/dev` at `08ffee2ad` (including PRs #1506–#1508)
- protocol build, 1,620-test provider-free isolated suite, and architecture checks
- API build/typechecks, 27 focused PersonalAgent queue/controller tests, changed-file ESLint, adapter and provider-free CLI suites
- root script tests, lockfile-version check, frozen install, subtree parity, and pre-commit build gate
- applicable Hermes/Mac security and runtime workflow gates
- `git diff --check`

## Residual risk
Cancellation is cooperative: an operation already in flight, and kickoff compensation after a round bump, may finish after the deadline. The queue prevents a timed-out user turn from starting later hidden work, and the controller retains a 20-second response buffer.
