### PR TITLE
Fix intent-scoped opportunity presentation

### DIFF
--- a/packages/protocol/src/internal/opportunities/opportunity.presentation.ts
+++ b/packages/protocol/src/internal/opportunities/opportunity.presentation.ts
@@ -667,8 +667,10 @@ export function buildRadarCardPresentationCacheKey(
   opportunityId: string,
   status: string,
   viewerId: string,
+  focusedViewerIntentId?: string,
 ): string {
-  return `radar:${OPPORTUNITY_PRESENTATION_CACHE_VERSION}:card:${opportunityId}:${status}:${viewerId}`;
+  const scope = focusedViewerIntentId ? `:intent:${focusedViewerIntentId}` : "";
+  return `radar:${OPPORTUNITY_PRESENTATION_CACHE_VERSION}:card:${opportunityId}:${status}:${viewerId}${scope}`;
 }
 
 export function buildDeliveryCardPresentationCacheKey(
@@ -1557,12 +1559,14 @@ export function summarizeSignalsForPresenter(
  * Fetches viewer profile, viewer intents, other party profile(s), and index in parallel.
  *
  * @param displayCounterpartUserId - When set (e.g. for a radar card), only this counterpart is included in otherPartyContext so the presenter writes about the person on the card. Omitted for introducer view (card shows both parties).
+ * @param focusedViewerIntentId - When set for a non-introducer viewer, include only that active intent in viewer context.
  */
 export async function gatherPresenterContext(
   database: PresenterDatabase,
   opportunity: Opportunity,
   viewerId: string,
   displayCounterpartUserId?: string,
+  focusedViewerIntentId?: string,
 ): Promise<PresenterInput> {
   const myActor = opportunity.actors.find((a) => a.userId === viewerId);
   if (!myActor) {
@@ -1610,6 +1614,9 @@ export async function gatherPresenterContext(
     );
   } else {
     viewerIntents = await database.getActiveIntents(viewerId);
+    if (focusedViewerIntentId) {
+      viewerIntents = viewerIntents.filter((intent) => intent.id === focusedViewerIntentId);
+    }
   }
 
   // Fetch premises when any actor is premise-grounded

--- a/packages/protocol/src/internal/opportunities/opportunity.tools.list.ts
+++ b/packages/protocol/src/internal/opportunities/opportunity.tools.list.ts
@@ -273,6 +273,7 @@ export function createListOpportunitiesTool(defineTool: DefineTool, deps: Opport
                       opp,
                       context.userId,
                       counterpartUserId,
+                      effectiveIntentScope.scopeId,
                     ),
                     loadNegotiationContext(deps.negotiationDatabase, opp.id, opp.status, context.userId),
                   ]);
@@ -451,6 +452,7 @@ export function createListOpportunitiesTool(defineTool: DefineTool, deps: Opport
                     opp,
                     context.userId,
                     counterpartUserId,
+                    effectiveIntentScope.scopeId,
                   ),
                   loadNegotiationContext(deps.negotiationDatabase, opp.id, opp.status, context.userId),
                 ]);

