### PR TITLE
feat(web): bucket radar by responsibility

### DIFF
--- a/apps/web/src/app/i/[intentId]/page.tsx
+++ b/apps/web/src/app/i/[intentId]/page.tsx
@@ -25,31 +25,15 @@ import type { IntentCycleSnapshot, IntentCycleTimelineEntry } from "@/services/c
 import type { RadarCardItem, OpportunityLifecycleStatus } from "@/services/opportunities";
 import type { IntentLifecycleStatus, MutableIntentLifecycleStatus } from "@/services/intents";
 import { cn } from "@/lib/utils";
-import { DEFAULT_RADAR_BUCKET, radarBucketBadgeTone } from "@/lib/radar-buckets";
+import { DEFAULT_RADAR_BUCKET, radarBucketBadgeTone, radarBucketForOpportunity, type RadarBucket } from "@/lib/radar-buckets";
 
-/** Raw opportunity status -> radar display bucket (mirrors the Hermes dashboard). */
-const STATUS_BUCKET: Record<string, string> = {
-  latent: "pending",
-  draft: "pending",
-  pending: "pending",
-  negotiating: "negotiating",
-  stalled: "negotiating",
-  accepted: "accepted",
-  rejected: "rejected",
-  expired: "expired",
-};
-
-const RADAR_BUCKETS: Array<{ key: string; label: string }> = [
-  { key: "pending", label: "Awaiting you" },
-  { key: "negotiating", label: "Negotiating" },
-  { key: "accepted", label: "Accepted" },
-  { key: "rejected", label: "Rejected" },
-  { key: "expired", label: "Missed" },
+const RADAR_BUCKETS: Array<{ key: RadarBucket; label: string }> = [
+  { key: "needs-you", label: "Needs you" },
+  { key: "agent-handling", label: "Agent handling" },
+  { key: "waiting", label: "Waiting" },
+  { key: "connected", label: "Connected" },
+  { key: "closed", label: "Closed" },
 ];
-
-function bucketForStatus(status?: string): string {
-  return STATUS_BUCKET[status ?? ""] ?? "pending";
-}
 
 function normalizeIntentLifecycleStatus(status: unknown): IntentLifecycleStatus {
   if (
@@ -121,7 +105,7 @@ function StatPill({
   active,
   onSelect,
 }: {
-  bucketKey: string;
+  bucketKey: RadarBucket;
   value: number;
   label: string;
   active: boolean;
@@ -483,15 +467,22 @@ export default function IntentDetailPage() {
     }
   }, [intentId, opportunitiesService]);
 
-  const inspectorHrefByOpportunity = useMemo(() => {
-    const hrefs = new Map<string, string>();
+  const negotiationByOpportunity = useMemo(() => {
+    const negotiations = new Map<string, IntentCycleSnapshot["negotiations"][number]>();
     for (const negotiation of intentCycle?.negotiations ?? []) {
-      if (!hrefs.has(negotiation.opportunityId)) {
-        hrefs.set(negotiation.opportunityId, `/i/${intentId}/negotiations/${negotiation.taskId}`);
+      if (!negotiations.has(negotiation.opportunityId)) {
+        negotiations.set(negotiation.opportunityId, negotiation);
       }
     }
+    return negotiations;
+  }, [intentCycle?.negotiations]);
+  const inspectorHrefByOpportunity = useMemo(() => {
+    const hrefs = new Map<string, string>();
+    for (const [opportunityId, negotiation] of negotiationByOpportunity) {
+      hrefs.set(opportunityId, `/i/${intentId}/negotiations/${negotiation.taskId}`);
+    }
     return hrefs;
-  }, [intentCycle?.negotiations, intentId]);
+  }, [negotiationByOpportunity, intentId]);
   const refreshLiveRadar = useCallback(() => {
     void loadOpportunities(true);
     void loadIntentCycle();
@@ -632,12 +623,15 @@ export default function IntentDetailPage() {
   const bucketOf = useCallback(
     // Local actions (accept/reject in this session) override the fetched status.
     (item: RadarCardItem) =>
-      bucketForStatus(opportunityStatusMap[item.opportunityId] ?? item.status),
-    [opportunityStatusMap],
+      radarBucketForOpportunity(
+        (opportunityStatusMap[item.opportunityId] as OpportunityLifecycleStatus | undefined) ?? item.status,
+        negotiationByOpportunity.get(item.opportunityId),
+      ),
+    [opportunityStatusMap, negotiationByOpportunity],
   );
 
   const bucketCounts = useMemo(() => {
-    const counts: Record<string, number> = {};
+    const counts: Partial<Record<RadarBucket, number>> = {};
     for (const item of opportunities) {
       const b = bucketOf(item);
       counts[b] = (counts[b] ?? 0) + 1;

--- a/apps/web/src/lib/__tests__/radar-buckets.test.ts
+++ b/apps/web/src/lib/__tests__/radar-buckets.test.ts
@@ -19,7 +19,7 @@ describe("Radar responsibility buckets", () => {
     ["latent", undefined, "agent-handling"],
     ["draft", undefined, "agent-handling"],
     ["negotiating", undefined, "agent-handling"],
-    ["pending", negotiation({ state: "working" }), "agent-handling"],
+    ["pending", negotiation({ state: "working" }), "needs-you"],
   ] as const)("maps %s without a blocking pause to %s", (status, task, bucket) => {
     expect(radarBucketForOpportunity(status, task)).toBe(bucket);
   });

--- a/apps/web/src/lib/__tests__/radar-buckets.test.ts
+++ b/apps/web/src/lib/__tests__/radar-buckets.test.ts
@@ -1,19 +1,64 @@
-import { describe, expect, it } from 'vitest';
+import { describe, expect, it } from "vitest";
 
-import { DEFAULT_RADAR_BUCKET, radarBucketBadgeTone } from '@/lib/radar-buckets';
+import type { IntentCycleSnapshot } from "@/services/conversation";
+import { DEFAULT_RADAR_BUCKET, radarBucketBadgeTone, radarBucketForOpportunity } from "@/lib/radar-buckets";
 
-describe('Radar bucket presentation', () => {
-  it('opens on live negotiations', () => {
-    expect(DEFAULT_RADAR_BUCKET).toBe('negotiating');
+type Negotiation = IntentCycleSnapshot["negotiations"][number];
+
+function negotiation(overrides: Partial<Pick<Negotiation, "state" | "pause">>): Pick<Negotiation, "state" | "pause"> {
+  return { state: "working", pause: null, ...overrides };
+}
+
+describe("Radar responsibility buckets", () => {
+  it("opens on agent handling", () => {
+    expect(DEFAULT_RADAR_BUCKET).toBe("agent-handling");
   });
 
-  it('gives a non-zero Awaiting you badge an attention tone', () => {
-    expect(radarBucketBadgeTone('pending', 1, false)).toBe('bg-amber-200 text-amber-950');
-    expect(radarBucketBadgeTone('pending', 3, true)).toBe('bg-amber-200 text-amber-950');
+  it.each([
+    ["pending", undefined, "needs-you"],
+    ["latent", undefined, "agent-handling"],
+    ["draft", undefined, "agent-handling"],
+    ["negotiating", undefined, "agent-handling"],
+    ["pending", negotiation({ state: "working" }), "agent-handling"],
+  ] as const)("maps %s without a blocking pause to %s", (status, task, bucket) => {
+    expect(radarBucketForOpportunity(status, task)).toBe(bucket);
   });
 
-  it('keeps zero and other badges neutral or selected', () => {
-    expect(radarBucketBadgeTone('pending', 0, false)).toBe('bg-gray-100 text-gray-500');
-    expect(radarBucketBadgeTone('negotiating', 2, true)).toBe('bg-white/20 text-white');
+  it.each([
+    ["needs_principal", "yours", "needs-you"],
+    ["needs_principal", "theirs", "waiting"],
+    ["counterparty_silent", "theirs", "waiting"],
+    ["ready_for_verdict", "yours", "agent-handling"],
+    ["turn_cap", "yours", "agent-handling"],
+    ["open_failed", "theirs", "agent-handling"],
+  ] as const)("maps paused %s owned by %s to %s", (reason, by, bucket) => {
+    expect(radarBucketForOpportunity(
+      "negotiating",
+      negotiation({ state: "paused", pause: { reason, by } }),
+    )).toBe(bucket);
+  });
+
+  it.each([
+    ["accepted", "connected"],
+    ["rejected", "closed"],
+    ["expired", "closed"],
+    ["stalled", "closed"],
+  ] as const)("gives terminal %s precedence over stale task data", (status, bucket) => {
+    expect(radarBucketForOpportunity(status, negotiation({
+      state: "paused",
+      pause: { reason: "needs_principal", by: "yours" },
+    }))).toBe(bucket);
+  });
+
+  it("falls back to opportunity status when cycle data is unavailable", () => {
+    expect(radarBucketForOpportunity("pending")).toBe("needs-you");
+    expect(radarBucketForOpportunity("accepted")).toBe("connected");
+  });
+
+  it("gives only a non-zero Needs you badge an attention tone", () => {
+    expect(radarBucketBadgeTone("needs-you", 1, false)).toBe("bg-amber-200 text-amber-950");
+    expect(radarBucketBadgeTone("needs-you", 3, true)).toBe("bg-amber-200 text-amber-950");
+    expect(radarBucketBadgeTone("needs-you", 0, false)).toBe("bg-gray-100 text-gray-500");
+    expect(radarBucketBadgeTone("agent-handling", 2, true)).toBe("bg-white/20 text-white");
   });
 });

--- a/apps/web/src/lib/radar-buckets.ts
+++ b/apps/web/src/lib/radar-buckets.ts
@@ -1,17 +1,64 @@
-/** The Radar opens on live broker activity instead of a passive backlog. */
-export const DEFAULT_RADAR_BUCKET = 'negotiating';
+import type { IntentCycleSnapshot } from "@/services/conversation";
+import type { OpportunityLifecycleStatus } from "@/services/opportunities";
 
-/**
- * Pending opportunities need a visible call to action even when another Radar
- * tab is selected. Other count badges remain neutral (or inherit selection).
- */
+export type RadarBucket =
+  | "needs-you"
+  | "agent-handling"
+  | "waiting"
+  | "connected"
+  | "closed";
+
+type IntentCycleNegotiation = IntentCycleSnapshot["negotiations"][number];
+
+export const DEFAULT_RADAR_BUCKET: RadarBucket = "agent-handling";
+
+const TERMINAL_BUCKETS: Partial<Record<OpportunityLifecycleStatus, RadarBucket>> = {
+  accepted: "connected",
+  rejected: "closed",
+  expired: "closed",
+  stalled: "closed",
+};
+
+const STATUS_BUCKETS: Record<OpportunityLifecycleStatus, RadarBucket> = {
+  latent: "agent-handling",
+  draft: "agent-handling",
+  pending: "needs-you",
+  negotiating: "agent-handling",
+  stalled: "closed",
+  accepted: "connected",
+  rejected: "closed",
+  expired: "closed",
+};
+
+/** Assign an opportunity to the person or agent currently responsible for it. */
+export function radarBucketForOpportunity(
+  status: OpportunityLifecycleStatus | undefined,
+  negotiation?: Pick<IntentCycleNegotiation, "state" | "pause">,
+): RadarBucket {
+  const terminalBucket = status ? TERMINAL_BUCKETS[status] : undefined;
+  if (terminalBucket) return terminalBucket;
+
+  if (negotiation?.state === "paused") {
+    if (negotiation.pause?.reason === "needs_principal") {
+      return negotiation.pause.by === "yours" ? "needs-you" : "waiting";
+    }
+    if (negotiation.pause?.reason === "counterparty_silent") return "waiting";
+    return "agent-handling";
+  }
+
+  if (negotiation?.state === "working") return "agent-handling";
+
+  return status ? STATUS_BUCKETS[status] : "agent-handling";
+}
+
+/** Only a non-zero Needs you count calls for visual attention. */
 export function radarBucketBadgeTone(
-  bucketKey: string,
+  bucketKey: RadarBucket,
   value: number,
   active: boolean,
 ): string {
-  if (bucketKey === 'pending' && value > 0) {
-    return 'bg-amber-200 text-amber-950';
+  if (bucketKey === "needs-you" && value > 0) {
+    return "bg-amber-200 text-amber-950";
   }
-  return active ? 'bg-white/20 text-white' : 'bg-gray-100 text-gray-500';
+  return active ? "bg-white/20 text-white" : "bg-gray-100 text-gray-500";
 }

--- a/apps/web/src/lib/radar-buckets.ts
+++ b/apps/web/src/lib/radar-buckets.ts
@@ -38,6 +38,10 @@ export function radarBucketForOpportunity(
   const terminalBucket = status ? TERMINAL_BUCKETS[status] : undefined;
   if (terminalBucket) return terminalBucket;
 
+  if (status !== "negotiating") {
+    return status ? STATUS_BUCKETS[status] : "agent-handling";
+  }
+
   if (negotiation?.state === "paused") {
     if (negotiation.pause?.reason === "needs_principal") {
       return negotiation.pause.by === "yours" ? "needs-you" : "waiting";
@@ -47,8 +51,7 @@ export function radarBucketForOpportunity(
   }
 
   if (negotiation?.state === "working") return "agent-handling";
-
-  return status ? STATUS_BUCKETS[status] : "agent-handling";
+  return "agent-handling";
 }
 
 /** Only a non-zero Needs you count calls for visual attention. */


### PR DESCRIPTION
## Summary
- replace raw lifecycle-status Radar tabs with responsibility-based buckets
- derive each card bucket from its owner-scoped negotiation cycle when available
- cover responsibility, terminal precedence, and fallback mappings

## Verification
- bun test src/lib/__tests__/radar-buckets.test.ts
- pre-commit build checks (protocol, API, and web builds)