### PR TITLE
Expire silent paused negotiations

### DIFF
--- a/apps/web/src/app/i/[intentId]/page.tsx
+++ b/apps/web/src/app/i/[intentId]/page.tsx
@@ -288,7 +288,7 @@ export default function IntentDetailPage() {
   useIntentVisitPing(intentId);
   const { error: showError } = useNotifications();
   const { user } = useAuthContext();
-  const { subscribePersonalAgentTurnCompleted, subscribeIntentDiscoveryProgress } = useConversation();
+  const { subscribePersonalAgentTurnCompleted, subscribeIntentDiscoveryProgress, subscribeIntentInvalidation } = useConversation();
 
   const [intent, setIntent] = useState<Awaited<
     ReturnType<typeof intentsService.getIntent>
@@ -517,6 +517,12 @@ export default function IntentDetailPage() {
       if (event.intentId === intentId) invalidateLiveIntent();
     });
   }, [intentId, invalidateLiveIntent, subscribeIntentDiscoveryProgress]);
+
+  useEffect(() => {
+    return subscribeIntentInvalidation((event) => {
+      if (event.intentId === intentId) invalidateLiveIntent();
+    });
+  }, [intentId, invalidateLiveIntent, subscribeIntentInvalidation]);
 
   useEffect(() => {
     if (!intentId) return;

--- a/apps/web/src/components/IntentNegotiationInspector.test.tsx
+++ b/apps/web/src/components/IntentNegotiationInspector.test.tsx
@@ -1,0 +1,38 @@
+import { render, screen } from '@testing-library/react';
+import { afterEach, describe, expect, test, vi } from 'vitest';
+
+import IntentNegotiationInspector from './IntentNegotiationInspector';
+import type { IntentCycleNegotiationDetail } from '@/services/conversation';
+
+const now = new Date('2026-07-21T12:00:00.000Z');
+
+function detail(reason: IntentCycleNegotiationDetail['task']['pause']['reason']): IntentCycleNegotiationDetail {
+  return {
+    intent: { id: 'intent-1', payload: 'Find a collaborator' },
+    task: {
+      id: 'task-1', conversationId: 'conversation-1', opportunityId: 'opportunity-1', round: 1,
+      state: 'paused', updatedAt: new Date(now.getTime() - 10 * 60 * 60 * 1000).toISOString(), brief: null,
+      pause: { reason, by: 'yours' },
+    },
+    transcript: [], outcome: null,
+  };
+}
+
+describe('IntentNegotiationInspector', () => {
+  afterEach(() => vi.useRealTimers());
+
+  test('shows the remaining expiry time for an eligible paused negotiation', () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(now);
+
+    render(<IntentNegotiationInspector detail={detail('needs_principal')} />);
+
+    expect(screen.getByText('Expires in 2h 0m')).toBeInTheDocument();
+  });
+
+  test('omits expiry time for a non-expiring pause reason', () => {
+    render(<IntentNegotiationInspector detail={detail('ready_for_verdict')} />);
+
+    expect(screen.queryByText(/Expires in/)).not.toBeInTheDocument();
+  });
+});

--- a/apps/web/src/components/IntentNegotiationInspector.tsx
+++ b/apps/web/src/components/IntentNegotiationInspector.tsx
@@ -8,6 +8,15 @@ function pauseLabel(reason: string): string {
   return reason.replace(/_/g, " ");
 }
 
+const PAUSED_NEGOTIATION_EXPIRE_AFTER_MS = 12 * 60 * 60 * 1000;
+
+function expiresIn(updatedAt: string): string {
+  const remainingMs = Math.max(0, new Date(updatedAt).getTime() + PAUSED_NEGOTIATION_EXPIRE_AFTER_MS - Date.now());
+  const hours = Math.floor(remainingMs / (60 * 60 * 1000));
+  const minutes = Math.ceil((remainingMs % (60 * 60 * 1000)) / (60 * 1000));
+  return hours > 0 ? `${hours}h ${minutes}m` : `${minutes}m`;
+}
+
 export default function IntentNegotiationInspector({ detail }: { detail: IntentCycleNegotiationDetail }) {
   return (
     <div className="space-y-4" aria-label="Negotiation inspector">
@@ -32,6 +41,9 @@ export default function IntentNegotiationInspector({ detail }: { detail: IntentC
         {detail.task.pause && (
           <div className="mt-3 rounded border border-amber-200 bg-amber-50 p-3">
             <p className="text-xs font-medium text-amber-900">Paused · {pauseLabel(detail.task.pause.reason)} · {detail.task.pause.by === 'yours' ? 'your agent' : detail.task.pause.by === 'theirs' ? 'their agent' : 'unknown seat'}</p>
+            {(detail.task.pause.reason === 'needs_principal' || detail.task.pause.reason === 'counterparty_silent') && (
+              <p className="mt-1 text-xs text-amber-800">Expires in {expiresIn(detail.task.updatedAt)}</p>
+            )}
             {detail.task.pause.payload !== undefined && (
               <pre className="mt-2 overflow-x-auto whitespace-pre-wrap font-ibm-plex-mono text-[11px] text-amber-950">{payload(detail.task.pause.payload)}</pre>
             )}

--- a/apps/web/src/contexts/ConversationContext.tsx
+++ b/apps/web/src/contexts/ConversationContext.tsx
@@ -49,6 +49,11 @@ export interface IntentDiscoveryProgressEvent {
   intentId: string;
 }
 
+/** An owner-scoped invalidation for an intent-owned view. */
+export interface IntentInvalidationEvent {
+  intentId: string;
+}
+
 interface ConversationContextType {
   conversations: ConversationSummary[];
   negotiations: ConversationSummary[];
@@ -77,6 +82,8 @@ interface ConversationContextType {
   subscribeConversationMessage: (handler: (event: ConversationMessageEvent) => void) => () => void;
   /** Subscribe to owner-scoped discovery-progress invalidations. */
   subscribeIntentDiscoveryProgress: (handler: (event: IntentDiscoveryProgressEvent) => void) => () => void;
+  /** Subscribe to owner-scoped intent invalidations. */
+  subscribeIntentInvalidation: (handler: (event: IntentInvalidationEvent) => void) => () => void;
 }
 
 const ConversationContext = createContext<ConversationContextType | null>(null);
@@ -104,6 +111,7 @@ export function ConversationProvider({ children }: { children: React.ReactNode }
   const personalAgentTurnCompletedHandlersRef = useRef(new Set<(event: PersonalAgentTurnCompletedEvent) => void>());
   const conversationMessageHandlersRef = useRef(new Set<(event: ConversationMessageEvent) => void>());
   const intentDiscoveryProgressHandlersRef = useRef(new Set<(event: IntentDiscoveryProgressEvent) => void>());
+  const intentInvalidationHandlersRef = useRef(new Set<(event: IntentInvalidationEvent) => void>());
 
   const subscribeQuestionRegeneration = useCallback(
     (handler: (event: QuestionRegenerationEvent) => void) => {
@@ -137,6 +145,14 @@ export function ConversationProvider({ children }: { children: React.ReactNode }
     (handler: (event: IntentDiscoveryProgressEvent) => void) => {
       intentDiscoveryProgressHandlersRef.current.add(handler);
       return () => { intentDiscoveryProgressHandlersRef.current.delete(handler); };
+    },
+    [],
+  );
+
+  const subscribeIntentInvalidation = useCallback(
+    (handler: (event: IntentInvalidationEvent) => void) => {
+      intentInvalidationHandlersRef.current.add(handler);
+      return () => { intentInvalidationHandlersRef.current.delete(handler); };
     },
     [],
   );
@@ -485,6 +501,12 @@ export function ConversationProvider({ children }: { children: React.ReactNode }
               intentDiscoveryProgressHandlersRef.current.forEach((handler) => handler({ intentId }));
               break;
             }
+            case 'intent_invalidated': {
+              const intentId = data.intentId as string | undefined;
+              if (!intentId) break;
+              intentInvalidationHandlersRef.current.forEach((handler) => handler({ intentId }));
+              break;
+            }
             case 'personal_agent_turn_completed': {
               const intentId = data.intentId as string | undefined;
               if (!intentId) break;
@@ -590,6 +612,7 @@ export function ConversationProvider({ children }: { children: React.ReactNode }
         subscribePersonalAgentTurnCompleted,
         subscribeConversationMessage,
         subscribeIntentDiscoveryProgress,
+        subscribeIntentInvalidation,
       }}
     >
       {children}

--- a/apps/web/src/services/conversation.ts
+++ b/apps/web/src/services/conversation.ts
@@ -145,6 +145,7 @@ export interface IntentCycleNegotiationDetail {
     opportunityId: string;
     round: number;
     state: NegotiationTaskState;
+    updatedAt: string;
     brief: string | null;
     pause: { reason: NegotiationPauseReason; by: 'yours' | 'theirs' | null; payload?: unknown } | null;
   };

--- a/apps/web/tests/intent-page-negotiator.test.tsx
+++ b/apps/web/tests/intent-page-negotiator.test.tsx
@@ -33,6 +33,7 @@ const mocks = vi.hoisted(() => ({
   },
   chatStubBehavior: { failBootstrap: false },
   turnCompletedHandlers: new Set<(event: { intentId: string }) => void>(),
+  intentInvalidationHandlers: new Set<(event: { intentId: string }) => void>(),
 }));
 
 vi.mock('@/components/ClientLayout', () => ({
@@ -83,6 +84,11 @@ vi.mock('@/contexts/ConversationContext', () => ({
       mocks.turnCompletedHandlers.add(handler);
       return () => mocks.turnCompletedHandlers.delete(handler);
     },
+    subscribeIntentDiscoveryProgress: () => () => {},
+    subscribeIntentInvalidation: (handler: (event: { intentId: string }) => void) => {
+      mocks.intentInvalidationHandlers.add(handler);
+      return () => mocks.intentInvalidationHandlers.delete(handler);
+    },
   }),
 }));
 
@@ -120,6 +126,12 @@ function emitTurnCompleted(event: { intentId: string }) {
   });
 }
 
+function emitIntentInvalidation(event: { intentId: string }) {
+  act(() => {
+    mocks.intentInvalidationHandlers.forEach((handler) => handler(event));
+  });
+}
+
 describe('Intent page — agent chat panel', () => {
   beforeEach(() => {
     vi.clearAllMocks();
@@ -136,6 +148,7 @@ describe('Intent page — agent chat panel', () => {
     mocks.conversationsService.getIntentCycleTimeline.mockResolvedValue([]);
     mocks.chatStubBehavior.failBootstrap = false;
     mocks.turnCompletedHandlers.clear();
+    mocks.intentInvalidationHandlers.clear();
   });
 
   test('the chat window renders unconditionally — no flag gates it', async () => {
@@ -166,6 +179,20 @@ describe('Intent page — agent chat panel', () => {
     vi.clearAllMocks();
 
     emitTurnCompleted({ intentId: 'intent-1' });
+
+    await waitFor(() => expect(mocks.intentsService.getIntent).toHaveBeenCalledWith('intent-1'));
+    expect(mocks.conversationsService.getIntentCycle).toHaveBeenCalledWith('intent-1');
+    expect(mocks.conversationsService.getIntentCycleTimeline).toHaveBeenCalledWith('intent-1');
+    expect(mocks.opportunitiesService.getRadarView).toHaveBeenCalled();
+  });
+
+  test('refreshes the entire workspace when negotiation expiry invalidates its intent', async () => {
+    renderIntentPage();
+    await screen.findByText('Looking for a technical co-founder');
+    await waitFor(() => expect(mocks.conversationsService.getIntentCycleTimeline).toHaveBeenCalledTimes(1));
+    vi.clearAllMocks();
+
+    emitIntentInvalidation({ intentId: 'intent-1' });
 
     await waitFor(() => expect(mocks.intentsService.getIntent).toHaveBeenCalledWith('intent-1'));
     expect(mocks.conversationsService.getIntentCycle).toHaveBeenCalledWith('intent-1');

--- a/packages/protocol/src/internal/negotiations/negotiation.graph.ts
+++ b/packages/protocol/src/internal/negotiations/negotiation.graph.ts
@@ -49,6 +49,7 @@ export type NegotiationGraphInput =
   /** `byUserId` is the seat submitting this turn; apply rejects a turn whose byUserId isn't the computed next speaker. */
   | { negotiationId: string; turn: NegotiationTurn; byUserId: string }
   | { negotiationId: string; pause: NegotiationSystemPauseReason }
+  | { negotiationId: string; expire: { expectedUpdatedAt: Date; reason: 'counterparty_silent' | 'needs_principal' } }
   /** A verdict is authored by one authenticated seat, never by an anonymous resolver. */
   | { negotiationId: string; verdict: NegotiationVerdict; reasoning: string; byUserId: string }
   | { negotiationId: string };
@@ -93,7 +94,7 @@ const NegotiationGraphState = Annotation.Root({
   pendingTurnByUserId: Annotation<string | null>({ reducer: (c, n) => (n === undefined ? c : n), default: () => null }),
   /** True once this invoke's own author/dispatch has produced `pendingTurn` — vs. one supplied on input. */
   authored: Annotation<boolean>({ reducer: (c, n) => n ?? c, default: () => false }),
-  phase: Annotation<"init" | "turn" | "apply" | "resolve" | "read" | "done" | "error">({
+  phase: Annotation<"init" | "turn" | "apply" | "resolve" | "expire" | "read" | "done" | "error">({
     reducer: (c, n) => n ?? c,
     default: () => "init",
   }),
@@ -147,7 +148,7 @@ async function initNode(state: NegotiationState, deps: NegotiationGraphDeps): Pr
     }
 
     // ── read-only ──
-    if (!("brief" in input) && !("turn" in input) && !("pause" in input)) {
+    if (!("brief" in input) && !("turn" in input) && !("pause" in input) && !("expire" in input)) {
       const task = await deps.database.getNegotiationTask(input.negotiationId);
       if (!task) return { phase: "error", error: "Negotiation not found" };
       const messages = await deps.database.getNegotiationMessages(task.id);
@@ -223,6 +224,8 @@ async function initNode(state: NegotiationState, deps: NegotiationGraphDeps): Pr
     const task = await deps.database.getNegotiationTask(input.negotiationId);
     if (!task) return { phase: "error", error: "Negotiation not found" };
     if (task.state === "completed") return { task, turns: [], phase: "read" };
+
+    if ("expire" in input) return { task, phase: "expire" };
 
     // A pause is one-way at rest, not a dead end: any resume (new brief, a
     // submitted turn, or a timeout) reopens the negotiation — but only once
@@ -489,6 +492,25 @@ async function resolveNode(state: NegotiationState, deps: NegotiationGraphDeps):
   }
 }
 
+/** System expiry has no user verdict or outcome artifact. */
+async function expireNode(state: NegotiationState, deps: NegotiationGraphDeps): Promise<Partial<NegotiationState>> {
+  const task = state.task;
+  const input = state.input;
+  if (!task || !("expire" in input)) return { phase: "error", error: "Missing task or expiry" };
+  try {
+    const expired = await deps.database.expirePausedNegotiation({
+      taskId: task.id,
+      expectedUpdatedAt: input.expire.expectedUpdatedAt,
+      reason: input.expire.reason,
+    });
+    if (!expired) return { task, phase: "done", result: toResult(task, []) };
+    await triggerReflectForEverySeat(deps, expired.metadata);
+    return { task: expired, phase: "done", result: { negotiationId: task.id, status: "resolved", turns: [] } };
+  } catch (err) {
+    return { phase: "error", error: err instanceof Error ? err.message : String(err) };
+  }
+}
+
 // ─── read ────────────────────────────────────────────────────────────────────
 
 function readNode(state: NegotiationState): Partial<NegotiationState> {
@@ -524,6 +546,7 @@ export class NegotiationGraphFactory {
       .addNode("turn", (s: NegotiationState) => turnNode(s, deps))
       .addNode("apply", (s: NegotiationState) => applyNode(s, deps))
       .addNode("resolve", (s: NegotiationState) => resolveNode(s, deps))
+      .addNode("expire", (s: NegotiationState) => expireNode(s, deps))
       .addNode("read", readNode)
       // Named "fail", not "error" — "error" is already the state's own
       // channel name, and LangGraph rejects a node name that collides with
@@ -534,12 +557,14 @@ export class NegotiationGraphFactory {
         turn: "turn",
         apply: "apply",
         resolve: "resolve",
+        expire: "expire",
         read: "read",
         error: "fail",
       })
       .addConditionalEdges("turn", (s: NegotiationState) => s.phase, { apply: "apply", done: END, error: "fail" })
       .addConditionalEdges("apply", (s: NegotiationState) => s.phase, { turn: "turn", done: END, error: "fail" })
       .addEdge("resolve", END)
+      .addEdge("expire", END)
       .addEdge("read", END)
       .addEdge("fail", END)
       .compile();

--- a/packages/protocol/src/internal/negotiations/tests/negotiation.graph.expiry.spec.ts
+++ b/packages/protocol/src/internal/negotiations/tests/negotiation.graph.expiry.spec.ts
@@ -1,0 +1,59 @@
+import { describe, expect, it, mock } from 'bun:test';
+
+import { NegotiationGraphFactory } from '../negotiation.graph.js';
+
+const updatedAt = new Date('2026-07-21T00:00:00.000Z');
+
+function task(state: 'paused' | 'completed' = 'paused') {
+  return {
+    id: 'task-1', conversationId: 'conversation-1', state, briefs: {}, createdAt: updatedAt, updatedAt,
+    metadata: {
+      type: 'negotiation' as const, opportunityId: 'opportunity-1', sourceUserId: 'user-1', candidateUserId: 'user-2',
+      initiatorUserId: 'user-1', networkId: 'network-1', seats: { 'intent-1': { userId: 'user-1', round: 2 } },
+      pause: { reason: 'needs_principal' as const },
+    },
+  };
+}
+
+function graph(overrides: Record<string, unknown> = {}) {
+  const database = {
+    getNegotiationTask: mock(async () => task()),
+    expirePausedNegotiation: mock(async () => ({ ...task(), state: 'completed' as const })),
+    createNegotiationOutcomeArtifact: mock(async () => undefined),
+    getIntentNegotiationRound: mock(async () => ({ round: 2, roundSize: 1, kickoffStartedAt: updatedAt })),
+    countActiveNegotiationsForRound: mock(async () => 0),
+    ...overrides,
+  };
+  const reflectEnqueue = mock(async () => undefined);
+  return {
+    database,
+    reflectEnqueue,
+    graph: new NegotiationGraphFactory({ database: database as never, author: {} as never, reflectEnqueue }).createGraph(),
+  };
+}
+
+describe('NegotiationGraph system expiry', () => {
+  it('completes an eligible paused task without authoring a verdict and reflects its round', async () => {
+    const fixture = graph();
+
+    const result = await fixture.graph.invoke({
+      negotiationId: 'task-1', expire: { expectedUpdatedAt: updatedAt, reason: 'needs_principal' },
+    });
+
+    expect(result.status).toBe('resolved');
+    expect(fixture.database.expirePausedNegotiation).toHaveBeenCalledWith({ taskId: 'task-1', expectedUpdatedAt: updatedAt, reason: 'needs_principal' });
+    expect(fixture.database.createNegotiationOutcomeArtifact).not.toHaveBeenCalled();
+    expect(fixture.reflectEnqueue).toHaveBeenCalledWith({ userId: 'user-1', intentId: 'intent-1', round: 2 });
+  });
+
+  it('leaves a changed task uncompleted and does not trigger round reflection', async () => {
+    const fixture = graph({ expirePausedNegotiation: mock(async () => null) });
+
+    const result = await fixture.graph.invoke({
+      negotiationId: 'task-1', expire: { expectedUpdatedAt: updatedAt, reason: 'needs_principal' },
+    });
+
+    expect(result.status).toBe('paused');
+    expect(fixture.reflectEnqueue).not.toHaveBeenCalled();
+  });
+});

--- a/packages/protocol/src/platform/database/negotiation.ts
+++ b/packages/protocol/src/platform/database/negotiation.ts
@@ -125,6 +125,13 @@ export type NegotiationGraphDatabase = Pick<Database, 'getOpportunity' | 'getInt
     pause?: NegotiationTaskMetadata['pause'],
   ): Promise<NegotiationTaskRow>;
 
+  /** Completes a still-paused task and expires its opportunity atomically. */
+  expirePausedNegotiation(input: {
+    taskId: string;
+    expectedUpdatedAt: Date;
+    reason: 'counterparty_silent' | 'needs_principal';
+  }): Promise<NegotiationTaskRow | null>;
+
   /** Writes ONE seat's brief, leaving the other seat's untouched. */
   setNegotiationBrief(taskId: string, userId: string, brief: string): Promise<void>;
 

--- a/services/api/src/adapters/conversation.database.adapter.ts
+++ b/services/api/src/adapters/conversation.database.adapter.ts
@@ -66,7 +66,7 @@ import { projectOwnerScreenDecision } from './negotiation-lifecycle.projection';
 import { buildHermesResponseMetadataSql } from './conversation-hermes-metadata.sql';
 import { buildProfileFromUser, schema, Artifact, ChatConversationMeta, ChatMessage, ChatMessageMeta, ChatScopeType, ChatSession, Conversation, ConversationParticipant, ConversationSession, ConversationSummary, CreateMessageInput, CreateSessionInput, Message, ResolvedParticipant, SYSTEM_AGENT_ID, Task, and, asc, count, db, desc, eq, gt, gte, inArray, intents, isNull, lt, ne, notInArray, opportunities, or, sql, toOpportunityRow, type OpportunityRow } from './database.shared';
 import { emitOpportunityLifecycleBestEffort, emitOpportunityTransitionBestEffort } from '../events/opportunity.event';
-import { publishConversationMessageEvent } from '../lib/conversation-events';
+import { publishConversationMessageEvent, publishIntentInvalidationEvent } from '../lib/conversation-events';
 import { log } from '../lib/log';
 import type { DrizzleDB } from '../lib/drizzle/drizzle';
 import { expectedNegotiationSpeaker, negotiationScopeKey } from '../lib/negotiation/expected-speaker';
@@ -2669,6 +2669,19 @@ export class ConversationDatabaseAdapter {
     if (result?.opportunityExpired) {
       emitOpportunityLifecycleBestEffort({ id: result.task.metadata.opportunityId, status: 'expired' });
       emitOpportunityTransitionBestEffort({ id: result.task.metadata.opportunityId, status: 'expired' });
+    }
+    if (result) {
+      await Promise.all(Object.entries(result.task.metadata.seats).map(async ([intentId, seat]) => {
+        try {
+          await publishIntentInvalidationEvent({ userId: seat.userId, intentId });
+        } catch (error) {
+          logger.error('Failed to publish negotiation expiry intent invalidation', {
+            taskId: result.task.id,
+            intentId,
+            error: error instanceof Error ? error.message : String(error),
+          });
+        }
+      }));
     }
     return result?.task ?? null;
   }

--- a/services/api/src/adapters/conversation.database.adapter.ts
+++ b/services/api/src/adapters/conversation.database.adapter.ts
@@ -377,7 +377,7 @@ export interface StaleNegotiationTasksInput {
 export interface StaleNegotiationTask {
   id: string;
   conversationId: string;
-  state: 'submitted' | 'working';
+  state: 'submitted' | 'working' | 'paused';
   createdAt: Date;
   updatedAt: Date;
   metadata: Record<string, unknown> | null;
@@ -1768,6 +1768,11 @@ export class ConversationDatabaseAdapter {
         or(
           and(eq(schema.tasks.state, 'submitted'), lt(schema.tasks.createdAt, submittedCutoff)),
           and(eq(schema.tasks.state, 'working'), lt(schema.tasks.updatedAt, workingCutoff)),
+          and(
+            eq(schema.tasks.state, 'paused'),
+            inArray(sql`${schema.tasks.metadata}->'pause'->>'reason'`, ['needs_principal', 'counterparty_silent']),
+            lt(schema.tasks.updatedAt, workingCutoff),
+          ),
         ),
       ))
       .orderBy(asc(schema.tasks.createdAt))
@@ -1775,7 +1780,7 @@ export class ConversationDatabaseAdapter {
 
     return rows.map((row) => ({
       ...row,
-      state: row.state as 'submitted' | 'working',
+      state: row.state as 'submitted' | 'working' | 'paused',
       metadata: (row.metadata as Record<string, unknown> | null) ?? null,
     }));
   }
@@ -2226,6 +2231,7 @@ export class ConversationDatabaseAdapter {
       round: number;
       state: string;
       brief: string | null;
+      updatedAt: Date;
       pause: { reason: NegotiationPauseReason; by: 'yours' | 'theirs' | null; payload?: unknown } | null;
     };
     transcript: Array<{
@@ -2252,6 +2258,7 @@ export class ConversationDatabaseAdapter {
         state: schema.tasks.state,
         briefs: schema.tasks.briefs,
         metadata: schema.tasks.metadata,
+        updatedAt: schema.tasks.updatedAt,
       })
       .from(schema.tasks)
       .where(and(
@@ -2299,6 +2306,7 @@ export class ConversationDatabaseAdapter {
         opportunityId: metadata.opportunityId,
         round: seat.round,
         state: task.state,
+        updatedAt: task.updatedAt,
         brief: typeof (task.briefs as Record<string, unknown> | null)?.[userId] === 'string'
           ? (task.briefs as Record<string, string>)[userId]
           : null,
@@ -2625,6 +2633,44 @@ export class ConversationDatabaseAdapter {
       .returning();
     if (!row) throw new Error(`Negotiation task ${taskId} not found`);
     return toNegotiationTaskRow(row);
+  }
+
+  async expirePausedNegotiation(input: {
+    taskId: string;
+    expectedUpdatedAt: Date;
+    reason: 'counterparty_silent' | 'needs_principal';
+  }): Promise<NegotiationTaskRowMirror | null> {
+    const result = await db.transaction(async (tx) => {
+      const [task] = await tx.select().from(schema.tasks)
+        .where(eq(schema.tasks.id, input.taskId)).for('update');
+      if (
+        !task
+        || task.state !== 'paused'
+        || task.updatedAt.getTime() !== input.expectedUpdatedAt.getTime()
+        || (task.metadata as NegotiationTaskMetadataMirror | null)?.pause?.reason !== input.reason
+      ) return null;
+
+      const metadata = task.metadata as NegotiationTaskMetadataMirror;
+      const [opportunity] = await tx.select({ status: opportunities.status }).from(opportunities)
+        .where(eq(opportunities.id, metadata.opportunityId)).for('update');
+      if (!opportunity) return null;
+
+      const now = new Date();
+      const [completed] = await tx.update(schema.tasks).set({ state: 'completed', updatedAt: now })
+        .where(eq(schema.tasks.id, task.id)).returning();
+      if (!completed) throw new Error(`Negotiation task ${task.id} not found`);
+      const opportunityExpired = !['accepted', 'rejected', 'expired'].includes(opportunity.status);
+      if (opportunityExpired) {
+        await tx.update(opportunities).set({ status: 'expired', updatedAt: now })
+          .where(eq(opportunities.id, metadata.opportunityId));
+      }
+      return { task: toNegotiationTaskRow(completed), opportunityExpired };
+    });
+    if (result?.opportunityExpired) {
+      emitOpportunityLifecycleBestEffort({ id: result.task.metadata.opportunityId, status: 'expired' });
+      emitOpportunityTransitionBestEffort({ id: result.task.metadata.opportunityId, status: 'expired' });
+    }
+    return result?.task ?? null;
   }
 
   /**

--- a/services/api/src/lib/conversation-events.ts
+++ b/services/api/src/lib/conversation-events.ts
@@ -90,3 +90,14 @@ export async function publishIntentDiscoveryProgressEvent(input: {
     JSON.stringify({ type: 'intent_discovery_progress', intentId: input.intentId }),
   );
 }
+
+/** Publishes an owner-scoped invalidation after another intent-owned view changes. */
+export async function publishIntentInvalidationEvent(input: {
+  userId: string;
+  intentId: string;
+}): Promise<void> {
+  await getRedisClient().publish(
+    `conversations:user:${input.userId}`,
+    JSON.stringify({ type: 'intent_invalidated', intentId: input.intentId }),
+  );
+}

--- a/services/api/src/lib/tests/conversation-events.spec.ts
+++ b/services/api/src/lib/tests/conversation-events.spec.ts
@@ -1,6 +1,6 @@
 import { describe, expect, test } from 'bun:test';
 
-import { conversationEventRecipientUserIds, publishConversationMessageEvent, publishIntentDiscoveryProgressEvent, publishPersonalAgentTurnCompletedEvent } from '../conversation-events';
+import { conversationEventRecipientUserIds, publishConversationMessageEvent, publishIntentDiscoveryProgressEvent, publishIntentInvalidationEvent, publishPersonalAgentTurnCompletedEvent } from '../conversation-events';
 import { getRedisClient } from '../../adapters/cache.adapter';
 
 describe('conversationEventRecipientUserIds', () => {
@@ -75,6 +75,25 @@ test('publishes discovery-progress invalidation without progress data', async ()
     expect(published).toEqual([{
       channel: 'conversations:user:owner-a',
       payload: JSON.stringify({ type: 'intent_discovery_progress', intentId: 'intent-a' }),
+    }]);
+  } finally {
+    redis.publish = originalPublish;
+  }
+});
+
+test('publishes an intent invalidation only to its owner', async () => {
+  const redis = getRedisClient();
+  const published: Array<{ channel: string; payload: string }> = [];
+  const originalPublish = redis.publish.bind(redis);
+  redis.publish = (async (channel: string, payload: string) => {
+    published.push({ channel, payload });
+    return 1;
+  }) as typeof redis.publish;
+  try {
+    await publishIntentInvalidationEvent({ userId: 'owner-a', intentId: 'intent-a' });
+    expect(published).toEqual([{
+      channel: 'conversations:user:owner-a',
+      payload: JSON.stringify({ type: 'intent_invalidated', intentId: 'intent-a' }),
     }]);
   } finally {
     redis.publish = originalPublish;

--- a/services/api/src/queues/negotiations/watchdog.queue.ts
+++ b/services/api/src/queues/negotiations/watchdog.queue.ts
@@ -33,7 +33,7 @@ type WatchdogOpportunities = Pick<ChatDatabaseAdapter, 'getOpportunity'>;
 
 type StaleTaskForWatchdog = {
   id: string;
-  state: 'submitted' | 'working';
+  state: 'submitted' | 'working' | 'paused';
   updatedAt: Date;
   metadata: Record<string, unknown> | null;
 };
@@ -236,6 +236,23 @@ export class NegotiationWatchdogQueue {
     const metadata = asRecord(staleTask.metadata);
     if (metadata.type !== 'negotiation') {
       this.logger.info('Negotiation watchdog skipped non-negotiation task', { taskId: candidate.id });
+      return;
+    }
+
+    const pause = asRecord(metadata.pause);
+    if (staleTask.state === 'paused') {
+      if (pause.reason !== 'needs_principal' && pause.reason !== 'counterparty_silent') return;
+      if (!this.negotiationGraph) {
+        this.logger.error('Negotiation watchdog fired before the graph was wired', { taskId: candidate.id });
+        return;
+      }
+      const result = await this.negotiationGraph.invoke({
+        negotiationId: staleTask.id,
+        expire: { expectedUpdatedAt: staleTask.updatedAt, reason: pause.reason },
+      });
+      if (result.status === 'error') {
+        this.logger.error('Negotiation watchdog expiry invoke returned an error status', { taskId: candidate.id, error: result.error });
+      }
       return;
     }
 

--- a/services/api/src/queues/tests/watchdog.queue.spec.ts
+++ b/services/api/src/queues/tests/watchdog.queue.spec.ts
@@ -100,6 +100,40 @@ describe('NegotiationWatchdogQueue', () => {
     expect(deps.negotiationGraph.invoke).toHaveBeenCalledTimes(1);
   });
 
+  it('expires a stale principal-needed pause through the graph', async () => {
+    const task = makeTask({
+      state: 'paused',
+      updatedAt: new Date(now.getTime() - WORKING_STALE_AFTER_MS - 1),
+      metadata: { type: 'negotiation', opportunityId: 'opportunity-1', pause: { reason: 'needs_principal' } },
+    });
+    const deps = makeDeps(task);
+    const queue = new NegotiationWatchdogQueue({ ...deps, clock: () => now });
+
+    await queue.sweep();
+
+    expect(deps.database.recordNegotiationWatchdogAttempt).not.toHaveBeenCalled();
+    expect(deps.opportunities.getOpportunity).not.toHaveBeenCalled();
+    expect(deps.negotiationGraph.invoke).toHaveBeenCalledWith({
+      negotiationId: task.id,
+      expire: { expectedUpdatedAt: task.updatedAt, reason: 'needs_principal' },
+    });
+  });
+
+  it('does not expire a paused task changed after the stale-list read', async () => {
+    const task = makeTask({
+      state: 'paused',
+      updatedAt: new Date(now.getTime() - WORKING_STALE_AFTER_MS - 1),
+      metadata: { type: 'negotiation', opportunityId: 'opportunity-1', pause: { reason: 'counterparty_silent' } },
+    });
+    const deps = makeDeps(task);
+    deps.database.getTask.mockResolvedValue({ ...task, updatedAt: now } as never);
+    const queue = new NegotiationWatchdogQueue({ ...deps, clock: () => now });
+
+    await queue.sweep();
+
+    expect(deps.negotiationGraph.invoke).not.toHaveBeenCalled();
+  });
+
   it('does nothing when the task changed state after the stale-list read', async () => {
     const deps = makeDeps();
     deps.database.getTask.mockResolvedValue(makeTask({ state: 'completed' }) as never);


### PR DESCRIPTION
## Summary
- Expire stale needs_principal and counterparty_silent negotiations atomically.
- Preserve terminal opportunity statuses and trigger per-seat reflection.
- Publish an owner-scoped intent invalidation for every bound seat after expiry.
- Refresh the open intent workspace from that event, including Radar and negotiation cycle data.
- Show the static remaining expiry time in the negotiation inspector.

## Verification
- bun test services/api/src/queues/tests/watchdog.queue.spec.ts
- bun test services/api/src/lib/tests/conversation-events.spec.ts
- bun --cwd apps/web --bun vitest run src/components/IntentNegotiationInspector.test.tsx
- bun --cwd apps/web --bun vitest run tests/intent-page-negotiator.test.tsx
- bun test src/internal/negotiations/tests/negotiation.graph.expiry.spec.ts (from packages/protocol)
- bun run architecture:check (from packages/protocol)
- pre-commit build checks