### PR TITLE
feat(agent-tui)!: add multi-user boards and intent selection

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -74,7 +74,7 @@
     },
     "packages/agent-tui": {
       "name": "@indexnetwork/agent-tui",
-      "version": "0.2.0",
+      "version": "0.3.0",
       "dependencies": {
         "@indexnetwork/agent": "workspace:*",
         "@indexnetwork/protocol": "workspace:*",

--- a/packages/agent-tui/README.md
+++ b/packages/agent-tui/README.md
@@ -2,7 +2,7 @@
 
 A terminal testing platform for personal agents. It displays one pane per selected
 user, with an intent selector and an independent H2A conversation for each
-user–intent pair. A two-user board can also display its selected intents' A2A
+user–intent pair. Two expanded users also display their selected intents' A2A
 conversation. Agent behavior is
 owned by `@indexnetwork/agent`; participation rules belong to
 `@indexnetwork/protocol`.
@@ -90,13 +90,16 @@ The roster requires at least two distinct users. Expanded chats share the width
 equally, targeting at least 40 columns each. Overflow collapses from the end of
 roster order while preserving the focused user. A 24-column scrollable list shows
 collapsed users, their selected intent, and counts of pending and queued questions
-across their intents. Selecting a collapsed user displaces another chat if needed.
+across their intents. Names and question indicators highlight only while a question
+awaits input; queue counts stay muted. Selecting a collapsed user displaces another
+chat if needed.
 Widening restores automatically collapsed chats; manually collapsed chats stay
 collapsed until selected.
 
-A2A appears between two expanded users at 122 columns or wider. It hides before
-H2A chats collapse, and always stays hidden with three or more users on the board,
-including collapsed users. An unmatched pair shows an empty A2A pane.
+A2A appears between exactly two expanded users, including when other users are
+collapsed. The two chats share space with A2A, becoming narrower when needed to
+keep the negotiation visible. With one or three or more expanded users, A2A is
+hidden. An unmatched pair shows an empty A2A pane.
 
 Each user–intent pair retains its agent, draft, history and scroll position,
 suggested-answer selection, pending questions, and in-flight sends through intent,

--- a/packages/agent-tui/README.md
+++ b/packages/agent-tui/README.md
@@ -1,7 +1,9 @@
 # @indexnetwork/agent-tui
 
-A terminal testing platform for personal agents. It displays one H2A conversation
-per principal/intent and a separate A2A conversation per match. Agent behavior is
+A terminal testing platform for personal agents. It displays one pane per selected
+user, with an intent selector and an independent H2A conversation for each
+user–intent pair. A two-user board can also display its selected intents' A2A
+conversation. Agent behavior is
 owned by `@indexnetwork/agent`; participation rules belong to
 `@indexnetwork/protocol`.
 
@@ -15,9 +17,10 @@ bun --env-file=.env.development run agent:tui
 ```
 
 Requires `OPENROUTER_API_KEY` and an interactive terminal. Choose a JSON scenario
-with Up/Down + Enter or a click. The default roster has 12 users and 66 simulated
-matches. All matches start automatically in the background. Changing a pane only
-changes what you see.
+with Up/Down + Enter or a click. The default roster has 12 users, two intents per
+user, and 264 simulated matches between different users' intents. All 24 personal
+agents and their matches run independently of the visible board. Changing users,
+intents, or collapsed panes only changes what you see.
 
 Override the shared model client's ordered model list with one to three IDs:
 
@@ -43,10 +46,11 @@ so it can acquire the selected sessions. The normal server now starts agents
 automatically; both entry points use the same exclusive session leases.
 
 Choose principal/intent sessions with Space or a click, then Enter to start.
-Select intents belonging to at least two users. Only selected personal agents
-run; an unselected counterparty needs its own runtime to respond. Each selected
-agent handles all its existing and newly received matches independently of the
-visible pair. Normal API discovery creates new matches; the TUI does not seed
+Select intents belonging to at least two users. Select every intent you want to
+switch between: the board's intent selectors offer these startup selections.
+Only selected personal agents run; an unselected counterparty needs its own
+runtime to respond. Each selected agent handles all its existing and newly
+received matches independently of the visible board. Normal API discovery creates new matches; the TUI does not seed
 users or bypass matching.
 
 The command calls API services as the selected principals directly. This is a
@@ -67,10 +71,13 @@ see [the API's live testing instructions](../../services/api/README.md#personal-
 
 | Control | Action |
 | --- | --- |
-| Click a name / Ctrl+U | Choose the principal/intent for that side |
-| Up/Down, Enter | Select and confirm a user or suggested answer |
-| Tab | Move between H2A, A2A, and H2A panes |
-| Ctrl+N | Cycle through matches between the selected intents |
+| Users button / Ctrl+U | Open the board roster; Space/click toggles users, Enter applies, Esc cancels |
+| Click the intent header / Ctrl+T | Choose that user's intent with Up/Down + Enter or a click; Esc cancels |
+| Header [−] / Ctrl+O | Collapse a chat, keeping at least one expanded |
+| Click a collapsed user | Expand and focus their selected intent |
+| Up/Down, Enter | Select and confirm a suggested answer |
+| Tab / Shift+Tab | Cycle users in roster order, expanding collapsed chats; include A2A only when visible |
+| Ctrl+N | Cycle matches between the selected intents while A2A is visible |
 | Enter in the text box | Answer the displayed question, or message the personal agent when none is active |
 | Custom reply / click the text box | Write an answer in your own words |
 | Esc | Return from custom editing to choices, or close a selector |
@@ -78,12 +85,25 @@ see [the API's live testing instructions](../../services/api/README.md#personal-
 | Mouse wheel / PgUp / PgDn | Scroll the selected history |
 | Ctrl+C | Stop the local run |
 
-Drafts follow their principal/intent. Questions keep their ID, wording, scope,
-and match references while you answer. Related requests for an intent-wide fact
-can join an existing question internally; approvals remain specific to a match.
-Routine A2A progress stays in the center; the principal agent decides which
-questions and outcomes deserve an H2A message. An unmatched pair shows an empty
-A2A pane.
+Every supplied user starts on the board with their first supplied intent selected.
+The roster requires at least two distinct users. Expanded chats share the width
+equally, targeting at least 40 columns each. Overflow collapses from the end of
+roster order while preserving the focused user. A 24-column scrollable list shows
+collapsed users, their selected intent, and counts of pending and queued questions
+across their intents. Selecting a collapsed user displaces another chat if needed.
+Widening restores automatically collapsed chats; manually collapsed chats stay
+collapsed until selected.
+
+A2A appears between two expanded users at 122 columns or wider. It hides before
+H2A chats collapse, and always stays hidden with three or more users on the board,
+including collapsed users. An unmatched pair shows an empty A2A pane.
+
+Each user–intent pair retains its agent, draft, history and scroll position,
+suggested-answer selection, pending questions, and in-flight sends through intent,
+roster, and layout changes. Questions keep their ID, wording, scope, and match
+references while you answer. Related requests for an intent-wide fact can join an
+existing question internally; approvals remain specific to a match. The personal
+agent decides which questions and outcomes deserve an H2A message.
 
 ## Scenario format
 
@@ -92,14 +112,31 @@ Add a JSON file under `scenarios/`:
 ```json
 {
   "users": [
-    { "id": "alice", "name": "Alice", "intent": "Find a design partner", "instructions": "I am a frontend engineer. Ask before committing me to work." },
-    { "id": "bob", "name": "Bob", "intent": "Find an engineering partner", "instructions": "I am a product designer. Ask before committing me to work." }
+    {
+      "id": "alice", "name": "Alice",
+      "instructions": "I am a frontend engineer. Ask before committing me to work.",
+      "intents": [
+        { "id": "prototype", "intent": "Find a design partner" },
+        { "id": "research", "intent": "Find a researcher for an accessibility prototype" }
+      ]
+    },
+    {
+      "id": "bob", "name": "Bob",
+      "instructions": "I am a product designer. Ask before committing me to work.",
+      "intents": [
+        { "id": "prototype", "intent": "Find an engineering partner" },
+        { "id": "content", "intent": "Find a plain-language content designer" }
+      ]
+    }
   ]
 }
 ```
 
-IDs must be unique; all four fields are required. Scenario `instructions` are
-private fixture context injected as the agent's `principalContext`. The API host
+User IDs must be unique, and intent IDs must be unique within each user. All shown
+fields are required, with at least two users and at least one intent per user.
+The `intents` array replaces the previous single `intent` field. Scenario
+`instructions` are shared private context for that user's intent agents, injected
+as each agent's `principalContext`. The API host
 instead supplies confirmed profile fields, the current intent, and that intent's
 stored H2A conversation. Neither host invents profile facts from an intent.
 

--- a/packages/agent-tui/package.json
+++ b/packages/agent-tui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@indexnetwork/agent-tui",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "private": true,
   "type": "module",
   "description": "A live terminal testing platform for personal agents and parallel negotiations.",

--- a/packages/agent-tui/scenarios/negotiation.json
+++ b/packages/agent-tui/scenarios/negotiation.json
@@ -3,74 +3,182 @@
     {
       "id": "alice",
       "name": "Alice",
-      "intent": "Find a product designer to build an accessibility-focused prototype.",
-      "instructions": "I am a frontend engineer exploring accessible collaboration tools. Explore whether the collaboration serves my stated intent. You may discuss possible terms, but do not commit me to paid or unpaid work, delivery dates, or exclusivity without my authorization. Ask me when a missing personal fact or decision matters."
+      "instructions": "I am a frontend engineer exploring accessible collaboration tools. Explore whether the collaboration serves my stated intent. You may discuss possible terms, but do not commit me to paid or unpaid work, delivery dates, or exclusivity without my authorization. Ask me when a missing personal fact or decision matters.",
+      "intents": [
+        {
+          "id": "primary",
+          "intent": "Find a product designer to build an accessibility-focused prototype."
+        },
+        {
+          "id": "secondary",
+          "intent": "Find a researcher to validate the keyboard navigation of my collaboration prototype."
+        }
+      ]
     },
     {
       "id": "bob",
       "name": "Bob",
-      "intent": "Collaborate with an engineer on an accessibility-focused product prototype.",
-      "instructions": "I am a product designer interested in accessible interfaces. Explore whether the collaboration serves my stated intent. You may discuss possible terms, but do not commit me to paid or unpaid work, delivery dates, or exclusivity without my authorization. Ask me when a missing personal fact or decision matters."
+      "instructions": "I am a product designer interested in accessible interfaces. Explore whether the collaboration serves my stated intent. You may discuss possible terms, but do not commit me to paid or unpaid work, delivery dates, or exclusivity without my authorization. Ask me when a missing personal fact or decision matters.",
+      "intents": [
+        {
+          "id": "primary",
+          "intent": "Collaborate with an engineer on an accessibility-focused product prototype."
+        },
+        {
+          "id": "secondary",
+          "intent": "Find a content designer to improve plain-language onboarding for my prototype."
+        }
+      ]
     },
     {
       "id": "carla",
       "name": "Carla",
-      "intent": "Find a designer or engineer who needs user research for an accessibility prototype.",
-      "instructions": "I am a UX researcher who conducts interviews and usability studies. I am looking for paid project work. Explore a relevant research scope, but ask me before agreeing to compensation, participant recruitment, or a timeline. Do not accept unpaid work."
+      "instructions": "I am a UX researcher who conducts interviews and usability studies. I am looking for paid project work. Explore a relevant research scope, but ask me before agreeing to compensation, participant recruitment, or a timeline. Do not accept unpaid work.",
+      "intents": [
+        {
+          "id": "primary",
+          "intent": "Find a designer or engineer who needs user research for an accessibility prototype."
+        },
+        {
+          "id": "secondary",
+          "intent": "Find a nonprofit that needs paid usability research for its volunteer onboarding."
+        }
+      ]
     },
     {
       "id": "diego",
       "name": "Diego",
-      "intent": "Find a designer to prototype an accessible mobile journaling app.",
-      "instructions": "I am a mobile engineer exploring this as a side project, with no hiring budget. You may discuss an unpaid collaboration openly, but ask me before committing my time, delivery dates, or ownership terms. Do not promise payment."
+      "instructions": "I am a mobile engineer exploring this as a side project, with no hiring budget. You may discuss an unpaid collaboration openly, but ask me before committing my time, delivery dates, or ownership terms. Do not promise payment.",
+      "intents": [
+        {
+          "id": "primary",
+          "intent": "Find a designer to prototype an accessible mobile journaling app."
+        },
+        {
+          "id": "secondary",
+          "intent": "Find an accessibility reviewer for an unpaid mobile journaling side project."
+        }
+      ]
     },
     {
       "id": "emma",
       "name": "Emma",
-      "intent": "Find a prototype team that needs a screen-reader and keyboard accessibility review.",
-      "instructions": "I am an accessibility consultant offering paid reviews. Clarify the product and review scope with the other agent. Ask me before quoting a fee or committing to availability, deliverables, or a deadline. Do not offer free consulting."
+      "instructions": "I am an accessibility consultant offering paid reviews. Clarify the product and review scope with the other agent. Ask me before quoting a fee or committing to availability, deliverables, or a deadline. Do not offer free consulting.",
+      "intents": [
+        {
+          "id": "primary",
+          "intent": "Find a prototype team that needs a screen-reader and keyboard accessibility review."
+        },
+        {
+          "id": "secondary",
+          "intent": "Find a community organization that needs a paid accessibility review of its website."
+        }
+      ]
     },
     {
       "id": "farah",
       "name": "Farah",
-      "intent": "Find an engineer or designer to explore accessible onboarding for my nonprofit's volunteer portal.",
-      "instructions": "I coordinate volunteers at a small nonprofit and can explain our onboarding needs. I cannot authorize spending or provide access to volunteer data. Ask me about scope and timing before committing to a collaboration."
+      "instructions": "I coordinate volunteers at a small nonprofit and can explain our onboarding needs. I cannot authorize spending or provide access to volunteer data. Ask me about scope and timing before committing to a collaboration.",
+      "intents": [
+        {
+          "id": "primary",
+          "intent": "Find an engineer or designer to explore accessible onboarding for my nonprofit's volunteer portal."
+        },
+        {
+          "id": "secondary",
+          "intent": "Find a content designer to simplify the volunteer portal onboarding instructions."
+        }
+      ]
     },
     {
       "id": "gabriel",
       "name": "Gabriel",
-      "intent": "Find a designer or researcher to explore privacy-conscious collaboration software.",
-      "instructions": "I am a backend engineer interested in data minimization. Discuss a small exploratory prototype using synthetic data only. Ask me before committing to work, dates, compensation, or ownership. Do not agree to use real personal data."
+      "instructions": "I am a backend engineer interested in data minimization. Discuss a small exploratory prototype using synthetic data only. Ask me before committing to work, dates, compensation, or ownership. Do not agree to use real personal data.",
+      "intents": [
+        {
+          "id": "primary",
+          "intent": "Find a designer or researcher to explore privacy-conscious collaboration software."
+        },
+        {
+          "id": "secondary",
+          "intent": "Find a QA engineer to explore testing a privacy-conscious collaboration prototype."
+        }
+      ]
     },
     {
       "id": "hana",
       "name": "Hana",
-      "intent": "Find a product team that needs plain-language content for an accessible onboarding flow.",
-      "instructions": "I am a content designer looking for a paid engagement. Explore whether there is a concrete writing and content-testing scope. Ask me before agreeing to fees, workload, or dates. Do not substitute a generic networking call for a project."
+      "instructions": "I am a content designer looking for a paid engagement. Explore whether there is a concrete writing and content-testing scope. Ask me before agreeing to fees, workload, or dates. Do not substitute a generic networking call for a project.",
+      "intents": [
+        {
+          "id": "primary",
+          "intent": "Find a product team that needs plain-language content for an accessible onboarding flow."
+        },
+        {
+          "id": "secondary",
+          "intent": "Find a community directory team that needs paid plain-language content design."
+        }
+      ]
     },
     {
       "id": "ivan",
       "name": "Ivan",
-      "intent": "Find a designer to explore an accessible dashboard for a community energy project.",
-      "instructions": "I am a data analyst and can work with public, aggregated energy data. I am exploring a volunteer project with no compensation budget. Ask me before committing my time or agreeing on deliverables, licensing, or deadlines."
+      "instructions": "I am a data analyst and can work with public, aggregated energy data. I am exploring a volunteer project with no compensation budget. Ask me before committing my time or agreeing on deliverables, licensing, or deadlines.",
+      "intents": [
+        {
+          "id": "primary",
+          "intent": "Find a designer to explore an accessible dashboard for a community energy project."
+        },
+        {
+          "id": "secondary",
+          "intent": "Find a researcher to explore the accessibility of a volunteer energy dashboard."
+        }
+      ]
     },
     {
       "id": "jules",
       "name": "Jules",
-      "intent": "Find an engineer or researcher to build a small accessible interaction prototype for my portfolio.",
-      "instructions": "I am an interaction design student open to a voluntary collaboration with shared portfolio credit. Discuss ideas, but ask me before committing to a scope, time budget, deadline, or ownership arrangement. Do not claim professional consulting experience."
+      "instructions": "I am an interaction design student open to a voluntary collaboration with shared portfolio credit. Discuss ideas, but ask me before committing to a scope, time budget, deadline, or ownership arrangement. Do not claim professional consulting experience.",
+      "intents": [
+        {
+          "id": "primary",
+          "intent": "Find an engineer or researcher to build a small accessible interaction prototype for my portfolio."
+        },
+        {
+          "id": "secondary",
+          "intent": "Find a content designer for a voluntary portfolio prototype with shared credit."
+        }
+      ]
     },
     {
       "id": "kai",
       "name": "Kai",
-      "intent": "Find a prototype team that needs help testing keyboard navigation and documenting accessibility defects.",
-      "instructions": "I am a QA engineer looking for paid accessibility testing work. Clarify the platform and scope with the other agent. Ask me before agreeing to a fee, workload, or delivery date. Do not promise formal accessibility certification."
+      "instructions": "I am a QA engineer looking for paid accessibility testing work. Clarify the platform and scope with the other agent. Ask me before agreeing to a fee, workload, or delivery date. Do not promise formal accessibility certification.",
+      "intents": [
+        {
+          "id": "primary",
+          "intent": "Find a prototype team that needs help testing keyboard navigation and documenting accessibility defects."
+        },
+        {
+          "id": "secondary",
+          "intent": "Find a mobile product team that needs paid keyboard navigation testing."
+        }
+      ]
     },
     {
       "id": "leila",
       "name": "Leila",
-      "intent": "Find a designer, engineer, or researcher to explore a multilingual, accessible community resource directory.",
-      "instructions": "I organize a community resource directory and can describe its users and content needs. Funding and project dates are undecided. Explore a useful collaboration, but ask me before committing money, volunteer time, data access, or delivery dates."
+      "instructions": "I organize a community resource directory and can describe its users and content needs. Funding and project dates are undecided. Explore a useful collaboration, but ask me before committing money, volunteer time, data access, or delivery dates.",
+      "intents": [
+        {
+          "id": "primary",
+          "intent": "Find a designer, engineer, or researcher to explore a multilingual, accessible community resource directory."
+        },
+        {
+          "id": "secondary",
+          "intent": "Find a content designer to plan multilingual resource-directory onboarding."
+        }
+      ]
     }
   ]
 }

--- a/packages/agent-tui/src/main.ts
+++ b/packages/agent-tui/src/main.ts
@@ -18,22 +18,30 @@ Optionally supply one to three ordered OpenRouter model IDs to replace the defau
 Choose a JSON scenario from packages/agent-tui/scenarios with Up/Down + Enter or
 click it. Esc or Ctrl+C exits the chooser. Agents start only after selection.
 
-Scenario: { "users": [{ "id", "name", "intent", "instructions" }, ...] }
-Click the name above either side or press Ctrl+U to change that user. Select with
-Up/Down + Enter or click a user. The opposite user is excluded. All distinct user
-pairs are simulated matches and start in parallel on launch (66 with 12 users).
-Each user has one H2A conversation and draft for their intent, across all matches.
-The center shows the selected pair's A2A turns. Questions identify their match;
-answering one resumes that match even while another pair is displayed.
-H2A shows focused questions and meaningful outcomes, with routine A2A progress
-kept in the center. Related requests can share an intent-wide question without
-changing it while you answer; match-specific approvals remain separate.
-Click either side to act as that user. Click or use Up/Down to highlight an
+Scenario users have id, name, instructions, and intents: [{ id, intent }, ...].
+The default has 12 users with two intents each: 24 personal agents and 264 matches
+between different users' intents, running independently in the background.
+Each user starts on the board with their first intent. Users/Ctrl+U opens the
+roster: Space/click toggles users, Enter applies, Esc cancels. Keep at least two.
+Click an intent header or press Ctrl+T to switch that user's intent with Up/Down
+and Enter, or a click. Esc cancels. Each user-intent pair retains its own agent,
+H2A history, scroll position, draft, pending questions, choices, and in-flight sends.
+Header [−]/Ctrl+O collapses a chat; at least one stays expanded. Overflow collapses
+from the end of roster order, preserving focus and targeting 40 columns per chat.
+Click a collapsed user to expand them. Widening restores automatic collapses;
+manual collapses stay until selected. The scrollable list shows pending questions.
+A2A is visible only with two users on the board, both expanded, at 122+ columns.
+Ctrl+N cycles their selected intents' matches. Three or more board users always
+hide A2A, including when some users are collapsed. All agents keep running.
+Related requests can share an intent-wide question without changing it while you
+answer; match-specific approvals remain separate.
+Click a chat to act as that user. Click or use Up/Down to highlight an
 agent-provided option, then Enter to confirm. Select Custom reply or click the
 text box to write your own answer. Esc returns from editing to the choices.
 When no question is active, Enter sends the text to your personal agent instead.
 Ask about your negotiations or give new instructions in the same H2A conversation.
-Tab cycles panes; Ctrl+J adds a newline; mouse wheel or PgUp/PgDn scrolls history.
+Tab/Shift+Tab cycles users, expanding collapsed chats, and includes visible A2A.
+Ctrl+J adds a newline; mouse wheel or PgUp/PgDn scrolls history.
 Ctrl+C stops all agents and exports each H2A conversation once, followed by A2A turns.
 Rerun the command for a fresh lab with an edited user roster.
 `;

--- a/packages/agent-tui/src/main.ts
+++ b/packages/agent-tui/src/main.ts
@@ -30,9 +30,10 @@ Header [−]/Ctrl+O collapses a chat; at least one stays expanded. Overflow coll
 from the end of roster order, preserving focus and targeting 40 columns per chat.
 Click a collapsed user to expand them. Widening restores automatic collapses;
 manual collapses stay until selected. The scrollable list shows pending questions.
-A2A is visible only with two users on the board, both expanded, at 122+ columns.
-Ctrl+N cycles their selected intents' matches. Three or more board users always
-hide A2A, including when some users are collapsed. All agents keep running.
+A2A appears between exactly two expanded users, even with other users collapsed.
+The chats share space with A2A at narrower widths. Ctrl+N cycles the expanded
+users' selected intents' matches. Other expanded counts hide A2A. All agents keep
+running.
 Related requests can share an intent-wide question without changing it while you
 answer; match-specific approvals remain separate.
 Click a chat to act as that user. Click or use Up/Down to highlight an

--- a/packages/agent-tui/src/negotiation.lab.ts
+++ b/packages/agent-tui/src/negotiation.lab.ts
@@ -9,7 +9,7 @@ import type { TuiPrincipal } from './negotiation.tui';
 export interface DemoPrincipal {
   id: string;
   name: string;
-  intent: string;
+  intents: { id: string; intent: string }[];
   instructions: string;
 }
 
@@ -27,22 +27,38 @@ export interface TranscriptEntry {
  * Validate a user-editable local scenario before starting model work.
  * @param value - Parsed JSON containing the selectable user roster.
  * @returns Users with stable IDs, names, intents, and private instructions.
- * @throws When fewer than two users are supplied, a field is empty, or IDs repeat.
+ * @throws When fewer than two users are supplied, a user has no intents, a field is empty, or IDs repeat within a roster.
  */
 export function parseScenario(value: unknown): DemoScenario {
   const users = value && typeof value === 'object' ? (value as Record<string, unknown>).users : undefined;
   if (!Array.isArray(users) || users.length < 2) throw new Error('Scenario.users must contain at least two users.');
   const ids = new Set<string>();
   return { users: users.map((raw: unknown, index) => {
-    if (!raw || typeof raw !== 'object') throw new Error(`Scenario.users[${index}] must contain id, name, intent, and instructions.`);
+    if (!raw || typeof raw !== 'object') throw new Error(`Scenario.users[${index}] must contain id, name, intents, and instructions.`);
     const principal = {} as DemoPrincipal;
-    for (const field of ['id', 'name', 'intent', 'instructions'] as const) {
+    for (const field of ['id', 'name', 'instructions'] as const) {
       const text = (raw as Record<string, unknown>)[field];
       if (typeof text !== 'string' || !text.trim()) throw new Error(`Scenario.users[${index}].${field} must be a nonempty string.`);
       principal[field] = text.trim();
     }
     if (ids.has(principal.id)) throw new Error(`Duplicate user ID: ${principal.id}`);
     ids.add(principal.id);
+    const intents = (raw as Record<string, unknown>).intents;
+    if (!Array.isArray(intents) || !intents.length) throw new Error(`Scenario.users[${index}].intents must contain at least one intent.`);
+    const intentIds = new Set<string>();
+    principal.intents = intents.map((rawIntent: unknown, intentIndex) => {
+      const path = `Scenario.users[${index}].intents[${intentIndex}]`;
+      if (!rawIntent || typeof rawIntent !== 'object') throw new Error(`${path} must contain id and intent.`);
+      const intent = {} as DemoPrincipal['intents'][number];
+      for (const field of ['id', 'intent'] as const) {
+        const text = (rawIntent as Record<string, unknown>)[field];
+        if (typeof text !== 'string' || !text.trim()) throw new Error(`${path}.${field} must be a nonempty string.`);
+        intent[field] = text.trim();
+      }
+      if (intentIds.has(intent.id)) throw new Error(`Duplicate intent ID for ${principal.id}: ${intent.id}`);
+      intentIds.add(intent.id);
+      return intent;
+    });
     return principal;
   }) };
 }
@@ -174,9 +190,13 @@ export class NegotiationLab extends EventEmitter {
 
   constructor(scenario: DemoScenario, options: { model: Model }) {
     super();
-    this.users = scenario.users.map((user) => ({ id: 'intent-' + user.id, userId: user.id, name: user.name, intentId: 'intent-' + user.id, intent: user.intent, principalContext: user.instructions }));
+    this.users = scenario.users.flatMap((user) => user.intents.map((intent) => {
+      const id = [user.id, intent.id].map(encodeURIComponent).join(':');
+      return { id, userId: user.id, name: user.name, intentId: id, intent: intent.intent, principalContext: user.instructions };
+    }));
     for (let index = 0; index < this.users.length; index++) {
       for (const other of this.users.slice(index + 1)) {
+        if (this.users[index].userId === other.userId) continue;
         const principals = [this.users[index], other] as const;
         const id = `local:${principals.map(({ id }) => id).sort().map(encodeURIComponent).join(':')}`;
         const demo = new NegotiationDemo(principals, id);
@@ -203,7 +223,7 @@ export class NegotiationLab extends EventEmitter {
         end: (record) => this.negotiations.get(record.opportunityId)!.end(record),
         error: (id, owner, reason) => {
           const affected = id === null
-            ? [...this.negotiations.values()].filter((demo) => demo.phase !== 'settled' && demo.principals.some((principal) => principal.userId === owner.id))
+            ? [...this.negotiations.values()].filter((demo) => demo.phase !== 'settled' && demo.principals.some((principal) => principal.id === user.id))
             : [this.negotiations.get(id)!];
           for (const demo of affected) {
             demo.error(reason);

--- a/packages/agent-tui/src/negotiation.tui.ts
+++ b/packages/agent-tui/src/negotiation.tui.ts
@@ -1,5 +1,5 @@
 import type { NegotiationAgent, PrincipalQuestion, NegotiationAction } from '@indexnetwork/agent';
-import { BoxRenderable, ScrollBoxRenderable, TextareaRenderable, TextRenderable, type CliRenderer, type KeyEvent } from '@opentui/core';
+import { BoxRenderable, ScrollBoxRenderable, TextareaRenderable, TextRenderable, fg, t, type CliRenderer, type KeyEvent } from '@opentui/core';
 
 /** An independently selectable principal/intent conversation. */
 export interface TuiPrincipal {
@@ -78,7 +78,7 @@ export function mountNegotiationTui(renderer: CliRenderer, lab: NegotiationTuiHo
   let pairKey = '';
   let opportunityId = '';
   let displayedTurns = 0;
-  const matches = () => [...lab.negotiations.values()].filter((match) => roster.every((user) => match.principals.some(({ id }) => id === user.current.id)));
+  const matches = () => [...lab.negotiations.values()].filter((match) => expanded.every((user) => match.principals.some(({ id }) => id === user.current.id)));
   const root = new BoxRenderable(renderer, { id: 'negotiation-lab', width: '100%', height: '100%', flexDirection: 'column', backgroundColor: COLORS.background });
   renderer.root.add(root);
   const header = new BoxRenderable(renderer, { height: 1, flexShrink: 0, flexDirection: 'row' });
@@ -223,10 +223,10 @@ export function mountNegotiationTui(renderer: CliRenderer, lab: NegotiationTuiHo
       if (expanded[index].id === lastSession) index--;
       expanded.splice(index, 1);
     }
-    a2a.visible = roster.length === 2 && expanded.length === 2 && renderer.width >= 122;
+    a2a.visible = expanded.length === 2;
     if (selected === null && !a2a.visible) selected = lastSession;
     if (a2a.visible) {
-      const right = panes.get(roster[1].current.id)!.box;
+      const right = panes.get(expanded[1].current.id)!.box;
       const children = board.getChildren();
       if (children.indexOf(a2a) + 1 !== children.indexOf(right)) board.insertBefore(a2a, right);
     }
@@ -393,10 +393,11 @@ export function mountNegotiationTui(renderer: CliRenderer, lab: NegotiationTuiHo
       const pending = agents.filter((agent) => agent.pending).length;
       const queued = agents.reduce((sum, agent) => sum + agent.queuedQuestions, 0);
       entry.visible = roster.includes(user) && !expanded.includes(user);
-      entry.content = `${user.name}\n${user.current.intent}\n${pending ? `? ${pending}` : '·'}${queued ? ` · ${queued} queued` : ''}`;
-      entry.fg = pending ? COLORS.question : COLORS.muted;
+      const highlight = fg(pending ? COLORS.question : COLORS.muted);
+      entry.fg = COLORS.muted;
+      entry.content = t`${highlight(user.name)}\n${user.current.intent}\n${highlight(pending ? `? ${pending}` : '·')}${queued ? ` · ${queued} queued` : ''}`;
     }
-    const key = roster.length === 2 ? roster.map(({ current }) => current.id).join('\0') : '';
+    const key = expanded.length === 2 ? expanded.map(({ current }) => current.id).join('\0') : '';
     if (key !== pairKey) { pairKey = key; matchIndex = 0; }
     let demo: TuiNegotiation | undefined;
     if (a2a.visible) {
@@ -408,14 +409,14 @@ export function mountNegotiationTui(renderer: CliRenderer, lab: NegotiationTuiHo
         opportunityId = nextId;
         clear(sharedHistory);
         displayedTurns = 0;
-        append(sharedHistory, roster.map(({ name }) => name).join(' ↔ '), demo ? `Match ${matchIndex + 1}/${available.length} · ${demo.opportunityId} · Ctrl+N changes match.` : 'No negotiation between these selected intents.', COLORS.muted);
+        append(sharedHistory, expanded.map(({ name }) => name).join(' ↔ '), demo ? `Match ${matchIndex + 1}/${available.length} · ${demo.opportunityId} · Ctrl+N changes match.` : 'No negotiation between these selected intents.', COLORS.muted);
       }
       while (demo && displayedTurns < demo.transcript.length) {
         const entry = demo.transcript[displayedTurns++];
         const name = demo.principals.find(({ userId }) => userId === entry.ownerId)!.name;
         append(sharedHistory, name + "'s agent · " + entry.action, entry.text, COLORS.focus);
       }
-      a2a.title = ` A2A · ${roster.map(({ name }) => name).join(' ↔ ')} `;
+      a2a.title = ` A2A · ${expanded.map(({ name }) => name).join(' ↔ ')} `;
       a2a.borderColor = selected === null ? COLORS.focus : COLORS.border;
       a2a.titleColor = selected === null ? COLORS.focus : COLORS.muted;
     }
@@ -454,7 +455,7 @@ export function mountNegotiationTui(renderer: CliRenderer, lab: NegotiationTuiHo
     } else if (key.name === 'tab') {
       key.preventDefault();
       const order: (string | null)[] = roster.map(({ id }) => id);
-      if (a2a.visible) order.splice(1, 0, null);
+      if (a2a.visible) order.splice(order.indexOf(expanded[0].id) + 1, 0, null);
       focus(order[(order.indexOf(selected) + (key.shift ? -1 : 1) + order.length) % order.length]);
     } else if (key.name === 'o' && key.ctrl) {
       key.preventDefault();

--- a/packages/agent-tui/src/negotiation.tui.ts
+++ b/packages/agent-tui/src/negotiation.tui.ts
@@ -30,70 +30,165 @@ export interface NegotiationTuiHost {
 
 export const COLORS = { background: '#10151e', text: '#dce4ef', muted: '#8996aa', border: '#364255', focus: '#77b8ff', question: '#f4c773', answer: '#8dd9b7' };
 
-interface Pane {
+interface BoardUser {
+  id: string;
+  name: string;
+  intents: TuiPrincipal[];
+  current: TuiPrincipal;
+}
+
+interface SessionPane {
+  principal: TuiPrincipal;
   box: BoxRenderable;
   history: ScrollBoxRenderable;
-  input?: TextareaRenderable;
-  hint?: TextRenderable;
-  choices?: ScrollBoxRenderable;
+  input: TextareaRenderable;
+  hint: TextRenderable;
+  choices: ScrollBoxRenderable;
+  collapse: TextRenderable;
   choiceRows: { box: BoxRenderable; label: TextRenderable; text: string }[];
   choiceIndex: number;
   editingReply: boolean;
   shownQuestion?: PrincipalQuestion | null;
   displayed: number;
-  sending?: boolean;
-  opportunityId?: string;
-  ownerId?: string;
-  selector?: TextRenderable;
-  users?: ScrollBoxRenderable;
-  userRows: { box: BoxRenderable; label: TextRenderable; ownerId: string; name: string }[];
-  userIndex: number;
+  sending: boolean;
+  sendError?: string;
 }
 
 /**
- * Mount the two private human/agent panes around a read-only shared negotiation.
+ * Mount one human/agent pane per user, retaining each intent session independently.
  * @param renderer - Owns terminal mouse, keyboard, and resize handling.
  * @param lab - The user/intent conversations and separate match records.
  */
 export function mountNegotiationTui(renderer: CliRenderer, lab: NegotiationTuiHost): void {
-  const selectedUsers: [TuiPrincipal, TuiPrincipal] = [lab.users[0], lab.users.find((user) => user.userId !== lab.users[0].userId)!];
+  const users: BoardUser[] = [];
+  for (const principal of lab.users) {
+    const user = users.find(({ id }) => id === principal.userId);
+    if (user) user.intents.push(principal);
+    else users.push({ id: principal.userId, name: principal.name, intents: [principal], current: principal });
+  }
+  let roster = [...users];
+  // Each retained session owns selection listeners for its history, choices, and editor.
+  renderer.setMaxListeners(Math.max(renderer.getMaxListeners(), lab.users.length * 3 + 10));
+  const panes = new Map<string, SessionPane>();
+  const manuallyCollapsed = new Set<string>();
+  let expanded: BoardUser[] = [];
+  let selected: string | null = roster[0].id;
+  let lastSession = selected;
   let matchIndex = 0;
   let pairKey = '';
-  let demo: TuiNegotiation | undefined;
-  const matches = () => [...lab.negotiations.values()].filter((match) => selectedUsers.every((user) => match.principals.some(({ id }) => id === user.id)));
+  let opportunityId = '';
+  let displayedTurns = 0;
+  const matches = () => [...lab.negotiations.values()].filter((match) => roster.every((user) => match.principals.some(({ id }) => id === user.current.id)));
   const root = new BoxRenderable(renderer, { id: 'negotiation-lab', width: '100%', height: '100%', flexDirection: 'column', backgroundColor: COLORS.background });
   renderer.root.add(root);
-  root.add(new TextRenderable(renderer, { content: ` ${lab.title} · ${lab.users.length} principal/intent sessions`, fg: COLORS.focus, height: 1, flexShrink: 0 }));
+  const header = new BoxRenderable(renderer, { height: 1, flexShrink: 0, flexDirection: 'row' });
+  header.add(new TextRenderable(renderer, { content: ` ${lab.title} · ${users.length} users · ${lab.users.length} intent sessions`, fg: COLORS.focus, flexGrow: 1, flexBasis: 0, minWidth: 0, height: 1, truncate: true }));
+  header.add(new TextRenderable(renderer, {
+    id: 'board-users', content: '[ Users ]', fg: COLORS.focus, width: 9, height: 1,
+    onMouseDown: (event) => { event.stopPropagation(); openSelector(); },
+  }));
+  root.add(header);
   const board = new BoxRenderable(renderer, { id: 'panes', flexDirection: 'row', flexGrow: 1, minHeight: 0, gap: 1 });
   root.add(board);
-  const status = new TextRenderable(renderer, { id: 'session-status', content: '', fg: COLORS.muted, height: 2, flexShrink: 0, wrapMode: 'word' });
-  const help = new TextRenderable(renderer, { content: ' Click name/Ctrl+U: change user · ↑↓: select · Enter: confirm · Esc: back · Tab: pane · Ctrl+J: newline · PgUp/PgDn/wheel: scroll · Ctrl+N: next match · Ctrl+C: quit', fg: COLORS.muted, height: 2, flexShrink: 0, wrapMode: 'word' });
+  const status = new TextRenderable(renderer, { id: 'session-status', fg: COLORS.muted, height: 2, flexShrink: 0, wrapMode: 'word' });
+  const help = new TextRenderable(renderer, { fg: COLORS.muted, height: 3, flexShrink: 0, wrapMode: 'word' });
   root.add(status);
   root.add(help);
 
-  const panes: Pane[] = [];
-  let selected = 0;
-  const drafts = new Map<string, string>();
+  const a2a = new BoxRenderable(renderer, {
+    id: 'pane-a2a', visible: false, flexDirection: 'column', flexGrow: 1, flexBasis: 0, minWidth: 0,
+    border: true, borderStyle: 'rounded', borderColor: COLORS.border, paddingX: 1,
+    onMouseDown: () => focus(null),
+  });
+  const sharedHistory = new ScrollBoxRenderable(renderer, {
+    id: 'history-a2a', flexGrow: 1, minHeight: 0, scrollX: false, scrollY: true,
+    stickyScroll: true, stickyStart: 'bottom', contentOptions: { flexDirection: 'column' },
+  });
+  a2a.add(sharedHistory);
+  board.add(a2a);
+  const collapsed = new ScrollBoxRenderable(renderer, {
+    id: 'collapsed-chats', visible: false, width: 24, flexShrink: 0, scrollX: false, scrollY: true,
+    border: true, borderColor: COLORS.border, title: ' Collapsed ', contentOptions: { flexDirection: 'column' },
+  });
+
+  const selector = new BoxRenderable(renderer, {
+    id: 'board-selector', visible: false, position: 'absolute', top: 0, left: 0, width: '100%', height: '100%', zIndex: 1,
+    flexDirection: 'column', border: true, borderColor: COLORS.focus, padding: 1, backgroundColor: COLORS.background,
+  });
+  const selectorTitle = new TextRenderable(renderer, { fg: COLORS.focus, height: 1 });
+  const selectorHint = new TextRenderable(renderer, { fg: COLORS.muted, height: 2, flexShrink: 0, wrapMode: 'word' });
+  selector.add(selectorTitle);
+  selector.add(selectorHint);
+  const selectorList = new ScrollBoxRenderable(renderer, {
+    id: 'board-selector-list', flexGrow: 1, minHeight: 0, scrollX: false, scrollY: true, contentOptions: { flexDirection: 'column' },
+  });
+  selector.add(selectorList);
+  root.add(selector);
+  let intentUser: BoardUser | undefined;
+  let chosen = new Set<string>();
+  let selectorIndex = 0;
+  let selectorRows: TextRenderable[] = [];
+  const selectorEntries = () => intentUser ? intentUser.intents : users;
+
+  function renderSelector(): void {
+    selectorRows.forEach((row, index) => {
+      const entry = selectorEntries()[index];
+      const principal = intentUser ? intentUser.intents[index] : users[index].current;
+      const pending = lab.agents.get(principal.id)!.pending;
+      row.content = `${index === selectorIndex ? '›' : ' '} ${intentUser ? (principal.id === intentUser.current.id ? '[x]' : '[ ]') : (chosen.has(entry.id) ? '[x]' : '[ ]')} ${intentUser ? principal.intent : entry.name + ' · ' + principal.intent}${pending ? ' · needs you' : ''}`;
+      row.fg = index === selectorIndex ? COLORS.focus : pending ? COLORS.question : COLORS.text;
+    });
+  }
+
+  function openSelector(user?: BoardUser): void {
+    intentUser = user;
+    chosen = new Set(roster.map(({ id }) => id));
+    selectorIndex = user ? user.intents.indexOf(user.current) : users.findIndex(({ id }) => id === lastSession);
+    selectorTitle.content = user ? `Choose an intent for ${user.name}` : 'Choose users on the board';
+    selectorHint.content = user ? '↑↓ moves · Enter/click selects · Esc cancels. Every intent agent keeps running.'
+      : 'Space/click toggles · ↑↓ moves · Enter applies · Esc cancels. Agents keep running.';
+    clear(selectorList);
+    selectorRows = selectorEntries().map((entry, index) => {
+      const row = new TextRenderable(renderer, {
+        id: `selector-${entry.id}`, height: 2, flexShrink: 0, wrapMode: 'word',
+        onMouseDown: (event) => { event.stopPropagation(); selectorIndex = index; if (intentUser) closeSelector(true); else toggleRosterEntry(); },
+      });
+      selectorList.add(row);
+      return row;
+    });
+    selector.visible = true;
+    renderSelector();
+    selectorList.scrollTo(0);
+    selectorList.scrollChildIntoView(`selector-${selectorEntries()[selectorIndex].id}`);
+    selectorList.focus();
+  }
+
+  function toggleRosterEntry(): void {
+    const id = users[selectorIndex].id;
+    if (chosen.has(id)) chosen.delete(id); else chosen.add(id);
+    renderSelector();
+  }
+
+  function closeSelector(apply: boolean): void {
+    if (apply && intentUser) intentUser.current = intentUser.intents[selectorIndex];
+    else if (apply) {
+      const next = users.filter(({ id }) => chosen.has(id));
+      if (next.length < 2) {
+        selectorHint.content = 'Select at least two users. Space/click toggles; Enter applies.';
+        return;
+      }
+      roster = next;
+      if (roster.every(({ id }) => manuallyCollapsed.has(id))) manuallyCollapsed.delete(roster[0].id);
+    }
+    selector.visible = false;
+    render();
+  }
 
   function append(history: ScrollBoxRenderable, label: string, text: string, color: string): void {
     const card = new BoxRenderable(renderer, { width: '100%', flexDirection: 'column', flexShrink: 0, marginBottom: 1 });
     card.add(new TextRenderable(renderer, { content: label, fg: color, wrapMode: 'word', flexShrink: 0 }));
     card.add(new TextRenderable(renderer, { content: text, fg: COLORS.text, wrapMode: 'word', flexShrink: 0 }));
     history.add(card);
-  }
-
-  function focusControl(pane: Pane): void {
-    if (pane.users?.visible) pane.users.focus();
-    else if (pane.choices?.visible && !pane.editingReply) pane.choices.focus();
-    else if (pane.input) pane.input.focus();
-    else pane.history.focus();
-  }
-
-  function focus(index: number): void {
-    selected = index;
-    panes.forEach((pane, paneIndex) => { if (pane.users && paneIndex !== index) pane.users.visible = false; });
-    render();
-    focusControl(panes[index]);
   }
 
   function clear(history: ScrollBoxRenderable): void {
@@ -103,273 +198,292 @@ export function mountNegotiationTui(renderer: CliRenderer, lab: NegotiationTuiHo
     }
   }
 
-  function chooseUser(index: number, ownerId: string): void {
-    panes[index].users!.visible = false;
-    selectedUsers[index === 0 ? 0 : 1] = lab.users.find(({ id }) => id === ownerId)!;
-    focus(index);
+  function focus(id: string | null): void {
+    if (selector.visible) return;
+    selected = id;
+    if (id !== null) { lastSession = id; manuallyCollapsed.delete(id); }
+    render();
   }
 
-  function toggleUsers(index: number): void {
-    const pane = panes[index];
-    if (!pane.users) return;
-    pane.users.visible = !pane.users.visible;
-    if (pane.users.visible) {
-      clear(pane.users);
-      pane.userRows = [];
-      const opposite = selectedUsers[index === 0 ? 1 : 0];
-      lab.users.filter(({ userId }) => userId !== opposite.userId).forEach((user, userIndex) => {
-        const button = new BoxRenderable(renderer, {
-          id: `user-${index}-${userIndex}`, width: '100%', height: 1, flexShrink: 0,
-          onMouseDown: (event) => { event.stopPropagation(); chooseUser(index, user.id); },
-        });
-        const label = new TextRenderable(renderer, { content: user.name + " · " + user.intent, height: 1 });
-        button.add(label);
-        pane.userRows.push({ box: button, label, ownerId: user.id, name: user.name + " · " + user.intent });
-        pane.users!.add(button);
-      });
-      pane.userIndex = pane.userRows.findIndex(({ ownerId }) => ownerId === pane.ownerId);
-      pane.users.scrollTo(0);
+  function collapse(id: string): void {
+    if (expanded.length < 2) return;
+    manuallyCollapsed.add(id);
+    render();
+  }
+
+  function layout(): void {
+    expanded = roster.filter(({ id }) => !manuallyCollapsed.has(id));
+    if (!expanded.some(({ id }) => id === lastSession)) lastSession = expanded[0].id;
+    if (selected !== null) selected = lastSession;
+    // Reserve the list as soon as any session is collapsed. Keep the focused chat.
+    while (expanded.length > 1) {
+      const listWidth = expanded.length < roster.length ? 25 : 0;
+      if (expanded.length * 40 + expanded.length - 1 + listWidth <= renderer.width) break;
+      let index = expanded.length - 1;
+      if (expanded[index].id === lastSession) index--;
+      expanded.splice(index, 1);
     }
-    focus(index);
-    if (pane.users.visible) pane.users.scrollChildIntoView(`user-${index}-${pane.userIndex}`);
+    a2a.visible = roster.length === 2 && expanded.length === 2 && renderer.width >= 122;
+    if (selected === null && !a2a.visible) selected = lastSession;
+    if (a2a.visible) {
+      const right = panes.get(roster[1].current.id)!.box;
+      const children = board.getChildren();
+      if (children.indexOf(a2a) + 1 !== children.indexOf(right)) board.insertBefore(a2a, right);
+    }
+    collapsed.visible = expanded.length < roster.length;
+    for (const [id, pane] of panes) {
+      pane.box.visible = expanded.some((user) => user.current.id === id);
+      pane.collapse.fg = expanded.length > 1 ? COLORS.focus : COLORS.muted;
+    }
   }
 
-  for (let index = 0; index < 3; index++) {
-    const principal = index === 1 ? undefined : selectedUsers[index === 0 ? 0 : 1];
+  for (const user of users) for (const principal of user.intents) {
+    const id = principal.id;
     const box = new BoxRenderable(renderer, {
-      id: `pane-${index}`,
-      flexDirection: 'column', flexGrow: principal ? 3 : 4, flexBasis: 0, minWidth: 0,
+      id: `pane-${id}`, visible: false, flexDirection: 'column', flexGrow: 1, flexBasis: 0, minWidth: 0,
       border: true, borderStyle: 'rounded', borderColor: COLORS.border, paddingX: 1,
-      onMouseDown: () => focus(index),
+      onMouseDown: () => focus(user.id),
     });
     board.add(box);
-    const history = new ScrollBoxRenderable(renderer, {
-      id: `history-${index}`,
-      flexGrow: 1, minHeight: 0, scrollX: false, scrollY: true,
-      stickyScroll: true, stickyStart: 'bottom',
-      contentOptions: { flexDirection: 'column' },
+    const collapseButton = new TextRenderable(renderer, {
+      id: `collapse-${id}`, content: '[−]', width: 3, height: 1, flexShrink: 0, fg: COLORS.focus,
+      onMouseDown: (event) => { event.stopPropagation(); collapse(user.id); },
     });
-    const pane: Pane = { box, history, displayed: 0, choiceRows: [], choiceIndex: 0, editingReply: true, userRows: [], userIndex: 0 };
-    panes.push(pane);
-    if (principal) {
-      pane.selector = new TextRenderable(renderer, {
-        id: `select-user-${index}`, height: 1, flexShrink: 0, fg: COLORS.focus,
-        onMouseDown: (event) => { event.stopPropagation(); toggleUsers(index); },
-      });
-      box.add(pane.selector);
-      pane.users = new ScrollBoxRenderable(renderer, {
-        id: `users-${index}`, visible: false, height: 11, maxHeight: '40%', flexShrink: 0,
-        scrollX: false, scrollY: true, contentOptions: { flexDirection: 'column' },
-        onMouseDown: (event) => { event.stopPropagation(); focus(index); },
-      });
-      box.add(pane.users);
-      box.add(history);
-      pane.hint = new TextRenderable(renderer, { content: 'Enter sends a message to your agent.', fg: COLORS.muted, height: 2, flexShrink: 0, wrapMode: 'word' });
-      box.add(pane.hint);
-      pane.choices = new ScrollBoxRenderable(renderer, {
-        id: `choices-${index}`, visible: false, height: 6, maxHeight: '30%', flexShrink: 0,
-        scrollX: false, scrollY: true, contentOptions: { flexDirection: 'column' },
-        onMouseDown: (event) => { event.stopPropagation(); pane.users!.visible = false; pane.editingReply = false; focus(index); },
-      });
-      box.add(pane.choices);
-      pane.input = new TextareaRenderable(renderer, {
-        id: `reply-${index}`, height: 5, flexShrink: 0, wrapMode: 'word',
-        placeholder: `Message your agent as ${principal.name}…`, textColor: COLORS.text,
-        backgroundColor: '#192230', focusedBackgroundColor: '#202e40', cursorColor: COLORS.focus,
-        onMouseDown: (event) => {
-          event.stopPropagation();
-          pane.users!.visible = false;
-          pane.editingReply = true;
-          pane.choiceIndex = pane.shownQuestion?.options?.length ?? 0;
-          focus(index);
-        },
-        keyBindings: [
-          { name: 'return', action: 'submit' },
-          { name: 'return', shift: true, action: 'newline' },
-          { name: 'j', ctrl: true, action: 'newline' },
-        ],
-        onSubmit: () => { void send(pane, pane.input!.plainText); },
-      });
-      box.add(pane.input);
-    } else {
-      box.add(history);
-    }
+    const paneHeader = new BoxRenderable(renderer, { height: 1, flexShrink: 0, flexDirection: 'row', gap: 1 });
+    paneHeader.add(new TextRenderable(renderer, {
+      id: `intent-${id}`, content: `Intent ▾ ${principal.intent}`, height: 1, flexGrow: 1, flexBasis: 0, minWidth: 0, truncate: true, fg: COLORS.focus,
+      onMouseDown: (event) => { event.stopPropagation(); focus(user.id); openSelector(user); },
+    }));
+    paneHeader.add(collapseButton);
+    box.add(paneHeader);
+    const history = new ScrollBoxRenderable(renderer, {
+      id: `history-${id}`, flexGrow: 1, minHeight: 0, scrollX: false, scrollY: true,
+      stickyScroll: true, stickyStart: 'bottom', contentOptions: { flexDirection: 'column' },
+    });
+    box.add(history);
+    append(history, 'Intent', principal.intent, COLORS.muted);
+    append(history, 'Principal context', principal.principalContext, COLORS.muted);
+    const hint = new TextRenderable(renderer, { fg: COLORS.muted, height: 3, flexShrink: 0, wrapMode: 'word' });
+    box.add(hint);
+    const choices = new ScrollBoxRenderable(renderer, {
+      id: `choices-${id}`, visible: false, height: 6, flexShrink: 0,
+      scrollX: false, scrollY: true, contentOptions: { flexDirection: 'column' },
+      onMouseDown: (event) => { event.stopPropagation(); pane.editingReply = false; focus(user.id); },
+    });
+    box.add(choices);
+    const input = new TextareaRenderable(renderer, {
+      id: `reply-${id}`, height: 5, flexShrink: 0, wrapMode: 'word',
+      placeholder: `Message your agent as ${principal.name}…`, textColor: COLORS.text,
+      backgroundColor: '#192230', focusedBackgroundColor: '#202e40', cursorColor: COLORS.focus,
+      onMouseDown: (event) => {
+        event.stopPropagation();
+        pane.editingReply = true;
+        pane.choiceIndex = pane.shownQuestion?.options?.length ?? 0;
+        focus(user.id);
+      },
+      keyBindings: [
+        { name: 'return', action: 'submit' },
+        { name: 'return', shift: true, action: 'newline' },
+        { name: 'j', ctrl: true, action: 'newline' },
+      ],
+      onSubmit: () => { void send(pane, input.plainText); },
+    });
+    box.add(input);
+    const pane: SessionPane = {
+      principal, box, history, input, hint, choices, collapse: collapseButton,
+      displayed: 0, choiceRows: [], choiceIndex: 0, editingReply: true, sending: false,
+    };
+    panes.set(id, pane);
   }
+  const collapsedEntries = new Map(users.map((user) => {
+    const entry = new TextRenderable(renderer, {
+      id: `collapsed-${user.id}`, height: 3, flexShrink: 0, wrapMode: 'none', truncate: true,
+      onMouseDown: (event) => { event.stopPropagation(); focus(user.id); },
+    });
+    collapsed.add(entry);
+    return [user.id, entry];
+  }));
+  board.add(collapsed);
 
-  async function send(pane: Pane, text: string): Promise<void> {
+  async function send(pane: SessionPane, text: string): Promise<void> {
     if (pane.sending) return;
-    const ownerId = pane.ownerId!;
-    const agent = lab.agents.get(ownerId)!;
+    const agent = lab.agents.get(pane.principal.id)!;
     const question = pane.shownQuestion;
-    const draft = pane.input!.plainText;
+    if ((question?.id ?? null) !== (agent.pending?.id ?? null)) { render(); return; }
+    const draft = pane.input.plainText;
     pane.sending = true;
+    pane.sendError = undefined;
     try {
       const sent = question ? await agent.answer(question.id, text) : await agent.message(text);
+      if (renderer.isDestroyed) return;
       if (sent) {
-        drafts.delete(ownerId);
-        if (pane.ownerId === ownerId && pane.input!.plainText === draft) pane.input!.clear();
-      } else if (pane.ownerId === ownerId) pane.hint!.content = 'Could not send. Draft kept.';
+        if (pane.input.plainText === draft) pane.input.clear();
+      } else pane.sendError = 'Could not send. Draft kept.';
     } catch (error) {
-      if (!renderer.isDestroyed) pane.hint!.content = 'Could not save: ' + (error instanceof Error ? error.message : String(error));
-    } finally { pane.sending = false; }
+      pane.sendError = 'Could not save: ' + (error instanceof Error ? error.message : String(error));
+    } finally { pane.sending = false; render(); }
   }
 
   function render(): void {
     if (renderer.isDestroyed) return;
-    for (const pane of panes) if (pane.ownerId) drafts.set(pane.ownerId, pane.input!.plainText);
-    const key = selectedUsers.map(({ id }) => id).join('\0');
-    if (key !== pairKey) { pairKey = key; matchIndex = 0; }
-    const available = matches();
-    matchIndex = Math.min(matchIndex, Math.max(0, available.length - 1));
-    demo = available[matchIndex];
-    panes.forEach((pane, index) => {
-      const principal = index === 1 ? undefined : selectedUsers[index === 0 ? 0 : 1];
-      if (principal && pane.ownerId !== principal.id) {
-        clear(pane.history);
-        pane.displayed = 0;
-        pane.ownerId = principal.id;
-        pane.shownQuestion = undefined;
-        pane.users!.visible = false;
-        pane.input!.setText(drafts.get(principal.id) ?? '');
-        pane.selector!.content = ' ' + principal.name + ' ▾ · ' + (lab.users.findIndex(({ id }) => id === principal.id) + 1) + '/' + lab.users.length;
-        append(pane.history, 'Intent', principal.intent, COLORS.muted);
-        append(pane.history, 'Principal context', principal.principalContext, COLORS.muted);
-      } else if (!principal && pane.opportunityId !== (demo?.opportunityId ?? pairKey)) {
-        clear(pane.history);
-        pane.displayed = 0;
-        pane.opportunityId = demo?.opportunityId ?? pairKey;
-        append(pane.history, selectedUsers.map(({ name }) => name).join(' ↔ '), demo ? `Match ${matchIndex + 1}/${available.length} · ${demo.opportunityId} · Ctrl+N changes match.` : 'No negotiation between these selected intents.', COLORS.muted);
+    layout();
+    for (const [id, pane] of panes) {
+      const principal = pane.principal;
+      const agent = lab.agents.get(id)!;
+      while (pane.displayed < agent.conversation.length) {
+        const entry = agent.conversation[pane.displayed++];
+        const human = entry.kind === 'answer' || entry.kind === 'user';
+        const who = human ? principal.name + ' (you)' : entry.kind === 'question' ? 'Your agent asks' : 'Your agent';
+        const text = entry.text + (entry.options ? '\n\n' + entry.options.map((option) => '• ' + option).join('\n') : '');
+        const about = entry.scope === 'intent' ? 'This intent' : entry.matches.map(({ counterparty }) => counterparty.name ?? counterparty.id).join(', ');
+        append(pane.history, who + (about ? ' · ' + about : ''), text,
+          entry.kind === 'question' ? COLORS.question : human ? COLORS.answer : COLORS.focus);
       }
-      const agent = principal ? lab.agents.get(principal.id)! : undefined;
-      if (agent) {
-        while (pane.displayed < agent.conversation.length) {
-          const entry = agent.conversation[pane.displayed++];
-          const human = entry.kind === 'answer' || entry.kind === 'user';
-          const who = human ? principal!.name + ' (you)' : entry.kind === 'question' ? 'Your agent asks' : 'Your agent';
-          const text = entry.text + (entry.options ? '\n\n' + entry.options.map((option) => '• ' + option).join('\n') : '');
-          const about = entry.scope === 'intent' ? 'This intent' : entry.matches.map(({ counterparty }) => counterparty.name ?? counterparty.id).join(', ');
-          append(pane.history, who + (about ? ' · ' + about : ''), text,
-            entry.kind === 'question' ? COLORS.question : human ? COLORS.answer : COLORS.focus);
-        }
-      } else {
-        while (demo && pane.displayed < demo.transcript.length) {
-          const entry = demo.transcript[pane.displayed++];
-          const name = demo.principals.find(({ userId }) => userId === entry.ownerId)!.name;
-          append(pane.history, name + "'s agent · " + entry.action, entry.text, COLORS.focus);
-        }
-      }
-      const question = agent?.pending ?? null;
-      const pending = Boolean(question);
-      if (pane.choices && pane.shownQuestion !== question) {
+      const question = agent.pending;
+      if (pane.shownQuestion !== question) {
         pane.shownQuestion = question;
-        pane.input!.placeholder = (question ? 'Custom reply as ' : 'Message your agent as ') + principal!.name + '…';
+        pane.input.placeholder = (question ? 'Custom reply as ' : 'Message your agent as ') + principal.name + '…';
         clear(pane.choices);
         pane.choiceRows = [];
         const options = question?.options ?? [];
         const labels = question ? [...options, 'Custom reply…'] : [];
-        pane.editingReply = options.length === 0 || Boolean(pane.input!.plainText);
+        pane.editingReply = options.length === 0 || Boolean(pane.input.plainText);
         pane.choiceIndex = pane.editingReply ? options.length : 0;
         pane.choices.visible = Boolean(question);
-        pane.choices.height = Math.min(8, labels.length * 3);
         labels.forEach((text, choiceIndex) => {
           const button = new BoxRenderable(renderer, {
-            id: `option-${pane.ownerId}-${choiceIndex}`, width: '100%', flexShrink: 0,
-            paddingX: 1, marginBottom: 1,
+            id: `option-${id}-${choiceIndex}`, width: '100%', flexShrink: 0, paddingX: 1, marginBottom: 1,
             onMouseDown: (event) => {
               event.stopPropagation();
-              if (agent?.pending !== question) return;
-              pane.users!.visible = false;
+              if (agent.pending?.id !== question?.id) return;
               pane.choiceIndex = choiceIndex;
               pane.editingReply = choiceIndex === options.length;
-              focus(index);
+              focus(principal.userId);
             },
           });
           const label = new TextRenderable(renderer, { content: text, wrapMode: 'word', flexShrink: 0 });
           button.add(label);
           pane.choiceRows.push({ box: button, label, text });
-          pane.choices!.add(button);
+          pane.choices.add(button);
         });
         pane.choices.scrollTo(0);
-        if (selected === index) focusControl(pane);
       }
+      // Whole rows avoid fractional layout overlapping the history and reply hint.
+      pane.choices.height = Math.min(8, pane.choiceRows.length * 3, Math.max(1, Math.floor((renderer.height - 8) * 0.3)));
       pane.choiceRows.forEach((row, choiceIndex) => {
         const highlighted = choiceIndex === pane.choiceIndex;
         row.box.backgroundColor = highlighted ? '#355073' : '#192230';
         row.label.fg = highlighted ? COLORS.text : COLORS.muted;
         row.label.content = `${highlighted ? '›' : ' '} ${row.text}`;
       });
-      pane.userRows.forEach((row, userIndex) => {
-        const highlighted = userIndex === pane.userIndex;
-        row.box.backgroundColor = highlighted ? '#355073' : '#192230';
-        row.label.fg = highlighted ? COLORS.text : COLORS.muted;
-        row.label.content = `${highlighted ? '›' : ' '} ${row.name}${row.ownerId === pane.ownerId ? ' · active' : ''}`;
-      });
-      pane.box.title = principal ? ` H2A · ${principal.name}${pending ? ' · needs you' : ''} ` : ` A2A · ${selectedUsers.map(({ name }) => name).join(' ↔ ')} `;
-      pane.box.borderColor = selected === index ? COLORS.focus : pending ? COLORS.question : COLORS.border;
-      pane.box.titleColor = pending ? COLORS.question : selected === index ? COLORS.focus : COLORS.muted;
-      if (pane.hint) {
-        let hint = pane.users?.visible ? 'Click a user or ↑/↓ + Enter · Esc cancels.' : pending
-          ? pane.editingReply ? 'Enter sends · Esc returns to choices.' : '↑/↓ choose · Enter confirms.'
-          : 'Enter sends a message to your agent.';
-        if (question) hint = (question.scope === 'intent' ? 'For this intent' : 'About ' + question.matches.map(({ counterparty }) => counterparty.name ?? counterparty.id).join(', ')) + ' · ' + hint;
-        if (agent?.queuedQuestions) hint += ' · ' + agent.queuedQuestions + ' queued';
-        pane.hint.content = hint;
-        pane.hint.fg = pending ? COLORS.question : COLORS.muted;
+      pane.box.title = ` H2A · ${principal.name}${question ? ' · needs you' : ''} `;
+      pane.box.borderColor = selected === principal.userId ? COLORS.focus : question ? COLORS.question : COLORS.border;
+      pane.box.titleColor = question ? COLORS.question : selected === principal.userId ? COLORS.focus : COLORS.muted;
+      let hint = question
+        ? pane.editingReply ? 'Enter sends · Esc returns to choices.' : '↑/↓ choose · Enter confirms.'
+        : 'Enter sends a message to your agent.';
+      if (question) hint = (question.scope === 'intent' ? 'For this intent' : 'About ' + question.matches.map(({ counterparty }) => counterparty.name ?? counterparty.id).join(', ')) + ' · ' + hint;
+      if (agent.queuedQuestions) hint += ' · ' + agent.queuedQuestions + ' queued';
+      pane.hint.content = pane.sendError ?? (pane.sending ? 'Sending… · ' + hint : hint);
+      pane.hint.fg = question ? COLORS.question : COLORS.muted;
+    }
+    for (const user of users) {
+      const entry = collapsedEntries.get(user.id)!;
+      const agents = user.intents.map(({ id }) => lab.agents.get(id)!);
+      const pending = agents.filter((agent) => agent.pending).length;
+      const queued = agents.reduce((sum, agent) => sum + agent.queuedQuestions, 0);
+      entry.visible = roster.includes(user) && !expanded.includes(user);
+      entry.content = `${user.name}\n${user.current.intent}\n${pending ? `? ${pending}` : '·'}${queued ? ` · ${queued} queued` : ''}`;
+      entry.fg = pending ? COLORS.question : COLORS.muted;
+    }
+    const key = roster.length === 2 ? roster.map(({ current }) => current.id).join('\0') : '';
+    if (key !== pairKey) { pairKey = key; matchIndex = 0; }
+    let demo: TuiNegotiation | undefined;
+    if (a2a.visible) {
+      const available = matches();
+      matchIndex = Math.min(matchIndex, Math.max(0, available.length - 1));
+      demo = available[matchIndex];
+      const nextId = demo?.opportunityId ?? pairKey;
+      if (opportunityId !== nextId) {
+        opportunityId = nextId;
+        clear(sharedHistory);
+        displayedTurns = 0;
+        append(sharedHistory, roster.map(({ name }) => name).join(' ↔ '), demo ? `Match ${matchIndex + 1}/${available.length} · ${demo.opportunityId} · Ctrl+N changes match.` : 'No negotiation between these selected intents.', COLORS.muted);
       }
-    });
+      while (demo && displayedTurns < demo.transcript.length) {
+        const entry = demo.transcript[displayedTurns++];
+        const name = demo.principals.find(({ userId }) => userId === entry.ownerId)!.name;
+        append(sharedHistory, name + "'s agent · " + entry.action, entry.text, COLORS.focus);
+      }
+      a2a.title = ` A2A · ${roster.map(({ name }) => name).join(' ↔ ')} `;
+      a2a.borderColor = selected === null ? COLORS.focus : COLORS.border;
+      a2a.titleColor = selected === null ? COLORS.focus : COLORS.muted;
+    }
     const waiting = [...lab.agents.values()].filter((agent) => agent.pending).length;
-    status.content = (demo?.status ?? 'No match selected') + ' · H2A: ' + lab.agents.size + ' · A2A: ' + lab.negotiations.size
-      + (waiting ? ' · Principals awaiting answers: ' + waiting : '')
-      + (lab.agentStatus ? ' · ' + lab.agentStatus : '')
-      + (renderer.width < 100 ? ' · Widen terminal to 100+ columns for more space.' : '');
+    status.content = (a2a.visible ? (demo?.status ?? 'No match selected') + ' · ' : '')
+      + 'Board: ' + roster.length + ' · Expanded: ' + expanded.length + ' · H2A: ' + lab.agents.size + ' · A2A: ' + lab.negotiations.size
+      + (waiting ? ' · Awaiting answers: ' + waiting : '') + (lab.agentStatus ? ' · ' + lab.agentStatus : '');
     status.fg = demo?.phase === 'error' ? '#f88a8a' : waiting ? COLORS.question : COLORS.muted;
+    help.content = ' Ctrl+U: users · Ctrl+T: intent · Ctrl+O: collapse · Tab/Shift+Tab: chat · ↑↓: choose · Enter: send · Esc: back · Ctrl+J: newline · PgUp/PgDn/wheel: scroll'
+      + (a2a.visible ? ' · Ctrl+N: next match' : '') + ' · Ctrl+C: quit';
+    if (selector.visible) { renderSelector(); selectorList.focus(); }
+    else if (selected === null) sharedHistory.focus();
+    else {
+      const pane = panes.get(users.find(({ id }) => id === selected)!.current.id)!;
+      if (pane.choices.visible && !pane.editingReply) pane.choices.focus(); else pane.input.focus();
+    }
   }
 
   const onKey = (key: KeyEvent) => {
-    const pane = panes[selected];
-    const agent = pane.ownerId ? lab.agents.get(pane.ownerId) : undefined;
-    const question = pane.shownQuestion === agent?.pending ? agent?.pending : null;
-    if (key.name === 'tab') {
+    if (key.name === 'u' && key.ctrl) {
       key.preventDefault();
-      focus((selected + (key.shift ? 2 : 1)) % 3);
+      if (selector.visible) closeSelector(false); else openSelector();
+    } else if (selector.visible) {
+      key.preventDefault();
+      if (key.name === 'escape') closeSelector(false);
+      else if (key.name === 'up' || key.name === 'down') {
+        selectorIndex = Math.max(0, Math.min(selectorEntries().length - 1, selectorIndex + (key.name === 'up' ? -1 : 1)));
+        renderSelector();
+        selectorList.scrollChildIntoView(`selector-${selectorEntries()[selectorIndex].id}`);
+      } else if (key.name === 'space' && !intentUser) toggleRosterEntry();
+      else if (key.name === 'return' && !key.ctrl && !key.shift && !key.meta) closeSelector(true);
+      else if (key.name === 'pageup' || key.name === 'pagedown') selectorList.scrollBy((key.name === 'pageup' ? -1 : 1) * Math.max(1, selectorList.height - 2));
+    } else if (key.name === 't' && key.ctrl) {
+      key.preventDefault();
+      if (selected !== null) openSelector(users.find(({ id }) => id === selected)!);
+    } else if (key.name === 'tab') {
+      key.preventDefault();
+      const order: (string | null)[] = roster.map(({ id }) => id);
+      if (a2a.visible) order.splice(1, 0, null);
+      focus(order[(order.indexOf(selected) + (key.shift ? -1 : 1) + order.length) % order.length]);
+    } else if (key.name === 'o' && key.ctrl) {
+      key.preventDefault();
+      if (selected !== null) collapse(selected);
     } else if (key.name === 'n' && key.ctrl) {
       key.preventDefault();
-      matchIndex = (matchIndex + 1) % Math.max(1, matches().length);
-      render();
-    } else if (key.name === 'u' && key.ctrl) {
-      key.preventDefault();
-      toggleUsers(selected);
-    } else if (pane.users?.visible && key.name === 'escape') {
-      key.preventDefault();
-      toggleUsers(selected);
-    } else if (pane.users?.visible && (key.name === 'up' || key.name === 'down')) {
-      key.preventDefault();
-      pane.userIndex = Math.max(0, Math.min(pane.userRows.length - 1, pane.userIndex + (key.name === 'up' ? -1 : 1)));
-      render();
-      pane.users.scrollChildIntoView(`user-${selected}-${pane.userIndex}`);
-    } else if (pane.users?.visible && key.name === 'return' && !key.ctrl && !key.shift && !key.meta) {
-      key.preventDefault();
-      chooseUser(selected, pane.userRows[pane.userIndex].ownerId);
-    } else if (question && key.name === 'escape' && pane.editingReply) {
-      key.preventDefault();
-      pane.editingReply = false;
-      focus(selected);
-    } else if (question && !pane.editingReply && (key.name === 'up' || key.name === 'down')) {
-      key.preventDefault();
-      pane.choiceIndex = Math.max(0, Math.min(pane.choiceRows.length - 1, pane.choiceIndex + (key.name === 'up' ? -1 : 1)));
-      render();
-      pane.choices!.scrollChildIntoView(`option-${pane.ownerId}-${pane.choiceIndex}`);
-    } else if (question && !pane.editingReply && key.name === 'return' && !key.ctrl && !key.shift && !key.meta) {
-      key.preventDefault();
-      const option = question.options?.[pane.choiceIndex];
-      if (option === undefined) {
-        pane.editingReply = true;
-      } else { void send(pane, option); }
-      focus(selected);
-    } else if (key.name === 'pageup' || key.name === 'pagedown') {
-      key.preventDefault();
-      const history = pane.users?.visible ? pane.users : pane.history;
-      history.scrollBy((key.name === 'pageup' ? -1 : 1) * Math.max(1, history.height - 2));
+      if (a2a.visible) { matchIndex = (matchIndex + 1) % Math.max(1, matches().length); render(); }
+    } else {
+      const pane = selected === null ? undefined : panes.get(users.find(({ id }) => id === selected)!.current.id)!;
+      const question = pane?.shownQuestion;
+      if (pane && question && key.name === 'escape' && pane.editingReply) {
+        key.preventDefault();
+        pane.editingReply = false;
+        render();
+      } else if (pane && question && !pane.editingReply && (key.name === 'up' || key.name === 'down')) {
+        key.preventDefault();
+        pane.choiceIndex = Math.max(0, Math.min(pane.choiceRows.length - 1, pane.choiceIndex + (key.name === 'up' ? -1 : 1)));
+        render();
+        pane.choices.scrollChildIntoView(`option-${pane.principal.id}-${pane.choiceIndex}`);
+      } else if (pane && question && !pane.editingReply && key.name === 'return' && !key.ctrl && !key.shift && !key.meta) {
+        key.preventDefault();
+        const option = question.options?.[pane.choiceIndex];
+        if (option === undefined) pane.editingReply = true; else void send(pane, option);
+        render();
+      } else if (key.name === 'pageup' || key.name === 'pagedown') {
+        key.preventDefault();
+        const history = pane?.history ?? sharedHistory;
+        history.scrollBy((key.name === 'pageup' ? -1 : 1) * Math.max(1, history.height - 2));
+      }
     }
   };
   renderer.keyInput.on('keypress', onKey);
@@ -380,5 +494,5 @@ export function mountNegotiationTui(renderer: CliRenderer, lab: NegotiationTuiHo
     renderer.off('resize', render);
     renderer.keyInput.off('keypress', onKey);
   });
-  focus(0);
+  render();
 }


### PR DESCRIPTION
The agent TUI now shows one pane per selected user and lets each user switch between intent sessions without losing the corresponding agent, H2A history, scroll position, draft, pending question, suggested-answer selection, or in-flight send.

- Add a Users roster selector with Space/click toggles, Enter to apply, and a two-user minimum. Add header intent selection and Ctrl+T.
- Share horizontal space equally between expanded chats, target 40 columns per chat, and collapse overflow into a 24-column scrollable list. Preserve focus, restore automatic collapses on widening, and retain manual collapses until selected. Add header/Ctrl+O collapse and Tab/Shift+Tab navigation through collapsed users. Highlight names/question indicators only for pending input; keep queue counts muted.
- Show central A2A whenever exactly two user chats are expanded, even with other users collapsed or at narrower widths. Follow the expanded users and their selected intents, including match cycling and keyboard focus; hide A2A for other expanded counts.
- Add multiple intents per scenario user, each with its own agent. The default scenario contains 12 users, 24 intent agents, and 264 matches between different users. Keep communication failures confined to the affected intent's matches.
- Update README/help and bump agent-tui to 0.3.0 with synchronized lockfile metadata.

Breaking scenario format: replace each user's single `intent` string with `intents: [{ id, intent }, ...]`. Intent IDs are unique within each user. The README and bundled scenario use the new format. The TUI host interface and API startup selection semantics are unchanged; API intent selectors offer the sessions selected at startup.

Verification:

- Protocol and agent prerequisite builds; agent-tui check/build; repository lint (0 errors, 35 existing warnings in untouched files); lockfile version sync/check; CLI help; diff whitespace check.
- Native renderer smoke: 2, 3, 4, and 12 users with one and two intents each at 80, 120, and 200 columns. Covered keyboard/mouse navigation, roster and intent changes, collapse/expand, resizing, 24-row rendering, drafts/history/scroll/question/choice preservation, queued indicators, in-flight sends, and A2A visibility/routing.
- Real tmux 3.7b terminal smoke with the scenario host and 24 real agent instances: roster Space/Enter/Esc, header/Ctrl+T intent switching, draft restoration, exact pending-question reply routing, mouse and keyboard collapse/expand, resizing, Tab/Shift+Tab, and Ctrl+C shutdown. Captured 2/3/4/12-user boards, including resizes to 80/120/200 columns and 24/36 rows.
- Follow-up smoke: all 2/3/4/12-user layouts at 80/120/200 columns, non-leading expanded pairs, match cycling, intent changes, and tab order. Tmux confirms the expanded pair and actual negotiation turns at 120 columns with ten collapsed users. Native rendered colors confirm queued-only users stay muted and pending-question highlights never color queue counts.
- Scenario smoke: 24 independent agent conversations with correct intent/context, 264 cross-user matches, 528 correctly routed match deliveries, transcript export, isolated intent failures, and malformed/duplicate input rejection.

Smoke runs used deterministic model responses and local fixtures; live provider and API database runs were not performed. No dependencies or repository tests were added.

