### PR TITLE
feat(notifications): make desktop toasts actionable and add question alerts

### DIFF
--- a/apps/mac/api/deeplink.mjs
+++ b/apps/mac/api/deeplink.mjs
@@ -22,6 +22,7 @@ const ROUTE_BY_SEGMENT = {
   u: 'profile',
   c: 'legacy-connect',
   chat: 'conversation',
+  i: 'signal',
 };
 
 /** Routes whose second segment is an opaque code rather than an entity id. */
@@ -31,7 +32,8 @@ const CODE_ROUTES = new Set(['legacy-connect']);
  * @typedef {{ route: 'card', id: string }
  *   | { route: 'profile', id: string }
  *   | { route: 'legacy-connect', code: string }
- *   | { route: 'conversation', id: string }} DeepLinkRoute
+ *   | { route: 'conversation', id: string }
+ *   | { route: 'signal', id: string }} DeepLinkRoute
  */
 
 /**

--- a/apps/mac/api/notifications.mjs
+++ b/apps/mac/api/notifications.mjs
@@ -2,9 +2,9 @@
  * Pure desktop-notification helpers for the macOS shell.
  *
  * Adapted from packages/hermes-plugin/desktop/notifications.mjs so both
- * desktop surfaces share one event vocabulary (opportunity.* persisted events
- * plus realtime conversation `message` events) and the same dedupe/snapshot
- * semantics. The Mac compose additionally returns an activate
+ * desktop surfaces share one event vocabulary (the three human frames:
+ * `opportunity.*`, `question.pending`, and conversation `message`) and the same
+ * dedupe semantics. The Mac compose additionally returns an activate
  * `url` (an index:// deep link the Swift tap handler feeds back through the
  * normal deep-link pipeline) and, for messages, an `imageUrl` used as the
  * notification's sender-avatar attachment.
@@ -15,6 +15,9 @@
 
 export const NOTIFIED_ENTITIES_KEY = 'notifiedEntitiesV2';
 export const MAX_NOTIFIED_ENTITIES = 200;
+
+/** Sender id the API writes agent-DM messages under (services/api database.shared). */
+const AGENT_SENDER_ID = 'system-agent';
 
 /**
  * @param {Object} event
@@ -37,6 +40,10 @@ export function notificationEntityKey(event) {
   if (event.type.indexOf('opportunity.') === 0) {
     const id = notificationId(event, 'opportunityId');
     return id ? `opportunity:${id}` : null;
+  }
+  if (event.type === 'question.pending') {
+    const id = notificationId(event, 'questionId');
+    return id ? `question:${id}` : null;
   }
   if (event.type === 'message' || event.type.indexOf('message.') === 0) {
     const id = event.message && typeof event.message.id === 'string'
@@ -101,9 +108,23 @@ export function composeNotification(event, options) {
       ...(id ? { url: `index://o/${encodeURIComponent(id)}` } : {}),
     };
   }
+  if (event.type === 'question.pending') {
+    if (typeof event.title !== 'string' || !event.title.trim()) return null;
+    const intentId = event.data && typeof event.data.intentId === 'string'
+      ? event.data.intentId.trim()
+      : '';
+    return {
+      title: event.title,
+      body: typeof event.body === 'string' ? event.body : '',
+      ...(intentId ? { url: `index://i/${encodeURIComponent(intentId)}` } : {}),
+    };
+  }
   if (event.type === 'message' || event.type.indexOf('message.') === 0) {
     const message = event.message;
     if (!message || typeof message !== 'object') return null;
+    // The owner's own agent speaks in the agent DM, and `question.pending`
+    // already announces the only thing it says that needs answering.
+    if (message.senderId === AGENT_SENDER_ID) return null;
     const sender = String(message.senderName || message.senderId || 'Someone');
     let text = '';
     if (Array.isArray(message.parts)) {
@@ -125,7 +146,7 @@ export function composeNotification(event, options) {
         : (/^https?:/i.test(avatar) ? avatar : null))
       : null;
     return {
-      title: `New message from ${sender}`,
+      title: sender,
       body: text || 'Open Index to read the message.',
       ...(conversationId ? { url: `index://chat/${encodeURIComponent(conversationId)}` } : {}),
       ...(imageUrl ? { imageUrl } : {}),

--- a/apps/mac/src/ui/app.jsx
+++ b/apps/mac/src/ui/app.jsx
@@ -35,11 +35,11 @@ function nativeAuthed() {
 // gets one fetch by id through the existing client methods, and null when even
 // that comes up empty, so the caller can say so instead of opening a blank
 // window.
-// A conversation link (minted by the app's own OS toasts) names an
-// intent-scoped destination rather than a person card: resolve which signal
-// owns it so the caller can open that signal, and the specific chat within it,
-// through the same machinery the menubar uses.
-async function resolveDeepLinkTarget(route, intents) {
+// A conversation link (minted by the app's own OS toasts) names a thread
+// rather than a person card, and the card it belongs to is what the floating
+// chat needs a name and face from: read the conversation's provenance, then
+// resolve that opportunity the same way a card link does.
+async function resolveDeepLinkConversation(route, people) {
   if (!nativeAuthed() || !window.IndexApp) return null;
   const client = window.IndexApp.getClient();
   if (!client) return null;
@@ -48,8 +48,8 @@ async function resolveDeepLinkTarget(route, intents) {
     const conv = window.IndexApp.normalizeList(res, "conversations").find((row) => row && row.id === route.id);
     const via = conv && Array.isArray(conv.via) ? conv.via[0] : null;
     if (!via) return null;
-    const intent = (intents || []).find((i) => i.id === via.intentId);
-    return intent ? { intent, personId: via.opportunityId } : null;
+    const person = await resolveDeepLinkPerson({ route: "card", id: via.opportunityId }, people);
+    return person ? { person, conversationId: route.id } : null;
   } catch (e) {
     return null;
   }
@@ -178,6 +178,10 @@ function App() {
   const [notice, setNotice] = useState(null);
   const [pendingLink, setPendingLink] = useState(null);   // parsed route, not applied yet
   const [linkedCard, setLinkedCard] = useState(null);     // { person, route } on screen
+  const [linkedChat, setLinkedChat] = useState(null);     // { person, conversationId } on screen
+  // Bumped when a question link lands, so the signal's feed scrolls to it even
+  // if that signal was already open and nothing else changed.
+  const [focusQuestion, setFocusQuestion] = useState(0);
 
   useEffect(() => {
     if (!window.IndexApp || !window.IndexApp.onDeepLink) return;
@@ -227,17 +231,27 @@ function App() {
     const link = pendingLink;
     resolvingRef.current = link;
     (async () => {
-      // Notification activate links land on a signal (and maybe a chat within
-      // it) rather than a floating person card.
+      // A conversation floats over whatever is on screen, like a card does:
+      // the thread is the interruption, not a reason to change signals.
       if (link.route === "conversation") {
-        const target = await resolveDeepLinkTarget(link, INTENTS);
+        const target = await resolveDeepLinkConversation(link, peopleRef.current);
         if (resolvingRef.current !== link) return;
         resolvingRef.current = null;
-        if (target) {
-          pickExistingIntent(target.intent);
-          if (target.personId) setPendingChat(target.personId);
+        if (target) setLinkedChat(target);
+        else setNotice("couldn't open that conversation.");
+        setPendingLink(null);
+        return;
+      }
+      // A question is the one link that does change signals: it is answered in
+      // that signal's own conversation with its agent, and nowhere else.
+      if (link.route === "signal") {
+        const intent = (INTENTS || []).find((i) => i.id === link.id);
+        resolvingRef.current = null;
+        if (intent) {
+          pickExistingIntent(intent);
+          setFocusQuestion(Date.now());
         } else {
-          setNotice("couldn't open that conversation.");
+          setNotice("that signal isn't on your hub.");
         }
         setPendingLink(null);
         return;
@@ -282,6 +296,7 @@ function App() {
         // over the login screen. Clearing resolvingRef makes the in-flight
         // resolve fail its own ownership check and bail when it completes.
         setLinkedCard(null);
+        setLinkedChat(null);
         setPendingLink(null);
         resolvingRef.current = null;
         setScreen("login");
@@ -531,6 +546,13 @@ function App() {
             onClose={() => setLinkedCard(null)}
           />
         )}
+        {linkedChat && (
+          <DeepLinkChatWindow
+            person={linkedChat.person}
+            conversationId={linkedChat.conversationId}
+            onClose={() => setLinkedChat(null)}
+          />
+        )}
         {notice && <MacNotice text={notice} onDismiss={() => setNotice(null)}/>}
         {screen === "main"        && (
           <MainView
@@ -544,6 +566,7 @@ function App() {
             registerChats={registerChats}
             pendingChat={pendingChat}
             onPendingHandled={() => setPendingChat(null)}
+            focusQuestion={focusQuestion}
           />
         )}
       </div>

--- a/apps/mac/src/ui/mainview/conversation.jsx
+++ b/apps/mac/src/ui/mainview/conversation.jsx
@@ -27,7 +27,9 @@ function SignalAction({ label, active = false, onClick, danger = false }) {
   );
 }
 
-function ConversationPane({ profile, conversation, negotiatingPeople = [], onRespondPerson, paused = false, onTogglePause, onArchive }) {
+function ConversationPane({ profile, conversation, negotiatingPeople = [], onRespondPerson,
+                            agentQuestion = null, onAnswerAgent, focusQuestion = 0,
+                            paused = false, onTogglePause, onArchive }) {
   const scrollRef = useRef(null);
   // Archiving takes the signal off the hub and there's no way back to it from
   // here, so the first click arms the button and the second one commits. It
@@ -50,6 +52,15 @@ function ConversationPane({ profile, conversation, negotiatingPeople = [], onRes
       .catch(() => {})
       .then(() => setArchiving(false));
   };
+  // A notification tap lands on the signal, not on the question inside it, so
+  // the card brings itself into view. Keyed on the tap rather than the question
+  // so tapping again re-focuses one that is already open.
+  const agentQuestionRef = useRef(null);
+  useEffect(() => {
+    if (!focusQuestion || !agentQuestionRef.current) return;
+    agentQuestionRef.current.scrollIntoView({ behavior: "smooth", block: "center" });
+  }, [focusQuestion, agentQuestion && agentQuestion.id]);
+
   const [stuck, setStuck] = useState(true);
   const [unread, setUnread] = useState(0);
   const lastLen = useRef(conversation.length);
@@ -181,6 +192,13 @@ function ConversationPane({ profile, conversation, negotiatingPeople = [], onRes
           marginTop:"auto",
           display:"flex", flexDirection:"column", gap:14,
         }}>
+          {/* the one question your own agent is held on for this signal */}
+          {agentQuestion && (
+            <div ref={agentQuestionRef}>
+              <AgentQuestionCard question={agentQuestion} onAnswer={onAnswerAgent}/>
+            </div>
+          )}
+
           {/* standing questions from people in your radar */}
           {groupQuestions(negotiatingPeople).map(g =>
             g.people.length >= 2 ? (
@@ -331,6 +349,30 @@ function CollectiveQuestionCard({ question, people, onRespond }) {
       onChip={(c) => people.forEach(p => onRespond && onRespond(p.id, c))}
       onWrite={(t) => people.forEach(p => onRespond && onRespond(p.id, t))}
       writePlaceholder={`answer all ${people.length} in your own words`}
+    />
+  );
+}
+
+/* Your own agent, held on this signal until you answer.
+
+   Unlike the cards around it this one is live: the question, its suggested
+   answers, and the matches it is asked about all come from the agent's
+   conversation, and the answer goes back to the same place. */
+function AgentQuestionCard({ question, onAnswer }) {
+  const matches = Array.isArray(question.matches) ? question.matches : [];
+  const about = matches
+    .map((m) => (m && m.counterparty && m.counterparty.name) || "")
+    .filter(Boolean)
+    .join(", ");
+  return (
+    <QuestionCard
+      icon={<AgentAvatar size={18} title="your agent"/>}
+      source="from your agent"
+      tag={about || (question.scope === "match" ? "about a match" : "about this signal")}
+      question={question.question}
+      chips={Array.isArray(question.options) ? question.options : []}
+      onChip={(c) => onAnswer && onAnswer(c)}
+      onWrite={(t) => onAnswer && onAnswer(t)}
     />
   );
 }

--- a/apps/mac/src/ui/mainview/core.jsx
+++ b/apps/mac/src/ui/mainview/core.jsx
@@ -12,7 +12,8 @@ const DISCOVERY_GIVE_UP_MS = 120000;
 
 function MainView({ profile, people, setPeople, conversation, setConversation,
                     field, setField, stats, simRate, setSimRate, tweaks = {},
-                    onOpenRoom, onBack, registerChats, pendingChat, onPendingHandled }) {
+                    onOpenRoom, onBack, registerChats, pendingChat, onPendingHandled,
+                    focusQuestion }) {
   // Live-only: these demo sim feeds no longer exist, so they default to empty.
   // The simulation loops below stay wired but idle on empty arrays.
   const { FIELD_EVENTS = [], AMBIENT_NOTES = [] } = window.INDEX_DATA;
@@ -246,6 +247,41 @@ function MainView({ profile, people, setPeople, conversation, setConversation,
     return () => clearInterval(t);
   }, [live, refreshRadar]);
 
+  /* ----- the signal's own agent: the question it is held on ----- */
+  // GET /conversations/agent?intentId= is the whole H2A contract: the agent's
+  // side of this signal plus the one question it is suspended on. The same poll
+  // the web app runs, because a question can appear without anything else on
+  // this screen changing.
+  const [agentQuestion, setAgentQuestion] = useState(null);
+  useEffect(() => {
+    setAgentQuestion(null);
+    if (!live || !client) return;
+    let alive = true;
+    const forIntent = intentId;
+    const read = () => client.conversations.messages("agent", { intentId: forIntent })
+      .then((res) => {
+        if (!alive || intentIdRef.current !== forIntent) return;
+        setAgentQuestion((res && res.agent && res.agent.pending) || null);
+      })
+      .catch(() => { /* a failed read leaves the last known question up */ });
+    read();
+    const t = setInterval(read, 5000);
+    return () => { alive = false; clearInterval(t); };
+  }, [live, client, intentId]);
+
+  // The answer goes back naming the question it answers, so a question that
+  // changed while it was being written is rejected rather than mis-filed.
+  const answerAgentQuestion = (text) => {
+    const question = agentQuestion;
+    if (!question || !client || !intentId) return;
+    setAgentQuestion(null);
+    client.conversations.sendMessage("agent", {
+      parts: [{ kind: "text", text }],
+      metadata: { intentId },
+      questionId: question.id,
+    }).catch(() => setAgentQuestion(question));
+  };
+
   // The four states an opportunity can be in for you, in the order they happen:
   // it needs you, agents are still talking, you took it, it ran out.
   // "awaiting you" leads because it is the only one you can act on.
@@ -273,16 +309,7 @@ function MainView({ profile, people, setPeople, conversation, setConversation,
   const [summaryId, setSummaryId] = useState(null);    // expired person whose summary is open
   const [profileId, setProfileId] = useState(null);    // person whose profile is open
 
-  const toChatMsg = (m) => {
-    const parts = Array.isArray(m.parts) ? m.parts : [];
-    const text = parts.map((p) => (p && typeof p === "object" && p.text) ? p.text : "")
-      .filter(Boolean).join("\n");
-    const who = m.senderId && myId && m.senderId === myId ? "you"
-      : m.role === "agent" ? "index" : "them";
-    // `at` is what the bubble reveals on hover; absent on older rows, and the
-    // bubble simply shows nothing then.
-    return { id: m.id || rid(), who, text, at: m.createdAt || m.created_at || null };
-  };
+  const toChatMsg = (m) => apiChatMessage(m, myId);
 
   const openChat = (personId) => {
     setChatId(personId);
@@ -553,6 +580,9 @@ function MainView({ profile, people, setPeople, conversation, setConversation,
             conversation={conversation}
             negotiatingPeople={live ? [] : negotiatingPeople}
             onRespondPerson={respondPerson}
+            agentQuestion={agentQuestion}
+            onAnswerAgent={answerAgentQuestion}
+            focusQuestion={focusQuestion}
             paused={paused}
             onTogglePause={togglePause}
             onArchive={archiveSignal}

--- a/apps/mac/src/ui/mainview/exports.jsx
+++ b/apps/mac/src/ui/mainview/exports.jsx
@@ -26,3 +26,4 @@ function BottomBar({ stats }) {
 
 window.MainView = MainView;
 window.DeepLinkWindow = DeepLinkWindow;
+window.DeepLinkChatWindow = DeepLinkChatWindow;

--- a/apps/mac/src/ui/mainview/windows.jsx
+++ b/apps/mac/src/ui/mainview/windows.jsx
@@ -19,6 +19,74 @@ function DeepLinkWindow({ person, route, onClose }) {
   );
 }
 
+/* A conversation opened from an OS notification.
+
+   The chat normally lives as a third column inside the signal that surfaced
+   the match, so opening it that way means switching signals — throwing away
+   whatever the person was already looking at. A notification is an
+   interruption, not a navigation, so it floats over the current screen
+   instead and talks to the same conversation endpoints the column uses. */
+function DeepLinkChatWindow({ person, conversationId, onClose }) {
+  const [messages, setMessages] = useState([]);
+  const [draft, setDraft] = useState("");
+  const myId = (window.INDEX_DATA && window.INDEX_DATA.ME && window.INDEX_DATA.ME.id) || null;
+
+  useEffect(() => {
+    if (!window.IndexApp || !window.IndexApp.isAuthed()) return;
+    const client = window.IndexApp.getClient();
+    if (!client) return;
+    let cancelled = false;
+    client.conversations.messages(conversationId)
+      .then((res) => {
+        if (cancelled) return;
+        setMessages(window.IndexApp.normalizeList(res, "messages").map((m) => apiChatMessage(m, myId)));
+      })
+      .catch(() => {});
+    // The thread stays live while it floats: the notification that opened it
+    // may well be followed by another line before it is closed.
+    const sub = window.IndexApp.streamInbox((event) => {
+      if (!event || event.type !== "message" || !event.message) return;
+      if (event.conversationId !== conversationId) return;
+      const m = apiChatMessage(event.message, myId);
+      if (m.who === "you") return;   // our own sends are already on screen
+      setMessages((prev) => prev.some((x) => x.id === m.id) ? prev : [...prev, m]);
+    });
+    return () => { cancelled = true; if (sub && sub.close) sub.close(); };
+  }, [conversationId, myId]);
+
+  const send = () => {
+    const text = draft.trim();
+    if (!text) return;
+    setDraft("");
+    setMessages((prev) => [...prev, { id: rid(), who:"you", text, at: nowISO() }]);
+    const client = window.IndexApp && window.IndexApp.getClient();
+    if (client) client.conversations.sendMessage(conversationId, { parts: [{ text }] }).catch(() => {});
+  };
+
+  return (
+    <div
+      onClick={onClose}
+      style={{
+        position:"fixed", inset:0, zIndex:900,
+        display:"flex", alignItems:"center", justifyContent:"center",
+        padding:"56px 18px",
+      }}>
+      <div
+        onClick={(e) => e.stopPropagation()}
+        style={{ display:"flex", width:"min(460px, 100%)", maxHeight:"100%", minHeight:0 }}>
+        <ChatWindow
+          person={person}
+          messages={messages}
+          draft={draft}
+          setDraft={setDraft}
+          onSend={send}
+          onClose={onClose}
+        />
+      </div>
+    </div>
+  );
+}
+
 /* Full profile for a person, opens in the 3rd window when you click their
    name or avatar on the radar. `actions` off drops the stage CTA, for a
    profile opened outside a signal (see DeepLinkWindow) where accepting or
@@ -153,6 +221,17 @@ function ProfileWindow({ person, onClose, onAccept, onPass, onOpenChat, actions 
       </div>
     </MacWindow>
   );
+}
+
+/* One API message in the shape the bubbles read. `at` is what a bubble reveals
+   on hover; older rows have none and simply show nothing. */
+function apiChatMessage(m, myId) {
+  const parts = Array.isArray(m.parts) ? m.parts : [];
+  const text = parts.map((p) => (p && typeof p === "object" && p.text) ? p.text : "")
+    .filter(Boolean).join("\n");
+  const who = m.senderId && myId && m.senderId === myId ? "you"
+    : m.role === "agent" ? "index" : "them";
+  return { id: m.id || rid(), who, text, at: m.createdAt || m.created_at || null };
 }
 
 function ChatWindow({ person, messages, draft, setDraft, onSend, onClose }) {

--- a/bun.lock
+++ b/bun.lock
@@ -107,7 +107,7 @@
     },
     "packages/hermes-plugin": {
       "name": "@indexnetwork/hermes-plugin",
-      "version": "0.37.0",
+      "version": "0.38.0",
     },
     "packages/protocol": {
       "name": "@indexnetwork/protocol",
@@ -127,7 +127,7 @@
     },
     "services/api": {
       "name": "@indexnetwork/api",
-      "version": "0.116.0",
+      "version": "0.117.0",
       "dependencies": {
         "@aws-sdk/client-s3": "^3.939.0",
         "@aws-sdk/s3-request-presigner": "^3.983.0",

--- a/packages/hermes-plugin/dashboard/dist/index.js
+++ b/packages/hermes-plugin/dashboard/dist/index.js
@@ -595,6 +595,30 @@
     };
   }
 
+  /**
+   * What an OS notification asked us to focus, as `?o=`, `?chat=` or `?intent=`
+   * on the activate URL. The web host carries it in the query; the desktop host
+   * routes on the hash, so it arrives inside that instead. Reading both keeps
+   * one activate URL working on both.
+   */
+  function parseFocusTarget() {
+    const hash = window.location.hash || "";
+    const mark = hash.indexOf("?");
+    const params = new URLSearchParams(window.location.search || "");
+    if (mark >= 0) {
+      new URLSearchParams(hash.slice(mark)).forEach(function (value, key) {
+        if (!params.has(key)) params.set(key, value);
+      });
+    }
+    const opportunityId = params.get("o");
+    if (opportunityId) return { kind: "opportunity", id: opportunityId };
+    const conversationId = params.get("chat");
+    if (conversationId) return { kind: "conversation", id: conversationId };
+    const intentId = params.get("intent");
+    if (intentId) return { kind: "intent", id: intentId };
+    return null;
+  }
+
   function writeHash(intentId) {
     if (DESKTOP_ENV) return;
     const target = intentId ? "#intent=" + encodeURIComponent(intentId) : "";
@@ -2158,6 +2182,91 @@
     );
   }
 
+  /**
+   * The one question this intent's personal agent is suspended on.
+   *
+   * The agent conversation is not in the messages list — it is per-signal and
+   * lives here, next to the radar it is asking about. Renders nothing until
+   * there is a question, which is most of the time.
+   */
+  function AgentQuestion(props) {
+    const questionState = React.useState(null);
+    const question = questionState[0];
+    const setQuestion = questionState[1];
+    const draftState = React.useState("");
+    const draft = draftState[0];
+    const setDraft = draftState[1];
+    const rootRef = React.useRef(null);
+    const intentId = props.intentId;
+
+    React.useEffect(function () {
+      let alive = true;
+      function read() {
+        fetchPluginJSON(API + "/agent/question?intentId=" + encodeURIComponent(intentId))
+          .then(function (payload) {
+            if (!alive || !payload || payload.success === false) return;
+            setQuestion(payload.question || null);
+          })
+          .catch(function () { /* a failed read leaves the last question up */ });
+      }
+      read();
+      const timer = setInterval(read, 5000);
+      return function () { alive = false; clearInterval(timer); };
+    }, [intentId]);
+
+    React.useEffect(function () {
+      if (!props.focusQuestion || !rootRef.current) return;
+      rootRef.current.scrollIntoView({ behavior: "smooth", block: "center" });
+    }, [props.focusQuestion, question && question.id]);
+
+    if (!question) return null;
+
+    function answer(text) {
+      const asked = question;
+      setQuestion(null);
+      setDraft("");
+      fetchPluginJSON(API + "/agent/answer", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ intentId: intentId, text: text, questionId: asked.id }),
+      }).catch(function () { setQuestion(asked); });
+    }
+
+    const options = Array.isArray(question.options) ? question.options : [];
+    return React.createElement("div", { ref: rootRef },
+      React.createElement(Panel, { title: "Your agent", description: "It is holding this signal until you answer." },
+        React.createElement("p", { className: "index-dashboard__card-description" }, question.question),
+        React.createElement("div", { className: "index-dashboard__action-group" },
+          options.map(function (option) {
+            return React.createElement(Button, {
+              key: option,
+              type: "button",
+              outlined: true,
+              onClick: function () { answer(option); },
+            }, option);
+          }),
+        ),
+        React.createElement("div", { className: "index-dashboard__msg-composer" },
+          React.createElement("textarea", {
+            className: "index-dashboard__textarea index-dashboard__msg-input",
+            rows: 1,
+            value: draft,
+            placeholder: "Write your answer…",
+            onChange: function (e) { setDraft(e.target.value); },
+            onKeyDown: function (e) {
+              if (e.key === "Enter" && !e.shiftKey) { e.preventDefault(); if (draft.trim()) answer(draft.trim()); }
+            },
+          }),
+          React.createElement(Button, {
+            type: "button",
+            disabled: !draft.trim(),
+            onClick: function () { if (draft.trim()) answer(draft.trim()); },
+          }, "Answer"),
+        ),
+      ),
+    );
+  }
+
   function IntentDetail(props) {
     const intent = props.intent;
     const bucketState = React.useState("pending");
@@ -2219,6 +2328,7 @@
         })(),
       }),
       React.createElement("div", { className: "index-dashboard__detail-cols" },
+        React.createElement(AgentQuestion, { intentId: intent.id, focusQuestion: props.focusQuestion }),
         React.createElement(Panel, { title: "Radar", primary: true, count: allOpps.length, titleAfter: RADAR_EYE(), description: "People the network surfaced for this intent." },
           props.actionError ? React.createElement("div", { className: "index-dashboard__error" }, props.actionError) : null,
           React.createElement(RadarStrip, { counts: intent.statusCounts, selected: selectedBucket, onSelect: setSelectedBucket }),
@@ -3462,6 +3572,11 @@
     const messagesTargetState = useState(null);
     const messagesTarget = messagesTargetState[0];
     const setMessagesTarget = messagesTargetState[1];
+    // Bumped by a question notification, so the card scrolls into view even
+    // when its signal was already the selected one.
+    const focusQuestionState = useState(0);
+    const focusQuestion = focusQuestionState[0];
+    const setFocusQuestion = focusQuestionState[1];
     const archivingState = useState(null);
     const archivingId = archivingState[0];
     const setArchivingId = archivingState[1];
@@ -3483,6 +3598,7 @@
     const headerCtlRef = useRef(null);
     const toggleProfileRef = useRef(null);
     const openMessagesRef = useRef(null);
+    const focusAppliedRef = useRef(null);
 
     function loadNetworks() {
       fetchPluginJSON(API + "/networks/home")
@@ -3973,6 +4089,44 @@
       };
     }, []);
 
