### PR TITLE
fix(api): cap dev replay at five paused signals

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -139,7 +139,7 @@
     },
     "services/api": {
       "name": "@indexnetwork/api",
-      "version": "0.121.0",
+      "version": "0.121.1",
       "dependencies": {
         "@aws-sdk/client-s3": "^3.939.0",
         "@aws-sdk/s3-request-presigner": "^3.983.0",

--- a/services/api/README.md
+++ b/services/api/README.md
@@ -68,12 +68,15 @@ registered SSH key (`railway ssh keys add`). It runs inside the dev API containe
 using that service's Redis and model credentials. Keep the terminal connected;
 Ctrl+C stops new activations and waits for current discovery scans to finish.
 
-Resume shuffles eligible paused intents and activates one every 10–30 seconds
-through the normal lifecycle graph. Discovery scans can overlap. Progress logs
-include activation times, intent IDs, and scan failures. Archived intents and
-intents without a current network assignment/member are reported and skipped.
-Re-running resume processes the remaining paused intents. Use reset to start
-the experiment from the beginning.
+Each resume shuffles eligible paused intents and selects at most five before
+activating any, then activates them through the normal lifecycle graph with
+10–30-second gaps. Discovery scans can overlap; the command waits for them to
+finish and exits. Progress logs include activation times, intent IDs, and scan
+failures, with selected, resumed, and remaining eligible paused counts in the
+final result (`remaining` is unavailable if the control connection is lost).
+Archived intents and intents without a current network assignment/member are
+reported and skipped. Re-running resume selects another batch from the remaining
+eligible paused intents. Use reset to start the experiment from the beginning.
 
 Reset briefly stops the dev API and any replay in its container, then pauses
 non-archived, non-terminal intents and clears discovery progress, opportunities,

--- a/services/api/package.json
+++ b/services/api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@indexnetwork/api",
-  "version": "0.121.0",
+  "version": "0.121.1",
   "license": "MIT",
   "private": true,
   "scripts": {

--- a/services/api/src/cli/dev-intents.ts
+++ b/services/api/src/cli/dev-intents.ts
@@ -151,14 +151,15 @@ export function replayDelayMs(): number {
   return 10_000 + Math.floor(Math.random() * 20_001);
 }
 
-/** Stagger transitions; discovery completion belongs to the caller, not this scheduler. */
+/** Select at most five intents before staggering transitions; the caller drains discovery. */
 export async function runReplay(
   candidates: readonly ReplayIntent[],
   activate: (intent: ReplayIntent) => Promise<IntentTransitionOutcome>,
   signal: AbortSignal,
-): Promise<{ resumed: number; skipped: number; failed: string[] }> {
-  const ordered = shuffled(candidates);
-  const result = { resumed: 0, skipped: 0, failed: [] as string[] };
+): Promise<{ selected: number; resumed: number; skipped: number; failed: string[] }> {
+  const ordered = shuffled(candidates).slice(0, 5);
+  const result = { selected: ordered.length, resumed: 0, skipped: 0, failed: [] as string[] };
+  console.log(`[dev-intents] Selected ${result.selected} of ${candidates.length} eligible paused intents.`);
   for (const [index, intent] of ordered.entries()) {
     if (signal.aborted) break;
     if (index > 0) {
@@ -236,7 +237,8 @@ async function resume(): Promise<void> {
     const result = await runReplay(candidates, ({ id, userId }) => service.transitionStatus(id, userId, 'ACTIVE'), stop.signal);
     console.log(`[dev-intents] Draining ${pending.size} discovery job(s).`);
     await Promise.all(pending);
-    console.log('[dev-intents] Replay result:', JSON.stringify({ ...result, discoveryFailures, interrupted: stop.signal.aborted }));
+    const remaining = connectionLost ? null : (await replayCandidates(control)).length;
+    console.log('[dev-intents] Replay result:', JSON.stringify({ ...result, remaining, discoveryFailures, interrupted: stop.signal.aborted }));
     if (connectionLost) throw new Error('Replay lost its control connection; remaining intents were not activated.');
     if (result.failed.length || discoveryFailures.length) throw new Error('Replay completed with failures; see intent IDs above.');
     if (stop.signal.aborted) process.exitCode = 130;


### PR DESCRIPTION
Limit `bun run db:dev:resume --confirm` to five eligible paused signals per invocation. Shuffle the full eligible cohort before selecting the batch, keep the 10–30-second activation gaps, and exit after discovery drains. Later invocations select from the remaining paused cohort; failed or skipped transitions do not enlarge the batch.

Report selected, resumed, and remaining eligible paused counts. Read the remaining count after discovery finishes; report it as unavailable if the control connection is lost. Preserve target validation, advisory locks, lifecycle transitions, interruption handling, and matching behavior. Update the replay documentation and bump the API from `0.121.0` to `0.121.1`, with `bun.lock` synchronized.

Validation:
- Focused ESLint and API typecheck after required dependency builds.
- Credential-free scheduler checks: cohorts of 0/1/4/5/6/12, full-cohort shuffle before activation, successive 5/5/2 batches, real delays and jitter bounds, failure/skip limits, interruption, and target validation.
- Source and compiled runtime import smoke checks, including graph/service construction, with dummy credentials and network requests blocked.
- Lockfile version check and required commit-hook builds.

No live replay or database mutation was run. The paused Railway dev environment was left untouched. No configuration flags or test files were added.