--- a/packages/protocol/src/internal/opportunities/radar/radar.graph.ts
+++ b/packages/protocol/src/internal/opportunities/radar/radar.graph.ts
@@ -389,7 +389,7 @@ export async function loadOpportunitiesNode(state: RadarState, deps: RadarGraphD
 
 export async function checkPresenterCacheNode(state: RadarState, deps: RadarGraphDeps) {
   return timed("RadarGraph.checkPresenterCache", async () => {
-    const { opportunities, userId } = state;
+    const { opportunities, userId, scopeId } = state;
     const poolRankingProvenance = getPoolRankingProvenance(state);
     if (opportunities.length === 0) {
       return { cachedCards: new Map(), uncachedOpportunities: [] };
@@ -412,7 +412,7 @@ export async function checkPresenterCacheNode(state: RadarState, deps: RadarGrap
       const liveNegotiating = opportunities.filter((opp) => opp.status === 'negotiating');
 
       const keys = cacheable.map((opp) =>
-        buildRadarCardPresentationCacheKey(opp.id, opp.status, userId)
+        buildRadarCardPresentationCacheKey(opp.id, opp.status, userId, scopeId)
       );
       const results = keys.length > 0 ? await deps.cache.mget<RadarCardItem>(keys) : [];
 
@@ -642,6 +642,7 @@ export async function generateCardTextNode(state: RadarState, deps: RadarGraphDe
               opportunity,
               state.userId,
               otherActor?.userId,
+              state.scopeId,
             ),
             loadNegotiationContext(db, opportunity.id, opportunity.status, state.userId),
           ]);
@@ -718,7 +719,7 @@ export async function generateCardTextNode(state: RadarState, deps: RadarGraphDe
 
 export async function cachePresenterResultsNode(state: RadarState, deps: RadarGraphDeps) {
   return timed("RadarGraph.cachePresenterResults", async () => {
-    const { cards, cachedCards, userId, opportunities } = state;
+    const { cards, cachedCards, userId, opportunities, scopeId } = state;
     const poolRankingProvenance = getPoolRankingProvenance(state);
     const liveById = new Map(opportunities.map((opportunity) => [opportunity.id, opportunity]));
     const cardsWithAdjustments = cards.map((card) => {
@@ -744,7 +745,7 @@ export async function cachePresenterResultsNode(state: RadarState, deps: RadarGr
           // safe for the current response but must not become 24h entries.
           if (!status || !isRadarPresentationCacheable(card, status)) return Promise.resolve();
           return deps.cache.set(
-            buildRadarCardPresentationCacheKey(card.opportunityId, status, userId),
+            buildRadarCardPresentationCacheKey(card.opportunityId, status, userId, scopeId),
             card,
             { ttl: RADAR_CACHE_TTL }
           );

--- a/packages/protocol/src/internal/opportunities/tests/opportunity.presentation.spec.ts
+++ b/packages/protocol/src/internal/opportunities/tests/opportunity.presentation.spec.ts
@@ -9,7 +9,7 @@
 import { config } from "dotenv";
 config({ path: '.env.test', override: true });
 import { describe, expect, it, mock, test } from 'bun:test';
-import { DEFAULT_EMPTY_FALLBACK_TEXT, DEFAULT_FALLBACK_ACTION, DEFAULT_FALLBACK_HEADLINE, OPPORTUNITY_PRESENTATION_CACHE_VERSION, OpportunityPresenter, presentOpportunity, SAFE_FALLBACK_MAX_CHARS, truncateAtBoundary, buildApiChatCardPresentationCacheKey, buildDeliveryCardPresentationCacheKey, buildRadarCardPresentationCacheKey, getSafePresentationOrSkip, safeFallbackSummary, summarizeSignalsForPresenter, type CardPresenterInput } from "../opportunity.presentation.js";
+import { DEFAULT_EMPTY_FALLBACK_TEXT, DEFAULT_FALLBACK_ACTION, DEFAULT_FALLBACK_HEADLINE, OPPORTUNITY_PRESENTATION_CACHE_VERSION, OpportunityPresenter, presentOpportunity, SAFE_FALLBACK_MAX_CHARS, truncateAtBoundary, buildApiChatCardPresentationCacheKey, buildDeliveryCardPresentationCacheKey, buildRadarCardPresentationCacheKey, gatherPresenterContext, getSafePresentationOrSkip, safeFallbackSummary, summarizeSignalsForPresenter, type CardPresenterInput, type PresenterDatabase } from "../opportunity.presentation.js";
 import type { Opportunity } from '../../../platform/database.js';
 import { HumanMessage, SystemMessage } from "@langchain/core/messages";
 import type { NegotiationContext } from "../negotiation-context.loader.js";
@@ -159,10 +159,48 @@ describe("opportunity presentation cache namespace", () => {
     expect(OPPORTUNITY_PRESENTATION_CACHE_VERSION).toBe("v2");
     expect(buildRadarCardPresentationCacheKey("opp", "pending", "viewer"))
       .toBe("radar:v2:card:opp:pending:viewer");
+    expect(buildRadarCardPresentationCacheKey("opp", "pending", "viewer", "intent-1"))
+      .toBe("radar:v2:card:opp:pending:viewer:intent:intent-1");
     expect(buildDeliveryCardPresentationCacheKey("opp", "pending", "viewer"))
       .toBe("delivery:v2:card:opp:pending:viewer");
     expect(buildApiChatCardPresentationCacheKey("opp", "viewer"))
       .toBe("chat:v2:card:opp:viewer");
+  });
+});
+
+describe("gatherPresenterContext", () => {
+  const opportunity = {
+    id: "opp-1",
+    actors: [
+      { userId: "viewer", role: "party" },
+      { userId: "other", role: "party" },
+    ],
+    interpretation: { reasoning: "A relevant match.", category: "connection", confidence: 0.8 },
+    detection: { source: "discovery" },
+    context: {},
+  } as Opportunity;
+  const database = {
+    getProfile: async (userId: string) => ({ identity: { name: userId, bio: "", location: "" }, context: "" }),
+    getNetwork: async () => null,
+    getPremisesForUser: async () => [],
+    getActiveIntents: async () => [
+      { id: "helicopter", payload: "Buy a helicopter", summary: null, createdAt: new Date() },
+      { id: "investment", payload: "I am in SF, looking for investment", summary: null, createdAt: new Date() },
+    ],
+  } as PresenterDatabase;
+
+  it("includes only the focused active intent for a non-introducer viewer", async () => {
+    const context = await gatherPresenterContext(database, opportunity, "viewer", undefined, "helicopter");
+
+    expect(context.viewerContext).toContain("Buy a helicopter");
+    expect(context.viewerContext).not.toContain("looking for investment");
+  });
+
+  it("keeps all active intents when no focused intent is supplied", async () => {
+    const context = await gatherPresenterContext(database, opportunity, "viewer");
+
+    expect(context.viewerContext).toContain("Buy a helicopter");
+    expect(context.viewerContext).toContain("looking for investment");
   });
 });
 

--- a/packages/protocol/src/internal/opportunities/tests/opportunity.tools.digest-presenter.spec.ts
+++ b/packages/protocol/src/internal/opportunities/tests/opportunity.tools.digest-presenter.spec.ts
@@ -32,6 +32,8 @@ const gatherPresenterContextMock = mock(async (
   _presenterDb: PresenterDatabase,
   opp: { status: string },
   _viewerId: string,
+  _displayCounterpartUserId?: string,
+  _focusedViewerIntentId?: string,
 ) => ({
   opportunityStatus: opp.status,
 }));
@@ -153,8 +155,8 @@ function makeDeps(overrides: Partial<Parameters<typeof createOpportunityTools>[1
     } as unknown as ToolDeps["graphs"],
     opportunityPresentation: {
       createPresenter: () => ({ presentCard: (input: unknown) => presentCardMock(input) }),
-      gatherPresenterContext: (database: PresenterDatabase, opportunity: Opportunity, viewerId: string) =>
-        gatherPresenterContextMock(database, opportunity, viewerId),
+      gatherPresenterContext: (database: PresenterDatabase, opportunity: Opportunity, viewerId: string, displayCounterpartUserId?: string, focusedViewerIntentId?: string) =>
+        gatherPresenterContextMock(database, opportunity, viewerId, displayCounterpartUserId, focusedViewerIntentId),
     },
     ...overrides,
   } as ToolDeps;
@@ -163,6 +165,21 @@ function makeDeps(overrides: Partial<Parameters<typeof createOpportunityTools>[1
 // ─── Tests ────────────────────────────────────────────────────────────────────
 
 describe('list_opportunities digest presenter path', () => {
+  it('passes its effective intent scope to presenter context generation', async () => {
+    const intentId = '123e4567-e89b-12d3-a456-426614174000';
+    candidateOpps = [makeOpp('opp-scoped', 'c-scoped')];
+    const deps = makeDeps();
+    const tools = createOpportunityTools(defineTool as unknown as DefineTool, deps);
+    const listTool = tools.find((t: { name: string }) => t.name === 'list_opportunities')!;
+
+    await listTool.handler({
+      context: { userId: testUserId, isMcp: true, userName: 'Viewer', userNetworks: [] },
+      query: { scopeType: 'intent', scopeId: intentId },
+    });
+
+    expect(gatherPresenterContextMock.mock.calls.at(-1)?.[4]).toBe(intentId);
+  });
+
   it('uses LLM presenter text when includeDigestMarkers=true and isMcp=true', async () => {
     candidateOpps = [makeOpp('opp-1', 'c-1')];
     getUser = mock(async () => ({ id: testUserId, name: 'Viewer' }) as UserRecord | null);

--- a/packages/protocol/src/internal/opportunities/tests/radar.graph.spec.ts
+++ b/packages/protocol/src/internal/opportunities/tests/radar.graph.spec.ts
@@ -4,16 +4,13 @@
 import { config } from 'dotenv';
 config({ path: '.env.test', override: true });
 
-import { afterAll, describe, test, expect, mock } from 'bun:test';
+import { afterAll, describe, test, expect, mock, spyOn } from 'bun:test';
 
 // This spec exercises uncached full-card presentation. Keep its model boundary
 // deterministic so the provider-free source suite cannot open a network request.
-const presenterMessages: unknown[] = [];
 mock.module('../../shared/agent/model.config', () => ({
   createStructuredModel: (agent: string) => ({
-    invoke: async (messages: unknown) => {
-      presenterMessages.push(messages);
-      return {
+    invoke: async () => ({
             presentation: {
               headline: 'A relevant connection',
               personalizedSummary: 'Their current goals may be relevant to yours.',
@@ -23,8 +20,7 @@ mock.module('../../shared/agent/model.config', () => ({
               mutualIntentsLabel: 'Shared interests',
               greeting: '',
             },
-      };
-    },
+    }),
   }),
 }));
 
@@ -36,6 +32,7 @@ import { selectByComposition, classifyOpportunity, RADAR_SOFT_TARGETS } from '..
 import type { RadarGraphDatabase } from '../../../platform/database.js';
 import type { Opportunity } from '../../../platform/database.js';
 import type { OpportunityCache } from '../../../platform/discovery/cache.js';
+import { OpportunityPresenter } from '../opportunity.presentation.js';
 
 function createMockCache(): OpportunityCache {
   const store = new Map<string, unknown>();
@@ -147,17 +144,18 @@ describe('RadarGraph', () => {
       set: async (key) => { cacheKeys.push(key); },
     };
 
-    presenterMessages.length = 0;
+    const presentCardSpy = spyOn(OpportunityPresenter.prototype, 'presentCard');
     await new RadarGraphFactory(db, cache).createGraph().invoke({
       userId: viewerId,
       scopeType: 'intent',
       scopeId: intentId,
     });
 
-    const prompt = String((presenterMessages.at(-1) as Array<{ content?: unknown }> | undefined)?.at(-1)?.content);
-    expect(prompt).toContain('Buy a helicopter');
-    expect(prompt).not.toContain('looking for investment');
+    const presenterInput = presentCardSpy.mock.calls.at(-1)?.[0];
+    expect(presenterInput?.viewerContext).toContain('Buy a helicopter');
+    expect(presenterInput?.viewerContext).not.toContain('looking for investment');
     expect(cacheKeys).toContain(`radar:v2:card:opp-scoped:pending:${viewerId}:intent:${intentId}`);
+    presentCardSpy.mockRestore();
 
     cacheKeys.length = 0;
     await new RadarGraphFactory(db, cache).createGraph().invoke({ userId: viewerId });

--- a/packages/protocol/src/internal/opportunities/tests/radar.graph.spec.ts
+++ b/packages/protocol/src/internal/opportunities/tests/radar.graph.spec.ts
@@ -8,9 +8,12 @@ import { afterAll, describe, test, expect, mock } from 'bun:test';
 
 // This spec exercises uncached full-card presentation. Keep its model boundary
 // deterministic so the provider-free source suite cannot open a network request.
+const presenterMessages: unknown[] = [];
 mock.module('../../shared/agent/model.config', () => ({
   createStructuredModel: (agent: string) => ({
-    invoke: async () => ({
+    invoke: async (messages: unknown) => {
+      presenterMessages.push(messages);
+      return {
             presentation: {
               headline: 'A relevant connection',
               personalizedSummary: 'Their current goals may be relevant to yours.',
@@ -20,7 +23,8 @@ mock.module('../../shared/agent/model.config', () => ({
               mutualIntentsLabel: 'Shared interests',
               greeting: '',
             },
-    }),
+      };
+    },
   }),
 }));
 
@@ -124,6 +128,42 @@ describe('radar presentation cache policy', () => {
 });
 
 describe('RadarGraph', () => {
+  test('uses the intent scope for presenter context and a distinct presentation cache key', async () => {
+    const viewerId = 'viewer-scoped';
+    const intentId = 'intent-helicopter';
+    const opp = minimalOpportunityAgentViewer(viewerId, 'other-scoped', 'opp-scoped');
+    const db = createMockDb([opp]);
+    db.getActiveIntents = async () => [
+      { id: intentId, payload: 'Buy a helicopter', summary: null, createdAt: new Date() },
+      { id: 'intent-investment', payload: 'I am in SF, looking for investment', summary: null, createdAt: new Date() },
+    ];
+    const cacheKeys: string[] = [];
+    const cache: OpportunityCache = {
+      get: async () => null,
+      mget: async (keys) => {
+        cacheKeys.push(...keys);
+        return keys.map(() => null);
+      },
+      set: async (key) => { cacheKeys.push(key); },
+    };
+
+    presenterMessages.length = 0;
+    await new RadarGraphFactory(db, cache).createGraph().invoke({
+      userId: viewerId,
+      scopeType: 'intent',
+      scopeId: intentId,
+    });
+
+    const prompt = String((presenterMessages.at(-1) as Array<{ content?: unknown }> | undefined)?.at(-1)?.content);
+    expect(prompt).toContain('Buy a helicopter');
+    expect(prompt).not.toContain('looking for investment');
+    expect(cacheKeys).toContain(`radar:v2:card:opp-scoped:pending:${viewerId}:intent:${intentId}`);
+
+    cacheKeys.length = 0;
+    await new RadarGraphFactory(db, cache).createGraph().invoke({ userId: viewerId });
+    expect(cacheKeys).toContain(`radar:v2:card:opp-scoped:pending:${viewerId}`);
+  }, 30000);
+
   test('renders a completed verdict reason only for the resolving viewer', async () => {
     const opportunity = {
       ...minimalOpportunity('resolver', 'counterparty'),


### PR DESCRIPTION
## Summary
- scope non-introducer presenter context to the selected active intent on intent Radar and list surfaces
- separate intent-scoped Radar presentation cache entries from unscoped cards
- cover focused/unscoped context, Radar cache/context propagation, and list propagation

## Verification
- `bun test src/internal/opportunities/tests/opportunity.presentation.spec.ts`
- `bun test src/internal/opportunities/tests/radar.graph.spec.ts`
- `bun test src/internal/opportunities/tests/opportunity.tools.digest-presenter.spec.ts`
- `bun run build:package` (in `packages/protocol`)
- `bun run lint`

No selection, evaluation, or stored opportunity data changed.