+    // A notification tap re-enters this page with its target on the URL. An
+    // opportunity or a conversation opens as a panel over whatever was already
+    // selected; only a question changes the selection, because it is answered
+    // in its own signal and nowhere else.
+    useEffect(function () {
+      if (auth !== "authed") return undefined;
+      function applyFocus() {
+        const target = parseFocusTarget();
+        if (!target) return;
+        // The target stays on the URL after it is applied, so every later
+        // navigation would otherwise re-open a panel the user has closed.
+        const key = target.kind + ":" + target.id;
+        if (focusAppliedRef.current === key) return;
+        focusAppliedRef.current = key;
+        if (target.kind === "opportunity") {
+          fetchPluginJSON(API + "/opportunities/" + encodeURIComponent(target.id) + "/counterpart")
+            .then(function (payload) {
+              if (payload && payload.success !== false && payload.userId) setViewUserId(payload.userId);
+            })
+            .catch(function () { /* the page is open, which is most of the ask */ });
+        } else if (target.kind === "conversation") {
+          setMessagesTarget(target.id);
+          setMessagesOpen(true);
+        } else {
+          setSelectedId(target.id);
+          writeHash(target.id);
+          setFocusQuestion(function (n) { return n + 1; });
+        }
+      }
+      applyFocus();
+      window.addEventListener("hashchange", applyFocus);
+      window.addEventListener("popstate", applyFocus);
+      return function () {
+        window.removeEventListener("hashchange", applyFocus);
+        window.removeEventListener("popstate", applyFocus);
+      };
+    }, [auth]);
+
     const intents = (summary && summary.intents) || [];
 
     function selectIntent(id) {
@@ -4003,7 +4157,7 @@
       : null;
 
     const intentsView = selectedIntent
-      ? React.createElement(IntentDetail, { key: selectedIntent.id, intent: selectedIntent, radarLoading: radarLoading, actionError: actionError, onBack: goBack, onOpenUser: openUser, onAccept: acceptOpportunity, onSkipOpportunity: skipOpportunity, onStartChat: startChatWithOpportunity, actingId: actingId, webUrl: summary && summary.webUrl, onArchive: archiveIntent, archivingId: archivingId, onPause: togglePauseIntent })
+      ? React.createElement(IntentDetail, { key: selectedIntent.id, intent: selectedIntent, radarLoading: radarLoading, actionError: actionError, onBack: goBack, onOpenUser: openUser, onAccept: acceptOpportunity, onSkipOpportunity: skipOpportunity, onStartChat: startChatWithOpportunity, actingId: actingId, webUrl: summary && summary.webUrl, onArchive: archiveIntent, archivingId: archivingId, onPause: togglePauseIntent, focusQuestion: focusQuestion })
       : React.createElement("div", { className: "index-dashboard__list-page" },
         React.createElement(IntentPitch, null),
         React.createElement("div", { className: "index-dashboard__list-cols" },

--- a/packages/hermes-plugin/dashboard/plugin_api.py
+++ b/packages/hermes-plugin/dashboard/plugin_api.py
@@ -1916,6 +1916,64 @@ def send_message(conversation_id: str, body: dict[str, Any] | None = Body(defaul
     return {"success": True, "message": message}
 
 
+@full_router.get("/opportunities/{opportunity_id}/counterpart")
+def opportunity_counterpart(opportunity_id: str) -> dict[str, Any]:
+    """Resolve an opportunity to the person on the other side of it.
+
+    A notification names the opportunity; the panel it opens is that person's
+    profile, so the tap needs this one hop.
+    """
+    opportunity_id = _text(opportunity_id)
+    if not opportunity_id:
+        return {"success": False, "error": "An opportunity id is required."}
+    current_user_id = _resolve_user_id()
+    if not current_user_id:
+        return {"success": False, "error": "Could not resolve the current user from the configured API key."}
+    payload = tools._api_request("GET", f"/opportunities/{quote(opportunity_id, safe='')}")
+    if payload.get("success") is False:
+        return payload
+    opp = payload.get("opportunity") if isinstance(payload.get("opportunity"), dict) else payload
+    counterpart_id = _counterpart_user_id(opp, current_user_id)
+    if not counterpart_id:
+        return {"success": False, "error": "That opportunity has no counterpart to open."}
+    return {"success": True, "userId": counterpart_id}
+
+
+@full_router.get("/agent/question")
+def agent_question(intentId: str = "") -> dict[str, Any]:
+    """Return the one question this signal's personal agent is suspended on."""
+    intent_id = _text(intentId)
+    if not intent_id:
+        return {"success": False, "error": "An intent id is required."}
+    payload = tools._api_request(
+        "GET",
+        f"/conversations/agent/messages?intentId={quote(intent_id, safe='')}",
+    )
+    if payload.get("success") is False:
+        return payload
+    agent = payload.get("agent") if isinstance(payload.get("agent"), dict) else {}
+    return {"success": True, "question": agent.get("pending")}
+
+
+@full_router.post("/agent/answer")
+def agent_answer(body: dict[str, Any] | None = Body(default=None)) -> dict[str, Any]:
+    """Answer that question, naming it so a stale answer is refused rather than mis-filed."""
+    intent_id = _text(body.get("intentId")) if isinstance(body, dict) else ""
+    text = _text(body.get("text")) if isinstance(body, dict) else ""
+    question_id = _text(body.get("questionId")) if isinstance(body, dict) else ""
+    if not intent_id or not text:
+        return {"success": False, "error": "An intent id and answer text are required."}
+    return tools._api_request(
+        "POST",
+        "/conversations/agent/messages",
+        {
+            "parts": [{"kind": "text", "text": text}],
+            "metadata": {"intentId": intent_id},
+            "questionId": question_id or None,
+        },
+    )
+
+
 def _conversation_stream():
     """Relay transport-owned, bounded SSE polling to the dashboard tab."""
     try:

--- a/packages/hermes-plugin/desktop/dist/plugin.js
+++ b/packages/hermes-plugin/desktop/dist/plugin.js
@@ -658,6 +658,30 @@ window.__INDEX_NETWORK_DESKTOP_ENV__ = DESKTOP_ENV;
     };
   }
 
+  /**
+   * What an OS notification asked us to focus, as `?o=`, `?chat=` or `?intent=`
+   * on the activate URL. The web host carries it in the query; the desktop host
+   * routes on the hash, so it arrives inside that instead. Reading both keeps
+   * one activate URL working on both.
+   */
+  function parseFocusTarget() {
+    const hash = window.location.hash || "";
+    const mark = hash.indexOf("?");
+    const params = new URLSearchParams(window.location.search || "");
+    if (mark >= 0) {
+      new URLSearchParams(hash.slice(mark)).forEach(function (value, key) {
+        if (!params.has(key)) params.set(key, value);
+      });
+    }
+    const opportunityId = params.get("o");
+    if (opportunityId) return { kind: "opportunity", id: opportunityId };
+    const conversationId = params.get("chat");
+    if (conversationId) return { kind: "conversation", id: conversationId };
+    const intentId = params.get("intent");
+    if (intentId) return { kind: "intent", id: intentId };
+    return null;
+  }
+
   function writeHash(intentId) {
     if (DESKTOP_ENV) return;
     const target = intentId ? "#intent=" + encodeURIComponent(intentId) : "";
@@ -2221,6 +2245,91 @@ window.__INDEX_NETWORK_DESKTOP_ENV__ = DESKTOP_ENV;
     );
   }
 
+  /**
+   * The one question this intent's personal agent is suspended on.
+   *
+   * The agent conversation is not in the messages list — it is per-signal and
+   * lives here, next to the radar it is asking about. Renders nothing until
+   * there is a question, which is most of the time.
+   */
+  function AgentQuestion(props) {
+    const questionState = React.useState(null);
+    const question = questionState[0];
+    const setQuestion = questionState[1];
+    const draftState = React.useState("");
+    const draft = draftState[0];
+    const setDraft = draftState[1];
+    const rootRef = React.useRef(null);
+    const intentId = props.intentId;
+
+    React.useEffect(function () {
+      let alive = true;
+      function read() {
+        fetchPluginJSON(API + "/agent/question?intentId=" + encodeURIComponent(intentId))
+          .then(function (payload) {
+            if (!alive || !payload || payload.success === false) return;
+            setQuestion(payload.question || null);
+          })
+          .catch(function () { /* a failed read leaves the last question up */ });
+      }
+      read();
+      const timer = setInterval(read, 5000);
+      return function () { alive = false; clearInterval(timer); };
+    }, [intentId]);
+
+    React.useEffect(function () {
+      if (!props.focusQuestion || !rootRef.current) return;
+      rootRef.current.scrollIntoView({ behavior: "smooth", block: "center" });
+    }, [props.focusQuestion, question && question.id]);
+
+    if (!question) return null;
+
+    function answer(text) {
+      const asked = question;
+      setQuestion(null);
+      setDraft("");
+      fetchPluginJSON(API + "/agent/answer", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ intentId: intentId, text: text, questionId: asked.id }),
+      }).catch(function () { setQuestion(asked); });
+    }
+
+    const options = Array.isArray(question.options) ? question.options : [];
+    return React.createElement("div", { ref: rootRef },
+      React.createElement(Panel, { title: "Your agent", description: "It is holding this signal until you answer." },
+        React.createElement("p", { className: "index-dashboard__card-description" }, question.question),
+        React.createElement("div", { className: "index-dashboard__action-group" },
+          options.map(function (option) {
+            return React.createElement(Button, {
+              key: option,
+              type: "button",
+              outlined: true,
+              onClick: function () { answer(option); },
+            }, option);
+          }),
+        ),
+        React.createElement("div", { className: "index-dashboard__msg-composer" },
+          React.createElement("textarea", {
+            className: "index-dashboard__textarea index-dashboard__msg-input",
+            rows: 1,
+            value: draft,
+            placeholder: "Write your answer…",
+            onChange: function (e) { setDraft(e.target.value); },
+            onKeyDown: function (e) {
+              if (e.key === "Enter" && !e.shiftKey) { e.preventDefault(); if (draft.trim()) answer(draft.trim()); }
+            },
+          }),
+          React.createElement(Button, {
+            type: "button",
+            disabled: !draft.trim(),
+            onClick: function () { if (draft.trim()) answer(draft.trim()); },
+          }, "Answer"),
+        ),
+      ),
+    );
+  }
+
   function IntentDetail(props) {
     const intent = props.intent;
     const bucketState = React.useState("pending");
@@ -2282,6 +2391,7 @@ window.__INDEX_NETWORK_DESKTOP_ENV__ = DESKTOP_ENV;
         })(),
       }),
       React.createElement("div", { className: "index-dashboard__detail-cols" },
+        React.createElement(AgentQuestion, { intentId: intent.id, focusQuestion: props.focusQuestion }),
         React.createElement(Panel, { title: "Radar", primary: true, count: allOpps.length, titleAfter: RADAR_EYE(), description: "People the network surfaced for this intent." },
           props.actionError ? React.createElement("div", { className: "index-dashboard__error" }, props.actionError) : null,
           React.createElement(RadarStrip, { counts: intent.statusCounts, selected: selectedBucket, onSelect: setSelectedBucket }),
@@ -3525,6 +3635,11 @@ window.__INDEX_NETWORK_DESKTOP_ENV__ = DESKTOP_ENV;
     const messagesTargetState = useState(null);
     const messagesTarget = messagesTargetState[0];
     const setMessagesTarget = messagesTargetState[1];
+    // Bumped by a question notification, so the card scrolls into view even
+    // when its signal was already the selected one.
+    const focusQuestionState = useState(0);
+    const focusQuestion = focusQuestionState[0];
+    const setFocusQuestion = focusQuestionState[1];
     const archivingState = useState(null);
     const archivingId = archivingState[0];
     const setArchivingId = archivingState[1];
@@ -3546,6 +3661,7 @@ window.__INDEX_NETWORK_DESKTOP_ENV__ = DESKTOP_ENV;
     const headerCtlRef = useRef(null);
     const toggleProfileRef = useRef(null);
     const openMessagesRef = useRef(null);
+    const focusAppliedRef = useRef(null);
 
     function loadNetworks() {
       fetchPluginJSON(API + "/networks/home")
@@ -4036,6 +4152,44 @@ window.__INDEX_NETWORK_DESKTOP_ENV__ = DESKTOP_ENV;
       };
     }, []);
 
