### PR TITLE
feat(mac): deep links open the signal that owns them

### DIFF
--- a/apps/mac/src/ui/app.jsx
+++ b/apps/mac/src/ui/app.jsx
@@ -36,9 +36,10 @@ function nativeAuthed() {
 // that comes up empty, so the caller can say so instead of opening a blank
 // window.
 // A conversation link (minted by the app's own OS toasts) names a thread
-// rather than a person card, and the card it belongs to is what the floating
-// chat needs a name and face from: read the conversation's provenance, then
-// resolve that opportunity the same way a card link does.
+// rather than a person card. Its provenance carries both the signal the thread
+// belongs to and the opportunity behind it, so the caller can open that signal
+// on the chat, and fall back to a floating chat with a name and face when the
+// signal is no longer on the hub.
 async function resolveDeepLinkConversation(route, people) {
   if (!nativeAuthed() || !window.IndexApp) return null;
   const client = window.IndexApp.getClient();
@@ -49,7 +50,9 @@ async function resolveDeepLinkConversation(route, people) {
     const via = conv && Array.isArray(conv.via) ? conv.via[0] : null;
     if (!via) return null;
     const person = await resolveDeepLinkPerson({ route: "card", id: via.opportunityId }, people);
-    return person ? { person, conversationId: route.id } : null;
+    return person
+      ? { person, conversationId: route.id, intentId: via.intentId || null }
+      : null;
   } catch (e) {
     return null;
   }
@@ -72,8 +75,11 @@ async function resolveDeepLinkPerson(route, people) {
       const person = window.IndexApi.mapPeopleFromOpportunities([row])[0] || null;
       // GET /opportunities/:id names the counterpart under otherParties rather
       // than the counterpartUserId/counterpartName the list mapper reads, and
-      // the profile needs the user id to fetch their bio.
+      // the profile needs the user id to fetch their bio. `intentId` is the
+      // viewer's own signal, which is what decides between opening that signal
+      // and floating a card.
       const other = Array.isArray(row.otherParties) ? row.otherParties[0] : null;
+      if (person) person.intentId = row.intentId || null;
       if (person && other) {
         person.userId = person.userId || other.id || null;
         person.name = other.name || person.name;
@@ -231,21 +237,28 @@ function App() {
     const link = pendingLink;
     resolvingRef.current = link;
     (async () => {
-      // A conversation floats over whatever is on screen, like a card does:
-      // the thread is the interruption, not a reason to change signals.
+      // A conversation belongs to a signal, so open that signal on the thread.
+      // The floating chat is what is left when the signal is gone: the thread
+      // still reads, it just has no session to live in.
       if (link.route === "conversation") {
         const target = await resolveDeepLinkConversation(link, peopleRef.current);
         if (resolvingRef.current !== link) return;
         resolvingRef.current = null;
-        if (target) setLinkedChat(target);
-        else setNotice("couldn't open that conversation.");
+        const intent = target && findIntent(target.intentId);
+        if (intent) {
+          openIntentOn(intent, { kind: "chat", personId: target.person.id });
+        } else if (target) {
+          setLinkedChat(target);
+        } else {
+          setNotice("couldn't open that conversation.");
+        }
         setPendingLink(null);
         return;
       }
-      // A question is the one link that does change signals: it is answered in
-      // that signal's own conversation with its agent, and nowhere else.
+      // A question names its signal directly: it is answered in that signal's
+      // own conversation with its agent, and nowhere else.
       if (link.route === "signal") {
-        const intent = (INTENTS || []).find((i) => i.id === link.id);
+        const intent = findIntent(link.id);
         resolvingRef.current = null;
         if (intent) {
           pickExistingIntent(intent);
@@ -260,10 +273,19 @@ function App() {
       // A newer link arrived mid-flight and owns the slot now; let it finish.
       if (resolvingRef.current !== link) return;
       resolvingRef.current = null;
-      if (person) setLinkedCard({ person, route: link.route });
-      else setNotice(link.route === "card"
-        ? "that opportunity isn't on your radar."
-        : "couldn't open that profile.");
+      // An opportunity is read inside the signal that surfaced it. A profile
+      // link names no signal at all, so it stays a floating card, as does an
+      // opportunity whose signal has left the hub.
+      const owner = link.route === "card" && person ? findIntent(person.intentId) : null;
+      if (owner) {
+        openIntentOn(owner, { kind: "profile", personId: person.id, status: person.status });
+      } else if (person) {
+        setLinkedCard({ person, route: link.route });
+      } else {
+        setNotice(link.route === "card"
+          ? "that opportunity isn't on your radar."
+          : "couldn't open that profile.");
+      }
       setPendingLink(null);
     })();
   }, [pendingLink, screen]);
@@ -385,7 +407,11 @@ function App() {
   // it persists across screens (so it works from the landing screen too).
   const [chatGroups, setChatGroups] = useState({}); // signalTitle -> [{id,name,unread}]
   const chatOpenRef = useRef(null);                  // { signal, open } for the active session
-  const [pendingChat, setPendingChat] = useState(null);
+  // What to open inside a signal once it mounts: { kind: "chat" | "profile",
+  // personId, status }. The menubar resumes a signal on a chat; a deep link can
+  // also land on a profile, and carries the status so the radar opens on the
+  // stage that person is actually in.
+  const [pendingFocus, setPendingFocus] = useState(null);
   const registerChats = (signal, list, openFn) => {
     if (!signal) return;
     setChatGroups(prev => ({ ...prev, [signal]: list }));
@@ -454,6 +480,9 @@ function App() {
     setScreen("main");
     seedField();
   };
+  const findIntent = (id) => (id ? (INTENTS || []).find((i) => i.id === id) || null : null);
+  // Resume a signal and say what to open inside it once the session mounts.
+  const openIntentOn = (intent, focus) => { pickExistingIntent(intent); setPendingFocus(focus); };
   const goNewIntent = () => setScreen("new-intent");
   const finishNewIntent = async (answers, created, intentId) => {
     setConversation([]);
@@ -499,7 +528,7 @@ function App() {
       chatOpenRef.current.open(personId);
     } else {
       const intent = INTENTS.find(i => i.title === signal);
-      if (intent) { pickExistingIntent(intent); setPendingChat(personId); }
+      if (intent) openIntentOn(intent, { kind: "chat", personId });
     }
   };
 
@@ -598,8 +627,8 @@ function App() {
             simRate={simRate} setSimRate={setSimRate}
             onBack={() => setScreen("intents")}
             registerChats={registerChats}
-            pendingChat={pendingChat}
-            onPendingHandled={() => setPendingChat(null)}
+            pendingFocus={pendingFocus}
+            onPendingHandled={() => setPendingFocus(null)}
             focusQuestion={focusQuestion}
           />
         )}

--- a/apps/mac/src/ui/mainview/core.jsx
+++ b/apps/mac/src/ui/mainview/core.jsx
@@ -12,7 +12,7 @@ const DISCOVERY_GIVE_UP_MS = 120000;
 
 function MainView({ profile, people, setPeople, conversation, setConversation,
                     field, setField, stats, simRate, setSimRate, tweaks = {},
-                    onOpenRoom, onBack, registerChats, pendingChat, onPendingHandled,
+                    onOpenRoom, onBack, registerChats, pendingFocus, onPendingHandled,
                     focusQuestion }) {
   // Live-only: these demo sim feeds no longer exist, so they default to empty.
   // The simulation loops below stay wired but idle on empty arrays.
@@ -170,7 +170,10 @@ function MainView({ profile, people, setPeople, conversation, setConversation,
       if (!radarR) return;
       const items = window.IndexApp.normalizeList(radarR, "items");
       const mapped = window.IndexApi.mapPeopleFromRadarItems(items).map((p) => ({
-        ...p, hidden: false, score: typeof p.score === "number" ? p.score : 0.7,
+        // The radar is intent-scoped, so stamping the signal onto each person
+        // lets a deep link know which signal already owns the one it names.
+        ...p, intentId: forIntent, hidden: false,
+        score: typeof p.score === "number" ? p.score : 0.7,
       }));
       const apply = window.IndexApi.applyRadarPeople || ((prev, next) => next);
       setPeople((prev) => apply(prev, mapped));
@@ -543,13 +546,28 @@ function MainView({ profile, people, setPeople, conversation, setConversation,
     if (registerChats) registerChats(signalTitle, roster, (id) => openChatRef.current(id));
   }, [rosterKey, signalTitle]);
 
-  // When asked to open a specific chat after resuming a signal from the menubar.
+  // What the menubar or a deep link asked to open once this signal mounted.
+  // A chat opens from the id alone, but a profile renders from the radar row,
+  // which arrives a moment after the signal does — so hold the request until
+  // that person lands rather than opening an empty panel.
+  const focusedTabRef = useRef(null);
   useEffect(() => {
-    if (pendingChat) {
-      openChat(pendingChat);
-      onPendingHandled && onPendingHandled();
+    if (!pendingFocus) return;
+    if (pendingFocus.kind === "profile") {
+      // The stage moves first and only once, so a person still loading is at
+      // least filtered into view, and a tab picked in the meantime stands.
+      if (focusedTabRef.current !== pendingFocus) {
+        focusedTabRef.current = pendingFocus;
+        const bucket = opportunityBucket(pendingFocus);
+        if (bucket) setTab(bucket);
+      }
+      if (!people.some((p) => p.id === pendingFocus.personId)) return;
+      openProfile(pendingFocus.personId);
+    } else {
+      openChat(pendingFocus.personId);
     }
-  }, [pendingChat]);
+    onPendingHandled && onPendingHandled();
+  }, [pendingFocus, people]);
 
   return (
     <div style={{

--- a/bun.lock
+++ b/bun.lock
@@ -127,7 +127,7 @@
     },
     "services/api": {
       "name": "@indexnetwork/api",
-      "version": "0.117.0",
+      "version": "0.118.0",
       "dependencies": {
         "@aws-sdk/client-s3": "^3.939.0",
         "@aws-sdk/s3-request-presigner": "^3.983.0",

--- a/services/api/package.json
+++ b/services/api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@indexnetwork/api",
-  "version": "0.117.0",
+  "version": "0.118.0",
   "license": "MIT",
   "private": true,
   "scripts": {

--- a/services/api/src/cli/notify-simulate.ts
+++ b/services/api/src/cli/notify-simulate.ts
@@ -154,19 +154,24 @@ async function main(): Promise<void> {
     return { id: fallback.id, email: fallback.email, name: fallback.name };
   }
 
+  async function newestActiveIntent(recipientEmail: string, recipientId: string) {
+    const [intent] = await db
+      .select({ id: intents.id, payload: intents.payload })
+      .from(intents)
+      .where(and(eq(intents.userId, recipientId), isNull(intents.archivedAt)))
+      .orderBy(desc(intents.createdAt))
+      .limit(1);
+    if (!intent) {
+      throw new Error(`${recipientEmail} has no active signal to ask about. Create one first.`);
+    }
+    return intent;
+  }
+
   try {
     const recipient = await resolveUserByEmail(args.userEmail);
 
     if (args.command === 'question') {
-      const [intent] = await db
-        .select({ id: intents.id, payload: intents.payload })
-        .from(intents)
-        .where(and(eq(intents.userId, recipient.id), isNull(intents.archivedAt)))
-        .orderBy(desc(intents.createdAt))
-        .limit(1);
-      if (!intent) {
-        throw new Error(`${recipient.email} has no active signal to ask about. Create one first.`);
-      }
+      const intent = await newestActiveIntent(recipient.email, recipient.id);
 
       const conversations = new ConversationDatabaseAdapter();
       const conversation = await conversations.getOrCreateAgentDm(recipient.id);
@@ -204,6 +209,9 @@ async function main(): Promise<void> {
     const counterpart = await resolveCounterpart(recipient.id, args.counterpartEmail);
 
     if (args.command === 'opportunity') {
+      // A real opportunity records the signal it was found for, and the app
+      // reads it to open that signal, so a simulated one has to carry it too.
+      const intent = await newestActiveIntent(recipient.email, recipient.id);
       const opportunities = new OpportunityDatabaseAdapter();
       const created = await opportunities.createOpportunity({
         detection: {
@@ -212,7 +220,7 @@ async function main(): Promise<void> {
           timestamp: new Date().toISOString(),
         },
         actors: [
-          { networkId: COMMONS_NETWORK_ID, userId: recipient.id, role: 'patient' },
+          { networkId: COMMONS_NETWORK_ID, userId: recipient.id, intent: intent.id, role: 'patient' },
           { networkId: COMMONS_NETWORK_ID, userId: counterpart.id, role: 'agent' },
         ],
         interpretation: {
@@ -240,6 +248,7 @@ async function main(): Promise<void> {
       console.log('  channel:', userEventChannel(recipient.id));
       console.log('  recipient:', recipient.email, `(${recipient.id})`);
       console.log('  counterpart:', counterpart.email, `(${counterpart.id})`);
+      console.log('  signal:', intent.id, `(${intent.payload.slice(0, 60)})`);
       return;
     }
 

--- a/services/api/src/services/opportunity.service.ts
+++ b/services/api/src/services/opportunity.service.ts
@@ -473,6 +473,9 @@ export class OpportunityService {
       id: opp.id,
       presentation,
       myRole: myActor.role,
+      // The viewer's own signal, so a client holding only an opportunity id can
+      // open the signal that owns it rather than a detached card.
+      intentId: myActor.intent ?? null,
       otherParties,
       category: opp.interpretation.category,
       confidence: confidenceNum,


### PR DESCRIPTION
An opportunity or conversation link used to float a card over whatever was on screen, leaving the signal it belongs to closed. Both now resume that signal and focus the person inside it. The floating window stays for the case it was always for: a signal that has left the hub.

## Changes

- **`GET /opportunities/:id` returns the viewer's `intentId`.** A client holding only an opportunity id had no way to find the signal that owns it. Universal links from the web carry no intent context either, so this has to come from the server.
- **Conversation links resolve their signal from the thread's provenance** (`via[0].intentId`), which the conversation list already returns.
- **Radar people carry the signal they were found for**, so a link naming someone already on screen knows the signal is the open one.
- **`pendingChat` becomes `pendingFocus`** (`{ kind, personId, status }`). The menubar still resumes a signal on a chat; a deep link can also land on a profile. A profile focus waits for the radar row to arrive rather than opening an empty panel, and sets the radar tab from the opportunity's status so the person is filtered into view even if the row never loads.
- **`notify:simulate opportunity` records the recipient's signal on the actor**, as the opportunity graph does. Without it a simulated opportunity could never open its signal, so the link was untestable.

## Behaviour

| Link | Signal on the hub | Signal archived |
|---|---|---|
| `index://o/<id>` | opens the signal, radar tab set from status, profile focused | floating card (unchanged) |
| `index://chat/<id>` | opens the signal, chat focused | floating chat (unchanged) |
| `index://i/<id>` | opens the signal, question focused | notice (unchanged) |
| `index://u/<id>` | floating profile (unchanged — a profile link names no signal) |

## Verification

- `bun run typecheck` in `services/api`, `bun run lint` at the root (0 errors, 35 pre-existing warnings), Mac bundle assembles and the app builds.
- `getOpportunityWithPresentation` called against the dev database returns `intentId: 47da103c-…` for a freshly simulated opportunity, and that signal is on the owner's hub.
- The in-app click-through was not run: it needs a locally built app signed in against a local API, and the installed build was in use.

## Breaking change

`GET /opportunities/:id` gains a field. Nothing is removed.