### PR TITLE
Fix durable negotiation drain ownership

### DIFF
--- a/apps/web/src/app/i/[intentId]/page.tsx
+++ b/apps/web/src/app/i/[intentId]/page.tsx
@@ -1054,6 +1054,7 @@ export default function IntentDetailPage() {
                             opportunityStatusMap[item.opportunityId]
                           }
                           negotiationInspectorHref={inspectorHrefByOpportunity.get(item.opportunityId)}
+                          negotiationState={negotiationByOpportunity.get(item.opportunityId)}
                           onPrimaryAction={(
                             oppId,
                             userId,

--- a/apps/web/src/components/IntentCycleInspector.tsx
+++ b/apps/web/src/components/IntentCycleInspector.tsx
@@ -8,7 +8,7 @@ function cyclePhase(cycle: IntentCycleSnapshot): { label: string; detail: string
   const { round } = cycle;
   if (round.number === 0) return { label: "Waiting for kickoff", detail: "", active: 1 };
   if (round.size === null) return { label: `Opening round ${round.number}`, detail: "The agent is creating this round's negotiations.", active: 3 };
-  if (round.working > 0) return { label: `Round ${round.number} negotiating`, detail: `${round.working} active · ${round.paused} paused`, active: 4 };
+  if (round.active > 0) return { label: `Round ${round.number} negotiating`, detail: `${round.active} active · ${round.paused} paused`, active: 4 };
   return { label: `Round ${round.number} ready to reflect`, detail: `${round.paused} paused · the intent agent decides the next step`, active: 5 };
 }
 

--- a/apps/web/src/components/__tests__/IntentCycleInspector.test.tsx
+++ b/apps/web/src/components/__tests__/IntentCycleInspector.test.tsx
@@ -1,5 +1,6 @@
 import { render, screen } from '@testing-library/react';
 import { describe, expect, it } from 'vitest';
+import { MemoryRouter } from 'react-router';
 
 import IntentCycleInspector from '../IntentCycleInspector';
 import type { IntentCycleSnapshot } from '@/services/conversation';
@@ -10,7 +11,7 @@ const cycle = (number: number): IntentCycleSnapshot => ({
     number,
     size: number === 0 ? null : 2,
     kickoffStartedAt: number === 0 ? null : '2026-08-24T12:00:00.000Z',
-    working: number === 0 ? 0 : 2,
+    active: number === 0 ? 0 : 2,
     paused: 0,
   },
   negotiations: [],
@@ -93,5 +94,27 @@ describe('IntentCycleInspector discovery progress', () => {
     expect(screen.queryByTestId('discovery-warmup')).toBeNull();
     expect(screen.getByText('Round 1 negotiating')).toBeInTheDocument();
     expect(screen.getByText('2 active · 0 paused')).toBeInTheDocument();
+  });
+
+  it('keeps a round negotiating while a submitted task is active', () => {
+    render(
+      <MemoryRouter><IntentCycleInspector
+        intentId="intent-1"
+        cycle={{
+          round: { number: 1, size: 1, kickoffStartedAt: null, active: 1, paused: 0 },
+          negotiations: [{
+            taskId: 'task-1', conversationId: 'conversation-1', opportunityId: 'opportunity-1',
+            opportunityStatus: 'negotiating', counterpartLabel: 'Counterpart', round: 1,
+            state: 'submitted', pause: null, latestActivity: null,
+            updatedAt: '2026-08-24T12:00:00.000Z',
+          }],
+        }}
+        loading={false}
+        error={false}
+      /></MemoryRouter>,
+    );
+
+    expect(screen.getByText('Round 1 negotiating')).toBeInTheDocument();
+    expect(screen.queryByText('Round 1 ready to reflect')).toBeNull();
   });
 });

--- a/apps/web/src/components/chat/OpportunityCardInChat.tsx
+++ b/apps/web/src/components/chat/OpportunityCardInChat.tsx
@@ -151,6 +151,30 @@ interface OpportunityCardProps {
   currentStatus?: string;
   /** Owner-seat inspector for a negotiating opportunity, if task state is known. */
   negotiationInspectorHref?: string;
+  /** Current owner-relative task state, used for truthful responsibility copy. */
+  negotiationState?: {
+    state: string;
+    pause: { reason: string; by: "yours" | "theirs" } | null;
+  };
+}
+
+function negotiationStatusCopy(negotiation: OpportunityCardProps["negotiationState"]): string {
+  if (!negotiation) return "This negotiation is in progress.";
+  if (negotiation.state !== "paused" || !negotiation.pause) {
+    return "Your PersonalAgent is handling this negotiation.";
+  }
+  if (negotiation.pause.by === "theirs") {
+    if (negotiation.pause.reason === "ready_for_verdict") return "The other side is deciding.";
+    if (negotiation.pause.reason === "needs_principal") return "The other side is waiting on its principal.";
+    return "Waiting for the other side.";
+  }
+  if (negotiation.pause.reason === "needs_principal") {
+    return "Your PersonalAgent needs your input. Questions appear in this intent's DM.";
+  }
+  if (negotiation.pause.reason === "ready_for_verdict") {
+    return "Your PersonalAgent is deciding what to do next.";
+  }
+  return "Your PersonalAgent is handling this negotiation.";
 }
 
 /**
@@ -204,6 +228,7 @@ export default function OpportunityCard({
   showScore = false,
   currentStatus,
   negotiationInspectorHref,
+  negotiationState,
 }: OpportunityCardProps) {
   const navigate = useNavigate();
   const [actionTaken, setActionTaken] = useState<
@@ -456,7 +481,7 @@ export default function OpportunityCard({
 
       {effectiveStatus === "negotiating" && (
         <div className="mb-3 rounded-md border border-slate-200 bg-slate-50 px-3 py-2.5 text-xs text-slate-700">
-          <p>Your PersonalAgent is handling this negotiation. Questions for you appear in this intent&apos;s DM.</p>
+          <p>{negotiationStatusCopy(negotiationState)}</p>
           {negotiationInspectorHref && (
             <Link
               to={negotiationInspectorHref}

--- a/apps/web/src/components/chat/__tests__/OpportunityCardInChat.test.tsx
+++ b/apps/web/src/components/chat/__tests__/OpportunityCardInChat.test.tsx
@@ -20,6 +20,7 @@ describe("OpportunityCard negotiation lifecycle", () => {
         <OpportunityCard
           card={baseCard}
           negotiationInspectorHref="/i/intent-7/negotiations/task-1"
+          negotiationState={{ state: "working", pause: null }}
           onPrimaryAction={action}
           onSecondaryAction={action}
         />
@@ -31,6 +32,21 @@ describe("OpportunityCard negotiation lifecycle", () => {
       .toBe("/i/intent-7/negotiations/task-1");
     expect(screen.queryByRole("button", { name: "Start Chat" })).toBeNull();
     expect(screen.queryByRole("button", { name: "Skip" })).toBeNull();
+  });
+
+  it("shows waiting copy for a counterparty-owned verdict pause", () => {
+    render(
+      <MemoryRouter>
+        <OpportunityCard
+          card={baseCard}
+          negotiationState={{ state: "paused", pause: { reason: "ready_for_verdict", by: "theirs" } }}
+        />
+      </MemoryRouter>,
+    );
+
+    expect(screen.getByText("The other side is deciding.")).toBeTruthy();
+    expect(screen.queryByText(/Your PersonalAgent is handling/)).toBeNull();
+    expect(screen.queryByText(/Questions appear/)).toBeNull();
   });
 
   it("keeps pending opportunities owner-actionable", () => {

--- a/apps/web/src/lib/__tests__/radar-buckets.test.ts
+++ b/apps/web/src/lib/__tests__/radar-buckets.test.ts
@@ -29,8 +29,9 @@ describe("Radar responsibility buckets", () => {
     ["needs_principal", "theirs", "waiting"],
     ["counterparty_silent", "theirs", "waiting"],
     ["ready_for_verdict", "yours", "agent-handling"],
+    ["ready_for_verdict", "theirs", "waiting"],
     ["turn_cap", "yours", "agent-handling"],
-    ["open_failed", "theirs", "agent-handling"],
+    ["open_failed", "theirs", "waiting"],
   ] as const)("maps paused %s owned by %s to %s", (reason, by, bucket) => {
     expect(radarBucketForOpportunity(
       "negotiating",

--- a/apps/web/src/lib/radar-buckets.ts
+++ b/apps/web/src/lib/radar-buckets.ts
@@ -43,10 +43,8 @@ export function radarBucketForOpportunity(
   }
 
   if (negotiation?.state === "paused") {
-    if (negotiation.pause?.reason === "needs_principal") {
-      return negotiation.pause.by === "yours" ? "needs-you" : "waiting";
-    }
-    if (negotiation.pause?.reason === "counterparty_silent") return "waiting";
+    if (negotiation.pause?.by === "theirs") return "waiting";
+    if (negotiation.pause?.reason === "needs_principal") return "needs-you";
     return "agent-handling";
   }
 

--- a/apps/web/src/services/conversation.ts
+++ b/apps/web/src/services/conversation.ts
@@ -2,8 +2,8 @@
  * Conversation service — typed API client for the conversations endpoints.
  */
 
-/** A negotiation task's lifecycle is now exactly these three states (negotiation-graph rewrite, #1494). */
-export type NegotiationTaskState = 'working' | 'paused' | 'completed';
+/** A negotiation task's lifecycle, including the queued state before its worker starts. */
+export type NegotiationTaskState = 'submitted' | 'working' | 'paused' | 'completed';
 
 /**
  * Every reason the protocol may pause a negotiation on — the wire vocabulary,
@@ -112,7 +112,7 @@ export interface IntentCycleSnapshot {
     number: number;
     size: number | null;
     kickoffStartedAt: string | null;
-    working: number;
+    active: number;
     paused: number;
   };
   negotiations: Array<{

--- a/apps/web/src/services/users.ts
+++ b/apps/web/src/services/users.ts
@@ -13,7 +13,7 @@ export interface NegotiationTurnSummary {
   createdAt: string;
 }
 
-export type NegotiationState = 'working' | 'paused' | 'completed';
+export type NegotiationState = 'submitted' | 'working' | 'paused' | 'completed';
 
 export type NegotiationStatusMessage =
   | string

--- a/packages/protocol/CHANGELOG.md
+++ b/packages/protocol/CHANGELOG.md
@@ -21,6 +21,7 @@ prereleases between the two promotions. To track every change, read `rc`; to
 pin a supported release, use `latest`.
 
 ## 36.0.0 - 2026-08-24
+
 ### Breaking
 
 - **Intent matches and negotiations are isolated by their exact intent pair.**
@@ -52,6 +53,11 @@ pin a supported release, use `latest`.
 - The negotiation watchdog retries reflect delivery for durable
   `ready_for_verdict` pauses, and intent-cycle projections count both
   `submitted` and `working` tasks as active.
+- Verdict completion now atomically records the outcome, completes the task,
+  and preserves any concurrent terminal human decision. Post-verdict reflect
+  delivery remains durably marked until it succeeds, terminal owner actions
+  left beside active tasks are recovered by the watchdog, and bounded sweeps
+  rotate checked rows so newer pauses cannot starve.
 
 ## 35.0.0 - 2026-08-24
 

--- a/packages/protocol/CHANGELOG.md
+++ b/packages/protocol/CHANGELOG.md
@@ -58,6 +58,9 @@ pin a supported release, use `latest`.
   delivery remains durably marked until it succeeds, terminal owner actions
   left beside active tasks are recovered by the watchdog, and bounded sweeps
   rotate checked rows so newer pauses cannot starve.
+- Scheduled opportunity expiry now closes any active negotiation through a
+  distinct system lane, without fabricating an owner verdict, so expired work
+  cannot hold either seat's round open.
 
 ## 35.0.0 - 2026-08-24
 

--- a/packages/protocol/CHANGELOG.md
+++ b/packages/protocol/CHANGELOG.md
@@ -37,6 +37,13 @@ pin a supported release, use `latest`.
 
 ### Breaking
 
+- **Negotiation drains are keyed by durable task generations and tasks bind
+  both seats at creation.** `NegotiationTaskMetadata` gains
+  `drainGeneration`; `NegotiationGraphDatabase.openNegotiationTask` accepts
+  the complete `seats` map; `NegotiationRoundReflectJobData` gains
+  `generation`; and `negotiationRoundReflectJobId` now requires it. Reopening
+  a paused task advances its generation, so one pause is deduplicated exactly
+  once without suppressing a later pause in the same round.
 - **PersonalAgent questions use the canonical structured question contract.**
   `message_user.options` is replaced by `message_user.questions` on decided
   and executed acts and on the conversation delivery port. Questions are
@@ -49,6 +56,12 @@ pin a supported release, use `latest`.
 - `PersonalAgentActivity` and `PersonalAgentActivityPort` provide bounded,
   user-facing progress updates for live intent turns without exposing internal
   identifiers, model reasoning, or private context.
+
+### Changed
+
+- PersonalAgent intent turns reload durable negotiation state after each
+  action, cannot finish while an own `ready_for_verdict` pause remains, and
+  expose counterparty pauses only through their public reason.
 
 ## 34.0.1 - 2026-08-24
 

--- a/packages/protocol/CHANGELOG.md
+++ b/packages/protocol/CHANGELOG.md
@@ -21,7 +21,6 @@ prereleases between the two promotions. To track every change, read `rc`; to
 pin a supported release, use `latest`.
 
 ## 36.0.0 - 2026-08-24
-
 ### Breaking
 
 - **Intent matches and negotiations are isolated by their exact intent pair.**
@@ -33,17 +32,25 @@ pin a supported release, use `latest`.
   from authoritative discovery candidates rather than evaluator-generated
   intent IDs, and intent-scoped persistence fails closed on an unbound seat.
 
-## 35.0.0 - 2026-08-24
-
-### Breaking
-
 - **Negotiation drains are keyed by durable task generations and tasks bind
   both seats at creation.** `NegotiationTaskMetadata` gains
   `drainGeneration`; `NegotiationGraphDatabase.openNegotiationTask` accepts
   the complete `seats` map; `NegotiationRoundReflectJobData` gains
-  `generation`; and `negotiationRoundReflectJobId` now requires it. Reopening
-  a paused task advances its generation, so one pause is deduplicated exactly
+  `generation`; `NegotiationTaskState` includes the active `submitted` state;
+  and `negotiationRoundReflectJobId` now requires its generation. Reopening a
+  paused task advances its generation, so one pause is deduplicated exactly
   once without suppressing a later pause in the same round.
+
+### Changed
+
+- PersonalAgent intent turns reload durable negotiation state after each
+  action, cannot finish while an own `ready_for_verdict` pause remains, and
+  expose counterparty pauses only through canonical public status prose.
+
+## 35.0.0 - 2026-08-24
+
+### Breaking
+
 - **PersonalAgent questions use the canonical structured question contract.**
   `message_user.options` is replaced by `message_user.questions` on decided
   and executed acts and on the conversation delivery port. Questions are
@@ -56,12 +63,6 @@ pin a supported release, use `latest`.
 - `PersonalAgentActivity` and `PersonalAgentActivityPort` provide bounded,
   user-facing progress updates for live intent turns without exposing internal
   identifiers, model reasoning, or private context.
-
-### Changed
-
-- PersonalAgent intent turns reload durable negotiation state after each
-  action, cannot finish while an own `ready_for_verdict` pause remains, and
-  expose counterparty pauses only through their public reason.
 
 ## 34.0.1 - 2026-08-24
 

--- a/packages/protocol/CHANGELOG.md
+++ b/packages/protocol/CHANGELOG.md
@@ -46,6 +46,12 @@ pin a supported release, use `latest`.
 - PersonalAgent intent turns reload durable negotiation state after each
   action, cannot finish while an own `ready_for_verdict` pause remains, and
   expose counterparty pauses only through canonical public status prose.
+- Only the seat owning a `ready_for_verdict` pause may resolve it;
+  counterparty-owned pauses cannot be re-opened, and kickoff strategy copy
+  cannot bypass canonical public status narration.
+- The negotiation watchdog retries reflect delivery for durable
+  `ready_for_verdict` pauses, and intent-cycle projections count both
+  `submitted` and `working` tasks as active.
 
 ## 35.0.0 - 2026-08-24
 

--- a/packages/protocol/src/capabilities/tests/fixtures/negotiation-host.fixture.ts
+++ b/packages/protocol/src/capabilities/tests/fixtures/negotiation-host.fixture.ts
@@ -185,25 +185,30 @@ export class FakeNegotiationHost {
     completeNegotiation: async (input) => {
       const task = this.tasks.get(input.taskId);
       if (!task || task.state === 'completed') return null;
-      const isSeat = Object.values(task.metadata.seats).some((seat) => seat.userId === input.resolvedByUserId)
-        || task.metadata.sourceUserId === input.resolvedByUserId
-        || task.metadata.candidateUserId === input.resolvedByUserId;
-      if (!isSeat) return null;
-      if (input.kind === 'pause_verdict' && (
-        task.state !== 'paused'
-        || task.metadata.pause?.reason !== 'ready_for_verdict'
-        || task.metadata.pause.pausedBy !== input.resolvedByUserId
-      )) return null;
+      if (input.kind !== 'opportunity_expired') {
+        const isSeat = Object.values(task.metadata.seats).some((seat) => seat.userId === input.resolvedByUserId)
+          || task.metadata.sourceUserId === input.resolvedByUserId
+          || task.metadata.candidateUserId === input.resolvedByUserId;
+        if (!isSeat) return null;
+        if (input.kind === 'pause_verdict' && (
+          task.state !== 'paused'
+          || task.metadata.pause?.reason !== 'ready_for_verdict'
+          || task.metadata.pause.pausedBy !== input.resolvedByUserId
+        )) return null;
+      }
       this.beforeCompleteNegotiation?.();
       const opportunity = this.opportunities.get(task.metadata.opportunityId);
       if (!opportunity) return null;
       const terminal = ['accepted', 'rejected', 'expired'].includes(opportunity.status);
       if (input.kind === 'owner_verdict' && !terminal) return null;
-      this.outcomeArtifacts.set(task.id, {
-        verdict: input.verdict,
-        reasoning: input.reasoning,
-        resolvedByUserId: input.resolvedByUserId,
-      });
+      if (input.kind === 'opportunity_expired' && opportunity.status !== 'expired') return null;
+      if (input.kind !== 'opportunity_expired') {
+        this.outcomeArtifacts.set(task.id, {
+          verdict: input.verdict,
+          reasoning: input.reasoning,
+          resolvedByUserId: input.resolvedByUserId,
+        });
+      }
       const updated = {
         ...task,
         state: 'completed' as const,

--- a/packages/protocol/src/capabilities/tests/fixtures/negotiation-host.fixture.ts
+++ b/packages/protocol/src/capabilities/tests/fixtures/negotiation-host.fixture.ts
@@ -218,7 +218,7 @@ export class FakeNegotiationHost {
     },
     countActiveNegotiationsForRound: async (intentId, round) =>
       [...this.tasks.values()].filter((t) =>
-        t.metadata.seats[intentId]?.round === round && t.state === "working").length,
+        t.metadata.seats[intentId]?.round === round && t.state !== "paused" && t.state !== "completed").length,
   };
 
   /**

--- a/packages/protocol/src/capabilities/tests/fixtures/negotiation-host.fixture.ts
+++ b/packages/protocol/src/capabilities/tests/fixtures/negotiation-host.fixture.ts
@@ -37,6 +37,8 @@ export class FakeNegotiationHost {
   readonly messages = new Map<string, FakeMessage[]>();
   readonly opportunityStatusUpdates: Array<{ id: string; status: string }> = [];
   readonly outcomeArtifacts = new Map<string, { verdict: 'pending' | 'reject'; reasoning?: string; resolvedByUserId: string }>();
+  /** Test-only interleave immediately before the atomic completion snapshot. */
+  beforeCompleteNegotiation?: () => void;
   /** Deduped by one durable drain generation, exactly as BullMQ does. */
   readonly reflectJobs: Array<{ userId: string; intentId: string; round: number; generation: string }> = [];
   private taskCounter = 0;
@@ -180,16 +182,51 @@ export class FakeNegotiationHost {
     },
     // A snapshot, not the live array — a real DB read would never see a later write reflected back.
     getNegotiationMessages: async (taskId) => [...(this.messages.get(taskId) ?? [])],
-    createNegotiationOutcomeArtifact: async (taskId, outcome) => {
-      this.outcomeArtifacts.set(taskId, outcome);
+    completeNegotiation: async (input) => {
+      const task = this.tasks.get(input.taskId);
+      if (!task || task.state === 'completed') return null;
+      const isSeat = Object.values(task.metadata.seats).some((seat) => seat.userId === input.resolvedByUserId)
+        || task.metadata.sourceUserId === input.resolvedByUserId
+        || task.metadata.candidateUserId === input.resolvedByUserId;
+      if (!isSeat) return null;
+      if (input.kind === 'pause_verdict' && (
+        task.state !== 'paused'
+        || task.metadata.pause?.reason !== 'ready_for_verdict'
+        || task.metadata.pause.pausedBy !== input.resolvedByUserId
+      )) return null;
+      this.beforeCompleteNegotiation?.();
+      const opportunity = this.opportunities.get(task.metadata.opportunityId);
+      if (!opportunity) return null;
+      const terminal = ['accepted', 'rejected', 'expired'].includes(opportunity.status);
+      if (input.kind === 'owner_verdict' && !terminal) return null;
+      this.outcomeArtifacts.set(task.id, {
+        verdict: input.verdict,
+        reasoning: input.reasoning,
+        resolvedByUserId: input.resolvedByUserId,
+      });
+      const updated = {
+        ...task,
+        state: 'completed' as const,
+        metadata: { ...task.metadata, watchdogReflectPending: true },
+        updatedAt: new Date(),
+      };
+      this.tasks.set(task.id, updated);
+      if (input.kind === 'pause_verdict' && !terminal) {
+        const status = input.verdict === 'pending' ? 'pending' : 'rejected';
+        this.opportunityStatusUpdates.push({ id: opportunity.id, status });
+        opportunity.status = status;
+      }
+      return updated;
+    },
+    clearNegotiationReflectPending: async (taskId) => {
+      const task = this.tasks.get(taskId);
+      if (!task) return;
+      this.tasks.set(taskId, {
+        ...task,
+        metadata: { ...task.metadata, watchdogReflectPending: false },
+      });
     },
     getArtifactsForTask: async () => [],
-    updateOpportunityStatus: async (id, status) => {
-      this.opportunityStatusUpdates.push({ id, status });
-      const opportunity = this.opportunities.get(id);
-      if (opportunity) opportunity.status = status;
-      return { id, status };
-    },
     getNegotiationTasksForIntentRound: async (intentId, round) =>
       [...this.tasks.values()].filter((t) => t.metadata.seats[intentId]?.round === round),
     // Signal-scoped on purpose: a negotiation a later round left behind must

--- a/packages/protocol/src/capabilities/tests/fixtures/negotiation-host.fixture.ts
+++ b/packages/protocol/src/capabilities/tests/fixtures/negotiation-host.fixture.ts
@@ -37,8 +37,8 @@ export class FakeNegotiationHost {
   readonly messages = new Map<string, FakeMessage[]>();
   readonly opportunityStatusUpdates: Array<{ id: string; status: string }> = [];
   readonly outcomeArtifacts = new Map<string, { verdict: 'pending' | 'reject'; reasoning?: string; resolvedByUserId: string }>();
-  /** Deduped by (intent, round), exactly as the deterministic BullMQ job id does. */
-  readonly reflectJobs: Array<{ userId: string; intentId: string; round: number }> = [];
+  /** Deduped by one durable drain generation, exactly as BullMQ does. */
+  readonly reflectJobs: Array<{ userId: string; intentId: string; round: number; generation: string }> = [];
   private taskCounter = 0;
   private messageCounter = 0;
 
@@ -71,7 +71,7 @@ export class FakeNegotiationHost {
       conversationId: input.conversationId,
       state: 'working',
       briefs: { ...input.briefs },
-      metadata: input.metadata,
+      metadata: { drainGeneration: 0, ...input.metadata },
       createdAt: new Date(),
       updatedAt: new Date(),
     };
@@ -117,7 +117,8 @@ export class FakeNegotiationHost {
           candidateUserId: input.candidateUserId,
           initiatorUserId: input.sourceUserId,
           networkId: input.networkId,
-          seats: { [input.intentId]: { userId: input.sourceUserId, round: input.round } },
+          seats: input.seats,
+          drainGeneration: 0,
         },
         createdAt: new Date(),
         updatedAt: new Date(),
@@ -141,7 +142,13 @@ export class FakeNegotiationHost {
       const updated: NegotiationTaskRow = {
         ...task,
         state,
-        metadata: { ...task.metadata, pause: pause ?? null },
+        metadata: {
+          ...task.metadata,
+          ...(state === "working" && task.state === "paused"
+            ? { drainGeneration: task.metadata.drainGeneration + 1 }
+            : {}),
+          ...(pause !== undefined || state === "working" ? { pause: pause ?? null } : {}),
+        },
         updatedAt: new Date(),
       };
       this.tasks.set(taskId, updated);
@@ -195,10 +202,16 @@ export class FakeNegotiationHost {
       this.kickoffStartedAt = new Date();
       return (this.round += 1);
     },
-    getIntentNegotiationRound: async () => ({
+    getIntentNegotiationRound: async (intentId) => intentId === INTENT_ID ? ({
       round: this.round,
       roundSize: this.roundSize,
       kickoffStartedAt: this.kickoffStartedAt,
+    }) : ({
+      // A counterparty that did not initiate a kickoff still owns a durable
+      // drain. Its passive round has no in-progress size gate.
+      round: 0,
+      roundSize: null,
+      kickoffStartedAt: null,
     }),
     stampIntentNegotiationRoundSize: async (_intentId, round, size) => {
       if (round === this.round) this.roundSize = size;
@@ -216,9 +229,10 @@ export class FakeNegotiationHost {
     if (this.kickoffStartedAt) this.kickoffStartedAt = new Date(this.kickoffStartedAt.getTime() - byMs);
   }
 
-  /** Records a reflect job the way the queue does: once per (intent, round). */
-  enqueueReflect(job: { userId: string; intentId: string; round: number }): void {
-    if (this.reflectJobs.some((existing) => existing.intentId === job.intentId && existing.round === job.round)) return;
+  /** Records a reflect job the way the queue does: once per durable generation. */
+  enqueueReflect(job: { userId: string; intentId: string; round: number; generation: string }): void {
+    if (this.reflectJobs.some((existing) =>
+      existing.intentId === job.intentId && existing.round === job.round && existing.generation === job.generation)) return;
     this.reflectJobs.push(job);
   }
 

--- a/packages/protocol/src/capabilities/tests/negotiations.e2e.spec.ts
+++ b/packages/protocol/src/capabilities/tests/negotiations.e2e.spec.ts
@@ -4,6 +4,7 @@ import { CANDIDATE_USER_ID, FakeNegotiationHost, INTENT_ID, NETWORK_ID, OPPORTUN
 import type { NegotiationTurnAuthor, NegotiationTurnAuthorInput } from "../../internal/negotiations/negotiation.turn-author.js";
 import { NegotiationAuthoredTurnSchema, NegotiationOpeningTurnSchema } from "../../internal/negotiations/negotiation.turn.js";
 import type { NegotiationAuthoredTurn, NegotiationTurn } from "../../internal/negotiations/negotiation.turn.js";
+import { maybeEnqueueRoundReflect } from "../../internal/negotiations/negotiation.round-reflect.js";
 import { Negotiations } from "../negotiations.js";
 
 /**
@@ -102,6 +103,7 @@ describe("NegotiationGraph — open, turns, pause, resume, verdict", () => {
       author,
       reflectEnqueue: async (job) => { host.enqueueReflect(job); },
     }).createGraph();
+    host.kickoffStartedAt = new Date();
 
     // open: self-play authors the opening turn (alice), loops straight into
     // the reply seat (bob), which immediately pauses per the script —
@@ -120,13 +122,21 @@ describe("NegotiationGraph — open, turns, pause, resume, verdict", () => {
       payload: { question: "What equity split are you open to?" },
     });
     expect(host.taskFor(negotiationId).state).toBe("paused");
-    // The round is not stamped yet, so the all-paused trigger is deliberately
-    // silent: kickoff opens a round's negotiations in parallel and stamps its
-    // size only once they have all settled, and an early first pause seeing
-    // zero working tasks would otherwise dedupe away the round's real reflect.
-    expect(host.reflectJobs).toEqual([]);
+    // The initiating round waits for its size stamp, while Bob's passive seat
+    // is already durably bound and wakes immediately.
+    expect(host.reflectJobs).toEqual([{
+      userId: CANDIDATE_USER_ID,
+      intentId: "intent-bob-1",
+      round: 0,
+      generation: "task-1.0",
+    }]);
     // Kickoff's own post-settle stamp, replayed here by hand.
     await host.database.stampIntentNegotiationRoundSize(INTENT_ID, 1, 1);
+    await maybeEnqueueRoundReflect(host.database, async (job) => { host.enqueueReflect(job); }, {
+      userId: SOURCE_USER_ID,
+      intentId: INTENT_ID,
+      round: 1,
+    });
 
     // resume with brief: IS-A answered the equity question (read from the task directly,
     // the same privileged path IS-A will use — never from the graph's own public result).
@@ -140,9 +150,12 @@ describe("NegotiationGraph — open, turns, pause, resume, verdict", () => {
       pausedBy: SOURCE_USER_ID,
       payload: { recommendation: "pending" },
     });
-    // Stamped now, and every negotiation of round 1 has stopped: exactly one
-    // reflect job, carrying the signal's owner.
-    expect(host.reflectJobs).toEqual([{ userId: SOURCE_USER_ID, intentId: INTENT_ID, round: 1 }]);
+    // The reopened pause is a new durable generation for both bound seats.
+    expect(host.reflectJobs).toEqual(expect.arrayContaining([
+      { userId: SOURCE_USER_ID, intentId: INTENT_ID, round: 1, generation: "task-1.0" },
+      { userId: SOURCE_USER_ID, intentId: INTENT_ID, round: 1, generation: "task-1.1" },
+      { userId: CANDIDATE_USER_ID, intentId: "intent-bob-1", round: 0, generation: "task-1.1" },
+    ]));
 
     // verdict: IS-A promotes to pending — the only terminal write
     const resolved = await graph.invoke({ negotiationId, verdict: "pending", reasoning: "Both sides converged on terms.", byUserId: SOURCE_USER_ID });
@@ -335,13 +348,11 @@ describe("NegotiationGraph — external turn submission (respond_to_negotiation 
     expect(author.calls[2]).toMatchObject({ userId: SOURCE_USER_ID, isOpening: false });
   });
 
-  test("a premise-matched counterparty (same `intent` field as the source) still resolves to the correct seats", async () => {
+  test("refuses to open when a premise-matched counterparty has no owning intent", async () => {
     // The real shape a premise match produces: the counterparty actor's own
     // `intent` field names the intent it matched AGAINST (the source's), not
     // one it owns — so both actors can carry the exact same intent value.
-    // Selecting by `actor.intent === input.intentId` would resolve BOTH
-    // seats to the source, or none at all. Selection must key off who owns
-    // `input.intentId` (via getIntent) and exclude the introducer role.
+    // The source intent cannot be reused as Bob's private signal context.
     const host = new FakeNegotiationHost();
     host.opportunity.actors = [
       { userId: SOURCE_USER_ID, intent: INTENT_ID, networkId: NETWORK_ID, role: "peer" },
@@ -351,10 +362,8 @@ describe("NegotiationGraph — external turn submission (respond_to_negotiation 
     const graph = new Negotiations({ database: host.database, author }).createGraph();
 
     const opened = await graph.invoke({ opportunityId: OPPORTUNITY_ID, intentId: INTENT_ID, brief: "brief", round: 1 });
-    expect(opened.status).toBe("paused"); // outreach, then bob's fallback pause
-    const task = host.taskFor(opened.negotiationId);
-    expect(task.metadata.sourceUserId).toBe(SOURCE_USER_ID);
-    expect(task.metadata.candidateUserId).toBe(CANDIDATE_USER_ID);
+    expect(opened).toMatchObject({ status: "error", error: "Counterparty actor intent is not owned by that seat" });
+    expect(host.tasks.size).toBe(0);
   });
 
   test("an introducer actor is never picked as a negotiation seat", async () => {

--- a/packages/protocol/src/capabilities/tests/negotiations.e2e.spec.ts
+++ b/packages/protocol/src/capabilities/tests/negotiations.e2e.spec.ts
@@ -318,6 +318,36 @@ describe("NegotiationGraph — open, turns, pause, resume, verdict", () => {
     expect(host.opportunityStatusUpdates).not.toContainEqual({ id: OPPORTUNITY_ID, status: "rejected" });
   });
 
+  test("an expired opportunity closes its active task without inventing an owner verdict", async () => {
+    const host = new FakeNegotiationHost();
+    const author = new ScriptedTurnAuthor(host, []);
+    const graph = new Negotiations({ database: host.database, author }).createGraph();
+    const task = await host.createNegotiationTask({
+      conversationId: "conversation-expired",
+      briefs: {},
+      metadata: {
+        type: "negotiation",
+        opportunityId: OPPORTUNITY_ID,
+        sourceUserId: SOURCE_USER_ID,
+        candidateUserId: CANDIDATE_USER_ID,
+        initiatorUserId: SOURCE_USER_ID,
+        networkId: NETWORK_ID,
+        seats: { [INTENT_ID]: { userId: SOURCE_USER_ID, round: 1 } },
+        drainGeneration: 0,
+      },
+    });
+    host.opportunity.status = "expired";
+
+    const result = await graph.invoke({
+      negotiationId: task.id,
+      close: { reason: "opportunity_expired" },
+    });
+
+    expect(result).toMatchObject({ status: "resolved", turns: [] });
+    expect(host.taskFor(task.id).state).toBe("completed");
+    expect(host.outcomeArtifacts.get(task.id)).toBeUndefined();
+  });
+
   test("a system pause (stale-negotiation timeout) does not invoke the author", async () => {
     const host = new FakeNegotiationHost();
     const author = new ScriptedTurnAuthor(host, [

--- a/packages/protocol/src/capabilities/tests/negotiations.e2e.spec.ts
+++ b/packages/protocol/src/capabilities/tests/negotiations.e2e.spec.ts
@@ -61,6 +61,55 @@ class ScriptedTurnAuthor implements NegotiationTurnAuthor {
 }
 
 describe("NegotiationGraph — open, turns, pause, resume, verdict", () => {
+  test("a submitted passive-round sibling prevents an early all-paused wake", async () => {
+    const host = new FakeNegotiationHost();
+    const passiveIntentId = "intent-bob-1";
+    const metadata = (opportunityId: string) => ({
+      type: "negotiation" as const,
+      opportunityId,
+      sourceUserId: SOURCE_USER_ID,
+      candidateUserId: CANDIDATE_USER_ID,
+      initiatorUserId: SOURCE_USER_ID,
+      networkId: NETWORK_ID,
+      seats: { [passiveIntentId]: { userId: CANDIDATE_USER_ID, round: 0 } },
+      drainGeneration: 0,
+    });
+    const paused = await host.createNegotiationTask({
+      conversationId: "conversation-paused",
+      briefs: {},
+      metadata: metadata("opportunity-paused"),
+    });
+    const submitted = await host.createNegotiationTask({
+      conversationId: "conversation-submitted",
+      briefs: {},
+      metadata: metadata("opportunity-submitted"),
+    });
+    await host.database.updateNegotiationTaskState(paused.id, "paused", {
+      reason: "needs_principal",
+      pausedBy: CANDIDATE_USER_ID,
+    });
+    host.tasks.set(submitted.id, { ...submitted, state: "submitted" });
+
+    const check = { userId: CANDIDATE_USER_ID, intentId: passiveIntentId, round: 0 };
+    await maybeEnqueueRoundReflect(host.database, async (job) => { host.enqueueReflect(job); }, check);
+    expect(host.reflectJobs).toEqual([]);
+
+    host.tasks.set(submitted.id, {
+      ...host.taskFor(submitted.id),
+      state: "paused",
+      metadata: {
+        ...host.taskFor(submitted.id).metadata,
+        pause: { reason: "needs_principal", pausedBy: CANDIDATE_USER_ID },
+      },
+    });
+    await maybeEnqueueRoundReflect(host.database, async (job) => { host.enqueueReflect(job); }, check);
+
+    expect(host.reflectJobs).toEqual([{
+      ...check,
+      generation: "task-1.0_task-2.0",
+    }]);
+  });
+
   test("concurrent opens that both miss the pre-read create one task and one opening outreach", async () => {
     const host = new FakeNegotiationHost();
     const author = new ScriptedTurnAuthor(host, [

--- a/packages/protocol/src/capabilities/tests/negotiations.e2e.spec.ts
+++ b/packages/protocol/src/capabilities/tests/negotiations.e2e.spec.ts
@@ -241,7 +241,7 @@ describe("NegotiationGraph — open, turns, pause, resume, verdict", () => {
       payload: { recommendation: "reject" },
     });
 
-    const resolved = await graph.invoke({ negotiationId: opened.negotiationId, verdict: "reject", reasoning: "Not a fit.", byUserId: SOURCE_USER_ID });
+    const resolved = await graph.invoke({ negotiationId: opened.negotiationId, verdict: "reject", reasoning: "Not a fit.", byUserId: CANDIDATE_USER_ID });
     expect(resolved.status).toBe("resolved");
     expect(resolved.verdict).toBe("reject");
     expect(host.opportunityStatusUpdates.at(-1)).toEqual({ id: OPPORTUNITY_ID, status: "rejected" });
@@ -265,6 +265,31 @@ describe("NegotiationGraph — open, turns, pause, resume, verdict", () => {
 
     expect(result).toMatchObject({ status: "error", error: "Only a negotiation seat may resolve it" });
     expect(host.outcomeArtifacts.get(opened.negotiationId)).toBeUndefined();
+    expect(host.taskFor(opened.negotiationId).state).toBe("paused");
+  });
+
+  test("rejects a verdict from the seat that does not own the ready pause", async () => {
+    const host = new FakeNegotiationHost();
+    const author = new ScriptedTurnAuthor(host, [
+      { verb: "outreach", message: "Opening.", reasoning: "r" },
+      { verb: "pause", reason: "ready_for_verdict", payload: { recommendation: "reject", reasoning: "Not a fit." } },
+    ]);
+    const graph = new Negotiations({ database: host.database, author }).createGraph();
+    const opened = await graph.invoke({ opportunityId: OPPORTUNITY_ID, intentId: INTENT_ID, brief: "brief", round: 1 });
+    expect(host.taskFor(opened.negotiationId).metadata.pause?.pausedBy).toBe(CANDIDATE_USER_ID);
+    host.opportunity.status = "accepted";
+
+    const result = await graph.invoke({
+      negotiationId: opened.negotiationId,
+      verdict: "reject",
+      reasoning: "The other seat cannot decide this pause.",
+      byUserId: SOURCE_USER_ID,
+    });
+
+    expect(result).toMatchObject({
+      status: "error",
+      error: "Only the seat owning a ready_for_verdict pause may resolve it",
+    });
     expect(host.taskFor(opened.negotiationId).state).toBe("paused");
   });
 

--- a/packages/protocol/src/capabilities/tests/negotiations.e2e.spec.ts
+++ b/packages/protocol/src/capabilities/tests/negotiations.e2e.spec.ts
@@ -293,6 +293,31 @@ describe("NegotiationGraph — open, turns, pause, resume, verdict", () => {
     expect(host.taskFor(opened.negotiationId).state).toBe("paused");
   });
 
+  test("a concurrent human verdict wins over PersonalAgent resolution", async () => {
+    const host = new FakeNegotiationHost();
+    const author = new ScriptedTurnAuthor(host, [
+      { verb: "outreach", message: "Opening.", reasoning: "r" },
+      { verb: "pause", reason: "ready_for_verdict", payload: { recommendation: "reject", reasoning: "Not a fit." } },
+    ]);
+    const graph = new Negotiations({ database: host.database, author }).createGraph();
+    const opened = await graph.invoke({ opportunityId: OPPORTUNITY_ID, intentId: INTENT_ID, brief: "brief", round: 1 });
+    host.beforeCompleteNegotiation = () => {
+      host.opportunity.status = "accepted";
+    };
+
+    const result = await graph.invoke({
+      negotiationId: opened.negotiationId,
+      verdict: "reject",
+      reasoning: "The agent's stale decision must not replace the human's.",
+      byUserId: CANDIDATE_USER_ID,
+    });
+
+    expect(result.status).toBe("resolved");
+    expect(host.taskFor(opened.negotiationId).state).toBe("completed");
+    expect(host.opportunity.status).toBe("accepted");
+    expect(host.opportunityStatusUpdates).not.toContainEqual({ id: OPPORTUNITY_ID, status: "rejected" });
+  });
+
   test("a system pause (stale-negotiation timeout) does not invoke the author", async () => {
     const host = new FakeNegotiationHost();
     const author = new ScriptedTurnAuthor(host, [

--- a/packages/protocol/src/capabilities/tests/personal-agent.e2e.spec.ts
+++ b/packages/protocol/src/capabilities/tests/personal-agent.e2e.spec.ts
@@ -646,10 +646,6 @@ describe("PersonalAgent — chat-first intent turns", () => {
 
   test("refuses a repeated terminal verdict for the same negotiation", async () => {
     const judgment = new ScriptedJudgment([
-      () => [
-        { tool: "kickoff", reasoning: "Open it." },
-        { tool: "message_user", text: "The negotiation is open." },
-      ],
       (context) => {
         const negotiationId = context.paused[0]!.negotiationId;
         return [
@@ -666,9 +662,27 @@ describe("PersonalAgent — chat-first intent turns", () => {
         : { tool: "message_user", text: "I did not see the refused verdict." };
     });
     const { agent, negotiationHost, principal } = buildCycle(judgment, [CANDIDATE_USER_ID]);
+    const task = await negotiationHost.createNegotiationTask({
+      conversationId: "conversation-repeated-verdict",
+      briefs: {},
+      metadata: {
+        type: "negotiation",
+        opportunityId: OPPORTUNITY_ID,
+        sourceUserId: SOURCE_USER_ID,
+        candidateUserId: CANDIDATE_USER_ID,
+        initiatorUserId: SOURCE_USER_ID,
+        networkId: "network-1",
+        seats: { [INTENT_ID]: { userId: SOURCE_USER_ID, round: 1 } },
+        drainGeneration: 0,
+      },
+    });
+    await negotiationHost.database.updateNegotiationTaskState(task.id, "paused", {
+      reason: "ready_for_verdict",
+      pausedBy: SOURCE_USER_ID,
+      payload: { recommendation: "reject", reasoning: "Not a fit." },
+    });
 
-    await agent.invoke({ userId: SOURCE_USER_ID, intentId: INTENT_ID, event: "matches_ready" });
-    const result = await agent.invoke({ userId: SOURCE_USER_ID, intentId: INTENT_ID, event: "all_paused", round: negotiationHost.round });
+    const result = await agent.invoke({ userId: SOURCE_USER_ID, intentId: INTENT_ID, event: "all_paused", round: 1 });
 
     expect(result.acts.map((act) => act.tool)).toEqual(["reject", "message_user"]);
     expect(result.messages).toEqual(["I closed that negotiation as not a fit; the conflicting verdict was refused."]);
@@ -812,17 +826,17 @@ describe("PersonalAgent — the whole cycle", () => {
     ]);
     expect(negotiationHost.opportunities.get(SECOND_OPPORTUNITY_ID)!.status).toBe("pending");
     expect(negotiationHost.opportunities.get(THIRD_OPPORTUNITY_ID)!.status).toBe("negotiating");
-    // Both still-undecided negotiations were sent back out; the already
-    // promoted match was not reopened.
+    // Only the own needs_principal pause was sent back out. The already
+    // promoted match and the counterparty-owned verdict pause were not reopened.
     const rekick = acted.acts.find((act) => act.tool === "kickoff")!;
-    expect(rekick).toMatchObject({ tool: "kickoff", opened: 2 });
+    expect(rekick).toMatchObject({ tool: "kickoff", opened: 1 });
     expect(negotiationHost.tasks.size).toBe(3); // re-kick resumed, never duplicated
     expect(negotiationHost.round).toBe(round + 1);
     expect(negotiationHost.reflectJobs.at(-1)).toEqual({
       userId: SOURCE_USER_ID,
       intentId: INTENT_ID,
       round: round + 1,
-      generation: "task-1.1_task-3.1",
+      generation: "task-1.1",
     });
   });
 
@@ -898,8 +912,9 @@ describe("PersonalAgent — termination and retry safety", () => {
         if (input.isOpening) return { verb: "outreach", message: `Opening on ${input.brief}`, reasoning: "Kickoff." };
         // Opportunity 2 stalls on its principal at the first reply, then plays
         // on when re-kicked — so it, too, eventually spends its budget.
-        if (input.brief.includes(SECOND_OPPORTUNITY_ID) && input.thread.length === 1) {
-          return { verb: "pause", reason: "needs_principal", payload: { question: "How soon?" } };
+        if (input.brief.includes(SECOND_OPPORTUNITY_ID)) {
+          if (input.thread.length === 1) return { verb: "counter", message: "How soon?", reasoning: "Asking." };
+          if (input.thread.length === 2) return { verb: "pause", reason: "needs_principal", payload: { question: "How soon?" } };
         }
         return { verb: "counter", message: "Pushing back.", reasoning: "Still talking." };
       },
@@ -1292,11 +1307,10 @@ describe("PersonalAgent — round-4 regressions", () => {
 });
 
 describe("PersonalAgent — round-5 regressions", () => {
-  test("a capped negotiation a later round left behind is still listed, and still rejectable", async () => {
-    // Being spent makes a negotiation ineligible for RE-KICK. It must not also
-    // make it invisible: conflating the two meant a table a later round left
-    // behind could never be promoted or rejected, so its opportunity sat
-    // `negotiating` forever and its principal never heard an outcome.
+  test("a capped negotiation left behind stays visible but is not verdict-actionable", async () => {
+    // Being spent makes a negotiation ineligible for RE-KICK, while the
+    // effects boundary also refuses a verdict unless this seat owns a
+    // ready_for_verdict pause. Visibility alone grants neither authority.
     const kickoff = (): PersonalAgentDecidedAct[] => [{ tool: "kickoff", reasoning: "Send them out." }];
     const judgment = new ScriptedJudgment(
       [kickoff, kickoff, (context) => {
@@ -1306,8 +1320,9 @@ describe("PersonalAgent — round-5 regressions", () => {
       }],
       (input) => {
         if (input.isOpening) return { verb: "outreach", message: `Opening on ${input.brief}`, reasoning: "Kickoff." };
-        if (input.brief.includes(SECOND_OPPORTUNITY_ID) && input.thread.length === 1) {
-          return { verb: "pause", reason: "needs_principal", payload: { question: "How soon?" } };
+        if (input.brief.includes(SECOND_OPPORTUNITY_ID)) {
+          if (input.thread.length === 1) return { verb: "counter", message: "How soon?", reasoning: "Asking." };
+          if (input.thread.length === 2) return { verb: "pause", reason: "needs_principal", payload: { question: "How soon?" } };
         }
         return { verb: "counter", message: "Pushing back.", reasoning: "Still talking." };
       },
@@ -1333,10 +1348,10 @@ describe("PersonalAgent — round-5 regressions", () => {
       negotiationId: capped.id,
       opportunityId: OPPORTUNITY_ID,
       reasoning: "Went nowhere.",
-      outcome: "resolved",
+      outcome: "error",
     });
     expect(acted.acts[1]).toMatchObject({ tool: "message_user" });
-    expect(negotiationHost.opportunities.get(OPPORTUNITY_ID)!.status).toBe("rejected");
+    expect(negotiationHost.opportunities.get(OPPORTUNITY_ID)!.status).toBe("negotiating");
   });
 
   test("a negotiation that pauses between the count and the stamp still gets its reflect", async () => {
@@ -1510,6 +1525,76 @@ describe("PersonalAgent — the three decided design questions", () => {
 
 describe("PersonalAgent — round-6: per-seat binding and the kickoff region", () => {
   const BOB_INTENT = "intent-bob-1";
+
+  test("a counterparty-owned pause is neither verdict-actionable nor kickoff-eligible", async () => {
+    const judgment = new ScriptedJudgment([(context) => {
+      expect(context.paused[0]).toMatchObject({ pausedByUs: false, reason: "ready_for_verdict" });
+      expect(context.kickoffTargets).toEqual([]);
+      return [{
+        tool: "reject",
+        negotiationId: context.paused[0]!.negotiationId,
+        reasoning: "An injected judgment must still be fenced.",
+      }];
+    }]);
+    const { agent, negotiationHost } = buildCycle(judgment, [CANDIDATE_USER_ID]);
+    const task = await negotiationHost.createNegotiationTask({
+      conversationId: "conversation-counterparty-owned",
+      briefs: {},
+      metadata: {
+        type: "negotiation",
+        opportunityId: OPPORTUNITY_ID,
+        sourceUserId: SOURCE_USER_ID,
+        candidateUserId: CANDIDATE_USER_ID,
+        initiatorUserId: SOURCE_USER_ID,
+        networkId: "network-1",
+        seats: { [INTENT_ID]: { userId: SOURCE_USER_ID, round: 1 } },
+        drainGeneration: 0,
+      },
+    });
+    await negotiationHost.database.updateNegotiationTaskState(task.id, "paused", {
+      reason: "ready_for_verdict",
+      pausedBy: CANDIDATE_USER_ID,
+    });
+
+    const result = await agent.invoke({ userId: SOURCE_USER_ID, intentId: INTENT_ID, event: "all_paused", round: 1 });
+
+    expect(result.acts).toContainEqual(expect.objectContaining({ tool: "reject", outcome: "error" }));
+    expect(negotiationHost.taskFor(task.id).state).toBe("paused");
+    expect(negotiationHost.outcomeArtifacts.has(task.id)).toBe(false);
+  });
+
+  test("kickoff replaces model strategy narration with canonical counterparty status", async () => {
+    const judgment = new ScriptedJudgment([() => [{ tool: "kickoff", reasoning: "Open only the fresh match." }]]);
+    const { agent, negotiationHost, principal } = buildCycle(judgment, [CANDIDATE_USER_ID, "carol"]);
+    const task = await negotiationHost.createNegotiationTask({
+      conversationId: "conversation-counterparty-strategy",
+      briefs: {},
+      metadata: {
+        type: "negotiation",
+        opportunityId: OPPORTUNITY_ID,
+        sourceUserId: SOURCE_USER_ID,
+        candidateUserId: CANDIDATE_USER_ID,
+        initiatorUserId: SOURCE_USER_ID,
+        networkId: "network-1",
+        seats: { [INTENT_ID]: { userId: SOURCE_USER_ID, round: 1 } },
+        drainGeneration: 0,
+      },
+    });
+    await negotiationHost.database.updateNegotiationTaskState(task.id, "paused", {
+      reason: "ready_for_verdict",
+      pausedBy: CANDIDATE_USER_ID,
+    });
+
+    await agent.invoke({ userId: SOURCE_USER_ID, intentId: INTENT_ID, event: "matches_ready" });
+
+    expect(judgment.strategyCalls[0]!.kickoffTargets.map((match) => match.opportunityId)).toEqual([SECOND_OPPORTUNITY_ID]);
+    expect(judgment.briefCalls[0]).toMatchObject({
+      opportunityId: SECOND_OPPORTUNITY_ID,
+      strategy: "I will put your constraints to each of them and find out who can actually move.",
+    });
+    expect(principal.dmMessages[0]?.content).toBe("The other side is deciding.");
+    expect(principal.dmMessages.some((message) => message.content.includes("put your constraints"))).toBe(false);
+  });
 
   test("message_user is refused until an own ready_for_verdict pause is resolved", async () => {
     class ResolveBeforeReplyJudgment extends ScriptedJudgment {
@@ -1746,10 +1831,9 @@ describe("PersonalAgent — round-6: per-seat binding and the kickoff region", (
     expect(replied.messages).toEqual(["Here is where things stand after 0 act(s)."]);
   });
 
-  test("D21: a negotiation the counterparty opened is still decidable by BOTH agents", async () => {
-    // The design doc's terminator rule — a side that wants out pauses
-    // ready_for_verdict(reject) and ITS OWN IS-A rejects — needs the seat's
-    // agent to be able to SEE the negotiation. Single ownership hid it.
+  test("D21: a negotiation the counterparty opened is visible to both agents but actionable only by its pause owner", async () => {
+    // Both seats need visibility, while only the seat whose negotiator paused
+    // ready_for_verdict may act on that recommendation.
     const judgment = new ScriptedJudgment([() => []]);
     const { agent, negotiationHost } = buildCycle(judgment, [CANDIDATE_USER_ID]);
     const task = await negotiationHost.createNegotiationTask({
@@ -1777,8 +1861,9 @@ describe("PersonalAgent — round-6: per-seat binding and the kickoff region", (
 
     await agent.invoke({ userId: SOURCE_USER_ID, intentId: INTENT_ID, event: "all_paused", round: 1 });
 
-    // Alice's agent sees it, so it can promote or reject it.
-    expect(judgment.decideCalls.at(-1)!.paused.map((paused) => paused.negotiationId)).toEqual([task.id]);
+    const context = judgment.decideCalls.at(-1)!;
+    expect(context.paused).toEqual([expect.objectContaining({ negotiationId: task.id, pausedByUs: false })]);
+    expect(context.kickoffTargets).toEqual([]);
   });
 
   test("D52: the agent is shown exactly what a kickoff would open", async () => {

--- a/packages/protocol/src/capabilities/tests/personal-agent.e2e.spec.ts
+++ b/packages/protocol/src/capabilities/tests/personal-agent.e2e.spec.ts
@@ -3,6 +3,7 @@ import { AsyncLocalStorage } from "async_hooks";
 
 import { CANDIDATE_USER_ID, FakeNegotiationHost, INTENT_ID, OPPORTUNITY_ID, SOURCE_USER_ID } from "./fixtures/negotiation-host.fixture.js";
 import { PersonalAgentGraphFactory, PERSONAL_AGENT_NOTHING_TO_OPEN, PERSONAL_AGENT_POST_ACTION_FAILURE, PERSONAL_AGENT_STRATEGY_FALLBACK, PERSONAL_AGENT_TOOL_BUDGET_EXHAUSTED, type PersonalAgentGraphLike } from "../../internal/agents/personal-agent/agent.graph.js";
+import { canonicalCounterpartyStatusProse } from "../../internal/agents/personal-agent/agent.judgment.js";
 import type { PersonalAgentDecidedAct, PersonalAgentDeps, PersonalAgentExecutedAct, PersonalAgentJudgment, PersonalAgentMatch, PersonalAgentNegotiationTurnInput, PersonalAgentNonDurableObservation, PersonalAgentSeatBriefInput, PersonalAgentTurnContext } from "../../internal/agents/personal-agent/agent.types.js";
 import type { NegotiationAuthoredTurn } from "../../internal/negotiations/negotiation.turn.js";
 import { Negotiations } from "../negotiations.js";
@@ -167,6 +168,10 @@ class ScriptedJudgment implements PersonalAgentJudgment {
             multiSelect: false,
           }],
         };
+      }
+      const canonicalCounterpartyStatus = canonicalCounterpartyStatusProse(context);
+      if (canonicalCounterpartyStatus) {
+        decided = { ...decided, text: canonicalCounterpartyStatus };
       }
     }
     if (fromPlan) this.activePlan.shift();

--- a/packages/protocol/src/capabilities/tests/personal-agent.e2e.spec.ts
+++ b/packages/protocol/src/capabilities/tests/personal-agent.e2e.spec.ts
@@ -138,9 +138,39 @@ class ScriptedJudgment implements PersonalAgentJudgment {
         this.activePlan = this.plans[this.cursor++]?.(context) ?? [];
       }
     }
-    return this.activePlan.shift()
+    const fromPlan = this.activePlan[0];
+    let decided = fromPlan
       ?? await this.afterActs?.(context, executed, nonDurable)
-      ?? { tool: "message_user", text: `Here is where things stand after ${executed.length} act(s).` };
+      ?? { tool: "message_user" as const, text: `Here is where things stand after ${executed.length} act(s).` };
+    if (decided.tool === "message_user") {
+      const ready = context.paused.find((paused) => paused.pausedByUs && paused.reason === "ready_for_verdict");
+      if (ready) {
+        const recommendation = (ready.payload as { recommendation?: string } | undefined)?.recommendation;
+        return {
+          tool: recommendation === "reject" ? "reject" : "promote",
+          negotiationId: ready.negotiationId,
+          reasoning: "Resolving the owned verdict pause before replying.",
+        };
+      }
+      const needs = context.paused.find((paused) => paused.pausedByUs && paused.reason === "needs_principal");
+      if (needs && !decided.questions?.length) {
+        const prompt = (needs.payload as { question?: string } | undefined)?.question ?? "What should I tell the other side?";
+        decided = {
+          ...decided,
+          questions: [{
+            title: "Your input",
+            prompt,
+            options: [
+              { label: "Proceed", description: "Continue with the current direction." },
+              { label: "Hold", description: "Wait before continuing." },
+            ],
+            multiSelect: false,
+          }],
+        };
+      }
+    }
+    if (fromPlan) this.activePlan.shift();
+    return decided;
   }
 
   async strategy(context: PersonalAgentTurnContext): Promise<string> {
@@ -623,11 +653,10 @@ describe("PersonalAgent — chat-first intent turns", () => {
         ];
       },
     ], undefined, (context, _executed, nonDurable) => {
-      const negotiationId = context.paused[0]!.negotiationId;
       return nonDurable.some((observation) =>
         observation.kind === "irreversible_tool_refused"
         && observation.tool === "promote"
-        && observation.negotiationId === negotiationId)
+      )
         ? { tool: "message_user", text: "I closed that negotiation as not a fit; the conflicting verdict was refused." }
         : { tool: "message_user", text: "I did not see the refused verdict." };
     });
@@ -644,7 +673,7 @@ describe("PersonalAgent — chat-first intent turns", () => {
     expect(principal.ledgerRows.filter((row) => row.act.tool === "promote")).toHaveLength(0);
   });
 
-  test("delivers the dedicated exhaustion response after kickoff's strategy", async () => {
+  test("tool exhaustion cannot bypass an owned verdict pause", async () => {
     const judgment = new ScriptedJudgment([() => [
       { tool: "kickoff", reasoning: "Open it." },
       ...Array.from({ length: 7 }, (_, index): PersonalAgentDecidedAct => ({ tool: "note_dossier", text: `Fact ${index + 1}.` })),
@@ -653,9 +682,9 @@ describe("PersonalAgent — chat-first intent turns", () => {
 
     const result = await agent.invoke({ userId: SOURCE_USER_ID, intentId: INTENT_ID, event: "matches_ready" });
 
-    expect(result.messages.at(-1)).toBe(PERSONAL_AGENT_TOOL_BUDGET_EXHAUSTED);
-    expect(principal.dmMessages.at(-1)?.content).toBe(PERSONAL_AGENT_TOOL_BUDGET_EXHAUSTED);
-    expect(result.acts.filter((act) => act.tool === "kickoff")).toHaveLength(1);
+    expect(result.error).toBe("PersonalAgent exhausted its tool budget with an unresolved owned pause");
+    expect(principal.dmMessages.at(-1)?.content).not.toBe(PERSONAL_AGENT_TOOL_BUDGET_EXHAUSTED);
+    expect(principal.ledgerRows.filter((row) => row.act.tool === "kickoff")).toHaveLength(1);
   });
 
   test("a strategy message makes a later round-bump failure non-retryable", async () => {
@@ -696,7 +725,7 @@ describe("PersonalAgent — the whole cycle", () => {
       ],
       // 3. all_paused: ask what one table still needs.
       (context) => {
-        expect(context.paused).toHaveLength(3);
+        expect(context.paused).toHaveLength(2);
         return [{
           tool: "message_user",
           text: "One of them needs your earliest start date.",
@@ -711,15 +740,8 @@ describe("PersonalAgent — the whole cycle", () => {
           }],
         }];
       },
-      // 4. their answer: promote, reject, and re-kick the rest.
-      (context) => {
-        const byOpportunity = new Map(context.paused.map((paused) => [paused.opportunityId, paused.negotiationId]));
-        return [
-          { tool: "promote", negotiationId: byOpportunity.get(SECOND_OPPORTUNITY_ID)!, reasoning: "They can move now." },
-          { tool: "reject", negotiationId: byOpportunity.get(THIRD_OPPORTUNITY_ID)!, reasoning: "Not a fit." },
-          { tool: "kickoff", reasoning: "Sending the rest back out with the start date." },
-        ];
-      },
+      // 4. their answer: re-kick the table that needed the principal.
+      () => [{ tool: "kickoff", reasoning: "Sending the answer back out." }],
     ]);
     const { agent, negotiationHost, principal } = buildCycle(judgment, [CANDIDATE_USER_ID, "carol", "dave"]);
 
@@ -735,6 +757,7 @@ describe("PersonalAgent — the whole cycle", () => {
       "note_dossier",
       "message_user", // the strategy, written into the DM before anyone is contacted
       "kickoff",
+      "promote", // an own ready_for_verdict pause is resolved before replying
       "message_user", // the model's natural terminal response
     ]);
     // One brief per match, all derived from the same strategy.
@@ -743,7 +766,7 @@ describe("PersonalAgent — the whole cycle", () => {
     expect(new Set(judgment.briefCalls.map((call) => call.strategy)).size).toBe(1);
     expect(negotiationHost.tasks.size).toBe(3);
     for (const task of negotiationHost.tasks.values()) {
-      expect(task.state).toBe("paused");
+      expect(task.state).toBe(task.metadata.opportunityId === SECOND_OPPORTUNITY_ID ? "completed" : "paused");
       expect(task.briefs[SOURCE_USER_ID]).toBe(`Brief for ${task.metadata.opportunityId}: ${judgment.briefCalls[0]!.strategy}`);
       // The counterparty seat wrote its OWN, and never read the initiator's.
       expect(task.briefs[task.metadata.candidateUserId]).toMatch(/^Seat brief from what we were told:/);
@@ -752,39 +775,50 @@ describe("PersonalAgent — the whole cycle", () => {
     // check then fires exactly once for it.
     const round = negotiationHost.round;
     expect(negotiationHost.roundSize).toBe(3);
-    expect(negotiationHost.reflectJobs).toEqual([{ userId: SOURCE_USER_ID, intentId: INTENT_ID, round }]);
+    expect(negotiationHost.reflectJobs).toHaveLength(4);
+    expect(negotiationHost.reflectJobs).toEqual(expect.arrayContaining([
+      { userId: SOURCE_USER_ID, intentId: INTENT_ID, round, generation: "task-1.0_task-2.0_task-3.0" },
+      { userId: CANDIDATE_USER_ID, intentId: "intent-bob-1", round: 0, generation: "task-1.0" },
+      { userId: "carol", intentId: "intent-carol-1", round: 0, generation: "task-2.0" },
+      { userId: "dave", intentId: "intent-dave-1", round: 0, generation: "task-3.0" },
+    ]));
     // Every act is on the ledger. The appends are guarded so a failure cannot
     // duplicate a real effect — which also means a broken one records nothing
     // and says nothing, so it is asserted rather than assumed.
     expect(principal.ledgerRows.map((row) => row.act.tool))
-      .toEqual(["message_user", "note_dossier", "message_user", "kickoff", "message_user"]);
+      .toEqual(["message_user", "note_dossier", "message_user", "kickoff", "promote", "message_user"]);
     // The principal's reply streamed back as ordered chunks.
     expect(principal.publishedChunks.map((chunk) => chunk.seq)).toEqual([1, 2, 3]);
 
     // ── 3. reflect: it asks, and decides nothing ──────────────────────────
     const reflectAsk = await agent.invoke({ userId: SOURCE_USER_ID, intentId: INTENT_ID, event: "all_paused", round });
+    expect(reflectAsk.error).toBeUndefined();
     expect(reflectAsk.acts.map((act) => act.tool)).toEqual(["message_user"]);
-    expect(negotiationHost.opportunityStatusUpdates.filter((update) => update.status === "pending")).toHaveLength(0);
+    expect(negotiationHost.opportunityStatusUpdates.filter((update) => update.status === "pending")).toHaveLength(1);
     expect(negotiationHost.opportunityStatusUpdates.filter((update) => update.status === "rejected")).toHaveLength(0);
 
     // ── 4. next turn: promote, reject, re-kick ────────────────────────────
     const acted = await agent.invoke(userMessage("I could start in three weeks."));
     expect(acted.acts.map((act) => act.tool)).toEqual([
-      "promote",
-      "reject",
       "message_user", // the new round's strategy
       "kickoff",
+      "promote", // the reopened own verdict is resolved before replying
       "message_user", // the model's natural terminal response
     ]);
     expect(negotiationHost.opportunities.get(SECOND_OPPORTUNITY_ID)!.status).toBe("pending");
-    expect(negotiationHost.opportunities.get(THIRD_OPPORTUNITY_ID)!.status).toBe("rejected");
-    // Only the undecided one was sent back out, with a brief of its own.
+    expect(negotiationHost.opportunities.get(THIRD_OPPORTUNITY_ID)!.status).toBe("negotiating");
+    // Both still-undecided negotiations were sent back out; the already
+    // promoted match was not reopened.
     const rekick = acted.acts.find((act) => act.tool === "kickoff")!;
-    expect(rekick).toMatchObject({ tool: "kickoff", opened: 1 });
-    expect(judgment.briefCalls.at(-1)!.opportunityId).toBe(OPPORTUNITY_ID);
+    expect(rekick).toMatchObject({ tool: "kickoff", opened: 2 });
     expect(negotiationHost.tasks.size).toBe(3); // re-kick resumed, never duplicated
     expect(negotiationHost.round).toBe(round + 1);
-    expect(negotiationHost.reflectJobs.at(-1)).toEqual({ userId: SOURCE_USER_ID, intentId: INTENT_ID, round: round + 1 });
+    expect(negotiationHost.reflectJobs.at(-1)).toEqual({
+      userId: SOURCE_USER_ID,
+      intentId: INTENT_ID,
+      round: round + 1,
+      generation: "task-1.1_task-3.1",
+    });
   });
 
   test("a pause payload is readable only by the seat that paused", async () => {
@@ -986,7 +1020,9 @@ describe("PersonalAgent — kickoff safety at the edges", () => {
     expect(judgment.briefCalls).toHaveLength(1);             // a brief was derived
     expect(negotiationHost.round).toBe(5);                   // a NEW round, not a stamp of the stale one
     expect(negotiationHost.roundSize).toBe(1);
-    expect(negotiationHost.reflectJobs).toEqual([{ userId: SOURCE_USER_ID, intentId: INTENT_ID, round: 5 }]);
+    expect(negotiationHost.reflectJobs).toEqual([{
+      userId: SOURCE_USER_ID, intentId: INTENT_ID, round: 5, generation: "task-1.0",
+    }]);
   });
 
   test("an open that fails leaves no live negotiation holding the round open", async () => {
@@ -1013,7 +1049,7 @@ describe("PersonalAgent — kickoff safety at the edges", () => {
     expect(await negotiationHost.database.countActiveNegotiationsForRound(INTENT_ID, negotiationHost.round)).toBe(0);
     // The round still settles, so its reflect fires instead of hanging.
     expect(negotiationHost.roundSize).toBe(1);
-    expect(negotiationHost.reflectJobs).toHaveLength(1);
+    expect(negotiationHost.reflectJobs.filter((job) => job.intentId === INTENT_ID)).toHaveLength(1);
   });
 
   test("a match that arrived during the turn wakes the agent again", async () => {
@@ -1136,8 +1172,8 @@ describe("PersonalAgent — what a turn may open, and what it may claim", () => 
   });
 
   test("a reflect turn whose reads fail does not report a successful empty turn", async () => {
-    // With the reflect job id retained forever, a swallowed read here would
-    // consume the round's one chance to reflect and stall the cycle for good.
+    // With this drain generation's job id retained forever, a swallowed read
+    // would consume that durable pause without deciding it.
     const judgment = new ScriptedJudgment([() => []]);
     const { agent, negotiationHost } = buildCycle(judgment, [CANDIDATE_USER_ID]);
     negotiationHost.database.getPausedNegotiationTasksForIntent = async () => {
@@ -1177,8 +1213,10 @@ describe("PersonalAgent — round-4 regressions", () => {
 
     await agent.invoke({ userId: SOURCE_USER_ID, intentId: INTENT_ID, event: "matches_ready" });
 
-    // Only the round that actually holds the negotiations is reflected on.
-    expect(negotiationHost.reflectJobs.map((job) => job.round)).toEqual([stranded + 1]);
+    // The superseded round's newly durable drain and the later reopened
+    // generation are distinct moments, so both are reflected exactly once.
+    expect(negotiationHost.reflectJobs.filter((job) => job.intentId === INTENT_ID).map((job) => job.round))
+      .toEqual([stranded + 1]);
     expect([...negotiationHost.tasks.values()][0]!.metadata.seats[INTENT_ID]!.round).toBe(stranded + 1);
   });
 
@@ -1314,8 +1352,8 @@ describe("PersonalAgent — round-5 regressions", () => {
     await agent.invoke({ userId: SOURCE_USER_ID, intentId: INTENT_ID, event: "matches_ready" });
 
     expect(negotiationHost.roundSize).toBe(1);
-    expect(negotiationHost.reflectJobs).toEqual([
-      { userId: SOURCE_USER_ID, intentId: INTENT_ID, round: negotiationHost.round },
+    expect(negotiationHost.reflectJobs.filter((job) => job.intentId === INTENT_ID)).toEqual([
+      { userId: SOURCE_USER_ID, intentId: INTENT_ID, round: negotiationHost.round, generation: "task-1.0" },
     ]);
   });
 
@@ -1356,23 +1394,26 @@ describe("PersonalAgent — the three decided design questions", () => {
     expect(theirs).not.toBe(ours);
     expect(judgment.seatBriefCalls).toHaveLength(1);
     expect(judgment.seatBriefCalls[0]!.intent.payload).toBe("bob wants a suitable match.");
-    expect(task.metadata.seats).toEqual({ [INTENT_ID]: { userId: SOURCE_USER_ID, round: negotiationHost.round } });
+    expect(task.metadata.seats).toEqual({
+      [INTENT_ID]: { userId: SOURCE_USER_ID, round: negotiationHost.round },
+      "intent-bob-1": { userId: CANDIDATE_USER_ID, round: 0 },
+    });
     expect(negotiationInputs.find((input) => input.userId === CANDIDATE_USER_ID)).toEqual({
       userId: CANDIDATE_USER_ID,
       intentId: "intent-bob-1",
       negotiationId: task.id,
     });
     const bobFirstTurn = judgment.negotiationTurnCalls.find((input) => input.intent.userId === CANDIDATE_USER_ID)!;
-    // Bob gets only Bob's resolved intent, the task context that still has
-    // Alice as its sole metadata seat, the history, and Bob's generated brief.
+    // Bob gets only Bob's resolved intent, the durable two-seat task context,
+    // the history, and Bob's generated brief.
     expect(bobFirstTurn.intent).toMatchObject({ id: "intent-bob-1", payload: "bob wants a suitable match." });
-    expect(bobFirstTurn.negotiation).toMatchObject({ id: task.id, metadata: { seats: { [INTENT_ID]: { userId: SOURCE_USER_ID, round: negotiationHost.round } } } });
+    expect(bobFirstTurn.negotiation).toMatchObject({ id: task.id, metadata: { seats: task.metadata.seats } });
     expect(bobFirstTurn.thread.length).toBeGreaterThan(0);
     expect(bobFirstTurn.brief).toBe(theirs);
     // The brief had the same own intent and actual history available when it
     // was authored; it was not inferred from the task's seat metadata.
     expect(judgment.seatBriefCalls[0]!.thread.length).toBeGreaterThan(0);
-    expect(judgment.seatBriefCalls[0]!.negotiation.metadata.seats).toEqual({ [INTENT_ID]: { userId: SOURCE_USER_ID, round: negotiationHost.round } });
+    expect(judgment.seatBriefCalls[0]!.negotiation.metadata.seats).toEqual(task.metadata.seats);
     // And a re-kick rewrites only the initiator's half.
     await negotiationHost.database.setNegotiationBrief(task.id, SOURCE_USER_ID, "a fresh brief");
     expect(negotiationHost.taskFor(task.id).briefs[CANDIDATE_USER_ID]).toBe(theirs);
@@ -1456,12 +1497,194 @@ describe("PersonalAgent — the three decided design questions", () => {
     await agent.invoke({ userId: SOURCE_USER_ID, intentId: INTENT_ID, event: "matches_ready" });
 
     expect(negotiationHost.roundSize).toBe(1);
-    expect(negotiationHost.reflectJobs).toEqual([{ userId: SOURCE_USER_ID, intentId: INTENT_ID, round: stranded }]);
+    expect(negotiationHost.reflectJobs.filter((job) => job.intentId === INTENT_ID)).toEqual([{
+      userId: SOURCE_USER_ID, intentId: INTENT_ID, round: stranded, generation: "task-1.0",
+    }]);
   });
 });
 
 describe("PersonalAgent — round-6: per-seat binding and the kickoff region", () => {
   const BOB_INTENT = "intent-bob-1";
+
+  test("message_user is refused until an own ready_for_verdict pause is resolved", async () => {
+    class ResolveBeforeReplyJudgment extends ScriptedJudgment {
+      calls = 0;
+      override async next(
+        context: PersonalAgentTurnContext,
+        _executed: PersonalAgentExecutedAct[],
+        nonDurable: PersonalAgentNonDurableObservation[] = [],
+      ): Promise<PersonalAgentDecidedAct> {
+        this.calls += 1;
+        if (this.calls === 1) return { tool: "message_user", text: "I am done." };
+        if (this.calls === 2) {
+          expect(nonDurable).toContainEqual(expect.objectContaining({ kind: "terminal_message_refused" }));
+          return { tool: "reject", negotiationId: context.paused[0]!.negotiationId, reasoning: "Not a fit." };
+        }
+        expect(context.paused).toHaveLength(0);
+        return { tool: "message_user", text: "I dismissed the match." };
+      }
+    }
+    const judgment = new ResolveBeforeReplyJudgment([]);
+    const { agent, negotiationHost, principal } = buildCycle(judgment, [CANDIDATE_USER_ID]);
+    const task = await negotiationHost.createNegotiationTask({
+      conversationId: "conversation-owned-verdict",
+      briefs: {},
+      metadata: {
+        type: "negotiation",
+        opportunityId: OPPORTUNITY_ID,
+        sourceUserId: SOURCE_USER_ID,
+        candidateUserId: CANDIDATE_USER_ID,
+        initiatorUserId: SOURCE_USER_ID,
+        networkId: "network-1",
+        seats: { [INTENT_ID]: { userId: SOURCE_USER_ID, round: 1 } },
+        drainGeneration: 0,
+      },
+    });
+    await negotiationHost.database.updateNegotiationTaskState(task.id, "paused", {
+      reason: "ready_for_verdict",
+      pausedBy: SOURCE_USER_ID,
+      payload: { recommendation: "reject", reasoning: "Not a fit." },
+    });
+
+    const result = await agent.invoke({ userId: SOURCE_USER_ID, intentId: INTENT_ID, event: "all_paused", round: 1 });
+
+    expect(result.acts.map((act) => act.tool)).toEqual(["reject", "message_user"]);
+    expect(result.messages).toEqual(["I dismissed the match."]);
+    expect(principal.dmMessages.some((message) => message.content === "I am done.")).toBe(false);
+  });
+
+  test("a post-action failure cannot fall back to a terminal message over an own verdict pause", async () => {
+    class FailAfterDurableActJudgment extends ScriptedJudgment {
+      calls = 0;
+      override async next(): Promise<PersonalAgentDecidedAct> {
+        this.calls += 1;
+        if (this.calls === 1) return { tool: "note_dossier", text: "The client prefers a short engagement." };
+        throw new Error("model unavailable before verdict");
+      }
+    }
+    const judgment = new FailAfterDurableActJudgment([]);
+    const { agent, negotiationHost, principal } = buildCycle(judgment, [CANDIDATE_USER_ID]);
+    const task = await negotiationHost.createNegotiationTask({
+      conversationId: "conversation-owned-verdict-failure",
+      briefs: {},
+      metadata: {
+        type: "negotiation",
+        opportunityId: OPPORTUNITY_ID,
+        sourceUserId: SOURCE_USER_ID,
+        candidateUserId: CANDIDATE_USER_ID,
+        initiatorUserId: SOURCE_USER_ID,
+        networkId: "network-1",
+        seats: { [INTENT_ID]: { userId: SOURCE_USER_ID, round: 1 } },
+        drainGeneration: 0,
+      },
+    });
+    await negotiationHost.database.updateNegotiationTaskState(task.id, "paused", {
+      reason: "ready_for_verdict",
+      pausedBy: SOURCE_USER_ID,
+    });
+
+    const result = await agent.invoke({ userId: SOURCE_USER_ID, intentId: INTENT_ID, event: "all_paused", round: 1 });
+
+    expect(result.error).toBe("model unavailable before verdict");
+    expect(principal.ledgerRows.map((row) => row.act.tool)).toEqual(["note_dossier"]);
+    expect(principal.dmMessages.some((message) => message.content === PERSONAL_AGENT_POST_ACTION_FAILURE)).toBe(false);
+  });
+
+  test("needs_principal remains paused and is delivered as structured questions", async () => {
+    class AskStructurallyJudgment extends ScriptedJudgment {
+      calls = 0;
+      override async next(
+        _context: PersonalAgentTurnContext,
+        _executed: PersonalAgentExecutedAct[],
+        nonDurable: PersonalAgentNonDurableObservation[] = [],
+      ): Promise<PersonalAgentDecidedAct> {
+        this.calls += 1;
+        if (this.calls === 1) return { tool: "message_user", text: "I need one detail." };
+        expect(nonDurable).toContainEqual(expect.objectContaining({ kind: "terminal_message_refused" }));
+        return {
+          tool: "message_user",
+          text: "I need one detail.",
+          questions: [{
+            title: "Timing",
+            prompt: "When can you start?",
+            options: [
+              { label: "This month", description: "Start within a few weeks." },
+              { label: "Later", description: "Wait until next quarter." },
+            ],
+            multiSelect: false,
+          }],
+        };
+      }
+    }
+    const judgment = new AskStructurallyJudgment([]);
+    const { agent, negotiationHost, principal } = buildCycle(judgment, [CANDIDATE_USER_ID]);
+    const task = await negotiationHost.createNegotiationTask({
+      conversationId: "conversation-owned-question",
+      briefs: {},
+      metadata: {
+        type: "negotiation",
+        opportunityId: OPPORTUNITY_ID,
+        sourceUserId: SOURCE_USER_ID,
+        candidateUserId: CANDIDATE_USER_ID,
+        initiatorUserId: SOURCE_USER_ID,
+        networkId: "network-1",
+        seats: { [INTENT_ID]: { userId: SOURCE_USER_ID, round: 1 } },
+        drainGeneration: 0,
+      },
+    });
+    await negotiationHost.database.updateNegotiationTaskState(task.id, "paused", {
+      reason: "needs_principal",
+      pausedBy: SOURCE_USER_ID,
+      payload: { question: "When can you start?" },
+    });
+
+    const result = await agent.invoke({ userId: SOURCE_USER_ID, intentId: INTENT_ID, event: "all_paused", round: 1 });
+
+    expect(result.acts.map((act) => act.tool)).toEqual(["message_user"]);
+    expect(principal.dmMessages.at(-1)?.questions?.[0]?.prompt).toBe("When can you start?");
+    expect(negotiationHost.taskFor(task.id).state).toBe("paused");
+  });
+
+  test("a counterparty-owned verdict pause wakes that seat and its reject closes the opportunity", async () => {
+    const judgment = new ScriptedJudgment(
+      [
+        () => [{ tool: "kickoff", reasoning: "Daniel opens the match." }],
+        (context) => {
+          expect(context.userId).toBe(CANDIDATE_USER_ID);
+          expect(context.intentId).toBe(BOB_INTENT);
+          const ownVerdict = context.paused.find((paused) =>
+            paused.pausedByUs && paused.reason === "ready_for_verdict")!;
+          return [{ tool: "reject", negotiationId: ownVerdict.negotiationId, reasoning: "Not a fit for this side." }];
+        },
+      ],
+      (input) => input.isOpening
+        ? { verb: "outreach", message: "Would this be useful?", reasoning: "Opening." }
+        : { verb: "pause", reason: "ready_for_verdict", payload: { recommendation: "reject", reasoning: "Not a fit." } },
+    );
+    const { agent, negotiationHost } = buildCycle(judgment, [CANDIDATE_USER_ID]);
+
+    await agent.invoke({ userId: SOURCE_USER_ID, intentId: INTENT_ID, event: "matches_ready" });
+
+    const task = [...negotiationHost.tasks.values()][0]!;
+    expect(task.metadata.seats[BOB_INTENT]).toEqual({ userId: CANDIDATE_USER_ID, round: 0 });
+    const wake = negotiationHost.reflectJobs.find((job) => job.intentId === BOB_INTENT);
+    expect(wake).toEqual({
+      userId: CANDIDATE_USER_ID,
+      intentId: BOB_INTENT,
+      round: 0,
+      generation: `${task.id}.0`,
+    });
+
+    const drained = await agent.invoke({
+      userId: wake!.userId,
+      intentId: wake!.intentId,
+      event: "all_paused",
+      round: wake!.round,
+    });
+    expect(drained.acts.map((act) => act.tool)).toEqual(["reject", "message_user"]);
+    expect(negotiationHost.opportunities.get(OPPORTUNITY_ID)!.status).toBe("rejected");
+    expect(negotiationHost.taskFor(task.id).state).toBe("completed");
+  });
 
   /**
    * The pair-dedup case. Opportunities appear in BOTH actors' match lists, so
@@ -1608,7 +1831,7 @@ describe("PersonalAgent — round-6: per-seat binding and the kickoff region", (
     expect(negotiationHost.tasks.size).toBe(2);
     // The round settles both the successful and compensated task, so it can reflect.
     expect(negotiationHost.roundSize).toBe(2);
-    expect(negotiationHost.reflectJobs).toHaveLength(1);
+    expect(negotiationHost.reflectJobs.filter((job) => job.intentId === INTENT_ID)).toHaveLength(1);
     // And the loss is on the record, not silent.
     expect(principal.ledgerRows.some((row) => typeof row.act.reasoning === "string"
       && row.act.reasoning.includes("Could not open 1 of 2"))).toBe(true);

--- a/packages/protocol/src/index.ts
+++ b/packages/protocol/src/index.ts
@@ -239,6 +239,7 @@ export type {
 export { negotiationRoundReflectJobId, maybeEnqueueRoundReflect } from "./internal/negotiations/negotiation.round-reflect.js";
 export type {
   NegotiationRoundReflectJobData,
+  NegotiationRoundReflectCheck,
   NegotiationRoundReflectEnqueueFn,
 } from "./internal/negotiations/negotiation.round-reflect.js";
 // ─── PersonalAgent (AgentGraph) ─────────────────────────────────────────────

--- a/packages/protocol/src/internal/agents/personal-agent/agent.graph.ts
+++ b/packages/protocol/src/internal/agents/personal-agent/agent.graph.ts
@@ -25,13 +25,16 @@ import { END, StateGraph, Annotation } from "@langchain/langgraph";
 import { protocolLogger } from "../../shared/observability/protocol.logger.js";
 import { requestContext } from "../../shared/observability/request-context.js";
 import { turnsWithSenders, type NegotiationAuthoredTurn } from "../../negotiations/negotiation.turn.js";
+import { maybeEnqueueRoundReflect } from "../../negotiations/negotiation.round-reflect.js";
 import type { NegotiationTaskRow } from "../../../platform/database/negotiation.js";
 import type { IntentRecord } from "../../../platform/database/entities.js";
-import { normalizeMessageQuestions, PersonalAgentModel } from "./agent.judgment.js";
+import { isSupportedPersonalAgentStatusProse, normalizeMessageQuestions, PersonalAgentModel } from "./agent.judgment.js";
 import type { Question } from "../../../protocol/question.js";
 import type { PersonalAgentActivity, PersonalAgentDecidedAct, PersonalAgentDeps, PersonalAgentExecutedAct, PersonalAgentInput, PersonalAgentIntentEventKind, PersonalAgentMatch, PersonalAgentNonDurableObservation, PersonalAgentPausedNegotiation, PersonalAgentResult, PersonalAgentScope, PersonalAgentThreadEntry, PersonalAgentTurnContext } from "./agent.types.js";
 
 const logger = protocolLogger("PersonalAgentGraph");
+
+class UnresolvedOwnedPauseError extends Error {}
 
 /** How much conversation memory a turn reads. */
 const MAX_DM_MESSAGES = 20;
@@ -93,6 +96,12 @@ const NOT_KICKOFF_ELIGIBLE_STATUSES = new Set(["pending"]);
 
 /** Bounded tool steps keep a faulty model from holding a serialized inbox forever. */
 const MAX_INTENT_TOOL_STEPS = 8;
+
+function hasUnresolvedOwnedPause(context: PersonalAgentTurnContext): boolean {
+  return context.paused.some((paused) => paused.pausedByUs && (
+    paused.reason === "ready_for_verdict" || paused.reason === "needs_principal"
+  ));
+}
 
 // ─── State ───────────────────────────────────────────────────────────────────
 
@@ -191,7 +200,7 @@ async function assembleContext(
   // a matches_ready that cannot see its matches, or an all_paused that cannot
   // see its paused negotiations, must FAIL and be retried — swallowed, it
   // becomes a successful turn that saw nothing, decided nothing, and (for
-  // reflect) permanently consumed its once-per-round job id.
+  // reflect) permanently consumed that drain generation's job id.
   const [agentName, intent, allMatches, paused, dossier, recentActs] = await Promise.all([
     deps.identity.readAgentName(userId).catch(() => null),
     deps.negotiationDatabase.getIntent(intentId),
@@ -431,9 +440,9 @@ async function ledgerTerminalFallback(
 
 /**
  * Fixed, server-owned copy for a kickoff that has no one to reach out to.
- * Without this, the principal is told nothing at all and — with no negotiation left active and
- * the round's reflect job retained forever — nothing can wake the agent for
- * this signal again.
+ * Without this, the principal is told nothing at all and — with no negotiation
+ * left active and that drain generation's reflect job retained forever —
+ * nothing can wake the agent for this signal again.
  */
 export const PERSONAL_AGENT_NOTHING_TO_OPEN =
   "There is nothing new for me to put to anyone on this signal right now — what I have is either "
@@ -519,7 +528,7 @@ async function runKickoff(
   if (matches.length === 0) {
     throwIfIntentAborted();
     // Say so. With nothing active
-    // and the reflect job retained forever, silence here ends the cycle for
+    // and this drain's reflect job retained forever, silence here ends the cycle for
     // this signal with the principal never told.
     if (context.event !== "user_message") {
       await say(deps, context, accumulator, "message_user",
@@ -748,11 +757,11 @@ async function triggerRoundReflect(
 ): Promise<void> {
   const enqueue = deps.reflectEnqueue;
   if (!enqueue) return;
-  await retryWrite(async () => {
-    const active = await deps.negotiationDatabase.countActiveNegotiationsForRound(context.intentId, round);
-    if (active !== 0) return;
-    await enqueue({ userId: context.userId, intentId: context.intentId, round });
-  }, "enqueue a round's reflect", { intentId: context.intentId, round });
+  await maybeEnqueueRoundReflect(deps.negotiationDatabase, enqueue, {
+    userId: context.userId,
+    intentId: context.intentId,
+    round,
+  });
 }
 
 /**
@@ -1062,6 +1071,28 @@ async function intentNode(state: PersonalAgentState, deps: PersonalAgentDeps): P
         tool: act.tool,
         judgmentDurationMs: Date.now() - judgmentStartedAt,
       });
+      if (act.tool === "message_user") {
+        const ownReady = context.paused.some((paused) =>
+          paused.pausedByUs && paused.reason === "ready_for_verdict");
+        const ownNeedsPrincipal = context.paused.some((paused) =>
+          paused.pausedByUs && paused.reason === "needs_principal");
+        const refusal = !isSupportedPersonalAgentStatusProse(act.text, context)
+          ? "Counterparty status prose must stay within the public pause reason."
+          : ownReady
+          ? "Resolve every own ready_for_verdict pause with promote or reject before replying."
+          : ownNeedsPrincipal && !act.questions?.length
+            ? "An own needs_principal pause must be delivered as structured questions before replying."
+            : null;
+        if (refusal) {
+          logger.warn("PersonalAgent refused a terminal message while owning unresolved work", {
+            intentId: context.intentId,
+            event: context.event,
+            reason: refusal,
+          });
+          accumulator.nonDurable.push({ kind: "terminal_message_refused", reason: refusal });
+          continue;
+        }
+      }
       if (act.tool === "accept_opportunity" && context.event !== "user_message") {
         logger.warn("PersonalAgent refused acceptance without a client message", {
           intentId: context.intentId,
@@ -1097,12 +1128,6 @@ async function intentNode(state: PersonalAgentState, deps: PersonalAgentDeps): P
         } else {
           await publishActivity(deps, input, { phase: "working", label: TOOL_ACTIVITY_LABELS[act.tool].before });
           await executeAct(deps, context, accumulator, act);
-          if (act.tool === "note_dossier" || act.tool === "retire_dossier") {
-            context = {
-              ...context,
-              dossier: await deps.dossier.readActiveEntries(context.userId, context.intentId),
-            };
-          }
           await publishActivity(deps, input, { phase: "working", label: TOOL_ACTIVITY_LABELS[act.tool].after });
         }
       } catch (err) {
@@ -1124,9 +1149,15 @@ async function intentNode(state: PersonalAgentState, deps: PersonalAgentDeps): P
         durationMs: Date.now() - toolStartedAt,
       });
       if (act.tool === "message_user") break;
+      // Every next choice — especially the final narration — reads the state
+      // the action actually persisted, not the turn's opening snapshot.
+      context = await assembleContext(deps, input);
     }
     if (!accumulator.finalMessageChosen) {
       if (accumulator.acts.length === 0) throwIfIntentAborted();
+      if (hasUnresolvedOwnedPause(context)) {
+        throw new UnresolvedOwnedPauseError("PersonalAgent exhausted its tool budget with an unresolved owned pause");
+      }
       logger.warn("PersonalAgent exhausted its intent tool budget", { intentId: context.intentId, event: context.event });
       await publishActivity(deps, input, { phase: "preparing_response", label: "Preparing a response" });
       await say(deps, context, accumulator, "message_user", PERSONAL_AGENT_TOOL_BUDGET_EXHAUSTED);
@@ -1138,6 +1169,14 @@ async function intentNode(state: PersonalAgentState, deps: PersonalAgentDeps): P
       result: { scope: "intent", acts: accumulator.acts, messages: accumulator.messages },
     };
   } catch (err) {
+    if (err instanceof UnresolvedOwnedPauseError) {
+      return { phase: "error", error: err.message };
+    }
+    // A generic terminal fallback would silently consume this drain without
+    // deciding the owned verdict or delivering its structured question.
+    if (context && hasUnresolvedOwnedPause(context)) {
+      return { phase: "error", error: err instanceof Error ? err.message : String(err) };
+    }
     // An outer queue retry repeats the entire turn. Once a durable tool has
     // completed, a later invalid model choice must therefore terminate this
     // turn rather than replaying its earlier effects.

--- a/packages/protocol/src/internal/agents/personal-agent/agent.graph.ts
+++ b/packages/protocol/src/internal/agents/personal-agent/agent.graph.ts
@@ -1077,7 +1077,7 @@ async function intentNode(state: PersonalAgentState, deps: PersonalAgentDeps): P
         const ownNeedsPrincipal = context.paused.some((paused) =>
           paused.pausedByUs && paused.reason === "needs_principal");
         const refusal = !isSupportedPersonalAgentStatusProse(act.text, context)
-          ? "Counterparty status prose must stay within the public pause reason."
+          ? "Counterparty status prose must match the canonical public response exactly."
           : ownReady
           ? "Resolve every own ready_for_verdict pause with promote or reject before replying."
           : ownNeedsPrincipal && !act.questions?.length

--- a/packages/protocol/src/internal/agents/personal-agent/agent.graph.ts
+++ b/packages/protocol/src/internal/agents/personal-agent/agent.graph.ts
@@ -28,7 +28,7 @@ import { turnsWithSenders, type NegotiationAuthoredTurn } from "../../negotiatio
 import { maybeEnqueueRoundReflect } from "../../negotiations/negotiation.round-reflect.js";
 import type { NegotiationTaskRow } from "../../../platform/database/negotiation.js";
 import type { IntentRecord } from "../../../platform/database/entities.js";
-import { isSupportedPersonalAgentStatusProse, normalizeMessageQuestions, PersonalAgentModel } from "./agent.judgment.js";
+import { canonicalCounterpartyStatusProse, isSupportedPersonalAgentStatusProse, normalizeMessageQuestions, PersonalAgentModel } from "./agent.judgment.js";
 import type { Question } from "../../../protocol/question.js";
 import type { PersonalAgentActivity, PersonalAgentDecidedAct, PersonalAgentDeps, PersonalAgentExecutedAct, PersonalAgentInput, PersonalAgentIntentEventKind, PersonalAgentMatch, PersonalAgentNonDurableObservation, PersonalAgentPausedNegotiation, PersonalAgentResult, PersonalAgentScope, PersonalAgentThreadEntry, PersonalAgentTurnContext } from "./agent.types.js";
 
@@ -101,6 +101,10 @@ function hasUnresolvedOwnedPause(context: PersonalAgentTurnContext): boolean {
   return context.paused.some((paused) => paused.pausedByUs && (
     paused.reason === "ready_for_verdict" || paused.reason === "needs_principal"
   ));
+}
+
+function isOwnedReadyPause(paused: PersonalAgentPausedNegotiation): boolean {
+  return paused.pausedByUs && paused.reason === "ready_for_verdict";
 }
 
 // ─── State ───────────────────────────────────────────────────────────────────
@@ -239,6 +243,7 @@ async function assembleContext(
     match,
     eligible: !match.awaitingIntroducerApproval
       && !NOT_KICKOFF_ELIGIBLE_STATUSES.has(match.status)
+      && !paused.some((entry) => entry.opportunityId === match.opportunityId && !entry.pausedByUs)
       && !(await spentItsTurnBudget(deps, match)),
   })));
   const kickoffTargets = eligibility.filter((entry) => entry.eligible).map((entry) => entry.match);
@@ -554,7 +559,10 @@ async function runKickoff(
   };
   const strategy = await strategyOrFallback(judgment, kickoffContext);
   throwIfIntentAborted();
-  await say(deps, context, accumulator, "message_user", strategy);
+  const publicStrategy = isSupportedPersonalAgentStatusProse(strategy, kickoffContext)
+    ? strategy
+    : canonicalCounterpartyStatusProse(kickoffContext) ?? PERSONAL_AGENT_STRATEGY_FALLBACK;
+  await say(deps, context, accumulator, "message_user", publicStrategy);
 
   throwIfIntentAborted();
   const round = await deps.negotiationDatabase.bumpIntentNegotiationRound(context.intentId);
@@ -847,20 +855,19 @@ async function executeAct(
       return;
     case "promote":
     case "reject": {
-      // `judgment` is a documented swap seam, so this id is only as bounded as
-      // whatever produced it. A ref that names nothing skips with a ledgered
-      // failure rather than throwing mid-turn, which would abandon the acts
-      // already executed above it and retry them all.
+      // `judgment` is a documented swap seam, so enforce both visibility and
+      // pause ownership again at the effects boundary. A refused ref is
+      // ledgered rather than thrown so earlier durable acts are not retried.
       const paused = context.paused.find((entry) => entry.negotiationId === act.negotiationId);
-      if (!paused) {
-        logger.warn("Decided a verdict on a negotiation this turn cannot see", {
+      if (!paused || !isOwnedReadyPause(paused)) {
+        logger.warn("Decided a verdict without an owned ready_for_verdict pause", {
           intentId: context.intentId,
           negotiationId: act.negotiationId,
         });
         const missing: PersonalAgentExecutedAct = {
           tool: act.tool,
           negotiationId: act.negotiationId,
-          opportunityId: "",
+          opportunityId: paused?.opportunityId ?? "",
           reasoning: act.reasoning,
           outcome: "error",
         };

--- a/packages/protocol/src/internal/agents/personal-agent/agent.judgment.ts
+++ b/packages/protocol/src/internal/agents/personal-agent/agent.judgment.ts
@@ -75,6 +75,18 @@ export function normalizeMessageQuestions(raw: unknown): Question[] | undefined 
   return questions.length > 0 ? questions : undefined;
 }
 
+const UNSUPPORTED_COUNTERPART_STATUS_PATTERN = /\b(?:respond(?:ed|ing)?|responses?|repl(?:y|ied|ying)|heard back|got(?:ten)? back|review(?:ed|ing)?|look(?:ed|ing)?\s+(?:at|over|through)|evaluat(?:ed|ing)?|assess(?:ed|ing)?|examin(?:ed|ing)?|check(?:ed|ing)?|consider(?:ed|ing)?|weigh(?:ed|ing)?|asked|questioned)\b/i;
+
+/** Fail closed on details the public counterpart pause state cannot prove. */
+export function isSupportedPersonalAgentStatusProse(
+  text: string,
+  context: PersonalAgentTurnContext,
+): boolean {
+  const counterpartIsOnlyDeciding = context.paused.some((paused) =>
+    !paused.pausedByUs && paused.reason === "ready_for_verdict");
+  return !counterpartIsOnlyDeciding || !UNSUPPORTED_COUNTERPART_STATUS_PATTERN.test(text);
+}
+
 // ─── Rendering ───────────────────────────────────────────────────────────────
 
 function renderThread(thread: PersonalAgentThreadEntry[], indent = ""): string {
@@ -90,6 +102,16 @@ function renderThread(thread: PersonalAgentThreadEntry[], indent = ""): string {
 function renderPaused(context: PersonalAgentTurnContext): string {
   if (context.paused.length === 0) return "Paused negotiations: none.";
   const lines = context.paused.map((paused, index) => {
+    if (!paused.pausedByUs) {
+      const publicState = paused.reason === "ready_for_verdict"
+        ? "The counterpart side is deciding. That is the complete public state: do not claim what it reviewed, whether it responded, or what it is deciding about."
+        : paused.reason === "needs_principal"
+          ? "The counterpart side is waiting on its principal. Their question is private."
+          : paused.reason === "counterparty_silent"
+            ? "The counterpart side is waiting for a response."
+            : `The counterpart side paused (${paused.reason}).`;
+      return `${index + 1}. ${publicState}`;
+    }
     const parts = [`${index + 1}. Paused (${paused.reason}) by ${paused.pausedByUs ? "your own seat" : "their agent"}`];
     const payload = paused.payload as { question?: string; recommendation?: string; reasoning?: string } | undefined;
     if (payload?.question) parts.push(`   Needs from your client: ${truncate(payload.question, MAX_TEXT_CHARS)}`);
@@ -196,6 +218,7 @@ function renderNonDurableObservations(
 ): string {
   if (observations.length === 0) return "";
   const lines = observations.map((observation) => {
+    if (observation.kind === "terminal_message_refused") return `- Refused message_user: ${observation.reason}`;
     if (observation.tool === "kickoff") return `- Refused kickoff: ${observation.reason}`;
     if (observation.tool === "accept_opportunity") {
       const position = context.matches.findIndex((match) => match.opportunityId === observation.opportunityId);
@@ -420,6 +443,7 @@ export function validateDecidedAct(
       {
         const text = act.text?.trim();
         if (!text || !isSafeAgentMessageProse(text)) return null;
+        if (!isSupportedPersonalAgentStatusProse(text, context)) return null;
         const questions = normalizeMessageQuestions(act.questions);
         // Questions belong in the structured field. Keeping them out of prose
         // prevents the same ask rendering twice and guarantees widget delivery.

--- a/packages/protocol/src/internal/agents/personal-agent/agent.judgment.ts
+++ b/packages/protocol/src/internal/agents/personal-agent/agent.judgment.ts
@@ -324,7 +324,7 @@ export class PersonalAgentModel implements PersonalAgentJudgment {
       { role: "user", content: renderPersonalAgentTurn(context) },
     ]));
     const text = parsed.success ? parsed.data.text.trim() : "";
-    if (!text || !isSafeAgentMessageProse(text)) {
+    if (!text || !isSafeAgentMessageProse(text) || !isSupportedPersonalAgentStatusProse(text, context)) {
       throw new Error("PersonalAgent produced no usable strategy");
     }
     return text;
@@ -479,9 +479,11 @@ export function validateDecidedAct(
       case "promote":
       case "reject": {
         if (!act.negotiation || act.negotiation > context.paused.length) return null;
+        const paused = context.paused[act.negotiation - 1]!;
+        if (!paused.pausedByUs || paused.reason !== "ready_for_verdict") return null;
         return {
           tool: act.act,
-          negotiationId: context.paused[act.negotiation - 1]!.negotiationId,
+          negotiationId: paused.negotiationId,
           reasoning: act.reasoning?.trim() || (act.act === "promote" ? "Worth surfacing." : "Not a match."),
         };
       }

--- a/packages/protocol/src/internal/agents/personal-agent/agent.judgment.ts
+++ b/packages/protocol/src/internal/agents/personal-agent/agent.judgment.ts
@@ -75,16 +75,40 @@ export function normalizeMessageQuestions(raw: unknown): Question[] | undefined 
   return questions.length > 0 ? questions : undefined;
 }
 
-const UNSUPPORTED_COUNTERPART_STATUS_PATTERN = /\b(?:respond(?:ed|ing)?|responses?|repl(?:y|ied|ying)|heard back|got(?:ten)? back|review(?:ed|ing)?|look(?:ed|ing)?\s+(?:at|over|through)|evaluat(?:ed|ing)?|assess(?:ed|ing)?|examin(?:ed|ing)?|check(?:ed|ing)?|consider(?:ed|ing)?|weigh(?:ed|ing)?|asked|questioned)\b/i;
+function canonicalCounterpartyPauseProse(
+  reason: PersonalAgentTurnContext["paused"][number]["reason"],
+): string {
+  switch (reason) {
+    case "ready_for_verdict":
+      return "The other side is deciding.";
+    case "needs_principal":
+      return "The other side is waiting on its principal.";
+    case "counterparty_silent":
+      return "The other side is waiting for a response.";
+    case "turn_cap":
+      return "The negotiation reached its turn limit.";
+    case "open_failed":
+      return "The negotiation could not be opened.";
+    default:
+      return "The other side is paused.";
+  }
+}
 
-/** Fail closed on details the public counterpart pause state cannot prove. */
+/** The complete server-owned narration for every public counterpart pause. */
+export function canonicalCounterpartyStatusProse(context: PersonalAgentTurnContext): string | null {
+  const statuses = [...new Set(context.paused
+    .filter((paused) => !paused.pausedByUs)
+    .map((paused) => canonicalCounterpartyPauseProse(paused.reason)))];
+  return statuses.length > 0 ? statuses.join(" ") : null;
+}
+
+/** Counterparty state is server-owned, never inferred from model vocabulary. */
 export function isSupportedPersonalAgentStatusProse(
   text: string,
   context: PersonalAgentTurnContext,
 ): boolean {
-  const counterpartIsOnlyDeciding = context.paused.some((paused) =>
-    !paused.pausedByUs && paused.reason === "ready_for_verdict");
-  return !counterpartIsOnlyDeciding || !UNSUPPORTED_COUNTERPART_STATUS_PATTERN.test(text);
+  const canonical = canonicalCounterpartyStatusProse(context);
+  return canonical === null || text.trim() === canonical;
 }
 
 // ─── Rendering ───────────────────────────────────────────────────────────────
@@ -103,14 +127,7 @@ function renderPaused(context: PersonalAgentTurnContext): string {
   if (context.paused.length === 0) return "Paused negotiations: none.";
   const lines = context.paused.map((paused, index) => {
     if (!paused.pausedByUs) {
-      const publicState = paused.reason === "ready_for_verdict"
-        ? "The counterpart side is deciding. That is the complete public state: do not claim what it reviewed, whether it responded, or what it is deciding about."
-        : paused.reason === "needs_principal"
-          ? "The counterpart side is waiting on its principal. Their question is private."
-          : paused.reason === "counterparty_silent"
-            ? "The counterpart side is waiting for a response."
-            : `The counterpart side paused (${paused.reason}).`;
-      return `${index + 1}. ${publicState}`;
+      return `${index + 1}. ${canonicalCounterpartyPauseProse(paused.reason)}`;
     }
     const parts = [`${index + 1}. Paused (${paused.reason}) by ${paused.pausedByUs ? "your own seat" : "their agent"}`];
     const payload = paused.payload as { question?: string; recommendation?: string; reasoning?: string } | undefined;
@@ -166,6 +183,7 @@ function renderEvent(context: PersonalAgentTurnContext): string {
 
 /** What judgment sees, rendered; exported for the live eval's transparency. */
 export function renderPersonalAgentTurn(context: PersonalAgentTurnContext): string {
+  const canonicalCounterpartyStatus = canonicalCounterpartyStatusProse(context);
   return [
     context.signalText ? `Your client's signal: ${truncate(context.signalText, 800)}` : "Your client's signal text is unavailable.",
     "",
@@ -177,6 +195,10 @@ export function renderPersonalAgentTurn(context: PersonalAgentTurnContext): stri
     renderLedger(context),
     "",
     renderDm(context),
+    "",
+    canonicalCounterpartyStatus
+      ? `CANONICAL COUNTERPART STATUS RESPONSE:\n${canonicalCounterpartyStatus}\nBecause counterpart status is present, message_user text must be exactly this server-owned response. Put any questions in the structured questions field.`
+      : "",
     "",
     renderEvent(context),
   ].join("\n");

--- a/packages/protocol/src/internal/agents/personal-agent/agent.prompt.ts
+++ b/packages/protocol/src/internal/agents/personal-agent/agent.prompt.ts
@@ -16,7 +16,7 @@ import { buildAgentSelfIntroduction, type AgentIdentityOptions } from "../../cha
 import { hasUnsupportedOpportunityClaim } from "../../shared/utils/claim-safety.js";
 import type { PersonalAgentIntentEventKind } from "./agent.types.js";
 
-export const PERSONAL_AGENT_SYSTEM_PROMPT_VERSION = 9;
+export const PERSONAL_AGENT_SYSTEM_PROMPT_VERSION = 10;
 
 const INTERNAL_OR_PRIVATE_PATTERN = /\b(?:[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}|(?:task|intent|network|opportunity|user|match)[_-]?id|private transcript|raw transcript|assessment(?:\.reasoning)?|seed assessment|evaluator reasoning|match reason|matchReason|internal metadata|counterparty profile)\b/i;
 
@@ -71,7 +71,7 @@ The law you operate under:
 
 2. Ask in your own words, grounded in what actually stalled: name the thing the negotiation needs, not the machinery behind it. Put each ask in a separate structured question and use the message text only for a short introduction; do not duplicate question prompts in prose. An unresolved question about one matter does not prevent you from acting on another matter that is resolved. When your client has answered — even late, even obliquely, even folded into another thought — take it as the answer and decide. They may also tell you to go with what you have; that is an answer too, and you then act on what you know, re-opening only the tables whose open questions you can now speak to.
 
-3. You are the only one who ends a negotiation. Your negotiator seats never accept, decline or withdraw — they reach out, push back, ask, or pause. A table that paused recommending "reject" is a recommendation, not a decision: it is yours to make, from the whole picture rather than one table's view.
+3. You end a negotiation only when your own negotiator seat paused ready_for_verdict. Your negotiator seats never accept, decline or withdraw — they reach out, push back, ask, or pause. A table that your seat paused recommending "reject" is a recommendation, not a decision: it is yours to make, from the whole picture rather than one table's view. A counterparty-owned pause belongs to that side's agent: never promote, reject, or re-open it.
 
 4. Everything you may use at the negotiation table must be in the dossier. When your client tells you something negotiations may rely on — even in passing, even mid-sentence — note it. What is not in the dossier stays in this room.
 
@@ -94,7 +94,7 @@ export function personalAgentEventInstruction(event: PersonalAgentIntentEventKin
     case "matches_ready":
       return `THE EVENT: discovery has just found matches for this signal. Decide what can usefully happen now. You may kickoff resolved work and still use message_user to ask about a separate unresolved matter.`;
     case "all_paused":
-      return `THE EVENT: every negotiation of this durable drain has paused; they are listed above with what each is waiting on. Reflect on each independently: promote or reject the tables you can resolve, re-kick those you can advance, and ask your client about what remains unresolved in your final message_user response. You may not finish while one of your own ready_for_verdict pauses remains unresolved.`;
+      return `THE EVENT: every negotiation of this durable drain has paused; they are listed above with what each is waiting on. Reflect on each independently: promote or reject only your own ready_for_verdict pauses, re-kick only your own pauses that new information can advance, and ask your client about what remains unresolved in your final message_user response. Counterparty-owned pauses are visible status only. You may not finish while one of your own ready_for_verdict pauses remains unresolved.`;
   }
 }
 

--- a/packages/protocol/src/internal/agents/personal-agent/agent.prompt.ts
+++ b/packages/protocol/src/internal/agents/personal-agent/agent.prompt.ts
@@ -16,7 +16,7 @@ import { buildAgentSelfIntroduction, type AgentIdentityOptions } from "../../cha
 import { hasUnsupportedOpportunityClaim } from "../../shared/utils/claim-safety.js";
 import type { PersonalAgentIntentEventKind } from "./agent.types.js";
 
-export const PERSONAL_AGENT_SYSTEM_PROMPT_VERSION = 7;
+export const PERSONAL_AGENT_SYSTEM_PROMPT_VERSION = 8;
 
 const INTERNAL_OR_PRIVATE_PATTERN = /\b(?:[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}|(?:task|intent|network|opportunity|user|match)[_-]?id|private transcript|raw transcript|assessment(?:\.reasoning)?|seed assessment|evaluator reasoning|match reason|matchReason|internal metadata|counterparty profile)\b/i;
 
@@ -81,7 +81,7 @@ The law you operate under:
 
 7. Never reveal or invent counterparty identity beyond what the match list shows, internal identifiers, scores, or system machinery. Speak about negotiations in terms of what they need from your client.
 
-8. When your client asks what is happening, tell them plainly from the listed state: which matches are live, what is waiting on them, what you are doing about it. Ordinary conversation gets an honest, brief reply from what you know about this signal — nothing more is required of it.
+8. When your client asks what is happening, tell them plainly from the listed durable state: which matches are live, what is waiting on them, what you are doing about it. A counterpart pause is exhaustive public state: never claim that side responded, failed to respond, reviewed a topic, or is considering a particular detail unless that exact fact is listed. Ordinary conversation gets an honest, brief reply from what you know about this signal — nothing more is required of it.
 
 You will be shown the paused negotiations, the dossier entries, and your client's matches as numbered lists. Refer to them ONLY by those numbers. Never invent a number that is not listed.`;
 }
@@ -94,7 +94,7 @@ export function personalAgentEventInstruction(event: PersonalAgentIntentEventKin
     case "matches_ready":
       return `THE EVENT: discovery has just found matches for this signal. Decide what can usefully happen now. You may kickoff resolved work and still use message_user to ask about a separate unresolved matter.`;
     case "all_paused":
-      return `THE EVENT: every negotiation of this round has paused; they are listed above with what each is waiting on. Reflect on each independently: promote or reject the tables you can resolve, re-kick those you can advance, and ask your client about what remains unresolved in your final message_user response.`;
+      return `THE EVENT: every negotiation of this durable drain has paused; they are listed above with what each is waiting on. Reflect on each independently: promote or reject the tables you can resolve, re-kick those you can advance, and ask your client about what remains unresolved in your final message_user response. You may not finish while one of your own ready_for_verdict pauses remains unresolved.`;
   }
 }
 

--- a/packages/protocol/src/internal/agents/personal-agent/agent.prompt.ts
+++ b/packages/protocol/src/internal/agents/personal-agent/agent.prompt.ts
@@ -16,7 +16,7 @@ import { buildAgentSelfIntroduction, type AgentIdentityOptions } from "../../cha
 import { hasUnsupportedOpportunityClaim } from "../../shared/utils/claim-safety.js";
 import type { PersonalAgentIntentEventKind } from "./agent.types.js";
 
-export const PERSONAL_AGENT_SYSTEM_PROMPT_VERSION = 8;
+export const PERSONAL_AGENT_SYSTEM_PROMPT_VERSION = 9;
 
 const INTERNAL_OR_PRIVATE_PATTERN = /\b(?:[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}|(?:task|intent|network|opportunity|user|match)[_-]?id|private transcript|raw transcript|assessment(?:\.reasoning)?|seed assessment|evaluator reasoning|match reason|matchReason|internal metadata|counterparty profile)\b/i;
 
@@ -81,7 +81,7 @@ The law you operate under:
 
 7. Never reveal or invent counterparty identity beyond what the match list shows, internal identifiers, scores, or system machinery. Speak about negotiations in terms of what they need from your client.
 
-8. When your client asks what is happening, tell them plainly from the listed durable state: which matches are live, what is waiting on them, what you are doing about it. A counterpart pause is exhaustive public state: never claim that side responded, failed to respond, reviewed a topic, or is considering a particular detail unless that exact fact is listed. Ordinary conversation gets an honest, brief reply from what you know about this signal — nothing more is required of it.
+8. When your client asks what is happening, tell them plainly from the listed durable state: which matches are live, what is waiting on them, what you are doing about it. When a CANONICAL COUNTERPART STATUS RESPONSE is listed, use it verbatim as the complete message_user text; any questions remain in the structured questions field. Ordinary conversation gets an honest, brief reply from what you know about this signal — nothing more is required of it.
 
 You will be shown the paused negotiations, the dossier entries, and your client's matches as numbered lists. Refer to them ONLY by those numbers. Never invent a number that is not listed.`;
 }

--- a/packages/protocol/src/internal/agents/personal-agent/agent.types.ts
+++ b/packages/protocol/src/internal/agents/personal-agent/agent.types.ts
@@ -129,6 +129,10 @@ export type PersonalAgentExecutedAct =
  */
 export type PersonalAgentNonDurableObservation =
   | {
+    kind: "terminal_message_refused";
+    reason: string;
+  }
+  | {
     kind: "irreversible_tool_refused";
     tool: "kickoff";
     reason: string;

--- a/packages/protocol/src/internal/agents/personal-agent/tests/agent.judgment.spec.ts
+++ b/packages/protocol/src/internal/agents/personal-agent/tests/agent.judgment.spec.ts
@@ -80,9 +80,53 @@ describe("validateDecidedAct", () => {
       context({ event: "matches_ready", message: undefined }),
     )).toBeNull();
   });
+
+  test("counterparty deciding state cannot become invented response or review narration", () => {
+    const deciding = context({
+      event: "all_paused",
+      message: undefined,
+      round: 1,
+      paused: [{
+        negotiationId: "task-1",
+        opportunityId: "opportunity-1",
+        reason: "ready_for_verdict",
+        pausedByUs: false,
+        thread: [],
+      }],
+    });
+
+    expect(validateDecidedAct({
+      act: "message_user",
+      text: "They still have not responded and are reviewing the pricing details.",
+    }, deciding)).toBeNull();
+    expect(validateDecidedAct({ act: "message_user", text: "There is no response yet." }, deciding)).toBeNull();
+    expect(validateDecidedAct({ act: "message_user", text: "They are assessing the pricing." }, deciding)).toBeNull();
+    expect(validateDecidedAct({ act: "message_user", text: "The other side is deciding." }, deciding))
+      .toEqual({ tool: "message_user", text: "The other side is deciding." });
+  });
 });
 
 describe("PersonalAgentModel", () => {
+  test("counterparty pause rendering exposes only public state, not thread topics", async () => {
+    const model = new CapturingPersonalAgentModel();
+    await model.next(context({
+      event: "all_paused",
+      message: undefined,
+      round: 1,
+      paused: [{
+        negotiationId: "task-1",
+        opportunityId: "opportunity-1",
+        reason: "ready_for_verdict",
+        pausedByUs: false,
+        thread: [{ speaker: "counterparty", turn: { verb: "counter", message: "SECRET_PRICING_TOPIC", reasoning: "private" } }],
+      }],
+    }), []);
+
+    const prompt = model.lastMessages.find((message) => message.role === "user")?.content;
+    expect(prompt).toContain("The counterpart side is deciding");
+    expect(prompt).not.toContain("SECRET_PRICING_TOPIC");
+  });
+
   test("renders refused irreversible calls as non-durable observations", async () => {
     const model = new CapturingPersonalAgentModel();
     const observation: PersonalAgentNonDurableObservation = {

--- a/packages/protocol/src/internal/agents/personal-agent/tests/agent.judgment.spec.ts
+++ b/packages/protocol/src/internal/agents/personal-agent/tests/agent.judgment.spec.ts
@@ -8,7 +8,7 @@ class CapturingPersonalAgentModel extends PersonalAgentModel {
 
   protected override async callActsModel(messages: Array<{ role: string; content: string }>): Promise<unknown> {
     this.lastMessages = messages;
-    return { act: "message_user", text: "I chose a different next step." };
+    return { act: "message_user", text: "The other side is deciding." };
   }
 }
 
@@ -101,6 +101,9 @@ describe("validateDecidedAct", () => {
     }, deciding)).toBeNull();
     expect(validateDecidedAct({ act: "message_user", text: "There is no response yet." }, deciding)).toBeNull();
     expect(validateDecidedAct({ act: "message_user", text: "They are assessing the pricing." }, deciding)).toBeNull();
+    expect(validateDecidedAct({ act: "message_user", text: "They are deliberating over the pricing terms." }, deciding)).toBeNull();
+    expect(validateDecidedAct({ act: "message_user", text: "They are thinking through your proposed timeline." }, deciding)).toBeNull();
+    expect(validateDecidedAct({ act: "message_user", text: "The other side is deciding. I will keep you posted." }, deciding)).toBeNull();
     expect(validateDecidedAct({ act: "message_user", text: "The other side is deciding." }, deciding))
       .toEqual({ tool: "message_user", text: "The other side is deciding." });
   });
@@ -123,7 +126,7 @@ describe("PersonalAgentModel", () => {
     }), []);
 
     const prompt = model.lastMessages.find((message) => message.role === "user")?.content;
-    expect(prompt).toContain("The counterpart side is deciding");
+    expect(prompt).toContain("CANONICAL COUNTERPART STATUS RESPONSE:\nThe other side is deciding.");
     expect(prompt).not.toContain("SECRET_PRICING_TOPIC");
   });
 

--- a/packages/protocol/src/internal/agents/personal-agent/tests/agent.judgment.spec.ts
+++ b/packages/protocol/src/internal/agents/personal-agent/tests/agent.judgment.spec.ts
@@ -35,6 +35,12 @@ class SignalCapturingPersonalAgentModel extends PersonalAgentModel {
   }
 }
 
+class UnsupportedStrategyModel extends PersonalAgentModel {
+  protected override async callProseModel(): Promise<unknown> {
+    return { text: "They are deliberating over the pricing terms while I contact another match." };
+  }
+}
+
 function context(overrides: Partial<PersonalAgentTurnContext> = {}): PersonalAgentTurnContext {
   return {
     userId: "alice", intentId: "intent-1", event: "user_message",
@@ -70,6 +76,17 @@ describe("validateDecidedAct", () => {
 
   test("keeps references bounded to the state the model was shown", () => {
     expect(validateDecidedAct({ act: "reject", negotiation: 2 }, context())).toBeNull();
+  });
+
+  test("permits verdicts only for an owned ready_for_verdict pause", () => {
+    expect(validateDecidedAct({ act: "promote", negotiation: 1 }, context()))
+      .toEqual({ tool: "promote", negotiationId: "task-1", reasoning: "Worth surfacing." });
+    expect(validateDecidedAct({ act: "reject", negotiation: 1 }, context({
+      paused: [{ negotiationId: "task-1", opportunityId: "opportunity-1", reason: "needs_principal", pausedByUs: true, thread: [] }],
+    }))).toBeNull();
+    expect(validateDecidedAct({ act: "reject", negotiation: 1 }, context({
+      paused: [{ negotiationId: "task-1", opportunityId: "opportunity-1", reason: "ready_for_verdict", pausedByUs: false, thread: [] }],
+    }))).toBeNull();
   });
 
   test("accepts only a bounded user-message verdict and rejects background acceptance", () => {
@@ -110,6 +127,19 @@ describe("validateDecidedAct", () => {
 });
 
 describe("PersonalAgentModel", () => {
+  test("rejects kickoff strategy prose that bypasses canonical counterpart status", async () => {
+    const model = new UnsupportedStrategyModel();
+    await expect(model.strategy(context({
+      paused: [{
+        negotiationId: "task-1",
+        opportunityId: "opportunity-1",
+        reason: "ready_for_verdict",
+        pausedByUs: false,
+        thread: [],
+      }],
+    }))).rejects.toThrow("PersonalAgent produced no usable strategy");
+  });
+
   test("counterparty pause rendering exposes only public state, not thread topics", async () => {
     const model = new CapturingPersonalAgentModel();
     await model.next(context({

--- a/packages/protocol/src/internal/negotiations/negotiation.graph.ts
+++ b/packages/protocol/src/internal/negotiations/negotiation.graph.ts
@@ -48,6 +48,8 @@ export type NegotiationGraphInput =
   | { negotiationId: string; verdict: NegotiationVerdict; reasoning: string; byUserId: string }
   /** Close a task after the host has already committed its owner's terminal opportunity action. */
   | { negotiationId: string; close: { reason: "owner_verdict"; verdict: NegotiationVerdict; reasoning: string }; byUserId: string }
+  /** Close an active task after the host has expired its opportunity. */
+  | { negotiationId: string; close: { reason: "opportunity_expired" } }
   | { negotiationId: string };
 
 export interface NegotiationGraphResult {
@@ -507,12 +509,24 @@ async function resolveNode(state: NegotiationState, deps: NegotiationGraphDeps):
   }
 }
 
-/** Host-only closure after OpportunityService has committed the owner's terminal action. */
+/** Host-only closure after a terminal opportunity action. */
 async function closeNode(state: NegotiationState, deps: NegotiationGraphDeps): Promise<Partial<NegotiationState>> {
   const task = state.task;
   const input = state.input;
   if (!task || !("close" in input)) return { phase: "error", error: "Missing task or close action" };
   try {
+    if (input.close.reason === "opportunity_expired") {
+      const updated = await deps.database.completeNegotiation({
+        taskId: task.id,
+        kind: "opportunity_expired",
+      });
+      if (!updated) return { phase: "error", error: "Expiry closure requires a live task and expired opportunity" };
+      if (await triggerReflectForEverySeat(deps, task.metadata)) {
+        await clearReflectPendingBestEffort(deps, task.id);
+      }
+      return { task: updated, phase: "done", result: { negotiationId: task.id, status: "resolved", turns: [] } };
+    }
+    if (!("byUserId" in input)) return { phase: "error", error: "Missing owner-verdict resolver" };
     const isSeat = Object.values(task.metadata.seats).some((seat) => seat.userId === input.byUserId)
       || task.metadata.sourceUserId === input.byUserId
       || task.metadata.candidateUserId === input.byUserId;

--- a/packages/protocol/src/internal/negotiations/negotiation.graph.ts
+++ b/packages/protocol/src/internal/negotiations/negotiation.graph.ts
@@ -6,11 +6,12 @@
  * port (callers pass ids, never pre-built contexts); `turn` produces the
  * current seat's move, in-process or via an external agent; `apply` is the
  * one sink for every turn regardless of source and decides continue/pause;
- * `resolve` is the only terminal write.
+ * `resolve` records a pause owner's verdict, while `close` ends a task after
+ * the host has already committed an opportunity-owner verdict.
  *
  * The negotiator never concludes a negotiation. It only ever continues or
- * pauses. `resolve` is invoked separately (by IS-A, in step 2; nothing calls
- * it yet in this PR) once a decision has actually been made.
+ * pauses. `resolve` is invoked separately by the owning PersonalAgent once a
+ * decision has actually been made.
  */
 import { END, StateGraph, Annotation } from "@langchain/langgraph";
 
@@ -52,6 +53,8 @@ export type NegotiationGraphInput =
   | { negotiationId: string; expire: { expectedUpdatedAt: Date; reason: 'counterparty_silent' | 'needs_principal' } }
   /** A verdict is authored by one authenticated seat, never by an anonymous resolver. */
   | { negotiationId: string; verdict: NegotiationVerdict; reasoning: string; byUserId: string }
+  /** Close a task after the host has already committed its owner's terminal opportunity action. */
+  | { negotiationId: string; close: { reason: "owner_verdict"; verdict: NegotiationVerdict; reasoning: string }; byUserId: string }
   | { negotiationId: string };
 
 export interface NegotiationGraphResult {
@@ -94,7 +97,7 @@ const NegotiationGraphState = Annotation.Root({
   pendingTurnByUserId: Annotation<string | null>({ reducer: (c, n) => (n === undefined ? c : n), default: () => null }),
   /** True once this invoke's own author/dispatch has produced `pendingTurn` — vs. one supplied on input. */
   authored: Annotation<boolean>({ reducer: (c, n) => n ?? c, default: () => false }),
-  phase: Annotation<"init" | "turn" | "apply" | "resolve" | "expire" | "read" | "done" | "error">({
+  phase: Annotation<"init" | "turn" | "apply" | "resolve" | "close" | "expire" | "read" | "done" | "error">({
     reducer: (c, n) => n ?? c,
     default: () => "init",
   }),
@@ -145,6 +148,12 @@ async function initNode(state: NegotiationState, deps: NegotiationGraphDeps): Pr
       const task = await deps.database.getNegotiationTask(input.negotiationId);
       if (!task) return { phase: "error", error: "Negotiation not found" };
       return { task, phase: "resolve" };
+    }
+
+    if ("close" in input) {
+      const task = await deps.database.getNegotiationTask(input.negotiationId);
+      if (!task) return { phase: "error", error: "Negotiation not found" };
+      return { task, phase: "close" };
     }
 
     // ── read-only ──
@@ -464,6 +473,13 @@ async function resolveNode(state: NegotiationState, deps: NegotiationGraphDeps):
       || task.metadata.sourceUserId === input.byUserId
       || task.metadata.candidateUserId === input.byUserId;
     if (!isSeat) return { phase: "error", error: "Only a negotiation seat may resolve it" };
+    const ownsReadyPause = task.state === "paused"
+      && task.metadata.pause?.reason === "ready_for_verdict"
+      && task.metadata.pause.pausedBy === input.byUserId;
+    if (!ownsReadyPause) {
+      return { phase: "error", error: "Only the seat owning a ready_for_verdict pause may resolve it" };
+    }
+    const opportunity = await deps.database.getOpportunity(task.metadata.opportunityId);
     // reasoning is private to the resolving side — recorded on the outcome
     // artifact only, never persisted into the A2A thread as a message; the
     // counterparty sees only that the negotiation closed.
@@ -473,17 +489,10 @@ async function resolveNode(state: NegotiationState, deps: NegotiationGraphDeps):
       resolvedByUserId: input.byUserId,
     });
     const updated = await deps.database.updateNegotiationTaskState(task.id, "completed");
-    // The opportunity status is resolve's to write UNLESS the owner has
-    // already written a terminal one. An owner verdict (Radar skip/accept,
-    // `PATCH /opportunities/:id/status`, the DM's accept/reject tools) is a
-    // user action outside this loop by design — it writes `accepted` /
-    // `rejected` itself and then calls resolve to CLOSE the negotiation,
-    // because a terminal opportunity whose task stays `working` holds its
-    // round open forever and the round's reflect job never fires. Rewriting
-    // the status here would downgrade that owner's `accepted` back to
-    // `pending` and re-fire the actionable notification for a match they
-    // have already accepted.
-    const opportunity = await deps.database.getOpportunity(task.metadata.opportunityId);
+    // A pause-owner verdict normally writes the opportunity status here. If a
+    // concurrent owner action already made it terminal, preserve that action;
+    // the host's explicit owner-close lane handles the ordinary owner-verdict
+    // path without granting this public verdict input broader authority.
     if (!opportunity || !TERMINAL_OPPORTUNITY_STATUSES.has(opportunity.status)) {
       await deps.database.updateOpportunityStatus(
         task.metadata.opportunityId,
@@ -495,6 +504,43 @@ async function resolveNode(state: NegotiationState, deps: NegotiationGraphDeps):
     // way a round finishes.
     await triggerReflectForEverySeat(deps, task.metadata);
     return { task: updated, phase: "done", result: { negotiationId: task.id, status: "resolved", verdict: input.verdict, reasoning: input.reasoning, turns: [] } };
+  } catch (err) {
+    return { phase: "error", error: err instanceof Error ? err.message : String(err) };
+  }
+}
+
+/** Host-only closure after OpportunityService has committed the owner's terminal action. */
+async function closeNode(state: NegotiationState, deps: NegotiationGraphDeps): Promise<Partial<NegotiationState>> {
+  const task = state.task;
+  const input = state.input;
+  if (!task || !("close" in input)) return { phase: "error", error: "Missing task or close action" };
+  try {
+    const isSeat = Object.values(task.metadata.seats).some((seat) => seat.userId === input.byUserId)
+      || task.metadata.sourceUserId === input.byUserId
+      || task.metadata.candidateUserId === input.byUserId;
+    if (!isSeat) return { phase: "error", error: "Only a negotiation seat may close it" };
+    const opportunity = await deps.database.getOpportunity(task.metadata.opportunityId);
+    if (!opportunity || !TERMINAL_OPPORTUNITY_STATUSES.has(opportunity.status)) {
+      return { phase: "error", error: "Owner-verdict closure requires a terminal opportunity" };
+    }
+    await deps.database.createNegotiationOutcomeArtifact(task.id, {
+      verdict: input.close.verdict,
+      reasoning: input.close.reasoning,
+      resolvedByUserId: input.byUserId,
+    });
+    const updated = await deps.database.updateNegotiationTaskState(task.id, "completed");
+    await triggerReflectForEverySeat(deps, task.metadata);
+    return {
+      task: updated,
+      phase: "done",
+      result: {
+        negotiationId: task.id,
+        status: "resolved",
+        verdict: input.close.verdict,
+        reasoning: input.close.reasoning,
+        turns: [],
+      },
+    };
   } catch (err) {
     return { phase: "error", error: err instanceof Error ? err.message : String(err) };
   }
@@ -554,6 +600,7 @@ export class NegotiationGraphFactory {
       .addNode("turn", (s: NegotiationState) => turnNode(s, deps))
       .addNode("apply", (s: NegotiationState) => applyNode(s, deps))
       .addNode("resolve", (s: NegotiationState) => resolveNode(s, deps))
+      .addNode("close", (s: NegotiationState) => closeNode(s, deps))
       .addNode("expire", (s: NegotiationState) => expireNode(s, deps))
       .addNode("read", readNode)
       // Named "fail", not "error" — "error" is already the state's own
@@ -565,6 +612,7 @@ export class NegotiationGraphFactory {
         turn: "turn",
         apply: "apply",
         resolve: "resolve",
+        close: "close",
         expire: "expire",
         read: "read",
         error: "fail",
@@ -572,6 +620,7 @@ export class NegotiationGraphFactory {
       .addConditionalEdges("turn", (s: NegotiationState) => s.phase, { apply: "apply", done: END, error: "fail" })
       .addConditionalEdges("apply", (s: NegotiationState) => s.phase, { turn: "turn", done: END, error: "fail" })
       .addEdge("resolve", END)
+      .addEdge("close", END)
       .addEdge("expire", END)
       .addEdge("read", END)
       .addEdge("fail", END)

--- a/packages/protocol/src/internal/negotiations/negotiation.graph.ts
+++ b/packages/protocol/src/internal/negotiations/negotiation.graph.ts
@@ -182,14 +182,23 @@ async function initNode(state: NegotiationState, deps: NegotiationGraphDeps): Pr
       const sourceActor = opportunity.actors.find((a) => a.userId === intent.userId && a.role !== "introducer");
       const candidateActor = opportunity.actors.find((a) => a.userId !== intent.userId && a.role !== "introducer");
       if (!sourceActor || !candidateActor) return { phase: "error", error: "Opportunity does not have two actors" };
+      if (!candidateActor.intent) return { phase: "error", error: "Counterparty actor has no owning intent" };
+      const candidateIntent = await deps.database.getIntent(candidateActor.intent);
+      if (!candidateIntent || candidateIntent.userId !== candidateActor.userId) {
+        return { phase: "error", error: "Counterparty actor intent is not owned by that seat" };
+      }
+      const candidateRound = await deps.database.getIntentNegotiationRound(candidateIntent.id);
+      const seats = {
+        [input.intentId]: { userId: sourceActor.userId, round: input.round },
+        [candidateIntent.id]: { userId: candidateActor.userId, round: candidateRound.round },
+      };
 
       const opened = await deps.database.openNegotiationTask({
         opportunityId: input.opportunityId,
         sourceUserId: sourceActor.userId,
         candidateUserId: candidateActor.userId,
         brief: input.brief,
-        intentId: input.intentId,
-        round: input.round,
+        seats,
         networkId: sourceActor.networkId,
         ...(existing ? { knownTaskId: existing.id } : {}),
       });
@@ -207,7 +216,7 @@ async function initNode(state: NegotiationState, deps: NegotiationGraphDeps): Pr
           briefs: { ...opened.task.briefs, [sourceActor.userId]: input.brief },
           metadata: {
             ...opened.task.metadata,
-            seats: { ...opened.task.metadata.seats, [input.intentId]: { userId: sourceActor.userId, round: input.round } },
+            seats: { ...opened.task.metadata.seats, [input.intentId]: seats[input.intentId]! },
           },
         };
         return {
@@ -298,9 +307,8 @@ async function turnNode(state: NegotiationState, deps: NegotiationGraphDeps): Pr
     // it because history is non-empty).
     const isOpening = messages.length === 0;
 
-    const opportunity = await deps.database.getOpportunity(task.metadata.opportunityId);
-    const actor = opportunity?.actors.find((candidate) => candidate.userId === speakerId && candidate.role !== "introducer");
-    if (!actor?.intent) return { task, turns, phase: "error", error: "Speaking opportunity actor has no intent" };
+    const intentId = Object.entries(meta.seats).find(([, seat]) => seat.userId === speakerId)?.[0];
+    if (!intentId) return { task, turns, phase: "error", error: "Speaking seat has no bound intent" };
 
     // Every turn is authored in-process, synchronously, within this invoke:
     // the author is the speaking seat's own PersonalAgent in negotiation
@@ -308,7 +316,7 @@ async function turnNode(state: NegotiationState, deps: NegotiationGraphDeps): Pr
     const authored = await deps.author.authorTurn({
       negotiationId: task.id,
       userId: speakerId,
-      intentId: actor.intent,
+      intentId,
     });
     const turn: NegotiationTurn = isOpening ? NegotiationOpeningTurnSchema.parse(authored) : authored;
 

--- a/packages/protocol/src/internal/negotiations/negotiation.graph.ts
+++ b/packages/protocol/src/internal/negotiations/negotiation.graph.ts
@@ -24,13 +24,6 @@ import type { NegotiationTurnAuthor } from "./negotiation.turn-author.js";
 
 const logger = protocolLogger("NegotiationGraph");
 
-/**
- * Opportunity statuses that are already decided. `resolve` never writes over
- * one: the decision behind them is the owner's, and this graph's verdict is
- * only ever the negotiation's own.
- */
-const TERMINAL_OPPORTUNITY_STATUSES = new Set(["accepted", "rejected", "expired"]);
-
 // ─── Invoke contract ─────────────────────────────────────────────────────────
 
 export type NegotiationGraphInput =
@@ -452,13 +445,24 @@ async function applyNode(state: NegotiationState, deps: NegotiationGraphDeps): P
  * either side's — checking only the opener's would leave the counterparty's
  * round waiting on a negotiation that had already stopped.
  */
-async function triggerReflectForEverySeat(deps: NegotiationGraphDeps, meta: NegotiationTaskMetadata): Promise<void> {
+async function triggerReflectForEverySeat(deps: NegotiationGraphDeps, meta: NegotiationTaskMetadata): Promise<boolean> {
+  let succeeded = true;
   for (const [intentId, binding] of Object.entries(meta.seats)) {
-    await maybeEnqueueRoundReflect(deps.database, deps.reflectEnqueue, {
+    const checked = await maybeEnqueueRoundReflect(deps.database, deps.reflectEnqueue, {
       userId: binding.userId,
       intentId,
       round: binding.round,
     });
+    succeeded &&= checked;
+  }
+  return succeeded;
+}
+
+async function clearReflectPendingBestEffort(deps: NegotiationGraphDeps, taskId: string): Promise<void> {
+  try {
+    await deps.database.clearNegotiationReflectPending(taskId);
+  } catch (error) {
+    logger.error("Failed to clear durable reflect marker; watchdog will retry", { taskId, error });
   }
 }
 
@@ -479,30 +483,24 @@ async function resolveNode(state: NegotiationState, deps: NegotiationGraphDeps):
     if (!ownsReadyPause) {
       return { phase: "error", error: "Only the seat owning a ready_for_verdict pause may resolve it" };
     }
-    const opportunity = await deps.database.getOpportunity(task.metadata.opportunityId);
-    // reasoning is private to the resolving side — recorded on the outcome
-    // artifact only, never persisted into the A2A thread as a message; the
-    // counterparty sees only that the negotiation closed.
-    await deps.database.createNegotiationOutcomeArtifact(task.id, {
+    // The database rechecks pause ownership and locks the task + opportunity
+    // before writing. That makes completion, the private outcome, and the
+    // non-terminal opportunity transition one transaction, so a concurrent
+    // human verdict cannot be overwritten after an earlier status read.
+    const updated = await deps.database.completeNegotiation({
+      taskId: task.id,
+      kind: "pause_verdict",
       verdict: input.verdict,
       reasoning: input.reasoning,
       resolvedByUserId: input.byUserId,
     });
-    const updated = await deps.database.updateNegotiationTaskState(task.id, "completed");
-    // A pause-owner verdict normally writes the opportunity status here. If a
-    // concurrent owner action already made it terminal, preserve that action;
-    // the host's explicit owner-close lane handles the ordinary owner-verdict
-    // path without granting this public verdict input broader authority.
-    if (!opportunity || !TERMINAL_OPPORTUNITY_STATUSES.has(opportunity.status)) {
-      await deps.database.updateOpportunityStatus(
-        task.metadata.opportunityId,
-        input.verdict === "pending" ? "pending" : "rejected",
-      );
-    }
+    if (!updated) return { phase: "error", error: "Negotiation changed before its verdict committed" };
     // A round whose last active negotiation ends by direct verdict (not a
     // pause) must still trigger the all-paused check — apply isn't the only
     // way a round finishes.
-    await triggerReflectForEverySeat(deps, task.metadata);
+    if (await triggerReflectForEverySeat(deps, task.metadata)) {
+      await clearReflectPendingBestEffort(deps, task.id);
+    }
     return { task: updated, phase: "done", result: { negotiationId: task.id, status: "resolved", verdict: input.verdict, reasoning: input.reasoning, turns: [] } };
   } catch (err) {
     return { phase: "error", error: err instanceof Error ? err.message : String(err) };
@@ -519,17 +517,17 @@ async function closeNode(state: NegotiationState, deps: NegotiationGraphDeps): P
       || task.metadata.sourceUserId === input.byUserId
       || task.metadata.candidateUserId === input.byUserId;
     if (!isSeat) return { phase: "error", error: "Only a negotiation seat may close it" };
-    const opportunity = await deps.database.getOpportunity(task.metadata.opportunityId);
-    if (!opportunity || !TERMINAL_OPPORTUNITY_STATUSES.has(opportunity.status)) {
-      return { phase: "error", error: "Owner-verdict closure requires a terminal opportunity" };
-    }
-    await deps.database.createNegotiationOutcomeArtifact(task.id, {
+    const updated = await deps.database.completeNegotiation({
+      taskId: task.id,
+      kind: "owner_verdict",
       verdict: input.close.verdict,
       reasoning: input.close.reasoning,
       resolvedByUserId: input.byUserId,
     });
-    const updated = await deps.database.updateNegotiationTaskState(task.id, "completed");
-    await triggerReflectForEverySeat(deps, task.metadata);
+    if (!updated) return { phase: "error", error: "Owner-verdict closure requires a live task and terminal opportunity" };
+    if (await triggerReflectForEverySeat(deps, task.metadata)) {
+      await clearReflectPendingBestEffort(deps, task.id);
+    }
     return {
       task: updated,
       phase: "done",

--- a/packages/protocol/src/internal/negotiations/negotiation.lifecycle-narration.ts
+++ b/packages/protocol/src/internal/negotiations/negotiation.lifecycle-narration.ts
@@ -18,6 +18,7 @@ type NegotiationConnectionState =
   | 'paused_ready_for_verdict'
   | 'paused_turn_cap'
   | 'paused_open_failed'
+  | 'negotiation_submitted'
   | 'unknown';
 
 /** How a negotiation task reads when it is currently paused. */
@@ -27,7 +28,7 @@ export interface NegotiationParkNarration {
 }
 
 export interface NegotiationLifecycleNarration {
-  agentNegotiation: 'working' | 'paused' | 'completed';
+  agentNegotiation: 'submitted' | 'working' | 'paused' | 'completed';
   opportunityStatus: OpportunityStatus | null;
   connectionState: NegotiationConnectionState;
   ownerAction: 'accepted' | 'not_recorded';
@@ -59,7 +60,7 @@ export function parkLifecycleLabel(pause: NegotiationParkNarration): string {
  * an H2H conversation.
  */
 export function buildLifecycleNarration(
-  taskState: 'working' | 'paused' | 'completed',
+  taskState: 'submitted' | 'working' | 'paused' | 'completed',
   opportunity?: NegotiationOpportunityLifecycle,
   pause?: NegotiationParkNarration,
 ): NegotiationLifecycleNarration {
@@ -83,6 +84,14 @@ export function buildLifecycleNarration(
     };
     const connectionState = CONNECTION_STATE[pause.reason];
     return { ...common, connectionState, lifecycleLabel: parkLifecycleLabel(pause), pause };
+  }
+
+  if (taskState === 'submitted') {
+    return {
+      ...common,
+      connectionState: 'negotiation_submitted',
+      lifecycleLabel: 'The agent negotiation is waiting to start.',
+    };
   }
 
   switch (opportunity?.status) {

--- a/packages/protocol/src/internal/negotiations/negotiation.round-reflect.ts
+++ b/packages/protocol/src/internal/negotiations/negotiation.round-reflect.ts
@@ -60,22 +60,24 @@ export type NegotiationRoundReflectDatabase = Pick<
 /**
  * Enqueue exactly one reflect job if this round's task set is complete and
  * every negotiation in it has stopped. Never throws: the caller's own transition is
- * already durable and must not fail over a trigger.
+ * already durable and must not fail over a trigger. Returns false only when
+ * the check or enqueue exhausted its retries, so a durable recovery marker
+ * can remain pending.
  */
 export async function maybeEnqueueRoundReflect(
   database: NegotiationRoundReflectDatabase,
   enqueue: NegotiationRoundReflectEnqueueFn | undefined,
   check: NegotiationRoundReflectCheck,
-): Promise<void> {
-  if (!enqueue) return;
+): Promise<boolean> {
+  if (!enqueue) return true;
   try {
     const stamp = await database.getIntentNegotiationRound(check.intentId);
     // A current kickoff has not finished binding all of its tasks yet. A
     // passive/counterparty seat (no kickoff marker) and a superseded round
     // already have their complete durable task sets and need no size gate.
-    if (stamp.round === check.round && stamp.roundSize === null && stamp.kickoffStartedAt !== null) return;
+    if (stamp.round === check.round && stamp.roundSize === null && stamp.kickoffStartedAt !== null) return true;
     const tasks = await database.getNegotiationTasksForIntentRound(check.intentId, check.round);
-    if (tasks.length === 0 || tasks.some((task) => task.state !== "paused" && task.state !== "completed")) return;
+    if (tasks.length === 0 || tasks.some((task) => task.state !== "paused" && task.state !== "completed")) return true;
     const generation = tasks
       .map((task) => `${task.id}.${task.metadata.drainGeneration}`)
       .sort()
@@ -90,7 +92,7 @@ export async function maybeEnqueueRoundReflect(
     for (let attempt = 0; attempt < ENQUEUE_ATTEMPTS; attempt++) {
       try {
         await enqueue(job);
-        return;
+        return true;
       } catch (err) {
         failure = err;
         await new Promise((resolve) => setTimeout(resolve, ENQUEUE_RETRY_DELAY_MS * (attempt + 1)));
@@ -103,5 +105,6 @@ export async function maybeEnqueueRoundReflect(
       round: check.round,
       error: err,
     });
+    return false;
   }
 }

--- a/packages/protocol/src/internal/negotiations/negotiation.round-reflect.ts
+++ b/packages/protocol/src/internal/negotiations/negotiation.round-reflect.ts
@@ -75,7 +75,7 @@ export async function maybeEnqueueRoundReflect(
     // already have their complete durable task sets and need no size gate.
     if (stamp.round === check.round && stamp.roundSize === null && stamp.kickoffStartedAt !== null) return;
     const tasks = await database.getNegotiationTasksForIntentRound(check.intentId, check.round);
-    if (tasks.length === 0 || tasks.some((task) => task.state === "working")) return;
+    if (tasks.length === 0 || tasks.some((task) => task.state !== "paused" && task.state !== "completed")) return;
     const generation = tasks
       .map((task) => `${task.id}.${task.metadata.drainGeneration}`)
       .sort()

--- a/packages/protocol/src/internal/negotiations/negotiation.round-reflect.ts
+++ b/packages/protocol/src/internal/negotiations/negotiation.round-reflect.ts
@@ -3,8 +3,9 @@
  *
  * Every pause is a DB transition. The graph's apply step ends by checking
  * whether any active negotiation remains for `(intentId, round)`; if not, it
- * enqueues one reflect job, keyed so ten pauses produce one job and a late
- * pause from an earlier round cannot re-trigger the current one. The consumer
+ * enqueues one reflect job keyed by the durable task-generation vector. Ten
+ * deliveries of one drain produce one job, while a later pause after a reopen
+ * produces a new one even when the seat binding still names the same round. The consumer
  * invokes the PersonalAgent with `{ userId, intentId, event: 'all_paused',
  * round }`.
  *
@@ -32,11 +33,15 @@ export interface NegotiationRoundReflectJobData {
   userId: string;
   intentId: string;
   round: number;
+  /** Exact durable all-paused state this job drains. */
+  generation: string;
 }
 
-/** Deterministic job id: ten pauses of the same round collapse to one job. */
-export function negotiationRoundReflectJobId(intentId: string, round: number): string {
-  return `reflect:${intentId}:${round}`;
+export type NegotiationRoundReflectCheck = Omit<NegotiationRoundReflectJobData, "generation">;
+
+/** Deterministic job id: duplicate delivery of one durable drain collapses. */
+export function negotiationRoundReflectJobId(intentId: string, round: number, generation: string): string {
+  return `reflect:${intentId}:${round}:${generation}`;
 }
 
 /**
@@ -49,26 +54,33 @@ export type NegotiationRoundReflectEnqueueFn = (job: NegotiationRoundReflectJobD
 /** The database reads the all-paused check needs. */
 export type NegotiationRoundReflectDatabase = Pick<
   NegotiationGraphDatabase,
-  "getIntentNegotiationRound" | "countActiveNegotiationsForRound"
+  "getIntentNegotiationRound" | "getNegotiationTasksForIntentRound"
 >;
 
 /**
- * Enqueue exactly one reflect job if this round is stamped and every one of
- * its negotiations has stopped. Never throws: the caller's own transition is
+ * Enqueue exactly one reflect job if this round's task set is complete and
+ * every negotiation in it has stopped. Never throws: the caller's own transition is
  * already durable and must not fail over a trigger.
  */
 export async function maybeEnqueueRoundReflect(
   database: NegotiationRoundReflectDatabase,
   enqueue: NegotiationRoundReflectEnqueueFn | undefined,
-  job: NegotiationRoundReflectJobData,
+  check: NegotiationRoundReflectCheck,
 ): Promise<void> {
   if (!enqueue) return;
   try {
-    const stamp = await database.getIntentNegotiationRound(job.intentId);
-    // Unstamped, or already superseded by a fresh kickoff: not this round's moment.
-    if (stamp.round !== job.round || stamp.roundSize === null) return;
-    const active = await database.countActiveNegotiationsForRound(job.intentId, job.round);
-    if (active !== 0) return;
+    const stamp = await database.getIntentNegotiationRound(check.intentId);
+    // A current kickoff has not finished binding all of its tasks yet. A
+    // passive/counterparty seat (no kickoff marker) and a superseded round
+    // already have their complete durable task sets and need no size gate.
+    if (stamp.round === check.round && stamp.roundSize === null && stamp.kickoffStartedAt !== null) return;
+    const tasks = await database.getNegotiationTasksForIntentRound(check.intentId, check.round);
+    if (tasks.length === 0 || tasks.some((task) => task.state === "working")) return;
+    const generation = tasks
+      .map((task) => `${task.id}.${task.metadata.drainGeneration}`)
+      .sort()
+      .join("_");
+    const job: NegotiationRoundReflectJobData = { ...check, generation };
     // The pause this runs behind is already persisted, so throwing would
     // report a failure for work that is durably done. But a swallowed enqueue
     // on the round's LAST pause is a round that never reflects and has no
@@ -87,9 +99,8 @@ export async function maybeEnqueueRoundReflect(
     throw failure;
   } catch (err) {
     logger.error("Failed to check all-paused / enqueue reflect — this round will not reflect", {
-      intentId: job.intentId,
-      round: job.round,
-      jobId: negotiationRoundReflectJobId(job.intentId, job.round),
+      intentId: check.intentId,
+      round: check.round,
       error: err,
     });
   }

--- a/packages/protocol/src/internal/negotiations/tests/negotiation.graph.expiry.spec.ts
+++ b/packages/protocol/src/internal/negotiations/tests/negotiation.graph.expiry.spec.ts
@@ -10,6 +10,7 @@ function task(state: 'paused' | 'completed' = 'paused') {
     metadata: {
       type: 'negotiation' as const, opportunityId: 'opportunity-1', sourceUserId: 'user-1', candidateUserId: 'user-2',
       initiatorUserId: 'user-1', networkId: 'network-1', seats: { 'intent-1': { userId: 'user-1', round: 2 } },
+      drainGeneration: 0,
       pause: { reason: 'needs_principal' as const },
     },
   };
@@ -21,7 +22,7 @@ function graph(overrides: Record<string, unknown> = {}) {
     expirePausedNegotiation: mock(async () => ({ ...task(), state: 'completed' as const })),
     createNegotiationOutcomeArtifact: mock(async () => undefined),
     getIntentNegotiationRound: mock(async () => ({ round: 2, roundSize: 1, kickoffStartedAt: updatedAt })),
-    countActiveNegotiationsForRound: mock(async () => 0),
+    getNegotiationTasksForIntentRound: mock(async () => [task('completed')]),
     ...overrides,
   };
   const reflectEnqueue = mock(async () => undefined);
@@ -43,7 +44,9 @@ describe('NegotiationGraph system expiry', () => {
     expect(result.status).toBe('resolved');
     expect(fixture.database.expirePausedNegotiation).toHaveBeenCalledWith({ taskId: 'task-1', expectedUpdatedAt: updatedAt, reason: 'needs_principal' });
     expect(fixture.database.createNegotiationOutcomeArtifact).not.toHaveBeenCalled();
-    expect(fixture.reflectEnqueue).toHaveBeenCalledWith({ userId: 'user-1', intentId: 'intent-1', round: 2 });
+    expect(fixture.reflectEnqueue).toHaveBeenCalledWith({
+      userId: 'user-1', intentId: 'intent-1', round: 2, generation: 'task-1.0',
+    });
   });
 
   it('leaves a changed task uncompleted and does not trigger round reflection', async () => {

--- a/packages/protocol/src/platform/database/negotiation.ts
+++ b/packages/protocol/src/platform/database/negotiation.ts
@@ -13,7 +13,7 @@ import type { Opportunity, OpportunityStatus } from './entities.js';
 import type { Database } from '../database.js';
 
 /** Negotiation task lifecycle. `paused` carries a reason in `metadata.pause`. */
-export type NegotiationTaskState = 'working' | 'paused' | 'completed';
+export type NegotiationTaskState = 'submitted' | 'working' | 'paused' | 'completed';
 
 /** One seat's binding to a signal, and that signal's kickoff round. */
 export interface NegotiationSeatBinding {
@@ -44,10 +44,8 @@ export interface NegotiationTaskMetadata {
    * terminators — and a re-kick from that side would either overwrite the
    * opener's round or be refused.
    *
-   * A seat appears here when its own kickoff opens or re-kicks this
-   * negotiation, never by guessing: an actor's `intent` field names the
-   * intent it matched AGAINST for a premise match, so it cannot be trusted to
-   * name the seat's own signal.
+   * Creation binds both seats after verifying each actor's intent ownership;
+   * a later kickoff updates only its own seat's round.
    */
   seats: Record<string, NegotiationSeatBinding>;
   /**
@@ -130,7 +128,7 @@ export type NegotiationGraphDatabase = Pick<Database, 'getOpportunity' | 'getInt
    */
   updateNegotiationTaskState(
     taskId: string,
-    state: NegotiationTaskState,
+    state: 'working' | 'paused' | 'completed',
     pause?: NegotiationTaskMetadata['pause'],
   ): Promise<NegotiationTaskRow>;
 

--- a/packages/protocol/src/platform/database/negotiation.ts
+++ b/packages/protocol/src/platform/database/negotiation.ts
@@ -51,6 +51,13 @@ export interface NegotiationTaskMetadata {
    */
   seats: Record<string, NegotiationSeatBinding>;
   /**
+   * Monotonic generation of this task's paused lifecycle. The opening run is
+   * generation 0; the first persisted turn after each pause increments it.
+   * An all-paused drain is deduplicated by the durable vector of these values,
+   * so reopening a task creates a new drain without duplicating one pause.
+   */
+  drainGeneration: number;
+  /**
    * `payload` is private to `pausedBy` — the seat whose turn produced this
    * pause. It is never persisted into a shared message or returned from a
    * generic invoke; only a read scoped to `pausedBy`'s own principal may see
@@ -104,8 +111,7 @@ export type NegotiationGraphDatabase = Pick<Database, 'getOpportunity' | 'getInt
     sourceUserId: string;
     candidateUserId: string;
     brief: string;
-    intentId: string;
-    round: number;
+    seats: Record<string, NegotiationSeatBinding>;
     networkId: string;
     knownTaskId?: string;
   }): Promise<{ task: NegotiationTaskRow; disposition: 'created' | 'existing' | 'raced' } | null>;
@@ -118,7 +124,10 @@ export type NegotiationGraphDatabase = Pick<Database, 'getOpportunity' | 'getInt
   /** Every negotiation task where the given user is source or candidate. */
   getNegotiationTasksForUser(userId: string): Promise<NegotiationTaskRow[]>;
 
-  /** Transitions state and, for `paused`, records the reason/payload. Merges into metadata; other keys are untouched. */
+  /**
+   * Transitions state and, for `paused`, records the reason/payload. Moving a
+   * paused task back to `working` also increments its durable drain generation.
+   */
   updateNegotiationTaskState(
     taskId: string,
     state: NegotiationTaskState,

--- a/packages/protocol/src/platform/database/negotiation.ts
+++ b/packages/protocol/src/platform/database/negotiation.ts
@@ -9,7 +9,7 @@
  * kickoff and resume.
  */
 
-import type { Opportunity, OpportunityStatus } from './entities.js';
+import type { Opportunity } from './entities.js';
 import type { Database } from '../database.js';
 
 /** Negotiation task lifecycle. `paused` carries a reason in `metadata.pause`. */
@@ -55,6 +55,10 @@ export interface NegotiationTaskMetadata {
    * so reopening a task creates a new drain without duplicating one pause.
    */
   drainGeneration: number;
+  /** True between atomic verdict completion and a successful round-reflect check. */
+  watchdogReflectPending?: boolean;
+  /** Fairness cursor for bounded watchdog sweeps; ISO-8601 when last checked. */
+  watchdogRecoveryCheckedAt?: string;
   /**
    * `payload` is private to `pausedBy` — the seat whose turn produced this
    * pause. It is never persisted into a shared message or returned from a
@@ -166,18 +170,26 @@ export type NegotiationGraphDatabase = Pick<Database, 'getOpportunity' | 'getInt
   /** This negotiation's own turns, oldest first. */
   getNegotiationMessages(taskId: string): Promise<NegotiationMessageRow[]>;
 
-  /** Persists the resolve outcome artifact. */
-  createNegotiationOutcomeArtifact(taskId: string, outcome: {
+  /**
+   * Atomically records an outcome and completes its task. A pause verdict also
+   * locks the opportunity and updates it only while it is still non-terminal;
+   * an owner verdict instead requires the host's opportunity write to already
+   * be terminal. Returns null when the task or opportunity changed before the
+   * transaction acquired its locks.
+   */
+  completeNegotiation(input: {
+    taskId: string;
+    kind: 'pause_verdict' | 'owner_verdict';
     verdict: 'pending' | 'reject';
     reasoning?: string;
-    /** The only user allowed to read the private verdict reasoning. */
     resolvedByUserId: string;
-  }): Promise<void>;
+  }): Promise<NegotiationTaskRow | null>;
+
+  /** Clears the durable post-verdict reflect marker after a successful check. */
+  clearNegotiationReflectPending(taskId: string): Promise<void>;
 
   /** Reads back artifacts persisted for a task (e.g. the resolve outcome). */
   getArtifactsForTask(taskId: string): Promise<Array<{ id: string; name: string | null; parts: unknown[]; metadata: Record<string, unknown> | null }>>;
-
-  updateOpportunityStatus(id: string, status: OpportunityStatus): Promise<{ id: string; status: OpportunityStatus } | null>;
 
   /** Every negotiation task bound to one intent's given round, whatever its state. The round-settling read. */
   getNegotiationTasksForIntentRound(intentId: string, round: number): Promise<NegotiationTaskRow[]>;

--- a/packages/protocol/src/platform/database/negotiation.ts
+++ b/packages/protocol/src/platform/database/negotiation.ts
@@ -173,17 +173,21 @@ export type NegotiationGraphDatabase = Pick<Database, 'getOpportunity' | 'getInt
   /**
    * Atomically records an outcome and completes its task. A pause verdict also
    * locks the opportunity and updates it only while it is still non-terminal;
-   * an owner verdict instead requires the host's opportunity write to already
-   * be terminal. Returns null when the task or opportunity changed before the
-   * transaction acquired its locks.
+   * an owner verdict requires a terminal host write, while expiry requires the
+   * opportunity to be expired and records no owner outcome. Returns null when
+   * the task or opportunity changed before the transaction acquired its locks.
    */
   completeNegotiation(input: {
     taskId: string;
-    kind: 'pause_verdict' | 'owner_verdict';
-    verdict: 'pending' | 'reject';
-    reasoning?: string;
-    resolvedByUserId: string;
-  }): Promise<NegotiationTaskRow | null>;
+  } & (
+    | {
+      kind: 'pause_verdict' | 'owner_verdict';
+      verdict: 'pending' | 'reject';
+      reasoning?: string;
+      resolvedByUserId: string;
+    }
+    | { kind: 'opportunity_expired' }
+  )): Promise<NegotiationTaskRow | null>;
 
   /** Clears the durable post-verdict reflect marker after a successful check. */
   clearNegotiationReflectPending(taskId: string): Promise<void>;

--- a/services/api/src/adapters/conversation.database.adapter.ts
+++ b/services/api/src/adapters/conversation.database.adapter.ts
@@ -30,6 +30,7 @@ type NegotiationTaskMetadataMirror = {
   networkId: string;
   /** One binding per seat, keyed by intent id — the protocol's `seats`. */
   seats: Record<string, { userId: string; round: number }>;
+  drainGeneration: number;
   pause?: { reason: NegotiationPauseReason; payload?: unknown; pausedBy?: string } | null;
 };
 
@@ -2438,8 +2439,7 @@ export class ConversationDatabaseAdapter {
     sourceUserId: string;
     candidateUserId: string;
     brief: string;
-    intentId: string;
-    round: number;
+    seats: Record<string, { userId: string; round: number }>;
     networkId: string;
     knownTaskId?: string;
   }): Promise<{ task: NegotiationTaskRowMirror; disposition: 'created' | 'existing' | 'raced' } | null> {
@@ -2459,6 +2459,8 @@ export class ConversationDatabaseAdapter {
         !introducers.every((actor) => actor.approved === true)
         || !actors.some((actor) => actor.userId === input.sourceUserId && actor.networkId === input.networkId)
         || !actors.some((actor) => actor.userId === input.candidateUserId)
+        || !Object.values(input.seats).some((seat) => seat.userId === input.sourceUserId)
+        || !Object.values(input.seats).some((seat) => seat.userId === input.candidateUserId)
       ) return null;
 
       const [existing] = await tx
@@ -2499,7 +2501,8 @@ export class ConversationDatabaseAdapter {
           candidateUserId: input.candidateUserId,
           initiatorUserId: input.sourceUserId,
           networkId: input.networkId,
-          seats: { [input.intentId]: { userId: input.sourceUserId, round: input.round } },
+          seats: input.seats,
+          drainGeneration: 0,
         },
       }).returning();
       if (!task) throw new Error('Failed to create negotiation task');
@@ -2606,7 +2609,19 @@ export class ConversationDatabaseAdapter {
       .update(schema.tasks)
       .set({
         state,
-        ...(pause !== undefined ? {
+        ...(state === 'working' ? {
+          metadata: sql`jsonb_set(
+            jsonb_set(coalesce(${schema.tasks.metadata}, '{}'::jsonb), '{pause}', 'null'::jsonb, true),
+            '{drainGeneration}',
+            to_jsonb(
+              CASE WHEN ${schema.tasks.state} = 'paused'
+                THEN coalesce((${schema.tasks.metadata}->>'drainGeneration')::int, 0) + 1
+                ELSE coalesce((${schema.tasks.metadata}->>'drainGeneration')::int, 0)
+              END
+            ),
+            true
+          )`,
+        } : pause !== undefined ? {
           metadata: sql`jsonb_set(coalesce(${schema.tasks.metadata}, '{}'::jsonb), '{pause}', ${JSON.stringify(pause ?? null)}::jsonb, true)`,
         } : {}),
         updatedAt: new Date(),

--- a/services/api/src/adapters/conversation.database.adapter.ts
+++ b/services/api/src/adapters/conversation.database.adapter.ts
@@ -1757,7 +1757,7 @@ export class ConversationDatabaseAdapter {
             sql`EXISTS (
               SELECT 1 FROM ${opportunities}
               WHERE ${opportunities.id} = ${schema.tasks.metadata}->>'opportunityId'
-                AND ${opportunities.status} IN ('accepted', 'rejected')
+                AND ${opportunities.status} IN ('accepted', 'rejected', 'expired')
             )`,
           ),
           and(
@@ -2683,11 +2683,15 @@ export class ConversationDatabaseAdapter {
 
   async completeNegotiation(input: {
     taskId: string;
-    kind: 'pause_verdict' | 'owner_verdict';
-    verdict: 'pending' | 'reject';
-    reasoning?: string;
-    resolvedByUserId: string;
-  }): Promise<NegotiationTaskRowMirror | null> {
+  } & (
+    | {
+      kind: 'pause_verdict' | 'owner_verdict';
+      verdict: 'pending' | 'reject';
+      reasoning?: string;
+      resolvedByUserId: string;
+    }
+    | { kind: 'opportunity_expired' }
+  )): Promise<NegotiationTaskRowMirror | null> {
     const result = await db.transaction(async (tx) => {
       const [task] = await tx.select().from(schema.tasks)
         .where(eq(schema.tasks.id, input.taskId)).for('update');
@@ -2695,32 +2699,37 @@ export class ConversationDatabaseAdapter {
 
       const metadata = task.metadata as NegotiationTaskMetadataMirror | null;
       if (!metadata || metadata.type !== 'negotiation') return null;
-      const isSeat = Object.values(metadata.seats).some((seat) => seat.userId === input.resolvedByUserId)
-        || metadata.sourceUserId === input.resolvedByUserId
-        || metadata.candidateUserId === input.resolvedByUserId;
-      if (!isSeat) return null;
-      if (input.kind === 'pause_verdict' && (
-        task.state !== 'paused'
-        || metadata.pause?.reason !== 'ready_for_verdict'
-        || metadata.pause.pausedBy !== input.resolvedByUserId
-      )) return null;
+      if (input.kind !== 'opportunity_expired') {
+        const isSeat = Object.values(metadata.seats).some((seat) => seat.userId === input.resolvedByUserId)
+          || metadata.sourceUserId === input.resolvedByUserId
+          || metadata.candidateUserId === input.resolvedByUserId;
+        if (!isSeat) return null;
+        if (input.kind === 'pause_verdict' && (
+          task.state !== 'paused'
+          || metadata.pause?.reason !== 'ready_for_verdict'
+          || metadata.pause.pausedBy !== input.resolvedByUserId
+        )) return null;
+      }
 
       const [opportunity] = await tx.select({ status: opportunities.status }).from(opportunities)
         .where(eq(opportunities.id, metadata.opportunityId)).for('update');
       if (!opportunity) return null;
       const terminal = ['accepted', 'rejected', 'expired'].includes(opportunity.status);
       if (input.kind === 'owner_verdict' && !terminal) return null;
+      if (input.kind === 'opportunity_expired' && opportunity.status !== 'expired') return null;
 
-      await tx.insert(schema.artifacts).values({
-        taskId: task.id,
-        name: 'negotiation_outcome',
-        parts: [{ kind: 'data', data: {
-          verdict: input.verdict,
-          reasoning: input.reasoning,
-          resolvedByUserId: input.resolvedByUserId,
-        } }],
-        metadata: { resolvedByUserId: input.resolvedByUserId },
-      });
+      if (input.kind !== 'opportunity_expired') {
+        await tx.insert(schema.artifacts).values({
+          taskId: task.id,
+          name: 'negotiation_outcome',
+          parts: [{ kind: 'data', data: {
+            verdict: input.verdict,
+            reasoning: input.reasoning,
+            resolvedByUserId: input.resolvedByUserId,
+          } }],
+          metadata: { resolvedByUserId: input.resolvedByUserId },
+        });
+      }
       const now = new Date();
       const [completed] = await tx.update(schema.tasks)
         .set({

--- a/services/api/src/adapters/conversation.database.adapter.ts
+++ b/services/api/src/adapters/conversation.database.adapter.ts
@@ -378,7 +378,7 @@ export interface StaleNegotiationTasksInput {
 export interface StaleNegotiationTask {
   id: string;
   conversationId: string;
-  state: 'submitted' | 'working' | 'paused';
+  state: 'submitted' | 'working' | 'paused' | 'completed';
   createdAt: Date;
   updatedAt: Date;
   metadata: Record<string, unknown> | null;
@@ -1753,6 +1753,14 @@ export class ConversationDatabaseAdapter {
           and(eq(schema.tasks.state, 'submitted'), lt(schema.tasks.createdAt, submittedCutoff)),
           and(eq(schema.tasks.state, 'working'), lt(schema.tasks.updatedAt, workingCutoff)),
           and(
+            inArray(schema.tasks.state, ['submitted', 'working']),
+            sql`EXISTS (
+              SELECT 1 FROM ${opportunities}
+              WHERE ${opportunities.id} = ${schema.tasks.metadata}->>'opportunityId'
+                AND ${opportunities.status} IN ('accepted', 'rejected')
+            )`,
+          ),
+          and(
             eq(schema.tasks.state, 'paused'),
             inArray(sql`${schema.tasks.metadata}->'pause'->>'reason'`, ['needs_principal', 'counterparty_silent']),
             lt(schema.tasks.updatedAt, workingCutoff),
@@ -1761,14 +1769,21 @@ export class ConversationDatabaseAdapter {
             eq(schema.tasks.state, 'paused'),
             sql`${schema.tasks.metadata}->'pause'->>'reason' = 'ready_for_verdict'`,
           ),
+          and(
+            eq(schema.tasks.state, 'completed'),
+            sql`${schema.tasks.metadata}->>'watchdogReflectPending' = 'true'`,
+          ),
         ),
       ))
-      .orderBy(asc(schema.tasks.createdAt))
+      .orderBy(
+        asc(sql`coalesce(${schema.tasks.metadata}->>'watchdogRecoveryCheckedAt', '')`),
+        asc(schema.tasks.createdAt),
+      )
       .limit(Math.max(1, Math.floor(limit)));
 
     return rows.map((row) => ({
       ...row,
-      state: row.state as 'submitted' | 'working' | 'paused',
+      state: row.state as 'submitted' | 'working' | 'paused' | 'completed',
       metadata: (row.metadata as Record<string, unknown> | null) ?? null,
     }));
   }
@@ -1806,6 +1821,35 @@ export class ConversationDatabaseAdapter {
       .returning();
 
     return task ?? null;
+  }
+
+  /**
+   * Moves a durable recovery check behind never-checked rows, so one bounded
+   * sweep cannot starve newer candidates indefinitely.
+   * `updatedAt` deliberately stays unchanged: this is watchdog bookkeeping,
+   * not a negotiation lifecycle transition.
+   */
+  async recordNegotiationWatchdogRecoveryCheck(input: {
+    taskId: string;
+    expectedUpdatedAt: Date;
+    checkedAt: Date;
+  }): Promise<boolean> {
+    const [task] = await db
+      .update(schema.tasks)
+      .set({
+        metadata: sql`jsonb_set(
+          coalesce(${schema.tasks.metadata}, '{}'::jsonb),
+          '{watchdogRecoveryCheckedAt}',
+          ${JSON.stringify(input.checkedAt.toISOString())}::jsonb,
+          true
+        )`,
+      })
+      .where(and(
+        eq(schema.tasks.id, input.taskId),
+        eq(schema.tasks.updatedAt, input.expectedUpdatedAt),
+      ))
+      .returning({ id: schema.tasks.id });
+    return Boolean(task);
   }
 
   /**
@@ -2637,6 +2681,93 @@ export class ConversationDatabaseAdapter {
     return toNegotiationTaskRow(row);
   }
 
+  async completeNegotiation(input: {
+    taskId: string;
+    kind: 'pause_verdict' | 'owner_verdict';
+    verdict: 'pending' | 'reject';
+    reasoning?: string;
+    resolvedByUserId: string;
+  }): Promise<NegotiationTaskRowMirror | null> {
+    const result = await db.transaction(async (tx) => {
+      const [task] = await tx.select().from(schema.tasks)
+        .where(eq(schema.tasks.id, input.taskId)).for('update');
+      if (!task || task.state === 'completed') return null;
+
+      const metadata = task.metadata as NegotiationTaskMetadataMirror | null;
+      if (!metadata || metadata.type !== 'negotiation') return null;
+      const isSeat = Object.values(metadata.seats).some((seat) => seat.userId === input.resolvedByUserId)
+        || metadata.sourceUserId === input.resolvedByUserId
+        || metadata.candidateUserId === input.resolvedByUserId;
+      if (!isSeat) return null;
+      if (input.kind === 'pause_verdict' && (
+        task.state !== 'paused'
+        || metadata.pause?.reason !== 'ready_for_verdict'
+        || metadata.pause.pausedBy !== input.resolvedByUserId
+      )) return null;
+
+      const [opportunity] = await tx.select({ status: opportunities.status }).from(opportunities)
+        .where(eq(opportunities.id, metadata.opportunityId)).for('update');
+      if (!opportunity) return null;
+      const terminal = ['accepted', 'rejected', 'expired'].includes(opportunity.status);
+      if (input.kind === 'owner_verdict' && !terminal) return null;
+
+      await tx.insert(schema.artifacts).values({
+        taskId: task.id,
+        name: 'negotiation_outcome',
+        parts: [{ kind: 'data', data: {
+          verdict: input.verdict,
+          reasoning: input.reasoning,
+          resolvedByUserId: input.resolvedByUserId,
+        } }],
+        metadata: { resolvedByUserId: input.resolvedByUserId },
+      });
+      const now = new Date();
+      const [completed] = await tx.update(schema.tasks)
+        .set({
+          state: 'completed',
+          metadata: sql`jsonb_set(
+            coalesce(${schema.tasks.metadata}, '{}'::jsonb),
+            '{watchdogReflectPending}',
+            'true'::jsonb,
+            true
+          )`,
+          updatedAt: now,
+        })
+        .where(eq(schema.tasks.id, task.id))
+        .returning();
+      if (!completed) throw new Error(`Negotiation task ${task.id} not found`);
+
+      let opportunityUpdatedTo: 'pending' | 'rejected' | null = null;
+      if (input.kind === 'pause_verdict' && !terminal) {
+        opportunityUpdatedTo = input.verdict === 'pending' ? 'pending' : 'rejected';
+        await tx.update(opportunities)
+          .set({ status: opportunityUpdatedTo, acceptedBy: null, updatedAt: now })
+          .where(eq(opportunities.id, metadata.opportunityId));
+      }
+      return { task: toNegotiationTaskRow(completed), opportunityUpdatedTo };
+    });
+
+    if (result?.opportunityUpdatedTo) {
+      const event = { id: result.task.metadata.opportunityId, status: result.opportunityUpdatedTo };
+      emitOpportunityLifecycleBestEffort(event);
+      emitOpportunityTransitionBestEffort(event);
+    }
+    return result?.task ?? null;
+  }
+
+  async clearNegotiationReflectPending(taskId: string): Promise<void> {
+    await db.update(schema.tasks)
+      .set({
+        metadata: sql`jsonb_set(
+          coalesce(${schema.tasks.metadata}, '{}'::jsonb),
+          '{watchdogReflectPending}',
+          'false'::jsonb,
+          true
+        )`,
+      })
+      .where(eq(schema.tasks.id, taskId));
+  }
+
   async expirePausedNegotiation(input: {
     taskId: string;
     expectedUpdatedAt: Date;
@@ -2810,20 +2941,6 @@ export class ConversationDatabaseAdapter {
       .where(eq(schema.messages.taskId, taskId))
       .orderBy(asc(schema.messages.createdAt), asc(schema.messages.id));
     return rows.map((r) => ({ ...r, parts: (r.parts as unknown[]) ?? [] }));
-  }
-
-  /** Persists the resolve outcome artifact. */
-  async createNegotiationOutcomeArtifact(taskId: string, outcome: {
-    verdict: 'pending' | 'reject';
-    reasoning?: string;
-    resolvedByUserId: string;
-  }): Promise<void> {
-    await db.insert(schema.artifacts).values({
-      taskId,
-      name: 'negotiation_outcome',
-      parts: [{ kind: 'data', data: outcome }],
-      metadata: { resolvedByUserId: outcome.resolvedByUserId },
-    });
   }
 
   /**

--- a/services/api/src/adapters/conversation.database.adapter.ts
+++ b/services/api/src/adapters/conversation.database.adapter.ts
@@ -1727,6 +1727,7 @@ export class ConversationDatabaseAdapter {
     return task;
   }
 
+  /** Stale active tasks plus durable paused states that require watchdog recovery. */
   async getStaleNegotiationTasks({
     submittedOlderThanMs,
     workingOlderThanMs,
@@ -1755,6 +1756,10 @@ export class ConversationDatabaseAdapter {
             eq(schema.tasks.state, 'paused'),
             inArray(sql`${schema.tasks.metadata}->'pause'->>'reason'`, ['needs_principal', 'counterparty_silent']),
             lt(schema.tasks.updatedAt, workingCutoff),
+          ),
+          and(
+            eq(schema.tasks.state, 'paused'),
+            sql`${schema.tasks.metadata}->'pause'->>'reason' = 'ready_for_verdict'`,
           ),
         ),
       ))
@@ -1952,7 +1957,7 @@ export class ConversationDatabaseAdapter {
    * payload never leave the graph boundary through this read.
    */
   async getIntentCycleForIntent(userId: string, intentId: string): Promise<{
-    round: { number: number; size: number | null; kickoffStartedAt: Date | null; working: number; paused: number };
+    round: { number: number; size: number | null; kickoffStartedAt: Date | null; active: number; paused: number };
     negotiations: Array<{
       taskId: string;
       conversationId: string;
@@ -2058,7 +2063,7 @@ export class ConversationDatabaseAdapter {
         number: ownedIntent.round,
         size: ownedIntent.roundSize,
         kickoffStartedAt: ownedIntent.kickoffStartedAt,
-        working: currentRound.filter((negotiation) => negotiation.state === 'working').length,
+        active: currentRound.filter((negotiation) => negotiation.state === 'submitted' || negotiation.state === 'working').length,
         paused: currentRound.filter((negotiation) => negotiation.state === 'paused').length,
       },
       negotiations,

--- a/services/api/src/adapters/conversation.database.adapter.ts
+++ b/services/api/src/adapters/conversation.database.adapter.ts
@@ -37,7 +37,7 @@ type NegotiationTaskMetadataMirror = {
 type NegotiationTaskRowMirror = {
   id: string;
   conversationId: string;
-  state: 'working' | 'paused' | 'completed';
+  state: 'submitted' | 'working' | 'paused' | 'completed';
   briefs: Record<string, string>;
   metadata: NegotiationTaskMetadataMirror;
   createdAt: Date;
@@ -2923,9 +2923,9 @@ export class ConversationDatabaseAdapter {
         and(
           sql`${schema.tasks.metadata}->>'type' = 'negotiation'`,
           sql`(${schema.tasks.metadata}->'seats'->${intentId}->>'round')::int = ${round}`,
-          eq(schema.tasks.state, 'working'),
+          notInArray(schema.tasks.state, ['paused', 'completed']),
           // The same predicate `getNegotiationTasksForIntentRound` applies:
-          // an archived task stuck in 'working' would hold this count above
+          // an archived task stuck in an active state would hold this count above
           // zero forever, stalling the signal's cycle, while being invisible
           // in the paused set the agent actually reasons over.
           notArchivedNegotiationTaskWhere(),

--- a/services/api/src/adapters/tests/conversation.database.adapter.spec.ts
+++ b/services/api/src/adapters/tests/conversation.database.adapter.spec.ts
@@ -236,7 +236,7 @@ describe('ConversationDatabaseAdapter', () => {
   });
 
   describe('getStaleNegotiationTasks', () => {
-    it('returns only stale submitted/working negotiation tasks', async () => {
+    it('returns stale active tasks and durable ready-for-verdict recovery markers', async () => {
       const conv = await adapter.createConversation([
         { participantId: 'agent:watchdog-a', participantType: 'agent' as const },
         { participantId: 'agent:watchdog-b', participantType: 'agent' as const },
@@ -252,6 +252,12 @@ describe('ConversationDatabaseAdapter', () => {
       await adapter.updateTaskState(staleWorking.id, 'working');
       const freshSubmitted = await adapter.createTask(conv.id, {
         type: 'negotiation', opportunityId: 'watchdog-opportunity-fresh', sourceUserId: 'watchdog-user', seats: { 'watchdog-intent': { userId: 'watchdog-user', round: 1 } },
+      });
+      const readyForVerdict = await adapter.createTask(conv.id, {
+        type: 'negotiation', opportunityId: 'watchdog-opportunity-ready', sourceUserId: 'watchdog-user', seats: { 'watchdog-intent': { userId: 'watchdog-user', round: 1 } },
+      });
+      await adapter.updateNegotiationTaskState(readyForVerdict.id, 'paused', {
+        reason: 'ready_for_verdict', pausedBy: 'watchdog-user',
       });
       const completed = await adapter.createTask(conv.id, {
         type: 'negotiation', opportunityId: 'watchdog-opportunity-completed', sourceUserId: 'watchdog-user', seats: { 'watchdog-intent': { userId: 'watchdog-user', round: 1 } },
@@ -289,6 +295,7 @@ describe('ConversationDatabaseAdapter', () => {
 
       expect(staleIds).toContain(staleSubmitted.id);
       expect(staleIds).toContain(staleWorking.id);
+      expect(staleIds).toContain(readyForVerdict.id);
       expect(staleIds).not.toContain(freshSubmitted.id);
       expect(staleIds).not.toContain(completed.id);
       expect(staleIds).not.toContain(nonNegotiation.id);
@@ -405,10 +412,14 @@ describe('ConversationDatabaseAdapter', () => {
           pausedBy: ownerId,
         },
       });
+      const submittedCycle = await adapter.getIntentCycleForIntent(ownerId, ownerIntentId);
+      expect(submittedCycle?.round.active).toBe(1);
+      expect(submittedCycle?.negotiations[0]?.state).toBe('submitted');
       await adapter.updateTaskState(task.id, 'paused');
 
       const ownerCycle = await adapter.getIntentCycleForIntent(ownerId, ownerIntentId);
       const counterpartCycle = await adapter.getIntentCycleForIntent(counterpartId, counterpartIntentId);
+      expect(ownerCycle?.round.active).toBe(0);
       expect(ownerCycle?.negotiations[0]?.pause?.by).toBe('yours');
       expect(counterpartCycle?.negotiations[0]?.pause?.by).toBe('theirs');
 

--- a/services/api/src/adapters/tests/conversation.database.adapter.spec.ts
+++ b/services/api/src/adapters/tests/conversation.database.adapter.spec.ts
@@ -888,6 +888,7 @@ describe('ConversationDatabaseAdapter', () => {
         sourceUserId: userId,
         candidateUserId: counterpart,
         seats: { 'intent-a': { userId, round: 1 } },
+        drainGeneration: 0,
       });
 
       // The old select-then-spread-then-update shape had a lost-update race
@@ -904,7 +905,69 @@ describe('ConversationDatabaseAdapter', () => {
       expect(reread?.metadata.seats['intent-a']).toEqual({ userId, round: 7 });
       expect(reread?.metadata.pause).toMatchObject({ reason: 'counterparty_silent' });
       expect(reread?.state).toBe('paused');
+
+      const firstResume = await adapter.updateNegotiationTaskState(task.id, 'working', null);
+      expect(firstResume.metadata.drainGeneration).toBe(1);
+      expect(firstResume.metadata.pause).toBeNull();
+      await adapter.updateNegotiationTaskState(task.id, 'paused', { reason: 'counterparty_silent' });
+      const secondResume = await adapter.updateNegotiationTaskState(task.id, 'working', null);
+      expect(secondResume.metadata.drainGeneration).toBe(2);
     });
+  });
+
+  describe('openNegotiationTask — durable seat binding', () => {
+    it('creates the task with both actor intents and generation zero in one write', async () => {
+      const run = `${Date.now()}-${crypto.randomUUID()}`;
+      const ownerId = `open-owner-${run}`;
+      const counterpartId = `open-counterpart-${run}`;
+      const ownerIntentId = `open-owner-intent-${run}`;
+      const counterpartIntentId = `open-counterpart-intent-${run}`;
+      const opportunityId = `open-opportunity-${run}`;
+
+      await db.insert(schema.users).values([
+        { id: ownerId, email: `${ownerId}@test.local`, name: 'Open Owner' },
+        { id: counterpartId, email: `${counterpartId}@test.local`, name: 'Open Counterpart' },
+      ]);
+      createdUserIds.push(ownerId, counterpartId);
+      await db.insert(schema.intents).values([
+        { id: ownerIntentId, userId: ownerId, payload: 'Owner intent' },
+        { id: counterpartIntentId, userId: counterpartId, payload: 'Counterpart intent' },
+      ]);
+      createdIntentIds.push(ownerIntentId, counterpartIntentId);
+      await db.insert(schema.opportunities).values({
+        id: opportunityId,
+        detection: { source: 'manual', timestamp: new Date().toISOString() },
+        actors: [
+          { networkId: 'open-network', userId: ownerId, role: 'peer', intent: ownerIntentId },
+          { networkId: 'open-network', userId: counterpartId, role: 'peer', intent: counterpartIntentId },
+        ],
+        interpretation: { category: 'test', reasoning: 'Two-seat open.', confidence: 0.8 },
+        context: {},
+        confidence: '0.8',
+        status: 'latent',
+      });
+      createdOpportunityIds.push(opportunityId);
+
+      const opened = await adapter.openNegotiationTask({
+        opportunityId,
+        sourceUserId: ownerId,
+        candidateUserId: counterpartId,
+        brief: 'Owner brief',
+        seats: {
+          [ownerIntentId]: { userId: ownerId, round: 3 },
+          [counterpartIntentId]: { userId: counterpartId, round: 5 },
+        },
+        networkId: 'open-network',
+      });
+
+      expect(opened?.disposition).toBe('created');
+      expect(opened?.task.metadata.seats).toEqual({
+        [ownerIntentId]: { userId: ownerId, round: 3 },
+        [counterpartIntentId]: { userId: counterpartId, round: 5 },
+      });
+      expect(opened?.task.metadata.drainGeneration).toBe(0);
+      if (opened) createdIds.push(opened.task.conversationId);
+    }, 30000);
   });
 
   describe('getConversationsForUser — pause projection (#1494 round-2 finding 10)', () => {

--- a/services/api/src/adapters/tests/conversation.database.adapter.spec.ts
+++ b/services/api/src/adapters/tests/conversation.database.adapter.spec.ts
@@ -841,6 +841,9 @@ describe('ConversationDatabaseAdapter', () => {
         candidateUserId: counterpart,
         seats: { [intentId]: { userId, round: 3 } },
       });
+      // A just-created negotiation is submitted, and still holds the round
+      // active until its worker starts and eventually pauses or completes it.
+      expect(await adapter.countActiveNegotiationsForRound(intentId, 3)).toBe(1);
       await adapter.updateTaskState(current.id, 'working');
 
       // Pre-rewrite rows have no seat binding.

--- a/services/api/src/adapters/tests/conversation.database.adapter.spec.ts
+++ b/services/api/src/adapters/tests/conversation.database.adapter.spec.ts
@@ -268,6 +268,21 @@ describe('ConversationDatabaseAdapter', () => {
         type: 'negotiation', opportunityId: terminalOpportunityId, sourceUserId: 'watchdog-user', candidateUserId: 'watchdog-peer', seats: { 'watchdog-intent': { userId: 'watchdog-user', round: 1 } },
       });
       await adapter.updateTaskState(terminalActive.id, 'working');
+      const expiredOpportunityId = `watchdog-expired-${crypto.randomUUID()}`;
+      await db.insert(schema.opportunities).values({
+        id: expiredOpportunityId,
+        detection: { source: 'manual', timestamp: new Date().toISOString() },
+        actors: [{ networkId: 'watchdog-network', userId: 'watchdog-user', role: 'peer' }],
+        interpretation: { category: 'test', reasoning: 'Scheduled expiry recovery.', confidence: 1 },
+        context: {},
+        confidence: '1',
+        status: 'expired',
+      });
+      createdOpportunityIds.push(expiredOpportunityId);
+      const expiredActive = await adapter.createTask(conv.id, {
+        type: 'negotiation', opportunityId: expiredOpportunityId, sourceUserId: 'watchdog-user', candidateUserId: 'watchdog-peer', seats: { 'watchdog-intent': { userId: 'watchdog-user', round: 1 } },
+      });
+      await adapter.updateTaskState(expiredActive.id, 'working');
       const readyForVerdict = await adapter.createTask(conv.id, {
         type: 'negotiation', opportunityId: 'watchdog-opportunity-ready', sourceUserId: 'watchdog-user', seats: { 'watchdog-intent': { userId: 'watchdog-user', round: 1 } },
       });
@@ -312,6 +327,7 @@ describe('ConversationDatabaseAdapter', () => {
       expect(staleIds).toContain(staleWorking.id);
       expect(staleIds).toContain(readyForVerdict.id);
       expect(staleIds).toContain(terminalActive.id);
+      expect(staleIds).toContain(expiredActive.id);
       expect(staleIds).not.toContain(freshSubmitted.id);
       expect(staleIds).not.toContain(completed.id);
       expect(staleIds).not.toContain(nonNegotiation.id);
@@ -529,6 +545,41 @@ describe('ConversationDatabaseAdapter', () => {
       expect(pendingReflect.map((candidate) => candidate.id)).toContain(task.id);
       await adapter.clearNegotiationReflectPending(task.id);
       expect((await adapter.getTask(task.id))?.metadata?.watchdogReflectPending).toBe(false);
+
+      const expiredOpportunityId = `expired-negotiation-${crypto.randomUUID()}`;
+      await db.insert(schema.opportunities).values({
+        id: expiredOpportunityId,
+        detection: { source: 'manual', timestamp: new Date().toISOString() },
+        actors: [
+          { networkId: 'pause-network', userId: ownerId, role: 'peer', intent: ownerIntentId },
+          { networkId: 'pause-network', userId: counterpartId, role: 'peer', intent: counterpartIntentId },
+        ],
+        interpretation: { category: 'test', reasoning: 'Scheduled expiry.', confidence: 0.8 },
+        context: {},
+        confidence: '0.8',
+        status: 'expired',
+      });
+      createdOpportunityIds.push(expiredOpportunityId);
+      const expiredTask = await adapter.createTask(conversation.id, {
+        type: 'negotiation',
+        opportunityId: expiredOpportunityId,
+        sourceUserId: ownerId,
+        candidateUserId: counterpartId,
+        initiatorUserId: ownerId,
+        networkId: 'pause-network',
+        seats: {
+          [ownerIntentId]: { userId: ownerId, round: 1 },
+          [counterpartIntentId]: { userId: counterpartId, round: 1 },
+        },
+        drainGeneration: 0,
+      });
+      await adapter.updateTaskState(expiredTask.id, 'working');
+      const expiredClosed = await adapter.completeNegotiation({
+        taskId: expiredTask.id,
+        kind: 'opportunity_expired',
+      });
+      expect(expiredClosed?.state).toBe('completed');
+      expect(await adapter.getArtifactsForTask(expiredTask.id)).toEqual([]);
     }, 30000);
 
     it('projects the latest task, opportunity, turn, and signal lifecycle', async () => {

--- a/services/api/src/adapters/tests/conversation.database.adapter.spec.ts
+++ b/services/api/src/adapters/tests/conversation.database.adapter.spec.ts
@@ -253,6 +253,21 @@ describe('ConversationDatabaseAdapter', () => {
       const freshSubmitted = await adapter.createTask(conv.id, {
         type: 'negotiation', opportunityId: 'watchdog-opportunity-fresh', sourceUserId: 'watchdog-user', seats: { 'watchdog-intent': { userId: 'watchdog-user', round: 1 } },
       });
+      const terminalOpportunityId = `watchdog-terminal-${crypto.randomUUID()}`;
+      await db.insert(schema.opportunities).values({
+        id: terminalOpportunityId,
+        detection: { source: 'manual', timestamp: new Date().toISOString() },
+        actors: [{ networkId: 'watchdog-network', userId: 'watchdog-user', role: 'peer' }],
+        interpretation: { category: 'test', reasoning: 'Owner verdict recovery.', confidence: 1 },
+        context: {},
+        confidence: '1',
+        status: 'accepted',
+      });
+      createdOpportunityIds.push(terminalOpportunityId);
+      const terminalActive = await adapter.createTask(conv.id, {
+        type: 'negotiation', opportunityId: terminalOpportunityId, sourceUserId: 'watchdog-user', candidateUserId: 'watchdog-peer', seats: { 'watchdog-intent': { userId: 'watchdog-user', round: 1 } },
+      });
+      await adapter.updateTaskState(terminalActive.id, 'working');
       const readyForVerdict = await adapter.createTask(conv.id, {
         type: 'negotiation', opportunityId: 'watchdog-opportunity-ready', sourceUserId: 'watchdog-user', seats: { 'watchdog-intent': { userId: 'watchdog-user', round: 1 } },
       });
@@ -296,12 +311,64 @@ describe('ConversationDatabaseAdapter', () => {
       expect(staleIds).toContain(staleSubmitted.id);
       expect(staleIds).toContain(staleWorking.id);
       expect(staleIds).toContain(readyForVerdict.id);
+      expect(staleIds).toContain(terminalActive.id);
       expect(staleIds).not.toContain(freshSubmitted.id);
       expect(staleIds).not.toContain(completed.id);
       expect(staleIds).not.toContain(nonNegotiation.id);
       expect(staleIds).not.toContain(legacySubmitted.id);
       expect(stale.every((task) => task.metadata && (task.metadata as Record<string, unknown>).type === 'negotiation')).toBe(true);
     }, 10000);
+
+    it('rotates checked ready pauses behind never-checked rows when the sweep is bounded', async () => {
+      const conv = await adapter.createConversation([
+        { participantId: 'agent:watchdog-rotation-a', participantType: 'agent' },
+        { participantId: 'agent:watchdog-rotation-b', participantType: 'agent' },
+      ]);
+      createdIds.push(conv.id);
+      const tasks = [];
+      for (let index = 0; index < 26; index++) {
+        const task = await adapter.createTask(conv.id, {
+          type: 'negotiation',
+          opportunityId: `watchdog-rotation-opportunity-${index}`,
+          sourceUserId: 'watchdog-rotation-user',
+          candidateUserId: 'watchdog-rotation-peer',
+          seats: { 'watchdog-rotation-intent': { userId: 'watchdog-rotation-user', round: 1 } },
+          drainGeneration: 0,
+        });
+        await adapter.updateNegotiationTaskState(task.id, 'paused', {
+          reason: 'ready_for_verdict', pausedBy: 'watchdog-rotation-user',
+        });
+        tasks.push(task.id);
+      }
+      await db.update(schema.tasks)
+        .set({ createdAt: new Date(Date.now() - 30 * 24 * 60 * 60 * 1000) })
+        .where(inArray(schema.tasks.id, tasks));
+
+      const first = await adapter.getStaleNegotiationTasks({
+        submittedOlderThanMs: 10 * 60 * 1000,
+        workingOlderThanMs: 12 * 60 * 60 * 1000,
+        limit: 25,
+      });
+      const rotationFirst = first.filter((task) => tasks.includes(task.id));
+      expect(rotationFirst).toHaveLength(25);
+      const neverCheckedId = tasks.find((id) => !rotationFirst.some((task) => task.id === id));
+      expect(neverCheckedId).toBeDefined();
+      const checkedAt = new Date();
+      for (const task of rotationFirst) {
+        await adapter.recordNegotiationWatchdogRecoveryCheck({
+          taskId: task.id,
+          expectedUpdatedAt: task.updatedAt,
+          checkedAt,
+        });
+      }
+
+      const second = await adapter.getStaleNegotiationTasks({
+        submittedOlderThanMs: 10 * 60 * 1000,
+        workingOlderThanMs: 12 * 60 * 60 * 1000,
+        limit: 25,
+      });
+      expect(second.map((task) => task.id)).toContain(neverCheckedId!);
+    }, 30000);
   });
 
   describe('getOpportunityLifecyclesForNegotiations', () => {
@@ -406,6 +473,7 @@ describe('ConversationDatabaseAdapter', () => {
           [ownerIntentId]: { userId: ownerId, round: 1 },
           [counterpartIntentId]: { userId: counterpartId, round: 1 },
         },
+        drainGeneration: 0,
         pause: {
           reason: 'ready_for_verdict',
           payload: { recommendation: 'pending', reasoning: 'Owner recommends proceeding.' },
@@ -436,6 +504,31 @@ describe('ConversationDatabaseAdapter', () => {
         payload: { recommendation: 'pending', reasoning: 'Owner recommends proceeding.' },
       });
       expect(counterpartDetail?.task.pause).toEqual({ reason: 'ready_for_verdict', by: 'theirs' });
+
+      // A human action that commits before the agent's transaction acquires
+      // the opportunity lock must remain authoritative.
+      await db.update(schema.opportunities).set({ status: 'accepted', acceptedBy: ownerId })
+        .where(eq(schema.opportunities.id, opportunityId));
+      const completed = await adapter.completeNegotiation({
+        taskId: task.id,
+        kind: 'pause_verdict',
+        verdict: 'reject',
+        reasoning: 'Stale agent verdict.',
+        resolvedByUserId: ownerId,
+      });
+      expect(completed?.state).toBe('completed');
+      expect(completed?.metadata.watchdogReflectPending).toBe(true);
+      const [preserved] = await db.select({ status: schema.opportunities.status }).from(schema.opportunities)
+        .where(eq(schema.opportunities.id, opportunityId));
+      expect(preserved?.status).toBe('accepted');
+      const pendingReflect = await adapter.getStaleNegotiationTasks({
+        submittedOlderThanMs: 10 * 60 * 1000,
+        workingOlderThanMs: 12 * 60 * 60 * 1000,
+        limit: 1000,
+      });
+      expect(pendingReflect.map((candidate) => candidate.id)).toContain(task.id);
+      await adapter.clearNegotiationReflectPending(task.id);
+      expect((await adapter.getTask(task.id))?.metadata?.watchdogReflectPending).toBe(false);
     }, 30000);
 
     it('projects the latest task, opportunity, turn, and signal lifecycle', async () => {

--- a/services/api/src/adapters/tests/negotiation-stalled-retry.database.spec.ts
+++ b/services/api/src/adapters/tests/negotiation-stalled-retry.database.spec.ts
@@ -67,8 +67,10 @@ function graphOpenInput(opportunity: typeof opportunities.$inferSelect) {
     sourceUserId: source!.userId,
     candidateUserId: candidate!.userId,
     brief: 'Atomic open fixture brief.',
-    intentId: `intent-${source!.userId}`,
-    round: 1,
+    seats: {
+      [`intent-${source!.userId}`]: { userId: source!.userId, round: 1 },
+      [`intent-${candidate!.userId}`]: { userId: candidate!.userId, round: 0 },
+    },
     networkId: source!.networkId,
   };
 }

--- a/services/api/src/controllers/tests/conversation.negotiation-activity.isolated.ts
+++ b/services/api/src/controllers/tests/conversation.negotiation-activity.isolated.ts
@@ -41,7 +41,7 @@ describe('ConversationController intent cycle', () => {
   });
 
   it('returns the exact owned cycle response', async () => {
-    const cycle = { round: { number: 1, size: 1, kickoffStartedAt: null, working: 1, paused: 0 }, negotiations: [] };
+    const cycle = { round: { number: 1, size: 1, kickoffStartedAt: null, active: 1, paused: 0 }, negotiations: [] };
     const read = mock(async () => cycle);
     const controller = new ConversationController(
       { getIntentCycleForIntent: read } as unknown as ConversationService,

--- a/services/api/src/lib/agent/negotiator-verdict.host.ts
+++ b/services/api/src/lib/agent/negotiator-verdict.host.ts
@@ -197,7 +197,7 @@ export async function readSignalMatches(
  *
  * This swallow is NOT for the PersonalAgent. Its turns are ABOUT this list —
  * a reflect that reads `[]` from a transient database error decides nothing,
- * succeeds, and permanently consumes the round's one retained reflect job.
+ * succeeds, and permanently consumes that drain generation's retained job.
  * That lane calls {@link readSignalMatches} and lets the error propagate.
  */
 export async function readActionableCounterparties(

--- a/services/api/src/lib/agent/tests/signal-matches.host.spec.ts
+++ b/services/api/src/lib/agent/tests/signal-matches.host.spec.ts
@@ -7,8 +7,8 @@ import { ACTIONABLE_VERDICT_STATUSES, PERSONAL_AGENT_MATCH_STATUSES, passVerdict
  * must FAIL the turn. Making the protocol seam throw achieved nothing while
  * the only host binding behind it caught everything and returned `[]`: a
  * transient database error still produced a reflect that saw no negotiations,
- * decided nothing, succeeded — and permanently consumed the round's one
- * retained reflect job.
+ * decided nothing, succeeded — and permanently consumed that drain
+ * generation's retained job.
  *
  * These run at the HOST binding, which is where the swallow actually lived.
  */

--- a/services/api/src/lib/negotiation/negotiation-graph.ts
+++ b/services/api/src/lib/negotiation/negotiation-graph.ts
@@ -43,8 +43,8 @@ export const agentDispatcher = new AgentDispatcherImpl(agentService);
 
 export const negotiationGraph = new NegotiationGraphFactory({
   database: conversationDatabaseAdapter,
-  // All-paused → reflect: the trigger is gated on the round's size stamp, so
-  // this fires exactly once per round, when kickoff's opens have all settled.
+  // All-paused → reflect: the trigger waits for an in-flight kickoff to finish,
+  // then deduplicates the durable task-generation vector for every bound seat.
   reflectEnqueue: async (job) => {
     const { personalAgentQueue } = await import('../../queues/personal-agent.queue');
     await personalAgentQueue.addAllPausedEvent(job);
@@ -75,8 +75,8 @@ export const personalAgentGraph: PersonalAgentGraphLike = new PersonalAgentGraph
     // `readSignalMatches`, NOT the degrading `readActionableCounterparties`:
     // every one of the agent's turns is about this list, and a read that
     // failed must fail the turn. Swallowed to `[]` it becomes a reflect that
-    // saw no negotiations, decided nothing, succeeded — and burned the round's
-    // one retained reflect job.
+    // saw no negotiations, decided nothing, succeeded — and burned that drain
+    // generation's one retained job.
     readMatches: async (userId, intentId) => (
       await readSignalMatches(userId, intentId, undefined, PERSONAL_AGENT_MATCH_STATUSES)
     ).map((match) => ({

--- a/services/api/src/lib/negotiation/tests/graph-composition.static.spec.ts
+++ b/services/api/src/lib/negotiation/tests/graph-composition.static.spec.ts
@@ -41,8 +41,9 @@ describe('host graph composition', () => {
     expect(personalAgentQueue).toContain("import { personalAgentGraph } from '../lib/negotiation/negotiation-graph'");
     expect(personalAgentQueue).toContain('personalAgentGraph.invoke(input)');
     expect(main).toContain('negotiationWatchdogQueue.setNegotiationGraph(negotiationGraph)');
+    expect(main).toContain('negotiationWatchdogQueue.setReflectEnqueue');
     expect(opportunityService).toContain("await import('../lib/negotiation/negotiation-graph')");
-    expect(opportunityService).toContain('resolve: (input) => negotiationGraph.invoke(input)');
+    expect(opportunityService).toContain("close: { reason: 'owner_verdict'");
     expect(mcp).toContain("import { matchesReadyBestEffort, negotiationGraph } from '../lib/negotiation/negotiation-graph'");
     expect(mcp).toMatch(/negotiationGraph,\n[\s\S]*?matchesReady: protocolDeps\.matchesReady/);
   });

--- a/services/api/src/main.ts
+++ b/services/api/src/main.ts
@@ -113,6 +113,9 @@ fromIntentQueue.setRuntimeDeps({
   agentDispatcher: backgroundAgentDispatcher,
 });
 negotiationWatchdogQueue.setNegotiationGraph(negotiationGraph);
+negotiationWatchdogQueue.setReflectEnqueue(async (job) => {
+  await personalAgentQueue.addAllPausedEvent(job);
+});
 
 const notificationOpportunityAdapter = new OpportunityDatabaseAdapter();
 const notificationDeliveryService = new NotificationDeliveryService({

--- a/services/api/src/queues/negotiations/watchdog.queue.ts
+++ b/services/api/src/queues/negotiations/watchdog.queue.ts
@@ -1,5 +1,5 @@
 import type { Job, Queue, Worker } from 'bullmq';
-import type { NegotiationGraphLike } from '@indexnetwork/protocol';
+import { maybeEnqueueRoundReflect, type NegotiationGraphLike, type NegotiationRoundReflectEnqueueFn } from '@indexnetwork/protocol';
 
 import type { ConversationDatabaseAdapter, StaleNegotiationTask, StaleNegotiationTasksInput } from '../../adapters/conversation.database.adapter';
 import type { ChatDatabaseAdapter } from '../../adapters/chat.database.adapter';
@@ -28,6 +28,7 @@ type WatchdogWorkerHandle = Pick<Worker<NegotiationWatchdogJobData>, 'close'>;
 type WatchdogDatabase = Pick<
   ConversationDatabaseAdapter,
   'getStaleNegotiationTasks' | 'getTask' | 'recordNegotiationWatchdogAttempt'
+  | 'getIntentNegotiationRound' | 'getNegotiationTasksForIntentRound'
 >;
 type WatchdogOpportunities = Pick<ChatDatabaseAdapter, 'getOpportunity'>;
 
@@ -48,6 +49,7 @@ export interface NegotiationWatchdogQueueDeps {
   database?: Pick<
     ConversationDatabaseAdapter,
     'getStaleNegotiationTasks' | 'getTask' | 'recordNegotiationWatchdogAttempt'
+    | 'getIntentNegotiationRound' | 'getNegotiationTasksForIntentRound'
   >;
   opportunities?: Pick<ChatDatabaseAdapter, 'getOpportunity'>;
   negotiationGraph?: NegotiationGraphLike;
@@ -57,6 +59,7 @@ export interface NegotiationWatchdogQueueDeps {
   ) => WatchdogWorkerHandle;
   logger?: WatchdogLogger;
   clock?: () => Date;
+  reflectEnqueue?: NegotiationRoundReflectEnqueueFn;
 }
 
 /**
@@ -90,17 +93,24 @@ export class NegotiationWatchdogQueue {
   private queueInstance: WatchdogQueueHandle | null = null;
   private worker: WatchdogWorkerHandle | null = null;
   private negotiationGraph: NegotiationGraphLike | undefined;
+  private reflectEnqueue: NegotiationRoundReflectEnqueueFn | undefined;
 
   constructor(deps: NegotiationWatchdogQueueDeps = {}) {
     this.deps = deps;
     this.logger = deps.logger ?? log.queue.from('NegotiationWatchdogQueue');
     this.clock = deps.clock ?? (() => new Date());
     this.negotiationGraph = deps.negotiationGraph;
+    this.reflectEnqueue = deps.reflectEnqueue;
   }
 
   /** Wired once at startup by main.ts, after the single NegotiationGraph is compiled. */
   setNegotiationGraph(graph: NegotiationGraphLike): void {
     this.negotiationGraph = graph;
+  }
+
+  /** Wired once at startup so durable ready pauses can retry their reflect enqueue. */
+  setReflectEnqueue(enqueue: NegotiationRoundReflectEnqueueFn): void {
+    this.reflectEnqueue = enqueue;
   }
 
   private get queue(): WatchdogQueueHandle {
@@ -241,6 +251,19 @@ export class NegotiationWatchdogQueue {
 
     const pause = asRecord(metadata.pause);
     if (staleTask.state === 'paused') {
+      if (pause.reason === 'ready_for_verdict') {
+        const seats = asRecord(metadata.seats);
+        for (const [intentId, rawBinding] of Object.entries(seats)) {
+          const binding = asRecord(rawBinding);
+          if (typeof binding.userId !== 'string' || typeof binding.round !== 'number') continue;
+          await maybeEnqueueRoundReflect(database, this.reflectEnqueue, {
+            userId: binding.userId,
+            intentId,
+            round: binding.round,
+          });
+        }
+        return;
+      }
       if (pause.reason !== 'needs_principal' && pause.reason !== 'counterparty_silent') return;
       if (!this.negotiationGraph) {
         this.logger.error('Negotiation watchdog fired before the graph was wired', { taskId: candidate.id });

--- a/services/api/src/queues/negotiations/watchdog.queue.ts
+++ b/services/api/src/queues/negotiations/watchdog.queue.ts
@@ -319,6 +319,32 @@ export class NegotiationWatchdogQueue {
     }
 
     const opportunity = await opportunities.getOpportunity(opportunityId);
+    if (opportunity?.status === 'expired') {
+      if (!this.negotiationGraph) {
+        this.logger.error('Negotiation watchdog cannot recover an expired opportunity', {
+          taskId: candidate.id,
+          opportunityId,
+        });
+      } else {
+        const result = await this.negotiationGraph.invoke({
+          negotiationId: staleTask.id,
+          close: { reason: 'opportunity_expired' },
+        });
+        if (result.status === 'error') {
+          this.logger.error('Negotiation watchdog expiry recovery returned an error status', {
+            taskId: candidate.id,
+            opportunityId,
+            error: result.error,
+          });
+        }
+      }
+      await database.recordNegotiationWatchdogRecoveryCheck({
+        taskId: staleTask.id,
+        expectedUpdatedAt: staleTask.updatedAt,
+        checkedAt: this.clock(),
+      });
+      return;
+    }
     if (opportunity?.status === 'accepted' || opportunity?.status === 'rejected') {
       const byUserId = typeof metadata.sourceUserId === 'string'
         ? metadata.sourceUserId

--- a/services/api/src/queues/negotiations/watchdog.queue.ts
+++ b/services/api/src/queues/negotiations/watchdog.queue.ts
@@ -27,14 +27,15 @@ interface WatchdogQueueHandle {
 type WatchdogWorkerHandle = Pick<Worker<NegotiationWatchdogJobData>, 'close'>;
 type WatchdogDatabase = Pick<
   ConversationDatabaseAdapter,
-  'getStaleNegotiationTasks' | 'getTask' | 'recordNegotiationWatchdogAttempt'
+  'getStaleNegotiationTasks' | 'getTask' | 'recordNegotiationWatchdogAttempt' | 'recordNegotiationWatchdogRecoveryCheck'
+  | 'clearNegotiationReflectPending'
   | 'getIntentNegotiationRound' | 'getNegotiationTasksForIntentRound'
 >;
 type WatchdogOpportunities = Pick<ChatDatabaseAdapter, 'getOpportunity'>;
 
 type StaleTaskForWatchdog = {
   id: string;
-  state: 'submitted' | 'working' | 'paused';
+  state: 'submitted' | 'working' | 'paused' | 'completed';
   updatedAt: Date;
   metadata: Record<string, unknown> | null;
 };
@@ -48,7 +49,8 @@ type WatchdogLogger = {
 export interface NegotiationWatchdogQueueDeps {
   database?: Pick<
     ConversationDatabaseAdapter,
-    'getStaleNegotiationTasks' | 'getTask' | 'recordNegotiationWatchdogAttempt'
+    'getStaleNegotiationTasks' | 'getTask' | 'recordNegotiationWatchdogAttempt' | 'recordNegotiationWatchdogRecoveryCheck'
+    | 'clearNegotiationReflectPending'
     | 'getIntentNegotiationRound' | 'getNegotiationTasksForIntentRound'
   >;
   opportunities?: Pick<ChatDatabaseAdapter, 'getOpportunity'>;
@@ -250,6 +252,30 @@ export class NegotiationWatchdogQueue {
     }
 
     const pause = asRecord(metadata.pause);
+    if (staleTask.state === 'completed') {
+      const seats = asRecord(metadata.seats);
+      let succeeded = true;
+      for (const [intentId, rawBinding] of Object.entries(seats)) {
+        const binding = asRecord(rawBinding);
+        if (typeof binding.userId !== 'string' || typeof binding.round !== 'number') continue;
+        const checked = await maybeEnqueueRoundReflect(database, this.reflectEnqueue, {
+          userId: binding.userId,
+          intentId,
+          round: binding.round,
+        });
+        succeeded &&= checked;
+      }
+      if (succeeded) {
+        await database.clearNegotiationReflectPending(staleTask.id);
+      } else {
+        await database.recordNegotiationWatchdogRecoveryCheck({
+          taskId: staleTask.id,
+          expectedUpdatedAt: staleTask.updatedAt,
+          checkedAt: this.clock(),
+        });
+      }
+      return;
+    }
     if (staleTask.state === 'paused') {
       if (pause.reason === 'ready_for_verdict') {
         const seats = asRecord(metadata.seats);
@@ -262,6 +288,11 @@ export class NegotiationWatchdogQueue {
             round: binding.round,
           });
         }
+        await database.recordNegotiationWatchdogRecoveryCheck({
+          taskId: staleTask.id,
+          expectedUpdatedAt: staleTask.updatedAt,
+          checkedAt: this.clock(),
+        });
         return;
       }
       if (pause.reason !== 'needs_principal' && pause.reason !== 'counterparty_silent') return;
@@ -288,11 +319,50 @@ export class NegotiationWatchdogQueue {
     }
 
     const opportunity = await opportunities.getOpportunity(opportunityId);
+    if (opportunity?.status === 'accepted' || opportunity?.status === 'rejected') {
+      const byUserId = typeof metadata.sourceUserId === 'string'
+        ? metadata.sourceUserId
+        : typeof metadata.candidateUserId === 'string' ? metadata.candidateUserId : null;
+      if (!this.negotiationGraph || !byUserId) {
+        this.logger.error('Negotiation watchdog cannot recover terminal owner verdict', {
+          taskId: candidate.id,
+          opportunityId,
+        });
+      } else {
+        const result = await this.negotiationGraph.invoke({
+          negotiationId: staleTask.id,
+          close: {
+            reason: 'owner_verdict',
+            verdict: opportunity.status === 'rejected' ? 'reject' : 'pending',
+            reasoning: 'Recovered after the owner verdict committed before negotiation closure.',
+          },
+          byUserId,
+        });
+        if (result.status === 'error') {
+          this.logger.error('Negotiation watchdog owner-verdict recovery returned an error status', {
+            taskId: candidate.id,
+            opportunityId,
+            error: result.error,
+          });
+        }
+      }
+      await database.recordNegotiationWatchdogRecoveryCheck({
+        taskId: staleTask.id,
+        expectedUpdatedAt: staleTask.updatedAt,
+        checkedAt: this.clock(),
+      });
+      return;
+    }
     if (!opportunity || opportunity.status !== 'negotiating') {
       this.logger.info('Negotiation watchdog skipped task whose opportunity is not negotiating', {
         taskId: candidate.id,
         opportunityId,
         opportunityStatus: opportunity?.status ?? 'missing',
+      });
+      await database.recordNegotiationWatchdogRecoveryCheck({
+        taskId: staleTask.id,
+        expectedUpdatedAt: staleTask.updatedAt,
+        checkedAt: this.clock(),
       });
       return;
     }

--- a/services/api/src/queues/personal-agent.queue.ts
+++ b/services/api/src/queues/personal-agent.queue.ts
@@ -12,8 +12,8 @@
  *   double-speak. Removed on completion; the chat controller awaits it.
  * - `matches_ready` — keyed by the signal, so a burst of discovery batches
  *   coalesces into one kickoff turn rather than one per batch.
- * - `all_paused` — keyed by `(intentId, round)` and NOT removed on
- *   completion: reflect must fire exactly once per round, or the agent acts
+ * - `all_paused` — keyed by one durable all-paused generation and NOT removed on
+ *   completion: reflect must fire exactly once per durable drain, or the agent acts
  *   twice on the same moment.
  */
 import { Job, UnrecoverableError } from 'bullmq';
@@ -145,20 +145,22 @@ export class PersonalAgentQueue {
 
   /**
    * Every negotiation of a round has paused. The deterministic job id is the
-   * whole dedup: ten pauses produce one reflect, and the completed job is
-   * retained FOREVER so the same round can never reflect twice — the queue's
+   * whole dedup: duplicate delivery of one durable drain produces one reflect,
+   * and the completed job is retained so that generation cannot run twice. A
+   * reopened task increments its durable generation and therefore gets a new
+   * job. The queue's
    * default `removeOnComplete: { age: 24h }` would free the id, and a late
-   * watchdog pause on a stale negotiation of that round would then wake the
-   * agent to re-decide a round it already closed out. One retained row per
-   * (signal, round) is the price of exactly-once.
+   * watchdog delivery of the same durable pause would then wake the agent to
+   * re-decide work it already closed out. One retained row per drain
+   * generation is the price of exactly-once.
    *
    * `removeOnFail` keeps the default 7-day window on purpose: a reflect lost
    * to a transient model outage should become reachable again, and a genuinely
-   * dead round is better re-run once than never.
+   * dead drain is better re-run once than never.
    */
   addAllPausedEvent(job: NegotiationRoundReflectJobData): Promise<Job<PersonalAgentEvent>> {
     return this.queue.add('all_paused', { ...job, event: 'all_paused' }, {
-      jobId: negotiationRoundReflectJobId(job.intentId, job.round),
+      jobId: negotiationRoundReflectJobId(job.intentId, job.round, job.generation),
       removeOnComplete: false,
     });
   }

--- a/services/api/src/queues/tests/personal-agent.queue.isolated.ts
+++ b/services/api/src/queues/tests/personal-agent.queue.isolated.ts
@@ -66,7 +66,7 @@ describe('PersonalAgentQueue serialization', () => {
     await withQueue(buildQueue(() => idle), async ({ queue, spans }) => {
       const jobs = await Promise.all([
         queue.addMatchesReadyEvent({ userId: 'user-1', intentId: 'intent-1' }),
-        queue.addAllPausedEvent({ userId: 'user-1', intentId: 'intent-1', round: 3 }),
+        queue.addAllPausedEvent({ userId: 'user-1', intentId: 'intent-1', round: 3, generation: 'task-1.0' }),
         queue.addUserMessageEvent({
           userId: 'user-1', intentId: 'intent-1', event: 'user_message',
           sessionId: 'session-1', messageId: 'reply-1', text: 'hello',
@@ -97,13 +97,20 @@ describe('PersonalAgentQueue serialization', () => {
     });
   });
 
-  it('a round reflects exactly once — ten pauses of one round collapse to one job', async () => {
+  it('one durable drain reflects exactly once, while a reopened generation runs again', async () => {
     await withQueue(buildQueue(() => idle), async ({ queue, invocations }) => {
       const jobs = await Promise.all(Array.from({ length: 10 }, () =>
-        queue.addAllPausedEvent({ userId: 'user-1', intentId: 'intent-1', round: 7 })));
+        queue.addAllPausedEvent({ userId: 'user-1', intentId: 'intent-1', round: 7, generation: 'task-1.0' })));
       expect(new Set(jobs.map((job) => job.id)).size).toBe(1);
       await jobs[0]!.waitUntilFinished(undefined as never, 10_000);
       expect(invocations()).toBe(1);
+
+      const reopened = await queue.addAllPausedEvent({
+        userId: 'user-1', intentId: 'intent-1', round: 7, generation: 'task-1.1',
+      });
+      expect(reopened.id).not.toBe(jobs[0]!.id);
+      await reopened.waitUntilFinished(undefined as never, 10_000);
+      expect(invocations()).toBe(2);
     });
   });
 
@@ -172,9 +179,9 @@ describe('PersonalAgentQueue serialization', () => {
     }
   });
 
-  it('a reflect job is retained on completion so the round can never reflect twice', async () => {
+  it('a reflect job is retained on completion so one generation cannot reflect twice', async () => {
     await withQueue(buildQueue(() => idle), async ({ queue }) => {
-      const job = await queue.addAllPausedEvent({ userId: 'user-1', intentId: 'intent-1', round: 4 });
+      const job = await queue.addAllPausedEvent({ userId: 'user-1', intentId: 'intent-1', round: 4, generation: 'task-1.0' });
       // The queue default is removeOnComplete { age: 24h }, which would free
       // the id and let a late pause on a stale negotiation re-wake the agent
       // for a round it already closed out.

--- a/services/api/src/queues/tests/watchdog.queue.spec.ts
+++ b/services/api/src/queues/tests/watchdog.queue.spec.ts
@@ -187,6 +187,22 @@ describe('NegotiationWatchdogQueue', () => {
     expect(deps.database.recordNegotiationWatchdogAttempt).not.toHaveBeenCalled();
   });
 
+  it('recovers an active task left behind after its opportunity expired', async () => {
+    const task = makeTask({ state: 'working' });
+    const deps = makeDeps(task);
+    deps.opportunities.getOpportunity.mockResolvedValue({ id: 'opportunity-1', status: 'expired' } as never);
+    deps.negotiationGraph.invoke.mockResolvedValue({ negotiationId: task.id, status: 'resolved', turns: [] } as never);
+    const queue = new NegotiationWatchdogQueue({ ...deps, clock: () => now });
+
+    await queue.sweep();
+
+    expect(deps.negotiationGraph.invoke).toHaveBeenCalledWith({
+      negotiationId: task.id,
+      close: { reason: 'opportunity_expired' },
+    });
+    expect(deps.database.recordNegotiationWatchdogAttempt).not.toHaveBeenCalled();
+  });
+
   it('keeps a completed verdict durable until its reflect check succeeds', async () => {
     const task = makeTask({
       state: 'completed',

--- a/services/api/src/queues/tests/watchdog.queue.spec.ts
+++ b/services/api/src/queues/tests/watchdog.queue.spec.ts
@@ -33,12 +33,15 @@ function makeDeps(task: ReturnType<typeof makeTask> | null = makeTask()) {
     getStaleNegotiationTasks: mock(async () => stale),
     getTask: mock(async () => task),
     recordNegotiationWatchdogAttempt: mock(async () => task),
+    getIntentNegotiationRound: mock(async () => ({ round: 1, roundSize: 1, kickoffStartedAt: null })),
+    getNegotiationTasksForIntentRound: mock(async () => task ? [task as never] : []),
   };
   const opportunities = {
     getOpportunity: mock(async () => ({ id: 'opportunity-1', status: 'negotiating' })),
   };
   const negotiationGraph = { invoke: mock(async () => ({ negotiationId: task?.id ?? '', status: 'paused' as const, turns: [] })) };
-  return { database, opportunities, negotiationGraph };
+  const reflectEnqueue = mock(async () => undefined);
+  return { database, opportunities, negotiationGraph, reflectEnqueue };
 }
 
 beforeEach(() => {
@@ -117,6 +120,43 @@ describe('NegotiationWatchdogQueue', () => {
       negotiationId: task.id,
       expire: { expectedUpdatedAt: task.updatedAt, reason: 'needs_principal' },
     });
+  });
+
+  it('retries a failed durable reflect generation on the next ready_for_verdict sweep', async () => {
+    const task = makeTask({
+      state: 'paused',
+      metadata: {
+        type: 'negotiation',
+        opportunityId: 'opportunity-1',
+        sourceUserId: 'user-1',
+        candidateUserId: 'user-2',
+        initiatorUserId: 'user-1',
+        networkId: 'network-1',
+        seats: { 'intent-1': { userId: 'user-1', round: 1 } },
+        drainGeneration: 0,
+        pause: { reason: 'ready_for_verdict', pausedBy: 'user-1' },
+      },
+    });
+    const deps = makeDeps(task);
+    deps.reflectEnqueue
+      .mockRejectedValueOnce(new Error('redis unavailable'))
+      .mockRejectedValueOnce(new Error('redis unavailable'))
+      .mockRejectedValueOnce(new Error('redis unavailable'));
+    const queue = new NegotiationWatchdogQueue({ ...deps, clock: () => now });
+
+    await queue.sweep();
+    expect(deps.reflectEnqueue).toHaveBeenCalledTimes(3);
+
+    await queue.sweep();
+
+    expect(deps.reflectEnqueue).toHaveBeenLastCalledWith({
+      userId: 'user-1',
+      intentId: 'intent-1',
+      round: 1,
+      generation: 'task-1.0',
+    });
+    expect(deps.reflectEnqueue).toHaveBeenCalledTimes(4);
+    expect(deps.negotiationGraph.invoke).not.toHaveBeenCalled();
   });
 
   it('does not expire a paused task changed after the stale-list read', async () => {

--- a/services/api/src/queues/tests/watchdog.queue.spec.ts
+++ b/services/api/src/queues/tests/watchdog.queue.spec.ts
@@ -33,6 +33,8 @@ function makeDeps(task: ReturnType<typeof makeTask> | null = makeTask()) {
     getStaleNegotiationTasks: mock(async () => stale),
     getTask: mock(async () => task),
     recordNegotiationWatchdogAttempt: mock(async () => task),
+    recordNegotiationWatchdogRecoveryCheck: mock(async () => true),
+    clearNegotiationReflectPending: mock(async () => undefined),
     getIntentNegotiationRound: mock(async () => ({ round: 1, roundSize: 1, kickoffStartedAt: null })),
     getNegotiationTasksForIntentRound: mock(async () => task ? [task as never] : []),
   };
@@ -157,6 +159,60 @@ describe('NegotiationWatchdogQueue', () => {
     });
     expect(deps.reflectEnqueue).toHaveBeenCalledTimes(4);
     expect(deps.negotiationGraph.invoke).not.toHaveBeenCalled();
+    expect(deps.database.recordNegotiationWatchdogRecoveryCheck).toHaveBeenCalledWith({
+      taskId: 'task-1',
+      expectedUpdatedAt: task.updatedAt,
+      checkedAt: now,
+    });
+  });
+
+  it('recovers an active task left behind after an owner verdict committed', async () => {
+    const task = makeTask({ state: 'working' });
+    const deps = makeDeps(task);
+    deps.opportunities.getOpportunity.mockResolvedValue({ id: 'opportunity-1', status: 'accepted' } as never);
+    deps.negotiationGraph.invoke.mockResolvedValue({ negotiationId: task.id, status: 'resolved', turns: [] } as never);
+    const queue = new NegotiationWatchdogQueue({ ...deps, clock: () => now });
+
+    await queue.sweep();
+
+    expect(deps.negotiationGraph.invoke).toHaveBeenCalledWith({
+      negotiationId: task.id,
+      close: {
+        reason: 'owner_verdict',
+        verdict: 'pending',
+        reasoning: 'Recovered after the owner verdict committed before negotiation closure.',
+      },
+      byUserId: 'user-1',
+    });
+    expect(deps.database.recordNegotiationWatchdogAttempt).not.toHaveBeenCalled();
+  });
+
+  it('keeps a completed verdict durable until its reflect check succeeds', async () => {
+    const task = makeTask({
+      state: 'completed',
+      metadata: {
+        type: 'negotiation',
+        opportunityId: 'opportunity-1',
+        sourceUserId: 'user-1',
+        candidateUserId: 'user-2',
+        seats: { 'intent-1': { userId: 'user-1', round: 1 } },
+        drainGeneration: 0,
+        watchdogReflectPending: true,
+      },
+    });
+    const deps = makeDeps(task);
+    deps.reflectEnqueue
+      .mockRejectedValueOnce(new Error('redis unavailable'))
+      .mockRejectedValueOnce(new Error('redis unavailable'))
+      .mockRejectedValueOnce(new Error('redis unavailable'));
+    const queue = new NegotiationWatchdogQueue({ ...deps, clock: () => now });
+
+    await queue.sweep();
+    expect(deps.database.clearNegotiationReflectPending).not.toHaveBeenCalled();
+    expect(deps.database.recordNegotiationWatchdogRecoveryCheck).toHaveBeenCalledTimes(1);
+
+    await queue.sweep();
+    expect(deps.database.clearNegotiationReflectPending).toHaveBeenCalledWith(task.id);
   });
 
   it('does not expire a paused task changed after the stale-list read', async () => {
@@ -192,6 +248,7 @@ describe('NegotiationWatchdogQueue', () => {
     await queue.sweep();
 
     expect(deps.negotiationGraph.invoke).not.toHaveBeenCalled();
+    expect(deps.database.recordNegotiationWatchdogRecoveryCheck).toHaveBeenCalledTimes(1);
   });
 
   it('a task that exhausted the watchdog retry budget is paused through the graph, not marked with an out-of-union state', async () => {

--- a/services/api/src/services/opportunity.service.ts
+++ b/services/api/src/services/opportunity.service.ts
@@ -309,8 +309,10 @@ export class OpportunityService {
    *
    * A match that never negotiated has no task and nothing happens here.
    *
-   * Best-effort: the owner's decision is already committed and their request
-   * must not fail because a background trigger could not be re-armed.
+   * Best-effort immediately: the owner's decision is already committed and
+   * their request must not fail because this follow-up is unavailable. Any
+   * active task left behind beside an accepted/rejected opportunity remains a
+   * durable watchdog candidate and is retried on the next bounded sweep.
    */
   private async closeNegotiationForOwnerVerdict(
     opportunityId: string,

--- a/services/api/src/services/opportunity.service.ts
+++ b/services/api/src/services/opportunity.service.ts
@@ -227,7 +227,7 @@ interface OpportunityPresentationDeps {
  *
  * An owner accept/reject is a user action on the OPPORTUNITY, outside the
  * negotiation loop — but the pairing it decides may still have a live
- * negotiation, and `NegotiationGraph`'s `resolve` is the only terminal write
+ * negotiation, and `NegotiationGraph`'s owner-close lane is the terminal write
  * on a negotiation task: it records the outcome artifact, completes the task,
  * and re-runs the all-paused check that arms each seat's drain-generation job.
  *
@@ -237,8 +237,8 @@ interface OpportunityPresentationDeps {
 export interface OwnerVerdictNegotiationCloser {
   /** The opportunity's live (non-completed) negotiation, or null when it never negotiated. */
   liveNegotiationId(opportunityId: string): Promise<string | null>;
-  /** `NegotiationGraph.invoke` with a verdict — the resolve lane. */
-  resolve(input: {
+  /** Close the task after this service has committed the owner's opportunity verdict. */
+  close(input: {
     negotiationId: string;
     verdict: 'pending' | 'reject';
     reasoning: string;
@@ -291,18 +291,21 @@ export class OpportunityService {
     return {
       liveNegotiationId: async (opportunityId: string) =>
         (await conversationDatabaseAdapter.getNegotiationTaskForOpportunity(opportunityId))?.id ?? null,
-      resolve: (input) => negotiationGraph.invoke(input),
+      close: (input) => negotiationGraph.invoke({
+        negotiationId: input.negotiationId,
+        close: { reason: 'owner_verdict', verdict: input.verdict, reasoning: input.reasoning },
+        byUserId: input.byUserId,
+      }),
     };
   }
 
   /**
    * End the pairing's negotiation, if it still has one, on the owner's verdict.
    *
-   * `resolve` is the negotiation's only terminal write: it records the outcome
-   * artifact, completes the task, and re-runs the all-paused check so each
+   * The graph's owner-close lane records the outcome artifact, completes the
+   * task, and re-runs the all-paused check so each
    * bound seat's current drain-generation job can finally be enqueued. It leaves
-   * the opportunity status this method already wrote alone — a terminal status
-   * is the owner's, never overwritten by a verdict (see `resolveNode`).
+   * the opportunity status this method already wrote alone.
    *
    * A match that never negotiated has no task and nothing happens here.
    *
@@ -318,7 +321,7 @@ export class OpportunityService {
       const closer = await this.getNegotiationCloser();
       const negotiationId = await closer.liveNegotiationId(opportunityId);
       if (!negotiationId) return;
-      const result = await closer.resolve({
+      const result = await closer.close({
         negotiationId,
         // An accept closes the negotiation on its promotable outcome — the
         // owner's own `accepted` is the status, already written above. A
@@ -331,7 +334,7 @@ export class OpportunityService {
         byUserId,
       });
       if (result.status === 'error') {
-        updateStatusLogger.error('negotiation resolve failed after owner verdict (non-blocking)', {
+        updateStatusLogger.error('negotiation close failed after owner verdict (non-blocking)', {
           opportunityId,
           negotiationId,
           action,

--- a/services/api/src/services/opportunity.service.ts
+++ b/services/api/src/services/opportunity.service.ts
@@ -229,7 +229,7 @@ interface OpportunityPresentationDeps {
  * negotiation loop — but the pairing it decides may still have a live
  * negotiation, and `NegotiationGraph`'s `resolve` is the only terminal write
  * on a negotiation task: it records the outcome artifact, completes the task,
- * and re-runs the all-paused check that arms the round's reflect job.
+ * and re-runs the all-paused check that arms each seat's drain-generation job.
  *
  * Production composes the conversation adapter's task read with the single
  * compiled graph; specs pass a fake pair.
@@ -299,8 +299,8 @@ export class OpportunityService {
    * End the pairing's negotiation, if it still has one, on the owner's verdict.
    *
    * `resolve` is the negotiation's only terminal write: it records the outcome
-   * artifact, completes the task, and re-runs the all-paused check so the
-   * round's `reflect:{intentId}:{round}` job can finally be enqueued. It leaves
+   * artifact, completes the task, and re-runs the all-paused check so each
+   * bound seat's current drain-generation job can finally be enqueued. It leaves
    * the opportunity status this method already wrote alone — a terminal status
    * is the owner's, never overwritten by a verdict (see `resolveNode`).
    *
@@ -757,11 +757,9 @@ export class OpportunityService {
     }
 
     // An owner verdict on a NEGOTIATED pairing has to end the negotiation too.
-    // The round's reflect trigger counts negotiation tasks still in `working`
-    // (`countActiveNegotiationsForRound`), so a reject or accept that flips only
-    // the opportunity leaves its task `working` forever: the round never reaches
-    // zero and `reflect:{intentId}:{round}` is never enqueued — the all-paused
-    // trigger defeated by the most ordinary user action.
+    // The reflect trigger waits for every task in each bound seat's round to
+    // stop working, so a reject or accept that flips only the opportunity
+    // leaves its task `working` forever and prevents that drain from enqueueing.
     if (captureAction) {
       await this.closeNegotiationForOwnerVerdict(opportunityId, captureAction, userId);
     }

--- a/services/api/src/services/tests/opportunity.service.negotiationClose.spec.ts
+++ b/services/api/src/services/tests/opportunity.service.negotiationClose.spec.ts
@@ -6,7 +6,7 @@
  * so its task stayed `working` forever and neither seat's drain was enqueued.
  *
  * The test drives the REAL `NegotiationGraph` over a fake database — the same
- * `resolve` production runs — rather than asserting that a mock was called, so
+ * owner-close lane production runs — rather than asserting that a mock was called, so
  * the count and the enqueue are observed, not stipulated.
  */
 /** Config */
@@ -119,7 +119,11 @@ function createWorld() {
   const closer: OwnerVerdictNegotiationCloser = {
     liveNegotiationId: async (opportunityId) =>
       (await negotiationDb.getNegotiationTaskForOpportunity(opportunityId))?.id ?? null,
-    resolve: (input) => graph.invoke(input),
+    close: (input) => graph.invoke({
+      negotiationId: input.negotiationId,
+      close: { reason: 'owner_verdict', verdict: input.verdict, reasoning: input.reasoning },
+      byUserId: input.byUserId,
+    }),
   };
 
   const opportunityDb = {
@@ -178,7 +182,7 @@ describe('OpportunityService owner verdict closes the negotiation', () => {
     const result = await world.service.updateOpportunityStatus(OPP_ID, 'accepted', USER_A);
     expect('error' in result).toBe(false);
 
-    // resolve never writes over a terminal status the owner just set.
+    // Owner-close never writes over the terminal status the owner just set.
     expect(world.opportunity.status).toBe('accepted');
     expect(world.task.state).toBe('completed');
     expect(await world.negotiationDb.countActiveNegotiationsForRound(INTENT_ID, ROUND)).toBe(0);

--- a/services/api/src/services/tests/opportunity.service.negotiationClose.spec.ts
+++ b/services/api/src/services/tests/opportunity.service.negotiationClose.spec.ts
@@ -1,10 +1,9 @@
 /**
  * The owner verdict must END the pairing's negotiation (D23).
  *
- * The round's reflect trigger counts negotiation tasks still in `working`
- * (`countActiveNegotiationsForRound`). Before this fix an ordinary user reject
- * flipped only the opportunity, so its task stayed `working` forever: the round
- * never reached zero and `reflect:{intentId}:{round}` was never enqueued.
+ * The reflect trigger waits for every task in a bound seat's round to stop
+ * working. Before this fix an ordinary user reject flipped only the opportunity,
+ * so its task stayed `working` forever and neither seat's drain was enqueued.
  *
  * The test drives the REAL `NegotiationGraph` over a fake database — the same
  * `resolve` production runs — rather than asserting that a mock was called, so
@@ -25,6 +24,7 @@ const USER_A = 'user-a-001';
 const USER_B = 'user-b-002';
 const OPP_ID = 'opp-negotiated-001';
 const INTENT_ID = 'intent-001';
+const COUNTERPART_INTENT_ID = 'intent-002';
 const NEGOTIATION_ID = 'task-negotiation-001';
 const ROUND = 3;
 
@@ -35,7 +35,7 @@ function negotiatedOpportunity(): Opportunity {
     detection: { source: 'opportunity_graph', timestamp: new Date().toISOString(), triggeredBy: INTENT_ID },
     actors: [
       { networkId: 'idx-1', userId: USER_A, role: 'patient', intent: INTENT_ID },
-      { networkId: 'idx-1', userId: USER_B, role: 'agent' },
+      { networkId: 'idx-1', userId: USER_B, role: 'agent', intent: COUNTERPART_INTENT_ID },
     ],
     interpretation: { category: 'collaboration', reasoning: 'Shared interests.', confidence: 0.85, signals: [] },
     context: { networkId: 'idx-1' },
@@ -60,7 +60,11 @@ function negotiationTask(): NegotiationTaskRow {
       candidateUserId: USER_B,
       initiatorUserId: USER_A,
       networkId: 'idx-1',
-      seats: { [INTENT_ID]: { userId: USER_A, round: ROUND } },
+      seats: {
+        [INTENT_ID]: { userId: USER_A, round: ROUND },
+        [COUNTERPART_INTENT_ID]: { userId: USER_B, round: 0 },
+      },
+      drainGeneration: 0,
     },
     createdAt: new Date(),
     updatedAt: new Date(),
@@ -101,6 +105,8 @@ function createWorld() {
       roundSize: 1,
       kickoffStartedAt: null,
     }),
+    getNegotiationTasksForIntentRound: async (intentId: string, round: number) =>
+      task.metadata.seats[intentId]?.round === round ? [task] : [],
   } as unknown as NegotiationGraphDatabase;
 
   const graph = new NegotiationGraphFactory({
@@ -153,7 +159,10 @@ describe('OpportunityService owner verdict closes the negotiation', () => {
     expect(world.opportunity.status).toBe('rejected');
     expect(world.task.state).toBe('completed');
     expect(await world.negotiationDb.countActiveNegotiationsForRound(INTENT_ID, ROUND)).toBe(0);
-    expect(world.reflectJobs).toEqual([{ userId: USER_A, intentId: INTENT_ID, round: ROUND }]);
+    expect(world.reflectJobs).toEqual([
+      { userId: USER_A, intentId: INTENT_ID, round: ROUND, generation: `${NEGOTIATION_ID}.0` },
+      { userId: USER_B, intentId: COUNTERPART_INTENT_ID, round: 0, generation: `${NEGOTIATION_ID}.0` },
+    ]);
     expect(world.artifacts).toEqual([
       {
         verdict: 'reject',
@@ -173,7 +182,10 @@ describe('OpportunityService owner verdict closes the negotiation', () => {
     expect(world.opportunity.status).toBe('accepted');
     expect(world.task.state).toBe('completed');
     expect(await world.negotiationDb.countActiveNegotiationsForRound(INTENT_ID, ROUND)).toBe(0);
-    expect(world.reflectJobs).toEqual([{ userId: USER_A, intentId: INTENT_ID, round: ROUND }]);
+    expect(world.reflectJobs).toEqual([
+      { userId: USER_A, intentId: INTENT_ID, round: ROUND, generation: `${NEGOTIATION_ID}.0` },
+      { userId: USER_B, intentId: COUNTERPART_INTENT_ID, round: 0, generation: `${NEGOTIATION_ID}.0` },
+    ]);
   });
 
   it('a match that never negotiated is unaffected', async () => {

--- a/services/api/src/services/tests/opportunity.service.negotiationClose.spec.ts
+++ b/services/api/src/services/tests/opportunity.service.negotiationClose.spec.ts
@@ -80,23 +80,30 @@ function createWorld() {
   const opportunity = negotiatedOpportunity();
   const task = negotiationTask();
   const reflectJobs: NegotiationRoundReflectJobData[] = [];
-  const artifacts: Array<{ verdict: string; reasoning?: string }> = [];
+  const artifacts: Array<{ verdict: string; reasoning?: string; resolvedByUserId?: string }> = [];
 
   const negotiationDb = {
     getOpportunity: async () => opportunity,
     getNegotiationTask: async (id: string) => (id === task.id ? task : null),
     getNegotiationTaskForOpportunity: async (opportunityId: string) =>
       opportunityId === OPP_ID && task.state !== 'completed' ? task : null,
-    createNegotiationOutcomeArtifact: async (_taskId: string, outcome: { verdict: string; reasoning?: string }) => {
-      artifacts.push(outcome);
+    completeNegotiation: async (input: { verdict: string; reasoning?: string; resolvedByUserId: string }) => {
+      if (!['accepted', 'rejected', 'expired'].includes(opportunity.status) || task.state === 'completed') return null;
+      artifacts.push({
+        verdict: input.verdict,
+        reasoning: input.reasoning,
+        resolvedByUserId: input.resolvedByUserId,
+      });
+      task.state = 'completed';
+      task.metadata.watchdogReflectPending = true;
+      return task;
+    },
+    clearNegotiationReflectPending: async () => {
+      task.metadata.watchdogReflectPending = false;
     },
     updateNegotiationTaskState: async (_taskId: string, state: NegotiationTaskRow['state']) => {
       task.state = state;
       return task;
-    },
-    updateOpportunityStatus: async (id: string, status: OpportunityStatus) => {
-      opportunity.status = status;
-      return { id, status };
     },
     countActiveNegotiationsForRound: async (intentId: string, round: number) =>
       task.metadata.seats[intentId]?.round === round && task.state === 'working' ? 1 : 0,
@@ -162,6 +169,7 @@ describe('OpportunityService owner verdict closes the negotiation', () => {
 
     expect(world.opportunity.status).toBe('rejected');
     expect(world.task.state).toBe('completed');
+    expect(world.task.metadata.watchdogReflectPending).toBe(false);
     expect(await world.negotiationDb.countActiveNegotiationsForRound(INTENT_ID, ROUND)).toBe(0);
     expect(world.reflectJobs).toEqual([
       { userId: USER_A, intentId: INTENT_ID, round: ROUND, generation: `${NEGOTIATION_ID}.0` },


### PR DESCRIPTION
## Summary

- bind both actor intents to each negotiation task so every paused seat can wake its owning PersonalAgent
- deduplicate all-paused jobs by durable task-generation vectors and recover failed reflect enqueues from durable task markers
- commit outcome artifact, task completion, and the non-terminal opportunity transition in one locked transaction
- recover active tasks after accepted, rejected, or expired opportunity transitions; expiry uses a system-only closure with no fabricated owner verdict
- keep submitted negotiation tasks active until every round task is paused or completed, including the API/web cycle contract
- allow verdicts only from the seat owning a `ready_for_verdict` pause and keep counterparty-owned pauses out of kickoff/reopen targets
- restrict counterpart and kickoff-strategy narration to exact server-owned public status prose
- rotate bounded watchdog recovery checks fairly so old unresolved rows cannot starve new pauses

## Breaking protocol changes

- bump `@indexnetwork/protocol` from 35.0.0 to 36.0.0
- `NegotiationTaskMetadata` now requires `drainGeneration` and exposes durable watchdog recovery markers
- `NegotiationTaskState` now includes `submitted`
- `openNegotiationTask` now accepts the complete `seats` map
- `NegotiationRoundReflectJobData` and job IDs now include a generation
- `NegotiationGraphDatabase.completeNegotiation` owns atomic pause verdict, owner verdict, and expired-opportunity completion; `clearNegotiationReflectPending` acknowledges successful reflect recovery
- separate pause-owner verdict resolution from host-owned terminal and system-expiry close lanes
- document the breaking drain contract in the 36.0.0 changelog entry; 35.0.0 remains the already-merged #1520 release

No compatibility path or data migration is included because this is sandbox data.

## Review blockers resolved

- submitted siblings suppress all-paused reflection until they pause or complete
- protocol release metadata and the lockfile consistently publish the replacement contract as 36.0.0
- counterparty status and kickoff strategy prose must exactly match canonical public narration
- promote/reject is gated at judgment, effects, and graph boundaries to the seat owning a `ready_for_verdict` pause; counterparty pauses cannot be reopened
- failed reflect delivery is retried from durable paused or completed task markers
- active tasks left behind after accepted, rejected, or expired opportunity transitions are immediately discoverable and retried by the watchdog
- PersonalAgent resolution locks task and opportunity rows in one transaction, preserving a concurrent terminal human verdict
- bounded sweeps persist a fairness cursor, moving checked rows behind never-checked candidates
- web contracts include `submitted`, and cycle summaries count `submitted` plus `working` as active

## Verification

- focused protocol suites: 95 passed
- watchdog, owner-close, expiry-recovery, and host-composition suites: 22 passed
- focused adapter durability regressions: 3 passed
- isolated conversation-controller suite: 5 passed
- focused web suites: 27 passed
- protocol architecture checks: passed
- protocol, API, and web production builds/typechecks: passed
- lockfile version consistency: passed
- repository lint: passed with 0 errors and 462 existing warnings
- pre-commit lint-staged, build, adapter-naming, and web production checks: passed
- `git diff --check`: passed

## Context

This is the replacement follow-up after #1520 was merged and its branch deleted. Commit `2f6109c7a` was part of #1520; this drain fix was developed afterward and was never included in that merged PR.