+    // A notification tap re-enters this page with its target on the URL. An
+    // opportunity or a conversation opens as a panel over whatever was already
+    // selected; only a question changes the selection, because it is answered
+    // in its own signal and nowhere else.
+    useEffect(function () {
+      if (auth !== "authed") return undefined;
+      function applyFocus() {
+        const target = parseFocusTarget();
+        if (!target) return;
+        // The target stays on the URL after it is applied, so every later
+        // navigation would otherwise re-open a panel the user has closed.
+        const key = target.kind + ":" + target.id;
+        if (focusAppliedRef.current === key) return;
+        focusAppliedRef.current = key;
+        if (target.kind === "opportunity") {
+          fetchPluginJSON(API + "/opportunities/" + encodeURIComponent(target.id) + "/counterpart")
+            .then(function (payload) {
+              if (payload && payload.success !== false && payload.userId) setViewUserId(payload.userId);
+            })
+            .catch(function () { /* the page is open, which is most of the ask */ });
+        } else if (target.kind === "conversation") {
+          setMessagesTarget(target.id);
+          setMessagesOpen(true);
+        } else {
+          setSelectedId(target.id);
+          writeHash(target.id);
+          setFocusQuestion(function (n) { return n + 1; });
+        }
+      }
+      applyFocus();
+      window.addEventListener("hashchange", applyFocus);
+      window.addEventListener("popstate", applyFocus);
+      return function () {
+        window.removeEventListener("hashchange", applyFocus);
+        window.removeEventListener("popstate", applyFocus);
+      };
+    }, [auth]);
+
     const intents = (summary && summary.intents) || [];
 
     function selectIntent(id) {
@@ -4066,7 +4220,7 @@ window.__INDEX_NETWORK_DESKTOP_ENV__ = DESKTOP_ENV;
       : null;
 
     const intentsView = selectedIntent
-      ? React.createElement(IntentDetail, { key: selectedIntent.id, intent: selectedIntent, radarLoading: radarLoading, actionError: actionError, onBack: goBack, onOpenUser: openUser, onAccept: acceptOpportunity, onSkipOpportunity: skipOpportunity, onStartChat: startChatWithOpportunity, actingId: actingId, webUrl: summary && summary.webUrl, onArchive: archiveIntent, archivingId: archivingId, onPause: togglePauseIntent })
+      ? React.createElement(IntentDetail, { key: selectedIntent.id, intent: selectedIntent, radarLoading: radarLoading, actionError: actionError, onBack: goBack, onOpenUser: openUser, onAccept: acceptOpportunity, onSkipOpportunity: skipOpportunity, onStartChat: startChatWithOpportunity, actingId: actingId, webUrl: summary && summary.webUrl, onArchive: archiveIntent, archivingId: archivingId, onPause: togglePauseIntent, focusQuestion: focusQuestion })
       : React.createElement("div", { className: "index-dashboard__list-page" },
         React.createElement(IntentPitch, null),
         React.createElement("div", { className: "index-dashboard__list-cols" },
@@ -4185,6 +4339,9 @@ window.__INDEX_NETWORK_DESKTOP_ENV__ = DESKTOP_ENV;
 export const NOTIFIED_ENTITIES_KEY = 'notifiedEntitiesV2'
 export const MAX_NOTIFIED_ENTITIES = 200
 
+/** Sender id the API writes agent-DM messages under (services/api database.shared). */
+const AGENT_SENDER_ID = 'system-agent'
+
 function notificationId(event, preferredField) {
   if (!event || typeof event !== 'object') return ''
   const value = event[preferredField] || event.id || ''
@@ -4196,6 +4353,10 @@ export function notificationEntityKey(event) {
   if (event.type.indexOf('opportunity.') === 0) {
     const id = notificationId(event, 'opportunityId')
     return id ? `opportunity:${id}` : null
+  }
+  if (event.type === 'question.pending') {
+    const id = notificationId(event, 'questionId')
+    return id ? `question:${id}` : null
   }
   if (event.type === 'message' || event.type.indexOf('message.') === 0) {
     const id = event.message && typeof event.message.id === 'string'
@@ -4225,8 +4386,15 @@ export async function refreshNotificationIdentity(loadAuthStatus) {
 
 // Every Index event lands on the plugin's dashboard page; the host turns this
 // into the notification's activate target so a click opens Index instead of
-// just focusing the Hermes window.
+// just focusing the Hermes window. The query names what to focus once there —
+// the dashboard reads it and opens that overlay over whatever was on screen.
 const PLUGIN_ACTIVATE_URL = '/index-network'
+
+function activateUrl(param, id) {
+  return id
+    ? `${PLUGIN_ACTIVATE_URL}?${param}=${encodeURIComponent(id)}`
+    : PLUGIN_ACTIVATE_URL
+}
 
 export function composeNotification(event) {
   if (!event || typeof event.type !== 'string') return null
@@ -4235,12 +4403,26 @@ export function composeNotification(event) {
     return {
       title: event.title,
       body: typeof event.body === 'string' ? event.body : '',
-      url: PLUGIN_ACTIVATE_URL,
+      url: activateUrl('o', notificationId(event, 'opportunityId')),
+    }
+  }
+  if (event.type === 'question.pending') {
+    if (typeof event.title !== 'string' || !event.title.trim()) return null
+    const intentId = event.data && typeof event.data.intentId === 'string'
+      ? event.data.intentId.trim()
+      : ''
+    return {
+      title: event.title,
+      body: typeof event.body === 'string' ? event.body : '',
+      url: activateUrl('intent', intentId),
     }
   }
   if (event.type === 'message' || event.type.indexOf('message.') === 0) {
     const message = event.message
     if (!message || typeof message !== 'object') return null
+    // The owner's own agent speaks in the agent DM, and `question.pending`
+    // already announces the only thing it says that needs answering.
+    if (message.senderId === AGENT_SENDER_ID) return null
     const sender = String(message.senderName || message.senderId || 'Someone')
     let text = ''
     if (Array.isArray(message.parts)) {
@@ -4258,10 +4440,11 @@ export function composeNotification(event) {
     // it is already a fetchable URL. (Electron's `icon` wants a filesystem
     // path, so the Hermes host does not consume this today.)
     const avatar = typeof message.senderAvatar === 'string' ? message.senderAvatar.trim() : ''
+    const conversationId = typeof event.conversationId === 'string' ? event.conversationId.trim() : ''
     return {
-      title: `New message from ${sender}`,
+      title: sender,
       body: text || 'Open Index to read the message.',
-      url: PLUGIN_ACTIVATE_URL,
+      url: activateUrl('chat', conversationId),
       ...(/^https?:/i.test(avatar) ? { imageUrl: avatar } : {}),
     }
   }

--- a/packages/hermes-plugin/desktop/notifications.mjs
+++ b/packages/hermes-plugin/desktop/notifications.mjs
@@ -2,6 +2,9 @@
 export const NOTIFIED_ENTITIES_KEY = 'notifiedEntitiesV2'
 export const MAX_NOTIFIED_ENTITIES = 200
 
+/** Sender id the API writes agent-DM messages under (services/api database.shared). */
+const AGENT_SENDER_ID = 'system-agent'
+
 function notificationId(event, preferredField) {
   if (!event || typeof event !== 'object') return ''
   const value = event[preferredField] || event.id || ''
@@ -13,6 +16,10 @@ export function notificationEntityKey(event) {
   if (event.type.indexOf('opportunity.') === 0) {
     const id = notificationId(event, 'opportunityId')
     return id ? `opportunity:${id}` : null
+  }
+  if (event.type === 'question.pending') {
+    const id = notificationId(event, 'questionId')
+    return id ? `question:${id}` : null
   }
   if (event.type === 'message' || event.type.indexOf('message.') === 0) {
     const id = event.message && typeof event.message.id === 'string'
@@ -42,8 +49,15 @@ export async function refreshNotificationIdentity(loadAuthStatus) {
 
 // Every Index event lands on the plugin's dashboard page; the host turns this
 // into the notification's activate target so a click opens Index instead of
-// just focusing the Hermes window.
+// just focusing the Hermes window. The query names what to focus once there —
+// the dashboard reads it and opens that overlay over whatever was on screen.
 const PLUGIN_ACTIVATE_URL = '/index-network'
+
+function activateUrl(param, id) {
+  return id
+    ? `${PLUGIN_ACTIVATE_URL}?${param}=${encodeURIComponent(id)}`
+    : PLUGIN_ACTIVATE_URL
+}
 
 export function composeNotification(event) {
   if (!event || typeof event.type !== 'string') return null
@@ -52,12 +66,26 @@ export function composeNotification(event) {
     return {
       title: event.title,
       body: typeof event.body === 'string' ? event.body : '',
-      url: PLUGIN_ACTIVATE_URL,
+      url: activateUrl('o', notificationId(event, 'opportunityId')),
+    }
+  }
+  if (event.type === 'question.pending') {
+    if (typeof event.title !== 'string' || !event.title.trim()) return null
+    const intentId = event.data && typeof event.data.intentId === 'string'
+      ? event.data.intentId.trim()
+      : ''
+    return {
+      title: event.title,
+      body: typeof event.body === 'string' ? event.body : '',
+      url: activateUrl('intent', intentId),
     }
   }
   if (event.type === 'message' || event.type.indexOf('message.') === 0) {
     const message = event.message
     if (!message || typeof message !== 'object') return null
+    // The owner's own agent speaks in the agent DM, and `question.pending`
+    // already announces the only thing it says that needs answering.
+    if (message.senderId === AGENT_SENDER_ID) return null
     const sender = String(message.senderName || message.senderId || 'Someone')
     let text = ''
     if (Array.isArray(message.parts)) {
@@ -75,10 +103,11 @@ export function composeNotification(event) {
     // it is already a fetchable URL. (Electron's `icon` wants a filesystem
     // path, so the Hermes host does not consume this today.)
     const avatar = typeof message.senderAvatar === 'string' ? message.senderAvatar.trim() : ''
+    const conversationId = typeof event.conversationId === 'string' ? event.conversationId.trim() : ''
     return {
-      title: `New message from ${sender}`,
+      title: sender,
       body: text || 'Open Index to read the message.',
-      url: PLUGIN_ACTIVATE_URL,
+      url: activateUrl('chat', conversationId),
       ...(/^https?:/i.test(avatar) ? { imageUrl: avatar } : {}),
     }
   }

--- a/packages/hermes-plugin/package.json
+++ b/packages/hermes-plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@indexnetwork/hermes-plugin",
-  "version": "0.37.0",
+  "version": "0.38.0",
   "description": "Hermes-native Index Network plugin with CLI tools and REST APIs",
   "license": "MIT",
   "type": "module",

--- a/services/api/package.json
+++ b/services/api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@indexnetwork/api",
-  "version": "0.116.0",
+  "version": "0.117.0",
   "license": "MIT",
   "private": true,
   "scripts": {

--- a/services/api/src/adapters/agent-session.database.adapter.ts
+++ b/services/api/src/adapters/agent-session.database.adapter.ts
@@ -1,7 +1,8 @@
-import type { PrincipalMessage, PrincipalState, PrincipalStore } from '@indexnetwork/agent';
+import type { PrincipalMessage, PrincipalQuestion, PrincipalState, PrincipalStore } from '@indexnetwork/agent';
 import { and, asc, eq, isNull, or, sql } from 'drizzle-orm';
 
 import db from '../lib/drizzle/drizzle';
+import { publishUserEvent } from '../lib/user-events';
 import { agentSessions, agents, intents, messages, type Message } from '../schemas/database.schema';
 
 import { ConversationDatabaseAdapter } from './conversation.database.adapter';
@@ -10,6 +11,41 @@ import { SYSTEM_AGENT_ID } from './database.shared';
 export interface AgentExecution { userId: string; intentId: string; token: string }
 type Transaction = Parameters<Parameters<typeof db.transaction>[0]>[0];
 const LEASE_SECONDS = 60;
+const QUESTION_HEADLINE = 'Question from your agent';
+const QUESTION_BODY_MAX_CHARS = 140;
+
+/**
+ * Announce a question the owner has to answer before their agent can continue.
+ *
+ * The frame names the intent rather than the H2A conversation: the question
+ * lives in that signal's agent conversation, and every surface reaches it by
+ * intent id.
+ *
+ * @param userId - The principal who owes the answer.
+ * @param intentId - Signal whose personal agent is suspended.
+ * @param question - The question as the agent recorded it.
+ */
+export async function publishPendingQuestionEvent(
+  userId: string,
+  intentId: string,
+  question: PrincipalQuestion,
+): Promise<void> {
+  const text = question.question.trim();
+  await publishUserEvent(userId, {
+    type: 'question.pending',
+    id: question.id,
+    title: QUESTION_HEADLINE,
+    body: text.length > QUESTION_BODY_MAX_CHARS
+      ? `${text.slice(0, QUESTION_BODY_MAX_CHARS - 1).trimEnd()}…`
+      : text,
+    data: {
+      intentId,
+      questionId: question.id,
+      scope: question.scope,
+      opportunityId: question.matches[0]?.opportunityId ?? null,
+    },
+  });
+}
 
 /** Fence checkpoints and A2A writes against the same exclusively owned runtime session. */
 export class AgentSessionDatabaseAdapter implements PrincipalStore {
@@ -19,6 +55,7 @@ export class AgentSessionDatabaseAdapter implements PrincipalStore {
   private heartbeat?: ReturnType<typeof setInterval>;
   private renewal: Promise<void> = Promise.resolve();
   private failure?: Error;
+  private askedQuestionId: string | null = null;
   private readonly conversations = new ConversationDatabaseAdapter();
 
   constructor(userId: string, intentId: string) {
@@ -69,6 +106,7 @@ export class AgentSessionDatabaseAdapter implements PrincipalStore {
     });
     this.revision = row.revision;
     this.conversationId = row.conversationId;
+    this.askedQuestionId = (row.state as PrincipalState | null)?.inbox.question?.id ?? null;
     this.heartbeat = setInterval(() => {
       this.renewal = this.renewal.then(async () => {
         const renewed = await db.update(agentSessions).set({ leaseExpiresAt: sql`now() + ${LEASE_SECONDS} * interval '1 second'` })
@@ -110,6 +148,13 @@ export class AgentSessionDatabaseAdapter implements PrincipalStore {
     });
     this.revision++;
     await Promise.all(persisted.map((message) => this.conversations.publishMessage(message)));
+    // A checkpoint saves the same pending question until it is answered, so the
+    // owner is told once per question rather than once per turn.
+    const question = state.inbox.question;
+    if (question && question.id !== this.askedQuestionId) {
+      await publishPendingQuestionEvent(this.execution.userId, this.execution.intentId, question);
+    }
+    this.askedQuestionId = question?.id ?? null;
   }
 
   /** Release this process's lease without erasing the saved conversation or pending question. */

--- a/services/api/src/cli/notify-simulate.ts
+++ b/services/api/src/cli/notify-simulate.ts
@@ -8,6 +8,7 @@
  * Usage:
  *   bun run notify:simulate opportunity --user <email> [--counterpart <email>]
  *   bun run notify:simulate message --user <email> [--counterpart <email>] [--text "..."]
+ *   bun run notify:simulate question --user <email> [--text "..."]
  *
  * Prerequisites: local API + Redis sharing this DB; seeded users (bun run db:seed).
  */
@@ -19,7 +20,7 @@ dotenv.config({ path: path.resolve(import.meta.dir, '../../../..', '.env.develop
 
 const COMMONS_NETWORK_ID = '5aff6cd6-d64e-4ef9-8bcf-6c89815f771c';
 
-type Command = 'opportunity' | 'message';
+type Command = 'opportunity' | 'message' | 'question';
 
 interface ParsedArgs {
   command: Command | null;
@@ -40,11 +41,13 @@ Commands:
                 OpportunityEventService (SSE).
   message       Insert a real conversation message from a counterpart so the
                 production conversation SSE publishes type:message.
+  question      Park a pending question on the user's newest signal and publish
+                question.pending, as a suspended personal agent would.
 
 Options:
   --user <email>          Recipient (required)
   --counterpart <email>   Other party / message sender (default: any other user)
-  --text <string>         Message body (message command)
+  --text <string>         Message body (message command) or question (question command)
   --help                  Show this help
 `);
 }
@@ -78,7 +81,7 @@ function parseArgs(argv: string[]): ParsedArgs {
       continue;
     }
     if (!arg.startsWith('-') && !out.command) {
-      if (arg === 'opportunity' || arg === 'message') {
+      if (arg === 'opportunity' || arg === 'message' || arg === 'question') {
         out.command = arg;
         continue;
       }
@@ -102,11 +105,12 @@ async function main(): Promise<void> {
     process.exit(1);
   }
 
-  const { eq, ne } = await import('drizzle-orm/sql');
+  const { and, desc, eq, isNull, ne } = await import('drizzle-orm/sql');
   const { default: db, closeDb } = await import('../lib/drizzle/drizzle');
-  const { users } = await import('../schemas/database.schema');
+  const { agentSessions, intents, users } = await import('../schemas/database.schema');
   const { OpportunityDatabaseAdapter } = await import('../adapters/opportunity.database.adapter');
   const { ConversationDatabaseAdapter } = await import('../adapters/conversation.database.adapter');
+  const { publishPendingQuestionEvent } = await import('../adapters/agent-session.database.adapter');
   const { buildProfileFromUser } = await import('../adapters/database.shared');
   const { closeRedisConnection } = await import('../adapters/cache.adapter');
   const {
@@ -152,6 +156,50 @@ async function main(): Promise<void> {
 
   try {
     const recipient = await resolveUserByEmail(args.userEmail);
+
+    if (args.command === 'question') {
+      const [intent] = await db
+        .select({ id: intents.id, payload: intents.payload })
+        .from(intents)
+        .where(and(eq(intents.userId, recipient.id), isNull(intents.archivedAt)))
+        .orderBy(desc(intents.createdAt))
+        .limit(1);
+      if (!intent) {
+        throw new Error(`${recipient.email} has no active signal to ask about. Create one first.`);
+      }
+
+      const conversations = new ConversationDatabaseAdapter();
+      const conversation = await conversations.getOrCreateAgentDm(recipient.id);
+      const question = {
+        id: crypto.randomUUID(),
+        question: args.text
+          ?? 'Are you open to a first call this week, or would you rather see their work first?',
+        options: ['A call this week', 'Send their work first'],
+        scope: 'intent' as const,
+        matches: [],
+      };
+      await db
+        .insert(agentSessions)
+        .values({
+          userId: recipient.id,
+          intentId: intent.id,
+          conversationId: conversation.id,
+          state: { inbox: { incomingMessageIds: [], requests: [], outcomes: [], question }, matches: [] },
+        })
+        .onConflictDoUpdate({
+          target: [agentSessions.userId, agentSessions.intentId],
+          set: { state: { inbox: { incomingMessageIds: [], requests: [], outcomes: [], question }, matches: [] } },
+        });
+      await publishPendingQuestionEvent(recipient.id, intent.id, question);
+
+      console.log('Parked pending question', question.id);
+      console.log('Published question.pending via publishPendingQuestionEvent');
+      console.log('  channel:', userEventChannel(recipient.id));
+      console.log('  recipient:', recipient.email, `(${recipient.id})`);
+      console.log('  signal:', intent.id, `(${intent.payload.slice(0, 60)})`);
+      console.log('  question:', question.question);
+      return;
+    }
 
     const counterpart = await resolveCounterpart(recipient.id, args.counterpartEmail);
 

--- a/services/api/src/lib/user-events.ts
+++ b/services/api/src/lib/user-events.ts
@@ -4,8 +4,8 @@ import { getRedisClient } from '../adapters/cache.adapter';
  * One channel per user carries every realtime frame, and nothing on the wire
  * separates the audiences: an agent-bound key resolves to its owner, so the
  * agent subscribes to the same channel the owner's app is already reading and
- * each side ignores the types it does not recognise. `opportunity.new` and
- * `message` are the human's; the rest are the agent's.
+ * each side ignores the types it does not recognise. `opportunity.new`,
+ * `question.pending` and `message` are the human's; the rest are the agent's.
  *
  * The agent types come in two scopes. `negotiation.turn` and
  * `negotiation.settled` point at one negotiation and carry a pointer rather
@@ -14,11 +14,16 @@ import { getRedisClient } from '../adapters/cache.adapter';
  * whether the agent should be working it at all, and that discovery gave it
  * something to work.
  *
+ * `question.pending` is scoped to a signal too, but the other way round: the
+ * personal agent stopped and cannot continue until its owner answers, so the
+ * frame names the intent whose H2A conversation holds the question.
+ *
  * `message` is the exception to the pointer shape: it is human-addressed and
  * carries its text inline, so a desktop toast needs no follow-up read.
  */
 export type UserEventType =
   | 'opportunity.new'
+  | 'question.pending'
   | 'negotiation.turn'
   | 'negotiation.settled'
   | 'negotiation.opened'

--- a/services/api/src/services/opportunity-event.service.ts
+++ b/services/api/src/services/opportunity-event.service.ts
@@ -8,8 +8,9 @@ import type { UserEvent, UserEventPublisher } from '../lib/user-events';
 
 const logger = log.service.from('OpportunityEventService');
 
-const OPPORTUNITY_HEADLINE = 'A promising connection';
-const OPPORTUNITY_EMPTY_SUMMARY = 'A new match that might be relevant to you.';
+const OPPORTUNITY_UNKNOWN_COUNTERPART = 'Someone';
+const OPPORTUNITY_EMPTY_SUMMARY = 'A new possibility that might be relevant to you.';
+const OPPORTUNITY_HEADLINE_SUFFIX = 'new possibility';
 const LABEL_MAX_CHARS = 80;
 
 interface OpportunityEventCopy {
@@ -55,9 +56,11 @@ function buildOpportunityEventCopy(
   opportunity: OpportunityRow,
   identities: OpportunityEventIdentities,
 ): OpportunityEventCopy {
-  const counterpartyName = displayName(identities.counterpart, 'Someone');
+  const counterpartyName = displayName(identities.counterpart, OPPORTUNITY_UNKNOWN_COUNTERPART);
   return {
-    headline: OPPORTUNITY_HEADLINE,
+    // The person leads the headline so the toast says who showed up, and the
+    // suffix keeps it distinct from a message toast, which is the name alone.
+    headline: `${counterpartyName} · ${OPPORTUNITY_HEADLINE_SUFFIX}`,
     summary: safeFallbackSummary(opportunity.interpretation.reasoning, {
       counterpartName: counterpartyName,
       viewerName: displayName(identities.viewer, 'you'),


### PR DESCRIPTION
Every question, opportunity and conversation now reaches the desktop, and tapping the toast lands on the thing it names.

## Added

- **`question.pending` user event.** A suspended personal agent used to wait silently: the H2A question was durable in the session checkpoint, but nothing told the owner it existed. `AgentSessionDatabaseAdapter.save` now publishes the frame when a new question appears, comparing against the last announced id so a long-lived question notifies once rather than once per checkpoint.
- **Agent DM read/answer surface on both desktops.** The question toast needs somewhere to land. The Mac left feed polls the agent conversation for the focused signal and renders the pending question as a card; Hermes gained `GET /agent/question`, `POST /agent/answer` and `GET /opportunities/{id}/counterpart` relays plus an `AgentQuestion` panel in the intent detail, because the existing conversation relay deliberately filters agent threads out and neither forwarded `intentId`/`questionId`.
- **`index://i/<intentId>`** deep link, which focuses a signal and scrolls to its H2A card.

## Changed

- **Toasts name the person, not the event.** An opportunity is `Emma Murf · new possibility` instead of a fixed `A promising connection`; a message is the sender's name instead of `New message from …`. A question is `Question from your agent` over the question text, truncated at 140 characters.
- **Focus preserves context.** An opportunity opens the counterpart's profile, a conversation opens a floating chat window over whatever signal is on screen rather than switching to it, and a question opens its signal scrolled to the question. Hermes reads `?o=`, `?chat=` and `?intent=` off the activate URL, guarded so a repeated hashchange does not reopen a panel the user dismissed.
- **Agent-DM messages no longer raise a toast.** The frame still publishes, because the web H2A chat renders from it live; only the OS notification is suppressed, client-side in each compose helper.

## Versions

`@indexnetwork/api` 0.116.0 → 0.117.0, `@indexnetwork/hermes-plugin` 0.37.0 → 0.38.0, `bun.lock` synced.

## Test plan

- [x] API typecheck clean; `bun run lint` 0 errors (35 pre-existing warnings, none in touched files); `bun run check:subtree-parity` and `check:lockfile-versions` pass.
- [x] Both bundles rebuild and pass `node --check`; `plugin_api.py` parses; the Mac bundle loads in-browser with no console errors.
- [x] Live end-to-end against the dev database and Redis: all three frames published by the production emitters and composed to the expected title, body and activate URL on both desktops; agent-DM suppression confirmed on the wire; answer-endpoint error contracts return clean JSON. All test artifacts removed afterwards.

## Notes

Two things found while testing, left alone as out of scope:

- `PersonalAgentService.state()` returns `pending` only when the session status is `running`, so a durable, genuinely blocking question is invisible whenever no process holds the lease. The 5s poll heals it within seconds of a restart, but a notification now points at that surface.
- Both desktops silently restore the question if the answer POST fails, so the user taps an option, it vanishes, then reappears with no explanation.