### PR TITLE
fix: wake Hermes signals, restore frontend polling, pin CLI lockfile

### DIFF
--- a/apps/mac/src/ui/history.jsx
+++ b/apps/mac/src/ui/history.jsx
@@ -153,13 +153,8 @@ function NegotiationHistory({ onClose }) {
       if (!dead) setThreads((prev) => prev || []);
     };
     load();
-    let refreshTimer;
-    const sub = live ? window.IndexApp.streamInbox((event) => {
-      if (!["negotiation.changed", "negotiation.opened"].includes(event.type)) return;
-      clearTimeout(refreshTimer);
-      refreshTimer = setTimeout(load, 100);
-    }) : null;
-    return () => { dead = true; if (sub) sub.close(); clearTimeout(refreshTimer); };
+    const t = setInterval(load, 3000);   // same cadence as the radar
+    return () => { dead = true; clearInterval(t); };
   }, [live, myId]);
 
   const all = threads || [];

--- a/apps/mac/src/ui/mainview/core.jsx
+++ b/apps/mac/src/ui/mainview/core.jsx
@@ -147,9 +147,9 @@ function MainView({ profile, people, setPeople, conversation, setConversation,
     }
   }, (paused || live) ? null : 14000 / simRate);
 
-  /* ----- live radar events ----- */
+  /* ----- live radar polling ----- */
   // Intent switches keep MainView mounted; wipe the previous signal's radar
