### PR TITLE
fix: record agent's file: a2a dependency in bun.lock

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -1916,6 +1916,8 @@
 
     "@hono/node-ws/@hono/node-server": ["@hono/node-server@1.19.14", "", { "peerDependencies": { "hono": "^4" } }, "sha512-GwtvgtXxnWsucXvbQXkRgqksiH2Qed37H9xHZocE5sA3N8O8O8/8FA3uclQXxXVzc9XBZuEOMK7+r02FmSpHtw=="],
 
+    "@indexnetwork/agent/@indexnetwork/a2a": ["@indexnetwork/a2a@file:packages/a2a", { "devDependencies": { "@types/bun": "1.3.14", "typescript": "5.9.3" }, "peerDependencies": { "typescript": "^5" }, "bin": { "index-a2a": "./dist/cli/index.js" } }],
+
     "@indexnetwork/protocol/@types/node": ["@types/node@25.9.1", "", { "dependencies": { "undici-types": ">=7.24.0 <7.24.7" } }, "sha512-xfrlY7UD5rMJk3ZVJP8BNzS28J36YJg+xp+LPXV1TdWxr8uMH5A860QNxYDGQe/ylDSgjxE52Q9VnO7p75tJxg=="],
 
     "@langchain/core/langsmith": ["langsmith@0.7.2", "", { "dependencies": { "p-queue": "6.6.2" }, "peerDependencies": { "@opentelemetry/api": "*", "@opentelemetry/exporter-trace-otlp-proto": "*", "@opentelemetry/sdk-trace-base": "*", "openai": "*", "ws": ">=7" }, "optionalPeers": ["@opentelemetry/api", "@opentelemetry/exporter-trace-otlp-proto", "@opentelemetry/sdk-trace-base", "openai", "ws"] }, "sha512-3dZUwQDJluxi2ih5eIygFODtlrQKrs3Tua0Ck3l+DAUkSGFkB1Dc0JPqkGbqiVSN+TQDElnkev/ydAOAz6jndA=="],


### PR DESCRIPTION
## Summary
- Adding `packages/a2a` and `packages/agent` as workspaces left the agent's `file:../a2a` resolution out of `bun.lock`.
- Railway frontend/protocol and the protocol-architecture CI job all run `bun install --frozen-lockfile`, which then failed.
- This records that one lockfile entry so frozen install succeeds again.

## Test plan
- [x] `bun install --frozen-lockfile` succeeds locally
- [ ] CI protocol-architecture job passes
- [ ] Index frontend and protocol Railway deploys succeed after merge to `dev`