### PR TITLE
feat(mac): open Hermes on the Index page after plugin install

### DIFF
--- a/apps/mac/Sources/AppDelegate.swift
+++ b/apps/mac/Sources/AppDelegate.swift
@@ -534,6 +534,14 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSWindowDelegate, WKNa
                 result = ["ok": false, "error": "sign in first"]
             }
             self?.postHermesResult(result, admittedGeneration: admittedGeneration)
+            // hermes://open/<path> focuses Desktop and navigates; bare
+            // hermes://index-network is ignored (plugin host with no rest).
+            if result["ok"] as? Bool == true {
+                DispatchQueue.main.async {
+                    guard let url = URL(string: "hermes://open/index-network") else { return }
+                    NSWorkspace.shared.open(url)
+                }
+            }
         }
     }
 


### PR DESCRIPTION
## Summary
- After a successful Hermes plugin install/enable in the Mac app, open `hermes://open/index-network`.
- That deep link focuses Hermes Desktop and navigates to the Index plugin page.

## Test plan
- [ ] In the Mac app, sign in and turn the Hermes switch on
- [ ] Confirm Hermes Desktop comes to the front on `/index-network`
- [ ] Confirm a failed install does not open Hermes
- [ ] Confirm turning Hermes off does not open it