### PR TITLE
fix: isolate matches and negotiations by intent pair

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -89,7 +89,7 @@
     },
     "packages/protocol": {
       "name": "@indexnetwork/protocol",
-      "version": "35.0.0",
+      "version": "36.0.0",
       "dependencies": {
         "@langchain/core": "1.1.48",
         "@langchain/langgraph": "1.3.2",

--- a/packages/protocol/CHANGELOG.md
+++ b/packages/protocol/CHANGELOG.md
@@ -29,7 +29,9 @@ pin a supported release, use `latest`.
   `pair_active_negotiation` conflict: any opportunity for the same two intent
   seats deduplicates persistence. Hosts must allow different intent
   pairs between the same users to persist and negotiate independently; task
-  creation remains idempotent per opportunity.
+  creation remains idempotent per opportunity. Counterparty seats are bound
+  from authoritative discovery candidates rather than evaluator-generated
+  intent IDs, and intent-scoped persistence fails closed on an unbound seat.
 
 ## 35.0.0 - 2026-08-24
 

--- a/packages/protocol/CHANGELOG.md
+++ b/packages/protocol/CHANGELOG.md
@@ -20,6 +20,17 @@ went 6.7.1 → 8.0.2 with no 7.x in between because the whole 7.x line shipped a
 prereleases between the two promotions. To track every change, read `rc`; to
 pin a supported release, use `latest`.
 
+## 36.0.0 - 2026-08-24
+
+### Breaking
+
+- **Intent matches and negotiations are isolated by their exact intent pair.**
+  `persistIntentScopedOpportunityIfNetworkEligible` no longer returns the
+  `pair_active_negotiation` conflict: any opportunity for the same two intent
+  seats deduplicates persistence. Hosts must allow different intent
+  pairs between the same users to persist and negotiate independently; task
+  creation remains idempotent per opportunity.
+
 ## 35.0.0 - 2026-08-24
 
 ### Breaking

--- a/packages/protocol/package.json
+++ b/packages/protocol/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@indexnetwork/protocol",
-  "version": "35.0.0",
+  "version": "36.0.0",
   "type": "module",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",

--- a/packages/protocol/src/internal/opportunities/opportunity.enricher.ts
+++ b/packages/protocol/src/internal/opportunities/opportunity.enricher.ts
@@ -108,11 +108,23 @@ function getNonIntroducerUserIds(data: CreateOpportunityData): Id<'users'>[] {
  */
 function belongsToOwnedIntent(
   opportunity: Opportunity,
+  newData: CreateOpportunityData,
   scope: { triggerIntentId: string; ownerUserId: string },
 ): boolean {
-  if (opportunity.detection.triggeredBy === scope.triggerIntentId) return true;
-  return opportunity.actors.some((actor) =>
-    actor.userId === scope.ownerUserId && actor.intent === scope.triggerIntentId);
+  const belongs = opportunity.detection.triggeredBy === scope.triggerIntentId
+    || opportunity.actors.some((actor) =>
+      actor.userId === scope.ownerUserId && actor.intent === scope.triggerIntentId);
+  if (!belongs) return false;
+
+  return newData.actors
+    .filter((actor) =>
+      actor.role !== 'introducer'
+      && actor.userId !== scope.ownerUserId
+      && actor.intent)
+    .every((actor) => {
+      const existingActors = opportunity.actors.filter((existing) => existing.userId === actor.userId);
+      return existingActors.some((existing) => !existing.intent || existing.intent === actor.intent);
+    });
 }
 
 function getIntentIdsFromActors(actors: OpportunityActor[]): Set<string> {
@@ -239,13 +251,13 @@ export async function enrichOrCreate(
   const pairOverlaps = await database.findOpportunitiesByActors(actorUserIds, { excludeStatuses });
   const ownedIntentScope = options?.ownedIntentScope;
   const overlapping = ownedIntentScope
-    ? pairOverlaps.filter((opportunity) => belongsToOwnedIntent(opportunity, ownedIntentScope))
+    ? pairOverlaps.filter((opportunity) => belongsToOwnedIntent(opportunity, newData, ownedIntentScope))
     : pairOverlaps;
   if (ownedIntentScope && pairOverlaps.length > overlapping.length) {
-    logger.info('Excluded cross-trigger overlaps from owned-intent enrichment', {
+    logger.info('Excluded other intent-pair overlaps from owned-intent enrichment', {
       triggerIntentId: ownedIntentScope.triggerIntentId,
       pairOverlapCount: pairOverlaps.length,
-      sameTriggerOverlapCount: overlapping.length,
+      sameIntentPairOverlapCount: overlapping.length,
     });
   }
   if (overlapping.length === 0) {

--- a/packages/protocol/src/internal/opportunities/opportunity.enricher.ts
+++ b/packages/protocol/src/internal/opportunities/opportunity.enricher.ts
@@ -116,14 +116,15 @@ function belongsToOwnedIntent(
       actor.userId === scope.ownerUserId && actor.intent === scope.triggerIntentId);
   if (!belongs) return false;
 
-  return newData.actors
-    .filter((actor) =>
-      actor.role !== 'introducer'
-      && actor.userId !== scope.ownerUserId
-      && actor.intent)
+  const counterpartyActors = newData.actors.filter((actor) =>
+    actor.role !== 'introducer'
+    && actor.userId !== scope.ownerUserId);
+  if (counterpartyActors.some((actor) => !actor.intent)) return false;
+
+  return counterpartyActors
     .every((actor) => {
       const existingActors = opportunity.actors.filter((existing) => existing.userId === actor.userId);
-      return existingActors.some((existing) => !existing.intent || existing.intent === actor.intent);
+      return existingActors.some((existing) => existing.intent === actor.intent);
     });
 }
 

--- a/packages/protocol/src/internal/opportunities/opportunity.graph.evaluation.ts
+++ b/packages/protocol/src/internal/opportunities/opportunity.graph.evaluation.ts
@@ -8,7 +8,7 @@
 import type { Id } from '../../platform/database.js';
 import type { DebugMetaAgent } from "../../protocol/core.js";
 import type { CandidateMatch, EvaluatedOpportunity } from './opportunity.state.js';
-import { OpportunityEvaluator, type EvaluatedOpportunityWithActors, type EvaluatorEntity, type EvaluatorInput, type EvaluatorRejection } from "./opportunity.evaluator.js";
+import { OpportunityEvaluator, type EvaluatorEntity, type EvaluatorInput, type EvaluatorRejection } from "./opportunity.evaluator.js";
 import { getModelName } from '../shared/agent/model.config.js';
 import { timed } from '../shared/observability/performance.js';
 import { requestContext } from '../shared/observability/request-context.js';
@@ -26,6 +26,9 @@ type PairwiseOpportunity = {
   /** Diagnostic-only entry: the evaluator answered, but nothing persistable came of it. */
   rejection?: EvaluatorRejection;
 };
+
+/** Pairwise verdict coupled to the authoritative discovery candidate that produced it. */
+type CandidateVerdict = PairwiseOpportunity & { candidate: CandidateMatch };
 
 /** Graph trace entry shape. */
 type TraceEntry = { node: string; detail?: string; data?: Record<string, unknown> };
@@ -221,11 +224,9 @@ async function evaluateCandidatePool(
   const candidateEntities = await buildCandidateEntities(pool, deps);
   const similarityByUserId = new Map(pool.map((c) => [c.candidateUserId, c.similarity]));
 
-  const userIdToIndexId = new Map<string, Id<'networks'>>();
   const evidenceByEntityKey = new Map<string, OpportunityEvidence[]>();
   const entityKeysByUserId = new Map<string, string[]>();
   for (const e of candidateEntities) {
-    if (!userIdToIndexId.has(e.userId)) userIdToIndexId.set(e.userId, e.networkId as Id<'networks'>);
     if (e.evidenceKey) {
       evidenceByEntityKey.set(
         e.evidenceKey,
@@ -249,8 +250,8 @@ async function evaluateCandidatePool(
   const networkContexts = await buildNetworkContexts([sourceEntity, ...candidateEntities], deps.database);
 
   // One evaluator call per candidate, fired in parallel — the whole pool, one round.
-  const evaluatorVerdicts: PairwiseOpportunity[] = await evaluateInParallel({
-    evaluator, sourceEntity, candidateEntities, state, discoveryUserId,
+  const evaluatorVerdicts = await evaluateInParallel({
+    evaluator, sourceEntity, candidateEntities, candidateMatches: pool, state, discoveryUserId,
     networkContexts, minScore, evaluatorSignalConfig, agentTimingsAccum, traceEntries,
   });
 
@@ -260,45 +261,39 @@ async function evaluateCandidatePool(
   const rejections = evaluatorVerdicts.filter((op) => op.rejection !== undefined);
   const pairwiseOpportunities = evaluatorVerdicts.filter((op) => op.rejection === undefined);
 
-  function mapActors(actors: PairwiseOpportunity['actors']): EvaluatedOpportunity['actors'] {
+  function mapActors(op: CandidateVerdict): EvaluatedOpportunity['actors'] {
+    const { actors, candidate } = op;
     return actors.map((a) => {
       const isSource = a.userId === discoveryUserId;
       if (isSource) {
-        // Source actor inherits the counterpart's networkId (shared match context)
-        const counterpart = actors.find((other) => other.userId !== a.userId);
-        const counterpartIndexId = counterpart
-          ? userIdToIndexId.get(counterpart.userId) ?? (candidateEntities.find((e) => e.userId === counterpart.userId)?.networkId as Id<'networks'>)
-          : undefined;
         return {
           userId: a.userId as Id<'users'>,
           role: a.role,
           intentId: a.intentId as Id<'intents'> | undefined,
-          networkId: counterpartIndexId ?? userIdToIndexId.get(a.userId) ?? ('' as Id<'networks'>),
+          networkId: candidate.networkId,
         };
       }
       return {
         userId: a.userId as Id<'users'>,
         role: a.role,
-        intentId: a.intentId as Id<'intents'> | undefined,
-        networkId: userIdToIndexId.get(a.userId) ?? (candidateEntities.find((e) => e.userId === a.userId)?.networkId as Id<'networks'>),
+        intentId: candidate.candidateIntentId,
+        networkId: candidate.networkId,
       };
     });
   }
 
-  function toScoredOpportunity(op: PairwiseOpportunity, candidateUserId: string): ScoredOpportunity {
+  function toScoredOpportunity(op: CandidateVerdict): ScoredOpportunity {
+    const actors = mapActors(op);
     return {
       reasoning: op.reasoning,
       score: op.score,
-      evidence: mergeOpportunityEvidence(...op.actors.map(evidenceForActor)),
-      actors: mapActors(op.actors),
-      _similarity: similarityByUserId.get(candidateUserId) ?? 0,
+      evidence: mergeOpportunityEvidence(...actors.map(evidenceForActor)),
+      actors,
+      _similarity: similarityByUserId.get(op.candidate.candidateUserId) ?? 0,
     };
   }
 
-  const evaluatedOpportunities: ScoredOpportunity[] = pairwiseOpportunities.map((op) => {
-    const candidateUserId = op.actors.find((a) => a.userId !== discoveryUserId)?.userId ?? '';
-    return toScoredOpportunity(op, candidateUserId);
-  });
+  const evaluatedOpportunities: ScoredOpportunity[] = pairwiseOpportunities.map(toScoredOpportunity);
   const passed = evaluatedOpportunities.filter((o) => o.score >= minScore);
 
   // Rejected-but-fillable pool for the match floor: accepted verdicts that
@@ -310,14 +305,14 @@ async function evaluateCandidatePool(
   const notAcceptedRejections = rejections
     .filter((op) => op.rejection!.reason === 'not_accepted')
     .map((op) => {
-      const candidateId = op.rejection!.candidateId;
+      const candidateId = op.candidate.candidateUserId;
       const actorIds = new Set(op.actors.map((a) => a.userId));
       const hasUsableActors = actorIds.size === 2 && actorIds.has(discoveryUserId) && actorIds.has(candidateId);
       const actors = hasUsableActors ? op.actors : [
         { userId: discoveryUserId, role: 'peer' as const, intentId: state.resolvedTriggerIntentId ?? sourceEntity.intents?.[0]?.intentId ?? null },
-        { userId: candidateId, role: 'peer' as const, intentId: candidateEntities.find((e) => e.userId === candidateId)?.intents?.[0]?.intentId ?? null },
+        { userId: candidateId, role: 'peer' as const, intentId: op.candidate.candidateIntentId ?? null },
       ];
-      return toScoredOpportunity({ ...op, actors }, candidateId);
+      return toScoredOpportunity({ ...op, actors });
     });
   const fillPool = [...belowScore, ...notAcceptedRejections]
     .sort((a, b) => (b.score - a.score) || (b._similarity - a._similarity));
@@ -363,7 +358,7 @@ async function evaluateCandidatePool(
   const rejectedByUserId = new Map<string, { score: number; reasoning: string; reason: EvaluatorRejection['reason'] }>();
   for (const op of rejections) {
     const rejection = op.rejection!;
-    rejectedByUserId.set(rejection.candidateId, {
+    rejectedByUserId.set(op.candidate.candidateUserId, {
       score: op.score,
       reasoning: op.reasoning,
       reason: rejection.reason,
@@ -605,6 +600,7 @@ interface EvaluateArgs {
   evaluator: OpportunityEvaluator;
   sourceEntity: EvaluatorEntity;
   candidateEntities: EvaluatorEntity[];
+  candidateMatches: CandidateMatch[];
   state: OpportunityState;
   discoveryUserId: string;
   networkContexts: Record<string, string>;
@@ -627,13 +623,15 @@ function buildEvaluatorInput(args: EvaluateArgs, entities: EvaluatorEntity[]): E
 /** Experimental: one LLM call per candidate, all fired in parallel. */
 async function evaluateInParallel(
   args: EvaluateArgs & { traceEntries: Array<{ node: string; detail?: string; data?: Record<string, unknown> }> },
-): Promise<PairwiseOpportunity[]> {
-  const { evaluator, sourceEntity, candidateEntities, minScore, evaluatorSignalConfig, agentTimingsAccum, traceEntries } = args;
+): Promise<CandidateVerdict[]> {
+  const { evaluator, sourceEntity, candidateEntities, candidateMatches, minScore, evaluatorSignalConfig, agentTimingsAccum, traceEntries } = args;
   evaluationLog.verbose('Running parallel evaluation', { candidates: candidateEntities.length });
   const parallelErrors: Array<{ candidateUserId: string; candidateName: string; error: string; durationMs: number }> = [];
 
   const parallelResults = await Promise.all(
-    candidateEntities.map((candidateEntity) => {
+    candidateEntities.map((candidateEntity, index) => {
+      const candidate = candidateMatches[index];
+      if (!candidate) throw new Error('Candidate entity has no discovery provenance');
       const input = buildEvaluatorInput(args, [sourceEntity, candidateEntity]);
       const _evalStart = Date.now();
       const _traceEmitter = requestContext.getStore()?.traceEmitter;
@@ -646,7 +644,7 @@ async function evaluateInParallel(
           const _topScore = res.length > 0 ? Math.max(...res.map(r => r.score)) : -1;
           const _summary = _topScore < 0 ? `${_candidateName}: no match` : `${_candidateName}: ${_topScore}`;
           _traceEmitter?.({ type: "agent_end", name: "opportunity-evaluator", durationMs: _evalDuration, summary: _summary });
-          return res;
+          return res.map((opportunity) => ({ ...opportunity, candidate }));
         })
         .catch((err) => {
           const _evalDuration = Date.now() - _evalStart;
@@ -663,7 +661,7 @@ async function evaluateInParallel(
             error: _errMsg,
             durationMs: _evalDuration,
           });
-          return [] as PairwiseOpportunity[];
+          return [] as CandidateVerdict[];
         });
     })
   );

--- a/packages/protocol/src/internal/opportunities/opportunity.graph.persist-node.ts
+++ b/packages/protocol/src/internal/opportunities/opportunity.graph.persist-node.ts
@@ -24,7 +24,7 @@ type ExistingBetweenActor = {
   networkId: Id<'networks'>;
   existingOpportunityId?: Id<'opportunities'>;
   existingStatus?: OpportunityStatus;
-  reason?: 'same_trigger_recent_duplicate' | 'pair_active_negotiation' | 'final_atomic_conflict';
+  reason?: 'same_intent_pair_duplicate' | 'final_atomic_conflict';
   existingTriggerIntentId?: string;
 };
 
@@ -33,12 +33,12 @@ type StatusUpdater = ReturnType<typeof createEligibleOpportunityStatusUpdater>;
 
 /**
  * Mutable state shared across the per-opportunity loop: what got reactivated,
- * what got suppressed, and how many cross-trigger matches were let through.
+ * what got suppressed, and how many different intent-pair matches were let through.
  */
 interface PersistLedger {
   reactivated: Opportunity[];
   existingBetweenActors: ExistingBetweenActor[];
-  crossTriggerAllowedCount: number;
+  crossIntentPairAllowedCount: number;
 }
 
 /** Everything the three persistence paths read. */
@@ -83,9 +83,8 @@ export async function persistNode(state: OpportunityState, deps: OpportunityGrap
           evaluatedCount: 0,
           createdCount: 0,
           reactivatedCount: 0,
-          sameTriggerDuplicateSuppressions: 0,
-          pairActiveNegotiationSuppressions: 0,
-          crossTriggerAllowedCount: 0,
+          sameIntentPairDuplicateSuppressions: 0,
+          crossIntentPairAllowedCount: 0,
           finalAtomicConflictCount: 0,
         },
       };
@@ -128,7 +127,7 @@ export async function persistNode(state: OpportunityState, deps: OpportunityGrap
         },
       );
 
-      const ledger: PersistLedger = { reactivated: [], existingBetweenActors: [], crossTriggerAllowedCount: 0 };
+      const ledger: PersistLedger = { reactivated: [], existingBetweenActors: [], crossIntentPairAllowedCount: 0 };
       const ctx: PersistPathContext = {
         state,
         deps,
@@ -200,7 +199,7 @@ export async function persistNode(state: OpportunityState, deps: OpportunityGrap
       );
 
       const intentDedupScope = finalTriggerIntentId && state.discoverySource === 'intent'
-        ? { triggerIntentId: finalTriggerIntentId, dedupWindowMs: DEDUP_WINDOW_MS }
+        ? { triggerIntentId: finalTriggerIntentId }
         : undefined;
       const { created: createdList, conflicts } = await persistOpportunities({
         database: deps.database,
@@ -248,11 +247,9 @@ export async function persistNode(state: OpportunityState, deps: OpportunityGrap
         evaluatedCount: state.evaluatedOpportunities.length,
         createdCount: createdList.length,
         reactivatedCount: ledger.reactivated.length,
-        sameTriggerDuplicateSuppressions: ledger.existingBetweenActors.filter((entry) =>
-          entry.reason === 'same_trigger_recent_duplicate').length,
-        pairActiveNegotiationSuppressions: ledger.existingBetweenActors.filter((entry) =>
-          entry.reason === 'pair_active_negotiation').length,
-        crossTriggerAllowedCount: ledger.crossTriggerAllowedCount,
+        sameIntentPairDuplicateSuppressions: ledger.existingBetweenActors.filter((entry) =>
+          entry.reason === 'same_intent_pair_duplicate').length,
+        crossIntentPairAllowedCount: ledger.crossIntentPairAllowedCount,
         finalAtomicConflictCount: conflicts.length,
       };
       return {
@@ -459,7 +456,8 @@ async function suppressDiscoveryDuplicate(
   evaluated: EvaluatedOpportunity,
 ): Promise<boolean> {
   const { state, deps, ledger, updateStatusIfStillEligible, initialStatus } = ctx;
-  const candidateUserId = evaluated.actors.find((a) => a.userId !== state.userId)?.userId;
+  const candidateActor = evaluated.actors.find((a) => a.userId !== state.userId);
+  const candidateUserId = candidateActor?.userId;
   persistDedupLog.verbose('Checking overlapping opportunities', {
     stateUserId: state.userId,
     candidateUserId: candidateUserId ?? 'NONE',
@@ -483,14 +481,19 @@ async function suppressDiscoveryDuplicate(
     : undefined;
 
   if (ownedIntentTriggerId && candidateUserId) {
-    return suppressOwnedIntentDuplicate(ctx, overlapping, candidateUserId, ownedIntentTriggerId);
+    return suppressOwnedIntentDuplicate(
+      ctx,
+      overlapping,
+      candidateUserId,
+      candidateActor?.intentId,
+      ownedIntentTriggerId,
+    );
   }
   if (overlapping.length === 0) return false;
 
   const existing = overlapping[0];
   const existingIndexId = (existing.context?.networkId ?? state.networkId ?? state.userNetworks?.[0] ?? '') as Id<'networks'>;
   const isRecent = new Date(existing.createdAt).getTime() > Date.now() - DEDUP_WINDOW_MS;
-
   if (existing.status === 'expired' || existing.status === 'stalled') {
     // Reactivate expired or stalled opportunities.
     // Stalled opportunities are reactivated regardless of age: a stalled negotiation
@@ -587,65 +590,37 @@ async function suppressDiscoveryDuplicate(
 
 /**
  * Dedup for a discovery run triggered by an intent the owner still holds.
- * A pair-global active negotiation always wins; otherwise only opportunities
- * carrying the *same* trigger intent can suppress this one.
+ * Only an opportunity carrying the same two intent seats can suppress this one.
  */
 async function suppressOwnedIntentDuplicate(
   ctx: PersistPathContext,
   overlapping: Opportunity[],
   candidateUserId: Id<'users'>,
+  candidateIntentId: Id<'intents'> | undefined,
   ownedIntentTriggerId: string,
 ): Promise<boolean> {
-  const { state, deps, ledger, updateStatusIfStillEligible, initialStatus } = ctx;
-
-  let activeNegotiation: { opportunity: Opportunity; taskState: string } | undefined;
-  for (const opportunity of overlapping) {
-    if (opportunity.status !== 'negotiating') continue;
-    const task = await deps.database.getNegotiationTaskForOpportunity(opportunity.id);
-    if (task && isActiveNegotiationTaskFresh(task)) {
-      activeNegotiation = { opportunity, taskState: task.state };
-      break;
-    }
-  }
-
-  if (activeNegotiation) {
-    const existingTriggerIntentId = triggerForOwner(activeNegotiation.opportunity, state.userId);
-    ledger.existingBetweenActors.push({
-      candidateUserId,
-      networkId: (activeNegotiation.opportunity.context?.networkId ?? state.networkId ?? state.userNetworks?.[0] ?? '') as Id<'networks'>,
-      existingOpportunityId: activeNegotiation.opportunity.id as Id<'opportunities'>,
-      existingStatus: activeNegotiation.opportunity.status,
-      reason: 'pair_active_negotiation',
-      ...(existingTriggerIntentId ? { existingTriggerIntentId } : {}),
-    });
-    persistDedupLog.info('Suppressing owned-intent match for pair-global active negotiation', {
-      triggerIntentId: ownedIntentTriggerId,
-      candidateUserId,
-      existingOpportunityId: activeNegotiation.opportunity.id,
-      existingTriggerIntentId,
-      existingStatus: activeNegotiation.opportunity.status,
-      existingAgeMs: Date.now() - new Date(activeNegotiation.opportunity.createdAt).getTime(),
-      taskState: activeNegotiation.taskState,
-      reason: 'pair_active_negotiation',
-    });
-    return true;
-  }
+  const { state, ledger, updateStatusIfStillEligible, initialStatus } = ctx;
 
   const sameTrigger = overlapping
-    .filter((opportunity) => belongsToOwnedIntent(opportunity, state.userId, ownedIntentTriggerId))
+    .filter((opportunity) => {
+      if (!belongsToOwnedIntent(opportunity, state.userId, ownedIntentTriggerId)) return false;
+      if (!candidateIntentId) return true;
+      const candidateActors = opportunity.actors.filter((actor) => actor.userId === candidateUserId);
+      return candidateActors.some((actor) => !actor.intent || actor.intent === candidateIntentId);
+    })
     .sort((a, b) => new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime());
-  const otherTrigger = overlapping.filter((opportunity) =>
-    !belongsToOwnedIntent(opportunity, state.userId, ownedIntentTriggerId));
+  const sameTriggerIds = new Set(sameTrigger.map((opportunity) => opportunity.id));
+  const otherTrigger = overlapping.filter((opportunity) => !sameTriggerIds.has(opportunity.id));
   const existing = sameTrigger[0];
 
   if (!existing) {
     if (otherTrigger.length > 0) {
-      ledger.crossTriggerAllowedCount += 1;
-      persistDedupLog.info('Allowing cross-trigger match for owned intent', {
+      ledger.crossIntentPairAllowedCount += 1;
+      persistDedupLog.info('Allowing a different intent-pair match', {
         triggerIntentId: ownedIntentTriggerId,
         candidateUserId,
-        reason: 'cross_trigger_match_allowed',
-        otherTriggers: otherTrigger.map((opportunity) => ({
+        reason: 'cross_intent_pair_match_allowed',
+        otherIntentPairs: otherTrigger.map((opportunity) => ({
           opportunityId: opportunity.id,
           triggerIntentId: triggerForOwner(opportunity, state.userId),
           status: opportunity.status,
@@ -657,14 +632,13 @@ async function suppressOwnedIntentDuplicate(
   }
 
   const existingIndexId = (existing.context?.networkId ?? state.networkId ?? state.userNetworks?.[0] ?? '') as Id<'networks'>;
-  const isRecent = new Date(existing.createdAt).getTime() > Date.now() - DEDUP_WINDOW_MS;
 
   if (existing.status === 'expired' || existing.status === 'stalled') {
     const reactivated = await updateStatusIfStillEligible(
       existing.id, initialStatus, existing.actors, existing.status,
     );
     if (reactivated) {
-      persistLog.info('Reactivated same-trigger opportunity', {
+      persistLog.info('Reactivated same-intent-pair opportunity', {
         triggerIntentId: ownedIntentTriggerId,
         opportunityId: existing.id,
         candidateUserId,
@@ -680,7 +654,7 @@ async function suppressOwnedIntentDuplicate(
       existing.id, initialStatus, existing.actors, existing.status,
     );
     if (reactivated) {
-      persistLog.info('Resuming same-trigger orphaned negotiating opportunity', {
+      persistLog.info('Resuming same-intent-pair orphaned negotiating opportunity', {
         triggerIntentId: ownedIntentTriggerId,
         opportunityId: existing.id,
         candidateUserId,
@@ -694,7 +668,7 @@ async function suppressOwnedIntentDuplicate(
       existing.id, initialStatus, existing.actors, existing.status,
     );
     if (upgraded) {
-      persistLog.info('Upgraded same-trigger latent opportunity', {
+      persistLog.info('Upgraded same-intent-pair latent opportunity', {
         triggerIntentId: ownedIntentTriggerId,
         opportunityId: existing.id,
         candidateUserId,
@@ -704,34 +678,24 @@ async function suppressOwnedIntentDuplicate(
     }
     return true;
   }
-  if (isRecent) {
-    ledger.existingBetweenActors.push({
-      candidateUserId,
-      networkId: existingIndexId,
-      existingOpportunityId: existing.id as Id<'opportunities'>,
-      existingStatus: existing.status,
-      reason: 'same_trigger_recent_duplicate',
-      existingTriggerIntentId: ownedIntentTriggerId,
-    });
-    persistDedupLog.info('Suppressing recent same-trigger duplicate', {
-      triggerIntentId: ownedIntentTriggerId,
-      candidateUserId,
-      existingOpportunityId: existing.id,
-      existingTriggerIntentId: ownedIntentTriggerId,
-      existingStatus: existing.status,
-      existingAgeMs: Date.now() - new Date(existing.createdAt).getTime(),
-      reason: 'same_trigger_recent_duplicate',
-    });
-    return true;
-  }
-  persistDedupLog.info('Allowing same-trigger opportunity outside dedup window', {
+  ledger.existingBetweenActors.push({
+    candidateUserId,
+    networkId: existingIndexId,
+    existingOpportunityId: existing.id as Id<'opportunities'>,
+    existingStatus: existing.status,
+    reason: 'same_intent_pair_duplicate',
+    existingTriggerIntentId: ownedIntentTriggerId,
+  });
+  persistDedupLog.info('Suppressing duplicate for the same intent pair', {
     triggerIntentId: ownedIntentTriggerId,
     candidateUserId,
     existingOpportunityId: existing.id,
+    existingTriggerIntentId: ownedIntentTriggerId,
     existingStatus: existing.status,
     existingAgeMs: Date.now() - new Date(existing.createdAt).getTime(),
+    reason: 'same_intent_pair_duplicate',
   });
-  return false;
+  return true;
 }
 
 /** Trace summary for {@link persistNode}. */

--- a/packages/protocol/src/internal/opportunities/opportunity.graph.persist-node.ts
+++ b/packages/protocol/src/internal/opportunities/opportunity.graph.persist-node.ts
@@ -604,9 +604,9 @@ async function suppressOwnedIntentDuplicate(
   const sameTrigger = overlapping
     .filter((opportunity) => {
       if (!belongsToOwnedIntent(opportunity, state.userId, ownedIntentTriggerId)) return false;
-      if (!candidateIntentId) return true;
+      if (!candidateIntentId) return false;
       const candidateActors = opportunity.actors.filter((actor) => actor.userId === candidateUserId);
-      return candidateActors.some((actor) => !actor.intent || actor.intent === candidateIntentId);
+      return candidateActors.some((actor) => actor.intent === candidateIntentId);
     })
     .sort((a, b) => new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime());
   const sameTriggerIds = new Set(sameTrigger.map((opportunity) => opportunity.id));

--- a/packages/protocol/src/internal/opportunities/opportunity.persist.ts
+++ b/packages/protocol/src/internal/opportunities/opportunity.persist.ts
@@ -126,6 +126,12 @@ export async function persistOpportunities(params: PersistOpportunitiesParams): 
             intentDedupScope.triggerIntentId,
           )
         : normalizedData;
+      if (
+        intentDedupScope
+        && scopedData.actors.some((actor) => actor.role !== 'introducer' && !actor.intent)
+      ) {
+        throw new Error('Intent-scoped opportunities require an intent for every participant');
+      }
       const enrichment = await enrichOrCreate(database, embedder, scopedData, intentDedupScope && networkEligibility
         ? {
             ownedIntentScope: {

--- a/packages/protocol/src/internal/opportunities/opportunity.persist.ts
+++ b/packages/protocol/src/internal/opportunities/opportunity.persist.ts
@@ -64,7 +64,6 @@ export type PersistOpportunityDatabase = EnricherDatabase & {
     data: CreateOpportunityData,
     expireIds: string[],
     eligibility: OpportunityNetworkEligibility & { triggerIntentId: string },
-    dedupWindowMs: number,
   ): Promise<IntentScopedOpportunityPersistenceResult | null>;
   /** Optional: used to populate expired list in non-atomic path. */
   getOpportunity?(id: string): Promise<Opportunity | null>;
@@ -78,7 +77,7 @@ export interface PersistOpportunitiesParams {
   /** Require adapter-level membership/assignment locks for discovery-created rows. */
   networkEligibility?: OpportunityNetworkEligibility;
   /** Scope dedup/enrichment and the final atomic re-check to one owned intent. */
-  intentDedupScope?: { triggerIntentId: string; dedupWindowMs: number };
+  intentDedupScope?: { triggerIntentId: string };
 }
 
 export interface PersistOpportunitiesError {
@@ -158,7 +157,6 @@ export async function persistOpportunities(params: PersistOpportunitiesParams): 
           toCreate,
           enrichment.enriched ? enrichment.expiredIds : [],
           { ...networkEligibility, triggerIntentId: networkEligibility.triggerIntentId },
-          intentDedupScope.dedupWindowMs,
         );
         if (!result) continue;
         if ('conflict' in result) {

--- a/packages/protocol/src/internal/opportunities/opportunity.state.ts
+++ b/packages/protocol/src/internal/opportunities/opportunity.state.ts
@@ -110,9 +110,8 @@ export interface OpportunityPersistenceOutcome {
   evaluatedCount: number;
   createdCount: number;
   reactivatedCount: number;
-  sameTriggerDuplicateSuppressions: number;
-  pairActiveNegotiationSuppressions: number;
-  crossTriggerAllowedCount: number;
+  sameIntentPairDuplicateSuppressions: number;
+  crossIntentPairAllowedCount: number;
   finalAtomicConflictCount: number;
 }
 
@@ -354,7 +353,7 @@ export const OpportunityGraphState = Annotation.Root({
     networkId: Id<'networks'>;
     existingOpportunityId?: Id<'opportunities'>;
     existingStatus?: OpportunityStatus;
-    reason?: 'same_trigger_recent_duplicate' | 'pair_active_negotiation' | 'final_atomic_conflict';
+    reason?: 'same_intent_pair_duplicate' | 'final_atomic_conflict';
     existingTriggerIntentId?: string;
   }>>({
     reducer: (curr, next) => next ?? curr,

--- a/packages/protocol/src/internal/opportunities/tests/opportunity.enricher.spec.ts
+++ b/packages/protocol/src/internal/opportunities/tests/opportunity.enricher.spec.ts
@@ -924,6 +924,29 @@ describe('Opportunity enricher — cross-domain deduplication', () => {
     expect(result.data.detection.triggeredBy).toBe('intent-current');
   });
 
+  test('owned-intent scope excludes a same-trigger overlap with no counterparty intent', async () => {
+    const existing = existingOpportunity(
+      'opp-unbound-counterparty',
+      [
+        { networkId: 'idx-1', userId: 'user-a', role: 'patient', intent: 'intent-current' },
+        { networkId: 'idx-1', userId: 'user-b', role: 'agent' },
+      ],
+      MEANINGFUL.reasoning.aiMlCofounder,
+    );
+    existing.detection.triggeredBy = 'intent-current';
+    const db = { findOpportunitiesByActors: async () => [existing] };
+    const newData = minimalNewData(['user-a', 'user-b'], 'idx-1', MEANINGFUL.reasoning.aiMlCofounder);
+    newData.detection.triggeredBy = 'intent-current';
+    newData.actors[0].intent = 'intent-current';
+    newData.actors[1].intent = 'intent-counterparty';
+
+    const result = await enrichOrCreate(db, domainEmbedder(), newData, {
+      ownedIntentScope: { triggerIntentId: 'intent-current', ownerUserId: 'user-a' },
+    });
+
+    expect(result.enriched).toBe(false);
+  });
+
   // ── Cross-index ──────────────────────────────────────────────────────
 
   test('same match found in two indexes merges and preserves both index contexts', async () => {

--- a/packages/protocol/src/internal/opportunities/tests/opportunity.graph.dedup.spec.ts
+++ b/packages/protocol/src/internal/opportunities/tests/opportunity.graph.dedup.spec.ts
@@ -316,6 +316,10 @@ describe('opportunity graph — newborn stamping seam', () => {
     const stalled = makeOpportunity({
       status: 'stalled',
       createdAt: new Date(),
+      actors: [
+        { userId: USER_A, role: 'patient', networkId: NET_ID, intent: INTENT_A },
+        { userId: USER_B, role: 'agent', networkId: NET_ID, intent: INTENT_B },
+      ],
       detection: {
         source: 'opportunity_graph',
         timestamp: new Date().toISOString(),
@@ -481,7 +485,7 @@ describe('opportunity graph — time-based dedup (Persist node)', () => {
       },
     });
     let inserted: Opportunity | undefined;
-    const result = await buildGraph(buildDb({
+    const db = buildDb({
       findOpportunitiesByActors: async () => [existing],
       createOpportunity: async (data) => {
         inserted = {
@@ -494,7 +498,19 @@ describe('opportunity graph — time-based dedup (Persist node)', () => {
         };
         return inserted;
       },
-    })).invoke(ownedIntentInput);
+    });
+    const hallucinatingEvaluator: OpportunityEvaluatorLike = {
+      invokeEntityBundle: async () => [{
+        reasoning: 'Good match with a hallucinated intent binding',
+        score: 80,
+        actors: [
+          { userId: USER_A, role: 'patient' as const, intentId: INTENT_OTHER },
+          { userId: USER_B, role: 'agent' as const, intentId: INTENT_OTHER },
+        ],
+      }],
+    };
+    const result = await buildGraph(db, undefined, { evaluator: hallucinatingEvaluator })
+      .invoke(ownedIntentInput);
 
     expect(inserted?.actors.find((actor) => actor.userId === USER_B)?.intent).toBe(INTENT_B);
     expect(result.opportunities.map((opportunity) => opportunity.id)).toEqual(['different-intent-pair']);
@@ -542,7 +558,7 @@ describe('opportunity graph — time-based dedup (Persist node)', () => {
     }
   });
 
-  test('owned intent inspects all overlaps when the first updated row belongs to another trigger', async () => {
+  test('owned intent does not treat a missing counterparty intent as an exact-pair duplicate', async () => {
     const otherTrigger = makeOpportunity({
       id: 'other-first' as Id<'opportunities'>,
       status: 'pending',
@@ -560,18 +576,18 @@ describe('opportunity graph — time-based dedup (Persist node)', () => {
         { userId: USER_B, role: 'agent', networkId: NET_ID },
       ],
     });
-    let createCalled = false;
+    let inserted: Opportunity | undefined;
     const result = await buildGraph(buildDb({
       findOpportunitiesByActors: async () => [otherTrigger, sameTrigger],
       createOpportunity: async (data) => {
-        createCalled = true;
-        return { ...data, id: 'unexpected', status: 'latent', createdAt: new Date(), updatedAt: new Date(), expiresAt: null };
+        inserted = { ...data, id: 'exact-pair', status: 'latent', createdAt: new Date(), updatedAt: new Date(), expiresAt: null };
+        return inserted;
       },
     })).invoke(ownedIntentInput);
 
-    expect(createCalled).toBe(false);
-    expect(result.existingBetweenActors[0]?.existingOpportunityId).toBe('same-second');
-    expect(result.existingBetweenActors[0]?.reason).toBe('same_intent_pair_duplicate');
+    expect(inserted?.actors.find((actor) => actor.userId === USER_B)?.intent).toBe(INTENT_B);
+    expect(result.opportunities.map((opportunity) => opportunity.id)).toEqual(['exact-pair']);
+    expect(result.existingBetweenActors).toEqual([]);
   });
 
   test('owned intent persists a cross-trigger match despite a fresh active negotiation', async () => {

--- a/packages/protocol/src/internal/opportunities/tests/opportunity.graph.dedup.spec.ts
+++ b/packages/protocol/src/internal/opportunities/tests/opportunity.graph.dedup.spec.ts
@@ -30,6 +30,7 @@ const USER_C = 'c0000000-0000-4000-8000-000000000003' as Id<'users'>;
 const NET_ID = 'n0000000-0000-4000-8000-000000000001' as Id<'networks'>;
 const OPP_ID = 'op000000-0000-4000-8000-000000000001' as Id<'opportunities'>;
 const INTENT_A = 'intent-1' as Id<'intents'>;
+const INTENT_B = 'intent-bob' as Id<'intents'>;
 const INTENT_OTHER = 'intent-other' as Id<'intents'>;
 
 // ---------------------------------------------------------------------------
@@ -45,8 +46,8 @@ const mockEvaluator: OpportunityEvaluatorLike = {
       reasoning: 'Good match',
       score: 80,
       actors: [
-        { userId: USER_A, role: 'patient' as const },
-        { userId: USER_B, role: 'agent' as const },
+        { userId: USER_A, role: 'patient' as const, intentId: INTENT_A },
+        { userId: USER_B, role: 'agent' as const, intentId: INTENT_B },
       ],
     },
   ],
@@ -437,10 +438,14 @@ describe('opportunity graph — time-based dedup (Persist node)', () => {
     expect(updateCalledWith![1]).toBe('pending');
   });
 
-  test('owned intent suppresses a recent same-trigger opportunity', async () => {
+  test('owned intent suppresses the same intent pair regardless of age', async () => {
     const existing = makeOpportunity({
       status: 'pending',
-      createdAt: new Date(Date.now() - 60_000),
+      createdAt: new Date(Date.now() - 45 * 24 * 60 * 60 * 1000),
+      actors: [
+        { userId: USER_A, role: 'patient', networkId: NET_ID, intent: INTENT_A },
+        { userId: USER_B, role: 'agent', networkId: NET_ID, intent: INTENT_B },
+      ],
       detection: {
         source: 'opportunity_graph',
         timestamp: new Date().toISOString(),
@@ -457,8 +462,43 @@ describe('opportunity graph — time-based dedup (Persist node)', () => {
     })).invoke(ownedIntentInput);
 
     expect(createCalled).toBe(false);
-    expect(result.existingBetweenActors[0]?.reason).toBe('same_trigger_recent_duplicate');
-    expect(result.persistenceOutcome?.sameTriggerDuplicateSuppressions).toBe(1);
+    expect(result.existingBetweenActors[0]?.reason).toBe('same_intent_pair_duplicate');
+    expect(result.persistenceOutcome?.sameIntentPairDuplicateSuppressions).toBe(1);
+  });
+
+  test('owned intent allows the same users to match through a different counterparty intent', async () => {
+    const existing = makeOpportunity({
+      status: 'pending',
+      createdAt: new Date(Date.now() - 60_000),
+      actors: [
+        { userId: USER_A, role: 'patient', networkId: NET_ID, intent: INTENT_A },
+        { userId: USER_B, role: 'agent', networkId: NET_ID, intent: INTENT_OTHER },
+      ],
+      detection: {
+        source: 'opportunity_graph',
+        timestamp: new Date().toISOString(),
+        triggeredBy: INTENT_A,
+      },
+    });
+    let inserted: Opportunity | undefined;
+    const result = await buildGraph(buildDb({
+      findOpportunitiesByActors: async () => [existing],
+      createOpportunity: async (data) => {
+        inserted = {
+          ...data,
+          id: 'different-intent-pair',
+          status: 'latent',
+          createdAt: new Date(),
+          updatedAt: new Date(),
+          expiresAt: null,
+        };
+        return inserted;
+      },
+    })).invoke(ownedIntentInput);
+
+    expect(inserted?.actors.find((actor) => actor.userId === USER_B)?.intent).toBe(INTENT_B);
+    expect(result.opportunities.map((opportunity) => opportunity.id)).toEqual(['different-intent-pair']);
+    expect(result.persistenceOutcome?.crossIntentPairAllowedCount).toBe(1);
   });
 
   test('owned intent allows other-trigger terminal and non-negotiating lifecycle rows without mutating them', async () => {
@@ -498,7 +538,7 @@ describe('opportunity graph — time-based dedup (Persist node)', () => {
       expect(updateCalls).toBe(0);
       expect(inserted?.detection.triggeredBy).toBe(INTENT_A);
       expect(result.opportunities).toHaveLength(1);
-      expect(result.persistenceOutcome?.crossTriggerAllowedCount).toBe(1);
+      expect(result.persistenceOutcome?.crossIntentPairAllowedCount).toBe(1);
     }
   });
 
@@ -531,16 +571,16 @@ describe('opportunity graph — time-based dedup (Persist node)', () => {
 
     expect(createCalled).toBe(false);
     expect(result.existingBetweenActors[0]?.existingOpportunityId).toBe('same-second');
-    expect(result.existingBetweenActors[0]?.reason).toBe('same_trigger_recent_duplicate');
+    expect(result.existingBetweenActors[0]?.reason).toBe('same_intent_pair_duplicate');
   });
 
-  test('owned intent keeps a pair-global fresh active negotiation guard', async () => {
+  test('owned intent persists a cross-trigger match despite a fresh active negotiation', async () => {
     const otherNegotiating = makeOpportunity({
       status: 'negotiating',
       createdAt: new Date(Date.now() - 60_000),
       detection: { source: 'opportunity_graph', timestamp: new Date().toISOString(), triggeredBy: INTENT_OTHER },
     });
-    let createCalled = false;
+    let inserted: Opportunity | undefined;
     const result = await buildGraph(buildDb({
       findOpportunitiesByActors: async () => [otherNegotiating],
       getNegotiationTaskForOpportunity: async () => ({
@@ -548,14 +588,90 @@ describe('opportunity graph — time-based dedup (Persist node)', () => {
         createdAt: new Date(), updatedAt: new Date(),
       }),
       createOpportunity: async (data) => {
-        createCalled = true;
-        return { ...data, id: 'unexpected', status: 'latent', createdAt: new Date(), updatedAt: new Date(), expiresAt: null };
+        inserted = {
+          ...data,
+          id: 'current-trigger',
+          status: 'latent',
+          createdAt: new Date(),
+          updatedAt: new Date(),
+          expiresAt: null,
+        };
+        return inserted;
       },
     })).invoke(ownedIntentInput);
 
-    expect(createCalled).toBe(false);
-    expect(result.existingBetweenActors[0]?.reason).toBe('pair_active_negotiation');
-    expect(result.persistenceOutcome?.pairActiveNegotiationSuppressions).toBe(1);
+    expect(inserted?.detection.triggeredBy).toBe(INTENT_A);
+    expect(result.opportunities.map((opportunity) => opportunity.id)).toEqual(['current-trigger']);
+    expect(result.existingBetweenActors).toEqual([]);
+    expect(result.persistenceOutcome).toMatchObject({
+      createdCount: 1,
+      crossIntentPairAllowedCount: 1,
+      finalAtomicConflictCount: 0,
+    });
+  });
+
+  test('owned-intent floor persists both counterparties when one has an unrelated active negotiation', async () => {
+    const otherNegotiating = makeOpportunity({
+      status: 'negotiating',
+      createdAt: new Date(Date.now() - 60_000),
+      detection: { source: 'opportunity_graph', timestamp: new Date().toISOString(), triggeredBy: INTENT_OTHER },
+    });
+    const twoCandidateEmbedder = {
+      ...dummyEmbedder,
+      searchWithHydeEmbeddings: async () => [
+        { type: 'intent' as const, id: 'intent-bob' as Id<'intents'>, userId: USER_B, score: 0.9, matchedVia: 'mirror' as const, networkId: NET_ID },
+        { type: 'intent' as const, id: 'intent-carol' as Id<'intents'>, userId: USER_C, score: 0.8, matchedVia: 'mirror' as const, networkId: NET_ID },
+      ],
+    } as unknown as Embedder;
+    const twoCandidateEvaluator: OpportunityEvaluatorLike = {
+      invokeEntityBundle: async () => [
+        {
+          reasoning: 'Bob match', score: 90,
+          actors: [{ userId: USER_A, role: 'patient' }, { userId: USER_B, role: 'agent' }],
+        },
+        {
+          reasoning: 'Carol match', score: 80,
+          actors: [{ userId: USER_A, role: 'patient' }, { userId: USER_C, role: 'agent' }],
+        },
+      ],
+    };
+    const inserted: Opportunity[] = [];
+    const db = buildDb({
+      findOpportunitiesByActors: async (actorIds) => actorIds.includes(USER_B) ? [otherNegotiating] : [],
+      getNegotiationTaskForOpportunity: async () => ({
+        id: 'active-task', conversationId: 'conversation', state: 'paused', metadata: null,
+        createdAt: new Date(), updatedAt: new Date(),
+      }),
+      createOpportunity: async (data) => {
+        const created = {
+          ...data,
+          id: `current-trigger-${inserted.length + 1}`,
+          status: 'latent' as const,
+          createdAt: new Date(),
+          updatedAt: new Date(),
+          expiresAt: null,
+        };
+        inserted.push(created);
+        return created;
+      },
+    });
+
+    const result = await buildGraph(
+      db,
+      undefined,
+      { embedder: twoCandidateEmbedder, evaluator: twoCandidateEvaluator },
+    ).invoke(ownedIntentInput);
+
+    expect(inserted).toHaveLength(2);
+    expect(inserted.map((opportunity) => opportunity.actors.find((actor) => actor.userId !== USER_A)?.userId))
+      .toEqual([USER_B, USER_C]);
+    expect(result.opportunities).toHaveLength(2);
+    expect(result.persistenceOutcome).toMatchObject({
+      evaluatedCount: 2,
+      createdCount: 2,
+      crossIntentPairAllowedCount: 1,
+      finalAtomicConflictCount: 0,
+    });
   });
 
   test('owned intent does not adopt a stale other-trigger negotiating row', async () => {

--- a/packages/protocol/src/internal/opportunities/tests/opportunity.persist.spec.ts
+++ b/packages/protocol/src/internal/opportunities/tests/opportunity.persist.spec.ts
@@ -338,6 +338,50 @@ describe('persistOpportunities', () => {
       .toBe('Intent-scoped dedup trigger must match network eligibility');
   });
 
+  it('fails closed before enrichment when an intent-scoped participant has no intent', async () => {
+    let findCalls = 0;
+    let atomicCalls = 0;
+    const database: PersistOpportunityDatabase = {
+      findOpportunitiesByActors: async () => {
+        findCalls += 1;
+        return [];
+      },
+      createOpportunity: async () => makeOpportunity(),
+      updateOpportunityStatus: async () => {},
+      persistIntentScopedOpportunityIfNetworkEligible: async () => {
+        atomicCalls += 1;
+        return { created: makeOpportunity(), expired: [] };
+      },
+    };
+    const result = await persistOpportunities({
+      database,
+      embedder: mockEmbedder,
+      items: [makeCreateData({
+        detection: {
+          source: 'opportunity_graph',
+          timestamp: new Date().toISOString(),
+          triggeredBy: 'intent-current' as never,
+        },
+        actors: [
+          { networkId: 'net-1', userId: 'user-1', role: 'patient', intent: 'intent-current' },
+          { networkId: 'net-1', userId: 'user-2', role: 'agent' },
+        ] as never,
+      })],
+      networkEligibility: {
+        ownerUserId: 'user-1',
+        allowedNetworkIds: ['net-1'],
+        triggerIntentId: 'intent-current',
+      },
+      intentDedupScope: { triggerIntentId: 'intent-current' },
+    });
+
+    expect(findCalls).toBe(0);
+    expect(atomicCalls).toBe(0);
+    expect(result.errors).toHaveLength(1);
+    expect((result.errors?.[0]?.error as Error).message)
+      .toBe('Intent-scoped opportunities require an intent for every participant');
+  });
+
   it('replaces evaluator and enriched stale owner intents with the authorized trigger', async () => {
     const triggerIntentId = 'af813171-6ca6-4ca3-8a2e-b8b48471acd2';
     const staleIntentId = 'af813171-6ca6-4ca3-8a2e-b8b48441acd2';
@@ -434,7 +478,7 @@ describe('persistOpportunities', () => {
       },
       actors: [
         { networkId: 'net-1', userId: 'user-1', role: 'patient', intent: 'intent-current' },
-        { networkId: 'net-1', userId: 'user-2', role: 'agent' },
+        { networkId: 'net-1', userId: 'user-2', role: 'agent', intent: 'intent-counterparty' },
       ] as never,
     });
 
@@ -490,7 +534,7 @@ describe('persistOpportunities', () => {
       detection: { source: 'opportunity_graph', timestamp: new Date().toISOString(), triggeredBy: 'intent-current' as never },
       actors: [
         { networkId: 'net-1', userId: 'user-1', role: 'patient', intent: 'intent-current' },
-        { networkId: 'net-1', userId: 'user-2', role: 'agent' },
+        { networkId: 'net-1', userId: 'user-2', role: 'agent', intent: 'intent-counterparty' },
       ] as never,
     });
 

--- a/packages/protocol/src/internal/opportunities/tests/opportunity.persist.spec.ts
+++ b/packages/protocol/src/internal/opportunities/tests/opportunity.persist.spec.ts
@@ -328,7 +328,7 @@ describe('persistOpportunities', () => {
         allowedNetworkIds: ['net-1'],
         triggerIntentId: 'intent-eligibility',
       },
-      intentDedupScope: { triggerIntentId: 'intent-dedup', dedupWindowMs: 1_000 },
+      intentDedupScope: { triggerIntentId: 'intent-dedup' },
     });
 
     expect(atomicCalls).toBe(0);
@@ -390,7 +390,7 @@ describe('persistOpportunities', () => {
         allowedNetworkIds: ['net-1'],
         triggerIntentId,
       },
-      intentDedupScope: { triggerIntentId, dedupWindowMs: 30 * 24 * 60 * 60 * 1000 },
+      intentDedupScope: { triggerIntentId },
     });
 
     expect(result.errors).toBeUndefined();
@@ -417,7 +417,7 @@ describe('persistOpportunities', () => {
         atomicCalls += 1;
         return {
           conflict: {
-            reason: 'same_trigger_recent_duplicate',
+            reason: 'same_intent_pair_duplicate',
             existingOpportunityId: 'opp-existing',
             existingTriggerIntentId: 'intent-current',
             existingStatus: 'pending',
@@ -447,7 +447,7 @@ describe('persistOpportunities', () => {
         allowedNetworkIds: ['net-1'],
         triggerIntentId: 'intent-current',
       },
-      intentDedupScope: { triggerIntentId: 'intent-current', dedupWindowMs: 30 * 24 * 60 * 60 * 1000 },
+      intentDedupScope: { triggerIntentId: 'intent-current' },
     });
 
     expect(atomicCalls).toBe(1);
@@ -455,7 +455,7 @@ describe('persistOpportunities', () => {
     expect(result.conflicts).toEqual([{
       itemIndex: 0,
       finalAtomic: true,
-      reason: 'same_trigger_recent_duplicate',
+      reason: 'same_intent_pair_duplicate',
       existingOpportunityId: 'opp-existing',
       existingTriggerIntentId: 'intent-current',
       existingStatus: 'pending',
@@ -499,7 +499,7 @@ describe('persistOpportunities', () => {
       embedder: mockEmbedder,
       items: [item],
       networkEligibility: { ownerUserId: 'user-1', allowedNetworkIds: ['net-1'], triggerIntentId: 'intent-current' },
-      intentDedupScope: { triggerIntentId: 'intent-current', dedupWindowMs: 1_000 },
+      intentDedupScope: { triggerIntentId: 'intent-current' },
     });
 
     expect(receivedExpireIds).toEqual([]);

--- a/packages/protocol/src/platform/database/entities.ts
+++ b/packages/protocol/src/platform/database/entities.ts
@@ -587,9 +587,7 @@ export interface OpportunityNetworkEligibility {
   triggerIntentId?: string;
 }
 
-export type OpportunityDedupConflictReason =
-  | 'same_trigger_recent_duplicate'
-  | 'pair_active_negotiation';
+export type OpportunityDedupConflictReason = 'same_intent_pair_duplicate';
 
 export interface OpportunityDedupConflict {
   reason: OpportunityDedupConflictReason;

--- a/packages/protocol/src/platform/database/opportunity-queries.ts
+++ b/packages/protocol/src/platform/database/opportunity-queries.ts
@@ -98,15 +98,14 @@ export interface DatabaseOpportunityQueries {
 
   /**
    * Intent-scoped discovery persistence boundary. Implementations serialize on
-   * normalized participant pair + trigger intent, re-check same-trigger recent
-   * duplicates and pair-global active negotiations, then create/expire while
-   * the existing network eligibility locks remain held.
+   * the normalized intent pair, reject any existing opportunity for that exact
+   * pair, then create/expire while the existing network eligibility locks
+   * remain held. Other intents remain fully independent.
    */
   persistIntentScopedOpportunityIfNetworkEligible?(
     data: CreateOpportunityData,
     expireIds: string[],
     eligibility: OpportunityNetworkEligibility & { triggerIntentId: string },
-    dedupWindowMs: number,
   ): Promise<IntentScopedOpportunityPersistenceResult | null>;
 
   /**

--- a/services/api/CHANGELOG.md
+++ b/services/api/CHANGELOG.md
@@ -14,7 +14,9 @@ section before promoting to `main`).
   between the same users no longer suppress another intent's opportunity or
   task, while exact intent-pair opportunity delivery and per-opportunity task
   creation remain serialized. Each negotiation keeps its own conversation,
-  seats, rounds, pause, verdict, and lifecycle state.
+  seats, rounds, pause, verdict, and lifecycle state. Final persistence locks
+  and revalidates every participant intent as active, non-archived, owned by
+  that actor, and assigned to the actor's exact network.
 - Give PersonalAgent user-message jobs an enqueue-relative 70-second execution
   deadline inside the controller's 90-second wait, with the same fresh budget
   for background turns. A user-message deadline failure before durable work

--- a/services/api/CHANGELOG.md
+++ b/services/api/CHANGELOG.md
@@ -10,6 +10,11 @@ section before promoting to `main`).
 ## [Unreleased]
 
 ### Fixed
+- Isolate discovery and negotiation by exact intent pair: active negotiations
+  between the same users no longer suppress another intent's opportunity or
+  task, while exact intent-pair opportunity delivery and per-opportunity task
+  creation remain serialized. Each negotiation keeps its own conversation,
+  seats, rounds, pause, verdict, and lifecycle state.
 - Give PersonalAgent user-message jobs an enqueue-relative 70-second execution
   deadline inside the controller's 90-second wait, with the same fresh budget
   for background turns. A user-message deadline failure before durable work
@@ -230,7 +235,7 @@ section before promoting to `main`).
 ### Fixed
 - Route creation-time and post-discovery intent refinements through one material-fingerprint-deduplicated service, and stop suppressing ordinary intent-page Personal Agent questions merely because discovery already produced an actionable opportunity. Pool and Questioner-generated intent questions now receive symmetric surfacing opportunities while retaining ownership, active-lifecycle, stale-answer, privacy-copy, and one-question-per-material-version gates.
 - Add a privacy-minimal batched opportunity lifecycle read for Personal Agent negotiation narration, exposing current status plus whether the authenticated owner is the persisted human acceptor without inferring an H2H conversation (IND-492).
-- Removed the pre-assignment create-event discovery race and added transaction-scoped participant-pair/trigger advisory dedup, same-trigger atomic rechecks, pair-global negotiation claims, and explicit evaluator-vs-persistence zero-output telemetry so separate intent matches persist without starting duplicate active negotiations (IND-495; independently corroborated by IND-494).
+- Removed the pre-assignment create-event discovery race and added transaction-scoped intent-pair advisory dedup, exact-pair atomic rechecks, opportunity-scoped negotiation claims, and explicit evaluator-vs-persistence zero-output telemetry so separate intent matches and negotiations proceed independently without duplicating the same intent pair or opportunity attempt (IND-495; independently corroborated by IND-494).
 - Added batched opportunity-actor intent resolution for intent-pinned `list_negotiations` clamping and explicit scope labeling (IND-483).
 - Recover negotiation tasks stuck in `submitted` or `working` with the default-off IND-491 watchdog: a five-minute repeatable sweep uses state-aware age thresholds, fresh reads, guarded cancellation/terminal CAS updates, a three-attempt retry budget, and re-enqueues the existing negotiation kickoff without leaving duplicate live tasks.
 - Clear `warming` after the first successful from-intent discovery (IND-482) by recording the idempotent `intents.first_discovery_succeeded_at` stamp (migration `0100`, additive). The async MCP discovery-run path continues to use its succeeded-run row.

--- a/services/api/src/adapters/chat.database.adapter.ts
+++ b/services/api/src/adapters/chat.database.adapter.ts
@@ -2468,13 +2468,11 @@ export class ChatDatabaseAdapter {
     data: CreateOpportunityInput,
     expireIds: string[],
     eligibility: Parameters<OpportunityDatabaseAdapter['persistIntentScopedOpportunityIfNetworkEligible']>[2],
-    dedupWindowMs: number,
   ): ReturnType<OpportunityDatabaseAdapter['persistIntentScopedOpportunityIfNetworkEligible']> {
     return this.opportunityAdapter.persistIntentScopedOpportunityIfNetworkEligible(
       data,
       expireIds,
       eligibility,
-      dedupWindowMs,
     );
   }
   async createOpportunityAndExpireIds(

--- a/services/api/src/adapters/conversation.database.adapter.ts
+++ b/services/api/src/adapters/conversation.database.adapter.ts
@@ -70,7 +70,7 @@ import { publishConversationMessageEvent, publishIntentInvalidationEvent } from 
 import { log } from '../lib/log';
 import type { DrizzleDB } from '../lib/drizzle/drizzle';
 import { expectedNegotiationSpeaker, negotiationScopeKey } from '../lib/negotiation/expected-speaker';
-import { acquireNegotiationAttemptLock, acquireNegotiationPairLock, notArchivedNegotiationTaskWhere, qualifyingNegotiationAttemptTaskWhere, qualifyingPairNegotiationTaskWhere, rewriteEraNegotiationTaskWhere, type NegotiationAttemptTransaction } from './negotiation-attempt.atomic';
+import { acquireNegotiationAttemptLock, notArchivedNegotiationTaskWhere, qualifyingNegotiationAttemptTaskWhere, rewriteEraNegotiationTaskWhere, type NegotiationAttemptTransaction } from './negotiation-attempt.atomic';
 
 /**
  * In-transaction read of ONE negotiation's turn history, for the locked floor
@@ -385,7 +385,7 @@ export interface StaleNegotiationTask {
 
 /**
  * Claim an exact eligible opportunity state, promote it to negotiating, and
- * insert its task while the shared attempt, row, and pair locks are held.
+ * insert its task while the opportunity attempt and row locks are held.
  */
 export async function createNegotiationTaskForAttemptInTransaction(
   tx: NegotiationAttemptTransaction,
@@ -401,19 +401,11 @@ export async function createNegotiationTaskForAttemptInTransaction(
     .select({
       status: opportunities.status,
       updatedAt: opportunities.updatedAt,
-      actors: opportunities.actors,
     })
     .from(opportunities)
     .where(eq(opportunities.id, input.opportunityId))
     .for('update');
   if (!opportunity) return null;
-
-  const actorUserIds = [...new Set(opportunity.actors
-    .filter((actor) => actor.role !== 'introducer')
-    .map((actor) => actor.userId))].sort();
-  if (actorUserIds.length >= 2) {
-    await acquireNegotiationPairLock(tx, actorUserIds);
-  }
 
   if (
     opportunity.status !== input.expectedStatus
@@ -421,16 +413,6 @@ export async function createNegotiationTaskForAttemptInTransaction(
     || opportunity.updatedAt.getTime() !== input.expectedUpdatedAt.getTime()
   ) {
     return null;
-  }
-
-  if (actorUserIds.length >= 2) {
-    const [pairTask] = await tx
-      .select({ id: schema.tasks.id })
-      .from(schema.tasks)
-      .innerJoin(opportunities, sql`TRUE`)
-      .where(qualifyingPairNegotiationTaskWhere(actorUserIds, input.opportunityId))
-      .limit(1);
-    if (pairTask) return null;
   }
 
   const [qualifyingTask] = await tx

--- a/services/api/src/adapters/negotiation-attempt.atomic.ts
+++ b/services/api/src/adapters/negotiation-attempt.atomic.ts
@@ -8,11 +8,6 @@ export function negotiationAttemptLockName(opportunityId: string): string {
   return `negotiation-attempt:${opportunityId}`;
 }
 
-/** Stable pair-global lock namespace preventing concurrent cross-trigger attempts. */
-export function negotiationPairLockName(actorUserIds: string[]): string {
-  return `negotiation-pair:${[...new Set(actorUserIds)].sort().join('|')}`;
-}
-
 /**
  * Serialize task creation and fallback compensation for one opportunity.
  * The transaction-scoped lock is released automatically on commit/rollback.
@@ -28,18 +23,6 @@ export async function acquireNegotiationAttemptLock(
   `);
 }
 
-/** Serialize negotiation claims for the same normalized participant pair. */
-export async function acquireNegotiationPairLock(
-  tx: NegotiationAttemptTransaction,
-  actorUserIds: string[],
-): Promise<void> {
-  await tx.execute(sql`
-    SELECT pg_advisory_xact_lock(
-      hashtextextended(${negotiationPairLockName(actorUserIds)}, 0)
-    )
-  `);
-}
-
 function qualifyingFreshNegotiationTaskStateWhere() {
   return sql`${schema.tasks.state} IN ('submitted', 'working', 'paused')`;
 }
@@ -49,28 +32,6 @@ export function qualifyingActiveNegotiationTaskWhere(opportunityId: string) {
   return sql`
     ${schema.tasks.metadata}->>'type' = 'negotiation'
     AND ${schema.tasks.metadata}->>'opportunityId' = ${opportunityId}
-    AND ${qualifyingFreshNegotiationTaskStateWhere()}
-  `;
-}
-
-/** Pair-global tasks fresh enough to block a concurrent cross-trigger attempt. */
-export function qualifyingPairNegotiationTaskWhere(
-  actorUserIds: string[],
-  excludeOpportunityId?: string,
-) {
-  const actorContainment = actorUserIds.map((userId) => sql`EXISTS (
-    SELECT 1 FROM jsonb_array_elements(${schema.opportunities.actors}) elem
-    WHERE elem->>'userId' = ${userId}
-      AND elem->>'role' IS DISTINCT FROM 'introducer'
-  )`);
-  return sql`
-    ${schema.tasks.metadata}->>'type' = 'negotiation'
-    AND ${schema.tasks.metadata}->>'opportunityId' = ${schema.opportunities.id}
-    ${excludeOpportunityId
-      ? sql`AND ${schema.opportunities.id} <> ${excludeOpportunityId}`
-      : sql``}
-    AND ${schema.opportunities.status} = 'negotiating'
-    AND ${sql.join(actorContainment, sql` AND `)}
     AND ${qualifyingFreshNegotiationTaskStateWhere()}
   `;
 }

--- a/services/api/src/adapters/opportunity.database.adapter.ts
+++ b/services/api/src/adapters/opportunity.database.adapter.ts
@@ -412,9 +412,20 @@ export class OpportunityDatabaseAdapter {
         && actor.intent === eligibility.triggerIntentId)
     ) return null;
     const participantScopeKeys = participantActors.map((actor) => `intent:${actor.intent!}`);
-    const intentBindings = [...new Map(participantActors.map((actor) => [
-      `${actor.userId}\u0000${actor.intent!}`,
-      { userId: actor.userId, intentId: actor.intent! },
+    const participantIntentNetworkBindings = [...new Map([
+      ...participantActors.map((actor) => ({
+        userId: actor.userId,
+        intentId: actor.intent!,
+        networkId: actor.networkId,
+      })),
+      ...actorNetworkIds.map((networkId) => ({
+        userId: eligibility.ownerUserId,
+        intentId: eligibility.triggerIntentId,
+        networkId,
+      })),
+    ].map((binding) => [
+      `${binding.userId}\u0000${binding.intentId}\u0000${binding.networkId}`,
+      binding,
     ] as const)).values()];
 
     const requestedPairs = [
@@ -452,38 +463,28 @@ export class OpportunityDatabaseAdapter {
       );
       await acquireIntentScopedPairLock(tx, participantScopeKeys);
 
-      const [ownedIntent] = await tx
-        .select({ id: schema.intents.id })
+      const activeAssignedIntents = await tx
+        .select({
+          id: schema.intents.id,
+          userId: schema.intents.userId,
+          networkId: schema.intentNetworks.networkId,
+        })
         .from(schema.intents)
+        .innerJoin(schema.intentNetworks, eq(schema.intentNetworks.intentId, schema.intents.id))
         .where(and(
-          eq(schema.intents.id, eligibility.triggerIntentId),
-          eq(schema.intents.userId, eligibility.ownerUserId),
+          or(...participantIntentNetworkBindings.map((binding) => and(
+            eq(schema.intents.id, binding.intentId),
+            eq(schema.intents.userId, binding.userId),
+            eq(schema.intentNetworks.networkId, binding.networkId),
+          ))),
           isNull(schema.intents.archivedAt),
           or(isNull(schema.intents.status), eq(schema.intents.status, 'ACTIVE')),
         ))
         .for('share');
-      if (!ownedIntent) return null;
-
-      const boundIntents = await tx
-        .select({ id: schema.intents.id, userId: schema.intents.userId })
-        .from(schema.intents)
-        .where(or(...intentBindings.map((binding) => and(
-          eq(schema.intents.id, binding.intentId),
-          eq(schema.intents.userId, binding.userId),
-        ))))
-        .for('share');
-      const boundIntentKeys = new Set(boundIntents.map((intent) => `${intent.userId}\u0000${intent.id}`));
-      if (intentBindings.some((binding) => !boundIntentKeys.has(`${binding.userId}\u0000${binding.intentId}`))) return null;
-
-      const assignments = await tx
-        .select({ networkId: schema.intentNetworks.networkId })
-        .from(schema.intentNetworks)
-        .where(and(
-          eq(schema.intentNetworks.intentId, eligibility.triggerIntentId),
-          inArray(schema.intentNetworks.networkId, actorNetworkIds),
-        ))
-        .for('share');
-      if (new Set(assignments.map((row) => row.networkId)).size !== actorNetworkIds.length) return null;
+      const activeAssignedIntentKeys = new Set(activeAssignedIntents.map((intent) =>
+        `${intent.userId}\u0000${intent.id}\u0000${intent.networkId}`));
+      if (participantIntentNetworkBindings.some((binding) =>
+        !activeAssignedIntentKeys.has(`${binding.userId}\u0000${binding.intentId}\u0000${binding.networkId}`))) return null;
 
       const activePairs = await tx
         .select({

--- a/services/api/src/adapters/opportunity.database.adapter.ts
+++ b/services/api/src/adapters/opportunity.database.adapter.ts
@@ -3,7 +3,7 @@ import { emitOpportunityLifecycleBestEffort, emitOpportunityTransitionBestEffort
 import { computeIntentFingerprint } from '../lib/intent/intent.fingerprint';
 import { computeOutcomeCounterpartDedupKey, computeOutcomeIdempotencyKey, computeOutcomeSnapshotHash } from '../lib/opportunity/outcome-feedback.identity';
 import { acquireIntentScopeAdvisoryLock } from './intent-scope.atomic';
-import { acquireNegotiationAttemptLock, acquireNegotiationPairLock, qualifyingActiveNegotiationTaskWhere, qualifyingNegotiationAttemptTaskWhere, qualifyingPairNegotiationTaskWhere } from './negotiation-attempt.atomic';
+import { acquireNegotiationAttemptLock, qualifyingActiveNegotiationTaskWhere, qualifyingNegotiationAttemptTaskWhere } from './negotiation-attempt.atomic';
 import { runTasklessNegotiationReactivation } from './negotiation-reactivation.atomic';
 import { exactEvidencePoolWhere, exactLivePoolWhere, POOL_LIVE_STATUSES } from './poolquery.shared';
 
@@ -14,7 +14,7 @@ interface OpportunityNetworkEligibilityInput {
 }
 
 interface IntentScopedOpportunityPersistenceConflict {
-  reason: 'same_trigger_recent_duplicate' | 'pair_active_negotiation';
+  reason: 'same_intent_pair_duplicate';
   existingOpportunityId: string;
   existingTriggerIntentId?: string;
   existingStatus: OpportunityRow['status'];
@@ -36,16 +36,14 @@ function participantUserIds(data: CreateOpportunityInput): string[] {
     .map((actor) => actor.userId))].sort();
 }
 
-async function acquireIntentScopedPairLocks(
+async function acquireIntentScopedPairLock(
   tx: DrizzleTx,
-  actorUserIds: string[],
-  triggerIntentId: string,
+  participantScopeKeys: string[],
 ): Promise<void> {
-  const pairKey = actorUserIds.join('|');
-  await acquireNegotiationPairLock(tx, actorUserIds);
+  const pairKey = [...new Set(participantScopeKeys)].sort().join('|');
   await tx.execute(sql`
     SELECT pg_advisory_xact_lock(
-      hashtextextended(${`opportunity-pair-intent:${pairKey}:${triggerIntentId}`}, 0)
+      hashtextextended(${`opportunity-intent-pair:${pairKey}`}, 0)
     )
   `);
 }
@@ -390,18 +388,24 @@ export class OpportunityDatabaseAdapter {
   }
 
   /**
-   * Persist one owned-intent discovery result under pair + pair/intent advisory
-   * locks, re-checking dedup and active negotiation state at the final boundary.
+   * Persist one owned-intent discovery result under intent-scope and exact-pair
+   * advisory locks, re-checking exact intent-pair dedup at the final boundary.
    */
   async persistIntentScopedOpportunityIfNetworkEligible(
     data: CreateOpportunityInput,
     expireIds: string[],
     eligibility: OpportunityNetworkEligibilityInput & { triggerIntentId: string },
-    dedupWindowMs: number,
   ): Promise<IntentScopedOpportunityPersistenceResult | null> {
     const actorNetworkIds = [...new Set(data.actors.map((actor) => actor.networkId))];
     const allowedNetworkIds = new Set(eligibility.allowedNetworkIds);
     const actorUserIds = participantUserIds(data);
+    const participantScopeKeys = data.actors
+      .filter((actor) => actor.role !== 'introducer')
+      .map((actor) => actor.intent
+        ? `intent:${actor.intent}`
+        : actor.userId === eligibility.ownerUserId
+          ? `intent:${eligibility.triggerIntentId}`
+          : `user:${actor.userId}`);
     if (
       data.detection.triggeredBy !== eligibility.triggerIntentId
       || actorNetworkIds.length === 0
@@ -411,8 +415,6 @@ export class OpportunityDatabaseAdapter {
         actor.userId === eligibility.ownerUserId
         && actor.role !== 'introducer'
         && actor.intent === eligibility.triggerIntentId)
-      || !Number.isFinite(dedupWindowMs)
-      || dedupWindowMs <= 0
     ) return null;
 
     const requestedPairs = [
@@ -423,11 +425,16 @@ export class OpportunityDatabaseAdapter {
       `${pair.userId}\u0000${pair.networkId}`,
       pair,
     ] as const)).values()];
-    const actorContainment = actorUserIds.map((userId) => sql`EXISTS (
-      SELECT 1 FROM jsonb_array_elements(${opportunities.actors}) elem
-      WHERE elem->>'userId' = ${userId}
-        AND elem->>'role' IS DISTINCT FROM 'introducer'
-    )`);
+    const actorContainment = data.actors
+      .filter((actor) => actor.role !== 'introducer')
+      .map((actor) => sql`EXISTS (
+        SELECT 1 FROM jsonb_array_elements(${opportunities.actors}) elem
+        WHERE elem->>'userId' = ${actor.userId}
+          AND elem->>'role' IS DISTINCT FROM 'introducer'
+          ${actor.intent
+            ? sql`AND (elem->>'intent' = ${actor.intent} OR elem->>'intent' IS NULL)`
+            : sql``}
+      )`);
     const sameTrigger = or(
       sql`${opportunities.detection}->>'triggeredBy' = ${eligibility.triggerIntentId}`,
       sql`${opportunities.actors} @> ${JSON.stringify([{
@@ -445,7 +452,7 @@ export class OpportunityDatabaseAdapter {
         eligibility.ownerUserId,
         eligibility.triggerIntentId,
       );
-      await acquireIntentScopedPairLocks(tx, actorUserIds, eligibility.triggerIntentId);
+      await acquireIntentScopedPairLock(tx, participantScopeKeys);
 
       const [ownedIntent] = await tx
         .select({ id: schema.intents.id })
@@ -487,26 +494,6 @@ export class OpportunityDatabaseAdapter {
         .for('share');
       if (activePairs.length !== pairs.length) return null;
 
-      const [activeNegotiationRow] = await tx
-        .select({ opportunity: opportunities })
-        .from(opportunities)
-        .innerJoin(schema.tasks, sql`TRUE`)
-        .where(qualifyingPairNegotiationTaskWhere(actorUserIds))
-        .orderBy(desc(schema.tasks.updatedAt))
-        .limit(1);
-      if (activeNegotiationRow) {
-        const existing = toOpportunityRow(activeNegotiationRow.opportunity);
-        return {
-          conflict: {
-            reason: 'pair_active_negotiation' as const,
-            existingOpportunityId: existing.id,
-            existingTriggerIntentId: opportunityTriggerForOwner(existing, eligibility.ownerUserId),
-            existingStatus: existing.status,
-            existingCreatedAt: existing.createdAt,
-          },
-        };
-      }
-
       const [sameTriggerRecentRow] = await tx
         .select()
         .from(opportunities)
@@ -514,7 +501,6 @@ export class OpportunityDatabaseAdapter {
           ...actorContainment,
           sameTrigger,
           ne(opportunities.status, 'draft'),
-          sql`${opportunities.createdAt} >= NOW() - (${dedupWindowMs} * INTERVAL '1 millisecond')`,
         ))
         .orderBy(desc(opportunities.createdAt))
         .limit(1);
@@ -522,7 +508,7 @@ export class OpportunityDatabaseAdapter {
         const existing = toOpportunityRow(sameTriggerRecentRow);
         return {
           conflict: {
-            reason: 'same_trigger_recent_duplicate' as const,
+            reason: 'same_intent_pair_duplicate' as const,
             existingOpportunityId: existing.id,
             existingTriggerIntentId: opportunityTriggerForOwner(existing, eligibility.ownerUserId),
             existingStatus: existing.status,

--- a/services/api/src/adapters/opportunity.database.adapter.ts
+++ b/services/api/src/adapters/opportunity.database.adapter.ts
@@ -3,7 +3,7 @@ import { emitOpportunityLifecycleBestEffort, emitOpportunityTransitionBestEffort
 import { computeIntentFingerprint } from '../lib/intent/intent.fingerprint';
 import { computeOutcomeCounterpartDedupKey, computeOutcomeIdempotencyKey, computeOutcomeSnapshotHash } from '../lib/opportunity/outcome-feedback.identity';
 import { acquireIntentScopeAdvisoryLock } from './intent-scope.atomic';
-import { acquireNegotiationAttemptLock, qualifyingActiveNegotiationTaskWhere, qualifyingNegotiationAttemptTaskWhere } from './negotiation-attempt.atomic';
+import { acquireNegotiationAttemptLock, qualifyingActiveNegotiationTaskWhere } from './negotiation-attempt.atomic';
 import { runTasklessNegotiationReactivation } from './negotiation-reactivation.atomic';
 import { exactEvidencePoolWhere, exactLivePoolWhere, POOL_LIVE_STATUSES } from './poolquery.shared';
 
@@ -399,23 +399,23 @@ export class OpportunityDatabaseAdapter {
     const actorNetworkIds = [...new Set(data.actors.map((actor) => actor.networkId))];
     const allowedNetworkIds = new Set(eligibility.allowedNetworkIds);
     const actorUserIds = participantUserIds(data);
-    const participantScopeKeys = data.actors
-      .filter((actor) => actor.role !== 'introducer')
-      .map((actor) => actor.intent
-        ? `intent:${actor.intent}`
-        : actor.userId === eligibility.ownerUserId
-          ? `intent:${eligibility.triggerIntentId}`
-          : `user:${actor.userId}`);
+    const participantActors = data.actors.filter((actor) => actor.role !== 'introducer');
     if (
       data.detection.triggeredBy !== eligibility.triggerIntentId
       || actorNetworkIds.length === 0
       || actorNetworkIds.some((id) => !allowedNetworkIds.has(id))
       || actorUserIds.length < 2
+      || participantActors.some((actor) => !actor.intent)
       || !data.actors.some((actor) =>
         actor.userId === eligibility.ownerUserId
         && actor.role !== 'introducer'
         && actor.intent === eligibility.triggerIntentId)
     ) return null;
+    const participantScopeKeys = participantActors.map((actor) => `intent:${actor.intent!}`);
+    const intentBindings = [...new Map(participantActors.map((actor) => [
+      `${actor.userId}\u0000${actor.intent!}`,
+      { userId: actor.userId, intentId: actor.intent! },
+    ] as const)).values()];
 
     const requestedPairs = [
       ...data.actors.map((actor) => ({ userId: actor.userId, networkId: actor.networkId })),
@@ -431,9 +431,7 @@ export class OpportunityDatabaseAdapter {
         SELECT 1 FROM jsonb_array_elements(${opportunities.actors}) elem
         WHERE elem->>'userId' = ${actor.userId}
           AND elem->>'role' IS DISTINCT FROM 'introducer'
-          ${actor.intent
-            ? sql`AND (elem->>'intent' = ${actor.intent} OR elem->>'intent' IS NULL)`
-            : sql``}
+          AND elem->>'intent' = ${actor.intent!}
       )`);
     const sameTrigger = or(
       sql`${opportunities.detection}->>'triggeredBy' = ${eligibility.triggerIntentId}`,
@@ -465,6 +463,17 @@ export class OpportunityDatabaseAdapter {
         ))
         .for('share');
       if (!ownedIntent) return null;
+
+      const boundIntents = await tx
+        .select({ id: schema.intents.id, userId: schema.intents.userId })
+        .from(schema.intents)
+        .where(or(...intentBindings.map((binding) => and(
+          eq(schema.intents.id, binding.intentId),
+          eq(schema.intents.userId, binding.userId),
+        ))))
+        .for('share');
+      const boundIntentKeys = new Set(boundIntents.map((intent) => `${intent.userId}\u0000${intent.id}`));
+      if (intentBindings.some((binding) => !boundIntentKeys.has(`${binding.userId}\u0000${binding.intentId}`))) return null;
 
       const assignments = await tx
         .select({ networkId: schema.intentNetworks.networkId })

--- a/services/api/src/adapters/opportunity.database.adapter.ts
+++ b/services/api/src/adapters/opportunity.database.adapter.ts
@@ -478,7 +478,7 @@ export class OpportunityDatabaseAdapter {
             eq(schema.intentNetworks.networkId, binding.networkId),
           ))),
           isNull(schema.intents.archivedAt),
-          or(isNull(schema.intents.status), eq(schema.intents.status, 'ACTIVE')),
+          eq(schema.intents.status, 'ACTIVE'),
         ))
         .for('share');
       const activeAssignedIntentKeys = new Set(activeAssignedIntents.map((intent) =>

--- a/services/api/src/adapters/tests/database.adapter.isolated.ts
+++ b/services/api/src/adapters/tests/database.adapter.isolated.ts
@@ -1387,6 +1387,65 @@ describe('OpportunityDatabaseAdapter', () => {
       expect(inserted).toEqual([]);
     });
 
+    it('fails closed when the counterparty intent is inactive, archived, or unassigned', async () => {
+      const candidateIntentId = uuidv4();
+      fixture.extraIntentIds.push(candidateIntentId);
+      await db.insert(intents).values({
+        id: candidateIntentId,
+        userId: fixture.userBId,
+        payload: `${TEST_PREFIX}ineligible counterparty intent`,
+        sourceType: 'discovery_form',
+        sourceId: fixture.userBId,
+        status: 'PAUSED',
+      });
+      await db.insert(intentNetworks).values({
+        intentId: candidateIntentId,
+        networkId: fixture.networkId,
+      });
+      const markerPrefix = `${TEST_PREFIX}ineligible-counterparty-${uuidv4()}`;
+      const persist = (suffix: string) => adapter.persistIntentScopedOpportunityIfNetworkEligible({
+        detection: {
+          source: 'opportunity_graph',
+          createdBy: `${markerPrefix}-${suffix}`,
+          timestamp: new Date().toISOString(),
+          triggeredBy: fixture.intent1Id,
+        },
+        actors: [
+          { networkId: fixture.networkId, userId: fixture.userAId, role: 'patient', intent: fixture.intent1Id },
+          { networkId: fixture.networkId, userId: fixture.userBId, role: 'agent', intent: candidateIntentId },
+        ],
+        interpretation: { category: 'collaboration', reasoning: 'Ineligible counterparty must not persist', confidence: 0.9 },
+        context: { networkId: fixture.networkId },
+        confidence: '0.9',
+        status: 'latent',
+      }, [], {
+        ownerUserId: fixture.userAId,
+        allowedNetworkIds: [fixture.networkId],
+        triggerIntentId: fixture.intent1Id,
+      });
+
+      const inactive = await persist('inactive');
+      await db.update(intents)
+        .set({ status: 'ACTIVE', archivedAt: new Date() })
+        .where(eq(intents.id, candidateIntentId));
+      const archived = await persist('archived');
+      await db.update(intents)
+        .set({ archivedAt: null })
+        .where(eq(intents.id, candidateIntentId));
+      await db.delete(intentNetworks).where(and(
+        eq(intentNetworks.intentId, candidateIntentId),
+        eq(intentNetworks.networkId, fixture.networkId),
+      ));
+      const unassigned = await persist('unassigned');
+      const inserted = await db
+        .select({ id: opportunities.id })
+        .from(opportunities)
+        .where(sql`${opportunities.detection}->>'createdBy' LIKE ${`${markerPrefix}%`}`);
+
+      expect([inactive, archived, unassigned]).toEqual([null, null, null]);
+      expect(inserted).toEqual([]);
+    });
+
     it('does not let an unbound legacy row suppress a fully bound intent pair', async () => {
       const triggerIntentId = uuidv4();
       const candidateIntentId = uuidv4();
@@ -1407,7 +1466,10 @@ describe('OpportunityDatabaseAdapter', () => {
           sourceId: fixture.userBId,
         },
       ]);
-      await db.insert(intentNetworks).values({ intentId: triggerIntentId, networkId: fixture.networkId });
+      await db.insert(intentNetworks).values([
+        { intentId: triggerIntentId, networkId: fixture.networkId },
+        { intentId: candidateIntentId, networkId: fixture.networkId },
+      ]);
       const legacy = await adapter.createOpportunity({
         detection: { source: 'opportunity_graph', timestamp: new Date().toISOString(), triggeredBy: triggerIntentId },
         actors: [
@@ -1463,7 +1525,10 @@ describe('OpportunityDatabaseAdapter', () => {
           sourceId: fixture.userBId,
         },
       ]);
-      await db.insert(intentNetworks).values({ intentId: triggerIntentId, networkId: fixture.networkId });
+      await db.insert(intentNetworks).values([
+        { intentId: triggerIntentId, networkId: fixture.networkId },
+        { intentId: candidateIntentId, networkId: fixture.networkId },
+      ]);
       const otherTrigger = await adapter.createOpportunity({
         detection: { source: 'opportunity_graph', timestamp: new Date().toISOString(), triggeredBy: fixture.intent1Id },
         actors: [
@@ -1598,7 +1663,10 @@ describe('OpportunityDatabaseAdapter', () => {
           sourceId: fixture.userBId,
         },
       ]);
-      await db.insert(intentNetworks).values({ intentId: triggerIntentId, networkId: fixture.networkId });
+      await db.insert(intentNetworks).values([
+        { intentId: triggerIntentId, networkId: fixture.networkId },
+        { intentId: candidateIntentId, networkId: fixture.networkId },
+      ]);
 
       const createData = {
         detection: {

--- a/services/api/src/adapters/tests/database.adapter.isolated.ts
+++ b/services/api/src/adapters/tests/database.adapter.isolated.ts
@@ -1316,6 +1316,133 @@ describe('OpportunityDatabaseAdapter', () => {
       expect(inserted).toEqual([]);
     });
 
+    it('fails closed when the counterparty actor has no intent', async () => {
+      const marker = `${TEST_PREFIX}missing-counterparty-intent-${uuidv4()}`;
+      const result = await adapter.persistIntentScopedOpportunityIfNetworkEligible({
+        detection: {
+          source: 'opportunity_graph',
+          createdBy: marker,
+          timestamp: new Date().toISOString(),
+          triggeredBy: fixture.intent1Id,
+        },
+        actors: [
+          { networkId: fixture.networkId, userId: fixture.userAId, role: 'patient', intent: fixture.intent1Id },
+          { networkId: fixture.networkId, userId: fixture.userBId, role: 'agent' },
+        ],
+        interpretation: { category: 'collaboration', reasoning: 'Unbound counterparty must not persist', confidence: 0.9 },
+        context: { networkId: fixture.networkId },
+        confidence: '0.9',
+        status: 'latent',
+      }, [], {
+        ownerUserId: fixture.userAId,
+        allowedNetworkIds: [fixture.networkId],
+        triggerIntentId: fixture.intent1Id,
+      });
+      const inserted = await db
+        .select({ id: opportunities.id })
+        .from(opportunities)
+        .where(sql`${opportunities.detection}->>'createdBy' = ${marker}`);
+
+      expect(result).toBeNull();
+      expect(inserted).toEqual([]);
+    });
+
+    it('fails closed when the counterparty intent belongs to another user', async () => {
+      const misownedIntentId = uuidv4();
+      fixture.extraIntentIds.push(misownedIntentId);
+      await db.insert(intents).values({
+        id: misownedIntentId,
+        userId: fixture.userAId,
+        payload: `${TEST_PREFIX}misowned counterparty intent`,
+        sourceType: 'discovery_form',
+        sourceId: fixture.userAId,
+      });
+      const marker = `${TEST_PREFIX}misowned-counterparty-intent-${uuidv4()}`;
+      const result = await adapter.persistIntentScopedOpportunityIfNetworkEligible({
+        detection: {
+          source: 'opportunity_graph',
+          createdBy: marker,
+          timestamp: new Date().toISOString(),
+          triggeredBy: fixture.intent1Id,
+        },
+        actors: [
+          { networkId: fixture.networkId, userId: fixture.userAId, role: 'patient', intent: fixture.intent1Id },
+          { networkId: fixture.networkId, userId: fixture.userBId, role: 'agent', intent: misownedIntentId },
+        ],
+        interpretation: { category: 'collaboration', reasoning: 'Misowned counterparty intent must not persist', confidence: 0.9 },
+        context: { networkId: fixture.networkId },
+        confidence: '0.9',
+        status: 'latent',
+      }, [], {
+        ownerUserId: fixture.userAId,
+        allowedNetworkIds: [fixture.networkId],
+        triggerIntentId: fixture.intent1Id,
+      });
+      const inserted = await db
+        .select({ id: opportunities.id })
+        .from(opportunities)
+        .where(sql`${opportunities.detection}->>'createdBy' = ${marker}`);
+
+      expect(result).toBeNull();
+      expect(inserted).toEqual([]);
+    });
+
+    it('does not let an unbound legacy row suppress a fully bound intent pair', async () => {
+      const triggerIntentId = uuidv4();
+      const candidateIntentId = uuidv4();
+      fixture.extraIntentIds.push(triggerIntentId, candidateIntentId);
+      await db.insert(intents).values([
+        {
+          id: triggerIntentId,
+          userId: fixture.userAId,
+          payload: `${TEST_PREFIX}legacy wildcard trigger`,
+          sourceType: 'discovery_form',
+          sourceId: fixture.userAId,
+        },
+        {
+          id: candidateIntentId,
+          userId: fixture.userBId,
+          payload: `${TEST_PREFIX}legacy wildcard counterparty`,
+          sourceType: 'discovery_form',
+          sourceId: fixture.userBId,
+        },
+      ]);
+      await db.insert(intentNetworks).values({ intentId: triggerIntentId, networkId: fixture.networkId });
+      const legacy = await adapter.createOpportunity({
+        detection: { source: 'opportunity_graph', timestamp: new Date().toISOString(), triggeredBy: triggerIntentId },
+        actors: [
+          { networkId: fixture.networkId, userId: fixture.userAId, role: 'patient', intent: triggerIntentId },
+          { networkId: fixture.networkId, userId: fixture.userBId, role: 'agent' },
+        ],
+        interpretation: { category: 'collaboration', reasoning: 'Legacy unbound row', confidence: 0.9 },
+        context: { networkId: fixture.networkId },
+        confidence: '0.9',
+        status: 'pending',
+      });
+
+      const result = await adapter.persistIntentScopedOpportunityIfNetworkEligible({
+        detection: { source: 'opportunity_graph', timestamp: new Date().toISOString(), triggeredBy: triggerIntentId },
+        actors: [
+          { networkId: fixture.networkId, userId: fixture.userAId, role: 'patient', intent: triggerIntentId },
+          { networkId: fixture.networkId, userId: fixture.userBId, role: 'agent', intent: candidateIntentId },
+        ],
+        interpretation: { category: 'collaboration', reasoning: 'Fully bound exact pair', confidence: 0.9 },
+        context: { networkId: fixture.networkId },
+        confidence: '0.9',
+        status: 'latent',
+      }, [], {
+        ownerUserId: fixture.userAId,
+        allowedNetworkIds: [fixture.networkId],
+        triggerIntentId,
+      });
+
+      expect(result && 'created' in result).toBe(true);
+      if (!result || !('created' in result)) throw new Error('expected fully bound opportunity');
+      expect(result.created.id).not.toBe(legacy.id);
+      expect(result.created.actors.find((actor) => actor.userId === fixture.userBId)?.intent)
+        .toBe(candidateIntentId);
+    });
+
     it('persists and starts a distinct intent negotiation while another intent for the pair is paused', async () => {
       const triggerIntentId = uuidv4();
       const candidateIntentId = uuidv4();

--- a/services/api/src/adapters/tests/database.adapter.isolated.ts
+++ b/services/api/src/adapters/tests/database.adapter.isolated.ts
@@ -1426,6 +1426,10 @@ describe('OpportunityDatabaseAdapter', () => {
 
       const inactive = await persist('inactive');
       await db.update(intents)
+        .set({ status: null })
+        .where(eq(intents.id, candidateIntentId));
+      const unsetStatus = await persist('unset-status');
+      await db.update(intents)
         .set({ status: 'ACTIVE', archivedAt: new Date() })
         .where(eq(intents.id, candidateIntentId));
       const archived = await persist('archived');
@@ -1442,7 +1446,7 @@ describe('OpportunityDatabaseAdapter', () => {
         .from(opportunities)
         .where(sql`${opportunities.detection}->>'createdBy' LIKE ${`${markerPrefix}%`}`);
 
-      expect([inactive, archived, unassigned]).toEqual([null, null, null]);
+      expect([inactive, unsetStatus, archived, unassigned]).toEqual([null, null, null, null]);
       expect(inserted).toEqual([]);
     });
 

--- a/services/api/src/adapters/tests/database.adapter.isolated.ts
+++ b/services/api/src/adapters/tests/database.adapter.isolated.ts
@@ -8,6 +8,7 @@ import { v4 as uuidv4 } from 'uuid';
 import db from '../../lib/drizzle/drizzle';
 import { conversations, tasks, users, userSocials, networks, networkMembers, intents, intentNetworks, premises, premiseNetworks, opportunities } from '../../schemas/database.schema';
 import { IntentDatabaseAdapter, ChatDatabaseAdapter, EnrichmentDatabaseAdapter, OpportunityDatabaseAdapter, HydeDatabaseAdapter } from '../database.adapter';
+import { ConversationDatabaseAdapter } from '../conversation.database.adapter';
 import { PremiseEvents } from '../../events/premise.event';
 import { IntentEvents } from '../../events/intent.event';
 import { computeIntentFingerprint } from '../../lib/intent/intent.fingerprint';
@@ -813,6 +814,7 @@ describe('EnrichmentDatabaseAdapter', () => {
 // ═══════════════════════════════════════════════════════════════════════════════
 describe('OpportunityDatabaseAdapter', () => {
   const adapter = new OpportunityDatabaseAdapter();
+  const conversationAdapter = new ConversationDatabaseAdapter();
 
   it('should get profile when exists', async () => {
     const profile = await adapter.getProfile(fixture.userAId);
@@ -1273,7 +1275,7 @@ describe('OpportunityDatabaseAdapter', () => {
         ownerUserId: fixture.userAId,
         allowedNetworkIds: [fixture.networkId],
         triggerIntentId: eligibilityTriggerIntentId,
-      }, 30 * 24 * 60 * 60 * 1000);
+      });
       const inserted = await db
         .select({ id: opportunities.id })
         .from(opportunities)
@@ -1304,7 +1306,7 @@ describe('OpportunityDatabaseAdapter', () => {
         ownerUserId: fixture.userAId,
         allowedNetworkIds: [fixture.networkId],
         triggerIntentId: fixture.intent1Id,
-      }, 30 * 24 * 60 * 60 * 1000);
+      });
       const inserted = await db
         .select({ id: opportunities.id })
         .from(opportunities)
@@ -1314,22 +1316,32 @@ describe('OpportunityDatabaseAdapter', () => {
       expect(inserted).toEqual([]);
     });
 
-    it('blocks final persistence while another trigger has a fresh active negotiation', async () => {
+    it('persists and starts a distinct intent negotiation while another intent for the pair is paused', async () => {
       const triggerIntentId = uuidv4();
-      fixture.extraIntentIds.push(triggerIntentId);
-      await db.insert(intents).values({
-        id: triggerIntentId,
-        userId: fixture.userAId,
-        payload: `${TEST_PREFIX}active negotiation guard intent`,
-        sourceType: 'discovery_form',
-        sourceId: fixture.userAId,
-      });
+      const candidateIntentId = uuidv4();
+      fixture.extraIntentIds.push(triggerIntentId, candidateIntentId);
+      await db.insert(intents).values([
+        {
+          id: triggerIntentId,
+          userId: fixture.userAId,
+          payload: `${TEST_PREFIX}independent negotiation intent`,
+          sourceType: 'discovery_form',
+          sourceId: fixture.userAId,
+        },
+        {
+          id: candidateIntentId,
+          userId: fixture.userBId,
+          payload: `${TEST_PREFIX}counterparty negotiation intent`,
+          sourceType: 'discovery_form',
+          sourceId: fixture.userBId,
+        },
+      ]);
       await db.insert(intentNetworks).values({ intentId: triggerIntentId, networkId: fixture.networkId });
       const otherTrigger = await adapter.createOpportunity({
         detection: { source: 'opportunity_graph', timestamp: new Date().toISOString(), triggeredBy: fixture.intent1Id },
         actors: [
           { networkId: fixture.networkId, userId: fixture.userAId, role: 'patient', intent: fixture.intent1Id },
-          { networkId: fixture.networkId, userId: fixture.userBId, role: 'agent' },
+          { networkId: fixture.networkId, userId: fixture.userBId, role: 'agent', intent: candidateIntentId },
         ],
         interpretation: { category: 'collaboration', reasoning: 'Other trigger active negotiation', confidence: 0.9 },
         context: { networkId: fixture.networkId },
@@ -1339,16 +1351,26 @@ describe('OpportunityDatabaseAdapter', () => {
       const [conversation] = await db.insert(conversations).values({}).returning();
       await db.insert(tasks).values({
         conversationId: conversation.id,
-        state: 'working',
-        metadata: { type: 'negotiation', opportunityId: otherTrigger.id },
+        state: 'paused',
+        metadata: {
+          type: 'negotiation',
+          opportunityId: otherTrigger.id,
+          seats: {
+            [fixture.intent1Id]: { userId: fixture.userAId, round: 1 },
+            [candidateIntentId]: { userId: fixture.userBId, round: 2 },
+          },
+          pause: { reason: 'ready_for_verdict', pausedBy: fixture.userAId },
+          drainGeneration: 0,
+        },
       });
+      const [attemptConversation] = await db.insert(conversations).values({}).returning();
 
       try {
         const result = await adapter.persistIntentScopedOpportunityIfNetworkEligible({
           detection: { source: 'opportunity_graph', timestamp: new Date().toISOString(), triggeredBy: triggerIntentId },
           actors: [
             { networkId: fixture.networkId, userId: fixture.userAId, role: 'patient', intent: triggerIntentId },
-            { networkId: fixture.networkId, userId: fixture.userBId, role: 'agent' },
+            { networkId: fixture.networkId, userId: fixture.userBId, role: 'agent', intent: candidateIntentId },
           ],
           interpretation: { category: 'collaboration', reasoning: 'Current trigger match', confidence: 0.9 },
           context: { networkId: fixture.networkId },
@@ -1358,25 +1380,97 @@ describe('OpportunityDatabaseAdapter', () => {
           ownerUserId: fixture.userAId,
           allowedNetworkIds: [fixture.networkId],
           triggerIntentId,
-        }, 30 * 24 * 60 * 60 * 1000);
+        });
 
-        expect(result && 'conflict' in result ? result.conflict.reason : null).toBe('pair_active_negotiation');
-        expect(result && 'conflict' in result ? result.conflict.existingOpportunityId : null).toBe(otherTrigger.id);
+        expect(result && 'created' in result).toBe(true);
+        if (!result || !('created' in result)) throw new Error('expected current-trigger opportunity');
+        expect(result.created.detection.triggeredBy).toBe(triggerIntentId);
+
+        const radarRows = await adapter.getOpportunitiesForUser(fixture.userAId, {
+          scopeType: 'intent',
+          scopeId: triggerIntentId,
+        });
+        expect(radarRows.map((row) => row.id)).toContain(result.created.id);
+
+        const attempt = await conversationAdapter.createNegotiationTaskForAttempt({
+          conversationId: attemptConversation.id,
+          opportunityId: result.created.id,
+          expectedStatus: result.created.status,
+          expectedUpdatedAt: result.created.updatedAt,
+          metadata: {
+            type: 'negotiation',
+            opportunityId: result.created.id,
+            seats: {
+              [triggerIntentId]: { userId: fixture.userAId, round: 3 },
+              [candidateIntentId]: { userId: fixture.userBId, round: 2 },
+            },
+            drainGeneration: 0,
+          },
+        });
+        expect(attempt).not.toBeNull();
+        expect(attempt?.conversationId).toBe(attemptConversation.id);
+        expect(attempt?.conversationId).not.toBe(conversation.id);
+        expect(attempt?.metadata).toMatchObject({
+          opportunityId: result.created.id,
+          seats: {
+            [triggerIntentId]: { userId: fixture.userAId, round: 3 },
+            [candidateIntentId]: { userId: fixture.userBId, round: 2 },
+          },
+          drainGeneration: 0,
+        });
+
+        const duplicateAttempt = await conversationAdapter.createNegotiationTaskForAttempt({
+          conversationId: attemptConversation.id,
+          opportunityId: result.created.id,
+          expectedStatus: result.created.status,
+          expectedUpdatedAt: result.created.updatedAt,
+          metadata: attempt!.metadata ?? {},
+        });
+        expect(duplicateAttempt).toBeNull();
+
+        const [currentOpportunity] = await db
+          .select({ status: opportunities.status })
+          .from(opportunities)
+          .where(eq(opportunities.id, result.created.id));
+        expect(currentOpportunity?.status).toBe('negotiating');
+
+        const [otherTaskAfter, currentTasks] = await Promise.all([
+          db.select({ state: tasks.state, metadata: tasks.metadata }).from(tasks)
+            .where(sql`${tasks.metadata}->>'opportunityId' = ${otherTrigger.id}`),
+          db.select({ id: tasks.id }).from(tasks)
+            .where(sql`${tasks.metadata}->>'opportunityId' = ${result.created.id}`),
+        ]);
+        expect(otherTaskAfter).toHaveLength(1);
+        expect(otherTaskAfter[0]).toMatchObject({
+          state: 'paused',
+          metadata: { pause: { reason: 'ready_for_verdict', pausedBy: fixture.userAId } },
+        });
+        expect(currentTasks).toHaveLength(1);
       } finally {
-        await db.delete(conversations).where(eq(conversations.id, conversation.id));
+        await db.delete(conversations).where(inArray(conversations.id, [conversation.id, attemptConversation.id]));
       }
     });
 
-    it('serializes parallel same-trigger creates and preserves exact intent visibility', async () => {
+    it('serializes parallel exact-intent-pair creates regardless of age', async () => {
       const triggerIntentId = uuidv4();
-      fixture.extraIntentIds.push(triggerIntentId);
-      await db.insert(intents).values({
-        id: triggerIntentId,
-        userId: fixture.userAId,
-        payload: `${TEST_PREFIX}parallel dedup intent`,
-        sourceType: 'discovery_form',
-        sourceId: fixture.userAId,
-      });
+      const candidateIntentId = uuidv4();
+      fixture.extraIntentIds.push(triggerIntentId, candidateIntentId);
+      await db.insert(intents).values([
+        {
+          id: triggerIntentId,
+          userId: fixture.userAId,
+          payload: `${TEST_PREFIX}parallel dedup intent`,
+          sourceType: 'discovery_form',
+          sourceId: fixture.userAId,
+        },
+        {
+          id: candidateIntentId,
+          userId: fixture.userBId,
+          payload: `${TEST_PREFIX}parallel dedup counterpart intent`,
+          sourceType: 'discovery_form',
+          sourceId: fixture.userBId,
+        },
+      ]);
       await db.insert(intentNetworks).values({ intentId: triggerIntentId, networkId: fixture.networkId });
 
       const createData = {
@@ -1388,7 +1482,7 @@ describe('OpportunityDatabaseAdapter', () => {
         },
         actors: [
           { networkId: fixture.networkId, userId: fixture.userAId, role: 'patient' as const, intent: triggerIntentId },
-          { networkId: fixture.networkId, userId: fixture.userBId, role: 'agent' as const },
+          { networkId: fixture.networkId, userId: fixture.userBId, role: 'agent' as const, intent: candidateIntentId },
         ],
         interpretation: { category: 'collaboration', reasoning: 'Intent-specific pair match', confidence: 0.9 },
         context: { networkId: fixture.networkId },
@@ -1402,8 +1496,8 @@ describe('OpportunityDatabaseAdapter', () => {
       };
 
       const results = await Promise.all([
-        adapter.persistIntentScopedOpportunityIfNetworkEligible(createData, [], eligibility, 30 * 24 * 60 * 60 * 1000),
-        adapter.persistIntentScopedOpportunityIfNetworkEligible(createData, [], eligibility, 30 * 24 * 60 * 60 * 1000),
+        adapter.persistIntentScopedOpportunityIfNetworkEligible(createData, [], eligibility),
+        adapter.persistIntentScopedOpportunityIfNetworkEligible(createData, [], eligibility),
       ]);
 
       const created = results.filter((result) => result && 'created' in result);
@@ -1411,7 +1505,20 @@ describe('OpportunityDatabaseAdapter', () => {
       expect(created).toHaveLength(1);
       expect(conflicts).toHaveLength(1);
       expect(conflicts[0] && 'conflict' in conflicts[0] ? conflicts[0].conflict.reason : null)
-        .toBe('same_trigger_recent_duplicate');
+        .toBe('same_intent_pair_duplicate');
+
+      const createdResult = created[0];
+      if (!createdResult || !('created' in createdResult)) throw new Error('expected one created opportunity');
+      await db.update(opportunities)
+        .set({ createdAt: new Date(Date.now() - 45 * 24 * 60 * 60 * 1000) })
+        .where(eq(opportunities.id, createdResult.created.id));
+      const agedDuplicate = await adapter.persistIntentScopedOpportunityIfNetworkEligible(
+        createData,
+        [],
+        eligibility,
+      );
+      expect(agedDuplicate && 'conflict' in agedDuplicate ? agedDuplicate.conflict.reason : null)
+        .toBe('same_intent_pair_duplicate');
 
       const radarRows = await adapter.getOpportunitiesForUser(fixture.userAId, {
         scopeType: 'intent',

--- a/services/api/src/adapters/tests/intent-scope-lock.contract.spec.ts
+++ b/services/api/src/adapters/tests/intent-scope-lock.contract.spec.ts
@@ -26,7 +26,7 @@ const intentDatabaseSource = readFileSync(
 // The executor node is where the graph issues the locked intent write, so that
 // is the file the CAS contract below is asserted against.
 const protocolIntentGraphSource = readFileSync(
-  new URL('../../../../../packages/protocol/src/intents/graph/intent.graph.execute.ts', import.meta.url),
+  new URL('../../../../../packages/protocol/src/internal/intents/graph/intent.graph.execute.ts', import.meta.url),
   'utf8',
 );
 
@@ -54,7 +54,7 @@ describe('intent-scope advisory lock contract', () => {
     expect(opportunity).toContain('eligibility.ownerUserId');
     expect(opportunity).toContain('eligibility.triggerIntentId');
     expect(opportunity.indexOf('acquireIntentScopeAdvisoryLock('))
-      .toBeLessThan(opportunity.indexOf('acquireIntentScopedPairLocks('));
+      .toBeLessThan(opportunity.indexOf('acquireIntentScopedPairLock('));
     expect(opportunity.indexOf('acquireIntentScopeAdvisoryLock('))
       .toBeLessThan(opportunity.indexOf(".from(schema.intents)"));
   });
@@ -63,7 +63,7 @@ describe('intent-scope advisory lock contract', () => {
     const reactivation = methodSlice(
       opportunitySource,
       'async updateOpportunityStatusIfNetworkEligible(',
-      'async compensateTasklessNegotiatingOpportunity(',
+      'async getOpportunity(',
     );
     const advisory = reactivation.indexOf('acquireIntentScopeAdvisoryLock(');
     const intentRow = reactivation.indexOf('.from(schema.intents)', advisory);
@@ -88,17 +88,13 @@ describe('intent-scope advisory lock contract', () => {
     const activeTask = methodSlice(
       negotiationAttemptSource,
       'export function qualifyingActiveNegotiationTaskWhere(',
-      '/** Pair-global tasks fresh enough',
-    );
-    const pairTask = methodSlice(
-      negotiationAttemptSource,
-      'export function qualifyingPairNegotiationTaskWhere(',
-      '/**\n * Qualifying tasks that prove an attempt',
+      '/**\n * Reusable SQL predicate',
     );
     expect(activeTask).toContain("metadata}->>'type' = 'negotiation'");
     expect(activeTask).toContain("metadata}->>'opportunityId' = ${opportunityId}");
     expect(activeTask).toContain('qualifyingFreshNegotiationTaskStateWhere()');
-    expect(pairTask).toContain('qualifyingFreshNegotiationTaskStateWhere()');
+    expect(negotiationAttemptSource).not.toContain('qualifyingPairNegotiationTaskWhere');
+    expect(negotiationAttemptSource).not.toContain('acquireNegotiationPairLock');
     expect(negotiationAttemptSource).toContain("IN ('submitted', 'working', 'paused')");
 
     const acquire = negotiationReactivationSource.indexOf('boundary.acquireAttemptLock()');

--- a/services/api/src/adapters/tests/intent-scope-lock.contract.spec.ts
+++ b/services/api/src/adapters/tests/intent-scope-lock.contract.spec.ts
@@ -57,6 +57,17 @@ describe('intent-scope advisory lock contract', () => {
       .toBeLessThan(opportunity.indexOf('acquireIntentScopedPairLock('));
     expect(opportunity.indexOf('acquireIntentScopeAdvisoryLock('))
       .toBeLessThan(opportunity.indexOf(".from(schema.intents)"));
+    const participantAssignments = opportunity.indexOf(
+      '.innerJoin(schema.intentNetworks, eq(schema.intentNetworks.intentId, schema.intents.id))',
+    );
+    const participantShareLock = opportunity.indexOf(".for('share')", participantAssignments);
+    const opportunityDedupRead = opportunity.indexOf('.from(opportunities)', participantShareLock);
+    expect(opportunity).toContain('participantIntentNetworkBindings');
+    expect(opportunity).toContain('isNull(schema.intents.archivedAt)');
+    expect(opportunity).toContain("eq(schema.intents.status, 'ACTIVE')");
+    expect(participantAssignments).toBeGreaterThanOrEqual(0);
+    expect(participantShareLock).toBeGreaterThan(participantAssignments);
+    expect(opportunityDedupRead).toBeGreaterThan(participantShareLock);
   });
 
   it('serializes exact-trigger opportunity reactivation before every conflicting row lock', () => {

--- a/services/api/src/adapters/tests/intent-scope-lock.contract.spec.ts
+++ b/services/api/src/adapters/tests/intent-scope-lock.contract.spec.ts
@@ -65,6 +65,7 @@ describe('intent-scope advisory lock contract', () => {
     expect(opportunity).toContain('participantIntentNetworkBindings');
     expect(opportunity).toContain('isNull(schema.intents.archivedAt)');
     expect(opportunity).toContain("eq(schema.intents.status, 'ACTIVE')");
+    expect(opportunity).not.toContain('isNull(schema.intents.status)');
     expect(participantAssignments).toBeGreaterThanOrEqual(0);
     expect(participantShareLock).toBeGreaterThan(participantAssignments);
     expect(opportunityDedupRead).toBeGreaterThan(participantShareLock);

--- a/services/api/src/queues/opportunity/discovery.shared.ts
+++ b/services/api/src/queues/opportunity/discovery.shared.ts
@@ -74,8 +74,7 @@ export type OpportunityDiscoveryCompletionReason =
   | 'created_or_reactivated'
   | 'no_search_candidates'
   | 'evaluator_rejected_all'
-  | 'same_trigger_duplicate_suppressed'
-  | 'pair_active_negotiation_suppressed'
+  | 'same_intent_pair_duplicate_suppressed'
   | 'final_atomic_conflict'
   | 'persistence_zero_other';
 
@@ -84,9 +83,8 @@ export interface OpportunityDiscoverySummary {
   evaluatedCount: number;
   opportunitiesCreated: number;
   completionReason: OpportunityDiscoveryCompletionReason;
-  sameTriggerDuplicateSuppressions: number;
-  pairActiveNegotiationSuppressions: number;
-  crossTriggerAllowedCount: number;
+  sameIntentPairDuplicateSuppressions: number;
+  crossIntentPairAllowedCount: number;
   finalAtomicConflictCount: number;
 }
 
@@ -96,9 +94,8 @@ interface OpportunityDiscoveryResultShape {
   opportunities?: unknown[];
   persistenceOutcome?: {
     evaluatedCount: number;
-    sameTriggerDuplicateSuppressions: number;
-    pairActiveNegotiationSuppressions: number;
-    crossTriggerAllowedCount: number;
+    sameIntentPairDuplicateSuppressions: number;
+    crossIntentPairAllowedCount: number;
     finalAtomicConflictCount: number;
   };
 }
@@ -112,9 +109,8 @@ export function summarizeOpportunityDiscoveryResult(
   const persistence = result.persistenceOutcome;
   const evaluatedCount = persistence?.evaluatedCount
     ?? (Array.isArray(result.evaluatedOpportunities) ? result.evaluatedOpportunities.length : 0);
-  const sameTriggerDuplicateSuppressions = persistence?.sameTriggerDuplicateSuppressions ?? 0;
-  const pairActiveNegotiationSuppressions = persistence?.pairActiveNegotiationSuppressions ?? 0;
-  const crossTriggerAllowedCount = persistence?.crossTriggerAllowedCount ?? 0;
+  const sameIntentPairDuplicateSuppressions = persistence?.sameIntentPairDuplicateSuppressions ?? 0;
+  const crossIntentPairAllowedCount = persistence?.crossIntentPairAllowedCount ?? 0;
   const finalAtomicConflictCount = persistence?.finalAtomicConflictCount ?? 0;
   const completionReason: OpportunityDiscoveryCompletionReason = opportunities.length > 0
     ? 'created_or_reactivated'
@@ -124,20 +120,17 @@ export function summarizeOpportunityDiscoveryResult(
         ? 'evaluator_rejected_all'
         : finalAtomicConflictCount > 0
           ? 'final_atomic_conflict'
-          : pairActiveNegotiationSuppressions > 0
-            ? 'pair_active_negotiation_suppressed'
-            : sameTriggerDuplicateSuppressions > 0
-              ? 'same_trigger_duplicate_suppressed'
-              : 'persistence_zero_other';
+          : sameIntentPairDuplicateSuppressions > 0
+            ? 'same_intent_pair_duplicate_suppressed'
+            : 'persistence_zero_other';
 
   return {
     candidatesFound: candidates.length,
     evaluatedCount,
     opportunitiesCreated: opportunities.length,
     completionReason,
-    sameTriggerDuplicateSuppressions,
-    pairActiveNegotiationSuppressions,
-    crossTriggerAllowedCount,
+    sameIntentPairDuplicateSuppressions,
+    crossIntentPairAllowedCount,
     finalAtomicConflictCount,
   };
 }

--- a/services/api/src/queues/tests/from-intent.queue.isolated.ts
+++ b/services/api/src/queues/tests/from-intent.queue.isolated.ts
@@ -86,9 +86,8 @@ const discoverySummary = (overrides: Partial<OpportunityDiscoverySummary> = {}):
   evaluatedCount: 0,
   opportunitiesCreated: 0,
   completionReason: 'created_or_reactivated',
-  sameTriggerDuplicateSuppressions: 0,
-  pairActiveNegotiationSuppressions: 0,
-  crossTriggerAllowedCount: 0,
+  sameIntentPairDuplicateSuppressions: 0,
+  crossIntentPairAllowedCount: 0,
   finalAtomicConflictCount: 0,
   ...overrides,
 });
@@ -181,9 +180,14 @@ describe('FromIntentQueue', () => {
       expect(recordIntentDiscoveryProgress).toHaveBeenCalledWith(expect.objectContaining({ status: 'succeeded', attempt: 2 }));
     });
 
-    it('carries the graph summary tallies into the succeeded write', async () => {
+    it('records both persisted floor matches when one different intent pair was allowed', async () => {
       const recordIntentDiscoveryProgress = mock(async (_input: ProgressWrite) => {});
-      nextDiscoverySummary = discoverySummary({ candidatesFound: 7, evaluatedCount: 4, opportunitiesCreated: 2 });
+      nextDiscoverySummary = discoverySummary({
+        candidatesFound: 2,
+        evaluatedCount: 2,
+        opportunitiesCreated: 2,
+        crossIntentPairAllowedCount: 1,
+      });
       const queue = new FromIntentQueue({
         database: asDb({
           getIntentForIndexing: async () => ({ id: 'i1', payload: 'P', userId: 'u1', sourceType: null, sourceId: null }),
@@ -204,7 +208,7 @@ describe('FromIntentQueue', () => {
         // The graph runs once across every valid network, so the whole
         // still-valid set is what was processed.
         processedCommunityCount: 2,
-        possibleOverlapCount: 7,
+        possibleOverlapCount: 2,
         conversationsStartedCount: 2,
       }));
     });
@@ -514,15 +518,38 @@ describe('FromIntentQueue', () => {
         opportunities: [],
         persistenceOutcome: {
           evaluatedCount: 1,
-          sameTriggerDuplicateSuppressions: 1,
-          pairActiveNegotiationSuppressions: 0,
-          crossTriggerAllowedCount: 0,
+          sameIntentPairDuplicateSuppressions: 1,
+          crossIntentPairAllowedCount: 0,
           finalAtomicConflictCount: 0,
         },
       });
 
       expect(evaluatorZero.completionReason).toBe('evaluator_rejected_all');
-      expect(persistenceDedupZero.completionReason).toBe('same_trigger_duplicate_suppressed');
+      expect(persistenceDedupZero.completionReason).toBe('same_intent_pair_duplicate_suppressed');
+    });
+
+    it('reports persisted different-intent-pair matches as created without an atomic conflict', () => {
+      const summary = summarizeOpportunityDiscoveryResult({
+        candidates: [{}, {}],
+        evaluatedOpportunities: [{}, {}],
+        opportunities: [{}, {}],
+        persistenceOutcome: {
+          evaluatedCount: 2,
+          sameIntentPairDuplicateSuppressions: 0,
+          crossIntentPairAllowedCount: 1,
+          finalAtomicConflictCount: 0,
+        },
+      });
+
+      expect(summary).toMatchObject({
+        candidatesFound: 2,
+        evaluatedCount: 2,
+        opportunitiesCreated: 2,
+        completionReason: 'created_or_reactivated',
+        crossIntentPairAllowedCount: 1,
+        finalAtomicConflictCount: 0,
+      });
+      expect(summary).not.toHaveProperty('pairActiveNegotiationSuppressions');
     });
   });
 


### PR DESCRIPTION
## Summary
- persist one opportunity per exact intent pair without suppressing different intents between the same users
- preserve each evaluator verdict’s authoritative discovery candidate and bind the counterparty seat from its discovered intent, never the model-generated intent
- require every participant intent at intent-scoped persistence, then lock and revalidate its ownership, active/non-archived lifecycle, and exact network assignment
- remove pair-global negotiation-task admission so each opportunity gets an independent task, conversation, seats, rounds, pause, verdict, and lifecycle
- report the full persisted intent-discovery floor and keep per-opportunity task creation idempotent
- bump @indexnetwork/protocol to 36.0.0 for the breaking host-contract correction

## Verification
- protocol opportunity graph, persistence, and enrichment: 68 passed
- API intent persistence database regressions: 8 passed
- API discovery, lock contract, and negotiation-attempt regressions: 39 passed
- API worker concurrency regressions, run in module isolation: 2 passed
- protocol build
- API build and spec typecheck
- protocol architecture check
- git diff --check
- repository pre-commit lint and build hooks

## Merge order
PR #1525 at 2df51fb70 is based on the same dev lineage and is not included here. Rebase whichever branch lands second so intent-pair independence composes with per-task drain generations and correct owning-PersonalAgent wakes.