### PR TITLE
fix: replace agent and app polling with events

### DIFF
--- a/apps/mac/src/ui/bridge.jsx
+++ b/apps/mac/src/ui/bridge.jsx
@@ -355,14 +355,11 @@ window.IndexApp = (function () {
 
   // ---- bounded native SSE -------------------------------------------------
 
-  // GET /events, live inbox events. Returns an abort handle.
+  // Views share the app's existing authenticated /events connection.
+  const inboxHandlers = new Set();
   function streamInbox(onEvent) {
-    const controller = new AbortController();
-    nativeAPIBridge.request(
-      { kind:"sse", method:"GET", path:"/events" },
-      { signal:controller.signal, onEvent, timeoutMs:300000 },
-    ).catch((e) => { /* aborted or network drop; caller may retry */ });
-    return { close: () => controller.abort() };
+    inboxHandlers.add(onEvent);
+    return { close: () => inboxHandlers.delete(onEvent) };
   }
 
   // ---- desktop notifications ------------------------------------------------
@@ -452,7 +449,9 @@ window.IndexApp = (function () {
       if (copy) notify(copy);
     }
     function onRealtime(event) {
-      if (stopped || !event || event.type === "connected") return;
+      if (stopped || !event) return;
+      inboxHandlers.forEach((handler) => handler(event));
+      if (event.type === "connected") return;
       // Own-send suppression is a message question: notification frames have no
       // sender, and isOwnMessage fails closed on anything without `message`.
       if (event.message && N.isOwnMessage(event, getUserId ? getUserId() : null)) return;

--- a/apps/mac/src/ui/history.jsx
+++ b/apps/mac/src/ui/history.jsx
@@ -153,8 +153,13 @@ function NegotiationHistory({ onClose }) {
       if (!dead) setThreads((prev) => prev || []);
     };
     load();
-    const t = setInterval(load, 3000);   // same cadence as the radar
-    return () => { dead = true; clearInterval(t); };
+    let refreshTimer;
+    const sub = live ? window.IndexApp.streamInbox((event) => {
+      if (!event.type?.startsWith("negotiation.") && event.type !== "intent.lifecycle") return;
+      clearTimeout(refreshTimer);
+      refreshTimer = setTimeout(load, 100);
+    }) : null;
+    return () => { dead = true; if (sub) sub.close(); clearTimeout(refreshTimer); };
   }, [live, myId]);
 
   const all = threads || [];

--- a/apps/mac/src/ui/history.jsx
+++ b/apps/mac/src/ui/history.jsx
@@ -155,7 +155,7 @@ function NegotiationHistory({ onClose }) {
     load();
     let refreshTimer;
     const sub = live ? window.IndexApp.streamInbox((event) => {
-      if (!event.type?.startsWith("negotiation.") && event.type !== "intent.lifecycle") return;
+      if (!["negotiation.changed", "negotiation.opened"].includes(event.type)) return;
       clearTimeout(refreshTimer);
       refreshTimer = setTimeout(load, 100);
     }) : null;

--- a/apps/mac/src/ui/mainview/core.jsx
+++ b/apps/mac/src/ui/mainview/core.jsx
@@ -249,7 +249,7 @@ function MainView({ profile, people, setPeople, conversation, setConversation,
     let refreshTimer;
     const sub = window.IndexApp.streamInbox((event) => {
       if (event.data?.intentId !== intentId
-        || !["intent.updated", "intent.lifecycle", "opportunity.new", "negotiation.opened", "negotiation.turn", "negotiation.settled"].includes(event.type)) return;
+        || !["intent.updated", "intent.lifecycle", "opportunity.new", "negotiation.opened", "negotiation.changed"].includes(event.type)) return;
       clearTimeout(refreshTimer);
       refreshTimer = setTimeout(refreshRadar, 100);
     });
@@ -266,12 +266,25 @@ function MainView({ profile, people, setPeople, conversation, setConversation,
     if (!live || !client) return;
     let alive = true;
     const forIntent = intentId;
-    const read = () => client.conversations.messages("agent", { intentId: forIntent })
-      .then((res) => {
-        if (!alive || intentIdRef.current !== forIntent) return;
+    let reading = false;
+    let refreshPending = false;
+    let revision = 0;
+    const read = async () => {
+      if (!alive || intentIdRef.current !== forIntent) return;
+      if (reading) { refreshPending = true; return; }
+      reading = true;
+      refreshPending = false;
+      const requestRevision = revision;
+      try {
+        const res = await client.conversations.messages("agent", { intentId: forIntent });
+        if (!alive || intentIdRef.current !== forIntent || requestRevision !== revision) return;
         setAgentQuestion((res && res.agent && res.agent.pending) || null);
-      })
-      .catch(() => { /* a failed read leaves the last known question up */ });
+      } catch { /* a failed read leaves the last known question up */ }
+      finally {
+        reading = false;
+        if (alive && refreshPending) void read();
+      }
+    };
     read();
     let refreshTimer;
     const sub = window.IndexApp.streamInbox((event) => {
@@ -279,8 +292,10 @@ function MainView({ profile, people, setPeople, conversation, setConversation,
         if (event.message?.metadata?.intentId !== forIntent) return;
       } else if (!["question.pending", "intent.lifecycle", "agent.configuration", "agent.status"].includes(event.type)
         || event.data?.intentId && event.data.intentId !== forIntent) return;
+      revision++;
       clearTimeout(refreshTimer);
-      refreshTimer = setTimeout(read, 100);
+      if (reading) refreshPending = true;
+      else refreshTimer = setTimeout(read, 100);
     });
     return () => { alive = false; sub.close(); clearTimeout(refreshTimer); };
   }, [live, client, intentId]);

--- a/apps/mac/src/ui/mainview/core.jsx
+++ b/apps/mac/src/ui/mainview/core.jsx
@@ -147,9 +147,9 @@ function MainView({ profile, people, setPeople, conversation, setConversation,
     }
   }, (paused || live) ? null : 14000 / simRate);
 
-  /* ----- live radar polling ----- */
+  /* ----- live radar events ----- */
   // Intent switches keep MainView mounted; wipe the previous signal's radar
-  // before the next poll lands.
+  // before the next read lands.
   useEffect(() => {
     if (!live) return;
     radarSeqRef.current += 1;
@@ -246,15 +246,20 @@ function MainView({ profile, people, setPeople, conversation, setConversation,
   useEffect(() => {
     if (!live) return;
     refreshRadar();
-    const t = setInterval(refreshRadar, 5000);
-    return () => clearInterval(t);
-  }, [live, refreshRadar]);
+    let refreshTimer;
+    const sub = window.IndexApp.streamInbox((event) => {
+      if (event.data?.intentId !== intentId
+        || !["intent.updated", "intent.lifecycle", "opportunity.new", "negotiation.opened", "negotiation.turn", "negotiation.settled"].includes(event.type)) return;
+      clearTimeout(refreshTimer);
+      refreshTimer = setTimeout(refreshRadar, 100);
+    });
+    return () => { sub.close(); clearTimeout(refreshTimer); };
+  }, [live, intentId, refreshRadar]);
 
   /* ----- the signal's own agent: the question it is held on ----- */
   // GET /conversations/agent?intentId= is the whole H2A contract: the agent's
-  // side of this signal plus the one question it is suspended on. The same poll
-  // the web app runs, because a question can appear without anything else on
-  // this screen changing.
+  // side of this signal plus the one question it is suspended on. Refresh when
+  // the question, intent lifecycle, or agent availability changes.
   const [agentQuestion, setAgentQuestion] = useState(null);
   useEffect(() => {
     setAgentQuestion(null);
@@ -268,8 +273,16 @@ function MainView({ profile, people, setPeople, conversation, setConversation,
       })
       .catch(() => { /* a failed read leaves the last known question up */ });
     read();
-    const t = setInterval(read, 5000);
-    return () => { alive = false; clearInterval(t); };
+    let refreshTimer;
+    const sub = window.IndexApp.streamInbox((event) => {
+      if (event.type === "message") {
+        if (event.message?.metadata?.intentId !== forIntent) return;
+      } else if (!["question.pending", "intent.lifecycle", "agent.configuration", "agent.status"].includes(event.type)
+        || event.data?.intentId && event.data.intentId !== forIntent) return;
+      clearTimeout(refreshTimer);
+      refreshTimer = setTimeout(read, 100);
+    });
+    return () => { alive = false; sub.close(); clearTimeout(refreshTimer); };
   }, [live, client, intentId]);
 
   // The answer goes back naming the question it answers, so a question that

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@indexnetwork/web",
-  "version": "0.75.0",
+  "version": "0.75.1",
   "license": "MIT",
   "scripts": {
     "dev": "vite --host ::",

--- a/apps/web/src/app/i/[intentId]/page.tsx
+++ b/apps/web/src/app/i/[intentId]/page.tsx
@@ -9,6 +9,7 @@ import { Button } from "@/components/ui/button";
 import IntentNegotiatorChat from "@/components/IntentNegotiatorChat";
 import NegotiationConversation from "@/components/NegotiationConversation";
 import OpportunityCard, { OpportunitySkeleton } from "@/components/chat/OpportunityCardInChat";
+import { useConversation } from "@/contexts/ConversationContext";
 import { useIntents, useOpportunities } from "@/contexts/APIContext";
 import { useNotifications } from "@/contexts/NotificationContext";
 import { useOpportunityActions } from "@/hooks/useOpportunityActions";
@@ -169,6 +170,7 @@ export default function IntentDetailPage() {
   const navigate = useNavigate();
   const { intentId } = useParams<{ intentId: string }>();
   const intentsService = useIntents();
+  const { subscribeUserEvent } = useConversation();
   const opportunitiesService = useOpportunities();
   useIntentVisitPing(intentId);
   const { error: showError } = useNotifications();
@@ -189,7 +191,6 @@ export default function IntentDetailPage() {
   const activeIntentIdRef = useRef(intentId);
   const [opportunities, setOpportunities] = useState<RadarCardItem[]>([]);
   const [opportunitiesLoading, setOpportunitiesLoading] = useState(true);
-  const opportunitiesLoadingRef = useRef(true);
   const [opportunitiesError, setOpportunitiesError] = useState(false);
   const [refineText, setRefineText] = useState("");
   const [refining, setRefining] = useState(false);
@@ -232,23 +233,25 @@ export default function IntentDetailPage() {
 
   /** Monotonic load ids guard every intent-scoped feed against stale responses. */
   const loadSeqRef = useRef(0);
+  const radarRequestIntentRef = useRef<string | null>(null);
+  const radarRefreshPendingRef = useRef(false);
 
-  const loadOpportunities = useCallback(async (preserveExisting = false) => {
+  const loadOpportunities = useCallback(async function load(preserveExisting = false): Promise<void> {
     if (!intentId) return;
-    // The live 5s refresh must not supersede the initial two-phase load. If it
-    // does, the initial request's sequence becomes stale and its finally block
-    // cannot clear the loading state; the passive request then populates badge
-    // counts behind a permanent pair of skeleton cards.
-    if (preserveExisting && opportunitiesLoadingRef.current) return;
+    // An event arriving during a read must refresh after that read finishes.
+    if (preserveExisting && radarRequestIntentRef.current === intentId) {
+      radarRefreshPendingRef.current = true;
+      return;
+    }
+    radarRequestIntentRef.current = intentId;
+    radarRefreshPendingRef.current = false;
     const seq = ++loadSeqRef.current;
     if (!preserveExisting) {
-      opportunitiesLoadingRef.current = true;
       setOpportunitiesLoading(true);
       setOpportunitiesError(false);
     }
     const settleLoading = () => {
       if (activeIntentIdRef.current !== intentId) return;
-      opportunitiesLoadingRef.current = false;
       setOpportunitiesLoading(false);
     };
     const applyItems = (items: RadarCardItem[]) => {
@@ -294,7 +297,14 @@ export default function IntentDetailPage() {
         setOpportunitiesError(true);
       }
     } finally {
-      if (seq === loadSeqRef.current && !preserveExisting) settleLoading();
+      if (seq === loadSeqRef.current) {
+        radarRequestIntentRef.current = null;
+        if (!preserveExisting) settleLoading();
+        if (radarRefreshPendingRef.current && activeIntentIdRef.current === intentId) {
+          radarRefreshPendingRef.current = false;
+          void load(true);
+        }
+      }
     }
   }, [intentId, opportunitiesService]);
 
@@ -328,9 +338,15 @@ export default function IntentDetailPage() {
   }, [loadOpportunities, selectedBucket]);
 
   useEffect(() => {
-    const timer = setInterval(() => { void loadOpportunities(true); }, 5_000);
-    return () => clearInterval(timer);
-  }, [loadOpportunities]);
+    let refreshTimer: ReturnType<typeof setTimeout>;
+    const unsubscribe = subscribeUserEvent((event) => {
+      if (event.data?.intentId !== intentId
+        || !['intent.updated', 'intent.lifecycle', 'opportunity.new', 'negotiation.opened', 'negotiation.turn', 'negotiation.settled'].includes(event.type)) return;
+      clearTimeout(refreshTimer);
+      refreshTimer = setTimeout(() => { void loadOpportunities(true); }, 100);
+    });
+    return () => { unsubscribe(); clearTimeout(refreshTimer); };
+  }, [intentId, loadOpportunities, subscribeUserEvent]);
 
   useEffect(() => {
     if (matchFocus) document.getElementById(`radar-match-${matchFocus.id}`)?.scrollIntoView({ behavior: "smooth", block: "nearest" });

--- a/apps/web/src/app/i/[intentId]/page.tsx
+++ b/apps/web/src/app/i/[intentId]/page.tsx
@@ -341,7 +341,7 @@ export default function IntentDetailPage() {
     let refreshTimer: ReturnType<typeof setTimeout>;
     const unsubscribe = subscribeUserEvent((event) => {
       if (event.data?.intentId !== intentId
-        || !['intent.updated', 'intent.lifecycle', 'opportunity.new', 'negotiation.opened', 'negotiation.turn', 'negotiation.settled'].includes(event.type)) return;
+        || !['intent.updated', 'intent.lifecycle', 'opportunity.new', 'negotiation.opened', 'negotiation.changed'].includes(event.type)) return;
       clearTimeout(refreshTimer);
       refreshTimer = setTimeout(() => { void loadOpportunities(true); }, 100);
     });

--- a/apps/web/src/components/DiscoverHome.tsx
+++ b/apps/web/src/components/DiscoverHome.tsx
@@ -35,7 +35,7 @@ export default function DiscoverHome() {
   const navigate = useNavigate();
   const { error: showError } = useNotifications();
   const { user } = useAuthContext();
-  const { negotiations } = useConversation();
+  const { negotiations, subscribeUserEvent } = useConversation();
   const [intents, setIntents] = useState<HomeIntent[]>([]);
   const [totalWaitingOpportunities, setTotalWaitingOpportunities] = useState(0);
   const [loading, setLoading] = useState(false);
@@ -79,10 +79,14 @@ export default function DiscoverHome() {
   }, [fetchIntents]);
 
   useEffect(() => {
-    if (!intents.some((intent) => intent.warming)) return;
-    const interval = setInterval(fetchIntents, 30_000);
-    return () => clearInterval(interval);
-  }, [fetchIntents, intents]);
+    let refreshTimer: ReturnType<typeof setTimeout>;
+    const unsubscribe = subscribeUserEvent((event) => {
+      if (!['intent.updated', 'intent.lifecycle', 'opportunity.new', 'negotiation.opened', 'negotiation.settled'].includes(event.type)) return;
+      clearTimeout(refreshTimer);
+      refreshTimer = setTimeout(() => { void fetchIntents(); }, 100);
+    });
+    return () => { unsubscribe(); clearTimeout(refreshTimer); };
+  }, [fetchIntents, subscribeUserEvent]);
 
   const handleArchive = useCallback(
     async (intent: HomeIntent) => {

--- a/apps/web/src/components/DiscoverHome.tsx
+++ b/apps/web/src/components/DiscoverHome.tsx
@@ -81,7 +81,7 @@ export default function DiscoverHome() {
   useEffect(() => {
     let refreshTimer: ReturnType<typeof setTimeout>;
     const unsubscribe = subscribeUserEvent((event) => {
-      if (!['intent.updated', 'intent.lifecycle', 'opportunity.new', 'negotiation.opened', 'negotiation.settled'].includes(event.type)) return;
+      if (!['intent.updated', 'intent.lifecycle', 'opportunity.new', 'negotiation.opened', 'negotiation.changed'].includes(event.type)) return;
       clearTimeout(refreshTimer);
       refreshTimer = setTimeout(() => { void fetchIntents(); }, 100);
     });

--- a/apps/web/src/components/IntentNegotiatorChat.tsx
+++ b/apps/web/src/components/IntentNegotiatorChat.tsx
@@ -20,7 +20,7 @@ function messageText(message: ConversationMessage): string {
 export default function IntentNegotiatorChat({ intentId, onSelectMatch }: { intentId: string; onSelectMatch(opportunityId: string): void }) {
   const { user } = useAuthContext();
   const conversations = useConversations();
-  const { subscribeConversationMessage, isConnected } = useConversation();
+  const { subscribeUserEvent, isConnected } = useConversation();
   const storageKey = `principal-draft:${user?.id}:${intentId}`;
   const [draft, setDraft] = useState<{ text: string; questionId: string | null }>(() => {
     try { return JSON.parse(sessionStorage.getItem(storageKey) ?? "null") ?? { text: "", questionId: null }; }
@@ -66,15 +66,22 @@ export default function IntentNegotiatorChat({ intentId, onSelectMatch }: { inte
     const state = requests.current;
     state.mounted = true;
     void Promise.resolve().then(refresh);
-    const timer = setInterval(() => { void refresh(); }, 5_000);
-    return () => { state.mounted = false; state.generation++; clearInterval(timer); };
+    return () => { state.mounted = false; state.generation++; };
   }, [refresh, isConnected, requests]);
 
-  useEffect(() => subscribeConversationMessage(({ conversationId: id, message }) => {
-    if (id !== conversationId || message.metadata?.intentId !== intentId) return;
-    mergeMessages([message]);
-    void refresh();
-  }), [conversationId, intentId, mergeMessages, refresh, subscribeConversationMessage]);
+  useEffect(() => {
+    let refreshTimer: ReturnType<typeof setTimeout>;
+    const unsubscribe = subscribeUserEvent((event) => {
+      if (event.type === 'message') {
+        if (event.message?.metadata?.intentId !== intentId) return;
+        mergeMessages([event.message]);
+      } else if (!['question.pending', 'intent.lifecycle', 'agent.configuration', 'agent.status'].includes(event.type)
+        || event.data?.intentId && event.data.intentId !== intentId) return;
+      clearTimeout(refreshTimer);
+      refreshTimer = setTimeout(() => { void refresh(); }, 100);
+    });
+    return () => { unsubscribe(); clearTimeout(refreshTimer); };
+  }, [intentId, mergeMessages, refresh, subscribeUserEvent]);
 
   useEffect(() => { sessionStorage.setItem(storageKey, JSON.stringify(draft)); }, [draft, storageKey]);
   useEffect(() => { endRef.current?.scrollIntoView({ behavior: "smooth", block: "nearest" }); }, [messages.length, pending?.id]);

--- a/apps/web/src/components/NegotiationConversation.tsx
+++ b/apps/web/src/components/NegotiationConversation.tsx
@@ -13,7 +13,7 @@ export default function NegotiationConversation({ intentId, opportunityId, expan
 }) {
   const { user } = useAuthContext();
   const service = useNegotiations();
-  const { negotiations, isConnected } = useConversation();
+  const { negotiations, isConnected, subscribeUserEvent } = useConversation();
   const match = negotiations.find((entry) => entry.opportunityId === opportunityId && entry.intentId === intentId);
   const [detail, setDetail] = useState<NegotiationDetail>();
   const [error, setError] = useState("");
@@ -24,9 +24,11 @@ export default function NegotiationConversation({ intentId, opportunityId, expan
     if (!expanded) return;
     let active = true;
     let loading = false;
+    let refreshPending = false;
     const refresh = async () => {
-      if (loading) return;
+      if (loading) { refreshPending = true; return; }
       loading = true;
+      refreshPending = false;
       try {
         const record = await service.getNegotiation(opportunityId);
         if (!active) return;
@@ -35,12 +37,21 @@ export default function NegotiationConversation({ intentId, opportunityId, expan
         setError("");
       } catch (failure) {
         if (active) setError(failure instanceof Error ? failure.message : "Could not load this conversation.");
-      } finally { loading = false; }
+      } finally {
+        loading = false;
+        if (active && refreshPending) void refresh();
+      }
     };
     void refresh();
-    const timer = setInterval(() => { void refresh(); }, 5_000);
-    return () => { active = false; clearInterval(timer); };
-  }, [expanded, intentId, opportunityId, service, match?.updatedAt, isConnected]);
+    let refreshTimer: ReturnType<typeof setTimeout>;
+    const unsubscribe = subscribeUserEvent((event) => {
+      if (!(event.type.startsWith('negotiation.') && event.data?.opportunityId === opportunityId)
+        && !(event.type === 'intent.lifecycle' && event.data?.intentId === intentId)) return;
+      clearTimeout(refreshTimer);
+      refreshTimer = setTimeout(() => { void refresh(); }, 100);
+    });
+    return () => { active = false; unsubscribe(); clearTimeout(refreshTimer); };
+  }, [expanded, intentId, opportunityId, service, isConnected, subscribeUserEvent]);
 
   useEffect(() => {
     if (history.current && follow.current) history.current.scrollTop = history.current.scrollHeight;

--- a/apps/web/src/components/NegotiationConversation.tsx
+++ b/apps/web/src/components/NegotiationConversation.tsx
@@ -45,8 +45,8 @@ export default function NegotiationConversation({ intentId, opportunityId, expan
     void refresh();
     let refreshTimer: ReturnType<typeof setTimeout>;
     const unsubscribe = subscribeUserEvent((event) => {
-      if (!(event.type.startsWith('negotiation.') && event.data?.opportunityId === opportunityId)
-        && !(event.type === 'intent.lifecycle' && event.data?.intentId === intentId)) return;
+      if (event.type !== 'negotiation.changed' || event.data?.intentId !== intentId
+        || event.data.opportunityId && event.data.opportunityId !== opportunityId) return;
       clearTimeout(refreshTimer);
       refreshTimer = setTimeout(() => { void refresh(); }, 100);
     });

--- a/apps/web/src/contexts/ConversationContext.tsx
+++ b/apps/web/src/contexts/ConversationContext.tsx
@@ -323,10 +323,8 @@ export function ConversationProvider({ children }: { children: React.ReactNode }
               setIsConnected(true);
               void refreshNegotiationsRef.current();
               break;
-            case 'negotiation.turn':
-            case 'negotiation.settled':
+            case 'negotiation.changed':
             case 'negotiation.opened':
-            case 'intent.lifecycle':
               if (negotiationsRefreshTimeoutRef.current) clearTimeout(negotiationsRefreshTimeoutRef.current);
               negotiationsRefreshTimeoutRef.current = setTimeout(() => {
                 negotiationsRefreshTimeoutRef.current = null;

--- a/apps/web/src/contexts/ConversationContext.tsx
+++ b/apps/web/src/contexts/ConversationContext.tsx
@@ -18,13 +18,16 @@ interface ConversationSessionHistoryState {
   loadingPrevious: boolean;
 }
 
-/** A persisted message received on the authenticated conversation SSE channel. */
-export interface ConversationMessageEvent {
-  conversationId: string;
-  message: ConversationMessage;
+/** A change notification on the existing authenticated SSE connection. */
+export interface UserEvent {
+  type: string;
+  data?: { intentId?: string; opportunityId?: string; status?: string };
+  conversationId?: string;
+  message?: ConversationMessage;
 }
 
 interface ConversationContextType {
+  subscribeUserEvent: (handler: (event: UserEvent) => void) => () => void;
   conversations: ConversationSummary[];
   negotiations: NegotiationSummary[];
   messages: Map<string, ConversationMessage[]>;
@@ -40,8 +43,6 @@ interface ConversationContextType {
   markConversationRead: (conversationId: string) => Promise<void>;
   hideConversation: (conversationId: string) => Promise<void>;
   getOrCreateDm: (peerUserId: string) => Promise<ConversationSummary>;
-  /** Subscribe to persisted conversation messages from the SSE stream. */
-  subscribeConversationMessage: (handler: (event: ConversationMessageEvent) => void) => () => void;
 }
 
 const ConversationContext = createContext<ConversationContextType | null>(null);
@@ -65,16 +66,12 @@ export function ConversationProvider({ children }: { children: React.ReactNode }
   const refreshConversationsRef = useRef<() => Promise<void>>(() => Promise.resolve());
   const refreshNegotiationsRef = useRef<() => Promise<void>>(() => Promise.resolve());
   const negotiationsRefreshTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
-  const conversationMessageHandlersRef = useRef(new Set<(event: ConversationMessageEvent) => void>());
+  const userEventHandlersRef = useRef(new Set<(event: UserEvent) => void>());
+  const subscribeUserEvent = useCallback((handler: (event: UserEvent) => void) => {
+    userEventHandlersRef.current.add(handler);
+    return () => { userEventHandlersRef.current.delete(handler); };
+  }, []);
   const pendingOptimisticIdsRef = useRef(new Set<string>());
-
-  const subscribeConversationMessage = useCallback(
-    (handler: (event: ConversationMessageEvent) => void) => {
-      conversationMessageHandlersRef.current.add(handler);
-      return () => { conversationMessageHandlersRef.current.delete(handler); };
-    },
-    [],
-  );
 
   // --- REST helpers (conversation calls go through the typed client) ---
 
@@ -320,6 +317,7 @@ export function ConversationProvider({ children }: { children: React.ReactNode }
       es.onmessage = (event) => {
         try {
           const data = JSON.parse(event.data);
+          userEventHandlersRef.current.forEach((handler) => handler(data));
           switch (data.type) {
             case 'connected':
               setIsConnected(true);
@@ -373,21 +371,6 @@ export function ConversationProvider({ children }: { children: React.ReactNode }
                     : c
                 );
               });
-              // Negotiation turns use the same stream but their summaries are
-              // owner-filtered separately (`agent:<ownerId>` participants).
-              // Trailing-debounce revalidation so a multi-turn burst refetches
-              // once; intent provenance and Radar still react without polling.
-              if (negotiationsRefreshTimeoutRef.current) {
-                clearTimeout(negotiationsRefreshTimeoutRef.current);
-              }
-              negotiationsRefreshTimeoutRef.current = setTimeout(() => {
-                negotiationsRefreshTimeoutRef.current = null;
-                void refreshNegotiationsRef.current();
-              }, 500);
-              conversationMessageHandlersRef.current.forEach((handler) => handler({
-                conversationId: convId,
-                message: msg,
-              }));
               break;
             }
           }
@@ -484,7 +467,7 @@ export function ConversationProvider({ children }: { children: React.ReactNode }
         markConversationRead,
         hideConversation,
         getOrCreateDm,
-        subscribeConversationMessage,
+        subscribeUserEvent,
       }}
     >
       {children}

--- a/apps/web/src/services/opportunities.ts
+++ b/apps/web/src/services/opportunities.ts
@@ -125,9 +125,7 @@ export interface ChatContextOpportunity {
   acceptedAt: string | null;
 }
 
-const RADAR_VIEW_RECENT_CACHE_TTL_MS = 1500;
 const radarViewInFlight = new Map<string, Promise<RadarViewResponse>>();
-const radarViewRecent = new Map<string, { data: RadarViewResponse; timestamp: number }>();
 
 export const createOpportunitiesService = (
   api: ReturnType<typeof import('../lib/api').useAuthenticatedAPI>
@@ -166,12 +164,6 @@ export const createOpportunitiesService = (
     }
 
     const cacheKey = url;
-    const now = Date.now();
-    const recent = radarViewRecent.get(cacheKey);
-    if (recent && now - recent.timestamp < RADAR_VIEW_RECENT_CACHE_TTL_MS) {
-      return recent.data;
-    }
-
     const inFlight = radarViewInFlight.get(cacheKey);
     if (inFlight) {
       return inFlight;
@@ -179,10 +171,6 @@ export const createOpportunitiesService = (
 
     const request = api
       .get<RadarViewResponse>(url)
-      .then((res) => {
-        radarViewRecent.set(cacheKey, { data: res, timestamp: Date.now() });
-        return res;
-      })
       .finally(() => {
         radarViewInFlight.delete(cacheKey);
       });

--- a/bun.lock
+++ b/bun.lock
@@ -119,7 +119,7 @@
     },
     "packages/hermes-plugin": {
       "name": "@indexnetwork/hermes-plugin",
-      "version": "0.41.1",
+      "version": "0.41.2",
     },
     "packages/protocol": {
       "name": "@indexnetwork/protocol",

--- a/bun.lock
+++ b/bun.lock
@@ -139,7 +139,7 @@
     },
     "services/api": {
       "name": "@indexnetwork/api",
-      "version": "0.121.1",
+      "version": "0.121.2",
       "dependencies": {
         "@aws-sdk/client-s3": "^3.939.0",
         "@aws-sdk/s3-request-presigner": "^3.983.0",

--- a/bun.lock
+++ b/bun.lock
@@ -20,7 +20,7 @@
     },
     "apps/web": {
       "name": "@indexnetwork/web",
-      "version": "0.75.0",
+      "version": "0.75.1",
       "dependencies": {
         "@better-auth/api-key": "1.6.11",
         "@indexnetwork/protocol": "workspace:*",

--- a/packages/hermes-plugin/CHANGELOG.md
+++ b/packages/hermes-plugin/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 0.41.2
+
+### Fixed
+- Wake the affected negotiation seat on `negotiation.changed`, including when a counterparty resumes its intent.
+
 
 ## 0.41.1
 

--- a/packages/hermes-plugin/events.py
+++ b/packages/hermes-plugin/events.py
@@ -30,10 +30,10 @@ from .transport import get_transport
 
 logger = logging.getLogger(__name__)
 
-# `negotiation.*` names a signal that owes a turn; `intent.lifecycle` changes
-# whether the signal should be worked at all.
+# Negotiation changes refresh the affected seat; intent.lifecycle describes
+# whether this owner's own signal should be worked at all.
 WAKE_TYPES = frozenset({
-    "negotiation.opened", "negotiation.turn", "negotiation.settled", "intent.lifecycle",
+    "negotiation.opened", "negotiation.changed", "intent.lifecycle",
 })
 # Matches on one signal move together, so let sibling frames land in one wake.
 SETTLE_SECONDS = 2.0

--- a/packages/hermes-plugin/package.json
+++ b/packages/hermes-plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@indexnetwork/hermes-plugin",
-  "version": "0.41.1",
+  "version": "0.41.2",
   "description": "Hermes-native Index Network plugin with CLI tools and REST APIs",
   "license": "MIT",
   "type": "module",

--- a/packages/hermes-plugin/plugin.yaml
+++ b/packages/hermes-plugin/plugin.yaml
@@ -1,5 +1,5 @@
 name: index-network
-version: 0.41.1
+version: 0.41.2
 description: Index Network Hermes plugin with native tools backed by the Index REST API.
 provides_tools:
   - index_configure_personal_agent

--- a/services/api/package.json
+++ b/services/api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@indexnetwork/api",
-  "version": "0.121.1",
+  "version": "0.121.2",
   "license": "MIT",
   "private": true,
   "scripts": {

--- a/services/api/src/adapters/agent-session.database.adapter.ts
+++ b/services/api/src/adapters/agent-session.database.adapter.ts
@@ -14,6 +14,19 @@ const LEASE_SECONDS = 60;
 const QUESTION_HEADLINE = 'Question from your agent';
 const QUESTION_BODY_MAX_CHARS = 140;
 
+/** Startup cannot continue until the intent or executor configuration changes. */
+export class AgentSessionIneligibleError extends Error {}
+
+/** A competing runtime owns the lease until the database's recorded expiry. */
+export class AgentSessionLeaseConflict extends Error {
+  readonly retryAt: number;
+
+  constructor(readonly leaseExpiresAt: Date, retryAfterMs: number) {
+    super('This principal/intent already has an active personal-agent session.');
+    this.retryAt = Date.now() + retryAfterMs;
+  }
+}
+
 /**
  * Announce a question the owner has to answer before their agent can continue.
  *
@@ -87,21 +100,30 @@ export class AgentSessionDatabaseAdapter implements PrincipalStore {
   /** Acquire the session and read its canonical intent conversation. @returns The checkpoint and H2A history. @throws If another process owns it or the intent is not the principal's. */
   async load(): Promise<{ state: PrincipalState | null; messages: PrincipalMessage[] }> {
     const { userId, intentId, token } = this.execution;
-    const [intent] = await db.select({ id: intents.id }).from(intents).where(and(eq(intents.id, intentId), eq(intents.userId, userId)));
-    if (!intent) throw new Error('The selected intent does not belong to this principal.');
+    const [intent] = await db.select({ id: intents.id, status: intents.status, archivedAt: intents.archivedAt })
+      .from(intents).where(and(eq(intents.id, intentId), eq(intents.userId, userId)));
+    if (!intent || intent.archivedAt || intent.status !== null && intent.status !== 'ACTIVE') {
+      throw new AgentSessionIneligibleError('The selected intent must be active and belong to this principal.');
+    }
     const conversation = await this.conversations.getOrCreateAgentDm(userId);
     const row = await db.transaction(async (tx) => {
       await tx.execute(sql`SELECT pg_advisory_xact_lock(hashtextextended(${`agent-runtime:${userId}`}, 0))`);
       const [external] = await tx.select({ id: agents.id }).from(agents).where(and(
         eq(agents.ownerId, userId), eq(agents.type, 'external'), eq(agents.handleNegotiations, true), isNull(agents.deletedAt),
       )).limit(1);
-      if (external) throw new Error('This principal has selected an external negotiation executor.');
+      if (external) throw new AgentSessionIneligibleError('This principal has selected an external negotiation executor.');
       await tx.insert(agentSessions).values({ userId, intentId, conversationId: conversation.id }).onConflictDoNothing();
       const [acquired] = await tx.update(agentSessions).set({
         leaseToken: token, leaseExpiresAt: sql`now() + ${LEASE_SECONDS} * interval '1 second'`, updatedAt: new Date(),
       }).where(and(eq(agentSessions.userId, userId), eq(agentSessions.intentId, intentId),
         or(isNull(agentSessions.leaseToken), sql`${agentSessions.leaseExpiresAt} <= now()`))).returning();
-      if (!acquired) throw new Error('This principal/intent already has an active personal-agent session.');
+      if (!acquired) {
+        const [lease] = await tx.select({
+          expiresAt: agentSessions.leaseExpiresAt,
+          retryAfterMs: sql<number>`greatest(0, extract(epoch from (${agentSessions.leaseExpiresAt} - clock_timestamp())) * 1000)::integer`,
+        }).from(agentSessions).where(and(eq(agentSessions.userId, userId), eq(agentSessions.intentId, intentId)));
+        throw new AgentSessionLeaseConflict(lease!.expiresAt!, lease!.retryAfterMs);
+      }
       return acquired;
     });
     this.revision = row.revision;

--- a/services/api/src/adapters/agent.database.adapter.ts
+++ b/services/api/src/adapters/agent.database.adapter.ts
@@ -4,8 +4,7 @@ import db from '../lib/drizzle/drizzle';
 import { RuntimeNotFoundError } from '../lib/agent/runtime-errors';
 import * as schema from '../schemas/database.schema';
 import { log } from '../lib/log';
-
-import { publishIntentLifecycle } from './intent.database.adapter';
+import { publishUserInvalidation } from '../lib/user-events';
 
 const logger = log.lib.from('agent.database.adapter');
 
@@ -128,14 +127,17 @@ export class AgentDatabaseAdapter implements AgentRegistryStore {
   }
 
   async deleteAgent(agentId: string): Promise<void> {
-    await db
+    const [deleted] = await db
       .update(schema.agents)
       .set({
         deletedAt: new Date(),
         status: 'inactive',
         updatedAt: new Date(),
       })
-      .where(and(eq(schema.agents.id, agentId), isNull(schema.agents.deletedAt)));
+      .where(and(eq(schema.agents.id, agentId), isNull(schema.agents.deletedAt)))
+      .returning({ ownerId: schema.agents.ownerId, handleNegotiations: schema.agents.handleNegotiations });
+
+    if (deleted?.handleNegotiations) await publishUserInvalidation(deleted.ownerId, 'agent.configuration');
 
     logger.info('Soft-deleted agent', { agentId });
   }
@@ -181,6 +183,14 @@ export class AgentDatabaseAdapter implements AgentRegistryStore {
       .limit(1);
 
     return row ? this.toAgentRow(row) : null;
+  }
+
+  /** @param ownerId - Restrict an event-triggered check to one owner. @returns Owners whose external executor is selected. */
+  async listSelectedNegotiatorOwners(ownerId?: string): Promise<string[]> {
+    const rows = await db.select({ ownerId: schema.agents.ownerId }).from(schema.agents)
+      .where(and(eq(schema.agents.type, 'external'), eq(schema.agents.handleNegotiations, true),
+        isNull(schema.agents.deletedAt), ownerId ? eq(schema.agents.ownerId, ownerId) : undefined));
+    return rows.map((row) => row.ownerId);
   }
 
   /**
@@ -262,16 +272,7 @@ export class AgentDatabaseAdapter implements AgentRegistryStore {
       return target.id;
     });
 
-    const rows = await db.select({
-      id: schema.intents.id, status: schema.intents.status, updatedAt: schema.intents.updatedAt,
-    }).from(schema.intents).where(and(eq(schema.intents.userId, input.ownerId), isNull(schema.intents.archivedAt)));
-    await Promise.all(rows.map((row) => {
-      const status = row.status === 'PAUSED' ? 'PAUSED' as const
-        : row.status === 'ACTIVE' || row.status == null ? 'ACTIVE' as const
-        : null;
-      return status ? publishIntentLifecycle(input.ownerId, row.id, status, row.updatedAt.getTime()) : undefined;
-    }));
-
+    await publishUserInvalidation(input.ownerId, 'agent.configuration');
     return selectedId ? this.getAgent(selectedId) : null;
   }
 

--- a/services/api/src/adapters/chat.database.adapter.ts
+++ b/services/api/src/adapters/chat.database.adapter.ts
@@ -4,6 +4,7 @@ import { EnrichmentDatabaseAdapter } from './enrichment.database.adapter';
 import { IntentDatabaseAdapter } from './intent.database.adapter';
 import { negotiationDatabaseAdapter, type NegotiationDatabaseAdapter } from './negotiation.database.adapter';
 import { IntentEvents } from '../events/intent.event';
+import { publishUserInvalidation } from '../lib/user-events';
 import { canApplyExpectedIntentUpdate, computeIntentFingerprint } from '../lib/intent/intent.fingerprint';
 import { toPublicNetworkPermissions } from '../lib/network-permissions';
 import { OpportunityDatabaseAdapter } from './opportunity.database.adapter';
@@ -234,6 +235,7 @@ export class ChatDatabaseAdapter {
           userId: schema.intents.userId,
         });
       if (!created) throw new Error('Insert did not return a row');
+      await publishUserInvalidation(created.userId, 'intent.updated', created.id);
       return created;
     } catch (error: unknown) {
       logger.error('ChatDatabaseAdapter.createIntent error', { error: error instanceof Error ? error.message : String(error) });
@@ -292,6 +294,7 @@ export class ChatDatabaseAdapter {
       });
       if (!result) return null;
       if (result.oldFingerprint !== result.newFingerprint) {
+        await publishUserInvalidation(result.updated.userId, 'intent.updated', intentId);
         await IntentEvents.onMaterialUpdated({
           intentId,
           userId: result.updated.userId,
@@ -311,8 +314,9 @@ export class ChatDatabaseAdapter {
       const [archived] = await db.update(schema.intents)
         .set({ archivedAt: new Date(), updatedAt: new Date() })
         .where(eq(schema.intents.id, intentId))
-        .returning({ id: schema.intents.id });
+        .returning({ id: schema.intents.id, userId: schema.intents.userId });
       if (!archived) return { success: false, error: 'Intent not found' };
+      await publishUserInvalidation(archived.userId, 'intent.updated', intentId);
       return { success: true };
     } catch (error: unknown) {
       logger.error('ChatDatabaseAdapter.archiveIntent error', { error: error instanceof Error ? error.message : String(error) });
@@ -777,10 +781,12 @@ export class ChatDatabaseAdapter {
    * stamp instead of waiting out the 24-hour freshness window (IND-482).
    */
   async markIntentFirstDiscoverySucceeded(intentId: string): Promise<void> {
-    await db
+    const [updated] = await db
       .update(intents)
       .set({ firstDiscoverySucceededAt: new Date() })
-      .where(and(eq(intents.id, intentId), isNull(intents.firstDiscoverySucceededAt)));
+      .where(and(eq(intents.id, intentId), isNull(intents.firstDiscoverySucceededAt)))
+      .returning({ userId: intents.userId });
+    if (updated) await publishUserInvalidation(updated.userId, 'intent.updated', intentId);
   }
 
   async getNetworkMemberContext(networkId: string, userId: string) {
@@ -2434,6 +2440,7 @@ export class ChatDatabaseAdapter {
       };
     });
     if (result.kind === 'applied' && result.oldFingerprint !== result.newFingerprint) {
+      await publishUserInvalidation(result.userId, 'intent.updated', result.id);
       await IntentEvents.onMaterialUpdated({
         intentId: result.id,
         userId: result.userId,

--- a/services/api/src/adapters/chat.database.adapter.ts
+++ b/services/api/src/adapters/chat.database.adapter.ts
@@ -310,18 +310,7 @@ export class ChatDatabaseAdapter {
   }
 
   async archiveIntent(intentId: string): Promise<ArchiveResultShape> {
-    try {
-      const [archived] = await db.update(schema.intents)
-        .set({ archivedAt: new Date(), updatedAt: new Date() })
-        .where(eq(schema.intents.id, intentId))
-        .returning({ id: schema.intents.id, userId: schema.intents.userId });
-      if (!archived) return { success: false, error: 'Intent not found' };
-      await publishUserInvalidation(archived.userId, 'intent.updated', intentId);
-      return { success: true };
-    } catch (error: unknown) {
-      logger.error('ChatDatabaseAdapter.archiveIntent error', { error: error instanceof Error ? error.message : String(error) });
-      return { success: false, error: error instanceof Error ? error.message : 'Unknown error' };
-    }
+    return this.intentAdapter.archiveIntent(intentId);
   }
 
   async getNetworkMemberships(userId: string): Promise<NetworkMembershipRow[]> {

--- a/services/api/src/adapters/database.shared.ts
+++ b/services/api/src/adapters/database.shared.ts
@@ -13,6 +13,7 @@ import type { User, NotificationPreferences, OnboardingState } from '../schemas/
 import type { Conversation, ConversationParticipant, ConversationSession, Message } from '../schemas/conversation.schema';
 import type { Id } from '../types/common.types';
 import { log } from '../lib/log';
+import { publishUserInvalidation } from '../lib/user-events';
 
 // Re-export the import surface so domain adapter files import everything from one module.
 export { schema, db, traceAppOperation, normalizeEmbedding, normalizeTelegramSocialValue, log };
@@ -201,6 +202,7 @@ export async function persistProfileIdentityToUser(userId: string, profile: User
   await db.update(users)
     .set({ ...update, updatedAt: new Date() })
     .where(eq(users.id, userId));
+  await publishUserInvalidation(userId, 'agent.configuration');
 }
 
 // HyDE row to document shape (embedding may come as number[] or pg vector)

--- a/services/api/src/adapters/enrichment.database.adapter.ts
+++ b/services/api/src/adapters/enrichment.database.adapter.ts
@@ -1,4 +1,5 @@
 import type { DrizzleDB } from '../lib/drizzle/drizzle';
+import { publishUserInvalidation } from '../lib/user-events';
 
 import { schema, OnboardingState, UserIdentity, asc, buildProfileFromUser, buildProfileWithIdFromUser, db, detectSocialLabel, eq, normalizeTelegramSocialValue, persistProfileIdentityToUser } from './database.shared';
 import { HydeDatabaseAdapter } from './hyde.database.adapter';
@@ -54,6 +55,7 @@ export class EnrichmentDatabaseAdapter {
 
     const updated = result[0];
     if (!updated) return null;
+    await publishUserInvalidation(userId, 'agent.configuration');
     const socials = await this.getUserSocials(userId);
     return {
       id: updated.id,

--- a/services/api/src/adapters/intent.database.adapter.ts
+++ b/services/api/src/adapters/intent.database.adapter.ts
@@ -46,6 +46,7 @@ async function publishIntentLifecycle(
       error: error instanceof Error ? error.message : String(error),
     });
   }
+  await negotiationDatabaseAdapter.notifyIntentNegotiations(intentId);
 }
 
 export class IntentDatabaseAdapter {

--- a/services/api/src/adapters/intent.database.adapter.ts
+++ b/services/api/src/adapters/intent.database.adapter.ts
@@ -3,7 +3,7 @@ import { buildProfileFromUser, schema, ActiveIntentRow, ArchiveResultShape, Crea
 import { IntentEvents } from '../events/intent.event';
 import { emitOpportunityTransitionBestEffort } from '../events/opportunity.event';
 import { canApplyExpectedIntentUpdate, computeIntentFingerprint } from '../lib/intent/intent.fingerprint';
-import { publishUserEvent, type IntentLifecycleWireStatus } from '../lib/user-events';
+import { publishUserEvent, publishUserInvalidation, type IntentLifecycleWireStatus } from '../lib/user-events';
 import { negotiationDatabaseAdapter } from './negotiation.database.adapter';
 
 
@@ -26,7 +26,7 @@ const LIFECYCLE_WIRE_COPY: Record<IntentLifecycleWireStatus, { title: string; bo
  * @param status - Its effective state as agents see it.
  * @param lifecycleVersionMs - Monotonic version, letting agents order frames.
  */
-export async function publishIntentLifecycle(
+async function publishIntentLifecycle(
   userId: string,
   intentId: string,
   status: IntentLifecycleWireStatus,
@@ -49,12 +49,12 @@ export async function publishIntentLifecycle(
 }
 
 export class IntentDatabaseAdapter {
-  /** @returns Existing active principal/intent choices and only explicitly confirmed profile facts for the local agent host. */
-  async listAgentPrincipals() {
+  /** @param userId - Restrict event-triggered discovery to this owner. @returns Active intents and confirmed profile facts. */
+  async listAgentPrincipals(userId?: string) {
     const rows = await db.select({ userId: schema.users.id, name: schema.users.name, intro: schema.users.intro,
       location: schema.users.location, onboarding: schema.users.onboarding, intentId: schema.intents.id, intent: schema.intents.payload })
       .from(schema.intents).innerJoin(schema.users, eq(schema.users.id, schema.intents.userId))
-      .where(and(isNull(schema.intents.archivedAt), activeIntentLifecycleWhere()))
+      .where(and(isNull(schema.intents.archivedAt), activeIntentLifecycleWhere(), userId ? eq(schema.intents.userId, userId) : undefined))
       .orderBy(schema.users.name, schema.intents.createdAt);
     return rows.map((row) => ({ userId: row.userId, name: row.name, intentId: row.intentId, intent: row.intent,
       confirmedProfile: row.onboarding?.profileConfirmedAt ? { name: row.name, intro: row.intro, location: row.location } : null }));
@@ -139,7 +139,7 @@ export class IntentDatabaseAdapter {
           userId: schema.intents.userId,
         });
       if (!created) throw new Error('Insert did not return a row');
-      await publishIntentLifecycle(created.userId, created.id, 'ACTIVE', created.updatedAt.getTime());
+      await publishUserInvalidation(created.userId, 'intent.updated', created.id);
       return created;
     } catch (error: unknown) {
       logger.error('IntentDatabaseAdapter.createIntent error', { error: error instanceof Error ? error.message : String(error) });
@@ -213,21 +213,17 @@ export class IntentDatabaseAdapter {
           updated,
           oldFingerprint,
           newFingerprint: computeIntentFingerprint(updated.payload, updated.summary),
-          status: before.status,
-          archivedAt: before.archivedAt,
         };
       });
       if (!result) return null;
       if (result.oldFingerprint !== result.newFingerprint) {
+        await publishUserInvalidation(result.updated.userId, 'intent.updated', intentId);
         await IntentEvents.onMaterialUpdated({
           intentId,
           userId: result.updated.userId,
           oldFingerprint: result.oldFingerprint,
           newFingerprint: result.newFingerprint,
         });
-        if (!result.archivedAt && (result.status === 'ACTIVE' || result.status == null)) {
-          await publishIntentLifecycle(result.updated.userId, intentId, 'ACTIVE', result.updated.updatedAt.getTime());
-        }
       }
       return result.updated;
     } catch (error: unknown) {

--- a/services/api/src/adapters/negotiation.database.adapter.ts
+++ b/services/api/src/adapters/negotiation.database.adapter.ts
@@ -9,7 +9,7 @@ import { activeIntentLifecycleWhere, and, asc, count, db, desc, eq, inArray, int
 
 import { AgentSessionDatabaseAdapter, type AgentExecution } from './agent-session.database.adapter';
 
-import { publishUserEvent } from '../lib/user-events';
+import { publishNegotiationChange, publishUserEvent } from '../lib/user-events';
 import { RuntimeConflictError } from '../lib/agent/runtime-errors';
 
 export type NegotiationExecution = AgentExecution | { userId: string; agentId: string };
@@ -198,6 +198,22 @@ async function announceOpened(opened: OpenedNegotiation[]): Promise<void> {
  * Persistence for negotiation records and their turn logs.
  */
 export class NegotiationDatabaseAdapter {
+  /** @param intentId - Intent whose committed lifecycle change affects both seats' eligibility. */
+  async notifyIntentNegotiations(intentId: string): Promise<void> {
+    try {
+      const affected = await db.select({
+        initiatorUserId: negotiations.initiatorUserId, initiatorIntentId: negotiations.initiatorIntentId,
+        responderUserId: negotiations.responderUserId, responderIntentId: negotiations.responderIntentId,
+      }).from(negotiations).where(or(eq(negotiations.initiatorIntentId, intentId), eq(negotiations.responderIntentId, intentId)));
+      await publishNegotiationChange(affected.flatMap((row) => [
+        { userId: row.initiatorUserId, intentId: row.initiatorIntentId },
+        { userId: row.responderUserId, intentId: row.responderIntentId },
+      ]));
+    } catch (error: unknown) {
+      logger.error('Failed to notify negotiations after intent lifecycle change', { intentId, error: String(error) });
+    }
+  }
+
   /**
    * Turn every pair discovery scored into an opportunity with a negotiation
    * beside it, and report the ones newly opened.

--- a/services/api/src/adapters/negotiation.database.adapter.ts
+++ b/services/api/src/adapters/negotiation.database.adapter.ts
@@ -602,27 +602,28 @@ export class NegotiationDatabaseAdapter {
   }
 
   /**
-   * Close the negotiations attached to these opportunities.
+   * Close open negotiations and refresh both seats after their opportunities change.
    *
    * Index closes a negotiation itself when consent, an archive, or expiry ends
-   * the opportunity underneath it. No seat declines anything; both seats are
-   * notified after the closure commits.
+   * the opportunity underneath it. Existing settlements stay unchanged, but
+   * both seats still need to refresh the opportunity's human decision state.
    *
-   * @param opportunityIds - Opportunities whose negotiations should close.
+   * @param opportunityIds - Opportunities whose status changes have committed.
    */
   async closeForOpportunities(opportunityIds: string[]): Promise<void> {
     if (opportunityIds.length === 0) return;
-    const closed = await db.update(negotiations)
+    await db.update(negotiations)
       .set({ outcome: 'closed', settledAt: new Date(), awaitingUserId: null, updatedAt: new Date() })
       .where(and(
         inArray(negotiations.opportunityId, opportunityIds),
         isNull(negotiations.settledAt),
-      )).returning({
-        opportunityId: negotiations.opportunityId,
-        initiatorUserId: negotiations.initiatorUserId, initiatorIntentId: negotiations.initiatorIntentId,
-        responderUserId: negotiations.responderUserId, responderIntentId: negotiations.responderIntentId,
-      });
-    await Promise.all(closed.map((row) => publishNegotiationChange([
+      ));
+    const affected = await db.select({
+      opportunityId: negotiations.opportunityId,
+      initiatorUserId: negotiations.initiatorUserId, initiatorIntentId: negotiations.initiatorIntentId,
+      responderUserId: negotiations.responderUserId, responderIntentId: negotiations.responderIntentId,
+    }).from(negotiations).where(inArray(negotiations.opportunityId, opportunityIds));
+    await Promise.all(affected.map((row) => publishNegotiationChange([
       { userId: row.initiatorUserId, intentId: row.initiatorIntentId },
       { userId: row.responderUserId, intentId: row.responderIntentId },
     ], row.opportunityId)));

--- a/services/api/src/adapters/negotiation.database.adapter.ts
+++ b/services/api/src/adapters/negotiation.database.adapter.ts
@@ -89,6 +89,13 @@ export interface NegotiationDetail extends NegotiationView {
   turns: NegotiationTurnRecord[];
 }
 
+/** Change detection without loading counterparties or turn logs. */
+export interface NegotiationScanRecord {
+  opportunityId: string;
+  version: string;
+  eligible: boolean;
+}
+
 /** Structural host contracts; protocol supplies all policy callbacks. */
 export interface NegotiationState {
   initiatorUserId: string;
@@ -396,6 +403,39 @@ export class NegotiationDatabaseAdapter {
     if (options.offset !== undefined) query = query.offset(options.offset);
 
     return this.toViews(await query, userId);
+  }
+
+  /**
+   * Scan one intent's negotiations, including eligibility changes outside the negotiation row.
+   *
+   * @param userId - The seat owner.
+   * @param intentId - The intent bound to the agent session.
+   * @returns IDs, precise database change versions, and current eligibility.
+   */
+  async scanForIntent(userId: string, intentId: string): Promise<NegotiationScanRecord[]> {
+    const networkId = sql<string>`nullif(${opportunities.context}->>'networkId', '')`;
+    // Match state(): both live intents must still belong to their seats and be
+    // assigned to the opportunity's network with a membership for each owner.
+    const eligibleSeats = [
+      { intentId: negotiations.initiatorIntentId, userId: negotiations.initiatorUserId },
+      { intentId: negotiations.responderIntentId, userId: negotiations.responderUserId },
+    ].map((seat) => sql<boolean>`exists (${db.select({ id: intents.id }).from(intents)
+      .innerJoin(intentNetworks, and(eq(intentNetworks.intentId, intents.id), eq(intentNetworks.networkId, networkId)))
+      .innerJoin(networkMembers, and(eq(networkMembers.userId, intents.userId), eq(networkMembers.networkId, networkId)))
+      .where(and(eq(intents.id, seat.intentId), eq(intents.userId, seat.userId), liveIntentWhere()))})`);
+
+    return db.select({
+      opportunityId: negotiations.opportunityId,
+      // Keep Postgres timestamp precision rather than truncating it to JavaScript milliseconds.
+      version: sql<string>`${negotiations.updatedAt}::text`,
+      eligible: sql<boolean>`${and(eq(opportunities.status, 'negotiating'), ...eligibleSeats)}`,
+    }).from(negotiations)
+      .innerJoin(opportunities, eq(opportunities.id, negotiations.opportunityId))
+      .where(or(
+        and(eq(negotiations.initiatorUserId, userId), eq(negotiations.initiatorIntentId, intentId)),
+        and(eq(negotiations.responderUserId, userId), eq(negotiations.responderIntentId, intentId)),
+      ))
+      .orderBy(desc(negotiations.updatedAt));
   }
 
   /**

--- a/services/api/src/adapters/negotiation.database.adapter.ts
+++ b/services/api/src/adapters/negotiation.database.adapter.ts
@@ -605,19 +605,27 @@ export class NegotiationDatabaseAdapter {
    * Close the negotiations attached to these opportunities.
    *
    * Index closes a negotiation itself when consent, an archive, or expiry ends
-   * the opportunity underneath it. No seat declines anything; the next read
-   * shows it closed.
+   * the opportunity underneath it. No seat declines anything; both seats are
+   * notified after the closure commits.
    *
    * @param opportunityIds - Opportunities whose negotiations should close.
    */
   async closeForOpportunities(opportunityIds: string[]): Promise<void> {
     if (opportunityIds.length === 0) return;
-    await db.update(negotiations)
+    const closed = await db.update(negotiations)
       .set({ outcome: 'closed', settledAt: new Date(), awaitingUserId: null, updatedAt: new Date() })
       .where(and(
         inArray(negotiations.opportunityId, opportunityIds),
         isNull(negotiations.settledAt),
-      ));
+      )).returning({
+        opportunityId: negotiations.opportunityId,
+        initiatorUserId: negotiations.initiatorUserId, initiatorIntentId: negotiations.initiatorIntentId,
+        responderUserId: negotiations.responderUserId, responderIntentId: negotiations.responderIntentId,
+      });
+    await Promise.all(closed.map((row) => publishNegotiationChange([
+      { userId: row.initiatorUserId, intentId: row.initiatorIntentId },
+      { userId: row.responderUserId, intentId: row.responderIntentId },
+    ], row.opportunityId)));
   }
 
   /** Resolve each row into the shape its reader's seat is allowed to see. */

--- a/services/api/src/adapters/opportunity.database.adapter.ts
+++ b/services/api/src/adapters/opportunity.database.adapter.ts
@@ -1136,6 +1136,7 @@ export class OpportunityDatabaseAdapter {
       return siblingIds;
     });
     for (const id of ids) emitOpportunityTransitionBestEffort({ id, status: 'accepted' });
+    await negotiationDatabaseAdapter.closeForOpportunities(ids);
     return ids;
   }
 

--- a/services/api/src/adapters/user.database.adapter.ts
+++ b/services/api/src/adapters/user.database.adapter.ts
@@ -1,3 +1,5 @@
+import { publishUserInvalidation } from '../lib/user-events';
+
 import { BasicUserInfo, NewsletterUserData, NotificationPreferences, User, UserWithGraph, and, db, desc, eq, gt, inArray, sessions, userNotificationSettings, userSocials, users } from './database.shared';
 
 /** A live session presented as a device: metadata only, never the token. */
@@ -192,6 +194,9 @@ export class UserDatabaseAdapter {
       .where(eq(users.id, userId))
       .returning();
 
+    if (result[0] && ['name', 'intro', 'location', 'onboarding'].some((key) => key in rest)) {
+      await publishUserInvalidation(userId, 'agent.configuration');
+    }
     return result[0] || null;
   }
 

--- a/services/api/src/lib/agent/negotiation.host.ts
+++ b/services/api/src/lib/agent/negotiation.host.ts
@@ -90,12 +90,11 @@ export class ApiNegotiationHost extends EventEmitter {
     this.subscriber.on('message', (_channel, raw: string) => {
       try {
         const { type } = JSON.parse(raw);
-        if (type === 'intent.lifecycle') this.versions.clear();
-        else if (!['negotiation.turn', 'negotiation.settled', 'negotiation.opened'].includes(type)) return;
+        if (!['intent.lifecycle', 'negotiation.turn', 'negotiation.settled', 'negotiation.opened'].includes(type)) return;
       } catch { return; }
       void this.scan();
     });
-    this.subscriber.on('ready', () => { this.versions.clear(); void this.scan(); });
+    this.subscriber.on('ready', () => { void this.scan(); });
     await this.subscriber.subscribe(...[...new Set(this.users.map(({ userId }) => userEventChannel(userId)))]);
     if (this.stopped) return;
     // Ongoing notifications can keep a scan alive indefinitely; discovery does not gate session readiness.
@@ -144,15 +143,14 @@ export class ApiNegotiationHost extends EventEmitter {
         this.rescan = false;
         if (this.stopped) return;
         for (const principal of this.users) {
-          const records = await this.runDatabase(() => negotiationService.list(principal.userId, { intentId: principal.intentId }));
+          const records = await this.runDatabase(() => negotiationService.scan(principal.userId, principal.intentId));
           for (const record of records) {
             const key = `${principal.id}:${record.opportunityId}`;
-            if (record.settledAt && this.versions.get(key) === record.updatedAt.toISOString()) continue;
+            const version = `${record.version}:${record.eligible}`;
+            if (this.versions.get(key) === version) continue;
             const detail = await this.runDatabase(() => negotiationService.read(record.opportunityId, principal.userId));
             if (this.stopped) return;
             if (!detail) continue;
-            const version = detail.updatedAt.toISOString() + (detail.settledAt ? '' : ':' + detail.protocol.blockedReason);
-            if (this.versions.get(key) === version) continue;
             this.observe(principal, detail);
             this.versions.set(key, version);
             void this.agents.get(principal.id)!.receive({ kind: 'opportunity.matched', opportunityId: record.opportunityId })

--- a/services/api/src/lib/agent/negotiation.host.ts
+++ b/services/api/src/lib/agent/negotiation.host.ts
@@ -10,6 +10,10 @@ import { IntentDatabaseAdapter } from '../../adapters/intent.database.adapter';
 import { negotiationService, type NegotiationDetail } from '../../services/negotiation.service';
 import { userEventChannel } from '../user-events';
 
+const DATABASE_CONCURRENCY = 4;
+let activeDatabaseOperations = 0;
+const databaseQueue: (() => void)[] = [];
+
 export interface ApiPrincipal {
   id: string; userId: string; name: string; intentId: string; intent: string; principalContext: string;
 }
@@ -38,7 +42,7 @@ export class ApiNegotiationHost extends EventEmitter {
     for (const principal of users) {
       const store = new AgentSessionDatabaseAdapter(principal.userId, principal.intentId);
       const read = async (id: string) => {
-        const record = await negotiationService.read(id, principal.userId);
+        const record = await this.runDatabase(() => negotiationService.read(id, principal.userId));
         if (!record || record.intentId !== principal.intentId) throw new Error('Negotiation is outside this principal/intent session.');
         this.observe(principal, record);
         return this.record(record);
@@ -55,7 +59,7 @@ export class ApiNegotiationHost extends EventEmitter {
         owner: { id: principal.userId, name: principal.name }, intent: { id: principal.intentId, payload: principal.intent },
         principalContext: principal.principalContext, guidance: NEGOTIATION_GUIDANCE,
         client: { readNegotiation: read, submitTurn: async (id, turn) => {
-          const result = await negotiationService.submitTurn(id, principal.userId, turn, store.execution);
+          const result = await this.runDatabase(() => negotiationService.submitTurn(id, principal.userId, turn, store.execution));
           if ('rejection' in result) throw new Error(result.rejection);
           this.observe(principal, result);
           void this.scan();
@@ -79,7 +83,9 @@ export class ApiNegotiationHost extends EventEmitter {
     for (const userId of new Set(this.users.map((user) => user.userId))) {
       if ((await registry.listAgentsForUser(userId)).some((agent) => agent.ownerId === userId && agent.type === 'external' && agent.handleNegotiations)) throw new Error('A selected principal already has an external negotiation executor. Disable that binding before running its local agent.');
     }
+    if (this.stopped) return;
     await Promise.all([...this.agents.values()].map((agent) => agent.start()));
+    if (this.stopped) return;
     this.subscriber = createRedisClient();
     this.subscriber.on('message', (_channel, raw: string) => {
       try {
@@ -92,6 +98,7 @@ export class ApiNegotiationHost extends EventEmitter {
     this.subscriber.on('ready', () => { this.versions.clear(); void this.scan(); });
     await this.subscriber.subscribe(...[...new Set(this.users.map(({ userId }) => userEventChannel(userId)))]);
     await this.scan();
+    if (this.stopped) return;
   }
 
   private record(record: NegotiationDetail): Negotiation {
@@ -110,6 +117,24 @@ export class ApiNegotiationHost extends EventEmitter {
     this.emit('change');
   }
 
+  /** Share capacity across hosts for one database operation, never a scan or agent task that may enqueue more work. */
+  private async runDatabase<T>(operation: () => Promise<T>): Promise<T> {
+    if (activeDatabaseOperations === DATABASE_CONCURRENCY) {
+      await new Promise<void>((resolve) => databaseQueue.push(resolve));
+    } else {
+      activeDatabaseOperations++;
+    }
+    try {
+      if (this.stopped) throw new Error('Negotiation host is stopped.');
+      return await operation();
+    } finally {
+      // Transfer the slot directly to the oldest waiter so new work cannot jump the queue.
+      const next = databaseQueue.shift();
+      if (next) next();
+      else activeDatabaseOperations--;
+    }
+  }
+
   private scan(): Promise<void> {
     this.rescan = true;
     if (this.scanning) return this.scanning;
@@ -117,23 +142,24 @@ export class ApiNegotiationHost extends EventEmitter {
       do {
         this.rescan = false;
         if (this.stopped) return;
-        await Promise.all(this.users.map(async (principal) => {
-          const records = await negotiationService.list(principal.userId, { intentId: principal.intentId });
-          await Promise.all(records.map(async (record) => {
+        for (const principal of this.users) {
+          const records = await this.runDatabase(() => negotiationService.list(principal.userId, { intentId: principal.intentId }));
+          for (const record of records) {
             const key = `${principal.id}:${record.opportunityId}`;
-            if (record.settledAt && this.versions.get(key) === record.updatedAt.toISOString()) return;
-            const detail = await negotiationService.read(record.opportunityId, principal.userId);
-            if (!detail || this.stopped) return;
+            if (record.settledAt && this.versions.get(key) === record.updatedAt.toISOString()) continue;
+            const detail = await this.runDatabase(() => negotiationService.read(record.opportunityId, principal.userId));
+            if (this.stopped) return;
+            if (!detail) continue;
             const version = detail.updatedAt.toISOString() + (detail.settledAt ? '' : ':' + detail.protocol.blockedReason);
-            if (this.versions.get(key) === version) return;
+            if (this.versions.get(key) === version) continue;
             this.observe(principal, detail);
             this.versions.set(key, version);
             void this.agents.get(principal.id)!.receive({ kind: 'opportunity.matched', opportunityId: record.opportunityId })
               .catch((error: unknown) => { this.agentStatus = String(error); this.emit('change'); });
-          }));
-        }));
+          }
+        }
       } while (this.rescan && !this.stopped);
-    })().catch((error: unknown) => { this.agentStatus = 'Could not refresh matches: ' + String(error); this.emit('change'); })
+    })().catch((error: unknown) => { if (!this.stopped) { this.agentStatus = 'Could not refresh matches: ' + String(error); this.emit('change'); } })
       .finally(() => { this.scanning = undefined; });
     return this.scanning;
   }
@@ -141,8 +167,7 @@ export class ApiNegotiationHost extends EventEmitter {
   /** Stop the local runtime and release its leases; conversations and matches remain in the database. */
   async stop(): Promise<void> {
     this.stopped = true;
-    await this.scanning;
-    await Promise.allSettled([...this.agents.values()].map((agent) => agent.stop()));
+    await Promise.allSettled([this.scanning, ...[...this.agents.values()].map((agent) => agent.stop())]);
     this.subscriber?.disconnect();
   }
 }

--- a/services/api/src/lib/agent/negotiation.host.ts
+++ b/services/api/src/lib/agent/negotiation.host.ts
@@ -69,9 +69,9 @@ export class ApiNegotiationHost extends EventEmitter {
     }
   }
 
-  /** @returns Existing active intents and confirmed profile context; no profile synthesis or scenario seeding. */
-  static async principals(): Promise<ApiPrincipal[]> {
-    return (await new IntentDatabaseAdapter().listAgentPrincipals()).map((row) => ({
+  /** @param userId - Owner whose context changed, or all owners at boot. @returns Active intents and confirmed profile context. */
+  static async principals(userId?: string): Promise<ApiPrincipal[]> {
+    return (await new IntentDatabaseAdapter().listAgentPrincipals(userId)).map((row) => ({
       id: row.intentId, userId: row.userId, intentId: row.intentId, name: row.name, intent: row.intent,
       principalContext: row.confirmedProfile ? JSON.stringify({ confirmedProfile: row.confirmedProfile }) : 'No confirmed profile is available. Ask for missing personal facts.',
     }));
@@ -89,8 +89,9 @@ export class ApiNegotiationHost extends EventEmitter {
     this.subscriber = createRedisClient();
     this.subscriber.on('message', (_channel, raw: string) => {
       try {
-        const { type } = JSON.parse(raw);
+        const { type, data } = JSON.parse(raw);
         if (!['intent.lifecycle', 'negotiation.turn', 'negotiation.settled', 'negotiation.opened'].includes(type)) return;
+        if (!this.users.some(({ intentId }) => intentId === data?.intentId)) return;
       } catch { return; }
       void this.scan();
     });

--- a/services/api/src/lib/agent/negotiation.host.ts
+++ b/services/api/src/lib/agent/negotiation.host.ts
@@ -77,7 +77,7 @@ export class ApiNegotiationHost extends EventEmitter {
     }));
   }
 
-  /** Restore sessions and relay existing/new match observations independently of TUI selection. @throws When a selected principal has an external negotiation executor. */
+  /** Restore sessions and subscribe to background match observations independently of TUI selection. @throws When a selected principal has an external negotiation executor. */
   async start(): Promise<void> {
     const registry = new AgentDatabaseAdapter();
     for (const userId of new Set(this.users.map((user) => user.userId))) {
@@ -97,8 +97,9 @@ export class ApiNegotiationHost extends EventEmitter {
     });
     this.subscriber.on('ready', () => { this.versions.clear(); void this.scan(); });
     await this.subscriber.subscribe(...[...new Set(this.users.map(({ userId }) => userEventChannel(userId)))]);
-    await this.scan();
     if (this.stopped) return;
+    // Ongoing notifications can keep a scan alive indefinitely; discovery does not gate session readiness.
+    void this.scan();
   }
 
   private record(record: NegotiationDetail): Negotiation {

--- a/services/api/src/lib/agent/negotiation.host.ts
+++ b/services/api/src/lib/agent/negotiation.host.ts
@@ -4,7 +4,7 @@ import { NegotiationAgent, type Model, type Negotiation, type NegotiationHost } 
 import { NEGOTIATION_GUIDANCE } from '@indexnetwork/protocol';
 
 import { AgentDatabaseAdapter } from '../../adapters/agent.database.adapter';
-import { AgentSessionDatabaseAdapter } from '../../adapters/agent-session.database.adapter';
+import { AgentSessionDatabaseAdapter, AgentSessionIneligibleError } from '../../adapters/agent-session.database.adapter';
 import { createRedisClient } from '../../adapters/cache.adapter';
 import { IntentDatabaseAdapter } from '../../adapters/intent.database.adapter';
 import { negotiationService, type NegotiationDetail } from '../../services/negotiation.service';
@@ -81,7 +81,7 @@ export class ApiNegotiationHost extends EventEmitter {
   async start(): Promise<void> {
     const registry = new AgentDatabaseAdapter();
     for (const userId of new Set(this.users.map((user) => user.userId))) {
-      if ((await registry.listAgentsForUser(userId)).some((agent) => agent.ownerId === userId && agent.type === 'external' && agent.handleNegotiations)) throw new Error('A selected principal already has an external negotiation executor. Disable that binding before running its local agent.');
+      if ((await registry.listAgentsForUser(userId)).some((agent) => agent.ownerId === userId && agent.type === 'external' && agent.handleNegotiations)) throw new AgentSessionIneligibleError('A selected principal already has an external negotiation executor. Disable that binding before running its local agent.');
     }
     if (this.stopped) return;
     await Promise.all([...this.agents.values()].map((agent) => agent.start()));
@@ -90,7 +90,7 @@ export class ApiNegotiationHost extends EventEmitter {
     this.subscriber.on('message', (_channel, raw: string) => {
       try {
         const { type, data } = JSON.parse(raw);
-        if (!['intent.lifecycle', 'negotiation.turn', 'negotiation.settled', 'negotiation.opened'].includes(type)) return;
+        if (!['negotiation.changed', 'negotiation.opened'].includes(type)) return;
         if (!this.users.some(({ intentId }) => intentId === data?.intentId)) return;
       } catch { return; }
       void this.scan();

--- a/services/api/src/lib/user-events.ts
+++ b/services/api/src/lib/user-events.ts
@@ -14,6 +14,9 @@ import { log } from './log';
  * `intent.lifecycle` and `negotiation.opened` are scoped to a signal instead:
  * whether the agent should be working it at all, and that discovery gave it
  * something to work.
+ * `negotiation.changed` refreshes both seats after a turn or a related intent's
+ * lifecycle change. It does not imply that either seat owes the next turn;
+ * `negotiation.turn` remains addressed to the seat that does.
  *
  * `question.pending` is scoped to a signal too, but the other way round: the
  * personal agent stopped and cannot continue until its owner answers, so the
@@ -28,6 +31,7 @@ export type UserEventType =
   | 'negotiation.turn'
   | 'negotiation.settled'
   | 'negotiation.opened'
+  | 'negotiation.changed'
   | 'intent.lifecycle'
   | 'intent.updated'
   | 'agent.configuration'
@@ -125,6 +129,27 @@ export async function publishUserInvalidation(
   } catch (error: unknown) {
     log.lib.from('user-events').error('Failed to publish user invalidation', { userId, intentId, type, error: String(error) });
   }
+}
+
+/**
+ * Refresh each affected seat without announcing that its owner owes a turn.
+ * @param seats - Negotiation seats affected by a committed change.
+ * @param opportunityId - Changed negotiation, or all negotiations for these seats after a lifecycle change.
+ */
+export async function publishNegotiationChange(
+  seats: readonly { userId: string; intentId: string }[],
+  opportunityId?: string,
+): Promise<void> {
+  const affected = new Map(seats.map((seat) => [JSON.stringify([seat.userId, seat.intentId]), seat]));
+  await Promise.all([...affected.values()].map(async ({ userId, intentId }) => {
+    try {
+      await publishUserEvent(userId, {
+        type: 'negotiation.changed', id: crypto.randomUUID(), title: '', body: '', data: { intentId, opportunityId },
+      });
+    } catch (error: unknown) {
+      log.lib.from('user-events').error('Failed to publish negotiation change', { userId, intentId, opportunityId, error: String(error) });
+    }
+  }));
 }
 
 /**

--- a/services/api/src/lib/user-events.ts
+++ b/services/api/src/lib/user-events.ts
@@ -1,4 +1,5 @@
 import { getRedisClient } from '../adapters/cache.adapter';
+import { log } from './log';
 
 /**
  * One channel per user carries every realtime frame, and nothing on the wire
@@ -28,6 +29,9 @@ export type UserEventType =
   | 'negotiation.settled'
   | 'negotiation.opened'
   | 'intent.lifecycle'
+  | 'intent.updated'
+  | 'agent.configuration'
+  | 'agent.status'
   | 'message';
 
 /**
@@ -103,6 +107,24 @@ export async function publishUserEvent(
   if (!userId) return;
   const publisher = getRedisClient();
   await publisher.publish(userEventChannel(userId), JSON.stringify(event));
+}
+
+/**
+ * Invalidate affected views after a committed change, without retrying delivery.
+ * @param userId - Owner whose agents and views should refresh.
+ * @param type - Intent content, agent configuration, or runtime availability change.
+ * @param intentId - Affected intent, when the change is scoped to one.
+ */
+export async function publishUserInvalidation(
+  userId: string,
+  type: 'intent.updated' | 'agent.configuration' | 'agent.status',
+  intentId?: string,
+): Promise<void> {
+  try {
+    await publishUserEvent(userId, { type, id: crypto.randomUUID(), title: '', body: '', data: { intentId } });
+  } catch (error: unknown) {
+    log.lib.from('user-events').error('Failed to publish user invalidation', { userId, intentId, type, error: String(error) });
+  }
 }
 
 /**

--- a/services/api/src/services/negotiation.service.ts
+++ b/services/api/src/services/negotiation.service.ts
@@ -1,7 +1,7 @@
 import { Negotiations, observeNegotiation, decideNegotiationOpening, pairKeyOf, type NegotiationTurn } from '@indexnetwork/protocol';
 
 import { log } from '../lib/log';
-import { negotiationDatabaseAdapter, type NegotiationDatabaseAdapter, type NegotiationDetail as StoredNegotiationDetail, type NegotiationExecution, type NegotiationTurnAction, type NegotiationView, type OpenedNegotiation, type SubmitTurnRejection } from '../adapters/negotiation.database.adapter';
+import { negotiationDatabaseAdapter, type NegotiationDatabaseAdapter, type NegotiationDetail as StoredNegotiationDetail, type NegotiationExecution, type NegotiationScanRecord, type NegotiationTurnAction, type NegotiationView, type OpenedNegotiation, type SubmitTurnRejection } from '../adapters/negotiation.database.adapter';
 import { publishUserEvent } from '../lib/user-events';
 
 const logger = log.service.from('NegotiationService');
@@ -49,6 +49,17 @@ export class NegotiationService {
     options: { intentId?: string; open?: boolean; counterpartyUserId?: string; limit?: number; offset?: number } = {},
   ): Promise<NegotiationView[]> {
     return this.negotiations.listForUser(userId, options);
+  }
+
+  /**
+   * Discover changes without loading negotiation details.
+   *
+   * @param userId - The seat owner.
+   * @param intentId - The intent bound to the agent session.
+   * @returns Negotiation IDs, change versions, and current eligibility.
+   */
+  async scan(userId: string, intentId: string): Promise<NegotiationScanRecord[]> {
+    return this.negotiations.scanForIntent(userId, intentId);
   }
 
   /**

--- a/services/api/src/services/negotiation.service.ts
+++ b/services/api/src/services/negotiation.service.ts
@@ -2,7 +2,7 @@ import { Negotiations, observeNegotiation, decideNegotiationOpening, pairKeyOf, 
 
 import { log } from '../lib/log';
 import { negotiationDatabaseAdapter, type NegotiationDatabaseAdapter, type NegotiationDetail as StoredNegotiationDetail, type NegotiationExecution, type NegotiationScanRecord, type NegotiationTurnAction, type NegotiationView, type OpenedNegotiation, type SubmitTurnRejection } from '../adapters/negotiation.database.adapter';
-import { publishUserEvent } from '../lib/user-events';
+import { publishNegotiationChange, publishUserEvent } from '../lib/user-events';
 
 const logger = log.service.from('NegotiationService');
 
@@ -103,8 +103,8 @@ export class NegotiationService {
     const result = await capability.execute(opportunityId, callerUserId, turn);
     if (!result.ok) return { rejection: result.rejection };
     const record = (await this.read(opportunityId, callerUserId))!;
-    const other = (await this.read(opportunityId, record.counterparty.userId))!;
-    const seats = [{ userId: callerUserId, intentId: record.intentId }, { userId: record.counterparty.userId, intentId: other.intentId }];
+    const seats = [{ userId: callerUserId, intentId: record.intentId }, { userId: record.counterparty.userId, intentId: record.counterparty.intentId }];
+    await publishNegotiationChange(seats, opportunityId);
     const ended = result.outcome !== null || result.blockedReason !== null;
     await Promise.all(seats.filter((seat) => ended || seat.userId !== callerUserId).map((seat) => this.notify(seat.userId, {
       type: result.outcome ? 'negotiation.settled' : 'negotiation.turn',

--- a/services/api/src/services/opportunity.service.ts
+++ b/services/api/src/services/opportunity.service.ts
@@ -786,6 +786,13 @@ export class OpportunityService {
     // Best-effort side effects — their failure must not block the user from
     // reaching the chat. The opportunity is already accepted and the DM already
     // resolved.
+    await this.negotiations.closeForOpportunities([opportunityId]).catch((err) => {
+      startChatLogger.error('closeForOpportunities failed (non-blocking)', {
+        opportunityId,
+        userId,
+        error: err,
+      });
+    });
     if (options?.scopeType !== 'intent') {
       await this.db.acceptSiblingOpportunities(userId, counterpart.userId, opportunityId).catch((err) => {
         startChatLogger.error('acceptSiblingOpportunities failed (non-blocking)', {

--- a/services/api/src/services/personal-agent.service.ts
+++ b/services/api/src/services/personal-agent.service.ts
@@ -26,6 +26,7 @@ interface Session {
   host: ApiNegotiationHost;
   ready: Promise<void>;
   active: boolean;
+  stopping?: Promise<void>;
 }
 
 /** Owns the API process's personal agents independently of HTTP requests and browser connections. */
@@ -41,7 +42,7 @@ export class PersonalAgentService {
 
   constructor(private readonly model: Model) {}
 
-  /** Restore eligible sessions at boot and reconcile when a signal's lifecycle or Redis connection changes. */
+  /** Schedule eligible sessions at boot and reconcile new/changed intents and executor bindings in the background. */
   async start(): Promise<void> {
     this.running = true;
     this.subscriber = createRedisClient();
@@ -62,34 +63,47 @@ export class PersonalAgentService {
         .map(async (userId) => await this.registry.getSelectedNegotiator(userId) ? userId : null))).filter((id) => id !== null));
       this.principals = new Map(principals.map((principal) => [principal.id, principal]));
       const desired = new Map(principals.filter(({ userId }) => !externalOwners.has(userId)).map((principal) => [principal.id, principal]));
-      await Promise.all([...this.sessions].map(async ([id, session]) => {
-        if (JSON.stringify(desired.get(id)) === JSON.stringify(session.principal) && !session.host.agents.get(id)?.stopped) return;
-        this.sessions.delete(id);
-        await session.host.stop();
-      }));
+      for (const [id, session] of this.sessions) {
+        if (session.stopping) continue;
+        if (JSON.stringify(desired.get(id)) === JSON.stringify(session.principal) && !session.host.agents.get(id)?.stopped) continue;
+        void this.stopSession(session);
+      }
       if (!this.running) return;
-      await Promise.all([...desired.values()].map(async (principal) => {
-        if (this.sessions.has(principal.id) || !this.running) return;
+      for (const principal of desired.values()) {
+        if (this.sessions.has(principal.id)) continue;
         const host = new ApiNegotiationHost([principal], this.model);
         const session: Session = { principal, host, active: false, ready: Promise.resolve() };
         this.sessions.set(principal.id, session);
         session.ready = host.start().then(() => {
+          if (!this.running || session.stopping || this.sessions.get(principal.id) !== session) return;
           session.active = true;
           this.errors.delete(principal.id);
         });
-        try { await session.ready; }
-        catch (error) {
-          this.sessions.delete(principal.id);
-          await host.stop();
+        void session.ready.catch((error: unknown) => {
+          if (session.stopping || this.sessions.get(principal.id) !== session) return;
           const reason = error instanceof Error ? error.message : String(error);
           if (this.errors.get(principal.id) !== reason) logger.warn('Personal agent could not start', { intentId: principal.intentId, error: reason });
           this.errors.set(principal.id, reason);
-        }
-      }));
+          void this.stopSession(session);
+        });
+      }
     })().catch((error: unknown) => {
       logger.error('Personal-agent reconciliation failed', { error: error instanceof Error ? error.message : String(error) });
     }).finally(() => { this.checking = undefined; });
     return this.checking;
+  }
+
+  /** Keep an intent reserved until its previous host has finished releasing its lease. */
+  private stopSession(session: Session): Promise<void> {
+    if (session.stopping) return session.stopping;
+    session.active = false;
+    session.stopping = session.host.stop().then(() => {
+      if (this.sessions.get(session.principal.id) === session) this.sessions.delete(session.principal.id);
+    });
+    void session.stopping.catch((error: unknown) => {
+      logger.error('Personal agent could not stop', { intentId: session.principal.intentId, error: error instanceof Error ? error.message : String(error) });
+    });
+    return session.stopping;
   }
 
   /** @param userId - Authenticated owner. @param intentId - Intent conversation being read. @returns Persisted question and current runtime availability. @throws When the caller does not own the intent. */
@@ -102,7 +116,7 @@ export class PersonalAgentService {
     if (external) return { status: 'external', pending: null, queuedQuestions: 0 };
     const session = this.sessions.get(intentId);
     const agent = session?.host.agents.get(intentId);
-    const status = agent?.stopped ? 'unavailable' : session?.active ? 'running' : session ? 'starting'
+    const status = session?.stopping || agent?.stopped ? 'unavailable' : session?.active ? 'running' : session ? 'starting'
       : this.principals.has(intentId) ? 'unavailable' : 'paused';
     return { status, pending: status === 'running' ? saved?.state?.inbox.question ?? null : null,
       queuedQuestions: agent?.queuedQuestions ?? 0 };
@@ -121,8 +135,10 @@ export class PersonalAgentService {
     if (!this.sessions.has(input.intentId) || this.sessions.get(input.intentId)?.host.agents.get(input.intentId)?.stopped) await this.reconcile();
     const session = this.sessions.get(input.intentId);
     if (!session || session.principal.userId !== input.userId) throw new PersonalAgentError('Your personal agent is unavailable. The intent must be active and its session must be free.', 409);
+    if (session.stopping) throw new PersonalAgentError('Your personal agent is restarting. Please try again.', 503);
     try { await session.ready; }
     catch { throw new PersonalAgentError('Your personal agent could not start. Please try again.', 503); }
+    if (!this.running || session.stopping || this.sessions.get(input.intentId) !== session) throw new PersonalAgentError('Your personal agent is restarting. Please try again.', 503);
     const saved = await AgentSessionDatabaseAdapter.readSession(input.userId, input.intentId);
     if (saved?.conversationId !== input.conversationId) throw new PersonalAgentError('Agent conversation not found.', 404);
     const agent = session.host.agents.get(input.intentId)!;
@@ -137,7 +153,7 @@ export class PersonalAgentService {
     this.running = false;
     this.subscriber?.disconnect();
     await this.checking;
-    await Promise.all([...this.sessions.values()].map(({ host }) => host.stop()));
+    await Promise.all([...this.sessions.values()].map((session) => this.stopSession(session)));
     this.sessions.clear();
   }
 }

--- a/services/api/src/services/personal-agent.service.ts
+++ b/services/api/src/services/personal-agent.service.ts
@@ -1,7 +1,7 @@
 import type { Model, PrincipalQuestion } from '@indexnetwork/agent';
 
 import { AgentDatabaseAdapter } from '../adapters/agent.database.adapter';
-import { AgentSessionDatabaseAdapter } from '../adapters/agent-session.database.adapter';
+import { AgentSessionDatabaseAdapter, AgentSessionIneligibleError, AgentSessionLeaseConflict } from '../adapters/agent-session.database.adapter';
 import { createRedisClient } from '../adapters/cache.adapter';
 import { IntentDatabaseAdapter } from '../adapters/intent.database.adapter';
 import { ApiNegotiationHost, type ApiPrincipal } from '../lib/agent/negotiation.host';
@@ -9,6 +9,7 @@ import { log } from '../lib/log';
 import { publishUserInvalidation, userEventChannel } from '../lib/user-events';
 
 const logger = log.service.from('PersonalAgentService');
+const MAX_STARTUP_RETRIES = 3;
 
 /** An owner-facing input failure; no agent work is acknowledged by this error. */
 export class PersonalAgentError extends Error {
@@ -29,6 +30,12 @@ interface Session {
   stopping?: Promise<void>;
 }
 
+interface StartupRetry {
+  principal: ApiPrincipal;
+  attempts: number;
+  timer?: ReturnType<typeof setTimeout>;
+}
+
 /** Owns the API process's personal agents independently of HTTP requests and browser connections. */
 export class PersonalAgentService {
   private readonly sessions = new Map<string, Session>();
@@ -37,6 +44,7 @@ export class PersonalAgentService {
   private readonly errors = new Map<string, string>();
   private readonly principals = new Map<string, ApiPrincipal>();
   private readonly desired = new Map<string, ApiPrincipal>();
+  private readonly retries = new Map<string, StartupRetry>();
   private readonly pendingOwners = new Set<string | undefined>();
   private running = false;
   private checking?: Promise<void>;
@@ -49,11 +57,14 @@ export class PersonalAgentService {
     this.running = true;
     this.subscriber = createRedisClient();
     this.subscriber.on('pmessage', (_pattern, channel: string, raw: string) => {
+      const ownerId = channel.slice(userEventChannel('').length);
       try {
-        const { type } = JSON.parse(raw);
+        const { type, data } = JSON.parse(raw);
         if (!['intent.lifecycle', 'intent.updated', 'agent.configuration'].includes(type)) return;
+        if (type === 'intent.lifecycle' && ['PAUSED', 'ARCHIVED'].includes(data?.status)
+          && this.retries.get(data.intentId)?.principal.userId === ownerId) this.cancelRetry(data.intentId);
       } catch { return; }
-      void this.reconcile(channel.slice(userEventChannel('').length));
+      void this.reconcile(ownerId);
     });
     await this.subscriber.psubscribe(userEventChannel('*'));
     this.subscriber.on('ready', () => { void this.reconcile(); });
@@ -81,6 +92,10 @@ export class PersonalAgentService {
           this.principals.set(principal.id, principal);
           if (!externalOwners.has(principal.userId)) this.desired.set(principal.id, principal);
         }
+        for (const [id, retry] of this.retries) {
+          if (ownerId !== undefined && retry.principal.userId !== ownerId) continue;
+          if (JSON.stringify(this.desired.get(id)) !== JSON.stringify(retry.principal)) this.cancelRetry(id);
+        }
         for (const [id, session] of this.sessions) {
           if (ownerId !== undefined && session.principal.userId !== ownerId) continue;
           if (!session.stopping && JSON.stringify(this.desired.get(id)) === JSON.stringify(session.principal)
@@ -104,8 +119,9 @@ export class PersonalAgentService {
     return this.checking;
   }
 
-  private startSession(principal: ApiPrincipal): void {
+  private startSession(principal: ApiPrincipal, retry?: StartupRetry): void {
     if (!this.running || this.sessions.has(principal.id)) return;
+    if (this.retries.has(principal.id) && this.retries.get(principal.id) !== retry) return;
     const host = new ApiNegotiationHost([principal], this.model);
     const session: Session = { principal, host, active: false, ready: Promise.resolve() };
     this.sessions.set(principal.id, session);
@@ -113,6 +129,7 @@ export class PersonalAgentService {
       if (!this.running || session.stopping || this.sessions.get(principal.id) !== session) return;
       session.active = true;
       this.errors.delete(principal.id);
+      this.cancelRetry(principal.id);
       void publishUserInvalidation(principal.userId, 'agent.status', principal.intentId);
     });
     void session.ready.catch((error: unknown) => {
@@ -120,8 +137,40 @@ export class PersonalAgentService {
       const reason = error instanceof Error ? error.message : String(error);
       if (this.errors.get(principal.id) !== reason) logger.warn('Personal agent could not start', { intentId: principal.intentId, error: reason });
       this.errors.set(principal.id, reason);
-      void this.stopSession(session);
+      const retry = this.retries.get(principal.id) ?? { principal, attempts: 0 };
+      this.retries.set(principal.id, retry);
+      void this.stopSession(session).then(() => this.retrySession(session, retry, error), () => {});
     });
+  }
+
+  /** Retry only a failed intent, after its previous host has released ownership. */
+  private retrySession(session: Session, retry: StartupRetry, error: unknown): void {
+    const { id } = session.principal;
+    if (!this.running || this.retries.get(id) !== retry) return;
+    if (!this.desired.has(id) || error instanceof AgentSessionIneligibleError) {
+      this.cancelRetry(id);
+      if (this.desired.get(id) === session.principal) {
+        this.desired.delete(id);
+        this.principals.delete(id);
+      }
+      return;
+    }
+    if (retry.attempts === MAX_STARTUP_RETRIES) return;
+    const delay = error instanceof AgentSessionLeaseConflict
+      ? Math.max(0, error.retryAt - Date.now()) + 250
+      : 1_000 * 2 ** retry.attempts;
+    retry.attempts++;
+    retry.timer = setTimeout(() => {
+      retry.timer = undefined;
+      const principal = this.desired.get(id);
+      if (this.running && this.retries.get(id) === retry && principal) this.startSession(principal, retry);
+    }, delay);
+    retry.timer.unref();
+  }
+
+  private cancelRetry(intentId: string): void {
+    clearTimeout(this.retries.get(intentId)?.timer);
+    this.retries.delete(intentId);
   }
 
   /** Keep an intent reserved until its previous host has finished releasing its lease. */
@@ -164,7 +213,10 @@ export class PersonalAgentService {
     if (!await this.intents.isOwnedByUser(input.intentId, input.userId)) throw new PersonalAgentError('Intent not found.', 404);
     if (await this.registry.getSelectedNegotiator(input.userId)) return null;
     if (!this.running) throw new PersonalAgentError('Your personal agent is unavailable.', 503);
-    if (!this.sessions.has(input.intentId) || this.sessions.get(input.intentId)?.host.agents.get(input.intentId)?.stopped) await this.reconcile(input.userId);
+    if (!this.sessions.has(input.intentId) || this.sessions.get(input.intentId)?.host.agents.get(input.intentId)?.stopped) {
+      this.cancelRetry(input.intentId);
+      await this.reconcile(input.userId);
+    }
     const session = this.sessions.get(input.intentId);
     if (!session || session.principal.userId !== input.userId) throw new PersonalAgentError('Your personal agent is unavailable. The intent must be active and its session must be free.', 409);
     if (session.stopping) throw new PersonalAgentError('Your personal agent is restarting. Please try again.', 503);
@@ -185,6 +237,7 @@ export class PersonalAgentService {
     this.running = false;
     this.subscriber?.disconnect();
     this.pendingOwners.clear();
+    for (const id of this.retries.keys()) this.cancelRetry(id);
     await this.checking;
     await Promise.all([...this.sessions.values()].map((session) => this.stopSession(session)));
     this.sessions.clear();

--- a/services/api/src/services/personal-agent.service.ts
+++ b/services/api/src/services/personal-agent.service.ts
@@ -6,7 +6,7 @@ import { createRedisClient } from '../adapters/cache.adapter';
 import { IntentDatabaseAdapter } from '../adapters/intent.database.adapter';
 import { ApiNegotiationHost, type ApiPrincipal } from '../lib/agent/negotiation.host';
 import { log } from '../lib/log';
-import { userEventChannel } from '../lib/user-events';
+import { publishUserInvalidation, userEventChannel } from '../lib/user-events';
 
 const logger = log.service.from('PersonalAgentService');
 
@@ -35,62 +35,93 @@ export class PersonalAgentService {
   private readonly intents = new IntentDatabaseAdapter();
   private readonly registry = new AgentDatabaseAdapter();
   private readonly errors = new Map<string, string>();
-  private principals = new Map<string, ApiPrincipal>();
+  private readonly principals = new Map<string, ApiPrincipal>();
+  private readonly desired = new Map<string, ApiPrincipal>();
+  private readonly pendingOwners = new Set<string | undefined>();
   private running = false;
   private checking?: Promise<void>;
   private subscriber?: ReturnType<typeof createRedisClient>;
 
   constructor(private readonly model: Model) {}
 
-  /** Schedule eligible sessions at boot and reconcile new/changed intents and executor bindings in the background. */
+  /** Subscribe before boot discovery, then reconcile only owners whose intent or executor configuration changes. */
   async start(): Promise<void> {
     this.running = true;
     this.subscriber = createRedisClient();
-    this.subscriber.on('pmessage', (_pattern, _channel, raw: string) => {
-      try { if (JSON.parse(raw).type !== 'intent.lifecycle') return; } catch { return; }
-      void this.reconcile();
+    this.subscriber.on('pmessage', (_pattern, channel: string, raw: string) => {
+      try {
+        const { type } = JSON.parse(raw);
+        if (!['intent.lifecycle', 'intent.updated', 'agent.configuration'].includes(type)) return;
+      } catch { return; }
+      void this.reconcile(channel.slice(userEventChannel('').length));
     });
-    this.subscriber.on('ready', () => { void this.reconcile(); });
     await this.subscriber.psubscribe(userEventChannel('*'));
-    await this.reconcile();
+    this.subscriber.on('ready', () => { void this.reconcile(); });
+    if (this.running) await this.reconcile();
   }
 
-  private reconcile(): Promise<void> {
+  private reconcile(userId?: string): Promise<void> {
+    if (!this.running) return Promise.resolve();
+    this.pendingOwners.add(userId);
     if (this.checking) return this.checking;
     this.checking = (async () => {
-      const principals = await ApiNegotiationHost.principals();
-      const externalOwners = new Set((await Promise.all([...new Set(principals.map(({ userId }) => userId))]
-        .map(async (userId) => await this.registry.getSelectedNegotiator(userId) ? userId : null))).filter((id) => id !== null));
-      this.principals = new Map(principals.map((principal) => [principal.id, principal]));
-      const desired = new Map(principals.filter(({ userId }) => !externalOwners.has(userId)).map((principal) => [principal.id, principal]));
-      for (const [id, session] of this.sessions) {
-        if (session.stopping) continue;
-        if (JSON.stringify(desired.get(id)) === JSON.stringify(session.principal) && !session.host.agents.get(id)?.stopped) continue;
-        void this.stopSession(session);
-      }
-      if (!this.running) return;
-      for (const principal of desired.values()) {
-        if (this.sessions.has(principal.id)) continue;
-        const host = new ApiNegotiationHost([principal], this.model);
-        const session: Session = { principal, host, active: false, ready: Promise.resolve() };
-        this.sessions.set(principal.id, session);
-        session.ready = host.start().then(() => {
-          if (!this.running || session.stopping || this.sessions.get(principal.id) !== session) return;
-          session.active = true;
-          this.errors.delete(principal.id);
-        });
-        void session.ready.catch((error: unknown) => {
-          if (session.stopping || this.sessions.get(principal.id) !== session) return;
-          const reason = error instanceof Error ? error.message : String(error);
-          if (this.errors.get(principal.id) !== reason) logger.warn('Personal agent could not start', { intentId: principal.intentId, error: reason });
-          this.errors.set(principal.id, reason);
-          void this.stopSession(session);
-        });
+      while (this.running && this.pendingOwners.size) {
+        const ownerId = this.pendingOwners.has(undefined) ? undefined : this.pendingOwners.values().next().value;
+        if (ownerId === undefined) this.pendingOwners.clear();
+        else this.pendingOwners.delete(ownerId);
+        const principals = await ApiNegotiationHost.principals(ownerId);
+        const externalOwners = new Set(await this.registry.listSelectedNegotiatorOwners(ownerId));
+        if (!this.running) return;
+        for (const [id, principal] of this.principals) {
+          if (ownerId !== undefined && principal.userId !== ownerId) continue;
+          this.principals.delete(id);
+          this.desired.delete(id);
+        }
+        for (const principal of principals) {
+          this.principals.set(principal.id, principal);
+          if (!externalOwners.has(principal.userId)) this.desired.set(principal.id, principal);
+        }
+        for (const [id, session] of this.sessions) {
+          if (ownerId !== undefined && session.principal.userId !== ownerId) continue;
+          if (!session.stopping && JSON.stringify(this.desired.get(id)) === JSON.stringify(session.principal)
+            && !session.host.agents.get(id)?.stopped) continue;
+          // Replacement waits only on this intent's lease release, never on the reconciliation loop.
+          void this.stopSession(session).then(() => {
+            const principal = this.desired.get(id);
+            if (principal) this.startSession(principal);
+          }, () => {});
+        }
+        for (const principal of principals) {
+          if (this.desired.has(principal.id)) this.startSession(principal);
+        }
       }
     })().catch((error: unknown) => {
       logger.error('Personal-agent reconciliation failed', { error: error instanceof Error ? error.message : String(error) });
-    }).finally(() => { this.checking = undefined; });
+    }).finally(() => {
+      this.checking = undefined;
+      if (this.pendingOwners.size && this.running) void this.reconcile(this.pendingOwners.values().next().value);
+    });
     return this.checking;
+  }
+
+  private startSession(principal: ApiPrincipal): void {
+    if (!this.running || this.sessions.has(principal.id)) return;
+    const host = new ApiNegotiationHost([principal], this.model);
+    const session: Session = { principal, host, active: false, ready: Promise.resolve() };
+    this.sessions.set(principal.id, session);
+    session.ready = host.start().then(() => {
+      if (!this.running || session.stopping || this.sessions.get(principal.id) !== session) return;
+      session.active = true;
+      this.errors.delete(principal.id);
+      void publishUserInvalidation(principal.userId, 'agent.status', principal.intentId);
+    });
+    void session.ready.catch((error: unknown) => {
+      if (session.stopping || this.sessions.get(principal.id) !== session) return;
+      const reason = error instanceof Error ? error.message : String(error);
+      if (this.errors.get(principal.id) !== reason) logger.warn('Personal agent could not start', { intentId: principal.intentId, error: reason });
+      this.errors.set(principal.id, reason);
+      void this.stopSession(session);
+    });
   }
 
   /** Keep an intent reserved until its previous host has finished releasing its lease. */
@@ -99,6 +130,7 @@ export class PersonalAgentService {
     session.active = false;
     session.stopping = session.host.stop().then(() => {
       if (this.sessions.get(session.principal.id) === session) this.sessions.delete(session.principal.id);
+      if (this.running) void publishUserInvalidation(session.principal.userId, 'agent.status', session.principal.intentId);
     });
     void session.stopping.catch((error: unknown) => {
       logger.error('Personal agent could not stop', { intentId: session.principal.intentId, error: error instanceof Error ? error.message : String(error) });
@@ -132,7 +164,7 @@ export class PersonalAgentService {
     if (!await this.intents.isOwnedByUser(input.intentId, input.userId)) throw new PersonalAgentError('Intent not found.', 404);
     if (await this.registry.getSelectedNegotiator(input.userId)) return null;
     if (!this.running) throw new PersonalAgentError('Your personal agent is unavailable.', 503);
-    if (!this.sessions.has(input.intentId) || this.sessions.get(input.intentId)?.host.agents.get(input.intentId)?.stopped) await this.reconcile();
+    if (!this.sessions.has(input.intentId) || this.sessions.get(input.intentId)?.host.agents.get(input.intentId)?.stopped) await this.reconcile(input.userId);
     const session = this.sessions.get(input.intentId);
     if (!session || session.principal.userId !== input.userId) throw new PersonalAgentError('Your personal agent is unavailable. The intent must be active and its session must be free.', 409);
     if (session.stopping) throw new PersonalAgentError('Your personal agent is restarting. Please try again.', 503);
@@ -152,6 +184,7 @@ export class PersonalAgentService {
   async stop(): Promise<void> {
     this.running = false;
     this.subscriber?.disconnect();
+    this.pendingOwners.clear();
     await this.checking;
     await Promise.all([...this.sessions.values()].map((session) => this.stopSession(session)));
     this.sessions.clear();


### PR DESCRIPTION
Keep login and agent registration responsive when many persisted negotiations are waiting. Replace periodic reconciliation and view refreshes with existing Redis/SSE events, and keep both negotiation seats current after committed changes.

- Share a FIFO limit of four negotiation database operations across API hosts. Start and stop each intent independently, retaining its ownership until the previous host releases its lease.
- Scan negotiation IDs, precise Postgres change versions and current eligibility; load details only for new or changed records. Eligibility includes both intents' lifecycle and ownership, network assignments and memberships, and the opportunity's status and network.
- Discover eligible agents at boot and on Redis reconnect, then reconcile owners affected by intent creation/content/lifecycle, confirmed-profile or executor changes. Events received during reconciliation stay queued. A stalled startup or stop cannot block unrelated registration. Explicit input also reconciles a stopped session for its owner.
- Recover failed startup with at most three retries for that intent, delayed by 1, 2 and 4 seconds; lease conflicts instead wait for the database's recorded lease expiry. Cancel on success, shutdown or loss of eligibility. Recheck eligibility before acquiring a session, and retain ownership fencing throughout recovery.
- Publish `negotiation.changed` to both seats after a committed turn, either intent's lifecycle change, or an opportunity status change from Connect acceptance, manual rejection or expiry, including after the agents already agreed. Connect publishes after its acceptance commits; the shared sibling-acceptance method refreshes every sibling it accepts, using each negotiation’s own seats and intent IDs. Settled negotiation outcomes and turn histories remain unchanged. Resuming B wakes A when A owes the turn, without changing the meaning of B's own lifecycle event. Keep “Your turn” notifications addressed to the next mover. Web, Mac and Hermes consume the shared change event; chat archiving uses the canonical lifecycle publisher.
- Remove the API's five-second negotiation and registration loops, web/Mac five-second refreshes, Mac's three-second history refresh and web's thirty-second warming refresh. Views read on events and coalesce bursts; Mac views share one event connection. Serialize Mac agent-question reads, discard stale responses, and retain refreshes received during a read, including when it fails.
- Preserve human-input waits, the ownership lease heartbeat, authoritative negotiation checks and shutdown. No timer repairs missed Pub/Sub notifications. Durable streams remain future work.
- Bump API to `0.121.2`, web to `0.75.1` and Hermes to `0.41.2`, with synchronized workspace versions in `bun.lock`.

Validation:

- Actual API hosts with 16,002 persisted sandbox fixtures: 14,000 warm negotiations, 2,000 uncached negotiations and two probes. Warm caches were initialized from actual database fingerprints; initial misses and changed records used real detail reads and agent runtimes.
- Across two former polling intervals, idle hosts performed zero scans, detail reads or registration sweeps. Unchanged scans produced zero detail reads/checkpoint writes and retained the pending human question. A microsecond change event refreshed only the affected negotiation.
- Under the uncached backlog, six HTTP sign-ins completed in 2.01–3.87 seconds (baseline 1.89–2.11 seconds), JWKS in 341–536 ms, and session reads returned the correct identity. A newly eligible agent registered in 10.75 seconds while both backlog scans and a deliberately held stop remained busy. Peak negotiation concurrency stayed at four; FIFO admission, same-intent reservation, replacement after release and release of all 11 leases passed.
- Actual-host startup reproductions: transient failure recovered, healthy agents started independently, lease conflict recovered at the known expiry without stealing ownership, repeated failure stopped after four total attempts, and pause/archive/external selection/shutdown cancelled retries. A pause whose notification was deliberately missed was rejected by the retry's eligibility check.
- Actual persisted negotiation reproduction: resuming B woke A without changing negotiation `updatedAt`; committed turns notified both owners and refreshed both hosts, while only B received “Your turn.” Pause and chat archive refreshed both seats without publishing a false lifecycle event for A. Rejected turn submissions emitted no change event.
- Opportunity decision reproductions used the real opportunity service, negotiation protocol, sandbox database, Redis and both API hosts. Rejection and expiry notify both owners for open negotiations and for already-agreed negotiations. The agreed cases submitted a proposal and acceptance before the human decision; settlement rows, timestamps and turn histories stayed identical. Both live lists excluded the terminal opportunity and history reads showed its current status. Captured events exercised the actual web radar loader, API client and bucket selection, moving both view states from Needs you to Closed with one refresh per owner. Missing and empty inputs emitted no events; idle negotiation reads remained zero and shutdown released both leases.
- Connect verification used the real opportunity service, negotiation protocol, sandbox database, Redis and two API hosts with four intent sessions. Intent-scoped Connect refreshed only its accepted opportunity. Unscoped Connect refreshed its main opportunity and both accepted siblings, including a sibling attached to different intents. Already-agreed rows, timestamps and turns stayed identical; the open sibling closed in both host caches, and only it needed detail reads. Accepted/rejected/expired controls stayed unchanged. Failed DM creation or acceptance emitted no refresh, and reopening an accepted chat emitted no extra event. Captured events exercised the actual radar loader, API client and bucket selection for both owners, moving pending and negotiating view states to Connected without idle reads. Separate injected-failure checks verified that refresh and sibling errors still return the committed chat destination.
- Rendered both web negotiation views using captured API frames and real before/after responses: both displayed the new turn and paused state, without duplicate “Your turn” refreshes or idle/unrelated reads. The actual Mac question effect discarded stale responses, retained refreshes through success/failure, and ignored late responses after an intent switch or unmount. The Hermes observer consumed the actual counterparty lifecycle change frame.
- Earlier focused checks covered both creation paths, registration during stalled startup, profile/executor changes, a new negotiation, 24 eligibility transitions against the authoritative check, web refreshes during in-flight reads, and the shared Mac event connection. A missed lifecycle notification caused no periodic recovery; a later event applied current eligibility.
- Integration checks against current `dev` preserved both creation paths, registration during a stalled startup, profile updates and executor handoff. Explicit input recovered a stopped session using owner-scoped discovery. Actual Redis disconnects recovered a missed pause and registered an intent whose eligibility event was missed; boot discovery ran once, with no periodic recovery reads.
- API typecheck, repository lint (35 existing warnings), Mac build, subtree parity, lockfile versions and diff whitespace checks passed. Commit hooks passed protocol/API/web builds and adapter naming. Standalone web TypeScript still reports the same 33 diagnostics as the unchanged baseline, with no new diagnostics.

The branch is rebased onto `origin/dev` at `463ede6d5`, retaining the earlier concurrency, lifecycle and event changes.

All sandbox fixtures and auth Redis keys were removed. Before/after hashes confirmed existing negotiations and turns were unchanged. Matchmaking policy, schema, OAuth handling and connection pool settings are unchanged. Verification used temporary exercises, with no permanent tests added. Measurements used the local API auth handler and real sandbox database; deployed dev latency and a full browser Google login remain unverified. The uncached backlog was exercised under load rather than drained completely.

Related poller audit: #1583, assigned to @serefyarar. PR targets `dev`; do not merge.
