### PR TITLE
fix: restore frontend polling and drop negotiation FIFO cap

### DIFF
--- a/apps/mac/src/ui/history.jsx
+++ b/apps/mac/src/ui/history.jsx
@@ -153,13 +153,8 @@ function NegotiationHistory({ onClose }) {
       if (!dead) setThreads((prev) => prev || []);
     };
     load();
-    let refreshTimer;
-    const sub = live ? window.IndexApp.streamInbox((event) => {
-      if (!["negotiation.changed", "negotiation.opened"].includes(event.type)) return;
-      clearTimeout(refreshTimer);
-      refreshTimer = setTimeout(load, 100);
-    }) : null;
-    return () => { dead = true; if (sub) sub.close(); clearTimeout(refreshTimer); };
+    const t = setInterval(load, 3000);   // same cadence as the radar
+    return () => { dead = true; clearInterval(t); };
   }, [live, myId]);
 
   const all = threads || [];

--- a/apps/mac/src/ui/mainview/core.jsx
+++ b/apps/mac/src/ui/mainview/core.jsx
@@ -147,9 +147,9 @@ function MainView({ profile, people, setPeople, conversation, setConversation,
     }
   }, (paused || live) ? null : 14000 / simRate);
 
-  /* ----- live radar events ----- */
+  /* ----- live radar polling ----- */
   // Intent switches keep MainView mounted; wipe the previous signal's radar
