### PR TITLE
refactor: replace negotiation round bookkeeping with an append-only event log

### DIFF
--- a/packages/protocol/src/capabilities/tests/fixtures/negotiation-host.fixture.ts
+++ b/packages/protocol/src/capabilities/tests/fixtures/negotiation-host.fixture.ts
@@ -1,12 +1,13 @@
 /**
- * In-memory host implementing the exact `NegotiationGraphDatabase` port both
- * the NegotiationGraph and the PersonalAgent read and write through.
+ * In-memory host implementing the exact `NegotiationGraphDatabase` and
+ * `NegotiationRoundLogDatabase` ports the NegotiationGraph and the
+ * PersonalAgent read and write through.
  *
  * Deliberately provider-free and dependency-free: the e2e specs that use it
  * run in the credential-free CI gate, driving the REAL compiled graphs
  * against this fake rather than mocking the graphs themselves.
  */
-import type { NegotiationGraphDatabase, NegotiationTaskRow } from "../../../platform/database/negotiation.js";
+import type { NegotiationGraphDatabase, NegotiationRoundLogDatabase, NegotiationRoundLogEventRecord, NegotiationTaskRow } from "../../../platform/database/negotiation.js";
 
 export const NETWORK_ID = "network-1";
 export const SOURCE_USER_ID = "alice";
@@ -28,10 +29,8 @@ export interface FakeMessage {
 }
 
 export class FakeNegotiationHost {
-  /** The intent's round lifecycle, exactly as the three columns behave. */
-  round = 1;
-  roundSize: number | null = null;
-  kickoffStartedAt: Date | null = null;
+  /** Per-intent batch lifecycle, exactly as `intents.negotiation_batch_id` behaves. */
+  readonly batchIds = new Map<string, string>();
   readonly opportunities = new Map<string, FakeOpportunity>();
   readonly tasks = new Map<string, NegotiationTaskRow>();
   readonly messages = new Map<string, FakeMessage[]>();
@@ -39,10 +38,13 @@ export class FakeNegotiationHost {
   readonly outcomeArtifacts = new Map<string, { verdict: 'pending' | 'reject'; reasoning?: string; resolvedByUserId: string }>();
   /** Test-only interleave immediately before the atomic completion snapshot. */
   beforeCompleteNegotiation?: () => void;
-  /** Deduped by one durable drain generation, exactly as BullMQ does. */
-  readonly reflectJobs: Array<{ userId: string; intentId: string; round: number; generation: string }> = [];
+  /** Deduped by one durable dedupe key, exactly as BullMQ does. */
+  readonly reflectJobs: Array<{ userId: string; intentId: string; batchId: string; dedupeKey: string }> = [];
+  /** `${intentId}::${batchId}` → append-order event log. */
+  readonly roundLogEvents = new Map<string, NegotiationRoundLogEventRecord[]>();
   private taskCounter = 0;
   private messageCounter = 0;
+  private batchCounter = 0;
 
   constructor(counterpartyUserIds: string[] = [CANDIDATE_USER_ID]) {
     counterpartyUserIds.forEach((userId, index) => {
@@ -63,6 +65,22 @@ export class FakeNegotiationHost {
     return this.opportunities.get(OPPORTUNITY_ID)!;
   }
 
+  /** Convenience accessor for INTENT_ID's own current batch — most specs only ever kick off one signal. */
+  get batchId(): string | null {
+    return this.batchIds.get(INTENT_ID) ?? null;
+  }
+
+  set batchId(value: string | null) {
+    if (value === null) this.batchIds.delete(INTENT_ID);
+    else this.batchIds.set(INTENT_ID, value);
+  }
+
+  /** Whether the given batch's round-log carries its opening_complete marker. */
+  isOpeningComplete(intentId: string = INTENT_ID, batchId: string | null = this.batchId): boolean {
+    if (!batchId) return false;
+    return (this.roundLogEvents.get(`${intentId}::${batchId}`) ?? []).some((event) => event.kind === "opening_complete");
+  }
+
   async createNegotiationTask(input: {
     conversationId: string;
     briefs: Record<string, string>;
@@ -73,7 +91,7 @@ export class FakeNegotiationHost {
       conversationId: input.conversationId,
       state: 'working',
       briefs: { ...input.briefs },
-      metadata: { drainGeneration: 0, ...input.metadata },
+      metadata: { ...input.metadata },
       createdAt: new Date(),
       updatedAt: new Date(),
     };
@@ -81,6 +99,17 @@ export class FakeNegotiationHost {
     this.messages.set(task.id, []);
     return task;
   }
+
+  readonly roundLog: NegotiationRoundLogDatabase = {
+    appendNegotiationRoundLogEvent: async (intentId, event) => {
+      const key = `${intentId}::${event.batchId}`;
+      const list = this.roundLogEvents.get(key) ?? [];
+      list.push({ ...event, createdAt: new Date() });
+      this.roundLogEvents.set(key, list);
+    },
+    readNegotiationRoundLogEvents: async (intentId, batchId) =>
+      [...(this.roundLogEvents.get(`${intentId}::${batchId}`) ?? [])],
+  };
 
   readonly database: NegotiationGraphDatabase = {
     getOpportunity: async (id: string) => (this.opportunities.get(id) as never) ?? null,
@@ -120,7 +149,6 @@ export class FakeNegotiationHost {
           initiatorUserId: input.sourceUserId,
           networkId: input.networkId,
           seats: input.seats,
-          drainGeneration: 0,
         },
         createdAt: new Date(),
         updatedAt: new Date(),
@@ -146,9 +174,6 @@ export class FakeNegotiationHost {
         state,
         metadata: {
           ...task.metadata,
-          ...(state === "working" && task.state === "paused"
-            ? { drainGeneration: task.metadata.drainGeneration + 1 }
-            : {}),
           ...(pause !== undefined || state === "working" ? { pause: pause ?? null } : {}),
         },
         updatedAt: new Date(),
@@ -232,49 +257,42 @@ export class FakeNegotiationHost {
       });
     },
     getArtifactsForTask: async () => [],
-    getNegotiationTasksForIntentRound: async (intentId, round) =>
-      [...this.tasks.values()].filter((t) => t.metadata.seats[intentId]?.round === round),
-    // Signal-scoped on purpose: a negotiation a later round left behind must
+    getNegotiationTasksForIntentBatch: async (intentId, batchId) =>
+      [...this.tasks.values()].filter((t) => t.metadata.seats[intentId]?.batchId === batchId),
+    // Signal-scoped on purpose: a negotiation a later batch left behind must
     // stay visible, or it can never be promoted or rejected.
     getPausedNegotiationTasksForIntent: async (intentId) =>
       [...this.tasks.values()].filter((t) => intentId in t.metadata.seats && t.state === "paused"),
-    // One write: the bump clears the stamp AND marks the kickoff as begun.
-    bumpIntentNegotiationRound: async () => {
-      this.roundSize = null;
-      this.kickoffStartedAt = new Date();
-      return (this.round += 1);
+    bumpIntentNegotiationBatch: async (intentId: string) => {
+      const batchId = `batch-${++this.batchCounter}`;
+      this.batchIds.set(intentId, batchId);
+      return { batchId };
     },
-    getIntentNegotiationRound: async (intentId) => intentId === INTENT_ID ? ({
-      round: this.round,
-      roundSize: this.roundSize,
-      kickoffStartedAt: this.kickoffStartedAt,
-    }) : ({
-      // A counterparty that did not initiate a kickoff still owns a durable
-      // drain. Its passive round has no in-progress size gate.
-      round: 0,
-      roundSize: null,
-      kickoffStartedAt: null,
+    getIntentNegotiationBatch: async (intentId) => ({
+      batchId: this.batchIds.get(intentId) ?? null,
     }),
-    stampIntentNegotiationRoundSize: async (_intentId, round, size) => {
-      if (round === this.round) this.roundSize = size;
-    },
-    countActiveNegotiationsForRound: async (intentId, round) =>
+    countActiveNegotiationsForBatch: async (intentId, batchId) =>
       [...this.tasks.values()].filter((t) =>
-        t.metadata.seats[intentId]?.round === round && t.state !== "paused" && t.state !== "completed").length,
+        t.metadata.seats[intentId]?.batchId === batchId && t.state !== "paused" && t.state !== "completed").length,
   };
 
   /**
-   * Push the kickoff marker past the staleness bound, so a later turn reads
-   * the round as abandoned rather than in flight (D20).
+   * Push every event of the given batch's log past the staleness bound, so a
+   * later turn reads the batch as abandoned rather than in flight (D20).
    */
-  ageKickoff(byMs = 11 * 60 * 1000): void {
-    if (this.kickoffStartedAt) this.kickoffStartedAt = new Date(this.kickoffStartedAt.getTime() - byMs);
+  ageKickoff(byMs = 11 * 60 * 1000, intentId: string = INTENT_ID, batchId?: string | null): void {
+    const resolvedBatchId = batchId ?? this.batchIds.get(intentId) ?? null;
+    if (!resolvedBatchId) return;
+    const key = `${intentId}::${resolvedBatchId}`;
+    const list = this.roundLogEvents.get(key);
+    if (!list) return;
+    this.roundLogEvents.set(key, list.map((event) => ({ ...event, createdAt: new Date(event.createdAt.getTime() - byMs) })));
   }
 
-  /** Records a reflect job the way the queue does: once per durable generation. */
-  enqueueReflect(job: { userId: string; intentId: string; round: number; generation: string }): void {
+  /** Records a reflect job the way the queue does: once per durable dedupe key. */
+  enqueueReflect(job: { userId: string; intentId: string; batchId: string; dedupeKey: string }): void {
     if (this.reflectJobs.some((existing) =>
-      existing.intentId === job.intentId && existing.round === job.round && existing.generation === job.generation)) return;
+      existing.intentId === job.intentId && existing.batchId === job.batchId && existing.dedupeKey === job.dedupeKey)) return;
     this.reflectJobs.push(job);
   }
 

--- a/packages/protocol/src/capabilities/tests/negotiations.e2e.spec.ts
+++ b/packages/protocol/src/capabilities/tests/negotiations.e2e.spec.ts
@@ -3,7 +3,7 @@ import { describe, expect, test } from "bun:test";
 import { CANDIDATE_USER_ID, FakeNegotiationHost, INTENT_ID, NETWORK_ID, OPPORTUNITY_ID, SOURCE_USER_ID } from "./fixtures/negotiation-host.fixture.js";
 import type { NegotiationTurnAuthor, NegotiationTurnAuthorInput } from "../../internal/negotiations/negotiation.turn-author.js";
 import { NegotiationAuthoredTurnSchema, NegotiationOpeningTurnSchema } from "../../internal/negotiations/negotiation.turn.js";
-import type { NegotiationAuthoredTurn, NegotiationTurn } from "../../internal/negotiations/negotiation.turn.js";
+import type { NegotiationAuthoredTurn } from "../../internal/negotiations/negotiation.turn.js";
 import { maybeEnqueueRoundReflect } from "../../internal/negotiations/negotiation.round-reflect.js";
 import { Negotiations } from "../negotiations.js";
 
@@ -65,10 +65,11 @@ describe("NegotiationGraph — open, turns, pause, resume, verdict", () => {
     const host = new FakeNegotiationHost();
     const graph = new Negotiations({
       database: host.database,
+      roundLog: host.roundLog,
       author: { authorTurn: async () => { throw new Error("provider unavailable"); } },
     }).createGraph();
 
-    const result = await graph.invoke({ opportunityId: OPPORTUNITY_ID, intentId: INTENT_ID, brief: "brief", round: 1 });
+    const result = await graph.invoke({ opportunityId: OPPORTUNITY_ID, intentId: INTENT_ID, brief: "brief", batchId: "batch-1" });
 
     expect(result).toMatchObject({ status: "paused", pause: { reason: "open_failed" } });
     expect(host.taskFor(result.negotiationId).metadata.pause).toMatchObject({
@@ -88,8 +89,7 @@ describe("NegotiationGraph — open, turns, pause, resume, verdict", () => {
       candidateUserId: CANDIDATE_USER_ID,
       initiatorUserId: SOURCE_USER_ID,
       networkId: NETWORK_ID,
-      seats: { [passiveIntentId]: { userId: CANDIDATE_USER_ID, round: 0 } },
-      drainGeneration: 0,
+      seats: { [passiveIntentId]: { userId: CANDIDATE_USER_ID, batchId: "batch-0" } },
     });
     const paused = await host.createNegotiationTask({
       conversationId: "conversation-paused",
@@ -101,14 +101,21 @@ describe("NegotiationGraph — open, turns, pause, resume, verdict", () => {
       briefs: {},
       metadata: metadata("opportunity-submitted"),
     });
+    // Both tasks belong to the same batch of the passive seat's log, and its
+    // opening_complete marker lands only once — as kickoff would append it
+    // after both parallel opens settled.
+    await host.roundLog.appendNegotiationRoundLogEvent(passiveIntentId, { kind: "opened", taskId: paused.id, batchId: "batch-0" });
+    await host.roundLog.appendNegotiationRoundLogEvent(passiveIntentId, { kind: "opened", taskId: submitted.id, batchId: "batch-0" });
+    await host.roundLog.appendNegotiationRoundLogEvent(passiveIntentId, { kind: "opening_complete", batchId: "batch-0" });
     await host.database.updateNegotiationTaskState(paused.id, "paused", {
       reason: "needs_principal",
       pausedBy: CANDIDATE_USER_ID,
     });
     host.tasks.set(submitted.id, { ...submitted, state: "submitted" });
 
-    const check = { userId: CANDIDATE_USER_ID, intentId: passiveIntentId, round: 0 };
-    await maybeEnqueueRoundReflect(host.database, async (job) => { host.enqueueReflect(job); }, check);
+    const check = { userId: CANDIDATE_USER_ID, intentId: passiveIntentId, batchId: "batch-0" };
+    await host.roundLog.appendNegotiationRoundLogEvent(passiveIntentId, { kind: "stopped", taskId: paused.id, batchId: "batch-0", via: "paused", reason: "needs_principal" });
+    await maybeEnqueueRoundReflect(host.roundLog, async (job) => { host.enqueueReflect(job); }, check);
     expect(host.reflectJobs).toEqual([]);
 
     host.tasks.set(submitted.id, {
@@ -119,11 +126,12 @@ describe("NegotiationGraph — open, turns, pause, resume, verdict", () => {
         pause: { reason: "needs_principal", pausedBy: CANDIDATE_USER_ID },
       },
     });
-    await maybeEnqueueRoundReflect(host.database, async (job) => { host.enqueueReflect(job); }, check);
+    await host.roundLog.appendNegotiationRoundLogEvent(passiveIntentId, { kind: "stopped", taskId: submitted.id, batchId: "batch-0", via: "paused", reason: "needs_principal" });
+    await maybeEnqueueRoundReflect(host.roundLog, async (job) => { host.enqueueReflect(job); }, check);
 
     expect(host.reflectJobs).toEqual([{
       ...check,
-      generation: "task-1.0_task-2.0",
+      dedupeKey: `${paused.id}.3_${submitted.id}.4`,
     }]);
   });
 
@@ -145,8 +153,8 @@ describe("NegotiationGraph — open, turns, pause, resume, verdict", () => {
         return null;
       },
     };
-    const graph = new Negotiations({ database, author }).createGraph();
-    const input = { opportunityId: OPPORTUNITY_ID, intentId: INTENT_ID, brief: "brief", round: 1 };
+    const graph = new Negotiations({ database, roundLog: host.roundLog, author }).createGraph();
+    const input = { opportunityId: OPPORTUNITY_ID, intentId: INTENT_ID, brief: "brief", batchId: "batch-1" };
 
     await Promise.all([graph.invoke(input), graph.invoke(input)]);
 
@@ -166,15 +174,14 @@ describe("NegotiationGraph — open, turns, pause, resume, verdict", () => {
     ]);
     const graph = new Negotiations({
       database: host.database,
+      roundLog: host.roundLog,
       author,
       reflectEnqueue: async (job) => { host.enqueueReflect(job); },
     }).createGraph();
-    host.kickoffStartedAt = new Date();
-
     // open: self-play authors the opening turn (alice), loops straight into
     // the reply seat (bob), which immediately pauses per the script —
     // exactly one call, two persisted turns (outreach + redacted pause marker).
-    const opened = await graph.invoke({ opportunityId: OPPORTUNITY_ID, intentId: INTENT_ID, brief: "Alice wants a technical co-founder.", round: 1 });
+    const opened = await graph.invoke({ opportunityId: OPPORTUNITY_ID, intentId: INTENT_ID, brief: "Alice wants a technical co-founder.", batchId: "batch-1" });
     expect(opened.status).toBe("paused");
     expect(opened.turns).toHaveLength(2);
     expect(opened.turns[0]).toMatchObject({ verb: "outreach" });
@@ -188,20 +195,24 @@ describe("NegotiationGraph — open, turns, pause, resume, verdict", () => {
       payload: { question: "What equity split are you open to?" },
     });
     expect(host.taskFor(negotiationId).state).toBe("paused");
-    // The initiating round waits for its size stamp, while Bob's passive seat
-    // is already durably bound and wakes immediately.
+    // Alice's own batch waits on a kickoff to mark opening_complete (nobody
+    // called it here, this test drives the graph directly), while Bob's
+    // never-kicked-off seat got a batch lazily on first touch, marked
+    // opening_complete immediately — so it settles and wakes as soon as this
+    // one task stops.
+    const bobBatchId = host.taskFor(negotiationId).metadata.seats["intent-bob-1"]!.batchId!;
     expect(host.reflectJobs).toEqual([{
       userId: CANDIDATE_USER_ID,
       intentId: "intent-bob-1",
-      round: 0,
-      generation: "task-1.0",
+      batchId: bobBatchId,
+      dedupeKey: `${negotiationId}.2`,
     }]);
-    // Kickoff's own post-settle stamp, replayed here by hand.
-    await host.database.stampIntentNegotiationRoundSize(INTENT_ID, 1, 1);
-    await maybeEnqueueRoundReflect(host.database, async (job) => { host.enqueueReflect(job); }, {
+    // Kickoff's own post-settle marker, replayed here by hand.
+    await host.roundLog.appendNegotiationRoundLogEvent(INTENT_ID, { kind: "opening_complete", batchId: "batch-1" });
+    await maybeEnqueueRoundReflect(host.roundLog, async (job) => { host.enqueueReflect(job); }, {
       userId: SOURCE_USER_ID,
       intentId: INTENT_ID,
-      round: 1,
+      batchId: "batch-1",
     });
 
     // resume with brief: IS-A answered the equity question (read from the task directly,
@@ -216,11 +227,14 @@ describe("NegotiationGraph — open, turns, pause, resume, verdict", () => {
       pausedBy: SOURCE_USER_ID,
       payload: { recommendation: "pending" },
     });
-    // The reopened pause is a new durable generation for both bound seats.
+    // The reopened pause is a new durable settle for both bound seats. Alice's
+    // batch never had an 'opened' event recorded (this test drives the graph
+    // directly, bypassing kickoff's own append) — its fold sees zero opened
+    // tasks and settles as the empty-batch case, both before and after resume.
     expect(host.reflectJobs).toEqual(expect.arrayContaining([
-      { userId: SOURCE_USER_ID, intentId: INTENT_ID, round: 1, generation: "task-1.0" },
-      { userId: SOURCE_USER_ID, intentId: INTENT_ID, round: 1, generation: "task-1.1" },
-      { userId: CANDIDATE_USER_ID, intentId: "intent-bob-1", round: 0, generation: "task-1.1" },
+      { userId: CANDIDATE_USER_ID, intentId: "intent-bob-1", batchId: bobBatchId, dedupeKey: `${negotiationId}.2` },
+      { userId: SOURCE_USER_ID, intentId: INTENT_ID, batchId: "batch-1", dedupeKey: "empty" },
+      { userId: CANDIDATE_USER_ID, intentId: "intent-bob-1", batchId: bobBatchId, dedupeKey: `${negotiationId}.4` },
     ]));
 
     // verdict: IS-A promotes to pending — the only terminal write
@@ -251,11 +265,12 @@ describe("NegotiationGraph — open, turns, pause, resume, verdict", () => {
     const notifications: Array<{ userId: string; intentId: string; negotiationId: string; verdict: "pending" | "reject" }> = [];
     const graph = new Negotiations({
       database: host.database,
+      roundLog: host.roundLog,
       author,
       resolutionEnqueue: async (input) => { notifications.push(input); },
     }).createGraph();
 
-    const opened = await graph.invoke({ opportunityId: OPPORTUNITY_ID, intentId: INTENT_ID, brief: "brief", round: 1 });
+    const opened = await graph.invoke({ opportunityId: OPPORTUNITY_ID, intentId: INTENT_ID, brief: "brief", batchId: "batch-1" });
     expect(opened.status).toBe("paused");
     expect(opened.pause).toEqual({ reason: "ready_for_verdict" });
     expect(host.taskFor(opened.negotiationId).metadata.pause).toMatchObject({
@@ -281,8 +296,8 @@ describe("NegotiationGraph — open, turns, pause, resume, verdict", () => {
       { verb: "outreach", message: "Opening.", reasoning: "r" },
       { verb: "pause", reason: "ready_for_verdict", payload: { recommendation: "reject", reasoning: "Not a fit." } },
     ]);
-    const graph = new Negotiations({ database: host.database, author }).createGraph();
-    const opened = await graph.invoke({ opportunityId: OPPORTUNITY_ID, intentId: INTENT_ID, brief: "brief", round: 1 });
+    const graph = new Negotiations({ database: host.database, roundLog: host.roundLog, author }).createGraph();
+    const opened = await graph.invoke({ opportunityId: OPPORTUNITY_ID, intentId: INTENT_ID, brief: "brief", batchId: "batch-1" });
 
     const result = await graph.invoke({
       negotiationId: opened.negotiationId,
@@ -302,8 +317,8 @@ describe("NegotiationGraph — open, turns, pause, resume, verdict", () => {
       { verb: "outreach", message: "Opening.", reasoning: "r" },
       { verb: "pause", reason: "ready_for_verdict", payload: { recommendation: "reject", reasoning: "Not a fit." } },
     ]);
-    const graph = new Negotiations({ database: host.database, author }).createGraph();
-    const opened = await graph.invoke({ opportunityId: OPPORTUNITY_ID, intentId: INTENT_ID, brief: "brief", round: 1 });
+    const graph = new Negotiations({ database: host.database, roundLog: host.roundLog, author }).createGraph();
+    const opened = await graph.invoke({ opportunityId: OPPORTUNITY_ID, intentId: INTENT_ID, brief: "brief", batchId: "batch-1" });
     expect(host.taskFor(opened.negotiationId).metadata.pause?.pausedBy).toBe(CANDIDATE_USER_ID);
     host.opportunity.status = "accepted";
 
@@ -327,8 +342,8 @@ describe("NegotiationGraph — open, turns, pause, resume, verdict", () => {
       { verb: "outreach", message: "Opening.", reasoning: "r" },
       { verb: "pause", reason: "ready_for_verdict", payload: { recommendation: "reject", reasoning: "Not a fit." } },
     ]);
-    const graph = new Negotiations({ database: host.database, author }).createGraph();
-    const opened = await graph.invoke({ opportunityId: OPPORTUNITY_ID, intentId: INTENT_ID, brief: "brief", round: 1 });
+    const graph = new Negotiations({ database: host.database, roundLog: host.roundLog, author }).createGraph();
+    const opened = await graph.invoke({ opportunityId: OPPORTUNITY_ID, intentId: INTENT_ID, brief: "brief", batchId: "batch-1" });
     host.beforeCompleteNegotiation = () => {
       host.opportunity.status = "accepted";
     };
@@ -349,7 +364,7 @@ describe("NegotiationGraph — open, turns, pause, resume, verdict", () => {
   test("an expired opportunity closes its active task without inventing an owner verdict", async () => {
     const host = new FakeNegotiationHost();
     const author = new ScriptedTurnAuthor(host, []);
-    const graph = new Negotiations({ database: host.database, author }).createGraph();
+    const graph = new Negotiations({ database: host.database, roundLog: host.roundLog, author }).createGraph();
     const task = await host.createNegotiationTask({
       conversationId: "conversation-expired",
       briefs: {},
@@ -360,8 +375,7 @@ describe("NegotiationGraph — open, turns, pause, resume, verdict", () => {
         candidateUserId: CANDIDATE_USER_ID,
         initiatorUserId: SOURCE_USER_ID,
         networkId: NETWORK_ID,
-        seats: { [INTENT_ID]: { userId: SOURCE_USER_ID, round: 1 } },
-        drainGeneration: 0,
+        seats: { [INTENT_ID]: { userId: SOURCE_USER_ID, batchId: "batch-1" } },
       },
     });
     host.opportunity.status = "expired";
@@ -382,9 +396,9 @@ describe("NegotiationGraph — open, turns, pause, resume, verdict", () => {
       { verb: "outreach", message: "Opening.", reasoning: "r" },
       { verb: "pause", reason: "needs_principal", payload: { question: "?" } },
     ]);
-    const graph = new Negotiations({ database: host.database, author }).createGraph();
+    const graph = new Negotiations({ database: host.database, roundLog: host.roundLog, author }).createGraph();
 
-    const opened = await graph.invoke({ opportunityId: OPPORTUNITY_ID, intentId: INTENT_ID, brief: "brief", round: 1 });
+    const opened = await graph.invoke({ opportunityId: OPPORTUNITY_ID, intentId: INTENT_ID, brief: "brief", batchId: "batch-1" });
     expect(opened.status).toBe("paused");
     const callsBeforeTimeout = author.calls.length;
 
@@ -406,9 +420,9 @@ describe("NegotiationGraph — external turn submission (respond_to_negotiation 
     // seat immediately falls back to pause(needs_principal) — self-play stops
     // after exactly one real turn, handing control to explicit test invokes.
     const author = new ScriptedTurnAuthor(host, []);
-    const graph = new Negotiations({ database: host.database, author }).createGraph();
+    const graph = new Negotiations({ database: host.database, roundLog: host.roundLog, author }).createGraph();
 
-    const opened = await graph.invoke({ opportunityId: OPPORTUNITY_ID, intentId: INTENT_ID, brief: "brief", round: 1 });
+    const opened = await graph.invoke({ opportunityId: OPPORTUNITY_ID, intentId: INTENT_ID, brief: "brief", batchId: "batch-1" });
     expect(opened.status).toBe("paused");
     expect(opened.turns).toHaveLength(2); // fallback outreach + bob's fallback pause
     expect(opened.pause).toEqual({ reason: "needs_principal" });
@@ -447,9 +461,9 @@ describe("NegotiationGraph — external turn submission (respond_to_negotiation 
   test("an externally submitted turn is re-validated at the graph's own boundary, not trusted verbatim", async () => {
     const host = new FakeNegotiationHost();
     const author = new ScriptedTurnAuthor(host, []);
-    const graph = new Negotiations({ database: host.database, author }).createGraph();
+    const graph = new Negotiations({ database: host.database, roundLog: host.roundLog, author }).createGraph();
 
-    const opened = await graph.invoke({ opportunityId: OPPORTUNITY_ID, intentId: INTENT_ID, brief: "brief", round: 1 });
+    const opened = await graph.invoke({ opportunityId: OPPORTUNITY_ID, intentId: INTENT_ID, brief: "brief", batchId: "batch-1" });
     expect(opened.status).toBe("paused"); // fallback outreach, then bob's fallback pause
     const negotiationId = opened.negotiationId;
     const messagesBefore = host.messages.get(negotiationId)!.length;
@@ -473,9 +487,9 @@ describe("NegotiationGraph — external turn submission (respond_to_negotiation 
       { verb: "outreach", message: "Hi Bob.", reasoning: "r" },
       { verb: "pause", reason: "needs_principal", payload: { question: "?" } },
     ]);
-    const graph = new Negotiations({ database: host.database, author }).createGraph();
+    const graph = new Negotiations({ database: host.database, roundLog: host.roundLog, author }).createGraph();
 
-    const opened = await graph.invoke({ opportunityId: OPPORTUNITY_ID, intentId: INTENT_ID, brief: "brief", round: 1 });
+    const opened = await graph.invoke({ opportunityId: OPPORTUNITY_ID, intentId: INTENT_ID, brief: "brief", batchId: "batch-1" });
     expect(opened.status).toBe("paused"); // outreach, then bob's scripted needs_principal
     const negotiationId = opened.negotiationId;
 
@@ -516,9 +530,9 @@ describe("NegotiationGraph — external turn submission (respond_to_negotiation 
       { userId: CANDIDATE_USER_ID, intent: INTENT_ID, networkId: NETWORK_ID, role: "agent" },
     ];
     const author = new ScriptedTurnAuthor(host, [{ verb: "outreach", message: "Hi Bob.", reasoning: "r" }]);
-    const graph = new Negotiations({ database: host.database, author }).createGraph();
+    const graph = new Negotiations({ database: host.database, roundLog: host.roundLog, author }).createGraph();
 
-    const opened = await graph.invoke({ opportunityId: OPPORTUNITY_ID, intentId: INTENT_ID, brief: "brief", round: 1 });
+    const opened = await graph.invoke({ opportunityId: OPPORTUNITY_ID, intentId: INTENT_ID, brief: "brief", batchId: "batch-1" });
     expect(opened).toMatchObject({ status: "error", error: "Counterparty actor intent is not owned by that seat" });
     expect(host.tasks.size).toBe(0);
   });
@@ -531,9 +545,9 @@ describe("NegotiationGraph — external turn submission (respond_to_negotiation 
       { userId: "carol-introducer", intent: INTENT_ID, networkId: NETWORK_ID, role: "introducer", approved: true },
     ];
     const author = new ScriptedTurnAuthor(host, [{ verb: "outreach", message: "Hi Bob.", reasoning: "r" }]);
-    const graph = new Negotiations({ database: host.database, author }).createGraph();
+    const graph = new Negotiations({ database: host.database, roundLog: host.roundLog, author }).createGraph();
 
-    const opened = await graph.invoke({ opportunityId: OPPORTUNITY_ID, intentId: INTENT_ID, brief: "brief", round: 1 });
+    const opened = await graph.invoke({ opportunityId: OPPORTUNITY_ID, intentId: INTENT_ID, brief: "brief", batchId: "batch-1" });
     expect(opened.status).toBe("paused"); // outreach, then bob's fallback pause
     const task = host.taskFor(opened.negotiationId);
     expect(task.metadata.sourceUserId).toBe(SOURCE_USER_ID);
@@ -552,9 +566,9 @@ describe("NegotiationGraph — external turn submission (respond_to_negotiation 
       { userId: "carol-introducer", intent: INTENT_ID, networkId: NETWORK_ID, role: "introducer" },
     ];
     const author = new ScriptedTurnAuthor(host, [{ verb: "outreach", message: "Hi Bob.", reasoning: "r" }]);
-    const graph = new Negotiations({ database: host.database, author }).createGraph();
+    const graph = new Negotiations({ database: host.database, roundLog: host.roundLog, author }).createGraph();
 
-    const opened = await graph.invoke({ opportunityId: OPPORTUNITY_ID, intentId: INTENT_ID, brief: "brief", round: 1 });
+    const opened = await graph.invoke({ opportunityId: OPPORTUNITY_ID, intentId: INTENT_ID, brief: "brief", batchId: "batch-1" });
 
     expect(opened.status).toBe("error");
     expect(opened.error).toContain("introducer approval");
@@ -571,9 +585,9 @@ describe("NegotiationGraph — external turn submission (respond_to_negotiation 
     // own outreach-only-first guard rejects it, forever.
     const host = new FakeNegotiationHost();
     const author = new ScriptedTurnAuthor(host, [{ verb: "outreach", message: "First real turn.", reasoning: "r" }]);
-    const graph = new Negotiations({ database: host.database, author }).createGraph();
+    const graph = new Negotiations({ database: host.database, roundLog: host.roundLog, author }).createGraph();
 
-    const opened = await graph.invoke({ opportunityId: OPPORTUNITY_ID, intentId: INTENT_ID, brief: "brief", round: 1 });
+    const opened = await graph.invoke({ opportunityId: OPPORTUNITY_ID, intentId: INTENT_ID, brief: "brief", batchId: "batch-1" });
     const negotiationId = opened.negotiationId;
 
     // Replace the real history with a legacy-shaped message — simulating a
@@ -582,7 +596,7 @@ describe("NegotiationGraph — external turn submission (respond_to_negotiation 
       { id: "legacy-1", senderId: `agent:${SOURCE_USER_ID}`, parts: [{ kind: "data", data: { action: "accept" } }], createdAt: new Date() },
     ]);
 
-    const rekicked = await graph.invoke({ opportunityId: OPPORTUNITY_ID, intentId: INTENT_ID, brief: "brief", round: 2 });
+    const rekicked = await graph.invoke({ opportunityId: OPPORTUNITY_ID, intentId: INTENT_ID, brief: "brief", batchId: "batch-2" });
     expect(rekicked.status).not.toBe("error");
     expect(rekicked.negotiationId).toBe(negotiationId);
   });
@@ -590,19 +604,19 @@ describe("NegotiationGraph — external turn submission (respond_to_negotiation 
   test("resuming an opportunity that already has a negotiation is idempotent, not a second open", async () => {
     const host = new FakeNegotiationHost();
     const author = new ScriptedTurnAuthor(host, [{ verb: "outreach", message: "Opening.", reasoning: "r" }]);
-    const graph = new Negotiations({ database: host.database, author }).createGraph();
+    const graph = new Negotiations({ database: host.database, roundLog: host.roundLog, author }).createGraph();
 
-    const first = await graph.invoke({ opportunityId: OPPORTUNITY_ID, intentId: INTENT_ID, brief: "brief", round: 1 });
+    const first = await graph.invoke({ opportunityId: OPPORTUNITY_ID, intentId: INTENT_ID, brief: "brief", batchId: "batch-1" });
     // A second `{ opportunityId, brief }` invoke (e.g. discovery re-running) finds the existing task and
     // updates its brief instead of creating a second negotiation for the same opportunity.
-    const second = await graph.invoke({ opportunityId: OPPORTUNITY_ID, intentId: INTENT_ID, brief: "updated brief", round: 2 });
+    const second = await graph.invoke({ opportunityId: OPPORTUNITY_ID, intentId: INTENT_ID, brief: "updated brief", batchId: "batch-2" });
 
     expect(second.negotiationId).toBe(first.negotiationId);
     expect(host.taskFor(first.negotiationId).briefs[SOURCE_USER_ID]).toBe("updated brief");
     expect([...host.tasks.values()]).toHaveLength(1);
     // The second kickoff's round must land on the task, not the round it opened with —
     // checkAllPaused's round-scoped count and the eventual pause both key off this.
-    expect(host.taskFor(first.negotiationId).metadata.seats[INTENT_ID]!.round).toBe(2);
+    expect(host.taskFor(first.negotiationId).metadata.seats[INTENT_ID]!.batchId).toBe("batch-2");
   });
 
   test("a turn rejected for the wrong seat does not resume a paused negotiation", async () => {
@@ -611,9 +625,9 @@ describe("NegotiationGraph — external turn submission (respond_to_negotiation 
       { verb: "outreach", message: "Hi Bob.", reasoning: "r" },
       { verb: "pause", reason: "needs_principal", payload: { question: "What equity split?" } },
     ]);
-    const graph = new Negotiations({ database: host.database, author }).createGraph();
+    const graph = new Negotiations({ database: host.database, roundLog: host.roundLog, author }).createGraph();
 
-    const opened = await graph.invoke({ opportunityId: OPPORTUNITY_ID, intentId: INTENT_ID, brief: "brief", round: 1 });
+    const opened = await graph.invoke({ opportunityId: OPPORTUNITY_ID, intentId: INTENT_ID, brief: "brief", batchId: "batch-1" });
     const negotiationId = opened.negotiationId;
     expect(opened.status).toBe("paused");
     expect(opened.pause).toEqual({ reason: "needs_principal" });
@@ -641,9 +655,9 @@ describe("NegotiationGraph — external turn submission (respond_to_negotiation 
       { verb: "outreach", message: "Hi Bob.", reasoning: "r" },
       { verb: "pause", reason: "needs_principal", payload: { question: "What equity split?" } },
     ]);
-    const graph = new Negotiations({ database: host.database, author }).createGraph();
+    const graph = new Negotiations({ database: host.database, roundLog: host.roundLog, author }).createGraph();
 
-    const opened = await graph.invoke({ opportunityId: OPPORTUNITY_ID, intentId: INTENT_ID, brief: "brief", round: 1 });
+    const opened = await graph.invoke({ opportunityId: OPPORTUNITY_ID, intentId: INTENT_ID, brief: "brief", batchId: "batch-1" });
     const negotiationId = opened.negotiationId;
     expect(host.taskFor(negotiationId).metadata.pause).toMatchObject({ reason: "needs_principal", pausedBy: CANDIDATE_USER_ID });
 
@@ -680,8 +694,8 @@ describe("NegotiationGraph — external turn submission (respond_to_negotiation 
     test("pause markers mixed into history do not trip the cap early", async () => {
       const host = new FakeNegotiationHost();
       const author = new ScriptedTurnAuthor(host, [{ verb: "outreach", message: "Opening.", reasoning: "r" }]);
-      const graph = new Negotiations({ database: host.database, author }).createGraph();
-      const opened = await graph.invoke({ opportunityId: OPPORTUNITY_ID, intentId: INTENT_ID, brief: "brief", round: 1 });
+      const graph = new Negotiations({ database: host.database, roundLog: host.roundLog, author }).createGraph();
+      const opened = await graph.invoke({ opportunityId: OPPORTUNITY_ID, intentId: INTENT_ID, brief: "brief", batchId: "batch-1" });
       const negotiationId = opened.negotiationId;
 
       // 2 substantive turns + 4 pause markers = 6 raw messages (the old,
@@ -708,8 +722,8 @@ describe("NegotiationGraph — external turn submission (respond_to_negotiation 
     test("an externally submitted turn that hits the cap is rejected, not silently swapped for a pause", async () => {
       const host = new FakeNegotiationHost();
       const author = new ScriptedTurnAuthor(host, [{ verb: "outreach", message: "Opening.", reasoning: "r" }]);
-      const graph = new Negotiations({ database: host.database, author }).createGraph();
-      const opened = await graph.invoke({ opportunityId: OPPORTUNITY_ID, intentId: INTENT_ID, brief: "brief", round: 1 });
+      const graph = new Negotiations({ database: host.database, roundLog: host.roundLog, author }).createGraph();
+      const opened = await graph.invoke({ opportunityId: OPPORTUNITY_ID, intentId: INTENT_ID, brief: "brief", batchId: "batch-1" });
       const negotiationId = opened.negotiationId;
 
       // 5 substantive turns already on record, alternating, ending on alice —
@@ -745,12 +759,12 @@ describe("NegotiationGraph — external turn submission (respond_to_negotiation 
           candidateUserId: CANDIDATE_USER_ID,
           initiatorUserId: SOURCE_USER_ID,
           networkId: NETWORK_ID,
-          seats: { [INTENT_ID]: { userId: SOURCE_USER_ID, round: 1 } },
+          seats: { [INTENT_ID]: { userId: SOURCE_USER_ID, batchId: "batch-1" } },
         },
       });
       const negotiationId = task.id;
       const author = new ScriptedTurnAuthor(host, [{ verb: "counter", message: "one more thing", reasoning: "r" }]);
-      const graph = new Negotiations({ database: host.database, author }).createGraph();
+      const graph = new Negotiations({ database: host.database, roundLog: host.roundLog, author }).createGraph();
 
       // 5 turns ending on bob (candidate) — alice is next, authored internally
       // (script[0]) since there is no more per-seat external/internal split.
@@ -774,9 +788,9 @@ describe("NegotiationGraph — external turn submission (respond_to_negotiation 
   test("a concurrent duplicate submission is fenced, not silently double-applied", async () => {
     const host = new FakeNegotiationHost();
     const author = new ScriptedTurnAuthor(host, [{ verb: "outreach", message: "Opening.", reasoning: "r" }]);
-    const graph = new Negotiations({ database: host.database, author }).createGraph();
+    const graph = new Negotiations({ database: host.database, roundLog: host.roundLog, author }).createGraph();
 
-    const opened = await graph.invoke({ opportunityId: OPPORTUNITY_ID, intentId: INTENT_ID, brief: "brief", round: 1 });
+    const opened = await graph.invoke({ opportunityId: OPPORTUNITY_ID, intentId: INTENT_ID, brief: "brief", batchId: "batch-1" });
     const negotiationId = opened.negotiationId;
     expect(opened.status).toBe("paused"); // outreach, then bob's fallback pause
 
@@ -818,10 +832,10 @@ describe("NegotiationGraph — external turn submission (respond_to_negotiation 
         candidateUserId: CANDIDATE_USER_ID,
         initiatorUserId: SOURCE_USER_ID,
         networkId: NETWORK_ID,
-        seats: { [INTENT_ID]: { userId: SOURCE_USER_ID, round: 1 } },
+        seats: { [INTENT_ID]: { userId: SOURCE_USER_ID, batchId: "batch-1" } },
       },
     });
-    const graph = new Negotiations({ database: host.database, author: new ScriptedTurnAuthor(host, []) }).createGraph();
+    const graph = new Negotiations({ database: host.database, roundLog: host.roundLog, author: new ScriptedTurnAuthor(host, []) }).createGraph();
 
     const timedOut = await graph.invoke({ negotiationId: task.id, pause: "counterparty_silent" });
     expect(timedOut.status).toBe("paused");

--- a/packages/protocol/src/capabilities/tests/personal-agent.e2e.spec.ts
+++ b/packages/protocol/src/capabilities/tests/personal-agent.e2e.spec.ts
@@ -244,9 +244,13 @@ function buildCycle(judgment: ScriptedJudgment, counterparties: string[]) {
   const wakes: Array<{ userId: string; intentId: string }> = [];
   const needsPrincipalWakes: Array<{ userId: string; intentId: string; negotiationId: string; generation: number }> = [];
   const negotiationInputs: Array<{ userId: string; intentId: string; negotiationId: string }> = [];
-  let agent: PersonalAgentGraphLike;
+  // `agent` is referenced inside `negotiations`'s closure below but not
+  // invoked until a later turn, so it can be declared after — same
+  // lazily-closed mutual dependency negotiation-graph.ts's own composition
+  // root uses between negotiationGraph and personalAgentGraph.
   const negotiations = new Negotiations({
     database: negotiationHost.database,
+    roundLog: negotiationHost.roundLog,
     reflectEnqueue: async (job) => { negotiationHost.enqueueReflect(job); },
     needsPrincipalEnqueue: async (input) => { needsPrincipalWakes.push(input); },
     author: {
@@ -258,9 +262,10 @@ function buildCycle(judgment: ScriptedJudgment, counterparties: string[]) {
       },
     },
   }).createGraph();
-  agent = new PersonalAgentGraphFactory({
+  const agent: PersonalAgentGraphLike = new PersonalAgentGraphFactory({
     negotiations,
     negotiationDatabase: negotiationHost.database,
+    roundLog: negotiationHost.roundLog,
     conversation: principal.conversation,
     dossier: principal.dossier,
     ledger: principal.ledger,
@@ -592,15 +597,15 @@ describe("PersonalAgent — chat-first intent turns", () => {
     expect(result.acts).toEqual([]);
     expect(principal.dmMessages).toEqual([]);
     expect(principal.ledgerRows).toEqual([]);
-    expect(negotiationHost.round).toBe(1);
+    expect(negotiationHost.batchId).toBeNull();
   });
 
   test("does not message, ledger, or wake when an empty kickoff expires during lifecycle reads", async () => {
     const controller = new AbortController();
     const judgment = new ScriptedJudgment([() => [{ tool: "kickoff", reasoning: "Check for work." }]]);
     const { agent, negotiationHost, principal, wakes } = buildCycle(judgment, []);
-    const readLifecycle = negotiationHost.database.getIntentNegotiationRound;
-    negotiationHost.database.getIntentNegotiationRound = async (intentId) => {
+    const readLifecycle = negotiationHost.database.getIntentNegotiationBatch;
+    negotiationHost.database.getIntentNegotiationBatch = async (intentId) => {
       const lifecycle = await readLifecycle.call(negotiationHost.database, intentId);
       controller.abort(new DOMException("deadline", "TimeoutError"));
       return lifecycle;
@@ -642,7 +647,7 @@ describe("PersonalAgent — chat-first intent turns", () => {
     expect(result.error).toBeUndefined();
     expect(task.state).toBe("paused");
     expect(task.metadata.pause?.reason).toBe("open_failed");
-    expect(negotiationHost.roundSize).toBe(1);
+    expect(negotiationHost.isOpeningComplete()).toBe(true);
     expect(principal.dmMessages.at(-1)?.content).toBe(PERSONAL_AGENT_POST_ACTION_FAILURE);
   });
 
@@ -664,7 +669,7 @@ describe("PersonalAgent — chat-first intent turns", () => {
 
     expect(result.acts.filter((act) => act.tool === "kickoff")).toHaveLength(1);
     expect(result.messages.at(-1)).toBe("The first outreach is underway; the repeated kickoff was refused.");
-    expect(negotiationHost.round).toBe(2);
+    expect(negotiationHost.batchId).toBe("batch-1");
     expect(principal.dmMessages.filter((message) => message.content.includes("find out who can actually move"))).toHaveLength(1);
     expect(principal.ledgerRows.filter((row) => row.act.tool === "kickoff")).toHaveLength(1);
   });
@@ -697,8 +702,7 @@ describe("PersonalAgent — chat-first intent turns", () => {
         candidateUserId: CANDIDATE_USER_ID,
         initiatorUserId: SOURCE_USER_ID,
         networkId: "network-1",
-        seats: { [INTENT_ID]: { userId: SOURCE_USER_ID, round: 1 } },
-        drainGeneration: 0,
+        seats: { [INTENT_ID]: { userId: SOURCE_USER_ID, batchId: "batch-1" } },
       },
     });
     await negotiationHost.database.updateNegotiationTaskState(task.id, "paused", {
@@ -707,7 +711,7 @@ describe("PersonalAgent — chat-first intent turns", () => {
       payload: { recommendation: "reject", reasoning: "Not a fit." },
     });
 
-    const result = await agent.invoke({ userId: SOURCE_USER_ID, intentId: INTENT_ID, event: "all_paused", round: 1 });
+    const result = await agent.invoke({ userId: SOURCE_USER_ID, intentId: INTENT_ID, event: "all_paused", batchId: "batch-1" });
 
     expect(result.acts.map((act) => act.tool)).toEqual(["reject", "message_user"]);
     expect(result.messages).toEqual(["I closed that negotiation as not a fit; the conflicting verdict was refused."]);
@@ -731,17 +735,17 @@ describe("PersonalAgent — chat-first intent turns", () => {
     expect(principal.ledgerRows.filter((row) => row.act.tool === "kickoff")).toHaveLength(1);
   });
 
-  test("a strategy message makes a later round-bump failure non-retryable", async () => {
+  test("a strategy message makes a later batch-bump failure non-retryable", async () => {
     const judgment = new ScriptedJudgment([() => [{ tool: "kickoff", reasoning: "Open it." }]]);
     const { agent, negotiationHost, principal } = buildCycle(judgment, [CANDIDATE_USER_ID]);
-    negotiationHost.database.bumpIntentNegotiationRound = async () => { throw new Error("round bump failed"); };
+    negotiationHost.database.bumpIntentNegotiationBatch = async () => { throw new Error("batch bump failed"); };
 
     const result = await agent.invoke({ userId: SOURCE_USER_ID, intentId: INTENT_ID, event: "matches_ready" });
 
     expect(result.error).toBeUndefined();
     expect(principal.dmMessages.filter((message) => message.content.includes("find out who can actually move"))).toHaveLength(1);
     expect(principal.dmMessages.at(-1)?.content).toBe(PERSONAL_AGENT_POST_ACTION_FAILURE);
-    expect(negotiationHost.round).toBe(1);
+    expect(negotiationHost.batchId).toBeNull();
   });
 });
 
@@ -815,17 +819,20 @@ describe("PersonalAgent — the whole cycle", () => {
       // The counterparty seat wrote its OWN, and never read the initiator's.
       expect(task.briefs[task.metadata.candidateUserId]).toMatch(/^Seat brief from what we were told:/);
     }
-    // The round is stamped only after every open settled, and the all-paused
-    // check then fires exactly once for it.
-    const round = negotiationHost.round;
-    expect(negotiationHost.roundSize).toBe(3);
-    expect(negotiationHost.reflectJobs).toHaveLength(4);
-    expect(negotiationHost.reflectJobs).toEqual(expect.arrayContaining([
-      { userId: SOURCE_USER_ID, intentId: INTENT_ID, round, generation: "task-1.0_task-2.0_task-3.0" },
-      { userId: CANDIDATE_USER_ID, intentId: "intent-bob-1", round: 0, generation: "task-1.0" },
-      { userId: "carol", intentId: "intent-carol-1", round: 0, generation: "task-2.0" },
-      { userId: "dave", intentId: "intent-dave-1", round: 0, generation: "task-3.0" },
-    ]));
+    // The batch is marked opening_complete only after every open settled, and
+    // the all-paused check then fires exactly once for it.
+    const batchId = negotiationHost.batchId!;
+    expect(negotiationHost.isOpeningComplete()).toBe(true);
+    // At least one settle per bound seat — a negotiation that resolves its
+    // own verdict during this same turn (SECOND_OPPORTUNITY_ID, auto-promoted
+    // below) appends a second, genuinely distinct settle (stopped via
+    // 'completed' on top of its earlier 'paused' stop), so more than one
+    // batch can legitimately reflect twice.
+    expect(negotiationHost.reflectJobs.length).toBeGreaterThanOrEqual(4);
+    expect(negotiationHost.reflectJobs.find((job) => job.intentId === INTENT_ID)).toMatchObject({ userId: SOURCE_USER_ID, intentId: INTENT_ID, batchId });
+    expect(negotiationHost.reflectJobs.find((job) => job.intentId === "intent-bob-1")).toMatchObject({ userId: CANDIDATE_USER_ID, intentId: "intent-bob-1" });
+    expect(negotiationHost.reflectJobs.find((job) => job.intentId === "intent-carol-1")).toMatchObject({ userId: "carol", intentId: "intent-carol-1" });
+    expect(negotiationHost.reflectJobs.find((job) => job.intentId === "intent-dave-1")).toMatchObject({ userId: "dave", intentId: "intent-dave-1" });
     // Every act is on the ledger. The appends are guarded so a failure cannot
     // duplicate a real effect — which also means a broken one records nothing
     // and says nothing, so it is asserted rather than assumed.
@@ -835,7 +842,7 @@ describe("PersonalAgent — the whole cycle", () => {
     expect(principal.publishedChunks.map((chunk) => chunk.seq)).toEqual([1, 2, 3]);
 
     // ── 3. reflect: it asks, and decides nothing ──────────────────────────
-    const reflectAsk = await agent.invoke({ userId: SOURCE_USER_ID, intentId: INTENT_ID, event: "all_paused", round });
+    const reflectAsk = await agent.invoke({ userId: SOURCE_USER_ID, intentId: INTENT_ID, event: "all_paused", batchId });
     expect(reflectAsk.error).toBeUndefined();
     expect(reflectAsk.acts.map((act) => act.tool)).toEqual(["message_user"]);
     expect(negotiationHost.opportunityStatusUpdates.filter((update) => update.status === "pending")).toHaveLength(1);
@@ -861,12 +868,11 @@ describe("PersonalAgent — the whole cycle", () => {
     const rekick = acted.acts.find((act) => act.tool === "kickoff")!;
     expect(rekick).toMatchObject({ tool: "kickoff", opened: 1 });
     expect(negotiationHost.tasks.size).toBe(3); // re-kick resumed, never duplicated
-    expect(negotiationHost.round).toBe(round + 1);
-    expect(negotiationHost.reflectJobs.at(-1)).toEqual({
+    expect(negotiationHost.batchId).not.toBe(batchId);
+    expect(negotiationHost.reflectJobs.filter((job) => job.intentId === INTENT_ID).at(-1)).toMatchObject({
       userId: SOURCE_USER_ID,
       intentId: INTENT_ID,
-      round: round + 1,
-      generation: "task-1.1",
+      batchId: negotiationHost.batchId,
     });
   });
 
@@ -890,30 +896,29 @@ describe("PersonalAgent — the whole cycle", () => {
     const { agent, negotiationHost } = buildCycle(judgment, [CANDIDATE_USER_ID, "carol", "dave"]);
 
     await agent.invoke({ userId: SOURCE_USER_ID, intentId: INTENT_ID, event: "matches_ready" });
-    const round = negotiationHost.round;
-    const reflected = await agent.invoke({ userId: SOURCE_USER_ID, intentId: INTENT_ID, event: "all_paused", round });
+    const batchId = negotiationHost.batchId!;
+    const reflected = await agent.invoke({ userId: SOURCE_USER_ID, intentId: INTENT_ID, event: "all_paused", batchId });
     expect(reflected.error).toBeUndefined();
     expect(judgment.decideCalls).toHaveLength(2);
   });
 
-  test("a kickoff that opens nothing leaves the round unstamped, so reflect cannot loop", async () => {
+  test("a kickoff that opens nothing leaves the batch unmarked, so reflect cannot loop", async () => {
     const judgment = new ScriptedJudgment([
       () => [{ tool: "kickoff", reasoning: "Nothing to open." }],
     ]);
     const { agent, negotiationHost } = buildCycle(judgment, []);
 
     const result = await agent.invoke({ userId: SOURCE_USER_ID, intentId: INTENT_ID, event: "matches_ready" });
-    // The act names the round it actually looked at, not a placeholder.
+    // The act names the batch it actually looked at, not a placeholder.
     // A background turn still tells the principal when a kickoff has nothing to open;
     // silence there ends the cycle with the principal
     // never told (the reflect job is retained and nothing is active).
     expect(result.acts.map((act) => act.tool)).toEqual(["message_user", "kickoff", "message_user"]);
     expect(result.acts.find((act) => act.tool === "kickoff")).toEqual({
-      tool: "kickoff", round: negotiationHost.round, opened: 0, attempted: 0, failed: 0, reasoning: "Nothing to open.",
+      tool: "kickoff", batchId: negotiationHost.batchId, opened: 0, attempted: 0, failed: 0, reasoning: "Nothing to open.",
     });
     expect(result.messages).toHaveLength(2);
-    expect(negotiationHost.roundSize).toBeNull();
-    expect(negotiationHost.kickoffStartedAt).toBeNull(); // no round was ever begun
+    expect(negotiationHost.batchId).toBeNull(); // no batch was ever begun
     expect(negotiationHost.reflectJobs).toEqual([]);
   });
 
@@ -951,33 +956,34 @@ describe("PersonalAgent — termination and retry safety", () => {
     );
     const { agent, negotiationHost, principal } = buildCycle(judgment, [CANDIDATE_USER_ID, "carol"]);
 
-    // ── round 2: both open; A self-plays to its turn cap, B stalls ────────
+    // ── batch 2: both open; A self-plays to its turn cap, B stalls ────────
     await agent.invoke({ userId: SOURCE_USER_ID, intentId: INTENT_ID, event: "matches_ready" });
-    const firstRound = negotiationHost.round;
+    const firstBatchId = negotiationHost.batchId!;
     const taskFor = (opportunityId: string) =>
       [...negotiationHost.tasks.values()].find((task) => task.metadata.opportunityId === opportunityId)!;
     expect(taskFor(OPPORTUNITY_ID).metadata.pause?.reason).toBe("turn_cap");
     expect(taskFor(SECOND_OPPORTUNITY_ID).metadata.pause?.reason).toBe("needs_principal");
 
-    // ── round 3: only B is re-kicked, so A stays behind in round 2 ────────
-    await agent.invoke({ userId: SOURCE_USER_ID, intentId: INTENT_ID, event: "all_paused", round: firstRound });
-    expect(negotiationHost.round).toBe(firstRound + 1);
-    expect(taskFor(SECOND_OPPORTUNITY_ID).metadata.seats[INTENT_ID]!.round).toBe(firstRound + 1);
-    expect(taskFor(OPPORTUNITY_ID).metadata.seats[INTENT_ID]!.round).toBe(firstRound); // left behind, capped
+    // ── batch 3: only B is re-kicked, so A stays behind in batch 2 ────────
+    await agent.invoke({ userId: SOURCE_USER_ID, intentId: INTENT_ID, event: "all_paused", batchId: firstBatchId });
+    const secondBatchId = negotiationHost.batchId!;
+    expect(secondBatchId).not.toBe(firstBatchId);
+    expect(taskFor(SECOND_OPPORTUNITY_ID).metadata.seats[INTENT_ID]!.batchId).toBe(secondBatchId);
+    expect(taskFor(OPPORTUNITY_ID).metadata.seats[INTENT_ID]!.batchId).toBe(firstBatchId); // left behind, capped
     expect(taskFor(SECOND_OPPORTUNITY_ID).metadata.pause?.reason).toBe("turn_cap");
 
-    // ── round 3 reflect: A is invisible to this round, and must STILL be
-    //    ineligible. Nothing opens, nothing stamps, nothing re-triggers. ──
+    // ── batch 3 reflect: A is invisible to this batch, and must STILL be
+    //    ineligible. Nothing opens, nothing marks, nothing re-triggers. ──
     const strategyMessagesBefore = principal.dmMessages.length;
     const reflectJobsBefore = negotiationHost.reflectJobs.length;
     const briefCallsBefore = judgment.briefCalls.length;
-    const acted = await agent.invoke({ userId: SOURCE_USER_ID, intentId: INTENT_ID, event: "all_paused", round: firstRound + 1 });
+    const acted = await agent.invoke({ userId: SOURCE_USER_ID, intentId: INTENT_ID, event: "all_paused", batchId: secondBatchId });
 
     expect(acted.acts.map((act) => act.tool)).toEqual(["message_user", "kickoff", "message_user"]);
     expect(acted.acts.find((act) => act.tool === "kickoff")).toEqual({
-      tool: "kickoff", round: firstRound + 1, opened: 0, attempted: 0, failed: 0, reasoning: "Send them out.",
+      tool: "kickoff", batchId: secondBatchId, opened: 0, attempted: 0, failed: 0, reasoning: "Send them out.",
     });
-    expect(negotiationHost.round).toBe(firstRound + 1); // no further bump
+    expect(negotiationHost.batchId).toBe(secondBatchId); // no further bump
     expect(negotiationHost.tasks.size).toBe(2); // nothing re-opened
     // No second STRATEGY and no extra brief spend — the turn adds the honest
     // "nothing to open" line and its natural terminal response.
@@ -989,66 +995,63 @@ describe("PersonalAgent — termination and retry safety", () => {
 
   /**
    * A turn runs on a queue that retries it whole. A crash after the opens —
-   * here, the size stamp failing — must not re-post the strategy, re-bump the
-   * round or re-open anything, and it must not leave the round unstamped.
+   * here, the opening_complete write failing — must not re-post the strategy,
+   * re-bump the batch or re-open anything, and it must not leave the batch
+   * unmarked.
    */
-  test("a kickoff that crashed mid-round is repaired without claiming opens it never made", async () => {
+  test("a kickoff that crashed mid-batch is repaired without claiming opens it never made", async () => {
     const kickoffPlan = (): PersonalAgentDecidedAct[] => [{ tool: "kickoff", reasoning: "Reaching out." }];
     const judgment = new ScriptedJudgment([kickoffPlan, kickoffPlan]);
     const { agent, negotiationHost, principal } = buildCycle(judgment, [CANDIDATE_USER_ID]);
 
     // Every attempt: the post-bump policy retries this write three times and
     // then gives up loudly rather than throwing out of the turn (D54).
-    const stamp = negotiationHost.database.stampIntentNegotiationRoundSize;
-    let failStamp = true;
-    negotiationHost.database.stampIntentNegotiationRoundSize = async (intentId, round, size) => {
-      if (failStamp) throw new Error("stamp write failed");
-      return stamp.call(negotiationHost.database, intentId, round, size);
+    const append = negotiationHost.roundLog.appendNegotiationRoundLogEvent;
+    let failComplete = true;
+    negotiationHost.roundLog.appendNegotiationRoundLogEvent = async (intentId, event) => {
+      if (failComplete && intentId === INTENT_ID && event.kind === "opening_complete") throw new Error("opening_complete write failed");
+      return append.call(negotiationHost.roundLog, intentId, event);
     };
 
     // ── the interrupted attempt ───────────────────────────────────────────
     // The turn does NOT fail: after the bump nothing throws (D54), so the
-    // strategy message and the round it already produced are never repeated.
+    // strategy message and the batch it already produced are never repeated.
     const crashed = await agent.invoke({ userId: SOURCE_USER_ID, intentId: INTENT_ID, event: "matches_ready" });
     expect(crashed.error).toBeUndefined();
-    const round = negotiationHost.round;
+    const batchId = negotiationHost.batchId!;
     expect(negotiationHost.tasks.size).toBe(1);
-    expect(negotiationHost.roundSize).toBeNull();   // begun, not settled
-    expect(negotiationHost.kickoffStartedAt).not.toBeNull();
-    failStamp = false;
+    expect(negotiationHost.isOpeningComplete()).toBe(false);   // begun, not settled
+    expect(negotiationHost.batchId).not.toBeNull();
+    failComplete = false;
     negotiationHost.ageKickoff();  // past the staleness bound: abandoned, not in flight
 
-    // ── the retry: repair the stranded round, then do this turn's own work ─
+    // ── the retry: repair the stranded batch, then do this turn's own work ─
     const retried = await agent.invoke({ userId: SOURCE_USER_ID, intentId: INTENT_ID, event: "matches_ready" });
     expect(retried.error).toBeUndefined();
     // The repair opened nothing, so it claims nothing: the one act reported is
-    // the round this turn actually opened.
+    // the batch this turn actually opened.
     expect(retried.acts.filter((act) => act.tool === "kickoff")).toEqual([
-      { tool: "kickoff", round: round + 1, opened: 1, attempted: 1, failed: 0, reasoning: "Reaching out." },
+      { tool: "kickoff", batchId: negotiationHost.batchId, opened: 1, attempted: 1, failed: 0, reasoning: "Reaching out." },
     ]);
-    expect(negotiationHost.roundSize).toBe(1);      // the stranded round is settled
-    // The negotiation is RESUMED into the new round, never duplicated — the
+    expect(negotiationHost.batchId).not.toBe(batchId);
+    expect(negotiationHost.isOpeningComplete()).toBe(true);      // the stranded batch is settled
+    // The negotiation is RESUMED into the new batch, never duplicated — the
     // only thing a retry repeats is the strategy message.
     expect(negotiationHost.tasks.size).toBe(1);
-    expect(negotiationHost.taskFor([...negotiationHost.tasks.keys()][0]!).metadata.seats[INTENT_ID]!.round).toBe(round + 1);
+    expect(negotiationHost.taskFor([...negotiationHost.tasks.keys()][0]!).metadata.seats[INTENT_ID]!.batchId).toBe(negotiationHost.batchId);
     expect(principal.dmMessages.filter((message) => message.content.includes("find out who can actually move"))).toHaveLength(2);
   });
 });
 
 describe("PersonalAgent — kickoff safety at the edges", () => {
-  test("a signal that predates round stamping runs a NORMAL kickoff, not a resume", async () => {
-    // Every intent alive when the migration lands has negotiation_round >= 1
-    // and no size stamp. Inferring "an interrupted kickoff" from that NULL
-    // would take the resume path on the first matches_ready per existing
-    // signal — no strategy, no briefs, no opens — and silently drop the batch
-    // that woke it. The marker, not the NULL-ness, is what says a kickoff began.
-    const judgment = new ScriptedJudgment([() => [{ tool: "kickoff", reasoning: "First real round." }]]);
+  test("a signal that predates the batch column runs a NORMAL kickoff, not a resume", async () => {
+    // Every intent alive when this migration lands has negotiation_batch_id
+    // NULL — exactly the same "never kicked off" state a brand new signal
+    // starts in. A stale negotiation left behind by some earlier, unrelated
+    // batch id must not confuse a fresh kickoff into treating itself as a
+    // resume of that old batch.
+    const judgment = new ScriptedJudgment([() => [{ tool: "kickoff", reasoning: "First real batch." }]]);
     const { agent, negotiationHost, principal } = buildCycle(judgment, [CANDIDATE_USER_ID]);
-    // A signal that was mid-negotiation when the mechanism landed: a round
-    // counter, negotiations already in that round, and no stamp of any kind.
-    negotiationHost.round = 4;
-    negotiationHost.roundSize = null;
-    negotiationHost.kickoffStartedAt = null;
     await negotiationHost.createNegotiationTask({
       conversationId: "legacy-conversation",
       brief: "written before this PR",
@@ -1059,7 +1062,10 @@ describe("PersonalAgent — kickoff safety at the edges", () => {
         candidateUserId: CANDIDATE_USER_ID,
         initiatorUserId: SOURCE_USER_ID,
         networkId: "network-1",
-        seats: { [INTENT_ID]: { userId: SOURCE_USER_ID, round: 4 } },
+        seats: {
+          [INTENT_ID]: { userId: SOURCE_USER_ID, batchId: "batch-old" },
+          "intent-bob-1": { userId: CANDIDATE_USER_ID, batchId: null },
+        },
       },
     });
 
@@ -1068,16 +1074,16 @@ describe("PersonalAgent — kickoff safety at the edges", () => {
     expect(result.acts.map((act) => act.tool)).toEqual(["message_user", "kickoff", "message_user"]);
     expect(principal.dmMessages).toHaveLength(2);            // strategy, then natural terminal response
     expect(judgment.briefCalls).toHaveLength(1);             // a brief was derived
-    expect(negotiationHost.round).toBe(5);                   // a NEW round, not a stamp of the stale one
-    expect(negotiationHost.roundSize).toBe(1);
+    expect(negotiationHost.batchId).not.toBe("batch-old");   // a NEW batch, not a resume of the legacy one
+    expect(negotiationHost.isOpeningComplete()).toBe(true);
     expect(negotiationHost.reflectJobs).toEqual([{
-      userId: SOURCE_USER_ID, intentId: INTENT_ID, round: 5, generation: "task-1.0",
+      userId: SOURCE_USER_ID, intentId: INTENT_ID, batchId: negotiationHost.batchId, dedupeKey: "task-1.0",
     }]);
   });
 
-  test("an open that fails leaves no live negotiation holding the round open", async () => {
+  test("an open that fails leaves no live negotiation holding the batch open", async () => {
     // `init` creates the task before a turn is ever authored, so a failure
-    // after that point strands it in `working`: the round's active count never
+    // after that point strands it in `working`: the batch's active count never
     // reaches zero and its reflect never fires.
     const judgment = new ScriptedJudgment([() => [{ tool: "kickoff", reasoning: "Reaching out." }]]);
     const { agent, negotiationHost } = buildCycle(judgment, [CANDIDATE_USER_ID]);
@@ -1096,9 +1102,9 @@ describe("PersonalAgent — kickoff safety at the edges", () => {
     const task = [...negotiationHost.tasks.values()][0]!;
     expect(task.state).toBe("paused");
     expect(task.metadata.pause?.reason).toBe("open_failed");
-    expect(await negotiationHost.database.countActiveNegotiationsForRound(INTENT_ID, negotiationHost.round)).toBe(0);
-    // The round still settles, so its reflect fires instead of hanging.
-    expect(negotiationHost.roundSize).toBe(1);
+    expect(await negotiationHost.database.countActiveNegotiationsForBatch(INTENT_ID, negotiationHost.batchId!)).toBe(0);
+    // The batch still settles, so its reflect fires instead of hanging.
+    expect(negotiationHost.isOpeningComplete()).toBe(true);
     expect(negotiationHost.reflectJobs.filter((job) => job.intentId === INTENT_ID)).toHaveLength(1);
   });
 
@@ -1180,12 +1186,12 @@ describe("PersonalAgent — what a turn may open, and what it may claim", () => 
     // outreach sitting in the thread, and would record the pause against the
     // seat that merely owed the next turn.
     expect(task.metadata.pause?.reason).toBe("counterparty_silent");
-    expect(await negotiationHost.database.countActiveNegotiationsForRound(INTENT_ID, negotiationHost.round)).toBe(0);
-    expect(negotiationHost.roundSize).toBe(1);
+    expect(await negotiationHost.database.countActiveNegotiationsForBatch(INTENT_ID, negotiationHost.batchId!)).toBe(0);
+    expect(negotiationHost.isOpeningComplete()).toBe(true);
   });
 
-  test("a principal who asks for a kickoff during an interrupted round gets one", async () => {
-    // The crashed turn left round R begun-but-unsettled. The principal then
+  test("a principal who asks for a kickoff during an interrupted batch gets one", async () => {
+    // The crashed turn left batch R begun-but-unsettled. The principal then
     // says go ahead. Repairing R is not the kickoff they asked for, and
     // reporting one would be a confirmation of work nobody did.
     const judgment = new ScriptedJudgment([
@@ -1193,36 +1199,36 @@ describe("PersonalAgent — what a turn may open, and what it may claim", () => 
       () => [{ tool: "kickoff", reasoning: "They said go ahead." }],
     ]);
     const { agent, negotiationHost, principal } = buildCycle(judgment, [CANDIDATE_USER_ID]);
-    const stamp = negotiationHost.database.stampIntentNegotiationRoundSize;
-    let failStamp = true;
-    negotiationHost.database.stampIntentNegotiationRoundSize = async (intentId, round, size) => {
-      if (failStamp) throw new Error("stamp write failed");
-      return stamp.call(negotiationHost.database, intentId, round, size);
+    const append = negotiationHost.roundLog.appendNegotiationRoundLogEvent;
+    let failComplete = true;
+    negotiationHost.roundLog.appendNegotiationRoundLogEvent = async (intentId, event) => {
+      if (failComplete && intentId === INTENT_ID && event.kind === "opening_complete") throw new Error("opening_complete write failed");
+      return append.call(negotiationHost.roundLog, intentId, event);
     };
 
     await agent.invoke({ userId: SOURCE_USER_ID, intentId: INTENT_ID, event: "matches_ready" });
-    const stranded = negotiationHost.round;
-    expect(negotiationHost.roundSize).toBeNull();
-    failStamp = false;
+    const stranded = negotiationHost.batchId!;
+    expect(negotiationHost.isOpeningComplete()).toBe(false);
+    failComplete = false;
     negotiationHost.ageKickoff();
     const briefsBefore = judgment.briefCalls.length;
     const messagesBefore = principal.dmMessages.length;
 
     const acted = await agent.invoke(userMessage("Go ahead."));
 
-    // A real kickoff happened: a new round, a fresh brief, a strategy the
-    // principal can read — and the act names the round it actually opened.
-    expect(negotiationHost.round).toBe(stranded + 1);
+    // A real kickoff happened: a new batch, a fresh brief, a strategy the
+    // principal can read — and the act names the batch it actually opened.
+    expect(negotiationHost.batchId).not.toBe(stranded);
     expect(judgment.briefCalls.length).toBe(briefsBefore + 1);
     expect(principal.dmMessages.length).toBeGreaterThan(messagesBefore);
     expect(acted.acts.filter((act) => act.tool === "kickoff")).toEqual([
-      { tool: "kickoff", round: stranded + 1, opened: 1, attempted: 1, failed: 0, reasoning: "They said go ahead." },
+      { tool: "kickoff", batchId: negotiationHost.batchId, opened: 1, attempted: 1, failed: 0, reasoning: "They said go ahead." },
     ]);
-    expect(negotiationHost.roundSize).toBe(1);
+    expect(negotiationHost.isOpeningComplete()).toBe(true);
   });
 
   test("a reflect turn whose reads fail does not report a successful empty turn", async () => {
-    // With this drain generation's job id retained forever, a swallowed read
+    // With this settle's dedupe key retained forever, a swallowed read
     // would consume that durable pause without deciding it.
     const judgment = new ScriptedJudgment([() => []]);
     const { agent, negotiationHost } = buildCycle(judgment, [CANDIDATE_USER_ID]);
@@ -1230,7 +1236,7 @@ describe("PersonalAgent — what a turn may open, and what it may claim", () => 
       throw new Error("connection reset");
     };
 
-    const result = await agent.invoke({ userId: SOURCE_USER_ID, intentId: INTENT_ID, event: "all_paused", round: 1 });
+    const result = await agent.invoke({ userId: SOURCE_USER_ID, intentId: INTENT_ID, event: "all_paused", batchId: "batch-1" });
 
     expect(result.error).toBe("connection reset");
     expect(judgment.decideCalls).toHaveLength(0);
@@ -1238,55 +1244,58 @@ describe("PersonalAgent — what a turn may open, and what it may claim", () => 
 });
 
 describe("PersonalAgent — round-4 regressions", () => {
-  test("the interrupted-round repair does not queue a reflect for a round this turn supersedes", async () => {
-    // Settling the old round and firing its reflect, then bumping past it and
-    // carrying its negotiations into the new round, wakes the agent with
-    // "every negotiation of this round has paused" and nothing listed — which
-    // invites a kickoff that strands the round that actually holds the work.
+  test("the interrupted-batch repair does not queue a reflect for a batch this turn supersedes", async () => {
+    // Settling the old batch and firing its reflect, then bumping past it and
+    // carrying its negotiations into the new batch, wakes the agent with
+    // "every negotiation of this batch has paused" and nothing listed — which
+    // invites a kickoff that strands the batch that actually holds the work.
     const judgment = new ScriptedJudgment([
       () => [{ tool: "kickoff", reasoning: "Reaching out." }],
       () => [{ tool: "kickoff", reasoning: "Again." }],
     ]);
     const { agent, negotiationHost } = buildCycle(judgment, [CANDIDATE_USER_ID]);
-    const stamp = negotiationHost.database.stampIntentNegotiationRoundSize;
-    let failStamp = true;
-    negotiationHost.database.stampIntentNegotiationRoundSize = async (intentId, round, size) => {
-      if (failStamp) throw new Error("stamp write failed");
-      return stamp.call(negotiationHost.database, intentId, round, size);
+    const append = negotiationHost.roundLog.appendNegotiationRoundLogEvent;
+    let failComplete = true;
+    negotiationHost.roundLog.appendNegotiationRoundLogEvent = async (intentId, event) => {
+      if (failComplete && intentId === INTENT_ID && event.kind === "opening_complete") throw new Error("opening_complete write failed");
+      return append.call(negotiationHost.roundLog, intentId, event);
     };
 
     await agent.invoke({ userId: SOURCE_USER_ID, intentId: INTENT_ID, event: "matches_ready" });
-    const stranded = negotiationHost.round;
+    const stranded = negotiationHost.batchId!;
     negotiationHost.reflectJobs.length = 0;
-    failStamp = false;
+    failComplete = false;
     negotiationHost.ageKickoff();
 
     await agent.invoke({ userId: SOURCE_USER_ID, intentId: INTENT_ID, event: "matches_ready" });
 
-    // The superseded round's newly durable drain and the later reopened
-    // generation are distinct moments, so both are reflected exactly once.
-    expect(negotiationHost.reflectJobs.filter((job) => job.intentId === INTENT_ID).map((job) => job.round))
-      .toEqual([stranded + 1]);
-    expect([...negotiationHost.tasks.values()][0]!.metadata.seats[INTENT_ID]!.round).toBe(stranded + 1);
+    // The superseded batch never durably settled (its opening_complete write
+    // failed), so nothing reflects for it; only the later, genuinely settled
+    // batch does.
+    expect(negotiationHost.reflectJobs.filter((job) => job.intentId === INTENT_ID).every((job) => job.batchId === negotiationHost.batchId))
+      .toBe(true);
+    expect(negotiationHost.reflectJobs.filter((job) => job.intentId === INTENT_ID).length).toBeGreaterThan(0);
+    expect(negotiationHost.batchId).not.toBe(stranded);
+    expect([...negotiationHost.tasks.values()][0]!.metadata.seats[INTENT_ID]!.batchId).toBe(negotiationHost.batchId);
   });
 
-  test("an interrupted round that nothing supersedes still gets its reflect", async () => {
+  test("an interrupted batch that nothing supersedes still gets its reflect", async () => {
     const judgment = new ScriptedJudgment([
       () => [{ tool: "kickoff", reasoning: "Reaching out." }],
       () => [{ tool: "kickoff", reasoning: "Nothing left to open." }],
     ]);
     const { agent, negotiationHost } = buildCycle(judgment, [CANDIDATE_USER_ID]);
-    const stamp = negotiationHost.database.stampIntentNegotiationRoundSize;
-    let failStamp = true;
-    negotiationHost.database.stampIntentNegotiationRoundSize = async (intentId, round, size) => {
-      if (failStamp) throw new Error("stamp write failed");
-      return stamp.call(negotiationHost.database, intentId, round, size);
+    const append = negotiationHost.roundLog.appendNegotiationRoundLogEvent;
+    let failComplete = true;
+    negotiationHost.roundLog.appendNegotiationRoundLogEvent = async (intentId, event) => {
+      if (failComplete && intentId === INTENT_ID && event.kind === "opening_complete") throw new Error("opening_complete write failed");
+      return append.call(negotiationHost.roundLog, intentId, event);
     };
 
     await agent.invoke({ userId: SOURCE_USER_ID, intentId: INTENT_ID, event: "matches_ready" });
-    const stranded = negotiationHost.round;
+    const stranded = negotiationHost.batchId!;
     negotiationHost.reflectJobs.length = 0;
-    failStamp = false;
+    failComplete = false;
     negotiationHost.ageKickoff();
     // The match is decided in the meantime, so the next turn opens nothing.
     negotiationHost.opportunities.get(OPPORTUNITY_ID)!.status = "rejected";
@@ -1295,11 +1304,11 @@ describe("PersonalAgent — round-4 regressions", () => {
 
     expect(acted.acts.map((act) => act.tool)).toEqual(["message_user", "kickoff", "message_user"]);
     expect(acted.acts.find((act) => act.tool === "kickoff")).toEqual({
-      tool: "kickoff", round: stranded, opened: 0, attempted: 0, failed: 0, reasoning: "Nothing left to open.",
+      tool: "kickoff", batchId: stranded, opened: 0, attempted: 0, failed: 0, reasoning: "Nothing left to open.",
     });
-    expect(negotiationHost.round).toBe(stranded);              // no bump
-    expect(negotiationHost.roundSize).toBe(1);                 // settled all the same
-    expect(negotiationHost.reflectJobs.map((job) => job.round)).toEqual([stranded]);
+    expect(negotiationHost.batchId).toBe(stranded);              // no bump
+    expect(negotiationHost.isOpeningComplete()).toBe(true);      // settled all the same
+    expect(negotiationHost.reflectJobs.map((job) => job.batchId)).toEqual([stranded]);
   });
 
   test("a model failure after durable work ends with a ledgered fallback instead of retrying", async () => {
@@ -1359,19 +1368,20 @@ describe("PersonalAgent — round-5 regressions", () => {
     );
     const { agent, negotiationHost } = buildCycle(judgment, [CANDIDATE_USER_ID, "carol"]);
 
-    // Round 2 caps opportunity-1; opportunity-2 only stalls on a question.
+    // Batch 2 caps opportunity-1; opportunity-2 only stalls on a question.
     await agent.invoke({ userId: SOURCE_USER_ID, intentId: INTENT_ID, event: "matches_ready" });
     const capped = [...negotiationHost.tasks.values()].find((task) => task.metadata.opportunityId === OPPORTUNITY_ID)!;
     expect(capped.metadata.pause?.reason).toBe("turn_cap");
-    const cappedRound = capped.metadata.seats[INTENT_ID]!.round;
+    const cappedBatchId = capped.metadata.seats[INTENT_ID]!.batchId!;
 
-    // Round 3 re-kicks only opportunity-2, leaving the capped one behind.
-    await agent.invoke({ userId: SOURCE_USER_ID, intentId: INTENT_ID, event: "all_paused", round: cappedRound });
-    expect(negotiationHost.taskFor(capped.id).metadata.seats[INTENT_ID]!.round).toBe(cappedRound);
-    expect(negotiationHost.round).toBe(cappedRound + 1);
+    // Batch 3 re-kicks only opportunity-2, leaving the capped one behind.
+    await agent.invoke({ userId: SOURCE_USER_ID, intentId: INTENT_ID, event: "all_paused", batchId: cappedBatchId });
+    expect(negotiationHost.taskFor(capped.id).metadata.seats[INTENT_ID]!.batchId).toBe(cappedBatchId);
+    const laterBatchId = negotiationHost.batchId!;
+    expect(laterBatchId).not.toBe(cappedBatchId);
 
-    // Reflecting on the LATER round must still see the one left behind.
-    const acted = await agent.invoke({ userId: SOURCE_USER_ID, intentId: INTENT_ID, event: "all_paused", round: cappedRound + 1 });
+    // Reflecting on the LATER batch must still see the one left behind.
+    const acted = await agent.invoke({ userId: SOURCE_USER_ID, intentId: INTENT_ID, event: "all_paused", batchId: laterBatchId });
 
     expect(acted.acts[0]).toEqual({
       tool: "reject",
@@ -1384,26 +1394,18 @@ describe("PersonalAgent — round-5 regressions", () => {
     expect(negotiationHost.opportunities.get(OPPORTUNITY_ID)!.status).toBe("negotiating");
   });
 
-  test("a negotiation that pauses between the count and the stamp still gets its reflect", async () => {
-    // The stamp opens a window: a pause landing inside it sees a null stamp
-    // and bails, while kickoff's own check has already counted. Checked on one
-    // side only, that round is waited on forever.
+  test("a batch settles and reflects only after its opening_complete marker is durable", async () => {
+    // The old two-sided count/stamp race this test covered no longer exists:
+    // the reflect check runs exactly once, strictly after the durable
+    // opening_complete append — there is no earlier read to race against.
     const judgment = new ScriptedJudgment([() => [{ tool: "kickoff", reasoning: "Reaching out." }]]);
     const { agent, negotiationHost } = buildCycle(judgment, [CANDIDATE_USER_ID]);
-    const count = negotiationHost.database.countActiveNegotiationsForRound;
-    let pretendStillWorking = true;
-    negotiationHost.database.countActiveNegotiationsForRound = async (intentId, round) => {
-      // The pre-stamp check sees the negotiation as still going; it pauses in
-      // the window, so only the post-stamp check can catch it.
-      if (pretendStillWorking) { pretendStillWorking = false; return 1; }
-      return count.call(negotiationHost.database, intentId, round);
-    };
 
     await agent.invoke({ userId: SOURCE_USER_ID, intentId: INTENT_ID, event: "matches_ready" });
 
-    expect(negotiationHost.roundSize).toBe(1);
+    expect(negotiationHost.isOpeningComplete()).toBe(true);
     expect(negotiationHost.reflectJobs.filter((job) => job.intentId === INTENT_ID)).toEqual([
-      { userId: SOURCE_USER_ID, intentId: INTENT_ID, round: negotiationHost.round, generation: "task-1.0" },
+      { userId: SOURCE_USER_ID, intentId: INTENT_ID, batchId: negotiationHost.batchId, dedupeKey: "task-1.0" },
     ]);
   });
 
@@ -1417,7 +1419,7 @@ describe("PersonalAgent — round-5 regressions", () => {
     ]]);
     const { agent, principal } = buildCycle(judgment, [CANDIDATE_USER_ID]);
 
-    const result = await agent.invoke({ userId: SOURCE_USER_ID, intentId: INTENT_ID, event: "all_paused", round: 1 });
+    const result = await agent.invoke({ userId: SOURCE_USER_ID, intentId: INTENT_ID, event: "all_paused", batchId: "batch-1" });
 
     expect(result.error).toBeUndefined();
     expect(result.acts.map((act) => act.tool)).toEqual(["note_dossier", "reject", "message_user"]);
@@ -1445,8 +1447,8 @@ describe("PersonalAgent — the three decided design questions", () => {
     expect(judgment.seatBriefCalls).toHaveLength(1);
     expect(judgment.seatBriefCalls[0]!.intent.payload).toBe("bob wants a suitable match.");
     expect(task.metadata.seats).toEqual({
-      [INTENT_ID]: { userId: SOURCE_USER_ID, round: negotiationHost.round },
-      "intent-bob-1": { userId: CANDIDATE_USER_ID, round: 0 },
+      [INTENT_ID]: { userId: SOURCE_USER_ID, batchId: negotiationHost.batchId },
+      "intent-bob-1": { userId: CANDIDATE_USER_ID, batchId: expect.any(String) },
     });
     expect(negotiationInputs.find((input) => input.userId === CANDIDATE_USER_ID)).toEqual({
       userId: CANDIDATE_USER_ID,
@@ -1482,8 +1484,8 @@ describe("PersonalAgent — the three decided design questions", () => {
     expect(judgment.seatBriefCalls).toHaveLength(1);
     const authored = [...negotiationHost.tasks.values()][0]!.briefs[CANDIDATE_USER_ID];
 
-    // A later round re-kicks it; the counterparty's seat already has one.
-    await agent.invoke({ userId: SOURCE_USER_ID, intentId: INTENT_ID, event: "all_paused", round: negotiationHost.round });
+    // A later batch re-kicks it; the counterparty's seat already has one.
+    await agent.invoke({ userId: SOURCE_USER_ID, intentId: INTENT_ID, event: "all_paused", batchId: negotiationHost.batchId! });
 
     expect(judgment.seatBriefCalls).toHaveLength(1);
     expect([...negotiationHost.tasks.values()][0]!.briefs[CANDIDATE_USER_ID]).toBe(authored);
@@ -1519,36 +1521,36 @@ describe("PersonalAgent — the three decided design questions", () => {
       () => [{ tool: "kickoff", reasoning: "Much later." }],
     ]);
     const { agent, negotiationHost } = buildCycle(judgment, [CANDIDATE_USER_ID]);
-    const stamp = negotiationHost.database.stampIntentNegotiationRoundSize;
-    let failStamp = true;
-    negotiationHost.database.stampIntentNegotiationRoundSize = async (intentId, round, size) => {
-      if (failStamp) throw new Error("stamp write failed");
-      return stamp.call(negotiationHost.database, intentId, round, size);
+    const append = negotiationHost.roundLog.appendNegotiationRoundLogEvent;
+    let failComplete = true;
+    negotiationHost.roundLog.appendNegotiationRoundLogEvent = async (intentId, event) => {
+      if (failComplete && intentId === INTENT_ID && event.kind === "opening_complete") throw new Error("opening_complete write failed");
+      return append.call(negotiationHost.roundLog, intentId, event);
     };
 
     await agent.invoke({ userId: SOURCE_USER_ID, intentId: INTENT_ID, event: "matches_ready" });
-    const stranded = negotiationHost.round;
-    expect(negotiationHost.roundSize).toBeNull();
+    const stranded = negotiationHost.batchId!;
+    expect(negotiationHost.isOpeningComplete()).toBe(false);
     // Decided in the meantime, so the later turns open nothing of their own
-    // and the only thing that could move the round is the repair itself.
+    // and the only thing that could move the batch is the repair itself.
     negotiationHost.opportunities.get(OPPORTUNITY_ID)!.status = "rejected";
 
     const concurrent = await agent.invoke({ userId: SOURCE_USER_ID, intentId: INTENT_ID, event: "matches_ready" });
     expect(concurrent.error).toBeUndefined();
-    expect(negotiationHost.round).toBe(stranded);      // no bump
-    expect(negotiationHost.roundSize).toBeNull();      // and NOT settled out from under it
+    expect(negotiationHost.batchId).toBe(stranded);      // no bump
+    expect(negotiationHost.isOpeningComplete()).toBe(false);      // and NOT settled out from under it
     expect(concurrent.acts.find((act) => act.tool === "kickoff")).toEqual({
-      tool: "kickoff", round: stranded, opened: 0, attempted: 0, failed: 0, reasoning: "Concurrent turn.",
+      tool: "kickoff", batchId: stranded, opened: 0, attempted: 0, failed: 0, reasoning: "Concurrent turn.",
     });
 
-    // Past the bound the same round reads as abandoned, and is repaired.
-    failStamp = false;
+    // Past the bound the same batch reads as abandoned, and is repaired.
+    failComplete = false;
     negotiationHost.ageKickoff();
     await agent.invoke({ userId: SOURCE_USER_ID, intentId: INTENT_ID, event: "matches_ready" });
 
-    expect(negotiationHost.roundSize).toBe(1);
+    expect(negotiationHost.isOpeningComplete()).toBe(true);
     expect(negotiationHost.reflectJobs.filter((job) => job.intentId === INTENT_ID)).toEqual([{
-      userId: SOURCE_USER_ID, intentId: INTENT_ID, round: stranded, generation: "task-1.0",
+      userId: SOURCE_USER_ID, intentId: INTENT_ID, batchId: stranded, dedupeKey: "task-1.0",
     }]);
   });
 });
@@ -1577,8 +1579,7 @@ describe("PersonalAgent — round-6: per-seat binding and the kickoff region", (
         candidateUserId: CANDIDATE_USER_ID,
         initiatorUserId: SOURCE_USER_ID,
         networkId: "network-1",
-        seats: { [INTENT_ID]: { userId: SOURCE_USER_ID, round: 1 } },
-        drainGeneration: 0,
+        seats: { [INTENT_ID]: { userId: SOURCE_USER_ID, batchId: "batch-1" } },
       },
     });
     await negotiationHost.database.updateNegotiationTaskState(task.id, "paused", {
@@ -1586,7 +1587,7 @@ describe("PersonalAgent — round-6: per-seat binding and the kickoff region", (
       pausedBy: CANDIDATE_USER_ID,
     });
 
-    const result = await agent.invoke({ userId: SOURCE_USER_ID, intentId: INTENT_ID, event: "all_paused", round: 1 });
+    const result = await agent.invoke({ userId: SOURCE_USER_ID, intentId: INTENT_ID, event: "all_paused", batchId: "batch-1" });
 
     expect(result.acts).toContainEqual(expect.objectContaining({ tool: "reject", outcome: "error" }));
     expect(negotiationHost.taskFor(task.id).state).toBe("paused");
@@ -1606,8 +1607,7 @@ describe("PersonalAgent — round-6: per-seat binding and the kickoff region", (
         candidateUserId: CANDIDATE_USER_ID,
         initiatorUserId: SOURCE_USER_ID,
         networkId: "network-1",
-        seats: { [INTENT_ID]: { userId: SOURCE_USER_ID, round: 1 } },
-        drainGeneration: 0,
+        seats: { [INTENT_ID]: { userId: SOURCE_USER_ID, batchId: "batch-1" } },
       },
     });
     await negotiationHost.database.updateNegotiationTaskState(task.id, "paused", {
@@ -1656,8 +1656,7 @@ describe("PersonalAgent — round-6: per-seat binding and the kickoff region", (
         candidateUserId: CANDIDATE_USER_ID,
         initiatorUserId: SOURCE_USER_ID,
         networkId: "network-1",
-        seats: { [INTENT_ID]: { userId: SOURCE_USER_ID, round: 1 } },
-        drainGeneration: 0,
+        seats: { [INTENT_ID]: { userId: SOURCE_USER_ID, batchId: "batch-1" } },
       },
     });
     await negotiationHost.database.updateNegotiationTaskState(task.id, "paused", {
@@ -1666,7 +1665,7 @@ describe("PersonalAgent — round-6: per-seat binding and the kickoff region", (
       payload: { recommendation: "reject", reasoning: "Not a fit." },
     });
 
-    const result = await agent.invoke({ userId: SOURCE_USER_ID, intentId: INTENT_ID, event: "all_paused", round: 1 });
+    const result = await agent.invoke({ userId: SOURCE_USER_ID, intentId: INTENT_ID, event: "all_paused", batchId: "batch-1" });
 
     expect(result.acts.map((act) => act.tool)).toEqual(["reject", "message_user"]);
     expect(result.messages).toEqual(["I dismissed the match."]);
@@ -1694,8 +1693,7 @@ describe("PersonalAgent — round-6: per-seat binding and the kickoff region", (
         candidateUserId: CANDIDATE_USER_ID,
         initiatorUserId: SOURCE_USER_ID,
         networkId: "network-1",
-        seats: { [INTENT_ID]: { userId: SOURCE_USER_ID, round: 1 } },
-        drainGeneration: 0,
+        seats: { [INTENT_ID]: { userId: SOURCE_USER_ID, batchId: "batch-1" } },
       },
     });
     await negotiationHost.database.updateNegotiationTaskState(task.id, "paused", {
@@ -1703,7 +1701,7 @@ describe("PersonalAgent — round-6: per-seat binding and the kickoff region", (
       pausedBy: SOURCE_USER_ID,
     });
 
-    const result = await agent.invoke({ userId: SOURCE_USER_ID, intentId: INTENT_ID, event: "all_paused", round: 1 });
+    const result = await agent.invoke({ userId: SOURCE_USER_ID, intentId: INTENT_ID, event: "all_paused", batchId: "batch-1" });
 
     expect(result.error).toBe("model unavailable before verdict");
     expect(principal.ledgerRows.map((row) => row.act.tool)).toEqual(["note_dossier"]);
@@ -1748,8 +1746,7 @@ describe("PersonalAgent — round-6: per-seat binding and the kickoff region", (
         candidateUserId: CANDIDATE_USER_ID,
         initiatorUserId: SOURCE_USER_ID,
         networkId: "network-1",
-        seats: { [INTENT_ID]: { userId: SOURCE_USER_ID, round: 1 } },
-        drainGeneration: 0,
+        seats: { [INTENT_ID]: { userId: SOURCE_USER_ID, batchId: "batch-1" } },
       },
     });
     await negotiationHost.database.updateNegotiationTaskState(task.id, "paused", {
@@ -1758,7 +1755,7 @@ describe("PersonalAgent — round-6: per-seat binding and the kickoff region", (
       payload: { question: "When can you start?" },
     });
 
-    const result = await agent.invoke({ userId: SOURCE_USER_ID, intentId: INTENT_ID, event: "all_paused", round: 1 });
+    const result = await agent.invoke({ userId: SOURCE_USER_ID, intentId: INTENT_ID, event: "all_paused", batchId: "batch-1" });
 
     expect(result.acts.map((act) => act.tool)).toEqual(["message_user"]);
     expect(principal.dmMessages.at(-1)?.questions?.[0]?.prompt).toBe("When can you start?");
@@ -1787,7 +1784,7 @@ describe("PersonalAgent — round-6: per-seat binding and the kickoff region", (
         type: "negotiation", opportunityId: OPPORTUNITY_ID,
         sourceUserId: SOURCE_USER_ID, candidateUserId: CANDIDATE_USER_ID,
         initiatorUserId: SOURCE_USER_ID, networkId: "network-1",
-        seats: { [INTENT_ID]: { userId: SOURCE_USER_ID, round: 1 } }, drainGeneration: 0,
+        seats: { [INTENT_ID]: { userId: SOURCE_USER_ID, batchId: "batch-1" } }, drainGeneration: 0,
       },
     });
     await negotiationHost.database.updateNegotiationTaskState(task.id, "paused", {
@@ -1814,7 +1811,7 @@ describe("PersonalAgent — round-6: per-seat binding and the kickoff region", (
     await agent.invoke({ userId: SOURCE_USER_ID, intentId: INTENT_ID, event: "matches_ready" });
 
     expect(needsPrincipalWakes).toEqual([
-      expect.objectContaining({ userId: CANDIDATE_USER_ID, generation: 0 }),
+      expect.objectContaining({ userId: CANDIDATE_USER_ID, generation: 1 }),
     ]);
   });
 
@@ -1839,20 +1836,21 @@ describe("PersonalAgent — round-6: per-seat binding and the kickoff region", (
     await agent.invoke({ userId: SOURCE_USER_ID, intentId: INTENT_ID, event: "matches_ready" });
 
     const task = [...negotiationHost.tasks.values()][0]!;
-    expect(task.metadata.seats[BOB_INTENT]).toEqual({ userId: CANDIDATE_USER_ID, round: 0 });
+    const bobBatchId = task.metadata.seats[BOB_INTENT]!.batchId!;
+    expect(task.metadata.seats[BOB_INTENT]).toEqual({ userId: CANDIDATE_USER_ID, batchId: bobBatchId });
     const wake = negotiationHost.reflectJobs.find((job) => job.intentId === BOB_INTENT);
     expect(wake).toEqual({
       userId: CANDIDATE_USER_ID,
       intentId: BOB_INTENT,
-      round: 0,
-      generation: `${task.id}.0`,
+      batchId: bobBatchId,
+      dedupeKey: `${task.id}.2`,
     });
 
     const drained = await agent.invoke({
       userId: wake!.userId,
       intentId: wake!.intentId,
       event: "all_paused",
-      round: wake!.round,
+      batchId: wake!.batchId,
     });
     expect(drained.acts.map((act) => act.tool)).toEqual(["reject", "message_user"]);
     expect(negotiationHost.opportunities.get(OPPORTUNITY_ID)!.status).toBe("rejected");
@@ -1880,7 +1878,7 @@ describe("PersonalAgent — round-6: per-seat binding and the kickoff region", (
         candidateUserId: SOURCE_USER_ID,
         initiatorUserId: CANDIDATE_USER_ID,
         networkId: "network-1",
-        seats: { [BOB_INTENT]: { userId: CANDIDATE_USER_ID, round: 7 } },
+        seats: { [BOB_INTENT]: { userId: CANDIDATE_USER_ID, batchId: "batch-7" } },
       },
     });
 
@@ -1890,12 +1888,12 @@ describe("PersonalAgent — round-6: per-seat binding and the kickoff region", (
     // Alice's brief went to ALICE's slot; Bob's is untouched.
     expect(task.briefs[SOURCE_USER_ID]).toContain("Brief for");
     expect(task.briefs[CANDIDATE_USER_ID]).toBe("Bob's own brief, written by Bob's agent.");
-    // Two bindings, side by side. Neither round overwrote the other, so the
-    // task is in BOTH rounds rather than in neither.
-    expect(task.metadata.seats[BOB_INTENT]).toEqual({ userId: CANDIDATE_USER_ID, round: 7 });
-    expect(task.metadata.seats[INTENT_ID]).toEqual({ userId: SOURCE_USER_ID, round: negotiationHost.round });
-    expect(await negotiationHost.database.getNegotiationTasksForIntentRound(BOB_INTENT, 7)).toHaveLength(1);
-    expect(await negotiationHost.database.getNegotiationTasksForIntentRound(INTENT_ID, negotiationHost.round)).toHaveLength(1);
+    // Two bindings, side by side. Neither batch overwrote the other, so the
+    // task is in BOTH batches rather than in neither.
+    expect(task.metadata.seats[BOB_INTENT]).toEqual({ userId: CANDIDATE_USER_ID, batchId: "batch-7" });
+    expect(task.metadata.seats[INTENT_ID]).toEqual({ userId: SOURCE_USER_ID, batchId: negotiationHost.batchId });
+    expect(await negotiationHost.database.getNegotiationTasksForIntentBatch(BOB_INTENT, "batch-7")).toHaveLength(1);
+    expect(await negotiationHost.database.getNegotiationTasksForIntentBatch(INTENT_ID, negotiationHost.batchId!)).toHaveLength(1);
   });
 
   test("a background turn can reply naturally without fabricating work", async () => {
@@ -1904,7 +1902,7 @@ describe("PersonalAgent — round-6: per-seat binding and the kickoff region", (
     const judgment = new ScriptedJudgment([() => [], () => []]);
     const { agent, principal } = buildCycle(judgment, [CANDIDATE_USER_ID]);
 
-    const reflected = await agent.invoke({ userId: SOURCE_USER_ID, intentId: INTENT_ID, event: "all_paused", round: 1 });
+    const reflected = await agent.invoke({ userId: SOURCE_USER_ID, intentId: INTENT_ID, event: "all_paused", batchId: "batch-1" });
     expect(reflected.acts.map((act) => act.tool)).toEqual(["message_user"]);
     expect(principal.dmMessages.at(-1)!.content).toBe("Here is where things stand after 0 act(s).");
 
@@ -1931,8 +1929,8 @@ describe("PersonalAgent — round-6: per-seat binding and the kickoff region", (
         networkId: "network-1",
         // Both seats have kicked this off for their own signals.
         seats: {
-          [BOB_INTENT]: { userId: CANDIDATE_USER_ID, round: 7 },
-          [INTENT_ID]: { userId: SOURCE_USER_ID, round: 1 },
+          [BOB_INTENT]: { userId: CANDIDATE_USER_ID, batchId: "batch-7" },
+          [INTENT_ID]: { userId: SOURCE_USER_ID, batchId: "batch-1" },
         },
       },
     });
@@ -1942,7 +1940,7 @@ describe("PersonalAgent — round-6: per-seat binding and the kickoff region", (
       payload: { recommendation: "reject", reasoning: "Not a fit." },
     });
 
-    await agent.invoke({ userId: SOURCE_USER_ID, intentId: INTENT_ID, event: "all_paused", round: 1 });
+    await agent.invoke({ userId: SOURCE_USER_ID, intentId: INTENT_ID, event: "all_paused", batchId: "batch-1" });
 
     const context = judgment.decideCalls.at(-1)!;
     expect(context.paused).toEqual([expect.objectContaining({ negotiationId: task.id, pausedByUs: false })]);
@@ -2002,8 +2000,8 @@ describe("PersonalAgent — round-6: per-seat binding and the kickoff region", (
     });
     expect(acted.messages.at(-1)).toBe("I reached one match, but the other failed to open this round.");
     expect(negotiationHost.tasks.size).toBe(2);
-    // The round settles both the successful and compensated task, so it can reflect.
-    expect(negotiationHost.roundSize).toBe(2);
+    // The batch settles both the successful and compensated task, so it can reflect.
+    expect(negotiationHost.isOpeningComplete()).toBe(true);
     expect(negotiationHost.reflectJobs.filter((job) => job.intentId === INTENT_ID)).toHaveLength(1);
     // And the loss is on the record, not silent.
     expect(principal.ledgerRows.some((row) => typeof row.act.reasoning === "string"
@@ -2019,7 +2017,7 @@ describe("PersonalAgent — round-6: per-seat binding and the kickoff region", (
     // Every post-bump write fails: the compensation lookup, the round tasks
     // read, the stamp and the reflect enqueue.
     negotiationHost.database.stampIntentNegotiationRoundSize = async () => { throw new Error("stamp down"); };
-    negotiationHost.database.getNegotiationTasksForIntentRound = async () => { throw new Error("read down"); };
+    negotiationHost.database.getNegotiationTasksForIntentBatch = async () => { throw new Error("read down"); };
 
     const acted = await agent.invoke({ userId: SOURCE_USER_ID, intentId: INTENT_ID, event: "matches_ready" });
 

--- a/packages/protocol/src/index.ts
+++ b/packages/protocol/src/index.ts
@@ -233,6 +233,14 @@ export type {
   NegotiationRoundReflectCheck,
   NegotiationRoundReflectEnqueueFn,
 } from "./internal/negotiations/negotiation.round-reflect.js";
+export { foldNegotiationRoundLog } from "./internal/negotiations/negotiation.round-log.js";
+export type {
+  NegotiationRoundLogEvent,
+  NegotiationRoundLogOpenedEvent,
+  NegotiationRoundLogStoppedEvent,
+  NegotiationRoundLogResumedEvent,
+  NegotiationRoundLogFoldResult,
+} from "./internal/negotiations/negotiation.round-log.js";
 // ─── PersonalAgent (AgentGraph) ─────────────────────────────────────────────
 /**
  * One persona, three scopes, routed on the shape of the invoke input. The
@@ -290,6 +298,9 @@ export type {
   NegotiationSeatBinding,
   NegotiationTaskState,
   NegotiationMessageRow,
+  NegotiationRoundLogDatabase,
+  NegotiationRoundLogEventKind,
+  NegotiationRoundLogEventRecord,
 } from "./platform/database/negotiation.js";
 
 // ─── Opportunity compatibility exports ─────────────────────────────────────

--- a/packages/protocol/src/internal/agents/personal-agent/agent.graph.ts
+++ b/packages/protocol/src/internal/agents/personal-agent/agent.graph.ts
@@ -26,6 +26,7 @@ import { protocolLogger } from "../../shared/observability/protocol.logger.js";
 import { requestContext } from "../../shared/observability/request-context.js";
 import { turnsWithSenders, type NegotiationAuthoredTurn } from "../../negotiations/negotiation.turn.js";
 import { maybeEnqueueRoundReflect } from "../../negotiations/negotiation.round-reflect.js";
+import { foldNegotiationRoundLog, type NegotiationRoundLogEvent } from "../../negotiations/negotiation.round-log.js";
 import type { NegotiationTaskRow } from "../../../platform/database/negotiation.js";
 import type { IntentRecord } from "../../../platform/database/entities.js";
 import { canonicalCounterpartyStatusProse, isSupportedPersonalAgentStatusProse, normalizeMessageQuestions, PersonalAgentModel } from "./agent.judgment.js";
@@ -285,7 +286,7 @@ async function assembleContext(
     ...(input.event === "user_message"
       ? { message: { text: input.text, sessionId: input.sessionId, messageId: input.messageId } }
       : {}),
-    ...(input.event === "all_paused" ? { round: input.round } : {}),
+    ...(input.event === "all_paused" ? { batchId: input.batchId } : {}),
     ...(name ? { agentName: name } : {}),
     signalText: intent ? (intent.summary ?? intent.payload ?? null) : null,
     matches,
@@ -316,7 +317,7 @@ async function appendLedger(
       kind: context.event,
       ...(context.traceId ? { traceId: context.traceId } : {}),
       ...(context.message ? { messageId: context.message.messageId } : {}),
-      ...(context.round !== undefined ? { round: context.round } : {}),
+      ...(context.batchId !== undefined ? { batchId: context.batchId } : {}),
     },
     act: act as unknown as Record<string, unknown>,
   });
@@ -466,7 +467,7 @@ async function ledgerTerminalFallback(
     await deps.ledger.append({
       userId: context.userId,
       intentId: context.intentId,
-      event: { kind: context.event, ...(context.round !== undefined ? { round: context.round } : {}) },
+      event: { kind: context.event, ...(context.batchId !== undefined ? { batchId: context.batchId } : {}) },
       act: {
         tool: "terminal_fallback",
         text,
@@ -538,12 +539,8 @@ async function runKickoff(
 ): Promise<void> {
   const judgment = deps.judgment ?? defaultJudgment();
 
-  const lifecycle = await deps.negotiationDatabase.getIntentNegotiationRound(context.intentId);
-  const interruptedRound = lifecycle.kickoffStartedAt
-    && lifecycle.roundSize === null
-    && Date.now() - lifecycle.kickoffStartedAt.getTime() >= KICKOFF_STALE_AFTER_MS
-    ? lifecycle.round
-    : null;
+  const lifecycle = await deps.negotiationDatabase.getIntentNegotiationBatch(context.intentId);
+  const interruptedBatch = await detectInterruptedBatch(deps, context.intentId, lifecycle.batchId);
 
   // Exactly the set the agent was shown, minus anything THIS turn resolved a
   // moment ago — a promote or reject completed that negotiation, and opening
@@ -555,14 +552,14 @@ async function runKickoff(
     .map((act) => act.opportunityId));
   const matches = context.kickoffTargets.filter((match) => !resolvedHere.has(match.opportunityId));
 
-  // A round a kickoff began and never finished has to be settled, and BEFORE
-  // this turn bumps: the size stamp is guarded on the intent's current round,
-  // so once the counter moves that round can never be stamped again.
-  let repairedRound: number | null = null;
-  if (interruptedRound !== null) {
-    logger.warn("Repairing a kickoff that did not finish its round", { intentId: context.intentId, round: interruptedRound });
-    const settled = await settleRound(deps, context, interruptedRound, { triggerReflect: matches.length === 0 });
-    if (settled > 0 && matches.length > 0) repairedRound = interruptedRound;
+  // A batch a kickoff began and never finished has to be settled, and BEFORE
+  // this turn bumps: once the intent's current batch moves, the old batch id
+  // is no longer reachable from `getIntentNegotiationBatch`.
+  let repairedBatch: string | null = null;
+  if (interruptedBatch !== null) {
+    logger.warn("Repairing a kickoff that did not finish its batch", { intentId: context.intentId, batchId: interruptedBatch });
+    const settled = await settleBatch(deps, context, interruptedBatch, { triggerReflect: matches.length === 0 });
+    if (settled > 0 && matches.length > 0) repairedBatch = interruptedBatch;
   }
 
   if (matches.length === 0) {
@@ -575,7 +572,7 @@ async function runKickoff(
         context.matches.length === 0 ? PERSONAL_AGENT_NO_MATCHES_YET : PERSONAL_AGENT_NOTHING_TO_OPEN);
     }
     await recordKickoff(deps, context, accumulator, {
-      tool: "kickoff", round: lifecycle.round, opened: 0, attempted: 0, failed: 0, reasoning,
+      tool: "kickoff", batchId: lifecycle.batchId, opened: 0, attempted: 0, failed: 0, reasoning,
     });
     // Runs on this path too: it is the authoritative recovery for a batch the
     // inbox could not coalesce, and a turn with nothing to open is exactly
@@ -600,11 +597,11 @@ async function runKickoff(
   await say(deps, context, accumulator, "message_user", publicStrategy);
 
   throwIfIntentAborted();
-  const round = await deps.negotiationDatabase.bumpIntentNegotiationRound(context.intentId);
+  const { batchId } = await deps.negotiationDatabase.bumpIntentNegotiationBatch(context.intentId);
   // ─── from here down, nothing throws (D54) ───────────────────────────────
   // There are deliberately no cancellation gates below the bump. This
   // kickoff is already underway: abort-aware brief/open calls reject into the
-  // settled results so compensation and round settlement can still finish.
+  // settled results so compensation and batch settlement can still finish.
   const threadByOpportunity = new Map(context.paused.map((paused) => [paused.opportunityId, paused.thread]));
 
   const opens = await mapWithConcurrency(matches, kickoffConcurrency(), async (match) => {
@@ -617,9 +614,19 @@ async function runKickoff(
       opportunityId: match.opportunityId,
       brief,
       intentId: context.intentId,
-      round,
+      batchId,
     });
     if (result.status === "error") throw new Error(result.error ?? "Negotiation open failed");
+    // Best-effort: a lost 'opened' event only means this task's stop, when it
+    // comes, is not one the fold was expecting — harmless, since the fold
+    // only requires stops for tasks it saw open. It never blocks settlement.
+    await deps.roundLog.appendNegotiationRoundLogEvent(context.intentId, {
+      kind: "opened", taskId: result.negotiationId, batchId,
+    }).catch((err: unknown) => {
+      logger.error("Failed to append an opened round-log event", {
+        intentId: context.intentId, batchId, negotiationId: result.negotiationId, error: err,
+      });
+    });
     return result;
   });
 
@@ -628,7 +635,7 @@ async function runKickoff(
     if (open.status !== "rejected") continue;
     const match = matches[index]!;
     failed.push(match);
-    await compensateFailedOpen(deps, context, match, round, open.reason);
+    await compensateFailedOpen(deps, context, match, batchId, open.reason);
   }
   if (failed.length > 0) {
     // Recorded, not silent: a brief that never generated leaves no task for
@@ -637,7 +644,7 @@ async function runKickoff(
     // accounted for.
     await ledgerOrLog(deps, context, {
       tool: "kickoff",
-      round,
+      batchId,
       opened: 0,
       attempted: matches.length,
       failed: failed.length,
@@ -645,12 +652,35 @@ async function runKickoff(
     });
   }
 
-  const opened = await settleRound(deps, context, round, { triggerReflect: true });
-  if (opened === 0 && repairedRound !== null) await triggerRoundReflect(deps, context, repairedRound);
+  const opened = await settleBatch(deps, context, batchId, { triggerReflect: true });
+  if (opened === 0 && repairedBatch !== null) await triggerBatchReflect(deps, context, repairedBatch);
   await recordKickoff(deps, context, accumulator, {
-    tool: "kickoff", round, opened, attempted: matches.length, failed: failed.length, reasoning,
+    tool: "kickoff", batchId, opened, attempted: matches.length, failed: failed.length, reasoning,
   });
   if (opened > 0) await wakeForNewMatches(deps, context);
+}
+
+/**
+ * A batch a kickoff began but never finished settling (crash, restart)
+ * leaves its round-log without an `opening_complete` marker. Staleness is
+ * read from the log's own event timestamps rather than a separate started-at
+ * stamp: the max timestamp across whatever events exist is how long ago this
+ * batch last did anything. A batch with zero events (the process died before
+ * even the first 'opened' event landed) cannot be distinguished this way from
+ * one that just began this instant — an accepted, narrow gap, since kickoff's
+ * own opens follow the bump within the same turn almost immediately.
+ */
+async function detectInterruptedBatch(
+  deps: PersonalAgentDeps,
+  intentId: string,
+  batchId: string | null,
+): Promise<string | null> {
+  if (!batchId) return null;
+  const events = await deps.roundLog.readNegotiationRoundLogEvents(intentId, batchId);
+  if (events.length === 0) return null;
+  if (foldNegotiationRoundLog(events as NegotiationRoundLogEvent[]).settled) return null;
+  const lastEventAt = events.reduce((max, event) => Math.max(max, event.createdAt.getTime()), 0);
+  return Date.now() - lastEventAt >= KICKOFF_STALE_AFTER_MS ? batchId : null;
 }
 
 /**
@@ -695,26 +725,26 @@ async function compensateFailedOpen(
   deps: PersonalAgentDeps,
   context: PersonalAgentTurnContext,
   match: PersonalAgentMatch,
-  round: number,
+  batchId: string,
   failure: unknown,
 ): Promise<void> {
-  logger.warn("PersonalAgent kickoff open failed", { intentId: context.intentId, round, error: failure });
+  logger.warn("PersonalAgent kickoff open failed", { intentId: context.intentId, batchId, error: failure });
   // Post-bump: a read that fails here must not fail the turn either.
   const task = await deps.negotiationDatabase.getNegotiationTaskForOpportunity(match.opportunityId).catch((err: unknown) => {
     logger.error("Could not look up a failed open's task", { opportunityId: match.opportunityId, error: err });
     return null;
   });
-  if (!task || task.state !== "working" || task.metadata.seats[context.intentId]?.round !== round) return;
+  if (!task || task.state !== "working" || task.metadata.seats[context.intentId]?.batchId !== batchId) return;
   const spoke = (await deps.negotiationDatabase.getNegotiationMessages(task.id).catch(() => [])).length > 0;
   const result = await deps.negotiations.invoke({
     negotiationId: task.id,
     pause: spoke ? "counterparty_silent" : "open_failed",
   });
   if (result.status !== "paused") {
-    // Left live, this task holds its round open — but the round bump has
-    // already happened, so throwing would retry the whole turn into a second
-    // strategy message and a second round (D54). Recorded instead: the round
-    // stays unsettled, and the interrupted-round repair picks it up.
+    // Left live, this task holds its batch open — but the bump has already
+    // happened, so throwing would retry the whole turn into a second
+    // strategy message and a second batch (D54). Recorded instead: the batch
+    // stays unsettled, and the interrupted-kickoff repair picks it up.
     logger.error("Could not pause a stranded negotiation", {
       negotiationId: task.id,
       outcome: result.error ?? result.status,
@@ -723,52 +753,36 @@ async function compensateFailedOpen(
 }
 
 /**
- * Settle a round: run its all-paused check and stamp its size. Returns how
- * many negotiations the round actually holds — zero means there is nothing to
- * settle, and the round is deliberately left unstamped, because a settled
- * empty round is instantly "all paused" and reflect would kick off again,
- * forever.
+ * Settle a batch: run its all-paused check and append its opening_complete
+ * marker. Returns how many negotiations the batch actually holds — read back
+ * from the database rather than counted from the opens, since a compensated
+ * task and a re-kicked task that `init` had already moved into this batch
+ * both belong to it, and only the database knows which survived.
  *
- * The SIZE is read back from the database rather than counted from the opens:
- * a compensated task and a re-kicked task that `init` had already moved into
- * this round both belong to it, and only the database knows which survived.
- * The value is a record; what gates a pause-driven check is that it is no
- * longer null.
- *
- * The all-paused check runs on BOTH sides of the stamp, and the enqueue is
- * allowed to throw. Before, so that a failed enqueue leaves the round
- * unstamped and therefore still findable by the repair path above — retryable
- * rather than a settled round nothing will ever reflect on. After, because a
- * negotiation that pauses in between gets nothing otherwise: its own
- * pause-side check bailed on the still-null stamp, and this one had already
- * counted. The enqueue is keyed by (signal, round), so running it twice is
- * one job either way.
+ * The all-paused check runs only AFTER the marker is appended: before that,
+ * the fold can never be settled (nothing has told it opening finished), so an
+ * earlier check would be a pure no-op. The marker write is retried, then
+ * given up on loudly (D54); an un-appended marker is not lost — the
+ * interrupted-kickoff repair settles it once its log goes stale.
  */
-async function settleRound(
+async function settleBatch(
   deps: PersonalAgentDeps,
   context: PersonalAgentTurnContext,
-  round: number,
+  batchId: string,
   options: { triggerReflect: boolean },
 ): Promise<number> {
-  const tasks = await deps.negotiationDatabase.getNegotiationTasksForIntentRound(context.intentId, round)
+  const tasks = await deps.negotiationDatabase.getNegotiationTasksForIntentBatch(context.intentId, batchId)
     .catch((err: unknown) => {
-      logger.error("Could not read a round's tasks to settle it", { intentId: context.intentId, round, error: err });
+      logger.error("Could not read a batch's tasks to settle it", { intentId: context.intentId, batchId, error: err });
       return [] as NegotiationTaskRow[];
     });
-  if (tasks.length === 0) return 0;
 
-  if (options.triggerReflect) await triggerRoundReflect(deps, context, round);
-  // Retried, then given up on loudly: this is the one post-bump write whose
-  // loss matters, and it must not throw (D54). An unstamped round is not
-  // lost — the interrupted-round repair settles it once it goes stale.
   await retryWrite(
-    () => deps.negotiationDatabase.stampIntentNegotiationRoundSize(context.intentId, round, tasks.length),
-    "stamp a round's size",
-    { intentId: context.intentId, round },
+    () => deps.roundLog.appendNegotiationRoundLogEvent(context.intentId, { kind: "opening_complete", batchId }),
+    "append a batch's opening_complete marker",
+    { intentId: context.intentId, batchId },
   );
-  // The window the stamp opens: anything that paused since the count above saw
-  // a null stamp and bailed, and would be waited on forever.
-  if (options.triggerReflect) await triggerRoundReflect(deps, context, round);
+  if (options.triggerReflect) await triggerBatchReflect(deps, context, batchId);
   return tasks.length;
 }
 
@@ -792,18 +806,18 @@ async function retryWrite(
   }
 }
 
-/** Enqueue this round's reflect if every negotiation in it has stopped. */
-async function triggerRoundReflect(
+/** Enqueue this batch's reflect if every negotiation in it has stopped. */
+async function triggerBatchReflect(
   deps: PersonalAgentDeps,
   context: PersonalAgentTurnContext,
-  round: number,
+  batchId: string,
 ): Promise<void> {
   const enqueue = deps.reflectEnqueue;
   if (!enqueue) return;
-  await maybeEnqueueRoundReflect(deps.negotiationDatabase, enqueue, {
+  await maybeEnqueueRoundReflect(deps.roundLog, enqueue, {
     userId: context.userId,
     intentId: context.intentId,
-    round,
+    batchId,
   });
 }
 

--- a/packages/protocol/src/internal/agents/personal-agent/agent.types.ts
+++ b/packages/protocol/src/internal/agents/personal-agent/agent.types.ts
@@ -22,7 +22,7 @@
  */
 import type { NegotiationAuthoredTurn } from "../../negotiations/negotiation.turn.js";
 import type { NegotiationGraphLike } from "../../negotiations/negotiation.graph.js";
-import type { NegotiationGraphDatabase, NegotiationTaskRow } from "../../../platform/database/negotiation.js";
+import type { NegotiationGraphDatabase, NegotiationRoundLogDatabase, NegotiationTaskRow } from "../../../platform/database/negotiation.js";
 import type { IntentRecord } from "../../../platform/database/entities.js";
 import type { NegotiationRoundReflectEnqueueFn } from "../../negotiations/negotiation.round-reflect.js";
 import type { Question } from "../../../protocol/question.js";
@@ -50,8 +50,8 @@ export type PersonalAgentInput =
   | { userId: string; intentId: string; event: "matches_ready" }
   /** One of this signal's negotiations needs its principal before it can continue. */
   | { userId: string; intentId: string; event: "needs_principal"; negotiationId: string }
-  /** Every negotiation of `(intentId, round)` has paused. */
-  | { userId: string; intentId: string; event: "all_paused"; round: number }
+  /** Every negotiation of `(intentId, batchId)` has paused. */
+  | { userId: string; intentId: string; event: "all_paused"; batchId: string }
   /** The other agent resolved a shared negotiation; fixed copy informs this principal. */
   | { userId: string; intentId: string; event: "counterparty_resolved"; negotiationId: string; verdict: "pending" | "reject" }
   /** One negotiator turn for the given seat and its own signal. */
@@ -100,8 +100,9 @@ export type PersonalAgentExecutedAct =
   }
   | {
     tool: "kickoff";
-    round: number;
-    /** How many negotiation tasks the round settled with; preserves the round-size semantics. */
+    /** Null only when nothing was ever kicked off for this signal — a turn with zero matches to open. */
+    batchId: string | null;
+    /** How many negotiation tasks the batch settled with; preserves the old round-size semantics. */
     opened: number;
     /** How many matches this kickoff tried to open or resume. */
     attempted: number;
@@ -260,8 +261,10 @@ export interface PersonalAgentIdentityPort {
 export interface PersonalAgentDeps {
   /** Every negotiation effect — kickoff, resume, verdict — goes through here. */
   negotiations: NegotiationGraphLike;
-  /** Reads negotiation state IS-A reasons over: round tasks, threads, briefs. */
+  /** Reads negotiation state IS-A reasons over: batch tasks, threads, briefs. */
   negotiationDatabase: NegotiationGraphDatabase;
+  /** The append-only round-log a batch's settlement is folded from (#1494). */
+  roundLog: NegotiationRoundLogDatabase;
   conversation: PersonalAgentConversationPort;
   dossier: PersonalAgentDossierPort;
   ledger: PersonalAgentLedgerPort;
@@ -271,7 +274,8 @@ export interface PersonalAgentDeps {
   activity?: PersonalAgentActivityPort;
   /**
    * The all-paused → reflect trigger. Kickoff runs one final check after
-   * stamping the round size, to cover pauses that landed before the stamp.
+   * appending the batch's opening_complete marker, to cover pauses that
+   * landed before it.
    */
   reflectEnqueue?: NegotiationRoundReflectEnqueueFn;
   /**
@@ -373,7 +377,7 @@ export interface PersonalAgentTurnContext {
   /** Present only for `user_message`. */
   message?: { text: string; sessionId: string; messageId: string };
   /** Present only for `all_paused`. */
-  round?: number;
+  batchId?: string;
   agentName?: string;
   signalText: string | null;
   /** Everything undecided on this signal — what the principal may act on. */

--- a/packages/protocol/src/internal/negotiations/negotiation.graph.ts
+++ b/packages/protocol/src/internal/negotiations/negotiation.graph.ts
@@ -15,7 +15,7 @@
  */
 import { END, StateGraph, Annotation } from "@langchain/langgraph";
 
-import type { NegotiationGraphDatabase, NegotiationTaskRow, NegotiationTaskMetadata } from "../../platform/database/negotiation.js";
+import type { NegotiationGraphDatabase, NegotiationRoundLogDatabase, NegotiationTaskRow, NegotiationTaskMetadata } from "../../platform/database/negotiation.js";
 import { protocolLogger } from "../shared/observability/protocol.logger.js";
 import { NEGOTIATION_MAX_TURNS_AMBIENT } from "../../protocol/core.js";
 import { NegotiationTurnSchema, NegotiationOpeningTurnSchema, isPauseTurn, turnsFromMessages, turnsWithSenders, type NegotiationTurn, type NegotiationVerdict, type NegotiationPauseReason, type NegotiationSystemPauseReason } from "./negotiation.turn.js";
@@ -28,12 +28,12 @@ const logger = protocolLogger("NegotiationGraph");
 
 export type NegotiationGraphInput =
   /**
-   * `round` is the caller's own batch counter — one bump per kickoff batch,
-   * not per opportunity. `brief` is the INITIATING seat's own brief — the
-   * seat that owns `intentId` — and never the counterparty's, which that
+   * `batchId` is the caller's own kickoff batch id — one bump per kickoff
+   * batch, not per opportunity. `brief` is the INITIATING seat's own brief —
+   * the seat that owns `intentId` — and never the counterparty's, which that
    * seat's own agent authors at its first turn.
    */
-  | { opportunityId: string; brief: string; intentId: string; round: number }
+  | { opportunityId: string; brief: string; intentId: string; batchId: string }
   /**
    * Resume with a fresh brief for ONE seat, named explicitly. `byUserId` is
    * not optional and is not inferred: the same "assume it is `sourceUserId`"
@@ -65,6 +65,8 @@ export interface NegotiationGraphResult {
 
 export interface NegotiationGraphDeps {
   database: NegotiationGraphDatabase;
+  /** The append-only round-log a batch's settlement is folded from (#1494). */
+  roundLog: NegotiationRoundLogDatabase;
   reflectEnqueue?: NegotiationRoundReflectEnqueueFn;
   /** Delivers an owned needs-principal pause immediately; batch reflection remains separate. */
   needsPrincipalEnqueue?: (input: { userId: string; intentId: string; negotiationId: string; generation: number }) => Promise<void>;
@@ -216,10 +218,21 @@ async function initNode(state: NegotiationState, deps: NegotiationGraphDeps): Pr
       if (!candidateIntent || candidateIntent.userId !== candidateActor.userId) {
         return { phase: "error", error: "Counterparty actor intent is not owned by that seat" };
       }
-      const candidateRound = await deps.database.getIntentNegotiationRound(candidateIntent.id);
+      const candidateBatch = await deps.database.getIntentNegotiationBatch(candidateIntent.id);
+      // A candidate seat that has never itself run a kickoff gets a batch
+      // lazily, the first time any negotiation touches it — the same
+      // "passive round" every never-kicked signal started on before this
+      // rewrite. Marked opening_complete immediately: nothing will ever
+      // stamp a size for a batch no kickoff opened, so this batch is never
+      // gated on one — it settles as soon as whatever tasks land in it stop.
+      let candidateBatchId = candidateBatch.batchId;
+      if (candidateBatchId === null) {
+        candidateBatchId = (await deps.database.bumpIntentNegotiationBatch(candidateIntent.id)).batchId;
+        await deps.roundLog.appendNegotiationRoundLogEvent(candidateIntent.id, { kind: "opening_complete", batchId: candidateBatchId });
+      }
       const seats = {
-        [input.intentId]: { userId: sourceActor.userId, round: input.round },
-        [candidateIntent.id]: { userId: candidateActor.userId, round: candidateRound.round },
+        [input.intentId]: { userId: sourceActor.userId, batchId: input.batchId },
+        [candidateIntent.id]: { userId: candidateActor.userId, batchId: candidateBatchId },
       };
 
       const opened = await deps.database.openNegotiationTask({
@@ -233,12 +246,22 @@ async function initNode(state: NegotiationState, deps: NegotiationGraphDeps): Pr
       });
       if (!opened) return { phase: "error", error: "Opportunity is not eligible to open" };
 
+      if (opened.disposition === 'created') {
+        // The candidate's own passive log must know this task belongs to its
+        // current batch, or that batch's fold would see zero opened tasks and
+        // settle trivially the instant opening_complete lands — ignoring a
+        // real, still-active negotiation.
+        await deps.roundLog.appendNegotiationRoundLogEvent(candidateIntent.id, {
+          kind: "opened", taskId: opened.task.id, batchId: candidateBatchId,
+        });
+      }
+
       if (opened.disposition !== 'created') {
         // Bind only the kicking seat. A task seen before the transaction is a
         // genuine re-kick and continues through turn; one first observed by
         // the transaction raced another opener and must not author opening.
         await deps.database.setNegotiationBrief(opened.task.id, sourceActor.userId, input.brief);
-        await deps.database.bindNegotiationSeat(opened.task.id, input.intentId, { userId: sourceActor.userId, round: input.round });
+        await deps.database.bindNegotiationSeat(opened.task.id, input.intentId, { userId: sourceActor.userId, batchId: input.batchId });
         const messages = await deps.database.getNegotiationMessages(opened.task.id);
         const task = {
           ...opened.task,
@@ -448,6 +471,7 @@ async function applyNode(state: NegotiationState, deps: NegotiationGraphDeps): P
       // that doesn't gate on state (the API's lifecycle-summary projection)
       // would keep showing "needs your input" for a question already resolved.
       currentTask = await deps.database.updateNegotiationTaskState(currentTask.id, "working", null);
+      await appendRoundLogEventForEverySeat(deps, meta, currentTask.id, { kind: "resumed" });
     }
 
     if (isPauseTurn(effectiveTurn)) {
@@ -466,7 +490,10 @@ async function applyNode(state: NegotiationState, deps: NegotiationGraphDeps): P
               userId: speakerId,
               intentId,
               negotiationId: updated.id,
-              generation: updated.metadata.drainGeneration,
+              // The persisted turn's own message-count position: unique and
+              // monotonic per task, same property the deleted drainGeneration
+              // counter gave this dedupe key.
+              generation: messages.length,
             });
           } catch (error) {
             // The pause is already durable. A missed wake must not undo it or
@@ -479,8 +506,13 @@ async function applyNode(state: NegotiationState, deps: NegotiationGraphDeps): P
           }
         }
       }
-      // EVERY bound seat: a pause can complete either side's round, and each
+      // EVERY bound seat: a pause can complete either side's batch, and each
       // side's IS-A reflects on its own.
+      await appendRoundLogEventForEverySeat(deps, meta, updated.id, {
+        kind: "stopped",
+        via: "paused",
+        reason: effectiveTurn.reason,
+      });
       await triggerReflectForEverySeat(deps, meta);
       return { task: updated, turns: allTurns, phase: "done", result: toResult(updated, allTurns) };
     }
@@ -493,19 +525,45 @@ async function applyNode(state: NegotiationState, deps: NegotiationGraphDeps): P
 }
 
 /**
+ * Append one round-log event (stopped or resumed) for every seat bound to
+ * this negotiation that has ever run a kickoff of its own (`batchId !==
+ * null`). A seat whose intent has never kicked off has no batch to log
+ * against — its own reflect will start once its first kickoff bumps one.
+ */
+async function appendRoundLogEventForEverySeat(
+  deps: NegotiationGraphDeps,
+  meta: NegotiationTaskMetadata,
+  taskId: string,
+  event: { kind: "resumed" } | { kind: "stopped"; via: "paused" | "completed"; reason?: NegotiationPauseReason },
+): Promise<void> {
+  await Promise.all(Object.entries(meta.seats).map(async ([intentId, binding]) => {
+    if (binding.batchId === null) return;
+    if (event.kind === "resumed") {
+      await deps.roundLog.appendNegotiationRoundLogEvent(intentId, { kind: "resumed", taskId, batchId: binding.batchId });
+      return;
+    }
+    await deps.roundLog.appendNegotiationRoundLogEvent(intentId, {
+      kind: "stopped", taskId, batchId: binding.batchId, via: event.via, ...(event.reason ? { reason: event.reason } : {}),
+    });
+  }));
+}
+
+/**
  * Run the all-paused check for every seat bound to this negotiation.
  *
- * Both sides batch their own rounds, so one pause can be the last one of
+ * Both sides batch their own kickoffs, so one pause can be the last one of
  * either side's — checking only the opener's would leave the counterparty's
- * round waiting on a negotiation that had already stopped.
+ * batch waiting on a negotiation that had already stopped. A seat with no
+ * batch (`batchId === null`) has never kicked off and has nothing to fold.
  */
 async function triggerReflectForEverySeat(deps: NegotiationGraphDeps, meta: NegotiationTaskMetadata): Promise<boolean> {
   let succeeded = true;
   for (const [intentId, binding] of Object.entries(meta.seats)) {
-    const checked = await maybeEnqueueRoundReflect(deps.database, deps.reflectEnqueue, {
+    if (binding.batchId === null) continue;
+    const checked = await maybeEnqueueRoundReflect(deps.roundLog, deps.reflectEnqueue, {
       userId: binding.userId,
       intentId,
-      round: binding.round,
+      batchId: binding.batchId,
     });
     succeeded &&= checked;
   }
@@ -564,9 +622,10 @@ async function resolveNode(state: NegotiationState, deps: NegotiationGraphDeps):
     });
     if (!updated) return { phase: "error", error: "Negotiation changed before its verdict committed" };
     await notifyCounterparties(deps, task.metadata, task.id, input.byUserId, input.verdict);
-    // A round whose last active negotiation ends by direct verdict (not a
+    // A batch whose last active negotiation ends by direct verdict (not a
     // pause) must still trigger the all-paused check — apply isn't the only
-    // way a round finishes.
+    // way a batch finishes.
+    await appendRoundLogEventForEverySeat(deps, task.metadata, task.id, { kind: "stopped", via: "completed" });
     if (await triggerReflectForEverySeat(deps, task.metadata)) {
       await clearReflectPendingBestEffort(deps, task.id);
     }
@@ -588,6 +647,7 @@ async function closeNode(state: NegotiationState, deps: NegotiationGraphDeps): P
         kind: "opportunity_expired",
       });
       if (!updated) return { phase: "error", error: "Expiry closure requires a live task and expired opportunity" };
+      await appendRoundLogEventForEverySeat(deps, task.metadata, task.id, { kind: "stopped", via: "completed" });
       if (await triggerReflectForEverySeat(deps, task.metadata)) {
         await clearReflectPendingBestEffort(deps, task.id);
       }
@@ -606,6 +666,7 @@ async function closeNode(state: NegotiationState, deps: NegotiationGraphDeps): P
       resolvedByUserId: input.byUserId,
     });
     if (!updated) return { phase: "error", error: "Owner-verdict closure requires a live task and terminal opportunity" };
+    await appendRoundLogEventForEverySeat(deps, task.metadata, task.id, { kind: "stopped", via: "completed" });
     if (await triggerReflectForEverySeat(deps, task.metadata)) {
       await clearReflectPendingBestEffort(deps, task.id);
     }
@@ -637,6 +698,7 @@ async function expireNode(state: NegotiationState, deps: NegotiationGraphDeps): 
       reason: input.expire.reason,
     });
     if (!expired) return { task, phase: "done", result: toResult(task, []) };
+    await appendRoundLogEventForEverySeat(deps, expired.metadata, task.id, { kind: "stopped", via: "completed" });
     await triggerReflectForEverySeat(deps, expired.metadata);
     return { task: expired, phase: "done", result: { negotiationId: task.id, status: "resolved", turns: [] } };
   } catch (err) {

--- a/packages/protocol/src/internal/negotiations/negotiation.round-log.ts
+++ b/packages/protocol/src/internal/negotiations/negotiation.round-log.ts
@@ -1,0 +1,132 @@
+/**
+ * The append-only event log a round's "has everything settled" answer is
+ * folded from, replacing the racy quartet of separately-written fields
+ * (`negotiation_round`, `negotiation_round_size`, `negotiation_kickoff_started_at`,
+ * `metadata.drainGeneration`) that `negotiation.round-reflect.ts` currently
+ * reads. Pure, additive logic only — nothing here is wired to a database or
+ * called by anything yet.
+ *
+ * One log per `(intentId, batchId)`. Two things can happen to a task in a
+ * batch: it opens once, and it stops (possibly more than once, since a
+ * `needs_principal` pause can be answered and the task resumed). `stopped`
+ * reuses `NegotiationPauseReasonName` from `negotiation.turn.ts` so this log
+ * never invents a second vocabulary for why a task paused.
+ *
+ * Design question: does a resumed task need its own event kind, or do
+ * `opened`/`stopped` alone already answer "is the batch settled" correctly
+ * across a resume?
+ *
+ * Trace a task that pauses, gets resumed, and pauses again, WITHOUT a
+ * `resumed` event: the log holds `opened(T)`, `stopped(T)`, `stopped(T)`.
+ * A fold that asks "does every opened taskId have a stopped event" cannot
+ * tell "T is currently stopped" from "T stopped once, is active again right
+ * now, and just happens to have a stopped event somewhere in its past" — it
+ * would report the batch settled *before* T's second pause actually lands,
+ * which is wrong. And even where that race doesn't bite, a dedupe key built
+ * from the deduped set of stopped task ids is identical across T's first and
+ * second settle (both include T exactly once), so the second, genuinely
+ * distinct drain would collide with the first under the old key and get
+ * silently swallowed as a duplicate — the exact bug the fixed counter had.
+ *
+ * So `resumed` is required, not optional: it is what lets the fold tell "T's
+ * most recent transition was a stop" (currently stopped) apart from "T's
+ * most recent transition was a resume" (currently active, ignore its earlier
+ * stop). With `resumed` in the log, a second full stop cycle produces a
+ * *different* current stopped-event position for T than the first cycle did,
+ * so the derived dedupe key changes across settles the same way the old
+ * incremented `drainGeneration` counter did — except derived from the log
+ * instead of a value every resume path had to remember to bump.
+ */
+import type { NegotiationPauseReasonName } from "./negotiation.turn.js";
+
+export interface NegotiationRoundLogOpenedEvent {
+  kind: "opened";
+  taskId: string;
+  batchId: string;
+}
+
+export interface NegotiationRoundLogStoppedEvent {
+  kind: "stopped";
+  taskId: string;
+  batchId: string;
+  via: "paused" | "completed";
+  reason?: NegotiationPauseReasonName;
+}
+
+/** A previously-stopped task got a turn again (e.g. its `needs_principal` pause was answered). */
+export interface NegotiationRoundLogResumedEvent {
+  kind: "resumed";
+  taskId: string;
+  batchId: string;
+}
+
+/**
+ * Appended once, after a kickoff's parallel match-opens have all settled.
+ * Replaces the old `negotiation_round_size` stamp: it is the signal that no
+ * more `opened` events are coming for this batch, including the zero-tasks
+ * case (a kickoff that had nothing to reach out to still settles this batch
+ * immediately once this lands).
+ */
+export interface NegotiationRoundLogOpeningCompleteEvent {
+  kind: "opening_complete";
+  batchId: string;
+}
+
+export type NegotiationRoundLogEvent =
+  | NegotiationRoundLogOpenedEvent
+  | NegotiationRoundLogStoppedEvent
+  | NegotiationRoundLogResumedEvent
+  | NegotiationRoundLogOpeningCompleteEvent;
+
+export interface NegotiationRoundLogFoldResult {
+  settled: boolean;
+  /** Only present when `settled` is true. Distinct across two settles of the same task set. */
+  dedupeKey?: string;
+}
+
+/**
+ * Pure fold over one `(intentId, batchId)`'s event log: no I/O, no clock, no
+ * randomness. Settled means (a) an `opening_complete` marker exists for this
+ * batch — no more `opened` events are coming — AND (b) every task that ever
+ * opened in this batch is, as of the last event touching it, stopped rather
+ * than resumed. The dedupe key is built from where in the log each task's
+ * *current* stop sits, so a second stop after a resume yields a different key
+ * than the first.
+ */
+export function foldNegotiationRoundLog(events: NegotiationRoundLogEvent[]): NegotiationRoundLogFoldResult {
+  const openedTaskIds = new Set<string>();
+  // Index (position in `events`) of each task's current stopped event, i.e.
+  // the most recent `stopped` not superseded by a later `resumed`. Absent
+  // means the task is currently active (never stopped, or resumed since).
+  const currentStopIndex = new Map<string, number>();
+  let openingComplete = false;
+
+  events.forEach((event, index) => {
+    switch (event.kind) {
+      case "opened":
+        openedTaskIds.add(event.taskId);
+        break;
+      case "stopped":
+        currentStopIndex.set(event.taskId, index);
+        break;
+      case "resumed":
+        currentStopIndex.delete(event.taskId);
+        break;
+      case "opening_complete":
+        openingComplete = true;
+        break;
+    }
+  });
+
+  if (!openingComplete) return { settled: false };
+  for (const taskId of openedTaskIds) {
+    if (!currentStopIndex.has(taskId)) return { settled: false };
+  }
+
+  const dedupeKey = Array.from(openedTaskIds)
+    .sort()
+    .map((taskId) => `${taskId}.${currentStopIndex.get(taskId)}`)
+    .join("_") || "empty";
+
+  return { settled: true, dedupeKey };
+}

--- a/packages/protocol/src/internal/negotiations/negotiation.round-reflect.ts
+++ b/packages/protocol/src/internal/negotiations/negotiation.round-reflect.ts
@@ -1,27 +1,20 @@
 /**
  * The all-paused → reflect trigger.
  *
- * Every pause is a DB transition. The graph's apply step ends by checking
- * whether any active negotiation remains for `(intentId, round)`; if not, it
- * enqueues one reflect job keyed by the durable task-generation vector. Ten
- * deliveries of one drain produce one job, while a later pause after a reopen
- * produces a new one even when the seat binding still names the same round. The consumer
+ * Every pause/resume/completion is appended to the batch's round-log
+ * (`negotiation.round-log.ts`). The graph's apply/resolve/close/expire steps
+ * end by folding that log; if it says the batch is settled, one reflect job
+ * is enqueued, keyed by the fold's own dedupe key so redelivery — or a second,
+ * genuinely distinct settle after a resume — behaves correctly. The consumer
  * invokes the PersonalAgent with `{ userId, intentId, event: 'all_paused',
- * round }`.
- *
- * The check is gated on the round's SIZE stamp. Kickoff opens a round's
- * negotiations in parallel and stamps the size only once every open has
- * settled; until then this is a no-op, because an early first pause would
- * otherwise see zero working tasks before its siblings had created theirs and
- * the deterministic job id would dedupe away the round's genuine reflect.
- * Kickoff runs one final check itself, right after stamping, to cover the
- * pauses that landed before it.
+ * batchId }`.
  *
  * Not to be confused with `negotiation.reflect.ts`'s `NegotiationReflector`,
  * the unrelated memory-distillation pass.
  */
-import type { NegotiationGraphDatabase } from "../../platform/database/negotiation.js";
+import type { NegotiationRoundLogDatabase } from "../../platform/database/negotiation.js";
 import { protocolLogger } from "../shared/observability/protocol.logger.js";
+import { foldNegotiationRoundLog, type NegotiationRoundLogEvent } from "./negotiation.round-log.js";
 
 const logger = protocolLogger("NegotiationRoundReflect");
 
@@ -32,18 +25,18 @@ export interface NegotiationRoundReflectJobData {
   /** The signal's owner — the principal whose PersonalAgent reflects. */
   userId: string;
   intentId: string;
-  round: number;
-  /** Exact durable all-paused state this job drains. */
-  generation: string;
+  batchId: string;
+  /** The fold's dedupe key for this settle — distinct across two settles of the same batch. */
+  dedupeKey: string;
 }
 
-export type NegotiationRoundReflectCheck = Omit<NegotiationRoundReflectJobData, "generation">;
+export type NegotiationRoundReflectCheck = Omit<NegotiationRoundReflectJobData, "dedupeKey">;
 
-/** Deterministic job id: duplicate delivery of one durable drain collapses. */
-export function negotiationRoundReflectJobId(intentId: string, round: number, generation: string): string {
+/** Deterministic job id: duplicate delivery of one durable settle collapses. */
+export function negotiationRoundReflectJobId(intentId: string, batchId: string, dedupeKey: string): string {
   // BullMQ rejects custom ids containing `:`. Keep the durable components,
   // but use a safe separator so a real all-paused check can reach its agent.
-  return `reflect.${intentId}.${round}.${generation}`;
+  return `reflect.${intentId}.${batchId}.${dedupeKey}`;
 }
 
 /**
@@ -53,61 +46,39 @@ export function negotiationRoundReflectJobId(intentId: string, round: number, ge
  */
 export type NegotiationRoundReflectEnqueueFn = (job: NegotiationRoundReflectJobData) => Promise<void>;
 
-/** The database reads the all-paused check needs. */
-export type NegotiationRoundReflectDatabase = Pick<
-  NegotiationGraphDatabase,
-  "getIntentNegotiationRound" | "getNegotiationTasksForIntentRound"
->;
-
 /**
- * Enqueue exactly one reflect job if this round's task set is complete and
- * every negotiation in it has stopped. Never throws: the caller's own transition is
- * already durable and must not fail over a trigger. Returns false only when
- * the check or enqueue exhausted its retries, so a durable recovery marker
- * can remain pending.
+ * Enqueue exactly one reflect job if this batch's event log folds settled.
+ * Never throws: the caller's own transition is already durable and must not
+ * fail over a trigger. Returns false only when the check or enqueue
+ * exhausted its retries, so a durable recovery marker can remain pending.
  */
 export async function maybeEnqueueRoundReflect(
-  database: NegotiationRoundReflectDatabase,
+  roundLog: NegotiationRoundLogDatabase,
   enqueue: NegotiationRoundReflectEnqueueFn | undefined,
   check: NegotiationRoundReflectCheck,
 ): Promise<boolean> {
   if (!enqueue) {
     logger.warn("Skipping all-paused reflect because no enqueue handler is configured", {
       intentId: check.intentId,
-      round: check.round,
+      batchId: check.batchId,
     });
     return true;
   }
   try {
-    const stamp = await database.getIntentNegotiationRound(check.intentId);
-    // A current kickoff has not finished binding all of its tasks yet. A
-    // passive/counterparty seat (no kickoff marker) and a superseded round
-    // already have their complete durable task sets and need no size gate.
-    if (stamp.round === check.round && stamp.roundSize === null && stamp.kickoffStartedAt !== null) {
-      logger.info("Deferring all-paused reflect until kickoff stamps its round", {
+    const events = await roundLog.readNegotiationRoundLogEvents(check.intentId, check.batchId);
+    const fold = foldNegotiationRoundLog(events as NegotiationRoundLogEvent[]);
+    if (!fold.settled || fold.dedupeKey === undefined) {
+      logger.info("Deferring all-paused reflect because the batch is not settled", {
         intentId: check.intentId,
-        round: check.round,
+        batchId: check.batchId,
+        eventCount: events.length,
       });
       return true;
     }
-    const tasks = await database.getNegotiationTasksForIntentRound(check.intentId, check.round);
-    if (tasks.length === 0 || tasks.some((task) => task.state !== "paused" && task.state !== "completed")) {
-      logger.info("Deferring all-paused reflect because the round is still active", {
-        intentId: check.intentId,
-        round: check.round,
-        taskCount: tasks.length,
-        states: tasks.map((task) => task.state),
-      });
-      return true;
-    }
-    const generation = tasks
-      .map((task) => `${task.id}.${task.metadata.drainGeneration}`)
-      .sort()
-      .join("_");
-    const job: NegotiationRoundReflectJobData = { ...check, generation };
+    const job: NegotiationRoundReflectJobData = { ...check, dedupeKey: fold.dedupeKey };
     // The pause this runs behind is already persisted, so throwing would
     // report a failure for work that is durably done. But a swallowed enqueue
-    // on the round's LAST pause is a round that never reflects and has no
+    // on the batch's LAST pause is a batch that never reflects and has no
     // second chance — nothing pauses again to re-check it. Retry a few times
     // before giving up, and give up loudly.
     let failure: unknown;
@@ -116,9 +87,8 @@ export async function maybeEnqueueRoundReflect(
         await enqueue(job);
         logger.info("Enqueued all-paused reflect", {
           intentId: check.intentId,
-          round: check.round,
-          generation,
-          taskCount: tasks.length,
+          batchId: check.batchId,
+          dedupeKey: fold.dedupeKey,
         });
         return true;
       } catch (err) {
@@ -128,9 +98,9 @@ export async function maybeEnqueueRoundReflect(
     }
     throw failure;
   } catch (err) {
-    logger.error("Failed to check all-paused / enqueue reflect — this round will not reflect", {
+    logger.error("Failed to check all-paused / enqueue reflect — this batch will not reflect", {
       intentId: check.intentId,
-      round: check.round,
+      batchId: check.batchId,
       error: err,
     });
     return false;

--- a/packages/protocol/src/internal/negotiations/tests/negotiation.graph.expiry.spec.ts
+++ b/packages/protocol/src/internal/negotiations/tests/negotiation.graph.expiry.spec.ts
@@ -10,8 +10,7 @@ function task(state: 'paused' | 'completed' = 'paused') {
     id: 'task-1', conversationId: 'conversation-1', state, briefs: {}, createdAt: updatedAt, updatedAt,
     metadata: {
       type: 'negotiation' as const, opportunityId: 'opportunity-1', sourceUserId: 'user-1', candidateUserId: 'user-2',
-      initiatorUserId: 'user-1', networkId: 'network-1', seats: { 'intent-1': { userId: 'user-1', round: 2 } },
-      drainGeneration: 0,
+      initiatorUserId: 'user-1', networkId: 'network-1', seats: { 'intent-1': { userId: 'user-1', batchId: 'batch-2' } },
       pause: { reason: 'needs_principal' as const },
     },
   };
@@ -22,24 +21,31 @@ function graph(overrides: Record<string, unknown> = {}) {
     getNegotiationTask: mock(async () => task()),
     expirePausedNegotiation: mock(async () => ({ ...task(), state: 'completed' as const })),
     createNegotiationOutcomeArtifact: mock(async () => undefined),
-    getIntentNegotiationRound: mock(async () => ({ round: 2, roundSize: 1, kickoffStartedAt: updatedAt })),
-    getNegotiationTasksForIntentRound: mock(async () => [task('completed')]),
     ...overrides,
+  };
+  const roundLog = {
+    appendNegotiationRoundLogEvent: mock(async () => undefined),
+    readNegotiationRoundLogEvents: mock(async () => [
+      { kind: 'opened' as const, taskId: 'task-1', batchId: 'batch-2', createdAt: updatedAt },
+      { kind: 'opening_complete' as const, batchId: 'batch-2', createdAt: updatedAt },
+      { kind: 'stopped' as const, taskId: 'task-1', batchId: 'batch-2', via: 'completed' as const, createdAt: updatedAt },
+    ]),
   };
   const reflectEnqueue = mock(async () => undefined);
   return {
     database,
+    roundLog,
     reflectEnqueue,
-    graph: new NegotiationGraphFactory({ database: database as never, author: {} as never, reflectEnqueue }).createGraph(),
+    graph: new NegotiationGraphFactory({ database: database as never, roundLog: roundLog as never, author: {} as never, reflectEnqueue }).createGraph(),
   };
 }
 
 describe('NegotiationGraph system expiry', () => {
   it('uses a BullMQ-safe id for a durable all-paused reflect', () => {
-    expect(negotiationRoundReflectJobId('intent-1', 2, 'task-1.0')).toBe('reflect.intent-1.2.task-1.0');
+    expect(negotiationRoundReflectJobId('intent-1', 'batch-2', 'task-1.0')).toBe('reflect.intent-1.batch-2.task-1.0');
   });
 
-  it('completes an eligible paused task without authoring a verdict and reflects its round', async () => {
+  it('completes an eligible paused task without authoring a verdict and reflects its batch', async () => {
     const fixture = graph();
 
     const result = await fixture.graph.invoke({
@@ -50,7 +56,7 @@ describe('NegotiationGraph system expiry', () => {
     expect(fixture.database.expirePausedNegotiation).toHaveBeenCalledWith({ taskId: 'task-1', expectedUpdatedAt: updatedAt, reason: 'needs_principal' });
     expect(fixture.database.createNegotiationOutcomeArtifact).not.toHaveBeenCalled();
     expect(fixture.reflectEnqueue).toHaveBeenCalledWith({
-      userId: 'user-1', intentId: 'intent-1', round: 2, generation: 'task-1.0',
+      userId: 'user-1', intentId: 'intent-1', batchId: 'batch-2', dedupeKey: 'task-1.2',
     });
   });
 

--- a/packages/protocol/src/internal/negotiations/tests/negotiation.round-log.spec.ts
+++ b/packages/protocol/src/internal/negotiations/tests/negotiation.round-log.spec.ts
@@ -1,0 +1,93 @@
+import { describe, expect, it } from 'bun:test';
+
+import { foldNegotiationRoundLog, type NegotiationRoundLogEvent } from '../negotiation.round-log.js';
+
+const BATCH = 'batch-1';
+
+function opened(taskId: string): NegotiationRoundLogEvent {
+  return { kind: 'opened', taskId, batchId: BATCH };
+}
+function stopped(taskId: string, via: 'paused' | 'completed' = 'paused'): NegotiationRoundLogEvent {
+  return { kind: 'stopped', taskId, batchId: BATCH, via, reason: via === 'paused' ? 'needs_principal' : undefined };
+}
+function resumed(taskId: string): NegotiationRoundLogEvent {
+  return { kind: 'resumed', taskId, batchId: BATCH };
+}
+function openingComplete(): NegotiationRoundLogEvent {
+  return { kind: 'opening_complete', batchId: BATCH };
+}
+
+describe('foldNegotiationRoundLog', () => {
+  it('is not settled when no tasks have stopped', () => {
+    const result = foldNegotiationRoundLog([opened('t1'), opened('t2')]);
+
+    expect(result.settled).toBe(false);
+    expect(result.dedupeKey).toBeUndefined();
+  });
+
+  it('is not settled when only some tasks have stopped', () => {
+    const result = foldNegotiationRoundLog([opened('t1'), opened('t2'), stopped('t1', 'completed'), openingComplete()]);
+
+    expect(result.settled).toBe(false);
+  });
+
+  it('is not settled before opening_complete lands, even if every opened task has already stopped', () => {
+    const result = foldNegotiationRoundLog([opened('t1'), opened('t2'), stopped('t1', 'paused'), stopped('t2', 'completed')]);
+
+    expect(result.settled).toBe(false);
+  });
+
+  it('settles once opening_complete lands after every opened task has stopped', () => {
+    const result = foldNegotiationRoundLog([
+      opened('t1'), opened('t2'), stopped('t1', 'paused'), stopped('t2', 'completed'), openingComplete(),
+    ]);
+
+    expect(result.settled).toBe(true);
+  });
+
+  it('settles a zero-task batch immediately once opening_complete lands', () => {
+    const result = foldNegotiationRoundLog([openingComplete()]);
+
+    expect(result.settled).toBe(true);
+    expect(result.dedupeKey).toBe('empty');
+  });
+
+  it('is settled with a dedupe key once every task has stopped, mixing paused and completed', () => {
+    const events = [opened('t1'), opened('t2'), stopped('t1', 'paused'), stopped('t2', 'completed'), openingComplete()];
+
+    const result = foldNegotiationRoundLog(events);
+
+    expect(result.settled).toBe(true);
+    expect(result.dedupeKey).toBe('t1.2_t2.3');
+  });
+
+  it('produces a different dedupe key on the second settle after a task resumes and stops again', () => {
+    const firstSettleEvents: NegotiationRoundLogEvent[] = [
+      opened('t1'), opened('t2'), stopped('t1', 'paused'), stopped('t2', 'completed'), openingComplete(),
+    ];
+    const firstResult = foldNegotiationRoundLog(firstSettleEvents);
+
+    const afterResume = [...firstSettleEvents, resumed('t1')];
+    expect(foldNegotiationRoundLog(afterResume).settled).toBe(false);
+
+    const secondSettleEvents = [...afterResume, stopped('t1', 'completed')];
+    const secondResult = foldNegotiationRoundLog(secondSettleEvents);
+
+    expect(firstResult.settled).toBe(true);
+    expect(secondResult.settled).toBe(true);
+    expect(secondResult.dedupeKey).not.toBe(firstResult.dedupeKey);
+    expect(firstResult.dedupeKey).toBe('t1.2_t2.3');
+    expect(secondResult.dedupeKey).toBe('t1.6_t2.3');
+  });
+
+  it('is idempotent: redelivering the same final log state yields the same dedupe key', () => {
+    const events = [opened('t1'), opened('t2'), stopped('t1', 'paused'), stopped('t2', 'completed'), openingComplete()];
+
+    const first = foldNegotiationRoundLog(events);
+    const second = foldNegotiationRoundLog([...events]);
+
+    expect(first.settled).toBe(true);
+    expect(second.settled).toBe(true);
+    expect(second.dedupeKey).toBe(first.dedupeKey);
+  });
+});

--- a/packages/protocol/src/platform/database/capabilities.ts
+++ b/packages/protocol/src/platform/database/capabilities.ts
@@ -132,7 +132,7 @@ export type ChatGraphCompositeDatabase = Pick<
   // Orphan heal in OpportunityGraph persist node
   | 'getNegotiationTaskForOpportunity'
   // negotiateNode bumps the round once per (intentId) in a kickoff batch
-  | 'bumpIntentNegotiationRound'
+  | 'bumpIntentNegotiationBatch'
 >;
 
 /**
@@ -194,7 +194,7 @@ export type OpportunityGraphDatabase = Pick<
   | 'getNegotiationTaskForOpportunity'
   // negotiateNode bumps the round once per (intentId) in a kickoff batch and
   // passes it to every open() in that batch — a round is the batch, not one opportunity.
-  | 'bumpIntentNegotiationRound'
+  | 'bumpIntentNegotiationBatch'
 >;
 export interface OutcomeOutbox {
   event: unknown;

--- a/packages/protocol/src/platform/database/negotiation.ts
+++ b/packages/protocol/src/platform/database/negotiation.ts
@@ -15,12 +15,16 @@ import type { Database } from '../database.js';
 /** Negotiation task lifecycle. `paused` carries a reason in `metadata.pause`. */
 export type NegotiationTaskState = 'submitted' | 'working' | 'paused' | 'completed';
 
-/** One seat's binding to a signal, and that signal's kickoff round. */
+/** One seat's binding to a signal, and that signal's kickoff batch. */
 export interface NegotiationSeatBinding {
   /** The seat that owns the signal this entry is keyed by. */
   userId: string;
-  /** The round of that signal's kickoff which last targeted this negotiation. */
-  round: number;
+  /**
+   * The batch id of that signal's kickoff which last targeted this
+   * negotiation. Null means the signal has never itself run a kickoff — the
+   * same meaning the old `round: 0` default carried for a passive seat.
+   */
+  batchId: string | null;
 }
 
 export interface NegotiationTaskMetadata {
@@ -48,13 +52,6 @@ export interface NegotiationTaskMetadata {
    * a later kickoff updates only its own seat's round.
    */
   seats: Record<string, NegotiationSeatBinding>;
-  /**
-   * Monotonic generation of this task's paused lifecycle. The opening run is
-   * generation 0; the first persisted turn after each pause increments it.
-   * An all-paused drain is deduplicated by the durable vector of these values,
-   * so reopening a task creates a new drain without duplicating one pause.
-   */
-  drainGeneration: number;
   /** True between atomic verdict completion and a successful round-reflect check. */
   watchdogReflectPending?: boolean;
   /** Fairness cursor for bounded watchdog sweeps; ISO-8601 when last checked. */
@@ -126,10 +123,7 @@ export type NegotiationGraphDatabase = Pick<Database, 'getOpportunity' | 'getInt
   /** Every negotiation task where the given user is source or candidate. */
   getNegotiationTasksForUser(userId: string): Promise<NegotiationTaskRow[]>;
 
-  /**
-   * Transitions state and, for `paused`, records the reason/payload. Moving a
-   * paused task back to `working` also increments its durable drain generation.
-   */
+  /** Transitions state and, for `paused`, records the reason/payload. */
   updateNegotiationTaskState(
     taskId: string,
     state: 'working' | 'paused' | 'completed',
@@ -195,8 +189,8 @@ export type NegotiationGraphDatabase = Pick<Database, 'getOpportunity' | 'getInt
   /** Reads back artifacts persisted for a task (e.g. the resolve outcome). */
   getArtifactsForTask(taskId: string): Promise<Array<{ id: string; name: string | null; parts: unknown[]; metadata: Record<string, unknown> | null }>>;
 
-  /** Every negotiation task bound to one intent's given round, whatever its state. The round-settling read. */
-  getNegotiationTasksForIntentRound(intentId: string, round: number): Promise<NegotiationTaskRow[]>;
+  /** Every negotiation task bound to one intent's given batch, whatever its state. The batch-settling read. */
+  getNegotiationTasksForIntentBatch(intentId: string, batchId: string): Promise<NegotiationTaskRow[]>;
 
   /**
    * Every PAUSED, unresolved negotiation of one signal, whatever round it
@@ -210,32 +204,57 @@ export type NegotiationGraphDatabase = Pick<Database, 'getOpportunity' | 'getInt
   getPausedNegotiationTasksForIntent(intentId: string): Promise<NegotiationTaskRow[]>;
 
   /**
-   * Opens a new round: bumps `intents.negotiation_round`, clears
-   * `negotiation_round_size` and stamps `negotiation_kickoff_started_at`, all
-   * in one write. Only kickoff bumps a round, so the bump IS the beginning of
-   * a kickoff and there is no gap in which a crash could leave the round
-   * begun-but-unmarked. Returns the new round.
+   * Opens a new batch: generates a fresh UUID and writes it to
+   * `intents.negotiation_batch_id`. Only kickoff bumps a batch, so this write
+   * IS the beginning of a kickoff and there is no gap in which a crash could
+   * leave a batch begun-but-unmarked. Returns the new batch id.
    */
-  bumpIntentNegotiationRound(intentId: string): Promise<number>;
+  bumpIntentNegotiationBatch(intentId: string): Promise<{ batchId: string }>;
 
   /**
-   * The intent's round lifecycle: which round it is on, when a kickoff for
-   * that round BEGAN (null if none ever did — including every intent that
-   * predates round stamping), and the settled size (null until the kickoff
-   * finished). `kickoffStartedAt` set with `roundSize` null is the one
-   * signature of a kickoff that died mid-round.
+   * The intent's current kickoff batch id, or null if no kickoff has ever run
+   * for this signal (including every intent that predates batch stamping).
    */
-  getIntentNegotiationRound(intentId: string): Promise<{ round: number; roundSize: number | null; kickoffStartedAt: Date | null }>;
+  getIntentNegotiationBatch(intentId: string): Promise<{ batchId: string | null }>;
 
-  /**
-   * Stamps how many negotiations this round actually opened. Written once, by
-   * kickoff, after every open has settled — the gate the all-paused check
-   * waits on. A no-op if the intent has already moved to a later round.
-   */
-  stampIntentNegotiationRoundSize(intentId: string, round: number, size: number): Promise<void>;
-
-  /** Count of this intent's round-`round` negotiations not yet `paused` or `completed`. Drives the all-paused → reflect trigger. */
-  countActiveNegotiationsForRound(intentId: string, round: number): Promise<number>;
+  /** Count of this intent's batch-`batchId` negotiations not yet `paused` or `completed`. Drives the all-paused → reflect trigger. */
+  countActiveNegotiationsForBatch(intentId: string, batchId: string): Promise<number>;
 };
+
+/**
+ * Structural mirror of `NegotiationRoundLogEvent`
+ * (internal/negotiations/negotiation.round-log.ts). `platform` may only
+ * depend on `protocol`/`platform` code (enforced by
+ * `architecture:kernel`), so this port defines its own shape instead of
+ * importing across that boundary; TypeScript's structural typing means the
+ * internal type satisfies this one at every call site.
+ */
+export type NegotiationRoundLogEventKind = 'opened' | 'stopped' | 'resumed' | 'opening_complete';
+
+export interface NegotiationRoundLogEventRecord {
+  kind: NegotiationRoundLogEventKind;
+  /** Absent only for 'opening_complete', which has no task. */
+  taskId?: string;
+  batchId: string;
+  /** Only set on 'stopped' events. */
+  via?: 'paused' | 'completed';
+  /** Only set on 'stopped' events whose `via` is 'paused'. */
+  reason?: string;
+  /** When this event was appended — the staleness clock for an in-flight batch. */
+  createdAt: Date;
+}
+
+/**
+ * Durable store for `NegotiationRoundLogEvent`s (#1494). The single write
+ * path for a batch's open/stop/resume/opening_complete history, folded by
+ * `foldNegotiationRoundLog` to decide when a batch has settled.
+ */
+export interface NegotiationRoundLogDatabase {
+  /** Appends one event to the intent's round log. Append-only — never mutates or removes a prior event. */
+  appendNegotiationRoundLogEvent(intentId: string, event: Omit<NegotiationRoundLogEventRecord, 'createdAt'>): Promise<void>;
+
+  /** This intent's events for one batch, in the order they were appended — the order the fold requires. */
+  readNegotiationRoundLogEvents(intentId: string, batchId: string): Promise<NegotiationRoundLogEventRecord[]>;
+}
 
 export type { Opportunity };

--- a/services/api/drizzle/0154_add_negotiation_round_log_events.sql
+++ b/services/api/drizzle/0154_add_negotiation_round_log_events.sql
@@ -1,0 +1,14 @@
+CREATE TYPE "public"."negotiation_round_log_event_kind" AS ENUM('opened', 'stopped', 'resumed');--> statement-breakpoint
+CREATE TYPE "public"."negotiation_round_log_event_via" AS ENUM('paused', 'completed');--> statement-breakpoint
+CREATE TABLE "negotiation_round_log_events" (
+	"id" text PRIMARY KEY NOT NULL,
+	"intent_id" text NOT NULL,
+	"batch_id" text NOT NULL,
+	"task_id" text NOT NULL,
+	"kind" "negotiation_round_log_event_kind" NOT NULL,
+	"via" "negotiation_round_log_event_via",
+	"reason" text,
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL
+);
+--> statement-breakpoint
+CREATE INDEX "idx_negotiation_round_log_events_batch" ON "negotiation_round_log_events" USING btree ("intent_id","batch_id","created_at");

--- a/services/api/drizzle/0155_drop_orphaned_tables.sql
+++ b/services/api/drizzle/0155_drop_orphaned_tables.sql
@@ -1,0 +1,2 @@
+DROP TABLE IF EXISTS "discovery_match_candidates";
+DROP TABLE IF EXISTS "user_contexts";

--- a/services/api/drizzle/0156_negotiation_batch_cutover.sql
+++ b/services/api/drizzle/0156_negotiation_batch_cutover.sql
@@ -1,0 +1,6 @@
+ALTER TYPE "public"."negotiation_round_log_event_kind" ADD VALUE 'opening_complete';--> statement-breakpoint
+ALTER TABLE "negotiation_round_log_events" ALTER COLUMN "task_id" DROP NOT NULL;--> statement-breakpoint
+ALTER TABLE "intents" ADD COLUMN "negotiation_batch_id" text;--> statement-breakpoint
+ALTER TABLE "intents" DROP COLUMN "negotiation_round";--> statement-breakpoint
+ALTER TABLE "intents" DROP COLUMN "negotiation_round_size";--> statement-breakpoint
+ALTER TABLE "intents" DROP COLUMN "negotiation_kickoff_started_at";

--- a/services/api/drizzle/meta/0154_snapshot.json
+++ b/services/api/drizzle/meta/0154_snapshot.json
@@ -1,0 +1,6876 @@
+{
+  "id": "6bb8665f-4754-4874-96ce-9b856eeae272",
+  "prevId": "127c0de0-0004-0008-0000-000000000127",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.intent_dossier": {
+      "name": "intent_dossier",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "intent_id": {
+          "name": "intent_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "text": {
+          "name": "text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source": {
+          "name": "source",
+          "type": "intent_dossier_source",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "retired_at": {
+          "name": "retired_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_intent_dossier_scope": {
+          "name": "idx_intent_dossier_scope",
+          "columns": [
+            {
+              "expression": "user_id",
+              "asc": true,
+              "nulls": "last",
+              "opclass": "timestamptz_ops",
+              "isExpression": false
+            },
+            {
+              "expression": "intent_id",
+              "asc": true,
+              "nulls": "last",
+              "opclass": "text_ops",
+              "isExpression": false
+            },
+            {
+              "expression": "retired_at",
+              "asc": true,
+              "nulls": "last",
+              "opclass": "timestamptz_ops",
+              "isExpression": false
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "intent_dossier_user_id_users_id_fk": {
+          "name": "intent_dossier_user_id_users_id_fk",
+          "tableFrom": "intent_dossier",
+          "tableTo": "users",
+          "schemaTo": "public",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "intent_dossier_intent_id_intents_id_fk": {
+          "name": "intent_dossier_intent_id_intents_id_fk",
+          "tableFrom": "intent_dossier",
+          "tableTo": "intents",
+          "schemaTo": "public",
+          "columnsFrom": [
+            "intent_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {},
+      "policies": {},
+      "isRLSEnabled": false
+    },
+    "public.intent_agent_acts": {
+      "name": "intent_agent_acts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "intent_id": {
+          "name": "intent_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "event": {
+          "name": "event",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "act": {
+          "name": "act",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_intent_agent_acts_scope": {
+          "name": "idx_intent_agent_acts_scope",
+          "columns": [
+            {
+              "expression": "user_id",
+              "asc": true,
+              "nulls": "last",
+              "opclass": "timestamptz_ops",
+              "isExpression": false
+            },
+            {
+              "expression": "intent_id",
+              "asc": true,
+              "nulls": "last",
+              "opclass": "text_ops",
+              "isExpression": false
+            },
+            {
+              "expression": "created_at",
+              "asc": true,
+              "nulls": "last",
+              "opclass": "timestamptz_ops",
+              "isExpression": false
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "intent_agent_acts_user_id_users_id_fk": {
+          "name": "intent_agent_acts_user_id_users_id_fk",
+          "tableFrom": "intent_agent_acts",
+          "tableTo": "users",
+          "schemaTo": "public",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {},
+      "policies": {},
+      "isRLSEnabled": false
+    },
+    "public.hyde_documents": {
+      "name": "hyde_documents",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "source_type": {
+          "name": "source_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_id": {
+          "name": "source_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source_text": {
+          "name": "source_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "strategy": {
+          "name": "strategy",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "target_corpus": {
+          "name": "target_corpus",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "context": {
+          "name": "context",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "hyde_text": {
+          "name": "hyde_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "hyde_embedding": {
+          "name": "hyde_embedding",
+          "type": "vector(2000)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "hyde_embedding_idx": {
+          "name": "hyde_embedding_idx",
+          "columns": [
+            {
+              "expression": "hyde_embedding",
+              "asc": true,
+              "nulls": "last",
+              "opclass": "vector_cosine_ops",
+              "isExpression": false
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "hnsw",
+          "with": {}
+        },
+        "hyde_expires_idx": {
+          "name": "hyde_expires_idx",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "asc": true,
+              "nulls": "last",
+              "opclass": "timestamptz_ops",
+              "isExpression": false
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "hyde_source_idx": {
+          "name": "hyde_source_idx",
+          "columns": [
+            {
+              "expression": "source_type",
+              "asc": true,
+              "nulls": "last",
+              "opclass": "text_ops",
+              "isExpression": false
+            },
+            {
+              "expression": "source_id",
+              "asc": true,
+              "nulls": "last",
+              "opclass": "text_ops",
+              "isExpression": false
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "hyde_source_strategy_unique": {
+          "name": "hyde_source_strategy_unique",
+          "columns": [
+            {
+              "expression": "source_type",
+              "asc": true,
+              "nulls": "last",
+              "opclass": "text_ops",
+              "isExpression": false
+            },
+            {
+              "expression": "source_id",
+              "asc": true,
+              "nulls": "last",
+              "opclass": "text_ops",
+              "isExpression": false
+            },
+            {
+              "expression": "strategy",
+              "asc": true,
+              "nulls": "last",
+              "opclass": "text_ops",
+              "isExpression": false
+            },
+            {
+              "expression": "target_corpus",
+              "asc": true,
+              "nulls": "last",
+              "opclass": "text_ops",
+              "isExpression": false
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "hyde_strategy_idx": {
+          "name": "hyde_strategy_idx",
+          "columns": [
+            {
+              "expression": "strategy",
+              "asc": true,
+              "nulls": "last",
+              "opclass": "text_ops",
+              "isExpression": false
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {},
+      "policies": {},
+      "isRLSEnabled": false
+    },
+    "public.discovery_match_candidates": {
+      "name": "discovery_match_candidates",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "pair_key": {
+          "name": "pair_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "network_id": {
+          "name": "network_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "intent_a": {
+          "name": "intent_a",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "intent_b": {
+          "name": "intent_b",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_a": {
+          "name": "user_a",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_b": {
+          "name": "user_b",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "score": {
+          "name": "score",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reasoning": {
+          "name": "reasoning",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "evidence": {
+          "name": "evidence",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "status": {
+          "name": "status",
+          "type": "discovery_match_candidate_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "opened_opportunity_id": {
+          "name": "opened_opportunity_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "discovery_match_candidates_intent_a_idx": {
+          "name": "discovery_match_candidates_intent_a_idx",
+          "columns": [
+            {
+              "expression": "intent_a",
+              "asc": true,
+              "nulls": "last",
+              "opclass": "text_ops",
+              "isExpression": false
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "discovery_match_candidates_intent_b_idx": {
+          "name": "discovery_match_candidates_intent_b_idx",
+          "columns": [
+            {
+              "expression": "intent_b",
+              "asc": true,
+              "nulls": "last",
+              "opclass": "text_ops",
+              "isExpression": false
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "discovery_match_candidates_pair_key_idx": {
+          "name": "discovery_match_candidates_pair_key_idx",
+          "columns": [
+            {
+              "expression": "pair_key",
+              "asc": true,
+              "nulls": "last",
+              "opclass": "text_ops",
+              "isExpression": false
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "discovery_match_candidates_network_id_fkey": {
+          "name": "discovery_match_candidates_network_id_fkey",
+          "tableFrom": "discovery_match_candidates",
+          "tableTo": "networks",
+          "schemaTo": "public",
+          "columnsFrom": [
+            "network_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "discovery_match_candidates_intent_a_fkey": {
+          "name": "discovery_match_candidates_intent_a_fkey",
+          "tableFrom": "discovery_match_candidates",
+          "tableTo": "intents",
+          "schemaTo": "public",
+          "columnsFrom": [
+            "intent_a"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "discovery_match_candidates_intent_b_fkey": {
+          "name": "discovery_match_candidates_intent_b_fkey",
+          "tableFrom": "discovery_match_candidates",
+          "tableTo": "intents",
+          "schemaTo": "public",
+          "columnsFrom": [
+            "intent_b"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "discovery_match_candidates_user_a_fkey": {
+          "name": "discovery_match_candidates_user_a_fkey",
+          "tableFrom": "discovery_match_candidates",
+          "tableTo": "users",
+          "schemaTo": "public",
+          "columnsFrom": [
+            "user_a"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "discovery_match_candidates_user_b_fkey": {
+          "name": "discovery_match_candidates_user_b_fkey",
+          "tableFrom": "discovery_match_candidates",
+          "tableTo": "users",
+          "schemaTo": "public",
+          "columnsFrom": [
+            "user_b"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "discovery_match_candidates_opened_opportunity_id_fkey": {
+          "name": "discovery_match_candidates_opened_opportunity_id_fkey",
+          "tableFrom": "discovery_match_candidates",
+          "tableTo": "opportunities",
+          "schemaTo": "public",
+          "columnsFrom": [
+            "opened_opportunity_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {},
+      "policies": {},
+      "isRLSEnabled": false
+    },
+    "public.verifications": {
+      "name": "verifications",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "identifier": {
+          "name": "identifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {},
+      "policies": {},
+      "isRLSEnabled": false
+    },
+    "public.accounts": {
+      "name": "accounts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "id_token": {
+          "name": "id_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "access_token_expires_at": {
+          "name": "access_token_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token_expires_at": {
+          "name": "refresh_token_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "password": {
+          "name": "password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "accounts_user_id_users_id_fk": {
+          "name": "accounts_user_id_users_id_fk",
+          "tableFrom": "accounts",
+          "tableTo": "users",
+          "schemaTo": "public",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {},
+      "policies": {},
+      "isRLSEnabled": false
+    },
+    "public.sessions": {
+      "name": "sessions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "ip_address": {
+          "name": "ip_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "sessions_user_id_users_id_fk": {
+          "name": "sessions_user_id_users_id_fk",
+          "tableFrom": "sessions",
+          "tableTo": "users",
+          "schemaTo": "public",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "sessions_token_unique": {
+          "columns": [
+            "token"
+          ],
+          "nullsNotDistinct": false,
+          "name": "sessions_token_unique"
+        }
+      },
+      "checkConstraints": {},
+      "policies": {},
+      "isRLSEnabled": false
+    },
+    "public.user_notification_settings": {
+      "name": "user_notification_settings",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "preferences": {
+          "name": "preferences",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'{\"connectionUpdates\":true,\"weeklyNewsletter\":true}'::json"
+        },
+        "unsubscribe_token": {
+          "name": "unsubscribe_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "user_notification_settings_user_id_users_id_fk": {
+          "name": "user_notification_settings_user_id_users_id_fk",
+          "tableFrom": "user_notification_settings",
+          "tableTo": "users",
+          "schemaTo": "public",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "user_notification_settings_user_id_unique": {
+          "columns": [
+            "user_id"
+          ],
+          "nullsNotDistinct": false,
+          "name": "user_notification_settings_user_id_unique"
+        },
+        "user_notification_settings_unsubscribe_token_unique": {
+          "columns": [
+            "unsubscribe_token"
+          ],
+          "nullsNotDistinct": false,
+          "name": "user_notification_settings_unsubscribe_token_unique"
+        }
+      },
+      "checkConstraints": {},
+      "policies": {},
+      "isRLSEnabled": false
+    },
+    "public.jwks": {
+      "name": "jwks",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "public_key": {
+          "name": "public_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "private_key": {
+          "name": "private_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {},
+      "policies": {},
+      "isRLSEnabled": false
+    },
+    "public.intent_discovery_progress": {
+      "name": "intent_discovery_progress",
+      "schema": "",
+      "columns": {
+        "intent_id": {
+          "name": "intent_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "intent_discovery_progress_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'queued'"
+        },
+        "attempt": {
+          "name": "attempt",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "max_attempts": {
+          "name": "max_attempts",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 3
+        },
+        "assigned_community_count": {
+          "name": "assigned_community_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "processed_community_count": {
+          "name": "processed_community_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "possible_overlap_count": {
+          "name": "possible_overlap_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "conversations_started_count": {
+          "name": "conversations_started_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "queued_at": {
+          "name": "queued_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "intent_discovery_progress_user_updated_idx": {
+          "name": "intent_discovery_progress_user_updated_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "asc": true,
+              "nulls": "last",
+              "opclass": "text_ops",
+              "isExpression": false
+            },
+            {
+              "expression": "updated_at",
+              "asc": true,
+              "nulls": "last",
+              "opclass": "text_ops",
+              "isExpression": false
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "intent_discovery_progress_intent_id_intents_id_fk": {
+          "name": "intent_discovery_progress_intent_id_intents_id_fk",
+          "tableFrom": "intent_discovery_progress",
+          "tableTo": "intents",
+          "schemaTo": "public",
+          "columnsFrom": [
+            "intent_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "intent_discovery_progress_user_id_users_id_fk": {
+          "name": "intent_discovery_progress_user_id_users_id_fk",
+          "tableFrom": "intent_discovery_progress",
+          "tableTo": "users",
+          "schemaTo": "public",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {},
+      "policies": {},
+      "isRLSEnabled": false
+    },
+    "public.artifacts": {
+      "name": "artifacts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "task_id": {
+          "name": "task_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "parts": {
+          "name": "parts",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "extensions": {
+          "name": "extensions",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "artifacts_task_id_idx": {
+          "name": "artifacts_task_id_idx",
+          "columns": [
+            {
+              "expression": "task_id",
+              "asc": true,
+              "nulls": "last",
+              "opclass": "text_ops",
+              "isExpression": false
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "artifacts_task_id_tasks_id_fk": {
+          "name": "artifacts_task_id_tasks_id_fk",
+          "tableFrom": "artifacts",
+          "tableTo": "tasks",
+          "schemaTo": "public",
+          "columnsFrom": [
+            "task_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {},
+      "policies": {},
+      "isRLSEnabled": false
+    },
+    "public.conversation_metadata": {
+      "name": "conversation_metadata",
+      "schema": "",
+      "columns": {
+        "conversation_id": {
+          "name": "conversation_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "conversation_metadata_conversation_id_conversations_id_fk": {
+          "name": "conversation_metadata_conversation_id_conversations_id_fk",
+          "tableFrom": "conversation_metadata",
+          "tableTo": "conversations",
+          "schemaTo": "public",
+          "columnsFrom": [
+            "conversation_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {},
+      "policies": {},
+      "isRLSEnabled": false
+    },
+    "public.oauth_application": {
+      "name": "oauth_application",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "icon": {
+          "name": "icon",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "client_secret": {
+          "name": "client_secret",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "redirect_urls": {
+          "name": "redirect_urls",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "disabled": {
+          "name": "disabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "oauth_application_user_id_idx": {
+          "name": "oauth_application_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "asc": true,
+              "nulls": "last",
+              "opclass": "text_ops",
+              "isExpression": false
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "oauth_application_user_id_users_id_fk": {
+          "name": "oauth_application_user_id_users_id_fk",
+          "tableFrom": "oauth_application",
+          "tableTo": "users",
+          "schemaTo": "public",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "oauth_application_client_id_unique": {
+          "columns": [
+            "client_id"
+          ],
+          "nullsNotDistinct": false,
+          "name": "oauth_application_client_id_unique"
+        }
+      },
+      "checkConstraints": {},
+      "policies": {},
+      "isRLSEnabled": false
+    },
+    "public.oauth_access_token": {
+      "name": "oauth_access_token",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "access_token_expires_at": {
+          "name": "access_token_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "refresh_token_expires_at": {
+          "name": "refresh_token_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scopes": {
+          "name": "scopes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "oauth_access_token_client_id_idx": {
+          "name": "oauth_access_token_client_id_idx",
+          "columns": [
+            {
+              "expression": "client_id",
+              "asc": true,
+              "nulls": "last",
+              "opclass": "text_ops",
+              "isExpression": false
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "oauth_access_token_user_id_idx": {
+          "name": "oauth_access_token_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "asc": true,
+              "nulls": "last",
+              "opclass": "text_ops",
+              "isExpression": false
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "oauth_access_token_client_id_oauth_application_client_id_fk": {
+          "name": "oauth_access_token_client_id_oauth_application_client_id_fk",
+          "tableFrom": "oauth_access_token",
+          "tableTo": "oauth_application",
+          "schemaTo": "public",
+          "columnsFrom": [
+            "client_id"
+          ],
+          "columnsTo": [
+            "client_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "oauth_access_token_user_id_users_id_fk": {
+          "name": "oauth_access_token_user_id_users_id_fk",
+          "tableFrom": "oauth_access_token",
+          "tableTo": "users",
+          "schemaTo": "public",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "oauth_access_token_access_token_unique": {
+          "columns": [
+            "access_token"
+          ],
+          "nullsNotDistinct": false,
+          "name": "oauth_access_token_access_token_unique"
+        },
+        "oauth_access_token_refresh_token_unique": {
+          "columns": [
+            "refresh_token"
+          ],
+          "nullsNotDistinct": false,
+          "name": "oauth_access_token_refresh_token_unique"
+        }
+      },
+      "checkConstraints": {},
+      "policies": {},
+      "isRLSEnabled": false
+    },
+    "public.oauth_consent": {
+      "name": "oauth_consent",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scopes": {
+          "name": "scopes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "consent_given": {
+          "name": "consent_given",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "oauth_consent_client_id_idx": {
+          "name": "oauth_consent_client_id_idx",
+          "columns": [
+            {
+              "expression": "client_id",
+              "asc": true,
+              "nulls": "last",
+              "opclass": "text_ops",
+              "isExpression": false
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "oauth_consent_user_id_idx": {
+          "name": "oauth_consent_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "asc": true,
+              "nulls": "last",
+              "opclass": "text_ops",
+              "isExpression": false
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "oauth_consent_client_id_oauth_application_client_id_fk": {
+          "name": "oauth_consent_client_id_oauth_application_client_id_fk",
+          "tableFrom": "oauth_consent",
+          "tableTo": "oauth_application",
+          "schemaTo": "public",
+          "columnsFrom": [
+            "client_id"
+          ],
+          "columnsTo": [
+            "client_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "oauth_consent_user_id_users_id_fk": {
+          "name": "oauth_consent_user_id_users_id_fk",
+          "tableFrom": "oauth_consent",
+          "tableTo": "users",
+          "schemaTo": "public",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {},
+      "policies": {},
+      "isRLSEnabled": false
+    },
+    "public.negotiation_round_log_events": {
+      "name": "negotiation_round_log_events",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "intent_id": {
+          "name": "intent_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "batch_id": {
+          "name": "batch_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "task_id": {
+          "name": "task_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "negotiation_round_log_event_kind",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "via": {
+          "name": "via",
+          "type": "negotiation_round_log_event_via",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reason": {
+          "name": "reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_negotiation_round_log_events_batch": {
+          "name": "idx_negotiation_round_log_events_batch",
+          "columns": [
+            {
+              "expression": "intent_id",
+              "asc": true,
+              "nulls": "last",
+              "opclass": "timestamptz_ops",
+              "isExpression": false
+            },
+            {
+              "expression": "batch_id",
+              "asc": true,
+              "nulls": "last",
+              "opclass": "text_ops",
+              "isExpression": false
+            },
+            {
+              "expression": "created_at",
+              "asc": true,
+              "nulls": "last",
+              "opclass": "timestamptz_ops",
+              "isExpression": false
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {},
+      "policies": {},
+      "isRLSEnabled": false
+    },
+    "public.tasks": {
+      "name": "tasks",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "conversation_id": {
+          "name": "conversation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "state": {
+          "name": "state",
+          "type": "task_state",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'submitted'"
+        },
+        "status_message": {
+          "name": "status_message",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status_timestamp": {
+          "name": "status_timestamp",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "extensions": {
+          "name": "extensions",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "claimed_by_agent_id": {
+          "name": "claimed_by_agent_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "claimed_at": {
+          "name": "claimed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "briefs": {
+          "name": "briefs",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        }
+      },
+      "indexes": {
+        "tasks_conversation_id_idx": {
+          "name": "tasks_conversation_id_idx",
+          "columns": [
+            {
+              "expression": "conversation_id",
+              "asc": true,
+              "nulls": "last",
+              "opclass": "text_ops",
+              "isExpression": false
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "tasks_metadata_opportunity_id_idx": {
+          "name": "tasks_metadata_opportunity_id_idx",
+          "columns": [
+            {
+              "expression": "((metadata ->> 'opportunityId'::text))",
+              "asc": true,
+              "nulls": "last",
+              "opclass": "text_ops",
+              "isExpression": true
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "where": "((metadata ->> 'type'::text) = 'negotiation'::text)",
+          "with": {}
+        },
+        "tasks_state_idx": {
+          "name": "tasks_state_idx",
+          "columns": [
+            {
+              "expression": "state",
+              "asc": true,
+              "nulls": "last",
+              "opclass": "enum_ops",
+              "isExpression": false
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "tasks_conversation_id_conversations_id_fk": {
+          "name": "tasks_conversation_id_conversations_id_fk",
+          "tableFrom": "tasks",
+          "tableTo": "conversations",
+          "schemaTo": "public",
+          "columnsFrom": [
+            "conversation_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {},
+      "policies": {},
+      "isRLSEnabled": false
+    },
+    "public.agent_permissions": {
+      "name": "agent_permissions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "agent_id": {
+          "name": "agent_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scope": {
+          "name": "scope",
+          "type": "permission_scope",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'global'"
+        },
+        "scope_id": {
+          "name": "scope_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "actions": {
+          "name": "actions",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "agent_permissions_agent_id_idx": {
+          "name": "agent_permissions_agent_id_idx",
+          "columns": [
+            {
+              "expression": "agent_id",
+              "asc": true,
+              "nulls": "last",
+              "opclass": "text_ops",
+              "isExpression": false
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "agent_permissions_agent_user_idx": {
+          "name": "agent_permissions_agent_user_idx",
+          "columns": [
+            {
+              "expression": "agent_id",
+              "asc": true,
+              "nulls": "last",
+              "opclass": "text_ops",
+              "isExpression": false
+            },
+            {
+              "expression": "user_id",
+              "asc": true,
+              "nulls": "last",
+              "opclass": "text_ops",
+              "isExpression": false
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "agent_permissions_user_id_idx": {
+          "name": "agent_permissions_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "asc": true,
+              "nulls": "last",
+              "opclass": "text_ops",
+              "isExpression": false
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "uniq_agent_permissions_global": {
+          "name": "uniq_agent_permissions_global",
+          "columns": [
+            {
+              "expression": "agent_id",
+              "asc": true,
+              "nulls": "last",
+              "opclass": "text_ops",
+              "isExpression": false
+            },
+            {
+              "expression": "user_id",
+              "asc": true,
+              "nulls": "last",
+              "opclass": "text_ops",
+              "isExpression": false
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "where": "(scope = 'global'::permission_scope)",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "agent_permissions_agent_id_agents_id_fk": {
+          "name": "agent_permissions_agent_id_agents_id_fk",
+          "tableFrom": "agent_permissions",
+          "tableTo": "agents",
+          "schemaTo": "public",
+          "columnsFrom": [
+            "agent_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "agent_permissions_user_id_users_id_fk": {
+          "name": "agent_permissions_user_id_users_id_fk",
+          "tableFrom": "agent_permissions",
+          "tableTo": "users",
+          "schemaTo": "public",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {},
+      "policies": {},
+      "isRLSEnabled": false
+    },
+    "public.agent_test_messages": {
+      "name": "agent_test_messages",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "agent_id": {
+          "name": "agent_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "requested_by_user_id": {
+          "name": "requested_by_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reservation_token": {
+          "name": "reservation_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reserved_at": {
+          "name": "reserved_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "delivered_at": {
+          "name": "delivered_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_agent_test_messages_agent_pending": {
+          "name": "idx_agent_test_messages_agent_pending",
+          "columns": [
+            {
+              "expression": "agent_id",
+              "asc": true,
+              "nulls": "last",
+              "opclass": "text_ops",
+              "isExpression": false
+            },
+            {
+              "expression": "reserved_at",
+              "asc": true,
+              "nulls": "last",
+              "opclass": "text_ops",
+              "isExpression": false
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "agent_test_messages_agent_id_agents_id_fk": {
+          "name": "agent_test_messages_agent_id_agents_id_fk",
+          "tableFrom": "agent_test_messages",
+          "tableTo": "agents",
+          "schemaTo": "public",
+          "columnsFrom": [
+            "agent_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "agent_test_messages_requested_by_user_id_users_id_fk": {
+          "name": "agent_test_messages_requested_by_user_id_users_id_fk",
+          "tableFrom": "agent_test_messages",
+          "tableTo": "users",
+          "schemaTo": "public",
+          "columnsFrom": [
+            "requested_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {},
+      "policies": {},
+      "isRLSEnabled": false
+    },
+    "public.opportunity_deliveries": {
+      "name": "opportunity_deliveries",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "opportunity_id": {
+          "name": "opportunity_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "agent_id": {
+          "name": "agent_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "channel": {
+          "name": "channel",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "trigger": {
+          "name": "trigger",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "delivered_at_status": {
+          "name": "delivered_at_status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reservation_token": {
+          "name": "reservation_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reserved_at": {
+          "name": "reserved_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "delivered_at": {
+          "name": "delivered_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_opp_deliveries_open_reservations": {
+          "name": "idx_opp_deliveries_open_reservations",
+          "columns": [
+            {
+              "expression": "user_id",
+              "asc": true,
+              "nulls": "last",
+              "opclass": "text_ops",
+              "isExpression": false
+            },
+            {
+              "expression": "channel",
+              "asc": true,
+              "nulls": "last",
+              "opclass": "timestamptz_ops",
+              "isExpression": false
+            },
+            {
+              "expression": "reserved_at",
+              "asc": true,
+              "nulls": "last",
+              "opclass": "timestamptz_ops",
+              "isExpression": false
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "where": "(delivered_at IS NULL)",
+          "with": {}
+        },
+        "uniq_opp_deliveries_committed": {
+          "name": "uniq_opp_deliveries_committed",
+          "columns": [
+            {
+              "expression": "user_id",
+              "asc": true,
+              "nulls": "last",
+              "opclass": "text_ops",
+              "isExpression": false
+            },
+            {
+              "expression": "opportunity_id",
+              "asc": true,
+              "nulls": "last",
+              "opclass": "text_ops",
+              "isExpression": false
+            },
+            {
+              "expression": "channel",
+              "asc": true,
+              "nulls": "last",
+              "opclass": "text_ops",
+              "isExpression": false
+            },
+            {
+              "expression": "delivered_at_status",
+              "asc": true,
+              "nulls": "last",
+              "opclass": "text_ops",
+              "isExpression": false
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "where": "(delivered_at IS NOT NULL)",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "opportunity_deliveries_opportunity_id_opportunities_id_fk": {
+          "name": "opportunity_deliveries_opportunity_id_opportunities_id_fk",
+          "tableFrom": "opportunity_deliveries",
+          "tableTo": "opportunities",
+          "schemaTo": "public",
+          "columnsFrom": [
+            "opportunity_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "opportunity_deliveries_user_id_users_id_fk": {
+          "name": "opportunity_deliveries_user_id_users_id_fk",
+          "tableFrom": "opportunity_deliveries",
+          "tableTo": "users",
+          "schemaTo": "public",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "opportunity_deliveries_agent_id_agents_id_fk": {
+          "name": "opportunity_deliveries_agent_id_agents_id_fk",
+          "tableFrom": "opportunity_deliveries",
+          "tableTo": "agents",
+          "schemaTo": "public",
+          "columnsFrom": [
+            "agent_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {},
+      "policies": {},
+      "isRLSEnabled": false
+    },
+    "public.agent_transports": {
+      "name": "agent_transports",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "agent_id": {
+          "name": "agent_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "channel": {
+          "name": "channel",
+          "type": "transport_channel",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "config": {
+          "name": "config",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'{}'::jsonb"
+        },
+        "priority": {
+          "name": "priority",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "active": {
+          "name": "active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "failure_count": {
+          "name": "failure_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "agent_transports_agent_id_idx": {
+          "name": "agent_transports_agent_id_idx",
+          "columns": [
+            {
+              "expression": "agent_id",
+              "asc": true,
+              "nulls": "last",
+              "opclass": "text_ops",
+              "isExpression": false
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "agent_transports_agent_id_agents_id_fk": {
+          "name": "agent_transports_agent_id_agents_id_fk",
+          "tableFrom": "agent_transports",
+          "tableTo": "agents",
+          "schemaTo": "public",
+          "columnsFrom": [
+            "agent_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {},
+      "policies": {},
+      "isRLSEnabled": false
+    },
+    "public.user_socials": {
+      "name": "user_socials",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "label": {
+          "name": "label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_user_socials_user_id": {
+          "name": "idx_user_socials_user_id",
+          "columns": [
+            {
+              "expression": "user_id",
+              "asc": true,
+              "nulls": "last",
+              "opclass": "text_ops",
+              "isExpression": false
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "uniq_user_socials_user_label": {
+          "name": "uniq_user_socials_user_label",
+          "columns": [
+            {
+              "expression": "user_id",
+              "asc": true,
+              "nulls": "last",
+              "opclass": "text_ops",
+              "isExpression": false
+            },
+            {
+              "expression": "label",
+              "asc": true,
+              "nulls": "last",
+              "opclass": "text_ops",
+              "isExpression": false
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "where": "(label <> 'custom'::text)",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "user_socials_user_id_fkey": {
+          "name": "user_socials_user_id_fkey",
+          "tableFrom": "user_socials",
+          "tableTo": "users",
+          "schemaTo": "public",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {},
+      "policies": {},
+      "isRLSEnabled": false
+    },
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email_verified": {
+          "name": "email_verified",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "avatar": {
+          "name": "avatar",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "intro": {
+          "name": "intro",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "location": {
+          "name": "location",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "onboarding": {
+          "name": "onboarding",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'{}'::json"
+        },
+        "timezone": {
+          "name": "timezone",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'UTC'"
+        },
+        "last_weekly_email_sent_at": {
+          "name": "last_weekly_email_sent_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "users_email_unique": {
+          "name": "users_email_unique",
+          "columns": [
+            {
+              "expression": "email",
+              "asc": true,
+              "nulls": "last",
+              "opclass": "text_ops",
+              "isExpression": false
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "users_key_unique": {
+          "name": "users_key_unique",
+          "columns": [
+            {
+              "expression": "key",
+              "asc": true,
+              "nulls": "last",
+              "opclass": "text_ops",
+              "isExpression": false
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {},
+      "policies": {},
+      "isRLSEnabled": false
+    },
+    "public.chat_session_summaries": {
+      "name": "chat_session_summaries",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "conversation_id": {
+          "name": "conversation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "from_message_id": {
+          "name": "from_message_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "to_message_id": {
+          "name": "to_message_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "digest": {
+          "name": "digest",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "model": {
+          "name": "model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "chat_session_summaries_session_latest_idx": {
+          "name": "chat_session_summaries_session_latest_idx",
+          "columns": [
+            {
+              "expression": "conversation_id",
+              "asc": true,
+              "nulls": "last",
+              "opclass": "text_ops",
+              "isExpression": false
+            },
+            {
+              "expression": "created_at",
+              "asc": false,
+              "nulls": "last",
+              "opclass": "text_ops",
+              "isExpression": false
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "chat_session_summaries_conversation_id_conversations_id_fk": {
+          "name": "chat_session_summaries_conversation_id_conversations_id_fk",
+          "tableFrom": "chat_session_summaries",
+          "tableTo": "conversations",
+          "schemaTo": "public",
+          "columnsFrom": [
+            "conversation_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "chat_session_summaries_from_message_id_messages_id_fk": {
+          "name": "chat_session_summaries_from_message_id_messages_id_fk",
+          "tableFrom": "chat_session_summaries",
+          "tableTo": "messages",
+          "schemaTo": "public",
+          "columnsFrom": [
+            "from_message_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "chat_session_summaries_to_message_id_messages_id_fk": {
+          "name": "chat_session_summaries_to_message_id_messages_id_fk",
+          "tableFrom": "chat_session_summaries",
+          "tableTo": "messages",
+          "schemaTo": "public",
+          "columnsFrom": [
+            "to_message_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {},
+      "policies": {},
+      "isRLSEnabled": false
+    },
+    "public.opportunities": {
+      "name": "opportunities",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "detection": {
+          "name": "detection",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "actors": {
+          "name": "actors",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "interpretation": {
+          "name": "interpretation",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "context": {
+          "name": "context",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "confidence": {
+          "name": "confidence",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "opportunity_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "accepted_by": {
+          "name": "accepted_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'{}'::jsonb"
+        }
+      },
+      "indexes": {
+        "opportunities_active_pair_idx": {
+          "name": "opportunities_active_pair_idx",
+          "columns": [
+            {
+              "expression": "((context ->> 'networkId'::text))",
+              "asc": true,
+              "nulls": "last",
+              "opclass": "text_ops",
+              "isExpression": true
+            },
+            {
+              "expression": "LEAST(((actors -> 0) ->> 'intent'::text), ((actors -> 1) ->> 'i",
+              "asc": true,
+              "nulls": "last",
+              "opclass": "text_ops",
+              "isExpression": true
+            },
+            {
+              "expression": "GREATEST(((actors -> 0) ->> 'intent'::text), ((actors -> 1) ->>",
+              "asc": true,
+              "nulls": "last",
+              "opclass": "text_ops",
+              "isExpression": true
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "where": "((status = ANY (ARRAY['negotiating'::opportunity_status, 'pending'::opportunity_status, 'stalled'::opportunity_status])) AND (((actors -> 0) ->> 'intent'::text) IS NOT NULL) AND (((actors -> 1) ->> 'intent'::text) IS NOT NULL))",
+          "with": {}
+        },
+        "opportunities_status_idx": {
+          "name": "opportunities_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "asc": true,
+              "nulls": "last",
+              "opclass": "enum_ops",
+              "isExpression": false
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "opportunities_accepted_by_users_id_fk": {
+          "name": "opportunities_accepted_by_users_id_fk",
+          "tableFrom": "opportunities",
+          "tableTo": "users",
+          "schemaTo": "public",
+          "columnsFrom": [
+            "accepted_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {},
+      "policies": {},
+      "isRLSEnabled": false
+    },
+    "public.premises": {
+      "name": "premises",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "assertion": {
+          "name": "assertion",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provenance": {
+          "name": "provenance",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "analysis": {
+          "name": "analysis",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "validity": {
+          "name": "validity",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "embedding": {
+          "name": "embedding",
+          "type": "vector(2000)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "premise_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'ACTIVE'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "retracted_at": {
+          "name": "retracted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "premises_embedding_idx": {
+          "name": "premises_embedding_idx",
+          "columns": [
+            {
+              "expression": "embedding",
+              "asc": true,
+              "nulls": "last",
+              "opclass": "vector_cosine_ops",
+              "isExpression": false
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "hnsw",
+          "with": {}
+        },
+        "premises_status_idx": {
+          "name": "premises_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "asc": true,
+              "nulls": "last",
+              "opclass": "enum_ops",
+              "isExpression": false
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "premises_user_id_idx": {
+          "name": "premises_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "asc": true,
+              "nulls": "last",
+              "opclass": "text_ops",
+              "isExpression": false
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "premises_user_id_users_id_fk": {
+          "name": "premises_user_id_users_id_fk",
+          "tableFrom": "premises",
+          "tableTo": "users",
+          "schemaTo": "public",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {},
+      "policies": {},
+      "isRLSEnabled": false
+    },
+    "public.questions": {
+      "name": "questions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "detection": {
+          "name": "detection",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "actors": {
+          "name": "actors",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "payload": {
+          "name": "payload",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "question_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "answer": {
+          "name": "answer",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "conversation_id": {
+          "name": "conversation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "questions_conversation_id_idx": {
+          "name": "questions_conversation_id_idx",
+          "columns": [
+            {
+              "expression": "conversation_id",
+              "asc": true,
+              "nulls": "last",
+              "opclass": "text_ops",
+              "isExpression": false
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "questions_recovery_recipient_intent_fingerprint_uniq": {
+          "name": "questions_recovery_recipient_intent_fingerprint_uniq",
+          "columns": [
+            {
+              "expression": "(((actors -> 0) ->> 'userId'::text))",
+              "asc": true,
+              "nulls": "last",
+              "opclass": "text_ops",
+              "isExpression": true
+            },
+            {
+              "expression": "((detection ->> 'sourceId'::text))",
+              "asc": true,
+              "nulls": "last",
+              "opclass": "text_ops",
+              "isExpression": true
+            },
+            {
+              "expression": "(((detection -> 'recovery'::text) ->> 'intentFingerprint'::text",
+              "asc": true,
+              "nulls": "last",
+              "opclass": "text_ops",
+              "isExpression": true
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "where": "(((detection ->> 'purpose'::text) = 'recovery'::text) AND ((detection ->> 'mode'::text) = 'intent'::text) AND ((detection ->> 'sourceType'::text) = 'intent'::text))",
+          "with": {}
+        },
+        "questions_status_idx": {
+          "name": "questions_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "asc": true,
+              "nulls": "last",
+              "opclass": "enum_ops",
+              "isExpression": false
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {},
+      "policies": {},
+      "isRLSEnabled": false
+    },
+    "public.user_contexts": {
+      "name": "user_contexts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "network_id": {
+          "name": "network_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "text": {
+          "name": "text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "embedding": {
+          "name": "embedding",
+          "type": "vector(2000)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "premise_hash": {
+          "name": "premise_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "generated_at": {
+          "name": "generated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "user_contexts_embedding_idx": {
+          "name": "user_contexts_embedding_idx",
+          "columns": [
+            {
+              "expression": "embedding",
+              "asc": true,
+              "nulls": "last",
+              "opclass": "vector_cosine_ops",
+              "isExpression": false
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "hnsw",
+          "with": {}
+        },
+        "user_contexts_network_id_idx": {
+          "name": "user_contexts_network_id_idx",
+          "columns": [
+            {
+              "expression": "network_id",
+              "asc": true,
+              "nulls": "last",
+              "opclass": "text_ops",
+              "isExpression": false
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "user_contexts_user_global_uniq": {
+          "name": "user_contexts_user_global_uniq",
+          "columns": [
+            {
+              "expression": "user_id",
+              "asc": true,
+              "nulls": "last",
+              "opclass": "text_ops",
+              "isExpression": false
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "where": "(network_id IS NULL)",
+          "with": {}
+        },
+        "user_contexts_user_id_idx": {
+          "name": "user_contexts_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "asc": true,
+              "nulls": "last",
+              "opclass": "text_ops",
+              "isExpression": false
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "user_contexts_user_network_uniq": {
+          "name": "user_contexts_user_network_uniq",
+          "columns": [
+            {
+              "expression": "user_id",
+              "asc": true,
+              "nulls": "last",
+              "opclass": "text_ops",
+              "isExpression": false
+            },
+            {
+              "expression": "network_id",
+              "asc": true,
+              "nulls": "last",
+              "opclass": "text_ops",
+              "isExpression": false
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "where": "(network_id IS NOT NULL)",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "user_contexts_user_id_users_id_fk": {
+          "name": "user_contexts_user_id_users_id_fk",
+          "tableFrom": "user_contexts",
+          "tableTo": "users",
+          "schemaTo": "public",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "user_contexts_network_id_networks_id_fk": {
+          "name": "user_contexts_network_id_networks_id_fk",
+          "tableFrom": "user_contexts",
+          "tableTo": "networks",
+          "schemaTo": "public",
+          "columnsFrom": [
+            "network_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {},
+      "policies": {},
+      "isRLSEnabled": false
+    },
+    "public.chat_session_scopes": {
+      "name": "chat_session_scopes",
+      "schema": "",
+      "columns": {
+        "conversation_id": {
+          "name": "conversation_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scope_type": {
+          "name": "scope_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scope_id": {
+          "name": "scope_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "chat_session_scopes_scope_idx": {
+          "name": "chat_session_scopes_scope_idx",
+          "columns": [
+            {
+              "expression": "scope_type",
+              "asc": true,
+              "nulls": "last",
+              "opclass": "text_ops",
+              "isExpression": false
+            },
+            {
+              "expression": "scope_id",
+              "asc": true,
+              "nulls": "last",
+              "opclass": "text_ops",
+              "isExpression": false
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "chat_session_scopes_user_id_idx": {
+          "name": "chat_session_scopes_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "asc": true,
+              "nulls": "last",
+              "opclass": "text_ops",
+              "isExpression": false
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "chat_session_scopes_user_scope_unique": {
+          "name": "chat_session_scopes_user_scope_unique",
+          "columns": [
+            {
+              "expression": "user_id",
+              "asc": true,
+              "nulls": "last",
+              "opclass": "text_ops",
+              "isExpression": false
+            },
+            {
+              "expression": "scope_type",
+              "asc": true,
+              "nulls": "last",
+              "opclass": "text_ops",
+              "isExpression": false
+            },
+            {
+              "expression": "scope_id",
+              "asc": true,
+              "nulls": "last",
+              "opclass": "text_ops",
+              "isExpression": false
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "chat_session_scopes_conversation_id_conversations_id_fk": {
+          "name": "chat_session_scopes_conversation_id_conversations_id_fk",
+          "tableFrom": "chat_session_scopes",
+          "tableTo": "conversations",
+          "schemaTo": "public",
+          "columnsFrom": [
+            "conversation_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {},
+      "policies": {},
+      "isRLSEnabled": false
+    },
+    "public.conversations": {
+      "name": "conversations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "last_message_at": {
+          "name": "last_message_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "dm_pair": {
+          "name": "dm_pair",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "persona": {
+          "name": "persona",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'none'"
+        }
+      },
+      "indexes": {
+        "conversations_dm_pair_idx": {
+          "name": "conversations_dm_pair_idx",
+          "columns": [
+            {
+              "expression": "dm_pair",
+              "asc": true,
+              "nulls": "last",
+              "opclass": "text_ops",
+              "isExpression": false
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {},
+      "policies": {},
+      "isRLSEnabled": false
+    },
+    "public.negotiator_memories": {
+      "name": "negotiator_memories",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "agent_id": {
+          "name": "agent_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "subject_user_id": {
+          "name": "subject_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "embedding": {
+          "name": "embedding",
+          "type": "vector(2000)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source_refs": {
+          "name": "source_refs",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "confidence": {
+          "name": "confidence",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0.5
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "negotiator_memories_agent_kind_idx": {
+          "name": "negotiator_memories_agent_kind_idx",
+          "columns": [
+            {
+              "expression": "agent_id",
+              "asc": true,
+              "nulls": "last",
+              "opclass": "text_ops",
+              "isExpression": false
+            },
+            {
+              "expression": "kind",
+              "asc": true,
+              "nulls": "last",
+              "opclass": "text_ops",
+              "isExpression": false
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "negotiator_memories_embedding_idx": {
+          "name": "negotiator_memories_embedding_idx",
+          "columns": [
+            {
+              "expression": "embedding",
+              "asc": true,
+              "nulls": "last",
+              "opclass": "vector_cosine_ops",
+              "isExpression": false
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "hnsw",
+          "with": {}
+        },
+        "negotiator_memories_user_subject_idx": {
+          "name": "negotiator_memories_user_subject_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "asc": true,
+              "nulls": "last",
+              "opclass": "text_ops",
+              "isExpression": false
+            },
+            {
+              "expression": "subject_user_id",
+              "asc": true,
+              "nulls": "last",
+              "opclass": "text_ops",
+              "isExpression": false
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "negotiator_memories_agent_id_agents_id_fk": {
+          "name": "negotiator_memories_agent_id_agents_id_fk",
+          "tableFrom": "negotiator_memories",
+          "tableTo": "agents",
+          "schemaTo": "public",
+          "columnsFrom": [
+            "agent_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "negotiator_memories_user_id_users_id_fk": {
+          "name": "negotiator_memories_user_id_users_id_fk",
+          "tableFrom": "negotiator_memories",
+          "tableTo": "users",
+          "schemaTo": "public",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "negotiator_memories_subject_user_id_users_id_fk": {
+          "name": "negotiator_memories_subject_user_id_users_id_fk",
+          "tableFrom": "negotiator_memories",
+          "tableTo": "users",
+          "schemaTo": "public",
+          "columnsFrom": [
+            "subject_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {},
+      "policies": {},
+      "isRLSEnabled": false
+    },
+    "public.frame_drift_observation_runs": {
+      "name": "frame_drift_observation_runs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "bucket_start": {
+          "name": "bucket_start",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "bucket_end": {
+          "name": "bucket_end",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "captured_at": {
+          "name": "captured_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "configured_embedding_model": {
+          "name": "configured_embedding_model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "max_networks": {
+          "name": "max_networks",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "max_pairs": {
+          "name": "max_pairs",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "min_users": {
+          "name": "min_users",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "stable_cohort_hash": {
+          "name": "stable_cohort_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "aggregate_diagnostics": {
+          "name": "aggregate_diagnostics",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        }
+      },
+      "indexes": {
+        "frame_drift_observation_runs_bucket_start_uniq": {
+          "name": "frame_drift_observation_runs_bucket_start_uniq",
+          "columns": [
+            {
+              "expression": "bucket_start",
+              "asc": true,
+              "nulls": "last",
+              "opclass": "timestamptz_ops",
+              "isExpression": false
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {
+        "frame_drift_observation_runs_bucket_check": {
+          "name": "frame_drift_observation_runs_bucket_check",
+          "value": "(bucket_end = (bucket_start + '1 day'::interval)) AND (captured_at >= bucket_end)"
+        },
+        "frame_drift_observation_runs_configured_embedding_model_check": {
+          "name": "frame_drift_observation_runs_configured_embedding_model_check",
+          "value": "length(btrim(configured_embedding_model)) > 0"
+        },
+        "frame_drift_observation_runs_max_networks_check": {
+          "name": "frame_drift_observation_runs_max_networks_check",
+          "value": "(max_networks >= 1) AND (max_networks <= 200)"
+        },
+        "frame_drift_observation_runs_max_pairs_check": {
+          "name": "frame_drift_observation_runs_max_pairs_check",
+          "value": "(max_pairs >= 1) AND (max_pairs <= 10000)"
+        },
+        "frame_drift_observation_runs_min_users_check": {
+          "name": "frame_drift_observation_runs_min_users_check",
+          "value": "(min_users >= 2) AND (min_users <= 100)"
+        },
+        "frame_drift_observation_runs_stable_cohort_hash_check": {
+          "name": "frame_drift_observation_runs_stable_cohort_hash_check",
+          "value": "(stable_cohort_hash IS NULL) OR (stable_cohort_hash ~ '^[0-9a-f]{64}$'::text)"
+        },
+        "frame_drift_observation_runs_aggregate_diagnostics_check": {
+          "name": "frame_drift_observation_runs_aggregate_diagnostics_check",
+          "value": "jsonb_typeof(aggregate_diagnostics) = 'object'::text"
+        }
+      },
+      "policies": {},
+      "isRLSEnabled": false
+    },
+    "public.cross_network_yield_snapshots": {
+      "name": "cross_network_yield_snapshots",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "run_id": {
+          "name": "run_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "network_a_id": {
+          "name": "network_a_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "network_b_id": {
+          "name": "network_b_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "opportunity_count": {
+          "name": "opportunity_count",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "potential_active_intent_pair_count": {
+          "name": "potential_active_intent_pair_count",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "yield_rate": {
+          "name": "yield_rate",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "yield_rate_delta": {
+          "name": "yield_rate_delta",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "prior_bucket_start": {
+          "name": "prior_bucket_start",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "bucket_start": {
+          "name": "bucket_start",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "bucket_end": {
+          "name": "bucket_end",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "captured_at": {
+          "name": "captured_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "cross_network_yield_snapshots_daily_uniq": {
+          "name": "cross_network_yield_snapshots_daily_uniq",
+          "columns": [
+            {
+              "expression": "network_a_id",
+              "asc": true,
+              "nulls": "last",
+              "opclass": "timestamptz_ops",
+              "isExpression": false
+            },
+            {
+              "expression": "network_b_id",
+              "asc": true,
+              "nulls": "last",
+              "opclass": "text_ops",
+              "isExpression": false
+            },
+            {
+              "expression": "bucket_start",
+              "asc": true,
+              "nulls": "last",
+              "opclass": "timestamptz_ops",
+              "isExpression": false
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "cross_network_yield_snapshots_run_id_frame_drift_observation_ru": {
+          "name": "cross_network_yield_snapshots_run_id_frame_drift_observation_ru",
+          "tableFrom": "cross_network_yield_snapshots",
+          "tableTo": "frame_drift_observation_runs",
+          "schemaTo": "public",
+          "columnsFrom": [
+            "run_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "cross_network_yield_snapshots_network_a_id_networks_id_fk": {
+          "name": "cross_network_yield_snapshots_network_a_id_networks_id_fk",
+          "tableFrom": "cross_network_yield_snapshots",
+          "tableTo": "networks",
+          "schemaTo": "public",
+          "columnsFrom": [
+            "network_a_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "cross_network_yield_snapshots_network_b_id_networks_id_fk": {
+          "name": "cross_network_yield_snapshots_network_b_id_networks_id_fk",
+          "tableFrom": "cross_network_yield_snapshots",
+          "tableTo": "networks",
+          "schemaTo": "public",
+          "columnsFrom": [
+            "network_b_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {
+        "cross_network_yield_snapshots_canonical_pair_check": {
+          "name": "cross_network_yield_snapshots_canonical_pair_check",
+          "value": "network_a_id < network_b_id"
+        },
+        "cross_network_yield_snapshots_opportunity_count_check": {
+          "name": "cross_network_yield_snapshots_opportunity_count_check",
+          "value": "opportunity_count >= 0"
+        },
+        "cross_network_yield_snapshots_potential_pair_count_check": {
+          "name": "cross_network_yield_snapshots_potential_pair_count_check",
+          "value": "potential_active_intent_pair_count > 0"
+        },
+        "cross_network_yield_snapshots_yield_rate_check": {
+          "name": "cross_network_yield_snapshots_yield_rate_check",
+          "value": "yield_rate >= (0)::double precision"
+        },
+        "cross_network_yield_snapshots_bucket_range_check": {
+          "name": "cross_network_yield_snapshots_bucket_range_check",
+          "value": "bucket_end > bucket_start"
+        }
+      },
+      "policies": {},
+      "isRLSEnabled": false
+    },
+    "public.frame_centroid_snapshots": {
+      "name": "frame_centroid_snapshots",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "run_id": {
+          "name": "run_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "network_id": {
+          "name": "network_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "corpus": {
+          "name": "corpus",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "centroid": {
+          "name": "centroid",
+          "type": "vector(2000)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sample_count": {
+          "name": "sample_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "configured_embedding_model": {
+          "name": "configured_embedding_model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "cosine_drift": {
+          "name": "cosine_drift",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "prior_bucket_start": {
+          "name": "prior_bucket_start",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "bucket_start": {
+          "name": "bucket_start",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "bucket_end": {
+          "name": "bucket_end",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "captured_at": {
+          "name": "captured_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "frame_centroid_snapshots_daily_uniq": {
+          "name": "frame_centroid_snapshots_daily_uniq",
+          "columns": [
+            {
+              "expression": "network_id",
+              "asc": true,
+              "nulls": "last",
+              "opclass": "text_ops",
+              "isExpression": false
+            },
+            {
+              "expression": "corpus",
+              "asc": true,
+              "nulls": "last",
+              "opclass": "text_ops",
+              "isExpression": false
+            },
+            {
+              "expression": "configured_embedding_model",
+              "asc": true,
+              "nulls": "last",
+              "opclass": "timestamptz_ops",
+              "isExpression": false
+            },
+            {
+              "expression": "bucket_start",
+              "asc": true,
+              "nulls": "last",
+              "opclass": "timestamptz_ops",
+              "isExpression": false
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "frame_centroid_snapshots_run_id_frame_drift_observation_runs_id": {
+          "name": "frame_centroid_snapshots_run_id_frame_drift_observation_runs_id",
+          "tableFrom": "frame_centroid_snapshots",
+          "tableTo": "frame_drift_observation_runs",
+          "schemaTo": "public",
+          "columnsFrom": [
+            "run_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "frame_centroid_snapshots_network_id_networks_id_fk": {
+          "name": "frame_centroid_snapshots_network_id_networks_id_fk",
+          "tableFrom": "frame_centroid_snapshots",
+          "tableTo": "networks",
+          "schemaTo": "public",
+          "columnsFrom": [
+            "network_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {
+        "frame_centroid_snapshots_corpus_check": {
+          "name": "frame_centroid_snapshots_corpus_check",
+          "value": "corpus = ANY (ARRAY['premise'::text, 'intent'::text, 'user_context'::text])"
+        },
+        "frame_centroid_snapshots_sample_count_check": {
+          "name": "frame_centroid_snapshots_sample_count_check",
+          "value": "sample_count > 0"
+        },
+        "frame_centroid_snapshots_cosine_drift_check": {
+          "name": "frame_centroid_snapshots_cosine_drift_check",
+          "value": "(cosine_drift IS NULL) OR ((cosine_drift >= (0)::double precision) AND (cosine_drift <= (2)::double precision))"
+        },
+        "frame_centroid_snapshots_bucket_range_check": {
+          "name": "frame_centroid_snapshots_bucket_range_check",
+          "value": "bucket_end > bucket_start"
+        }
+      },
+      "policies": {},
+      "isRLSEnabled": false
+    },
+    "public.intents": {
+      "name": "intents",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "payload": {
+          "name": "payload",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "summary": {
+          "name": "summary",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_incognito": {
+          "name": "is_incognito",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "archived_at": {
+          "name": "archived_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_id": {
+          "name": "source_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source_type": {
+          "name": "source_type",
+          "type": "source_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "embedding": {
+          "name": "embedding",
+          "type": "vector(2000)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "semantic_entropy": {
+          "name": "semantic_entropy",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 1
+        },
+        "referential_anchor": {
+          "name": "referential_anchor",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "intent_mode": {
+          "name": "intent_mode",
+          "type": "intent_mode",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'ATTRIBUTIVE'"
+        },
+        "speech_act_type": {
+          "name": "speech_act_type",
+          "type": "speech_act_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "felicity_authority": {
+          "name": "felicity_authority",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "felicity_sincerity": {
+          "name": "felicity_sincerity",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "intent_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'ACTIVE'"
+        },
+        "felicity_clarity": {
+          "name": "felicity_clarity",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_visited_at": {
+          "name": "last_visited_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "first_discovery_succeeded_at": {
+          "name": "first_discovery_succeeded_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "negotiation_round": {
+          "name": "negotiation_round",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "negotiation_round_size": {
+          "name": "negotiation_round_size",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "negotiation_kickoff_started_at": {
+          "name": "negotiation_kickoff_started_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "embeddingIndex": {
+          "name": "embeddingIndex",
+          "columns": [
+            {
+              "expression": "embedding",
+              "asc": true,
+              "nulls": "last",
+              "opclass": "vector_cosine_ops",
+              "isExpression": false
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "hnsw",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "intents_user_id_users_id_fk": {
+          "name": "intents_user_id_users_id_fk",
+          "tableFrom": "intents",
+          "tableTo": "users",
+          "schemaTo": "public",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {},
+      "policies": {},
+      "isRLSEnabled": false
+    },
+    "public.opportunity_outcome_events": {
+      "name": "opportunity_outcome_events",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "recipient_user_id": {
+          "name": "recipient_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "intent_id": {
+          "name": "intent_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "intent_fingerprint": {
+          "name": "intent_fingerprint",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "opportunity_id": {
+          "name": "opportunity_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "network_id": {
+          "name": "network_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "action": {
+          "name": "action",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "candidate_snapshot": {
+          "name": "candidate_snapshot",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "snapshot_hash": {
+          "name": "snapshot_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "dedup_key": {
+          "name": "dedup_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "idempotency_key": {
+          "name": "idempotency_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_opp_outcome_events_scope": {
+          "name": "idx_opp_outcome_events_scope",
+          "columns": [
+            {
+              "expression": "recipient_user_id",
+              "asc": true,
+              "nulls": "last",
+              "opclass": "text_ops",
+              "isExpression": false
+            },
+            {
+              "expression": "intent_id",
+              "asc": true,
+              "nulls": "last",
+              "opclass": "text_ops",
+              "isExpression": false
+            },
+            {
+              "expression": "intent_fingerprint",
+              "asc": true,
+              "nulls": "last",
+              "opclass": "text_ops",
+              "isExpression": false
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "uniq_opp_outcome_events_idempotency": {
+          "name": "uniq_opp_outcome_events_idempotency",
+          "columns": [
+            {
+              "expression": "idempotency_key",
+              "asc": true,
+              "nulls": "last",
+              "opclass": "text_ops",
+              "isExpression": false
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "opportunity_outcome_events_recipient_user_id_users_id_fk": {
+          "name": "opportunity_outcome_events_recipient_user_id_users_id_fk",
+          "tableFrom": "opportunity_outcome_events",
+          "tableTo": "users",
+          "schemaTo": "public",
+          "columnsFrom": [
+            "recipient_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {},
+      "policies": {},
+      "isRLSEnabled": false
+    },
+    "public.frame_drift_execution_attempts": {
+      "name": "frame_drift_execution_attempts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "queue_name": {
+          "name": "queue_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scheduler_id": {
+          "name": "scheduler_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "job_id": {
+          "name": "job_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "job_name": {
+          "name": "job_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scheduled_at": {
+          "name": "scheduled_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "bucket_start": {
+          "name": "bucket_start",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "bucket_end": {
+          "name": "bucket_end",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "attempt": {
+          "name": "attempt",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "max_attempts": {
+          "name": "max_attempts",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "terminal_status": {
+          "name": "terminal_status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "will_retry": {
+          "name": "will_retry",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "failure_category": {
+          "name": "failure_category",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "frame_drift_execution_attempts_bucket_start_idx": {
+          "name": "frame_drift_execution_attempts_bucket_start_idx",
+          "columns": [
+            {
+              "expression": "bucket_start",
+              "asc": true,
+              "nulls": "last",
+              "opclass": "timestamptz_ops",
+              "isExpression": false
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "frame_drift_execution_attempts_incomplete_idx": {
+          "name": "frame_drift_execution_attempts_incomplete_idx",
+          "columns": [
+            {
+              "expression": "started_at",
+              "asc": true,
+              "nulls": "last",
+              "opclass": "timestamptz_ops",
+              "isExpression": false
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "where": "(completed_at IS NULL)",
+          "with": {}
+        },
+        "frame_drift_execution_attempts_job_attempt_uniq": {
+          "name": "frame_drift_execution_attempts_job_attempt_uniq",
+          "columns": [
+            {
+              "expression": "job_id",
+              "asc": true,
+              "nulls": "last",
+              "opclass": "int4_ops",
+              "isExpression": false
+            },
+            {
+              "expression": "attempt",
+              "asc": true,
+              "nulls": "last",
+              "opclass": "int4_ops",
+              "isExpression": false
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {
+        "frame_drift_execution_attempts_identity_check": {
+          "name": "frame_drift_execution_attempts_identity_check",
+          "value": "(length(btrim(queue_name)) > 0) AND (length(btrim(scheduler_id)) > 0) AND (length(btrim(job_id)) > 0) AND (length(btrim(job_name)) > 0)"
+        },
+        "frame_drift_execution_attempts_daily_bucket_check": {
+          "name": "frame_drift_execution_attempts_daily_bucket_check",
+          "value": "(bucket_end = (bucket_start + '1 day'::interval)) AND (date_trunc('day'::text, (bucket_start AT TIME ZONE 'UTC'::text)) = (bucket_start AT TIME ZONE 'UTC'::text)) AND (date_trunc('day'::text, (bucket_end AT TIME ZONE 'UTC'::text)) = (bucket_end AT TIME ZONE 'UTC'::text)) AND (scheduled_at >= bucket_end) AND (scheduled_at < (bucket_end + '1 day'::interval))"
+        },
+        "frame_drift_execution_attempts_attempt_bounds_check": {
+          "name": "frame_drift_execution_attempts_attempt_bounds_check",
+          "value": "((attempt >= 1) AND (attempt <= max_attempts)) AND ((max_attempts >= 1) AND (max_attempts <= 100))"
+        },
+        "frame_drift_execution_attempts_terminal_status_check": {
+          "name": "frame_drift_execution_attempts_terminal_status_check",
+          "value": "(terminal_status IS NULL) OR (terminal_status = ANY (ARRAY['inserted'::text, 'duplicate'::text, 'skipped'::text, 'failed'::text]))"
+        },
+        "frame_drift_execution_attempts_failure_category_check": {
+          "name": "frame_drift_execution_attempts_failure_category_check",
+          "value": "(failure_category IS NULL) OR (failure_category = 'measurement'::text)"
+        },
+        "frame_drift_execution_attempts_terminal_state_check": {
+          "name": "frame_drift_execution_attempts_terminal_state_check",
+          "value": "((terminal_status IS NULL) AND (completed_at IS NULL) AND (will_retry IS NULL) AND (failure_category IS NULL)) OR ((terminal_status = ANY (ARRAY['inserted'::text, 'duplicate'::text, 'skipped'::text])) AND (completed_at IS NOT NULL) AND (completed_at >= started_at) AND (will_retry IS NOT NULL) AND (will_retry = false) AND (failure_category IS NULL)) OR ((terminal_status = 'failed'::text) AND (completed_at IS NOT NULL) AND (completed_at >= started_at) AND (will_retry IS NOT NULL) AND (failure_category IS NOT NULL) AND (failure_category = 'measurement'::text))"
+        }
+      },
+      "policies": {},
+      "isRLSEnabled": false
+    },
+    "public.apikey": {
+      "name": "apikey",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reference_id": {
+          "name": "reference_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "rate_limit_enabled": {
+          "name": "rate_limit_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "request_count": {
+          "name": "request_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "config_id": {
+          "name": "config_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'default'"
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "prefix": {
+          "name": "prefix",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "start": {
+          "name": "start",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "rate_limit_max": {
+          "name": "rate_limit_max",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "rate_limit_time_window": {
+          "name": "rate_limit_time_window",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "remaining": {
+          "name": "remaining",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refill_amount": {
+          "name": "refill_amount",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refill_interval": {
+          "name": "refill_interval",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_refill_at": {
+          "name": "last_refill_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_request": {
+          "name": "last_request",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "permissions": {
+          "name": "permissions",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "apikey_user_id_fkey": {
+          "name": "apikey_user_id_fkey",
+          "tableFrom": "apikey",
+          "tableTo": "users",
+          "schemaTo": "public",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {},
+      "policies": {},
+      "isRLSEnabled": false
+    },
+    "public.messages": {
+      "name": "messages",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "conversation_id": {
+          "name": "conversation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "task_id": {
+          "name": "task_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sender_id": {
+          "name": "sender_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "message_role",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "parts": {
+          "name": "parts",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "extensions": {
+          "name": "extensions",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reference_task_ids": {
+          "name": "reference_task_ids",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "messages_conversation_id_created_at_idx": {
+          "name": "messages_conversation_id_created_at_idx",
+          "columns": [
+            {
+              "expression": "conversation_id",
+              "asc": true,
+              "nulls": "last",
+              "opclass": "text_ops",
+              "isExpression": false
+            },
+            {
+              "expression": "created_at",
+              "asc": true,
+              "nulls": "last",
+              "opclass": "timestamptz_ops",
+              "isExpression": false
+            },
+            {
+              "expression": "id",
+              "asc": true,
+              "nulls": "last",
+              "opclass": "timestamptz_ops",
+              "isExpression": false
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "messages_sender_id_idx": {
+          "name": "messages_sender_id_idx",
+          "columns": [
+            {
+              "expression": "sender_id",
+              "asc": true,
+              "nulls": "last",
+              "opclass": "text_ops",
+              "isExpression": false
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "messages_session_id_created_at_idx": {
+          "name": "messages_session_id_created_at_idx",
+          "columns": [
+            {
+              "expression": "session_id",
+              "asc": true,
+              "nulls": "last",
+              "opclass": "timestamptz_ops",
+              "isExpression": false
+            },
+            {
+              "expression": "created_at",
+              "asc": true,
+              "nulls": "last",
+              "opclass": "text_ops",
+              "isExpression": false
+            },
+            {
+              "expression": "id",
+              "asc": true,
+              "nulls": "last",
+              "opclass": "text_ops",
+              "isExpression": false
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "messages_task_id_idx": {
+          "name": "messages_task_id_idx",
+          "columns": [
+            {
+              "expression": "task_id",
+              "asc": true,
+              "nulls": "last",
+              "opclass": "text_ops",
+              "isExpression": false
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "messages_conversation_id_conversations_id_fk": {
+          "name": "messages_conversation_id_conversations_id_fk",
+          "tableFrom": "messages",
+          "tableTo": "conversations",
+          "schemaTo": "public",
+          "columnsFrom": [
+            "conversation_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "messages_task_id_tasks_id_fk": {
+          "name": "messages_task_id_tasks_id_fk",
+          "tableFrom": "messages",
+          "tableTo": "tasks",
+          "schemaTo": "public",
+          "columnsFrom": [
+            "task_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "messages_session_id_conversation_sessions_id_fk": {
+          "name": "messages_session_id_conversation_sessions_id_fk",
+          "tableFrom": "messages",
+          "tableTo": "conversation_sessions",
+          "schemaTo": "public",
+          "columnsFrom": [
+            "session_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {},
+      "policies": {},
+      "isRLSEnabled": false
+    },
+    "public.conversation_sessions": {
+      "name": "conversation_sessions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "conversation_id": {
+          "name": "conversation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "task_id": {
+          "name": "task_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_message_at": {
+          "name": "last_message_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "conversation_sessions_conversation_started_idx": {
+          "name": "conversation_sessions_conversation_started_idx",
+          "columns": [
+            {
+              "expression": "conversation_id",
+              "asc": true,
+              "nulls": "last",
+              "opclass": "text_ops",
+              "isExpression": false
+            },
+            {
+              "expression": "started_at",
+              "asc": true,
+              "nulls": "last",
+              "opclass": "text_ops",
+              "isExpression": false
+            },
+            {
+              "expression": "id",
+              "asc": true,
+              "nulls": "last",
+              "opclass": "timestamptz_ops",
+              "isExpression": false
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "conversation_sessions_task_id_uniq": {
+          "name": "conversation_sessions_task_id_uniq",
+          "columns": [
+            {
+              "expression": "task_id",
+              "asc": true,
+              "nulls": "last",
+              "opclass": "text_ops",
+              "isExpression": false
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "conversation_sessions_conversation_id_conversations_id_fk": {
+          "name": "conversation_sessions_conversation_id_conversations_id_fk",
+          "tableFrom": "conversation_sessions",
+          "tableTo": "conversations",
+          "schemaTo": "public",
+          "columnsFrom": [
+            "conversation_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "conversation_sessions_task_id_tasks_id_fk": {
+          "name": "conversation_sessions_task_id_tasks_id_fk",
+          "tableFrom": "conversation_sessions",
+          "tableTo": "tasks",
+          "schemaTo": "public",
+          "columnsFrom": [
+            "task_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {},
+      "policies": {},
+      "isRLSEnabled": false
+    },
+    "public.intent_proposals": {
+      "name": "intent_proposals",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "network_id": {
+          "name": "network_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "analysis": {
+          "name": "analysis",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "intent_proposal_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "consumed_at": {
+          "name": "consumed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "consumed_intent_id": {
+          "name": "consumed_intent_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "intent_proposals_expires_at_idx": {
+          "name": "intent_proposals_expires_at_idx",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "asc": true,
+              "nulls": "last",
+              "opclass": "timestamptz_ops",
+              "isExpression": false
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "intent_proposals_user_id_idx": {
+          "name": "intent_proposals_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "asc": true,
+              "nulls": "last",
+              "opclass": "text_ops",
+              "isExpression": false
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "intent_proposals_user_id_users_id_fk": {
+          "name": "intent_proposals_user_id_users_id_fk",
+          "tableFrom": "intent_proposals",
+          "tableTo": "users",
+          "schemaTo": "public",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "intent_proposals_consumed_intent_id_intents_id_fk": {
+          "name": "intent_proposals_consumed_intent_id_intents_id_fk",
+          "tableFrom": "intent_proposals",
+          "tableTo": "intents",
+          "schemaTo": "public",
+          "columnsFrom": [
+            "consumed_intent_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {},
+      "policies": {},
+      "isRLSEnabled": false
+    },
+    "public.signal_intake_packs": {
+      "name": "signal_intake_packs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "brief": {
+          "name": "brief",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "question": {
+          "name": "question",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "premise_hash": {
+          "name": "premise_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "generated_at": {
+          "name": "generated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "signal_intake_packs_user_id_users_id_fk": {
+          "name": "signal_intake_packs_user_id_users_id_fk",
+          "tableFrom": "signal_intake_packs",
+          "tableTo": "users",
+          "schemaTo": "public",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "signal_intake_packs_user_id_unique": {
+          "columns": [
+            "user_id"
+          ],
+          "nullsNotDistinct": false,
+          "name": "signal_intake_packs_user_id_unique"
+        }
+      },
+      "checkConstraints": {},
+      "policies": {},
+      "isRLSEnabled": false
+    },
+    "public.signal_intake_runs": {
+      "name": "signal_intake_runs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "answers_hash": {
+          "name": "answers_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "signal_intake_run_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "proposal_id": {
+          "name": "proposal_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error": {
+          "name": "error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "looking_for": {
+          "name": "looking_for",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "you_bring": {
+          "name": "you_bring",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "signal_intake_runs_created_at_idx": {
+          "name": "signal_intake_runs_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "asc": true,
+              "nulls": "last",
+              "opclass": "timestamptz_ops",
+              "isExpression": false
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "signal_intake_runs_user_answers_uniq": {
+          "name": "signal_intake_runs_user_answers_uniq",
+          "columns": [
+            {
+              "expression": "user_id",
+              "asc": true,
+              "nulls": "last",
+              "opclass": "text_ops",
+              "isExpression": false
+            },
+            {
+              "expression": "answers_hash",
+              "asc": true,
+              "nulls": "last",
+              "opclass": "text_ops",
+              "isExpression": false
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "signal_intake_runs_user_id_idx": {
+          "name": "signal_intake_runs_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "asc": true,
+              "nulls": "last",
+              "opclass": "text_ops",
+              "isExpression": false
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "signal_intake_runs_user_id_users_id_fk": {
+          "name": "signal_intake_runs_user_id_users_id_fk",
+          "tableFrom": "signal_intake_runs",
+          "tableTo": "users",
+          "schemaTo": "public",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {},
+      "policies": {},
+      "isRLSEnabled": false
+    },
+    "public.networks": {
+      "name": "networks",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "prompt": {
+          "name": "prompt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "permissions": {
+          "name": "permissions",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'{\"joinPolicy\":\"invite_only\",\"invitationLink\":null}'::json"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "image_url": {
+          "name": "image_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "master_key_hash": {
+          "name": "master_key_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "request_status": {
+          "name": "request_status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "indexes_key_unique": {
+          "name": "indexes_key_unique",
+          "columns": [
+            {
+              "expression": "key",
+              "asc": true,
+              "nulls": "last",
+              "opclass": "text_ops",
+              "isExpression": false
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {},
+      "policies": {},
+      "isRLSEnabled": false
+    },
+    "public.agents": {
+      "name": "agents",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "owner_id": {
+          "name": "owner_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "type": {
+          "name": "type",
+          "type": "agent_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "agent_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'{}'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_seen_at": {
+          "name": "last_seen_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "notify_on_opportunity": {
+          "name": "notify_on_opportunity",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "daily_summary_enabled": {
+          "name": "daily_summary_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "handle_negotiations": {
+          "name": "handle_negotiations",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "last_daily_summary_at": {
+          "name": "last_daily_summary_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_negotiation_pickup_at": {
+          "name": "last_negotiation_pickup_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "runtime_kind": {
+          "name": "runtime_kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "installation_id": {
+          "name": "installation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "runtime_setup_attempt_id": {
+          "name": "runtime_setup_attempt_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "agents_last_negotiation_pickup_at_idx": {
+          "name": "agents_last_negotiation_pickup_at_idx",
+          "columns": [
+            {
+              "expression": "last_negotiation_pickup_at",
+              "asc": true,
+              "nulls": "last",
+              "opclass": "timestamptz_ops",
+              "isExpression": false
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "agents_last_seen_at_idx": {
+          "name": "agents_last_seen_at_idx",
+          "columns": [
+            {
+              "expression": "last_seen_at",
+              "asc": true,
+              "nulls": "last",
+              "opclass": "timestamptz_ops",
+              "isExpression": false
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "agents_owner_id_idx": {
+          "name": "agents_owner_id_idx",
+          "columns": [
+            {
+              "expression": "owner_id",
+              "asc": true,
+              "nulls": "last",
+              "opclass": "text_ops",
+              "isExpression": false
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "agents_type_idx": {
+          "name": "agents_type_idx",
+          "columns": [
+            {
+              "expression": "type",
+              "asc": true,
+              "nulls": "last",
+              "opclass": "enum_ops",
+              "isExpression": false
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "uniq_agents_hermes_installation": {
+          "name": "uniq_agents_hermes_installation",
+          "columns": [
+            {
+              "expression": "owner_id",
+              "asc": true,
+              "nulls": "last",
+              "opclass": "text_ops",
+              "isExpression": false
+            },
+            {
+              "expression": "runtime_kind",
+              "asc": true,
+              "nulls": "last",
+              "opclass": "text_ops",
+              "isExpression": false
+            },
+            {
+              "expression": "installation_id",
+              "asc": true,
+              "nulls": "last",
+              "opclass": "text_ops",
+              "isExpression": false
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "where": "((type = 'external'::agent_type) AND (runtime_kind = 'hermes'::text) AND (installation_id IS NOT NULL) AND (deleted_at IS NULL))",
+          "with": {}
+        },
+        "uniq_agents_personal_per_owner": {
+          "name": "uniq_agents_personal_per_owner",
+          "columns": [
+            {
+              "expression": "owner_id",
+              "asc": true,
+              "nulls": "last",
+              "opclass": "text_ops",
+              "isExpression": false
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "where": "((type = 'personal'::agent_type) AND (deleted_at IS NULL))",
+          "with": {}
+        },
+        "uniq_agents_selected_negotiation_executor": {
+          "name": "uniq_agents_selected_negotiation_executor",
+          "columns": [
+            {
+              "expression": "owner_id",
+              "asc": true,
+              "nulls": "last",
+              "opclass": "text_ops",
+              "isExpression": false
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "where": "((type = 'external'::agent_type) AND (handle_negotiations = true) AND (deleted_at IS NULL))",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "agents_owner_id_users_id_fk": {
+          "name": "agents_owner_id_users_id_fk",
+          "tableFrom": "agents",
+          "tableTo": "users",
+          "schemaTo": "public",
+          "columnsFrom": [
+            "owner_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {},
+      "policies": {},
+      "isRLSEnabled": false
+    },
+    "public.network_integrations": {
+      "name": "network_integrations",
+      "schema": "",
+      "columns": {
+        "network_id": {
+          "name": "network_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "toolkit": {
+          "name": "toolkit",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "connected_account_id": {
+          "name": "connected_account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "sync_config": {
+          "name": "sync_config",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "network_integrations_network_id_networks_id_fk": {
+          "name": "network_integrations_network_id_networks_id_fk",
+          "tableFrom": "network_integrations",
+          "tableTo": "networks",
+          "schemaTo": "public",
+          "columnsFrom": [
+            "network_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "network_integrations_network_id_toolkit_pk": {
+          "name": "network_integrations_network_id_toolkit_pk",
+          "columns": [
+            "network_id",
+            "toolkit"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {},
+      "policies": {},
+      "isRLSEnabled": false
+    },
+    "public.intent_networks": {
+      "name": "intent_networks",
+      "schema": "",
+      "columns": {
+        "intent_id": {
+          "name": "intent_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "network_id": {
+          "name": "network_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "relevancy_score": {
+          "name": "relevancy_score",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "assignment_metadata": {
+          "name": "assignment_metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "intent_networks_network_id_idx": {
+          "name": "intent_networks_network_id_idx",
+          "columns": [
+            {
+              "expression": "network_id",
+              "asc": true,
+              "nulls": "last",
+              "opclass": "text_ops",
+              "isExpression": false
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "intent_networks_intent_id_intents_id_fk": {
+          "name": "intent_networks_intent_id_intents_id_fk",
+          "tableFrom": "intent_networks",
+          "tableTo": "intents",
+          "schemaTo": "public",
+          "columnsFrom": [
+            "intent_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "intent_networks_network_id_networks_id_fk": {
+          "name": "intent_networks_network_id_networks_id_fk",
+          "tableFrom": "intent_networks",
+          "tableTo": "networks",
+          "schemaTo": "public",
+          "columnsFrom": [
+            "network_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "intent_networks_intent_id_network_id_pk": {
+          "name": "intent_networks_intent_id_network_id_pk",
+          "columns": [
+            "intent_id",
+            "network_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {},
+      "policies": {},
+      "isRLSEnabled": false
+    },
+    "public.premise_networks": {
+      "name": "premise_networks",
+      "schema": "",
+      "columns": {
+        "premise_id": {
+          "name": "premise_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "network_id": {
+          "name": "network_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "relevancy_score": {
+          "name": "relevancy_score",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "assignment_metadata": {
+          "name": "assignment_metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "premise_networks_network_id_idx": {
+          "name": "premise_networks_network_id_idx",
+          "columns": [
+            {
+              "expression": "network_id",
+              "asc": true,
+              "nulls": "last",
+              "opclass": "text_ops",
+              "isExpression": false
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "premise_networks_premise_id_premises_id_fk": {
+          "name": "premise_networks_premise_id_premises_id_fk",
+          "tableFrom": "premise_networks",
+          "tableTo": "premises",
+          "schemaTo": "public",
+          "columnsFrom": [
+            "premise_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "premise_networks_network_id_networks_id_fk": {
+          "name": "premise_networks_network_id_networks_id_fk",
+          "tableFrom": "premise_networks",
+          "tableTo": "networks",
+          "schemaTo": "public",
+          "columnsFrom": [
+            "network_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "premise_networks_premise_id_network_id_pk": {
+          "name": "premise_networks_premise_id_network_id_pk",
+          "columns": [
+            "premise_id",
+            "network_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {},
+      "policies": {},
+      "isRLSEnabled": false
+    },
+    "public.conversation_participants": {
+      "name": "conversation_participants",
+      "schema": "",
+      "columns": {
+        "conversation_id": {
+          "name": "conversation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "participant_id": {
+          "name": "participant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "participant_type": {
+          "name": "participant_type",
+          "type": "participant_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "joined_at": {
+          "name": "joined_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "hidden_at": {
+          "name": "hidden_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_read_at": {
+          "name": "last_read_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "conversation_participants_conversation_id_idx": {
+          "name": "conversation_participants_conversation_id_idx",
+          "columns": [
+            {
+              "expression": "conversation_id",
+              "asc": true,
+              "nulls": "last",
+              "opclass": "text_ops",
+              "isExpression": false
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "conversation_participants_participant_id_idx": {
+          "name": "conversation_participants_participant_id_idx",
+          "columns": [
+            {
+              "expression": "participant_id",
+              "asc": true,
+              "nulls": "last",
+              "opclass": "text_ops",
+              "isExpression": false
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "conversation_participants_conversation_id_conversations_id_fk": {
+          "name": "conversation_participants_conversation_id_conversations_id_fk",
+          "tableFrom": "conversation_participants",
+          "tableTo": "conversations",
+          "schemaTo": "public",
+          "columnsFrom": [
+            "conversation_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "conversation_participants_conversation_id_participant_id_pk": {
+          "name": "conversation_participants_conversation_id_participant_id_pk",
+          "columns": [
+            "conversation_id",
+            "participant_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {},
+      "policies": {},
+      "isRLSEnabled": false
+    },
+    "public.network_members": {
+      "name": "network_members",
+      "schema": "",
+      "columns": {
+        "network_id": {
+          "name": "network_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "permissions": {
+          "name": "permissions",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{\"\"}'"
+        },
+        "prompt": {
+          "name": "prompt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "auto_assign": {
+          "name": "auto_assign",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "network_members_network_id_networks_id_fk": {
+          "name": "network_members_network_id_networks_id_fk",
+          "tableFrom": "network_members",
+          "tableTo": "networks",
+          "schemaTo": "public",
+          "columnsFrom": [
+            "network_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "network_members_user_id_users_id_fk": {
+          "name": "network_members_user_id_users_id_fk",
+          "tableFrom": "network_members",
+          "tableTo": "users",
+          "schemaTo": "public",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "network_members_network_id_user_id_pk": {
+          "name": "network_members_network_id_user_id_pk",
+          "columns": [
+            "network_id",
+            "user_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {},
+      "policies": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.agent_status": {
+      "name": "agent_status",
+      "values": [
+        "active",
+        "inactive"
+      ],
+      "schema": "public"
+    },
+    "public.agent_type": {
+      "name": "agent_type",
+      "values": [
+        "personal",
+        "external",
+        "system"
+      ],
+      "schema": "public"
+    },
+    "public.discovery_match_candidate_status": {
+      "name": "discovery_match_candidate_status",
+      "values": [
+        "pending",
+        "opened",
+        "superseded",
+        "expired"
+      ],
+      "schema": "public"
+    },
+    "public.intent_discovery_progress_status": {
+      "name": "intent_discovery_progress_status",
+      "values": [
+        "queued",
+        "running",
+        "succeeded",
+        "failed",
+        "blocked"
+      ],
+      "schema": "public"
+    },
+    "public.intent_dossier_source": {
+      "name": "intent_dossier_source",
+      "values": [
+        "user_message",
+        "answer",
+        "agent_note"
+      ],
+      "schema": "public"
+    },
+    "public.intent_mode": {
+      "name": "intent_mode",
+      "values": [
+        "REFERENTIAL",
+        "ATTRIBUTIVE"
+      ],
+      "schema": "public"
+    },
+    "public.intent_proposal_status": {
+      "name": "intent_proposal_status",
+      "values": [
+        "pending",
+        "consumed",
+        "rejected"
+      ],
+      "schema": "public"
+    },
+    "public.intent_status": {
+      "name": "intent_status",
+      "values": [
+        "ACTIVE",
+        "PAUSED",
+        "FULFILLED",
+        "EXPIRED"
+      ],
+      "schema": "public"
+    },
+    "public.message_role": {
+      "name": "message_role",
+      "values": [
+        "user",
+        "agent"
+      ],
+      "schema": "public"
+    },
+    "public.negotiation_round_log_event_kind": {
+      "name": "negotiation_round_log_event_kind",
+      "values": [
+        "opened",
+        "stopped",
+        "resumed"
+      ],
+      "schema": "public"
+    },
+    "public.negotiation_round_log_event_via": {
+      "name": "negotiation_round_log_event_via",
+      "values": [
+        "paused",
+        "completed"
+      ],
+      "schema": "public"
+    },
+    "public.opportunity_status": {
+      "name": "opportunity_status",
+      "values": [
+        "negotiating",
+        "pending",
+        "stalled",
+        "accepted",
+        "rejected",
+        "expired"
+      ],
+      "schema": "public"
+    },
+    "public.participant_type": {
+      "name": "participant_type",
+      "values": [
+        "user",
+        "agent"
+      ],
+      "schema": "public"
+    },
+    "public.permission_scope": {
+      "name": "permission_scope",
+      "values": [
+        "global",
+        "node",
+        "network"
+      ],
+      "schema": "public"
+    },
+    "public.premise_status": {
+      "name": "premise_status",
+      "values": [
+        "ACTIVE",
+        "RETRACTED",
+        "EXPIRED"
+      ],
+      "schema": "public"
+    },
+    "public.question_status": {
+      "name": "question_status",
+      "values": [
+        "pending",
+        "answered",
+        "dismissed"
+      ],
+      "schema": "public"
+    },
+    "public.signal_intake_run_status": {
+      "name": "signal_intake_run_status",
+      "values": [
+        "pending",
+        "ready",
+        "failed"
+      ],
+      "schema": "public"
+    },
+    "public.source_type": {
+      "name": "source_type",
+      "values": [
+        "integration",
+        "discovery_form",
+        "enrichment"
+      ],
+      "schema": "public"
+    },
+    "public.speech_act_type": {
+      "name": "speech_act_type",
+      "values": [
+        "COMMISSIVE",
+        "DIRECTIVE"
+      ],
+      "schema": "public"
+    },
+    "public.task_state": {
+      "name": "task_state",
+      "values": [
+        "submitted",
+        "working",
+        "completed",
+        "failed",
+        "canceled",
+        "rejected",
+        "auth_required",
+        "waiting_for_agent",
+        "claimed",
+        "paused"
+      ],
+      "schema": "public"
+    },
+    "public.transport_channel": {
+      "name": "transport_channel",
+      "values": [
+        "mcp"
+      ],
+      "schema": "public"
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "schemas": {},
+    "tables": {},
+    "columns": {}
+  },
+  "internal": {
+    "tables": {
+      "agent_permissions": {
+        "columns": {
+          "actions": {
+            "isArray": true,
+            "dimensions": 1,
+            "rawType": "text"
+          }
+        }
+      },
+      "network_members": {
+        "columns": {
+          "permissions": {
+            "isArray": true,
+            "dimensions": 1,
+            "rawType": "text"
+          }
+        }
+      }
+    }
+  }
+}

--- a/services/api/drizzle/meta/0155_snapshot.json
+++ b/services/api/drizzle/meta/0155_snapshot.json
@@ -1,0 +1,6455 @@
+{
+  "id": "256fcc7f-5a9d-4ceb-a413-1112c5cff383",
+  "prevId": "6bb8665f-4754-4874-96ce-9b856eeae272",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.intent_dossier": {
+      "name": "intent_dossier",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "intent_id": {
+          "name": "intent_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "text": {
+          "name": "text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source": {
+          "name": "source",
+          "type": "intent_dossier_source",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "retired_at": {
+          "name": "retired_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_intent_dossier_scope": {
+          "name": "idx_intent_dossier_scope",
+          "columns": [
+            {
+              "expression": "user_id",
+              "asc": true,
+              "nulls": "last",
+              "opclass": "timestamptz_ops",
+              "isExpression": false
+            },
+            {
+              "expression": "intent_id",
+              "asc": true,
+              "nulls": "last",
+              "opclass": "text_ops",
+              "isExpression": false
+            },
+            {
+              "expression": "retired_at",
+              "asc": true,
+              "nulls": "last",
+              "opclass": "timestamptz_ops",
+              "isExpression": false
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "intent_dossier_user_id_users_id_fk": {
+          "name": "intent_dossier_user_id_users_id_fk",
+          "tableFrom": "intent_dossier",
+          "tableTo": "users",
+          "schemaTo": "public",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "intent_dossier_intent_id_intents_id_fk": {
+          "name": "intent_dossier_intent_id_intents_id_fk",
+          "tableFrom": "intent_dossier",
+          "tableTo": "intents",
+          "schemaTo": "public",
+          "columnsFrom": [
+            "intent_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {},
+      "policies": {},
+      "isRLSEnabled": false
+    },
+    "public.intent_agent_acts": {
+      "name": "intent_agent_acts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "intent_id": {
+          "name": "intent_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "event": {
+          "name": "event",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "act": {
+          "name": "act",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_intent_agent_acts_scope": {
+          "name": "idx_intent_agent_acts_scope",
+          "columns": [
+            {
+              "expression": "user_id",
+              "asc": true,
+              "nulls": "last",
+              "opclass": "timestamptz_ops",
+              "isExpression": false
+            },
+            {
+              "expression": "intent_id",
+              "asc": true,
+              "nulls": "last",
+              "opclass": "text_ops",
+              "isExpression": false
+            },
+            {
+              "expression": "created_at",
+              "asc": true,
+              "nulls": "last",
+              "opclass": "timestamptz_ops",
+              "isExpression": false
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "intent_agent_acts_user_id_users_id_fk": {
+          "name": "intent_agent_acts_user_id_users_id_fk",
+          "tableFrom": "intent_agent_acts",
+          "tableTo": "users",
+          "schemaTo": "public",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {},
+      "policies": {},
+      "isRLSEnabled": false
+    },
+    "public.hyde_documents": {
+      "name": "hyde_documents",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "source_type": {
+          "name": "source_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_id": {
+          "name": "source_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source_text": {
+          "name": "source_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "strategy": {
+          "name": "strategy",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "target_corpus": {
+          "name": "target_corpus",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "context": {
+          "name": "context",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "hyde_text": {
+          "name": "hyde_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "hyde_embedding": {
+          "name": "hyde_embedding",
+          "type": "vector(2000)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "hyde_embedding_idx": {
+          "name": "hyde_embedding_idx",
+          "columns": [
+            {
+              "expression": "hyde_embedding",
+              "asc": true,
+              "nulls": "last",
+              "opclass": "vector_cosine_ops",
+              "isExpression": false
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "hnsw",
+          "with": {}
+        },
+        "hyde_expires_idx": {
+          "name": "hyde_expires_idx",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "asc": true,
+              "nulls": "last",
+              "opclass": "timestamptz_ops",
+              "isExpression": false
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "hyde_source_idx": {
+          "name": "hyde_source_idx",
+          "columns": [
+            {
+              "expression": "source_type",
+              "asc": true,
+              "nulls": "last",
+              "opclass": "text_ops",
+              "isExpression": false
+            },
+            {
+              "expression": "source_id",
+              "asc": true,
+              "nulls": "last",
+              "opclass": "text_ops",
+              "isExpression": false
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "hyde_source_strategy_unique": {
+          "name": "hyde_source_strategy_unique",
+          "columns": [
+            {
+              "expression": "source_type",
+              "asc": true,
+              "nulls": "last",
+              "opclass": "text_ops",
+              "isExpression": false
+            },
+            {
+              "expression": "source_id",
+              "asc": true,
+              "nulls": "last",
+              "opclass": "text_ops",
+              "isExpression": false
+            },
+            {
+              "expression": "strategy",
+              "asc": true,
+              "nulls": "last",
+              "opclass": "text_ops",
+              "isExpression": false
+            },
+            {
+              "expression": "target_corpus",
+              "asc": true,
+              "nulls": "last",
+              "opclass": "text_ops",
+              "isExpression": false
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "hyde_strategy_idx": {
+          "name": "hyde_strategy_idx",
+          "columns": [
+            {
+              "expression": "strategy",
+              "asc": true,
+              "nulls": "last",
+              "opclass": "text_ops",
+              "isExpression": false
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {},
+      "policies": {},
+      "isRLSEnabled": false
+    },
+    "public.verifications": {
+      "name": "verifications",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "identifier": {
+          "name": "identifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {},
+      "policies": {},
+      "isRLSEnabled": false
+    },
+    "public.accounts": {
+      "name": "accounts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "id_token": {
+          "name": "id_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "access_token_expires_at": {
+          "name": "access_token_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token_expires_at": {
+          "name": "refresh_token_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "password": {
+          "name": "password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "accounts_user_id_users_id_fk": {
+          "name": "accounts_user_id_users_id_fk",
+          "tableFrom": "accounts",
+          "tableTo": "users",
+          "schemaTo": "public",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {},
+      "policies": {},
+      "isRLSEnabled": false
+    },
+    "public.sessions": {
+      "name": "sessions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "ip_address": {
+          "name": "ip_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "sessions_user_id_users_id_fk": {
+          "name": "sessions_user_id_users_id_fk",
+          "tableFrom": "sessions",
+          "tableTo": "users",
+          "schemaTo": "public",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "sessions_token_unique": {
+          "columns": [
+            "token"
+          ],
+          "nullsNotDistinct": false,
+          "name": "sessions_token_unique"
+        }
+      },
+      "checkConstraints": {},
+      "policies": {},
+      "isRLSEnabled": false
+    },
+    "public.user_notification_settings": {
+      "name": "user_notification_settings",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "preferences": {
+          "name": "preferences",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'{\"connectionUpdates\":true,\"weeklyNewsletter\":true}'::json"
+        },
+        "unsubscribe_token": {
+          "name": "unsubscribe_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "user_notification_settings_user_id_users_id_fk": {
+          "name": "user_notification_settings_user_id_users_id_fk",
+          "tableFrom": "user_notification_settings",
+          "tableTo": "users",
+          "schemaTo": "public",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "user_notification_settings_user_id_unique": {
+          "columns": [
+            "user_id"
+          ],
+          "nullsNotDistinct": false,
+          "name": "user_notification_settings_user_id_unique"
+        },
+        "user_notification_settings_unsubscribe_token_unique": {
+          "columns": [
+            "unsubscribe_token"
+          ],
+          "nullsNotDistinct": false,
+          "name": "user_notification_settings_unsubscribe_token_unique"
+        }
+      },
+      "checkConstraints": {},
+      "policies": {},
+      "isRLSEnabled": false
+    },
+    "public.jwks": {
+      "name": "jwks",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "public_key": {
+          "name": "public_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "private_key": {
+          "name": "private_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {},
+      "policies": {},
+      "isRLSEnabled": false
+    },
+    "public.intent_discovery_progress": {
+      "name": "intent_discovery_progress",
+      "schema": "",
+      "columns": {
+        "intent_id": {
+          "name": "intent_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "intent_discovery_progress_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'queued'"
+        },
+        "attempt": {
+          "name": "attempt",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "max_attempts": {
+          "name": "max_attempts",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 3
+        },
+        "assigned_community_count": {
+          "name": "assigned_community_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "processed_community_count": {
+          "name": "processed_community_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "possible_overlap_count": {
+          "name": "possible_overlap_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "conversations_started_count": {
+          "name": "conversations_started_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "queued_at": {
+          "name": "queued_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "intent_discovery_progress_user_updated_idx": {
+          "name": "intent_discovery_progress_user_updated_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "asc": true,
+              "nulls": "last",
+              "opclass": "text_ops",
+              "isExpression": false
+            },
+            {
+              "expression": "updated_at",
+              "asc": true,
+              "nulls": "last",
+              "opclass": "text_ops",
+              "isExpression": false
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "intent_discovery_progress_intent_id_intents_id_fk": {
+          "name": "intent_discovery_progress_intent_id_intents_id_fk",
+          "tableFrom": "intent_discovery_progress",
+          "tableTo": "intents",
+          "schemaTo": "public",
+          "columnsFrom": [
+            "intent_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "intent_discovery_progress_user_id_users_id_fk": {
+          "name": "intent_discovery_progress_user_id_users_id_fk",
+          "tableFrom": "intent_discovery_progress",
+          "tableTo": "users",
+          "schemaTo": "public",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {},
+      "policies": {},
+      "isRLSEnabled": false
+    },
+    "public.artifacts": {
+      "name": "artifacts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "task_id": {
+          "name": "task_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "parts": {
+          "name": "parts",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "extensions": {
+          "name": "extensions",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "artifacts_task_id_idx": {
+          "name": "artifacts_task_id_idx",
+          "columns": [
+            {
+              "expression": "task_id",
+              "asc": true,
+              "nulls": "last",
+              "opclass": "text_ops",
+              "isExpression": false
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "artifacts_task_id_tasks_id_fk": {
+          "name": "artifacts_task_id_tasks_id_fk",
+          "tableFrom": "artifacts",
+          "tableTo": "tasks",
+          "schemaTo": "public",
+          "columnsFrom": [
+            "task_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {},
+      "policies": {},
+      "isRLSEnabled": false
+    },
+    "public.conversation_metadata": {
+      "name": "conversation_metadata",
+      "schema": "",
+      "columns": {
+        "conversation_id": {
+          "name": "conversation_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "conversation_metadata_conversation_id_conversations_id_fk": {
+          "name": "conversation_metadata_conversation_id_conversations_id_fk",
+          "tableFrom": "conversation_metadata",
+          "tableTo": "conversations",
+          "schemaTo": "public",
+          "columnsFrom": [
+            "conversation_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {},
+      "policies": {},
+      "isRLSEnabled": false
+    },
+    "public.oauth_application": {
+      "name": "oauth_application",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "icon": {
+          "name": "icon",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "client_secret": {
+          "name": "client_secret",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "redirect_urls": {
+          "name": "redirect_urls",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "disabled": {
+          "name": "disabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "oauth_application_user_id_idx": {
+          "name": "oauth_application_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "asc": true,
+              "nulls": "last",
+              "opclass": "text_ops",
+              "isExpression": false
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "oauth_application_user_id_users_id_fk": {
+          "name": "oauth_application_user_id_users_id_fk",
+          "tableFrom": "oauth_application",
+          "tableTo": "users",
+          "schemaTo": "public",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "oauth_application_client_id_unique": {
+          "columns": [
+            "client_id"
+          ],
+          "nullsNotDistinct": false,
+          "name": "oauth_application_client_id_unique"
+        }
+      },
+      "checkConstraints": {},
+      "policies": {},
+      "isRLSEnabled": false
+    },
+    "public.oauth_access_token": {
+      "name": "oauth_access_token",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "access_token_expires_at": {
+          "name": "access_token_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "refresh_token_expires_at": {
+          "name": "refresh_token_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scopes": {
+          "name": "scopes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "oauth_access_token_client_id_idx": {
+          "name": "oauth_access_token_client_id_idx",
+          "columns": [
+            {
+              "expression": "client_id",
+              "asc": true,
+              "nulls": "last",
+              "opclass": "text_ops",
+              "isExpression": false
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "oauth_access_token_user_id_idx": {
+          "name": "oauth_access_token_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "asc": true,
+              "nulls": "last",
+              "opclass": "text_ops",
+              "isExpression": false
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "oauth_access_token_client_id_oauth_application_client_id_fk": {
+          "name": "oauth_access_token_client_id_oauth_application_client_id_fk",
+          "tableFrom": "oauth_access_token",
+          "tableTo": "oauth_application",
+          "schemaTo": "public",
+          "columnsFrom": [
+            "client_id"
+          ],
+          "columnsTo": [
+            "client_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "oauth_access_token_user_id_users_id_fk": {
+          "name": "oauth_access_token_user_id_users_id_fk",
+          "tableFrom": "oauth_access_token",
+          "tableTo": "users",
+          "schemaTo": "public",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "oauth_access_token_access_token_unique": {
+          "columns": [
+            "access_token"
+          ],
+          "nullsNotDistinct": false,
+          "name": "oauth_access_token_access_token_unique"
+        },
+        "oauth_access_token_refresh_token_unique": {
+          "columns": [
+            "refresh_token"
+          ],
+          "nullsNotDistinct": false,
+          "name": "oauth_access_token_refresh_token_unique"
+        }
+      },
+      "checkConstraints": {},
+      "policies": {},
+      "isRLSEnabled": false
+    },
+    "public.oauth_consent": {
+      "name": "oauth_consent",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scopes": {
+          "name": "scopes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "consent_given": {
+          "name": "consent_given",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "oauth_consent_client_id_idx": {
+          "name": "oauth_consent_client_id_idx",
+          "columns": [
+            {
+              "expression": "client_id",
+              "asc": true,
+              "nulls": "last",
+              "opclass": "text_ops",
+              "isExpression": false
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "oauth_consent_user_id_idx": {
+          "name": "oauth_consent_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "asc": true,
+              "nulls": "last",
+              "opclass": "text_ops",
+              "isExpression": false
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "oauth_consent_client_id_oauth_application_client_id_fk": {
+          "name": "oauth_consent_client_id_oauth_application_client_id_fk",
+          "tableFrom": "oauth_consent",
+          "tableTo": "oauth_application",
+          "schemaTo": "public",
+          "columnsFrom": [
+            "client_id"
+          ],
+          "columnsTo": [
+            "client_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "oauth_consent_user_id_users_id_fk": {
+          "name": "oauth_consent_user_id_users_id_fk",
+          "tableFrom": "oauth_consent",
+          "tableTo": "users",
+          "schemaTo": "public",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {},
+      "policies": {},
+      "isRLSEnabled": false
+    },
+    "public.negotiation_round_log_events": {
+      "name": "negotiation_round_log_events",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "intent_id": {
+          "name": "intent_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "batch_id": {
+          "name": "batch_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "task_id": {
+          "name": "task_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "negotiation_round_log_event_kind",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "via": {
+          "name": "via",
+          "type": "negotiation_round_log_event_via",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reason": {
+          "name": "reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_negotiation_round_log_events_batch": {
+          "name": "idx_negotiation_round_log_events_batch",
+          "columns": [
+            {
+              "expression": "intent_id",
+              "asc": true,
+              "nulls": "last",
+              "opclass": "timestamptz_ops",
+              "isExpression": false
+            },
+            {
+              "expression": "batch_id",
+              "asc": true,
+              "nulls": "last",
+              "opclass": "text_ops",
+              "isExpression": false
+            },
+            {
+              "expression": "created_at",
+              "asc": true,
+              "nulls": "last",
+              "opclass": "timestamptz_ops",
+              "isExpression": false
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {},
+      "policies": {},
+      "isRLSEnabled": false
+    },
+    "public.tasks": {
+      "name": "tasks",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "conversation_id": {
+          "name": "conversation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "state": {
+          "name": "state",
+          "type": "task_state",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'submitted'"
+        },
+        "status_message": {
+          "name": "status_message",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status_timestamp": {
+          "name": "status_timestamp",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "extensions": {
+          "name": "extensions",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "claimed_by_agent_id": {
+          "name": "claimed_by_agent_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "claimed_at": {
+          "name": "claimed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "briefs": {
+          "name": "briefs",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        }
+      },
+      "indexes": {
+        "tasks_conversation_id_idx": {
+          "name": "tasks_conversation_id_idx",
+          "columns": [
+            {
+              "expression": "conversation_id",
+              "asc": true,
+              "nulls": "last",
+              "opclass": "text_ops",
+              "isExpression": false
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "tasks_metadata_opportunity_id_idx": {
+          "name": "tasks_metadata_opportunity_id_idx",
+          "columns": [
+            {
+              "expression": "((metadata ->> 'opportunityId'::text))",
+              "asc": true,
+              "nulls": "last",
+              "opclass": "text_ops",
+              "isExpression": true
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "where": "((metadata ->> 'type'::text) = 'negotiation'::text)",
+          "with": {}
+        },
+        "tasks_state_idx": {
+          "name": "tasks_state_idx",
+          "columns": [
+            {
+              "expression": "state",
+              "asc": true,
+              "nulls": "last",
+              "opclass": "enum_ops",
+              "isExpression": false
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "tasks_conversation_id_conversations_id_fk": {
+          "name": "tasks_conversation_id_conversations_id_fk",
+          "tableFrom": "tasks",
+          "tableTo": "conversations",
+          "schemaTo": "public",
+          "columnsFrom": [
+            "conversation_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {},
+      "policies": {},
+      "isRLSEnabled": false
+    },
+    "public.agent_permissions": {
+      "name": "agent_permissions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "agent_id": {
+          "name": "agent_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scope": {
+          "name": "scope",
+          "type": "permission_scope",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'global'"
+        },
+        "scope_id": {
+          "name": "scope_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "actions": {
+          "name": "actions",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "agent_permissions_agent_id_idx": {
+          "name": "agent_permissions_agent_id_idx",
+          "columns": [
+            {
+              "expression": "agent_id",
+              "asc": true,
+              "nulls": "last",
+              "opclass": "text_ops",
+              "isExpression": false
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "agent_permissions_agent_user_idx": {
+          "name": "agent_permissions_agent_user_idx",
+          "columns": [
+            {
+              "expression": "agent_id",
+              "asc": true,
+              "nulls": "last",
+              "opclass": "text_ops",
+              "isExpression": false
+            },
+            {
+              "expression": "user_id",
+              "asc": true,
+              "nulls": "last",
+              "opclass": "text_ops",
+              "isExpression": false
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "agent_permissions_user_id_idx": {
+          "name": "agent_permissions_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "asc": true,
+              "nulls": "last",
+              "opclass": "text_ops",
+              "isExpression": false
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "uniq_agent_permissions_global": {
+          "name": "uniq_agent_permissions_global",
+          "columns": [
+            {
+              "expression": "agent_id",
+              "asc": true,
+              "nulls": "last",
+              "opclass": "text_ops",
+              "isExpression": false
+            },
+            {
+              "expression": "user_id",
+              "asc": true,
+              "nulls": "last",
+              "opclass": "text_ops",
+              "isExpression": false
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "where": "(scope = 'global'::permission_scope)",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "agent_permissions_agent_id_agents_id_fk": {
+          "name": "agent_permissions_agent_id_agents_id_fk",
+          "tableFrom": "agent_permissions",
+          "tableTo": "agents",
+          "schemaTo": "public",
+          "columnsFrom": [
+            "agent_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "agent_permissions_user_id_users_id_fk": {
+          "name": "agent_permissions_user_id_users_id_fk",
+          "tableFrom": "agent_permissions",
+          "tableTo": "users",
+          "schemaTo": "public",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {},
+      "policies": {},
+      "isRLSEnabled": false
+    },
+    "public.agent_test_messages": {
+      "name": "agent_test_messages",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "agent_id": {
+          "name": "agent_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "requested_by_user_id": {
+          "name": "requested_by_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reservation_token": {
+          "name": "reservation_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reserved_at": {
+          "name": "reserved_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "delivered_at": {
+          "name": "delivered_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_agent_test_messages_agent_pending": {
+          "name": "idx_agent_test_messages_agent_pending",
+          "columns": [
+            {
+              "expression": "agent_id",
+              "asc": true,
+              "nulls": "last",
+              "opclass": "text_ops",
+              "isExpression": false
+            },
+            {
+              "expression": "reserved_at",
+              "asc": true,
+              "nulls": "last",
+              "opclass": "text_ops",
+              "isExpression": false
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "agent_test_messages_agent_id_agents_id_fk": {
+          "name": "agent_test_messages_agent_id_agents_id_fk",
+          "tableFrom": "agent_test_messages",
+          "tableTo": "agents",
+          "schemaTo": "public",
+          "columnsFrom": [
+            "agent_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "agent_test_messages_requested_by_user_id_users_id_fk": {
+          "name": "agent_test_messages_requested_by_user_id_users_id_fk",
+          "tableFrom": "agent_test_messages",
+          "tableTo": "users",
+          "schemaTo": "public",
+          "columnsFrom": [
+            "requested_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {},
+      "policies": {},
+      "isRLSEnabled": false
+    },
+    "public.opportunity_deliveries": {
+      "name": "opportunity_deliveries",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "opportunity_id": {
+          "name": "opportunity_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "agent_id": {
+          "name": "agent_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "channel": {
+          "name": "channel",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "trigger": {
+          "name": "trigger",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "delivered_at_status": {
+          "name": "delivered_at_status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reservation_token": {
+          "name": "reservation_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reserved_at": {
+          "name": "reserved_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "delivered_at": {
+          "name": "delivered_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_opp_deliveries_open_reservations": {
+          "name": "idx_opp_deliveries_open_reservations",
+          "columns": [
+            {
+              "expression": "user_id",
+              "asc": true,
+              "nulls": "last",
+              "opclass": "text_ops",
+              "isExpression": false
+            },
+            {
+              "expression": "channel",
+              "asc": true,
+              "nulls": "last",
+              "opclass": "timestamptz_ops",
+              "isExpression": false
+            },
+            {
+              "expression": "reserved_at",
+              "asc": true,
+              "nulls": "last",
+              "opclass": "timestamptz_ops",
+              "isExpression": false
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "where": "(delivered_at IS NULL)",
+          "with": {}
+        },
+        "uniq_opp_deliveries_committed": {
+          "name": "uniq_opp_deliveries_committed",
+          "columns": [
+            {
+              "expression": "user_id",
+              "asc": true,
+              "nulls": "last",
+              "opclass": "text_ops",
+              "isExpression": false
+            },
+            {
+              "expression": "opportunity_id",
+              "asc": true,
+              "nulls": "last",
+              "opclass": "text_ops",
+              "isExpression": false
+            },
+            {
+              "expression": "channel",
+              "asc": true,
+              "nulls": "last",
+              "opclass": "text_ops",
+              "isExpression": false
+            },
+            {
+              "expression": "delivered_at_status",
+              "asc": true,
+              "nulls": "last",
+              "opclass": "text_ops",
+              "isExpression": false
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "where": "(delivered_at IS NOT NULL)",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "opportunity_deliveries_opportunity_id_opportunities_id_fk": {
+          "name": "opportunity_deliveries_opportunity_id_opportunities_id_fk",
+          "tableFrom": "opportunity_deliveries",
+          "tableTo": "opportunities",
+          "schemaTo": "public",
+          "columnsFrom": [
+            "opportunity_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "opportunity_deliveries_user_id_users_id_fk": {
+          "name": "opportunity_deliveries_user_id_users_id_fk",
+          "tableFrom": "opportunity_deliveries",
+          "tableTo": "users",
+          "schemaTo": "public",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "opportunity_deliveries_agent_id_agents_id_fk": {
+          "name": "opportunity_deliveries_agent_id_agents_id_fk",
+          "tableFrom": "opportunity_deliveries",
+          "tableTo": "agents",
+          "schemaTo": "public",
+          "columnsFrom": [
+            "agent_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {},
+      "policies": {},
+      "isRLSEnabled": false
+    },
+    "public.agent_transports": {
+      "name": "agent_transports",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "agent_id": {
+          "name": "agent_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "channel": {
+          "name": "channel",
+          "type": "transport_channel",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "config": {
+          "name": "config",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'{}'::jsonb"
+        },
+        "priority": {
+          "name": "priority",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "active": {
+          "name": "active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "failure_count": {
+          "name": "failure_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "agent_transports_agent_id_idx": {
+          "name": "agent_transports_agent_id_idx",
+          "columns": [
+            {
+              "expression": "agent_id",
+              "asc": true,
+              "nulls": "last",
+              "opclass": "text_ops",
+              "isExpression": false
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "agent_transports_agent_id_agents_id_fk": {
+          "name": "agent_transports_agent_id_agents_id_fk",
+          "tableFrom": "agent_transports",
+          "tableTo": "agents",
+          "schemaTo": "public",
+          "columnsFrom": [
+            "agent_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {},
+      "policies": {},
+      "isRLSEnabled": false
+    },
+    "public.user_socials": {
+      "name": "user_socials",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "label": {
+          "name": "label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_user_socials_user_id": {
+          "name": "idx_user_socials_user_id",
+          "columns": [
+            {
+              "expression": "user_id",
+              "asc": true,
+              "nulls": "last",
+              "opclass": "text_ops",
+              "isExpression": false
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "uniq_user_socials_user_label": {
+          "name": "uniq_user_socials_user_label",
+          "columns": [
+            {
+              "expression": "user_id",
+              "asc": true,
+              "nulls": "last",
+              "opclass": "text_ops",
+              "isExpression": false
+            },
+            {
+              "expression": "label",
+              "asc": true,
+              "nulls": "last",
+              "opclass": "text_ops",
+              "isExpression": false
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "where": "(label <> 'custom'::text)",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "user_socials_user_id_fkey": {
+          "name": "user_socials_user_id_fkey",
+          "tableFrom": "user_socials",
+          "tableTo": "users",
+          "schemaTo": "public",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {},
+      "policies": {},
+      "isRLSEnabled": false
+    },
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email_verified": {
+          "name": "email_verified",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "avatar": {
+          "name": "avatar",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "intro": {
+          "name": "intro",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "location": {
+          "name": "location",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "onboarding": {
+          "name": "onboarding",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'{}'::json"
+        },
+        "timezone": {
+          "name": "timezone",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'UTC'"
+        },
+        "last_weekly_email_sent_at": {
+          "name": "last_weekly_email_sent_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "users_email_unique": {
+          "name": "users_email_unique",
+          "columns": [
+            {
+              "expression": "email",
+              "asc": true,
+              "nulls": "last",
+              "opclass": "text_ops",
+              "isExpression": false
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "users_key_unique": {
+          "name": "users_key_unique",
+          "columns": [
+            {
+              "expression": "key",
+              "asc": true,
+              "nulls": "last",
+              "opclass": "text_ops",
+              "isExpression": false
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {},
+      "policies": {},
+      "isRLSEnabled": false
+    },
+    "public.chat_session_summaries": {
+      "name": "chat_session_summaries",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "conversation_id": {
+          "name": "conversation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "from_message_id": {
+          "name": "from_message_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "to_message_id": {
+          "name": "to_message_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "digest": {
+          "name": "digest",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "model": {
+          "name": "model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "chat_session_summaries_session_latest_idx": {
+          "name": "chat_session_summaries_session_latest_idx",
+          "columns": [
+            {
+              "expression": "conversation_id",
+              "asc": true,
+              "nulls": "last",
+              "opclass": "text_ops",
+              "isExpression": false
+            },
+            {
+              "expression": "created_at",
+              "asc": false,
+              "nulls": "last",
+              "opclass": "text_ops",
+              "isExpression": false
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "chat_session_summaries_conversation_id_conversations_id_fk": {
+          "name": "chat_session_summaries_conversation_id_conversations_id_fk",
+          "tableFrom": "chat_session_summaries",
+          "tableTo": "conversations",
+          "schemaTo": "public",
+          "columnsFrom": [
+            "conversation_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "chat_session_summaries_from_message_id_messages_id_fk": {
+          "name": "chat_session_summaries_from_message_id_messages_id_fk",
+          "tableFrom": "chat_session_summaries",
+          "tableTo": "messages",
+          "schemaTo": "public",
+          "columnsFrom": [
+            "from_message_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "chat_session_summaries_to_message_id_messages_id_fk": {
+          "name": "chat_session_summaries_to_message_id_messages_id_fk",
+          "tableFrom": "chat_session_summaries",
+          "tableTo": "messages",
+          "schemaTo": "public",
+          "columnsFrom": [
+            "to_message_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {},
+      "policies": {},
+      "isRLSEnabled": false
+    },
+    "public.opportunities": {
+      "name": "opportunities",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "detection": {
+          "name": "detection",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "actors": {
+          "name": "actors",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "interpretation": {
+          "name": "interpretation",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "context": {
+          "name": "context",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "confidence": {
+          "name": "confidence",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "opportunity_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "accepted_by": {
+          "name": "accepted_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'{}'::jsonb"
+        }
+      },
+      "indexes": {
+        "opportunities_active_pair_idx": {
+          "name": "opportunities_active_pair_idx",
+          "columns": [
+            {
+              "expression": "((context ->> 'networkId'::text))",
+              "asc": true,
+              "nulls": "last",
+              "opclass": "text_ops",
+              "isExpression": true
+            },
+            {
+              "expression": "LEAST(((actors -> 0) ->> 'intent'::text), ((actors -> 1) ->> 'i",
+              "asc": true,
+              "nulls": "last",
+              "opclass": "text_ops",
+              "isExpression": true
+            },
+            {
+              "expression": "GREATEST(((actors -> 0) ->> 'intent'::text), ((actors -> 1) ->>",
+              "asc": true,
+              "nulls": "last",
+              "opclass": "text_ops",
+              "isExpression": true
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "where": "((status = ANY (ARRAY['negotiating'::opportunity_status, 'pending'::opportunity_status, 'stalled'::opportunity_status])) AND (((actors -> 0) ->> 'intent'::text) IS NOT NULL) AND (((actors -> 1) ->> 'intent'::text) IS NOT NULL))",
+          "with": {}
+        },
+        "opportunities_status_idx": {
+          "name": "opportunities_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "asc": true,
+              "nulls": "last",
+              "opclass": "enum_ops",
+              "isExpression": false
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "opportunities_accepted_by_users_id_fk": {
+          "name": "opportunities_accepted_by_users_id_fk",
+          "tableFrom": "opportunities",
+          "tableTo": "users",
+          "schemaTo": "public",
+          "columnsFrom": [
+            "accepted_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {},
+      "policies": {},
+      "isRLSEnabled": false
+    },
+    "public.premises": {
+      "name": "premises",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "assertion": {
+          "name": "assertion",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provenance": {
+          "name": "provenance",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "analysis": {
+          "name": "analysis",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "validity": {
+          "name": "validity",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "embedding": {
+          "name": "embedding",
+          "type": "vector(2000)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "premise_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'ACTIVE'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "retracted_at": {
+          "name": "retracted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "premises_embedding_idx": {
+          "name": "premises_embedding_idx",
+          "columns": [
+            {
+              "expression": "embedding",
+              "asc": true,
+              "nulls": "last",
+              "opclass": "vector_cosine_ops",
+              "isExpression": false
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "hnsw",
+          "with": {}
+        },
+        "premises_status_idx": {
+          "name": "premises_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "asc": true,
+              "nulls": "last",
+              "opclass": "enum_ops",
+              "isExpression": false
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "premises_user_id_idx": {
+          "name": "premises_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "asc": true,
+              "nulls": "last",
+              "opclass": "text_ops",
+              "isExpression": false
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "premises_user_id_users_id_fk": {
+          "name": "premises_user_id_users_id_fk",
+          "tableFrom": "premises",
+          "tableTo": "users",
+          "schemaTo": "public",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {},
+      "policies": {},
+      "isRLSEnabled": false
+    },
+    "public.questions": {
+      "name": "questions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "detection": {
+          "name": "detection",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "actors": {
+          "name": "actors",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "payload": {
+          "name": "payload",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "question_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "answer": {
+          "name": "answer",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "conversation_id": {
+          "name": "conversation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "questions_conversation_id_idx": {
+          "name": "questions_conversation_id_idx",
+          "columns": [
+            {
+              "expression": "conversation_id",
+              "asc": true,
+              "nulls": "last",
+              "opclass": "text_ops",
+              "isExpression": false
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "questions_recovery_recipient_intent_fingerprint_uniq": {
+          "name": "questions_recovery_recipient_intent_fingerprint_uniq",
+          "columns": [
+            {
+              "expression": "(((actors -> 0) ->> 'userId'::text))",
+              "asc": true,
+              "nulls": "last",
+              "opclass": "text_ops",
+              "isExpression": true
+            },
+            {
+              "expression": "((detection ->> 'sourceId'::text))",
+              "asc": true,
+              "nulls": "last",
+              "opclass": "text_ops",
+              "isExpression": true
+            },
+            {
+              "expression": "(((detection -> 'recovery'::text) ->> 'intentFingerprint'::text",
+              "asc": true,
+              "nulls": "last",
+              "opclass": "text_ops",
+              "isExpression": true
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "where": "(((detection ->> 'purpose'::text) = 'recovery'::text) AND ((detection ->> 'mode'::text) = 'intent'::text) AND ((detection ->> 'sourceType'::text) = 'intent'::text))",
+          "with": {}
+        },
+        "questions_status_idx": {
+          "name": "questions_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "asc": true,
+              "nulls": "last",
+              "opclass": "enum_ops",
+              "isExpression": false
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {},
+      "policies": {},
+      "isRLSEnabled": false
+    },
+    "public.chat_session_scopes": {
+      "name": "chat_session_scopes",
+      "schema": "",
+      "columns": {
+        "conversation_id": {
+          "name": "conversation_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scope_type": {
+          "name": "scope_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scope_id": {
+          "name": "scope_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "chat_session_scopes_scope_idx": {
+          "name": "chat_session_scopes_scope_idx",
+          "columns": [
+            {
+              "expression": "scope_type",
+              "asc": true,
+              "nulls": "last",
+              "opclass": "text_ops",
+              "isExpression": false
+            },
+            {
+              "expression": "scope_id",
+              "asc": true,
+              "nulls": "last",
+              "opclass": "text_ops",
+              "isExpression": false
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "chat_session_scopes_user_id_idx": {
+          "name": "chat_session_scopes_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "asc": true,
+              "nulls": "last",
+              "opclass": "text_ops",
+              "isExpression": false
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "chat_session_scopes_user_scope_unique": {
+          "name": "chat_session_scopes_user_scope_unique",
+          "columns": [
+            {
+              "expression": "user_id",
+              "asc": true,
+              "nulls": "last",
+              "opclass": "text_ops",
+              "isExpression": false
+            },
+            {
+              "expression": "scope_type",
+              "asc": true,
+              "nulls": "last",
+              "opclass": "text_ops",
+              "isExpression": false
+            },
+            {
+              "expression": "scope_id",
+              "asc": true,
+              "nulls": "last",
+              "opclass": "text_ops",
+              "isExpression": false
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "chat_session_scopes_conversation_id_conversations_id_fk": {
+          "name": "chat_session_scopes_conversation_id_conversations_id_fk",
+          "tableFrom": "chat_session_scopes",
+          "tableTo": "conversations",
+          "schemaTo": "public",
+          "columnsFrom": [
+            "conversation_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {},
+      "policies": {},
+      "isRLSEnabled": false
+    },
+    "public.conversations": {
+      "name": "conversations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "last_message_at": {
+          "name": "last_message_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "dm_pair": {
+          "name": "dm_pair",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "persona": {
+          "name": "persona",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'none'"
+        }
+      },
+      "indexes": {
+        "conversations_dm_pair_idx": {
+          "name": "conversations_dm_pair_idx",
+          "columns": [
+            {
+              "expression": "dm_pair",
+              "asc": true,
+              "nulls": "last",
+              "opclass": "text_ops",
+              "isExpression": false
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {},
+      "policies": {},
+      "isRLSEnabled": false
+    },
+    "public.negotiator_memories": {
+      "name": "negotiator_memories",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "agent_id": {
+          "name": "agent_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "subject_user_id": {
+          "name": "subject_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "embedding": {
+          "name": "embedding",
+          "type": "vector(2000)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source_refs": {
+          "name": "source_refs",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "confidence": {
+          "name": "confidence",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0.5
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "negotiator_memories_agent_kind_idx": {
+          "name": "negotiator_memories_agent_kind_idx",
+          "columns": [
+            {
+              "expression": "agent_id",
+              "asc": true,
+              "nulls": "last",
+              "opclass": "text_ops",
+              "isExpression": false
+            },
+            {
+              "expression": "kind",
+              "asc": true,
+              "nulls": "last",
+              "opclass": "text_ops",
+              "isExpression": false
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "negotiator_memories_embedding_idx": {
+          "name": "negotiator_memories_embedding_idx",
+          "columns": [
+            {
+              "expression": "embedding",
+              "asc": true,
+              "nulls": "last",
+              "opclass": "vector_cosine_ops",
+              "isExpression": false
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "hnsw",
+          "with": {}
+        },
+        "negotiator_memories_user_subject_idx": {
+          "name": "negotiator_memories_user_subject_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "asc": true,
+              "nulls": "last",
+              "opclass": "text_ops",
+              "isExpression": false
+            },
+            {
+              "expression": "subject_user_id",
+              "asc": true,
+              "nulls": "last",
+              "opclass": "text_ops",
+              "isExpression": false
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "negotiator_memories_agent_id_agents_id_fk": {
+          "name": "negotiator_memories_agent_id_agents_id_fk",
+          "tableFrom": "negotiator_memories",
+          "tableTo": "agents",
+          "schemaTo": "public",
+          "columnsFrom": [
+            "agent_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "negotiator_memories_user_id_users_id_fk": {
+          "name": "negotiator_memories_user_id_users_id_fk",
+          "tableFrom": "negotiator_memories",
+          "tableTo": "users",
+          "schemaTo": "public",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "negotiator_memories_subject_user_id_users_id_fk": {
+          "name": "negotiator_memories_subject_user_id_users_id_fk",
+          "tableFrom": "negotiator_memories",
+          "tableTo": "users",
+          "schemaTo": "public",
+          "columnsFrom": [
+            "subject_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {},
+      "policies": {},
+      "isRLSEnabled": false
+    },
+    "public.frame_drift_observation_runs": {
+      "name": "frame_drift_observation_runs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "bucket_start": {
+          "name": "bucket_start",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "bucket_end": {
+          "name": "bucket_end",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "captured_at": {
+          "name": "captured_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "configured_embedding_model": {
+          "name": "configured_embedding_model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "max_networks": {
+          "name": "max_networks",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "max_pairs": {
+          "name": "max_pairs",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "min_users": {
+          "name": "min_users",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "stable_cohort_hash": {
+          "name": "stable_cohort_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "aggregate_diagnostics": {
+          "name": "aggregate_diagnostics",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        }
+      },
+      "indexes": {
+        "frame_drift_observation_runs_bucket_start_uniq": {
+          "name": "frame_drift_observation_runs_bucket_start_uniq",
+          "columns": [
+            {
+              "expression": "bucket_start",
+              "asc": true,
+              "nulls": "last",
+              "opclass": "timestamptz_ops",
+              "isExpression": false
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {
+        "frame_drift_observation_runs_bucket_check": {
+          "name": "frame_drift_observation_runs_bucket_check",
+          "value": "(bucket_end = (bucket_start + '1 day'::interval)) AND (captured_at >= bucket_end)"
+        },
+        "frame_drift_observation_runs_configured_embedding_model_check": {
+          "name": "frame_drift_observation_runs_configured_embedding_model_check",
+          "value": "length(btrim(configured_embedding_model)) > 0"
+        },
+        "frame_drift_observation_runs_max_networks_check": {
+          "name": "frame_drift_observation_runs_max_networks_check",
+          "value": "(max_networks >= 1) AND (max_networks <= 200)"
+        },
+        "frame_drift_observation_runs_max_pairs_check": {
+          "name": "frame_drift_observation_runs_max_pairs_check",
+          "value": "(max_pairs >= 1) AND (max_pairs <= 10000)"
+        },
+        "frame_drift_observation_runs_min_users_check": {
+          "name": "frame_drift_observation_runs_min_users_check",
+          "value": "(min_users >= 2) AND (min_users <= 100)"
+        },
+        "frame_drift_observation_runs_stable_cohort_hash_check": {
+          "name": "frame_drift_observation_runs_stable_cohort_hash_check",
+          "value": "(stable_cohort_hash IS NULL) OR (stable_cohort_hash ~ '^[0-9a-f]{64}$'::text)"
+        },
+        "frame_drift_observation_runs_aggregate_diagnostics_check": {
+          "name": "frame_drift_observation_runs_aggregate_diagnostics_check",
+          "value": "jsonb_typeof(aggregate_diagnostics) = 'object'::text"
+        }
+      },
+      "policies": {},
+      "isRLSEnabled": false
+    },
+    "public.cross_network_yield_snapshots": {
+      "name": "cross_network_yield_snapshots",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "run_id": {
+          "name": "run_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "network_a_id": {
+          "name": "network_a_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "network_b_id": {
+          "name": "network_b_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "opportunity_count": {
+          "name": "opportunity_count",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "potential_active_intent_pair_count": {
+          "name": "potential_active_intent_pair_count",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "yield_rate": {
+          "name": "yield_rate",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "yield_rate_delta": {
+          "name": "yield_rate_delta",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "prior_bucket_start": {
+          "name": "prior_bucket_start",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "bucket_start": {
+          "name": "bucket_start",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "bucket_end": {
+          "name": "bucket_end",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "captured_at": {
+          "name": "captured_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "cross_network_yield_snapshots_daily_uniq": {
+          "name": "cross_network_yield_snapshots_daily_uniq",
+          "columns": [
+            {
+              "expression": "network_a_id",
+              "asc": true,
+              "nulls": "last",
+              "opclass": "timestamptz_ops",
+              "isExpression": false
+            },
+            {
+              "expression": "network_b_id",
+              "asc": true,
+              "nulls": "last",
+              "opclass": "text_ops",
+              "isExpression": false
+            },
+            {
+              "expression": "bucket_start",
+              "asc": true,
+              "nulls": "last",
+              "opclass": "timestamptz_ops",
+              "isExpression": false
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "cross_network_yield_snapshots_run_id_frame_drift_observation_ru": {
+          "name": "cross_network_yield_snapshots_run_id_frame_drift_observation_ru",
+          "tableFrom": "cross_network_yield_snapshots",
+          "tableTo": "frame_drift_observation_runs",
+          "schemaTo": "public",
+          "columnsFrom": [
+            "run_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "cross_network_yield_snapshots_network_a_id_networks_id_fk": {
+          "name": "cross_network_yield_snapshots_network_a_id_networks_id_fk",
+          "tableFrom": "cross_network_yield_snapshots",
+          "tableTo": "networks",
+          "schemaTo": "public",
+          "columnsFrom": [
+            "network_a_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "cross_network_yield_snapshots_network_b_id_networks_id_fk": {
+          "name": "cross_network_yield_snapshots_network_b_id_networks_id_fk",
+          "tableFrom": "cross_network_yield_snapshots",
+          "tableTo": "networks",
+          "schemaTo": "public",
+          "columnsFrom": [
+            "network_b_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {
+        "cross_network_yield_snapshots_canonical_pair_check": {
+          "name": "cross_network_yield_snapshots_canonical_pair_check",
+          "value": "network_a_id < network_b_id"
+        },
+        "cross_network_yield_snapshots_opportunity_count_check": {
+          "name": "cross_network_yield_snapshots_opportunity_count_check",
+          "value": "opportunity_count >= 0"
+        },
+        "cross_network_yield_snapshots_potential_pair_count_check": {
+          "name": "cross_network_yield_snapshots_potential_pair_count_check",
+          "value": "potential_active_intent_pair_count > 0"
+        },
+        "cross_network_yield_snapshots_yield_rate_check": {
+          "name": "cross_network_yield_snapshots_yield_rate_check",
+          "value": "yield_rate >= (0)::double precision"
+        },
+        "cross_network_yield_snapshots_bucket_range_check": {
+          "name": "cross_network_yield_snapshots_bucket_range_check",
+          "value": "bucket_end > bucket_start"
+        }
+      },
+      "policies": {},
+      "isRLSEnabled": false
+    },
+    "public.frame_centroid_snapshots": {
+      "name": "frame_centroid_snapshots",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "run_id": {
+          "name": "run_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "network_id": {
+          "name": "network_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "corpus": {
+          "name": "corpus",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "centroid": {
+          "name": "centroid",
+          "type": "vector(2000)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sample_count": {
+          "name": "sample_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "configured_embedding_model": {
+          "name": "configured_embedding_model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "cosine_drift": {
+          "name": "cosine_drift",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "prior_bucket_start": {
+          "name": "prior_bucket_start",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "bucket_start": {
+          "name": "bucket_start",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "bucket_end": {
+          "name": "bucket_end",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "captured_at": {
+          "name": "captured_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "frame_centroid_snapshots_daily_uniq": {
+          "name": "frame_centroid_snapshots_daily_uniq",
+          "columns": [
+            {
+              "expression": "network_id",
+              "asc": true,
+              "nulls": "last",
+              "opclass": "text_ops",
+              "isExpression": false
+            },
+            {
+              "expression": "corpus",
+              "asc": true,
+              "nulls": "last",
+              "opclass": "text_ops",
+              "isExpression": false
+            },
+            {
+              "expression": "configured_embedding_model",
+              "asc": true,
+              "nulls": "last",
+              "opclass": "timestamptz_ops",
+              "isExpression": false
+            },
+            {
+              "expression": "bucket_start",
+              "asc": true,
+              "nulls": "last",
+              "opclass": "timestamptz_ops",
+              "isExpression": false
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "frame_centroid_snapshots_run_id_frame_drift_observation_runs_id": {
+          "name": "frame_centroid_snapshots_run_id_frame_drift_observation_runs_id",
+          "tableFrom": "frame_centroid_snapshots",
+          "tableTo": "frame_drift_observation_runs",
+          "schemaTo": "public",
+          "columnsFrom": [
+            "run_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "frame_centroid_snapshots_network_id_networks_id_fk": {
+          "name": "frame_centroid_snapshots_network_id_networks_id_fk",
+          "tableFrom": "frame_centroid_snapshots",
+          "tableTo": "networks",
+          "schemaTo": "public",
+          "columnsFrom": [
+            "network_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {
+        "frame_centroid_snapshots_corpus_check": {
+          "name": "frame_centroid_snapshots_corpus_check",
+          "value": "corpus = ANY (ARRAY['premise'::text, 'intent'::text, 'user_context'::text])"
+        },
+        "frame_centroid_snapshots_sample_count_check": {
+          "name": "frame_centroid_snapshots_sample_count_check",
+          "value": "sample_count > 0"
+        },
+        "frame_centroid_snapshots_cosine_drift_check": {
+          "name": "frame_centroid_snapshots_cosine_drift_check",
+          "value": "(cosine_drift IS NULL) OR ((cosine_drift >= (0)::double precision) AND (cosine_drift <= (2)::double precision))"
+        },
+        "frame_centroid_snapshots_bucket_range_check": {
+          "name": "frame_centroid_snapshots_bucket_range_check",
+          "value": "bucket_end > bucket_start"
+        }
+      },
+      "policies": {},
+      "isRLSEnabled": false
+    },
+    "public.intents": {
+      "name": "intents",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "payload": {
+          "name": "payload",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "summary": {
+          "name": "summary",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_incognito": {
+          "name": "is_incognito",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "archived_at": {
+          "name": "archived_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_id": {
+          "name": "source_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source_type": {
+          "name": "source_type",
+          "type": "source_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "embedding": {
+          "name": "embedding",
+          "type": "vector(2000)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "semantic_entropy": {
+          "name": "semantic_entropy",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 1
+        },
+        "referential_anchor": {
+          "name": "referential_anchor",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "intent_mode": {
+          "name": "intent_mode",
+          "type": "intent_mode",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'ATTRIBUTIVE'"
+        },
+        "speech_act_type": {
+          "name": "speech_act_type",
+          "type": "speech_act_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "felicity_authority": {
+          "name": "felicity_authority",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "felicity_sincerity": {
+          "name": "felicity_sincerity",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "intent_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'ACTIVE'"
+        },
+        "felicity_clarity": {
+          "name": "felicity_clarity",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_visited_at": {
+          "name": "last_visited_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "first_discovery_succeeded_at": {
+          "name": "first_discovery_succeeded_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "negotiation_round": {
+          "name": "negotiation_round",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "negotiation_round_size": {
+          "name": "negotiation_round_size",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "negotiation_kickoff_started_at": {
+          "name": "negotiation_kickoff_started_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "embeddingIndex": {
+          "name": "embeddingIndex",
+          "columns": [
+            {
+              "expression": "embedding",
+              "asc": true,
+              "nulls": "last",
+              "opclass": "vector_cosine_ops",
+              "isExpression": false
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "hnsw",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "intents_user_id_users_id_fk": {
+          "name": "intents_user_id_users_id_fk",
+          "tableFrom": "intents",
+          "tableTo": "users",
+          "schemaTo": "public",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {},
+      "policies": {},
+      "isRLSEnabled": false
+    },
+    "public.opportunity_outcome_events": {
+      "name": "opportunity_outcome_events",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "recipient_user_id": {
+          "name": "recipient_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "intent_id": {
+          "name": "intent_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "intent_fingerprint": {
+          "name": "intent_fingerprint",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "opportunity_id": {
+          "name": "opportunity_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "network_id": {
+          "name": "network_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "action": {
+          "name": "action",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "candidate_snapshot": {
+          "name": "candidate_snapshot",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "snapshot_hash": {
+          "name": "snapshot_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "dedup_key": {
+          "name": "dedup_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "idempotency_key": {
+          "name": "idempotency_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_opp_outcome_events_scope": {
+          "name": "idx_opp_outcome_events_scope",
+          "columns": [
+            {
+              "expression": "recipient_user_id",
+              "asc": true,
+              "nulls": "last",
+              "opclass": "text_ops",
+              "isExpression": false
+            },
+            {
+              "expression": "intent_id",
+              "asc": true,
+              "nulls": "last",
+              "opclass": "text_ops",
+              "isExpression": false
+            },
+            {
+              "expression": "intent_fingerprint",
+              "asc": true,
+              "nulls": "last",
+              "opclass": "text_ops",
+              "isExpression": false
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "uniq_opp_outcome_events_idempotency": {
+          "name": "uniq_opp_outcome_events_idempotency",
+          "columns": [
+            {
+              "expression": "idempotency_key",
+              "asc": true,
+              "nulls": "last",
+              "opclass": "text_ops",
+              "isExpression": false
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "opportunity_outcome_events_recipient_user_id_users_id_fk": {
+          "name": "opportunity_outcome_events_recipient_user_id_users_id_fk",
+          "tableFrom": "opportunity_outcome_events",
+          "tableTo": "users",
+          "schemaTo": "public",
+          "columnsFrom": [
+            "recipient_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {},
+      "policies": {},
+      "isRLSEnabled": false
+    },
+    "public.frame_drift_execution_attempts": {
+      "name": "frame_drift_execution_attempts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "queue_name": {
+          "name": "queue_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scheduler_id": {
+          "name": "scheduler_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "job_id": {
+          "name": "job_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "job_name": {
+          "name": "job_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scheduled_at": {
+          "name": "scheduled_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "bucket_start": {
+          "name": "bucket_start",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "bucket_end": {
+          "name": "bucket_end",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "attempt": {
+          "name": "attempt",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "max_attempts": {
+          "name": "max_attempts",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "terminal_status": {
+          "name": "terminal_status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "will_retry": {
+          "name": "will_retry",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "failure_category": {
+          "name": "failure_category",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "frame_drift_execution_attempts_bucket_start_idx": {
+          "name": "frame_drift_execution_attempts_bucket_start_idx",
+          "columns": [
+            {
+              "expression": "bucket_start",
+              "asc": true,
+              "nulls": "last",
+              "opclass": "timestamptz_ops",
+              "isExpression": false
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "frame_drift_execution_attempts_incomplete_idx": {
+          "name": "frame_drift_execution_attempts_incomplete_idx",
+          "columns": [
+            {
+              "expression": "started_at",
+              "asc": true,
+              "nulls": "last",
+              "opclass": "timestamptz_ops",
+              "isExpression": false
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "where": "(completed_at IS NULL)",
+          "with": {}
+        },
+        "frame_drift_execution_attempts_job_attempt_uniq": {
+          "name": "frame_drift_execution_attempts_job_attempt_uniq",
+          "columns": [
+            {
+              "expression": "job_id",
+              "asc": true,
+              "nulls": "last",
+              "opclass": "int4_ops",
+              "isExpression": false
+            },
+            {
+              "expression": "attempt",
+              "asc": true,
+              "nulls": "last",
+              "opclass": "int4_ops",
+              "isExpression": false
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {
+        "frame_drift_execution_attempts_identity_check": {
+          "name": "frame_drift_execution_attempts_identity_check",
+          "value": "(length(btrim(queue_name)) > 0) AND (length(btrim(scheduler_id)) > 0) AND (length(btrim(job_id)) > 0) AND (length(btrim(job_name)) > 0)"
+        },
+        "frame_drift_execution_attempts_daily_bucket_check": {
+          "name": "frame_drift_execution_attempts_daily_bucket_check",
+          "value": "(bucket_end = (bucket_start + '1 day'::interval)) AND (date_trunc('day'::text, (bucket_start AT TIME ZONE 'UTC'::text)) = (bucket_start AT TIME ZONE 'UTC'::text)) AND (date_trunc('day'::text, (bucket_end AT TIME ZONE 'UTC'::text)) = (bucket_end AT TIME ZONE 'UTC'::text)) AND (scheduled_at >= bucket_end) AND (scheduled_at < (bucket_end + '1 day'::interval))"
+        },
+        "frame_drift_execution_attempts_attempt_bounds_check": {
+          "name": "frame_drift_execution_attempts_attempt_bounds_check",
+          "value": "((attempt >= 1) AND (attempt <= max_attempts)) AND ((max_attempts >= 1) AND (max_attempts <= 100))"
+        },
+        "frame_drift_execution_attempts_terminal_status_check": {
+          "name": "frame_drift_execution_attempts_terminal_status_check",
+          "value": "(terminal_status IS NULL) OR (terminal_status = ANY (ARRAY['inserted'::text, 'duplicate'::text, 'skipped'::text, 'failed'::text]))"
+        },
+        "frame_drift_execution_attempts_failure_category_check": {
+          "name": "frame_drift_execution_attempts_failure_category_check",
+          "value": "(failure_category IS NULL) OR (failure_category = 'measurement'::text)"
+        },
+        "frame_drift_execution_attempts_terminal_state_check": {
+          "name": "frame_drift_execution_attempts_terminal_state_check",
+          "value": "((terminal_status IS NULL) AND (completed_at IS NULL) AND (will_retry IS NULL) AND (failure_category IS NULL)) OR ((terminal_status = ANY (ARRAY['inserted'::text, 'duplicate'::text, 'skipped'::text])) AND (completed_at IS NOT NULL) AND (completed_at >= started_at) AND (will_retry IS NOT NULL) AND (will_retry = false) AND (failure_category IS NULL)) OR ((terminal_status = 'failed'::text) AND (completed_at IS NOT NULL) AND (completed_at >= started_at) AND (will_retry IS NOT NULL) AND (failure_category IS NOT NULL) AND (failure_category = 'measurement'::text))"
+        }
+      },
+      "policies": {},
+      "isRLSEnabled": false
+    },
+    "public.apikey": {
+      "name": "apikey",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reference_id": {
+          "name": "reference_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "rate_limit_enabled": {
+          "name": "rate_limit_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "request_count": {
+          "name": "request_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "config_id": {
+          "name": "config_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'default'"
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "prefix": {
+          "name": "prefix",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "start": {
+          "name": "start",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "rate_limit_max": {
+          "name": "rate_limit_max",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "rate_limit_time_window": {
+          "name": "rate_limit_time_window",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "remaining": {
+          "name": "remaining",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refill_amount": {
+          "name": "refill_amount",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refill_interval": {
+          "name": "refill_interval",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_refill_at": {
+          "name": "last_refill_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_request": {
+          "name": "last_request",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "permissions": {
+          "name": "permissions",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "apikey_user_id_fkey": {
+          "name": "apikey_user_id_fkey",
+          "tableFrom": "apikey",
+          "tableTo": "users",
+          "schemaTo": "public",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {},
+      "policies": {},
+      "isRLSEnabled": false
+    },
+    "public.messages": {
+      "name": "messages",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "conversation_id": {
+          "name": "conversation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "task_id": {
+          "name": "task_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sender_id": {
+          "name": "sender_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "message_role",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "parts": {
+          "name": "parts",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "extensions": {
+          "name": "extensions",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reference_task_ids": {
+          "name": "reference_task_ids",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "messages_conversation_id_created_at_idx": {
+          "name": "messages_conversation_id_created_at_idx",
+          "columns": [
+            {
+              "expression": "conversation_id",
+              "asc": true,
+              "nulls": "last",
+              "opclass": "text_ops",
+              "isExpression": false
+            },
+            {
+              "expression": "created_at",
+              "asc": true,
+              "nulls": "last",
+              "opclass": "timestamptz_ops",
+              "isExpression": false
+            },
+            {
+              "expression": "id",
+              "asc": true,
+              "nulls": "last",
+              "opclass": "timestamptz_ops",
+              "isExpression": false
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "messages_sender_id_idx": {
+          "name": "messages_sender_id_idx",
+          "columns": [
+            {
+              "expression": "sender_id",
+              "asc": true,
+              "nulls": "last",
+              "opclass": "text_ops",
+              "isExpression": false
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "messages_session_id_created_at_idx": {
+          "name": "messages_session_id_created_at_idx",
+          "columns": [
+            {
+              "expression": "session_id",
+              "asc": true,
+              "nulls": "last",
+              "opclass": "timestamptz_ops",
+              "isExpression": false
+            },
+            {
+              "expression": "created_at",
+              "asc": true,
+              "nulls": "last",
+              "opclass": "text_ops",
+              "isExpression": false
+            },
+            {
+              "expression": "id",
+              "asc": true,
+              "nulls": "last",
+              "opclass": "text_ops",
+              "isExpression": false
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "messages_task_id_idx": {
+          "name": "messages_task_id_idx",
+          "columns": [
+            {
+              "expression": "task_id",
+              "asc": true,
+              "nulls": "last",
+              "opclass": "text_ops",
+              "isExpression": false
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "messages_conversation_id_conversations_id_fk": {
+          "name": "messages_conversation_id_conversations_id_fk",
+          "tableFrom": "messages",
+          "tableTo": "conversations",
+          "schemaTo": "public",
+          "columnsFrom": [
+            "conversation_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "messages_task_id_tasks_id_fk": {
+          "name": "messages_task_id_tasks_id_fk",
+          "tableFrom": "messages",
+          "tableTo": "tasks",
+          "schemaTo": "public",
+          "columnsFrom": [
+            "task_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "messages_session_id_conversation_sessions_id_fk": {
+          "name": "messages_session_id_conversation_sessions_id_fk",
+          "tableFrom": "messages",
+          "tableTo": "conversation_sessions",
+          "schemaTo": "public",
+          "columnsFrom": [
+            "session_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {},
+      "policies": {},
+      "isRLSEnabled": false
+    },
+    "public.conversation_sessions": {
+      "name": "conversation_sessions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "conversation_id": {
+          "name": "conversation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "task_id": {
+          "name": "task_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_message_at": {
+          "name": "last_message_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "conversation_sessions_conversation_started_idx": {
+          "name": "conversation_sessions_conversation_started_idx",
+          "columns": [
+            {
+              "expression": "conversation_id",
+              "asc": true,
+              "nulls": "last",
+              "opclass": "text_ops",
+              "isExpression": false
+            },
+            {
+              "expression": "started_at",
+              "asc": true,
+              "nulls": "last",
+              "opclass": "text_ops",
+              "isExpression": false
+            },
+            {
+              "expression": "id",
+              "asc": true,
+              "nulls": "last",
+              "opclass": "timestamptz_ops",
+              "isExpression": false
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "conversation_sessions_task_id_uniq": {
+          "name": "conversation_sessions_task_id_uniq",
+          "columns": [
+            {
+              "expression": "task_id",
+              "asc": true,
+              "nulls": "last",
+              "opclass": "text_ops",
+              "isExpression": false
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "conversation_sessions_conversation_id_conversations_id_fk": {
+          "name": "conversation_sessions_conversation_id_conversations_id_fk",
+          "tableFrom": "conversation_sessions",
+          "tableTo": "conversations",
+          "schemaTo": "public",
+          "columnsFrom": [
+            "conversation_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "conversation_sessions_task_id_tasks_id_fk": {
+          "name": "conversation_sessions_task_id_tasks_id_fk",
+          "tableFrom": "conversation_sessions",
+          "tableTo": "tasks",
+          "schemaTo": "public",
+          "columnsFrom": [
+            "task_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {},
+      "policies": {},
+      "isRLSEnabled": false
+    },
+    "public.intent_proposals": {
+      "name": "intent_proposals",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "network_id": {
+          "name": "network_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "analysis": {
+          "name": "analysis",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "intent_proposal_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "consumed_at": {
+          "name": "consumed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "consumed_intent_id": {
+          "name": "consumed_intent_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "intent_proposals_expires_at_idx": {
+          "name": "intent_proposals_expires_at_idx",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "asc": true,
+              "nulls": "last",
+              "opclass": "timestamptz_ops",
+              "isExpression": false
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "intent_proposals_user_id_idx": {
+          "name": "intent_proposals_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "asc": true,
+              "nulls": "last",
+              "opclass": "text_ops",
+              "isExpression": false
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "intent_proposals_user_id_users_id_fk": {
+          "name": "intent_proposals_user_id_users_id_fk",
+          "tableFrom": "intent_proposals",
+          "tableTo": "users",
+          "schemaTo": "public",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "intent_proposals_consumed_intent_id_intents_id_fk": {
+          "name": "intent_proposals_consumed_intent_id_intents_id_fk",
+          "tableFrom": "intent_proposals",
+          "tableTo": "intents",
+          "schemaTo": "public",
+          "columnsFrom": [
+            "consumed_intent_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {},
+      "policies": {},
+      "isRLSEnabled": false
+    },
+    "public.signal_intake_packs": {
+      "name": "signal_intake_packs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "brief": {
+          "name": "brief",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "question": {
+          "name": "question",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "premise_hash": {
+          "name": "premise_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "generated_at": {
+          "name": "generated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "signal_intake_packs_user_id_users_id_fk": {
+          "name": "signal_intake_packs_user_id_users_id_fk",
+          "tableFrom": "signal_intake_packs",
+          "tableTo": "users",
+          "schemaTo": "public",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "signal_intake_packs_user_id_unique": {
+          "columns": [
+            "user_id"
+          ],
+          "nullsNotDistinct": false,
+          "name": "signal_intake_packs_user_id_unique"
+        }
+      },
+      "checkConstraints": {},
+      "policies": {},
+      "isRLSEnabled": false
+    },
+    "public.signal_intake_runs": {
+      "name": "signal_intake_runs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "answers_hash": {
+          "name": "answers_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "signal_intake_run_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "proposal_id": {
+          "name": "proposal_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error": {
+          "name": "error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "looking_for": {
+          "name": "looking_for",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "you_bring": {
+          "name": "you_bring",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "signal_intake_runs_created_at_idx": {
+          "name": "signal_intake_runs_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "asc": true,
+              "nulls": "last",
+              "opclass": "timestamptz_ops",
+              "isExpression": false
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "signal_intake_runs_user_answers_uniq": {
+          "name": "signal_intake_runs_user_answers_uniq",
+          "columns": [
+            {
+              "expression": "user_id",
+              "asc": true,
+              "nulls": "last",
+              "opclass": "text_ops",
+              "isExpression": false
+            },
+            {
+              "expression": "answers_hash",
+              "asc": true,
+              "nulls": "last",
+              "opclass": "text_ops",
+              "isExpression": false
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "signal_intake_runs_user_id_idx": {
+          "name": "signal_intake_runs_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "asc": true,
+              "nulls": "last",
+              "opclass": "text_ops",
+              "isExpression": false
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "signal_intake_runs_user_id_users_id_fk": {
+          "name": "signal_intake_runs_user_id_users_id_fk",
+          "tableFrom": "signal_intake_runs",
+          "tableTo": "users",
+          "schemaTo": "public",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {},
+      "policies": {},
+      "isRLSEnabled": false
+    },
+    "public.networks": {
+      "name": "networks",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "prompt": {
+          "name": "prompt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "permissions": {
+          "name": "permissions",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'{\"joinPolicy\":\"invite_only\",\"invitationLink\":null}'::json"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "image_url": {
+          "name": "image_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "master_key_hash": {
+          "name": "master_key_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "request_status": {
+          "name": "request_status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "indexes_key_unique": {
+          "name": "indexes_key_unique",
+          "columns": [
+            {
+              "expression": "key",
+              "asc": true,
+              "nulls": "last",
+              "opclass": "text_ops",
+              "isExpression": false
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {},
+      "policies": {},
+      "isRLSEnabled": false
+    },
+    "public.agents": {
+      "name": "agents",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "owner_id": {
+          "name": "owner_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "type": {
+          "name": "type",
+          "type": "agent_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "agent_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'{}'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_seen_at": {
+          "name": "last_seen_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "notify_on_opportunity": {
+          "name": "notify_on_opportunity",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "daily_summary_enabled": {
+          "name": "daily_summary_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "handle_negotiations": {
+          "name": "handle_negotiations",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "last_daily_summary_at": {
+          "name": "last_daily_summary_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_negotiation_pickup_at": {
+          "name": "last_negotiation_pickup_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "runtime_kind": {
+          "name": "runtime_kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "installation_id": {
+          "name": "installation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "runtime_setup_attempt_id": {
+          "name": "runtime_setup_attempt_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "agents_last_negotiation_pickup_at_idx": {
+          "name": "agents_last_negotiation_pickup_at_idx",
+          "columns": [
+            {
+              "expression": "last_negotiation_pickup_at",
+              "asc": true,
+              "nulls": "last",
+              "opclass": "timestamptz_ops",
+              "isExpression": false
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "agents_last_seen_at_idx": {
+          "name": "agents_last_seen_at_idx",
+          "columns": [
+            {
+              "expression": "last_seen_at",
+              "asc": true,
+              "nulls": "last",
+              "opclass": "timestamptz_ops",
+              "isExpression": false
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "agents_owner_id_idx": {
+          "name": "agents_owner_id_idx",
+          "columns": [
+            {
+              "expression": "owner_id",
+              "asc": true,
+              "nulls": "last",
+              "opclass": "text_ops",
+              "isExpression": false
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "agents_type_idx": {
+          "name": "agents_type_idx",
+          "columns": [
+            {
+              "expression": "type",
+              "asc": true,
+              "nulls": "last",
+              "opclass": "enum_ops",
+              "isExpression": false
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "uniq_agents_hermes_installation": {
+          "name": "uniq_agents_hermes_installation",
+          "columns": [
+            {
+              "expression": "owner_id",
+              "asc": true,
+              "nulls": "last",
+              "opclass": "text_ops",
+              "isExpression": false
+            },
+            {
+              "expression": "runtime_kind",
+              "asc": true,
+              "nulls": "last",
+              "opclass": "text_ops",
+              "isExpression": false
+            },
+            {
+              "expression": "installation_id",
+              "asc": true,
+              "nulls": "last",
+              "opclass": "text_ops",
+              "isExpression": false
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "where": "((type = 'external'::agent_type) AND (runtime_kind = 'hermes'::text) AND (installation_id IS NOT NULL) AND (deleted_at IS NULL))",
+          "with": {}
+        },
+        "uniq_agents_personal_per_owner": {
+          "name": "uniq_agents_personal_per_owner",
+          "columns": [
+            {
+              "expression": "owner_id",
+              "asc": true,
+              "nulls": "last",
+              "opclass": "text_ops",
+              "isExpression": false
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "where": "((type = 'personal'::agent_type) AND (deleted_at IS NULL))",
+          "with": {}
+        },
+        "uniq_agents_selected_negotiation_executor": {
+          "name": "uniq_agents_selected_negotiation_executor",
+          "columns": [
+            {
+              "expression": "owner_id",
+              "asc": true,
+              "nulls": "last",
+              "opclass": "text_ops",
+              "isExpression": false
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "where": "((type = 'external'::agent_type) AND (handle_negotiations = true) AND (deleted_at IS NULL))",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "agents_owner_id_users_id_fk": {
+          "name": "agents_owner_id_users_id_fk",
+          "tableFrom": "agents",
+          "tableTo": "users",
+          "schemaTo": "public",
+          "columnsFrom": [
+            "owner_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {},
+      "policies": {},
+      "isRLSEnabled": false
+    },
+    "public.network_integrations": {
+      "name": "network_integrations",
+      "schema": "",
+      "columns": {
+        "network_id": {
+          "name": "network_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "toolkit": {
+          "name": "toolkit",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "connected_account_id": {
+          "name": "connected_account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "sync_config": {
+          "name": "sync_config",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "network_integrations_network_id_networks_id_fk": {
+          "name": "network_integrations_network_id_networks_id_fk",
+          "tableFrom": "network_integrations",
+          "tableTo": "networks",
+          "schemaTo": "public",
+          "columnsFrom": [
+            "network_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "network_integrations_network_id_toolkit_pk": {
+          "name": "network_integrations_network_id_toolkit_pk",
+          "columns": [
+            "network_id",
+            "toolkit"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {},
+      "policies": {},
+      "isRLSEnabled": false
+    },
+    "public.intent_networks": {
+      "name": "intent_networks",
+      "schema": "",
+      "columns": {
+        "intent_id": {
+          "name": "intent_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "network_id": {
+          "name": "network_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "relevancy_score": {
+          "name": "relevancy_score",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "assignment_metadata": {
+          "name": "assignment_metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "intent_networks_network_id_idx": {
+          "name": "intent_networks_network_id_idx",
+          "columns": [
+            {
+              "expression": "network_id",
+              "asc": true,
+              "nulls": "last",
+              "opclass": "text_ops",
+              "isExpression": false
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "intent_networks_intent_id_intents_id_fk": {
+          "name": "intent_networks_intent_id_intents_id_fk",
+          "tableFrom": "intent_networks",
+          "tableTo": "intents",
+          "schemaTo": "public",
+          "columnsFrom": [
+            "intent_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "intent_networks_network_id_networks_id_fk": {
+          "name": "intent_networks_network_id_networks_id_fk",
+          "tableFrom": "intent_networks",
+          "tableTo": "networks",
+          "schemaTo": "public",
+          "columnsFrom": [
+            "network_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "intent_networks_intent_id_network_id_pk": {
+          "name": "intent_networks_intent_id_network_id_pk",
+          "columns": [
+            "intent_id",
+            "network_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {},
+      "policies": {},
+      "isRLSEnabled": false
+    },
+    "public.premise_networks": {
+      "name": "premise_networks",
+      "schema": "",
+      "columns": {
+        "premise_id": {
+          "name": "premise_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "network_id": {
+          "name": "network_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "relevancy_score": {
+          "name": "relevancy_score",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "assignment_metadata": {
+          "name": "assignment_metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "premise_networks_network_id_idx": {
+          "name": "premise_networks_network_id_idx",
+          "columns": [
+            {
+              "expression": "network_id",
+              "asc": true,
+              "nulls": "last",
+              "opclass": "text_ops",
+              "isExpression": false
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "premise_networks_premise_id_premises_id_fk": {
+          "name": "premise_networks_premise_id_premises_id_fk",
+          "tableFrom": "premise_networks",
+          "tableTo": "premises",
+          "schemaTo": "public",
+          "columnsFrom": [
+            "premise_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "premise_networks_network_id_networks_id_fk": {
+          "name": "premise_networks_network_id_networks_id_fk",
+          "tableFrom": "premise_networks",
+          "tableTo": "networks",
+          "schemaTo": "public",
+          "columnsFrom": [
+            "network_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "premise_networks_premise_id_network_id_pk": {
+          "name": "premise_networks_premise_id_network_id_pk",
+          "columns": [
+            "premise_id",
+            "network_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {},
+      "policies": {},
+      "isRLSEnabled": false
+    },
+    "public.conversation_participants": {
+      "name": "conversation_participants",
+      "schema": "",
+      "columns": {
+        "conversation_id": {
+          "name": "conversation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "participant_id": {
+          "name": "participant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "participant_type": {
+          "name": "participant_type",
+          "type": "participant_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "joined_at": {
+          "name": "joined_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "hidden_at": {
+          "name": "hidden_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_read_at": {
+          "name": "last_read_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "conversation_participants_conversation_id_idx": {
+          "name": "conversation_participants_conversation_id_idx",
+          "columns": [
+            {
+              "expression": "conversation_id",
+              "asc": true,
+              "nulls": "last",
+              "opclass": "text_ops",
+              "isExpression": false
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "conversation_participants_participant_id_idx": {
+          "name": "conversation_participants_participant_id_idx",
+          "columns": [
+            {
+              "expression": "participant_id",
+              "asc": true,
+              "nulls": "last",
+              "opclass": "text_ops",
+              "isExpression": false
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "conversation_participants_conversation_id_conversations_id_fk": {
+          "name": "conversation_participants_conversation_id_conversations_id_fk",
+          "tableFrom": "conversation_participants",
+          "tableTo": "conversations",
+          "schemaTo": "public",
+          "columnsFrom": [
+            "conversation_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "conversation_participants_conversation_id_participant_id_pk": {
+          "name": "conversation_participants_conversation_id_participant_id_pk",
+          "columns": [
+            "conversation_id",
+            "participant_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {},
+      "policies": {},
+      "isRLSEnabled": false
+    },
+    "public.network_members": {
+      "name": "network_members",
+      "schema": "",
+      "columns": {
+        "network_id": {
+          "name": "network_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "permissions": {
+          "name": "permissions",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{\"\"}'"
+        },
+        "prompt": {
+          "name": "prompt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "auto_assign": {
+          "name": "auto_assign",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "network_members_network_id_networks_id_fk": {
+          "name": "network_members_network_id_networks_id_fk",
+          "tableFrom": "network_members",
+          "tableTo": "networks",
+          "schemaTo": "public",
+          "columnsFrom": [
+            "network_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "network_members_user_id_users_id_fk": {
+          "name": "network_members_user_id_users_id_fk",
+          "tableFrom": "network_members",
+          "tableTo": "users",
+          "schemaTo": "public",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "network_members_network_id_user_id_pk": {
+          "name": "network_members_network_id_user_id_pk",
+          "columns": [
+            "network_id",
+            "user_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {},
+      "policies": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.agent_status": {
+      "name": "agent_status",
+      "values": [
+        "active",
+        "inactive"
+      ],
+      "schema": "public"
+    },
+    "public.agent_type": {
+      "name": "agent_type",
+      "values": [
+        "personal",
+        "external",
+        "system"
+      ],
+      "schema": "public"
+    },
+    "public.intent_discovery_progress_status": {
+      "name": "intent_discovery_progress_status",
+      "values": [
+        "queued",
+        "running",
+        "succeeded",
+        "failed",
+        "blocked"
+      ],
+      "schema": "public"
+    },
+    "public.intent_dossier_source": {
+      "name": "intent_dossier_source",
+      "values": [
+        "user_message",
+        "answer",
+        "agent_note"
+      ],
+      "schema": "public"
+    },
+    "public.intent_mode": {
+      "name": "intent_mode",
+      "values": [
+        "REFERENTIAL",
+        "ATTRIBUTIVE"
+      ],
+      "schema": "public"
+    },
+    "public.intent_proposal_status": {
+      "name": "intent_proposal_status",
+      "values": [
+        "pending",
+        "consumed",
+        "rejected"
+      ],
+      "schema": "public"
+    },
+    "public.intent_status": {
+      "name": "intent_status",
+      "values": [
+        "ACTIVE",
+        "PAUSED",
+        "FULFILLED",
+        "EXPIRED"
+      ],
+      "schema": "public"
+    },
+    "public.message_role": {
+      "name": "message_role",
+      "values": [
+        "user",
+        "agent"
+      ],
+      "schema": "public"
+    },
+    "public.negotiation_round_log_event_kind": {
+      "name": "negotiation_round_log_event_kind",
+      "values": [
+        "opened",
+        "stopped",
+        "resumed"
+      ],
+      "schema": "public"
+    },
+    "public.negotiation_round_log_event_via": {
+      "name": "negotiation_round_log_event_via",
+      "values": [
+        "paused",
+        "completed"
+      ],
+      "schema": "public"
+    },
+    "public.opportunity_status": {
+      "name": "opportunity_status",
+      "values": [
+        "negotiating",
+        "pending",
+        "stalled",
+        "accepted",
+        "rejected",
+        "expired"
+      ],
+      "schema": "public"
+    },
+    "public.participant_type": {
+      "name": "participant_type",
+      "values": [
+        "user",
+        "agent"
+      ],
+      "schema": "public"
+    },
+    "public.permission_scope": {
+      "name": "permission_scope",
+      "values": [
+        "global",
+        "node",
+        "network"
+      ],
+      "schema": "public"
+    },
+    "public.premise_status": {
+      "name": "premise_status",
+      "values": [
+        "ACTIVE",
+        "RETRACTED",
+        "EXPIRED"
+      ],
+      "schema": "public"
+    },
+    "public.question_status": {
+      "name": "question_status",
+      "values": [
+        "pending",
+        "answered",
+        "dismissed"
+      ],
+      "schema": "public"
+    },
+    "public.signal_intake_run_status": {
+      "name": "signal_intake_run_status",
+      "values": [
+        "pending",
+        "ready",
+        "failed"
+      ],
+      "schema": "public"
+    },
+    "public.source_type": {
+      "name": "source_type",
+      "values": [
+        "integration",
+        "discovery_form",
+        "enrichment"
+      ],
+      "schema": "public"
+    },
+    "public.speech_act_type": {
+      "name": "speech_act_type",
+      "values": [
+        "COMMISSIVE",
+        "DIRECTIVE"
+      ],
+      "schema": "public"
+    },
+    "public.task_state": {
+      "name": "task_state",
+      "values": [
+        "submitted",
+        "working",
+        "completed",
+        "failed",
+        "canceled",
+        "rejected",
+        "auth_required",
+        "waiting_for_agent",
+        "claimed",
+        "paused"
+      ],
+      "schema": "public"
+    },
+    "public.transport_channel": {
+      "name": "transport_channel",
+      "values": [
+        "mcp"
+      ],
+      "schema": "public"
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "schemas": {},
+    "tables": {},
+    "columns": {}
+  },
+  "internal": {
+    "tables": {
+      "agent_permissions": {
+        "columns": {
+          "actions": {
+            "isArray": true,
+            "dimensions": 1,
+            "rawType": "text"
+          }
+        }
+      },
+      "network_members": {
+        "columns": {
+          "permissions": {
+            "isArray": true,
+            "dimensions": 1,
+            "rawType": "text"
+          }
+        }
+      }
+    }
+  }
+}

--- a/services/api/drizzle/meta/0156_snapshot.json
+++ b/services/api/drizzle/meta/0156_snapshot.json
@@ -1,0 +1,6443 @@
+{
+  "id": "d77fb61f-8667-45ed-8160-f36e2f20382a",
+  "prevId": "256fcc7f-5a9d-4ceb-a413-1112c5cff383",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.intent_dossier": {
+      "name": "intent_dossier",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "intent_id": {
+          "name": "intent_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "text": {
+          "name": "text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source": {
+          "name": "source",
+          "type": "intent_dossier_source",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "retired_at": {
+          "name": "retired_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_intent_dossier_scope": {
+          "name": "idx_intent_dossier_scope",
+          "columns": [
+            {
+              "expression": "user_id",
+              "asc": true,
+              "nulls": "last",
+              "opclass": "timestamptz_ops",
+              "isExpression": false
+            },
+            {
+              "expression": "intent_id",
+              "asc": true,
+              "nulls": "last",
+              "opclass": "text_ops",
+              "isExpression": false
+            },
+            {
+              "expression": "retired_at",
+              "asc": true,
+              "nulls": "last",
+              "opclass": "timestamptz_ops",
+              "isExpression": false
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "intent_dossier_user_id_users_id_fk": {
+          "name": "intent_dossier_user_id_users_id_fk",
+          "tableFrom": "intent_dossier",
+          "tableTo": "users",
+          "schemaTo": "public",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "intent_dossier_intent_id_intents_id_fk": {
+          "name": "intent_dossier_intent_id_intents_id_fk",
+          "tableFrom": "intent_dossier",
+          "tableTo": "intents",
+          "schemaTo": "public",
+          "columnsFrom": [
+            "intent_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {},
+      "policies": {},
+      "isRLSEnabled": false
+    },
+    "public.intent_agent_acts": {
+      "name": "intent_agent_acts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "intent_id": {
+          "name": "intent_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "event": {
+          "name": "event",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "act": {
+          "name": "act",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_intent_agent_acts_scope": {
+          "name": "idx_intent_agent_acts_scope",
+          "columns": [
+            {
+              "expression": "user_id",
+              "asc": true,
+              "nulls": "last",
+              "opclass": "timestamptz_ops",
+              "isExpression": false
+            },
+            {
+              "expression": "intent_id",
+              "asc": true,
+              "nulls": "last",
+              "opclass": "text_ops",
+              "isExpression": false
+            },
+            {
+              "expression": "created_at",
+              "asc": true,
+              "nulls": "last",
+              "opclass": "timestamptz_ops",
+              "isExpression": false
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "intent_agent_acts_user_id_users_id_fk": {
+          "name": "intent_agent_acts_user_id_users_id_fk",
+          "tableFrom": "intent_agent_acts",
+          "tableTo": "users",
+          "schemaTo": "public",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {},
+      "policies": {},
+      "isRLSEnabled": false
+    },
+    "public.hyde_documents": {
+      "name": "hyde_documents",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "source_type": {
+          "name": "source_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_id": {
+          "name": "source_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source_text": {
+          "name": "source_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "strategy": {
+          "name": "strategy",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "target_corpus": {
+          "name": "target_corpus",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "context": {
+          "name": "context",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "hyde_text": {
+          "name": "hyde_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "hyde_embedding": {
+          "name": "hyde_embedding",
+          "type": "vector(2000)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "hyde_embedding_idx": {
+          "name": "hyde_embedding_idx",
+          "columns": [
+            {
+              "expression": "hyde_embedding",
+              "asc": true,
+              "nulls": "last",
+              "opclass": "vector_cosine_ops",
+              "isExpression": false
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "hnsw",
+          "with": {}
+        },
+        "hyde_expires_idx": {
+          "name": "hyde_expires_idx",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "asc": true,
+              "nulls": "last",
+              "opclass": "timestamptz_ops",
+              "isExpression": false
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "hyde_source_idx": {
+          "name": "hyde_source_idx",
+          "columns": [
+            {
+              "expression": "source_type",
+              "asc": true,
+              "nulls": "last",
+              "opclass": "text_ops",
+              "isExpression": false
+            },
+            {
+              "expression": "source_id",
+              "asc": true,
+              "nulls": "last",
+              "opclass": "text_ops",
+              "isExpression": false
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "hyde_source_strategy_unique": {
+          "name": "hyde_source_strategy_unique",
+          "columns": [
+            {
+              "expression": "source_type",
+              "asc": true,
+              "nulls": "last",
+              "opclass": "text_ops",
+              "isExpression": false
+            },
+            {
+              "expression": "source_id",
+              "asc": true,
+              "nulls": "last",
+              "opclass": "text_ops",
+              "isExpression": false
+            },
+            {
+              "expression": "strategy",
+              "asc": true,
+              "nulls": "last",
+              "opclass": "text_ops",
+              "isExpression": false
+            },
+            {
+              "expression": "target_corpus",
+              "asc": true,
+              "nulls": "last",
+              "opclass": "text_ops",
+              "isExpression": false
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "hyde_strategy_idx": {
+          "name": "hyde_strategy_idx",
+          "columns": [
+            {
+              "expression": "strategy",
+              "asc": true,
+              "nulls": "last",
+              "opclass": "text_ops",
+              "isExpression": false
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {},
+      "policies": {},
+      "isRLSEnabled": false
+    },
+    "public.verifications": {
+      "name": "verifications",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "identifier": {
+          "name": "identifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {},
+      "policies": {},
+      "isRLSEnabled": false
+    },
+    "public.accounts": {
+      "name": "accounts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "id_token": {
+          "name": "id_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "access_token_expires_at": {
+          "name": "access_token_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token_expires_at": {
+          "name": "refresh_token_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "password": {
+          "name": "password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "accounts_user_id_users_id_fk": {
+          "name": "accounts_user_id_users_id_fk",
+          "tableFrom": "accounts",
+          "tableTo": "users",
+          "schemaTo": "public",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {},
+      "policies": {},
+      "isRLSEnabled": false
+    },
+    "public.sessions": {
+      "name": "sessions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "ip_address": {
+          "name": "ip_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "sessions_user_id_users_id_fk": {
+          "name": "sessions_user_id_users_id_fk",
+          "tableFrom": "sessions",
+          "tableTo": "users",
+          "schemaTo": "public",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "sessions_token_unique": {
+          "columns": [
+            "token"
+          ],
+          "nullsNotDistinct": false,
+          "name": "sessions_token_unique"
+        }
+      },
+      "checkConstraints": {},
+      "policies": {},
+      "isRLSEnabled": false
+    },
+    "public.user_notification_settings": {
+      "name": "user_notification_settings",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "preferences": {
+          "name": "preferences",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'{\"connectionUpdates\":true,\"weeklyNewsletter\":true}'::json"
+        },
+        "unsubscribe_token": {
+          "name": "unsubscribe_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "user_notification_settings_user_id_users_id_fk": {
+          "name": "user_notification_settings_user_id_users_id_fk",
+          "tableFrom": "user_notification_settings",
+          "tableTo": "users",
+          "schemaTo": "public",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "user_notification_settings_user_id_unique": {
+          "columns": [
+            "user_id"
+          ],
+          "nullsNotDistinct": false,
+          "name": "user_notification_settings_user_id_unique"
+        },
+        "user_notification_settings_unsubscribe_token_unique": {
+          "columns": [
+            "unsubscribe_token"
+          ],
+          "nullsNotDistinct": false,
+          "name": "user_notification_settings_unsubscribe_token_unique"
+        }
+      },
+      "checkConstraints": {},
+      "policies": {},
+      "isRLSEnabled": false
+    },
+    "public.jwks": {
+      "name": "jwks",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "public_key": {
+          "name": "public_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "private_key": {
+          "name": "private_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {},
+      "policies": {},
+      "isRLSEnabled": false
+    },
+    "public.intent_discovery_progress": {
+      "name": "intent_discovery_progress",
+      "schema": "",
+      "columns": {
+        "intent_id": {
+          "name": "intent_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "intent_discovery_progress_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'queued'"
+        },
+        "attempt": {
+          "name": "attempt",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "max_attempts": {
+          "name": "max_attempts",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 3
+        },
+        "assigned_community_count": {
+          "name": "assigned_community_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "processed_community_count": {
+          "name": "processed_community_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "possible_overlap_count": {
+          "name": "possible_overlap_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "conversations_started_count": {
+          "name": "conversations_started_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "queued_at": {
+          "name": "queued_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "intent_discovery_progress_user_updated_idx": {
+          "name": "intent_discovery_progress_user_updated_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "asc": true,
+              "nulls": "last",
+              "opclass": "text_ops",
+              "isExpression": false
+            },
+            {
+              "expression": "updated_at",
+              "asc": true,
+              "nulls": "last",
+              "opclass": "text_ops",
+              "isExpression": false
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "intent_discovery_progress_intent_id_intents_id_fk": {
+          "name": "intent_discovery_progress_intent_id_intents_id_fk",
+          "tableFrom": "intent_discovery_progress",
+          "tableTo": "intents",
+          "schemaTo": "public",
+          "columnsFrom": [
+            "intent_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "intent_discovery_progress_user_id_users_id_fk": {
+          "name": "intent_discovery_progress_user_id_users_id_fk",
+          "tableFrom": "intent_discovery_progress",
+          "tableTo": "users",
+          "schemaTo": "public",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {},
+      "policies": {},
+      "isRLSEnabled": false
+    },
+    "public.artifacts": {
+      "name": "artifacts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "task_id": {
+          "name": "task_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "parts": {
+          "name": "parts",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "extensions": {
+          "name": "extensions",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "artifacts_task_id_idx": {
+          "name": "artifacts_task_id_idx",
+          "columns": [
+            {
+              "expression": "task_id",
+              "asc": true,
+              "nulls": "last",
+              "opclass": "text_ops",
+              "isExpression": false
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "artifacts_task_id_tasks_id_fk": {
+          "name": "artifacts_task_id_tasks_id_fk",
+          "tableFrom": "artifacts",
+          "tableTo": "tasks",
+          "schemaTo": "public",
+          "columnsFrom": [
+            "task_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {},
+      "policies": {},
+      "isRLSEnabled": false
+    },
+    "public.conversation_metadata": {
+      "name": "conversation_metadata",
+      "schema": "",
+      "columns": {
+        "conversation_id": {
+          "name": "conversation_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "conversation_metadata_conversation_id_conversations_id_fk": {
+          "name": "conversation_metadata_conversation_id_conversations_id_fk",
+          "tableFrom": "conversation_metadata",
+          "tableTo": "conversations",
+          "schemaTo": "public",
+          "columnsFrom": [
+            "conversation_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {},
+      "policies": {},
+      "isRLSEnabled": false
+    },
+    "public.oauth_application": {
+      "name": "oauth_application",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "icon": {
+          "name": "icon",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "client_secret": {
+          "name": "client_secret",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "redirect_urls": {
+          "name": "redirect_urls",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "disabled": {
+          "name": "disabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "oauth_application_user_id_idx": {
+          "name": "oauth_application_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "asc": true,
+              "nulls": "last",
+              "opclass": "text_ops",
+              "isExpression": false
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "oauth_application_user_id_users_id_fk": {
+          "name": "oauth_application_user_id_users_id_fk",
+          "tableFrom": "oauth_application",
+          "tableTo": "users",
+          "schemaTo": "public",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "oauth_application_client_id_unique": {
+          "columns": [
+            "client_id"
+          ],
+          "nullsNotDistinct": false,
+          "name": "oauth_application_client_id_unique"
+        }
+      },
+      "checkConstraints": {},
+      "policies": {},
+      "isRLSEnabled": false
+    },
+    "public.oauth_access_token": {
+      "name": "oauth_access_token",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "access_token_expires_at": {
+          "name": "access_token_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "refresh_token_expires_at": {
+          "name": "refresh_token_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scopes": {
+          "name": "scopes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "oauth_access_token_client_id_idx": {
+          "name": "oauth_access_token_client_id_idx",
+          "columns": [
+            {
+              "expression": "client_id",
+              "asc": true,
+              "nulls": "last",
+              "opclass": "text_ops",
+              "isExpression": false
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "oauth_access_token_user_id_idx": {
+          "name": "oauth_access_token_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "asc": true,
+              "nulls": "last",
+              "opclass": "text_ops",
+              "isExpression": false
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "oauth_access_token_client_id_oauth_application_client_id_fk": {
+          "name": "oauth_access_token_client_id_oauth_application_client_id_fk",
+          "tableFrom": "oauth_access_token",
+          "tableTo": "oauth_application",
+          "schemaTo": "public",
+          "columnsFrom": [
+            "client_id"
+          ],
+          "columnsTo": [
+            "client_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "oauth_access_token_user_id_users_id_fk": {
+          "name": "oauth_access_token_user_id_users_id_fk",
+          "tableFrom": "oauth_access_token",
+          "tableTo": "users",
+          "schemaTo": "public",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "oauth_access_token_access_token_unique": {
+          "columns": [
+            "access_token"
+          ],
+          "nullsNotDistinct": false,
+          "name": "oauth_access_token_access_token_unique"
+        },
+        "oauth_access_token_refresh_token_unique": {
+          "columns": [
+            "refresh_token"
+          ],
+          "nullsNotDistinct": false,
+          "name": "oauth_access_token_refresh_token_unique"
+        }
+      },
+      "checkConstraints": {},
+      "policies": {},
+      "isRLSEnabled": false
+    },
+    "public.oauth_consent": {
+      "name": "oauth_consent",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scopes": {
+          "name": "scopes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "consent_given": {
+          "name": "consent_given",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "oauth_consent_client_id_idx": {
+          "name": "oauth_consent_client_id_idx",
+          "columns": [
+            {
+              "expression": "client_id",
+              "asc": true,
+              "nulls": "last",
+              "opclass": "text_ops",
+              "isExpression": false
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "oauth_consent_user_id_idx": {
+          "name": "oauth_consent_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "asc": true,
+              "nulls": "last",
+              "opclass": "text_ops",
+              "isExpression": false
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "oauth_consent_client_id_oauth_application_client_id_fk": {
+          "name": "oauth_consent_client_id_oauth_application_client_id_fk",
+          "tableFrom": "oauth_consent",
+          "tableTo": "oauth_application",
+          "schemaTo": "public",
+          "columnsFrom": [
+            "client_id"
+          ],
+          "columnsTo": [
+            "client_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "oauth_consent_user_id_users_id_fk": {
+          "name": "oauth_consent_user_id_users_id_fk",
+          "tableFrom": "oauth_consent",
+          "tableTo": "users",
+          "schemaTo": "public",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {},
+      "policies": {},
+      "isRLSEnabled": false
+    },
+    "public.negotiation_round_log_events": {
+      "name": "negotiation_round_log_events",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "intent_id": {
+          "name": "intent_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "batch_id": {
+          "name": "batch_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "task_id": {
+          "name": "task_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "kind": {
+          "name": "kind",
+          "type": "negotiation_round_log_event_kind",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "via": {
+          "name": "via",
+          "type": "negotiation_round_log_event_via",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reason": {
+          "name": "reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_negotiation_round_log_events_batch": {
+          "name": "idx_negotiation_round_log_events_batch",
+          "columns": [
+            {
+              "expression": "intent_id",
+              "asc": true,
+              "nulls": "last",
+              "opclass": "timestamptz_ops",
+              "isExpression": false
+            },
+            {
+              "expression": "batch_id",
+              "asc": true,
+              "nulls": "last",
+              "opclass": "text_ops",
+              "isExpression": false
+            },
+            {
+              "expression": "created_at",
+              "asc": true,
+              "nulls": "last",
+              "opclass": "timestamptz_ops",
+              "isExpression": false
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {},
+      "policies": {},
+      "isRLSEnabled": false
+    },
+    "public.tasks": {
+      "name": "tasks",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "conversation_id": {
+          "name": "conversation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "state": {
+          "name": "state",
+          "type": "task_state",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'submitted'"
+        },
+        "status_message": {
+          "name": "status_message",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status_timestamp": {
+          "name": "status_timestamp",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "extensions": {
+          "name": "extensions",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "claimed_by_agent_id": {
+          "name": "claimed_by_agent_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "claimed_at": {
+          "name": "claimed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "briefs": {
+          "name": "briefs",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        }
+      },
+      "indexes": {
+        "tasks_conversation_id_idx": {
+          "name": "tasks_conversation_id_idx",
+          "columns": [
+            {
+              "expression": "conversation_id",
+              "asc": true,
+              "nulls": "last",
+              "opclass": "text_ops",
+              "isExpression": false
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "tasks_metadata_opportunity_id_idx": {
+          "name": "tasks_metadata_opportunity_id_idx",
+          "columns": [
+            {
+              "expression": "((metadata ->> 'opportunityId'::text))",
+              "asc": true,
+              "nulls": "last",
+              "opclass": "text_ops",
+              "isExpression": true
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "where": "((metadata ->> 'type'::text) = 'negotiation'::text)",
+          "with": {}
+        },
+        "tasks_state_idx": {
+          "name": "tasks_state_idx",
+          "columns": [
+            {
+              "expression": "state",
+              "asc": true,
+              "nulls": "last",
+              "opclass": "enum_ops",
+              "isExpression": false
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "tasks_conversation_id_conversations_id_fk": {
+          "name": "tasks_conversation_id_conversations_id_fk",
+          "tableFrom": "tasks",
+          "tableTo": "conversations",
+          "schemaTo": "public",
+          "columnsFrom": [
+            "conversation_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {},
+      "policies": {},
+      "isRLSEnabled": false
+    },
+    "public.agent_permissions": {
+      "name": "agent_permissions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "agent_id": {
+          "name": "agent_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scope": {
+          "name": "scope",
+          "type": "permission_scope",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'global'"
+        },
+        "scope_id": {
+          "name": "scope_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "actions": {
+          "name": "actions",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "agent_permissions_agent_id_idx": {
+          "name": "agent_permissions_agent_id_idx",
+          "columns": [
+            {
+              "expression": "agent_id",
+              "asc": true,
+              "nulls": "last",
+              "opclass": "text_ops",
+              "isExpression": false
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "agent_permissions_agent_user_idx": {
+          "name": "agent_permissions_agent_user_idx",
+          "columns": [
+            {
+              "expression": "agent_id",
+              "asc": true,
+              "nulls": "last",
+              "opclass": "text_ops",
+              "isExpression": false
+            },
+            {
+              "expression": "user_id",
+              "asc": true,
+              "nulls": "last",
+              "opclass": "text_ops",
+              "isExpression": false
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "agent_permissions_user_id_idx": {
+          "name": "agent_permissions_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "asc": true,
+              "nulls": "last",
+              "opclass": "text_ops",
+              "isExpression": false
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "uniq_agent_permissions_global": {
+          "name": "uniq_agent_permissions_global",
+          "columns": [
+            {
+              "expression": "agent_id",
+              "asc": true,
+              "nulls": "last",
+              "opclass": "text_ops",
+              "isExpression": false
+            },
+            {
+              "expression": "user_id",
+              "asc": true,
+              "nulls": "last",
+              "opclass": "text_ops",
+              "isExpression": false
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "where": "(scope = 'global'::permission_scope)",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "agent_permissions_agent_id_agents_id_fk": {
+          "name": "agent_permissions_agent_id_agents_id_fk",
+          "tableFrom": "agent_permissions",
+          "tableTo": "agents",
+          "schemaTo": "public",
+          "columnsFrom": [
+            "agent_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "agent_permissions_user_id_users_id_fk": {
+          "name": "agent_permissions_user_id_users_id_fk",
+          "tableFrom": "agent_permissions",
+          "tableTo": "users",
+          "schemaTo": "public",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {},
+      "policies": {},
+      "isRLSEnabled": false
+    },
+    "public.agent_test_messages": {
+      "name": "agent_test_messages",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "agent_id": {
+          "name": "agent_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "requested_by_user_id": {
+          "name": "requested_by_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reservation_token": {
+          "name": "reservation_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reserved_at": {
+          "name": "reserved_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "delivered_at": {
+          "name": "delivered_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_agent_test_messages_agent_pending": {
+          "name": "idx_agent_test_messages_agent_pending",
+          "columns": [
+            {
+              "expression": "agent_id",
+              "asc": true,
+              "nulls": "last",
+              "opclass": "text_ops",
+              "isExpression": false
+            },
+            {
+              "expression": "reserved_at",
+              "asc": true,
+              "nulls": "last",
+              "opclass": "text_ops",
+              "isExpression": false
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "agent_test_messages_agent_id_agents_id_fk": {
+          "name": "agent_test_messages_agent_id_agents_id_fk",
+          "tableFrom": "agent_test_messages",
+          "tableTo": "agents",
+          "schemaTo": "public",
+          "columnsFrom": [
+            "agent_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "agent_test_messages_requested_by_user_id_users_id_fk": {
+          "name": "agent_test_messages_requested_by_user_id_users_id_fk",
+          "tableFrom": "agent_test_messages",
+          "tableTo": "users",
+          "schemaTo": "public",
+          "columnsFrom": [
+            "requested_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {},
+      "policies": {},
+      "isRLSEnabled": false
+    },
+    "public.opportunity_deliveries": {
+      "name": "opportunity_deliveries",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "opportunity_id": {
+          "name": "opportunity_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "agent_id": {
+          "name": "agent_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "channel": {
+          "name": "channel",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "trigger": {
+          "name": "trigger",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "delivered_at_status": {
+          "name": "delivered_at_status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reservation_token": {
+          "name": "reservation_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reserved_at": {
+          "name": "reserved_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "delivered_at": {
+          "name": "delivered_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_opp_deliveries_open_reservations": {
+          "name": "idx_opp_deliveries_open_reservations",
+          "columns": [
+            {
+              "expression": "user_id",
+              "asc": true,
+              "nulls": "last",
+              "opclass": "text_ops",
+              "isExpression": false
+            },
+            {
+              "expression": "channel",
+              "asc": true,
+              "nulls": "last",
+              "opclass": "timestamptz_ops",
+              "isExpression": false
+            },
+            {
+              "expression": "reserved_at",
+              "asc": true,
+              "nulls": "last",
+              "opclass": "timestamptz_ops",
+              "isExpression": false
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "where": "(delivered_at IS NULL)",
+          "with": {}
+        },
+        "uniq_opp_deliveries_committed": {
+          "name": "uniq_opp_deliveries_committed",
+          "columns": [
+            {
+              "expression": "user_id",
+              "asc": true,
+              "nulls": "last",
+              "opclass": "text_ops",
+              "isExpression": false
+            },
+            {
+              "expression": "opportunity_id",
+              "asc": true,
+              "nulls": "last",
+              "opclass": "text_ops",
+              "isExpression": false
+            },
+            {
+              "expression": "channel",
+              "asc": true,
+              "nulls": "last",
+              "opclass": "text_ops",
+              "isExpression": false
+            },
+            {
+              "expression": "delivered_at_status",
+              "asc": true,
+              "nulls": "last",
+              "opclass": "text_ops",
+              "isExpression": false
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "where": "(delivered_at IS NOT NULL)",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "opportunity_deliveries_opportunity_id_opportunities_id_fk": {
+          "name": "opportunity_deliveries_opportunity_id_opportunities_id_fk",
+          "tableFrom": "opportunity_deliveries",
+          "tableTo": "opportunities",
+          "schemaTo": "public",
+          "columnsFrom": [
+            "opportunity_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "opportunity_deliveries_user_id_users_id_fk": {
+          "name": "opportunity_deliveries_user_id_users_id_fk",
+          "tableFrom": "opportunity_deliveries",
+          "tableTo": "users",
+          "schemaTo": "public",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "opportunity_deliveries_agent_id_agents_id_fk": {
+          "name": "opportunity_deliveries_agent_id_agents_id_fk",
+          "tableFrom": "opportunity_deliveries",
+          "tableTo": "agents",
+          "schemaTo": "public",
+          "columnsFrom": [
+            "agent_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {},
+      "policies": {},
+      "isRLSEnabled": false
+    },
+    "public.agent_transports": {
+      "name": "agent_transports",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "agent_id": {
+          "name": "agent_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "channel": {
+          "name": "channel",
+          "type": "transport_channel",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "config": {
+          "name": "config",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'{}'::jsonb"
+        },
+        "priority": {
+          "name": "priority",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "active": {
+          "name": "active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "failure_count": {
+          "name": "failure_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "agent_transports_agent_id_idx": {
+          "name": "agent_transports_agent_id_idx",
+          "columns": [
+            {
+              "expression": "agent_id",
+              "asc": true,
+              "nulls": "last",
+              "opclass": "text_ops",
+              "isExpression": false
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "agent_transports_agent_id_agents_id_fk": {
+          "name": "agent_transports_agent_id_agents_id_fk",
+          "tableFrom": "agent_transports",
+          "tableTo": "agents",
+          "schemaTo": "public",
+          "columnsFrom": [
+            "agent_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {},
+      "policies": {},
+      "isRLSEnabled": false
+    },
+    "public.user_socials": {
+      "name": "user_socials",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "label": {
+          "name": "label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_user_socials_user_id": {
+          "name": "idx_user_socials_user_id",
+          "columns": [
+            {
+              "expression": "user_id",
+              "asc": true,
+              "nulls": "last",
+              "opclass": "text_ops",
+              "isExpression": false
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "uniq_user_socials_user_label": {
+          "name": "uniq_user_socials_user_label",
+          "columns": [
+            {
+              "expression": "user_id",
+              "asc": true,
+              "nulls": "last",
+              "opclass": "text_ops",
+              "isExpression": false
+            },
+            {
+              "expression": "label",
+              "asc": true,
+              "nulls": "last",
+              "opclass": "text_ops",
+              "isExpression": false
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "where": "(label <> 'custom'::text)",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "user_socials_user_id_fkey": {
+          "name": "user_socials_user_id_fkey",
+          "tableFrom": "user_socials",
+          "tableTo": "users",
+          "schemaTo": "public",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {},
+      "policies": {},
+      "isRLSEnabled": false
+    },
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email_verified": {
+          "name": "email_verified",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "avatar": {
+          "name": "avatar",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "intro": {
+          "name": "intro",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "location": {
+          "name": "location",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "onboarding": {
+          "name": "onboarding",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'{}'::json"
+        },
+        "timezone": {
+          "name": "timezone",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'UTC'"
+        },
+        "last_weekly_email_sent_at": {
+          "name": "last_weekly_email_sent_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "users_email_unique": {
+          "name": "users_email_unique",
+          "columns": [
+            {
+              "expression": "email",
+              "asc": true,
+              "nulls": "last",
+              "opclass": "text_ops",
+              "isExpression": false
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "users_key_unique": {
+          "name": "users_key_unique",
+          "columns": [
+            {
+              "expression": "key",
+              "asc": true,
+              "nulls": "last",
+              "opclass": "text_ops",
+              "isExpression": false
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {},
+      "policies": {},
+      "isRLSEnabled": false
+    },
+    "public.chat_session_summaries": {
+      "name": "chat_session_summaries",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "conversation_id": {
+          "name": "conversation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "from_message_id": {
+          "name": "from_message_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "to_message_id": {
+          "name": "to_message_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "digest": {
+          "name": "digest",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "model": {
+          "name": "model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "chat_session_summaries_session_latest_idx": {
+          "name": "chat_session_summaries_session_latest_idx",
+          "columns": [
+            {
+              "expression": "conversation_id",
+              "asc": true,
+              "nulls": "last",
+              "opclass": "text_ops",
+              "isExpression": false
+            },
+            {
+              "expression": "created_at",
+              "asc": false,
+              "nulls": "last",
+              "opclass": "text_ops",
+              "isExpression": false
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "chat_session_summaries_conversation_id_conversations_id_fk": {
+          "name": "chat_session_summaries_conversation_id_conversations_id_fk",
+          "tableFrom": "chat_session_summaries",
+          "tableTo": "conversations",
+          "schemaTo": "public",
+          "columnsFrom": [
+            "conversation_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "chat_session_summaries_from_message_id_messages_id_fk": {
+          "name": "chat_session_summaries_from_message_id_messages_id_fk",
+          "tableFrom": "chat_session_summaries",
+          "tableTo": "messages",
+          "schemaTo": "public",
+          "columnsFrom": [
+            "from_message_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "chat_session_summaries_to_message_id_messages_id_fk": {
+          "name": "chat_session_summaries_to_message_id_messages_id_fk",
+          "tableFrom": "chat_session_summaries",
+          "tableTo": "messages",
+          "schemaTo": "public",
+          "columnsFrom": [
+            "to_message_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {},
+      "policies": {},
+      "isRLSEnabled": false
+    },
+    "public.opportunities": {
+      "name": "opportunities",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "detection": {
+          "name": "detection",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "actors": {
+          "name": "actors",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "interpretation": {
+          "name": "interpretation",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "context": {
+          "name": "context",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "confidence": {
+          "name": "confidence",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "opportunity_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "accepted_by": {
+          "name": "accepted_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'{}'::jsonb"
+        }
+      },
+      "indexes": {
+        "opportunities_active_pair_idx": {
+          "name": "opportunities_active_pair_idx",
+          "columns": [
+            {
+              "expression": "((context ->> 'networkId'::text))",
+              "asc": true,
+              "nulls": "last",
+              "opclass": "text_ops",
+              "isExpression": true
+            },
+            {
+              "expression": "LEAST(((actors -> 0) ->> 'intent'::text), ((actors -> 1) ->> 'i",
+              "asc": true,
+              "nulls": "last",
+              "opclass": "text_ops",
+              "isExpression": true
+            },
+            {
+              "expression": "GREATEST(((actors -> 0) ->> 'intent'::text), ((actors -> 1) ->>",
+              "asc": true,
+              "nulls": "last",
+              "opclass": "text_ops",
+              "isExpression": true
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "where": "((status = ANY (ARRAY['negotiating'::opportunity_status, 'pending'::opportunity_status, 'stalled'::opportunity_status])) AND (((actors -> 0) ->> 'intent'::text) IS NOT NULL) AND (((actors -> 1) ->> 'intent'::text) IS NOT NULL))",
+          "with": {}
+        },
+        "opportunities_status_idx": {
+          "name": "opportunities_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "asc": true,
+              "nulls": "last",
+              "opclass": "enum_ops",
+              "isExpression": false
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "opportunities_accepted_by_users_id_fk": {
+          "name": "opportunities_accepted_by_users_id_fk",
+          "tableFrom": "opportunities",
+          "tableTo": "users",
+          "schemaTo": "public",
+          "columnsFrom": [
+            "accepted_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {},
+      "policies": {},
+      "isRLSEnabled": false
+    },
+    "public.premises": {
+      "name": "premises",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "assertion": {
+          "name": "assertion",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provenance": {
+          "name": "provenance",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "analysis": {
+          "name": "analysis",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "validity": {
+          "name": "validity",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "embedding": {
+          "name": "embedding",
+          "type": "vector(2000)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "premise_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'ACTIVE'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "retracted_at": {
+          "name": "retracted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "premises_embedding_idx": {
+          "name": "premises_embedding_idx",
+          "columns": [
+            {
+              "expression": "embedding",
+              "asc": true,
+              "nulls": "last",
+              "opclass": "vector_cosine_ops",
+              "isExpression": false
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "hnsw",
+          "with": {}
+        },
+        "premises_status_idx": {
+          "name": "premises_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "asc": true,
+              "nulls": "last",
+              "opclass": "enum_ops",
+              "isExpression": false
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "premises_user_id_idx": {
+          "name": "premises_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "asc": true,
+              "nulls": "last",
+              "opclass": "text_ops",
+              "isExpression": false
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "premises_user_id_users_id_fk": {
+          "name": "premises_user_id_users_id_fk",
+          "tableFrom": "premises",
+          "tableTo": "users",
+          "schemaTo": "public",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {},
+      "policies": {},
+      "isRLSEnabled": false
+    },
+    "public.questions": {
+      "name": "questions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "detection": {
+          "name": "detection",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "actors": {
+          "name": "actors",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "payload": {
+          "name": "payload",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "question_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "answer": {
+          "name": "answer",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "conversation_id": {
+          "name": "conversation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "questions_conversation_id_idx": {
+          "name": "questions_conversation_id_idx",
+          "columns": [
+            {
+              "expression": "conversation_id",
+              "asc": true,
+              "nulls": "last",
+              "opclass": "text_ops",
+              "isExpression": false
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "questions_recovery_recipient_intent_fingerprint_uniq": {
+          "name": "questions_recovery_recipient_intent_fingerprint_uniq",
+          "columns": [
+            {
+              "expression": "(((actors -> 0) ->> 'userId'::text))",
+              "asc": true,
+              "nulls": "last",
+              "opclass": "text_ops",
+              "isExpression": true
+            },
+            {
+              "expression": "((detection ->> 'sourceId'::text))",
+              "asc": true,
+              "nulls": "last",
+              "opclass": "text_ops",
+              "isExpression": true
+            },
+            {
+              "expression": "(((detection -> 'recovery'::text) ->> 'intentFingerprint'::text",
+              "asc": true,
+              "nulls": "last",
+              "opclass": "text_ops",
+              "isExpression": true
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "where": "(((detection ->> 'purpose'::text) = 'recovery'::text) AND ((detection ->> 'mode'::text) = 'intent'::text) AND ((detection ->> 'sourceType'::text) = 'intent'::text))",
+          "with": {}
+        },
+        "questions_status_idx": {
+          "name": "questions_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "asc": true,
+              "nulls": "last",
+              "opclass": "enum_ops",
+              "isExpression": false
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {},
+      "policies": {},
+      "isRLSEnabled": false
+    },
+    "public.chat_session_scopes": {
+      "name": "chat_session_scopes",
+      "schema": "",
+      "columns": {
+        "conversation_id": {
+          "name": "conversation_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scope_type": {
+          "name": "scope_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scope_id": {
+          "name": "scope_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "chat_session_scopes_scope_idx": {
+          "name": "chat_session_scopes_scope_idx",
+          "columns": [
+            {
+              "expression": "scope_type",
+              "asc": true,
+              "nulls": "last",
+              "opclass": "text_ops",
+              "isExpression": false
+            },
+            {
+              "expression": "scope_id",
+              "asc": true,
+              "nulls": "last",
+              "opclass": "text_ops",
+              "isExpression": false
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "chat_session_scopes_user_id_idx": {
+          "name": "chat_session_scopes_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "asc": true,
+              "nulls": "last",
+              "opclass": "text_ops",
+              "isExpression": false
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "chat_session_scopes_user_scope_unique": {
+          "name": "chat_session_scopes_user_scope_unique",
+          "columns": [
+            {
+              "expression": "user_id",
+              "asc": true,
+              "nulls": "last",
+              "opclass": "text_ops",
+              "isExpression": false
+            },
+            {
+              "expression": "scope_type",
+              "asc": true,
+              "nulls": "last",
+              "opclass": "text_ops",
+              "isExpression": false
+            },
+            {
+              "expression": "scope_id",
+              "asc": true,
+              "nulls": "last",
+              "opclass": "text_ops",
+              "isExpression": false
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "chat_session_scopes_conversation_id_conversations_id_fk": {
+          "name": "chat_session_scopes_conversation_id_conversations_id_fk",
+          "tableFrom": "chat_session_scopes",
+          "tableTo": "conversations",
+          "schemaTo": "public",
+          "columnsFrom": [
+            "conversation_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {},
+      "policies": {},
+      "isRLSEnabled": false
+    },
+    "public.conversations": {
+      "name": "conversations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "last_message_at": {
+          "name": "last_message_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "dm_pair": {
+          "name": "dm_pair",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "persona": {
+          "name": "persona",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'none'"
+        }
+      },
+      "indexes": {
+        "conversations_dm_pair_idx": {
+          "name": "conversations_dm_pair_idx",
+          "columns": [
+            {
+              "expression": "dm_pair",
+              "asc": true,
+              "nulls": "last",
+              "opclass": "text_ops",
+              "isExpression": false
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {},
+      "policies": {},
+      "isRLSEnabled": false
+    },
+    "public.negotiator_memories": {
+      "name": "negotiator_memories",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "agent_id": {
+          "name": "agent_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "subject_user_id": {
+          "name": "subject_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "embedding": {
+          "name": "embedding",
+          "type": "vector(2000)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source_refs": {
+          "name": "source_refs",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "confidence": {
+          "name": "confidence",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0.5
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "negotiator_memories_agent_kind_idx": {
+          "name": "negotiator_memories_agent_kind_idx",
+          "columns": [
+            {
+              "expression": "agent_id",
+              "asc": true,
+              "nulls": "last",
+              "opclass": "text_ops",
+              "isExpression": false
+            },
+            {
+              "expression": "kind",
+              "asc": true,
+              "nulls": "last",
+              "opclass": "text_ops",
+              "isExpression": false
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "negotiator_memories_embedding_idx": {
+          "name": "negotiator_memories_embedding_idx",
+          "columns": [
+            {
+              "expression": "embedding",
+              "asc": true,
+              "nulls": "last",
+              "opclass": "vector_cosine_ops",
+              "isExpression": false
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "hnsw",
+          "with": {}
+        },
+        "negotiator_memories_user_subject_idx": {
+          "name": "negotiator_memories_user_subject_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "asc": true,
+              "nulls": "last",
+              "opclass": "text_ops",
+              "isExpression": false
+            },
+            {
+              "expression": "subject_user_id",
+              "asc": true,
+              "nulls": "last",
+              "opclass": "text_ops",
+              "isExpression": false
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "negotiator_memories_agent_id_agents_id_fk": {
+          "name": "negotiator_memories_agent_id_agents_id_fk",
+          "tableFrom": "negotiator_memories",
+          "tableTo": "agents",
+          "schemaTo": "public",
+          "columnsFrom": [
+            "agent_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "negotiator_memories_user_id_users_id_fk": {
+          "name": "negotiator_memories_user_id_users_id_fk",
+          "tableFrom": "negotiator_memories",
+          "tableTo": "users",
+          "schemaTo": "public",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "negotiator_memories_subject_user_id_users_id_fk": {
+          "name": "negotiator_memories_subject_user_id_users_id_fk",
+          "tableFrom": "negotiator_memories",
+          "tableTo": "users",
+          "schemaTo": "public",
+          "columnsFrom": [
+            "subject_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {},
+      "policies": {},
+      "isRLSEnabled": false
+    },
+    "public.frame_drift_observation_runs": {
+      "name": "frame_drift_observation_runs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "bucket_start": {
+          "name": "bucket_start",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "bucket_end": {
+          "name": "bucket_end",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "captured_at": {
+          "name": "captured_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "configured_embedding_model": {
+          "name": "configured_embedding_model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "max_networks": {
+          "name": "max_networks",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "max_pairs": {
+          "name": "max_pairs",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "min_users": {
+          "name": "min_users",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "stable_cohort_hash": {
+          "name": "stable_cohort_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "aggregate_diagnostics": {
+          "name": "aggregate_diagnostics",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        }
+      },
+      "indexes": {
+        "frame_drift_observation_runs_bucket_start_uniq": {
+          "name": "frame_drift_observation_runs_bucket_start_uniq",
+          "columns": [
+            {
+              "expression": "bucket_start",
+              "asc": true,
+              "nulls": "last",
+              "opclass": "timestamptz_ops",
+              "isExpression": false
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {
+        "frame_drift_observation_runs_bucket_check": {
+          "name": "frame_drift_observation_runs_bucket_check",
+          "value": "(bucket_end = (bucket_start + '1 day'::interval)) AND (captured_at >= bucket_end)"
+        },
+        "frame_drift_observation_runs_configured_embedding_model_check": {
+          "name": "frame_drift_observation_runs_configured_embedding_model_check",
+          "value": "length(btrim(configured_embedding_model)) > 0"
+        },
+        "frame_drift_observation_runs_max_networks_check": {
+          "name": "frame_drift_observation_runs_max_networks_check",
+          "value": "(max_networks >= 1) AND (max_networks <= 200)"
+        },
+        "frame_drift_observation_runs_max_pairs_check": {
+          "name": "frame_drift_observation_runs_max_pairs_check",
+          "value": "(max_pairs >= 1) AND (max_pairs <= 10000)"
+        },
+        "frame_drift_observation_runs_min_users_check": {
+          "name": "frame_drift_observation_runs_min_users_check",
+          "value": "(min_users >= 2) AND (min_users <= 100)"
+        },
+        "frame_drift_observation_runs_stable_cohort_hash_check": {
+          "name": "frame_drift_observation_runs_stable_cohort_hash_check",
+          "value": "(stable_cohort_hash IS NULL) OR (stable_cohort_hash ~ '^[0-9a-f]{64}$'::text)"
+        },
+        "frame_drift_observation_runs_aggregate_diagnostics_check": {
+          "name": "frame_drift_observation_runs_aggregate_diagnostics_check",
+          "value": "jsonb_typeof(aggregate_diagnostics) = 'object'::text"
+        }
+      },
+      "policies": {},
+      "isRLSEnabled": false
+    },
+    "public.cross_network_yield_snapshots": {
+      "name": "cross_network_yield_snapshots",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "run_id": {
+          "name": "run_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "network_a_id": {
+          "name": "network_a_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "network_b_id": {
+          "name": "network_b_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "opportunity_count": {
+          "name": "opportunity_count",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "potential_active_intent_pair_count": {
+          "name": "potential_active_intent_pair_count",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "yield_rate": {
+          "name": "yield_rate",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "yield_rate_delta": {
+          "name": "yield_rate_delta",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "prior_bucket_start": {
+          "name": "prior_bucket_start",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "bucket_start": {
+          "name": "bucket_start",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "bucket_end": {
+          "name": "bucket_end",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "captured_at": {
+          "name": "captured_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "cross_network_yield_snapshots_daily_uniq": {
+          "name": "cross_network_yield_snapshots_daily_uniq",
+          "columns": [
+            {
+              "expression": "network_a_id",
+              "asc": true,
+              "nulls": "last",
+              "opclass": "timestamptz_ops",
+              "isExpression": false
+            },
+            {
+              "expression": "network_b_id",
+              "asc": true,
+              "nulls": "last",
+              "opclass": "text_ops",
+              "isExpression": false
+            },
+            {
+              "expression": "bucket_start",
+              "asc": true,
+              "nulls": "last",
+              "opclass": "timestamptz_ops",
+              "isExpression": false
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "cross_network_yield_snapshots_run_id_frame_drift_observation_ru": {
+          "name": "cross_network_yield_snapshots_run_id_frame_drift_observation_ru",
+          "tableFrom": "cross_network_yield_snapshots",
+          "tableTo": "frame_drift_observation_runs",
+          "schemaTo": "public",
+          "columnsFrom": [
+            "run_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "cross_network_yield_snapshots_network_a_id_networks_id_fk": {
+          "name": "cross_network_yield_snapshots_network_a_id_networks_id_fk",
+          "tableFrom": "cross_network_yield_snapshots",
+          "tableTo": "networks",
+          "schemaTo": "public",
+          "columnsFrom": [
+            "network_a_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "cross_network_yield_snapshots_network_b_id_networks_id_fk": {
+          "name": "cross_network_yield_snapshots_network_b_id_networks_id_fk",
+          "tableFrom": "cross_network_yield_snapshots",
+          "tableTo": "networks",
+          "schemaTo": "public",
+          "columnsFrom": [
+            "network_b_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {
+        "cross_network_yield_snapshots_canonical_pair_check": {
+          "name": "cross_network_yield_snapshots_canonical_pair_check",
+          "value": "network_a_id < network_b_id"
+        },
+        "cross_network_yield_snapshots_opportunity_count_check": {
+          "name": "cross_network_yield_snapshots_opportunity_count_check",
+          "value": "opportunity_count >= 0"
+        },
+        "cross_network_yield_snapshots_potential_pair_count_check": {
+          "name": "cross_network_yield_snapshots_potential_pair_count_check",
+          "value": "potential_active_intent_pair_count > 0"
+        },
+        "cross_network_yield_snapshots_yield_rate_check": {
+          "name": "cross_network_yield_snapshots_yield_rate_check",
+          "value": "yield_rate >= (0)::double precision"
+        },
+        "cross_network_yield_snapshots_bucket_range_check": {
+          "name": "cross_network_yield_snapshots_bucket_range_check",
+          "value": "bucket_end > bucket_start"
+        }
+      },
+      "policies": {},
+      "isRLSEnabled": false
+    },
+    "public.frame_centroid_snapshots": {
+      "name": "frame_centroid_snapshots",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "run_id": {
+          "name": "run_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "network_id": {
+          "name": "network_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "corpus": {
+          "name": "corpus",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "centroid": {
+          "name": "centroid",
+          "type": "vector(2000)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sample_count": {
+          "name": "sample_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "configured_embedding_model": {
+          "name": "configured_embedding_model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "cosine_drift": {
+          "name": "cosine_drift",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "prior_bucket_start": {
+          "name": "prior_bucket_start",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "bucket_start": {
+          "name": "bucket_start",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "bucket_end": {
+          "name": "bucket_end",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "captured_at": {
+          "name": "captured_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "frame_centroid_snapshots_daily_uniq": {
+          "name": "frame_centroid_snapshots_daily_uniq",
+          "columns": [
+            {
+              "expression": "network_id",
+              "asc": true,
+              "nulls": "last",
+              "opclass": "text_ops",
+              "isExpression": false
+            },
+            {
+              "expression": "corpus",
+              "asc": true,
+              "nulls": "last",
+              "opclass": "text_ops",
+              "isExpression": false
+            },
+            {
+              "expression": "configured_embedding_model",
+              "asc": true,
+              "nulls": "last",
+              "opclass": "timestamptz_ops",
+              "isExpression": false
+            },
+            {
+              "expression": "bucket_start",
+              "asc": true,
+              "nulls": "last",
+              "opclass": "timestamptz_ops",
+              "isExpression": false
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "frame_centroid_snapshots_run_id_frame_drift_observation_runs_id": {
+          "name": "frame_centroid_snapshots_run_id_frame_drift_observation_runs_id",
+          "tableFrom": "frame_centroid_snapshots",
+          "tableTo": "frame_drift_observation_runs",
+          "schemaTo": "public",
+          "columnsFrom": [
+            "run_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "frame_centroid_snapshots_network_id_networks_id_fk": {
+          "name": "frame_centroid_snapshots_network_id_networks_id_fk",
+          "tableFrom": "frame_centroid_snapshots",
+          "tableTo": "networks",
+          "schemaTo": "public",
+          "columnsFrom": [
+            "network_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {
+        "frame_centroid_snapshots_corpus_check": {
+          "name": "frame_centroid_snapshots_corpus_check",
+          "value": "corpus = ANY (ARRAY['premise'::text, 'intent'::text, 'user_context'::text])"
+        },
+        "frame_centroid_snapshots_sample_count_check": {
+          "name": "frame_centroid_snapshots_sample_count_check",
+          "value": "sample_count > 0"
+        },
+        "frame_centroid_snapshots_cosine_drift_check": {
+          "name": "frame_centroid_snapshots_cosine_drift_check",
+          "value": "(cosine_drift IS NULL) OR ((cosine_drift >= (0)::double precision) AND (cosine_drift <= (2)::double precision))"
+        },
+        "frame_centroid_snapshots_bucket_range_check": {
+          "name": "frame_centroid_snapshots_bucket_range_check",
+          "value": "bucket_end > bucket_start"
+        }
+      },
+      "policies": {},
+      "isRLSEnabled": false
+    },
+    "public.intents": {
+      "name": "intents",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "payload": {
+          "name": "payload",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "summary": {
+          "name": "summary",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_incognito": {
+          "name": "is_incognito",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "archived_at": {
+          "name": "archived_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_id": {
+          "name": "source_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source_type": {
+          "name": "source_type",
+          "type": "source_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "embedding": {
+          "name": "embedding",
+          "type": "vector(2000)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "semantic_entropy": {
+          "name": "semantic_entropy",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 1
+        },
+        "referential_anchor": {
+          "name": "referential_anchor",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "intent_mode": {
+          "name": "intent_mode",
+          "type": "intent_mode",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'ATTRIBUTIVE'"
+        },
+        "speech_act_type": {
+          "name": "speech_act_type",
+          "type": "speech_act_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "felicity_authority": {
+          "name": "felicity_authority",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "felicity_sincerity": {
+          "name": "felicity_sincerity",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "intent_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'ACTIVE'"
+        },
+        "felicity_clarity": {
+          "name": "felicity_clarity",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_visited_at": {
+          "name": "last_visited_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "first_discovery_succeeded_at": {
+          "name": "first_discovery_succeeded_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "negotiation_batch_id": {
+          "name": "negotiation_batch_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "embeddingIndex": {
+          "name": "embeddingIndex",
+          "columns": [
+            {
+              "expression": "embedding",
+              "asc": true,
+              "nulls": "last",
+              "opclass": "vector_cosine_ops",
+              "isExpression": false
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "hnsw",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "intents_user_id_users_id_fk": {
+          "name": "intents_user_id_users_id_fk",
+          "tableFrom": "intents",
+          "tableTo": "users",
+          "schemaTo": "public",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {},
+      "policies": {},
+      "isRLSEnabled": false
+    },
+    "public.opportunity_outcome_events": {
+      "name": "opportunity_outcome_events",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "recipient_user_id": {
+          "name": "recipient_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "intent_id": {
+          "name": "intent_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "intent_fingerprint": {
+          "name": "intent_fingerprint",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "opportunity_id": {
+          "name": "opportunity_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "network_id": {
+          "name": "network_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "action": {
+          "name": "action",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "candidate_snapshot": {
+          "name": "candidate_snapshot",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "snapshot_hash": {
+          "name": "snapshot_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "dedup_key": {
+          "name": "dedup_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "idempotency_key": {
+          "name": "idempotency_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_opp_outcome_events_scope": {
+          "name": "idx_opp_outcome_events_scope",
+          "columns": [
+            {
+              "expression": "recipient_user_id",
+              "asc": true,
+              "nulls": "last",
+              "opclass": "text_ops",
+              "isExpression": false
+            },
+            {
+              "expression": "intent_id",
+              "asc": true,
+              "nulls": "last",
+              "opclass": "text_ops",
+              "isExpression": false
+            },
+            {
+              "expression": "intent_fingerprint",
+              "asc": true,
+              "nulls": "last",
+              "opclass": "text_ops",
+              "isExpression": false
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "uniq_opp_outcome_events_idempotency": {
+          "name": "uniq_opp_outcome_events_idempotency",
+          "columns": [
+            {
+              "expression": "idempotency_key",
+              "asc": true,
+              "nulls": "last",
+              "opclass": "text_ops",
+              "isExpression": false
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "opportunity_outcome_events_recipient_user_id_users_id_fk": {
+          "name": "opportunity_outcome_events_recipient_user_id_users_id_fk",
+          "tableFrom": "opportunity_outcome_events",
+          "tableTo": "users",
+          "schemaTo": "public",
+          "columnsFrom": [
+            "recipient_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {},
+      "policies": {},
+      "isRLSEnabled": false
+    },
+    "public.frame_drift_execution_attempts": {
+      "name": "frame_drift_execution_attempts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "queue_name": {
+          "name": "queue_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scheduler_id": {
+          "name": "scheduler_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "job_id": {
+          "name": "job_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "job_name": {
+          "name": "job_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scheduled_at": {
+          "name": "scheduled_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "bucket_start": {
+          "name": "bucket_start",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "bucket_end": {
+          "name": "bucket_end",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "attempt": {
+          "name": "attempt",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "max_attempts": {
+          "name": "max_attempts",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "terminal_status": {
+          "name": "terminal_status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "will_retry": {
+          "name": "will_retry",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "failure_category": {
+          "name": "failure_category",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "frame_drift_execution_attempts_bucket_start_idx": {
+          "name": "frame_drift_execution_attempts_bucket_start_idx",
+          "columns": [
+            {
+              "expression": "bucket_start",
+              "asc": true,
+              "nulls": "last",
+              "opclass": "timestamptz_ops",
+              "isExpression": false
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "frame_drift_execution_attempts_incomplete_idx": {
+          "name": "frame_drift_execution_attempts_incomplete_idx",
+          "columns": [
+            {
+              "expression": "started_at",
+              "asc": true,
+              "nulls": "last",
+              "opclass": "timestamptz_ops",
+              "isExpression": false
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "where": "(completed_at IS NULL)",
+          "with": {}
+        },
+        "frame_drift_execution_attempts_job_attempt_uniq": {
+          "name": "frame_drift_execution_attempts_job_attempt_uniq",
+          "columns": [
+            {
+              "expression": "job_id",
+              "asc": true,
+              "nulls": "last",
+              "opclass": "int4_ops",
+              "isExpression": false
+            },
+            {
+              "expression": "attempt",
+              "asc": true,
+              "nulls": "last",
+              "opclass": "int4_ops",
+              "isExpression": false
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {
+        "frame_drift_execution_attempts_identity_check": {
+          "name": "frame_drift_execution_attempts_identity_check",
+          "value": "(length(btrim(queue_name)) > 0) AND (length(btrim(scheduler_id)) > 0) AND (length(btrim(job_id)) > 0) AND (length(btrim(job_name)) > 0)"
+        },
+        "frame_drift_execution_attempts_daily_bucket_check": {
+          "name": "frame_drift_execution_attempts_daily_bucket_check",
+          "value": "(bucket_end = (bucket_start + '1 day'::interval)) AND (date_trunc('day'::text, (bucket_start AT TIME ZONE 'UTC'::text)) = (bucket_start AT TIME ZONE 'UTC'::text)) AND (date_trunc('day'::text, (bucket_end AT TIME ZONE 'UTC'::text)) = (bucket_end AT TIME ZONE 'UTC'::text)) AND (scheduled_at >= bucket_end) AND (scheduled_at < (bucket_end + '1 day'::interval))"
+        },
+        "frame_drift_execution_attempts_attempt_bounds_check": {
+          "name": "frame_drift_execution_attempts_attempt_bounds_check",
+          "value": "((attempt >= 1) AND (attempt <= max_attempts)) AND ((max_attempts >= 1) AND (max_attempts <= 100))"
+        },
+        "frame_drift_execution_attempts_terminal_status_check": {
+          "name": "frame_drift_execution_attempts_terminal_status_check",
+          "value": "(terminal_status IS NULL) OR (terminal_status = ANY (ARRAY['inserted'::text, 'duplicate'::text, 'skipped'::text, 'failed'::text]))"
+        },
+        "frame_drift_execution_attempts_failure_category_check": {
+          "name": "frame_drift_execution_attempts_failure_category_check",
+          "value": "(failure_category IS NULL) OR (failure_category = 'measurement'::text)"
+        },
+        "frame_drift_execution_attempts_terminal_state_check": {
+          "name": "frame_drift_execution_attempts_terminal_state_check",
+          "value": "((terminal_status IS NULL) AND (completed_at IS NULL) AND (will_retry IS NULL) AND (failure_category IS NULL)) OR ((terminal_status = ANY (ARRAY['inserted'::text, 'duplicate'::text, 'skipped'::text])) AND (completed_at IS NOT NULL) AND (completed_at >= started_at) AND (will_retry IS NOT NULL) AND (will_retry = false) AND (failure_category IS NULL)) OR ((terminal_status = 'failed'::text) AND (completed_at IS NOT NULL) AND (completed_at >= started_at) AND (will_retry IS NOT NULL) AND (failure_category IS NOT NULL) AND (failure_category = 'measurement'::text))"
+        }
+      },
+      "policies": {},
+      "isRLSEnabled": false
+    },
+    "public.apikey": {
+      "name": "apikey",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reference_id": {
+          "name": "reference_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "rate_limit_enabled": {
+          "name": "rate_limit_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "request_count": {
+          "name": "request_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "config_id": {
+          "name": "config_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'default'"
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "prefix": {
+          "name": "prefix",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "start": {
+          "name": "start",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "rate_limit_max": {
+          "name": "rate_limit_max",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "rate_limit_time_window": {
+          "name": "rate_limit_time_window",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "remaining": {
+          "name": "remaining",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refill_amount": {
+          "name": "refill_amount",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refill_interval": {
+          "name": "refill_interval",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_refill_at": {
+          "name": "last_refill_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_request": {
+          "name": "last_request",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "permissions": {
+          "name": "permissions",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "apikey_user_id_fkey": {
+          "name": "apikey_user_id_fkey",
+          "tableFrom": "apikey",
+          "tableTo": "users",
+          "schemaTo": "public",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {},
+      "policies": {},
+      "isRLSEnabled": false
+    },
+    "public.messages": {
+      "name": "messages",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "conversation_id": {
+          "name": "conversation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "task_id": {
+          "name": "task_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sender_id": {
+          "name": "sender_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "message_role",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "parts": {
+          "name": "parts",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "extensions": {
+          "name": "extensions",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reference_task_ids": {
+          "name": "reference_task_ids",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "messages_conversation_id_created_at_idx": {
+          "name": "messages_conversation_id_created_at_idx",
+          "columns": [
+            {
+              "expression": "conversation_id",
+              "asc": true,
+              "nulls": "last",
+              "opclass": "text_ops",
+              "isExpression": false
+            },
+            {
+              "expression": "created_at",
+              "asc": true,
+              "nulls": "last",
+              "opclass": "timestamptz_ops",
+              "isExpression": false
+            },
+            {
+              "expression": "id",
+              "asc": true,
+              "nulls": "last",
+              "opclass": "timestamptz_ops",
+              "isExpression": false
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "messages_sender_id_idx": {
+          "name": "messages_sender_id_idx",
+          "columns": [
+            {
+              "expression": "sender_id",
+              "asc": true,
+              "nulls": "last",
+              "opclass": "text_ops",
+              "isExpression": false
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "messages_session_id_created_at_idx": {
+          "name": "messages_session_id_created_at_idx",
+          "columns": [
+            {
+              "expression": "session_id",
+              "asc": true,
+              "nulls": "last",
+              "opclass": "timestamptz_ops",
+              "isExpression": false
+            },
+            {
+              "expression": "created_at",
+              "asc": true,
+              "nulls": "last",
+              "opclass": "text_ops",
+              "isExpression": false
+            },
+            {
+              "expression": "id",
+              "asc": true,
+              "nulls": "last",
+              "opclass": "text_ops",
+              "isExpression": false
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "messages_task_id_idx": {
+          "name": "messages_task_id_idx",
+          "columns": [
+            {
+              "expression": "task_id",
+              "asc": true,
+              "nulls": "last",
+              "opclass": "text_ops",
+              "isExpression": false
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "messages_conversation_id_conversations_id_fk": {
+          "name": "messages_conversation_id_conversations_id_fk",
+          "tableFrom": "messages",
+          "tableTo": "conversations",
+          "schemaTo": "public",
+          "columnsFrom": [
+            "conversation_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "messages_task_id_tasks_id_fk": {
+          "name": "messages_task_id_tasks_id_fk",
+          "tableFrom": "messages",
+          "tableTo": "tasks",
+          "schemaTo": "public",
+          "columnsFrom": [
+            "task_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "messages_session_id_conversation_sessions_id_fk": {
+          "name": "messages_session_id_conversation_sessions_id_fk",
+          "tableFrom": "messages",
+          "tableTo": "conversation_sessions",
+          "schemaTo": "public",
+          "columnsFrom": [
+            "session_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {},
+      "policies": {},
+      "isRLSEnabled": false
+    },
+    "public.conversation_sessions": {
+      "name": "conversation_sessions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "conversation_id": {
+          "name": "conversation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "task_id": {
+          "name": "task_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_message_at": {
+          "name": "last_message_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "conversation_sessions_conversation_started_idx": {
+          "name": "conversation_sessions_conversation_started_idx",
+          "columns": [
+            {
+              "expression": "conversation_id",
+              "asc": true,
+              "nulls": "last",
+              "opclass": "text_ops",
+              "isExpression": false
+            },
+            {
+              "expression": "started_at",
+              "asc": true,
+              "nulls": "last",
+              "opclass": "text_ops",
+              "isExpression": false
+            },
+            {
+              "expression": "id",
+              "asc": true,
+              "nulls": "last",
+              "opclass": "timestamptz_ops",
+              "isExpression": false
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "conversation_sessions_task_id_uniq": {
+          "name": "conversation_sessions_task_id_uniq",
+          "columns": [
+            {
+              "expression": "task_id",
+              "asc": true,
+              "nulls": "last",
+              "opclass": "text_ops",
+              "isExpression": false
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "conversation_sessions_conversation_id_conversations_id_fk": {
+          "name": "conversation_sessions_conversation_id_conversations_id_fk",
+          "tableFrom": "conversation_sessions",
+          "tableTo": "conversations",
+          "schemaTo": "public",
+          "columnsFrom": [
+            "conversation_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "conversation_sessions_task_id_tasks_id_fk": {
+          "name": "conversation_sessions_task_id_tasks_id_fk",
+          "tableFrom": "conversation_sessions",
+          "tableTo": "tasks",
+          "schemaTo": "public",
+          "columnsFrom": [
+            "task_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {},
+      "policies": {},
+      "isRLSEnabled": false
+    },
+    "public.intent_proposals": {
+      "name": "intent_proposals",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "network_id": {
+          "name": "network_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "analysis": {
+          "name": "analysis",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "intent_proposal_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "consumed_at": {
+          "name": "consumed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "consumed_intent_id": {
+          "name": "consumed_intent_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "intent_proposals_expires_at_idx": {
+          "name": "intent_proposals_expires_at_idx",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "asc": true,
+              "nulls": "last",
+              "opclass": "timestamptz_ops",
+              "isExpression": false
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "intent_proposals_user_id_idx": {
+          "name": "intent_proposals_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "asc": true,
+              "nulls": "last",
+              "opclass": "text_ops",
+              "isExpression": false
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "intent_proposals_user_id_users_id_fk": {
+          "name": "intent_proposals_user_id_users_id_fk",
+          "tableFrom": "intent_proposals",
+          "tableTo": "users",
+          "schemaTo": "public",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "intent_proposals_consumed_intent_id_intents_id_fk": {
+          "name": "intent_proposals_consumed_intent_id_intents_id_fk",
+          "tableFrom": "intent_proposals",
+          "tableTo": "intents",
+          "schemaTo": "public",
+          "columnsFrom": [
+            "consumed_intent_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {},
+      "policies": {},
+      "isRLSEnabled": false
+    },
+    "public.signal_intake_packs": {
+      "name": "signal_intake_packs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "brief": {
+          "name": "brief",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "question": {
+          "name": "question",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "premise_hash": {
+          "name": "premise_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "generated_at": {
+          "name": "generated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "signal_intake_packs_user_id_users_id_fk": {
+          "name": "signal_intake_packs_user_id_users_id_fk",
+          "tableFrom": "signal_intake_packs",
+          "tableTo": "users",
+          "schemaTo": "public",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "signal_intake_packs_user_id_unique": {
+          "columns": [
+            "user_id"
+          ],
+          "nullsNotDistinct": false,
+          "name": "signal_intake_packs_user_id_unique"
+        }
+      },
+      "checkConstraints": {},
+      "policies": {},
+      "isRLSEnabled": false
+    },
+    "public.signal_intake_runs": {
+      "name": "signal_intake_runs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "answers_hash": {
+          "name": "answers_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "signal_intake_run_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "proposal_id": {
+          "name": "proposal_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error": {
+          "name": "error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "looking_for": {
+          "name": "looking_for",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "you_bring": {
+          "name": "you_bring",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "signal_intake_runs_created_at_idx": {
+          "name": "signal_intake_runs_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "asc": true,
+              "nulls": "last",
+              "opclass": "timestamptz_ops",
+              "isExpression": false
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "signal_intake_runs_user_answers_uniq": {
+          "name": "signal_intake_runs_user_answers_uniq",
+          "columns": [
+            {
+              "expression": "user_id",
+              "asc": true,
+              "nulls": "last",
+              "opclass": "text_ops",
+              "isExpression": false
+            },
+            {
+              "expression": "answers_hash",
+              "asc": true,
+              "nulls": "last",
+              "opclass": "text_ops",
+              "isExpression": false
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "signal_intake_runs_user_id_idx": {
+          "name": "signal_intake_runs_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "asc": true,
+              "nulls": "last",
+              "opclass": "text_ops",
+              "isExpression": false
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "signal_intake_runs_user_id_users_id_fk": {
+          "name": "signal_intake_runs_user_id_users_id_fk",
+          "tableFrom": "signal_intake_runs",
+          "tableTo": "users",
+          "schemaTo": "public",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {},
+      "policies": {},
+      "isRLSEnabled": false
+    },
+    "public.networks": {
+      "name": "networks",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "prompt": {
+          "name": "prompt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "permissions": {
+          "name": "permissions",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'{\"joinPolicy\":\"invite_only\",\"invitationLink\":null}'::json"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "image_url": {
+          "name": "image_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "master_key_hash": {
+          "name": "master_key_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "request_status": {
+          "name": "request_status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "indexes_key_unique": {
+          "name": "indexes_key_unique",
+          "columns": [
+            {
+              "expression": "key",
+              "asc": true,
+              "nulls": "last",
+              "opclass": "text_ops",
+              "isExpression": false
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {},
+      "policies": {},
+      "isRLSEnabled": false
+    },
+    "public.agents": {
+      "name": "agents",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "owner_id": {
+          "name": "owner_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "type": {
+          "name": "type",
+          "type": "agent_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "agent_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'{}'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_seen_at": {
+          "name": "last_seen_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "notify_on_opportunity": {
+          "name": "notify_on_opportunity",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "daily_summary_enabled": {
+          "name": "daily_summary_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "handle_negotiations": {
+          "name": "handle_negotiations",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "last_daily_summary_at": {
+          "name": "last_daily_summary_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_negotiation_pickup_at": {
+          "name": "last_negotiation_pickup_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "runtime_kind": {
+          "name": "runtime_kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "installation_id": {
+          "name": "installation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "runtime_setup_attempt_id": {
+          "name": "runtime_setup_attempt_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "agents_last_negotiation_pickup_at_idx": {
+          "name": "agents_last_negotiation_pickup_at_idx",
+          "columns": [
+            {
+              "expression": "last_negotiation_pickup_at",
+              "asc": true,
+              "nulls": "last",
+              "opclass": "timestamptz_ops",
+              "isExpression": false
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "agents_last_seen_at_idx": {
+          "name": "agents_last_seen_at_idx",
+          "columns": [
+            {
+              "expression": "last_seen_at",
+              "asc": true,
+              "nulls": "last",
+              "opclass": "timestamptz_ops",
+              "isExpression": false
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "agents_owner_id_idx": {
+          "name": "agents_owner_id_idx",
+          "columns": [
+            {
+              "expression": "owner_id",
+              "asc": true,
+              "nulls": "last",
+              "opclass": "text_ops",
+              "isExpression": false
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "agents_type_idx": {
+          "name": "agents_type_idx",
+          "columns": [
+            {
+              "expression": "type",
+              "asc": true,
+              "nulls": "last",
+              "opclass": "enum_ops",
+              "isExpression": false
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "uniq_agents_hermes_installation": {
+          "name": "uniq_agents_hermes_installation",
+          "columns": [
+            {
+              "expression": "owner_id",
+              "asc": true,
+              "nulls": "last",
+              "opclass": "text_ops",
+              "isExpression": false
+            },
+            {
+              "expression": "runtime_kind",
+              "asc": true,
+              "nulls": "last",
+              "opclass": "text_ops",
+              "isExpression": false
+            },
+            {
+              "expression": "installation_id",
+              "asc": true,
+              "nulls": "last",
+              "opclass": "text_ops",
+              "isExpression": false
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "where": "((type = 'external'::agent_type) AND (runtime_kind = 'hermes'::text) AND (installation_id IS NOT NULL) AND (deleted_at IS NULL))",
+          "with": {}
+        },
+        "uniq_agents_personal_per_owner": {
+          "name": "uniq_agents_personal_per_owner",
+          "columns": [
+            {
+              "expression": "owner_id",
+              "asc": true,
+              "nulls": "last",
+              "opclass": "text_ops",
+              "isExpression": false
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "where": "((type = 'personal'::agent_type) AND (deleted_at IS NULL))",
+          "with": {}
+        },
+        "uniq_agents_selected_negotiation_executor": {
+          "name": "uniq_agents_selected_negotiation_executor",
+          "columns": [
+            {
+              "expression": "owner_id",
+              "asc": true,
+              "nulls": "last",
+              "opclass": "text_ops",
+              "isExpression": false
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "where": "((type = 'external'::agent_type) AND (handle_negotiations = true) AND (deleted_at IS NULL))",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "agents_owner_id_users_id_fk": {
+          "name": "agents_owner_id_users_id_fk",
+          "tableFrom": "agents",
+          "tableTo": "users",
+          "schemaTo": "public",
+          "columnsFrom": [
+            "owner_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {},
+      "policies": {},
+      "isRLSEnabled": false
+    },
+    "public.network_integrations": {
+      "name": "network_integrations",
+      "schema": "",
+      "columns": {
+        "network_id": {
+          "name": "network_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "toolkit": {
+          "name": "toolkit",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "connected_account_id": {
+          "name": "connected_account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "sync_config": {
+          "name": "sync_config",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "network_integrations_network_id_networks_id_fk": {
+          "name": "network_integrations_network_id_networks_id_fk",
+          "tableFrom": "network_integrations",
+          "tableTo": "networks",
+          "schemaTo": "public",
+          "columnsFrom": [
+            "network_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "network_integrations_network_id_toolkit_pk": {
+          "name": "network_integrations_network_id_toolkit_pk",
+          "columns": [
+            "network_id",
+            "toolkit"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {},
+      "policies": {},
+      "isRLSEnabled": false
+    },
+    "public.intent_networks": {
+      "name": "intent_networks",
+      "schema": "",
+      "columns": {
+        "intent_id": {
+          "name": "intent_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "network_id": {
+          "name": "network_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "relevancy_score": {
+          "name": "relevancy_score",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "assignment_metadata": {
+          "name": "assignment_metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "intent_networks_network_id_idx": {
+          "name": "intent_networks_network_id_idx",
+          "columns": [
+            {
+              "expression": "network_id",
+              "asc": true,
+              "nulls": "last",
+              "opclass": "text_ops",
+              "isExpression": false
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "intent_networks_intent_id_intents_id_fk": {
+          "name": "intent_networks_intent_id_intents_id_fk",
+          "tableFrom": "intent_networks",
+          "tableTo": "intents",
+          "schemaTo": "public",
+          "columnsFrom": [
+            "intent_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "intent_networks_network_id_networks_id_fk": {
+          "name": "intent_networks_network_id_networks_id_fk",
+          "tableFrom": "intent_networks",
+          "tableTo": "networks",
+          "schemaTo": "public",
+          "columnsFrom": [
+            "network_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "intent_networks_intent_id_network_id_pk": {
+          "name": "intent_networks_intent_id_network_id_pk",
+          "columns": [
+            "intent_id",
+            "network_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {},
+      "policies": {},
+      "isRLSEnabled": false
+    },
+    "public.premise_networks": {
+      "name": "premise_networks",
+      "schema": "",
+      "columns": {
+        "premise_id": {
+          "name": "premise_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "network_id": {
+          "name": "network_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "relevancy_score": {
+          "name": "relevancy_score",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "assignment_metadata": {
+          "name": "assignment_metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "premise_networks_network_id_idx": {
+          "name": "premise_networks_network_id_idx",
+          "columns": [
+            {
+              "expression": "network_id",
+              "asc": true,
+              "nulls": "last",
+              "opclass": "text_ops",
+              "isExpression": false
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "premise_networks_premise_id_premises_id_fk": {
+          "name": "premise_networks_premise_id_premises_id_fk",
+          "tableFrom": "premise_networks",
+          "tableTo": "premises",
+          "schemaTo": "public",
+          "columnsFrom": [
+            "premise_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "premise_networks_network_id_networks_id_fk": {
+          "name": "premise_networks_network_id_networks_id_fk",
+          "tableFrom": "premise_networks",
+          "tableTo": "networks",
+          "schemaTo": "public",
+          "columnsFrom": [
+            "network_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "premise_networks_premise_id_network_id_pk": {
+          "name": "premise_networks_premise_id_network_id_pk",
+          "columns": [
+            "premise_id",
+            "network_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {},
+      "policies": {},
+      "isRLSEnabled": false
+    },
+    "public.conversation_participants": {
+      "name": "conversation_participants",
+      "schema": "",
+      "columns": {
+        "conversation_id": {
+          "name": "conversation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "participant_id": {
+          "name": "participant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "participant_type": {
+          "name": "participant_type",
+          "type": "participant_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "joined_at": {
+          "name": "joined_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "hidden_at": {
+          "name": "hidden_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_read_at": {
+          "name": "last_read_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "conversation_participants_conversation_id_idx": {
+          "name": "conversation_participants_conversation_id_idx",
+          "columns": [
+            {
+              "expression": "conversation_id",
+              "asc": true,
+              "nulls": "last",
+              "opclass": "text_ops",
+              "isExpression": false
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "conversation_participants_participant_id_idx": {
+          "name": "conversation_participants_participant_id_idx",
+          "columns": [
+            {
+              "expression": "participant_id",
+              "asc": true,
+              "nulls": "last",
+              "opclass": "text_ops",
+              "isExpression": false
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "conversation_participants_conversation_id_conversations_id_fk": {
+          "name": "conversation_participants_conversation_id_conversations_id_fk",
+          "tableFrom": "conversation_participants",
+          "tableTo": "conversations",
+          "schemaTo": "public",
+          "columnsFrom": [
+            "conversation_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "conversation_participants_conversation_id_participant_id_pk": {
+          "name": "conversation_participants_conversation_id_participant_id_pk",
+          "columns": [
+            "conversation_id",
+            "participant_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {},
+      "policies": {},
+      "isRLSEnabled": false
+    },
+    "public.network_members": {
+      "name": "network_members",
+      "schema": "",
+      "columns": {
+        "network_id": {
+          "name": "network_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "permissions": {
+          "name": "permissions",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{\"\"}'"
+        },
+        "prompt": {
+          "name": "prompt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "auto_assign": {
+          "name": "auto_assign",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "network_members_network_id_networks_id_fk": {
+          "name": "network_members_network_id_networks_id_fk",
+          "tableFrom": "network_members",
+          "tableTo": "networks",
+          "schemaTo": "public",
+          "columnsFrom": [
+            "network_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "network_members_user_id_users_id_fk": {
+          "name": "network_members_user_id_users_id_fk",
+          "tableFrom": "network_members",
+          "tableTo": "users",
+          "schemaTo": "public",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "network_members_network_id_user_id_pk": {
+          "name": "network_members_network_id_user_id_pk",
+          "columns": [
+            "network_id",
+            "user_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {},
+      "policies": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.agent_status": {
+      "name": "agent_status",
+      "values": [
+        "active",
+        "inactive"
+      ],
+      "schema": "public"
+    },
+    "public.agent_type": {
+      "name": "agent_type",
+      "values": [
+        "personal",
+        "external",
+        "system"
+      ],
+      "schema": "public"
+    },
+    "public.intent_discovery_progress_status": {
+      "name": "intent_discovery_progress_status",
+      "values": [
+        "queued",
+        "running",
+        "succeeded",
+        "failed",
+        "blocked"
+      ],
+      "schema": "public"
+    },
+    "public.intent_dossier_source": {
+      "name": "intent_dossier_source",
+      "values": [
+        "user_message",
+        "answer",
+        "agent_note"
+      ],
+      "schema": "public"
+    },
+    "public.intent_mode": {
+      "name": "intent_mode",
+      "values": [
+        "REFERENTIAL",
+        "ATTRIBUTIVE"
+      ],
+      "schema": "public"
+    },
+    "public.intent_proposal_status": {
+      "name": "intent_proposal_status",
+      "values": [
+        "pending",
+        "consumed",
+        "rejected"
+      ],
+      "schema": "public"
+    },
+    "public.intent_status": {
+      "name": "intent_status",
+      "values": [
+        "ACTIVE",
+        "PAUSED",
+        "FULFILLED",
+        "EXPIRED"
+      ],
+      "schema": "public"
+    },
+    "public.message_role": {
+      "name": "message_role",
+      "values": [
+        "user",
+        "agent"
+      ],
+      "schema": "public"
+    },
+    "public.negotiation_round_log_event_kind": {
+      "name": "negotiation_round_log_event_kind",
+      "values": [
+        "opened",
+        "stopped",
+        "resumed",
+        "opening_complete"
+      ],
+      "schema": "public"
+    },
+    "public.negotiation_round_log_event_via": {
+      "name": "negotiation_round_log_event_via",
+      "values": [
+        "paused",
+        "completed"
+      ],
+      "schema": "public"
+    },
+    "public.opportunity_status": {
+      "name": "opportunity_status",
+      "values": [
+        "negotiating",
+        "pending",
+        "stalled",
+        "accepted",
+        "rejected",
+        "expired"
+      ],
+      "schema": "public"
+    },
+    "public.participant_type": {
+      "name": "participant_type",
+      "values": [
+        "user",
+        "agent"
+      ],
+      "schema": "public"
+    },
+    "public.permission_scope": {
+      "name": "permission_scope",
+      "values": [
+        "global",
+        "node",
+        "network"
+      ],
+      "schema": "public"
+    },
+    "public.premise_status": {
+      "name": "premise_status",
+      "values": [
+        "ACTIVE",
+        "RETRACTED",
+        "EXPIRED"
+      ],
+      "schema": "public"
+    },
+    "public.question_status": {
+      "name": "question_status",
+      "values": [
+        "pending",
+        "answered",
+        "dismissed"
+      ],
+      "schema": "public"
+    },
+    "public.signal_intake_run_status": {
+      "name": "signal_intake_run_status",
+      "values": [
+        "pending",
+        "ready",
+        "failed"
+      ],
+      "schema": "public"
+    },
+    "public.source_type": {
+      "name": "source_type",
+      "values": [
+        "integration",
+        "discovery_form",
+        "enrichment"
+      ],
+      "schema": "public"
+    },
+    "public.speech_act_type": {
+      "name": "speech_act_type",
+      "values": [
+        "COMMISSIVE",
+        "DIRECTIVE"
+      ],
+      "schema": "public"
+    },
+    "public.task_state": {
+      "name": "task_state",
+      "values": [
+        "submitted",
+        "working",
+        "completed",
+        "failed",
+        "canceled",
+        "rejected",
+        "auth_required",
+        "waiting_for_agent",
+        "claimed",
+        "paused"
+      ],
+      "schema": "public"
+    },
+    "public.transport_channel": {
+      "name": "transport_channel",
+      "values": [
+        "mcp"
+      ],
+      "schema": "public"
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "schemas": {},
+    "tables": {},
+    "columns": {}
+  },
+  "internal": {
+    "tables": {
+      "agent_permissions": {
+        "columns": {
+          "actions": {
+            "isArray": true,
+            "dimensions": 1,
+            "rawType": "text"
+          }
+        }
+      },
+      "network_members": {
+        "columns": {
+          "permissions": {
+            "isArray": true,
+            "dimensions": 1,
+            "rawType": "text"
+          }
+        }
+      }
+    }
+  }
+}

--- a/services/api/drizzle/meta/_journal.json
+++ b/services/api/drizzle/meta/_journal.json
@@ -1058,6 +1058,27 @@
       "when": 1786886087831,
       "tag": "0153_dismiss_retired_pool_discovery_questions",
       "breakpoints": true
+    },
+    {
+      "idx": 154,
+      "version": "7",
+      "when": 1787861836036,
+      "tag": "0154_add_negotiation_round_log_events",
+      "breakpoints": true
+    },
+    {
+      "idx": 155,
+      "version": "7",
+      "when": 1787948236037,
+      "tag": "0155_drop_orphaned_tables",
+      "breakpoints": true
+    },
+    {
+      "idx": 156,
+      "version": "7",
+      "when": 1788034636038,
+      "tag": "0156_negotiation_batch_cutover",
+      "breakpoints": true
     }
   ]
 }

--- a/services/api/src/adapters/chat.database.adapter.ts
+++ b/services/api/src/adapters/chat.database.adapter.ts
@@ -55,7 +55,7 @@ export class ChatDatabaseAdapter {
 
   // Negotiation context methods — required by RadarGraphDatabase
   async getNegotiationTaskForOpportunity(opportunityId: string) { return _convDb().getNegotiationTaskForOpportunity(opportunityId); }
-  async bumpIntentNegotiationRound(intentId: string) { return _convDb().bumpIntentNegotiationRound(intentId); }
+  async bumpIntentNegotiationBatch(intentId: string) { return _convDb().bumpIntentNegotiationBatch(intentId); }
   async getNegotiationTasksForOpportunity(opportunityId: string) { return _convDb().getNegotiationTasksForOpportunity(opportunityId); }
   async getMessagesForConversation(conversationId: string) { return _convDb().getMessagesForConversation(conversationId); }
   async getNegotiationMessages(opportunityId: string) { return _convDb().getNegotiationMessages(opportunityId); }

--- a/services/api/src/adapters/conversation.database.adapter.ts
+++ b/services/api/src/adapters/conversation.database.adapter.ts
@@ -29,8 +29,7 @@ type NegotiationTaskMetadataMirror = {
   initiatorUserId: string;
   networkId: string;
   /** One binding per seat, keyed by intent id — the protocol's `seats`. */
-  seats: Record<string, { userId: string; round: number }>;
-  drainGeneration: number;
+  seats: Record<string, { userId: string; batchId: string | null }>;
   pause?: { reason: NegotiationPauseReason; payload?: unknown; pausedBy?: string; failure?: string; failureDetail?: string } | null;
 };
 
@@ -2001,14 +2000,14 @@ export class ConversationDatabaseAdapter {
    * payload never leave the graph boundary through this read.
    */
   async getIntentCycleForIntent(userId: string, intentId: string): Promise<{
-    round: { number: number; size: number | null; kickoffStartedAt: Date | null; active: number; paused: number };
+    batch: { id: string | null; active: number; paused: number };
     negotiations: Array<{
       taskId: string;
       conversationId: string;
       opportunityId: string;
       opportunityStatus: string;
       counterpartLabel: string;
-      round: number;
+      batchId: string | null;
       state: string;
       pause: { reason: NegotiationPauseReason; by: 'yours' | 'theirs' | null } | null;
       latestActivity: { actor: 'yours' | 'theirs'; verb: string | null; text: string | null; createdAt: Date } | null;
@@ -2017,9 +2016,7 @@ export class ConversationDatabaseAdapter {
     const [ownedIntent] = await db
       .select({
         id: schema.intents.id,
-        round: schema.intents.negotiationRound,
-        roundSize: schema.intents.negotiationRoundSize,
-        kickoffStartedAt: schema.intents.negotiationKickoffStartedAt,
+        batchId: schema.intents.negotiationBatchId,
       })
       .from(schema.intents)
       .where(and(eq(schema.intents.id, intentId), eq(schema.intents.userId, userId)))
@@ -2091,7 +2088,7 @@ export class ConversationDatabaseAdapter {
         opportunityId: opportunity.id,
         opportunityStatus: opportunity.status,
         counterpartLabel: counterpartById.get(counterpartId ?? '')?.name?.trim() || 'Unknown counterpart',
-        round: task.seat.round,
+        batchId: task.seat.batchId,
         state: task.state,
         pause: pauseReason
           ? { reason: pauseReason, by: pauseBy }
@@ -2101,14 +2098,12 @@ export class ConversationDatabaseAdapter {
       }];
     }).sort((left, right) => right.updatedAt.getTime() - left.updatedAt.getTime() || left.taskId.localeCompare(right.taskId));
 
-    const currentRound = negotiations.filter((negotiation) => negotiation.round === ownedIntent.round);
+    const currentBatch = negotiations.filter((negotiation) => negotiation.batchId === ownedIntent.batchId);
     return {
-      round: {
-        number: ownedIntent.round,
-        size: ownedIntent.roundSize,
-        kickoffStartedAt: ownedIntent.kickoffStartedAt,
-        active: currentRound.filter((negotiation) => negotiation.state === 'submitted' || negotiation.state === 'working').length,
-        paused: currentRound.filter((negotiation) => negotiation.state === 'paused').length,
+      batch: {
+        id: ownedIntent.batchId,
+        active: currentBatch.filter((negotiation) => negotiation.state === 'submitted' || negotiation.state === 'working').length,
+        paused: currentBatch.filter((negotiation) => negotiation.state === 'paused').length,
       },
       negotiations,
     };
@@ -2123,7 +2118,7 @@ export class ConversationDatabaseAdapter {
     opportunityId: string;
     opportunityStatus: string;
     counterpartLabel: string;
-    round: number;
+    batchId: string | null;
     state: string;
     pause: { reason: NegotiationPauseReason; by: 'yours' | 'theirs' | null } | null;
     latestActivity: { actor: 'yours' | 'theirs'; verb: string | null; createdAt: Date | null };
@@ -2203,7 +2198,7 @@ export class ConversationDatabaseAdapter {
         opportunityId: opportunity.id,
         opportunityStatus: opportunity.status,
         counterpartLabel: counterpartById.get(counterpartId ?? '')?.name?.trim() || 'Unknown counterpart',
-        round: seat.seat.round,
+        batchId: seat.seat.batchId,
         state: seat.state,
         pause: pauseReason
           ? { reason: pauseReason, by: pauseBy }
@@ -2260,7 +2255,7 @@ export class ConversationDatabaseAdapter {
       id: string;
       conversationId: string;
       opportunityId: string;
-      round: number;
+      batchId: string | null;
       state: string;
       brief: string | null;
       updatedAt: Date;
@@ -2336,7 +2331,7 @@ export class ConversationDatabaseAdapter {
         id: task.id,
         conversationId: task.conversationId,
         opportunityId: metadata.opportunityId,
-        round: seat.round,
+        batchId: seat.batchId,
         state: task.state,
         updatedAt: task.updatedAt,
         brief: typeof (task.briefs as Record<string, unknown> | null)?.[userId] === 'string'
@@ -2488,7 +2483,7 @@ export class ConversationDatabaseAdapter {
     sourceUserId: string;
     candidateUserId: string;
     brief: string;
-    seats: Record<string, { userId: string; round: number }>;
+    seats: Record<string, { userId: string; batchId: string | null }>;
     networkId: string;
     knownTaskId?: string;
   }): Promise<{ task: NegotiationTaskRowMirror; disposition: 'created' | 'existing' | 'raced' } | null> {
@@ -2551,7 +2546,6 @@ export class ConversationDatabaseAdapter {
           initiatorUserId: input.sourceUserId,
           networkId: input.networkId,
           seats: input.seats,
-          drainGeneration: 0,
         },
       }).returning();
       if (!task) throw new Error('Failed to create negotiation task');
@@ -2659,17 +2653,7 @@ export class ConversationDatabaseAdapter {
       .set({
         state,
         ...(state === 'working' ? {
-          metadata: sql`jsonb_set(
-            jsonb_set(coalesce(${schema.tasks.metadata}, '{}'::jsonb), '{pause}', 'null'::jsonb, true),
-            '{drainGeneration}',
-            to_jsonb(
-              CASE WHEN ${schema.tasks.state} = 'paused'
-                THEN coalesce((${schema.tasks.metadata}->>'drainGeneration')::int, 0) + 1
-                ELSE coalesce((${schema.tasks.metadata}->>'drainGeneration')::int, 0)
-              END
-            ),
-            true
-          )`,
+          metadata: sql`jsonb_set(coalesce(${schema.tasks.metadata}, '{}'::jsonb), '{pause}', 'null'::jsonb, true)`,
         } : pause !== undefined ? {
           metadata: sql`jsonb_set(coalesce(${schema.tasks.metadata}, '{}'::jsonb), '{pause}', ${JSON.stringify(pause ?? null)}::jsonb, true)`,
         } : {}),
@@ -2847,7 +2831,7 @@ export class ConversationDatabaseAdapter {
    * kickoff clobber the other's binding — the very thing per-seat exists to
    * make impossible.
    */
-  async bindNegotiationSeat(taskId: string, intentId: string, binding: { userId: string; round: number }): Promise<void> {
+  async bindNegotiationSeat(taskId: string, intentId: string, binding: { userId: string; batchId: string | null }): Promise<void> {
     await db.update(schema.tasks).set({
       metadata: sql`jsonb_set(
         jsonb_set(coalesce(${schema.tasks.metadata}, '{}'::jsonb), '{seats}', coalesce(${schema.tasks.metadata}->'seats', '{}'::jsonb), true),
@@ -2981,83 +2965,70 @@ export class ConversationDatabaseAdapter {
    * the beginning of a kickoff and there is no window in which a crash could
    * leave a round begun-but-unmarked.
    */
-  async bumpIntentNegotiationRound(intentId: string): Promise<number> {
-    const [row] = await db
+  async bumpIntentNegotiationBatch(intentId: string): Promise<{ batchId: string }> {
+    const batchId = crypto.randomUUID();
+    await db
       .update(schema.intents)
-      .set({
-        negotiationRound: sql`${schema.intents.negotiationRound} + 1`,
-        negotiationRoundSize: null,
-        negotiationKickoffStartedAt: new Date(),
-      })
-      .where(eq(schema.intents.id, intentId))
-      .returning({ negotiationRound: schema.intents.negotiationRound });
-    return row?.negotiationRound ?? 0;
+      .set({ negotiationBatchId: batchId })
+      .where(eq(schema.intents.id, intentId));
+    return { batchId };
   }
 
   /**
-   * The intent's round lifecycle. `kickoffStartedAt` set with a null
-   * `roundSize` is the ONE signature of a kickoff that died mid-round; a null
-   * marker means no kickoff has ever run here, which is where every intent
-   * predating 0146/0147 sits.
+   * The intent's current kickoff batch id, or null if no kickoff has ever run
+   * for this signal (including every intent that predates this column).
    */
-  async getIntentNegotiationRound(intentId: string): Promise<{ round: number; roundSize: number | null; kickoffStartedAt: Date | null }> {
+  async getIntentNegotiationBatch(intentId: string): Promise<{ batchId: string | null }> {
     const [row] = await db
-      .select({
-        round: schema.intents.negotiationRound,
-        roundSize: schema.intents.negotiationRoundSize,
-        kickoffStartedAt: schema.intents.negotiationKickoffStartedAt,
-      })
+      .select({ batchId: schema.intents.negotiationBatchId })
       .from(schema.intents)
       .where(eq(schema.intents.id, intentId));
-    return { round: row?.round ?? 0, roundSize: row?.roundSize ?? null, kickoffStartedAt: row?.kickoffStartedAt ?? null };
+    return { batchId: row?.batchId ?? null };
   }
 
   /**
-   * Signals whose current round began but never finished settling — a
-   * kickoff that was interrupted (crash, restart) before it could stamp
-   * `negotiationRoundSize` or hand off to reflect. `runKickoff`'s own
-   * `interruptedRound` repair already knows how to settle these; it just
+   * Signals whose current batch began but never finished settling — a
+   * kickoff that was interrupted (crash, restart) before it could append its
+   * `opening_complete` round-log marker. A batch with no events at all yet
+   * (crashed before its first `opened` event landed) is excluded: there is no
+   * event timestamp to judge staleness by, and that window is narrow (opens
+   * follow the bump within the same turn). `runKickoff`'s own
+   * `interruptedBatch` repair already knows how to settle these; it just
    * needs a fresh wake to run it, which is what this list is for.
    */
   async getIntentsWithInterruptedKickoff(staleBeforeMs: number): Promise<Array<{ id: string; userId: string }>> {
     const cutoff = new Date(Date.now() - staleBeforeMs);
-    const rows = await db
-      .select({ id: schema.intents.id, userId: schema.intents.userId })
-      .from(schema.intents)
-      .where(and(
-        eq(schema.intents.status, 'ACTIVE'),
-        isNull(schema.intents.negotiationRoundSize),
-        lt(schema.intents.negotiationKickoffStartedAt, cutoff),
-      ));
-    return rows;
+    const result = await db.execute(sql`
+      SELECT i.id, i.user_id AS "userId"
+      FROM intents i
+      WHERE i.status = 'ACTIVE'
+        AND i.negotiation_batch_id IS NOT NULL
+        AND NOT EXISTS (
+          SELECT 1 FROM negotiation_round_log_events e
+          WHERE e.intent_id = i.id AND e.batch_id = i.negotiation_batch_id AND e.kind = 'opening_complete'
+        )
+        AND EXISTS (
+          SELECT 1 FROM negotiation_round_log_events e2
+          WHERE e2.intent_id = i.id AND e2.batch_id = i.negotiation_batch_id
+          HAVING max(e2.created_at) < ${cutoff}
+        )
+    `);
+    return result as unknown as Array<{ id: string; userId: string }>;
   }
 
   /**
-   * Settles a round: records how many negotiations it holds. Guarded on the
-   * round itself, so a kickoff that lost a race to a newer round cannot stamp
-   * the newer one's size with its own count. The value is a record; what the
-   * all-paused check reads is that it is no longer null.
+   * Every negotiation task of one intent's batch, whatever its state — what
+   * reflect reads. The `batchId` key is also the rewrite-era predicate: a
+   * pre-rewrite task has no `batchId` in its metadata and can never match.
    */
-  async stampIntentNegotiationRoundSize(intentId: string, round: number, size: number): Promise<void> {
-    await db
-      .update(schema.intents)
-      .set({ negotiationRoundSize: size })
-      .where(and(eq(schema.intents.id, intentId), eq(schema.intents.negotiationRound, round)));
-  }
-
-  /**
-   * Every negotiation task of one intent's round, whatever its state — what
-   * reflect reads. The `round` key is also the rewrite-era predicate: a
-   * pre-rewrite task has no `round` in its metadata and can never match.
-   */
-  async getNegotiationTasksForIntentRound(intentId: string, round: number): Promise<NegotiationTaskRowMirror[]> {
+  async getNegotiationTasksForIntentBatch(intentId: string, batchId: string): Promise<NegotiationTaskRowMirror[]> {
     const rows = await db
       .select()
       .from(schema.tasks)
       .where(
         and(
           sql`${schema.tasks.metadata}->>'type' = 'negotiation'`,
-          sql`(${schema.tasks.metadata}->'seats'->${intentId}->>'round')::int = ${round}`,
+          sql`${schema.tasks.metadata}->'seats'->${intentId}->>'batchId' = ${batchId}`,
           notArchivedNegotiationTaskWhere(),
         ),
       )
@@ -3065,17 +3036,17 @@ export class ConversationDatabaseAdapter {
     return rows.map((row) => toNegotiationTaskRow(row));
   }
 
-  /** Count of this intent's round-`round` negotiations not yet `paused` or `completed`. */
-  async countActiveNegotiationsForRound(intentId: string, round: number): Promise<number> {
+  /** Count of this intent's batch-`batchId` negotiations not yet `paused` or `completed`. */
+  async countActiveNegotiationsForBatch(intentId: string, batchId: string): Promise<number> {
     const [row] = await db
       .select({ value: count() })
       .from(schema.tasks)
       .where(
         and(
           sql`${schema.tasks.metadata}->>'type' = 'negotiation'`,
-          sql`(${schema.tasks.metadata}->'seats'->${intentId}->>'round')::int = ${round}`,
+          sql`${schema.tasks.metadata}->'seats'->${intentId}->>'batchId' = ${batchId}`,
           notInArray(schema.tasks.state, ['paused', 'completed']),
-          // The same predicate `getNegotiationTasksForIntentRound` applies:
+          // The same predicate `getNegotiationTasksForIntentBatch` applies:
           // an archived task stuck in an active state would hold this count above
           // zero forever, stalling the signal's cycle, while being invisible
           // in the paused set the agent actually reasons over.

--- a/services/api/src/adapters/negotiation-round-log.database.adapter.ts
+++ b/services/api/src/adapters/negotiation-round-log.database.adapter.ts
@@ -1,0 +1,65 @@
+/**
+ * Adapter for `@indexnetwork/protocol`'s `NegotiationRoundLogDatabase` port
+ * (negotiation round-log refactor, #1494).
+ *
+ * Append-only: append writes one row, read returns a batch's rows in append
+ * order — the order `foldNegotiationRoundLog` requires.
+ *
+ * Adapters may not import from `@indexnetwork/protocol` (see the lint rule),
+ * so `NegotiationRoundLogEventRecord` is a local structural mirror of the
+ * protocol's type of the same name; compatibility is verified by TypeScript
+ * duck typing at the composition root.
+ */
+
+import { and, asc, eq } from 'drizzle-orm/sql';
+
+import db from '../lib/drizzle/drizzle';
+import * as schema from '../schemas/database.schema';
+
+export interface NegotiationRoundLogEventRecord {
+  kind: 'opened' | 'stopped' | 'resumed' | 'opening_complete';
+  /** Absent only for 'opening_complete', which has no task. */
+  taskId?: string;
+  batchId: string;
+  /** Only set on 'stopped' events. */
+  via?: 'paused' | 'completed';
+  /** Only set on 'stopped' events whose `via` is 'paused'. */
+  reason?: string;
+  /** When this event was appended — the staleness clock for an in-flight batch. */
+  createdAt: Date;
+}
+
+export class NegotiationRoundLogDatabaseAdapter {
+  async appendNegotiationRoundLogEvent(intentId: string, event: Omit<NegotiationRoundLogEventRecord, 'createdAt'>): Promise<void> {
+    await db.insert(schema.negotiationRoundLogEvents).values({
+      intentId,
+      batchId: event.batchId,
+      taskId: event.taskId ?? null,
+      kind: event.kind,
+      via: event.via ?? null,
+      reason: event.reason ?? null,
+    });
+  }
+
+  async readNegotiationRoundLogEvents(intentId: string, batchId: string): Promise<NegotiationRoundLogEventRecord[]> {
+    const rows = await db
+      .select()
+      .from(schema.negotiationRoundLogEvents)
+      .where(and(
+        eq(schema.negotiationRoundLogEvents.intentId, intentId),
+        eq(schema.negotiationRoundLogEvents.batchId, batchId),
+      ))
+      .orderBy(asc(schema.negotiationRoundLogEvents.createdAt), asc(schema.negotiationRoundLogEvents.id));
+
+    return rows.map((row) => ({
+      kind: row.kind,
+      batchId: row.batchId,
+      createdAt: row.createdAt,
+      ...(row.taskId ? { taskId: row.taskId } : {}),
+      ...(row.via ? { via: row.via } : {}),
+      ...(row.reason ? { reason: row.reason } : {}),
+    }));
+  }
+}
+
+export const negotiationRoundLogDatabaseAdapter = new NegotiationRoundLogDatabaseAdapter();

--- a/services/api/src/adapters/tests/adapter-interface-alignment.spec.ts
+++ b/services/api/src/adapters/tests/adapter-interface-alignment.spec.ts
@@ -23,6 +23,8 @@ import type { LensEmbedding as ProtocolLensEmbedding, HydeSearchOptions as Proto
 
 import type { UserDatabase as ProtocolUserDatabase, SystemDatabase as ProtocolSystemDatabase } from '@indexnetwork/protocol';
 
+import type { NegotiationRoundLogEventRecord as ProtocolNegotiationRoundLogEventRecord } from '@indexnetwork/protocol';
+
 
 // ─────────────────────────────────────────────────────────────────────────────
 // Adapter local types (the structurally-aligned copies)
@@ -32,6 +34,8 @@ import type { Cache as AdapterCache, CacheOptions as AdapterCacheOptions } from 
 import type { LensEmbedding as AdapterLensEmbedding, HydeSearchOptions as AdapterHydeSearchOptions, HydeCandidate as AdapterHydeCandidate, VectorSearchResult as AdapterVectorSearchResult, VectorStoreOption as AdapterVectorStoreOption } from '../embedder.adapter';
 
 import { createUserDatabase, createSystemDatabase } from '../database.adapter';
+
+import type { NegotiationRoundLogEventRecord as AdapterNegotiationRoundLogEventRecord } from '../negotiation-round-log.database.adapter';
 
 
 // ═══════════════════════════════════════════════════════════════════════════════
@@ -130,6 +134,22 @@ describe('Database adapter ↔ protocol interface alignment', () => {
   it('createSystemDatabase return type is assignable to protocol SystemDatabase', () => {
     type SystemDbReturn = ReturnType<typeof createSystemDatabase>;
     const check: (_: SystemDbReturn) => ProtocolSystemDatabase = (v) => v;
+    expect(check).toBeDefined();
+  });
+});
+
+// ═══════════════════════════════════════════════════════════════════════════════
+// NEGOTIATION ROUND LOG ADAPTER ALIGNMENT
+// ═══════════════════════════════════════════════════════════════════════════════
+
+describe('Negotiation round log adapter ↔ protocol interface alignment', () => {
+  it('NegotiationRoundLogEventRecord: adapter → protocol', () => {
+    const check: (_: AdapterNegotiationRoundLogEventRecord) => ProtocolNegotiationRoundLogEventRecord = (v) => v;
+    expect(check).toBeDefined();
+  });
+
+  it('NegotiationRoundLogEventRecord: protocol → adapter', () => {
+    const check: (_: ProtocolNegotiationRoundLogEventRecord) => AdapterNegotiationRoundLogEventRecord = (v) => v;
     expect(check).toBeDefined();
   });
 });

--- a/services/api/src/adapters/tests/conversation.database.adapter.spec.ts
+++ b/services/api/src/adapters/tests/conversation.database.adapter.spec.ts
@@ -244,14 +244,14 @@ describe('ConversationDatabaseAdapter', () => {
       createdIds.push(conv.id);
 
       const staleSubmitted = await adapter.createTask(conv.id, {
-        type: 'negotiation', opportunityId: 'watchdog-opportunity-submitted', sourceUserId: 'watchdog-user', seats: { 'watchdog-intent': { userId: 'watchdog-user', round: 1 } },
+        type: 'negotiation', opportunityId: 'watchdog-opportunity-submitted', sourceUserId: 'watchdog-user', seats: { 'watchdog-intent': { userId: 'watchdog-user', batchId: 'batch-1' } },
       });
       const staleWorking = await adapter.createTask(conv.id, {
-        type: 'negotiation', opportunityId: 'watchdog-opportunity-working', sourceUserId: 'watchdog-user', seats: { 'watchdog-intent': { userId: 'watchdog-user', round: 1 } },
+        type: 'negotiation', opportunityId: 'watchdog-opportunity-working', sourceUserId: 'watchdog-user', seats: { 'watchdog-intent': { userId: 'watchdog-user', batchId: 'batch-1' } },
       });
       await adapter.updateTaskState(staleWorking.id, 'working');
       const freshSubmitted = await adapter.createTask(conv.id, {
-        type: 'negotiation', opportunityId: 'watchdog-opportunity-fresh', sourceUserId: 'watchdog-user', seats: { 'watchdog-intent': { userId: 'watchdog-user', round: 1 } },
+        type: 'negotiation', opportunityId: 'watchdog-opportunity-fresh', sourceUserId: 'watchdog-user', seats: { 'watchdog-intent': { userId: 'watchdog-user', batchId: 'batch-1' } },
       });
       const terminalOpportunityId = `watchdog-terminal-${crypto.randomUUID()}`;
       await db.insert(schema.opportunities).values({
@@ -265,7 +265,7 @@ describe('ConversationDatabaseAdapter', () => {
       });
       createdOpportunityIds.push(terminalOpportunityId);
       const terminalActive = await adapter.createTask(conv.id, {
-        type: 'negotiation', opportunityId: terminalOpportunityId, sourceUserId: 'watchdog-user', candidateUserId: 'watchdog-peer', seats: { 'watchdog-intent': { userId: 'watchdog-user', round: 1 } },
+        type: 'negotiation', opportunityId: terminalOpportunityId, sourceUserId: 'watchdog-user', candidateUserId: 'watchdog-peer', seats: { 'watchdog-intent': { userId: 'watchdog-user', batchId: 'batch-1' } },
       });
       await adapter.updateTaskState(terminalActive.id, 'working');
       const expiredOpportunityId = `watchdog-expired-${crypto.randomUUID()}`;
@@ -280,17 +280,17 @@ describe('ConversationDatabaseAdapter', () => {
       });
       createdOpportunityIds.push(expiredOpportunityId);
       const expiredActive = await adapter.createTask(conv.id, {
-        type: 'negotiation', opportunityId: expiredOpportunityId, sourceUserId: 'watchdog-user', candidateUserId: 'watchdog-peer', seats: { 'watchdog-intent': { userId: 'watchdog-user', round: 1 } },
+        type: 'negotiation', opportunityId: expiredOpportunityId, sourceUserId: 'watchdog-user', candidateUserId: 'watchdog-peer', seats: { 'watchdog-intent': { userId: 'watchdog-user', batchId: 'batch-1' } },
       });
       await adapter.updateTaskState(expiredActive.id, 'working');
       const readyForVerdict = await adapter.createTask(conv.id, {
-        type: 'negotiation', opportunityId: 'watchdog-opportunity-ready', sourceUserId: 'watchdog-user', seats: { 'watchdog-intent': { userId: 'watchdog-user', round: 1 } },
+        type: 'negotiation', opportunityId: 'watchdog-opportunity-ready', sourceUserId: 'watchdog-user', seats: { 'watchdog-intent': { userId: 'watchdog-user', batchId: 'batch-1' } },
       });
       await adapter.updateNegotiationTaskState(readyForVerdict.id, 'paused', {
         reason: 'ready_for_verdict', pausedBy: 'watchdog-user',
       });
       const completed = await adapter.createTask(conv.id, {
-        type: 'negotiation', opportunityId: 'watchdog-opportunity-completed', sourceUserId: 'watchdog-user', seats: { 'watchdog-intent': { userId: 'watchdog-user', round: 1 } },
+        type: 'negotiation', opportunityId: 'watchdog-opportunity-completed', sourceUserId: 'watchdog-user', seats: { 'watchdog-intent': { userId: 'watchdog-user', batchId: 'batch-1' } },
       });
       await adapter.updateTaskState(completed.id, 'completed');
       const nonNegotiation = await adapter.createTask(conv.id, { type: 'chat' });
@@ -348,8 +348,7 @@ describe('ConversationDatabaseAdapter', () => {
           opportunityId: `watchdog-rotation-opportunity-${index}`,
           sourceUserId: 'watchdog-rotation-user',
           candidateUserId: 'watchdog-rotation-peer',
-          seats: { 'watchdog-rotation-intent': { userId: 'watchdog-rotation-user', round: 1 } },
-          drainGeneration: 0,
+          seats: { 'watchdog-rotation-intent': { userId: 'watchdog-rotation-user', batchId: 'batch-1' } },
         });
         await adapter.updateNegotiationTaskState(task.id, 'paused', {
           reason: 'ready_for_verdict', pausedBy: 'watchdog-rotation-user',
@@ -455,8 +454,8 @@ describe('ConversationDatabaseAdapter', () => {
       ]);
       createdUserIds.push(ownerId, counterpartId);
       await db.insert(schema.intents).values([
-        { id: ownerIntentId, userId: ownerId, payload: 'Owner intent', negotiationRound: 1, negotiationRoundSize: 1 },
-        { id: counterpartIntentId, userId: counterpartId, payload: 'Counterpart intent', negotiationRound: 1, negotiationRoundSize: 1 },
+        { id: ownerIntentId, userId: ownerId, payload: 'Owner intent', negotiationBatchId: 'batch-1' },
+        { id: counterpartIntentId, userId: counterpartId, payload: 'Counterpart intent', negotiationBatchId: 'batch-1' },
       ]);
       createdIntentIds.push(ownerIntentId, counterpartIntentId);
       await db.insert(schema.opportunities).values({
@@ -486,10 +485,9 @@ describe('ConversationDatabaseAdapter', () => {
         initiatorUserId: ownerId,
         networkId: 'pause-network',
         seats: {
-          [ownerIntentId]: { userId: ownerId, round: 1 },
-          [counterpartIntentId]: { userId: counterpartId, round: 1 },
+          [ownerIntentId]: { userId: ownerId, batchId: 'batch-1' },
+          [counterpartIntentId]: { userId: counterpartId, batchId: 'batch-1' },
         },
-        drainGeneration: 0,
         pause: {
           reason: 'ready_for_verdict',
           payload: { recommendation: 'pending', reasoning: 'Owner recommends proceeding.' },
@@ -497,13 +495,13 @@ describe('ConversationDatabaseAdapter', () => {
         },
       });
       const submittedCycle = await adapter.getIntentCycleForIntent(ownerId, ownerIntentId);
-      expect(submittedCycle?.round.active).toBe(1);
+      expect(submittedCycle?.batch.active).toBe(1);
       expect(submittedCycle?.negotiations[0]?.state).toBe('submitted');
       await adapter.updateTaskState(task.id, 'paused');
 
       const ownerCycle = await adapter.getIntentCycleForIntent(ownerId, ownerIntentId);
       const counterpartCycle = await adapter.getIntentCycleForIntent(counterpartId, counterpartIntentId);
-      expect(ownerCycle?.round.active).toBe(0);
+      expect(ownerCycle?.batch.active).toBe(0);
       expect(ownerCycle?.negotiations[0]?.pause?.by).toBe('yours');
       expect(counterpartCycle?.negotiations[0]?.pause?.by).toBe('theirs');
 
@@ -568,10 +566,9 @@ describe('ConversationDatabaseAdapter', () => {
         initiatorUserId: ownerId,
         networkId: 'pause-network',
         seats: {
-          [ownerIntentId]: { userId: ownerId, round: 1 },
-          [counterpartIntentId]: { userId: counterpartId, round: 1 },
+          [ownerIntentId]: { userId: ownerId, batchId: "batch-1" },
+          [counterpartIntentId]: { userId: counterpartId, batchId: "batch-1" },
         },
-        drainGeneration: 0,
       });
       await adapter.updateTaskState(expiredTask.id, 'working');
       const expiredClosed = await adapter.completeNegotiation({
@@ -918,7 +915,7 @@ describe('ConversationDatabaseAdapter', () => {
         type: 'negotiation',
         sourceUserId: userId,
         candidateUserId: counterpart,
-        seats: { 'intent-live': { userId, round: 1 } },
+        seats: { 'intent-live': { userId, batchId: 'batch-1' } },
       });
 
       // A pre-rewrite row (no seat binding) is inert: the graph reads it back as
@@ -976,12 +973,13 @@ describe('ConversationDatabaseAdapter', () => {
   });
 
   describe('pre-rewrite negotiations are inert to the new lifecycle (#1494 round-4)', () => {
-    it('a legacy row without a seat binding is invisible to the round count and to every graph lookup', async () => {
+    it('a legacy row without a seat binding is invisible to the batch count and to every graph lookup', async () => {
       const run = `${Date.now()}-${crypto.randomUUID()}`;
       const intentId = `legacy-inert-intent-${run}`;
       const userId = `legacy-inert-user-${run}`;
       const counterpart = `legacy-inert-counterpart-${run}`;
       const legacyOpportunityId = `legacy-inert-opportunity-${run}`;
+      const batchId = `legacy-inert-batch-${run}`;
 
       const conversation = await adapter.createConversation([
         { participantId: `agent:${userId}`, participantType: 'agent' as const },
@@ -994,11 +992,11 @@ describe('ConversationDatabaseAdapter', () => {
         opportunityId: `legacy-inert-current-${run}`,
         sourceUserId: userId,
         candidateUserId: counterpart,
-        seats: { [intentId]: { userId, round: 3 } },
+        seats: { [intentId]: { userId, batchId } },
       });
-      // A just-created negotiation is submitted, and still holds the round
+      // A just-created negotiation is submitted, and still holds the batch
       // active until its worker starts and eventually pauses or completes it.
-      expect(await adapter.countActiveNegotiationsForRound(intentId, 3)).toBe(1);
+      expect(await adapter.countActiveNegotiationsForBatch(intentId, batchId)).toBe(1);
       await adapter.updateTaskState(current.id, 'working');
 
       // Pre-rewrite rows have no seat binding.
@@ -1019,9 +1017,9 @@ describe('ConversationDatabaseAdapter', () => {
       });
       await adapter.updateTaskState(legacyOffContract.id, 'paused');
 
-      // Only the round-3 row counts; a legacy row can neither inflate the
+      // Only the batch row counts; a legacy row can neither inflate the
       // count nor sit outside it while still being resumable.
-      expect(await adapter.countActiveNegotiationsForRound(intentId, 3)).toBe(1);
+      expect(await adapter.countActiveNegotiationsForBatch(intentId, batchId)).toBe(1);
 
       expect((await adapter.getNegotiationTask(current.id))?.id).toBe(current.id);
       expect(await adapter.getNegotiationTask(legacyWorking.id)).toBeNull();
@@ -1045,8 +1043,7 @@ describe('ConversationDatabaseAdapter', () => {
         type: 'negotiation',
         sourceUserId: userId,
         candidateUserId: counterpart,
-        seats: { 'intent-a': { userId, round: 1 } },
-        drainGeneration: 0,
+        seats: { 'intent-a': { userId, batchId: 'batch-1' } },
       });
 
       // The old select-then-spread-then-update shape had a lost-update race
@@ -1055,26 +1052,25 @@ describe('ConversationDatabaseAdapter', () => {
       // key. jsonb_set merges one key server-side, so both survive
       // regardless of interleaving.
       await Promise.all([
-        adapter.bindNegotiationSeat(task.id, 'intent-a', { userId, round: 7 }),
+        adapter.bindNegotiationSeat(task.id, 'intent-a', { userId, batchId: 'batch-7' }),
         adapter.updateNegotiationTaskState(task.id, 'paused', { reason: 'counterparty_silent' }),
       ]);
 
       const reread = await adapter.getNegotiationTask(task.id);
-      expect(reread?.metadata.seats['intent-a']).toEqual({ userId, round: 7 });
+      expect(reread?.metadata.seats['intent-a']).toEqual({ userId, batchId: 'batch-7' });
       expect(reread?.metadata.pause).toMatchObject({ reason: 'counterparty_silent' });
       expect(reread?.state).toBe('paused');
 
       const firstResume = await adapter.updateNegotiationTaskState(task.id, 'working', null);
-      expect(firstResume.metadata.drainGeneration).toBe(1);
       expect(firstResume.metadata.pause).toBeNull();
       await adapter.updateNegotiationTaskState(task.id, 'paused', { reason: 'counterparty_silent' });
       const secondResume = await adapter.updateNegotiationTaskState(task.id, 'working', null);
-      expect(secondResume.metadata.drainGeneration).toBe(2);
+      expect(secondResume.metadata.pause).toBeNull();
     });
   });
 
   describe('openNegotiationTask — durable seat binding', () => {
-    it('creates the task with both actor intents and generation zero in one write', async () => {
+    it('creates the task with both actor intents bound in one write', async () => {
       const run = `${Date.now()}-${crypto.randomUUID()}`;
       const ownerId = `open-owner-${run}`;
       const counterpartId = `open-counterpart-${run}`;
@@ -1112,18 +1108,17 @@ describe('ConversationDatabaseAdapter', () => {
         candidateUserId: counterpartId,
         brief: 'Owner brief',
         seats: {
-          [ownerIntentId]: { userId: ownerId, round: 3 },
-          [counterpartIntentId]: { userId: counterpartId, round: 5 },
+          [ownerIntentId]: { userId: ownerId, batchId: 'batch-3' },
+          [counterpartIntentId]: { userId: counterpartId, batchId: 'batch-5' },
         },
         networkId: 'open-network',
       });
 
       expect(opened?.disposition).toBe('created');
       expect(opened?.task.metadata.seats).toEqual({
-        [ownerIntentId]: { userId: ownerId, round: 3 },
-        [counterpartIntentId]: { userId: counterpartId, round: 5 },
+        [ownerIntentId]: { userId: ownerId, batchId: 'batch-3' },
+        [counterpartIntentId]: { userId: counterpartId, batchId: 'batch-5' },
       });
-      expect(opened?.task.metadata.drainGeneration).toBe(0);
       if (opened) createdIds.push(opened.task.conversationId);
     }, 30000);
   });

--- a/services/api/src/adapters/tests/database.adapter.isolated.ts
+++ b/services/api/src/adapters/tests/database.adapter.isolated.ts
@@ -1586,11 +1586,10 @@ describe('OpportunityDatabaseAdapter', () => {
           type: 'negotiation',
           opportunityId: otherTrigger.id,
           seats: {
-            [fixture.intent1Id]: { userId: fixture.userAId, round: 1 },
-            [candidateIntentId]: { userId: fixture.userBId, round: 2 },
+            [fixture.intent1Id]: { userId: fixture.userAId, batchId: "batch-1" },
+            [candidateIntentId]: { userId: fixture.userBId, batchId: "batch-2" },
           },
           pause: { reason: 'ready_for_verdict', pausedBy: fixture.userAId },
-          drainGeneration: 0,
         },
       });
       const [attemptConversation] = await db.insert(conversations).values({}).returning();
@@ -1631,10 +1630,9 @@ describe('OpportunityDatabaseAdapter', () => {
             type: 'negotiation',
             opportunityId: result.created.id,
             seats: {
-              [triggerIntentId]: { userId: fixture.userAId, round: 3 },
-              [candidateIntentId]: { userId: fixture.userBId, round: 2 },
+              [triggerIntentId]: { userId: fixture.userAId, batchId: "batch-3" },
+              [candidateIntentId]: { userId: fixture.userBId, batchId: "batch-2" },
             },
-            drainGeneration: 0,
           },
         });
         expect(attempt).not.toBeNull();
@@ -1643,10 +1641,9 @@ describe('OpportunityDatabaseAdapter', () => {
         expect(attempt?.metadata).toMatchObject({
           opportunityId: result.created.id,
           seats: {
-            [triggerIntentId]: { userId: fixture.userAId, round: 3 },
-            [candidateIntentId]: { userId: fixture.userBId, round: 2 },
+            [triggerIntentId]: { userId: fixture.userAId, batchId: "batch-3" },
+            [candidateIntentId]: { userId: fixture.userBId, batchId: "batch-2" },
           },
-          drainGeneration: 0,
         });
 
         const duplicateAttempt = await conversationAdapter.createNegotiationTaskForAttempt({

--- a/services/api/src/adapters/tests/negotiation-round-log.database.spec.ts
+++ b/services/api/src/adapters/tests/negotiation-round-log.database.spec.ts
@@ -1,0 +1,102 @@
+/**
+ * Integration test for NegotiationRoundLogDatabaseAdapter (negotiation
+ * round-log refactor, #1494 follow-up).
+ *
+ * Requires a live database connection (.env.test). Covers: append + read in
+ * append order, and scoping reads to a single intent/batch pair.
+ */
+
+import { config } from 'dotenv';
+config({ path: '.env.test', override: true });
+
+import { describe, it, expect } from 'bun:test';
+import { randomUUID } from 'crypto';
+import { NegotiationRoundLogDatabaseAdapter } from '../negotiation-round-log.database.adapter';
+import db from '../../lib/drizzle/drizzle';
+import * as schema from '../../schemas/database.schema';
+import { eq } from 'drizzle-orm/sql';
+
+describe('NegotiationRoundLogDatabaseAdapter', () => {
+  const adapter = new NegotiationRoundLogDatabaseAdapter();
+
+  it('appends events and reads them back in append order', async () => {
+    const intentId = randomUUID();
+    const batchId = randomUUID();
+
+    await adapter.appendNegotiationRoundLogEvent(intentId, {
+      kind: 'opened',
+      taskId: randomUUID(),
+      batchId,
+    });
+    await adapter.appendNegotiationRoundLogEvent(intentId, {
+      kind: 'stopped',
+      taskId: randomUUID(),
+      batchId,
+      via: 'completed',
+    });
+
+    const events = await adapter.readNegotiationRoundLogEvents(intentId, batchId);
+    expect(events).toHaveLength(2);
+    expect(events[0].kind).toBe('opened');
+    expect(events[0].via).toBeUndefined();
+    expect(events[1].kind).toBe('stopped');
+    expect(events[1].via).toBe('completed');
+
+    await db.delete(schema.negotiationRoundLogEvents).where(eq(schema.negotiationRoundLogEvents.intentId, intentId));
+  });
+
+  it('carries the pause reason on a stopped/paused event', async () => {
+    const intentId = randomUUID();
+    const batchId = randomUUID();
+
+    await adapter.appendNegotiationRoundLogEvent(intentId, {
+      kind: 'stopped',
+      taskId: randomUUID(),
+      batchId,
+      via: 'paused',
+      reason: 'counterparty_unreachable',
+    });
+
+    const events = await adapter.readNegotiationRoundLogEvents(intentId, batchId);
+    expect(events).toHaveLength(1);
+    expect(events[0].via).toBe('paused');
+    expect(events[0].reason).toBe('counterparty_unreachable');
+
+    await db.delete(schema.negotiationRoundLogEvents).where(eq(schema.negotiationRoundLogEvents.intentId, intentId));
+  });
+
+  it('scopes reads to the given intent/batch pair — no cross-batch or cross-intent leaks', async () => {
+    const intentId = randomUUID();
+    const batchA = randomUUID();
+    const batchB = randomUUID();
+    const otherIntentId = randomUUID();
+
+    await adapter.appendNegotiationRoundLogEvent(intentId, { kind: 'opened', taskId: randomUUID(), batchId: batchA });
+    await adapter.appendNegotiationRoundLogEvent(intentId, { kind: 'opened', taskId: randomUUID(), batchId: batchB });
+    await adapter.appendNegotiationRoundLogEvent(otherIntentId, { kind: 'opened', taskId: randomUUID(), batchId: batchA });
+
+    const forBatchA = await adapter.readNegotiationRoundLogEvents(intentId, batchA);
+    expect(forBatchA).toHaveLength(1);
+
+    const forUnknownBatch = await adapter.readNegotiationRoundLogEvents(intentId, randomUUID());
+    expect(forUnknownBatch).toHaveLength(0);
+
+    await db.delete(schema.negotiationRoundLogEvents).where(eq(schema.negotiationRoundLogEvents.intentId, intentId));
+    await db.delete(schema.negotiationRoundLogEvents).where(eq(schema.negotiationRoundLogEvents.intentId, otherIntentId));
+  });
+
+  it('appends an opening_complete marker with no taskId and stamps a createdAt', async () => {
+    const intentId = randomUUID();
+    const batchId = randomUUID();
+
+    await adapter.appendNegotiationRoundLogEvent(intentId, { kind: 'opening_complete', batchId });
+
+    const events = await adapter.readNegotiationRoundLogEvents(intentId, batchId);
+    expect(events).toHaveLength(1);
+    expect(events[0].kind).toBe('opening_complete');
+    expect(events[0].taskId).toBeUndefined();
+    expect(events[0].createdAt).toBeInstanceOf(Date);
+
+    await db.delete(schema.negotiationRoundLogEvents).where(eq(schema.negotiationRoundLogEvents.intentId, intentId));
+  });
+});

--- a/services/api/src/cli/db-clear-negotiations.ts
+++ b/services/api/src/cli/db-clear-negotiations.ts
@@ -5,7 +5,7 @@
  * dossiers, orphan orchestrator conversations, and any conversation that
  * has an agent participant (H2A / A2A chat shells).
  * Also wipes every BullMQ queue in Redis (all `bull:*` keys) and resets each
- * intent's negotiation-cycle state (round, round size, kickoff stamp).
+ * intent's negotiation-cycle state (batch id) plus its round-log events.
  * Keeps intents, users, HyDE, and profile data.
  *
  * Usage:
@@ -46,8 +46,9 @@ async function readCounts(): Promise<Counts> {
     UNION ALL SELECT 'opportunity_deliveries', count(*)::text FROM opportunity_deliveries
     UNION ALL SELECT 'opportunity_outcome_events', count(*)::text FROM opportunity_outcome_events
     UNION ALL SELECT 'agents_with_neg_pickup', count(*)::text FROM agents WHERE last_negotiation_pickup_at IS NOT NULL
-    UNION ALL SELECT 'intents_with_round_state', count(*)::text FROM intents
-      WHERE negotiation_round > 0 OR negotiation_round_size IS NOT NULL OR negotiation_kickoff_started_at IS NOT NULL
+    UNION ALL SELECT 'intents_with_batch_state', count(*)::text FROM intents
+      WHERE negotiation_batch_id IS NOT NULL
+    UNION ALL SELECT 'negotiation_round_log_events', count(*)::text FROM negotiation_round_log_events
     UNION ALL SELECT 'intent_discovery_progress', count(*)::text FROM intent_discovery_progress
     UNION ALL SELECT 'questions_intent', count(*)::text FROM questions WHERE detection->>'mode' = 'intent'
     UNION ALL SELECT 'questions_nego_opp', count(*)::text FROM questions
@@ -118,13 +119,12 @@ async function clearNegotiationsAndOpportunities(): Promise<Counts> {
       WHERE last_negotiation_pickup_at IS NOT NULL
     `);
     // Intents survive the wipe, so their negotiation-cycle state must not:
-    // a kept round/kickoff stamp with no matches or tasks behind it renders
-    // as a permanently "opening" round in the UI.
+    // a kept batch id with no matches or tasks behind it renders as a
+    // permanently "opening" batch in the UI.
     await tx.execute(sql`
-      UPDATE intents
-      SET negotiation_round = 0, negotiation_round_size = NULL, negotiation_kickoff_started_at = NULL
-      WHERE negotiation_round > 0 OR negotiation_round_size IS NOT NULL OR negotiation_kickoff_started_at IS NOT NULL
+      UPDATE intents SET negotiation_batch_id = NULL WHERE negotiation_batch_id IS NOT NULL
     `);
+    await tx.execute(sql`DELETE FROM negotiation_round_log_events`);
   });
   return readCounts();
 }

--- a/services/api/src/controllers/tests/conversation.negotiation-activity.isolated.ts
+++ b/services/api/src/controllers/tests/conversation.negotiation-activity.isolated.ts
@@ -41,7 +41,7 @@ describe('ConversationController intent cycle', () => {
   });
 
   it('returns the exact owned cycle response', async () => {
-    const cycle = { round: { number: 1, size: 1, kickoffStartedAt: null, active: 1, paused: 0 }, negotiations: [] };
+    const cycle = { batch: { id: 'batch-1', active: 1, paused: 0 }, negotiations: [] };
     const read = mock(async () => cycle);
     const controller = new ConversationController(
       { getIntentCycleForIntent: read } as unknown as ConversationService,
@@ -57,7 +57,7 @@ describe('ConversationController intent cycle', () => {
   });
 
   it('returns only the owner-scoped act timeline', async () => {
-    const entries = [{ id: 'act-1', event: { kind: 'matches_ready' }, act: { tool: 'kickoff', round: 1 }, createdAt: new Date() }];
+    const entries = [{ id: 'act-1', event: { kind: 'matches_ready' }, act: { tool: 'kickoff', batchId: 'batch-1' }, createdAt: new Date() }];
     const read = mock(async () => entries);
     const controller = new ConversationController(
       { getIntentCycleTimelineForIntent: read } as unknown as ConversationService,

--- a/services/api/src/lib/negotiation/negotiation-graph.ts
+++ b/services/api/src/lib/negotiation/negotiation-graph.ts
@@ -24,6 +24,7 @@ import { NegotiationGraphFactory, PersonalAgentGraphFactory } from '@indexnetwor
 import type { MatchesReadyFn, PersonalAgentGraphLike } from '@indexnetwork/protocol';
 
 import { conversationDatabaseAdapter } from '../../adapters/database.adapter';
+import { negotiationRoundLogDatabaseAdapter } from '../../adapters/negotiation-round-log.database.adapter';
 import { log } from '../log';
 import { intentAgentLedgerAdapter } from '../../adapters/intent-agent-ledger.adapter';
 import { intentDossierAdapter } from '../../adapters/intent-dossier.adapter';
@@ -43,6 +44,7 @@ export const agentDispatcher = new AgentDispatcherImpl(agentService);
 
 export const negotiationGraph = new NegotiationGraphFactory({
   database: conversationDatabaseAdapter,
+  roundLog: negotiationRoundLogDatabaseAdapter,
   // All-paused → reflect: the trigger waits for an in-flight kickoff to finish,
   // then deduplicates the durable task-generation vector for every bound seat.
   reflectEnqueue: async (job) => {
@@ -78,6 +80,7 @@ export const negotiationGraph = new NegotiationGraphFactory({
 export const personalAgentGraph: PersonalAgentGraphLike = new PersonalAgentGraphFactory({
   negotiations: negotiationGraph,
   negotiationDatabase: conversationDatabaseAdapter,
+  roundLog: negotiationRoundLogDatabaseAdapter,
   conversation: {
     findSession: (userId, intentId) => chatSessionService.findNegotiatorIntentSession(userId, intentId),
     resolveSession: (userId, intentId) => chatSessionService.resolveNegotiatorIntentSession(userId, intentId),

--- a/services/api/src/queues/negotiations/watchdog.queue.ts
+++ b/services/api/src/queues/negotiations/watchdog.queue.ts
@@ -1,8 +1,9 @@
 import type { Job, Queue, Worker } from 'bullmq';
-import { KICKOFF_STALE_AFTER_MS, maybeEnqueueRoundReflect, type MatchesReadyFn, type NegotiationGraphLike, type NegotiationRoundReflectEnqueueFn } from '@indexnetwork/protocol';
+import { KICKOFF_STALE_AFTER_MS, maybeEnqueueRoundReflect, type MatchesReadyFn, type NegotiationGraphLike, type NegotiationRoundLogDatabase, type NegotiationRoundReflectEnqueueFn } from '@indexnetwork/protocol';
 
 import type { ConversationDatabaseAdapter, StaleNegotiationTask, StaleNegotiationTasksInput } from '../../adapters/conversation.database.adapter';
 import type { ChatDatabaseAdapter } from '../../adapters/chat.database.adapter';
+import { negotiationRoundLogDatabaseAdapter } from '../../adapters/negotiation-round-log.database.adapter';
 import { QueueFactory } from '../../lib/bullmq/bullmq';
 import { log } from '../../lib/log';
 
@@ -29,7 +30,6 @@ type WatchdogDatabase = Pick<
   ConversationDatabaseAdapter,
   'getStaleNegotiationTasks' | 'getTask' | 'recordNegotiationWatchdogAttempt' | 'recordNegotiationWatchdogRecoveryCheck'
   | 'clearNegotiationReflectPending'
-  | 'getIntentNegotiationRound' | 'getNegotiationTasksForIntentRound'
   | 'getIntentsWithInterruptedKickoff'
 >;
 type WatchdogOpportunities = Pick<ChatDatabaseAdapter, 'getOpportunity'>;
@@ -52,9 +52,10 @@ export interface NegotiationWatchdogQueueDeps {
     ConversationDatabaseAdapter,
     'getStaleNegotiationTasks' | 'getTask' | 'recordNegotiationWatchdogAttempt' | 'recordNegotiationWatchdogRecoveryCheck'
     | 'clearNegotiationReflectPending'
-    | 'getIntentNegotiationRound' | 'getNegotiationTasksForIntentRound'
     | 'getIntentsWithInterruptedKickoff'
   >;
+  /** The append-only round-log a batch's settlement is folded from (#1494). */
+  roundLog?: NegotiationRoundLogDatabase;
   opportunities?: Pick<ChatDatabaseAdapter, 'getOpportunity'>;
   negotiationGraph?: NegotiationGraphLike;
   queue?: WatchdogQueueHandle;
@@ -181,10 +182,11 @@ export class NegotiationWatchdogQueue {
       ?? (await import('../../adapters/database.adapter')).conversationDatabaseAdapter;
     const opportunities: WatchdogOpportunities = this.deps.opportunities
       ?? (await import('../../adapters/database.adapter')).chatDatabaseAdapter;
+    const roundLog: NegotiationRoundLogDatabase = this.deps.roundLog ?? negotiationRoundLogDatabaseAdapter;
     const staleTasks = await database.getStaleNegotiationTasks(input);
 
     for (const candidate of staleTasks) {
-      await this.reconcileCandidate(candidate, database, opportunities).catch((error) => {
+      await this.reconcileCandidate(candidate, database, roundLog, opportunities).catch((error) => {
         this.logger.error('Negotiation watchdog candidate failed; continuing sweep', {
           taskId: candidate.id,
           error: error instanceof Error ? error.message : String(error),
@@ -196,13 +198,13 @@ export class NegotiationWatchdogQueue {
   }
 
   /**
-   * A kickoff that bumped the round and stamped `kickoffStartedAt` but never
-   * finished (crash, restart) leaves zero negotiation tasks behind — nothing
-   * for the stale-task sweep above to find, and no reflect wake scheduled
-   * either, since that requires `negotiationRoundSize` to be stamped. Without
-   * this, such a signal sits idle forever. `runKickoff`'s own
-   * `interruptedRound` check already knows how to settle it; re-waking with
-   * `matches_ready` is what gives that check a turn to run in.
+   * A kickoff that bumped the batch but never finished (crash, restart)
+   * leaves zero negotiation tasks behind — nothing for the stale-task sweep
+   * above to find, and no reflect wake scheduled either, since that requires
+   * the batch's `opening_complete` round-log marker. Without this, such a
+   * signal sits idle forever. `runKickoff`'s own `interruptedBatch` check
+   * already knows how to settle it; re-waking with `matches_ready` is what
+   * gives that check a turn to run in.
    */
   private async repairInterruptedKickoffs(database: WatchdogDatabase): Promise<void> {
     const matchesReady: MatchesReadyFn = this.matchesReadyFn
@@ -258,6 +260,7 @@ export class NegotiationWatchdogQueue {
   private async reconcileCandidate(
     candidate: StaleNegotiationTask,
     database: WatchdogDatabase,
+    roundLog: NegotiationRoundLogDatabase,
     opportunities: WatchdogOpportunities,
   ): Promise<void> {
     const task = await database.getTask(candidate.id);
@@ -288,11 +291,11 @@ export class NegotiationWatchdogQueue {
       let succeeded = true;
       for (const [intentId, rawBinding] of Object.entries(seats)) {
         const binding = asRecord(rawBinding);
-        if (typeof binding.userId !== 'string' || typeof binding.round !== 'number') continue;
-        const checked = await maybeEnqueueRoundReflect(database, this.reflectEnqueue, {
+        if (typeof binding.userId !== 'string' || typeof binding.batchId !== 'string') continue;
+        const checked = await maybeEnqueueRoundReflect(roundLog, this.reflectEnqueue, {
           userId: binding.userId,
           intentId,
-          round: binding.round,
+          batchId: binding.batchId,
         });
         succeeded &&= checked;
       }
@@ -312,11 +315,11 @@ export class NegotiationWatchdogQueue {
         const seats = asRecord(metadata.seats);
         for (const [intentId, rawBinding] of Object.entries(seats)) {
           const binding = asRecord(rawBinding);
-          if (typeof binding.userId !== 'string' || typeof binding.round !== 'number') continue;
-          await maybeEnqueueRoundReflect(database, this.reflectEnqueue, {
+          if (typeof binding.userId !== 'string' || typeof binding.batchId !== 'string') continue;
+          await maybeEnqueueRoundReflect(roundLog, this.reflectEnqueue, {
             userId: binding.userId,
             intentId,
-            round: binding.round,
+            batchId: binding.batchId,
           });
         }
         await database.recordNegotiationWatchdogRecoveryCheck({

--- a/services/api/src/queues/personal-agent.queue.ts
+++ b/services/api/src/queues/personal-agent.queue.ts
@@ -191,23 +191,23 @@ export class PersonalAgentQueue {
   }
 
   /**
-   * Every negotiation of a round has paused. The deterministic job id is the
-   * whole dedup: duplicate delivery of one durable drain produces one reflect,
-   * and the completed job is retained so that generation cannot run twice. A
-   * reopened task increments its durable generation and therefore gets a new
-   * job. The queue's
+   * Every negotiation of a batch has paused. The deterministic job id is the
+   * whole dedup: duplicate delivery of one durable settle produces one
+   * reflect, and the completed job is retained so that dedupe key cannot run
+   * twice. A reopened task produces a new dedupe key (the round-log fold's
+   * own position marker) and therefore a new job. The queue's
    * default `removeOnComplete: { age: 24h }` would free the id, and a late
    * watchdog delivery of the same durable pause would then wake the agent to
-   * re-decide work it already closed out. One retained row per drain
-   * generation is the price of exactly-once.
+   * re-decide work it already closed out. One retained row per settle's
+   * dedupe key is the price of exactly-once.
    *
    * `removeOnFail` keeps the default 7-day window on purpose: a reflect lost
    * to a transient model outage should become reachable again, and a genuinely
-   * dead drain is better re-run once than never.
+   * dead settle is better re-run once than never.
    */
   addAllPausedEvent(job: NegotiationRoundReflectJobData): Promise<Job<PersonalAgentEvent>> {
     return this.queue.add('all_paused', { ...job, event: 'all_paused' }, {
-      jobId: negotiationRoundReflectJobId(job.intentId, job.round, job.generation),
+      jobId: negotiationRoundReflectJobId(job.intentId, job.batchId, job.dedupeKey),
       removeOnComplete: false,
     });
   }

--- a/services/api/src/queues/tests/personal-agent.queue.isolated.ts
+++ b/services/api/src/queues/tests/personal-agent.queue.isolated.ts
@@ -66,7 +66,7 @@ describe('PersonalAgentQueue serialization', () => {
     await withQueue(buildQueue(() => idle), async ({ queue, spans }) => {
       const jobs = await Promise.all([
         queue.addMatchesReadyEvent({ userId: 'user-1', intentId: 'intent-1' }),
-        queue.addAllPausedEvent({ userId: 'user-1', intentId: 'intent-1', round: 3, generation: 'task-1.0' }),
+        queue.addAllPausedEvent({ userId: 'user-1', intentId: 'intent-1', batchId: 'batch-3', dedupeKey: 'task-1.0' }),
         queue.addUserMessageEvent({
           userId: 'user-1', intentId: 'intent-1', event: 'user_message',
           sessionId: 'session-1', messageId: 'reply-1', text: 'hello',
@@ -114,13 +114,13 @@ describe('PersonalAgentQueue serialization', () => {
   it('one durable drain reflects exactly once, while a reopened generation runs again', async () => {
     await withQueue(buildQueue(() => idle), async ({ queue, invocations }) => {
       const jobs = await Promise.all(Array.from({ length: 10 }, () =>
-        queue.addAllPausedEvent({ userId: 'user-1', intentId: 'intent-1', round: 7, generation: 'task-1.0' })));
+        queue.addAllPausedEvent({ userId: 'user-1', intentId: 'intent-1', batchId: 'batch-7', dedupeKey: 'task-1.0' })));
       expect(new Set(jobs.map((job) => job.id)).size).toBe(1);
       await jobs[0]!.waitUntilFinished(undefined as never, 10_000);
       expect(invocations()).toBe(1);
 
       const reopened = await queue.addAllPausedEvent({
-        userId: 'user-1', intentId: 'intent-1', round: 7, generation: 'task-1.1',
+        userId: 'user-1', intentId: 'intent-1', batchId: 'batch-7', dedupeKey: 'task-1.1',
       });
       expect(reopened.id).not.toBe(jobs[0]!.id);
       await reopened.waitUntilFinished(undefined as never, 10_000);
@@ -236,7 +236,7 @@ describe('PersonalAgentQueue serialization', () => {
 
   it('a reflect job is retained on completion so one generation cannot reflect twice', async () => {
     await withQueue(buildQueue(() => idle), async ({ queue }) => {
-      const job = await queue.addAllPausedEvent({ userId: 'user-1', intentId: 'intent-1', round: 4, generation: 'task-1.0' });
+      const job = await queue.addAllPausedEvent({ userId: 'user-1', intentId: 'intent-1', batchId: 'batch-4', dedupeKey: 'task-1.0' });
       // The queue default is removeOnComplete { age: 24h }, which would free
       // the id and let a late pause on a stale negotiation re-wake the agent
       // for a round it already closed out.

--- a/services/api/src/queues/tests/watchdog.queue.spec.ts
+++ b/services/api/src/queues/tests/watchdog.queue.spec.ts
@@ -35,9 +35,17 @@ function makeDeps(task: ReturnType<typeof makeTask> | null = makeTask()) {
     recordNegotiationWatchdogAttempt: mock(async () => task),
     recordNegotiationWatchdogRecoveryCheck: mock(async () => true),
     clearNegotiationReflectPending: mock(async () => undefined),
-    getIntentNegotiationRound: mock(async () => ({ round: 1, roundSize: 1, kickoffStartedAt: null })),
-    getNegotiationTasksForIntentRound: mock(async () => task ? [task as never] : []),
     getIntentsWithInterruptedKickoff: mock(async () => []),
+  };
+  // Settled by default: an opening_complete marker plus every opened task
+  // already stopped, so `maybeEnqueueRoundReflect` enqueues immediately.
+  const roundLog = {
+    appendNegotiationRoundLogEvent: mock(async () => undefined),
+    readNegotiationRoundLogEvents: mock(async () => [
+      { kind: 'opened' as const, taskId: 'task-1', batchId: 'batch-1' },
+      { kind: 'opening_complete' as const, batchId: 'batch-1' },
+      { kind: 'stopped' as const, taskId: 'task-1', batchId: 'batch-1', via: 'completed' as const },
+    ]),
   };
   const opportunities = {
     getOpportunity: mock(async () => ({ id: 'opportunity-1', status: 'negotiating' })),
@@ -45,7 +53,7 @@ function makeDeps(task: ReturnType<typeof makeTask> | null = makeTask()) {
   const negotiationGraph = { invoke: mock(async () => ({ negotiationId: task?.id ?? '', status: 'paused' as const, turns: [] })) };
   const reflectEnqueue = mock(async () => undefined);
   const matchesReady = mock(async () => undefined);
-  return { database, opportunities, negotiationGraph, reflectEnqueue, matchesReady };
+  return { database, roundLog, opportunities, negotiationGraph, reflectEnqueue, matchesReady };
 }
 
 beforeEach(() => {
@@ -126,7 +134,7 @@ describe('NegotiationWatchdogQueue', () => {
     });
   });
 
-  it('retries a failed durable reflect generation on the next ready_for_verdict sweep', async () => {
+  it('retries a failed durable reflect dedupe key on the next ready_for_verdict sweep', async () => {
     const task = makeTask({
       state: 'paused',
       metadata: {
@@ -136,8 +144,7 @@ describe('NegotiationWatchdogQueue', () => {
         candidateUserId: 'user-2',
         initiatorUserId: 'user-1',
         networkId: 'network-1',
-        seats: { 'intent-1': { userId: 'user-1', round: 1 } },
-        drainGeneration: 0,
+        seats: { 'intent-1': { userId: 'user-1', batchId: 'batch-1' } },
         pause: { reason: 'ready_for_verdict', pausedBy: 'user-1' },
       },
     });
@@ -156,8 +163,8 @@ describe('NegotiationWatchdogQueue', () => {
     expect(deps.reflectEnqueue).toHaveBeenLastCalledWith({
       userId: 'user-1',
       intentId: 'intent-1',
-      round: 1,
-      generation: 'task-1.0',
+      batchId: 'batch-1',
+      dedupeKey: 'task-1.2',
     });
     expect(deps.reflectEnqueue).toHaveBeenCalledTimes(4);
     expect(deps.negotiationGraph.invoke).not.toHaveBeenCalled();
@@ -213,8 +220,7 @@ describe('NegotiationWatchdogQueue', () => {
         opportunityId: 'opportunity-1',
         sourceUserId: 'user-1',
         candidateUserId: 'user-2',
-        seats: { 'intent-1': { userId: 'user-1', round: 1 } },
-        drainGeneration: 0,
+        seats: { 'intent-1': { userId: 'user-1', batchId: 'batch-1' } },
         watchdogReflectPending: true,
       },
     });

--- a/services/api/src/schemas/database.schema.ts
+++ b/services/api/src/schemas/database.schema.ts
@@ -553,25 +553,13 @@ export const intents = pgTable('intents', {
   archivedAt: timestamp('archived_at'),
   lastVisitedAt: timestamp('last_visited_at', { withTimezone: true }),
   /**
-   * Bumped by NegotiationGraph at every fresh kickoff of a round of
-   * negotiations for this intent. The reflect trigger's key, alongside the
-   * negotiation task's `round` metadata (design doc 2026-08-23).
+   * Written by NegotiationGraph at every fresh kickoff batch for this intent.
+   * A fresh UUID per kickoff; null means this signal has never itself kicked
+   * off (#1494). The reflect trigger's key, alongside the negotiation task's
+   * `batchId` metadata — settlement itself is folded from
+   * `negotiation_round_log_events`, not read from a size/timestamp pair here.
    */
-  negotiationRound: integer('negotiation_round').notNull().default(0),
-  /**
-   * How many negotiations the current round actually opened, stamped by
-   * kickoff only after every parallel open has settled. NULL means the round
-   * is still opening, and the all-paused → reflect check is a no-op until the
-   * stamp lands (design doc 2026-08-23, decision D2).
-   */
-  negotiationRoundSize: integer('negotiation_round_size'),
-  /**
-   * When a kickoff for the CURRENT round began — stamped by the round bump,
-   * the one write that begins one. Read with `negotiationRoundSize`: set with
-   * a null size is a kickoff that did not finish; null means no kickoff has
-   * ever run for this signal, which is where every pre-0146 intent starts.
-   */
-  negotiationKickoffStartedAt: timestamp('negotiation_kickoff_started_at', { withTimezone: true }),
+  negotiationBatchId: text('negotiation_batch_id'),
   /**
    * When the intent's first background discovery run completed successfully
    * (any path: web from-intent queue or async MCP discovery-run). Null until
@@ -1159,6 +1147,40 @@ export const intentAgentActs = pgTable(
 
 export type IntentAgentAct = typeof intentAgentActs.$inferSelect;
 export type NewIntentAgentAct = typeof intentAgentActs.$inferInsert;
+
+export const negotiationRoundLogEventKindEnum = pgEnum('negotiation_round_log_event_kind', ['opened', 'stopped', 'resumed', 'opening_complete']);
+export const negotiationRoundLogEventViaEnum = pgEnum('negotiation_round_log_event_via', ['paused', 'completed']);
+
+/**
+ * Append-only event log a batch's "has everything settled" answer is folded
+ * from (`@indexnetwork/protocol`'s `foldNegotiationRoundLog`), replacing the
+ * racy quartet of separately-written fields (`intents.negotiation_round`,
+ * `negotiation_round_size`, `negotiation_kickoff_started_at`,
+ * `metadata.drainGeneration`) that used to live on `intents`/`tasks`.
+ */
+export const negotiationRoundLogEvents = pgTable(
+  'negotiation_round_log_events',
+  {
+    id: text('id').primaryKey().$defaultFn(() => crypto.randomUUID()),
+    intentId: text('intent_id').notNull(),
+    batchId: text('batch_id').notNull(),
+    /** Absent only for 'opening_complete', which has no task. */
+    taskId: text('task_id'),
+    kind: negotiationRoundLogEventKindEnum('kind').notNull(),
+    /** Only set on 'stopped' events. */
+    via: negotiationRoundLogEventViaEnum('via'),
+    /** Only set on 'stopped' events whose `via` is 'paused' (a `NegotiationPauseReasonName`). */
+    reason: text('reason'),
+    createdAt: timestamp('created_at', { withTimezone: true }).notNull().defaultNow(),
+  },
+  (t) => ({
+    // The fold's read: one intent's one batch, in append order.
+    batchIdx: index('idx_negotiation_round_log_events_batch').on(t.intentId, t.batchId, t.createdAt),
+  }),
+);
+
+export type NegotiationRoundLogEventRow = typeof negotiationRoundLogEvents.$inferSelect;
+export type NewNegotiationRoundLogEventRow = typeof negotiationRoundLogEvents.$inferInsert;
 
 // ═══════════════════════════════════════════════════════════════════════════════
 // Relations

--- a/services/api/src/services/tests/opportunity.service.negotiationClose.spec.ts
+++ b/services/api/src/services/tests/opportunity.service.negotiationClose.spec.ts
@@ -1,9 +1,9 @@
 /**
  * The owner verdict must END the pairing's negotiation (D23).
  *
- * The reflect trigger waits for every task in a bound seat's round to stop
+ * The reflect trigger waits for every task in a bound seat's batch to stop
  * working. Before this fix an ordinary user reject flipped only the opportunity,
- * so its task stayed `working` forever and neither seat's drain was enqueued.
+ * so its task stayed `working` forever and neither seat's settle was enqueued.
  *
  * The test drives the REAL `NegotiationGraph` over a fake database — the same
  * owner-close lane production runs — rather than asserting that a mock was called, so
@@ -16,7 +16,7 @@ config({ path: '.env.test', override: true });
 import { describe, it, expect, mock } from 'bun:test';
 
 import { NegotiationGraphFactory } from '@indexnetwork/protocol';
-import type { NegotiationGraphDatabase, NegotiationTaskRow, NegotiationRoundReflectJobData, Opportunity, OpportunityControllerDatabase, OpportunityStatus } from '@indexnetwork/protocol';
+import type { NegotiationGraphDatabase, NegotiationRoundLogDatabase, NegotiationTaskRow, NegotiationRoundReflectJobData, Opportunity, OpportunityControllerDatabase, OpportunityStatus } from '@indexnetwork/protocol';
 
 import { OpportunityService, type OwnerVerdictNegotiationCloser } from '../opportunity.service';
 
@@ -26,7 +26,8 @@ const OPP_ID = 'opp-negotiated-001';
 const INTENT_ID = 'intent-001';
 const COUNTERPART_INTENT_ID = 'intent-002';
 const NEGOTIATION_ID = 'task-negotiation-001';
-const ROUND = 3;
+const BATCH_ID = 'batch-003';
+const COUNTERPART_BATCH_ID = 'batch-passive';
 
 /** One negotiating pairing, shared by both fakes so status writes are observable. */
 function negotiatedOpportunity(): Opportunity {
@@ -61,10 +62,9 @@ function negotiationTask(): NegotiationTaskRow {
       initiatorUserId: USER_A,
       networkId: 'idx-1',
       seats: {
-        [INTENT_ID]: { userId: USER_A, round: ROUND },
-        [COUNTERPART_INTENT_ID]: { userId: USER_B, round: 0 },
+        [INTENT_ID]: { userId: USER_A, batchId: BATCH_ID },
+        [COUNTERPART_INTENT_ID]: { userId: USER_B, batchId: COUNTERPART_BATCH_ID },
       },
-      drainGeneration: 0,
     },
     createdAt: new Date(),
     updatedAt: new Date(),
@@ -73,14 +73,37 @@ function negotiationTask(): NegotiationTaskRow {
 
 /**
  * The world both the opportunity service and the negotiation graph write into:
- * one opportunity row and one negotiation task, plus the reflect enqueue the
- * all-paused check calls.
+ * one opportunity row, one negotiation task, an in-memory round-log (both
+ * seats' batches pre-seeded as already opened+opening_complete, matching
+ * what a real kickoff would have left behind before this close), plus the
+ * reflect enqueue the all-paused check calls.
  */
 function createWorld() {
   const opportunity = negotiatedOpportunity();
   const task = negotiationTask();
   const reflectJobs: NegotiationRoundReflectJobData[] = [];
   const artifacts: Array<{ verdict: string; reasoning?: string; resolvedByUserId?: string }> = [];
+
+  type RoundLogEvent = { kind: string; taskId?: string; batchId: string; via?: string; reason?: string; createdAt: Date };
+  const roundLogEvents = new Map<string, RoundLogEvent[]>();
+  const seed = (intentId: string, batchId: string) => {
+    roundLogEvents.set(`${intentId}::${batchId}`, [
+      { kind: 'opened', taskId: task.id, batchId, createdAt: new Date() },
+      { kind: 'opening_complete', batchId, createdAt: new Date() },
+    ]);
+  };
+  seed(INTENT_ID, BATCH_ID);
+  seed(COUNTERPART_INTENT_ID, COUNTERPART_BATCH_ID);
+  const roundLog: NegotiationRoundLogDatabase = {
+    appendNegotiationRoundLogEvent: async (intentId, event) => {
+      const key = `${intentId}::${event.batchId}`;
+      const list = roundLogEvents.get(key) ?? [];
+      list.push({ ...event, createdAt: new Date() });
+      roundLogEvents.set(key, list);
+    },
+    readNegotiationRoundLogEvents: async (intentId, batchId) =>
+      [...(roundLogEvents.get(`${intentId}::${batchId}`) ?? [])] as never,
+  };
 
   const negotiationDb = {
     getOpportunity: async () => opportunity,
@@ -105,19 +128,18 @@ function createWorld() {
       task.state = state;
       return task;
     },
-    countActiveNegotiationsForRound: async (intentId: string, round: number) =>
-      task.metadata.seats[intentId]?.round === round && task.state === 'working' ? 1 : 0,
-    getIntentNegotiationRound: async (intentId: string) => ({
-      round: task.metadata.seats[intentId]?.round ?? 0,
-      roundSize: 1,
-      kickoffStartedAt: null,
+    countActiveNegotiationsForBatch: async (intentId: string, batchId: string) =>
+      task.metadata.seats[intentId]?.batchId === batchId && task.state === 'working' ? 1 : 0,
+    getIntentNegotiationBatch: async (intentId: string) => ({
+      batchId: task.metadata.seats[intentId]?.batchId ?? null,
     }),
-    getNegotiationTasksForIntentRound: async (intentId: string, round: number) =>
-      task.metadata.seats[intentId]?.round === round ? [task] : [],
+    getNegotiationTasksForIntentBatch: async (intentId: string, batchId: string) =>
+      task.metadata.seats[intentId]?.batchId === batchId ? [task] : [],
   } as unknown as NegotiationGraphDatabase;
 
   const graph = new NegotiationGraphFactory({
     database: negotiationDb,
+    roundLog,
     reflectEnqueue: async (job) => {
       reflectJobs.push(job);
     },
@@ -158,11 +180,11 @@ function createWorld() {
 }
 
 describe('OpportunityService owner verdict closes the negotiation', () => {
-  it('a user reject drops the round to zero active negotiations and enqueues reflect', async () => {
+  it('a user reject drops the batch to zero active negotiations and enqueues reflect', async () => {
     const world = createWorld();
 
-    // Before: the round still has one negotiation holding it open.
-    expect(await world.negotiationDb.countActiveNegotiationsForRound(INTENT_ID, ROUND)).toBe(1);
+    // Before: the batch still has one negotiation holding it open.
+    expect(await world.negotiationDb.countActiveNegotiationsForBatch(INTENT_ID, BATCH_ID)).toBe(1);
 
     const result = await world.service.updateOpportunityStatus(OPP_ID, 'rejected', USER_A);
     expect('error' in result).toBe(false);
@@ -170,10 +192,10 @@ describe('OpportunityService owner verdict closes the negotiation', () => {
     expect(world.opportunity.status).toBe('rejected');
     expect(world.task.state).toBe('completed');
     expect(world.task.metadata.watchdogReflectPending).toBe(false);
-    expect(await world.negotiationDb.countActiveNegotiationsForRound(INTENT_ID, ROUND)).toBe(0);
+    expect(await world.negotiationDb.countActiveNegotiationsForBatch(INTENT_ID, BATCH_ID)).toBe(0);
     expect(world.reflectJobs).toEqual([
-      { userId: USER_A, intentId: INTENT_ID, round: ROUND, generation: `${NEGOTIATION_ID}.0` },
-      { userId: USER_B, intentId: COUNTERPART_INTENT_ID, round: 0, generation: `${NEGOTIATION_ID}.0` },
+      { userId: USER_A, intentId: INTENT_ID, batchId: BATCH_ID, dedupeKey: `${NEGOTIATION_ID}.2` },
+      { userId: USER_B, intentId: COUNTERPART_INTENT_ID, batchId: COUNTERPART_BATCH_ID, dedupeKey: `${NEGOTIATION_ID}.2` },
     ]);
     expect(world.artifacts).toEqual([
       {
@@ -193,10 +215,10 @@ describe('OpportunityService owner verdict closes the negotiation', () => {
     // Owner-close never writes over the terminal status the owner just set.
     expect(world.opportunity.status).toBe('accepted');
     expect(world.task.state).toBe('completed');
-    expect(await world.negotiationDb.countActiveNegotiationsForRound(INTENT_ID, ROUND)).toBe(0);
+    expect(await world.negotiationDb.countActiveNegotiationsForBatch(INTENT_ID, BATCH_ID)).toBe(0);
     expect(world.reflectJobs).toEqual([
-      { userId: USER_A, intentId: INTENT_ID, round: ROUND, generation: `${NEGOTIATION_ID}.0` },
-      { userId: USER_B, intentId: COUNTERPART_INTENT_ID, round: 0, generation: `${NEGOTIATION_ID}.0` },
+      { userId: USER_A, intentId: INTENT_ID, batchId: BATCH_ID, dedupeKey: `${NEGOTIATION_ID}.2` },
+      { userId: USER_B, intentId: COUNTERPART_INTENT_ID, batchId: COUNTERPART_BATCH_ID, dedupeKey: `${NEGOTIATION_ID}.2` },
     ]);
   });
 


### PR DESCRIPTION
## Summary
- Four racy, separately-written fields (`intents.negotiation_round`, `negotiation_round_size`, `negotiation_kickoff_started_at`, and each negotiation task's `metadata.drainGeneration`) decided whether a signal's negotiation round had settled. Replaced with `negotiation_round_log_events`, an append-only log per `(intentId, batchId)`, and a pure fold (`foldNegotiationRoundLog`) that answers settlement and derives the reflect job's dedupe key directly from the log.
- New event kinds: `opened`, `stopped`, `resumed`, and `opening_complete` (the kickoff-finished-opening marker replacing the old size stamp).
- `NegotiationSeatBinding.round` → `.batchId`; `intents.negotiation_batch_id` (one column) replaces the old three. `drainGeneration` retired.
- `negotiation.graph.ts`'s apply/resolve/close/expire nodes append the corresponding event and fold before triggering reflect; a counterparty seat that has never kicked off gets its batch created lazily on first touch (documented behavior change: passive negotiations now group by first-touch batch rather than one shared implicit "round 0" — reflect still fires correctly, just possibly more granularly).
- `agent.graph.ts`'s kickoff appends `opened`/`opening_complete` events; interrupted-kickoff staleness reads the log's own event timestamps instead of a dedicated started-at column.
- Migrations 0154–0156: adds the event-log table, drops two orphaned tables left over from earlier feature removals (`discovery_match_candidates`, `user_contexts`) whose drop migrations were never applied, and the round-to-batch column cutover.

## Test plan
- [x] `bun run architecture:check` (protocol) — clean
- [x] `bun run build` (protocol) — clean
- [x] `tsc --noEmit` (services/api) — clean
- [x] `bun run test` (protocol, non-live-model suite): 1545 pass / 0 fail
- [x] Negotiation-specific suites (both packages): 129/131 pass — 2 pre-existing failures are unrelated `opportunity_status` enum drift on the test DB, predates this change
- [x] Migrations applied and verified against a local test database
- [ ] CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019nsBwFVRmNQ1rqzQXVc2vL