### PR TITLE
Add anonymized matching research export

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -60,6 +60,8 @@ apps/mac/Resources/index.html
 
 # Local Postgres dump used to reset the synthetic development sandbox quickly.
 .cache/index/
+# Anonymized research dumps (never commit production extracts).
+.cache/research-export/
 
 # Root-only Pi subagent runtime state; nested/source artifacts remain visible.
 /.pi-subagents/

--- a/services/api/package.json
+++ b/services/api/package.json
@@ -29,6 +29,7 @@
     "maintenance:backfill-intent-questions": "bun ./src/cli/backfill-intent-questions.ts",
     "maintenance:backfill-intent-networks": "bun ./src/cli/backfill-intent-networks.ts",
     "maintenance:reconcile-orphaned-intent-indexing": "bun ./src/cli/reconcile-orphaned-intent-indexing.ts",
+    "maintenance:export-research-dump": "bun ./src/cli/export-research-dump.ts",
     "test:opportunity-three-user": "bun ./src/cli/opportunity-three-user-test.ts",
     "test:sandbox:e2e": "bun test ./tests/personal-agent-negotiation.sandbox.e2e.ts",
     "test": "NODE_ENV=test bash scripts/test-safe.sh",

--- a/services/api/src/cli/export-research-dump.ts
+++ b/services/api/src/cli/export-research-dump.ts
@@ -67,7 +67,7 @@ async function resolveNetwork(db: ExportDb, query: string | null) {
         .from(schema.networks)
         .where(and(
           isNull(schema.networks.deletedAt),
-          sql`(lower(${schema.networks.title}) like '%edge esmeralda%' or lower(coalesce(${schema.networks.key}, '')) like '%esmeralda%')`,
+          sql`(lower(${schema.networks.title}) like '%edge esmeralda%' or lower(${schema.networks.title}) like '%edge city%' or lower(coalesce(${schema.networks.key}, '')) like '%esmeralda%')`,
         ));
   if (rows.length === 0) throw new Error(query ? `No network matched ${query}` : 'No Edge Esmeralda network found');
   if (rows.length > 1) {

--- a/services/api/src/cli/export-research-dump.ts
+++ b/services/api/src/cli/export-research-dump.ts
@@ -1,0 +1,283 @@
+#!/usr/bin/env node
+/**
+ * Read-only anonymized export of matching data for a network (default: Edge Esmeralda).
+ *
+ * Usage:
+ *   RESEARCH_HMAC_SECRET=... DATABASE_URL=... bun ./src/cli/export-research-dump.ts --confirm --out /path
+ *   Optional: --network <id|key|title>
+ */
+import dotenv from 'dotenv';
+import path from 'path';
+
+const envFile = process.env.NODE_ENV === 'development' ? '.env.development' : '.env.production';
+dotenv.config({ path: path.resolve(import.meta.dir, '../../../..', envFile) });
+
+import { mkdir, writeFile } from 'node:fs/promises';
+
+import { drizzle } from 'drizzle-orm/postgres-js';
+import { and, eq, inArray, isNull, or, sql } from 'drizzle-orm/sql';
+import postgres from 'postgres';
+
+import * as schema from '../schemas/database.schema';
+import { buildDictionary, buildMetrics, renderDatasetCard, transformIntents, transformNegotiations, transformOpportunities, transformUsers, type RawArtifact, type RawIntent, type RawNegotiationMessage, type RawNegotiationTask, type RawOpportunity, type RawSocial, type RawUser } from './research-export/transform';
+
+function inList(ids: string[]) {
+  return sql`(${sql.join(ids.map((id) => sql`${id}`), sql`, `)})`;
+}
+
+interface Args {
+  confirm: boolean;
+  out: string | null;
+  network: string | null;
+}
+
+function parseArgs(argv: string[]): Args {
+  const args: Args = { confirm: false, out: null, network: null };
+  for (let i = 0; i < argv.length; i += 1) {
+    const token = argv[i];
+    if (token === '--confirm') args.confirm = true;
+    else if (token === '--out') args.out = argv[++i] ?? null;
+    else if (token === '--network') args.network = argv[++i] ?? null;
+  }
+  return args;
+}
+
+async function writeJsonl(file: string, rows: object[]): Promise<void> {
+  const body = rows.map((row) => JSON.stringify(row)).join('\n');
+  await writeFile(file, body ? `${body}\n` : '');
+}
+
+type ExportDb = ReturnType<typeof drizzle<typeof schema>>;
+
+async function resolveNetwork(db: ExportDb, query: string | null) {
+  const rows = query
+    ? await db
+        .select({ id: schema.networks.id, title: schema.networks.title, key: schema.networks.key })
+        .from(schema.networks)
+        .where(and(
+          isNull(schema.networks.deletedAt),
+          or(
+            eq(schema.networks.id, query),
+            eq(schema.networks.key, query),
+            sql`lower(${schema.networks.title}) = lower(${query})`,
+          ),
+        ))
+    : await db
+        .select({ id: schema.networks.id, title: schema.networks.title, key: schema.networks.key })
+        .from(schema.networks)
+        .where(and(
+          isNull(schema.networks.deletedAt),
+          sql`(lower(${schema.networks.title}) like '%edge esmeralda%' or lower(coalesce(${schema.networks.key}, '')) like '%esmeralda%')`,
+        ));
+  if (rows.length === 0) throw new Error(query ? `No network matched ${query}` : 'No Edge Esmeralda network found');
+  if (rows.length > 1) {
+    throw new Error(`Multiple networks matched; pass --network with an exact id/key/title: ${rows.map((row) => `${row.title} (${row.id})`).join('; ')}`);
+  }
+  return rows[0];
+}
+
+async function main(): Promise<void> {
+  const args = parseArgs(process.argv.slice(2));
+  const secret = process.env.RESEARCH_HMAC_SECRET;
+  if (!args.confirm) {
+    console.error('Refusing to export without --confirm');
+    process.exit(1);
+  }
+  if (!args.out) {
+    console.error('Missing --out <dir>');
+    process.exit(1);
+  }
+  if (!secret) {
+    console.error('RESEARCH_HMAC_SECRET is required');
+    process.exit(1);
+  }
+  if (!process.env.DATABASE_URL) {
+    console.error('DATABASE_URL is required');
+    process.exit(1);
+  }
+
+  const client = postgres(process.env.DATABASE_URL, { prepare: false, max: 1 });
+  const db = drizzle(client, { schema });
+  try {
+    await client`SET default_transaction_read_only = on`;
+  const network = await resolveNetwork(db, args.network);
+  console.log(`[export-research-dump] Network ${network.title}`);
+
+  const memberships = await db
+    .select({ userId: schema.networkMembers.userId })
+    .from(schema.networkMembers)
+    .where(eq(schema.networkMembers.networkId, network.id));
+  const memberIds = [...new Set(memberships.map((row) => row.userId))];
+  if (memberIds.length === 0) throw new Error('Network has no members');
+
+  const users = await db
+    .select({
+      id: schema.users.id,
+      name: schema.users.name,
+      email: schema.users.email,
+      key: schema.users.key,
+      intro: schema.users.intro,
+      onboarding: schema.users.onboarding,
+      createdAt: schema.users.createdAt,
+      deletedAt: schema.users.deletedAt,
+    })
+    .from(schema.users)
+    .where(inArray(schema.users.id, memberIds)) as RawUser[];
+
+  const socials = await db
+    .select({ userId: schema.userSocials.userId, value: schema.userSocials.value })
+    .from(schema.userSocials)
+    .where(inArray(schema.userSocials.userId, memberIds)) as RawSocial[];
+
+  const notificationRows = await db
+    .select({ preferences: schema.userNotificationSettings.preferences })
+    .from(schema.userNotificationSettings)
+    .where(inArray(schema.userNotificationSettings.userId, memberIds));
+  const telegramChatIds = notificationRows
+    .map((row) => row.preferences?.telegram?.chatId)
+    .filter((value): value is string => typeof value === 'string' && value.length > 0);
+
+  const assignedIntentIds = await db
+    .select({ intentId: schema.intentNetworks.intentId })
+    .from(schema.intentNetworks)
+    .where(eq(schema.intentNetworks.networkId, network.id));
+
+  const intents = await db
+    .select({
+      id: schema.intents.id,
+      userId: schema.intents.userId,
+      payload: schema.intents.payload,
+      summary: schema.intents.summary,
+      status: schema.intents.status,
+      isIncognito: schema.intents.isIncognito,
+      createdAt: schema.intents.createdAt,
+      updatedAt: schema.intents.updatedAt,
+      archivedAt: schema.intents.archivedAt,
+    })
+    .from(schema.intents)
+    .where(or(
+      inArray(schema.intents.userId, memberIds),
+      assignedIntentIds.length > 0 ? inArray(schema.intents.id, assignedIntentIds.map((row) => row.intentId)) : sql`1 = 0`,
+    )) as RawIntent[];
+
+  const opportunityRows = await db
+    .select({
+      id: schema.opportunities.id,
+      detection: schema.opportunities.detection,
+      actors: schema.opportunities.actors,
+      interpretation: schema.opportunities.interpretation,
+      context: schema.opportunities.context,
+      confidence: schema.opportunities.confidence,
+      status: schema.opportunities.status,
+      acceptedBy: schema.opportunities.acceptedBy,
+      createdAt: schema.opportunities.createdAt,
+      updatedAt: schema.opportunities.updatedAt,
+      expiresAt: schema.opportunities.expiresAt,
+    })
+    .from(schema.opportunities)
+    .where(sql`
+      ${schema.opportunities.context}->>'networkId' = ${network.id}
+      OR EXISTS (
+        SELECT 1 FROM jsonb_array_elements(${schema.opportunities.actors}) AS actor
+        WHERE actor->>'networkId' = ${network.id}
+           OR actor->>'userId' IN ${inList(memberIds)}
+      )
+    `) as RawOpportunity[];
+
+  const taskRows = await db
+    .select({
+      id: schema.tasks.id,
+      conversationId: schema.tasks.conversationId,
+      state: schema.tasks.state,
+      createdAt: schema.tasks.createdAt,
+      metadata: schema.tasks.metadata,
+    })
+    .from(schema.tasks)
+    .where(sql`
+      ${schema.tasks.metadata}->>'type' = 'negotiation'
+      AND (
+        ${schema.tasks.metadata}->>'networkId' = ${network.id}
+        OR ${schema.tasks.metadata}->>'sourceUserId' IN ${inList(memberIds)}
+        OR ${schema.tasks.metadata}->>'candidateUserId' IN ${inList(memberIds)}
+      )
+    `);
+
+  const tasks: RawNegotiationTask[] = taskRows.map((row) => ({
+    id: row.id,
+    conversationId: row.conversationId,
+    state: row.state,
+    createdAt: row.createdAt,
+    metadata: (row.metadata ?? {}) as RawNegotiationTask['metadata'],
+  }));
+  const taskIds = tasks.map((task) => task.id);
+
+  const messages: RawNegotiationMessage[] = taskIds.length === 0
+    ? []
+    : await db
+        .select({
+          taskId: schema.messages.taskId,
+          senderId: schema.messages.senderId,
+          parts: schema.messages.parts,
+          createdAt: schema.messages.createdAt,
+          id: schema.messages.id,
+        })
+        .from(schema.messages)
+        .where(inArray(schema.messages.taskId, taskIds))
+        .then((rows) => rows.filter((row): row is RawNegotiationMessage => typeof row.taskId === 'string'));
+
+  const artifacts: RawArtifact[] = taskIds.length === 0
+    ? []
+    : await db
+        .select({
+          taskId: schema.artifacts.taskId,
+          name: schema.artifacts.name,
+          parts: schema.artifacts.parts,
+        })
+        .from(schema.artifacts)
+        .where(and(
+          inArray(schema.artifacts.taskId, taskIds),
+          eq(schema.artifacts.name, 'negotiation-outcome'),
+        ));
+
+  const terms = buildDictionary({ users, socials, telegramChatIds });
+  const outUsers = transformUsers(secret, users);
+  const outIntents = transformIntents(secret, intents, terms);
+  const outOpportunities = transformOpportunities(secret, opportunityRows, terms);
+  const outNegotiations = transformNegotiations(secret, tasks, messages, artifacts, terms);
+  const metrics = buildMetrics({
+    networkTitle: network.title,
+    networkIdKind: 'network',
+    networkRawId: network.id,
+    secret,
+    users: outUsers,
+    intents: outIntents,
+    opportunities: outOpportunities,
+    negotiations: outNegotiations,
+  });
+
+  await mkdir(args.out, { recursive: true });
+  await writeJsonl(path.join(args.out, 'users.jsonl'), outUsers);
+  await writeJsonl(path.join(args.out, 'intents.jsonl'), outIntents);
+  await writeJsonl(path.join(args.out, 'opportunities.jsonl'), outOpportunities);
+  await writeJsonl(path.join(args.out, 'negotiations.jsonl'), outNegotiations);
+  await writeFile(path.join(args.out, 'metrics.json'), `${JSON.stringify(metrics, null, 2)}\n`);
+  await writeFile(path.join(args.out, 'DATASET.md'), renderDatasetCard(metrics));
+
+  console.log(`[export-research-dump] Wrote ${args.out}`);
+  console.log(JSON.stringify({
+    users: metrics.users,
+    intents: metrics.intents,
+    opportunities: metrics.opportunities,
+    opportunities_by_status: metrics.opportunities_by_status,
+    negotiations: metrics.negotiations,
+    negotiations_screened_out: metrics.negotiations_screened_out,
+  }));
+  } finally {
+    await client.end({ timeout: 5 });
+  }
+}
+
+main().catch((error: unknown) => {
+  console.error('[export-research-dump] Failed:', error instanceof Error ? error.message : error);
+  process.exit(1);
+});

--- a/services/api/src/cli/research-export/anonymize.ts
+++ b/services/api/src/cli/research-export/anonymize.ts
@@ -1,0 +1,72 @@
+import { createHmac } from 'node:crypto';
+
+export type IdKind = 'user' | 'intent' | 'opp' | 'session' | 'network';
+
+const KIND_PREFIX: Record<IdKind, string> = {
+  user: 'user_',
+  intent: 'intent_',
+  opp: 'opp_',
+  session: 'session_',
+  network: 'network_',
+};
+
+const EMAIL_RE = /[A-Z0-9._%+-]+@[A-Z0-9.-]+\.[A-Z]{2,}/gi;
+const URL_RE = /https?:\/\/[^\s)\]>'"]+/gi;
+const HANDLE_RE = /(^|[^A-Z0-9_])@[A-Z0-9_]{2,30}\b/gi;
+const PHONE_RE = /(?<!\d)(?:\+?\d{1,3}[\s.-])?(?:\(?\d{3}\)?[\s.-])\d{3}[\s.-]\d{4}(?!\d)/g;
+const CREDENTIAL_RE = /\b(?:idxh_|idxo_|sk-|sk_live_|sk_test_|Bearer\s+)[A-Za-z0-9._-]{8,}/g;
+const UUID_RE = /[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}/gi;
+
+export function hmacId(secret: string, kind: IdKind, rawId: string): string {
+  const digest = createHmac('sha256', secret).update(`${kind}:${rawId}`).digest('hex').slice(0, 32);
+  return `${KIND_PREFIX[kind]}${digest}`;
+}
+
+export function hmacIdOrNull(secret: string, kind: IdKind, rawId: string | null | undefined): string | null {
+  if (!rawId) return null;
+  return hmacId(secret, kind, rawId);
+}
+
+function escapeRegExp(value: string): string {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}
+
+/** Unique dictionary terms, longest first, skipping very short tokens. */
+export function uniqueTerms(values: Array<string | null | undefined>, minLength = 3): string[] {
+  const seen = new Set<string>();
+  const terms: string[] = [];
+  for (const value of values) {
+    const trimmed = value?.trim();
+    if (!trimmed || trimmed.length < minLength) continue;
+    const key = trimmed.toLowerCase();
+    if (seen.has(key)) continue;
+    seen.add(key);
+    terms.push(trimmed);
+  }
+  terms.sort((a, b) => b.length - a.length);
+  return terms;
+}
+
+export function redactKnownTerms(text: string, terms: string[]): string {
+  let out = text;
+  for (const term of terms) {
+    out = out.replace(new RegExp(escapeRegExp(term), 'gi'), '[PERSON]');
+  }
+  return out;
+}
+
+export function redactPatterns(text: string): string {
+  return text
+    .replace(EMAIL_RE, '[EMAIL]')
+    .replace(URL_RE, '[URL]')
+    .replace(HANDLE_RE, '$1[HANDLE]')
+    .replace(PHONE_RE, '[PHONE]')
+    .replace(CREDENTIAL_RE, '[CREDENTIAL]')
+    .replace(UUID_RE, '');
+}
+
+export function redactText(text: string | null | undefined, terms: string[]): string | null {
+  if (text == null) return null;
+  const reduced = redactPatterns(redactKnownTerms(text, terms)).replace(/\s{2,}/g, ' ').trim();
+  return reduced;
+}

--- a/services/api/src/cli/research-export/transform.ts
+++ b/services/api/src/cli/research-export/transform.ts
@@ -322,6 +322,77 @@ It is intended for authorized research on matching and negotiation behavior. It 
 - \`negotiations.jsonl\` — one agent-to-agent thread per row (Hugging Face conversation envelope plus Index ids)
 - \`metrics.json\` — aggregate counts
 
+## Data structure
+
+\`users.jsonl\`
+
+\`\`\`json
+{ "user_id": "user_<pseudonym>", "created_at": 1780000000.0, "deleted": false }
+\`\`\`
+
+\`intents.jsonl\`
+
+\`\`\`json
+{
+  "intent_id": "intent_<pseudonym>",
+  "user_id": "user_<pseudonym>",
+  "payload": "Privacy-reduced intent text",
+  "summary": "Privacy-reduced summary",
+  "status": "ACTIVE",
+  "is_incognito": false,
+  "created_at": 1780000000.0,
+  "updated_at": 1780000000.0,
+  "archived_at": null
+}
+\`\`\`
+
+\`opportunities.jsonl\`
+
+\`\`\`json
+{
+  "opportunity_id": "opp_<pseudonym>",
+  "status": "accepted",
+  "confidence": 80,
+  "created_at": 1780000000.0,
+  "updated_at": 1780000100.0,
+  "expires_at": null,
+  "accepted_by": "user_<pseudonym>",
+  "detection_source": "opportunity_graph",
+  "triggered_by_intent_id": "intent_<pseudonym>",
+  "network_id": "network_<pseudonym>",
+  "actors": [{ "user_id": "user_<pseudonym>", "intent_id": "intent_<pseudonym>", "role": "patient", "acted_at": "2026-06-04T00:00:00.000Z", "approved": null }],
+  "category": "collaboration",
+  "reasoning": "Privacy-reduced match reasoning"
+}
+\`\`\`
+
+\`negotiations.jsonl\` — one agent-to-agent thread per row:
+
+\`\`\`json
+{
+  "conversation_id": "session_<pseudonym>",
+  "opportunity_id": "opp_<pseudonym>",
+  "source_user_id": "user_<pseudonym>",
+  "candidate_user_id": "user_<pseudonym>",
+  "started_at": 1780000000.0,
+  "task_state": "completed",
+  "outcome_has_opportunity": true,
+  "outcome_reason": null,
+  "messages": [
+    {
+      "seq": 0,
+      "timestamp": 1780000000.0,
+      "role": "agent",
+      "speaker_user_id": "user_<pseudonym>",
+      "verb": "outreach",
+      "text": "Privacy-reduced negotiation turn"
+    }
+  ]
+}
+\`\`\`
+
+Messages are ordered by original timestamp, then id. The public \`seq\` field is assigned after sorting.
+
 ## Identifiers
 
 User, intent, opportunity, and conversation identifiers are stable HMAC-SHA256 pseudonyms generated for this dump (\`user_\`, \`intent_\`, \`opp_\`, \`session_\`, \`network_\`). Raw platform identifiers are not included.

--- a/services/api/src/cli/research-export/transform.ts
+++ b/services/api/src/cli/research-export/transform.ts
@@ -324,9 +324,7 @@ It is intended for authorized research on matching and negotiation behavior. It 
 
 ## Identifiers
 
-Tenant/user/conversation identifiers are stable HMAC-SHA256 pseudonyms generated for this dump (\`user_\`, \`intent_\`, \`opp_\`, \`session_\`, \`network_\`). Raw platform identifiers are not included.
-
-This HMAC namespace is **not** the Hermes conversation namespace used by \`jshph/agentvillage-sanitized-conversations-edge-esmeralda-2026\`. Do not join \`user_*\` to that dataset's \`tenant_*\` values.
+User, intent, opportunity, and conversation identifiers are stable HMAC-SHA256 pseudonyms generated for this dump (\`user_\`, \`intent_\`, \`opp_\`, \`session_\`, \`network_\`). Raw platform identifiers are not included.
 
 ## Privacy processing
 

--- a/services/api/src/cli/research-export/transform.ts
+++ b/services/api/src/cli/research-export/transform.ts
@@ -1,0 +1,353 @@
+import { hmacId, hmacIdOrNull, redactText, uniqueTerms, type IdKind } from './anonymize';
+
+export interface RawUser {
+  id: string;
+  name: string;
+  email: string;
+  key: string | null;
+  intro: string | null;
+  onboarding: unknown;
+  createdAt: Date;
+  deletedAt: Date | null;
+}
+
+export interface RawSocial {
+  userId: string;
+  value: string;
+}
+
+export interface RawIntent {
+  id: string;
+  userId: string;
+  payload: string;
+  summary: string | null;
+  status: string | null;
+  isIncognito: boolean;
+  createdAt: Date;
+  updatedAt: Date;
+  archivedAt: Date | null;
+}
+
+export interface RawOpportunityActor {
+  userId?: string;
+  intent?: string;
+  role?: string;
+  actedAt?: string;
+  approved?: boolean;
+  networkId?: string;
+}
+
+export interface RawOpportunity {
+  id: string;
+  detection: { source?: string; triggeredBy?: string };
+  actors: RawOpportunityActor[];
+  interpretation: { category?: string; reasoning?: string; confidence?: number };
+  context: { networkId?: string };
+  confidence: string | number;
+  status: string;
+  acceptedBy: string | null;
+  createdAt: Date;
+  updatedAt: Date;
+  expiresAt: Date | null;
+}
+
+export interface RawNegotiationTask {
+  id: string;
+  conversationId: string;
+  state: string;
+  createdAt: Date;
+  metadata: {
+    opportunityId?: string;
+    sourceUserId?: string;
+    candidateUserId?: string;
+    networkId?: string;
+  };
+}
+
+export interface RawNegotiationMessage {
+  taskId: string;
+  senderId: string;
+  parts: unknown;
+  createdAt: Date;
+  id: string;
+}
+
+export interface RawArtifact {
+  taskId: string;
+  name: string | null;
+  parts: unknown;
+}
+
+export interface IdentifierSource {
+  users: RawUser[];
+  socials: RawSocial[];
+  telegramChatIds: string[];
+}
+
+function unix(date: Date | null | undefined): number | null {
+  if (!date) return null;
+  return date.getTime() / 1000;
+}
+
+function asRecord(value: unknown): Record<string, unknown> | null {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) return null;
+  return value as Record<string, unknown>;
+}
+
+function stringField(value: unknown): string | null {
+  return typeof value === 'string' && value.trim() ? value : null;
+}
+
+function collectOnboardingStrings(onboarding: unknown): string[] {
+  const record = asRecord(onboarding);
+  const seeds = record?.profileSeeds;
+  if (!Array.isArray(seeds)) return [];
+  const out: string[] = [];
+  for (const seed of seeds) {
+    const row = asRecord(seed);
+    if (!row) continue;
+    if (typeof row.name === 'string') out.push(row.name);
+    if (typeof row.bio === 'string') out.push(row.bio);
+    const socials = row.socials;
+    if (Array.isArray(socials)) {
+      for (const social of socials) {
+        const item = asRecord(social);
+        if (typeof item?.value === 'string') out.push(item.value);
+      }
+    }
+  }
+  return out;
+}
+
+export function buildDictionary(source: IdentifierSource): string[] {
+  const values: Array<string | null | undefined> = [];
+  for (const user of source.users) {
+    values.push(user.name, user.email, user.key, user.intro);
+    values.push(...collectOnboardingStrings(user.onboarding));
+  }
+  for (const social of source.socials) values.push(social.value);
+  values.push(...source.telegramChatIds);
+  return uniqueTerms(values);
+}
+
+export function extractTurn(parts: unknown): { verb: string | null; text: string } {
+  const list = Array.isArray(parts) ? parts : [];
+  for (const part of list) {
+    const row = asRecord(part);
+    const data = asRecord(row?.data) ?? (row?.kind === undefined ? row : null);
+    if (!data) continue;
+    const verb = stringField(data.verb) ?? stringField(data.action);
+    const message = stringField(data.message);
+    const reasoning = stringField(data.reasoning) ?? stringField(asRecord(data.assessment)?.reasoning);
+    const reason = stringField(data.reason);
+    const text = [message, reasoning].filter(Boolean).join('\n') || (verb === 'pause' && reason ? `pause:${reason}` : '');
+    if (verb || text) return { verb: verb ?? null, text };
+  }
+  return { verb: null, text: '' };
+}
+
+function speakerUserId(senderId: string): string | null {
+  if (senderId.startsWith('agent:')) return senderId.slice('agent:'.length) || null;
+  return senderId || null;
+}
+
+function artifactOutcome(parts: unknown): { hasOpportunity?: boolean; reason?: string } {
+  const list = Array.isArray(parts) ? parts : [];
+  for (const part of list) {
+    const data = asRecord(asRecord(part)?.data);
+    if (!data) continue;
+    return {
+      hasOpportunity: typeof data.hasOpportunity === 'boolean' ? data.hasOpportunity : undefined,
+      reason: stringField(data.reason) ?? undefined,
+    };
+  }
+  return {};
+}
+
+export function transformUsers(secret: string, users: RawUser[]) {
+  return users.map((user) => ({
+    user_id: hmacId(secret, 'user', user.id),
+    created_at: unix(user.createdAt),
+    deleted: user.deletedAt != null,
+  }));
+}
+
+export function transformIntents(secret: string, intents: RawIntent[], terms: string[]) {
+  return intents.map((intent) => ({
+    intent_id: hmacId(secret, 'intent', intent.id),
+    user_id: hmacId(secret, 'user', intent.userId),
+    payload: redactText(intent.payload, terms),
+    summary: redactText(intent.summary, terms),
+    status: intent.status,
+    is_incognito: intent.isIncognito,
+    created_at: unix(intent.createdAt),
+    updated_at: unix(intent.updatedAt),
+    archived_at: unix(intent.archivedAt),
+  }));
+}
+
+export function transformOpportunities(secret: string, opportunities: RawOpportunity[], terms: string[]) {
+  return opportunities.map((opportunity) => ({
+    opportunity_id: hmacId(secret, 'opp', opportunity.id),
+    status: opportunity.status,
+    confidence: Number(opportunity.confidence),
+    created_at: unix(opportunity.createdAt),
+    updated_at: unix(opportunity.updatedAt),
+    expires_at: unix(opportunity.expiresAt),
+    accepted_by: hmacIdOrNull(secret, 'user', opportunity.acceptedBy),
+    detection_source: opportunity.detection?.source ?? null,
+    triggered_by_intent_id: hmacIdOrNull(secret, 'intent', opportunity.detection?.triggeredBy),
+    network_id: hmacIdOrNull(secret, 'network', opportunity.context?.networkId),
+    actors: (opportunity.actors ?? []).map((actor) => ({
+      user_id: hmacIdOrNull(secret, 'user', actor.userId),
+      intent_id: hmacIdOrNull(secret, 'intent', actor.intent),
+      role: actor.role ?? null,
+      acted_at: actor.actedAt ?? null,
+      approved: actor.approved ?? null,
+    })),
+    category: opportunity.interpretation?.category ?? null,
+    reasoning: redactText(opportunity.interpretation?.reasoning, terms),
+  }));
+}
+
+export function transformNegotiations(
+  secret: string,
+  tasks: RawNegotiationTask[],
+  messages: RawNegotiationMessage[],
+  artifacts: RawArtifact[],
+  terms: string[],
+) {
+  const messagesByTask = new Map<string, RawNegotiationMessage[]>();
+  for (const message of messages) {
+    const list = messagesByTask.get(message.taskId) ?? [];
+    list.push(message);
+    messagesByTask.set(message.taskId, list);
+  }
+  const artifactsByTask = new Map<string, RawArtifact>();
+  for (const artifact of artifacts) {
+    if (artifact.name === 'negotiation-outcome') artifactsByTask.set(artifact.taskId, artifact);
+  }
+
+  return tasks.map((task) => {
+    const thread = (messagesByTask.get(task.id) ?? [])
+      .slice()
+      .sort((a, b) => a.createdAt.getTime() - b.createdAt.getTime() || a.id.localeCompare(b.id));
+    const outcome = artifactOutcome(artifactsByTask.get(task.id)?.parts);
+    return {
+      conversation_id: hmacId(secret, 'session', task.conversationId),
+      opportunity_id: hmacIdOrNull(secret, 'opp', task.metadata.opportunityId),
+      source_user_id: hmacIdOrNull(secret, 'user', task.metadata.sourceUserId),
+      candidate_user_id: hmacIdOrNull(secret, 'user', task.metadata.candidateUserId),
+      started_at: unix(task.createdAt),
+      task_state: task.state,
+      outcome_has_opportunity: outcome.hasOpportunity ?? null,
+      outcome_reason: outcome.reason ?? null,
+      messages: thread.map((message, seq) => {
+        const turn = extractTurn(message.parts);
+        const speaker = speakerUserId(message.senderId);
+        return {
+          seq,
+          timestamp: unix(message.createdAt),
+          role: 'agent' as const,
+          speaker_user_id: hmacIdOrNull(secret, 'user', speaker),
+          verb: turn.verb,
+          text: redactText(turn.text, terms) ?? '',
+        };
+      }),
+    };
+  });
+}
+
+export function countBy<T>(rows: T[], key: (row: T) => string | null | undefined): Record<string, number> {
+  const out: Record<string, number> = {};
+  for (const row of rows) {
+    const value = key(row) ?? 'unknown';
+    out[value] = (out[value] ?? 0) + 1;
+  }
+  return out;
+}
+
+export function buildMetrics(input: {
+  networkTitle: string;
+  networkIdKind: IdKind;
+  networkRawId: string;
+  secret: string;
+  users: ReturnType<typeof transformUsers>;
+  intents: ReturnType<typeof transformIntents>;
+  opportunities: ReturnType<typeof transformOpportunities>;
+  negotiations: ReturnType<typeof transformNegotiations>;
+}) {
+  const pauseCounts: Record<string, number> = {};
+  let continueTurns = 0;
+  for (const negotiation of input.negotiations) {
+    for (const message of negotiation.messages) {
+      if (message.verb === 'pause') {
+        const reason = message.text.startsWith('pause:') ? message.text.slice('pause:'.length) : 'pause';
+        pauseCounts[reason] = (pauseCounts[reason] ?? 0) + 1;
+      } else if (message.verb) {
+        continueTurns += 1;
+      }
+    }
+  }
+  return {
+    network_title: input.networkTitle,
+    network_id: hmacId(input.secret, input.networkIdKind, input.networkRawId),
+    exported_at: new Date().toISOString(),
+    users: input.users.length,
+    intents: input.intents.length,
+    opportunities: input.opportunities.length,
+    opportunities_by_status: countBy(input.opportunities, (row) => row.status),
+    opportunities_with_actor_action: input.opportunities.filter((row) => row.actors.some((actor) => actor.acted_at)).length,
+    negotiations: input.negotiations.length,
+    negotiations_by_task_state: countBy(input.negotiations, (row) => row.task_state),
+    negotiations_screened_out: input.negotiations.filter((row) => row.outcome_reason === 'screened_out').length,
+    negotiations_with_opportunity: input.negotiations.filter((row) => row.outcome_has_opportunity === true).length,
+    negotiation_continue_turns: continueTurns,
+    negotiation_pauses_by_reason: pauseCounts,
+  };
+}
+
+export function renderDatasetCard(metrics: ReturnType<typeof buildMetrics>): string {
+  return `# Index matching export (Edge Esmeralda)
+
+This private dataset contains privacy-reduced Index Network matching records for the Edge Esmeralda program: users, intents, opportunities, and agent-to-agent negotiation transcripts.
+
+It is intended for authorized research on matching and negotiation behavior. It is not intended for identity inference, contact discovery, profiling of individuals, or attempts to reverse anonymization.
+
+## Files
+
+- \`users.jsonl\` — pseudonymous user ids and timestamps only
+- \`intents.jsonl\` — privacy-reduced intent text
+- \`opportunities.jsonl\` — match records with status, actors, and privacy-reduced reasoning
+- \`negotiations.jsonl\` — one agent-to-agent thread per row (Hugging Face conversation envelope plus Index ids)
+- \`metrics.json\` — aggregate counts
+
+## Identifiers
+
+Tenant/user/conversation identifiers are stable HMAC-SHA256 pseudonyms generated for this dump (\`user_\`, \`intent_\`, \`opp_\`, \`session_\`, \`network_\`). Raw platform identifiers are not included.
+
+This HMAC namespace is **not** the Hermes conversation namespace used by \`jshph/agentvillage-sanitized-conversations-edge-esmeralda-2026\`. Do not join \`user_*\` to that dataset's \`tenant_*\` values.
+
+## Privacy processing
+
+Deterministic reduction only: known-identifier dictionary (names, emails, handles, keys, bios, Telegram chat ids), regex redaction of email/URL/handle/phone/credential shapes, and UUID stripping. Negotiation briefs and pause payloads are dropped. Embeddings, contact fields, and human chat transcripts are not exported.
+
+No claim of complete anonymization is made. Unusual semantic context can remain quasi-identifying. Timestamps are retained for ordering and may contribute to reidentification risk when combined with outside information.
+
+## Access
+
+Restricted-use research only. Do not identify or contact participants, link pseudonyms to external identities, publish message-level examples without an additional privacy review, or redistribute identifiable material.
+
+## Counts
+
+- Users: ${metrics.users}
+- Intents: ${metrics.intents}
+- Opportunities: ${metrics.opportunities}
+- Negotiations: ${metrics.negotiations}
+- Opportunities by status: ${JSON.stringify(metrics.opportunities_by_status)}
+- Negotiations by task state: ${JSON.stringify(metrics.negotiations_by_task_state)}
+- Screened out: ${metrics.negotiations_screened_out}
+- Matches accepted (opportunity status accepted): ${metrics.opportunities_by_status.accepted ?? 0}
+- Matches rejected (opportunity status rejected): ${metrics.opportunities_by_status.rejected ?? 0}
+`;
+}