-  // before the next read lands.
+  // before the next poll lands.
   useEffect(() => {
     if (!live) return;
     radarSeqRef.current += 1;
@@ -246,58 +246,30 @@ function MainView({ profile, people, setPeople, conversation, setConversation,
   useEffect(() => {
     if (!live) return;
     refreshRadar();
-    let refreshTimer;
-    const sub = window.IndexApp.streamInbox((event) => {
-      if (event.data?.intentId !== intentId
-        || !["intent.updated", "intent.lifecycle", "opportunity.new", "negotiation.opened", "negotiation.changed"].includes(event.type)) return;
-      clearTimeout(refreshTimer);
-      refreshTimer = setTimeout(refreshRadar, 100);
-    });
-    return () => { sub.close(); clearTimeout(refreshTimer); };
-  }, [live, intentId, refreshRadar]);
+    const t = setInterval(refreshRadar, 5000);
+    return () => clearInterval(t);
+  }, [live, refreshRadar]);
 
   /* ----- the signal's own agent: the question it is held on ----- */
   // GET /conversations/agent?intentId= is the whole H2A contract: the agent's
-  // side of this signal plus the one question it is suspended on. Refresh when
-  // the question, intent lifecycle, or agent availability changes.
+  // side of this signal plus the one question it is suspended on. The same poll
+  // the web app runs, because a question can appear without anything else on
+  // this screen changing.
   const [agentQuestion, setAgentQuestion] = useState(null);
   useEffect(() => {
     setAgentQuestion(null);
     if (!live || !client) return;
     let alive = true;
     const forIntent = intentId;
-    let reading = false;
-    let refreshPending = false;
-    let revision = 0;
-    const read = async () => {
-      if (!alive || intentIdRef.current !== forIntent) return;
-      if (reading) { refreshPending = true; return; }
-      reading = true;
-      refreshPending = false;
-      const requestRevision = revision;
-      try {
-        const res = await client.conversations.messages("agent", { intentId: forIntent });
-        if (!alive || intentIdRef.current !== forIntent || requestRevision !== revision) return;
+    const read = () => client.conversations.messages("agent", { intentId: forIntent })
+      .then((res) => {
+        if (!alive || intentIdRef.current !== forIntent) return;
         setAgentQuestion((res && res.agent && res.agent.pending) || null);
-      } catch { /* a failed read leaves the last known question up */ }
-      finally {
-        reading = false;
-        if (alive && refreshPending) void read();
-      }
-    };
+      })
+      .catch(() => { /* a failed read leaves the last known question up */ });
     read();
-    let refreshTimer;
-    const sub = window.IndexApp.streamInbox((event) => {
-      if (event.type === "message") {
-        if (event.message?.metadata?.intentId !== forIntent) return;
-      } else if (!["question.pending", "intent.lifecycle", "agent.configuration", "agent.status"].includes(event.type)
-        || event.data?.intentId && event.data.intentId !== forIntent) return;
-      revision++;
-      clearTimeout(refreshTimer);
-      if (reading) refreshPending = true;
-      else refreshTimer = setTimeout(read, 100);
-    });
-    return () => { alive = false; sub.close(); clearTimeout(refreshTimer); };
+    const t = setInterval(read, 5000);
+    return () => { alive = false; clearInterval(t); };
   }, [live, client, intentId]);
 
   // The answer goes back naming the question it answers, so a question that

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@indexnetwork/web",
-  "version": "0.75.1",
+  "version": "0.75.2",
   "license": "MIT",
   "scripts": {
     "dev": "vite --host ::",

--- a/apps/web/src/app/i/[intentId]/page.tsx
+++ b/apps/web/src/app/i/[intentId]/page.tsx
@@ -9,7 +9,6 @@ import { Button } from "@/components/ui/button";
 import IntentNegotiatorChat from "@/components/IntentNegotiatorChat";
 import NegotiationConversation from "@/components/NegotiationConversation";
 import OpportunityCard, { OpportunitySkeleton } from "@/components/chat/OpportunityCardInChat";
-import { useConversation } from "@/contexts/ConversationContext";
 import { useIntents, useOpportunities } from "@/contexts/APIContext";
 import { useNotifications } from "@/contexts/NotificationContext";
 import { useOpportunityActions } from "@/hooks/useOpportunityActions";
@@ -170,7 +169,6 @@ export default function IntentDetailPage() {
   const navigate = useNavigate();
   const { intentId } = useParams<{ intentId: string }>();
   const intentsService = useIntents();
-  const { subscribeUserEvent } = useConversation();
   const opportunitiesService = useOpportunities();
   useIntentVisitPing(intentId);
   const { error: showError } = useNotifications();
@@ -191,6 +189,7 @@ export default function IntentDetailPage() {
   const activeIntentIdRef = useRef(intentId);
   const [opportunities, setOpportunities] = useState<RadarCardItem[]>([]);
   const [opportunitiesLoading, setOpportunitiesLoading] = useState(true);
+  const opportunitiesLoadingRef = useRef(true);
   const [opportunitiesError, setOpportunitiesError] = useState(false);
   const [refineText, setRefineText] = useState("");
   const [refining, setRefining] = useState(false);
@@ -233,25 +232,23 @@ export default function IntentDetailPage() {
 
   /** Monotonic load ids guard every intent-scoped feed against stale responses. */
   const loadSeqRef = useRef(0);
-  const radarRequestIntentRef = useRef<string | null>(null);
-  const radarRefreshPendingRef = useRef(false);
 
-  const loadOpportunities = useCallback(async function load(preserveExisting = false): Promise<void> {
+  const loadOpportunities = useCallback(async (preserveExisting = false) => {
     if (!intentId) return;
-    // An event arriving during a read must refresh after that read finishes.
-    if (preserveExisting && radarRequestIntentRef.current === intentId) {
-      radarRefreshPendingRef.current = true;
-      return;
-    }
-    radarRequestIntentRef.current = intentId;
-    radarRefreshPendingRef.current = false;
+    // The live 5s refresh must not supersede the initial two-phase load. If it
+    // does, the initial request's sequence becomes stale and its finally block
+    // cannot clear the loading state; the passive request then populates badge
+    // counts behind a permanent pair of skeleton cards.
+    if (preserveExisting && opportunitiesLoadingRef.current) return;
     const seq = ++loadSeqRef.current;
     if (!preserveExisting) {
+      opportunitiesLoadingRef.current = true;
       setOpportunitiesLoading(true);
       setOpportunitiesError(false);
     }
     const settleLoading = () => {
       if (activeIntentIdRef.current !== intentId) return;
+      opportunitiesLoadingRef.current = false;
       setOpportunitiesLoading(false);
     };
     const applyItems = (items: RadarCardItem[]) => {
@@ -297,14 +294,7 @@ export default function IntentDetailPage() {
         setOpportunitiesError(true);
       }
     } finally {
-      if (seq === loadSeqRef.current) {
-        radarRequestIntentRef.current = null;
-        if (!preserveExisting) settleLoading();
-        if (radarRefreshPendingRef.current && activeIntentIdRef.current === intentId) {
-          radarRefreshPendingRef.current = false;
-          void load(true);
-        }
-      }
+      if (seq === loadSeqRef.current && !preserveExisting) settleLoading();
     }
   }, [intentId, opportunitiesService]);
 
@@ -338,15 +328,9 @@ export default function IntentDetailPage() {
   }, [loadOpportunities, selectedBucket]);
 
   useEffect(() => {
-    let refreshTimer: ReturnType<typeof setTimeout>;
-    const unsubscribe = subscribeUserEvent((event) => {
-      if (event.data?.intentId !== intentId
-        || !['intent.updated', 'intent.lifecycle', 'opportunity.new', 'negotiation.opened', 'negotiation.changed'].includes(event.type)) return;
-      clearTimeout(refreshTimer);
-      refreshTimer = setTimeout(() => { void loadOpportunities(true); }, 100);
-    });
-    return () => { unsubscribe(); clearTimeout(refreshTimer); };
-  }, [intentId, loadOpportunities, subscribeUserEvent]);
+    const timer = setInterval(() => { void loadOpportunities(true); }, 5_000);
+    return () => clearInterval(timer);
+  }, [loadOpportunities]);
 
   useEffect(() => {
     if (matchFocus) document.getElementById(`radar-match-${matchFocus.id}`)?.scrollIntoView({ behavior: "smooth", block: "nearest" });

--- a/apps/web/src/components/DiscoverHome.tsx
+++ b/apps/web/src/components/DiscoverHome.tsx
@@ -35,7 +35,7 @@ export default function DiscoverHome() {
   const navigate = useNavigate();
   const { error: showError } = useNotifications();
   const { user } = useAuthContext();
-  const { negotiations, subscribeUserEvent } = useConversation();
+  const { negotiations } = useConversation();
   const [intents, setIntents] = useState<HomeIntent[]>([]);
   const [totalWaitingOpportunities, setTotalWaitingOpportunities] = useState(0);
   const [loading, setLoading] = useState(false);
@@ -79,14 +79,10 @@ export default function DiscoverHome() {
   }, [fetchIntents]);
 
   useEffect(() => {
-    let refreshTimer: ReturnType<typeof setTimeout>;
-    const unsubscribe = subscribeUserEvent((event) => {
-      if (!['intent.updated', 'intent.lifecycle', 'opportunity.new', 'negotiation.opened', 'negotiation.changed'].includes(event.type)) return;
-      clearTimeout(refreshTimer);
-      refreshTimer = setTimeout(() => { void fetchIntents(); }, 100);
-    });
-    return () => { unsubscribe(); clearTimeout(refreshTimer); };
-  }, [fetchIntents, subscribeUserEvent]);
+    if (!intents.some((intent) => intent.warming)) return;
+    const interval = setInterval(fetchIntents, 30_000);
+    return () => clearInterval(interval);
+  }, [fetchIntents, intents]);
 
   const handleArchive = useCallback(
     async (intent: HomeIntent) => {

--- a/apps/web/src/components/IntentNegotiatorChat.tsx
+++ b/apps/web/src/components/IntentNegotiatorChat.tsx
@@ -20,7 +20,7 @@ function messageText(message: ConversationMessage): string {
 export default function IntentNegotiatorChat({ intentId, onSelectMatch }: { intentId: string; onSelectMatch(opportunityId: string): void }) {
   const { user } = useAuthContext();
   const conversations = useConversations();
-  const { subscribeUserEvent, isConnected } = useConversation();
+  const { subscribeConversationMessage, isConnected } = useConversation();
   const storageKey = `principal-draft:${user?.id}:${intentId}`;
   const [draft, setDraft] = useState<{ text: string; questionId: string | null }>(() => {
     try { return JSON.parse(sessionStorage.getItem(storageKey) ?? "null") ?? { text: "", questionId: null }; }
@@ -66,22 +66,15 @@ export default function IntentNegotiatorChat({ intentId, onSelectMatch }: { inte
     const state = requests.current;
     state.mounted = true;
     void Promise.resolve().then(refresh);
-    return () => { state.mounted = false; state.generation++; };
+    const timer = setInterval(() => { void refresh(); }, 5_000);
+    return () => { state.mounted = false; state.generation++; clearInterval(timer); };
   }, [refresh, isConnected, requests]);
 
-  useEffect(() => {
-    let refreshTimer: ReturnType<typeof setTimeout>;
-    const unsubscribe = subscribeUserEvent((event) => {
-      if (event.type === 'message') {
-        if (event.message?.metadata?.intentId !== intentId) return;
-        mergeMessages([event.message]);
-      } else if (!['question.pending', 'intent.lifecycle', 'agent.configuration', 'agent.status'].includes(event.type)
-        || event.data?.intentId && event.data.intentId !== intentId) return;
-      clearTimeout(refreshTimer);
-      refreshTimer = setTimeout(() => { void refresh(); }, 100);
-    });
-    return () => { unsubscribe(); clearTimeout(refreshTimer); };
-  }, [intentId, mergeMessages, refresh, subscribeUserEvent]);
+  useEffect(() => subscribeConversationMessage(({ conversationId: id, message }) => {
+    if (id !== conversationId || message.metadata?.intentId !== intentId) return;
+    mergeMessages([message]);
+    void refresh();
+  }), [conversationId, intentId, mergeMessages, refresh, subscribeConversationMessage]);
 
   useEffect(() => { sessionStorage.setItem(storageKey, JSON.stringify(draft)); }, [draft, storageKey]);
   useEffect(() => { endRef.current?.scrollIntoView({ behavior: "smooth", block: "nearest" }); }, [messages.length, pending?.id]);

--- a/apps/web/src/components/NegotiationConversation.tsx
+++ b/apps/web/src/components/NegotiationConversation.tsx
@@ -13,7 +13,7 @@ export default function NegotiationConversation({ intentId, opportunityId, expan
 }) {
   const { user } = useAuthContext();
   const service = useNegotiations();
-  const { negotiations, isConnected, subscribeUserEvent } = useConversation();
+  const { negotiations, isConnected } = useConversation();
   const match = negotiations.find((entry) => entry.opportunityId === opportunityId && entry.intentId === intentId);
   const [detail, setDetail] = useState<NegotiationDetail>();
   const [error, setError] = useState("");
@@ -24,11 +24,9 @@ export default function NegotiationConversation({ intentId, opportunityId, expan
     if (!expanded) return;
     let active = true;
     let loading = false;
-    let refreshPending = false;
     const refresh = async () => {
-      if (loading) { refreshPending = true; return; }
+      if (loading) return;
       loading = true;
-      refreshPending = false;
       try {
         const record = await service.getNegotiation(opportunityId);
         if (!active) return;
@@ -37,21 +35,12 @@ export default function NegotiationConversation({ intentId, opportunityId, expan
         setError("");
       } catch (failure) {
         if (active) setError(failure instanceof Error ? failure.message : "Could not load this conversation.");
-      } finally {
-        loading = false;
-        if (active && refreshPending) void refresh();
-      }
+      } finally { loading = false; }
     };
     void refresh();
-    let refreshTimer: ReturnType<typeof setTimeout>;
-    const unsubscribe = subscribeUserEvent((event) => {
-      if (event.type !== 'negotiation.changed' || event.data?.intentId !== intentId
-        || event.data.opportunityId && event.data.opportunityId !== opportunityId) return;
-      clearTimeout(refreshTimer);
-      refreshTimer = setTimeout(() => { void refresh(); }, 100);
-    });
-    return () => { active = false; unsubscribe(); clearTimeout(refreshTimer); };
-  }, [expanded, intentId, opportunityId, service, isConnected, subscribeUserEvent]);
+    const timer = setInterval(() => { void refresh(); }, 5_000);
+    return () => { active = false; clearInterval(timer); };
+  }, [expanded, intentId, opportunityId, service, match?.updatedAt, isConnected]);
 
   useEffect(() => {
     if (history.current && follow.current) history.current.scrollTop = history.current.scrollHeight;

--- a/apps/web/src/contexts/ConversationContext.tsx
+++ b/apps/web/src/contexts/ConversationContext.tsx
@@ -18,16 +18,13 @@ interface ConversationSessionHistoryState {
   loadingPrevious: boolean;
 }
 
-/** A change notification on the existing authenticated SSE connection. */
-export interface UserEvent {
-  type: string;
-  data?: { intentId?: string; opportunityId?: string; status?: string };
-  conversationId?: string;
-  message?: ConversationMessage;
+/** A persisted message received on the authenticated conversation SSE channel. */
+export interface ConversationMessageEvent {
+  conversationId: string;
+  message: ConversationMessage;
 }
 
 interface ConversationContextType {
-  subscribeUserEvent: (handler: (event: UserEvent) => void) => () => void;
   conversations: ConversationSummary[];
   negotiations: NegotiationSummary[];
   messages: Map<string, ConversationMessage[]>;
@@ -43,6 +40,8 @@ interface ConversationContextType {
   markConversationRead: (conversationId: string) => Promise<void>;
   hideConversation: (conversationId: string) => Promise<void>;
   getOrCreateDm: (peerUserId: string) => Promise<ConversationSummary>;
+  /** Subscribe to persisted conversation messages from the SSE stream. */
+  subscribeConversationMessage: (handler: (event: ConversationMessageEvent) => void) => () => void;
 }
 
 const ConversationContext = createContext<ConversationContextType | null>(null);
@@ -66,11 +65,14 @@ export function ConversationProvider({ children }: { children: React.ReactNode }
   const refreshConversationsRef = useRef<() => Promise<void>>(() => Promise.resolve());
   const refreshNegotiationsRef = useRef<() => Promise<void>>(() => Promise.resolve());
   const negotiationsRefreshTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
-  const userEventHandlersRef = useRef(new Set<(event: UserEvent) => void>());
-  const subscribeUserEvent = useCallback((handler: (event: UserEvent) => void) => {
-    userEventHandlersRef.current.add(handler);
-    return () => { userEventHandlersRef.current.delete(handler); };
-  }, []);
+  const conversationMessageHandlersRef = useRef(new Set<(event: ConversationMessageEvent) => void>());
+  const subscribeConversationMessage = useCallback(
+    (handler: (event: ConversationMessageEvent) => void) => {
+      conversationMessageHandlersRef.current.add(handler);
+      return () => { conversationMessageHandlersRef.current.delete(handler); };
+    },
+    [],
+  );
   const pendingOptimisticIdsRef = useRef(new Set<string>());
 
   // --- REST helpers (conversation calls go through the typed client) ---
@@ -317,7 +319,6 @@ export function ConversationProvider({ children }: { children: React.ReactNode }
       es.onmessage = (event) => {
         try {
           const data = JSON.parse(event.data);
-          userEventHandlersRef.current.forEach((handler) => handler(data));
           switch (data.type) {
             case 'connected':
               setIsConnected(true);
@@ -369,6 +370,10 @@ export function ConversationProvider({ children }: { children: React.ReactNode }
                     : c
                 );
               });
+              conversationMessageHandlersRef.current.forEach((handler) => handler({
+                conversationId: convId,
+                message: msg,
+              }));
               break;
             }
           }
@@ -465,7 +470,7 @@ export function ConversationProvider({ children }: { children: React.ReactNode }
         markConversationRead,
         hideConversation,
         getOrCreateDm,
-        subscribeUserEvent,
+        subscribeConversationMessage,
       }}
     >
       {children}

--- a/apps/web/src/services/opportunities.ts
+++ b/apps/web/src/services/opportunities.ts
@@ -125,7 +125,9 @@ export interface ChatContextOpportunity {
   acceptedAt: string | null;
 }
 
+const RADAR_VIEW_RECENT_CACHE_TTL_MS = 1500;
 const radarViewInFlight = new Map<string, Promise<RadarViewResponse>>();
+const radarViewRecent = new Map<string, { data: RadarViewResponse; timestamp: number }>();
 
 export const createOpportunitiesService = (
   api: ReturnType<typeof import('../lib/api').useAuthenticatedAPI>
@@ -164,6 +166,12 @@ export const createOpportunitiesService = (
     }
 
     const cacheKey = url;
+    const now = Date.now();
+    const recent = radarViewRecent.get(cacheKey);
+    if (recent && now - recent.timestamp < RADAR_VIEW_RECENT_CACHE_TTL_MS) {
+      return recent.data;
+    }
+
     const inFlight = radarViewInFlight.get(cacheKey);
     if (inFlight) {
       return inFlight;
@@ -171,6 +179,10 @@ export const createOpportunitiesService = (
 
     const request = api
       .get<RadarViewResponse>(url)
+      .then((res) => {
+        radarViewRecent.set(cacheKey, { data: res, timestamp: Date.now() });
+        return res;
+      })
       .finally(() => {
         radarViewInFlight.delete(cacheKey);
       });

--- a/bun.lock
+++ b/bun.lock
@@ -20,7 +20,7 @@
     },
     "apps/web": {
       "name": "@indexnetwork/web",
-      "version": "0.75.1",
+      "version": "0.75.2",
       "dependencies": {
         "@better-auth/api-key": "1.6.11",
         "@indexnetwork/protocol": "workspace:*",
@@ -139,7 +139,7 @@
     },
     "services/api": {
       "name": "@indexnetwork/api",
-      "version": "0.121.2",
+      "version": "0.121.3",
       "dependencies": {
         "@aws-sdk/client-s3": "^3.939.0",
         "@aws-sdk/s3-request-presigner": "^3.983.0",

--- a/services/api/package.json
+++ b/services/api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@indexnetwork/api",
-  "version": "0.121.2",
+  "version": "0.121.3",
   "license": "MIT",
   "private": true,
   "scripts": {

--- a/services/api/src/lib/agent/negotiation.host.ts
+++ b/services/api/src/lib/agent/negotiation.host.ts
@@ -10,10 +10,6 @@ import { IntentDatabaseAdapter } from '../../adapters/intent.database.adapter';
 import { negotiationService, type NegotiationDetail } from '../../services/negotiation.service';
 import { userEventChannel } from '../user-events';
 
-const DATABASE_CONCURRENCY = 4;
-let activeDatabaseOperations = 0;
-const databaseQueue: (() => void)[] = [];
-
 export interface ApiPrincipal {
   id: string; userId: string; name: string; intentId: string; intent: string; principalContext: string;
 }
@@ -42,7 +38,7 @@ export class ApiNegotiationHost extends EventEmitter {
     for (const principal of users) {
       const store = new AgentSessionDatabaseAdapter(principal.userId, principal.intentId);
       const read = async (id: string) => {
-        const record = await this.runDatabase(() => negotiationService.read(id, principal.userId));
+        const record = await negotiationService.read(id, principal.userId);
         if (!record || record.intentId !== principal.intentId) throw new Error('Negotiation is outside this principal/intent session.');
         this.observe(principal, record);
         return this.record(record);
@@ -59,7 +55,7 @@ export class ApiNegotiationHost extends EventEmitter {
         owner: { id: principal.userId, name: principal.name }, intent: { id: principal.intentId, payload: principal.intent },
         principalContext: principal.principalContext, guidance: NEGOTIATION_GUIDANCE,
         client: { readNegotiation: read, submitTurn: async (id, turn) => {
-          const result = await this.runDatabase(() => negotiationService.submitTurn(id, principal.userId, turn, store.execution));
+          const result = await negotiationService.submitTurn(id, principal.userId, turn, store.execution);
           if ('rejection' in result) throw new Error(result.rejection);
           this.observe(principal, result);
           void this.scan();
@@ -118,24 +114,6 @@ export class ApiNegotiationHost extends EventEmitter {
     this.emit('change');
   }
 
-  /** Share capacity across hosts for one database operation, never a scan or agent task that may enqueue more work. */
-  private async runDatabase<T>(operation: () => Promise<T>): Promise<T> {
-    if (activeDatabaseOperations === DATABASE_CONCURRENCY) {
-      await new Promise<void>((resolve) => databaseQueue.push(resolve));
-    } else {
-      activeDatabaseOperations++;
-    }
-    try {
-      if (this.stopped) throw new Error('Negotiation host is stopped.');
-      return await operation();
-    } finally {
-      // Transfer the slot directly to the oldest waiter so new work cannot jump the queue.
-      const next = databaseQueue.shift();
-      if (next) next();
-      else activeDatabaseOperations--;
-    }
-  }
-
   private scan(): Promise<void> {
     this.rescan = true;
     if (this.scanning) return this.scanning;
@@ -144,12 +122,12 @@ export class ApiNegotiationHost extends EventEmitter {
         this.rescan = false;
         if (this.stopped) return;
         for (const principal of this.users) {
-          const records = await this.runDatabase(() => negotiationService.scan(principal.userId, principal.intentId));
+          const records = await negotiationService.scan(principal.userId, principal.intentId);
           for (const record of records) {
             const key = `${principal.id}:${record.opportunityId}`;
             const version = `${record.version}:${record.eligible}`;
             if (this.versions.get(key) === version) continue;
-            const detail = await this.runDatabase(() => negotiationService.read(record.opportunityId, principal.userId));
+            const detail = await negotiationService.read(record.opportunityId, principal.userId);
             if (this.stopped) return;
             if (!detail) continue;
             this.observe(principal, detail);


### PR DESCRIPTION
## Summary
- Restore web and Mac view timers (5s radar/chat/negotiation, 30s home warming, 3s Mac history) and the 1.5s radar cache. Conversation SSE still handles `negotiation.changed` for the inbox list.
- Remove the shared FIFO cap of four negotiation database operations. Scan fingerprints, event publishing, and the Mac inbox multiplexer stay.

## Test plan
- [ ] Intent radar, home warming list, H2A chat, and a negotiation thread refresh on their old intervals
- [ ] Mac radar, history, and agent question poll again; floating/H2H chat still appends via `streamInbox`
- [ ] Login and agent registration stay responsive without the FIFO limiter