### PR TITLE
fix(web): clarify PersonalAgent tool trace

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@indexnetwork/web",
-  "version": "0.59.0",
+  "version": "0.59.1",
   "license": "MIT",
   "scripts": {
     "dev": "vite --host 127.0.0.1",

--- a/apps/web/src/components/PersonalAgentTimeline.tsx
+++ b/apps/web/src/components/PersonalAgentTimeline.tsx
@@ -4,17 +4,76 @@ function json(value: Record<string, unknown>): string {
   return JSON.stringify(value, null, 2);
 }
 
-function actDetail(act: Record<string, unknown>): string | null {
-  if (typeof act.text === 'string') return act.text;
-  if (typeof act.reasoning === 'string') return act.reasoning;
-  const parts = [
-    typeof act.round === 'number' ? `round ${act.round}` : null,
-    typeof act.opened === 'number' ? `${act.opened} opened` : null,
-    typeof act.negotiationId === 'string' ? `negotiation ${act.negotiationId}` : null,
-    typeof act.opportunityId === 'string' ? `opportunity ${act.opportunityId}` : null,
-    typeof act.outcome === 'string' ? act.outcome : null,
-  ].filter((part): part is string => part !== null);
-  return parts.length > 0 ? parts.join(' · ') : null;
+function toolResult(act: Record<string, unknown>): { tool: string; result: string; detail: string | null } {
+  const tool = typeof act.tool === "string" ? act.tool : "unknown act";
+  switch (tool) {
+    case "message_user":
+      return { tool, result: "Delivered", detail: typeof act.text === "string" ? act.text : null };
+    case "kickoff": {
+      const counts = [
+        typeof act.round === "number" ? `round ${act.round}` : null,
+        typeof act.attempted === "number" ? `${act.attempted} attempted` : null,
+        typeof act.opened === "number" ? `${act.opened} opened` : null,
+        typeof act.failed === "number" ? `${act.failed} failed` : null,
+      ].filter((part): part is string => part !== null);
+      return { tool, result: "Completed", detail: counts.join(" · ") || null };
+    }
+    case "promote":
+    case "reject":
+      return {
+        tool,
+        result: act.outcome === "error" ? "Failed" : act.outcome === "resolved" ? "Resolved" : "Executed",
+        detail: [
+          typeof act.negotiationId === "string" ? `negotiation ${act.negotiationId}` : null,
+          typeof act.opportunityId === "string" && act.opportunityId ? `opportunity ${act.opportunityId}` : null,
+          typeof act.reasoning === "string" ? act.reasoning : null,
+        ].filter((part): part is string => part !== null).join(" · ") || null,
+      };
+    case "note_dossier":
+      return {
+        tool,
+        result: typeof act.entryId === "string" ? "Saved" : "Completed",
+        detail: typeof act.text === "string" ? act.text : null,
+      };
+    case "retire_dossier":
+      return {
+        tool,
+        result: act.retired === false ? "Not retired" : act.retired === true ? "Retired" : "Completed",
+        detail: typeof act.entryId === "string" ? `dossier entry ${act.entryId}` : null,
+      };
+    case "accept_opportunity":
+      return {
+        tool,
+        result: typeof act.outcome === "string" ? act.outcome : "Executed",
+        detail: [
+          typeof act.opportunityId === "string" ? `opportunity ${act.opportunityId}` : null,
+          typeof act.counterparty === "string" ? act.counterparty : null,
+          typeof act.reason === "string" ? act.reason : null,
+        ].filter((part): part is string => part !== null).join(" · ") || null,
+      };
+    default:
+      return { tool, result: "Executed", detail: null };
+  }
+}
+
+function PersonalAgentActRow({ entry, rawBackground }: { entry: IntentCycleTimelineEntry; rawBackground: string }) {
+  const { tool, result, detail } = toolResult(entry.act);
+  return (
+    <li className="border-l-2 border-slate-200 pl-3">
+      <p className="font-ibm-plex-mono text-[10px] uppercase tracking-[0.12em] text-slate-600">
+        {tool} · {result}
+      </p>
+      {detail && <p className="mt-1 whitespace-pre-wrap text-xs text-gray-700">{detail}</p>}
+      <time className="mt-1 block font-ibm-plex-mono text-[10px] text-gray-400">{new Date(entry.createdAt).toLocaleString()} · {entry.id}</time>
+      <details className="mt-2">
+        <summary className="cursor-pointer text-[11px] text-[#35799C]">Raw event and executed act</summary>
+        <div className="mt-2 grid gap-2 lg:grid-cols-2">
+          <pre className={`overflow-x-auto rounded ${rawBackground} p-2 font-ibm-plex-mono text-[10px] text-slate-700`}>{json(entry.event)}</pre>
+          <pre className={`overflow-x-auto rounded ${rawBackground} p-2 font-ibm-plex-mono text-[10px] text-slate-700`}>{json(entry.act)}</pre>
+        </div>
+      </details>
+    </li>
+  );
 }
 
 export function PersonalAgentDebugTrace({
@@ -34,24 +93,7 @@ export function PersonalAgentDebugTrace({
       {loading ? <p role="status" className="mt-2 text-xs text-gray-500">Loading agent trace…</p>
         : error ? <p role="status" className="mt-2 text-xs text-red-600">Agent trace could not be loaded.</p>
           : entries.length === 0 ? <p className="mt-2 text-xs text-gray-500">No persisted IS-A acts for this intent.</p>
-            : <ol className="mt-3 space-y-3">
-              {entries.map((entry) => (
-                <li key={entry.id} className="border-l-2 border-slate-200 pl-3">
-                  <p className="font-ibm-plex-mono text-[10px] uppercase tracking-[0.12em] text-slate-600">
-                    event {typeof entry.event.kind === 'string' ? entry.event.kind : 'unknown'} → {typeof entry.act.tool === 'string' ? entry.act.tool : 'unknown act'}
-                  </p>
-                  {actDetail(entry.act) && <p className="mt-1 whitespace-pre-wrap text-xs text-gray-700">{actDetail(entry.act)}</p>}
-                  <time className="mt-1 block font-ibm-plex-mono text-[10px] text-gray-400">{new Date(entry.createdAt).toLocaleString()} · {entry.id}</time>
-                  <details className="mt-2">
-                    <summary className="cursor-pointer text-[11px] text-[#35799C]">Raw event and executed act</summary>
-                    <div className="mt-2 grid gap-2 lg:grid-cols-2">
-                      <pre className="overflow-x-auto rounded bg-white p-2 font-ibm-plex-mono text-[10px] text-slate-700">{json(entry.event)}</pre>
-                      <pre className="overflow-x-auto rounded bg-white p-2 font-ibm-plex-mono text-[10px] text-slate-700">{json(entry.act)}</pre>
-                    </div>
-                  </details>
-                </li>
-              ))}
-            </ol>}
+            : <ol className="mt-3 space-y-3">{entries.map((entry) => <PersonalAgentActRow key={entry.id} entry={entry} rawBackground="bg-white" />)}</ol>}
     </details>
   );
 }
@@ -70,7 +112,7 @@ export default function PersonalAgentTimeline({
       <div className="flex flex-wrap items-baseline justify-between gap-2">
         <div>
           <p className="font-ibm-plex-mono text-[10px] uppercase tracking-[0.12em] text-gray-500">PersonalAgent acts</p>
-          <p className="mt-1 text-xs text-gray-600">Executed effects from the append-only IS-A ledger. Message-user entries may be strategy or ordinary DM copy; the ledger does not label them further.</p>
+          <p className="mt-1 text-xs text-gray-600">Executed durable tools from the append-only IS-A ledger. It does not include model reasoning or queue attempts that produced no act.</p>
         </div>
         <p className="font-ibm-plex-mono text-[10px] text-gray-400">latest 100</p>
       </div>
@@ -78,24 +120,7 @@ export default function PersonalAgentTimeline({
         : error ? <p role="status" className="mt-3 text-xs text-red-600">Agent act ledger could not be loaded.</p>
           : entries.length === 0 ? <p className="mt-3 text-xs text-gray-500">No persisted IS-A acts for this intent. Discovery or a queued wake may not have reached the agent yet.</p>
             : (
-              <ol className="mt-3 space-y-3">
-                {entries.map((entry) => (
-                  <li key={entry.id} className="border-l-2 border-slate-200 pl-3">
-                    <p className="font-ibm-plex-mono text-[10px] uppercase tracking-[0.12em] text-slate-600">
-                      event {typeof entry.event.kind === 'string' ? entry.event.kind : 'unknown'} → {typeof entry.act.tool === 'string' ? entry.act.tool : 'unknown act'}
-                    </p>
-                    {actDetail(entry.act) && <p className="mt-1 whitespace-pre-wrap text-xs text-gray-700">{actDetail(entry.act)}</p>}
-                    <time className="mt-1 block font-ibm-plex-mono text-[10px] text-gray-400">{new Date(entry.createdAt).toLocaleString()} · {entry.id}</time>
-                    <details className="mt-2">
-                      <summary className="cursor-pointer text-[11px] text-[#35799C]">Raw event and executed act</summary>
-                      <div className="mt-2 grid gap-2 lg:grid-cols-2">
-                        <pre className="overflow-x-auto rounded bg-slate-50 p-2 font-ibm-plex-mono text-[10px] text-slate-700">{json(entry.event)}</pre>
-                        <pre className="overflow-x-auto rounded bg-slate-50 p-2 font-ibm-plex-mono text-[10px] text-slate-700">{json(entry.act)}</pre>
-                      </div>
-                    </details>
-                  </li>
-                ))}
-              </ol>
+              <ol className="mt-3 space-y-3">{entries.map((entry) => <PersonalAgentActRow key={entry.id} entry={entry} rawBackground="bg-slate-50" />)}</ol>
             )}
     </section>
   );

--- a/apps/web/src/components/PersonalAgentTimeline.tsx
+++ b/apps/web/src/components/PersonalAgentTimeline.tsx
@@ -10,13 +10,16 @@ function toolResult(act: Record<string, unknown>): { tool: string; result: strin
     case "message_user":
       return { tool, result: "Delivered", detail: typeof act.text === "string" ? act.text : null };
     case "kickoff": {
+      const opened = typeof act.opened === "number" ? act.opened : null;
+      const failed = typeof act.failed === "number" ? act.failed : null;
       const counts = [
         typeof act.round === "number" ? `round ${act.round}` : null,
         typeof act.attempted === "number" ? `${act.attempted} attempted` : null,
-        typeof act.opened === "number" ? `${act.opened} opened` : null,
-        typeof act.failed === "number" ? `${act.failed} failed` : null,
+        opened !== null ? `${opened} opened` : null,
+        failed !== null ? `${failed} failed` : null,
       ].filter((part): part is string => part !== null);
-      return { tool, result: "Completed", detail: counts.join(" · ") || null };
+      const result = failed && opened === 0 ? "Failed" : failed ? "Partial" : "Completed";
+      return { tool, result, detail: counts.join(" · ") || null };
     }
     case "promote":
     case "reject":
@@ -58,10 +61,11 @@ function toolResult(act: Record<string, unknown>): { tool: string; result: strin
 
 function PersonalAgentActRow({ entry, rawBackground }: { entry: IntentCycleTimelineEntry; rawBackground: string }) {
   const { tool, result, detail } = toolResult(entry.act);
+  const event = typeof entry.event.kind === "string" ? entry.event.kind : "unknown event";
   return (
     <li className="border-l-2 border-slate-200 pl-3">
       <p className="font-ibm-plex-mono text-[10px] uppercase tracking-[0.12em] text-slate-600">
-        {tool} · {result}
+        {event} → {tool} · {result}
       </p>
       {detail && <p className="mt-1 whitespace-pre-wrap text-xs text-gray-700">{detail}</p>}
       <time className="mt-1 block font-ibm-plex-mono text-[10px] text-gray-400">{new Date(entry.createdAt).toLocaleString()} · {entry.id}</time>

--- a/apps/web/src/components/__tests__/IntentNegotiatorChatOptions.test.tsx
+++ b/apps/web/src/components/__tests__/IntentNegotiatorChatOptions.test.tsx
@@ -115,11 +115,13 @@ describe('IntentNegotiatorChat option chips', () => {
         timelineEntries={[
           { id: 'act-1', event: { kind: 'matches_ready' }, act: { tool: 'message_user', text: 'I opened the conversation.' }, createdAt: '2026-08-21T10:00:00.000Z' },
           { id: 'act-2', event: { kind: 'matches_ready' }, act: { tool: 'kickoff', round: 3, attempted: 4, opened: 2, failed: 2 }, createdAt: '2026-08-21T10:01:00.000Z' },
-          { id: 'act-3', event: { kind: 'round_paused' }, act: { tool: 'promote', negotiationId: 'neg-1', opportunityId: 'opp-1', reasoning: 'Strong fit.', outcome: 'resolved' }, createdAt: '2026-08-21T10:02:00.000Z' },
-          { id: 'act-4', event: { kind: 'round_paused' }, act: { tool: 'reject', negotiationId: 'neg-2', opportunityId: 'opp-2', reasoning: 'Timing does not work.', outcome: 'error' }, createdAt: '2026-08-21T10:03:00.000Z' },
+          { id: 'act-3', event: { kind: 'all_paused' }, act: { tool: 'promote', negotiationId: 'neg-1', opportunityId: 'opp-1', reasoning: 'Strong fit.', outcome: 'resolved' }, createdAt: '2026-08-21T10:02:00.000Z' },
+          { id: 'act-4', event: { kind: 'all_paused' }, act: { tool: 'reject', negotiationId: 'neg-2', opportunityId: 'opp-2', reasoning: 'Timing does not work.', outcome: 'error' }, createdAt: '2026-08-21T10:03:00.000Z' },
           { id: 'act-5', event: { kind: 'user_message' }, act: { tool: 'note_dossier', text: 'Prefers remote work.', entryId: 'dossier-1' }, createdAt: '2026-08-21T10:04:00.000Z' },
           { id: 'act-6', event: { kind: 'user_message' }, act: { tool: 'retire_dossier', entryId: 'dossier-2', retired: false }, createdAt: '2026-08-21T10:05:00.000Z' },
           { id: 'act-7', event: { kind: 'user_message' }, act: { tool: 'accept_opportunity', opportunityId: 'opp-3', outcome: 'accepted', counterparty: 'Riley' }, createdAt: '2026-08-21T10:06:00.000Z' },
+          { id: 'act-8', event: { kind: 'matches_ready' }, act: { tool: 'kickoff', round: 4, attempted: 1, opened: 1, failed: 0 }, createdAt: '2026-08-21T10:07:00.000Z' },
+          { id: 'act-9', event: { kind: 'matches_ready' }, act: { tool: 'kickoff', round: 5, attempted: 3, opened: 0, failed: 3 }, createdAt: '2026-08-21T10:08:00.000Z' },
         ]}
         timelineLoading={false}
         timelineError={false}
@@ -132,16 +134,18 @@ describe('IntentNegotiatorChat option chips', () => {
     );
     const trace = await screen.findByTestId('personal-agent-debug-trace');
     expect(trace).toHaveTextContent('PersonalAgent debug trace');
-    expect(trace).toHaveTextContent('message_user · Delivered');
+    expect(trace).toHaveTextContent('matches_ready → message_user · Delivered');
     expect(trace).toHaveTextContent('I opened the conversation.');
-    expect(trace).toHaveTextContent('kickoff · Completed');
+    expect(trace).toHaveTextContent('matches_ready → kickoff · Partial');
     expect(trace).toHaveTextContent('round 3 · 4 attempted · 2 opened · 2 failed');
-    expect(trace).toHaveTextContent('promote · Resolved');
+    expect(trace).toHaveTextContent('matches_ready → kickoff · Completed');
+    expect(trace).toHaveTextContent('matches_ready → kickoff · Failed');
+    expect(trace).toHaveTextContent('all_paused → promote · Resolved');
     expect(trace).toHaveTextContent('negotiation neg-1 · opportunity opp-1 · Strong fit.');
-    expect(trace).toHaveTextContent('reject · Failed');
-    expect(trace).toHaveTextContent('note_dossier · Saved');
-    expect(trace).toHaveTextContent('retire_dossier · Not retired');
-    expect(trace).toHaveTextContent('accept_opportunity · accepted');
+    expect(trace).toHaveTextContent('all_paused → reject · Failed');
+    expect(trace).toHaveTextContent('user_message → note_dossier · Saved');
+    expect(trace).toHaveTextContent('user_message → retire_dossier · Not retired');
+    expect(trace).toHaveTextContent('user_message → accept_opportunity · accepted');
     expect(trace).toHaveTextContent('opportunity opp-3 · Riley');
   });
 

--- a/apps/web/src/components/__tests__/IntentNegotiatorChatOptions.test.tsx
+++ b/apps/web/src/components/__tests__/IntentNegotiatorChatOptions.test.tsx
@@ -112,12 +112,15 @@ describe('IntentNegotiatorChat option chips', () => {
     render(
       <IntentNegotiatorChat
         intentId="intent-1"
-        timelineEntries={[{
-          id: 'act-1',
-          event: { kind: 'matches_ready' },
-          act: { tool: 'message_user', text: 'I opened the conversation.' },
-          createdAt: '2026-08-21T10:00:00.000Z',
-        }]}
+        timelineEntries={[
+          { id: 'act-1', event: { kind: 'matches_ready' }, act: { tool: 'message_user', text: 'I opened the conversation.' }, createdAt: '2026-08-21T10:00:00.000Z' },
+          { id: 'act-2', event: { kind: 'matches_ready' }, act: { tool: 'kickoff', round: 3, attempted: 4, opened: 2, failed: 2 }, createdAt: '2026-08-21T10:01:00.000Z' },
+          { id: 'act-3', event: { kind: 'round_paused' }, act: { tool: 'promote', negotiationId: 'neg-1', opportunityId: 'opp-1', reasoning: 'Strong fit.', outcome: 'resolved' }, createdAt: '2026-08-21T10:02:00.000Z' },
+          { id: 'act-4', event: { kind: 'round_paused' }, act: { tool: 'reject', negotiationId: 'neg-2', opportunityId: 'opp-2', reasoning: 'Timing does not work.', outcome: 'error' }, createdAt: '2026-08-21T10:03:00.000Z' },
+          { id: 'act-5', event: { kind: 'user_message' }, act: { tool: 'note_dossier', text: 'Prefers remote work.', entryId: 'dossier-1' }, createdAt: '2026-08-21T10:04:00.000Z' },
+          { id: 'act-6', event: { kind: 'user_message' }, act: { tool: 'retire_dossier', entryId: 'dossier-2', retired: false }, createdAt: '2026-08-21T10:05:00.000Z' },
+          { id: 'act-7', event: { kind: 'user_message' }, act: { tool: 'accept_opportunity', opportunityId: 'opp-3', outcome: 'accepted', counterparty: 'Riley' }, createdAt: '2026-08-21T10:06:00.000Z' },
+        ]}
         timelineLoading={false}
         timelineError={false}
         opportunityStatusMap={{}}
@@ -129,8 +132,17 @@ describe('IntentNegotiatorChat option chips', () => {
     );
     const trace = await screen.findByTestId('personal-agent-debug-trace');
     expect(trace).toHaveTextContent('PersonalAgent debug trace');
-    expect(trace).toHaveTextContent('matches_ready');
-    expect(trace).toHaveTextContent('message_user');
+    expect(trace).toHaveTextContent('message_user · Delivered');
+    expect(trace).toHaveTextContent('I opened the conversation.');
+    expect(trace).toHaveTextContent('kickoff · Completed');
+    expect(trace).toHaveTextContent('round 3 · 4 attempted · 2 opened · 2 failed');
+    expect(trace).toHaveTextContent('promote · Resolved');
+    expect(trace).toHaveTextContent('negotiation neg-1 · opportunity opp-1 · Strong fit.');
+    expect(trace).toHaveTextContent('reject · Failed');
+    expect(trace).toHaveTextContent('note_dossier · Saved');
+    expect(trace).toHaveTextContent('retire_dossier · Not retired');
+    expect(trace).toHaveTextContent('accept_opportunity · accepted');
+    expect(trace).toHaveTextContent('opportunity opp-3 · Riley');
   });
 
   it('reconciles an agent SSE message for its session, but ignores another session', async () => {

--- a/bun.lock
+++ b/bun.lock
@@ -19,7 +19,7 @@
     },
     "apps/web": {
       "name": "@indexnetwork/web",
-      "version": "0.59.0",
+      "version": "0.59.1",
       "dependencies": {
         "@indexnetwork/protocol": "workspace:*",
         "@radix-ui/react-alert-dialog": "^1.1.15",


### PR DESCRIPTION
## Summary
- render each durable PersonalAgent tool with a readable result in both debug traces
- retain raw event and act JSON behind a disclosure
- cover message, kickoff, verdict, dossier, acceptance, and failed-result rendering

## Verification
- `bun --cwd apps/web test src/components/__tests__/IntentNegotiatorChatOptions.test.tsx`
- commit hook: protocol/API/web builds and TypeScript checks

No IS-A behavior, queueing, negotiation semantics, or message delivery changed.