### PR TITLE
feat(web): show discovery progress before kickoff

### DIFF
--- a/apps/web/src/app/i/[intentId]/page.tsx
+++ b/apps/web/src/app/i/[intentId]/page.tsx
@@ -1002,6 +1002,8 @@ export default function IntentDetailPage() {
                       cycle={intentCycle}
                       loading={intentCycleLoading}
                       error={intentCycleError}
+                      discoveryProgress={intent?.discoveryProgress}
+                      networks={intent?.networks}
                     />
                     <PersonalAgentTimeline
                       entries={intentTimeline}

--- a/apps/web/src/components/DiscoveryWarmupLog.tsx
+++ b/apps/web/src/components/DiscoveryWarmupLog.tsx
@@ -13,7 +13,7 @@
 import { useMemo } from "react";
 
 import type { DiscoveryProgress, DiscoveryProgressStatus } from "@/services/intents";
-import { ACTIVE_DISCOVERY_STATUSES, DISCOVERY_STATUS_CHIP, WARMUP_PAUSED_HEADLINE, buildWarmupLog, formatLogClock, warmupHeadline, type WarmupConversation } from "@/lib/discovery-warmup-log";
+import { ACTIVE_DISCOVERY_STATUSES, DISCOVERY_STATUS_CHIP, WARMUP_PAUSED_HEADLINE, buildWarmupLog, formatLogClock, warmupHeadline } from "@/lib/discovery-warmup-log";
 import { cn } from "@/lib/utils";
 
 const STATUS_TONE: Record<DiscoveryProgressStatus, string> = {
@@ -29,21 +29,21 @@ const STATUS_TONE: Record<DiscoveryProgressStatus, string> = {
 export default function DiscoveryWarmupLog({
   progress,
   communities,
-  conversations,
 }: {
   progress?: DiscoveryProgress;
-  communities: Array<{ id: string; title: string }>;
-  conversations?: WarmupConversation[];
+  communities?: Array<{ id: string; title: string }>;
 }) {
   const status = progress?.status ?? "unknown";
   const active = ACTIVE_DISCOVERY_STATUSES.has(status);
-  // No community means no run can start, whatever the stored row last said.
-  const paused = status === "blocked" || communities.length === 0;
+  // A loaded empty community list means no run can start, whatever the stored
+  // row last said. An omitted list is still loading, not evidence of a block.
+  const communityCount = communities?.length ?? 0;
+  const paused = status === "blocked" || communities?.length === 0;
   const chipStatus: DiscoveryProgressStatus = paused ? "blocked" : status;
-  const log = useMemo(() => buildWarmupLog({ progress, conversations }), [progress, conversations]);
+  const log = useMemo(() => buildWarmupLog({ progress }), [progress]);
   const headline = useMemo(
-    () => (paused ? { ...WARMUP_PAUSED_HEADLINE } : warmupHeadline(progress, communities.length)),
-    [paused, communities.length, progress],
+    () => (paused ? { ...WARMUP_PAUSED_HEADLINE } : warmupHeadline(progress, communityCount)),
+    [paused, communityCount, progress],
   );
 
   return (
@@ -79,13 +79,13 @@ export default function DiscoveryWarmupLog({
           data-testid="discovery-warmup-log"
         >
           {log.map((entry) => (
-            <li key={entry.id} className="flex items-start gap-2" data-lane={entry.lane}>
+            <li key={entry.id} className="flex items-start gap-2">
               <span className="shrink-0 text-gray-400">{formatLogClock(entry.at)}</span>
               <span
                 aria-hidden="true"
                 className={cn(
                   "mt-[5px] h-1.5 w-1.5 shrink-0 rounded-full",
-                  entry.lane === "progress" ? "bg-gray-400" : "border border-gray-400",
+                  "bg-gray-400",
                   entry.current && "warmup-pulse",
                 )}
               />

--- a/apps/web/src/components/IntentCycleInspector.tsx
+++ b/apps/web/src/components/IntentCycleInspector.tsx
@@ -1,10 +1,12 @@
 import { Link } from "react-router";
 
+import DiscoveryWarmupLog from "@/components/DiscoveryWarmupLog";
 import type { IntentCycleSnapshot, NegotiationPauseReason } from "@/services/conversation";
+import type { DiscoveryProgress } from "@/services/intents";
 
 function cyclePhase(cycle: IntentCycleSnapshot): { label: string; detail: string; active: number } {
   const { round } = cycle;
-  if (round.number === 0) return { label: "Waiting for kickoff", detail: "No negotiation round has been started.", active: 1 };
+  if (round.number === 0) return { label: "Waiting for kickoff", detail: "", active: 1 };
   if (round.size === null) return { label: `Opening round ${round.number}`, detail: "The agent is creating this round's negotiations.", active: 3 };
   if (round.working > 0) return { label: `Round ${round.number} negotiating`, detail: `${round.working} active · ${round.paused} paused`, active: 4 };
   return { label: `Round ${round.number} ready to reflect`, detail: `${round.paused} paused · the intent agent decides the next step`, active: 5 };
@@ -33,11 +35,15 @@ export default function IntentCycleInspector({
   cycle,
   loading,
   error,
+  discoveryProgress,
+  networks,
 }: {
   intentId: string;
   cycle: IntentCycleSnapshot | null;
   loading: boolean;
   error: boolean;
+  discoveryProgress?: DiscoveryProgress;
+  networks?: Array<{ id: string; title: string }>;
 }) {
   if (loading) return <p role="status" className="text-xs text-gray-500">Loading negotiation cycle…</p>;
   if (error || !cycle) return <p role="status" className="text-xs text-red-600">Negotiation cycle could not be loaded.</p>;
@@ -52,7 +58,7 @@ export default function IntentCycleInspector({
             <p className="font-ibm-plex-mono text-[10px] uppercase tracking-[0.12em] text-slate-500">PersonalAgent cycle</p>
             <p className="mt-1 text-sm font-semibold text-slate-900">{phase.label}</p>
           </div>
-          <p className="font-ibm-plex-mono text-[11px] text-slate-600">{phase.detail}</p>
+          {phase.detail && <p className="font-ibm-plex-mono text-[11px] text-slate-600">{phase.detail}</p>}
         </div>
         <ol className="mt-3 grid grid-cols-5 gap-1" aria-label="Cycle stages">
           {stages.map((stage, index) => (
@@ -66,6 +72,10 @@ export default function IntentCycleInspector({
           round {cycle.round.number} · {cycle.round.size === null ? 'opening not yet stamped' : `${cycle.round.size} opened`}
         </p>
       </div>
+
+      {cycle.round.number === 0 && (
+        <DiscoveryWarmupLog progress={discoveryProgress} communities={networks} />
+      )}
 
       {cycle.negotiations.length === 0 ? (
         <p className="rounded-lg border border-dashed border-gray-200 px-3 py-4 text-center text-xs text-gray-500">No negotiations have been opened for this intent.</p>

--- a/apps/web/src/components/__tests__/DiscoveryWarmupLog.test.tsx
+++ b/apps/web/src/components/__tests__/DiscoveryWarmupLog.test.tsx
@@ -47,11 +47,25 @@ const logLines = () =>
     .map((item) => item.textContent ?? '');
 
 describe('DiscoveryWarmupLog states', () => {
+  it('queued: shows discovery waiting to scan', () => {
+    render(
+      <DiscoveryWarmupLog
+        progress={progress({ status: 'queued', startedAt: null, updatedAt: QUEUED_AT })}
+        communities={communities}
+      />,
+    );
+
+    expect(screen.getByTestId('discovery-warmup-status')).toHaveTextContent('queued');
+    expect(screen.getByText('Finding your first matches')).toBeInTheDocument();
+    expect(screen.getByText('Queued — 4 communities to scan.')).toBeInTheDocument();
+    expect(logLines().join('\n')).toContain('queued');
+  });
+
   it('running: narrates the run in progress and says the page can be left', () => {
     render(<DiscoveryWarmupLog progress={progress()} communities={communities} />);
 
     expect(screen.getByTestId('discovery-warmup-status')).toHaveTextContent('scanning');
-    expect(screen.getByText('Finding your first conversations')).toBeInTheDocument();
+    expect(screen.getByText('Finding your first matches')).toBeInTheDocument();
     expect(screen.getByText('Scanning 4 communities for possible overlaps.')).toBeInTheDocument();
     expect(logLines().join('\n')).toContain('scanning 4 communities…');
     expect(screen.getByText(/matching continues in the background/i)).toBeInTheDocument();
@@ -92,7 +106,23 @@ describe('DiscoveryWarmupLog states', () => {
     expect(screen.getByText('Scanning is paused')).toBeInTheDocument();
   });
 
-  it('completed: keeps the tallies in the summary', () => {
+  it('failed: reports the stopped attempt without promising a retry', () => {
+    render(
+      <DiscoveryWarmupLog
+        progress={progress({ status: 'failed', attempt: 3 })}
+        communities={communities}
+      />,
+    );
+
+    expect(screen.getByTestId('discovery-warmup-status')).toHaveTextContent('failed');
+    expect(screen.getByText('Scanning needs attention')).toBeInTheDocument();
+    expect(screen.getByText('Discovery stopped after 3 attempts.')).toBeInTheDocument();
+    expect(screen.queryByText(/picked up again/i)).toBeNull();
+    expect(logLines().join('\n')).toContain('scan started across 4 communities');
+    expect(logLines().join('\n')).not.toContain('scanned 4 communities');
+  });
+
+  it('completed with matches: reports the PersonalAgent handoff and pending kickoff', () => {
     render(
       <DiscoveryWarmupLog
         progress={progress({
@@ -108,8 +138,9 @@ describe('DiscoveryWarmupLog states', () => {
 
     expect(screen.getByTestId('discovery-warmup-status')).toHaveTextContent('completed');
     expect(screen.getByText('First scan complete')).toBeInTheDocument();
-    expect(screen.getByText('Scanned 4 communities — 11 possible overlaps, 2 conversations started')).toBeInTheDocument();
-    expect(logLines().join('\n')).toContain('＋ 11 possible overlaps found, 2 conversations started');
+    expect(screen.getByText('Scanned 4 communities — 2 matches handed to the PersonalAgent. Kickoff has not started yet.')).toBeInTheDocument();
+    expect(logLines().join('\n')).toContain('＋ 2 matches handed to the PersonalAgent; kickoff has not started yet');
+    expect(screen.queryByText(/conversations? started/i)).toBeNull();
   });
 
   it('completed with nothing found: reports the zero run rather than an empty card', () => {
@@ -120,8 +151,8 @@ describe('DiscoveryWarmupLog states', () => {
       />,
     );
 
-    expect(screen.getByText('Scanned 4 communities — no overlaps yet')).toBeInTheDocument();
-    expect(logLines().join('\n')).toContain('＋ 0 possible overlaps found, 0 conversations started');
+    expect(screen.getByText('Scanned 4 communities — no matches yet.')).toBeInTheDocument();
+    expect(logLines().join('\n')).toContain('scan completed with no matches yet');
     // Past tense: the scan is over, so the line must not read as still running.
     expect(logLines().join('\n')).toContain('scanned 4 communities');
   });
@@ -130,7 +161,8 @@ describe('DiscoveryWarmupLog states', () => {
     render(<DiscoveryWarmupLog communities={communities} />);
 
     expect(screen.getByTestId('discovery-warmup-status')).toHaveTextContent('unknown');
-    expect(screen.getByText('Status unavailable.')).toBeInTheDocument();
+    expect(screen.getByText('Discovery status unavailable')).toBeInTheDocument();
+    expect(screen.getByText('Progress is unavailable or stale.')).toBeInTheDocument();
     expect(screen.queryByTestId('discovery-warmup-log')).toBeNull();
   });
 
@@ -140,51 +172,6 @@ describe('DiscoveryWarmupLog states', () => {
 
     expect(screen.getByTestId('discovery-warmup-sweep')).toHaveAttribute('aria-hidden', 'true');
     expect(screen.getByTestId('discovery-warmup-log')).toBeInTheDocument();
-  });
-});
-
-describe('DiscoveryWarmupLog conversation lane', () => {
-  it('logs each started negotiation, merged into the progress lane by time', () => {
-    render(
-      <DiscoveryWarmupLog
-        progress={progress({
-          status: 'completed',
-          processedCommunityCount: 4,
-          possibleOverlapCount: 3,
-          conversationsStartedCount: 1,
-          completedAt: COMPLETED_AT,
-        })}
-        communities={communities}
-        conversations={[{ id: 'conv-1', counterpartLabel: 'Ashley', startedAt: '2026-08-19T09:18:00.000Z' }]}
-      />,
-    );
-
-    const lines = logLines();
-    expect(lines.some((line) => line.includes("conversation with Ashley's agent started"))).toBe(true);
-    // Merged chronologically: started 09:15 → conversation 09:18 → completed 09:21.
-    const order = lines.map((line) => line.replace(/^\d{2}:\d{2}/, ''));
-    expect(order.findIndex((line) => line.includes('scanned'))).toBeLessThan(
-      order.findIndex((line) => line.includes('Ashley')),
-    );
-    expect(order.findIndex((line) => line.includes('Ashley'))).toBeLessThan(
-      order.findIndex((line) => line.includes('possible overlaps found')),
-    );
-  });
-
-  it('marks the two lanes apart so the live feed is distinguishable', () => {
-    render(
-      <DiscoveryWarmupLog
-        progress={progress()}
-        communities={communities}
-        conversations={[{ id: 'conv-1', counterpartLabel: 'Ashley', startedAt: '2026-08-19T09:18:00.000Z' }]}
-      />,
-    );
-
-    const lanes = within(screen.getByTestId('discovery-warmup-log'))
-      .getAllByRole('listitem')
-      .map((item) => item.getAttribute('data-lane'));
-    expect(lanes).toContain('progress');
-    expect(lanes).toContain('conversation');
   });
 });
 
@@ -211,7 +198,6 @@ describe('buildWarmupLog', () => {
   it('drops rows with no timestamp instead of inventing one', () => {
     const entries = buildWarmupLog({
       progress: progress({ queuedAt: null, startedAt: null, completedAt: null, updatedAt: null }),
-      conversations: [{ id: 'conv-1', counterpartLabel: 'Ashley', startedAt: null }],
     });
 
     expect(entries).toEqual([]);
@@ -220,24 +206,9 @@ describe('buildWarmupLog', () => {
   it('is stable across reloads: the same snapshot yields the same log', () => {
     const snapshot = {
       progress: progress({ status: 'completed', completedAt: COMPLETED_AT }),
-      conversations: [{ id: 'conv-1', counterpartLabel: 'Ashley', startedAt: '2026-08-19T09:18:00.000Z' }],
     };
 
     expect(buildWarmupLog(snapshot)).toEqual(buildWarmupLog(snapshot));
-  });
-
-  it('caps the live lane at the most recent conversations', () => {
-    const conversations = Array.from({ length: 8 }, (_, index) => ({
-      id: `conv-${index}`,
-      counterpartLabel: `Person ${index}`,
-      startedAt: new Date(Date.parse(STARTED_AT) + index * 60_000).toISOString(),
-    }));
-
-    const lane = buildWarmupLog({ conversations }).filter((entry) => entry.lane === 'conversation');
-
-    expect(lane).toHaveLength(5);
-    expect(lane[0]!.text).toContain('Person 3');
-    expect(lane[4]!.text).toContain('Person 7');
   });
 
   it('marks only the line the run is currently sitting on', () => {

--- a/apps/web/src/components/__tests__/IntentCycleInspector.test.tsx
+++ b/apps/web/src/components/__tests__/IntentCycleInspector.test.tsx
@@ -1,0 +1,97 @@
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+
+import IntentCycleInspector from '../IntentCycleInspector';
+import type { IntentCycleSnapshot } from '@/services/conversation';
+import type { DiscoveryProgress } from '@/services/intents';
+
+const cycle = (number: number): IntentCycleSnapshot => ({
+  round: {
+    number,
+    size: number === 0 ? null : 2,
+    kickoffStartedAt: number === 0 ? null : '2026-08-24T12:00:00.000Z',
+    working: number === 0 ? 0 : 2,
+    paused: 0,
+  },
+  negotiations: [],
+});
+
+const progress: DiscoveryProgress = {
+  status: 'completed',
+  attempt: 1,
+  maxAttempts: 3,
+  assignedCommunityCount: 2,
+  processedCommunityCount: 2,
+  possibleOverlapCount: 3,
+  conversationsStartedCount: 2,
+  queuedAt: '2026-08-24T11:58:00.000Z',
+  startedAt: '2026-08-24T11:59:00.000Z',
+  completedAt: '2026-08-24T12:00:00.000Z',
+  updatedAt: '2026-08-24T12:00:00.000Z',
+};
+
+const networks = [
+  { id: 'network-1', title: 'Builders' },
+  { id: 'network-2', title: 'Climate Founders' },
+];
+
+describe('IntentCycleInspector discovery progress', () => {
+  it.each([
+    ['queued', 'queued'],
+    ['running', 'scanning'],
+  ] as const)('shows %s discovery during round zero', (status, chip) => {
+    render(
+      <IntentCycleInspector
+        intentId="intent-1"
+        cycle={cycle(0)}
+        loading={false}
+        error={false}
+        discoveryProgress={{
+          ...progress,
+          status,
+          startedAt: status === 'queued' ? null : progress.startedAt,
+          completedAt: null,
+        }}
+        networks={networks}
+      />,
+    );
+
+    expect(screen.getByText('Waiting for kickoff')).toBeInTheDocument();
+    expect(screen.getByTestId('discovery-warmup-status')).toHaveTextContent(chip);
+  });
+
+  it('shows durable discovery progress while round zero waits for kickoff', () => {
+    render(
+      <IntentCycleInspector
+        intentId="intent-1"
+        cycle={cycle(0)}
+        loading={false}
+        error={false}
+        discoveryProgress={progress}
+        networks={networks}
+      />,
+    );
+
+    expect(screen.getByText('Waiting for kickoff')).toBeInTheDocument();
+    expect(screen.getByTestId('discovery-warmup')).toBeInTheDocument();
+    expect(screen.getAllByText(/2 matches handed to the PersonalAgent/)).toHaveLength(2);
+    expect(screen.queryByText('No negotiation round has been started.')).toBeNull();
+  });
+
+  it('removes discovery progress and preserves the existing cycle state after kickoff', () => {
+    render(
+      <IntentCycleInspector
+        intentId="intent-1"
+        cycle={cycle(1)}
+        loading={false}
+        error={false}
+        discoveryProgress={progress}
+        networks={networks}
+      />,
+    );
+
+    expect(screen.queryByTestId('discovery-warmup')).toBeNull();
+    expect(screen.getByText('Round 1 negotiating')).toBeInTheDocument();
+    expect(screen.getByText('2 active · 0 paused')).toBeInTheDocument();
+  });
+});

--- a/apps/web/src/lib/discovery-warmup-log.ts
+++ b/apps/web/src/lib/discovery-warmup-log.ts
@@ -5,9 +5,8 @@
  * on every render, so a reload reproduces the identical log and no client-side
  * delta tracking (or new table) is involved.
  *
- *  - Lane ● reads the `intent_discovery_progress` row the from-intent worker
+ *  - The log reads the `intent_discovery_progress` row the from-intent worker
  *    writes at its run boundaries (queued / started / retried / succeeded).
- *  - Lane ○ reads the negotiation conversations the page already fetches.
  *
  * There is deliberately no per-community narration ("scanning Climate
  * Founders…"): the discovery graph runs once across every valid network and
@@ -16,18 +15,8 @@
  */
 import type { DiscoveryProgress, DiscoveryProgressStatus } from '@/services/intents';
 
-/** A negotiation conversation on this signal, for the live lane. */
-export interface WarmupConversation {
-  /** Conversation id; stable log key across refreshes. */
-  id: string;
-  counterpartLabel: string;
-  /** Conversation creation time — when the agents actually started talking. */
-  startedAt: string | null;
-}
-
 export interface WarmupLogEntry {
   id: string;
-  lane: 'progress' | 'conversation';
   text: string;
   /** Epoch ms; entries without a durable timestamp are never invented. */
   at: number;
@@ -77,12 +66,8 @@ export function formatLogClock(at: number): string {
  */
 export function buildWarmupLog({
   progress,
-  conversations = [],
-  maxConversations = 5,
 }: {
   progress?: DiscoveryProgress;
-  conversations?: WarmupConversation[];
-  maxConversations?: number;
 }): WarmupLogEntry[] {
   const status = progress?.status ?? 'unknown';
   const active = ACTIVE_DISCOVERY_STATUSES.has(status);
@@ -93,7 +78,7 @@ export function buildWarmupLog({
   if (progress && status !== 'unknown') {
     const queuedAt = epoch(progress.queuedAt);
     if (queuedAt !== null) {
-      entries.push({ id: 'queued', lane: 'progress', text: 'queued', at: queuedAt, current: status === 'queued', order: 0 });
+      entries.push({ id: 'queued', text: 'queued', at: queuedAt, current: status === 'queued', order: 0 });
     }
 
     const startedAt = epoch(progress.startedAt);
@@ -102,7 +87,6 @@ export function buildWarmupLog({
       if (retriedAt !== null) {
         entries.push({
           id: 'attempt',
-          lane: 'progress',
           text: `attempt ${progress.attempt} of ${progress.maxAttempts} — retrying`,
           at: retriedAt,
           current: status === 'retrying',
@@ -115,8 +99,11 @@ export function buildWarmupLog({
       const communities = count(progress.assignedCommunityCount, 'community', 'communities');
       entries.push({
         id: 'scanning',
-        lane: 'progress',
-        text: active ? `scanning ${communities}…` : `scanned ${communities}`,
+        text: status === 'completed'
+          ? `scanned ${communities}`
+          : active
+            ? `scanning ${communities}…`
+            : `scan started across ${communities}`,
         at: startedAt,
         current: status === 'running',
         order: 2,
@@ -125,11 +112,12 @@ export function buildWarmupLog({
 
     const completedAt = epoch(progress.completedAt);
     if (completedAt !== null && status === 'completed') {
+      const matches = progress.conversationsStartedCount;
       entries.push({
         id: 'completed',
-        lane: 'progress',
-        text: `＋ ${count(progress.possibleOverlapCount, 'possible overlap', 'possible overlaps')} found, `
-          + `${count(progress.conversationsStartedCount, 'conversation', 'conversations')} started`,
+        text: matches === 0
+          ? 'scan completed with no matches yet'
+          : `＋ ${count(matches, 'match', 'matches')} handed to the PersonalAgent; kickoff has not started yet`,
         at: completedAt,
         current: false,
         order: 3,
@@ -137,24 +125,7 @@ export function buildWarmupLog({
     }
   }
 
-  const conversationEntries = conversations
-    .flatMap((conversation): WarmupLogEntry[] => {
-      const at = epoch(conversation.startedAt);
-      if (at === null) return [];
-      return [{
-        id: `conversation:${conversation.id}`,
-        lane: 'conversation',
-        text: `conversation with ${conversation.counterpartLabel}'s agent started`,
-        at,
-        current: false,
-        order: 4,
-      }];
-    })
-    .sort((left, right) => left.at - right.at)
-    .slice(-maxConversations);
-
-  return [...entries, ...conversationEntries]
-    .sort((left, right) => left.at - right.at || left.order - right.order);
+  return entries.sort((left, right) => left.at - right.at || left.order - right.order);
 }
 
 /** The card's paused copy — one wording for both ways a run can be unable to start. */
@@ -173,38 +144,37 @@ export function warmupHeadline(
 
   if (status === 'blocked') return { ...WARMUP_PAUSED_HEADLINE };
   if (status === 'unknown') {
-    return { title: 'Preparing your first conversations', summary: 'Status unavailable.' };
+    return { title: 'Discovery status unavailable', summary: 'Progress is unavailable or stale.' };
   }
   if (status === 'completed') {
     // `processedCommunityCount` is written only by runs that carried a graph
     // summary; older rows fall back to what the run was assigned.
     const scanned = progress?.processedCommunityCount || assigned;
-    const overlaps = progress?.possibleOverlapCount ?? 0;
-    const conversations = progress?.conversationsStartedCount ?? 0;
-    // A zero-result run still reports its tallies — an empty card would read as
-    // "nothing happened" when in fact the whole search ran and found nothing.
-    const tally = overlaps === 0 && conversations === 0
-      ? 'no overlaps yet'
-      : `${count(overlaps, 'possible overlap', 'possible overlaps')}, ${count(conversations, 'conversation', 'conversations')} started`;
+    // This legacy field now counts persisted matches. A successful progress
+    // stamp means their matches_ready event was handed to the PersonalAgent;
+    // it does not mean negotiation conversations have opened.
+    const matches = progress?.conversationsStartedCount ?? 0;
     return {
       title: 'First scan complete',
-      summary: `Scanned ${count(scanned, 'community', 'communities')} — ${tally}`,
+      summary: matches === 0
+        ? `Scanned ${count(scanned, 'community', 'communities')} — no matches yet.`
+        : `Scanned ${count(scanned, 'community', 'communities')} — ${count(matches, 'match', 'matches')} handed to the PersonalAgent. Kickoff has not started yet.`,
     };
   }
   if (status === 'failed') {
     return {
       title: 'Scanning needs attention',
-      summary: `Stopped after ${count(progress?.attempt ?? 0, 'attempt', 'attempts')}. It will be picked up again.`,
+      summary: `Discovery stopped after ${count(progress?.attempt ?? 0, 'attempt', 'attempts')}.`,
     };
   }
   if (status === 'queued') {
     return {
-      title: 'Finding your first conversations',
+      title: 'Finding your first matches',
       summary: `Queued — ${count(assigned, 'community', 'communities')} to scan.`,
     };
   }
   return {
-    title: 'Finding your first conversations',
+    title: 'Finding your first matches',
     summary: `Scanning ${count(assigned, 'community', 'communities')} for possible overlaps.`,
   };
 }


### PR DESCRIPTION
## Summary
- mount durable discovery progress in the intent cycle while negotiation remains at round 0
- report queued, scanning, retrying, completed, blocked, failed, and unavailable/stale states without inventing scan boundaries
- replace stale conversation-start claims with truthful match handoff and pending-kickoff copy
- remove the discovery progress card after kickoff while preserving existing negotiation-cycle states

## Verification
- `bun --bun vitest run src/components/__tests__/DiscoveryWarmupLog.test.tsx src/components/__tests__/IntentCycleInspector.test.tsx` (19 passed)
- `bun run lint` (0 errors; 86 existing warnings)
- changed-file ESLint (0 errors; 2 existing intent-page warnings)
- `bun run build:package:protocol`
- `cd apps/web && bun run build`
- `git diff --check`

## Notes
- No backend, database, protocol, polling, or API-contract changes.
- A standalone `bunx tsc --noEmit` is not currently a clean web gate because of existing missing generated modules and unrelated type errors; the supported production build and commit build checks pass.