### PR TITLE
Fix intent page realtime state

### DIFF
--- a/apps/web/src/app/i/[intentId]/page.tsx
+++ b/apps/web/src/app/i/[intentId]/page.tsx
@@ -288,7 +288,7 @@ export default function IntentDetailPage() {
   useIntentVisitPing(intentId);
   const { error: showError } = useNotifications();
   const { user } = useAuthContext();
-  const { subscribePersonalAgentTurnCompleted } = useConversation();
+  const { subscribePersonalAgentTurnCompleted, subscribeIntentDiscoveryProgress } = useConversation();
 
   const [intent, setIntent] = useState<Awaited<
     ReturnType<typeof intentsService.getIntent>
@@ -314,6 +314,7 @@ export default function IntentDetailPage() {
   const [intentTimeline, setIntentTimeline] = useState<IntentCycleTimelineEntry[]>([]);
   const [intentTimelineLoading, setIntentTimelineLoading] = useState(true);
   const [intentTimelineError, setIntentTimelineError] = useState(false);
+  const [liveInvalidation, setLiveInvalidation] = useState(0);
   const [refineText, setRefineText] = useState("");
   const [refining, setRefining] = useState(false);
   const [showRefine, setShowRefine] = useState(false);
@@ -500,27 +501,22 @@ export default function IntentDetailPage() {
     if (intentId) void intentsService.getIntent(intentId).then(setIntent).catch(() => {});
   }, [intentId, intentsService, loadIntentCycle, loadIntentTimeline, loadOpportunities]);
 
+  const invalidateLiveIntent = useCallback(() => {
+    setLiveInvalidation((value) => value + 1);
+    refreshLiveRadar();
+  }, [refreshLiveRadar]);
+
   useEffect(() => {
     return subscribePersonalAgentTurnCompleted((event) => {
-      if (event.intentId === intentId) refreshLiveRadar();
+      if (event.intentId === intentId) invalidateLiveIntent();
     });
-  }, [intentId, refreshLiveRadar, subscribePersonalAgentTurnCompleted]);
+  }, [intentId, invalidateLiveIntent, subscribePersonalAgentTurnCompleted]);
 