-  // before the next read lands.
+  // before the next poll lands.
   useEffect(() => {
     if (!live) return;
     radarSeqRef.current += 1;
@@ -246,58 +246,30 @@ function MainView({ profile, people, setPeople, conversation, setConversation,
   useEffect(() => {
     if (!live) return;
     refreshRadar();
-    let refreshTimer;
-    const sub = window.IndexApp.streamInbox((event) => {
-      if (event.data?.intentId !== intentId
-        || !["intent.updated", "intent.lifecycle", "opportunity.new", "negotiation.opened", "negotiation.changed"].includes(event.type)) return;
-      clearTimeout(refreshTimer);
-      refreshTimer = setTimeout(refreshRadar, 100);
-    });
-    return () => { sub.close(); clearTimeout(refreshTimer); };
-  }, [live, intentId, refreshRadar]);
+    const t = setInterval(refreshRadar, 5000);
+    return () => clearInterval(t);
+  }, [live, refreshRadar]);
 
   /* ----- the signal's own agent: the question it is held on ----- */
   // GET /conversations/agent?intentId= is the whole H2A contract: the agent's
-  // side of this signal plus the one question it is suspended on. Refresh when
-  // the question, intent lifecycle, or agent availability changes.
+  // side of this signal plus the one question it is suspended on. The same poll
+  // the web app runs, because a question can appear without anything else on
+  // this screen changing.
   const [agentQuestion, setAgentQuestion] = useState(null);
   useEffect(() => {
     setAgentQuestion(null);
     if (!live || !client) return;
     let alive = true;
     const forIntent = intentId;
-    let reading = false;
-    let refreshPending = false;
-    let revision = 0;
-    const read = async () => {
-      if (!alive || intentIdRef.current !== forIntent) return;
-      if (reading) { refreshPending = true; return; }
-      reading = true;
-      refreshPending = false;
-      const requestRevision = revision;
-      try {
-        const res = await client.conversations.messages("agent", { intentId: forIntent });
-        if (!alive || intentIdRef.current !== forIntent || requestRevision !== revision) return;
+    const read = () => client.conversations.messages("agent", { intentId: forIntent })
+      .then((res) => {
+        if (!alive || intentIdRef.current !== forIntent) return;
         setAgentQuestion((res && res.agent && res.agent.pending) || null);
-      } catch { /* a failed read leaves the last known question up */ }
-      finally {
-        reading = false;
-        if (alive && refreshPending) void read();
-      }
-    };
+      })
+      .catch(() => { /* a failed read leaves the last known question up */ });
     read();
-    let refreshTimer;
-    const sub = window.IndexApp.streamInbox((event) => {
-      if (event.type === "message") {
-        if (event.message?.metadata?.intentId !== forIntent) return;
-      } else if (!["question.pending", "intent.lifecycle", "agent.configuration", "agent.status"].includes(event.type)
-        || event.data?.intentId && event.data.intentId !== forIntent) return;
-      revision++;
-      clearTimeout(refreshTimer);
-      if (reading) refreshPending = true;
-      else refreshTimer = setTimeout(read, 100);
-    });
-    return () => { alive = false; sub.close(); clearTimeout(refreshTimer); };
+    const t = setInterval(read, 5000);
+    return () => { alive = false; clearInterval(t); };
   }, [live, client, intentId]);
 
   // The answer goes back naming the question it answers, so a question that

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@indexnetwork/web",
-  "version": "0.75.1",
+  "version": "0.75.2",
   "license": "MIT",
   "scripts": {
     "dev": "vite --host ::",

--- a/apps/web/src/app/i/[intentId]/page.tsx
+++ b/apps/web/src/app/i/[intentId]/page.tsx
@@ -9,7 +9,6 @@ import { Button } from "@/components/ui/button";
 import IntentNegotiatorChat from "@/components/IntentNegotiatorChat";
 import NegotiationConversation from "@/components/NegotiationConversation";
 import OpportunityCard, { OpportunitySkeleton } from "@/components/chat/OpportunityCardInChat";
-import { useConversation } from "@/contexts/ConversationContext";
 import { useIntents, useOpportunities } from "@/contexts/APIContext";
 import { useNotifications } from "@/contexts/NotificationContext";
 import { useOpportunityActions } from "@/hooks/useOpportunityActions";
@@ -170,7 +169,6 @@ export default function IntentDetailPage() {
   const navigate = useNavigate();
   const { intentId } = useParams<{ intentId: string }>();
   const intentsService = useIntents();
-  const { subscribeUserEvent } = useConversation();
   const opportunitiesService = useOpportunities();
   useIntentVisitPing(intentId);
   const { error: showError } = useNotifications();
@@ -191,6 +189,7 @@ export default function IntentDetailPage() {
   const activeIntentIdRef = useRef(intentId);
   const [opportunities, setOpportunities] = useState<RadarCardItem[]>([]);
   const [opportunitiesLoading, setOpportunitiesLoading] = useState(true);
+  const opportunitiesLoadingRef = useRef(true);
   const [opportunitiesError, setOpportunitiesError] = useState(false);
   const [refineText, setRefineText] = useState("");
   const [refining, setRefining] = useState(false);
@@ -233,25 +232,23 @@ export default function IntentDetailPage() {
 
   /** Monotonic load ids guard every intent-scoped feed against stale responses. */
   const loadSeqRef = useRef(0);
-  const radarRequestIntentRef = useRef<string | null>(null);
-  const radarRefreshPendingRef = useRef(false);
 
-  const loadOpportunities = useCallback(async function load(preserveExisting = false): Promise<void> {
+  const loadOpportunities = useCallback(async (preserveExisting = false) => {
     if (!intentId) return;
-    // An event arriving during a read must refresh after that read finishes.
-    if (preserveExisting && radarRequestIntentRef.current === intentId) {
-      radarRefreshPendingRef.current = true;
-      return;
-    }
-    radarRequestIntentRef.current = intentId;
-    radarRefreshPendingRef.current = false;
+    // The live 5s refresh must not supersede the initial two-phase load. If it
+    // does, the initial request's sequence becomes stale and its finally block
+    // cannot clear the loading state; the passive request then populates badge
+    // counts behind a permanent pair of skeleton cards.
+    if (preserveExisting && opportunitiesLoadingRef.current) return;
     const seq = ++loadSeqRef.current;
     if (!preserveExisting) {
+      opportunitiesLoadingRef.current = true;
       setOpportunitiesLoading(true);
       setOpportunitiesError(false);
     }
     const settleLoading = () => {
       if (activeIntentIdRef.current !== intentId) return;
+      opportunitiesLoadingRef.current = false;
       setOpportunitiesLoading(false);
     };
     const applyItems = (items: RadarCardItem[]) => {
@@ -297,14 +294,7 @@ export default function IntentDetailPage() {
         setOpportunitiesError(true);
       }
     } finally {
-      if (seq === loadSeqRef.current) {
-        radarRequestIntentRef.current = null;
-        if (!preserveExisting) settleLoading();
-        if (radarRefreshPendingRef.current && activeIntentIdRef.current === intentId) {
-          radarRefreshPendingRef.current = false;
-          void load(true);
-        }
-      }
+      if (seq === loadSeqRef.current && !preserveExisting) settleLoading();
     }
   }, [intentId, opportunitiesService]);
 
@@ -338,15 +328,9 @@ export default function IntentDetailPage() {
   }, [loadOpportunities, selectedBucket]);
 
   useEffect(() => {
-    let refreshTimer: ReturnType<typeof setTimeout>;
-    const unsubscribe = subscribeUserEvent((event) => {
-      if (event.data?.intentId !== intentId
-        || !['intent.updated', 'intent.lifecycle', 'opportunity.new', 'negotiation.opened', 'negotiation.changed'].includes(event.type)) return;
-      clearTimeout(refreshTimer);
-      refreshTimer = setTimeout(() => { void loadOpportunities(true); }, 100);
-    });
-    return () => { unsubscribe(); clearTimeout(refreshTimer); };
-  }, [intentId, loadOpportunities, subscribeUserEvent]);
+    const timer = setInterval(() => { void loadOpportunities(true); }, 5_000);
+    return () => clearInterval(timer);
+  }, [loadOpportunities]);
 
   useEffect(() => {
     if (matchFocus) document.getElementById(`radar-match-${matchFocus.id}`)?.scrollIntoView({ behavior: "smooth", block: "nearest" });

--- a/apps/web/src/components/DiscoverHome.tsx
+++ b/apps/web/src/components/DiscoverHome.tsx
@@ -35,7 +35,7 @@ export default function DiscoverHome() {
   const navigate = useNavigate();
   const { error: showError } = useNotifications();
   const { user } = useAuthContext();
-  const { negotiations, subscribeUserEvent } = useConversation();
+  const { negotiations } = useConversation();
   const [intents, setIntents] = useState<HomeIntent[]>([]);
   const [totalWaitingOpportunities, setTotalWaitingOpportunities] = useState(0);
   const [loading, setLoading] = useState(false);
@@ -79,14 +79,10 @@ export default function DiscoverHome() {
   }, [fetchIntents]);
 
   useEffect(() => {
-    let refreshTimer: ReturnType<typeof setTimeout>;
-    const unsubscribe = subscribeUserEvent((event) => {
-      if (!['intent.updated', 'intent.lifecycle', 'opportunity.new', 'negotiation.opened', 'negotiation.changed'].includes(event.type)) return;
-      clearTimeout(refreshTimer);
-      refreshTimer = setTimeout(() => { void fetchIntents(); }, 100);
-    });
-    return () => { unsubscribe(); clearTimeout(refreshTimer); };
-  }, [fetchIntents, subscribeUserEvent]);
+    if (!intents.some((intent) => intent.warming)) return;
+    const interval = setInterval(fetchIntents, 30_000);
+    return () => clearInterval(interval);
+  }, [fetchIntents, intents]);
 
   const handleArchive = useCallback(
     async (intent: HomeIntent) => {

--- a/apps/web/src/components/IntentNegotiatorChat.tsx
+++ b/apps/web/src/components/IntentNegotiatorChat.tsx
@@ -20,7 +20,7 @@ function messageText(message: ConversationMessage): string {
 export default function IntentNegotiatorChat({ intentId, onSelectMatch }: { intentId: string; onSelectMatch(opportunityId: string): void }) {
   const { user } = useAuthContext();
   const conversations = useConversations();
-  const { subscribeUserEvent, isConnected } = useConversation();
+  const { subscribeConversationMessage, isConnected } = useConversation();
   const storageKey = `principal-draft:${user?.id}:${intentId}`;
   const [draft, setDraft] = useState<{ text: string; questionId: string | null }>(() => {
     try { return JSON.parse(sessionStorage.getItem(storageKey) ?? "null") ?? { text: "", questionId: null }; }
@@ -66,22 +66,15 @@ export default function IntentNegotiatorChat({ intentId, onSelectMatch }: { inte
     const state = requests.current;
     state.mounted = true;
     void Promise.resolve().then(refresh);
-    return () => { state.mounted = false; state.generation++; };
+    const timer = setInterval(() => { void refresh(); }, 5_000);
+    return () => { state.mounted = false; state.generation++; clearInterval(timer); };
   }, [refresh, isConnected, requests]);
 
-  useEffect(() => {
-    let refreshTimer: ReturnType<typeof setTimeout>;
-    const unsubscribe = subscribeUserEvent((event) => {
-      if (event.type === 'message') {
-        if (event.message?.metadata?.intentId !== intentId) return;
-        mergeMessages([event.message]);
-      } else if (!['question.pending', 'intent.lifecycle', 'agent.configuration', 'agent.status'].includes(event.type)
-        || event.data?.intentId && event.data.intentId !== intentId) return;
-      clearTimeout(refreshTimer);
-      refreshTimer = setTimeout(() => { void refresh(); }, 100);
-    });
-    return () => { unsubscribe(); clearTimeout(refreshTimer); };
-  }, [intentId, mergeMessages, refresh, subscribeUserEvent]);
+  useEffect(() => subscribeConversationMessage(({ conversationId: id, message }) => {
+    if (id !== conversationId || message.metadata?.intentId !== intentId) return;
+    mergeMessages([message]);
+    void refresh();
+  }), [conversationId, intentId, mergeMessages, refresh, subscribeConversationMessage]);
 
   useEffect(() => { sessionStorage.setItem(storageKey, JSON.stringify(draft)); }, [draft, storageKey]);
   useEffect(() => { endRef.current?.scrollIntoView({ behavior: "smooth", block: "nearest" }); }, [messages.length, pending?.id]);

--- a/apps/web/src/components/NegotiationConversation.tsx
+++ b/apps/web/src/components/NegotiationConversation.tsx
@@ -13,7 +13,7 @@ export default function NegotiationConversation({ intentId, opportunityId, expan
 }) {
   const { user } = useAuthContext();
   const service = useNegotiations();
-  const { negotiations, isConnected, subscribeUserEvent } = useConversation();
+  const { negotiations, isConnected } = useConversation();
   const match = negotiations.find((entry) => entry.opportunityId === opportunityId && entry.intentId === intentId);
   const [detail, setDetail] = useState<NegotiationDetail>();
   const [error, setError] = useState("");
@@ -24,11 +24,9 @@ export default function NegotiationConversation({ intentId, opportunityId, expan
     if (!expanded) return;
     let active = true;
     let loading = false;
-    let refreshPending = false;
     const refresh = async () => {
-      if (loading) { refreshPending = true; return; }
+      if (loading) return;
       loading = true;
-      refreshPending = false;
       try {
         const record = await service.getNegotiation(opportunityId);
         if (!active) return;
@@ -37,21 +35,12 @@ export default function NegotiationConversation({ intentId, opportunityId, expan
         setError("");
       } catch (failure) {
         if (active) setError(failure instanceof Error ? failure.message : "Could not load this conversation.");
-      } finally {
-        loading = false;
-        if (active && refreshPending) void refresh();
-      }
+      } finally { loading = false; }
     };
     void refresh();
-    let refreshTimer: ReturnType<typeof setTimeout>;
-    const unsubscribe = subscribeUserEvent((event) => {
-      if (event.type !== 'negotiation.changed' || event.data?.intentId !== intentId
-        || event.data.opportunityId && event.data.opportunityId !== opportunityId) return;
-      clearTimeout(refreshTimer);
-      refreshTimer = setTimeout(() => { void refresh(); }, 100);
-    });
-    return () => { active = false; unsubscribe(); clearTimeout(refreshTimer); };
-  }, [expanded, intentId, opportunityId, service, isConnected, subscribeUserEvent]);
+    const timer = setInterval(() => { void refresh(); }, 5_000);
+    return () => { active = false; clearInterval(timer); };
+  }, [expanded, intentId, opportunityId, service, match?.updatedAt, isConnected]);
 
   useEffect(() => {
     if (history.current && follow.current) history.current.scrollTop = history.current.scrollHeight;

--- a/apps/web/src/contexts/ConversationContext.tsx
+++ b/apps/web/src/contexts/ConversationContext.tsx
@@ -18,16 +18,13 @@ interface ConversationSessionHistoryState {
   loadingPrevious: boolean;
 }
 
-/** A change notification on the existing authenticated SSE connection. */
-export interface UserEvent {
-  type: string;
-  data?: { intentId?: string; opportunityId?: string; status?: string };
-  conversationId?: string;
-  message?: ConversationMessage;
+/** A persisted message received on the authenticated conversation SSE channel. */
+export interface ConversationMessageEvent {
+  conversationId: string;
+  message: ConversationMessage;
 }
 
 interface ConversationContextType {
-  subscribeUserEvent: (handler: (event: UserEvent) => void) => () => void;
   conversations: ConversationSummary[];
   negotiations: NegotiationSummary[];
   messages: Map<string, ConversationMessage[]>;
@@ -43,6 +40,8 @@ interface ConversationContextType {
   markConversationRead: (conversationId: string) => Promise<void>;
   hideConversation: (conversationId: string) => Promise<void>;
   getOrCreateDm: (peerUserId: string) => Promise<ConversationSummary>;
+  /** Subscribe to persisted conversation messages from the SSE stream. */
+  subscribeConversationMessage: (handler: (event: ConversationMessageEvent) => void) => () => void;
 }
 
 const ConversationContext = createContext<ConversationContextType | null>(null);
@@ -66,11 +65,14 @@ export function ConversationProvider({ children }: { children: React.ReactNode }
   const refreshConversationsRef = useRef<() => Promise<void>>(() => Promise.resolve());
   const refreshNegotiationsRef = useRef<() => Promise<void>>(() => Promise.resolve());
   const negotiationsRefreshTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
-  const userEventHandlersRef = useRef(new Set<(event: UserEvent) => void>());
-  const subscribeUserEvent = useCallback((handler: (event: UserEvent) => void) => {
-    userEventHandlersRef.current.add(handler);
-    return () => { userEventHandlersRef.current.delete(handler); };
-  }, []);
+  const conversationMessageHandlersRef = useRef(new Set<(event: ConversationMessageEvent) => void>());
+  const subscribeConversationMessage = useCallback(
+    (handler: (event: ConversationMessageEvent) => void) => {
+      conversationMessageHandlersRef.current.add(handler);
+      return () => { conversationMessageHandlersRef.current.delete(handler); };
+    },
+    [],
+  );
   const pendingOptimisticIdsRef = useRef(new Set<string>());
 
   // --- REST helpers (conversation calls go through the typed client) ---
@@ -317,7 +319,6 @@ export function ConversationProvider({ children }: { children: React.ReactNode }
       es.onmessage = (event) => {
         try {
           const data = JSON.parse(event.data);
-          userEventHandlersRef.current.forEach((handler) => handler(data));
           switch (data.type) {
             case 'connected':
               setIsConnected(true);
@@ -369,6 +370,10 @@ export function ConversationProvider({ children }: { children: React.ReactNode }
                     : c
                 );
               });
+              conversationMessageHandlersRef.current.forEach((handler) => handler({
+                conversationId: convId,
+                message: msg,
+              }));
               break;
             }
           }
@@ -465,7 +470,7 @@ export function ConversationProvider({ children }: { children: React.ReactNode }
         markConversationRead,
         hideConversation,
         getOrCreateDm,
-        subscribeUserEvent,
+        subscribeConversationMessage,
       }}
     >
       {children}

--- a/apps/web/src/services/opportunities.ts
+++ b/apps/web/src/services/opportunities.ts
@@ -125,7 +125,9 @@ export interface ChatContextOpportunity {
   acceptedAt: string | null;
 }
 
+const RADAR_VIEW_RECENT_CACHE_TTL_MS = 1500;
 const radarViewInFlight = new Map<string, Promise<RadarViewResponse>>();
+const radarViewRecent = new Map<string, { data: RadarViewResponse; timestamp: number }>();
 
 export const createOpportunitiesService = (
   api: ReturnType<typeof import('../lib/api').useAuthenticatedAPI>
@@ -164,6 +166,12 @@ export const createOpportunitiesService = (
     }
 
     const cacheKey = url;
+    const now = Date.now();
+    const recent = radarViewRecent.get(cacheKey);
+    if (recent && now - recent.timestamp < RADAR_VIEW_RECENT_CACHE_TTL_MS) {
+      return recent.data;
+    }
+
     const inFlight = radarViewInFlight.get(cacheKey);
     if (inFlight) {
       return inFlight;
@@ -171,6 +179,10 @@ export const createOpportunitiesService = (
 
     const request = api
       .get<RadarViewResponse>(url)
+      .then((res) => {
+        radarViewRecent.set(cacheKey, { data: res, timestamp: Date.now() });
+        return res;
+      })
       .finally(() => {
         radarViewInFlight.delete(cacheKey);
       });

--- a/bun.lock
+++ b/bun.lock
@@ -20,7 +20,7 @@
     },
     "apps/web": {
       "name": "@indexnetwork/web",
-      "version": "0.75.1",
+      "version": "0.75.2",
       "dependencies": {
         "@better-auth/api-key": "1.6.11",
         "@indexnetwork/protocol": "workspace:*",
@@ -139,7 +139,7 @@
     },
     "services/api": {
       "name": "@indexnetwork/api",
-      "version": "0.121.2",
+      "version": "0.121.3",
       "dependencies": {
         "@aws-sdk/client-s3": "^3.939.0",
         "@aws-sdk/s3-request-presigner": "^3.983.0",

--- a/bun.lock
+++ b/bun.lock
@@ -119,7 +119,7 @@
     },
     "packages/hermes-plugin": {
       "name": "@indexnetwork/hermes-plugin",
-      "version": "0.41.2",
+      "version": "0.41.3",
     },
     "packages/protocol": {
       "name": "@indexnetwork/protocol",

--- a/bun.lock
+++ b/bun.lock
@@ -100,10 +100,10 @@
         "@types/bun": "1.3.14",
       },
       "optionalDependencies": {
-        "@indexnetwork/cli-darwin-arm64": "0.24.0",
-        "@indexnetwork/cli-darwin-x64": "0.24.0",
-        "@indexnetwork/cli-linux-arm64": "0.24.0",
-        "@indexnetwork/cli-linux-x64": "0.24.0",
+        "@indexnetwork/cli-darwin-arm64": "0.25.0",
+        "@indexnetwork/cli-darwin-x64": "0.25.0",
+        "@indexnetwork/cli-linux-arm64": "0.25.0",
+        "@indexnetwork/cli-linux-x64": "0.25.0",
       },
     },
     "packages/discovery": {

--- a/packages/hermes-plugin/CHANGELOG.md
+++ b/packages/hermes-plugin/CHANGELOG.md
@@ -1,10 +1,25 @@
 # Changelog
 
+
+## 0.41.3
+
+### Added
+- Each submitted turn is written into a Hermes session on the Index platform,
+  one chat per signal, so the session list shows Hermes's Index copy without a
+  bound owner conversation.
+
+### Fixed
+- Background wakes no longer treat every signal as foreign. `GET /intents/:id`
+  is already owner-scoped and does not return `userId`, so the sidecar's
+  ownership check always failed and no turn ever started.
+- Opening Discover while a session tile covers the workspace. The tab is
+  re-opened on every Discover click so the host fronts it instead of leaving
+  the dashboard behind.
+
 ## 0.41.2
 
 ### Fixed
 - Wake the affected negotiation seat on `negotiation.changed`, including when a counterparty resumes its intent.
-
 
 ## 0.41.1
 

--- a/packages/hermes-plugin/bridge.py
+++ b/packages/hermes-plugin/bridge.py
@@ -1,11 +1,13 @@
 """Loopback bridge between the Index negotiator and Hermes.
 
 The negotiator is `@indexnetwork/agent` running in a Bun sidecar, so it needs
-two things from Hermes that it cannot reach itself: a tool-capable model call,
-and the owner's conversation. `/complete` runs one completion on the model the
-owner is already using; `/deliver` hands the entries the negotiator selected to
-the bound conversation. Neither route decides anything about a negotiation —
-scheduling, questions, and turns stay inside the agent package.
+three things from Hermes that it cannot reach itself: a tool-capable model call,
+the owner's conversation, and a session to show submitted turns. `/complete`
+runs one completion on the model the owner is already using; `/deliver` hands
+the entries the negotiator selected to the bound conversation; `/announce`
+writes one turn into an Index platform session. None of those routes decide
+anything about a negotiation — scheduling, questions, and turns stay inside
+the agent package.
 
 Hermes's public `ctx.llm.complete` cannot return tool calls, so completions go
 through the host's `auxiliary_client.call_llm`, which accepts `tools` and keeps
@@ -75,6 +77,11 @@ class HermesBridge:
         self.store = store
         self.token = secrets.token_urlsafe(32)
         self._server: ThreadingHTTPServer | None = None
+        self._announce = None
+
+    def set_announce(self, announce) -> None:
+        """@param announce - The connected Index adapter's session writer, or None."""
+        self._announce = announce
 
     @property
     def url(self) -> str:
@@ -158,10 +165,27 @@ class HermesBridge:
             return {"delivered": False, "reason": str(result["error"])}
         return {"delivered": True}
 
+    def announce(self, payload):
+        """Write one submitted turn into the signal's Index session.
+
+        @param payload - `intentId`, `text`, and optional `title`.
+        @returns Whether the adapter accepted the turn.
+        """
+        intent_id = payload.get("intentId")
+        text = payload.get("text")
+        title = payload.get("title")
+        if not isinstance(intent_id, str) or not intent_id.strip() or not isinstance(text, str) or not text.strip():
+            raise ValueError("intentId and text are required.")
+        if self._announce is None:
+            logger.warning("Index announce dropped: the platform is not connected.")
+            return {"delivered": False, "reason": "The Index platform is not connected."}
+        self._announce(intent_id.strip(), title.strip() if isinstance(title, str) else "", text.strip())
+        return {"delivered": True}
+
 
 def _handler(bridge: HermesBridge):
     """Build the request handler bound to one bridge instance."""
-    routes = {"/complete": bridge.complete, "/deliver": bridge.deliver}
+    routes = {"/complete": bridge.complete, "/deliver": bridge.deliver, "/announce": bridge.announce}
 
     class Handler(BaseHTTPRequestHandler):
         protocol_version = "HTTP/1.1"

--- a/packages/hermes-plugin/desktop/dist/plugin.js
+++ b/packages/hermes-plugin/desktop/dist/plugin.js
@@ -4887,23 +4887,13 @@ function discoverHash() {
   return path === DISCOVER_PATH || path.startsWith(DISCOVER_PATH + '/')
 }
 
-function workspaceIsShowing() {
-  if (typeof host.paneVisibility !== 'function') return false
-  try {
-    const vis = host.paneVisibility('workspace')
-    return Boolean(vis && vis.get && vis.get())
-  } catch (e) {
-    return false
-  }
-}
-
-// Discover is a workspace-pane route. A focused session tile keeps that pane
-// behind the tile, so hash navigation looks dead until restart. Front a
-// dedicated tab only while workspace is covered; skip when it is already up.
+// Discover is a workspace-pane route. Hash navigation is a no-op when the
+// workspace already holds the zone (a chat or another page), and a focused
+// session tile keeps the page behind it. Re-open the tab every time — the
+// host fronts an existing id instead of stacking a duplicate.
 function showDiscover(to) {
   if (to) host.navigate(to)
   else if (!discoverHash()) host.navigate(DISCOVER_PATH)
-  if (workspaceIsShowing()) return
   if (typeof host.openWorkspace !== 'function') return
   try {
     host.openWorkspace('index-network', {
@@ -4918,8 +4908,12 @@ function onDiscoverHash() {
 }
 
 function onDiscoverNavClick(event) {
-  const node = event.target && event.target.closest && event.target.closest('[data-tour="' + DISCOVER_NAV_TOUR + '"]')
-  if (node) showDiscover(DISCOVER_PATH)
+  const t = event.target
+  if (!t || !t.closest) return
+  const labeled = t.closest('[data-tour="' + DISCOVER_NAV_TOUR + '"]')
+  const button = t.closest('button')
+  if (!labeled && !(button && button.querySelector('[data-tour="' + DISCOVER_NAV_TOUR + '"]'))) return
+  showDiscover(DISCOVER_PATH)
 }
 
 export default {

--- a/packages/hermes-plugin/desktop/tail.js
+++ b/packages/hermes-plugin/desktop/tail.js
@@ -155,23 +155,13 @@ function discoverHash() {
   return path === DISCOVER_PATH || path.startsWith(DISCOVER_PATH + '/')
 }
 
-function workspaceIsShowing() {
-  if (typeof host.paneVisibility !== 'function') return false
-  try {
-    const vis = host.paneVisibility('workspace')
-    return Boolean(vis && vis.get && vis.get())
-  } catch (e) {
-    return false
-  }
-}
-
-// Discover is a workspace-pane route. A focused session tile keeps that pane
-// behind the tile, so hash navigation looks dead until restart. Front a
-// dedicated tab only while workspace is covered; skip when it is already up.
+// Discover is a workspace-pane route. Hash navigation is a no-op when the
+// workspace already holds the zone (a chat or another page), and a focused
+// session tile keeps the page behind it. Re-open the tab every time — the
+// host fronts an existing id instead of stacking a duplicate.
 function showDiscover(to) {
   if (to) host.navigate(to)
   else if (!discoverHash()) host.navigate(DISCOVER_PATH)
-  if (workspaceIsShowing()) return
   if (typeof host.openWorkspace !== 'function') return
   try {
     host.openWorkspace('index-network', {
@@ -186,8 +176,12 @@ function onDiscoverHash() {
 }
 
 function onDiscoverNavClick(event) {
-  const node = event.target && event.target.closest && event.target.closest('[data-tour="' + DISCOVER_NAV_TOUR + '"]')
-  if (node) showDiscover(DISCOVER_PATH)
+  const t = event.target
+  if (!t || !t.closest) return
+  const labeled = t.closest('[data-tour="' + DISCOVER_NAV_TOUR + '"]')
+  const button = t.closest('button')
+  if (!labeled && !(button && button.querySelector('[data-tour="' + DISCOVER_NAV_TOUR + '"]'))) return
+  showDiscover(DISCOVER_PATH)
 }
 
 export default {

--- a/packages/hermes-plugin/events.py
+++ b/packages/hermes-plugin/events.py
@@ -5,10 +5,9 @@ negotiator is woken by those frames instead of by a schedule. Every frame is a
 pointer: the negotiator re-reads authoritative state over REST before deciding
 anything, which is what makes a missed or duplicated frame cost nothing.
 
-The work itself happens in the negotiator sidecar, not in a Hermes session, so
-this platform opens no chats and delivers no messages. It exists for its
-connection lifecycle: while this machine is the selected negotiator, it keeps the
-stream and the sidecar running together.
+The work itself happens in the negotiator sidecar. This platform keeps the stream
+and the sidecar running together, and writes each submitted turn into one Hermes
+session per signal so the session list shows the copy.
 """
 
 from __future__ import annotations
@@ -19,10 +18,12 @@ import logging
 import os
 import threading
 import time
+from datetime import datetime
 from typing import Any
 
 from gateway.config import Platform, PlatformConfig
 from gateway.platforms.base import BasePlatformAdapter, SendResult
+from gateway.session import SessionSource
 
 from .native_agent import PLATFORM
 from .transport import get_transport
@@ -70,16 +71,43 @@ class IndexAdapter(BasePlatformAdapter):
         self._closing = False
         self._loop = asyncio.get_running_loop()
         self._signal = asyncio.Event()
+        self._sidecar.bridge.set_announce(self.announce)
         self._dispatcher = self._loop.create_task(self._dispatch())
         threading.Thread(target=self._read, name="index-events", daemon=True).start()
         return True
 
     async def disconnect(self) -> None:
         self._closing = True
+        self._sidecar.bridge.set_announce(None)
         if self._dispatcher is not None:
             self._dispatcher.cancel()
             self._dispatcher = None
         await asyncio.to_thread(self._sidecar.stop)
+
+    def announce(self, intent_id: str, title: str, text: str) -> None:
+        """Write one submitted turn into this signal's Hermes session.
+
+        @param intent_id - The signal this turn belongs to; also the chat id.
+        @param title - Short signal label for the session tile.
+        @param text - Action, counterpart, and the copy posted to Index.
+        """
+        store = getattr(self, "_session_store", None)
+        if store is None:
+            raise RuntimeError("The Index platform has no session store.")
+        source = SessionSource(
+            platform=self.platform,
+            chat_id=intent_id,
+            chat_type="dm",
+            chat_name=title or f"Index signal {intent_id}",
+            user_id=self._owner or "index",
+            user_name="Index",
+        )
+        entry = store.get_or_create_session(source)
+        store.append_to_transcript(entry.session_id, {
+            "role": "assistant",
+            "content": text,
+            "timestamp": datetime.now().isoformat(),
+        })
 
     async def get_chat_info(self, chat_id: str) -> dict[str, Any]:
         return {"name": f"Index signal {chat_id}", "type": "dm", "id": chat_id}
@@ -166,7 +194,7 @@ def register_platform(ctx, sidecar) -> None:
         emoji="\U0001f9ed",
         pii_safe=True,
         platform_hint=(
-            "This platform only carries Index events to the negotiator process. "
-            "It is not a conversation with the owner."
+            "This platform wakes the negotiator and holds a turn log, one Hermes "
+            "session per signal. It is not a conversation with the owner."
         ),
     )

--- a/packages/hermes-plugin/package.json
+++ b/packages/hermes-plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@indexnetwork/hermes-plugin",
-  "version": "0.41.2",
+  "version": "0.41.3",
   "description": "Hermes-native Index Network plugin with CLI tools and REST APIs",
   "license": "MIT",
   "type": "module",

--- a/packages/hermes-plugin/plugin.yaml
+++ b/packages/hermes-plugin/plugin.yaml
@@ -1,5 +1,5 @@
 name: index-network
-version: 0.41.2
+version: 0.41.3
 description: Index Network Hermes plugin with native tools backed by the Index REST API.
 provides_tools:
   - index_configure_personal_agent

--- a/packages/hermes-plugin/runtime/dist/negotiator.js
+++ b/packages/hermes-plugin/runtime/dist/negotiator.js
@@ -998,9 +998,9 @@ class IndexClient {
       principalContext: confirmedProfile ? JSON.stringify({ confirmedProfile }) : "No confirmed profile is available. Ask for missing personal facts."
     };
   }
-  async intent(id, ownerId) {
+  async intent(id) {
     const { intent } = await this.request("GET", `/intents/${encodeURIComponent(id)}`);
-    if (intent.userId !== ownerId || intent.archivedAt || (intent.status ?? "ACTIVE") !== "ACTIVE") {
+    if (intent.archivedAt || (intent.status ?? "ACTIVE") !== "ACTIVE") {
       throw new Error("This signal is inactive or belongs to another owner.");
     }
     return { id: intent.id, payload: intent.payload };
@@ -1082,6 +1082,16 @@ class FilePrincipalStore {
 }
 
 // runtime/src/main.ts
+var ACTIONS = {
+  propose: "Proposed",
+  counter: "Countered",
+  accept: "Accepted",
+  decline: "Declined"
+};
+function signalTitle(payload) {
+  const line = payload.trim().replace(/\s+/g, " ");
+  return line.length > 80 ? `${line.slice(0, 79)}\u2026` : line || "Index signal";
+}
 function log(level, event, detail = {}) {
   process.stderr.write(`${JSON.stringify({ level, event, ...detail })}
 `);
@@ -1126,14 +1136,19 @@ class Negotiator {
   }
   async create(intentId) {
     const { principal: { owner, principalContext }, guidance } = await this.context();
-    const intent = await this.client.intent(intentId, owner.id);
+    const intent = await this.client.intent(intentId);
     const store = new FilePrincipalStore(join(this.stateDirectory, `${owner.id}.${intentId}.json`));
-    const runtime = { store, flushing: Promise.resolve() };
+    const runtime = { store, title: signalTitle(intent.payload), flushing: Promise.resolve() };
     const host = {
       status: (opportunityId, message) => log("info", "status", { intentId, opportunityId, message }),
       retry: (_owner, attempt, reason) => log("warn", "retry", { intentId, attempt, reason }),
       step: () => {},
       conversation: () => this.flush(runtime, intentId),
+      turn: (_owner, input, record) => {
+        log("info", "turn", { intentId, opportunityId: record.opportunityId, action: input.action });
+        this.announce(intentId, runtime.title, `${ACTIONS[input.action] ?? input.action} \xB7 ${record.counterparty.name || "Match"}
+${input.message}`);
+      },
       end: (record) => log("info", "end", {
         intentId,
         opportunityId: record.opportunityId,
@@ -1185,6 +1200,20 @@ class Negotiator {
   async stop() {
     const runtimes = await Promise.allSettled([...this.runtimes.values()]);
     await Promise.allSettled(runtimes.map((result) => result.status === "fulfilled" ? result.value.agent.stop() : undefined));
+  }
+  async announce(intentId, title, text) {
+    try {
+      const response = await fetch(`${this.bridge.url}/announce`, {
+        method: "POST",
+        headers: { Authorization: `Bearer ${this.bridge.token}`, "Content-Type": "application/json" },
+        body: JSON.stringify({ intentId, title, text })
+      });
+      if (!response.ok) {
+        log("warn", "announce.failed", { intentId, reason: (await response.text()).slice(0, 300) });
+      }
+    } catch (error) {
+      log("warn", "announce.failed", { intentId, reason: String(error) });
+    }
   }
   flush(runtime, intentId) {
     runtime.flushing = runtime.flushing.then(() => this.deliver(runtime, intentId)).catch((error) => log("warn", "error", { intentId, reason: `Delivery failed: ${String(error)}` }));

--- a/packages/hermes-plugin/runtime/src/client.ts
+++ b/packages/hermes-plugin/runtime/src/client.ts
@@ -22,7 +22,6 @@ interface ApiUser {
 interface ApiIntent {
   id: string;
   payload: string;
-  userId: string;
   status?: string | null;
   archivedAt?: string | null;
 }
@@ -109,13 +108,13 @@ export class IndexClient {
   }
 
   /**
-   * @param id - The signal. @param ownerId - The authenticated owner.
+   * @param id - The signal.
    * @returns The signal's statement.
-   * @throws When the signal is inactive or belongs to someone else.
+   * @throws When the signal is paused, archived, or not this owner's (the API 404s).
    */
-  async intent(id: string, ownerId: string): Promise<{ id: string; payload: string }> {
+  async intent(id: string): Promise<{ id: string; payload: string }> {
     const { intent } = await this.request<{ intent: ApiIntent }>('GET', `/intents/${encodeURIComponent(id)}`);
-    if (intent.userId !== ownerId || intent.archivedAt || (intent.status ?? 'ACTIVE') !== 'ACTIVE') {
+    if (intent.archivedAt || (intent.status ?? 'ACTIVE') !== 'ACTIVE') {
       throw new Error('This signal is inactive or belongs to another owner.');
     }
     return { id: intent.id, payload: intent.payload };

--- a/packages/hermes-plugin/runtime/src/main.ts
+++ b/packages/hermes-plugin/runtime/src/main.ts
@@ -14,8 +14,23 @@ interface Bridge {
 interface IntentRuntime {
   agent: NegotiationAgent;
   store: FilePrincipalStore;
+  /** Short signal label for the Hermes session tile. */
+  title: string;
   /** Serializes delivery so one H2A entry cannot be sent twice concurrently. */
   flushing: Promise<void>;
+}
+
+const ACTIONS: Record<string, string> = {
+  propose: 'Proposed',
+  counter: 'Countered',
+  accept: 'Accepted',
+  decline: 'Declined',
+};
+
+/** @param payload - The signal statement. @returns A session-tile label. */
+function signalTitle(payload: string): string {
+  const line = payload.trim().replace(/\s+/g, ' ');
+  return line.length > 80 ? `${line.slice(0, 79)}…` : line || 'Index signal';
 }
 
 /** Structured lines on stderr; the Hermes plugin relays them into its own log. */
@@ -70,15 +85,19 @@ class Negotiator {
 
   private async create(intentId: string): Promise<IntentRuntime> {
     const { principal: { owner, principalContext }, guidance } = await this.context();
-    const intent = await this.client.intent(intentId, owner.id);
+    const intent = await this.client.intent(intentId);
     const store = new FilePrincipalStore(join(this.stateDirectory, `${owner.id}.${intentId}.json`));
-    const runtime = { store, flushing: Promise.resolve() } as IntentRuntime;
+    const runtime = { store, title: signalTitle(intent.payload), flushing: Promise.resolve() } as IntentRuntime;
 
     const host: NegotiationHost = {
       status: (opportunityId, message) => log('info', 'status', { intentId, opportunityId, message }),
       retry: (_owner, attempt, reason) => log('warn', 'retry', { intentId, attempt, reason }),
       step: () => {},
       conversation: () => this.flush(runtime, intentId),
+      turn: (_owner, input, record) => {
+        log('info', 'turn', { intentId, opportunityId: record.opportunityId, action: input.action });
+        void this.announce(intentId, runtime.title, `${ACTIONS[input.action] ?? input.action} · ${record.counterparty.name || 'Match'}\n${input.message}`);
+      },
       end: (record) => log('info', 'end', {
         intentId, opportunityId: record.opportunityId,
         outcome: record.outcome ?? record.protocol.blockedReason,
@@ -148,6 +167,25 @@ class Negotiator {
   async stop(): Promise<void> {
     const runtimes = await Promise.allSettled([...this.runtimes.values()]);
     await Promise.allSettled(runtimes.map((result) => result.status === 'fulfilled' ? result.value.agent.stop() : undefined));
+  }
+
+  /**
+   * @param intentId - The signal. @param title - Session tile label. @param text - The submitted turn.
+   * @returns When the bridge has accepted or refused the write.
+   */
+  private async announce(intentId: string, title: string, text: string): Promise<void> {
+    try {
+      const response = await fetch(`${this.bridge.url}/announce`, {
+        method: 'POST',
+        headers: { Authorization: `Bearer ${this.bridge.token}`, 'Content-Type': 'application/json' },
+        body: JSON.stringify({ intentId, title, text }),
+      });
+      if (!response.ok) {
+        log('warn', 'announce.failed', { intentId, reason: (await response.text()).slice(0, 300) });
+      }
+    } catch (error: unknown) {
+      log('warn', 'announce.failed', { intentId, reason: String(error) });
+    }
   }
 
   private flush(runtime: IntentRuntime, intentId: string): void {

--- a/services/api/package.json
+++ b/services/api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@indexnetwork/api",
-  "version": "0.121.2",
+  "version": "0.121.3",
   "license": "MIT",
   "private": true,
   "scripts": {

--- a/services/api/src/lib/agent/negotiation.host.ts
+++ b/services/api/src/lib/agent/negotiation.host.ts
@@ -10,10 +10,6 @@ import { IntentDatabaseAdapter } from '../../adapters/intent.database.adapter';
 import { negotiationService, type NegotiationDetail } from '../../services/negotiation.service';
 import { userEventChannel } from '../user-events';
 
-const DATABASE_CONCURRENCY = 4;
-let activeDatabaseOperations = 0;
-const databaseQueue: (() => void)[] = [];
-
 export interface ApiPrincipal {
   id: string; userId: string; name: string; intentId: string; intent: string; principalContext: string;
 }
@@ -42,7 +38,7 @@ export class ApiNegotiationHost extends EventEmitter {
     for (const principal of users) {
       const store = new AgentSessionDatabaseAdapter(principal.userId, principal.intentId);
       const read = async (id: string) => {
-        const record = await this.runDatabase(() => negotiationService.read(id, principal.userId));
+        const record = await negotiationService.read(id, principal.userId);
         if (!record || record.intentId !== principal.intentId) throw new Error('Negotiation is outside this principal/intent session.');
         this.observe(principal, record);
         return this.record(record);
@@ -59,7 +55,7 @@ export class ApiNegotiationHost extends EventEmitter {
         owner: { id: principal.userId, name: principal.name }, intent: { id: principal.intentId, payload: principal.intent },
         principalContext: principal.principalContext, guidance: NEGOTIATION_GUIDANCE,
         client: { readNegotiation: read, submitTurn: async (id, turn) => {
-          const result = await this.runDatabase(() => negotiationService.submitTurn(id, principal.userId, turn, store.execution));
+          const result = await negotiationService.submitTurn(id, principal.userId, turn, store.execution);
           if ('rejection' in result) throw new Error(result.rejection);
           this.observe(principal, result);
           void this.scan();
@@ -118,24 +114,6 @@ export class ApiNegotiationHost extends EventEmitter {
     this.emit('change');
   }
 
-  /** Share capacity across hosts for one database operation, never a scan or agent task that may enqueue more work. */
-  private async runDatabase<T>(operation: () => Promise<T>): Promise<T> {
-    if (activeDatabaseOperations === DATABASE_CONCURRENCY) {
-      await new Promise<void>((resolve) => databaseQueue.push(resolve));
-    } else {
-      activeDatabaseOperations++;
-    }
-    try {
-      if (this.stopped) throw new Error('Negotiation host is stopped.');
-      return await operation();
-    } finally {
-      // Transfer the slot directly to the oldest waiter so new work cannot jump the queue.
-      const next = databaseQueue.shift();
-      if (next) next();
-      else activeDatabaseOperations--;
-    }
-  }
-
   private scan(): Promise<void> {
     this.rescan = true;
     if (this.scanning) return this.scanning;
@@ -144,12 +122,12 @@ export class ApiNegotiationHost extends EventEmitter {
         this.rescan = false;
         if (this.stopped) return;
         for (const principal of this.users) {
-          const records = await this.runDatabase(() => negotiationService.scan(principal.userId, principal.intentId));
+          const records = await negotiationService.scan(principal.userId, principal.intentId);
           for (const record of records) {
             const key = `${principal.id}:${record.opportunityId}`;
             const version = `${record.version}:${record.eligible}`;
             if (this.versions.get(key) === version) continue;
-            const detail = await this.runDatabase(() => negotiationService.read(record.opportunityId, principal.userId));
+            const detail = await negotiationService.read(record.opportunityId, principal.userId);
             if (this.stopped) return;
             if (!detail) continue;
             this.observe(principal, detail);


### PR DESCRIPTION
## Summary
- Hermes sidecar now treats owner-scoped signals as wakeable (GET `/intents/:id` has no `userId`, so wakes were marked foreign), records submitted turns on one Index session per signal, and re-opens Discover's workspace tab
- Restore frontend polling so views recover when a change event is missed, and drop the four-op negotiation FIFO cap
- Pin CLI optional platform packages in `bun.lock` to 0.25.0 to match the workspace CLI

## Test plan
- [ ] Wake an owner-scoped signal from Hermes and confirm it is not treated as foreign
- [ ] Submit a turn and confirm it lands in one Index session for that signal
- [ ] Confirm Discover re-opens its workspace tab
- [ ] Load intent/negotiation views and confirm they recover after a missed change event
- [ ] Confirm `bun.lock` optional CLI binaries are 0.25.0