### PR TITLE
feat(web): make Index Negotiator the hosted default on /agents

### DIFF
--- a/apps/web/CHANGELOG.md
+++ b/apps/web/CHANGELOG.md
@@ -26,11 +26,13 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
   handshake mints from the same client. Agent pages no longer show keys, setup
   wizards or a Permissions tab — an agent is a name, a status and notification
   preferences.
-- **You pick your negotiator on `/agents`.** The personal agent list is a
-  single-choice selector, so the one place that sets it is the list itself; the
-  "Handle negotiations on my behalf" checkbox is gone from the agent detail
-  page. The System Agents section is replaced by a static, disabled "Index
-  Negotiator" row labelled *not yet active*, because nothing runs it yet.
+- **You pick your negotiator on `/agents`, and Index is the default.** The list
+  is a single-choice radio selector, so the one place that sets it is the list
+  itself; the "Handle negotiations on my behalf" checkbox is gone from the agent
+  detail page. The System Agents section is replaced by an "Index Negotiator"
+  row that is selected whenever no registered agent is bound — the API runs that
+  hosted agent for your active intents — and choosing a registered agent hands
+  negotiations over. Choosing Index again hands them back.
 - Inviting someone to a network reports membership only. There is no
   "agent provisioned" state and no resend-invitation action, because the
   invitation carries no credential to refresh.

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@indexnetwork/web",
-  "version": "0.71.0",
+  "version": "0.72.0",
   "license": "MIT",
   "scripts": {
     "dev": "vite --host ::",

--- a/apps/web/src/app/agents/page.tsx
+++ b/apps/web/src/app/agents/page.tsx
@@ -48,7 +48,7 @@ export default function AgentsPage() {
   const [registerOpen, setRegisterOpen] = useState(false);
   const [newAgentName, setNewAgentName] = useState('');
   const [newAgentDescription, setNewAgentDescription] = useState('');
-  const [selecting, setSelecting] = useState<string | null>(null);
+  const [selecting, setSelecting] = useState(false);
 
   useEffect(() => {
     if (!authLoading && !isAuthenticated) {
@@ -87,6 +87,12 @@ export default function AgentsPage() {
     [agents],
   );
 
+  // No registered agent bound to negotiations means the Index-hosted agent runs them.
+  const selectedNegotiator = useMemo(
+    () => personalAgents.find((agent) => agent.handleNegotiations) ?? null,
+    [personalAgents],
+  );
+
   async function refreshAgents() {
     const next = await agentsService.list();
     setAgents(next);
@@ -112,17 +118,25 @@ export default function AgentsPage() {
     }
   }
 
-  async function handleSelectNegotiator(agent: Agent) {
-    const next = !agent.handleNegotiations;
-    setSelecting(agent.id);
+  /**
+   * @param agent - The registered agent to bind, or null to hand negotiations
+   *   back to the Index-hosted agent by clearing the current binding.
+   */
+  async function handleSelectNegotiator(agent: Agent | null) {
+    const target = agent ?? selectedNegotiator;
+    if (!target) {
+      return;
+    }
+
+    setSelecting(true);
     try {
-      await agentsService.update(agent.id, { handleNegotiations: next });
+      await agentsService.update(target.id, { handleNegotiations: agent !== null });
       await refreshAgents();
-      success(next ? `${agent.name} handles negotiations` : 'No agent handles negotiations');
+      success(agent ? `${agent.name} handles negotiations` : 'Index Negotiator handles negotiations');
     } catch (err) {
       error('Failed to set the negotiator', err instanceof Error ? err.message : undefined);
     } finally {
-      setSelecting(null);
+      setSelecting(false);
     }
   }
 
@@ -227,18 +241,20 @@ export default function AgentsPage() {
                       <tr className="border-b border-gray-100 last:border-b-0">
                         <td className="px-4 py-2">
                           <input
-                            type="checkbox"
-                            checked={false}
-                            disabled
+                            type="radio"
+                            name="negotiator"
+                            checked={selectedNegotiator === null}
+                            onChange={() => handleSelectNegotiator(null)}
+                            disabled={selecting}
                             aria-label="Index Negotiator handles negotiations"
-                            className="w-4 h-4 accent-black"
+                            className="w-4 h-4 accent-black disabled:cursor-not-allowed"
                           />
                         </td>
                         <td className="px-4 py-2">
                           <span className="text-sm text-gray-700">Index Negotiator</span>
-                          <span className="ml-2 text-xs text-gray-400 font-ibm-plex-mono">not yet active</span>
+                          <span className="ml-2 text-xs text-gray-400 font-ibm-plex-mono">hosted</span>
                           <p className="text-xs text-gray-400 font-ibm-plex-mono mt-0.5">
-                            Hosted by Index. It does not run yet, so negotiations wait for your own agent.
+                            Hosted by Index. Runs for your active intents.
                           </p>
                         </td>
                         <td className="px-4 py-2 text-xs text-gray-400 font-ibm-plex-mono">—</td>
@@ -249,10 +265,11 @@ export default function AgentsPage() {
                         <tr key={agent.id} className="border-b border-gray-100 last:border-b-0">
                           <td className="px-4 py-2">
                             <input
-                              type="checkbox"
+                              type="radio"
+                              name="negotiator"
                               checked={agent.handleNegotiations}
                               onChange={() => handleSelectNegotiator(agent)}
-                              disabled={selecting !== null}
+                              disabled={selecting}
                               aria-label={`${agent.name} handles negotiations`}
                               className="w-4 h-4 accent-black disabled:cursor-not-allowed"
                             />
@@ -288,10 +305,6 @@ export default function AgentsPage() {
                     </tbody>
                   </table>
                 </div>
-
-                {personalAgents.length === 0 ? (
-                  <p className="text-xs text-gray-400 font-ibm-plex-mono">No personal agents yet.</p>
-                ) : null}
               </div>
             </div>
           )}

--- a/bun.lock
+++ b/bun.lock
@@ -19,7 +19,7 @@
     },
     "apps/web": {
       "name": "@indexnetwork/web",
-      "version": "0.71.0",
+      "version": "0.72.0",
       "dependencies": {
         "@better-auth/api-key": "1.6.11",
         "@indexnetwork/protocol": "workspace:*",


### PR DESCRIPTION
## Changed

- **Index Negotiator is the default negotiator on `/agents`, and it is selectable.** The API has run the builtin personal agent for every active intent since the negotiation lab merged (#1559), so the settings row claiming it *"does not run yet"* was the last surface describing the old world. The row is now selected whenever no registered agent is bound, its status reads `hosted`, and its description is "Hosted by Index. Runs for your active intents."
- **The selector is single-choice.** The negotiator column is radios sharing one `name`, so there is no longer a state where nothing is selected. Choosing a registered agent binds it; choosing Index clears that binding, which `setNegotiationExecutorBinding` already treats as "hosted again" — it drops the session leases so `PersonalAgentService` resumes. No new endpoint, no schema change.
- **Copy that described the gap is gone.** Unselecting used to toast "No agent handles negotiations", which named a state that does not exist; it now says "Index Negotiator handles negotiations". The "No personal agents yet." line is removed because the table always has the Index row.

Because a radio only fires `onChange` when it becomes the selection, each click is exactly one `PATCH` and clicking the already-selected row is a no-op.

## Verification

- `bunx eslint src/app/agents/page.tsx` — clean
- `vite build` — passes
- Pre-commit build checks across `protocol`, `agent`, `agent-tui`, `api`, `web` — pass
- `bun run check:lockfile-versions` — matches after the `0.72.0` bump

`tsc --noEmit` on `apps/web` reports 33 errors, all pre-existing in other files and none in the agents page; the app has no `typecheck` script and does not gate on it.

Not done: the hosted-default → registered agent → back round trip has not been clicked through in a browser.

## Notes

`GET /agents/me` and the MCP `read_own_agent` tool still answer "No negotiator agent is selected" when hosted is the default, because the builtin identity has no `protocol_agents` row. Left as-is — it is the external-runtime contract and a separate decision for CLI/MCP identity.