### PR TITLE
Present /negotiations as an inbox, not a task dump

### DIFF
--- a/apps/web/src/app/negotiations/page.tsx
+++ b/apps/web/src/app/negotiations/page.tsx
@@ -33,15 +33,9 @@ export default function NegotiationsPage() {
   if (isLoading || !isAuthenticated) return null;
   return (
     <ClientLayout>
-      <div className="px-10 py-6 lg:px-16">
+      <div className="px-6 pb-12 lg:px-8">
         <ContentContainer size="wide">
-          <h1 className="font-ibm-plex-mono text-lg font-bold text-black">Negotiation task index</h1>
-          <p className="mt-1 text-sm text-gray-500">One row per owned intent seat. This is task state, not a conversation inbox.</p>
-          <div className="mt-6">
-            {loading ? <p className="text-sm text-gray-500">Loading negotiation tasks…</p>
-              : error ? <p className="text-sm text-red-600">Negotiation task index could not be loaded.</p>
-                : <NegotiationTaskIndex entries={entries} />}
-          </div>
+          <NegotiationTaskIndex entries={entries} loading={loading} error={error} />
         </ContentContainer>
       </div>
     </ClientLayout>

--- a/apps/web/src/components/NegotiationTaskIndex.tsx
+++ b/apps/web/src/components/NegotiationTaskIndex.tsx
@@ -1,43 +1,101 @@
 import { Link } from "react-router";
 
+import UserAvatar from "@/components/UserAvatar";
+import { deriveTaskIndexInbox, type TaskIndexInboxItem } from "@/lib/negotiation-inbox";
+import { presentationForStatus } from "@/lib/negotiation-presentation";
 import type { NegotiationTaskIndexEntry } from "@/services/conversation";
 
-function pauseLabel(entry: NegotiationTaskIndexEntry): string | null {
-  if (!entry.pause) return null;
-  const owner = entry.pause.by === 'yours' ? 'your agent' : entry.pause.by === 'theirs' ? 'their agent' : 'unknown seat';
-  return `${entry.pause.reason.replace(/_/g, ' ')} · ${owner}`;
-}
-
-function latestLabel(entry: NegotiationTaskIndexEntry): string {
-  if (!entry.latestActivity.createdAt) return 'No shared A2A turn recorded.';
-  const actor = entry.latestActivity.actor === 'yours' ? 'Your agent' : 'Their agent';
-  const verb = entry.latestActivity.verb?.replace(/_/g, ' ') ?? 'event';
-  return `${actor} · ${verb} · ${new Date(entry.latestActivity.createdAt).toLocaleString()}`;
-}
-
-export default function NegotiationTaskIndex({ entries }: { entries: NegotiationTaskIndexEntry[] }) {
-  if (entries.length === 0) {
-    return <p className="rounded-lg border border-dashed border-gray-200 px-4 py-10 text-center font-ibm-plex-mono text-sm text-gray-500">No negotiation seats are recorded for this owner.</p>;
-  }
+function StatusChip({ item }: { item: TaskIndexInboxItem }) {
+  const presentation = presentationForStatus(item.status);
   return (
-    <ol className="space-y-3" aria-label="Negotiation task index">
-      {entries.map((entry) => (
-        <li key={`${entry.taskId}:${entry.intentId}`} className="rounded-lg border border-gray-200 bg-white p-4">
-          <div className="flex flex-wrap items-start justify-between gap-3">
-            <div className="min-w-0">
-              <p className="text-sm font-semibold text-gray-900">{entry.counterpartLabel}</p>
-              <p className="mt-1 truncate font-ibm-plex-mono text-[11px] text-slate-600">intent · {entry.intentLabel}</p>
-              <p className="mt-1 font-ibm-plex-mono text-[10px] text-gray-500">round {entry.round} · task {entry.state} · opportunity {entry.opportunityStatus}</p>
-            </div>
-            <Link to={`/i/${entry.intentId}/negotiations/${entry.taskId}`} className="text-xs font-medium text-[#35799C] hover:underline">Inspect seat</Link>
-          </div>
-          <p className="mt-3 text-xs text-gray-700">{latestLabel(entry)}</p>
-          {pauseLabel(entry) && <p className="mt-1 font-ibm-plex-mono text-[10px] text-amber-700">pause · {pauseLabel(entry)}</p>}
-          <p className="mt-2 font-ibm-plex-mono text-[10px] text-gray-400" title={`task ${entry.taskId} · opportunity ${entry.opportunityId} · intent ${entry.intentId}`}>
-            task {entry.taskId} · opportunity {entry.opportunityId} · intent {entry.intentId}
-          </p>
-        </li>
-      ))}
-    </ol>
+    <span className={`inline-flex shrink-0 items-center whitespace-nowrap rounded-full border px-2.5 py-1 text-[10px] font-semibold font-ibm-plex-mono ${presentation.chipClass}`}>
+      {presentation.label}
+    </span>
+  );
+}
+
+function NegotiationRow({ item }: { item: TaskIndexInboxItem }) {
+  const isResolved = item.group === "resolved";
+  return (
+    <Link
+      to={`/i/${item.intentId}/negotiations/${item.taskId}`}
+      className={`group flex w-full flex-wrap items-center gap-3 px-4 py-3 text-left transition-colors hover:bg-gray-50 focus:outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-[#4091BB] sm:flex-nowrap ${isResolved ? "bg-gray-50/60 opacity-80" : "bg-white"}`}
+      aria-label={`Open negotiation with ${item.counterpartName} about ${item.intentLabel}`}
+    >
+      <UserAvatar id={item.counterpartName} name={item.counterpartName} avatar={null} size={28} className="shrink-0" />
+      <div className="min-w-0 flex-1">
+        <p className="truncate text-sm font-semibold text-[#041729] font-ibm-plex-mono">{item.counterpartName}</p>
+        <p className="mt-0.5 truncate text-xs text-gray-400 font-ibm-plex-mono">
+          {item.intentLabel} · {item.lastAction} · {item.timeAgo}
+        </p>
+      </div>
+      <div className="ml-auto flex shrink-0 items-center gap-2">
+        <StatusChip item={item} />
+        {item.status === "awaiting_review" && (
+          <span className="rounded-sm bg-[#041729] px-3 py-1.5 text-xs font-semibold text-white">Review</span>
+        )}
+        {item.status === "negotiating" && (
+          <span className="h-2 w-2 rounded-full bg-amber-400 animate-pulse" aria-hidden="true" />
+        )}
+      </div>
+    </Link>
+  );
+}
+
+function InboxGroup({ label, items }: { label: string; items: TaskIndexInboxItem[] }) {
+  if (items.length === 0) return null;
+  return (
+    <section aria-labelledby={`negotiations-${label.toLowerCase().replace(/\s+/g, "-")}`}>
+      <h2
+        id={`negotiations-${label.toLowerCase().replace(/\s+/g, "-")}`}
+        className="mb-2 font-ibm-plex-mono text-[10px] font-semibold uppercase tracking-[0.18em] text-gray-400"
+      >
+        {label} · {items.length}
+      </h2>
+      <div className="divide-y divide-gray-100 overflow-hidden rounded-md border border-gray-200 bg-white">
+        {items.map((item) => <NegotiationRow key={item.key} item={item} />)}
+      </div>
+    </section>
+  );
+}
+
+export default function NegotiationTaskIndex({
+  entries,
+  loading,
+  error,
+}: {
+  entries: NegotiationTaskIndexEntry[];
+  loading: boolean;
+  error: boolean;
+}) {
+  const groups = deriveTaskIndexInbox(entries);
+  const totalCount = groups.yourMove.length + groups.inProgress.length + groups.resolved.length;
+
+  return (
+    <div>
+      <div className="mb-6 mt-12 text-center">
+        <h1 className="text-[28px] font-bold text-black font-ibm-plex-mono">Negotiations</h1>
+        <p className="mt-2 text-xs text-gray-400 font-ibm-plex-mono">
+          {groups.yourMove.length} your move · {groups.inProgress.length} in progress · {groups.resolved.length} resolved
+        </p>
+      </div>
+
+      {loading && totalCount === 0 ? (
+        <p className="py-16 text-center text-sm text-gray-500">Loading negotiations…</p>
+      ) : error ? (
+        <p className="text-center text-sm text-red-600">Negotiations could not be loaded.</p>
+      ) : totalCount === 0 ? (
+        <div className="rounded-md border border-dashed border-gray-200 py-12 text-center text-sm text-gray-500 font-ibm-plex-mono">
+          <p>No negotiations yet</p>
+          <p className="mt-2 text-xs text-gray-400">Your agents' connection work will appear here.</p>
+        </div>
+      ) : (
+        <div className="space-y-8" aria-label="Negotiations">
+          <InboxGroup label="Your move" items={groups.yourMove} />
+          <InboxGroup label="In progress" items={groups.inProgress} />
+          <InboxGroup label="Resolved" items={groups.resolved} />
+        </div>
+      )}
+    </div>
   );
 }

--- a/apps/web/src/components/__tests__/NegotiationTaskIndex.test.tsx
+++ b/apps/web/src/components/__tests__/NegotiationTaskIndex.test.tsx
@@ -1,0 +1,80 @@
+import { render, screen } from '@testing-library/react';
+import { MemoryRouter } from 'react-router';
+import { describe, expect, it } from 'vitest';
+
+import NegotiationTaskIndex from '../NegotiationTaskIndex';
+import type { NegotiationTaskIndexEntry } from '@/services/conversation';
+
+function entry(input: Partial<NegotiationTaskIndexEntry> & { id: string }): NegotiationTaskIndexEntry {
+  return {
+    intentId: `${input.id}-intent`,
+    intentLabel: input.intentLabel ?? 'Find a collaborator',
+    taskId: `${input.id}-task`,
+    conversationId: `${input.id}-conversation`,
+    opportunityId: `${input.id}-opportunity`,
+    opportunityStatus: input.opportunityStatus ?? 'negotiating',
+    counterpartLabel: input.counterpartLabel ?? 'Mira Chen',
+    round: input.round ?? 1,
+    state: input.state ?? 'working',
+    pause: input.pause ?? null,
+    latestActivity: input.latestActivity ?? { actor: 'theirs', verb: 'counter', createdAt: '2026-07-24T11:00:00.000Z' },
+    updatedAt: input.updatedAt ?? '2026-07-24T11:00:00.000Z',
+  };
+}
+
+describe('NegotiationTaskIndex', () => {
+  it('shows posture groups and human labels instead of task ids', () => {
+    render(
+      <MemoryRouter>
+        <NegotiationTaskIndex
+          loading={false}
+          error={false}
+          entries={[
+            entry({
+              id: 'guidance',
+              counterpartLabel: 'Yankı Ekin Yüksel',
+              intentLabel: 'Sell a Robinson R22 helicopter',
+              state: 'paused',
+              pause: { reason: 'needs_principal', by: 'yours' },
+              latestActivity: { actor: 'yours', verb: 'pause', createdAt: '2026-07-24T11:00:00.000Z' },
+            }),
+            entry({
+              id: 'rejected',
+              counterpartLabel: 'Yankı Ekin Yüksel',
+              intentLabel: 'Find a technical co-founder',
+              state: 'completed',
+              opportunityStatus: 'rejected',
+              pause: { reason: 'ready_for_verdict', by: 'theirs' },
+              latestActivity: { actor: 'theirs', verb: 'pause', createdAt: '2026-07-24T10:00:00.000Z' },
+            }),
+          ]}
+        />
+      </MemoryRouter>,
+    );
+
+    expect(screen.getByRole('heading', { name: 'Negotiations' })).toBeInTheDocument();
+    expect(screen.getByText('1 your move · 0 in progress · 1 resolved')).toBeInTheDocument();
+    expect(screen.getByText('Your move · 1')).toBeInTheDocument();
+    expect(screen.getByText('Resolved · 1')).toBeInTheDocument();
+    expect(screen.getByText('Needs your input')).toBeInTheDocument();
+    expect(screen.getByText('No match')).toBeInTheDocument();
+    expect(screen.getByText(/your agent asked for guidance/)).toBeInTheDocument();
+    expect(screen.queryByText(/Inspect seat/)).not.toBeInTheDocument();
+    expect(screen.queryByText(/task completed/)).not.toBeInTheDocument();
+    expect(screen.queryByText(/ready for verdict/)).not.toBeInTheDocument();
+    expect(screen.queryByText(/guidance-task/)).not.toBeInTheDocument();
+    expect(screen.getByRole('link', { name: 'Open negotiation with Yankı Ekin Yüksel about Sell a Robinson R22 helicopter' })).toHaveAttribute(
+      'href',
+      '/i/guidance-intent/negotiations/guidance-task',
+    );
+  });
+
+  it('shows an empty state when there are no seats', () => {
+    render(
+      <MemoryRouter>
+        <NegotiationTaskIndex entries={[]} loading={false} error={false} />
+      </MemoryRouter>,
+    );
+    expect(screen.getByText('No negotiations yet')).toBeInTheDocument();
+  });
+});

--- a/apps/web/src/lib/__tests__/negotiation-inbox.test.ts
+++ b/apps/web/src/lib/__tests__/negotiation-inbox.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it } from 'vitest';
 
-import { countNegotiationsRequiringAction, deriveNegotiationInbox, flattenNegotiationInbox } from '@/lib/negotiation-inbox';
-import type { ConversationSummary } from '@/services/conversation';
+import { countNegotiationsRequiringAction, deriveNegotiationInbox, deriveTaskIndexInbox, flattenNegotiationInbox } from '@/lib/negotiation-inbox';
+import type { ConversationSummary, NegotiationTaskIndexEntry } from '@/services/conversation';
 
 const NOW = new Date('2026-07-24T12:00:00.000Z').getTime();
 
@@ -268,5 +268,95 @@ describe('negotiations inbox presentation', () => {
       ['resolved', 'resolved'],
       ['agreed', 'your_move'],
     ]);
+  });
+});
+
+function taskEntry(input: Partial<NegotiationTaskIndexEntry> & { id: string }): NegotiationTaskIndexEntry {
+  return {
+    intentId: `${input.id}-intent`,
+    intentLabel: input.intentLabel ?? 'Find a collaborator',
+    taskId: `${input.id}-task`,
+    conversationId: `${input.id}-conversation`,
+    opportunityId: `${input.id}-opportunity`,
+    opportunityStatus: input.opportunityStatus ?? 'negotiating',
+    counterpartLabel: input.counterpartLabel ?? 'Mira Chen',
+    round: input.round ?? 1,
+    state: input.state ?? 'working',
+    pause: input.pause ?? null,
+    latestActivity: input.latestActivity ?? { actor: 'theirs', verb: 'counter', createdAt: '2026-07-24T11:00:00.000Z' },
+    updatedAt: input.updatedAt ?? '2026-07-24T11:00:00.000Z',
+  };
+}
+
+describe('task-index inbox presentation', () => {
+  it('maps the raw task dump into your-move, in-progress, and resolved groups', () => {
+    const groups = deriveTaskIndexInbox([
+      taskEntry({
+        id: 'guidance',
+        intentLabel: 'Sell a Robinson R22 helicopter',
+        state: 'paused',
+        pause: { reason: 'needs_principal', by: 'yours' },
+        latestActivity: { actor: 'yours', verb: 'pause', createdAt: '2026-07-24T11:30:00.000Z' },
+      }),
+      taskEntry({
+        id: 'live',
+        intentLabel: 'Connect with TypeScript enthusiasts',
+        latestActivity: { actor: 'theirs', verb: 'counter', createdAt: '2026-07-24T11:20:00.000Z' },
+      }),
+      taskEntry({
+        id: 'rejected',
+        intentLabel: 'Find a technical co-founder',
+        state: 'completed',
+        opportunityStatus: 'rejected',
+        pause: { reason: 'ready_for_verdict', by: 'theirs' },
+        latestActivity: { actor: 'theirs', verb: 'pause', createdAt: '2026-07-24T11:10:00.000Z' },
+      }),
+      taskEntry({
+        id: 'accepted',
+        intentLabel: "I'm in NYC, looking to invest",
+        state: 'completed',
+        opportunityStatus: 'accepted',
+        latestActivity: { actor: 'yours', verb: 'outreach', createdAt: '2026-07-24T10:00:00.000Z' },
+      }),
+    ], NOW);
+
+    expect(groups.yourMove.map((item) => [item.status, item.lastAction])).toEqual([
+      ['needs_input', 'your agent asked for guidance'],
+    ]);
+    expect(groups.inProgress.map((item) => [item.status, item.lastAction])).toEqual([
+      ['negotiating', 'their agent countered'],
+    ]);
+    expect(groups.resolved.map((item) => [item.status, item.lastAction])).toEqual([
+      ['no_match', 'agents did not recommend moving forward'],
+      ['connection_accepted', 'the connection was accepted'],
+    ]);
+  });
+
+  it('does not treat the other side asking their principal as your move', () => {
+    const groups = deriveTaskIndexInbox([
+      taskEntry({
+        id: 'theirs',
+        state: 'paused',
+        pause: { reason: 'needs_principal', by: 'theirs' },
+        latestActivity: { actor: 'theirs', verb: 'pause', createdAt: '2026-07-24T11:00:00.000Z' },
+      }),
+    ], NOW);
+    expect(groups.yourMove).toEqual([]);
+    expect(groups.inProgress[0]?.status).toBe('negotiating');
+  });
+
+  it('surfaces a pending opportunity as awaiting review', () => {
+    const groups = deriveTaskIndexInbox([
+      taskEntry({
+        id: 'pending',
+        state: 'completed',
+        opportunityStatus: 'pending',
+        latestActivity: { actor: 'theirs', verb: null, createdAt: '2026-07-24T11:00:00.000Z' },
+      }),
+    ], NOW);
+    expect(groups.yourMove[0]).toMatchObject({
+      status: 'awaiting_review',
+      lastAction: 'agents recommended moving forward',
+    });
   });
 });

