### PR TITLE
fix: close counterparty agent privacy leaks in discovery

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -89,7 +89,7 @@
     },
     "packages/protocol": {
       "name": "@indexnetwork/protocol",
-      "version": "36.0.0",
+      "version": "37.0.0",
       "dependencies": {
         "@langchain/core": "1.1.48",
         "@langchain/langgraph": "1.4.12",

--- a/packages/protocol/CHANGELOG.md
+++ b/packages/protocol/CHANGELOG.md
@@ -24,9 +24,11 @@ pin a supported release, use `latest`.
 
 ### Breaking
 
-- **`read_premises(userId)` requires a shared network.** Cross-user premise
+- **`read_premises(userId)` is scoped to shared networks.** Cross-user premise
   reads are denied unless the caller and target share at least one network
-  membership. `includeRetracted` is own-only.
+  membership, and return only the premises assigned to a shared network — a
+  premise its author never put into a network you are both in stays private.
+  `includeRetracted` is own-only.
 - **`get_negotiation` redacts counterparty continue-turn `reasoning`.** The
   shared thread still exposes `message`; each seat keeps its own `reasoning`.
   Pause payloads remain private to the pausing seat (now also on the presenter

--- a/packages/protocol/CHANGELOG.md
+++ b/packages/protocol/CHANGELOG.md
@@ -20,6 +20,18 @@ went 6.7.1 → 8.0.2 with no 7.x in between because the whole 7.x line shipped a
 prereleases between the two promotions. To track every change, read `rc`; to
 pin a supported release, use `latest`.
 
+## 37.0.0 - 2026-08-27
+
+### Breaking
+
+- **`read_premises(userId)` requires a shared network.** Cross-user premise
+  reads are denied unless the caller and target share at least one network
+  membership. `includeRetracted` is own-only.
+- **`get_negotiation` redacts counterparty continue-turn `reasoning`.** The
+  shared thread still exposes `message`; each seat keeps its own `reasoning`.
+  Pause payloads remain private to the pausing seat (now also on the presenter
+  loader path).
+
 ## 36.0.0 - 2026-08-24
 
 ### Breaking

--- a/packages/protocol/package.json
+++ b/packages/protocol/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@indexnetwork/protocol",
-  "version": "36.0.0",
+  "version": "37.0.0",
   "type": "module",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",

--- a/packages/protocol/src/internal/negotiations/negotiation.tools.ts
+++ b/packages/protocol/src/internal/negotiations/negotiation.tools.ts
@@ -30,16 +30,27 @@ function pauseFor(task: NegotiationTaskRow, viewerId: string): (NegotiationTaskM
 export function createNegotiationTools(defineTool: DefineTool, deps: NegotiationToolDeps) {
   const { negotiationDatabase, negotiationGraph } = deps;
 
-  function turnsOf(task: NegotiationTaskRow, messages: Array<{ senderId: string; parts: unknown[]; createdAt: Date }>) {
+  function turnsOf(
+    task: NegotiationTaskRow,
+    messages: Array<{ senderId: string; parts: unknown[]; createdAt: Date }>,
+    viewerId: string,
+  ) {
+    const viewerAgentId = `agent:${viewerId}`;
     return messages.map((m, i) => {
       const part = (m.parts as Array<{ kind?: string; data?: unknown }>).find((p) => p.kind === 'data');
       const parsed = part ? NegotiationTurnSchema.safeParse(part.data) : undefined;
       const speaker = m.senderId === `agent:${task.metadata.sourceUserId}` ? 'source' : 'candidate';
+      let turn = parsed?.success ? parsed.data : null;
+      // Counterparty continue-turn reasoning is seat-private; keep message only.
+      if (turn && turn.verb !== 'pause' && m.senderId !== viewerAgentId && 'reasoning' in turn) {
+        const { reasoning: _reasoning, ...rest } = turn;
+        turn = rest as typeof turn;
+      }
       return {
         turnNumber: i + 1,
         speaker,
         senderId: m.senderId,
-        turn: parsed?.success ? parsed.data : null,
+        turn,
         createdAt: m.createdAt,
       };
     });
@@ -148,7 +159,7 @@ export function createNegotiationTools(defineTool: DefineTool, deps: Negotiation
           // A seat sees ITS OWN brief and never the counterparty's: a brief is
           // what that side's agent was told about its own principal.
           brief: task.briefs[context.userId] ?? null,
-          turns: turnsOf(task, messages),
+          turns: turnsOf(task, messages, context.userId),
           ...(scopedPause ? { pause: scopedPause } : {}),
           lifecycle: buildLifecycleNarration(
             task.state,

--- a/packages/protocol/src/internal/negotiations/negotiation.tools.ts
+++ b/packages/protocol/src/internal/negotiations/negotiation.tools.ts
@@ -6,7 +6,7 @@ import { success, error } from '../shared/agent/tool.helpers.js';
 import { focusedIntentId, focusedNetworkId } from '../shared/agent/tool.scope.js';
 import { protocolLogger } from '../shared/observability/protocol.logger.js';
 import { buildLifecycleNarration, parkLifecycleLabel } from './negotiation.lifecycle-narration.js';
-import { NegotiationTurnSchema, NEGOTIATION_CONTINUE_VERBS } from './negotiation.turn.js';
+import { NegotiationTurnSchema, NEGOTIATION_CONTINUE_VERBS, turnForViewer } from './negotiation.turn.js';
 import type { NegotiationTaskMetadata, NegotiationTaskRow } from '../../platform/database/negotiation.js';
 
 export { buildLifecycleNarration, parkLifecycleLabel } from './negotiation.lifecycle-narration.js';
@@ -35,22 +35,15 @@ export function createNegotiationTools(defineTool: DefineTool, deps: Negotiation
     messages: Array<{ senderId: string; parts: unknown[]; createdAt: Date }>,
     viewerId: string,
   ) {
-    const viewerAgentId = `agent:${viewerId}`;
     return messages.map((m, i) => {
       const part = (m.parts as Array<{ kind?: string; data?: unknown }>).find((p) => p.kind === 'data');
       const parsed = part ? NegotiationTurnSchema.safeParse(part.data) : undefined;
       const speaker = m.senderId === `agent:${task.metadata.sourceUserId}` ? 'source' : 'candidate';
-      let turn = parsed?.success ? parsed.data : null;
-      // Counterparty continue-turn reasoning is seat-private; keep message only.
-      if (turn && turn.verb !== 'pause' && m.senderId !== viewerAgentId && 'reasoning' in turn) {
-        const { reasoning: _reasoning, ...rest } = turn;
-        turn = rest as typeof turn;
-      }
       return {
         turnNumber: i + 1,
         speaker,
         senderId: m.senderId,
-        turn,
+        turn: parsed?.success ? turnForViewer(parsed.data, m.senderId, viewerId) : null,
         createdAt: m.createdAt,
       };
     });

--- a/packages/protocol/src/internal/negotiations/negotiation.turn.ts
+++ b/packages/protocol/src/internal/negotiations/negotiation.turn.ts
@@ -125,6 +125,29 @@ export const NegotiationOpeningTurnSchema = z.object({
   reasoning: z.string().min(1),
 });
 
+/**
+ * A turn as a reader sees it. `reasoning` on a continuing turn is why that
+ * seat said what it said — private to the seat that authored it — so it is
+ * optional here even though the persisted shape requires it. Anything that
+ * reads a transcript reads this type, and the compiler makes it handle the
+ * absence.
+ */
+export type NegotiationTurnView =
+  | NegotiationPauseTurn
+  | (Omit<NegotiationContinueTurn, "reasoning"> & { reasoning?: string });
+
+/**
+ * Projects one persisted turn into what `viewerId` may read: its own turns
+ * whole, the counterparty's without `reasoning`. Pause turns pass through —
+ * what reaches the shared thread is already the redacted `{verb, reason}`
+ * marker, and the real payload never leaves `task.metadata.pause`.
+ */
+export function turnForViewer(turn: NegotiationTurn, senderId: string, viewerId: string): NegotiationTurnView {
+  if (isPauseTurn(turn) || senderId === `agent:${viewerId}`) return turn;
+  const { reasoning: _reasoning, ...rest } = turn;
+  return rest;
+}
+
 export function isPauseTurn(turn: NegotiationTurn): turn is NegotiationPauseTurn {
   return (turn as { verb?: string }).verb === "pause";
 }

--- a/packages/protocol/src/internal/negotiations/tests/negotiation.tools.get.spec.ts
+++ b/packages/protocol/src/internal/negotiations/tests/negotiation.tools.get.spec.ts
@@ -1,0 +1,88 @@
+import { describe, expect, it } from "bun:test";
+import { z } from "zod";
+
+import { createNegotiationTools } from "../negotiation.tools.js";
+import type { NegotiationToolDeps } from "../negotiation.tools.port.js";
+import type { DefineTool } from "../../shared/agent/tool.helpers.js";
+
+function defineTool<T extends z.ZodType>(opts: {
+  name: string;
+  description: string;
+  querySchema: T;
+  handler: (input: { context: unknown; query: z.infer<T> }) => Promise<string>;
+}) {
+  return opts;
+}
+
+const NEGOTIATION_ID = "negotiation-1";
+const SOURCE_ID = "user-1";
+const CANDIDATE_ID = "user-2";
+
+function parseResult(text: string) {
+  return JSON.parse(text) as {
+    success: boolean;
+    data?: {
+      turns: Array<{
+        speaker: string;
+        turn: { verb: string; message?: string; reasoning?: string } | null;
+      }>;
+    };
+    error?: string;
+  };
+}
+
+describe("get_negotiation — counterparty reasoning is seat-private", () => {
+  it("strips continue-turn reasoning from the counterparty seat", async () => {
+    const task = {
+      id: NEGOTIATION_ID,
+      conversationId: "conversation-1",
+      state: "working" as const,
+      brief: "brief",
+      briefs: { [SOURCE_ID]: "source brief", [CANDIDATE_ID]: "candidate brief" },
+      metadata: {
+        type: "negotiation" as const,
+        opportunityId: "opportunity-1",
+        sourceUserId: SOURCE_ID,
+        candidateUserId: CANDIDATE_ID,
+        initiatorUserId: SOURCE_ID,
+        networkId: "network-1",
+        intentId: "intent-1",
+        round: 1,
+        seats: {},
+      },
+      createdAt: new Date(),
+      updatedAt: new Date(),
+    };
+
+    const deps: NegotiationToolDeps = {
+      negotiationDatabase: {
+        getNegotiationTask: async () => task,
+        getNegotiationMessages: async () => [
+          {
+            senderId: `agent:${SOURCE_ID}`,
+            parts: [{ kind: "data", data: { verb: "outreach", message: "Hello", reasoning: "source private why" } }],
+            createdAt: new Date(),
+          },
+          {
+            senderId: `agent:${CANDIDATE_ID}`,
+            parts: [{ kind: "data", data: { verb: "counter", message: "Hi back", reasoning: "candidate private why" } }],
+            createdAt: new Date(),
+          },
+        ],
+        getOpportunity: async () => null,
+      } as never,
+      negotiationGraph: { invoke: async () => ({ negotiationId: NEGOTIATION_ID, status: "working", turns: [] }) } as never,
+    };
+
+    const [, getTool] = createNegotiationTools(defineTool as unknown as DefineTool, deps);
+    const query = getTool.querySchema.parse({ negotiationId: NEGOTIATION_ID });
+    const result = parseResult(await getTool.handler({ context: { userId: SOURCE_ID }, query }));
+
+    expect(result.success).toBe(true);
+    const turns = result.data?.turns ?? [];
+    expect(turns).toHaveLength(2);
+    expect(turns[0]?.turn).toMatchObject({ verb: "outreach", message: "Hello", reasoning: "source private why" });
+    expect(turns[1]?.turn).toMatchObject({ verb: "counter", message: "Hi back" });
+    expect(turns[1]?.turn).not.toHaveProperty("reasoning");
+  });
+});

--- a/packages/protocol/src/internal/opportunities/negotiation-context.loader.ts
+++ b/packages/protocol/src/internal/opportunities/negotiation-context.loader.ts
@@ -9,7 +9,7 @@
 
 import type { NegotiationGraphDatabase, OpportunityStatus } from '../../platform/database.js';
 import { NEGOTIATION_MAX_TURNS_AMBIENT } from '../../protocol/core.js';
-import { NegotiationTurnSchema, type NegotiationTurn } from "../negotiations/negotiation.turn.js";
+import { NegotiationTurnSchema, turnForViewer, type NegotiationTurnView } from "../negotiations/negotiation.turn.js";
 import { protocolLogger } from '../shared/observability/protocol.logger.js';
 
 const logger = protocolLogger('NegotiationContextLoader');
@@ -34,7 +34,7 @@ export interface NegotiationContext {
   turnCount: number;
   /** Max turns before the negotiation pauses (`counterparty_silent`). */
   turnCap: number;
-  turns: NegotiationTurn[];
+  turns: NegotiationTurnView[];
   /** Present once the negotiation has paused. */
   pause?: { reason: string; payload?: unknown };
   /** The resolve artifact's private reasoning, present only for its resolver. */
@@ -114,20 +114,13 @@ function outcomeReasoningForViewer(
 function extractTurns(
   messages: Array<{ senderId: string; parts: unknown[] }>,
   viewerId: string,
-): NegotiationTurn[] {
-  const turns: NegotiationTurn[] = [];
-  const viewerAgentId = `agent:${viewerId}`;
+): NegotiationTurnView[] {
+  const turns: NegotiationTurnView[] = [];
   for (const message of messages) {
     const dataPart = (message.parts as Array<{ kind?: string; data?: unknown }>).find((p) => p.kind === 'data');
     const parsed = dataPart ? NegotiationTurnSchema.safeParse(dataPart.data) : undefined;
     if (!parsed?.success) continue;
-    const turn = parsed.data;
-    if (turn.verb !== 'pause' && message.senderId !== viewerAgentId && 'reasoning' in turn) {
-      const { reasoning: _reasoning, ...rest } = turn;
-      turns.push(rest as NegotiationTurn);
-    } else {
-      turns.push(turn);
-    }
+    turns.push(turnForViewer(parsed.data, message.senderId, viewerId));
   }
   return turns;
 }

--- a/packages/protocol/src/internal/opportunities/negotiation-context.loader.ts
+++ b/packages/protocol/src/internal/opportunities/negotiation-context.loader.ts
@@ -69,7 +69,7 @@ export async function loadNegotiationContext(
     db.getNegotiationMessages(task.id),
     task.state === 'completed' ? db.getArtifactsForTask(task.id) : Promise.resolve([]),
   ]);
-  const turns = extractTurns(messages);
+  const turns = extractTurns(messages, viewerId);
 
   return {
     status: opportunityStatus,
@@ -77,9 +77,24 @@ export async function loadNegotiationContext(
     turnCount: turns.length,
     turnCap: NEGOTIATION_MAX_TURNS_AMBIENT,
     turns,
-    ...(task.state === 'paused' && task.metadata.pause ? { pause: task.metadata.pause } : {}),
+    ...(task.state === 'paused' && task.metadata.pause
+      ? { pause: pauseForViewer(task.metadata.pause, viewerId) }
+      : {}),
     ...outcomeReasoningForViewer(artifacts, viewerId),
   };
+}
+
+/** Pause payload is private to the pausing seat — other viewers see the reason only. */
+function pauseForViewer(
+  pause: { reason: string; payload?: unknown; pausedBy?: string },
+  viewerId: string,
+): { reason: string; payload?: unknown } {
+  if (pause.pausedBy === viewerId) {
+    return pause.payload !== undefined
+      ? { reason: pause.reason, payload: pause.payload }
+      : { reason: pause.reason };
+  }
+  return { reason: pause.reason };
 }
 
 function outcomeReasoningForViewer(
@@ -95,12 +110,24 @@ function outcomeReasoningForViewer(
   return reasoning ? { outcomeReasoning: reasoning } : {};
 }
 
-function extractTurns(messages: Array<{ parts: unknown[] }>): NegotiationTurn[] {
+/** Strip counterparty continue-turn reasoning; the authoring seat keeps its own. */
+function extractTurns(
+  messages: Array<{ senderId: string; parts: unknown[] }>,
+  viewerId: string,
+): NegotiationTurn[] {
   const turns: NegotiationTurn[] = [];
+  const viewerAgentId = `agent:${viewerId}`;
   for (const message of messages) {
     const dataPart = (message.parts as Array<{ kind?: string; data?: unknown }>).find((p) => p.kind === 'data');
     const parsed = dataPart ? NegotiationTurnSchema.safeParse(dataPart.data) : undefined;
-    if (parsed?.success) turns.push(parsed.data);
+    if (!parsed?.success) continue;
+    const turn = parsed.data;
+    if (turn.verb !== 'pause' && message.senderId !== viewerAgentId && 'reasoning' in turn) {
+      const { reasoning: _reasoning, ...rest } = turn;
+      turns.push(rest as NegotiationTurn);
+    } else {
+      turns.push(turn);
+    }
   }
   return turns;
 }

--- a/packages/protocol/src/internal/opportunities/opportunity.presentation.ts
+++ b/packages/protocol/src/internal/opportunities/opportunity.presentation.ts
@@ -1499,7 +1499,12 @@ function buildNegotiationPromptBlock(context: NegotiationContext | undefined): s
     if (turn.verb === 'pause') {
       return `Turn ${index + 1} (pause: ${turn.reason})`;
     }
-    return `Turn ${index + 1} (${turn.verb}): ${turn.reasoning} — said: "${turn.message}"`;
+    const reasoning = 'reasoning' in turn && typeof turn.reasoning === 'string' && turn.reasoning.trim()
+      ? turn.reasoning
+      : undefined;
+    return reasoning
+      ? `Turn ${index + 1} (${turn.verb}): ${reasoning} — said: "${turn.message}"`
+      : `Turn ${index + 1} (${turn.verb}): "${turn.message}"`;
   });
 
   return `

--- a/packages/protocol/src/internal/opportunities/opportunity.presentation.ts
+++ b/packages/protocol/src/internal/opportunities/opportunity.presentation.ts
@@ -1499,11 +1499,10 @@ function buildNegotiationPromptBlock(context: NegotiationContext | undefined): s
     if (turn.verb === 'pause') {
       return `Turn ${index + 1} (pause: ${turn.reason})`;
     }
-    const reasoning = 'reasoning' in turn && typeof turn.reasoning === 'string' && turn.reasoning.trim()
-      ? turn.reasoning
-      : undefined;
-    return reasoning
-      ? `Turn ${index + 1} (${turn.verb}): ${reasoning} — said: "${turn.message}"`
+    // Only the seat that authored a turn sees its reasoning — every other
+    // reader gets the message alone.
+    return turn.reasoning?.trim()
+      ? `Turn ${index + 1} (${turn.verb}): ${turn.reasoning} — said: "${turn.message}"`
       : `Turn ${index + 1} (${turn.verb}): "${turn.message}"`;
   });
 

--- a/packages/protocol/src/internal/opportunities/tests/negotiation-context.loader.spec.ts
+++ b/packages/protocol/src/internal/opportunities/tests/negotiation-context.loader.spec.ts
@@ -11,10 +11,11 @@ const OPPORTUNITY_ID = "opp-123";
 function turnMessage(
   verb: "outreach" | "counter" | "question",
   message: string,
+  senderId = "agent:u-source",
 ): { id: string; senderId: string; role: "user" | "agent"; parts: unknown[]; createdAt: Date } {
   return {
     id: `msg-${Math.random().toString(36).slice(2, 8)}`,
-    senderId: "agent-1",
+    senderId,
     role: "agent",
     parts: [{ kind: "data", data: { verb, message, reasoning: `why: ${message}` } }],
     createdAt: new Date(),
@@ -117,6 +118,46 @@ describe("loadNegotiationContext", () => {
     const result = await loadNegotiationContext(db, OPPORTUNITY_ID, "stalled", "u-source");
 
     expect(result!.pause?.reason).toBe("counterparty_silent");
+  });
+
+  it("keeps pause payload only for the pausing seat", async () => {
+    const pause = {
+      reason: "needs_principal" as const,
+      payload: { question: "What is your budget?" },
+      pausedBy: "u-source",
+    };
+    const db = buildDb({
+      getNegotiationTaskForOpportunity: async () =>
+        baseTask({
+          state: "paused",
+          metadata: { ...baseTask().metadata, pause },
+        }),
+      getNegotiationMessages: async () => [turnMessage("outreach", "Opening pitch")],
+    });
+
+    const ownerView = await loadNegotiationContext(db, OPPORTUNITY_ID, "stalled", "u-source");
+    const otherView = await loadNegotiationContext(db, OPPORTUNITY_ID, "stalled", "u-candidate");
+
+    expect(ownerView!.pause).toEqual({ reason: "needs_principal", payload: { question: "What is your budget?" } });
+    expect(otherView!.pause).toEqual({ reason: "needs_principal" });
+    expect(otherView!.pause).not.toHaveProperty("payload");
+  });
+
+  it("redacts counterparty continue-turn reasoning for the viewer", async () => {
+    const db = buildDb({
+      getNegotiationTaskForOpportunity: async () => baseTask(),
+      getNegotiationMessages: async () => [
+        turnMessage("outreach", "Opening pitch", "agent:u-source"),
+        turnMessage("counter", "Different angle", "agent:u-candidate"),
+      ],
+    });
+
+    const result = await loadNegotiationContext(db, OPPORTUNITY_ID, "negotiating", "u-source");
+
+    expect(result!.turns).toHaveLength(2);
+    expect(result!.turns[0]).toMatchObject({ verb: "outreach", message: "Opening pitch", reasoning: "why: Opening pitch" });
+    expect(result!.turns[1]).toMatchObject({ verb: "counter", message: "Different angle" });
+    expect(result!.turns[1]).not.toHaveProperty("reasoning");
   });
 
   it("drops turns that fail to parse against the new turn schema", async () => {

--- a/packages/protocol/src/internal/premises/premise.tools.ts
+++ b/packages/protocol/src/internal/premises/premise.tools.ts
@@ -98,20 +98,39 @@ export function createPremiseTools(defineTool: DefineTool, deps: PremiseToolDeps
       "Premises represent stable identity facts (assertive) and temporal context (contextual).\n\n" +
       "**Usage modes:**\n" +
       "- No parameters: returns the caller's own active premises.\n" +
-      "- With `userId`: returns that user's premises (use when reviewing another member's context).\n" +
-      "- With `includeRetracted: true`: returns all premises regardless of status (active, retracted, expired) for history review.\n\n" +
+      "- With `userId`: returns that user's active premises when you share at least one network. " +
+      "History (`includeRetracted`) is own-only.\n" +
+      "- With `includeRetracted: true` (own premises only): returns all premises regardless of status " +
+      "(active, retracted, expired) for history review.\n\n" +
       "**When to use:** Call before creating a premise to check if it already exists. " +
       "Call when the user asks what they have shared about themselves, or to review their current context. " +
       "Each premise includes: id, text, tier, status, analysis summary, and validity range.",
     querySchema: z.object({
       userId: z.string().optional().describe("User ID to fetch premises for. Omit to fetch the current user's own premises."),
-      includeRetracted: z.boolean().default(false).describe("When true, returns all premises regardless of status (active, retracted, expired). Defaults to false (active only)."),
+      includeRetracted: z.boolean().default(false).describe("When true, returns all premises regardless of status (active, retracted, expired). Own premises only. Defaults to false (active only)."),
     }),
     handler: async ({ context, query }) => {
       const targetUserId = query.userId?.trim() || context.userId;
+      const isCrossUser = targetUserId !== context.userId;
 
       if (query.userId?.trim() && !UUID_REGEX.test(query.userId.trim())) {
         return error("Invalid userId format.");
+      }
+
+      if (isCrossUser && query.includeRetracted) {
+        return error("includeRetracted is only allowed for your own premises.");
+      }
+
+      if (isCrossUser) {
+        const [callerNetworks, targetNetworks] = await Promise.all([
+          database.getAssignmentNetworkIdsForUser(context.userId),
+          database.getAssignmentNetworkIdsForUser(targetUserId),
+        ]);
+        const targetSet = new Set(targetNetworks);
+        const sharesNetwork = callerNetworks.some((id) => targetSet.has(id));
+        if (!sharesNetwork) {
+          return error("Access denied: no shared network with user.");
+        }
       }
 
       readPremisesLog.verbose('Fetching premises for user', { userId: targetUserId });

--- a/packages/protocol/src/internal/premises/premise.tools.ts
+++ b/packages/protocol/src/internal/premises/premise.tools.ts
@@ -91,6 +91,17 @@ export function createPremiseTools(defineTool: DefineTool, deps: PremiseToolDeps
     },
   });
 
+  /**
+   * Keeps only the premises their author assigned into one of `networkIds` —
+   * the co-membership that unlocked the read is per network, so the answer is
+   * too. Unassigned premises belong to nobody's community and stay private.
+   */
+  async function filterToSharedNetworks(premises: PremiseRecord[], networkIds: string[]): Promise<PremiseRecord[]> {
+    const shared = new Set(networkIds);
+    const assignments = await Promise.all(premises.map((p) => database.getPremiseNetworks(p.id)));
+    return premises.filter((_, i) => (assignments[i] ?? []).some((a) => shared.has(a.networkId)));
+  }
+
   const readPremises = defineTool({
     name: "read_premises",
     description:
@@ -98,7 +109,7 @@ export function createPremiseTools(defineTool: DefineTool, deps: PremiseToolDeps
       "Premises represent stable identity facts (assertive) and temporal context (contextual).\n\n" +
       "**Usage modes:**\n" +
       "- No parameters: returns the caller's own active premises.\n" +
-      "- With `userId`: returns that user's active premises when you share at least one network. " +
+      "- With `userId`: returns the active premises that user has shared into a network you are both in. " +
       "History (`includeRetracted`) is own-only.\n" +
       "- With `includeRetracted: true` (own premises only): returns all premises regardless of status " +
       "(active, retracted, expired) for history review.\n\n" +
@@ -121,14 +132,15 @@ export function createPremiseTools(defineTool: DefineTool, deps: PremiseToolDeps
         return error("includeRetracted is only allowed for your own premises.");
       }
 
+      let sharedNetworkIds: string[] = [];
       if (isCrossUser) {
         const [callerNetworks, targetNetworks] = await Promise.all([
-          database.getAssignmentNetworkIdsForUser(context.userId),
-          database.getAssignmentNetworkIdsForUser(targetUserId),
+          database.getAssignmentNetworkMembershipsForUser(context.userId),
+          database.getAssignmentNetworkMembershipsForUser(targetUserId),
         ]);
-        const targetSet = new Set(targetNetworks);
-        const sharesNetwork = callerNetworks.some((id) => targetSet.has(id));
-        if (!sharesNetwork) {
+        const targetSet = new Set(targetNetworks.map((m) => m.networkId));
+        sharedNetworkIds = callerNetworks.map((m) => m.networkId).filter((id) => targetSet.has(id));
+        if (sharedNetworkIds.length === 0) {
           return error("Access denied: no shared network with user.");
         }
       }
@@ -139,7 +151,14 @@ export function createPremiseTools(defineTool: DefineTool, deps: PremiseToolDeps
       // The graph's query node hardcodes ACTIVE status, so includeRetracted
       // would be dead code if we routed through it.
       const statusFilter = query.includeRetracted ? undefined : "ACTIVE" as const;
-      const premises = await database.getPremisesForUser(targetUserId, statusFilter);
+      const all = await database.getPremisesForUser(targetUserId, statusFilter);
+
+      // Sharing a network is the right to read what the other user put into
+      // *that* network, not their whole premise set: the indexer assigns each
+      // premise per network, and one it never assigned was never shared.
+      const premises = isCrossUser
+        ? await filterToSharedNetworks(all, sharedNetworkIds)
+        : all;
 
       const mapped = premises.map((p: PremiseRecord) => ({
         id: p.id,

--- a/packages/protocol/src/internal/premises/tests/premise.tools.spec.ts
+++ b/packages/protocol/src/internal/premises/tests/premise.tools.spec.ts
@@ -31,6 +31,7 @@ function makeDeps(overrides?: {
   premiseGraph?: { invoke: (...args: unknown[]) => Promise<unknown> } | undefined;
   getPremise?: (id: string) => Promise<unknown>;
   getPremisesForUser?: (userId: string, status?: string) => Promise<unknown[]>;
+  getAssignmentNetworkIdsForUser?: (userId: string) => Promise<string[]>;
   updatePremise?: (id: string, data: unknown) => Promise<unknown>;
 }) {
   // Use `in` to distinguish "not provided" from "explicitly undefined"
@@ -43,6 +44,7 @@ function makeDeps(overrides?: {
     database: {
       getPremise: overrides?.getPremise ?? (async () => null),
       getPremisesForUser: overrides?.getPremisesForUser ?? (async () => []),
+      getAssignmentNetworkIdsForUser: overrides?.getAssignmentNetworkIdsForUser ?? (async () => []),
       updatePremise: overrides?.updatePremise ?? (async () => {}),
     } as unknown as PremiseGraphDatabase,
     graphs: {
@@ -267,6 +269,66 @@ describe('createPremiseTools - read_premises', () => {
 
     expect(result.success).toBe(false);
     expect(result.error).toContain('Invalid userId format');
+  });
+
+  const otherUserId = '00000000-0000-4000-8000-000000000002';
+
+  it('returns another member\'s premises when they share a network', async () => {
+    const { defineTool, call } = makeDefineTool();
+    createPremiseTools(defineTool, makeDeps({
+      getPremisesForUser: async (uid: string) => (uid === otherUserId ? [activePremise] : []),
+      getAssignmentNetworkIdsForUser: async (uid: string) =>
+        uid === userId || uid === otherUserId ? ['net-1'] : [],
+    }));
+
+    const result = await call('read_premises', { userId: otherUserId }) as {
+      success: boolean;
+      data: { count: number; premises: Array<{ text: string }> };
+    };
+
+    expect(result.success).toBe(true);
+    expect(result.data.count).toBe(1);
+    expect(result.data.premises[0].text).toBe('I am a software engineer');
+  });
+
+  it('denies cross-user read when there is no shared network', async () => {
+    let fetched = false;
+    const { defineTool, call } = makeDefineTool();
+    createPremiseTools(defineTool, makeDeps({
+      getPremisesForUser: async () => {
+        fetched = true;
+        return [activePremise];
+      },
+      getAssignmentNetworkIdsForUser: async (uid: string) =>
+        uid === userId ? ['net-1'] : ['net-2'],
+    }));
+
+    const result = await call('read_premises', { userId: otherUserId }) as { success: boolean; error: string };
+
+    expect(result.success).toBe(false);
+    expect(result.error).toContain('no shared network');
+    expect(fetched).toBe(false);
+  });
+
+  it('rejects includeRetracted for cross-user reads', async () => {
+    let fetched = false;
+    const { defineTool, call } = makeDefineTool();
+    createPremiseTools(defineTool, makeDeps({
+      getPremisesForUser: async () => {
+        fetched = true;
+        return [activePremise];
+      },
+      getAssignmentNetworkIdsForUser: async () => ['net-1'],
+    }));
+
+    const result = await call('read_premises', {
+      userId: otherUserId,
+      includeRetracted: true,
+    }) as { success: boolean; error: string };
+
+    expect(result.success).toBe(false);
+    expect(result.error).toContain('includeRetracted is only allowed for your own premises');
+    expect(fetched).toBe(false);
   });
 });
 

--- a/packages/protocol/src/internal/premises/tests/premise.tools.spec.ts
+++ b/packages/protocol/src/internal/premises/tests/premise.tools.spec.ts
@@ -31,7 +31,8 @@ function makeDeps(overrides?: {
   premiseGraph?: { invoke: (...args: unknown[]) => Promise<unknown> } | undefined;
   getPremise?: (id: string) => Promise<unknown>;
   getPremisesForUser?: (userId: string, status?: string) => Promise<unknown[]>;
-  getAssignmentNetworkIdsForUser?: (userId: string) => Promise<string[]>;
+  getAssignmentNetworkMembershipsForUser?: (userId: string) => Promise<Array<{ networkId: string }>>;
+  getPremiseNetworks?: (premiseId: string) => Promise<Array<{ networkId: string }>>;
   updatePremise?: (id: string, data: unknown) => Promise<unknown>;
 }) {
   // Use `in` to distinguish "not provided" from "explicitly undefined"
@@ -44,7 +45,8 @@ function makeDeps(overrides?: {
     database: {
       getPremise: overrides?.getPremise ?? (async () => null),
       getPremisesForUser: overrides?.getPremisesForUser ?? (async () => []),
-      getAssignmentNetworkIdsForUser: overrides?.getAssignmentNetworkIdsForUser ?? (async () => []),
+      getAssignmentNetworkMembershipsForUser: overrides?.getAssignmentNetworkMembershipsForUser ?? (async () => []),
+      getPremiseNetworks: overrides?.getPremiseNetworks ?? (async () => []),
       updatePremise: overrides?.updatePremise ?? (async () => {}),
     } as unknown as PremiseGraphDatabase,
     graphs: {
@@ -273,12 +275,13 @@ describe('createPremiseTools - read_premises', () => {
 
   const otherUserId = '00000000-0000-4000-8000-000000000002';
 
-  it('returns another member\'s premises when they share a network', async () => {
+  it('returns a co-member\'s premises that are assigned to the shared network', async () => {
     const { defineTool, call } = makeDefineTool();
     createPremiseTools(defineTool, makeDeps({
       getPremisesForUser: async (uid: string) => (uid === otherUserId ? [activePremise] : []),
-      getAssignmentNetworkIdsForUser: async (uid: string) =>
-        uid === userId || uid === otherUserId ? ['net-1'] : [],
+      getAssignmentNetworkMembershipsForUser: async (uid: string) =>
+        uid === userId || uid === otherUserId ? [{ networkId: 'net-1' }] : [],
+      getPremiseNetworks: async () => [{ networkId: 'net-1' }],
     }));
 
     const result = await call('read_premises', { userId: otherUserId }) as {
@@ -291,6 +294,25 @@ describe('createPremiseTools - read_premises', () => {
     expect(result.data.premises[0].text).toBe('I am a software engineer');
   });
 
+  it('hides a co-member\'s premises that were never assigned to the shared network', async () => {
+    const { defineTool, call } = makeDefineTool();
+    createPremiseTools(defineTool, makeDeps({
+      getPremisesForUser: async (uid: string) => (uid === otherUserId ? [activePremise] : []),
+      getAssignmentNetworkMembershipsForUser: async (uid: string) =>
+        uid === userId ? [{ networkId: 'net-1' }] : [{ networkId: 'net-1' }, { networkId: 'net-2' }],
+      // Assigned only to the network the caller is not in.
+      getPremiseNetworks: async () => [{ networkId: 'net-2' }],
+    }));
+
+    const result = await call('read_premises', { userId: otherUserId }) as {
+      success: boolean;
+      data: { count: number };
+    };
+
+    expect(result.success).toBe(true);
+    expect(result.data.count).toBe(0);
+  });
+
   it('denies cross-user read when there is no shared network', async () => {
     let fetched = false;
     const { defineTool, call } = makeDefineTool();
@@ -299,8 +321,8 @@ describe('createPremiseTools - read_premises', () => {
         fetched = true;
         return [activePremise];
       },
-      getAssignmentNetworkIdsForUser: async (uid: string) =>
-        uid === userId ? ['net-1'] : ['net-2'],
+      getAssignmentNetworkMembershipsForUser: async (uid: string) =>
+        uid === userId ? [{ networkId: 'net-1' }] : [{ networkId: 'net-2' }],
     }));
 
     const result = await call('read_premises', { userId: otherUserId }) as { success: boolean; error: string };
@@ -318,7 +340,7 @@ describe('createPremiseTools - read_premises', () => {
         fetched = true;
         return [activePremise];
       },
-      getAssignmentNetworkIdsForUser: async () => ['net-1'],
+      getAssignmentNetworkMembershipsForUser: async () => [{ networkId: 'net-1' }],
     }));
 
     const result = await call('read_premises', {

--- a/packages/protocol/src/platform/database/entities.ts
+++ b/packages/protocol/src/platform/database/entities.ts
@@ -615,6 +615,8 @@ export interface OpportunityQueryOptions {
   scopeType?: 'intent';
   scopeId?: string;
   role?: string;
+  /** When set, filter to opportunities this user is an actor on. Applied in the query so pagination counts only visible rows. */
+  actorUserId?: string;
   limit?: number;
   offset?: number;
   /** When set, include draft opportunities for this chat session. When unset, exclude all draft opportunities (e.g. radar view, API). */

--- a/services/api/src/adapters/chat.database.adapter.ts
+++ b/services/api/src/adapters/chat.database.adapter.ts
@@ -2504,7 +2504,7 @@ export class ChatDatabaseAdapter {
   }
   async getOpportunitiesForNetwork(
     networkId: string,
-    options?: { status?: string; statuses?: string[]; limit?: number; offset?: number }
+    options?: { status?: string; statuses?: string[]; actorUserId?: string; limit?: number; offset?: number }
   ): Promise<OpportunityRow[]> {
     return this.opportunityAdapter.getOpportunitiesForNetwork(networkId, options);
   }

--- a/services/api/src/adapters/opportunity.database.adapter.ts
+++ b/services/api/src/adapters/opportunity.database.adapter.ts
@@ -949,7 +949,7 @@ export class OpportunityDatabaseAdapter {
 
   async getOpportunitiesForNetwork(
     networkId: string,
-    options?: { status?: string; statuses?: string[]; limit?: number; offset?: number }
+    options?: { status?: string; statuses?: string[]; actorUserId?: string; limit?: number; offset?: number }
   ): Promise<OpportunityRow[]> {
     // Actor-anchored scope: an opportunity belongs to the network when at
     // least one actor was matched there. Replaces an earlier `context.networkId`
@@ -959,6 +959,16 @@ export class OpportunityDatabaseAdapter {
       SELECT 1 FROM jsonb_array_elements(${opportunities.actors}) AS actor
       WHERE actor->>'networkId' = ${networkId}
     )`];
+    // Per-actor visibility, as a separate predicate: the network scope asks
+    // whether *some* actor was matched here, this asks whether *this user* is
+    // one of them. Filtering here rather than after the read keeps limit/offset
+    // counting visible rows only.
+    if (options?.actorUserId) {
+      conditions.push(sql`EXISTS (
+        SELECT 1 FROM jsonb_array_elements(${opportunities.actors}) AS actor
+        WHERE actor->>'userId' = ${options.actorUserId}
+      )`);
+    }
     if (options?.status && !options?.statuses?.length) conditions.push(eq(opportunities.status, options.status as typeof opportunities.$inferSelect.status));
     if (options?.statuses?.length) {
       conditions.push(inArray(opportunities.status, options.statuses as Array<typeof opportunities.$inferSelect.status>));

--- a/services/api/src/adapters/tests/database.adapter.isolated.ts
+++ b/services/api/src/adapters/tests/database.adapter.isolated.ts
@@ -1164,6 +1164,40 @@ describe('OpportunityDatabaseAdapter', () => {
       }
     });
 
+    it('getOpportunitiesForNetwork narrows to actorUserId so pagination counts visible rows', async () => {
+      // Non-owner members read the network list through this predicate. It runs
+      // in SQL, not on the result, so `limit`/`offset` page over the rows the
+      // caller may actually see.
+      const mk = (userIds: [string, string]) =>
+        adapter.createOpportunity({
+          detection: { source: 'opportunity_graph', createdBy: 'agent-opportunity-finder', timestamp: new Date().toISOString() },
+          actors: [
+            { networkId: fixture.networkId, userId: userIds[0], role: 'patient' },
+            { networkId: fixture.networkId, userId: userIds[1], role: 'agent' },
+          ],
+          interpretation: { category: 'collaboration', reasoning: 'actor visibility', confidence: 0.8 },
+          context: { networkId: fixture.networkId },
+          confidence: '0.8',
+          status: 'pending',
+        });
+      const own = await mk([fixture.userAId, fixture.userBId]);
+      // Actors are jsonb, not a foreign key — a third pair needs no real rows.
+      const thirdParty = await mk([fixture.userBId, uuidv4()]);
+
+      try {
+        const mine = await adapter.getOpportunitiesForNetwork(fixture.networkId, { actorUserId: fixture.userAId });
+        expect(mine.some((o) => o.id === own.id)).toBe(true);
+        expect(mine.some((o) => o.id === thirdParty.id)).toBe(false);
+
+        // No actor filter (the owner's curator view) ⇒ both.
+        const all = await adapter.getOpportunitiesForNetwork(fixture.networkId);
+        expect(all.some((o) => o.id === own.id)).toBe(true);
+        expect(all.some((o) => o.id === thirdParty.id)).toBe(true);
+      } finally {
+        await db.delete(opportunities).where(inArray(opportunities.id, [own.id, thirdParty.id]));
+      }
+    });
+
     it('getOpportunitiesForNetwork narrows results by the statuses filter (IND-254)', async () => {
       // The network/community list relies on this SQL `statuses` filter to hide
       // stale/pre-draft opportunities (the service passes a live-status allow-list).

--- a/services/api/src/lib/drizzle/test-database-readiness.ts
+++ b/services/api/src/lib/drizzle/test-database-readiness.ts
@@ -51,7 +51,6 @@ export const REQUIRED_TEST_DATABASE_OBJECTS = [
   'public.negotiator_memories',
   'public.opportunity_outcome_events',
   'public.questions_recovery_recipient_intent_fingerprint_uniq',
-  'public.questions_pool_push_recipient_intent_cycle_uniq',
 ] as const;
 
 export const REQUIRED_TEST_DATABASE_COLUMNS = [

--- a/services/api/src/queues/negotiations/reflect.queue.ts
+++ b/services/api/src/queues/negotiations/reflect.queue.ts
@@ -213,13 +213,17 @@ export class NegotiationReflectQueue {
 
     for (const { user, other } of sides) {
       try {
-        const transcript: ReflectionTranscriptEntry[] = turns.map((t, index) => ({
-          index,
-          speaker: t.senderId === `agent:${user.id}` ? 'client' as const : 'counterparty' as const,
-          action: t.turn.verb === 'pause' ? `pause:${t.turn.reason ?? 'unknown'}` : (t.turn.verb ?? 'unknown'),
-          ...(t.turn.message && { message: t.turn.message }),
-          ...(t.turn.reasoning && { reasoning: t.turn.reasoning }),
-        }));
+        const transcript: ReflectionTranscriptEntry[] = turns.map((t, index) => {
+          const speaker = t.senderId === `agent:${user.id}` ? 'client' as const : 'counterparty' as const;
+          return {
+            index,
+            speaker,
+            action: t.turn.verb === 'pause' ? `pause:${t.turn.reason ?? 'unknown'}` : (t.turn.verb ?? 'unknown'),
+            ...(t.turn.message && { message: t.turn.message }),
+            // Counterparty continue-turn reasoning stays seat-private.
+            ...(speaker === 'client' && t.turn.reasoning && { reasoning: t.turn.reasoning }),
+          };
+        });
 
         const entries = await this.getReflector().reflectNegotiation({
           clientUser: user,

--- a/services/api/src/queues/tests/reflect.queue.isolated.ts
+++ b/services/api/src/queues/tests/reflect.queue.isolated.ts
@@ -124,16 +124,21 @@ describe('NegotiationReflectQueue', () => {
       const alicePass = reflectCalls.find((c) => c.clientUser.id === 'u-alice')!;
       expect(alicePass.seat).toBe('initiator');
       expect(alicePass.counterpartyUser.id).toBe('u-bob');
+      // Each side reflects on its own reasoning and on what the other side
+      // actually said — never on why the other side said it.
       expect(alicePass.transcript).toEqual([
         { index: 0, speaker: 'client', action: 'outreach', message: 'hello', reasoning: 'outreach reasoning' },
-        { index: 1, speaker: 'counterparty', action: 'accept', message: 'deal', reasoning: 'accept reasoning' },
+        { index: 1, speaker: 'counterparty', action: 'accept', message: 'deal' },
       ]);
 
-      // Bob's pass: same transcript, flipped perspective, counterparty seat.
+      // Bob's pass: same transcript, flipped perspective, counterparty seat —
+      // so the reasoning that is his to keep flips with it.
       const bobPass = reflectCalls.find((c) => c.clientUser.id === 'u-bob')!;
       expect(bobPass.seat).toBe('counterparty');
       expect(bobPass.transcript[0].speaker).toBe('counterparty');
+      expect(bobPass.transcript[0]).not.toHaveProperty('reasoning');
       expect(bobPass.transcript[1].speaker).toBe('client');
+      expect(bobPass.transcript[1].reasoning).toBe('accept reasoning');
 
       // Both sides write with negotiation provenance and the counterparty as dossier subject.
       expect(writes.length).toBe(2);

--- a/services/api/src/services/opportunity.service.ts
+++ b/services/api/src/services/opportunity.service.ts
@@ -996,16 +996,15 @@ export class OpportunityService {
     // draft/latent and terminal-stale expired/rejected into the community view.
     // Default to live community statuses (no latent) unless an explicit
     // status/statuses filter is given. Non-owner members only see opportunities
-    // they are an actor on; owners keep the full curator list.
+    // they are an actor on; owners keep the full curator list. The actor filter
+    // goes to the query, not to the result, so limit/offset paginate visible rows.
     const hasExplicitStatus = !!options?.status || (options?.statuses?.length ?? 0) > 0;
+    const scoped = { ...options, ...(isOwner ? {} : { actorUserId: userId }) };
     const rows = await this.db.getOpportunitiesForNetwork(
       networkId,
-      hasExplicitStatus ? options : { ...options, statuses: DEFAULT_NETWORK_LIST_STATUSES },
+      hasExplicitStatus ? scoped : { ...scoped, statuses: DEFAULT_NETWORK_LIST_STATUSES },
     );
-    const visible = isOwner
-      ? rows
-      : rows.filter((opp) => opp.actors.some((actor) => actor.userId === userId));
-    return visible.map((opp) => sanitizeOpportunityForResponse(opp));
+    return rows.map((opp) => sanitizeOpportunityForResponse(opp));
   }
 
   /**

--- a/services/api/src/services/opportunity.service.ts
+++ b/services/api/src/services/opportunity.service.ts
@@ -994,14 +994,18 @@ export class OpportunityService {
 
     // IND-254: the network list had no status filtering at all, so it leaked
     // draft/latent and terminal-stale expired/rejected into the community view.
-    // Default to live community statuses (no latent — there's no per-actor
-    // visibility guard here) unless an explicit status/statuses filter is given.
+    // Default to live community statuses (no latent) unless an explicit
+    // status/statuses filter is given. Non-owner members only see opportunities
+    // they are an actor on; owners keep the full curator list.
     const hasExplicitStatus = !!options?.status || (options?.statuses?.length ?? 0) > 0;
     const rows = await this.db.getOpportunitiesForNetwork(
       networkId,
       hasExplicitStatus ? options : { ...options, statuses: DEFAULT_NETWORK_LIST_STATUSES },
     );
-    return rows.map((opp) => sanitizeOpportunityForResponse(opp));
+    const visible = isOwner
+      ? rows
+      : rows.filter((opp) => opp.actors.some((actor) => actor.userId === userId));
+    return visible.map((opp) => sanitizeOpportunityForResponse(opp));
   }
 
   /**

--- a/services/api/src/services/tests/opportunity.service.listStatusFilter.spec.ts
+++ b/services/api/src/services/tests/opportunity.service.listStatusFilter.spec.ts
@@ -165,6 +165,55 @@ describe("OpportunityService list status filtering (IND-254)", () => {
       expect(rows[0]?.interpretation.reasoning).toBe('Connection opportunity');
       expect(JSON.stringify(rows[0])).not.toContain('attendee');
     });
+
+    it('filters non-owner members to opportunities they are an actor on', async () => {
+      const own = unsafeOpportunity();
+      const thirdParty: Opportunity = {
+        ...unsafeOpportunity(),
+        id: 'opp-third-party',
+        actors: [
+          { userId: 'user-a' as never, networkId: 'net-1' as never, role: 'peer' },
+          { userId: 'user-b' as never, networkId: 'net-1' as never, role: 'peer' },
+        ],
+      };
+      const db = {
+        getOpportunitiesForNetwork: mock(async () => [own, thirdParty]),
+        isIndexOwner: mock(async () => false),
+        isNetworkMember: mock(async () => true),
+      } as unknown as OpportunityControllerDatabase;
+      const service = new OpportunityService(db);
+
+      const rows = await service.getOpportunitiesForNetwork('net-1', 'user-1');
+
+      expect(Array.isArray(rows)).toBe(true);
+      if (!Array.isArray(rows)) throw new Error('Expected opportunity rows');
+      expect(rows).toHaveLength(1);
+      expect(rows[0]?.id).toBe('opp-unsafe');
+    });
+
+    it('keeps the full list for network owners', async () => {
+      const own = unsafeOpportunity();
+      const thirdParty: Opportunity = {
+        ...unsafeOpportunity(),
+        id: 'opp-third-party',
+        actors: [
+          { userId: 'user-a' as never, networkId: 'net-1' as never, role: 'peer' },
+          { userId: 'user-b' as never, networkId: 'net-1' as never, role: 'peer' },
+        ],
+      };
+      const db = {
+        getOpportunitiesForNetwork: mock(async () => [own, thirdParty]),
+        isIndexOwner: mock(async () => true),
+        isNetworkMember: mock(async () => true),
+      } as unknown as OpportunityControllerDatabase;
+      const service = new OpportunityService(db);
+
+      const rows = await service.getOpportunitiesForNetwork('net-1', 'user-1');
+
+      expect(Array.isArray(rows)).toBe(true);
+      if (!Array.isArray(rows)) throw new Error('Expected opportunity rows');
+      expect(rows).toHaveLength(2);
+    });
   });
 
 

--- a/services/api/src/services/tests/opportunity.service.listStatusFilter.spec.ts
+++ b/services/api/src/services/tests/opportunity.service.listStatusFilter.spec.ts
@@ -23,7 +23,7 @@ const EXPECTED_NETWORK_STATUSES = ["negotiating", "pending", "stalled", "accepte
 
 type Captured = { opts?: Record<string, unknown> };
 
-function createService() {
+function createService(overrides?: { isIndexOwner?: boolean }) {
   const userCall: Captured = {};
   const networkCall: Captured = {};
   const db = {
@@ -36,7 +36,7 @@ function createService() {
       return Promise.resolve([] as Opportunity[]);
     }),
     getUser: mock(() => Promise.resolve(null)),
-    isIndexOwner: mock(() => Promise.resolve(true)),
+    isIndexOwner: mock(() => Promise.resolve(overrides?.isIndexOwner ?? true)),
     isNetworkMember: mock(() => Promise.resolve(true)),
   } as unknown as OpportunityControllerDatabase;
   const service = new OpportunityService(db);
@@ -166,53 +166,25 @@ describe("OpportunityService list status filtering (IND-254)", () => {
       expect(JSON.stringify(rows[0])).not.toContain('attendee');
     });
 
-    it('filters non-owner members to opportunities they are an actor on', async () => {
-      const own = unsafeOpportunity();
-      const thirdParty: Opportunity = {
-        ...unsafeOpportunity(),
-        id: 'opp-third-party',
-        actors: [
-          { userId: 'user-a' as never, networkId: 'net-1' as never, role: 'peer' },
-          { userId: 'user-b' as never, networkId: 'net-1' as never, role: 'peer' },
-        ],
-      };
-      const db = {
-        getOpportunitiesForNetwork: mock(async () => [own, thirdParty]),
-        isIndexOwner: mock(async () => false),
-        isNetworkMember: mock(async () => true),
-      } as unknown as OpportunityControllerDatabase;
-      const service = new OpportunityService(db);
+    // The actor filter belongs in the query: applied to the result instead, a
+    // page of `limit` network rows could come back empty while later pages hold
+    // visible ones, and the caller cannot tell that from the end of the list.
+    it('scopes non-owner members to their own actor rows in the query', async () => {
+      const { service, networkCall } = createService({ isIndexOwner: false });
 
-      const rows = await service.getOpportunitiesForNetwork('net-1', 'user-1');
+      await service.getOpportunitiesForNetwork('net-1', 'user-1', { limit: 20, offset: 40 });
 
-      expect(Array.isArray(rows)).toBe(true);
-      if (!Array.isArray(rows)) throw new Error('Expected opportunity rows');
-      expect(rows).toHaveLength(1);
-      expect(rows[0]?.id).toBe('opp-unsafe');
+      expect(networkCall.opts?.actorUserId).toBe('user-1');
+      expect(networkCall.opts?.limit).toBe(20);
+      expect(networkCall.opts?.offset).toBe(40);
     });
 
-    it('keeps the full list for network owners', async () => {
-      const own = unsafeOpportunity();
-      const thirdParty: Opportunity = {
-        ...unsafeOpportunity(),
-        id: 'opp-third-party',
-        actors: [
-          { userId: 'user-a' as never, networkId: 'net-1' as never, role: 'peer' },
-          { userId: 'user-b' as never, networkId: 'net-1' as never, role: 'peer' },
-        ],
-      };
-      const db = {
-        getOpportunitiesForNetwork: mock(async () => [own, thirdParty]),
-        isIndexOwner: mock(async () => true),
-        isNetworkMember: mock(async () => true),
-      } as unknown as OpportunityControllerDatabase;
-      const service = new OpportunityService(db);
+    it('leaves the full curator list unscoped for network owners', async () => {
+      const { service, networkCall } = createService({ isIndexOwner: true });
 
-      const rows = await service.getOpportunitiesForNetwork('net-1', 'user-1');
+      await service.getOpportunitiesForNetwork('net-1', 'user-1');
 
-      expect(Array.isArray(rows)).toBe(true);
-      if (!Array.isArray(rows)) throw new Error('Expected opportunity rows');
-      expect(rows).toHaveLength(2);
+      expect(networkCall.opts?.actorUserId).toBeUndefined();
     });
   });
 


### PR DESCRIPTION
## Summary

Four places let one party's agent read data belonging to the counterparty. Rebased onto `dev`; `@indexnetwork/protocol` goes to **37.0.0**.

- **Premises are readable per network, not per user.** `read_premises(userId)` is denied unless caller and target share a network membership, and returns only the premises the author actually assigned into a shared network — the indexer assigns per network, so a premise it never put into a network you are both in was never shared with you. `includeRetracted` is own-only.
- **`GET /networks/:id/opportunities` is scoped to the caller's own actor rows** for non-owner members; network owners keep the full curator list. The filter is a SQL predicate (`actorUserId`), not a pass over the result, so `limit`/`offset` paginate rows the caller can actually see — filtering afterwards would hand back an empty page while later pages still held visible rows, with no way for the client to tell that from the end of the list.
- **Pause payloads are private to the pausing seat** in the presenter loader. MCP and the PersonalAgent already did this; the loader did not.
- **Counterparty continue-turn `reasoning` is redacted** from `get_negotiation`, the presenter loader, and post-negotiation reflect transcripts. The shared thread still carries `message` — what the other side *said* is public, why they said it is not. Each seat keeps its own. Pause turns pass through untouched: what reaches the thread is already the redacted `{verb, reason}` marker, and dropping it would break `nextSpeaker`'s read of the last turn.

One `turnForViewer` helper in `negotiation.turn.ts` expresses that last rule for both parsing sites, and a `NegotiationTurnView` type makes `reasoning` optional on a read turn — so the compiler forces every reader to handle its absence instead of trusting a cast.

**Unrelated fix, included because it blocks CI:** `0177cbabb` dropped `questions_pool_push_recipient_intent_cycle_uniq` in migration `0153` along with the pool_discovery write path, but left it in `REQUIRED_TEST_DATABASE_OBJECTS`. On a correctly migrated database the readiness gate demands an index the migrations delete, and every DB-backed spec fails before its first assertion. One line.

## Test plan

- [x] `bun run test` in `packages/protocol` — 1544 pass, 0 fail
- [x] `bun run architecture:check` in `packages/protocol`
- [x] `tsc --noEmit` in `packages/protocol` and `services/api`; `tsc -p tsconfig.spec.json` in `services/api`
- [x] Premise tools: co-member premise assigned to the shared network is returned; one assigned only elsewhere is hidden; no shared network denies without reading premises; `includeRetracted` refused cross-user
- [x] `get_negotiation` + negotiation-context loader: own reasoning kept, counterparty's stripped, pause payload only for the pausing seat
- [x] `reflect.queue.isolated.ts` — each side reflects on its own reasoning and on what the other side said
- [x] `database.adapter.isolated.ts` — `actorUserId` narrows in SQL; owner view unfiltered (113 pass; the one failure, `updateMemberRole > should reject role change on a contact`, pre-dates this branch)
- [x] `opportunity.service.listStatusFilter.spec.ts` — the actor filter reaches the query alongside `limit`/`offset`
- [ ] Smoke: agent with `manage:premises` cannot read a non-co-member's premises, and sees only shared-network premises for a co-member
- [ ] Smoke: non-owner network member API key cannot list third-party opportunities on the network route

## Breaks

Cross-user `read_premises` returns strictly less than before: co-membership no longer implies the whole premise set. `get_negotiation` and the negotiation card context no longer carry counterparty `reasoning` — internal and external negotiators now read the same thing, which is the point.