-  // Refresh only the owner-scoped progress snapshot while work is non-terminal;
-  // this intentionally leaves the negotiator chat mounted and untouched.
-  // `blocked` belongs here: a blocked card can only observe its own recovery
-  // (the signal joining an active community) by polling for it.
-  const discoveryStatus = intent?.discoveryProgress?.status;
   useEffect(() => {
-    // Depend on the status alone, not the whole intent: refetching the intent
-    // replaces the object on every live refresh, which would reset this
-    // interval before it ever fired.
-    if (!intentId || !["queued", "running", "retrying", "blocked"].includes(discoveryStatus ?? "")) return;
-    const timer = window.setInterval(() => {
-      void intentsService.getIntent(intentId).then(setIntent).catch(() => {});
-    }, 15_000);
-    return () => window.clearInterval(timer);
-  }, [intentId, discoveryStatus, intentsService]);
+    return subscribeIntentDiscoveryProgress((event) => {
+      if (event.intentId === intentId) invalidateLiveIntent();
+    });
+  }, [intentId, invalidateLiveIntent, subscribeIntentDiscoveryProgress]);
 
   useEffect(() => {
     if (!intentId) return;
@@ -928,7 +924,7 @@ export default function IntentDetailPage() {
                     className="min-h-0 flex-1"
                   >
                     {user?.id && (
-                      <IntentMemoryStrip intentId={intentId} userId={user.id} />
+                      <IntentMemoryStrip intentId={intentId} userId={user.id} liveInvalidation={liveInvalidation} />
                     )}
                     <IntentNegotiatorChat
                       key={intentId}
@@ -942,6 +938,7 @@ export default function IntentDetailPage() {
                         handleOpportunityAction(id, action, userId, role, name)
                       }
                       onUnavailable={() => setChatUnavailable(true)}
+                      onLiveInvalidation={invalidateLiveIntent}
                     />
                   </Panel>
                 ) : (

--- a/apps/web/src/components/IntentMemoryStrip.tsx
+++ b/apps/web/src/components/IntentMemoryStrip.tsx
@@ -27,9 +27,11 @@ const MAX_ROWS = 5;
 export default function IntentMemoryStrip({
   intentId,
   userId,
+  liveInvalidation = 0,
 }: {
   intentId: string;
   userId: string;
+  liveInvalidation?: number;
 }) {
   const api = useAuthenticatedAPI();
   const [memories, setMemories] = useState<NegotiatorMemory[]>([]);
@@ -50,7 +52,7 @@ export default function IntentMemoryStrip({
       cancelled = true;
     };
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [userId, intentId]);
+  }, [userId, intentId, liveInvalidation]);
 
   if (memories.length === 0) return null;
 

--- a/apps/web/src/components/IntentNegotiatorChat.tsx
+++ b/apps/web/src/components/IntentNegotiatorChat.tsx
@@ -59,6 +59,8 @@ export interface IntentNegotiatorChatProps {
    * static panel.
    */
   onUnavailable: () => void;
+  /** Revalidate the intent workspace after a durable agent message arrives. */
+  onLiveInvalidation?: () => void;
 }
 
 /**
@@ -81,6 +83,7 @@ export default function IntentNegotiatorChat({
   opportunityActionLoading,
   onOpportunityAction,
   onUnavailable,
+  onLiveInvalidation,
 }: IntentNegotiatorChatProps) {
   const {
     messages,
@@ -94,7 +97,7 @@ export default function IntentNegotiatorChat({
     clearChat,
     sessionId,
   } = useAIChat();
-  const { subscribeQuestionRegeneration, subscribePersonalAgentTurnCompleted } = useConversation();
+  const { subscribeQuestionRegeneration, subscribePersonalAgentTurnCompleted, subscribeConversationMessage } = useConversation();
 
   const [agentName, setAgentName] = useState<string | null>(null);
   const [bootstrapRegenerationPending, setBootstrapRegenerationPending] = useState(false);
@@ -142,6 +145,17 @@ export default function IntentNegotiatorChat({
       if (event.intentId === intentId) setTurnReloadToken((token) => token + 1);
     });
   }, [intentId, subscribePersonalAgentTurnCompleted]);
+
+  // A2H writes can happen outside the local POST stream. Reconcile this
+  // session on any persisted agent message, then let the parent refresh its
+  // intent-scoped server snapshots.
+  useEffect(() => {
+    return subscribeConversationMessage((event) => {
+      if (event.conversationId !== sessionId || event.message.role !== "agent") return;
+      setTurnReloadToken((token) => token + 1);
+      onLiveInvalidation?.();
+    });
+  }, [onLiveInvalidation, sessionId, subscribeConversationMessage]);
 
   // Apply the reload outside the active stream: while the negotiator is
   // streaming, the shared context owns the message list, so wait for

--- a/apps/web/src/components/__tests__/IntentMemoryStrip.test.tsx
+++ b/apps/web/src/components/__tests__/IntentMemoryStrip.test.tsx
@@ -1,0 +1,23 @@
+import { render, waitFor } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+
+const get = vi.fn(async () => ({ memories: [] }));
+
+vi.mock('@/lib/api', () => ({
+  useAuthenticatedAPI: () => ({ get }),
+}));
+
+import IntentMemoryStrip from '../IntentMemoryStrip';
+
+describe('IntentMemoryStrip', () => {
+  it('re-fetches intent memory when its live intent invalidation changes', async () => {
+    const { rerender } = render(
+      <IntentMemoryStrip intentId="intent-1" userId="user-1" liveInvalidation={0} />,
+    );
+    await waitFor(() => expect(get).toHaveBeenCalledTimes(1));
+
+    rerender(<IntentMemoryStrip intentId="intent-1" userId="user-1" liveInvalidation={1} />);
+    await waitFor(() => expect(get).toHaveBeenCalledTimes(2));
+    expect(get).toHaveBeenLastCalledWith('/users/user-1/negotiator/memories?intentId=intent-1');
+  });
+});

--- a/apps/web/src/components/__tests__/IntentNegotiatorChatOptions.test.tsx
+++ b/apps/web/src/components/__tests__/IntentNegotiatorChatOptions.test.tsx
@@ -3,6 +3,7 @@ import userEvent from '@testing-library/user-event';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 const sendMessage = vi.fn(async () => {});
+let conversationMessageHandler: ((event: { conversationId: string; message: { role: string } }) => void) | undefined;
 const chatState = {
   messages: [] as Array<Record<string, unknown>>,
   isLoading: false,
@@ -21,6 +22,10 @@ vi.mock('@/contexts/ConversationContext', () => ({
   useConversation: () => ({
     subscribeQuestionRegeneration: () => () => {},
     subscribePersonalAgentTurnCompleted: () => () => {},
+    subscribeConversationMessage: (handler: typeof conversationMessageHandler) => {
+      conversationMessageHandler = handler;
+      return () => { conversationMessageHandler = undefined; };
+    },
   }),
 }));
 vi.mock('@/lib/api', () => ({
@@ -61,6 +66,7 @@ function renderChat() {
       opportunityActionLoading={{}}
       onOpportunityAction={() => {}}
       onUnavailable={() => {}}
+      onLiveInvalidation={() => {}}
     />,
   );
 }
@@ -75,6 +81,7 @@ describe('IntentNegotiatorChat option chips', () => {
     sendMessage.mockClear();
     chatState.isLoading = false;
     chatState.messages = [agentMessage()];
+    conversationMessageHandler = undefined;
   });
 
   it('sends the tapped chip as an ordinary user message', async () => {
@@ -116,12 +123,41 @@ describe('IntentNegotiatorChat option chips', () => {
         opportunityStatusMap={{}}
         opportunityActionLoading={{}}
         onOpportunityAction={() => {}}
-        onUnavailable={() => {}}
+      onUnavailable={() => {}}
+        onLiveInvalidation={() => {}}
       />,
     );
     const trace = await screen.findByTestId('personal-agent-debug-trace');
     expect(trace).toHaveTextContent('PersonalAgent debug trace');
     expect(trace).toHaveTextContent('matches_ready');
     expect(trace).toHaveTextContent('message_user');
+  });
+
+  it('reconciles an agent SSE message for its session, but ignores another session', async () => {
+    const onLiveInvalidation = vi.fn();
+    render(
+      <IntentNegotiatorChat
+        intentId="intent-1"
+        timelineEntries={[]}
+        timelineLoading={false}
+        timelineError={false}
+        opportunityStatusMap={{}}
+        opportunityActionLoading={{}}
+        onOpportunityAction={() => {}}
+        onUnavailable={() => {}}
+        onLiveInvalidation={onLiveInvalidation}
+      />,
+    );
+    await waitFor(() => expect(conversationMessageHandler).toBeTypeOf('function'));
+    chatState.loadSession.mockClear();
+
+    conversationMessageHandler?.({ conversationId: 'session-other', message: { role: 'agent' } });
+    await Promise.resolve();
+    expect(chatState.loadSession).not.toHaveBeenCalled();
+    expect(onLiveInvalidation).not.toHaveBeenCalled();
+
+    conversationMessageHandler?.({ conversationId: 'session-1', message: { role: 'agent' } });
+    await waitFor(() => expect(chatState.loadSession).toHaveBeenCalledWith('session-1'));
+    expect(onLiveInvalidation).toHaveBeenCalledTimes(1);
   });
 });

--- a/apps/web/src/contexts/ConversationContext.tsx
+++ b/apps/web/src/contexts/ConversationContext.tsx
@@ -38,6 +38,17 @@ export interface PersonalAgentTurnCompletedEvent {
   intentId: string;
 }
 
+/** A persisted message received on the authenticated conversation SSE channel. */
+export interface ConversationMessageEvent {
+  conversationId: string;
+  message: ConversationMessage;
+}
+
+/** An owner-visible discovery-progress write; fetch the intent for its data. */
+export interface IntentDiscoveryProgressEvent {
+  intentId: string;
+}
+
 interface ConversationContextType {
   conversations: ConversationSummary[];
   negotiations: ConversationSummary[];
@@ -62,6 +73,10 @@ interface ConversationContextType {
   subscribeQuestionRegeneration: (handler: (event: QuestionRegenerationEvent) => void) => () => void;
   /** Subscribe to durable PersonalAgent completion signals from the SSE stream. */
   subscribePersonalAgentTurnCompleted: (handler: (event: PersonalAgentTurnCompletedEvent) => void) => () => void;
+  /** Subscribe to persisted conversation messages from the SSE stream. */
+  subscribeConversationMessage: (handler: (event: ConversationMessageEvent) => void) => () => void;
+  /** Subscribe to owner-scoped discovery-progress invalidations. */
+  subscribeIntentDiscoveryProgress: (handler: (event: IntentDiscoveryProgressEvent) => void) => () => void;
 }
 
 const ConversationContext = createContext<ConversationContextType | null>(null);
@@ -87,6 +102,8 @@ export function ConversationProvider({ children }: { children: React.ReactNode }
   const negotiationsRefreshTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const questionRegenerationHandlersRef = useRef(new Set<(event: QuestionRegenerationEvent) => void>());
   const personalAgentTurnCompletedHandlersRef = useRef(new Set<(event: PersonalAgentTurnCompletedEvent) => void>());
+  const conversationMessageHandlersRef = useRef(new Set<(event: ConversationMessageEvent) => void>());
+  const intentDiscoveryProgressHandlersRef = useRef(new Set<(event: IntentDiscoveryProgressEvent) => void>());
 
   const subscribeQuestionRegeneration = useCallback(
     (handler: (event: QuestionRegenerationEvent) => void) => {
@@ -104,6 +121,22 @@ export function ConversationProvider({ children }: { children: React.ReactNode }
       return () => {
         personalAgentTurnCompletedHandlersRef.current.delete(handler);
       };
+    },
+    [],
+  );
+
+  const subscribeConversationMessage = useCallback(
+    (handler: (event: ConversationMessageEvent) => void) => {
+      conversationMessageHandlersRef.current.add(handler);
+      return () => { conversationMessageHandlersRef.current.delete(handler); };
+    },
+    [],
+  );
+
+  const subscribeIntentDiscoveryProgress = useCallback(
+    (handler: (event: IntentDiscoveryProgressEvent) => void) => {
+      intentDiscoveryProgressHandlersRef.current.add(handler);
+      return () => { intentDiscoveryProgressHandlersRef.current.delete(handler); };
     },
     [],
   );
@@ -427,6 +460,10 @@ export function ConversationProvider({ children }: { children: React.ReactNode }
                 negotiationsRefreshTimeoutRef.current = null;
                 void refreshNegotiationsRef.current();
               }, 500);
+              conversationMessageHandlersRef.current.forEach((handler) => handler({
+                conversationId: convId,
+                message: msg,
+              }));
               break;
             }
             case 'question_regeneration': {
@@ -440,6 +477,12 @@ export function ConversationProvider({ children }: { children: React.ReactNode }
                 pending: Boolean(data.pending),
               };
               questionRegenerationHandlersRef.current.forEach((handler) => handler(regenerationEvent));
+              break;
+            }
+            case 'intent_discovery_progress': {
+              const intentId = data.intentId as string | undefined;
+              if (!intentId) break;
+              intentDiscoveryProgressHandlersRef.current.forEach((handler) => handler({ intentId }));
               break;
             }
             case 'personal_agent_turn_completed': {
@@ -545,6 +588,8 @@ export function ConversationProvider({ children }: { children: React.ReactNode }
         getOrCreateDM,
         subscribeQuestionRegeneration,
         subscribePersonalAgentTurnCompleted,
+        subscribeConversationMessage,
+        subscribeIntentDiscoveryProgress,
       }}
     >
       {children}

--- a/apps/web/tests/intent-negotiator-chat.test.tsx
+++ b/apps/web/tests/intent-negotiator-chat.test.tsx
@@ -32,6 +32,7 @@ const mocks = vi.hoisted(() => ({
   },
   regenerationHandlers: new Set<(event: { intentId: string; pending: boolean }) => void>(),
   turnCompletedHandlers: new Set<(event: { intentId: string }) => void>(),
+  conversationMessageHandlers: new Set<(event: { conversationId: string; message: { role: string } }) => void>(),
 }));
 
 vi.mock('@/lib/api', () => ({
@@ -57,6 +58,12 @@ vi.mock('@/contexts/ConversationContext', () => ({
         mocks.turnCompletedHandlers.delete(handler);
       };
     },
+    subscribeConversationMessage: (handler: (event: { conversationId: string; message: { role: string } }) => void) => {
+      mocks.conversationMessageHandlers.add(handler);
+      return () => {
+        mocks.conversationMessageHandlers.delete(handler);
+      };
+    },
   }),
 }));
 
@@ -70,6 +77,12 @@ function emitRegeneration(event: { intentId: string; pending: boolean }) {
 function emitTurnCompleted(event: { intentId: string }) {
   act(() => {
     mocks.turnCompletedHandlers.forEach((handler) => handler(event));
+  });
+}
+
+function emitConversationMessage(event: { conversationId: string; message: { role: string } }) {
+  act(() => {
+    mocks.conversationMessageHandlers.forEach((handler) => handler(event));
   });
 }
 
@@ -123,6 +136,7 @@ describe('IntentNegotiatorChat', () => {
     vi.clearAllMocks();
     mocks.regenerationHandlers.clear();
     mocks.turnCompletedHandlers.clear();
+    mocks.conversationMessageHandlers.clear();
     mocks.chat.messages = [];
     mocks.chat.isLoading = false;
     mocks.chat.sessionId = null;
@@ -199,6 +213,21 @@ describe('IntentNegotiatorChat', () => {
     emitTurnCompleted({ intentId: 'intent-1' });
     await waitFor(() => expect(mocks.chat.loadSession).toHaveBeenCalledTimes(2));
     expect(mocks.chat.loadSession).toHaveBeenLastCalledWith('neg-intent-sess-1');
+  });
+
+  test('reconciles an agent message for the current session and invalidates its workspace', async () => {
+    mocks.chat.sessionId = 'neg-intent-sess-1';
+    const onLiveInvalidation = vi.fn();
+    renderChat({ onLiveInvalidation });
+    await waitFor(() => expect(mocks.chat.loadSession).toHaveBeenCalledTimes(1));
+
+    emitConversationMessage({ conversationId: 'someone-elses-session', message: { role: 'agent' } });
+    expect(mocks.chat.loadSession).toHaveBeenCalledTimes(1);
+    expect(onLiveInvalidation).not.toHaveBeenCalled();
+
+    emitConversationMessage({ conversationId: 'neg-intent-sess-1', message: { role: 'agent' } });
+    await waitFor(() => expect(mocks.chat.loadSession).toHaveBeenCalledTimes(2));
+    expect(onLiveInvalidation).toHaveBeenCalledTimes(1);
   });
 
   test('releases the shared chat context on unmount', async () => {

--- a/services/api/src/adapters/chat.database.adapter.ts
+++ b/services/api/src/adapters/chat.database.adapter.ts
@@ -13,6 +13,7 @@ import { OpportunityDatabaseAdapter } from './opportunity.database.adapter';
 import { HydeDatabaseAdapter } from './hyde.database.adapter';
 import { ConversationDatabaseAdapter } from './conversation.database.adapter';
 import { _convDb } from './conversation.database.adapter';
+import { publishIntentDiscoveryProgressEvent } from '../lib/conversation-events';
 
 export interface NetworkShareResponseRow {
   id: string;
@@ -954,6 +955,14 @@ export class ChatDatabaseAdapter {
     }).onConflictDoUpdate({ target: schema.intentDiscoveryProgress.intentId, set: {
       status: input.status, attempt: input.attempt, ...counts, updatedAt: now, ...timestamps,
     }});
+    try {
+      await publishIntentDiscoveryProgressEvent(input);
+    } catch (error) {
+      logger.error('Failed to publish intent discovery-progress SSE event', {
+        intentId: input.intentId,
+        error: error instanceof Error ? error.message : String(error),
+      });
+    }
   }
 
   async getNetworkMemberContext(networkId: string, userId: string) {

--- a/services/api/src/adapters/conversation.database.adapter.ts
+++ b/services/api/src/adapters/conversation.database.adapter.ts
@@ -3773,7 +3773,7 @@ export class ConversationDatabaseAdapter {
     if (data.interrupted) msgMeta.interrupted = true;
     if (data.options?.length) msgMeta.options = data.options;
 
-    await this.insertMessageWithConversationSession({
+    const message = await this.insertMessageWithConversationSession({
       id: data.id,
       conversationId: data.sessionId,
       senderId,
@@ -3784,6 +3784,17 @@ export class ConversationDatabaseAdapter {
       extensions: null,
       referenceTaskIds: null,
     });
+
+    // Chat-session writers include background A2H replies. Publish only after
+    // their durable write, using stored participants as the privacy boundary.
+    try {
+      await publishConversationMessageEvent(message, await this.getParticipants(data.sessionId));
+    } catch (error) {
+      logger.error('Failed to publish chat-session SSE event', {
+        conversationId: data.sessionId,
+        error: error instanceof Error ? error.message : String(error),
+      });
+    }
   }
 
   /**

--- a/services/api/src/lib/conversation-events.ts
+++ b/services/api/src/lib/conversation-events.ts
@@ -75,3 +75,18 @@ export async function publishPersonalAgentTurnCompletedEvent(input: {
     JSON.stringify({ type: 'personal_agent_turn_completed', intentId: input.intentId }),
   );
 }
+
+/**
+ * Publishes an owner-scoped invalidation after the durable discovery-progress
+ * snapshot changes. The client re-fetches its authoritative intent response;
+ * no progress data crosses the shared SSE channel.
+ */
+export async function publishIntentDiscoveryProgressEvent(input: {
+  userId: string;
+  intentId: string;
+}): Promise<void> {
+  await getRedisClient().publish(
+    `conversations:user:${input.userId}`,
+    JSON.stringify({ type: 'intent_discovery_progress', intentId: input.intentId }),
+  );
+}

--- a/services/api/src/lib/tests/conversation-events.spec.ts
+++ b/services/api/src/lib/tests/conversation-events.spec.ts
@@ -1,6 +1,6 @@
 import { describe, expect, test } from 'bun:test';
 
-import { conversationEventRecipientUserIds, publishPersonalAgentTurnCompletedEvent } from '../conversation-events';
+import { conversationEventRecipientUserIds, publishConversationMessageEvent, publishIntentDiscoveryProgressEvent, publishPersonalAgentTurnCompletedEvent } from '../conversation-events';
 import { getRedisClient } from '../../adapters/cache.adapter';
 
 describe('conversationEventRecipientUserIds', () => {
@@ -33,6 +33,48 @@ test('publishes a completed PersonalAgent turn only to its owner channel', async
     expect(published).toEqual([{
       channel: 'conversations:user:owner-a',
       payload: JSON.stringify({ type: 'personal_agent_turn_completed', intentId: 'intent-a' }),
+    }]);
+  } finally {
+    redis.publish = originalPublish;
+  }
+});
+
+test('publishes a persisted chat-session agent message only after it has participant recipients', async () => {
+  const redis = getRedisClient();
+  const published: Array<{ channel: string; payload: string }> = [];
+  const originalPublish = redis.publish.bind(redis);
+  redis.publish = (async (channel: string, payload: string) => {
+    published.push({ channel, payload });
+    return 1;
+  }) as typeof redis.publish;
+  try {
+    await publishConversationMessageEvent({
+      conversationId: 'session-a', id: 'message-a', senderId: 'system-agent',
+      role: 'agent', parts: [{ type: 'text', text: 'Background reply' }], createdAt: new Date('2026-08-24T00:00:00Z'),
+    }, [{ participantId: 'agent:owner-a' }]);
+    expect(published).toHaveLength(1);
+    expect(published[0]?.channel).toBe('conversations:user:owner-a');
+    expect(JSON.parse(published[0]!.payload)).toMatchObject({
+      type: 'message', conversationId: 'session-a', message: { id: 'message-a', role: 'agent' },
+    });
+  } finally {
+    redis.publish = originalPublish;
+  }
+});
+
+test('publishes discovery-progress invalidation without progress data', async () => {
+  const redis = getRedisClient();
+  const published: Array<{ channel: string; payload: string }> = [];
+  const originalPublish = redis.publish.bind(redis);
+  redis.publish = (async (channel: string, payload: string) => {
+    published.push({ channel, payload });
+    return 1;
+  }) as typeof redis.publish;
+  try {
+    await publishIntentDiscoveryProgressEvent({ userId: 'owner-a', intentId: 'intent-a' });
+    expect(published).toEqual([{
+      channel: 'conversations:user:owner-a',
+      payload: JSON.stringify({ type: 'intent_discovery_progress', intentId: 'intent-a' }),
     }]);
   } finally {
     redis.publish = originalPublish;


### PR DESCRIPTION
## Summary
- publish persisted chat-session messages and discovery-progress invalidations through the authenticated conversation SSE channel
- reconcile negotiator A2H messages and revalidate intent, Radar, cycle, timeline, and memory state from live events
- replace discovery-progress polling with realtime invalidation

## Verification
- `bun --bun vitest run tests/intent-negotiator-chat.test.tsx src/components/__tests__/IntentNegotiatorChatOptions.test.tsx src/components/__tests__/IntentMemoryStrip.test.tsx`
- `bun test ./src/lib/tests/conversation-events.spec.ts`
- pre-commit build checks (protocol, API, web)
