### PR TITLE
feat(mac): publish notarized DMG to GitHub Releases

### DIFF
--- a/.github/workflows/mac-app-build.yml
+++ b/.github/workflows/mac-app-build.yml
@@ -40,7 +40,7 @@ jobs:
 
       - name: Shell syntax check
         working-directory: apps/mac
-        run: bash -n scripts/build.sh scripts/link-host.sh scripts/provisioning-profile.sh scripts/notarize.sh scripts/dmg.sh
+        run: bash -n scripts/build.sh scripts/link-host.sh scripts/provisioning-profile.sh scripts/notary-submit.sh scripts/notarize.sh scripts/dmg.sh
 
       - name: Assemble web layer
         working-directory: apps/mac

--- a/.github/workflows/mac-app-release.yml
+++ b/.github/workflows/mac-app-release.yml
@@ -1,0 +1,125 @@
+# Signs, notarizes, and publishes dist/Index.dmg to a rolling GitHub Release.
+#
+# PRs stay on mac-app-build.yml (ad-hoc compile). This job is the
+# distributable: Developer ID + notarized app + notarized DMG.
+#
+# Durable downloads:
+#   dev  → …/releases/download/mac-dev/Index.dmg  (prerelease)
+#   main → …/releases/download/mac/Index.dmg
+name: Release macOS DMG
+
+on:
+  push:
+    branches: [dev, main]
+    paths:
+      - "apps/mac/**"
+      - ".github/workflows/mac-app-release.yml"
+  workflow_dispatch:
+
+concurrency:
+  group: mac-app-release-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: write
+
+jobs:
+  dmg:
+    runs-on: macos-latest
+    timeout-minutes: 60
+    env:
+      MAC_CODESIGN_P12: ${{ secrets.MAC_CODESIGN_P12 }}
+      MAC_CODESIGN_P12_PASSWORD: ${{ secrets.MAC_CODESIGN_P12_PASSWORD }}
+      MAC_CODESIGN_IDENTITY: ${{ secrets.MAC_CODESIGN_IDENTITY }}
+      MAC_APP_IDENTIFIER_PREFIX: ${{ secrets.MAC_APP_IDENTIFIER_PREFIX }}
+      MAC_PROVISIONING_PROFILE: ${{ secrets.MAC_PROVISIONING_PROFILE }}
+      MAC_NOTARY_KEY: ${{ secrets.MAC_NOTARY_KEY }}
+      MAC_NOTARY_KEY_ID: ${{ secrets.MAC_NOTARY_KEY_ID }}
+      MAC_NOTARY_ISSUER: ${{ secrets.MAC_NOTARY_ISSUER }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Require signing secrets
+        run: |
+          set -euo pipefail
+          missing=0
+          for name in MAC_CODESIGN_P12 MAC_CODESIGN_P12_PASSWORD MAC_CODESIGN_IDENTITY \
+            MAC_APP_IDENTIFIER_PREFIX MAC_PROVISIONING_PROFILE \
+            MAC_NOTARY_KEY MAC_NOTARY_KEY_ID MAC_NOTARY_ISSUER; do
+            if [ -z "${!name}" ]; then
+              echo "missing secret: $name"
+              missing=1
+            fi
+          done
+          exit "$missing"
+
+      - name: Channel
+        id: channel
+        run: |
+          set -euo pipefail
+          if [ "${GITHUB_REF_NAME}" = "main" ]; then
+            echo "link_host=index.network" >> "$GITHUB_OUTPUT"
+            echo "tag=mac" >> "$GITHUB_OUTPUT"
+            echo "prerelease=false" >> "$GITHUB_OUTPUT"
+            echo "title=Index macOS" >> "$GITHUB_OUTPUT"
+          else
+            echo "link_host=dev.index.network" >> "$GITHUB_OUTPUT"
+            echo "tag=mac-dev" >> "$GITHUB_OUTPUT"
+            echo "prerelease=true" >> "$GITHUB_OUTPUT"
+            echo "title=Index macOS (dev)" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Import Developer ID certificate
+        uses: apple-actions/import-codesign-certs@b2e261033a9e248f91a9b57201e8d1e12b15a24e # v7.0.0
+        with:
+          p12-file-base64: ${{ secrets.MAC_CODESIGN_P12 }}
+          p12-password: ${{ secrets.MAC_CODESIGN_P12_PASSWORD }}
+
+      - name: Write provisioning profile and notary key
+        run: |
+          set -euo pipefail
+          umask 077
+          printf '%s' "$MAC_PROVISIONING_PROFILE" | base64 -D > "$RUNNER_TEMP/Index.provisionprofile"
+          printf '%s\n' "$MAC_NOTARY_KEY" > "$RUNNER_TEMP/AuthKey.p8"
+
+      - name: Shell syntax check
+        working-directory: apps/mac
+        run: bash -n scripts/build.sh scripts/link-host.sh scripts/provisioning-profile.sh scripts/notary-submit.sh scripts/notarize.sh scripts/dmg.sh
+
+      - name: Build, notarize, and package DMG
+        working-directory: apps/mac
+        env:
+          INDEX_LINK_HOST: ${{ steps.channel.outputs.link_host }}
+          INDEX_APP_IDENTIFIER_PREFIX: ${{ secrets.MAC_APP_IDENTIFIER_PREFIX }}
+          CODESIGN_IDENTITY: ${{ secrets.MAC_CODESIGN_IDENTITY }}
+          PROVISIONING_PROFILE: ${{ runner.temp }}/Index.provisionprofile
+          NOTARYTOOL_KEY: ${{ runner.temp }}/AuthKey.p8
+          NOTARYTOOL_KEY_ID: ${{ secrets.MAC_NOTARY_KEY_ID }}
+          NOTARYTOOL_ISSUER: ${{ secrets.MAC_NOTARY_ISSUER }}
+        run: |
+          set -euo pipefail
+          ./scripts/build.sh
+          ./scripts/notarize.sh
+          open -a Finder
+          ./scripts/dmg.sh
+          xcrun stapler validate dist/Index.dmg
+
+      - name: Publish GitHub Release
+        working-directory: apps/mac
+        env:
+          GH_TOKEN: ${{ github.token }}
+          TAG: ${{ steps.channel.outputs.tag }}
+          TITLE: ${{ steps.channel.outputs.title }}
+          PRERELEASE: ${{ steps.channel.outputs.prerelease }}
+        run: |
+          set -euo pipefail
+          test -f dist/Index.dmg
+          notes="Index.dmg from ${GITHUB_SHA} on ${GITHUB_REF_NAME}."
+          if gh release view "$TAG" >/dev/null 2>&1; then
+            gh release upload "$TAG" dist/Index.dmg --clobber
+            gh release edit "$TAG" --title "$TITLE" --notes "$notes"
+          elif [ "$PRERELEASE" = "true" ]; then
+            gh release create "$TAG" dist/Index.dmg --target "$GITHUB_SHA" --title "$TITLE" --notes "$notes" --prerelease
+          else
+            gh release create "$TAG" dist/Index.dmg --target "$GITHUB_SHA" --title "$TITLE" --notes "$notes" --latest
+          fi

--- a/apps/mac/README.md
+++ b/apps/mac/README.md
@@ -32,6 +32,17 @@ Generated HTML must be regenerated through `assemble.py`, never hand-edited. The
 
 Production distribution is direct Developer ID distribution, not the Mac App Store. It requires macOS 13+, Universal 2 artifacts, Hardened Runtime, Developer ID signing, notarization, stapling, checksums, immutable production HTTPS endpoint inputs, and a clean-account acceptance run. **App Sandbox is not a production requirement** for this direct-distribution model; release validation rejects unexpected sandbox/debug entitlements rather than requiring them.
 
+Pushes to `dev` and `main` that touch `apps/mac` run `.github/workflows/mac-app-release.yml`: Developer ID sign, notarize the app, package the branded DMG, notarize that, and attach `Index.dmg` to a rolling release.
+
+| Branch | Release | Download |
+| --- | --- | --- |
+| `dev` | prerelease `mac-dev` | `https://github.com/indexnetwork/index/releases/download/mac-dev/Index.dmg` |
+| `main` | `mac` (latest) | `https://github.com/indexnetwork/index/releases/download/mac/Index.dmg` |
+
+Required Actions secrets (fail closed if any are missing): `MAC_CODESIGN_P12`, `MAC_CODESIGN_P12_PASSWORD`, `MAC_CODESIGN_IDENTITY`, `MAC_APP_IDENTIFIER_PREFIX`, `MAC_PROVISIONING_PROFILE`, `MAC_NOTARY_KEY`, `MAC_NOTARY_KEY_ID`, `MAC_NOTARY_ISSUER`. Pull requests do not produce a DMG; they stay on the ad-hoc compile in `mac-app-build.yml`.
+
+`./scripts/notarize.sh` and `./scripts/dmg.sh` accept either a local `NOTARYTOOL_PROFILE` or CI's `NOTARYTOOL_KEY` / `NOTARYTOOL_KEY_ID` / `NOTARYTOOL_ISSUER`.
+
 ### Development: Hot-Reload Mode
 
 For rapid iteration without rebuilding the Swift binary each time:
@@ -149,6 +160,6 @@ NOTARYTOOL_PROFILE='<local-keychain-profile>' ./scripts/dmg.sh
 xcrun stapler validate dist/Index.dmg
 ```
 
-`./scripts/dmg.sh` revalidates the signed, stapled bundle, lays out the branded disk image, notarizes it, and staples `dist/Index.dmg`. The DMG is the handoff artifact.
+`./scripts/dmg.sh` revalidates the signed, stapled bundle, lays out the branded disk image, notarizes it, and staples `dist/Index.dmg`. The local DMG is for debugging; GitHub Releases are the distribution path.
 
 Record only redacted commands and pass/fail status in PR evidence; never IDs, credentials, certificate subjects, or profile names.

--- a/apps/mac/scripts/dmg.sh
+++ b/apps/mac/scripts/dmg.sh
@@ -8,13 +8,15 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 MAC_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
 cd "$MAC_ROOT"
 
+source "$SCRIPT_DIR/notary-submit.sh"
+
 APP_PATH="${APP_PATH:-dist/Index.app}"
 DMG_PATH="${DMG_PATH:-dist/Index.dmg}"
 VOLUME_NAME="${VOLUME_NAME:-Index}"
 SKIP_NOTARY="${SKIP_NOTARY:-0}"
 
 if [ "$SKIP_NOTARY" != "1" ]; then
-    PROFILE="${NOTARYTOOL_PROFILE:?set NOTARYTOOL_PROFILE to a local keychain profile (SKIP_NOTARY=1 exists only for CI packaging tests)}"
+    require_notary_auth
 fi
 
 [ -d "$APP_PATH" ] || { echo "app not found: $APP_PATH" >&2; exit 1; }
@@ -133,7 +135,7 @@ mv -f "$WORK/compressed.dmg" "$DMG_PATH"
 
 if [ "$SKIP_NOTARY" != "1" ]; then
     echo "==> Notarizing DMG"
-    xcrun notarytool submit "$DMG_PATH" --keychain-profile "$PROFILE" --wait
+    notary_submit "$DMG_PATH"
     xcrun stapler staple "$DMG_PATH"
     xcrun stapler validate "$DMG_PATH"
 fi

--- a/apps/mac/scripts/notarize.sh
+++ b/apps/mac/scripts/notarize.sh
@@ -7,17 +7,18 @@ cd "$MAC_ROOT"
 
 source "$SCRIPT_DIR/link-host.sh"
 source "$SCRIPT_DIR/provisioning-profile.sh"
+source "$SCRIPT_DIR/notary-submit.sh"
 
 APP_PATH="${APP_PATH:-dist/Index.app}"
-PROFILE="${NOTARYTOOL_PROFILE:?set NOTARYTOOL_PROFILE to a local keychain profile}"
 ARCHIVE="${ARCHIVE_PATH:-dist/index-notarize.zip}"
+require_notary_auth
 
 [ -d "$APP_PATH" ] || { echo "app not found: $APP_PATH" >&2; exit 1; }
 codesign --verify --deep --strict --verbose=2 "$APP_PATH"
 LINK_HOST="$(/usr/libexec/PlistBuddy -c 'Print :IndexDeepLinkHost' "$APP_PATH/Contents/Info.plist")"
 validate_embedded_profile "$APP_PATH" "$LINK_HOST"
 ditto -c -k --keepParent "$APP_PATH" "$ARCHIVE"
-xcrun notarytool submit "$ARCHIVE" --keychain-profile "$PROFILE" --wait
+notary_submit "$ARCHIVE"
 xcrun stapler staple "$APP_PATH"
 xcrun stapler validate "$APP_PATH"
 codesign --verify --deep --strict --verbose=2 "$APP_PATH"

--- a/apps/mac/scripts/notary-submit.sh
+++ b/apps/mac/scripts/notary-submit.sh
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+# Notary auth for notarize.sh and dmg.sh. Source this file; do not execute it.
+#
+# CI: NOTARYTOOL_KEY (path to .p8) + NOTARYTOOL_KEY_ID + NOTARYTOOL_ISSUER
+# Local: NOTARYTOOL_PROFILE (keychain profile from `notarytool store-credentials`)
+
+require_notary_auth() {
+  if [ -n "${NOTARYTOOL_KEY:-}" ]; then
+    : "${NOTARYTOOL_KEY_ID:?set NOTARYTOOL_KEY_ID with NOTARYTOOL_KEY}"
+    : "${NOTARYTOOL_ISSUER:?set NOTARYTOOL_ISSUER with NOTARYTOOL_KEY}"
+    [ -f "$NOTARYTOOL_KEY" ] || {
+      echo "notary API key file not found: $NOTARYTOOL_KEY" >&2
+      return 1
+    }
+    return 0
+  fi
+  : "${NOTARYTOOL_PROFILE:?set NOTARYTOOL_PROFILE or NOTARYTOOL_KEY}"
+}
+
+# Submit an artifact and wait for Apple's notarization result.
+# @param $1 Path to the zip or DMG to submit.
+notary_submit() {
+  local artifact="${1:?artifact path required}"
+  require_notary_auth
+  if [ -n "${NOTARYTOOL_KEY:-}" ]; then
+    xcrun notarytool submit "$artifact" --key "$NOTARYTOOL_KEY" --key-id "$NOTARYTOOL_KEY_ID" --issuer "$NOTARYTOOL_ISSUER" --wait
+  else
+    xcrun notarytool submit "$artifact" --keychain-profile "$NOTARYTOOL_PROFILE" --wait
+  fi
+}


### PR DESCRIPTION
## Summary
- Adds `.github/workflows/mac-app-release.yml`: on push to `dev`/`main` (and manual dispatch), Developer ID-sign, notarize `Index.app`, package the branded DMG, notarize it, and attach `Index.dmg` to rolling releases `mac-dev` (prerelease) and `mac` (latest).
- `notarize.sh` / `dmg.sh` accept an App Store Connect API key (`NOTARYTOOL_KEY` + id + issuer) for CI, keeping the local keychain profile path.
- PR compile job stays ad-hoc; Actions secrets `MAC_*` are already set on the repo.

## Test plan
- [ ] After merge to `dev`, confirm the release workflow runs and `https://github.com/indexnetwork/index/releases/download/mac-dev/Index.dmg` appears
- [ ] `xcrun stapler validate` on that DMG; Gatekeeper opens it without a warning on a clean Mac
- [ ] PR that only touches `apps/mac` still runs `mac-app-build.yml` and does **not** publish a DMG