--- a/services/api/src/cli/tests/research-export.spec.ts
+++ b/services/api/src/cli/tests/research-export.spec.ts
@@ -1,0 +1,201 @@
+import { describe, expect, it } from 'bun:test';
+
+import { hmacId, redactText, uniqueTerms } from '../research-export/anonymize';
+import { buildDictionary, buildMetrics, extractTurn, transformIntents, transformNegotiations, transformOpportunities, transformUsers } from '../research-export/transform';
+
+const SECRET = 'test-research-hmac-secret';
+const USER_A = '11111111-1111-4111-8111-111111111111';
+const USER_B = '22222222-2222-4222-8222-222222222222';
+const INTENT_A = 'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa';
+const OPP_A = 'bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb';
+const CONV_A = 'cccccccc-cccc-4ccc-8ccc-cccccccccccc';
+
+describe('research export anonymize', () => {
+  it('produces stable HMAC pseudonyms and never echoes raw ids', () => {
+    const first = hmacId(SECRET, 'user', USER_A);
+    const second = hmacId(SECRET, 'user', USER_A);
+    expect(first).toBe(second);
+    expect(first.startsWith('user_')).toBe(true);
+    expect(first).not.toContain(USER_A);
+    expect(hmacId(SECRET, 'user', USER_B)).not.toBe(first);
+    expect(hmacId('other-secret', 'user', USER_A)).not.toBe(first);
+  });
+
+  it('redacts names, emails, handles, phones, urls, credentials, and UUIDs', () => {
+    const named = redactText('Ada Lovelace visited London', uniqueTerms(['Ada Lovelace']));
+    expect(named).toBe('[PERSON] visited London');
+
+    const patterned = redactText(
+      `email ada@example.com handle @ada_codes url https://linkedin.com/in/ada secret idxh_abc12345SECRET uuid ${USER_A} phone 415-555-0100`,
+      [],
+    );
+    expect(patterned).not.toMatch(/ada@example.com/i);
+    expect(patterned).not.toMatch(/@ada_codes/i);
+    expect(patterned).not.toMatch(/linkedin\.com/);
+    expect(patterned).not.toMatch(/idxh_/);
+    expect(patterned).not.toMatch(/11111111-1111-4111-8111-111111111111/);
+    expect(patterned).not.toMatch(/415-555-0100/);
+    expect(patterned).toContain('[EMAIL]');
+    expect(patterned).toContain('[HANDLE]');
+    expect(patterned).toContain('[URL]');
+    expect(patterned).toContain('[CREDENTIAL]');
+    expect(patterned).toContain('[PHONE]');
+  });
+});
+
+describe('research export transform', () => {
+  const users = [
+    {
+      id: USER_A,
+      name: 'Ada Lovelace',
+      email: 'ada@example.com',
+      key: 'ada',
+      intro: 'Mathematician in London',
+      onboarding: { profileSeeds: [{ name: 'Ada Lovelace', bio: 'Born in 1815', socials: [{ label: 'x', value: '@ada_codes' }] }] },
+      createdAt: new Date('2026-06-01T00:00:00Z'),
+      deletedAt: null,
+    },
+    {
+      id: USER_B,
+      name: 'Charles Babbage',
+      email: 'charles@example.com',
+      key: null,
+      intro: null,
+      onboarding: {},
+      createdAt: new Date('2026-06-02T00:00:00Z'),
+      deletedAt: new Date('2026-07-01T00:00:00Z'),
+    },
+  ];
+  const terms = buildDictionary({
+    users,
+    socials: [{ userId: USER_A, value: 'https://github.com/ada' }],
+    telegramChatIds: ['999888777'],
+  });
+
+  it('builds a dictionary from profile fields and drops identity from users.jsonl', () => {
+    expect(terms.some((term) => /ada lovelace/i.test(term))).toBe(true);
+    const rows = transformUsers(SECRET, users);
+    expect(rows).toEqual([
+      { user_id: hmacId(SECRET, 'user', USER_A), created_at: Date.parse('2026-06-01T00:00:00Z') / 1000, deleted: false },
+      { user_id: hmacId(SECRET, 'user', USER_B), created_at: Date.parse('2026-06-02T00:00:00Z') / 1000, deleted: true },
+    ]);
+    expect(JSON.stringify(rows)).not.toMatch(/ada@example.com/i);
+    expect(JSON.stringify(rows)).not.toMatch(/Lovelace/);
+  });
+
+  it('redacts intent text and opportunity reasoning', () => {
+    const intents = transformIntents(SECRET, [{
+      id: INTENT_A,
+      userId: USER_A,
+      payload: 'Ada Lovelace wants to meet founders at ada@example.com',
+      summary: 'Meet founders',
+      status: 'ACTIVE',
+      isIncognito: false,
+      createdAt: new Date('2026-06-03T00:00:00Z'),
+      updatedAt: new Date('2026-06-03T00:00:00Z'),
+      archivedAt: null,
+    }], terms);
+    expect(intents[0].payload).not.toMatch(/Ada Lovelace/i);
+    expect(intents[0].payload).not.toMatch(/ada@example.com/i);
+    expect(intents[0].user_id).toBe(hmacId(SECRET, 'user', USER_A));
+
+    const opportunities = transformOpportunities(SECRET, [{
+      id: OPP_A,
+      detection: { source: 'opportunity_graph', triggeredBy: INTENT_A, createdByName: 'Ada Lovelace' } as { source?: string; triggeredBy?: string },
+      actors: [{ userId: USER_A, intent: INTENT_A, role: 'patient', actedAt: '2026-06-04T00:00:00.000Z', networkId: 'net-1' }],
+      interpretation: { category: 'collaboration', reasoning: 'Ada Lovelace is a strong match with uuid ' + USER_B },
+      context: { networkId: 'net-1' },
+      confidence: '80',
+      status: 'accepted',
+      acceptedBy: USER_A,
+      createdAt: new Date('2026-06-03T00:00:00Z'),
+      updatedAt: new Date('2026-06-04T00:00:00Z'),
+      expiresAt: null,
+    }], terms);
+    expect(JSON.stringify(opportunities)).not.toContain('createdByName');
+    expect(opportunities[0].reasoning).not.toMatch(/Ada Lovelace/i);
+    expect(opportunities[0].reasoning).not.toContain(USER_B);
+    expect(opportunities[0].accepted_by).toBe(hmacId(SECRET, 'user', USER_A));
+    expect(opportunities[0].status).toBe('accepted');
+  });
+
+  it('extracts A2A turns, strips pause payloads, and sorts messages onto seq', () => {
+    expect(extractTurn([{ kind: 'data', data: { verb: 'outreach', message: 'Hello Ada Lovelace', reasoning: 'Opening.' } }])).toEqual({
+      verb: 'outreach',
+      text: 'Hello Ada Lovelace\nOpening.',
+    });
+    expect(extractTurn([{ kind: 'data', data: { verb: 'pause', reason: 'needs_principal', payload: { question: 'What is Ada budget?' } } }])).toEqual({
+      verb: 'pause',
+      text: 'pause:needs_principal',
+    });
+
+    const negotiations = transformNegotiations(
+      SECRET,
+      [{
+        id: 'task-1',
+        conversationId: CONV_A,
+        state: 'completed',
+        createdAt: new Date('2026-06-05T00:00:00Z'),
+        metadata: { opportunityId: OPP_A, sourceUserId: USER_A, candidateUserId: USER_B, networkId: 'net-1' },
+      }],
+      [
+        {
+          id: 'm2',
+          taskId: 'task-1',
+          senderId: `agent:${USER_B}`,
+          createdAt: new Date('2026-06-05T00:00:10Z'),
+          parts: [{ kind: 'data', data: { verb: 'counter', message: 'Ada Lovelace is busy', reasoning: 'Push back.' } }],
+        },
+        {
+          id: 'm1',
+          taskId: 'task-1',
+          senderId: `agent:${USER_A}`,
+          createdAt: new Date('2026-06-05T00:00:00Z'),
+          parts: [{ kind: 'data', data: { verb: 'outreach', message: 'Hello from ada@example.com', reasoning: 'Open.' } }],
+        },
+      ],
+      [{
+        taskId: 'task-1',
+        name: 'negotiation-outcome',
+        parts: [{ kind: 'data', data: { hasOpportunity: false, reason: 'screened_out', reasoning: 'Ada Lovelace is fundraising.' } }],
+      }],
+      terms,
+    );
+
+    expect(negotiations[0].messages.map((message) => message.seq)).toEqual([0, 1]);
+    expect(negotiations[0].messages[0].verb).toBe('outreach');
+    expect(negotiations[0].messages[0].role).toBe('agent');
+    expect(negotiations[0].messages[1].speaker_user_id).toBe(hmacId(SECRET, 'user', USER_B));
+    expect(JSON.stringify(negotiations)).not.toMatch(/Ada Lovelace/i);
+    expect(JSON.stringify(negotiations)).not.toMatch(/ada@example.com/i);
+    expect(JSON.stringify(negotiations)).not.toContain('payload');
+    expect(negotiations[0].outcome_reason).toBe('screened_out');
+    expect(negotiations[0].conversation_id).toBe(hmacId(SECRET, 'session', CONV_A));
+  });
+
+  it('counts accepted, rejected, and screened-out metrics', () => {
+    const metrics = buildMetrics({
+      networkTitle: 'Edge Esmeralda 2026',
+      networkIdKind: 'network',
+      networkRawId: 'net-1',
+      secret: SECRET,
+      users: transformUsers(SECRET, users),
+      intents: [],
+      opportunities: [
+        { status: 'accepted', actors: [{ acted_at: 'x' }] },
+        { status: 'rejected', actors: [{ acted_at: null }] },
+        { status: 'pending', actors: [] },
+      ] as ReturnType<typeof transformOpportunities>,
+      negotiations: [
+        { task_state: 'completed', outcome_reason: 'screened_out', outcome_has_opportunity: false, messages: [] },
+        { task_state: 'completed', outcome_reason: null, outcome_has_opportunity: true, messages: [{ verb: 'outreach', text: 'hi' }] },
+        { task_state: 'paused', outcome_reason: null, outcome_has_opportunity: null, messages: [{ verb: 'pause', text: 'pause:turn_cap' }] },
+      ] as ReturnType<typeof transformNegotiations>,
+    });
+    expect(metrics.opportunities_by_status).toEqual({ accepted: 1, rejected: 1, pending: 1 });
+    expect(metrics.negotiations_screened_out).toBe(1);
+    expect(metrics.negotiation_continue_turns).toBe(1);
+    expect(metrics.negotiation_pauses_by_reason).toEqual({ turn_cap: 1 });
+    expect(metrics.users).toBe(2);
+  });
+});


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What

Adds a read-only maintenance CLI that exports Edge Esmeralda matching data from Postgres as privacy-reduced JSONL:

- `users.jsonl`, `intents.jsonl`, `opportunities.jsonl`, `negotiations.jsonl`
- `metrics.json` (accepted/rejected/stalled/screened_out counts)
- `DATASET.md`

Identifiers are HMAC-SHA256 pseudonyms. Free text is dictionary- and regex-redacted. Negotiation briefs, pause payloads, embeddings, and contact fields are dropped.

## Why

ASU asked for Index matching data beyond the Hermes user-assistant chats already on Hugging Face: agent-to-agent negotiation logs and match accept/deny metrics.

## Usage

```bash
RESEARCH_HMAC_SECRET=... DATABASE_URL=... bun run maintenance:export-research-dump -- --confirm --out .cache/research-export
```

Output is gitignored. Do not commit the dump or the HMAC secret.

## Verification

`bun test src/cli/tests/research-export.spec.ts` — HMAC stability, PII redaction, A2A turn extraction, metrics.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-3ac7368f-623c-467b-86f7-4cabfc3be573?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-3ac7368f-623c-467b-86f7-4cabfc3be573&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

