### PR TITLE
Fix PersonalAgent question UI and live activity feedback

### DIFF
--- a/apps/web/src/components/IntentNegotiatorChat.tsx
+++ b/apps/web/src/components/IntentNegotiatorChat.tsx
@@ -4,6 +4,7 @@ import { ArrowUp, BotMessageSquare, Square } from "lucide-react";
 import { useAIChat } from "@/contexts/AIChatContext";
 import { useConversation } from "@/contexts/ConversationContext";
 import AssistantMessageContent from "@/components/chat/AssistantMessageContent";
+import { DecisionQuestions } from "@/components/DecisionQuestions";
 import { QuestionRegenerationIndicator } from "@/components/chat/QuestionSteps";
 import { ToolCallsDisplay } from "@/components/chat/ToolCallsDisplay";
 import { PersonalAgentDebugTrace } from "@/components/PersonalAgentTimeline";
@@ -109,6 +110,9 @@ export default function IntentNegotiatorChat({
   const [ready, setReady] = useState(false);
   const [restoredHistoryLoaded, setRestoredHistoryLoaded] = useState(false);
   const [input, setInput] = useState("");
+  const [decisionQuestionsSubmittedIds, setDecisionQuestionsSubmittedIds] = useState<Set<string>>(
+    () => new Set(),
+  );
   const scrollRef = useRef<HTMLDivElement>(null);
   const inputRef = useRef<HTMLInputElement>(null);
   const clearChatRef = useRef(clearChat);
@@ -228,15 +232,6 @@ export default function IntentNegotiatorChat({
     inputRef.current?.focus();
   }, []);
 
-  // A chip is a canned reply, not a new answer channel: its text is sent
-  // through the ordinary send path, so the agent's next turn cannot tell it
-  // from something the user typed.
-  const handleOptionSelect = useCallback(async (option: string) => {
-    if (isLoading || !ready) return;
-    setInput("");
-    await sendMessage(option);
-  }, [isLoading, ready, sendMessage]);
-
   const handleSend = useCallback(async () => {
     const text = input.trim();
     if (!text || isLoading || !ready) return;
@@ -339,13 +334,6 @@ export default function IntentNegotiatorChat({
 
             {messages.map((msg, messageIndex) => {
               const previousMessage = messageIndex > 0 ? messages[messageIndex - 1] : undefined;
-              // Chips belong to an unanswered question only. Any later message
-              // — the user's typed answer, their tapped chip, the agent's next
-              // word — is that answer, so message order is the whole rule and
-              // there is no "answered" state to keep.
-              const options = messageIndex === messages.length - 1 && !msg.isStreaming
-                ? msg.options ?? []
-                : [];
               const startsSession = previousMessage !== undefined
                 && previousMessage.conversationSessionId !== msg.conversationSessionId;
               return (
@@ -373,37 +361,52 @@ export default function IntentNegotiatorChat({
                           stoppedAt={msg.stoppedAt}
                         />
                       )}
-                      <AssistantMessageContent
-                        content={msg.content}
-                        isStreaming={msg.isStreaming ?? false}
-                        onOpportunityPrimaryAction={(id, userId, role, name) =>
-                          onOpportunityAction(id, "accepted", userId, role, name)
-                        }
-                        onOpportunitySecondaryAction={(id, userId, role, name) =>
-                          onOpportunityAction(id, "rejected", userId, role, name)
-                        }
-                        opportunityLoadingMap={opportunityActionLoading}
-                        currentStatusMap={opportunityStatusMap}
-                        onIntentProposalApprove={handleProposalApprove}
-                        onIntentProposalReject={handleProposalReject}
-                        onIntentProposalUndo={handleProposalUndo}
-                        intentProposalStatusMap={proposalStatusMap}
-                        onQuestionQuote={handleQuestionQuote}
-                      />
-                      {options.length > 0 && (
-                        <div className="mt-2 flex flex-wrap gap-1.5" data-testid="negotiator-chat-options">
-                          {options.map((option) => (
-                            <button
-                              key={option}
-                              type="button"
-                              onClick={() => void handleOptionSelect(option)}
-                              disabled={isLoading || !ready}
-                              className="rounded-full border border-[#E9E9E9] bg-[#FCFCFC] px-3 py-1 text-xs font-ibm-plex-mono text-gray-700 transition-colors hover:border-[#4091BB] hover:text-[#041729] disabled:cursor-not-allowed disabled:opacity-50"
-                            >
-                              {option}
-                            </button>
-                          ))}
+                      {msg.isStreaming && msg.agentActivityLabel && !msg.content.trim() ? (
+                        <div
+                          className="flex items-center gap-2 py-1 text-xs font-ibm-plex-mono text-gray-500"
+                          role="status"
+                          aria-live="polite"
+                          data-testid="negotiator-agent-activity"
+                        >
+                          <span className="h-1.5 w-1.5 animate-pulse rounded-full bg-[#4091BB]" />
+                          <span>{msg.agentActivityLabel}</span>
                         </div>
+                      ) : (
+                        <AssistantMessageContent
+                          content={msg.content}
+                          isStreaming={msg.isStreaming ?? false}
+                          onOpportunityPrimaryAction={(id, userId, role, name) =>
+                            onOpportunityAction(id, "accepted", userId, role, name)
+                          }
+                          onOpportunitySecondaryAction={(id, userId, role, name) =>
+                            onOpportunityAction(id, "rejected", userId, role, name)
+                          }
+                          opportunityLoadingMap={opportunityActionLoading}
+                          currentStatusMap={opportunityStatusMap}
+                          onIntentProposalApprove={handleProposalApprove}
+                          onIntentProposalReject={handleProposalReject}
+                          onIntentProposalUndo={handleProposalUndo}
+                          intentProposalStatusMap={proposalStatusMap}
+                          onQuestionQuote={handleQuestionQuote}
+                        />
+                      )}
+                      {msg.decisionQuestions && msg.decisionQuestions.length > 0 && (
+                        <DecisionQuestions
+                          questions={msg.decisionQuestions}
+                          submitted={
+                            messageIndex < messages.length - 1 ||
+                            (msg.decisionQuestionsSubmitted ??
+                              decisionQuestionsSubmittedIds.has(msg.id))
+                          }
+                          onSubmit={(flattened) => {
+                            setDecisionQuestionsSubmittedIds((previous) => {
+                              const next = new Set(previous);
+                              next.add(msg.id);
+                              return next;
+                            });
+                            void sendMessage(flattened);
+                          }}
+                        />
                       )}
                     </div>
                   )}

--- a/apps/web/src/components/__tests__/IntentNegotiatorChat.test.tsx
+++ b/apps/web/src/components/__tests__/IntentNegotiatorChat.test.tsx
@@ -50,10 +50,30 @@ function agentMessage(overrides: Record<string, unknown> = {}) {
     role: 'assistant',
     content: 'What should I push hardest on?',
     timestamp: new Date('2026-08-21T10:00:00.000Z'),
-    options: ['Hiring speed', 'Comp banding'],
     ...overrides,
   };
 }
+
+const decisionQuestions = [
+  {
+    title: 'Sofia',
+    prompt: 'Does your design-partner experience include a scalable SaaS transition?',
+    options: [
+      { label: 'Yes, directly', description: 'I led that transition.' },
+      { label: 'Not yet', description: 'My experience is still services-led.' },
+    ],
+    multiSelect: false,
+  },
+  {
+    title: 'Aisha',
+    prompt: 'What product domain are you building in?',
+    options: [
+      { label: 'AI', description: 'AI product or infrastructure.' },
+      { label: 'Dev tools', description: 'Developer tooling.' },
+    ],
+    multiSelect: false,
+  },
+];
 
 function renderChat() {
   return render(
@@ -71,12 +91,7 @@ function renderChat() {
   );
 }
 
-/**
- * Option chips are canned replies: they render under an unanswered agent
- * question and, when tapped, go out through the ordinary send path — the same
- * one typing uses. Nothing about them is a separate answer channel.
- */
-describe('IntentNegotiatorChat option chips', () => {
+describe('IntentNegotiatorChat', () => {
   beforeEach(() => {
     sendMessage.mockClear();
     chatState.isLoading = false;
@@ -84,28 +99,75 @@ describe('IntentNegotiatorChat option chips', () => {
     conversationMessageHandler = undefined;
   });
 
-  it('sends the tapped chip as an ordinary user message', async () => {
+  it('renders numbered decision choices and submits flattened answers through chat', async () => {
+    chatState.messages = [agentMessage({ decisionQuestions })];
     renderChat();
-    const chip = await screen.findByRole('button', { name: 'Hiring speed' });
-    await userEvent.click(chip);
-    await waitFor(() => expect(sendMessage).toHaveBeenCalledWith('Hiring speed'));
+    await userEvent.click(await screen.findByRole('radio', { name: /Yes, directly/i }));
+    await userEvent.click(screen.getByRole('radio', { name: /AI/i }));
+    await userEvent.click(screen.getByRole('button', { name: 'Submit' }));
+
+    await waitFor(() => expect(sendMessage).toHaveBeenCalledWith(
+      'Sofia (Does your design-partner experience include a scalable SaaS transition?): Yes, directly\n' +
+      'Aisha (What product domain are you building in?): AI',
+    ));
+    expect(screen.getByText('Submitted.')).toBeInTheDocument();
   });
 
-  it('drops the chips once anything answers the question', async () => {
+  it('disables a historical question form once a later message exists', async () => {
     chatState.messages = [
-      agentMessage(),
-      { id: 'msg-user', role: 'user', content: 'Hiring speed', timestamp: new Date('2026-08-21T10:01:00.000Z') },
+      agentMessage({ decisionQuestions }),
+      {
+        id: 'msg-user',
+        role: 'user',
+        content: 'I have already answered these.',
+        timestamp: new Date('2026-08-21T10:01:00.000Z'),
+      },
     ];
     renderChat();
-    await screen.findByText('Hiring speed');
-    expect(screen.queryByRole('button', { name: 'Hiring speed' })).toBeNull();
+
+    expect(await screen.findByText('Submitted.')).toBeInTheDocument();
+    expect(screen.getByRole('radio', { name: /Yes, directly/i })).toBeDisabled();
+    expect(screen.queryByRole('button', { name: 'Submit' })).toBeNull();
+    expect(sendMessage).not.toHaveBeenCalled();
   });
 
-  it('renders nothing extra for a message that offered no chips', async () => {
-    chatState.messages = [agentMessage({ options: undefined })];
-    renderChat();
-    await screen.findByText('What should I push hardest on?');
-    expect(screen.queryByTestId('negotiator-chat-options')).toBeNull();
+  it('shows the latest agent activity until response text arrives', async () => {
+    chatState.messages = [agentMessage({ content: '', isStreaming: true, agentActivityLabel: 'Reviewing your signal' })];
+    const view = renderChat();
+    expect(await screen.findByRole('status')).toHaveTextContent('Reviewing your signal');
+
+    chatState.messages = [agentMessage({ content: '', isStreaming: true, agentActivityLabel: 'Checking Sofia and Aisha' })];
+    view.rerender(
+      <IntentNegotiatorChat
+        intentId="intent-1"
+        timelineEntries={[]}
+        timelineLoading={false}
+        timelineError={false}
+        opportunityStatusMap={{}}
+        opportunityActionLoading={{}}
+        onOpportunityAction={() => {}}
+        onUnavailable={() => {}}
+        onLiveInvalidation={() => {}}
+      />,
+    );
+    expect(screen.getByRole('status')).toHaveTextContent('Checking Sofia and Aisha');
+
+    chatState.messages = [agentMessage({ content: 'Here is what I found.', isStreaming: true })];
+    view.rerender(
+      <IntentNegotiatorChat
+        intentId="intent-1"
+        timelineEntries={[]}
+        timelineLoading={false}
+        timelineError={false}
+        opportunityStatusMap={{}}
+        opportunityActionLoading={{}}
+        onOpportunityAction={() => {}}
+        onUnavailable={() => {}}
+        onLiveInvalidation={() => {}}
+      />,
+    );
+    expect(screen.queryByTestId('negotiator-agent-activity')).toBeNull();
+    expect(screen.getByText('Here is what I found.')).toBeInTheDocument();
   });
 
   it('shows the owner-scoped PersonalAgent trace inside the DM', async () => {

--- a/apps/web/src/contexts/AIChatContext.tsx
+++ b/apps/web/src/contexts/AIChatContext.tsx
@@ -141,17 +141,26 @@ interface ChatMessage {
   decisionQuestions?: Question[];
   /** True once the user has submitted answers; disables/mutes the renderer. */
   decisionQuestionsSubmitted?: boolean;
+  /** Current user-facing activity for an empty streaming assistant placeholder. */
+  agentActivityLabel?: string;
   isPending?: boolean;
   isQueued?: boolean;
   wasInterrupted?: boolean;
   /** Durable timeline session that supplied this persisted message. */
   conversationSessionId?: string | null;
-  /**
-   * Canned replies the agent offered under a question — tap one and its exact
-   * text is sent as an ordinary user message. Nothing else reads them, so a
-   * chip is a shortcut for typing and never a separate answer channel.
-   */
-  options?: string[];
+}
+
+function safeAgentActivityLabel(value: unknown): string | undefined {
+  if (typeof value !== "string") return undefined;
+  const withoutControls = Array.from(value, (character) => {
+    const codePoint = character.codePointAt(0) ?? 0;
+    return codePoint < 32 || codePoint === 127 ? " " : character;
+  }).join("");
+  const label = withoutControls
+    .replace(/\s+/g, " ")
+    .trim()
+    .slice(0, 120);
+  return label || undefined;
 }
 
 export type ChatScope =
@@ -737,11 +746,27 @@ export function AIChatProvider({ children }: { children: React.ReactNode }) {
                     setMessages((prev) =>
                       prev.map((msg) =>
                         msg.id === assistantMessageId
-                          ? { ...msg, content: msg.content + event.content }
+                          ? {
+                              ...msg,
+                              content: msg.content + event.content,
+                              agentActivityLabel: undefined,
+                            }
                           : msg,
                       ),
                     );
                     break;
+                  case "agent_activity": {
+                    const label = safeAgentActivityLabel(event.label);
+                    if (!label) break;
+                    setMessages((prev) =>
+                      prev.map((msg) =>
+                        msg.id === assistantMessageId && !msg.content.trim()
+                          ? { ...msg, agentActivityLabel: label }
+                          : msg,
+                      ),
+                    );
+                    break;
+                  }
                   case "response_reset":
                     // Discard all previously streamed tokens — the agent detected
                     // hallucinated code blocks and is forcing a correction iteration.
@@ -1030,18 +1055,12 @@ export function AIChatProvider({ children }: { children: React.ReactNode }) {
                           msg.decisionQuestions && msg.decisionQuestions.length > 0
                             ? msg.decisionQuestions
                             : fromDone;
-                        // Chips ride the done event only so this turn shows
-                        // them without a reload; the persisted message carries
-                        // the same list for every later read.
-                        const options = Array.isArray(event.options)
-                          ? (event.options as string[])
-                          : undefined;
                         return {
                           ...msg,
                           content: finalContent,
                           isStreaming: false,
+                          agentActivityLabel: undefined,
                           ...(decisionQuestions ? { decisionQuestions } : {}),
-                          ...(options && options.length > 0 ? { options } : {}),
                         };
                       }),
                     );
@@ -1143,7 +1162,7 @@ export function AIChatProvider({ children }: { children: React.ReactNode }) {
         setMessages((prev) =>
           prev.map((msg) =>
             msg.id === assistantMessageId
-              ? { ...msg, isStreaming: false }
+              ? { ...msg, isStreaming: false, agentActivityLabel: undefined }
               : msg,
           ),
         );
@@ -1315,7 +1334,6 @@ export function AIChatProvider({ children }: { children: React.ReactNode }) {
           decisionQuestions?: Question[] | null;
           decisionQuestionsSubmitted?: boolean | null;
           interrupted?: boolean | null;
-          options?: string[] | null;
           debugMeta?: {
             tools?: Array<{
               name: string;
@@ -1361,7 +1379,6 @@ export function AIChatProvider({ children }: { children: React.ReactNode }) {
           : {}),
         ...(m.decisionQuestionsSubmitted ? { decisionQuestionsSubmitted: true } : {}),
         ...(m.interrupted ? { wasInterrupted: true } : {}),
-        ...(Array.isArray(m.options) && m.options.length > 0 ? { options: m.options } : {}),
         conversationSessionId: data.sessionId,
       }));
 
@@ -1406,7 +1423,6 @@ export function AIChatProvider({ children }: { children: React.ReactNode }) {
           decisionQuestions?: Question[] | null;
           decisionQuestionsSubmitted?: boolean | null;
           interrupted?: boolean | null;
-          options?: string[] | null;
           debugMeta?: {
             tools?: Array<{
               name: string;
@@ -1439,7 +1455,6 @@ export function AIChatProvider({ children }: { children: React.ReactNode }) {
           : {}),
         ...(message.decisionQuestionsSubmitted ? { decisionQuestionsSubmitted: true } : {}),
         ...(message.interrupted ? { wasInterrupted: true } : {}),
-        ...(Array.isArray(message.options) && message.options.length > 0 ? { options: message.options } : {}),
         conversationSessionId: data.sessionId,
       }));
       setMessages((current) => {

--- a/apps/web/tests/ai-chat-context-signal.test.tsx
+++ b/apps/web/tests/ai-chat-context-signal.test.tsx
@@ -119,6 +119,9 @@ function Probe() {
       <span data-testid="session">{chat.sessionId ?? 'none'}</span>
       <span data-testid="persona">{chat.sessionPersona ?? 'none'}</span>
       <span data-testid="messages">{chat.messages.map((message) => message.content).join('|')}</span>
+      <span data-testid="agent-activity">
+        {chat.messages.map((message) => message.agentActivityLabel).filter(Boolean).join('|') || 'none'}
+      </span>
       <span data-testid="message-count">{chat.messages.length}</span>
       <span data-testid="streaming-count">{chat.messages.filter((message) => message.isStreaming).length}</span>
       <span data-testid="block">{chat.turnBlock?.code ?? 'none'}</span>
@@ -179,6 +182,43 @@ describe('AIChatContext Signal persona transport and ownership', () => {
     fireEvent.click(screen.getByRole('button', { name: 'compatibility' }));
     await waitFor(() => expect(mocks.apiClient.stream).toHaveBeenCalledTimes(3));
     expect(mocks.apiClient.stream.mock.calls[2]?.[0]).toBe('/chat/stream');
+  });
+
+  test('tracks the latest safe agent activity until response content or completion arrives', async () => {
+    const textStream = controlledStream({ sessionId: 'signal-session-1', persona: 'personal' });
+    const doneStream = controlledStream();
+    mocks.apiClient.stream
+      .mockResolvedValueOnce(textStream.response)
+      .mockResolvedValueOnce(doneStream.response);
+
+    renderProvider();
+    fireEvent.click(screen.getByRole('button', { name: 'web first' }));
+    await waitFor(() => expect(text('loading')).toBe('yes'));
+
+    act(() => textStream.event({ type: 'agent_activity', label: '  Reviewing\n your signal  ' }));
+    await waitFor(() => expect(text('agent-activity')).toBe('Reviewing your signal'));
+
+    act(() => textStream.event({ type: 'agent_activity', label: 'Checking Sofia and Aisha' }));
+    await waitFor(() => expect(text('agent-activity')).toBe('Checking Sofia and Aisha'));
+
+    act(() => {
+      textStream.event({ type: 'token', content: 'I found the relevant context.' });
+      textStream.close();
+    });
+    await waitFor(() => expect(text('agent-activity')).toBe('none'));
+    await waitFor(() => expect(text('loading')).toBe('no'));
+
+    fireEvent.click(screen.getByRole('button', { name: 'web second' }));
+    await waitFor(() => expect(text('loading')).toBe('yes'));
+    act(() => doneStream.event({ type: 'agent_activity', label: 'Preparing the response' }));
+    await waitFor(() => expect(text('agent-activity')).toBe('Preparing the response'));
+
+    act(() => {
+      doneStream.event({ type: 'done', response: 'done' });
+      doneStream.close();
+    });
+    await waitFor(() => expect(text('loading')).toBe('no'));
+    expect(text('agent-activity')).toBe('none');
   });
 
   test('preserves a message submitted before the first web session id arrives', async () => {

--- a/bun.lock
+++ b/bun.lock
@@ -89,7 +89,7 @@
     },
     "packages/protocol": {
       "name": "@indexnetwork/protocol",
-      "version": "34.0.1",
+      "version": "35.0.0",
       "dependencies": {
         "@langchain/core": "1.1.48",
         "@langchain/langgraph": "1.3.2",

--- a/packages/protocol/CHANGELOG.md
+++ b/packages/protocol/CHANGELOG.md
@@ -20,6 +20,23 @@ went 6.7.1 → 8.0.2 with no 7.x in between because the whole 7.x line shipped a
 prereleases between the two promotions. To track every change, read `rc`; to
 pin a supported release, use `latest`.
 
+## 35.0.0 - 2026-08-24
+
+### Breaking
+
+- **PersonalAgent questions use the canonical structured question contract.**
+  `message_user.options` is replaced by `message_user.questions` on decided
+  and executed acts and on the conversation delivery port. Questions are
+  safety-checked and delivered separately from the message introduction so
+  clients can render the guided question UI directly. The exported
+  `normalizeMessageOptions` helper is replaced by `normalizeMessageQuestions`.
+
+### Added
+
+- `PersonalAgentActivity` and `PersonalAgentActivityPort` provide bounded,
+  user-facing progress updates for live intent turns without exposing internal
+  identifiers, model reasoning, or private context.
+
 ## 34.0.1 - 2026-08-24
 
 ### Changed

--- a/packages/protocol/package.json
+++ b/packages/protocol/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@indexnetwork/protocol",
-  "version": "34.0.1",
+  "version": "35.0.0",
   "type": "module",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",

--- a/packages/protocol/src/capabilities/tests/personal-agent.e2e.spec.ts
+++ b/packages/protocol/src/capabilities/tests/personal-agent.e2e.spec.ts
@@ -28,7 +28,8 @@ const TERMINAL_STATUSES = new Set(["accepted", "rejected", "expired"]);
 
 /** The DM, the dossier and the ledger, in memory. */
 class FakePrincipalHost {
-  readonly dmMessages: Array<{ role: string; content: string; options?: string[] }> = [];
+  readonly dmMessages: Array<{ role: string; content: string; questions?: import("../../protocol/question.js").Question[] }> = [];
+  readonly activities: Array<import("../../internal/agents/personal-agent/agent.types.js").PersonalAgentActivity> = [];
   readonly dossierEntries: Array<{ id: string; text: string; source: string; createdAt: Date }> = [];
   readonly ledgerRows: Array<{ event: Record<string, unknown>; act: Record<string, unknown> }> = [];
   readonly publishedChunks: Array<{ messageId: string; seq: number; content: string }> = [];
@@ -42,8 +43,8 @@ class FakePrincipalHost {
     findSession: async () => ({ id: "dm-1" }),
     resolveSession: async () => ({ session: { id: "dm-1" } }),
     getMessages: async () => this.dmMessages.map(({ role, content }) => ({ role, content })),
-    addMessage: async ({ role, content, options }) => {
-      this.dmMessages.push({ role, content, ...(options ? { options } : {}) });
+    addMessage: async ({ role, content, questions }) => {
+      this.dmMessages.push({ role, content, ...(questions ? { questions } : {}) });
       return `dm-message-${++this.messageCounter}`;
     },
   };
@@ -97,6 +98,10 @@ class FakePrincipalHost {
 
   readonly replyStream: PersonalAgentDeps["replyStream"] = {
     publish: async (messageId, chunk) => { this.publishedChunks.push({ messageId, ...chunk }); },
+  };
+
+  readonly activity: PersonalAgentDeps["activity"] = {
+    publish: async (_messageId, activity) => { this.activities.push(activity); },
   };
 }
 
@@ -225,6 +230,7 @@ function buildCycle(judgment: ScriptedJudgment, counterparties: string[]) {
     opportunities: principal.opportunities,
     identity: principal.identity,
     replyStream: principal.replyStream,
+    activity: principal.activity,
     reflectEnqueue: async (job) => { negotiationHost.enqueueReflect(job); },
     wakeForMatches: async (input) => { wakes.push(input); },
     judgment,
@@ -244,9 +250,18 @@ const userMessage = (text: string) => ({
 
 describe("PersonalAgent — chat-first intent turns", () => {
   test("acts on one resolved matter and asks about another in the same turn", async () => {
+    const questions = [{
+      title: "Compensation",
+      prompt: "What compensation range should I use?",
+      options: [
+        { label: "$100k-$150k", description: "Use a six-figure cash range." },
+        { label: "Equity-led", description: "Prioritize ownership over cash." },
+      ],
+      multiSelect: false,
+    }];
     const judgment = new ScriptedJudgment([() => [
       { tool: "note_dossier", text: "Can start in three weeks." },
-      { tool: "message_user", text: "I noted the timing. What compensation range should I use?" },
+      { tool: "message_user", text: "I noted the timing. One more detail will help.", questions },
     ]]);
     const { agent, principal } = buildCycle(judgment, [CANDIDATE_USER_ID]);
 
@@ -254,31 +269,48 @@ describe("PersonalAgent — chat-first intent turns", () => {
 
     expect(result.acts.map((act) => act.tool)).toEqual(["note_dossier", "message_user"]);
     expect(principal.dossierEntries.map((entry) => entry.text)).toEqual(["Can start in three weeks."]);
-    expect(result.messages).toEqual(["I noted the timing. What compensation range should I use?"]);
+    expect(result.messages).toEqual(["I noted the timing. One more detail will help."]);
+    expect(principal.dmMessages.at(-1)?.questions).toEqual(questions);
   });
 
   test("can ask naturally without fabricating work", async () => {
     const judgment = new ScriptedJudgment([() => [
-      { tool: "message_user", text: "What timing would work for you?" },
+      {
+        tool: "message_user",
+        text: "One timing detail will help.",
+        questions: [{
+          title: "Timing",
+          prompt: "What timing would work for you?",
+          options: [
+            { label: "This month", description: "Start in the next few weeks." },
+            { label: "Next quarter", description: "Plan for a later start." },
+          ],
+          multiSelect: false,
+        }],
+      },
     ]]);
     const { agent } = buildCycle(judgment, [CANDIDATE_USER_ID]);
 
     const result = await agent.invoke({ userId: SOURCE_USER_ID, intentId: INTENT_ID, event: "matches_ready" });
 
     expect(result.acts.map((act) => act.tool)).toEqual(["message_user"]);
-    expect(result.messages).toEqual(["What timing would work for you?"]);
+    expect(result.messages).toEqual(["One timing detail will help."]);
   });
 
   test("answers a plain conversation without fabricated work", async () => {
     const judgment = new ScriptedJudgment([() => [
       { tool: "message_user", text: "I am here and keeping an eye on this signal." },
     ]]);
-    const { agent } = buildCycle(judgment, [CANDIDATE_USER_ID]);
+    const { agent, principal } = buildCycle(judgment, [CANDIDATE_USER_ID]);
 
     const result = await agent.invoke(userMessage("Thanks."));
 
     expect(result.acts.map((act) => act.tool)).toEqual(["message_user"]);
     expect(result.messages).toEqual(["I am here and keeping an eye on this signal."]);
+    expect(principal.activities).toEqual([
+      { phase: "reviewing", label: "Reviewing the conversation" },
+      { phase: "preparing_response", label: "Preparing a response" },
+    ]);
   });
 
   test("uses the actual executed tool result before choosing the response", async () => {
@@ -292,12 +324,18 @@ describe("PersonalAgent — chat-first intent turns", () => {
           : { tool: "message_user", text: "I could not save that preference." };
       },
     );
-    const { agent } = buildCycle(judgment, [CANDIDATE_USER_ID]);
+    const { agent, principal } = buildCycle(judgment, [CANDIDATE_USER_ID]);
 
     const result = await agent.invoke(userMessage("Remote is important."));
 
     expect(result.acts.map((act) => act.tool)).toEqual(["note_dossier", "message_user"]);
     expect(result.messages).toEqual(["I saved your remote preference for the negotiation table."]);
+    expect(principal.activities).toEqual([
+      { phase: "reviewing", label: "Reviewing the conversation" },
+      { phase: "working", label: "Saving what you shared" },
+      { phase: "working", label: "Saved what you shared" },
+      { phase: "preparing_response", label: "Preparing a response" },
+    ]);
   });
 
   test("refreshes the dossier after note_dossier before kickoff strategy and briefs", async () => {
@@ -435,7 +473,19 @@ describe("PersonalAgent — chat-first intent turns", () => {
 
   test("does not accept a match from hedge text", async () => {
     const judgment = new ScriptedJudgment([() => [
-      { tool: "message_user", text: "It sounds promising. What would settle it for you?" },
+      {
+        tool: "message_user",
+        text: "It sounds promising. One detail could settle it.",
+        questions: [{
+          title: "Decision",
+          prompt: "What would settle it for you?",
+          options: [
+            { label: "Terms", description: "Clarify the practical terms first." },
+            { label: "Fit", description: "Clarify the working fit first." },
+          ],
+          multiSelect: false,
+        }],
+      },
     ]]);
     const { agent, principal } = buildCycle(judgment, [CANDIDATE_USER_ID]);
 
@@ -626,7 +676,19 @@ describe("PersonalAgent — the whole cycle", () => {
   test("matches_ready → conversation → kickoff → all_paused → further conversation and actions", async () => {
     const judgment = new ScriptedJudgment([
       // 1. matches_ready: the agent asks for the missing timing.
-      () => [{ tool: "message_user", text: "Before I reach out — what is your timeline?" }],
+      () => [{
+        tool: "message_user",
+        text: "Before I reach out, I need one timeline detail.",
+        questions: [{
+          title: "Timeline",
+          prompt: "What is your timeline?",
+          options: [
+            { label: "This month", description: "Move within the next few weeks." },
+            { label: "Next quarter", description: "Plan for a later start." },
+          ],
+          multiSelect: false,
+        }],
+      }],
       // 2. their answer: note it, then kick every match off.
       () => [
         { tool: "note_dossier", text: "Wants to start within a month." },
@@ -635,7 +697,19 @@ describe("PersonalAgent — the whole cycle", () => {
       // 3. all_paused: ask what one table still needs.
       (context) => {
         expect(context.paused).toHaveLength(3);
-        return [{ tool: "message_user", text: "One of them needs your earliest start date — what should I say?" }];
+        return [{
+          tool: "message_user",
+          text: "One of them needs your earliest start date.",
+          questions: [{
+            title: "Start date",
+            prompt: "What should I say your earliest start date is?",
+            options: [
+              { label: "Two weeks", description: "Say you can start in two weeks." },
+              { label: "One month", description: "Say you can start in one month." },
+            ],
+            multiSelect: false,
+          }],
+        }];
       },
       // 4. their answer: promote, reject, and re-kick the rest.
       (context) => {
@@ -653,7 +727,7 @@ describe("PersonalAgent — the whole cycle", () => {
     const asked = await agent.invoke({ userId: SOURCE_USER_ID, intentId: INTENT_ID, event: "matches_ready" });
     expect(asked.acts.map((act) => act.tool)).toEqual(["message_user"]);
     expect(negotiationHost.tasks.size).toBe(0);
-    expect(principal.dmMessages.at(-1)?.content).toContain("what is your timeline");
+    expect(principal.dmMessages.at(-1)?.questions?.[0]?.prompt).toBe("What is your timeline?");
 
     // ── 2. the answer kicks the round off ─────────────────────────────────
     const kicked = await agent.invoke(userMessage("Within a month, ideally sooner."));

--- a/packages/protocol/src/index.ts
+++ b/packages/protocol/src/index.ts
@@ -249,7 +249,7 @@ export type {
  */
 export { PersonalAgentGraphFactory, chunkReplyText } from "./internal/agents/personal-agent/agent.graph.js";
 export type { PersonalAgentGraphLike } from "./internal/agents/personal-agent/agent.graph.js";
-export { PersonalAgentModel, renderPersonalAgentTurn, normalizeMessageOptions, validateDecidedAct } from "./internal/agents/personal-agent/agent.judgment.js";
+export { PersonalAgentModel, renderPersonalAgentTurn, normalizeMessageQuestions, validateDecidedAct } from "./internal/agents/personal-agent/agent.judgment.js";
 export { buildPersonalAgentSystemPrompt, isSafeAgentMessageProse, PERSONAL_AGENT_SYSTEM_PROMPT_VERSION } from "./internal/agents/personal-agent/agent.prompt.js";
 export type {
   PersonalAgentInput,
@@ -272,6 +272,8 @@ export type {
   PersonalAgentLedgerPort,
   PersonalAgentConversationPort,
   PersonalAgentReplyStreamPort,
+  PersonalAgentActivity,
+  PersonalAgentActivityPort,
   PersonalAgentOpportunityPort,
   PersonalAgentIdentityPort,
 } from "./internal/agents/personal-agent/agent.types.js";

--- a/packages/protocol/src/internal/agents/personal-agent/agent.graph.ts
+++ b/packages/protocol/src/internal/agents/personal-agent/agent.graph.ts
@@ -27,8 +27,9 @@ import { requestContext } from "../../shared/observability/request-context.js";
 import { turnsWithSenders, type NegotiationAuthoredTurn } from "../../negotiations/negotiation.turn.js";
 import type { NegotiationTaskRow } from "../../../platform/database/negotiation.js";
 import type { IntentRecord } from "../../../platform/database/entities.js";
-import { PersonalAgentModel } from "./agent.judgment.js";
-import type { PersonalAgentDecidedAct, PersonalAgentDeps, PersonalAgentExecutedAct, PersonalAgentInput, PersonalAgentIntentEventKind, PersonalAgentMatch, PersonalAgentNonDurableObservation, PersonalAgentPausedNegotiation, PersonalAgentResult, PersonalAgentScope, PersonalAgentThreadEntry, PersonalAgentTurnContext } from "./agent.types.js";
+import { normalizeMessageQuestions, PersonalAgentModel } from "./agent.judgment.js";
+import type { Question } from "../../../protocol/question.js";
+import type { PersonalAgentActivity, PersonalAgentDecidedAct, PersonalAgentDeps, PersonalAgentExecutedAct, PersonalAgentInput, PersonalAgentIntentEventKind, PersonalAgentMatch, PersonalAgentNonDurableObservation, PersonalAgentPausedNegotiation, PersonalAgentResult, PersonalAgentScope, PersonalAgentThreadEntry, PersonalAgentTurnContext } from "./agent.types.js";
 
 const logger = protocolLogger("PersonalAgentGraph");
 
@@ -276,7 +277,7 @@ async function deliverMessage(
   deps: PersonalAgentDeps,
   context: PersonalAgentTurnContext,
   text: string,
-  options?: string[],
+  questions?: Question[],
 ): Promise<{ sessionId: string; messageId: string } | null> {
   const resolved = await deps.conversation.resolveSession(context.userId, context.intentId);
   if ("error" in resolved) {
@@ -295,7 +296,7 @@ async function deliverMessage(
     sessionId: resolved.session.id,
     role: "assistant",
     content: text,
-    ...(options ? { options } : {}),
+    ...(questions ? { questions } : {}),
   });
   return { sessionId: resolved.session.id, messageId };
 }
@@ -367,14 +368,17 @@ async function say(
   accumulator: TurnAccumulator,
   tool: "message_user",
   text: string,
-  options?: string[],
+  questions?: Question[],
 ): Promise<void> {
-  const delivered = await deliverMessage(deps, context, text, options);
+  if (text.includes("?")) throw new Error("PersonalAgent questions must use the structured questions field");
+  const safeQuestions = normalizeMessageQuestions(questions);
+  if (questions && !safeQuestions) throw new Error("PersonalAgent produced no safe questions");
+  const delivered = await deliverMessage(deps, context, text, safeQuestions);
   if (!delivered) return;
   const executed: PersonalAgentExecutedAct = {
     tool,
     text,
-    ...(options ? { options } : {}),
+    ...(safeQuestions ? { questions: safeQuestions } : {}),
     ...delivered,
   };
   // Guarded, like every other post-delivery ledger write: the message is on
@@ -830,7 +834,7 @@ async function executeAct(
 ): Promise<void> {
   switch (act.tool) {
     case "message_user":
-      await say(deps, context, accumulator, act.tool, act.text, act.options);
+      await say(deps, context, accumulator, act.tool, act.text, act.questions);
       return;
     case "promote":
     case "reject": {
@@ -992,6 +996,29 @@ async function publishTurnMessages(
   }
 }
 
+const TOOL_ACTIVITY_LABELS: Record<Exclude<PersonalAgentDecidedAct["tool"], "message_user">, { before: string; after: string }> = {
+  kickoff: { before: "Preparing outreach", after: "Outreach prepared" },
+  promote: { before: "Updating a match", after: "Match updated" },
+  reject: { before: "Updating a match", after: "Match updated" },
+  note_dossier: { before: "Saving what you shared", after: "Saved what you shared" },
+  retire_dossier: { before: "Updating what I remember", after: "Updated what I remember" },
+  accept_opportunity: { before: "Recording your decision", after: "Decision recorded" },
+};
+
+/** Activity is best-effort UI feedback and must never decide turn success. */
+async function publishActivity(
+  deps: PersonalAgentDeps,
+  input: Extract<PersonalAgentInput, { event: PersonalAgentIntentEventKind }>,
+  activity: PersonalAgentActivity,
+): Promise<void> {
+  if (!deps.activity || input.event !== "user_message") return;
+  try {
+    await deps.activity.publish(input.messageId, activity);
+  } catch (err) {
+    logger.warn("Failed to publish PersonalAgent activity", { phase: activity.phase, error: err });
+  }
+}
+
 // ─── Nodes ───────────────────────────────────────────────────────────────────
 
 async function intentNode(state: PersonalAgentState, deps: PersonalAgentDeps): Promise<Partial<PersonalAgentState>> {
@@ -999,6 +1026,7 @@ async function intentNode(state: PersonalAgentState, deps: PersonalAgentDeps): P
   let context: PersonalAgentTurnContext | null = null;
   let accumulator: TurnAccumulator | null = null;
   try {
+    await publishActivity(deps, input, { phase: "reviewing", label: "Reviewing the conversation" });
     const contextStartedAt = Date.now();
     context = await assembleContext(deps, input);
     logger.info("PersonalAgent context assembled", {
@@ -1059,11 +1087,15 @@ async function intentNode(state: PersonalAgentState, deps: PersonalAgentDeps): P
       const toolStartedAt = Date.now();
       try {
         if (act.tool === "message_user") {
+          await publishActivity(deps, input, { phase: "preparing_response", label: "Preparing a response" });
           accumulator.finalMessageChosen = true;
           await executeAct(deps, context, accumulator, act);
         } else if (act.tool === "kickoff") {
+          await publishActivity(deps, input, { phase: "working", label: TOOL_ACTIVITY_LABELS.kickoff.before });
           await runKickoff(deps, context, accumulator, act.reasoning);
+          await publishActivity(deps, input, { phase: "working", label: TOOL_ACTIVITY_LABELS.kickoff.after });
         } else {
+          await publishActivity(deps, input, { phase: "working", label: TOOL_ACTIVITY_LABELS[act.tool].before });
           await executeAct(deps, context, accumulator, act);
           if (act.tool === "note_dossier" || act.tool === "retire_dossier") {
             context = {
@@ -1071,6 +1103,7 @@ async function intentNode(state: PersonalAgentState, deps: PersonalAgentDeps): P
               dossier: await deps.dossier.readActiveEntries(context.userId, context.intentId),
             };
           }
+          await publishActivity(deps, input, { phase: "working", label: TOOL_ACTIVITY_LABELS[act.tool].after });
         }
       } catch (err) {
         logger.error("PersonalAgent tool failed", {
@@ -1095,6 +1128,7 @@ async function intentNode(state: PersonalAgentState, deps: PersonalAgentDeps): P
     if (!accumulator.finalMessageChosen) {
       if (accumulator.acts.length === 0) throwIfIntentAborted();
       logger.warn("PersonalAgent exhausted its intent tool budget", { intentId: context.intentId, event: context.event });
+      await publishActivity(deps, input, { phase: "preparing_response", label: "Preparing a response" });
       await say(deps, context, accumulator, "message_user", PERSONAL_AGENT_TOOL_BUDGET_EXHAUSTED);
     }
     if (input.event === "user_message") await publishTurnMessages(deps, input.messageId, accumulator.messages);
@@ -1115,6 +1149,7 @@ async function intentNode(state: PersonalAgentState, deps: PersonalAgentDeps): P
         error: err,
       });
       try {
+        await publishActivity(deps, input, { phase: "preparing_response", label: "Preparing a response" });
         await say(deps, context, accumulator, "message_user", PERSONAL_AGENT_POST_ACTION_FAILURE);
       } catch (fallbackError) {
         logger.error("PersonalAgent terminal fallback could not be delivered", {

--- a/packages/protocol/src/internal/agents/personal-agent/agent.judgment.ts
+++ b/packages/protocol/src/internal/agents/personal-agent/agent.judgment.ts
@@ -19,6 +19,7 @@ import { createStructuredModel } from "../../shared/agent/model.config.js";
 import { invokeWithAbortSignal } from "../../shared/agent/model-signal.js";
 import { protocolLogger } from "../../shared/observability/protocol.logger.js";
 import { NegotiationAuthoredTurnSchema, NegotiationOpeningTurnSchema, type NegotiationAuthoredTurn, type NegotiationTurn } from "../../negotiations/negotiation.turn.js";
+import { QuestionSchema, type Question } from "../../../protocol/question.js";
 import { buildPersonalAgentSystemPrompt, isSafeAgentMessageProse, personalAgentEventInstruction, PERSONAL_AGENT_BRIEF_INSTRUCTION, PERSONAL_AGENT_NEGOTIATION_OPENING_PROMPT, PERSONAL_AGENT_NEGOTIATION_TURN_PROMPT, PERSONAL_AGENT_SEAT_BRIEF_INSTRUCTION, PERSONAL_AGENT_STRATEGY_INSTRUCTION } from "./agent.prompt.js";
 import type { PersonalAgentBriefInput, PersonalAgentSeatBriefInput, PersonalAgentDecidedAct, PersonalAgentExecutedAct, PersonalAgentJudgment, PersonalAgentNegotiationTurnInput, PersonalAgentNonDurableObservation, PersonalAgentThreadEntry, PersonalAgentTurnContext } from "./agent.types.js";
 
@@ -38,9 +39,7 @@ const MAX_TEXT_CHARS = 500;
 const MAX_DM_CHARS = 1000;
 const MAX_DM_MESSAGES = 20;
 const MAX_THREAD_TURNS = 8;
-const MAX_OPTION_CHARS = 60;
-const MIN_OPTIONS = 2;
-const MAX_OPTIONS = 4;
+const MAX_QUESTIONS = 3;
 
 function truncate(text: string, max: number): string {
   const trimmed = text.trim();
@@ -48,27 +47,32 @@ function truncate(text: string, max: number): string {
 }
 
 /**
- * Canned replies, normalized. Options are a shortcut for typing and nothing
- * more, so a malformed set is DROPPED rather than rejected: the question
- * still reads fine as prose, and refusing the whole round trip over chip
- * wording would trade a convenience for a lost turn.
+ * Structured questions, normalized through the canonical renderer schema and
+ * the same prose leak gate used for chat copy. One malformed question is
+ * dropped without losing the other safe questions in the response.
  */
-export function normalizeMessageOptions(raw: unknown): string[] | undefined {
+export function normalizeMessageQuestions(raw: unknown): Question[] | undefined {
   if (!Array.isArray(raw)) return undefined;
   const seen = new Set<string>();
-  const options: string[] = [];
+  const questions: Question[] = [];
   for (const candidate of raw) {
-    if (typeof candidate !== "string") continue;
-    const text = candidate.trim();
-    if (!text || text.length > MAX_OPTION_CHARS) continue;
-    if (!isSafeAgentMessageProse(text)) continue;
-    const key = text.toLowerCase();
+    const parsed = QuestionSchema.safeParse(candidate);
+    if (!parsed.success) continue;
+    const question = parsed.data;
+    const prose = [
+      question.title,
+      question.prompt,
+      question.evidence,
+      ...question.options.flatMap((option) => [option.label, option.description]),
+    ].filter((value): value is string => typeof value === "string");
+    if (!prose.every(isSafeAgentMessageProse)) continue;
+    const key = question.prompt.trim().toLowerCase();
     if (seen.has(key)) continue;
     seen.add(key);
-    options.push(text);
-    if (options.length === MAX_OPTIONS) break;
+    questions.push(question);
+    if (questions.length === MAX_QUESTIONS) break;
   }
-  return options.length >= MIN_OPTIONS ? options : undefined;
+  return questions.length > 0 ? questions : undefined;
 }
 
 // ─── Rendering ───────────────────────────────────────────────────────────────
@@ -231,8 +235,8 @@ const DecidedActSchema = z.object({
     act: z.enum(["message_user", "kickoff", "promote", "reject", "note_dossier", "retire_dossier", "accept_opportunity"]),
     /** message_user: the prose. note_dossier: the fact. */
     text: z.string().max(4000).nullable().optional(),
-    /** message_user: 2-4 short canned replies. */
-    options: z.array(z.string().max(MAX_OPTION_CHARS)).max(8).nullable().optional(),
+    /** message_user: renderer-ready questions; all asking lives here, not in text. */
+    questions: z.array(QuestionSchema).max(MAX_QUESTIONS).nullable().optional(),
     /** promote / reject: 1-based number from the paused list. */
     negotiation: z.number().int().min(1).nullable().optional(),
     /** accept_opportunity: 1-based number from the match list. */
@@ -416,8 +420,12 @@ export function validateDecidedAct(
       {
         const text = act.text?.trim();
         if (!text || !isSafeAgentMessageProse(text)) return null;
-        const options = normalizeMessageOptions(act.options);
-        return { tool: "message_user", text, ...(options ? { options } : {}) };
+        const questions = normalizeMessageQuestions(act.questions);
+        // Questions belong in the structured field. Keeping them out of prose
+        // prevents the same ask rendering twice and guarantees widget delivery.
+        if (text.includes("?")) return null;
+        if (Array.isArray(act.questions) && act.questions.length > 0 && !questions) return null;
+        return { tool: "message_user", text, ...(questions ? { questions } : {}) };
       }
       case "kickoff": {
         return { tool: "kickoff", reasoning: act.reasoning?.trim() || "Reaching out to this signal's matches." };

--- a/packages/protocol/src/internal/agents/personal-agent/agent.prompt.ts
+++ b/packages/protocol/src/internal/agents/personal-agent/agent.prompt.ts
@@ -16,7 +16,7 @@ import { buildAgentSelfIntroduction, type AgentIdentityOptions } from "../../cha
 import { hasUnsupportedOpportunityClaim } from "../../shared/utils/claim-safety.js";
 import type { PersonalAgentIntentEventKind } from "./agent.types.js";
 
-export const PERSONAL_AGENT_SYSTEM_PROMPT_VERSION = 6;
+export const PERSONAL_AGENT_SYSTEM_PROMPT_VERSION = 7;
 
 const INTERNAL_OR_PRIVATE_PATTERN = /\b(?:[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}|(?:task|intent|network|opportunity|user|match)[_-]?id|private transcript|raw transcript|assessment(?:\.reasoning)?|seed assessment|evaluator reasoning|match reason|matchReason|internal metadata|counterparty profile)\b/i;
 
@@ -55,7 +55,7 @@ export function buildPersonalAgentSystemPrompt(identity: AgentIdentityOptions = 
   return `${introduction} You decide when to reach out to this signal's matches, you run those negotiations through your negotiator seat at each table, and you hold the WHOLE conversation with your client about this signal: every message they send here comes to you, whether it is an answer, an instruction, a question, or small talk. You have just been woken by an event; decide what to do, then act through your tools.
 
 Your tools, each of which is recorded in your ledger:
-- message_user: say something to your client. This is your normal conversational response on every event, whether it reports an action, answers a question, or asks for information. When it asks something you can reduce to a few clean candidates, give an \`options\` list: 2-4 short, concrete, mutually distinct candidate answers in their language. They are a shortcut for typing, nothing more, so never offer an "other", "something else" or "let me type" option.
+- message_user: say something to your client. This is your normal conversational response on every event, whether it reports an action, answers a question, or asks for information. Put every question in the structured \`questions\` field, never in \`text\`. Keep \`text\` to a short introduction or plain conversational prose that does not repeat the questions. Each question must use the canonical shape: a short title, a focused prompt, 2-4 concrete choices with consequence descriptions, and \`multiSelect\`. Never add an "other" choice because the client supplies it automatically. Omit \`questions\` when you are not asking anything.
 - kickoff: open every undecided match of this signal — or re-open the ones still running — with a fresh brief each. You write a short strategy into the conversation first and your client sees it. There is no selection here: you reach out to all of them and judge later, when the tables have given you something to judge on.
 - promote: this negotiation has converged into something your client should see. The match moves to their decision queue. This ENDS the negotiation.
 - reject: this negotiation is not a match. The match is dismissed. This ENDS the negotiation.
@@ -69,7 +69,7 @@ The law you operate under:
 
 1. The conversation is your memory. Read it before deciding. Never ask your client for something they already told you — if a table needs a fact the conversation or the dossier already contains, use it. If you are unsure the fact still holds, confirm it in one short question; do not re-ask it from scratch.
 
-2. Ask in your own words, grounded in what actually stalled: name the thing the negotiation needs, not the machinery behind it. An unresolved question about one matter does not prevent you from acting on another matter that is resolved. When your client has answered — even late, even obliquely, even folded into another thought — take it as the answer and decide. They may also tell you to go with what you have; that is an answer too, and you then act on what you know, re-opening only the tables whose open questions you can now speak to.
+2. Ask in your own words, grounded in what actually stalled: name the thing the negotiation needs, not the machinery behind it. Put each ask in a separate structured question and use the message text only for a short introduction; do not duplicate question prompts in prose. An unresolved question about one matter does not prevent you from acting on another matter that is resolved. When your client has answered — even late, even obliquely, even folded into another thought — take it as the answer and decide. They may also tell you to go with what you have; that is an answer too, and you then act on what you know, re-opening only the tables whose open questions you can now speak to.
 
 3. You are the only one who ends a negotiation. Your negotiator seats never accept, decline or withdraw — they reach out, push back, ask, or pause. A table that paused recommending "reject" is a recommendation, not a decision: it is yours to make, from the whole picture rather than one table's view.
 

--- a/packages/protocol/src/internal/agents/personal-agent/agent.types.ts
+++ b/packages/protocol/src/internal/agents/personal-agent/agent.types.ts
@@ -25,6 +25,7 @@ import type { NegotiationGraphLike } from "../../negotiations/negotiation.graph.
 import type { NegotiationGraphDatabase, NegotiationTaskRow } from "../../../platform/database/negotiation.js";
 import type { IntentRecord } from "../../../platform/database/entities.js";
 import type { NegotiationRoundReflectEnqueueFn } from "../../negotiations/negotiation.round-reflect.js";
+import type { Question } from "../../../protocol/question.js";
 
 // ─── Invoke contract ─────────────────────────────────────────────────────────
 
@@ -69,10 +70,10 @@ export interface PersonalAgentResult {
 
 /**
  * One model choice is one tool call. `message_user` is the natural terminal
- * response, including a question when more information is needed.
+ * response; any asks travel as canonical structured questions beside its prose.
  */
 export type PersonalAgentDecidedAct =
-  | { tool: "message_user"; text: string; options?: string[] }
+  | { tool: "message_user"; text: string; questions?: Question[] }
   /** Open (or re-open) every undecided match of this signal with fresh briefs. */
   | { tool: "kickoff"; reasoning: string }
   /** Terminal writes IS-A owns: opportunity → `pending` / `rejected`. */
@@ -89,7 +90,7 @@ export type PersonalAgentExecutedAct =
   | {
     tool: "message_user";
     text: string;
-    options?: string[];
+    questions?: Question[];
     sessionId: string;
     messageId: string;
   }
@@ -193,13 +194,24 @@ export interface PersonalAgentConversationPort {
     sessionId: string;
     role: "user" | "assistant" | "system";
     content: string;
-    options?: string[];
+    questions?: Question[];
   }): Promise<string>;
 }
 
 /** Token transport for completed conversational messages. */
 export interface PersonalAgentReplyStreamPort {
   publish(messageId: string, chunk: { seq: number; content: string }): Promise<void>;
+}
+
+/** A bounded, user-facing description of an intent turn's visible progress. */
+export interface PersonalAgentActivity {
+  phase: "reviewing" | "working" | "preparing_response";
+  label: string;
+}
+
+/** Live activity transport. `messageId` is the channel key, never event data. */
+export interface PersonalAgentActivityPort {
+  publish(messageId: string, activity: PersonalAgentActivity): Promise<void>;
 }
 
 /** One of this signal's matches, as the prompt numbers it. */
@@ -248,6 +260,7 @@ export interface PersonalAgentDeps {
   opportunities: PersonalAgentOpportunityPort;
   identity: PersonalAgentIdentityPort;
   replyStream?: PersonalAgentReplyStreamPort;
+  activity?: PersonalAgentActivityPort;
   /**
    * The all-paused → reflect trigger. Kickoff runs one final check after
    * stamping the round size, to cover pauses that landed before the stamp.

--- a/packages/protocol/src/internal/agents/personal-agent/tests/agent.judgment.spec.ts
+++ b/packages/protocol/src/internal/agents/personal-agent/tests/agent.judgment.spec.ts
@@ -48,9 +48,24 @@ function context(overrides: Partial<PersonalAgentTurnContext> = {}): PersonalAge
 }
 
 describe("validateDecidedAct", () => {
-  test("allows a normal conversational response on a client-message turn", () => {
-    expect(validateDecidedAct({ act: "message_user", text: "What timing works for you?" }, context()))
-      .toEqual({ tool: "message_user", text: "What timing works for you?" });
+  test("keeps asks in safe canonical questions instead of message prose", () => {
+    const question = {
+      title: "Timing",
+      prompt: "What timing works for you?",
+      options: [
+        { label: "This month", description: "Start within the next few weeks." },
+        { label: "Next quarter", description: "Plan for a later start." },
+      ],
+      multiSelect: false,
+    };
+    expect(validateDecidedAct({ act: "message_user", text: "A quick detail will help.", questions: [question] }, context()))
+      .toEqual({ tool: "message_user", text: "A quick detail will help.", questions: [question] });
+    expect(validateDecidedAct({ act: "message_user", text: "What timing works for you?" }, context())).toBeNull();
+    expect(validateDecidedAct({
+      act: "message_user",
+      text: "A quick detail will help.",
+      questions: [{ ...question, prompt: "What is the opportunity_id?" }],
+    }, context())).toBeNull();
   });
 
   test("keeps references bounded to the state the model was shown", () => {

--- a/services/api/src/adapters/conversation.database.adapter.ts
+++ b/services/api/src/adapters/conversation.database.adapter.ts
@@ -3830,7 +3830,7 @@ export class ConversationDatabaseAdapter {
     if (data.subgraphResults) msgMeta.subgraphResults = data.subgraphResults;
     if (data.tokenCount !== undefined) msgMeta.tokenCount = data.tokenCount;
     if (data.interrupted) msgMeta.interrupted = true;
-    if (data.options?.length) msgMeta.options = data.options;
+    if (data.questions?.length) msgMeta.decisionQuestions = data.questions;
 
     const message = await this.insertMessageWithConversationSession({
       id: data.id,
@@ -3955,7 +3955,7 @@ export class ConversationDatabaseAdapter {
         subgraphResults: (meta.subgraphResults as Record<string, unknown>) ?? null,
         tokenCount: typeof meta.tokenCount === 'number' ? meta.tokenCount : null,
         interrupted: meta.interrupted ?? null,
-        options: Array.isArray(meta.options) ? meta.options.filter((o): o is string => typeof o === 'string') : null,
+        decisionQuestions: Array.isArray(meta.decisionQuestions) ? meta.decisionQuestions : null,
         createdAt: msg.createdAt,
       };
     });

--- a/services/api/src/adapters/database.shared.ts
+++ b/services/api/src/adapters/database.shared.ts
@@ -361,12 +361,8 @@ export interface ChatMessage {
   subgraphResults: Record<string, unknown> | null;
   tokenCount: number | null;
   interrupted?: boolean | null;
-  /**
-   * Canned replies the client may tap instead of typing. Present only on an
-   * agent question that offered them; tapping one sends its text as an
-   * ordinary user message, so nothing else reads this.
-   */
-  options?: string[] | null;
+  /** Structured questions rendered by the chat question widget. */
+  decisionQuestions?: unknown[] | null;
   createdAt: Date;
 }
 
@@ -399,8 +395,8 @@ export interface ChatMessageMeta {
   discoveries?: unknown;
   /** Set to true when the assistant message was partially generated before a steer interrupt. */
   interrupted?: boolean;
-  /** Canned replies offered under an agent question (2-4 short strings). */
-  options?: string[];
+  /** Structured questions rendered by the chat question widget. */
+  decisionQuestions?: unknown[];
   [key: string]: unknown;
 }
 
@@ -425,8 +421,8 @@ export interface CreateMessageInput {
   subgraphResults?: Record<string, unknown>;
   tokenCount?: number;
   interrupted?: boolean;
-  /** Canned replies for an agent question; stored in messages.metadata. */
-  options?: string[];
+  /** Structured questions for an agent message; stored in messages.metadata. */
+  questions?: unknown[];
 }
 
 /**

--- a/services/api/src/adapters/intent.database.adapter.ts
+++ b/services/api/src/adapters/intent.database.adapter.ts
@@ -678,10 +678,9 @@ export class IntentDatabaseAdapter {
 
   /**
    * The signals whose agent is waiting on the owner: the newest message in the
-   * signal's ('personal-intent', intentId) DM is agent-authored AND offered
-   * canned replies, so it is a question nobody has answered yet. A later
-   * message of any kind — the owner's typed answer or their tapped chip, both
-   * ordinary user messages — makes the newest row theirs and clears the flag.
+   * signal's ('personal-intent', intentId) DM is agent-authored AND carries
+   * structured decision questions, so it is a question nobody has answered
+   * yet. A later owner message makes the newest row theirs and clears the flag.
    *
    * Derived, never stored: there is no "answered" bit to drift out of sync,
    * and one DISTINCT ON read covers the whole page.
@@ -716,8 +715,8 @@ export class IntentDatabaseAdapter {
       );
     for (const row of rows) {
       if (row.role !== 'agent') continue;
-      const options = (row.metadata as { options?: unknown } | null)?.options;
-      if (Array.isArray(options) && options.length > 0) waiting.add(row.intentId);
+      const decisionQuestions = (row.metadata as { decisionQuestions?: unknown } | null)?.decisionQuestions;
+      if (Array.isArray(decisionQuestions) && decisionQuestions.length > 0) waiting.add(row.intentId);
     }
     return waiting;
   }

--- a/services/api/src/adapters/tests/intent.awaiting-reply.spec.ts
+++ b/services/api/src/adapters/tests/intent.awaiting-reply.spec.ts
@@ -1,7 +1,7 @@
 /**
- * Canned replies and the your-move badge, against the real database.
+ * Decision questions and the your-move badge, against the real database.
  *
- * Two derived reads, one fact. An agent question carries its options in the
+ * Two derived reads, one fact. An agent question carries its questions in the
  * message's own metadata (no new table, no new column), and a signal is
  * "your move" exactly while the newest message in its ('negotiator-intent',
  * intentId) DM is such a question. Nothing records that it was answered:
@@ -25,7 +25,7 @@ const OTHER_EMAIL = 'test-intent-awaiting-reply-other@example.com';
 const beforeAll = withMinimumDatabaseHookBudget(bunBeforeAll, 30_000);
 const afterAll = withMinimumDatabaseHookBudget(bunAfterAll, 30_000);
 
-describe('agent question options and the per-signal your-move flag', () => {
+describe('agent decision questions and the per-signal your-move flag', () => {
   const users = new UserDatabaseAdapter();
   let userId: string;
   let otherUserId: string;
@@ -79,28 +79,37 @@ describe('agent question options and the per-signal your-move flag', () => {
     }
   });
 
-  test('an agent question keeps its options, and the signal reads as your move until the owner answers', async () => {
+  test('an agent question keeps its structure, and the signal reads as your move until the owner answers', async () => {
     const intentId = await createIntent(userId);
     const sessionId = await pinnedSession(userId, intentId);
     expect(await awaitingReplyFor(userId, intentId)).toBe(false);
 
-    const options = ['Hiring speed', 'Comp banding', 'Team shape'];
+    const questions = [{
+      title: 'Priority',
+      prompt: 'What should I push hardest on when I talk to her?',
+      options: [
+        { label: 'Hiring speed', description: 'Prioritize time to hire.' },
+        { label: 'Comp banding', description: 'Prioritize compensation.' },
+        { label: 'Team shape', description: 'Prioritize organization design.' },
+      ],
+      multiSelect: false,
+    }];
     await chatSessionService.addMessage({
       sessionId,
       role: 'assistant',
       content: 'What should I push hardest on when I talk to her?',
-      options,
+      questions,
     });
 
-    // The chips survive the round trip on the message itself.
+    // The question survives the round trip on the message itself.
     const history = await chatSessionService.getConversationSessionHistory(sessionId);
     const asked = history.messages[history.messages.length - 1]!;
     expect(asked.role).toBe('assistant');
-    expect(asked.options).toEqual(options);
+    expect(asked.decisionQuestions).toEqual(questions);
 
     expect(await awaitingReplyFor(userId, intentId)).toBe(true);
 
-    // A tapped chip is an ordinary user message — and that is what answers.
+    // A submitted answer is an ordinary user message — and that is what answers.
     await chatSessionService.addMessage({ sessionId, role: 'user', content: 'Hiring speed' });
     expect(await awaitingReplyFor(userId, intentId)).toBe(false);
   });
@@ -116,7 +125,7 @@ describe('agent question options and the per-signal your-move flag', () => {
     });
 
     const history = await chatSessionService.getConversationSessionHistory(sessionId);
-    expect(history.messages[history.messages.length - 1]!.options).toBeNull();
+    expect(history.messages[history.messages.length - 1]!.decisionQuestions).toBeNull();
     expect(await awaitingReplyFor(userId, intentId)).toBe(false);
   });
 
@@ -127,7 +136,15 @@ describe('agent question options and the per-signal your-move flag', () => {
       sessionId: foreignSessionId,
       role: 'assistant',
       content: 'Which of these matters more to you?',
-      options: ['Speed', 'Reach'],
+      questions: [{
+        title: 'Priority',
+        prompt: 'Which of these matters more to you?',
+        options: [
+          { label: 'Speed', description: 'Move quickly.' },
+          { label: 'Reach', description: 'Maximize distribution.' },
+        ],
+        multiSelect: false,
+      }],
     });
 
     expect(await awaitingReplyFor(otherUserId, foreignIntentId)).toBe(true);

--- a/services/api/src/controllers/chat.controller.ts
+++ b/services/api/src/controllers/chat.controller.ts
@@ -13,10 +13,10 @@ import { negotiationReflectQueue } from "../queues/negotiations/reflect.queue";
 import { personalAgentQueue } from "../queues/personal-agent.queue";
 import type { PersonalAgentUserMessageEvent } from "../queues/personal-agent.queue";
 import { subscribePersonalAgentReply } from "../lib/agent/personal-agent-reply.stream";
-import type { PersonalAgentReplyChunk } from "../lib/agent/personal-agent-reply.stream";
+import type { PersonalAgentReplyStreamEvent } from "../lib/agent/personal-agent-reply.stream";
 import { SuggestionGenerator, ChatInterruptClassifier, PERSONAL_AGENT_PERSONA_ID } from '@indexnetwork/protocol';
 import type { PersonalAgentResult } from '@indexnetwork/protocol';
-import { createDoneEvent, createErrorEvent, createStatusEvent, createSteerOrQueueEvent, createTokenEvent, formatSSEEvent } from "../types/chat-streaming.types";
+import { createAgentActivityEvent, createDoneEvent, createErrorEvent, createStatusEvent, createSteerOrQueueEvent, createTokenEvent, formatSSEEvent } from "../types/chat-streaming.types";
 import { emitChatInterrupt, onChatInterrupt } from '../lib/chat-interrupt.events';
 
 type RouteParams = Record<string, string>;
@@ -534,8 +534,6 @@ export class ChatController {
           let agentTurn: PersonalAgentResult | null = null;
           let agentUserMessageId: string | null = null;
           let agentAssistantMessageId: string | undefined;
-          /** Canned replies the agent attached to its delivered message. */
-          let agentReplyOptions: string[] | undefined;
 
           if (agentOwnsTurn && effectiveScope) {
             // The conversation is the agent's memory, so the client's message
@@ -554,13 +552,19 @@ export class ChatController {
             let lastSeq = 0;
             let unsubscribeReply: (() => void) | null = null;
             try {
-              unsubscribeReply = await subscribePersonalAgentReply(agentUserMessageId, (chunk: PersonalAgentReplyChunk) => {
-                if (chunk.seq <= lastSeq) return;
-                lastSeq = chunk.seq;
-                streamedText += chunk.content;
+              unsubscribeReply = await subscribePersonalAgentReply(agentUserMessageId, (event: PersonalAgentReplyStreamEvent) => {
                 try {
+                  if (event.type === 'activity') {
+                    controller.enqueue(
+                      encoder.encode(formatSSEEvent(createAgentActivityEvent(sessionId, event.label))),
+                    );
+                    return;
+                  }
+                  if (event.seq <= lastSeq) return;
+                  lastSeq = event.seq;
+                  streamedText += event.content;
                   controller.enqueue(
-                    encoder.encode(formatSSEEvent(createTokenEvent(sessionId, chunk.content))),
+                    encoder.encode(formatSSEEvent(createTokenEvent(sessionId, event.content))),
                   );
                 } catch {
                   // Stream may have already closed.
@@ -583,11 +587,10 @@ export class ChatController {
               for (const act of agentTurn.acts) {
                 if (act.tool !== 'message_user') continue;
                 agentAssistantMessageId = act.messageId;
-                // The chips belong to the last message the turn delivered —
-                // the same one `agentAssistantMessageId` names. They are
-                // already persisted on it; the done event only spares the
-                // client a reload to see them.
-                agentReplyOptions = act.options;
+                // Questions belong to the last delivered message named by
+                // `agentAssistantMessageId`. They are already persisted on
+                // it; done only spares the client a reload.
+                decisionQuestions = act.questions;
               }
               // Dropped-subscription fallback: whatever the channel did not
               // deliver of the completed turn is emitted as one token event.
@@ -825,7 +828,6 @@ export class ChatController {
                     title: sessionTitle,
                     suggestions,
                     ...(decisionQuestions !== undefined ? { decisionQuestions } : {}),
-                    ...(agentReplyOptions ? { options: agentReplyOptions } : {}),
                   }),
                 ),
               ),

--- a/services/api/src/controllers/tests/chat.negotiator.isolated.ts
+++ b/services/api/src/controllers/tests/chat.negotiator.isolated.ts
@@ -33,7 +33,7 @@ import db from "../../lib/drizzle/drizzle";
 import { agents, chatSessionScopes, conversationParticipants, conversations, intents } from "../../schemas/database.schema";
 import type { AuthenticatedUser } from "../../guards/auth.guard";
 import { PERSONAL_AGENT_TURN_FAILURE_REPLY } from "../chat.controller";
-import { publishPersonalAgentReplyChunk } from "../../lib/agent/personal-agent-reply.stream";
+import { publishPersonalAgentActivity, publishPersonalAgentReplyChunk } from "../../lib/agent/personal-agent-reply.stream";
 import type { PersonalAgentResult } from "@indexnetwork/protocol";
 import type { PersonalAgentUserMessageEvent } from "../../queues/personal-agent.queue";
 
@@ -332,6 +332,8 @@ describe("Signal DM (intent-scoped PersonalAgent chat)", () => {
       // The host's shape: chunks published (post-check, post-persist) before
       // the job resolves, concatenating to exactly the joined messages.
       await publishPersonalAgentReplyChunk(event.messageId, { seq: 1, content: 'Declined that match. ' });
+      await publishPersonalAgentActivity(event.messageId, { label: 'Preparing your update' });
+      await publishPersonalAgentReplyChunk(event.messageId, { seq: 1, content: 'duplicate' });
       await publishPersonalAgentReplyChunk(event.messageId, { seq: 2, content: 'Nothing else needs you.' });
       return {
         acts: [{ tool: 'message_user', text: 'Declined that match. Nothing else needs you.', sessionId: event.sessionId, messageId: 'assistant-3' }],
@@ -349,8 +351,65 @@ describe("Signal DM (intent-scoped PersonalAgent chat)", () => {
 
     const tokens = events.filter((e) => e.type === 'token').map((e) => e.content);
     expect(tokens).toEqual(['Declined that match. ', 'Nothing else needs you.']);
+    expect(events.filter((e) => e.type === 'agent_activity')).toEqual([
+      expect.objectContaining({ type: 'agent_activity', label: 'Preparing your update' }),
+    ]);
     const done = events.find((e) => e.type === 'done') as { response: string } | undefined;
     expect(done?.response).toBe('Declined that match. Nothing else needs you.');
+  }, 60000);
+
+  test("structured agent questions are returned in done and persist on the assistant message", async () => {
+    const questions = [{
+      title: 'Product',
+      prompt: 'What product domain are you building in?',
+      options: [
+        { label: 'Dev tools', description: 'Tools for software teams.' },
+        { label: 'Data infra', description: 'Data platforms and infrastructure.' },
+      ],
+      multiSelect: false,
+    }];
+    scriptedAgentTurn = async (event) => {
+      const messageId = await chatSessionService.addMessage({
+        sessionId: event.sessionId,
+        role: 'assistant',
+        content: 'I need one detail before moving forward.',
+        questions,
+      });
+      return {
+        acts: [{
+          tool: 'message_user',
+          text: 'I need one detail before moving forward.',
+          questions,
+          sessionId: event.sessionId,
+          messageId,
+        }],
+        messages: ['I need one detail before moving forward.'],
+      };
+    };
+
+    const pinned = (await conversationDatabaseAdapter.getNegotiatorIntentChatSession(testUserId, testIntentId))!;
+    const res = await controller.messageStream(
+      streamReq({ message: 'What do you need?', sessionId: pinned.id }),
+      mockUser(),
+    );
+    expect(res.status).toBe(200);
+    const events = sseEvents(await res.text());
+    const done = events.find((event) => event.type === 'done');
+    expect(done?.decisionQuestions).toEqual(questions);
+
+    const history = await chatSessionService.getConversationSessionHistory(pinned.id);
+    expect(history.messages.at(-1)?.decisionQuestions).toEqual(questions);
+
+    const loaded = await controller.getWebSession(
+      new Request('http://localhost/chat/web/session', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ sessionId: pinned.id }),
+      }),
+      mockUser(),
+    );
+    const loadedBody = (await loaded.json()) as { messages: Array<{ decisionQuestions?: unknown[] | null }> };
+    expect(loadedBody.messages.at(-1)?.decisionQuestions).toEqual(questions);
   }, 60000);
 
   test("a failed agent turn answers with the fixed honest copy and persists it", async () => {

--- a/services/api/src/lib/agent/personal-agent-reply.stream.ts
+++ b/services/api/src/lib/agent/personal-agent-reply.stream.ts
@@ -1,5 +1,5 @@
 /**
- * Token transport for the PersonalAgent's completed conversational messages.
+ * Transport for the PersonalAgent's checked replies and safe activity labels.
  *
  * The turn runs on the inbox worker — serialization stays THE inbox — so the
  * reply's chunks cross back to the waiting chat controller over Redis
@@ -32,6 +32,10 @@ export interface PersonalAgentReplyChunk {
   content: string;
 }
 
+export type PersonalAgentReplyStreamEvent =
+  | { type: 'chunk'; seq: number; content: string }
+  | { type: 'activity'; label: string };
+
 export function personalAgentReplyChannel(messageId: string): string {
   return `personal-agent:reply:${messageId}`;
 }
@@ -48,18 +52,33 @@ export async function publishPersonalAgentReplyChunk(
   messageId: string,
   chunk: PersonalAgentReplyChunk,
 ): Promise<void> {
+  await publishPersonalAgentReplyEvent(messageId, { type: 'chunk', ...chunk });
+}
+
+/** Publish only the user-safe label; protocol-internal activity state stays server-side. */
+export async function publishPersonalAgentActivity(
+  messageId: string,
+  activity: { label: string },
+): Promise<void> {
+  await publishPersonalAgentReplyEvent(messageId, { type: 'activity', label: activity.label });
+}
+
+async function publishPersonalAgentReplyEvent(
+  messageId: string,
+  event: PersonalAgentReplyStreamEvent,
+): Promise<void> {
   const channel = personalAgentReplyChannel(messageId);
   try {
     if (useHermeticRedis()) {
-      hermeticBus.emit(channel, JSON.stringify(chunk));
+      hermeticBus.emit(channel, JSON.stringify(event));
       return;
     }
     const { getRedisClient } = await import('../../adapters/cache.adapter');
-    await getRedisClient().publish(channel, JSON.stringify(chunk));
+    await getRedisClient().publish(channel, JSON.stringify(event));
   } catch (err) {
     logger.warn('personal_agent_reply_publish_failed', {
       messageId,
-      seq: chunk.seq,
+      ...(event.type === 'chunk' ? { seq: event.seq } : {}),
       error: err instanceof Error ? err.message : String(err),
     });
   }
@@ -73,13 +92,17 @@ export async function publishPersonalAgentReplyChunk(
  */
 export async function subscribePersonalAgentReply(
   messageId: string,
-  onChunk: (chunk: PersonalAgentReplyChunk) => void,
+  onEvent: (event: PersonalAgentReplyStreamEvent) => void,
 ): Promise<() => void> {
   const channel = personalAgentReplyChannel(messageId);
   const handle = (data: string) => {
     try {
-      const parsed = JSON.parse(data) as PersonalAgentReplyChunk;
-      if (typeof parsed?.seq === 'number' && typeof parsed?.content === 'string') onChunk(parsed);
+      const parsed = JSON.parse(data) as Partial<PersonalAgentReplyStreamEvent>;
+      if (parsed.type === 'chunk' && typeof parsed.seq === 'number' && typeof parsed.content === 'string') {
+        onEvent(parsed as Extract<PersonalAgentReplyStreamEvent, { type: 'chunk' }>);
+      } else if (parsed.type === 'activity' && typeof parsed.label === 'string') {
+        onEvent(parsed as Extract<PersonalAgentReplyStreamEvent, { type: 'activity' }>);
+      }
     } catch {
       // Malformed chunk: drop; the job-result fallback delivers the reply.
     }

--- a/services/api/src/lib/negotiation/negotiation-graph.ts
+++ b/services/api/src/lib/negotiation/negotiation-graph.ts
@@ -31,7 +31,7 @@ import { agentService } from '../../services/agent.service';
 import { AgentDispatcherImpl } from '../../services/agent-dispatcher.service';
 import { chatSessionService } from '../../services/chat.service';
 import { PERSONAL_AGENT_MATCH_STATUSES, passVerdictOnOpportunity, readSignalMatches } from '../agent/negotiator-verdict.host';
-import { publishPersonalAgentReplyChunk } from '../agent/personal-agent-reply.stream';
+import { publishPersonalAgentActivity, publishPersonalAgentReplyChunk } from '../agent/personal-agent-reply.stream';
 
 /**
  * `agentDispatcher` is exported separately: it is no longer part of the
@@ -96,6 +96,7 @@ export const personalAgentGraph: PersonalAgentGraphLike = new PersonalAgentGraph
     readAgentName: async (userId) => (await agentService.getNegotiatorAgent(userId))?.name ?? null,
   },
   replyStream: { publish: publishPersonalAgentReplyChunk },
+  activity: { publish: publishPersonalAgentActivity },
   reflectEnqueue: async (job) => {
     const { personalAgentQueue } = await import('../../queues/personal-agent.queue');
     await personalAgentQueue.addAllPausedEvent(job);

--- a/services/api/src/lib/negotiation/tests/graph-composition.static.spec.ts
+++ b/services/api/src/lib/negotiation/tests/graph-composition.static.spec.ts
@@ -46,4 +46,9 @@ describe('host graph composition', () => {
     expect(mcp).toContain("import { matchesReadyBestEffort, negotiationGraph } from '../lib/negotiation/negotiation-graph'");
     expect(mcp).toMatch(/negotiationGraph,\n[\s\S]*?matchesReady: protocolDeps\.matchesReady/);
   });
+
+  it('binds reply text and safe activity to the same per-message transport', () => {
+    expect(composition).toContain('replyStream: { publish: publishPersonalAgentReplyChunk }');
+    expect(composition).toContain('activity: { publish: publishPersonalAgentActivity }');
+  });
 });

--- a/services/api/src/services/chat.service.ts
+++ b/services/api/src/services/chat.service.ts
@@ -2,7 +2,7 @@ import { log } from '../lib/log';
 import { conversationDatabaseAdapter, ConversationDatabaseAdapter, ChatDatabaseAdapter } from '../adapters/database.adapter';
 import type { ChatPersonaId, ChatScopeType } from '../adapters/database.shared';
 import { ChatGraphFactory, ChatTitleGenerator, PERSONAL_AGENT_PERSONA_ID, createPersonalAgentPersona } from '@indexnetwork/protocol';
-import type { ChatGraphCompositeDatabase } from '@indexnetwork/protocol';
+import type { ChatGraphCompositeDatabase, Question } from '@indexnetwork/protocol';
 import { getCheckpointer } from '../adapters/checkpointer.adapter';
 import type { PostgresSaver } from '@langchain/langgraph-checkpoint-postgres';
 
@@ -422,8 +422,8 @@ export class ChatSessionService {
     subgraphResults?: Record<string, unknown>;
     tokenCount?: number;
     interrupted?: boolean;
-    /** Canned replies rendered as chips under an agent question. */
-    options?: string[];
+    /** Structured questions rendered by the chat question widget. */
+    questions?: Question[];
   }): Promise<string> {
     logger.verbose('Adding message', {
       sessionId: params.sessionId,
@@ -442,7 +442,7 @@ export class ChatSessionService {
       subgraphResults: params.subgraphResults,
       tokenCount: params.tokenCount,
       interrupted: params.interrupted,
-      options: params.options,
+      questions: params.questions,
     });
 
     // Update session timestamp

--- a/services/api/src/types/chat-streaming.types.ts
+++ b/services/api/src/types/chat-streaming.types.ts
@@ -48,6 +48,7 @@ export type ChatStreamEventType =
   | "chat_summarizer_start"
   | "chat_summarizer_end"
   | "decision_questions"
+  | "agent_activity"
   | "steer_or_queue";
 
 /**
@@ -198,12 +199,6 @@ export interface DoneEvent extends ChatStreamEventBase {
   opportunityCards?: OpportunityCardPayload[];
   /** Decision questions to render, harvested from any tool result carrying `questions`. */
   decisionQuestions?: Question[];
-  /**
-   * Canned replies offered under this reply, when the agent asked something.
-   * The persisted message carries the same list; this only saves the client a
-   * reload to see the chips on the turn that produced them.
-   */
-  options?: string[];
 }
 
 /**
@@ -536,6 +531,11 @@ export interface DecisionQuestionsEvent extends ChatStreamEventBase {
   questions: Question[];
 }
 
+export interface AgentActivityEvent extends ChatStreamEventBase {
+  type: "agent_activity";
+  label: string;
+}
+
 /**
  * Steer-or-queue event — injected by /chat/interrupt onto the active SSE stream.
  */
@@ -587,6 +587,7 @@ export type ChatStreamEvent =
   | ChatSummarizerStartEvent
   | ChatSummarizerEndEvent
   | DecisionQuestionsEvent
+  | AgentActivityEvent
   | SteerOrQueueEvent;
 
 /**
@@ -723,7 +724,6 @@ export interface CreateDoneEventOptions {
   suggestions?: ChatSuggestion[];
   opportunityCards?: OpportunityCardPayload[];
   decisionQuestions?: Question[];
-  options?: string[];
 }
 
 /**
@@ -1039,6 +1039,13 @@ export function createDecisionQuestionsEvent(
   payload: { questions: Question[] },
 ): DecisionQuestionsEvent {
   return createStreamEvent<DecisionQuestionsEvent>("decision_questions", sessionId, payload);
+}
+
+export function createAgentActivityEvent(
+  sessionId: string,
+  label: string,
+): AgentActivityEvent {
+  return createStreamEvent<AgentActivityEvent>("agent_activity", sessionId, { label });
 }
 
 export function createSteerOrQueueEvent(


### PR DESCRIPTION
## Summary

- emit canonical structured `DecisionQuestions` from PersonalAgent instead of flat option chips or prose questions
- persist and stream those questions through the API, then render the existing guided question UI in signal chat
- stream bounded user-facing PersonalAgent activity so an in-progress turn no longer appears as a blank cursor
- bump `@indexnetwork/protocol` to 35.0.0 for the breaking `message_user.questions` contract

## Verification

- protocol focused tests: 59 passed
- protocol full suite: 1,628 passed
- protocol typecheck and architecture check
- API typecheck and spec typecheck
- API focused tests: 9 passed
- API isolated PersonalAgent integration: 15 passed
- web focused tests: 23 passed
- web production build
- pre-commit lint and build checks
- `git diff --check`

## Notes

The production web build retains existing warnings for an unset `VITE_PROTOCOL_URL`, CSS `context`, mixed dynamic/static imports, and large chunks.