### PR TITLE
fix: treat a missing batchId the same as null when skipping seats

### DIFF
--- a/packages/protocol/src/internal/negotiations/negotiation.graph.ts
+++ b/packages/protocol/src/internal/negotiations/negotiation.graph.ts
@@ -526,9 +526,13 @@ async function applyNode(state: NegotiationState, deps: NegotiationGraphDeps): P
 
 /**
  * Append one round-log event (stopped or resumed) for every seat bound to
- * this negotiation that has ever run a kickoff of its own (`batchId !==
- * null`). A seat whose intent has never kicked off has no batch to log
- * against — its own reflect will start once its first kickoff bumps one.
+ * this negotiation that has a batch to log against. Two cases skip: a seat
+ * whose intent has never kicked off (`batchId` is `null`) — its own reflect
+ * starts once its first kickoff bumps one — and a seat bound before this
+ * mechanism existed, whose stored `{userId, round}` shape has no `batchId`
+ * field at all (`undefined`, not `null`); `!binding.batchId` catches both,
+ * where `=== null` alone would let a pre-cutover task try to log an
+ * `undefined` batch id and fail the NOT NULL write.
  */
 async function appendRoundLogEventForEverySeat(
   deps: NegotiationGraphDeps,
@@ -537,7 +541,7 @@ async function appendRoundLogEventForEverySeat(
   event: { kind: "resumed" } | { kind: "stopped"; via: "paused" | "completed"; reason?: NegotiationPauseReason },
 ): Promise<void> {
   await Promise.all(Object.entries(meta.seats).map(async ([intentId, binding]) => {
-    if (binding.batchId === null) return;
+    if (!binding.batchId) return;
     if (event.kind === "resumed") {
       await deps.roundLog.appendNegotiationRoundLogEvent(intentId, { kind: "resumed", taskId, batchId: binding.batchId });
       return;
@@ -554,12 +558,13 @@ async function appendRoundLogEventForEverySeat(
  * Both sides batch their own kickoffs, so one pause can be the last one of
  * either side's — checking only the opener's would leave the counterparty's
  * batch waiting on a negotiation that had already stopped. A seat with no
- * batch (`batchId === null`) has never kicked off and has nothing to fold.
+ * batch — never kicked off (`batchId` is `null`), or bound before this
+ * mechanism existed (`batchId` is `undefined`) — has nothing to fold.
  */
 async function triggerReflectForEverySeat(deps: NegotiationGraphDeps, meta: NegotiationTaskMetadata): Promise<boolean> {
   let succeeded = true;
   for (const [intentId, binding] of Object.entries(meta.seats)) {
-    if (binding.batchId === null) continue;
+    if (!binding.batchId) continue;
     const checked = await maybeEnqueueRoundReflect(deps.roundLog, deps.reflectEnqueue, {
       userId: binding.userId,
       intentId,


### PR DESCRIPTION
## Summary
- #1540 replaced negotiation round bookkeeping with an event log; seat bindings moved from `{userId, round}` to `{userId, batchId}`.
- The guards in `negotiation.graph.ts` that skip a seat with nothing to fold checked `binding.batchId === null` — but a negotiation task bound **before** #1540 stores the old `{userId, round}` shape, with no `batchId` field at all, so `binding.batchId` is `undefined`, not `null`. `undefined === null` is `false` in JS, so the guard didn't catch legacy rows.
- Confirmed live on the dev database (Neon, `protocol_prod`/`dev` branch): 3 paused pre-cutover negotiation tasks have this exact shape. The next pause/resume/resolve/close/expire on any of them would try to write a round-log event with `batch_id: undefined` into a `NOT NULL` column and fail that turn.
- Fix: `!binding.batchId` catches both `null` and `undefined`.

## Test plan
- [x] `bun run architecture:check` (protocol) — clean
- [x] `bun run build` (protocol) — clean
- [x] `bun test src/internal/negotiations` (protocol) — 18 pass / 0 fail
- [ ] CI

Follow-up (not in this PR, needs explicit sign-off before touching real data): whether to backfill the 3 legacy tasks' seat bindings + round-log so their batch-reflect trigger works going forward, versus leaving them permanently skipped by this guard (soft degradation — they still surface for verdicts via the non-batch-scoped paused-task read, just won't fire the batch-settle reflect).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019nsBwFVRmNQ1rqzQXVc2vL