### PR TITLE
chore: default chat reasoning effort to low

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -112,7 +112,7 @@ OPENROUTER_API_KEY=your-openrouter-api-key
 # Chat agent model and reasoning effort. Values, not gates: they choose which
 # model answers, and every environment currently runs the two below.
 # CHAT_MODEL=google/gemini-3.7-flash
-# CHAT_REASONING_EFFORT=high   # low | medium | high
+# CHAT_REASONING_EFFORT=low    # low | medium | high
 
 # Local-only. Per-agent model overrides for ad-hoc experiments,
 # e.g. {"opportunityEvaluator":"anthropic/claude-sonnet-4"}.


### PR DESCRIPTION
## Summary
- document low as the default CHAT_REASONING_EFFORT in .env.example

## Verification
- searched all repository .env* files for CHAT_REASONING_EFFORT values
- confirmed no repository .env* file references Gemini 2.5 Flash
- pre-commit build checks