### PR TITLE
feat(api): local notification simulator CLI

### DIFF
--- a/services/api/package.json
+++ b/services/api/package.json
@@ -19,6 +19,7 @@
     "db:studio": "drizzle-kit studio",
     "db:seed": "bun ./src/cli/db-seed.ts",
     "db:seed:sandbox": "bun ./src/cli/db-seed-sandbox.ts",
+    "notify:simulate": "bun ./src/cli/notify-simulate.ts",
     "db:flush": "bun ./src/cli/db-flush.ts",
     "db:clear-negotiations": "NODE_ENV=development bun ./src/cli/db-clear-negotiations.ts",
     "maintenance:fix-migrations": "bash ./scripts/fix-migrations.sh",

--- a/services/api/src/cli/notify-simulate.ts
+++ b/services/api/src/cli/notify-simulate.ts
@@ -1,0 +1,282 @@
+#!/usr/bin/env bun
+/**
+ * Local notification simulator.
+ *
+ * Fires realistic notification payloads against the local stack by creating
+ * real DB rows and invoking production emitters — never hand-writing frames.
+ *
+ * Usage:
+ *   bun run notify:simulate opportunity --user <email> [--counterpart <email>]
+ *   bun run notify:simulate message --user <email> [--counterpart <email>] [--text "..."]
+ *   bun run notify:simulate question --user <email> [--title "..."] [--body "..."]
+ *
+ * Prerequisites: local API + Redis sharing this DB; seeded users (bun run db:seed).
+ */
+import dotenv from 'dotenv';
+import path from 'path';
+
+// Load env before any module that reads DATABASE_URL / Redis at import time.
+dotenv.config({ path: path.resolve(import.meta.dir, '../../../..', '.env.development') });
+
+const COMMONS_NETWORK_ID = '5aff6cd6-d64e-4ef9-8bcf-6c89815f771c';
+
+type Command = 'opportunity' | 'message' | 'question';
+
+interface ParsedArgs {
+  command: Command | null;
+  userEmail: string | null;
+  counterpartEmail: string | null;
+  text: string | null;
+  title: string | null;
+  body: string | null;
+  help: boolean;
+}
+
+function printHelp(): void {
+  console.log(`Local notification simulator
+
+Usage:
+  bun run notify:simulate <command> --user <email> [options]
+
+Commands:
+  opportunity   Create a pending opportunity and publish opportunity.new via
+                NotificationDeliveryService (SSE + snapshot).
+  message       Insert a real conversation message from a counterpart so the
+                production conversation SSE publishes type:message.
+  question      SIMULATION ONLY — publishes a question.new frame directly.
+                No production emitter exists; SSE clients only (snapshot
+                pollers never see it). Shape follows desktop client expectations.
+
+Options:
+  --user <email>          Recipient (required)
+  --counterpart <email>   Other party / message sender (default: a seeded tester)
+  --text <string>         Message body (message command)
+  --title <string>        Question title (question command)
+  --body <string>         Question body (question command)
+  --help                  Show this help
+`);
+}
+
+function parseArgs(argv: string[]): ParsedArgs {
+  const args = argv.slice(2);
+  const out: ParsedArgs = {
+    command: null,
+    userEmail: null,
+    counterpartEmail: null,
+    text: null,
+    title: null,
+    body: null,
+    help: false,
+  };
+
+  for (let i = 0; i < args.length; i++) {
+    const arg = args[i];
+    if (arg === '--help' || arg === '-h') {
+      out.help = true;
+      continue;
+    }
+    if (arg === '--user') {
+      out.userEmail = args[++i] ?? null;
+      continue;
+    }
+    if (arg === '--counterpart') {
+      out.counterpartEmail = args[++i] ?? null;
+      continue;
+    }
+    if (arg === '--text') {
+      out.text = args[++i] ?? null;
+      continue;
+    }
+    if (arg === '--title') {
+      out.title = args[++i] ?? null;
+      continue;
+    }
+    if (arg === '--body') {
+      out.body = args[++i] ?? null;
+      continue;
+    }
+    if (!arg.startsWith('-') && !out.command) {
+      if (arg === 'opportunity' || arg === 'message' || arg === 'question') {
+        out.command = arg;
+        continue;
+      }
+      throw new Error(`Unknown command: ${arg}`);
+    }
+    throw new Error(`Unknown argument: ${arg}`);
+  }
+  return out;
+}
+
+async function main(): Promise<void> {
+  const args = parseArgs(process.argv);
+  if (args.help || !args.command) {
+    printHelp();
+    if (!args.help && !args.command) process.exit(1);
+    return;
+  }
+  if (!args.userEmail) {
+    console.error('Missing --user <email>');
+    printHelp();
+    process.exit(1);
+  }
+
+  const { eq, ne } = await import('drizzle-orm/sql');
+  const { default: db, closeDb } = await import('../lib/drizzle/drizzle');
+  const { users } = await import('../schemas/database.schema');
+  const { OpportunityDatabaseAdapter } = await import('../adapters/opportunity.database.adapter');
+  const { ConversationDatabaseAdapter } = await import('../adapters/conversation.database.adapter');
+  const { buildProfileFromUser } = await import('../adapters/database.shared');
+  const { closeRedisConnection } = await import('../adapters/cache.adapter');
+  const {
+    notificationStreamChannel,
+    publishNotificationStreamEvent,
+  } = await import('../lib/notification-stream-events');
+  const { NotificationDeliveryService } = await import('../services/notification-delivery.service');
+  const { TESTER_PERSONAS } = await import('./test-data');
+  type NotificationStreamEvent = import('../lib/notification-stream-events').NotificationStreamEvent;
+
+  async function resolveUserByEmail(email: string): Promise<{ id: string; email: string; name: string | null }> {
+    const [row] = await db
+      .select({ id: users.id, email: users.email, name: users.name })
+      .from(users)
+      .where(eq(users.email, email))
+      .limit(1);
+    if (!row?.email) {
+      throw new Error(`No user with email ${email}. Run: bun run db:seed`);
+    }
+    return { id: row.id, email: row.email, name: row.name };
+  }
+
+  async function resolveCounterpart(
+    recipientId: string,
+    counterpartEmail: string | null,
+  ): Promise<{ id: string; email: string; name: string | null }> {
+    if (counterpartEmail) {
+      const counterpart = await resolveUserByEmail(counterpartEmail);
+      if (counterpart.id === recipientId) {
+        throw new Error('--counterpart must be a different user than --user');
+      }
+      return counterpart;
+    }
+
+    for (const persona of TESTER_PERSONAS) {
+      const [row] = await db
+        .select({ id: users.id, email: users.email, name: users.name })
+        .from(users)
+        .where(eq(users.email, persona.email))
+        .limit(1);
+      if (row?.email && row.id !== recipientId) {
+        return { id: row.id, email: row.email, name: row.name };
+      }
+    }
+
+    const [fallback] = await db
+      .select({ id: users.id, email: users.email, name: users.name })
+      .from(users)
+      .where(ne(users.id, recipientId))
+      .limit(1);
+    if (!fallback?.email) {
+      throw new Error('Need a second user as counterpart. Run: bun run db:seed');
+    }
+    return { id: fallback.id, email: fallback.email, name: fallback.name };
+  }
+
+  try {
+    const recipient = await resolveUserByEmail(args.userEmail);
+
+    if (args.command === 'question') {
+      const id = crypto.randomUUID();
+      const title = args.title ?? 'A quick question for you';
+      const body = args.body ?? 'Does this opportunity still look relevant, or should I look elsewhere?';
+      // Production NotificationStreamEventType is opportunity.new only. Cast via
+      // unknown is intentional: this command simulates the desktop-expected
+      // question.new shape that no server emitter publishes today.
+      const event = {
+        type: 'question.new',
+        id,
+        title,
+        body,
+      } as unknown as NotificationStreamEvent;
+
+      await publishNotificationStreamEvent(recipient.id, event);
+
+      console.log('Published simulated question.new (NOT a production emitter)');
+      console.log('  id:', id);
+      console.log('  channel:', notificationStreamChannel(recipient.id));
+      console.log('  recipient:', recipient.email, `(${recipient.id})`);
+      console.log('  title:', title);
+      console.log('  body:', body);
+      console.log('  note: SSE only — /notifications/snapshot will not include this');
+      return;
+    }
+
+    const counterpart = await resolveCounterpart(recipient.id, args.counterpartEmail);
+
+    if (args.command === 'opportunity') {
+      const opportunities = new OpportunityDatabaseAdapter();
+      const created = await opportunities.createOpportunity({
+        detection: {
+          source: 'manual',
+          createdBy: counterpart.id,
+          timestamp: new Date().toISOString(),
+        },
+        actors: [
+          { networkId: COMMONS_NETWORK_ID, userId: recipient.id, role: 'patient' },
+          { networkId: COMMONS_NETWORK_ID, userId: counterpart.id, role: 'agent' },
+        ],
+        interpretation: {
+          category: 'collaboration',
+          reasoning: `${counterpart.name ?? 'Someone'} is working on something that overlaps with what ${recipient.name ?? 'you'} are looking for.`,
+          confidence: 0.9,
+          signals: [{ type: 'notify_simulate', weight: 1, detail: 'Local notification simulator' }],
+        },
+        context: { networkId: COMMONS_NETWORK_ID },
+        confidence: '0.9',
+        status: 'pending',
+      });
+
+      const delivery = new NotificationDeliveryService({
+        opportunities,
+        getIdentity: buildProfileFromUser,
+        publish: publishNotificationStreamEvent,
+      });
+      await delivery.publishOpportunityActionable({
+        opportunity: { id: created.id, status: created.status },
+      });
+
+      console.log('Created opportunity', created.id);
+      console.log('Published opportunity.new via NotificationDeliveryService');
+      console.log('  channel:', notificationStreamChannel(recipient.id));
+      console.log('  recipient:', recipient.email, `(${recipient.id})`);
+      console.log('  counterpart:', counterpart.email, `(${counterpart.id})`);
+      console.log('  snapshot: GET /api/notifications/snapshot will include this row');
+      return;
+    }
+
+    const conversations = new ConversationDatabaseAdapter();
+    const text = args.text ?? 'Hey — wanted to follow up on the match Index surfaced. Free for a quick chat?';
+    const conversation = await conversations.getOrCreateDM(recipient.id, counterpart.id);
+    const message = await conversations.createMessage({
+      conversationId: conversation.id,
+      senderId: counterpart.id,
+      role: 'user',
+      parts: [{ type: 'text', text }],
+    });
+
+    console.log('Inserted message', message.id);
+    console.log('Published type:message via conversation adapter SSE');
+    console.log('  conversation:', conversation.id);
+    console.log('  channel: conversations:user:' + recipient.id);
+    console.log('  sender:', counterpart.email, `(${counterpart.id})`);
+    console.log('  recipient:', recipient.email, `(${recipient.id})`);
+    console.log('  text:', text);
+  } finally {
+    await closeRedisConnection().catch(() => undefined);
+    await closeDb().catch(() => undefined);
+  }
+}
+
+main().catch((error) => {
+  console.error(error instanceof Error ? error.message : error);
+  process.exit(1);
+});


### PR DESCRIPTION
## Summary
- Adds `bun run notify:simulate` in `services/api` to fire realistic local notifications (`opportunity`, `message`, `question`) against the shared Postgres/Redis stack.
- `opportunity` and `message` create real DB rows and use production emitters (`NotificationDeliveryService` / conversation SSE). `question` is an explicit SSE-only simulation (no server publisher exists yet).

## Test plan
- [x] `bun run notify:simulate opportunity --user <email>` creates pending opportunity and publishes `opportunity.new` (snapshot includes it)
- [x] `bun run notify:simulate message --user <email>` inserts DM message and publishes `type:message`
- [x] `bun run notify:simulate question --user <email>` publishes simulated `question.new` on notifications channel
- [ ] With Mac/Hermes connected to local API as that user, confirm OS notifications appear