--- a/apps/web/src/lib/negotiation-inbox.ts
+++ b/apps/web/src/lib/negotiation-inbox.ts
@@ -1,4 +1,4 @@
-import type { ConversationSummary } from '@/services/conversation';
+import type { ConversationSummary, NegotiationTaskIndexEntry } from '@/services/conversation';
 import { deriveNegotiationPresentation, type NegotiationPresentationStatus } from '@/lib/negotiation-presentation';
 import type { NegotiationPauseReason } from '@/services/conversation';
 
@@ -31,6 +31,26 @@ export interface NegotiationInboxGroups {
   yourMove: NegotiationInboxItem[];
   inProgress: NegotiationInboxItem[];
   resolved: NegotiationInboxItem[];
+}
+
+/** One row per owned intent seat, presented the same way as the conversation inbox. */
+export interface TaskIndexInboxItem {
+  key: string;
+  intentId: string;
+  taskId: string;
+  counterpartName: string;
+  intentLabel: string;
+  group: NegotiationInboxGroup;
+  status: NegotiationInboxStatus;
+  lastAction: string;
+  timeAgo: string;
+  sortTimestamp: number;
+}
+
+export interface TaskIndexInboxGroups {
+  yourMove: TaskIndexInboxItem[];
+  inProgress: TaskIndexInboxItem[];
+  resolved: TaskIndexInboxItem[];
 }
 
 export interface LastTurnData {
@@ -272,4 +292,62 @@ export function countNegotiationsRequiringAction(
   viewerUserId: string | undefined,
 ): number {
   return deriveNegotiationInbox(negotiations, viewerUserId).yourMove.length;
+}
+
+/**
+ * Same presentation as the conversation inbox, keyed per owned intent seat
+ * rather than per A2A conversation. The /negotiations page lists these rows
+ * so two pairings with the same person stay distinct.
+ */
+export function deriveTaskIndexInbox(
+  entries: NegotiationTaskIndexEntry[],
+  now = Date.now(),
+): TaskIndexInboxGroups {
+  const items = entries.map<TaskIndexInboxItem>((entry) => {
+    const presentation = deriveNegotiationPresentation({
+      lifecycle: {
+        taskId: entry.taskId,
+        state: entry.state,
+        pause: entry.pause ? { reason: entry.pause.reason } : null,
+        statusTimestamp: entry.latestActivity.createdAt,
+        opportunityId: entry.opportunityId,
+        opportunityStatus: entry.opportunityStatus,
+        acceptedByViewer: false,
+        turnCount: 0,
+        signalCount: 0,
+        updatedAt: entry.updatedAt,
+      },
+      latestSenderId: entry.latestActivity.actor === 'yours' ? 'agent:viewer' : 'agent:peer',
+      viewerUserId: 'viewer',
+    });
+    const lastTurn: LastTurnData = {
+      verb: entry.latestActivity.verb ?? (entry.pause ? 'pause' : null),
+      pauseReason: entry.pause?.reason ?? null,
+    };
+    const sortTimestamp = new Date(entry.latestActivity.createdAt ?? entry.updatedAt).getTime();
+    const safeTimestamp = Number.isFinite(sortTimestamp) ? sortTimestamp : 0;
+    return {
+      key: `${entry.taskId}:${entry.intentId}`,
+      intentId: entry.intentId,
+      taskId: entry.taskId,
+      counterpartName: entry.counterpartLabel,
+      intentLabel: entry.intentLabel,
+      group: presentation.group,
+      status: presentation.status,
+      lastAction: presentation.group === 'resolved'
+        ? describeResolved(presentation.status)
+        : describeLive(presentation.status, lastTurn, entry.latestActivity.actor === 'yours'),
+      timeAgo: formatTimeAgo(safeTimestamp, now),
+      sortTimestamp: safeTimestamp,
+    };
+  });
+
+  const byNewest = (left: TaskIndexInboxItem, right: TaskIndexInboxItem) => right.sortTimestamp - left.sortTimestamp;
+  return {
+    yourMove: items
+      .filter((item) => item.group === 'your_move')
+      .sort((left, right) => (left.status === right.status ? byNewest(left, right) : left.status === 'needs_input' ? -1 : 1)),
+    inProgress: items.filter((item) => item.group === 'in_progress').sort(byNewest),
+    resolved: items.filter((item) => item.group === 'resolved').sort(byNewest),
+  };
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
The Negotiations tab was rendering the owner-seat task index as a debug dump: UUIDs, `round N · task completed · opportunity rejected`, pause reasons like `ready_for_verdict`, and an “Inspect seat” link. That does not tell a person what happened or what to do.

This keeps one row per owned intent seat (so two pairings with the same person stay distinct) and runs each row through the existing presentation layer already used by the chat rail and your-move badge.

**What you see now**
- Title: Negotiations, with `N your move · N in progress · N resolved`
- Groups: **Your move**, **In progress**, **Resolved**
- Human chips: Needs your input, Awaiting your review, Negotiating, No match, Connection accepted, …
- Subtitle: signal · last action · time ago
- Whole row opens the existing seat page; IDs and raw task/opportunity state stay off the list

**Out of scope**
- The click-through inspector is still a debug view
- Accepted rows all say “Connection accepted” (the task index does not yet say who accepted)
- Grouped / Last updated toggle and live flashes from the old inbox are not restored

**Verification**
- `cd apps/web && bun --bun vitest run src/lib/__tests__/negotiation-inbox.test.ts src/components/__tests__/NegotiationTaskIndex.test.tsx` — 18 passed

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-85cd51c4-79fe-419c-a771-f352ed552d92?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-85cd51c4-79fe-419c-a771-f352ed552d92&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

